### PR TITLE
If in a multinode environment, always run blocks from Quarry

### DIFF
--- a/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
@@ -67,6 +67,7 @@ import           Blockchain.DB.StateDB
 import           Blockchain.DB.StorageDB
 import           Blockchain.ExtWord
 import           Blockchain.Format
+import qualified Blockchain.Mining                       as Mining
 import           Blockchain.Sequencer.Event
 import           Blockchain.TheDAOFork
 import           Blockchain.Verifier
@@ -208,10 +209,13 @@ addBlocks blocks = do
         let blockSR = blockDataStateRoot $ obBlockData block
         lift $ $logInfoS "addBlocks" . T.pack $ "Bagger state root: " ++ format currentBaggerSR
         lift $ $logInfoS "addBlocks" . T.pack $ "Block  state root: " ++ format blockSR
-        if (blockSR == currentBaggerSR)
+        if (flags_miner /= Mining.Instant || blockSR == currentBaggerSR)
           then do
             _ <- setParentStateRoot block
-            updates <- Bagger.lastExecutedTxs . Bagger.miningCache <$> Bagger.getBaggerState
+            lastRun <- Bagger.lastExecutedTxs . Bagger.miningCache <$> Bagger.getBaggerState
+            let updates = if (flags_miner == Mining.Instant)
+                            then lastRun
+                            else [trr | trr <- lastRun, otx <- obReceiptTransactions block, otx == trrTransaction trr]
             lift $ $logInfoS "addBlocks" $ T.pack ("Block data from Quarry: " ++ format (obBlockData block))
             Bagger.updateTxCallback
               updates


### PR DESCRIPTION
When the sequencer emits a block, it not only goes to the VM, but also P2P. This is probably not optimal behavior, as the sequencer does not validate the block in any way, except that all transactions in the block are correctly signed. However, changing this behavior is more involved than a hotfix release permits. The problem arises when a stale block from Adit (still labelled as `Quarry` internally), reaches the VM. The new performance optimizations only run a block from Adit if its stateroot matches Bagger's latest stateroot, reducing the number of times transactions are run in the VM. This works great for single-node, but, on a multinode network, since other peers will see the thrown-away block because the sequencer emits it, it is possible that other nodes will start mining from it, and completely surprise our node when they give us a new block with our thrown-away block's hash as its parent hash. Since we don't pass the thrown-away block to the indexer, p2p-indexer specifically, Redis doesn't recognize its hash, and has a field day crashing and taking down the network.