### PR TITLE
Sync fix

### DIFF
--- a/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
@@ -202,8 +202,8 @@ addBlocks blocks = do
   let oldStateRoot = blockDataStateRoot oldHeader
   didReplaceBest <- liftIO (newIORef False)
   replacedBest   <- liftIO (newIORef undefined)
-  potentialBestBlocks <- forM blocks' $ \block -> timeit "Block insertion" timerToUse $ do
-    case (obOrigin block) of
+  forM_ blocks' $ \block -> timeit "Block insertion" timerToUse $ do
+    replace <- case (obOrigin block) of
       TO.Quarry -> do
         currentBaggerSR <- Bagger.lastRewardedStateRoot . Bagger.miningCache <$> Bagger.getBaggerState
         let blockSR = blockDataStateRoot $ obBlockData block
@@ -222,28 +222,24 @@ addBlocks blocks = do
               (blockHeaderPartialHash $ obBlockData block)
               (blockHeaderHash $ obBlockData block)
               Mined
-            return [block]
-          else return []
-      _ -> addBlock block >> return [block]
-  forM_ (concat potentialBestBlocks) $ \bestBlock -> do -- TODO: Redis needs to see each incremental best block to properly
-                                                        --       build the canonical chain. However, running each new
-                                                        --       block could be inefficient, and inadvertently spam
-                                                        --       the network with NewBestBlock messages.
-      (didReplaceThisTime, newBestBlock, replacedBits) <- replaceBestIfBetter bestBlock
+            return True
+          else return False -- don't let old local blocks become the best block
+      _ -> addBlock block >> return True
+    when replace $ do
+      (didReplaceThisTime, replacedBits) <- replaceBestIfBetter block
       when didReplaceThisTime . liftIO $ do
-          let Just nbb = newBestBlock
           writeIORef didReplaceBest True
-          writeIORef replacedBest (nbb, replacedBits)
-      didReplaceBest' <- liftIO (readIORef didReplaceBest)
-      void . withKafkaViolently $ writeIndexEvents (RanBlock <$> blocks')
-      when didReplaceBest' $ do
-          $logInfoS "addBlocks" "done inserting, now will emit stateDiff if necessary"
-          (theBlock, nbb) <- liftIO (readIORef replacedBest)
-          void . withKafkaViolently $ writeIndexEvents [NewBestBlock nbb]
-          let b = obBlockData theBlock
-              codeSource = getSource False b
-              codeContractName = getContractName False b
-          calculateAndEmitStateDiffs theBlock oldStateRoot codeSource codeContractName
+          writeIORef replacedBest (block, replacedBits)
+  didReplaceBest' <- liftIO (readIORef didReplaceBest)
+  void . withKafkaViolently $ writeIndexEvents (RanBlock <$> blocks') -- emit all blocks to the indexers
+  when didReplaceBest' $ do
+      $logInfoS "addBlocks" "done inserting, now will emit stateDiff if necessary"
+      (theBlock, nbb) <- liftIO (readIORef replacedBest)
+      void . withKafkaViolently $ writeIndexEvents [NewBestBlock nbb] -- only emit one NewBestBlock message
+      let b = obBlockData theBlock
+          codeSource = getSource False b
+          codeContractName = getContractName False b
+      calculateAndEmitStateDiffs theBlock oldStateRoot codeSource codeContractName -- only calculate stateDiff once per batch
 
   where
     timerToUse = Just time_vm_block_insertion_mined

--- a/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
@@ -572,7 +572,7 @@ formatAddress (Address x) = BC.unpack $ B16.encode $ B.pack $ word160ToBytes x
 
 ----------------
 
-replaceBestIfBetter :: OutputBlock -> ContextM (Bool, Maybe OutputBlock, (SHA, Integer, Integer))
+replaceBestIfBetter :: OutputBlock -> ContextM (Bool, (SHA, Integer, Integer))
 replaceBestIfBetter b@OutputBlock{obBlockData = bd, obTotalDifficulty = td, obReceiptTransactions=txs, obBlockUncles=uncles} = do
     ContextBestBlockInfo(oldBestSha, oldBestBlock, oldBestDifficulty, oldTxCount, _) <- getContextBestBlockInfo
 
@@ -605,7 +605,7 @@ replaceBestIfBetter b@OutputBlock{obBlockData = bd, obTotalDifficulty = td, obRe
         bestNum       = if shouldReplace then newNumber else oldNumber
         bestTdiff     = if shouldReplace then td        else oldBestDifficulty
 
-    return (shouldReplace, Just b, bestBlockInfo)
+    return (shouldReplace, bestBlockInfo)
 
 calculateAndEmitStateDiffs :: (TransactionLike t, Format b, BlockLike BlockData t b) -- todo: generalize commitSqlDiffs etc. to take all BlockHeaderLikes
                            => b


### PR DESCRIPTION
Emit `RanBlock` messages for each block in a batch, but only emit `NewBestBlock` and calculate stateDiff for the best block in the batch. Also, don't consider old local blocks to be best blocks if running single node