### PR TITLE
Expect multiple keywords on state variable declarations

### DIFF
--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/Declarations.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/Declarations.hs
@@ -14,6 +14,7 @@ import qualified Data.Text                            as Text
 
 import           Text.Parsec
 import           Text.Parsec.Token                    (GenLanguageDef(..))
+import           Text.Printf                          (printf)
 
 import           BlockApps.Solidity.Parse.Lexer
 import           BlockApps.Solidity.Parse.ParserTypes
@@ -167,9 +168,28 @@ usingDeclaration = do
 
 -- | Parses a variable definition
 variableDeclaration :: SolidityParser (String, Declaration)
-variableDeclaration = do
-  vDecl <- simpleVariableDeclaration
-  return vDecl
+variableDeclaration = simpleVariableDeclaration
+
+data StateVariableKeyword = KConstant | KPublic | KPrivate | KInternal
+  deriving (Eq, Show, Enum, Ord)
+
+stateVariableKeyword :: SolidityParser StateVariableKeyword
+stateVariableKeyword =
+     (try (reserved "constant") >> return KConstant) <|>
+     (try (reserved "public") >> return KPublic) <|>
+     (try (reserved "private") >> return KPrivate) <|>
+     (try (reserved "internal") >> return KInternal)
+
+public :: [StateVariableKeyword] -> SolidityParser Bool
+public keywords =
+  let visibilities = nub . filter (/= KConstant) $ keywords
+  in case visibilities of
+        (v1:v2:_) -> fail $ printf "multiple visibilities declared: %s vs %s" (show v1) (show v2)
+        [KPublic] -> return True
+        _ -> return False
+
+constant :: [StateVariableKeyword] -> Bool
+constant = any (KConstant ==)
 
 -- | Parses the declaration part of a variable definition, which is
 -- everything except possibly the initializer and semicolon.  Necessary
@@ -180,34 +200,16 @@ simpleVariableDeclaration = do
   variableType <- simpleTypeExpression
   -- We have to remember which variables are "public", because they
   -- generate accessor functions
-  --TODO - deal with the variableVisible flag
---  (variableVisible, variableIsPublic) <- option (True, False) $
-  (_, variableIsPublic, variableIsConstant) <- option (True, False, False) $
-                     (reserved "constant" >> return (False, False, True)) <|>
-                     (reserved "storage" >> return (True, False, False)) <|>
-                     (reserved "memory" >> return (False, False, False)) <|>
-                     (reserved "public" >> return (True, True, False)) <|>
-                     (reserved "private" >> return (False, False, False)) <|>
-                     (reserved "internal" >> return (False, False, False))
+  keywords <- many stateVariableKeyword
+  let isConstant = constant keywords
+  isPublic <- public keywords
   variableName <- identifier
   value <- optionMaybe $ do
     reservedOp "="
     many $ noneOf ";"
   semi
---  let objValueType' =
---        if variableVisible
---        then SingleValue variableType
---        else NoValue
 
-  return (variableName, VariableDeclaration variableType variableIsPublic variableIsConstant value)
-
---  ObjDef{
---    objName = variableName,
---    objValueType = objValueType',
---    objArgType = NoValue,
---    objDefn = "",
---    objIsPublic = variableIsPublic
---    }
+  return (variableName, VariableDeclaration variableType isPublic isConstant value)
 
 {- Functions and function-like -}
 

--- a/blockapps-haskell/solidity/test/BlockApps/Solidity/Parse/DeclarationsSpec.hs
+++ b/blockapps-haskell/solidity/test/BlockApps/Solidity/Parse/DeclarationsSpec.hs
@@ -219,12 +219,12 @@ spec = do
           eRes = runParser solidityContract "" "" contractString
       fst <$> eRes `shouldBe` Right "e"
 
-    xit "should parse unbalanced strings inside a comment" $ do
-      let contractString = "contract f { \
-                           \  function x() constant returns (string) { \
-                           \    return // \"  \
-                           \  } \
-                           \}"
+    it "should parse unbalanced strings inside a comment" $ do
+      let contractString = unlines ["contract f { ",
+                                    "  function x() { ",
+                                    "    return // \"  ",
+                                    "  } ",
+                                    "}"]
           eRes = runParser solidityContract "" "" contractString
       fst <$> eRes `shouldBe` Right "f"
 
@@ -271,6 +271,27 @@ spec = do
       let funcString = "constructor(){}"
           eRes = runParser functionDeclaration "Contract" "" funcString
       (fst <$> eRes) `shouldBe` Right "Contract"
+
+  describe "Declarations - variableDeclaration" $ do
+    let parseVarName = fmap fst . runParser variableDeclaration "" ""
+    it "should parse a uint variable" $
+      parseVarName "uint aeon;" `shouldBe` Right "aeon"
+    it "should parse a constant variable" $
+      parseVarName "uint constant flux;" `shouldBe` Right "flux"
+    it "should parse a public variable" $
+      parseVarName "uint private x;" `shouldBe` Right "x"
+    it "should parse a public variable" $
+      parseVarName "uint public z;" `shouldBe` Right "z"
+    it "should fail a public private variable -- which is nonsense" $
+      parseVarName "uint public private mixture;" `shouldSatisfy` isLeft
+    it "should parse public constant -- which is sensible" $
+      parseVarName "uint public constant change;" `shouldBe` Right "change"
+    it "should parse constant public -- which is sensible" $
+      parseVarName "uint public constant herd;" `shouldBe` Right "herd"
+    it "should parse initialized constants" $
+      parseVarName "uint constant start = 0xfff;" `shouldBe` Right "start"
+    it "should parse initialized public public constants" $
+      parseVarName "uint public public constant nothing = 0x0;" `shouldBe` Right "nothing"
 
 printLeft :: Either String a -> IO ()
 printLeft (Left msg) = putStrLn msg


### PR DESCRIPTION
Note also that `memory` and `storage` are only valid for variable local to functions,
and so there it is incorrect to apply them to contract scoped variables. (c.f. https://github.com/ethereum/solidity/blob/develop/docs/grammar.txt)