### PR TITLE
Export blocRoot to apex

### DIFF
--- a/apex/api/docker-run.sh
+++ b/apex/api/docker-run.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-blocRoot=http://${blocHost}/bloc/v2.2
 cirrusRoot=http://${cirrusHost}
+export blocRoot=http://${blocHost}/bloc/v2.2 # Used in apex to compile contracts
 export stratoRoot=http://${stratoHost}/eth/v1.2 # to be available from js AS WELL
 export STRATO_GS_MODE=${STRATO_GS_MODE} # to be available from js
 export PROD_DEV_MODE=${PROD_DEV_MODE:-false} # to be available from js


### PR DESCRIPTION
@Tanooj0902 reported an issue where he was getting strange parse errors uploading to stratodev and cd-multinode.

I had changed the URL where that parse happens from `${stratoRoot}/extabi` to `${blocRoot}/contracts/xabi`, but neglected to ensure that the environment variable was set in deployment scripts. As a result, dapp uploads fail with entries in apex's logs like:
```
{ RequestError: Error: Invalid URI "undefined/contracts/xabi"
    at new RequestError (/usr/src/app/node_modules/request-promise-core/lib/errors.js:14:15)
    at Request.plumbing.callback (/usr/src/app/node_modules/request-promise-core/lib/plumbing.js:87:29)
    at Request.RP$callback [as _callback] (/usr/src/app/node_modules/request-promise-core/lib/plumbing.js:46:31)
    at self.callback (/usr/src/app/node_modules/request/request.js:186:22)
    at Request.emit (events.js:180:13)
    at Request.init (/usr/src/app/node_modules/request/request.js:274:17)
    at Request.RP$initInterceptor [as init] (/usr/src/app/node_modules/request-promise-core/configure/request2.js:45:29)
    at new Request (/usr/src/app/node_modules/request/request.js:128:8)
    at request (/usr/src/app/node_modules/request/index.js:53:10)
    at parseContractData (/usr/src/app/controllers/dapp.js:38:10)
    at checkFileCompiles (/usr/src/app/controllers/dapp.js:60:24)
    at <anonymous>
  name: 'RequestError',
  message: 'Error: Invalid URI "undefined/contracts/xabi"',
  cause: Error: Invalid URI "undefined/contracts/xabi"
``` 