### PR TITLE
Jump to the latest release of solc.

### DIFF
--- a/blockapps-haskell/Makefile
+++ b/blockapps-haskell/Makefile
@@ -15,8 +15,8 @@ DEPLOYBASE_NAME=bloch-deploybase
 DOCKER_SHELL=docker run -i --rm --ulimit nofile=65535 -v $(shell pwd):/workspace -v $(BUILDER_HOME):/root $(BUILDBASE_NAME):latest bash -c
 
 
-SOLCBRANCH=0.4.8-no-md
-SOLCREPOSITORY=https://github.com/blockapps/solidity.git
+SOLCBRANCH=v0.4.24
+SOLCREPOSITORY=https://github.com/ethereum/solidity.git
 SOLCBUILDDIR=$(SOLCWORK)/solidity/build
 SOLCMAKEFLAGS=-j4
 SOLCCMAKEFLAGS=-DSOLC_LINK_STATIC=1 -DTESTS=1 -DCMAKE_BUILD_TYPE=Release

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Solc.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Solc.hs
@@ -79,7 +79,7 @@ runSolc optsObj mainSrc importsSrc =
   execSolc solcCompileOpts solcLinkOpts mainSrc importsSrc
   where
     solcCompileOpts = List.concat [
-      solcOParam, solcORunsParam, solcStdParam, ["--combined-json=abi,bin,bin-runtime"]
+      solcOParam, solcORunsParam, solcStdParam, ["--combined-json=abi,bin,bin-runtime", "--evm-version=homestead"]
       ]
     solcLinkOpts = List.concat [solcLinkParam, solcLibsParam]
 

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Solc.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Solc.hs
@@ -79,7 +79,7 @@ runSolc optsObj mainSrc importsSrc =
   execSolc solcCompileOpts solcLinkOpts mainSrc importsSrc
   where
     solcCompileOpts = List.concat [
-      solcOParam, solcORunsParam, solcStdParam, ["--combined-json=abi,bin,bin-runtime", "--metadata-disable"]
+      solcOParam, solcORunsParam, solcStdParam, ["--combined-json=abi,bin,bin-runtime"]
       ]
     solcLinkOpts = List.concat [solcLinkParam, solcLibsParam]
 


### PR DESCRIPTION
Note that the --metadata-disable flag was introduced for a bug that was fixed in v0.4.14:
  See https://github.com/ethereum/solidity/pull/2566/files for the PR
  and https://github.com/ethereum/solidity/pull/2476 for our complaint
  and https://github.com/ethereum/solidity/issues/2561 for the solution issue.
Also, missing that kept us on v0.4.8 were INVALID, STATICCALL, RETURNDATASIZE/RETURNDATALOAD, and REVERT.
Those were implemented in the following PRs:
  INVALID: https://github.com/blockapps/monstrato/pull/102
  STATICCALL: https://github.com/blockapps/monstrato/pull/104
  RETURNDATA{SIZE,LOAD}: https://github.com/blockapps/strato-platform/pull/29
  REVERT: https://github.com/blockapps/strato-platform/pull/28
  SHR,SHL,SAR: https://github.com/blockapps/strato-platform/pull/79

There is an 4 additional opcode not yet implemented: CREATE2. `solc` does not yet generate any CREATE2 calls: https://github.com/ethereum/solidity/issues/2136