### PR TITLE
Ecrecover recid

### DIFF
--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -149,7 +149,7 @@ instance ToCapture (Capture "contractAddress" Address) where
   toCapture _ = DocCapture "contractAddress" "an Ethereum address"
 
 instance RLPEncodable Address where
-  rlpEncode (Address addr) = rlpEncode $ toInteger addr
+  rlpEncode addr = rlpEncode . fst . Base16.decode . Char8.pack $ addressString addr
   rlpDecode obj = Address . fromInteger <$> rlpDecode obj
 
 instance RLPEncodable (Maybe Address) where

--- a/monstrato/blockapps-data/src/Blockchain/Data/Transaction.hs
+++ b/monstrato/blockapps-data/src/Blockchain/Data/Transaction.hs
@@ -168,7 +168,7 @@ createMessageTX n gp gl to' val theData prvKey = do
                      transactionV = 0
                    }
   let SHA theHash = partialTransactionHash unsignedTX
-  ExtendedSignature signature yIsOdd <- extSignMsg theHash prvKey
+  ExtendedSignature signature recId <- extSignMsg theHash prvKey
   return
     unsignedTX {
       transactionR =
@@ -179,7 +179,7 @@ createMessageTX n gp gl to' val theData prvKey = do
         case B16.decode $ B.pack $ map c2w $ addLeadingZerosTo64 $ showHex (sigS signature) "" of
           (val', "") -> byteString2Integer val'
           _          -> error ("error: sigS is: " ++ showHex (sigS signature) ""),
-      transactionV = if yIsOdd then 0x1c else 0x1b
+      transactionV = fromRecId recId
     }
 
 createContractCreationTX::MonadIO m=>Integer->Integer->Integer->Integer->Code->PrvKey->SecretT m Transaction
@@ -196,7 +196,7 @@ createContractCreationTX n gp gl val init' prvKey = do
                    }
 
   let SHA theHash = partialTransactionHash unsignedTX
-  ExtendedSignature signature yIsOdd <- extSignMsg theHash prvKey
+  ExtendedSignature signature recId <- extSignMsg theHash prvKey
   return
     unsignedTX {
       transactionR =
@@ -207,17 +207,17 @@ createContractCreationTX n gp gl val init' prvKey = do
         case B16.decode $ B.pack $ map c2w $ addLeadingZerosTo64 $ showHex (sigS signature) "" of
           (val', "") -> byteString2Integer val'
           _          -> error ("error: sigS is: " ++ showHex (sigS signature) ""),
-      transactionV = if yIsOdd then 0x1c else 0x1b
+      transactionV = fromRecId recId
     }
 
 
 {-
   Switch to Either?
 -}
-whoSignedThisTransaction::Transaction->Maybe Address -- Signatures can be malformed, hence the Maybe
+whoSignedThisTransaction :: Transaction -> Maybe Address -- Signatures can be malformed, hence the Maybe
 whoSignedThisTransaction t = pubKey2Address <$> getPubKeyFromSignature_fast xSignature theHash
         where
-          xSignature = ExtendedSignature (Signature (fromInteger $ transactionR t) (fromInteger $ transactionS t)) (0x1c == transactionV t)
+          xSignature = ExtendedSignature (Signature (fromInteger $ transactionR t) (fromInteger $ transactionS t)) (toRecId (transactionV t))
           SHA theHash = partialTransactionHash t
 
 isMessageTX::Transaction->Bool

--- a/monstrato/ethereum-discovery/src/Blockchain/Strato/Discovery/ExtendedECDSA.hs
+++ b/monstrato/ethereum-discovery/src/Blockchain/Strato/Discovery/ExtendedECDSA.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Blockchain.Strato.Discovery.ExtendedECDSA (
   ExtendedSignature(..),
+  fromRecId,
+  toRecId,
   extSignMsg,
   getPubKeyFromSignature
   ) where
@@ -9,6 +12,7 @@ import           Control.Monad
 import qualified Control.Monad.State       as S
 import           Control.Monad.Trans       (lift)
 import           Data.Bits
+import           Data.Word                 (Word8)
 
 import           Network.Haskoin.Constants
 import           Network.Haskoin.Crypto
@@ -44,7 +48,19 @@ genKeyPair = do
 
 -----------------------
 
-data ExtendedSignature = ExtendedSignature Signature Bool deriving (Show, Eq)
+recIdOffset :: Word8
+recIdOffset = 0x1b
+
+newtype RecId = RecId Word8 deriving (Show, Eq, Ord, Enum, Num, Real, Integral)
+
+toRecId :: Word8 -> RecId
+toRecId w | w < recIdOffset = error $ "toRecId: value less than recIdOffset. Expected >=" ++ show recIdOffset ++ ", got " ++ show w
+          | otherwise       = RecId (w - recIdOffset)
+
+fromRecId :: RecId -> Word8
+fromRecId (RecId r) = r + recIdOffset
+
+data ExtendedSignature = ExtendedSignature Signature RecId deriving (Show, Eq)
 
 unsafeExtSignMsg :: Word256 -> FieldN -> (FieldN, Point) -> Maybe ExtendedSignature
 unsafeExtSignMsg _ 0 _ = Nothing
@@ -64,7 +80,7 @@ unsafeExtSignMsg h d (k,p) = do
     guard (s /= 0)
     -- 4.1.3.7
     --return $ (Signature r s, odd y `xor` (s' > (maxBound `div` 2)))
-    return $ ExtendedSignature (Signature r s) (odd y `xor` (s' > (maxBound `div` 2)))
+    return $ ExtendedSignature (Signature r s) (fromIntegral $ (y `mod` 2) `xor` (if s' > (maxBound `div` 2) then 1 else 0))
 
 extSignMsg :: Monad m => Word256 -> PrvKey -> SecretT m ExtendedSignature
 --extSignMsg _ (PrvKey  0) = error "signMsg: Invalid private key 0"
@@ -80,16 +96,13 @@ extSignMsg h d = do
 
 -------------------
 
-getPubKeyFromSignature::ExtendedSignature->Word256->Maybe PubKey
-getPubKeyFromSignature (ExtendedSignature sig yIsOdd) msgHash =
-  case ys of
-    (firstY:secondY:_) ->
-      let
-        correctY = if odd firstY == yIsOdd then firstY else secondY
-        Just bigR = makePoint (fromIntegral r) correctY
-
-      in Just $ makePubKey $ ((s / r) `mulPoint` bigR) `addPoint` ((fromIntegral curveN - fromIntegral msgHash/r) `mulPoint` curveG)
-    _ -> Nothing
+getPubKeyFromSignature :: ExtendedSignature -> Word256 -> Maybe PubKey
+getPubKeyFromSignature (ExtendedSignature sig recId) msgHash =
+  case drop (fromIntegral recId) ys of
+    [] -> Nothing
+    (y:_) ->
+      let Just bigR = makePoint (fromIntegral r) y
+       in Just $ makePubKey $ ((s / r) `mulPoint` bigR) `addPoint` ((fromIntegral curveN - fromIntegral msgHash/r) `mulPoint` curveG)
   where
     r = sigR sig
     s = sigS sig

--- a/monstrato/ethereum-discovery/src/Blockchain/Strato/Discovery/ExtendedECDSA.hs
+++ b/monstrato/ethereum-discovery/src/Blockchain/Strato/Discovery/ExtendedECDSA.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 
 module Blockchain.Strato.Discovery.ExtendedECDSA (
   ExtendedSignature(..),
@@ -80,7 +81,11 @@ unsafeExtSignMsg h d (k,p) = do
     guard (s /= 0)
     -- 4.1.3.7
     --return $ (Signature r s, odd y `xor` (s' > (maxBound `div` 2)))
-    return $ ExtendedSignature (Signature r s) (fromIntegral $ (y `mod` 2) `xor` (if s' > (maxBound `div` 2) then 1 else 0))
+    let (recId :: Word8) = (if (toInteger r) >= curveN then 2 else 0)
+                           + ((fromIntegral (y `mod` 2))
+                             `xor` (if s' > (maxBound `div` 2) then 1 else 0))
+    return $ ExtendedSignature (Signature r s) (fromIntegral recId)
+
 
 extSignMsg :: Monad m => Word256 -> PrvKey -> SecretT m ExtendedSignature
 --extSignMsg _ (PrvKey  0) = error "signMsg: Invalid private key 0"

--- a/monstrato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
+++ b/monstrato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
@@ -183,8 +183,7 @@ dataToPacket msg = do
     let r = bytesToWord256 $ B.unpack $ B.take 32 $ B.drop 32 msg
         s = bytesToWord256 $ B.unpack $ B.take 32 $ B.drop 64 msg
     v <- note (ByteStringLengthException $ show msg) $ listToMaybe . B.unpack $ B.take 1 $ B.drop 96 msg
-    let yIsOdd = v == 1
-        signature = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) yIsOdd
+    let signature = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) (toRecId v)
         theRest = B.unpack $ B.drop 98 msg
         (rlp, _) = rlpSplit $ B.pack theRest
     theType <- note (ByteStringLengthException $ show msg) $ listToMaybe . B.unpack $ B.take 1 $ B.drop 97 msg
@@ -213,9 +212,9 @@ sendPacket sock prv addr packet = do
       theData = B.unpack $ rlpSerialize theRLP
       SHA theMsgHash = hash $ B.pack $ theType' : theData
 
-  ExtendedSignature signature' yIsOdd' <- liftIO $ H.withSource H.devURandom $ extSignMsg theMsgHash prv
+  ExtendedSignature signature' recId' <- liftIO $ H.withSource H.devURandom $ extSignMsg theMsgHash prv
 
-  let v' = if yIsOdd' then 1 else 0
+  let v' = fromRecId recId'
       r' = H.sigR signature'
       s' = H.sigS signature'
       theSignature = word256ToBytes (fromIntegral r') ++ word256ToBytes (fromIntegral s') ++ [v']
@@ -240,8 +239,7 @@ processDataStream'
                           r17,r18,r19,r20,r21,r22,r23,r24,r25,r26,r27,r28,r29,r30,r31,r32]
       s = bytesToWord256 [s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,
                           s17,s18,s19,s20,s21,s22,s23,s24,s25,s26,s27,s28,s29,s30,s31,s32]
-      yIsOdd = v == 1 -- 0x1c
-      signature = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) yIsOdd
+      signature = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) (toRecId v)
 
   let (rlp, _) = rlpSplit $ B.pack rest
 
@@ -302,9 +300,9 @@ getServerPubKey myPriv domain port =
           theData = B.unpack $ rlpSerialize theRLP
           SHA theMsgHash = hash $ B.pack $ theType : theData
 
-      ExtendedSignature signature yIsOdd <- H.withSource H.devURandom $ encrypt prvKey' theMsgHash
+      ExtendedSignature signature recId <- H.withSource H.devURandom $ encrypt prvKey' theMsgHash
 
-      let v = if yIsOdd then 1 else 0 -- 0x1c else 0x1b
+      let v = fromRecId recId
           r = H.sigR signature
           s = H.sigS signature
           theSignature =
@@ -334,10 +332,10 @@ findNeighbors myPriv domain port =
           theData = B.unpack $ rlpSerialize theRLP
           SHA theMsgHash = hash $ B.pack (theType : theData)
 
-      ExtendedSignature signature yIsOdd <-
+      ExtendedSignature signature recId <-
         H.withSource H.devURandom $ encrypt prvKey' theMsgHash
 
-      let v = if yIsOdd then 1 else 0 -- 0x1c else 0x1b
+      let v = fromRecId recId
           r = H.sigR signature
           s = H.sigS signature
           theSignature =

--- a/monstrato/ethereum-encryption/src/Blockchain/ExtendedECDSA.hs
+++ b/monstrato/ethereum-encryption/src/Blockchain/ExtendedECDSA.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Blockchain.ExtendedECDSA (
   ExtendedSignature(..),
+  toRecId,
+  fromRecId,
   extSignMsg,
   getPubKeyFromSignature
   ) where
@@ -9,6 +12,7 @@ import           Control.Monad
 import qualified Control.Monad.State       as S
 import           Control.Monad.Trans       (lift)
 import           Data.Bits
+import           Data.Word                 (Word8)
 
 import           Network.Haskoin.Constants
 import           Network.Haskoin.Crypto
@@ -44,7 +48,19 @@ genKeyPair = do
 
 -----------------------
 
-data ExtendedSignature = ExtendedSignature Signature Bool deriving (Show, Eq)
+recIdOffset :: Word8
+recIdOffset = 0x1b
+
+newtype RecId = RecId Word8 deriving (Show, Eq, Ord, Enum, Num, Real, Integral)
+
+toRecId :: Word8 -> RecId
+toRecId w | w < recIdOffset = error $ "toRecId: value less than recIdOffset. Expected >=" ++ show recIdOffset ++ ", got " ++ show w
+          | otherwise       = RecId (w - recIdOffset)
+
+fromRecId :: RecId -> Word8
+fromRecId (RecId r) = r + recIdOffset
+
+data ExtendedSignature = ExtendedSignature Signature RecId deriving (Show, Eq)
 
 unsafeExtSignMsg :: Word256 -> FieldN -> (FieldN, Point) -> Maybe ExtendedSignature
 unsafeExtSignMsg _ 0 _ = Nothing
@@ -64,7 +80,7 @@ unsafeExtSignMsg h d (k,p) = do
     guard (s /= 0)
     -- 4.1.3.7
     --return $ (Signature r s, odd y `xor` (s' > (maxBound `div` 2)))
-    return $ ExtendedSignature (Signature r s) (odd y `xor` (s' > (maxBound `div` 2)))
+    return $ ExtendedSignature (Signature r s) (fromIntegral $ (y `mod` 2) `xor` (if s' > (maxBound `div` 2) then 1 else 0))
 
 extSignMsg :: Monad m => Word256 -> PrvKey -> SecretT m ExtendedSignature
 --extSignMsg _ (PrvKey  0) = error "signMsg: Invalid private key 0"
@@ -80,19 +96,21 @@ extSignMsg h d = do
 
 -------------------
 
-recoverPoint :: FieldN -> Bool -> Maybe Point
-recoverPoint r yIsOdd = do
-  firstY:secondY:_ <- case quadraticResidue $ (fromIntegral r)^(3::Integer) + 7 of
+recoverPoint :: FieldN -> Word8 -> Maybe Point
+recoverPoint r recId = do
+  ys <- case quadraticResidue $ (fromIntegral r)^(3::Integer) + 7 of
     [] -> Nothing
     l  -> Just l
-  makePoint (fromIntegral r) $ if odd firstY == yIsOdd then firstY else secondY
+  case drop (fromIntegral recId) ys of
+    [] -> Nothing
+    (y:_) -> makePoint (fromIntegral r) y
 
-getPubKeyFromSignature :: ExtendedSignature->Word256-> Maybe PubKey
-getPubKeyFromSignature (ExtendedSignature sig yIsOdd) msgHash = do
+getPubKeyFromSignature :: ExtendedSignature -> Word256 -> Maybe PubKey
+getPubKeyFromSignature (ExtendedSignature sig recId) msgHash = do
   let r = sigR sig
       s = sigS sig
       h = fromIntegral msgHash
-  p <- recoverPoint r yIsOdd
+  p <- recoverPoint r (fromIntegral recId)
   w <- if r == 0 then Nothing else Just $ recip r
   return $ makePubKey $ shamirsTrick (s * w) p (-h * w) curveG
 

--- a/monstrato/ethereum-encryption/src/Blockchain/ExtendedECDSA.hs
+++ b/monstrato/ethereum-encryption/src/Blockchain/ExtendedECDSA.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 
 module Blockchain.ExtendedECDSA (
   ExtendedSignature(..),
@@ -80,7 +81,10 @@ unsafeExtSignMsg h d (k,p) = do
     guard (s /= 0)
     -- 4.1.3.7
     --return $ (Signature r s, odd y `xor` (s' > (maxBound `div` 2)))
-    return $ ExtendedSignature (Signature r s) (fromIntegral $ (y `mod` 2) `xor` (if s' > (maxBound `div` 2) then 1 else 0))
+    let (recId :: Word8) = (if (toInteger r) >= curveN then 2 else 0)
+                           + ((fromIntegral (y `mod` 2))
+                             `xor` (if s' > (maxBound `div` 2) then 1 else 0))
+    return $ ExtendedSignature (Signature r s) (fromIntegral recId)
 
 extSignMsg :: Monad m => Word256 -> PrvKey -> SecretT m ExtendedSignature
 --extSignMsg _ (PrvKey  0) = error "signMsg: Invalid private key 0"

--- a/monstrato/ethereum-encryption/src/Blockchain/Handshake.hs
+++ b/monstrato/ethereum-encryption/src/Blockchain/Handshake.hs
@@ -23,11 +23,11 @@ import qualified Blockchain.ECIES          as ECIES
 import           Blockchain.ExtendedECDSA
 import           Blockchain.ExtWord
 
-sigToBytes::ExtendedSignature->[Word8]
-sigToBytes (ExtendedSignature signature yIsOdd) =
+sigToBytes :: ExtendedSignature -> [Word8]
+sigToBytes (ExtendedSignature signature recId) =
   word256ToBytes (fromIntegral $ H.sigR signature) ++
   word256ToBytes (fromIntegral $ H.sigS signature) ++
-  [if yIsOdd then 1 else 0]
+  [fromIntegral recId]
 
 
 data AckMessage = AckMessage {

--- a/monstrato/ethereum-encryption/src/Blockchain/RLPx.hs
+++ b/monstrato/ethereum-encryption/src/Blockchain/RLPx.hs
@@ -143,9 +143,8 @@ ethCryptAcceptEIP8 myPriv _ hsBytes eciesMsgIBytes = do
       r = bytesToWord256 $ B.unpack $ B.take 32 $ signatureBytes
       s = bytesToWord256 $ B.unpack $ B.take 32 $ B.drop 32 $ signatureBytes
       v = head . B.unpack $ B.take 1 $ B.drop 64 signatureBytes
-      yIsOdd = v == 1
 
-      extSig = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) yIsOdd
+      extSig = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) (toRecId v)
       otherEphemeral = hPubKeyToPubKey $
                             fromMaybe (error "malformed signature in tcpHandshakeServer") $
                             getPubKeyFromSignature extSig msg
@@ -198,9 +197,8 @@ ethCryptAcceptOld myPriv otherPoint hsBytes eciesMsgIBytes = do
         r = bytesToWord256 $ B.unpack $ B.take 32 $ eciesMsgIBytes
         s = bytesToWord256 $ B.unpack $ B.take 32 $ B.drop 32 $ eciesMsgIBytes
         v = head . B.unpack $ B.take 1 $ B.drop 64 eciesMsgIBytes
-        yIsOdd = v == 1
 
-        extSig = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) yIsOdd
+        extSig = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) (toRecId v)
         otherEphemeral = hPubKeyToPubKey $
                             fromMaybe (error "malformed signature in tcpHandshakeServer") $
                             getPubKeyFromSignature extSig msg

--- a/monstrato/ethereum-vm/src/Blockchain/VM/PrecompiledContracts.hs
+++ b/monstrato/ethereum-vm/src/Blockchain/VM/PrecompiledContracts.hs
@@ -29,9 +29,9 @@ ecdsaRecover input =
         v = byteString2Integer $ B.take 32 $ B.drop 32 input
         r = fromInteger $ byteString2Integer $ B.take 32 $ B.drop 64 input
         s = fromInteger $ byteString2Integer $ B.take 32 $ B.drop 96 input
-        maybePubKey = getPubKeyFromSignature (ExtendedSignature (Signature r s) (v == 28)) h
+        maybePubKey = getPubKeyFromSignature (ExtendedSignature (Signature r s) (toRecId (fromInteger v))) h
     in
-     case (v >= 27, v <= 28, maybePubKey) of
+     case (v >= 27, v <= 30, maybePubKey) of
        (True, True, Just pubKey) ->
          B.pack [0,0,0,0,0,0,0,0,0,0,0,0] `B.append` BL.toStrict (encode $ pubKey2Address pubKey)
        _ -> B.empty -- B.pack (replicate 32 0)

--- a/monstrato/fast-ecrecover/benchmark/Main.hs
+++ b/monstrato/fast-ecrecover/benchmark/Main.hs
@@ -30,7 +30,7 @@ transaction =
   (es, hash)
   where
     !es =
-      F.ExtendedSignature signature True
+      F.ExtendedSignature signature (toRecId 0x1c)
       where
         !signature =
           G.Signature sigR sigS

--- a/monstrato/fast-ecrecover/src/Blockchain/FastECRecover.hs
+++ b/monstrato/fast-ecrecover/src/Blockchain/FastECRecover.hs
@@ -15,9 +15,9 @@ import qualified Network.Haskoin.Internals         as C
 
 {-# INLINE getPubKeyFromSignature_fast #-}
 getPubKeyFromSignature_fast :: D.ExtendedSignature -> E.Word256 -> Maybe C.PubKey
-getPubKeyFromSignature_fast (D.ExtendedSignature sig yIsOdd) hashWord =
+getPubKeyFromSignature_fast (D.ExtendedSignature sig recId) hashWord =
   do
-    pubKeyBytes <- liftEither (F.recoverUncompressed sigR sigS recId hash)
+    pubKeyBytes <- liftEither (F.recoverUncompressed sigR sigS (fromIntegral recId) hash)
     (_, _, result) <- liftEither (A.decodeOrFail (G.fromStrict pubKeyBytes))
     return result
   where
@@ -27,7 +27,5 @@ getPubKeyFromSignature_fast (D.ExtendedSignature sig yIsOdd) hashWord =
       C.getBigWordInteger (C.sigR sig)
     sigS =
       C.getBigWordInteger (C.sigS sig)
-    recId =
-        if yIsOdd then 1 else 0
     hash =
       C.getBigWordInteger hashWord

--- a/monstrato/strato-model/test/Blockchain/Strato/Model/TransactionModel.hs
+++ b/monstrato/strato-model/test/Blockchain/Strato/Model/TransactionModel.hs
@@ -180,7 +180,7 @@ createMessageTX n gp gl to' val theData prvKey = do
                      transactionV = 0
                    }
   let SHA theHash = partialTransactionHash unsignedTX
-  ExtendedSignature signature yIsOdd <- extSignMsg theHash prvKey
+  ExtendedSignature signature recId <- extSignMsg theHash prvKey
   return
     unsignedTX {
       transactionR =
@@ -191,7 +191,7 @@ createMessageTX n gp gl to' val theData prvKey = do
         case B16.decode $ B.pack $ map c2w $ addLeadingZerosTo64 $ showHex (sigS signature) "" of
           (val', "") -> byteString2Integer val'
           _          -> error ("error: sigS is: " ++ showHex (sigS signature) ""),
-      transactionV = if yIsOdd then 0x1c else 0x1b
+      transactionV = fromRecId recId
     }
 
 createContractCreationTX :: MonadIO m=>Integer->Integer->Integer->Integer->Code->PrvKey->SecretT m Transaction
@@ -208,7 +208,7 @@ createContractCreationTX n gp gl val init' prvKey = do
                    }
 
   let SHA theHash = partialTransactionHash unsignedTX
-  ExtendedSignature signature yIsOdd <- extSignMsg theHash prvKey
+  ExtendedSignature signature recId <- extSignMsg theHash prvKey
   return
     unsignedTX {
       transactionR =
@@ -219,13 +219,13 @@ createContractCreationTX n gp gl val init' prvKey = do
         case B16.decode $ B.pack $ map c2w $ addLeadingZerosTo64 $ showHex (sigS signature) "" of
           (val', "") -> byteString2Integer val'
           _          -> error ("error: sigS is: " ++ showHex (sigS signature) ""),
-      transactionV = if yIsOdd then 0x1c else 0x1b
+      transactionV = fromRecId recId
     }
 
 whoSignedThisTransaction :: Transaction->Maybe Address -- Signatures can be malformed, hence the Maybe
 whoSignedThisTransaction t = pubKey2Address <$> getPubKeyFromSignature' xSignature theHash
         where
-          xSignature = ExtendedSignature (Signature (fromInteger $ transactionR t) (fromInteger $ transactionS t)) (0x1c == transactionV t)
+          xSignature = ExtendedSignature (Signature (fromInteger $ transactionR t) (fromInteger $ transactionS t)) (toRecId $ transactionV t)
           SHA theHash = partialTransactionHash t
           getPubKeyFromSignature' = getPubKeyFromSignature_fast
 

--- a/monstrato/test-suite/test/Blockchain/Strato/Model/TransactionModel.hs
+++ b/monstrato/test-suite/test/Blockchain/Strato/Model/TransactionModel.hs
@@ -180,7 +180,7 @@ createMessageTX n gp gl to' val theData prvKey = do
                      transactionV = 0
                    }
   let SHA theHash = partialTransactionHash unsignedTX
-  ExtendedSignature signature yIsOdd <- extSignMsg theHash prvKey
+  ExtendedSignature signature recId <- extSignMsg theHash prvKey
   return
     unsignedTX {
       transactionR =
@@ -191,7 +191,7 @@ createMessageTX n gp gl to' val theData prvKey = do
         case B16.decode $ B.pack $ map c2w $ addLeadingZerosTo64 $ showHex (sigS signature) "" of
           (val', "") -> byteString2Integer val'
           _          -> error ("error: sigS is: " ++ showHex (sigS signature) ""),
-      transactionV = if yIsOdd then 0x1c else 0x1b
+      transactionV = fromRecId recId
     }
 
 createContractCreationTX  ::  MonadIO m=>Integer->Integer->Integer->Integer->Code->PrvKey->SecretT m Transaction
@@ -208,7 +208,7 @@ createContractCreationTX n gp gl val init' prvKey = do
                    }
 
   let SHA theHash = partialTransactionHash unsignedTX
-  ExtendedSignature signature yIsOdd <- extSignMsg theHash prvKey
+  ExtendedSignature signature recId <- extSignMsg theHash prvKey
   return
     unsignedTX {
       transactionR =
@@ -219,13 +219,13 @@ createContractCreationTX n gp gl val init' prvKey = do
         case B16.decode $ B.pack $ map c2w $ addLeadingZerosTo64 $ showHex (sigS signature) "" of
           (val', "") -> byteString2Integer val'
           _          -> error ("error: sigS is: " ++ showHex (sigS signature) ""),
-      transactionV = if yIsOdd then 0x1c else 0x1b
+      transactionV = fromRecId recId
     }
 
-whoSignedThisTransaction  ::  Transaction->Maybe Address -- Signatures can be malformed, hence the Maybe
+whoSignedThisTransaction :: Transaction -> Maybe Address -- Signatures can be malformed, hence the Maybe
 whoSignedThisTransaction t = pubKey2Address <$> getPubKeyFromSignature' xSignature theHash
         where
-          xSignature = ExtendedSignature (Signature (fromInteger $ transactionR t) (fromInteger $ transactionS t)) (0x1c == transactionV t)
+          xSignature = ExtendedSignature (Signature (fromInteger $ transactionR t) (fromInteger $ transactionS t)) (toRecId (transactionV t))
           SHA theHash = partialTransactionHash t
           getPubKeyFromSignature' = getPubKeyFromSignature_fast
 


### PR DESCRIPTION
In the secp256k1 curve, there is a small probability where r will be greater than n, causing four valid signature points, rather than the usual number of two. Previously, we only accounted for two valid points, and this caused sporadic failed transactions, from looking up the state of a nonexistent account.