### PR TITLE
Split SeqEvents into SeqVmEvents and SeqP2pEvents

### DIFF
--- a/core-strato/blockapps-tools/exec_src/Checkpoints.hs
+++ b/core-strato/blockapps-tools/exec_src/Checkpoints.hs
@@ -68,7 +68,7 @@ kafkaBitsForService = \case
     Sequencer -> let clientId = KP.KString (S8.pack SeqConst.defaultKafkaClientId') in
         (clientId, lookupConsumerGroup clientId, SeqKafka.unseqEventsTopicName)
     EVM -> let clientId = "ethereum-vm" in
-        (clientId, lookupConsumerGroup clientId, SeqKafka.seqEventsTopicName)
+        (clientId, lookupConsumerGroup clientId, SeqKafka.seqVmEventsTopicName)
     ApiIndexer -> let clientId = "strato-api-indexer" in
         (clientId, lookupConsumerGroup clientId, IdxKafka.indexEventsTopicName)
     P2PIndexer -> let clientId = "strato-p2p-indexer" in

--- a/core-strato/blockapps-tools/exec_src/DumpKafkaSequencer.hs
+++ b/core-strato/blockapps-tools/exec_src/DumpKafkaSequencer.hs
@@ -10,8 +10,18 @@ import           Blockchain.EthConf
 import           Blockchain.Sequencer.Kafka
 import           Blockchain.Stream.Raw      (setDefaultKafkaState)
 
-dumpKafkaSequencer::Offset->IO ()
-dumpKafkaSequencer startingBlock = do
+dumpKafkaSequencer :: Offset -> IO ()
+dumpKafkaSequencer ofs = do
+  mapM_ putStrLn [ "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ dumpKafkaSequencer ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                 , "DEPRECATED!!! seqEvents has been split into two topics: seqVmEvents, and seqP2pEvents."
+                 , "Please use dumpKafkaSequencerVM or dumpKafkaSequencerP2P instead."
+                 , "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                 , ""
+                 ]
+  dumpKafkaSequencerVM ofs
+
+dumpKafkaSequencerVM :: Offset -> IO ()
+dumpKafkaSequencerVM startingBlock = do
   ret <- runKafkaConfigured "queryStrato" $ doConsume' startingBlock
   case ret of
     Left e  -> error $ show e
@@ -19,6 +29,19 @@ dumpKafkaSequencer startingBlock = do
   where
     doConsume' offset = do
       setDefaultKafkaState
-      seqEvents <- readSeqEvents offset
+      seqEvents <- readSeqVmEvents offset
+      liftIO . putStrLn . unlines $ show <$> seqEvents
+      doConsume' (offset + fromIntegral (length seqEvents))
+
+dumpKafkaSequencerP2P :: Offset -> IO ()
+dumpKafkaSequencerP2P startingBlock = do
+  ret <- runKafkaConfigured "queryStrato" $ doConsume' startingBlock
+  case ret of
+    Left e  -> error $ show e
+    Right _ -> return ()
+  where
+    doConsume' offset = do
+      setDefaultKafkaState
+      seqEvents <- readSeqP2pEvents offset
       liftIO . putStrLn . unlines $ show <$> seqEvents
       doConsume' (offset + fromIntegral (length seqEvents))

--- a/core-strato/blockapps-tools/exec_src/Main.hs
+++ b/core-strato/blockapps-tools/exec_src/Main.hs
@@ -43,6 +43,8 @@ data Options = State{root::String, db::String}
              | Checkpoints{service :: CheckpointService, operation :: CheckpointOperation, offset :: Maybe Int64, cp :: Maybe String}
              | DumpKafkaBlocks{startingBlock::Int}
              | DumpKafkaSequencer{startingBlock::Int}
+             | DumpKafkaSequencerVM{startingBlock::Int}
+             | DumpKafkaSequencerP2P{startingBlock::Int}
              | DumpKafkaUnSequencer{startingBlock::Int}
              | DumpKafkaUnminedBlocks{startingBlock::Int}
              | DumpKafkaRaw{streamName::String, startingBlock::Int}
@@ -134,6 +136,18 @@ dumpKafkaSequencerOptions =
     startingBlock := 0 += typ "INT"
     ]
 
+dumpKafkaSequencerVmOptions:: Annotate Ann
+dumpKafkaSequencerVmOptions =
+  record DumpKafkaSequencerVM{startingBlock = undefined} [
+    startingBlock := 0 += typ "INT"
+    ]
+
+dumpKafkaSequencerP2pOptions:: Annotate Ann
+dumpKafkaSequencerP2pOptions =
+  record DumpKafkaSequencerP2P{startingBlock = undefined} [
+    startingBlock := 0 += typ "INT"
+    ]
+
 dumpKafkaUnSequencerOptions:: Annotate Ann
 dumpKafkaUnSequencerOptions =
   record DumpKafkaUnSequencer{startingBlock = undefined} [
@@ -192,6 +206,8 @@ options = modes_ [blockGoOptions
                 , dumpKafkaBlocksOptions
                 , dumpKafkaRawOptions
                 , dumpKafkaSequencerOptions
+                , dumpKafkaSequencerVmOptions
+                , dumpKafkaSequencerP2pOptions
                 , dumpKafkaStateDiffOptions
                 , dumpKafkaUnSequencerOptions
                 , dumpKafkaUnminedBlocksOptions
@@ -227,6 +243,8 @@ run RLP{..}                    = RLP.doit filename
 run RawMP{..}                  = RawMP.doit filename (MP.StateRoot . fst . B16.decode $ BC.pack stateRoot)
 run FRawMP{..}                 = FRawMP.doit filename (MP.StateRoot . fst . B16.decode $ BC.pack stateRoot)
 run DumpKafkaSequencer{..}     = dumpKafkaSequencer (fromIntegral startingBlock)
+run DumpKafkaSequencerVM{..}   = dumpKafkaSequencerVM (fromIntegral startingBlock)
+run DumpKafkaSequencerP2P{..}  = dumpKafkaSequencerP2P (fromIntegral startingBlock)
 run DumpKafkaUnSequencer{..}   = dumpKafkaUnSequencer (fromIntegral startingBlock)
 run DumpKafkaBlocks{..}        = dumpKafkaBlocks (fromIntegral startingBlock)
 run DumpKafkaUnminedBlocks{..} = dumpKafkaUnminedBlocks (fromIntegral startingBlock)

--- a/core-strato/ethereum-jsonrpc/src/Commands.hs
+++ b/core-strato/ethereum-jsonrpc/src/Commands.hs
@@ -230,7 +230,7 @@ emitKafkaJsonRlpCommand::JsonRpcCommand->IO ()
 emitKafkaJsonRlpCommand c = do
     rets <-
       liftIO $ runKafkaConfigured "strato-api" $
-      writeSeqEvents [OEJsonRpcCommand c]
+      writeSeqVmEvents [OEJsonRpcCommand c]
     case rets of
         Left e      -> error $ "Could not write txs to Kafka: " ++ show e
         Right resps -> return ()

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -139,7 +139,7 @@ initBlockSummary block =
 
 getCheckpoint :: ContextM (KP.Offset, EVMCheckpoint)
 getCheckpoint = do
-    let topic  = seqEventsTopicName
+    let topic  = seqVmEventsTopicName
         topic' = show topic
         cg'    = show consumerGroup
     $logInfoS "getCheckpoint" . T.pack $ "Getting checkpoint for " ++ topic' ++ "#0 for " ++ cg'
@@ -153,7 +153,7 @@ getCheckpoint = do
 
 getCheckpointNoMetadata :: ContextM KP.Offset
 getCheckpointNoMetadata = do
-    let topic  = seqEventsTopicName
+    let topic  = seqVmEventsTopicName
         topic' = show topic
         cg'    = show consumerGroup
     $logInfoS "getCheckpointNoMetadata" . T.pack $ "Getting checkpoint for " ++ topic' ++ "#0 for " ++ cg'
@@ -168,20 +168,20 @@ setCheckpoint :: KP.Offset -> EVMCheckpoint -> ContextM ()
 setCheckpoint ofs checkpoint = do
     $logInfoS "setCheckpoint" . T.pack $ "Setting checkpoint to " ++ show ofs ++ " / " ++ format checkpoint
     let kMetadata = toKafkaMetadata checkpoint
-    ret  <- K.withKafkaViolently $ K.commitSingleOffset consumerGroup seqEventsTopicName 0 ofs kMetadata
+    ret  <- K.withKafkaViolently $ K.commitSingleOffset consumerGroup seqVmEventsTopicName 0 ofs kMetadata
     either (error . show) return ret
 
 setCheckpointNoMetadata :: KP.Offset -> ContextM ()
 setCheckpointNoMetadata ofs = do
     $logInfoS "setCheckpointNoMetadata" . T.pack $ "Setting checkpoint to " ++ show ofs
     let emptyMetadata = KP.Metadata $ KP.KString BS.empty
-    ret  <- K.withKafkaViolently $ K.commitSingleOffset consumerGroup seqEventsTopicName 0 ofs emptyMetadata
+    ret  <- K.withKafkaViolently $ K.commitSingleOffset consumerGroup seqVmEventsTopicName 0 ofs emptyMetadata
     either (error . show) return ret
 
 getUnprocessedKafkaEvents :: KP.Offset -> ContextM [OutputEvent]
 getUnprocessedKafkaEvents offset = do
     $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Fetching sequenced blockchain events with offset " ++ show offset
-    ret <- K.withKafkaViolently (readSeqEvents offset)
+    ret <- K.withKafkaViolently (readSeqVmEvents offset)
     $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Got: " ++ show (length ret) ++ " unprocessed blocks/txs"
     return ret
 

--- a/core-strato/strato-init/src/Blockchain/Setup.hs
+++ b/core-strato/strato-init/src/Blockchain/Setup.hs
@@ -246,7 +246,8 @@ createKafkaTopic topic = do
 topics  ::  [String]
 topics = [ "unminedblock"
          , "statediff"
-         , "seqevents"
+         , "seq_vm_events"
+         , "seq_p2p_events"
          , "unseqevents"
          , "jsonrpcresponse"
          , "indexevents"

--- a/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -16,7 +16,7 @@ import qualified Blockchain.MilenaTools     as K
 import qualified Network.Kafka.Protocol     as KP
 
 import           Blockchain.Sequencer.Event
-import           Blockchain.Sequencer.Kafka (readSeqEvents, seqEventsTopicName)
+import           Blockchain.Sequencer.Kafka (readSeqP2pEvents, seqP2pEventsTopicName)
 
 seqEventNotificationSource :: ( MonadIO m
                               , MonadBaseControl IO m
@@ -26,10 +26,10 @@ seqEventNotificationSource :: ( MonadIO m
                               )
                            => Source m OutputEvent
 seqEventNotificationSource = do
-    ofs' <- lift $ K.withKafkaViolently $ K.getLastOffset K.LatestTime 0 seqEventsTopicName
+    ofs' <- lift $ K.withKafkaViolently $ K.getLastOffset K.LatestTime 0 seqP2pEventsTopicName
     loop ofs'
     where loop nextOffset = do
-              events <- lift $ K.withKafkaViolently $ readSeqEvents nextOffset
+              events <- lift $ K.withKafkaViolently $ readSeqP2pEvents nextOffset
               unless (null events) $ do -- stop bloating the logs
                 $logInfoS "seqEventNotify" . T.pack $ "read kafka seqevents @ " ++ show nextOffset
                 forM_ events $ \e -> do

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -52,7 +52,8 @@ sequencer = forever $ do
         setGauge (length pendingLDBWrites) ctr_sequencer_ldb_batch_size
         $logInfoS "sequencer" "Applied pending LDB writes"
         unless (lenOutEv == 0) $ do
-            writeSeqEvents' outEv
+            writeSeqVmEvents' outEv
+            writeSeqP2pEvents' outEv
             $logInfoS "sequencer" . T.pack $ "Wrote " ++ show lenOutEv ++ " SeqEvents"
         setNextIngestedOffset ofs
 
@@ -78,7 +79,8 @@ bootstrap BDB.Block{BDB.blockBlockData = bd, BDB.blockReceiptTransactions = txs,
               shouldEmit <- bootstrapDoEmit <$> ask
               when shouldEmit $ do
                   assertTopicCreation'
-                  writeSeqEvents' [OEBlock shortCircuit]  -- todo handle the error :)
+                  writeSeqVmEvents' [OEBlock shortCircuit]  -- todo handle the error :)
+                  writeSeqP2pEvents' [OEBlock shortCircuit]  -- todo handle the error :)
               return shortCircuit
 
 transformEvents :: [IngestEvent] -> SequencerM ([Maybe LDB.BatchOp], [OutputEvent])
@@ -155,9 +157,14 @@ readUnseqEvents' = do
     tickBy (length ret) ctr_sequencer_kafka_unseq_reads
     return ret
 
-writeSeqEvents' :: [OutputEvent] -> SequencerM ()
-writeSeqEvents' events = void $ do
-    void $ K.withKafkaViolently (writeSeqEvents events)
+writeSeqVmEvents' :: [OutputEvent] -> SequencerM ()
+writeSeqVmEvents' events = void $ do
+    void $ K.withKafkaViolently (writeSeqVmEvents events)
+    tickBy (length events) ctr_sequencer_kafka_seq_writes
+
+writeSeqP2pEvents' :: [OutputEvent] -> SequencerM ()
+writeSeqP2pEvents' events = void $ do
+    void $ K.withKafkaViolently (writeSeqP2pEvents events)
     tickBy (length events) ctr_sequencer_kafka_seq_writes
 
 getNextIngestedOffset :: SequencerM KP.Offset

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Kafka.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Kafka.hs
@@ -2,13 +2,17 @@
 module Blockchain.Sequencer.Kafka (
     assertTopicCreation,
     unseqEventsTopicName,
-    seqEventsTopicName,
+    seqVmEventsTopicName,
+    seqP2pEventsTopicName,
     readUnseqEvents,
     readUnseqEventsFromTopic,
-    readSeqEvents,
-    readSeqEventsFromTopic,
+    readSeqVmEvents,
+    readSeqP2pEvents,
+    readSeqVmEventsFromTopic,
+    readSeqP2pEventsFromTopic,
     writeUnseqEvents,
-    writeSeqEvents,
+    writeSeqVmEvents,
+    writeSeqP2pEvents,
     HasUnseqSink(..),
     HasSeqSink(..),
     emitKafkaTransactions,
@@ -35,13 +39,17 @@ import qualified Network.Kafka.Protocol     as KP
 unseqEventsTopicName :: KP.TopicName
 unseqEventsTopicName = lookupTopic "unseqevents"
 
-seqEventsTopicName :: KP.TopicName
-seqEventsTopicName = lookupTopic "seqevents"
+seqVmEventsTopicName :: KP.TopicName
+seqVmEventsTopicName = lookupTopic "seq_vm_events"
+
+seqP2pEventsTopicName :: KP.TopicName
+seqP2pEventsTopicName = lookupTopic "seq_p2p_events"
 
 assertTopicCreation :: K.Kafka k => k ()
 assertTopicCreation = do
     K.updateMetadata unseqEventsTopicName
-    K.updateMetadata seqEventsTopicName
+    K.updateMetadata seqVmEventsTopicName
+    K.updateMetadata seqP2pEventsTopicName
 
 readUnseqEvents :: K.Kafka k => KP.Offset -> k [IngestEvent]
 readUnseqEvents = readUnseqEventsFromTopic unseqEventsTopicName
@@ -50,20 +58,31 @@ readUnseqEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [IngestE
 readUnseqEventsFromTopic = readFromTopic'
 {-# INLINE readUnseqEventsFromTopic #-}
 
-readSeqEvents :: K.Kafka k => KP.Offset -> k [OutputEvent]
-readSeqEvents = readSeqEventsFromTopic seqEventsTopicName
+readSeqVmEvents :: K.Kafka k => KP.Offset -> k [OutputEvent]
+readSeqVmEvents = readSeqVmEventsFromTopic seqVmEventsTopicName
 
-readSeqEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [OutputEvent]
-readSeqEventsFromTopic = readFromTopic'
-{-# INLINE readSeqEventsFromTopic #-}
+readSeqVmEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [OutputEvent]
+readSeqVmEventsFromTopic = readFromTopic'
+{-# INLINE readSeqVmEventsFromTopic #-}
+
+readSeqP2pEvents :: K.Kafka k => KP.Offset -> k [OutputEvent]
+readSeqP2pEvents = readSeqP2pEventsFromTopic seqP2pEventsTopicName
+
+readSeqP2pEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [OutputEvent]
+readSeqP2pEventsFromTopic = readFromTopic'
+{-# INLINE readSeqP2pEventsFromTopic #-}
 
 writeUnseqEvents :: K.Kafka k => [IngestEvent] -> k [KP.ProduceResponse]
 writeUnseqEvents events = KW.produceMessages $
     (K.TopicAndMessage unseqEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 
-writeSeqEvents :: K.Kafka k => [OutputEvent] -> k [KP.ProduceResponse]
-writeSeqEvents events = KW.produceMessages $
-    (K.TopicAndMessage seqEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
+writeSeqVmEvents :: K.Kafka k => [OutputEvent] -> k [KP.ProduceResponse]
+writeSeqVmEvents events = KW.produceMessages $
+    (K.TopicAndMessage seqVmEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
+
+writeSeqP2pEvents :: K.Kafka k => [OutputEvent] -> k [KP.ProduceResponse]
+writeSeqP2pEvents events = KW.produceMessages $
+    (K.TopicAndMessage seqP2pEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 
 readFromTopic' :: (Binary b, K.Kafka k) => KP.TopicName -> KP.Offset -> k [b]
 readFromTopic' topic offset = do


### PR DESCRIPTION
For private chains and Blockstanbul, additional message types will be emitted from the sequencer to P2P that do not pertain to the VM. Additionally, for private chains, it is desirable to emit transactions to the VM or P2P individually in some cases. Although this can be achieved with one Kafka topic, the processes will have to read through a lot of irrelevant messages to find pertinent ones. Also, with one partition, only one consumer can read from the topic at a time (I think?), so the processes are competing for the resource anyway. 