### PR TITLE
Add a ContractName to AddressStateRef

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -355,10 +355,11 @@ getContractsMetaDataIdExhaustive contractName contractAddr = do
         Nothing -> do
           return Nothing
 
-        Just (src,codeHash) -> do
+        Just (src, codeHash) -> do
           cmIds <- compileContract src
-          let correctContract = listToMaybe . filter (\cd -> codeHash == (contractdetailsCodeHash $ snd cd)) . map snd . Map.toList $ cmIds
-          return correctContract
+          let valid cd = codeHash == contractDetailsCodeHash (snd cd) ||
+                         contractName == contractDetailsName (snd cd)
+          return . listToMaybe . filter valid . Map.elems $ cmIds
     getSourceFromStrato addr = do
       let afp = accountsFilterParams{qaAddress=Just addr}
       mAcc <- listToMaybe <$> blocStrato (getAccountsFilter afp)
@@ -394,8 +395,9 @@ getContractDetailsByAddressOnly contractAddr = do
 
         Just acct -> do
           cds <- compileContract (accountSource acct)
-          let correctContract = listToMaybe . filter (\cd -> (accountCodeHash acct) == (contractdetailsCodeHash $ snd cd)) . map snd . Map.toList $ cds
-          return correctContract
+          let valid cd = accountCodeHash acct == contractDetailsCodeHash (snd cd) ||
+                         accountContractName acct == contractDetailsName (snd cd)
+          return . listToMaybe . filter valid . Map.elems $ cds
     getSourceFromStrato addr = do
       let afp = accountsFilterParams{qaAddress=Just addr}
       listToMaybe <$> blocStrato (getAccountsFilter afp)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -770,7 +770,7 @@ getXabiFunctionsArgsQuery funcId = do
   for argsWithIds $ \ (index,tyid) -> do
     ty <- getXabiType tyid
     return $ Xabi.IndexedType index ty
-    
+
 {- |
 SELECT
   (CASE WHEN XFR.name IS NULL THEN '#' + CAST(XFR.index AS VARCHAR(20)) ELSE XFR.name END) as name
@@ -1462,7 +1462,7 @@ getContractXabi (ContractName contractName) contractId = do
   metadataId <- case contractId of
     Named _ -> blocQuery1 $ getContractsMetaDataId contractName contractId
     Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr
-  getContractXabiByMetadataId metadataId 
+  getContractXabiByMetadataId metadataId
 
 getContractXabiAndMetadataId :: HasCallStack =>
                    ContractName -> MaybeNamed Address -> Bloc (Int32, Xabi)
@@ -1471,7 +1471,7 @@ getContractXabiAndMetadataId (ContractName contractName) contractId = do
   metadataId <- case contractId of
     Named _ -> blocQuery1 $ getContractsMetaDataId contractName contractId
     Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr
-  xabi <- getContractXabiByMetadataId metadataId 
+  xabi <- getContractXabiByMetadataId metadataId
   return (metadataId, xabi)
 
 getContractMetadataAndBin :: Text -> Bloc (Int32, ByteString)

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
@@ -185,6 +185,7 @@ instance ToSchema Account where
           , accountCodeHash       = keccak256 "989ad6524e83e1a38b485bb898d27b5dbc65fc33905c3d3a2fd41c5bb91c3fc8"
           , accountLatestBlockNum = 23
           , accountSource         = "pragma solidity ^0.4.8;\n\ncontract SimpleStorage {\n\n\tuint public myInt;\n\n\tfunction SimpleStorage(uint _myInt) {\n\t\tmyInt = _myInt;\n\t}\n}"
+          , accountContractName   = Just "SimpleStorage"
           }
 
 instance ToSchema Difficulty
@@ -405,6 +406,7 @@ data Account = Account
   , accountCodeHash       :: Keccak256
   , accountLatestBlockNum :: Natural
   , accountSource         :: Text
+  , accountContractName   :: Maybe Text
   } deriving (Eq, Show, Generic)
 
 instance FromJSON Account where

--- a/blockapps-haskell/strato/api/test/BlockApps/Strato/TypesSpec.hs
+++ b/blockapps-haskell/strato/api/test/BlockApps/Strato/TypesSpec.hs
@@ -32,14 +32,29 @@ spec = modifyMaxSuccess (const 10) $ do
     prop "has inverse JSON decode/encode" $ jsonProp @ BlockData
   describe "Block" $
     prop "has inverse JSON decode/encode" $ jsonProp @ Block
-  describe "Account" $
+  describe "Account" $ do
     prop "has inverse JSON decode/encode" $ jsonProp @ Account
+    it "should be backwords compatible without contractName" $
+      let input = "{   \
+            \ \"contractRoot\": \"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\
+            \ \"next\": \"/eth/v1.2/account?address=50e2752ac29be7777aff0c40850d96cbfc01eaa4&index=5\", \
+            \ \"kind\": \"AddressStateRef\",\
+            \ \"balance\": \"999999999999931774202\",\
+            \ \"address\": \"50e2752ac29be7777aff0c40850d96cbfc01eaa4\",\
+            \ \"latestBlockNum\": 21,\
+            \ \"codeHash\": \"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\",\
+            \ \"code\": \"\",\
+            \ \"source\": \"\",\
+            \ \"nonce\": 19 }"
+          acc = eitherDecode input :: Either String Account
+      in fmap accountContractName acc `shouldBe` Right Nothing
   describe "Difficulty" $
     prop "has inverse JSON decode/encode" $ jsonProp @ Difficulty
   describe "TxCount" $
     prop "has inverse JSON decode/encode" $ jsonProp @ TxCount
   describe "Storage" $
     prop "has inverse JSON decode/encode" $ jsonProp @ Storage
+
 
 -- helpers
 

--- a/monstrato/blockapps-data/src/Blockchain/Data/DataDefs.txt
+++ b/monstrato/blockapps-data/src/Blockchain/Data/DataDefs.txt
@@ -11,7 +11,7 @@ BlockData
     gasLimit Integer sqltype=numeric(1000,0)
     gasUsed Integer sqltype=numeric(1000,0)
     timestamp UTCTime
-    extraData Integer 
+    extraData Integer
     nonce Word64
     mixHash SHA
     deriving Eq Read Show
@@ -39,7 +39,7 @@ BlockDataRef
     totalDifficulty Integer sqltype=numeric(1000,0)
     deriving Eq Read Show
 
-Block 
+Block
     blockData BlockData
     receiptTransactions [Transaction]
     blockUncles [BlockData]
@@ -59,11 +59,11 @@ BlockTransaction
     transaction RawTransactionId
     deriving Eq Read Show
 
-AddressState 
+AddressState
     nonce Integer sqltype=numeric(1000,0)
     balance Integer sqltype=numeric(1000,0)
-    contractRoot StateRoot 
-    codeHash SHA 
+    contractRoot StateRoot
+    codeHash SHA
     deriving Eq Generic Read Show
 
 AddressStateRef
@@ -75,6 +75,7 @@ AddressStateRef
     codeHash SHA
     latestBlockDataRefNumber Integer
     source String
+    contractName String Maybe
     deriving Eq Read Show
 
 RawTransaction
@@ -83,7 +84,7 @@ RawTransaction
     nonce Integer sqltype=numeric(1000,0)
     gasPrice Integer sqltype=numeric(1000,0)
     gasLimit Integer sqltype=numeric(1000,0)
-    toAddress Address Maybe 
+    toAddress Address Maybe
     value Integer sqltype=numeric(1000,0)
     codeOrData BS.ByteString
     r Integer
@@ -132,7 +133,7 @@ UserData json
     address Address
     userId UserNId
     deriving Eq Read Show
-    
+
 BlockApp json
     name String
     developerName String

--- a/monstrato/blockapps-data/src/Blockchain/Data/Json.hs
+++ b/monstrato/blockapps-data/src/Blockchain/Data/Json.hs
@@ -249,9 +249,12 @@ bdrToBdrPrime = BlockDataRef'
 data AddressStateRef' = AddressStateRef' AddressStateRef String deriving (Eq, Show)
 
 instance ToJSON AddressStateRef' where
-    toJSON (AddressStateRef' (AddressStateRef (Address x) n b cr c ch bNum src) next) =
-        object ["next" .= next, "kind" .= ("AddressStateRef" :: String), "address" .= (showHex x ""), "nonce" .= n, "balance" .= show b,
-        "contractRoot" .= cr, "code" .= c, "codeHash" .= ch, "latestBlockNum" .= bNum, "source" .= src]
+    toJSON (AddressStateRef' (AddressStateRef (Address x) n b cr c ch bNum src mName) next) =
+        let name = maybeToList . fmap ("contractName" .=) $ mName
+        in object $ name ++ ["next" .= next, "kind" .= ("AddressStateRef" :: String),
+                             "address" .= (showHex x ""), "nonce" .= n, "balance" .= show b,
+                             "contractRoot" .= cr, "code" .= c, "codeHash" .= ch,
+                             "latestBlockNum" .= bNum, "source" .= src]
 
 instance FromJSON AddressStateRef' where
     parseJSON (Object s) = do
@@ -267,6 +270,7 @@ instance FromJSON AddressStateRef' where
                 <*> s .: "codeHash"
                 <*> s .: "latestBlockNum"
                 <*> s .: "source"
+                <*> s .:? "contractName"
               )
     parseJSON _ = fail "JSON not an object"
 

--- a/monstrato/strato-api/Handler/Filters.hs
+++ b/monstrato/strato-api/Handler/Filters.hs
@@ -296,7 +296,7 @@ getTxNum (RawTransaction _ (Address _) _ _ _ _ _ _ _ _ _ bn _ _) = bn
 
 -- probably need to pad here
 getAccNum :: AddressStateRef -> String
-getAccNum (AddressStateRef (Address x) _ _ _ _ _ _ _) = (showHex x "")
+getAccNum (AddressStateRef (Address x) _ _ _ _ _ _ _ _) = (showHex x "")
 
 if' :: Bool -> a -> b -> Either a b
 if' x a b = if x == True then Left a else Right b

--- a/monstrato/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
+++ b/monstrato/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
@@ -64,7 +64,8 @@ createAccount blockNumber addressSource address diff = do
       addressStateRefCode = getField (theError "code") $ code diff,
       addressStateRefCodeHash = codeHash diff,
       addressStateRefLatestBlockDataRefNumber = blockNumber,
-      addressStateRefSource = source
+      addressStateRefSource = source,
+      addressStateRefContractName = Nothing
       }
     makeIncremental (Value x) = Create{newValue = x}
     theError :: String -> a


### PR DESCRIPTION
Put a column in strato denoting what the name of the contract is at a particular address.
This is a complement to the src column, as the src actually contains more than one contract and they may need to be disambiguated by name.

What this PR doesn't address is the population of this table, which I've not decided yet on how:
- a genesis block specific write
- from statediffs
- storing on-chain with an additional `__getContractName__` next to `__getSource__`