### PR TITLE
Run each block through replaceBestIfBetter

### DIFF
--- a/monstrato/ethereum-vm/src/Blockchain/BlockChain.hs
+++ b/monstrato/ethereum-vm/src/Blockchain/BlockChain.hs
@@ -221,9 +221,10 @@ addBlocks blocks = do
             return [block]
           else return []
       _ -> addBlock block >> return [block]
-  case getBestBlockInList (concat potentialBestBlocks) of
-    Nothing -> return ()
-    Just bestBlock -> do
+  forM_ (concat potentialBestBlocks) $ \bestBlock -> do -- TODO: Redis needs to see each incremental best block to properly
+                                                        --       build the canonical chain. However, running each new
+                                                        --       block could be inefficient, and inadvertently spam
+                                                        --       the network with NewBestBlock messages.
       (didReplaceThisTime, newBestBlock, replacedBits) <- replaceBestIfBetter bestBlock
       when didReplaceThisTime . liftIO $ do
           let Just nbb = newBestBlock
@@ -570,22 +571,6 @@ formatAddress :: Address->String
 formatAddress (Address x) = BC.unpack $ B16.encode $ B.pack $ word160ToBytes x
 
 ----------------
-
-getBestBlockInList :: [OutputBlock] -> Maybe OutputBlock
-getBestBlockInList [] = Nothing
-getBestBlockInList (b:bs) = Just $ foldl' compareBlocks b bs
-  where compareBlocks b1 b2 =
-          if ((blockDataNumber $ obBlockData b1) /= (blockDataNumber $ obBlockData b2))
-            then if ((blockDataNumber $ obBlockData b1) > (blockDataNumber $ obBlockData b2))
-                    then b1
-                    else b2
-            else if (obTotalDifficulty b1 /= obTotalDifficulty b2)
-                    then if (obTotalDifficulty b1 > obTotalDifficulty b2)
-                            then b1
-                            else b2
-                    else if ((length $ obReceiptTransactions b1) >= (length $ obReceiptTransactions b2))
-                            then b1
-                            else b2
 
 replaceBestIfBetter :: OutputBlock -> ContextM (Bool, Maybe OutputBlock, (SHA, Integer, Integer))
 replaceBestIfBetter b@OutputBlock{obBlockData = bd, obTotalDifficulty = td, obReceiptTransactions=txs, obBlockUncles=uncles} = do


### PR DESCRIPTION
If two or more new blocks in the canonical chain come through in the same pass of the VM, Redis will have a break in the chain and cause the p2p-indexer to fail