### PR TITLE
remove container faster on solc build

### DIFF
--- a/blockapps-haskell/pull_solc.sh
+++ b/blockapps-haskell/pull_solc.sh
@@ -9,7 +9,7 @@ fi
 VERSION=$1
 TARGET_DIR=$2
 
-CONTAINER=$(docker run --rm -d --entrypoint=sleep "ethereum/solc:${VERSION}" 10000)
-trap "docker stop ${CONTAINER}" EXIT
+CONTAINER=$(docker run -d --entrypoint=sleep "ethereum/solc:${VERSION}" 10000)
+trap "docker rm -f ${CONTAINER}" EXIT
 
 docker cp "${CONTAINER}:/usr/bin/solc" "${TARGET_DIR}"


### PR DESCRIPTION
this makes the solc build step much faster (`docker stop` takes time, `docker rm -f` happens immediately) - saves ~7 sec on each build run