### PR TITLE
Replace strato's /extabi endpoint with bloc's /contracts/xabi

### DIFF
--- a/apex/api/config/api-patterns.js
+++ b/apex/api/config/api-patterns.js
@@ -23,6 +23,7 @@ module.exports = [
   '/bloc/v2.2/contracts/:contractName/all/states',
   '/bloc/v2.2/contracts/:contractName/:contractAddress/enum/:enumName',
   '/bloc/v2.2/contracts/compile',
+  '/bloc/v2.2/contracts/xabi',
   '/bloc/v2.2/search/:contractName',
   '/bloc/v2.2/search/:contractName/state',
   '/bloc/v2.2/search/:contractName/state/reduced(?:query)',
@@ -40,5 +41,4 @@ module.exports = [
   '/strato-api/eth/v1.2/storage(?:query)',
   '/strato-api/eth/v1.2/faucet',
   '/strato-api/eth/v1.2/solc',
-  '/strato-api/eth/v1.2/extabi',
 ];

--- a/apex/api/controllers/dapp.js
+++ b/apex/api/controllers/dapp.js
@@ -27,7 +27,7 @@ parseContractData = function(data) {
   // todo: find another way (using solc.js) or change bloc endpoint to have an option to make ALL contracts searchable instead of listing by one
   const options = {
     method: 'POST',
-    uri: `${process.env.stratoRoot}/extabi`,
+    uri: `${process.env.blocRoot}/contracts/xabi`,
     headers: {
       'content-type': 'application/x-www-form-urlencoded'
     },

--- a/apex/api/run-tests.sh
+++ b/apex/api/run-tests.sh
@@ -13,6 +13,7 @@ if [ "$NODE_ENV" == development ]; then
   export SINGLE_NODE=true
   export NODE_HOST=localhost
   export stratoRoot=http://localhost/strato-api/eth/v1.2/
+  export blocRoot=http://localhost/bloc/v2.2/
 
   export PG_HOST=localhost
   export PG_PORT=5432
@@ -46,5 +47,6 @@ fi
 # For jenkins, we expect a running environment
 if [ "$NODE_ENV" == test ]; then
   export stratoRoot="http://${stratoHost}/eth/v1.2"
+  export blocRoot="http://${blocHost}/bloc/v2.2"
   ./node_modules/mocha/bin/mocha $NODE_DEBUG_OPTION --config=config-prod.yaml test/
 fi

--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API.hs
@@ -58,6 +58,7 @@ type BlocAPI =
   :<|> GetContractsStates
   :<|> GetContractsEnum
   :<|> PostContractsCompile
+  :<|> PostContractsXabi
   -- /search endpoints
   :<|> GetSearchContract
   :<|> GetSearchContractState

--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Contracts.hs
@@ -26,6 +26,7 @@ import           Servant.API
 import           Servant.Docs
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances        ()
+import           Web.FormUrlEncoded               hiding (fieldLabelModifier)
 
 import           BlockApps.Bloc22.API.SwaggerSchema
 import           BlockApps.Bloc22.API.Utils
@@ -335,6 +336,68 @@ instance ToSchema PostCompileResponse where
         , postcompileresponseCodeHash = keccak256 "codeHash"
         }
 
+type PostContractsXabi = "contracts"
+  :> "xabi"
+  -- Leave FormUrlEncoded just for backwords compatibility with current extabi users.
+  :> ReqBody '[JSON, FormUrlEncoded] PostXabiRequest
+  :> Post '[JSON] PostXabiResponse
+
+data PostXabiRequest = PostXabiRequest
+  { postxabirequestSrc :: Text
+  } deriving (Eq, Show, Generic)
+
+postXabiOptions :: FormOptions
+postXabiOptions = FormOptions (const "src")
+
+instance ToForm PostXabiRequest where
+  toForm = genericToForm postXabiOptions
+
+instance FromForm PostXabiRequest where
+  fromForm = genericFromForm postXabiOptions
+
+instance ToJSON PostXabiRequest where
+  toJSON = genericToJSON (aesonPrefix camelCase)
+
+instance FromJSON PostXabiRequest where
+  parseJSON = genericParseJSON (aesonPrefix camelCase)
+
+instance ToSample PostXabiRequest where
+  toSamples _ = noSamples
+
+instance Arbitrary PostXabiRequest where
+  arbitrary = genericArbitrary uniform
+
+instance ToSchema PostXabiRequest where
+  declareNamedSchema proxy = genericDeclareNamedSchema blocSchemaOptions proxy
+    & mapped.name ?~ "Post Xabi Request"
+    & mapped.schema.example ?~ toJSON ex
+    where
+      ex :: PostXabiRequest
+      ex = PostXabiRequest "contract x { }"
+
+data PostXabiResponse = PostXabiResponse
+  { postxabiresponseSrc :: Map Text Xabi
+  } deriving (Eq, Show, Generic)
+
+instance ToJSON PostXabiResponse where
+  toJSON = genericToJSON (aesonPrefix camelCase)
+
+instance FromJSON PostXabiResponse where
+  parseJSON = genericParseJSON (aesonPrefix camelCase)
+
+instance ToSample PostXabiResponse where
+  toSamples _ = noSamples
+
+instance Arbitrary PostXabiResponse where
+  arbitrary = genericArbitrary uniform
+
+instance ToSchema PostXabiResponse where
+  declareNamedSchema proxy = genericDeclareNamedSchema blocSchemaOptions proxy
+    & mapped.name ?~ "Post Xabi Response"
+    & mapped.schema.example ?~ toJSON ex
+    where
+      ex :: PostXabiResponse
+      ex = PostXabiResponse Map.empty
 
 --------------------------------------------------------------------------------
 

--- a/blockapps-haskell/bloc/bloc22/client/src/BlockApps/Bloc22/Client.hs
+++ b/blockapps-haskell/bloc/bloc22/client/src/BlockApps/Bloc22/Client.hs
@@ -16,6 +16,7 @@ module BlockApps.Bloc22.Client
   , getContractsStateMapping
   , getContractsStates
   , postContractsCompile
+  , postContractsXabi
   , getSearchContract
   , getSearchContractState
   , getSearchContractStateReduced
@@ -97,6 +98,9 @@ getContractsStates = client (Proxy @ GetContractsStates)
 postContractsCompile :: [PostCompileRequest] -> ClientM [PostCompileResponse]
 postContractsCompile = client (Proxy @ PostContractsCompile)
 
+postContractsXabi :: PostXabiRequest -> ClientM PostXabiResponse
+postContractsXabi = client (Proxy @ PostContractsXabi)
+
 getSearchContract :: ContractName -> ClientM [MaybeNamed Address]
 getSearchContract = client (Proxy @ GetSearchContract)
 
@@ -130,7 +134,7 @@ postUsersContract = client (Proxy @ PostUsersContract)
 postUsersUploadList
   :: UserName
   -> Address
-  -> Bool 
+  -> Bool
   -> UploadListRequest
   -> ClientM [BlocTransactionResult]
 postUsersUploadList = client (Proxy @ PostUsersUploadList)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -1065,8 +1065,6 @@ insertContract parentContr contr bin binRuntime xabi = do
 
 compileContract :: Text -> Bloc (Map Text (Int32, ContractDetails))
 compileContract source' = do
---  (ExtabiResponse xabis,SolcResponse abiBins) <- blocStrato $
---     (,) <$> postExtabi (Src source) <*> postSolc (Src source)
   source <- addGetSourceFuncToSource' source'
   eabiBins <- fromJSON <$> compileSolc source
   abiBins <- case eabiBins of

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server.hs
@@ -44,6 +44,7 @@ bloc = getHomepage
   :<|> getContractsStates
   :<|> getContractsEnum
   :<|> postContractsCompile
+  :<|> postContractsXabi
   :<|> getSearchContract
   :<|> getSearchContractState
   :<|> getSearchContractStateReduced

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -31,6 +31,7 @@ import           BlockApps.Bloc22.Monad
 import           BlockApps.Cirrus.Client
 import           BlockApps.Ethereum
 import           BlockApps.Solidity.Contract
+import           BlockApps.Solidity.Parse.Parser (parseXabi)
 import           BlockApps.Solidity.Xabi
 import           BlockApps.SolidityVarReader
 import           BlockApps.Storage               as S
@@ -231,15 +232,26 @@ postContractsCompile = blocTransaction . fmap concat . traverse compileOneContra
             void . blocCirrusFireForget $ postContract contractDetails{contractdetailsXabi=blockappsjsXabi}
         return $ PostCompileResponse (contractdetailsName contractDetails) (contractdetailsCodeHash contractDetails)
 
+postContractsXabi :: PostXabiRequest -> Bloc PostXabiResponse
+postContractsXabi PostXabiRequest{..} =
+   let xabis :: Either String (Map.Map Text Xabi)
+       xabis = do
+         partialXabis <- Map.fromList <$> parseXabi "src" (Text.unpack postxabirequestSrc)
+         traverse completeXabi partialXabis
+   in case xabis of
+        Left msg -> throwError . AnError .
+            ("contract compilation for xabi failed: " <>) . Text.pack $msg
+        Right xs -> return . PostXabiResponse $ xs
+
 
 completeContractDetailXabi :: ContractDetails -> ContractDetails
-completeContractDetailXabi cd = 
+completeContractDetailXabi cd =
   let eXabi = xAbiToContract $ contractdetailsXabi cd in
   case eXabi of
-    Right xabi -> cd { contractdetailsXabi = contractToXabi xabi } 
+    Right xabi -> cd { contractdetailsXabi = contractToXabi xabi }
     Left _ -> cd
-  
-  
+
+
 completeXabi :: Xabi -> Either String Xabi
 completeXabi xabi = do
   c <- xAbiToContract xabi

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/API.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/API.hs
@@ -93,9 +93,3 @@ type API =
   :<|> "faucet"
     :> ReqBody '[FormUrlEncoded] Address
     :> Post '[PlainText] Keccak256
-  :<|> "solc"
-    :> ReqBody '[FormUrlEncoded] Src
-    :> Post '[PlainText] SolcResponse
-  :<|> "extabi"
-    :> ReqBody '[FormUrlEncoded] Src
-    :> Post '[PlainText] ExtabiResponse

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
@@ -32,9 +32,6 @@ module BlockApps.Strato.Types
   , Difficulty (..)
   , TxCount (..)
   , Storage (..)
-  , Src (..)
-  , ExtabiResponse (..)
-  , SolcResponse (..)
   , AbiBin (..)
   , exampleTxResult
   ) where
@@ -69,14 +66,10 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Instances    ()
 import           Text.Read
 import           Text.Read.Lex
-import           Web.FormUrlEncoded           hiding (fieldLabelModifier)
-
 import           BlockApps.Ethereum           (Address (..), Keccak256 (..),
                                                Nonce (..), addressString,
                                                keccak256, keccak256lazy,
                                                stringAddress)
-
-import           BlockApps.Solidity.Xabi
 
 newtype FaucetResponse = FaucetResponse Text deriving (Eq, Generic, Show)
 
@@ -194,17 +187,8 @@ instance ToSchema Storage
 instance ToSchema Word160 where
   declareNamedSchema = const . pure $ named "Word160" binarySchema
 -- add min max
-instance ToSchema Src where
-  declareNamedSchema _ = do
-             _ <- declareSchemaRef (Proxy :: Proxy Text)
-             return $ NamedSchema (Just "Post Users Contract Request")
-                 ( mempty
-                 & type_ .~ SwaggerString
-                 )
 
-instance ToSchema SolcResponse
 instance ToSchema AbiBin
-instance ToSchema ExtabiResponse
 
 instance ToParamSchema Keccak256 where
   toParamSchema _ = mempty & type_ .~ SwaggerString
@@ -447,30 +431,10 @@ instance FromJSON Storage where
 instance ToJSON Storage where
   toJSON = genericToJSON (aesonPrefix camelCase)
 
-newtype Src = Src { unSrc :: Text } deriving (Eq, Show)
-
-instance ToForm Src where
-  toForm (Src src) = Form $ HashMap.singleton "src" [src]
-
-newtype ExtabiResponse = ExtabiResponse { extabiresponseSrc :: Map Text Xabi }
-  deriving (Eq, Show, Generic)
-
-instance FromJSON ExtabiResponse where
-  parseJSON = genericParseJSON (aesonPrefix camelCase)
-
-instance ToJSON ExtabiResponse where
-  toJSON = genericToJSON (aesonPrefix camelCase)
-
-instance MimeUnrender PlainText ExtabiResponse where
-  mimeUnrender _ = eitherDecode
-
 instance FromJSON FaucetResponse where
   parseJSON = fmap FaucetResponse . parseJSON
 instance ToJSON FaucetResponse where
   toJSON (FaucetResponse x) = toJSON x
-
-instance MimeRender PlainText ExtabiResponse where
-  mimeRender _ = encode
 
 instance MimeUnrender PlainText FaucetResponse where
   mimeUnrender _ =
@@ -479,15 +443,6 @@ instance MimeUnrender PlainText FaucetResponse where
 instance MimeRender PlainText FaucetResponse where
   mimeRender _ (FaucetResponse x) =
     Lazy.fromStrict $ Text.encodeUtf8 x
-
-newtype SolcResponse = SolcResponse { solcresponseSrc :: Map Text AbiBin }
-                     deriving (Eq,Show,Generic)
-
-instance FromJSON SolcResponse where
-  parseJSON = genericParseJSON (aesonPrefix camelCase)
-
-instance ToJSON SolcResponse where
-  toJSON = genericToJSON (aesonPrefix camelCase)
 
 data AbiBin = AbiBin
   { abi        :: Text
@@ -507,12 +462,6 @@ instance ToJSON AbiBin where
     , "bin" .= bin
     , "bin-runtime" .= binRuntime
     ]
-
-instance MimeUnrender PlainText SolcResponse where
-  mimeUnrender _ = eitherDecode
-
-instance MimeRender PlainText SolcResponse where
-  mimeRender _ = encode
 
 data TransactionResult = TransactionResult
   { transactionresultBlockHash        :: Keccak256

--- a/blockapps-haskell/strato/client/src/BlockApps/Strato/Client.hs
+++ b/blockapps-haskell/strato/client/src/BlockApps/Strato/Client.hs
@@ -24,8 +24,6 @@ module BlockApps.Strato.Client
   , getTotalTx
   , getStorage
   , postFaucet
-  , postSolc
-  , postExtabi
   ) where
 
 import           Data.Proxy
@@ -124,8 +122,6 @@ getDifficulty :: ClientM Difficulty
 getTotalTx :: ClientM TxCount
 getStorage :: StorageFilterParams -> ClientM [Storage]
 postFaucet :: Address -> ClientM Keccak256
-postSolc :: Src -> ClientM SolcResponse
-postExtabi :: Src -> ClientM ExtabiResponse
 getTxsFilter
   :<|> getTxsLast
   :<|> postTx
@@ -138,9 +134,7 @@ getTxsFilter
   :<|> getDifficulty
   :<|> getTotalTx
   :<|> getStorage
-  :<|> postFaucet
-  :<|> postSolc
-  :<|> postExtabi =
+  :<|> postFaucet =
     uncurryTxsFilterParams getTxsFilter'
     :<|> getTxsLast'
     :<|> postTx'
@@ -154,8 +148,6 @@ getTxsFilter
     :<|> getTotalTx'
     :<|> uncurryStorageFilterParams getStorage'
     :<|> postFaucet'
-    :<|> postSolc'
-    :<|> postExtabi'
   where
     getTxsFilter'
       :<|> getTxsLast'
@@ -169,9 +161,7 @@ getTxsFilter
       :<|> getDifficulty'
       :<|> getTotalTx'
       :<|> getStorage'
-      :<|> postFaucet'
-      :<|> postSolc'
-      :<|> postExtabi' =
+      :<|> postFaucet' =
         client (Proxy @ API)
     uncurryTxsFilterParams f TxsFilterParams{..} = f
       qtFrom qtTo qtAddress qtValue qtMaxValue qtMinValue qtGasPrice

--- a/blockapps-haskell/strato/client/test/BlockApps/Strato/ClientSpec.hs
+++ b/blockapps-haskell/strato/client/test/BlockApps/Strato/ClientSpec.hs
@@ -97,15 +97,6 @@ spec
       forAll arbitrary $ \ addr -> do
         resp <- runClientM (postFaucet addr) (ClientEnv mgr stratoDev)
         resp `shouldSatisfy` isRight
-  let src = Src "contract f {uint global; function f() {global=7;}}"
-  describe "postSolc" $
-    it "works" $ \ mgr -> do
-      resp <- runClientM (postSolc src) (ClientEnv mgr stratoDev)
-      resp `shouldSatisfy` isRight
-  describe "postExtabi" $
-    it "works" $ \ mgr -> do
-      resp <- runClientM (postExtabi src) (ClientEnv mgr stratoDev)
-      resp `shouldSatisfy` isRight
 
 -- orphans
 

--- a/smd-ui/src/components/Accounts/components/SendTokens/index.js
+++ b/smd-ui/src/components/Accounts/components/SendTokens/index.js
@@ -16,7 +16,7 @@ import ValueInput from '../../../ValueInput';
 import validate from './validate';
 import { isModePublic } from '../../../../lib/checkMode';
 
-// TODO: use solc instead of extabi for compile
+// TODO: use solc instead of /contracts/xabi for compile
 
 class SendTokens extends Component {
 

--- a/smd-ui/src/components/CodeEditor/codeEditor.saga.js
+++ b/smd-ui/src/components/CodeEditor/codeEditor.saga.js
@@ -11,7 +11,7 @@ import {
 
 import { env } from '../../env';
 
-const compileUrl = env.STRATO_URL + "/extabi";
+const compileUrl = env.BLOC_URL + "/contracts/xabi";
 const blocCompileUrl = env.BLOC_URL + "/contracts/compile";
 
 export function tokenizeSource(source) {
@@ -40,7 +40,7 @@ export function tokenizeSource(source) {
 }
 
 export function compileSource(contractName, source) {
-  
+
   const searchable = [];
   return fetch(blocCompileUrl, {
     method: 'POST',

--- a/smd-ui/src/components/CreateContract/createContract.saga.js
+++ b/smd-ui/src/components/CreateContract/createContract.saga.js
@@ -15,7 +15,7 @@ import {fetchCirrusInstances} from '../Contracts/components/ContractCard/contrac
 import {env} from '../../env';
 
 const url = env.BLOC_URL + "/users/:user/:address/contract?resolve"
-const compileUrl = env.STRATO_URL + "/extabi";
+const compileUrl = env.BLOC_URL + "/contracts/xabi";
 const blocCompileUrl = env.BLOC_URL + "/contracts/compile";
 
 export function createContractApiCall(contract, src, username, address, password, args) {

--- a/smd-ui/src/components/CreateContract/index.js
+++ b/smd-ui/src/components/CreateContract/index.js
@@ -21,7 +21,7 @@ import { required } from '../../lib/reduxFormsValidations'
 import { toasts } from "../Toasts";
 import { isModePublic } from '../../lib/checkMode';
 
-// TODO: use solc instead of extabi for compile
+// TODO: use solc instead of /contracts/xabi for compile
 
 class CreateContract extends Component {
 


### PR DESCRIPTION
This can be thought of as a counterpart to /contracts/compile, but one that doesn't affect the state of bloc's databases: a stateless compiler for extracting the abi.

I'll remove /extabi itself and monstrato's solidity-abi in a later PR.