### PR TITLE
Parallelize running tests

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -72,53 +72,45 @@ pipeline {
         '''
       }
     }
-
-    stage('Unit-tests') {
+    stage('Testing') {
       steps {
-        sh '''#!/bin/bash -le
-          set -x
-          echo "Running apex unit tests"
-          APEX_CONTAINER=$(docker ps --format '{{.Names}}' | grep apex_1)
-          docker exec -t -e NODE_ENV=test "$APEX_CONTAINER" ./run-tests.sh
-        '''
-      }
-    }
+        parallel(
+          "Apex tests": {
+            sh '''#!/bin/bash -le
+              set -x
+              echo "Running apex unit tests"
+              APEX_CONTAINER=$(docker ps --format '{{.Names}}' | grep apex_1)
+              docker exec -t -e NODE_ENV=test "$APEX_CONTAINER" ./run-tests.sh
+            '''},
 
-    stage('E2E-Test') {
-      steps {
-        sh '''#!/bin/bash -le
-          set -x
-          echo 'Running BlockApps BA deploy script and tests to verify the build to be healthy'
-          rm -rf blockapps-ba
-          git clone https://github.com/blockapps/blockapps-ba.git -b master
-          cd blockapps-ba
-          npm i
-          SERVER=localhost npm run deploy
-          sleep 5
-          SERVER=localhost npm run test
-        '''
-      }
-    }
-
-    stage('Monstrato tests') {
-      steps {
-        sh '''#!/bin/bash -le
-          set -x
-          echo "Running monstrato unit tests"
-          cd monstrato
-          ./run_unit_tests.sh
-        '''
-      }
-    }
-
-    stage('bloch-tests') {
-      steps {
-        sh '''#!/bin/bash -le
-          set -x
-          echo 'Running BlockApps Haskell tests to verify the build to be healthy'
-          cd blockapps-haskell
-          ./run_unit_tests.sh
-        '''
+          "E2E Tests": {
+            sh '''#!/bin/bash -le
+              set -x
+              echo 'Running BlockApps BA deploy script and tests to verify the build to be healthy'
+              rm -rf blockapps-ba
+              git clone https://github.com/blockapps/blockapps-ba.git -b master
+              cd blockapps-ba
+              npm i
+              SERVER=localhost npm run deploy
+              sleep 5
+              SERVER=localhost npm run test
+            '''},
+          "Monstrato tests": {
+            sh '''#!/bin/bash -le
+              set -x
+              echo "Running monstrato unit tests"
+              cd monstrato
+              ./run_unit_tests.sh
+            '''},
+          "Bloch tests": {
+            sh '''#!/bin/bash -le
+              set -x
+              echo 'Running BlockApps Haskell tests to verify the build to be healthy'
+              cd blockapps-haskell
+              ./run_unit_tests.sh
+            '''
+          }
+        )
       }
     }
 

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -72,7 +72,7 @@ pipeline {
         '''
       }
     }
-    stage('Testing') {
+    stage('Test') {
       steps {
         parallel(
           "Apex tests": {

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -65,7 +65,7 @@ pipeline {
     stage('Testing') {
       steps {
         parallel (
-          'Apex tests':
+          'Apex tests': {
             sh '''#!/bin/bash -le
               set -x
               echo "Running apex unit tests"
@@ -74,7 +74,7 @@ pipeline {
             '''
           },
 
-          'E2E-Test':
+          'E2E-Test': {
             sh '''#!/bin/bash -le
               set -x
               echo 'Running BlockApps BA deploy script and tests'

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -62,52 +62,50 @@ pipeline {
       }
     }
 
-    stage('Unit-tests') {
+    stage('Testing') {
       steps {
-        sh '''#!/bin/bash -le
-          set -x
-          echo "Running apex unit tests"
-          APEX_CONTAINER=$(docker ps --format '{{.Names}}' | grep apex_1)
-          docker exec -t -e NODE_ENV=test "$APEX_CONTAINER" ./run-tests.sh
-        '''
-      }
-    }
+        parallel (
+          'Apex tests':
+            sh '''#!/bin/bash -le
+              set -x
+              echo "Running apex unit tests"
+              APEX_CONTAINER=$(docker ps --format '{{.Names}}' | grep apex_1)
+              docker exec -t -e NODE_ENV=test "$APEX_CONTAINER" ./run-tests.sh
+            '''
+          },
 
-    stage('E2E-Test') {
-      steps {
-        sh '''#!/bin/bash -le
-          set -x
-          echo 'Running BlockApps BA deploy script and tests to verify the build to be healthy'
-          rm -rf blockapps-ba
-          git clone https://github.com/blockapps/blockapps-ba.git -b master
-          cd blockapps-ba
-          npm i
-          SERVER=localhost npm run deploy
-          sleep 5
-          SERVER=localhost npm run test
-        '''
-      }
-    }
+          'E2E-Test':
+            sh '''#!/bin/bash -le
+              set -x
+              echo 'Running BlockApps BA deploy script and tests'
+              rm -rf blockapps-ba
+              git clone https://github.com/blockapps/blockapps-ba.git -b master
+              cd blockapps-ba
+              npm i
+              SERVER=localhost npm run deploy
+              sleep 5
+              SERVER=localhost npm run test
+            '''
+          },
 
-    stage('Monstrato tests') {
-      steps {
-        sh '''#!/bin/bash -le
-          set -x
-          echo "Running monstrato unit tests"
-          cd monstrato
-          ./run_unit_tests.sh
-        '''
-      }
-    }
+          'Monstrato tests': {
+            sh '''#!/bin/bash -le
+              set -x
+              echo "Running monstrato unit tests"
+              cd monstrato
+              ./run_unit_tests.sh
+            '''
+          },
 
-    stage('bloch-tests') {
-      steps {
-        sh '''#!/bin/bash -le
-          set -x
-          echo 'Running BlockApps Haskell tests to verify the build to be healthy'
-          cd blockapps-haskell
-          ./run_unit_tests.sh
-        '''
+          'Bloch tests': {
+            sh '''#!/bin/bash -le
+              set -x
+              echo 'Running BlockApps Haskell tests'
+              cd blockapps-haskell
+              ./run_unit_tests.sh
+            '''
+          }
+        )
       }
     }
 

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -62,7 +62,7 @@ pipeline {
       }
     }
 
-    stage('Testing') {
+    stage('Test') {
       steps {
         parallel (
           'Apex tests': {


### PR DESCRIPTION
For now, this isn't a big performance win because the e2e tests take up 5 minutes of 5minutes and 30seconds devoted to testing.
Still, it opens the door to parallezing the e2e tests
http://blockapps-ci.eastus.cloudapp.azure.com/job/STRATO_test_build/23/