### PR TITLE
Pass loglevel in to bloc from the environment

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -64,6 +64,7 @@ services:
     - postgres
     environment:
     - cirrusHost=cirrus:3333
+    - loglevel=${loglevel}
     - postgres_user=postgres
     - postgres_host=postgres
     - postgres_password=${postgres_password:-api}


### PR DESCRIPTION
Now `$ loglevel=7 ./strato-run.sh` will set the most verbose logging and `$ loglevel=0 ./strato-run.sh` will set the quietest.