### PR TITLE
Make an alternative JSON parsing scheme with hashmaps

### DIFF
--- a/monstrato/strato-init/src/Blockchain/Data/GenesisBlock.hs
+++ b/monstrato/strato-init/src/Blockchain/Data/GenesisBlock.hs
@@ -14,6 +14,7 @@ import           Control.Monad.Trans.Resource
 import           Data.Aeson
 import qualified Data.ByteString.Char8                as C8
 import qualified Data.ByteString.Lazy.Char8           as BLC
+import           Data.Maybe                           (catMaybes)
 
 import           Blockchain.Database.MerklePatricia
 
@@ -92,16 +93,23 @@ initializeStateDB addressInfo = do
 initializeCodeDB :: (HasCodeDB m, MonadResource m) => [CodeInfo] -> m ()
 initializeCodeDB = mapM_ (addCode . (\(CodeInfo bin _ _) -> bin))
 
+zipSourceInfo :: [AccountInfo] -> [CodeInfo] -> [(AccountInfo, CodeInfo)]
+zipSourceInfo accounts codes =
+  let hashPair c@(CodeInfo bs _ _) = (hash bs, c)
+      codeMap = Map.fromList . map hashPair $ codes
+      findCodeFor :: AccountInfo -> Maybe (AccountInfo, CodeInfo)
+      findCodeFor (NonContract _ _) = Nothing
+      findCodeFor acc@(ContractNoStorage _ _ hsh) = (acc,) <$> Map.lookup hsh codeMap
+      findCodeFor acc@(ContractWithStorage _ _ hsh _) = (acc,) <$> Map.lookup hsh codeMap
+  in catMaybes . map findCodeFor $ accounts
+
 genesisInfoToGenesisBlock :: (HasCodeDB m, HasHashDB m, Mem.HasMemAddressStateDB m, HasStateDB m, HasStorageDB m)
                           => GenesisInfo
                           -> m ([(AccountInfo, CodeInfo)], Block)
 genesisInfoToGenesisBlock gi = do
     let codes = genesisInfoCodeInfo gi
     let accounts = genesisInfoAccountInfo gi
-    let sourceInfo = case codes of
-                    [] -> []
-                    [c] -> zip accounts (repeat c)
-                    _ -> error "not equipped to seed for multiple contract types"
+    let sourceInfo = zipSourceInfo accounts codes
     initializeCodeDB codes
     initializeStateDB accounts
     db <- getStateDB

--- a/monstrato/strato-init/src/Blockchain/Generation.hs
+++ b/monstrato/strato-init/src/Blockchain/Generation.hs
@@ -5,11 +5,15 @@
 module Blockchain.Generation (
   encodeAllRecords,
   encodeJSON,
+  encodeJSONHashMaps,
   insertContractsCount,
   insertContractsJSON,
+  insertContractsJSONHashMaps,
   insertContracts,
   Records(..),
-  Type(..)
+  RecordsHashMap(..),
+  Type(..),
+  TypeHashMap(..)
 ) where
 
 import Control.Monad ((<=<))
@@ -32,22 +36,45 @@ import Blockchain.Strato.Model.SHA
 import Blockchain.Strato.Model.ExtendedWord
 import Blockchain.Data.GenesisInfo
 
-data Type = Number Integer | Stryng T.Text | List (V.Vector Type) | Struct [Type]
+data Type = Number Integer
+          | Stryng T.Text
+          | List (V.Vector Type)
+          | Struct [Type]
+          -- TODO(tim): Make the key type generic over hashable things.
+          | Mapping (HM.HashMap T.Text Type)
   deriving (Eq, Show, Generic)
 
 instance Ae.FromJSON Type where
-  parseJSON (Ae.String s) = return $ Stryng s
+  parseJSON (Ae.String s) = return . Stryng $ s
   parseJSON (Ae.Number x) = case floatingOrInteger x :: Either Double Integer of
                                 Left f -> fail $ "must be int or string: " ++ show f
-                                Right n -> return $ Number n
+                                Right n -> return . Number $ n
   parseJSON (Ae.Array as) = List <$> V.mapM Ae.parseJSON as
   parseJSON (Ae.Object ss) = let a `cmp` b = fst a `compare` fst b
                              in Struct <$> (mapM (Ae.parseJSON . snd) . List.sortBy cmp . HM.toList $ ss)
-  parseJSON _ = fail "must be int or string"
+  parseJSON (Ae.Bool b) = return . Number $ if b then 1 else 0
+  parseJSON _ = fail "unknown aeson type"
+
+-- This is a clumsy hack to just create a mapping(bytes32 => uint),
+-- and probably needs to be replaced with something more generic.
+-- For example, this prohibits mapping(address => mapping(address => bool)),
+-- both because it only uses a string key and because the values is not Type2
+data TypeHashMap = Type Type | MappingHashMap (HM.HashMap T.Text Type) deriving (Eq, Show, Generic)
+
+toType :: TypeHashMap -> Type
+toType (Type t) = t
+toType (MappingHashMap hm) = Mapping hm
+
+instance Ae.FromJSON TypeHashMap where
+  parseJSON (Ae.Object ss) = MappingHashMap <$> traverse Ae.parseJSON ss
+  parseJSON v = Type <$> Ae.parseJSON v
+
 
 newtype Records = Records [[Type]] deriving (Eq, Show, Generic)
-
 instance Ae.FromJSON Records
+
+newtype RecordsHashMap = RecordsHashMap [[TypeHashMap]] deriving (Eq, Show, Generic)
+instance Ae.FromJSON RecordsHashMap
 
 equalChunksOf :: Int -> [Word8] -> [[Word8]]
 equalChunksOf n ws | length ws == 0 = []
@@ -58,6 +85,10 @@ equalChunksOf n ws | length ws == 0 = []
 hash :: Word256 -> Word256
 hash x = let SHA w = superProprietaryStratoSHAHash . BS.pack . word256ToBytes $ x
          in w
+
+mapHash :: Word256 -> Word256 -> Word256
+mapHash x y = let SHA w = superProprietaryStratoSHAHash . BS.pack $ (word256ToBytes x ++ word256ToBytes y)
+              in w
 
 encodeSequentially :: Word256 -> [Type] -> Either String ([(Word256, Word256)], Word256)
 encodeSequentially k [] = return ([], k)
@@ -90,6 +121,20 @@ encodeType k (List payload) =
       (packets, _) <- encodeSequentially start (V.toList payload)
       return (pointer:packets, k + 1)
 encodeType k (Struct ts) = encodeSequentially k ts
+encodeType p (Mapping hm) =
+  let pointer = (p, 0)
+      -- This is very specific to the case of using bytes32 as keys.
+      -- Using strings as key hashes the whole string, rather than
+      -- slicing to 32 bytes and extending by 0s.
+      payload s = let raw = BS.unpack . encodeUtf8 $ s
+                  in if length raw < 33
+                        then raw ++ replicate (32 - length raw) 0
+                        else take 32 raw
+      -- For a mapping value located in contract slot p with key s
+      -- the slot is keccak256(s <> p)
+      trieKey s = mapHash (bytesToWord256 . payload $ s) p
+      place (s, v) = fst <$> encodeType (trieKey s) v
+  in (, p+1) . (pointer:) . concat <$> (mapM place . HM.toList $ hm)
 
 encodeRecord :: Word256 -> [Type] -> Either String [(Word256, Word256)]
 encodeRecord k ts = fst <$> encodeSequentially k ts
@@ -97,16 +142,26 @@ encodeRecord k ts = fst <$> encodeSequentially k ts
 encodeAllRecords :: Records -> Either String [[(Word256, Word256)]]
 encodeAllRecords (Records recs) = mapM (encodeRecord 0) recs
 
+encodeAllRecordsHashMaps :: RecordsHashMap -> Either String [[(Word256, Word256)]]
+encodeAllRecordsHashMaps (RecordsHashMap recs) = encodeAllRecords . Records . map (map toType) $ recs
+
 encodeJSON :: L.ByteString -> Either String [[(Word256, Word256)]]
 encodeJSON = encodeAllRecords <=< Ae.eitherDecode
+
+encodeJSONHashMaps :: L.ByteString -> Either String [[(Word256, Word256)]]
+encodeJSONHashMaps = encodeAllRecordsHashMaps <=< Ae.eitherDecode
 
 insertContractsCount :: Int -> String -> String -> BS.ByteString -> Address -> GenesisInfo -> Either String GenesisInfo
 insertContractsCount n name src code start gi = return $ insertContracts (replicate n []) name src code start gi
 
-
 insertContractsJSON :: L.ByteString -> String -> String -> BS.ByteString -> Address -> GenesisInfo -> Either String GenesisInfo
 insertContractsJSON rawJSON name src code start gi = do
   slotss <- encodeJSON rawJSON
+  return $ insertContracts slotss name src code start gi
+
+insertContractsJSONHashMaps :: L.ByteString -> String -> String -> BS.ByteString -> Address -> GenesisInfo -> Either String GenesisInfo
+insertContractsJSONHashMaps rawJSON name src code start gi = do
+  slotss <- encodeJSONHashMaps rawJSON
   return $ insertContracts slotss name src code start gi
 
 insertContracts :: [[(Word256, Word256)]] -> String -> String -> BS.ByteString -> Address -> GenesisInfo -> GenesisInfo

--- a/monstrato/strato-init/src/GenerateGenesis.hs
+++ b/monstrato/strato-init/src/GenerateGenesis.hs
@@ -12,7 +12,7 @@ import Data.ByteString (hGetContents, ByteString)
 import qualified Data.ByteString.Lazy as L
 import Data.List (intercalate)
 
-import Blockchain.Generation (insertContractsCount, insertContractsJSON)
+import Blockchain.Generation (insertContractsCount, insertContractsJSON, insertContractsJSONHashMaps)
 import Blockchain.Strato.Model.Address ()
 
 defineFlag "g:genesis_file" ("" :: String) "Filename containing pre-modifications genesis block"
@@ -27,7 +27,8 @@ defineFlag "r:records_file" ("" :: String) "Filename containing CSV records of d
                                            \ small strings as well). Little validation is \
                                            \ performed. Rows with fewer columns will \
                                            \ have fewer columns inserted."
-
+defineFlag "t:hash_maps" (False :: Bool) "Use an alternative JSON parsing scheme, where objects\
+                                          \ are hashmaps instead of structs"
 defineFlag "f:fake_flag" (0:: Integer) "Hflags will ignore this flag."
 
 
@@ -68,7 +69,9 @@ main = do
               then return $ insertContractsCount flags_number
               else do
                   json <- L.readFile flags_records_file
-                  return $ insertContractsJSON json
+                  return $ if flags_hash_maps
+                             then insertContractsJSONHashMaps json
+                             else insertContractsJSON json
   let output = insert name src bytes (fromInteger flags_start) genesis
 
   case output of

--- a/monstrato/strato-init/test/GenerationSpec.hs
+++ b/monstrato/strato-init/test/GenerationSpec.hs
@@ -276,3 +276,25 @@ spec = do
             ]]
         got = encodeJSON input
     in got `shouldBe` want
+
+  it "Should encode mapping(bytes32 => uint)" $
+    let input = "[[{\"hello, world\": 255, \
+                 \  \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\":65535, \
+                 \  \"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\": 16777215}]]"
+        want = Right [[
+            -- Mapping reserved spot
+            (0x0000000000000000000000000000000000000000000000000000000000000000,
+             0x0000000000000000000000000000000000000000000000000000000000000000),
+            -- keccak256("hello, world" + '\0' * 20 <> uint256(0)) = 0cfed6...
+            (0x0cfed68a184422f13ee7ec91f5da2bb2308dd2f99b1e970d69a8fe4a32752620,
+             0x00000000000000000000000000000000000000000000000000000000000000ff),
+            -- keccak256('a' * 32 + '\0' * 32) = 31db...
+            (0x31bdf21e71593a7b324dcbb99d5d011856259a09fdda85b2c97448b1bb45c2de,
+             0x000000000000000000000000000000000000000000000000000000000000ffff),
+            -- Strings longer than 32 bytes are truncated to 32
+            -- keccak256('z' * 32 + '\0' * 32) = 4490...
+            (0x4490202cf2d5b5a4a1cc5b09643c81c0a37330a9ec8d1249a2b2febd1150027b,
+             0x0000000000000000000000000000000000000000000000000000000000ffffff)
+            ]]
+        got = encodeJSONHashMaps input
+    in got `shouldBe` want


### PR DESCRIPTION
I made the choice in previous versions to parse JSON objects as hashmaps.

In lieu of making a robust correspondence between JSON datatypes and solidity datatypes, I choose to just make an alternative type that will read objects as mappings(bytes32 -> t), where for t it uses the original parsing scheme.

This is definitely a hack, as it only allows using mappings or structs but not both. Additionally, {"x": {"y: 10}} will parse as mapping(text -> struct{y: uint}), which will certainly be surprising. However, this change has the beneift of being quick to write...