### PR TITLE
Change bloc's homepage to have compilation details

### DIFF
--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API.hs
@@ -31,7 +31,7 @@ import           BlockApps.Bloc22.API.Utils
 import           BlockApps.Bloc22.Crypto
 
 type BlocAPI =
-  -- / endpoint, for smoke test
+  -- / endpoint, for smoke test. Also exports git details.
   GetHomepage
   -- /users endpoints
   :<|> GetUsers

--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API.hs
@@ -32,7 +32,7 @@ import           BlockApps.Bloc22.Crypto
 
 type BlocAPI =
   -- / endpoint, for smoke test. Also exports git details.
-  GetHomepage
+  GetGitInfo
   -- /users endpoints
   :<|> GetUsers
   :<|> PostUsersUser

--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Git.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Git.hs
@@ -21,7 +21,7 @@ import           Test.QuickCheck
 --------------------------------------------------------------------------------
 -- Routes and Types
 --------------------------------------------------------------------------------
-type GetHomepage = Get '[JSON, PlainText] GitInfo
+type GetGitInfo = Get '[JSON, PlainText] GitInfo
 
 gitInfo :: GitInfo
 gitInfo = GitInfo

--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Git.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Git.hs
@@ -21,7 +21,7 @@ import           Test.QuickCheck
 --------------------------------------------------------------------------------
 -- Routes and Types
 --------------------------------------------------------------------------------
-type GetHomepage = Get '[PlainText, JSON] GitInfo
+type GetHomepage = Get '[JSON, PlainText] GitInfo
 
 gitInfo :: GitInfo
 gitInfo = GitInfo

--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Git.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Git.hs
@@ -3,11 +3,15 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators   #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 module BlockApps.Bloc22.API.Git where
 
 import           Data.Aeson
 import           Data.Swagger
+import           Data.Proxy
+import           Data.ByteString.Char8 (pack, unpack)
+import           Data.ByteString.Lazy  (fromStrict, toStrict)
 import           Development.GitRev
 import           GHC.Generics
 import           Servant.API
@@ -17,7 +21,7 @@ import           Test.QuickCheck
 --------------------------------------------------------------------------------
 -- Routes and Types
 --------------------------------------------------------------------------------
-type GetGitInfo = "git" :> Get '[JSON] GitInfo
+type GetHomepage = Get '[PlainText, JSON] GitInfo
 
 gitInfo :: GitInfo
 gitInfo = GitInfo
@@ -38,9 +42,16 @@ data GitInfo = GitInfo
   , gitInfoDescribe :: String
   , gitInfoDirty :: Bool
   , gitInfoDirtyTracked :: Bool
-  } deriving (Show,Generic)
+  } deriving (Show, Generic, Ord, Read, Eq)
+
 instance ToJSON GitInfo
 instance FromJSON GitInfo
 instance ToSample GitInfo where toSamples _ = singleSample gitInfo
 instance Arbitrary GitInfo where arbitrary = return gitInfo
 instance ToSchema GitInfo
+
+instance MimeRender PlainText GitInfo where
+  mimeRender Proxy = fromStrict . pack . show
+
+instance MimeUnrender PlainText GitInfo where
+  mimeUnrender Proxy = read . unpack . toStrict

--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Utils.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Utils.hs
@@ -27,24 +27,6 @@ import           Test.QuickCheck.Instances        ()
 
 import           BlockApps.Bloc22.API.SwaggerSchema
 import           BlockApps.Ethereum
---------------------------------------------------------------------------------
-
-type GetHomepage = Get '[PlainText, JSON] Homepage
-whoWouldveThoughtThisIsActuallyTheHomepage :: Homepage
-whoWouldveThoughtThisIsActuallyTheHomepage = Homepage "home page!"
-newtype Homepage = Homepage { unHomepage :: Text }
-    deriving (Eq, Ord, Read, Show, Generic, MimeRender PlainText, MimeUnrender PlainText)
-instance ToSample Homepage where
-    toSamples _ = noSamples
-instance Arbitrary Homepage where -- seriously, lmfao
-    arbitrary = return whoWouldveThoughtThisIsActuallyTheHomepage
-instance ToSchema Homepage where
-    declareNamedSchema _ = declareNamedSchema $ Proxy @ Text
-instance ToJSON Homepage
-instance FromJSON Homepage
-
-
---------------------------------------------------------------------------------
 
 newtype ContractName = ContractName Text deriving (Eq,Ord,Show,Generic)
 

--- a/blockapps-haskell/bloc/bloc22/client/src/BlockApps/Bloc22/Client.hs
+++ b/blockapps-haskell/bloc/bloc22/client/src/BlockApps/Bloc22/Client.hs
@@ -4,7 +4,6 @@
 
 module BlockApps.Bloc22.Client
   ( getHomepage
-  , getGitInfo
   , getAddresses
   , getContracts
   , getContractsData
@@ -45,11 +44,8 @@ import           BlockApps.Solidity.SolidityValue
 import           BlockApps.Solidity.Xabi
 import           BlockApps.Strato.Types()
 
-getHomepage :: ClientM Homepage
+getHomepage :: ClientM GitInfo
 getHomepage = client (Proxy @ GetHomepage)
-
-getGitInfo :: ClientM GitInfo
-getGitInfo = client (Proxy @ GetGitInfo)
 
 getAddresses :: ClientM [Address]
 getAddresses = client (Proxy @ GetAddresses)

--- a/blockapps-haskell/bloc/bloc22/client/src/BlockApps/Bloc22/Client.hs
+++ b/blockapps-haskell/bloc/bloc22/client/src/BlockApps/Bloc22/Client.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 module BlockApps.Bloc22.Client
-  ( getHomepage
+  ( getGitInfo
   , getAddresses
   , getContracts
   , getContractsData
@@ -44,8 +44,8 @@ import           BlockApps.Solidity.SolidityValue
 import           BlockApps.Solidity.Xabi
 import           BlockApps.Strato.Types()
 
-getHomepage :: ClientM GitInfo
-getHomepage = client (Proxy @ GetHomepage)
+getGitInfo :: ClientM GitInfo
+getGitInfo = client (Proxy @ GetGitInfo)
 
 getAddresses :: ClientM [Address]
 getAddresses = client (Proxy @ GetAddresses)

--- a/blockapps-haskell/bloc/bloc22/server/blockapps-bloc22-server.cabal
+++ b/blockapps-haskell/bloc/bloc22/server/blockapps-bloc22-server.cabal
@@ -24,7 +24,6 @@ library
     BlockApps.Bloc22.Server
     BlockApps.Bloc22.Server.Addresses
     BlockApps.Bloc22.Server.Contracts
-    BlockApps.Bloc22.Server.Git
     BlockApps.Bloc22.Server.Search
     BlockApps.Bloc22.Server.Users
     BlockApps.Bloc22.Server.Utils

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server.hs
@@ -22,7 +22,7 @@ import           BlockApps.Bloc22.Server.Search
 import           BlockApps.Bloc22.Server.Users
 
 bloc :: ServerT BlocAPI Bloc
-bloc = getHomepage
+bloc = (return gitInfo)
   :<|> getUsers
   :<|> postUsersUser
   :<|> getUsersUser
@@ -51,9 +51,6 @@ bloc = getHomepage
   :<|> getSearchContractStateReduced
   :<|> getBlocTransactionResult
   :<|> postBlocTransactionResults
-
-getHomepage :: Bloc Homepage
-getHomepage = return whoWouldveThoughtThisIsActuallyTheHomepage
 
 serveBloc :: BlocEnv -> Server BlocAPI
 serveBloc env = enter (NT (enterBloc env)) bloc

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Git.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Git.hs
@@ -1,6 +1,0 @@
-module BlockApps.Bloc22.Server.Git where
-
-import           BlockApps.Bloc22.API.Git
-
-getGitInfo :: Monad m => m GitInfo
-getGitInfo = return gitInfo


### PR DESCRIPTION
This is more informative than "home page!" but will still
be just as available for health checks, since it is
just serving string constants.
```
$ curl --user admin:admin -H "Accept: text/plain" localhost/bloc/v2.2/
GitInfo {gitInfoHash = "981e2c37a0fc5a3505a42e27b6302eb5f2801b7a", gitInfoBranch = "hide", gitInfoCommitCount = "7200", gitInfoCommitDate = "Wed Jun 13 17:44:19 2018 -0400", gitInfoDescribe = "v3.0.1-546-g981e2c3", gitInfoDirty = True, gitInfoDirtyTracked = True}%
$ curl --user admin:admin -H "Accept: application/json" localhost/bloc/v2.2/
{"gitInfoBranch":"hide","gitInfoDirtyTracked":true,"gitInfoCommitCount":"7200","gitInfoHash":"981e2c37a0fc5a3505a42e27b6302eb5f2801b7a","gitInfoDirty":true,"gitInfoDescribe":"v3.0.1-546-g981e2c3","gitInfoCommitDate":"Wed Jun 13 17:44:19 2018 -0400"}
```