### PR TITLE
Remove usage of Control.Monad.Trans.Either because it is deprecated

### DIFF
--- a/core-strato/blockapps-haskoin/Network/Haskoin/Transaction/Builder.hs
+++ b/core-strato/blockapps-haskoin/Network/Haskoin/Transaction/Builder.hs
@@ -21,7 +21,7 @@ module Network.Haskoin.Transaction.Builder
 
 import Control.Monad (mzero, foldM, unless)
 import Control.Monad.Trans (lift)
-import Control.Monad.Trans.Either (EitherT, left)
+import Control.Monad.Trans.Except (ExceptT, throwE)
 import Control.Monad.Identity (runIdentity)
 import Control.DeepSeq (NFData, rnf)
 
@@ -268,9 +268,9 @@ signTx :: Monad m
        => Tx                        -- ^ Transaction to sign
        -> [SigInput]                -- ^ SigInput signing parameters
        -> [PrvKey]                  -- ^ List of private keys to use for signing
-       -> EitherT String (SecretT m) Tx -- ^ Signed transaction
+       -> ExceptT String (SecretT m) Tx -- ^ Signed transaction
 signTx otx@(Tx _ ti _ _) sigis allKeys
-    | null ti   = left "signTx: Transaction has no inputs"
+    | null ti   = throwE "signTx: Transaction has no inputs"
     | otherwise = foldM go otx $ findSigInput sigis ti
   where
     go tx (sigi@(SigInput so _ _ rdmM), i) = do
@@ -279,7 +279,7 @@ signTx otx@(Tx _ ti _ _) sigis allKeys
 
 -- | Sign a single input in a transaction within the 'SecretT' monad.
 signInput :: Monad m => Tx -> Int -> SigInput -> PrvKey
-          -> EitherT String (SecretT m) Tx
+          -> ExceptT String (SecretT m) Tx
 signInput tx i (SigInput so _ sh rdmM) key = do
     sig <- flip TxSignature sh <$> lift (signMsg msg key)
     si  <- liftEither $ buildInput tx i so rdmM sig $ derivePubKey key

--- a/core-strato/blockapps-haskoin/Network/Haskoin/Util.hs
+++ b/core-strato/blockapps-haskoin/Network/Haskoin/Util.hs
@@ -56,7 +56,7 @@ module Network.Haskoin.Util
 ) where
 
 import Control.Monad (guard)
-import Control.Monad.Trans.Either (EitherT, hoistEither)
+import Control.Monad.Trans.Except (ExceptT(..))
 import Control.Monad.State (MonadState, get, put)
 
 import Data.Word (Word8)
@@ -237,12 +237,12 @@ eitherToMaybe _ = Nothing
 maybeToEither :: b -> Maybe a -> Either b a
 maybeToEither err m = maybe (Left err) Right m
 
--- | Lift a Either computation into the EitherT monad
-liftEither :: Monad m => Either b a -> EitherT b m a
-liftEither = hoistEither
+-- | Lift a Either computation into the ExceptT monad
+liftEither :: Monad m => Either b a -> ExceptT b m a
+liftEither = ExceptT . return
 
--- | Lift a Maybe computation into the EitherT monad
-liftMaybe :: Monad m => b -> Maybe a -> EitherT b m a
+-- | Lift a Maybe computation into the ExceptT monad
+liftMaybe :: Monad m => b -> Maybe a -> ExceptT b m a
 liftMaybe err = liftEither . (maybeToEither err)
 
 -- Various helpers

--- a/core-strato/blockapps-haskoin/blockapps-haskoin.cabal
+++ b/core-strato/blockapps-haskoin/blockapps-haskoin.cabal
@@ -80,7 +80,6 @@ library
                  , containers               >= 0.5          && < 0.6
                  , cryptohash               >= 0.11         && < 0.12
                  , deepseq                  >= 1.4          && < 2
-                 , either 
                  , mtl                      >= 2.2          && < 3
                  , murmur3                  >= 1.0          && < 2
                  , network                  >= 2.6          && < 3
@@ -88,6 +87,7 @@ library
                  , QuickCheck               >= 2.6          && < 3
                  , split                    >= 0.2          && < 0.3
                  , text                     >= 0.11         && < 2
+                 , transformers
                  , time                     >= 1.4          && < 2
 
     ghc-options:       -Wall

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -5,31 +5,15 @@
 module Blockchain.MilenaTools where
 
 
-import           Control.Applicative
 import           Control.Concurrent     (threadDelay)
 import           Control.Monad.Except   (throwError)
-import           Control.Monad.IO.Class
-import           Control.Exception           (IOException)
-import           Control.Exception.Lifted    (catch)
 import           Control.Lens
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Control.Monad.IO.Class      (MonadIO, liftIO)
-import           Control.Monad.Except        (ExceptT (..), MonadError (..), runExceptT)
+import           Control.Monad.Except        (ExceptT (..), runExceptT)
 import           Control.Monad.Trans.State
-import           Control.Monad.State.Class   (MonadState)
-import           Data.ByteString.Char8       (ByteString)
-import           Data.List.NonEmpty          (NonEmpty (..))
-import qualified Data.List.NonEmpty          as NE
-import           Data.Monoid                 ((<>))
-import qualified Data.Pool                   as Pool
-import qualified Data.Map                    as M
-import           Data.Set                    (Set)
-import qualified Data.Set                    as Set
-import qualified Network
 import           Network.Kafka
 import           Network.Kafka.Protocol
 import           Prelude
-import           System.IO
 
 
 _kMetadata::Metadata->KafkaString

--- a/core-strato/blockapps-util/src/Blockchain/Output.hs
+++ b/core-strato/blockapps-util/src/Blockchain/Output.hs
@@ -10,7 +10,6 @@ module Blockchain.Output
 
 import           Control.Concurrent     (ThreadId, myThreadId)
 import           Control.Monad
-import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import qualified Data.ByteString.Char8  as BC
 import qualified Data.Text              as Text

--- a/core-strato/blockapps-util/src/Blockchain/SHA.hs
+++ b/core-strato/blockapps-util/src/Blockchain/SHA.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS -fno-warn-orphans #-}
 
 module Blockchain.SHA (
   module Blockchain.Strato.Model.SHA,
@@ -7,25 +8,16 @@ module Blockchain.SHA (
   hash
   ) where
 
-import           Control.Monad
-import qualified Data.Aeson                  as JSON
-import           Data.Binary
-import qualified Data.ByteString             as B
-import qualified Data.ByteString.Base16      as B16
 import qualified Data.ByteString.Char8       as BC
-import qualified Data.ByteString.Lazy        as BL
 import qualified Data.Text                   as T
 import           Numeric
 import           Web.HttpApiData
 import           Web.PathPieces
 
 import qualified Blockchain.Colors           as CL
-import           Blockchain.Data.RLP
-import           Blockchain.ExtWord
 import           Blockchain.Format
 import           Blockchain.Util
 
-import           GHC.Generics
 
 import           Blockchain.Strato.Model.SHA
 

--- a/core-strato/blockapps-util/src/Blockchain/Util.hs
+++ b/core-strato/blockapps-util/src/Blockchain/Util.hs
@@ -5,7 +5,6 @@ import           Data.Bits
 import qualified Data.ByteString          as B
 import           Data.ByteString.Internal
 import           Data.Char
-import           Data.List
 import qualified Data.NibbleString        as N
 import           Data.Word
 import           Numeric

--- a/core-strato/ethereum-encryption/ethereum-encryption.cabal
+++ b/core-strato/ethereum-encryption/ethereum-encryption.cabal
@@ -33,7 +33,7 @@ library
                      , strato-model
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -Wall -O2  -fno-warn-warnings-deprecations
+  ghc-options:         -Wall -O2
   exposed-modules:     Blockchain.AESCTR
                      , Blockchain.Data.PubKey
                      , Blockchain.ExtendedECDSA

--- a/core-strato/ethereum-jsonrpc/src/Commands.hs
+++ b/core-strato/ethereum-jsonrpc/src/Commands.hs
@@ -5,7 +5,6 @@ module Commands (
   ) where
 
 import           Control.Monad.Except
-import           Control.Monad.IO.Class
 import qualified Data.Aeson                  as JSON
 import           Data.Binary
 import qualified Data.ByteString             as B
@@ -17,30 +16,23 @@ import qualified Data.Map                    as M
 import qualified Data.Text                   as T
 import qualified Data.Vector                 as V
 import qualified Network.Haskoin.Internals   as H
-import           Network.HTTP.Client
 import           Network.JsonRpc.Server
 import           Network.Kafka
 import           Network.Kafka.Protocol
-import           Numeric
 import           System.Random
 
 import           Blockchain.Constants
-import           Blockchain.Data.DataDefs
-import           Blockchain.Data.Json
-import           Blockchain.Data.RLP
 import           Blockchain.Data.Transaction
-import           Blockchain.Data.TXOrigin
-import           Blockchain.DB.DetailsDB
 import           Blockchain.EthConf
 import           Blockchain.KafkaTopics
 import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Kafka
-import           Blockchain.SHA
 import           Blockchain.Strato.Model.SHA (keccak256)
 import           Blockchain.Stream.Raw
 
 import qualified APIProxy                    as API
 import           Binary
+import           Prelude                     hiding (id)
 
 type Server = IO
 
@@ -206,9 +198,10 @@ getBlockNumber (JSON.Array val) =
       Just (JSON.Object v) ->
         case H.lookup "number" v of
          Just (JSON.Number n) -> Just $ round n
-         Nothing              -> Nothing
+         _                    -> Nothing
       _ -> Nothing
    _ -> Nothing
+getBlockNumber _ = Nothing
 
 
 eth_blockNumber::Method Server
@@ -233,7 +226,7 @@ emitKafkaJsonRlpCommand c = do
       writeSeqEvents [OEJsonRpcCommand c]
     case rets of
         Left e      -> error $ "Could not write txs to Kafka: " ++ show e
-        Right resps -> return ()
+        Right _ -> return ()
 
 waitForResponse::String->Offset->IO B.ByteString
 waitForResponse id offset = do
@@ -320,7 +313,7 @@ eth_getTransactionCount = toMethod "eth_getTransactionCount" f (Required "addres
 eth_getStorageAt::Method Server
 eth_getStorageAt = toMethod "eth_getStorageAt" f (Required "address" :+: Required "key" :+: Required "block" :+: ())
   where f::String->String->String->RpcResult Server String
-        f addressString key blockString = do
+        f addressString _ blockString = do
           id <- liftIO $ fmap (take 10 . randomRs ('a','z')) newStdGen
           case strToAddress addressString of
            Left err -> throwError $ rpcError (-32602) $ T.pack err
@@ -340,7 +333,7 @@ eth_call = toMethod "eth_call" f (Required "codeString" :+: Required "blockStrin
   where f::String->String->RpcResult Server String
         f codeString blockString = do
           let id = "qqqq"
-          tx <- liftIO $ H.withSource H.devURandom $
+          _ <- liftIO $ H.withSource H.devURandom $
             createMessageTX undefined undefined undefined undefined undefined undefined undefined
           case strToByteString codeString of
            Left err -> throwError $ rpcError (-32602) $ T.pack err

--- a/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
@@ -26,7 +26,7 @@ import           Control.Monad.Logger
 import qualified Control.Monad.State                     as State
 import           Control.Monad.Stats                     hiding (Success)
 import           Control.Monad.Trans
-import           Control.Monad.Trans.Either
+import           Control.Monad.Trans.Except
 import qualified Data.ByteString                         as B
 import qualified Data.ByteString.Base16                  as B16
 import qualified Data.ByteString.Char8                   as BC
@@ -299,7 +299,7 @@ addTransactions :: BlockData -> Integer -> [OutputTx] -> ContextM Integer
 addTransactions _ remGas [] = return remGas
 addTransactions b blockGas (t:rest) = do
   beforeMap <- getAddressStateDBMap
-  !(deltaT, result) <- timeIt $ runEitherT $ addTransaction False b blockGas t
+  !(deltaT, result) <- timeIt $ runExceptT $ addTransaction False b blockGas t
   afterMap <- getAddressStateDBMap
 
   printTransactionMessage t result deltaT
@@ -324,7 +324,7 @@ mineTransactions' :: BlockData -> Integer -> [TxRunResult] -> [OutputTx] -> Cont
 mineTransactions' _ remGas ran [] = return $ TxMiningResult Nothing (reverse ran) [] remGas
 mineTransactions' header remGas ran unran@(tx:txs) = do
     beforeMap <- getAddressStateDBMap
-    (time', !result) <- timeIt . runEitherT $ addTransaction False header remGas tx
+    (time', !result) <- timeIt . runExceptT $ addTransaction False header remGas tx
     afterMap <- getAddressStateDBMap
     time time' time_vm_tx_mining
     printTransactionMessage tx result time'
@@ -336,7 +336,7 @@ mineTransactions' header remGas ran unran@(tx:txs) = do
 blockIsHomestead :: Integer -> Bool
 blockIsHomestead blockNum = blockNum >= gHomesteadFirstBlock
 
-addTransaction :: Bool -> BlockData -> Integer -> OutputTx -> EitherT TransactionFailureCause ContextM ExecResults
+addTransaction :: Bool -> BlockData -> Integer -> OutputTx -> ExceptT TransactionFailureCause ContextM ExecResults
 addTransaction isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=bt,otSigner=tAddr} = do
     nonceValid <- lift $ isNonceValid t
 
@@ -352,10 +352,10 @@ addTransaction isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=bt,otSign
 
     let txCost      = transactionGasLimit bt * transactionGasPrice bt + transactionValue bt
         acctBalance = addressStateBalance addressState
-    when (txCost > acctBalance) $ left $ TFInsufficientFunds txCost acctBalance t
-    when (intrinsicGas' > transactionGasLimit bt) $ left $ TFIntrinsicGasExceedsTxLimit intrinsicGas' (transactionGasLimit bt) t
-    when (transactionGasLimit bt > remainingBlockGas) $ left $ TFBlockGasLimitExceeded (transactionGasLimit bt) remainingBlockGas t
-    unless nonceValid $ left $ TFNonceMismatch (transactionNonce bt) (addressStateNonce addressState) t
+    when (txCost > acctBalance) $ throwE $ TFInsufficientFunds txCost acctBalance t
+    when (intrinsicGas' > transactionGasLimit bt) $ throwE $ TFIntrinsicGasExceedsTxLimit intrinsicGas' (transactionGasLimit bt) t
+    when (transactionGasLimit bt > remainingBlockGas) $ throwE $ TFBlockGasLimitExceeded (transactionGasLimit bt) remainingBlockGas t
+    unless nonceValid $ throwE $ TFNonceMismatch (transactionNonce bt) (addressStateNonce addressState) t
 
     let availableGas = transactionGasLimit bt - intrinsicGas'
 
@@ -623,7 +623,7 @@ calculateAndEmitStateDiffs newBlock oldStateRoot codeSource codeContractName = w
 
     let allNewCodeHashes = S.toList $ S.fromList $ map (codeHash . snd) $ M.toList $ createdAccounts diffs
 
-    
+
     codeSourceMap <- fmap M.fromList $
       forM allNewCodeHashes $ \codeHash -> do
         codeSource' <- codeSource codeHash

--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -109,7 +109,7 @@ logN n = do
 guardStorage :: VMM ()
 guardStorage = do
   w <- lift $ writable <$> get
-  when (not w) (left WriteProtection)
+  when (not w) (throwE WriteProtection)
 
 
 dupN::Int->VMM ()
@@ -117,7 +117,7 @@ dupN n = do
   stack' <- lift $ fmap stack get
   if length stack' < n
     then do
-    left StackTooSmallException
+    throwE StackTooSmallException
     else push $ stack' !! (n-1)
 
 
@@ -133,7 +133,7 @@ swapn n = do
   vmState <- lift get
   if length (stack vmState) < n
     then do
-      left StackTooSmallException
+      throwE StackTooSmallException
     else do
       let (middle, v2:rest2) = splitAt (n-1) $ stack vmState
       lift $ put vmState{stack = v2:(middle++(v1:rest2))}
@@ -420,7 +420,7 @@ runOperation JUMP = do
 
   if p `elem` jumpDests
     then setPC $ fromIntegral p - 1 -- Subtracting 1 to compensate for the pc-increment that occurs every step.
-    else left InvalidJump
+    else throwE InvalidJump
 
 runOperation JUMPI = do
   p <- pop
@@ -430,7 +430,7 @@ runOperation JUMPI = do
   case (p `elem` jumpDests, (0::Word256) /= condition) of
     (_, False) -> return ()
     (True, _)  -> setPC $ fromIntegral p - 1
-    _          -> left InvalidJump
+    _          -> throwE InvalidJump
 
 runOperation PC = pushVMStateVar pc
 
@@ -694,7 +694,7 @@ runOperation DELEGATECALL = do
     else do
       let MalformedOpcode opcode = DELEGATECALL
       when flags_debug $ lift $ $logInfoS "runOp/DELEGATECALL" . T.pack $ CL.red ("Malformed Opcode: " ++ showHex opcode "")
-      left MalformedOpcodeException
+      throwE MalformedOpcodeException
 
 runOperation STATICCALL = do
   gas <- pop :: VMM Word256
@@ -711,9 +711,9 @@ runOperation REVERT = do
   retVal <- unsafeSliceByteString address' size
 
   setReturnVal $ Just retVal
-  left RevertException
+  throwE RevertException
 
-runOperation INVALID = left InvalidInstruction
+runOperation INVALID = throwE InvalidInstruction
 
 runOperation SUICIDE = do
   guardStorage
@@ -733,7 +733,7 @@ runOperation SUICIDE = do
 
 runOperation (MalformedOpcode opcode) = do
   when flags_debug $ lift $ $logInfoS "runOp/MalformedOpcode" . T.pack $ CL.red ("Malformed Opcode: " ++ showHex opcode "")
-  left MalformedOpcodeException
+  throwE MalformedOpcodeException
 
 runOperation x = error $ "Missing case in runOperation: " ++ show x
 

--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -17,7 +17,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.Stats
 import           Control.Monad.Trans
-import           Control.Monad.Trans.Either
+import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.State
 import           Data.Bits
 import qualified Data.ByteString                    as B
@@ -942,7 +942,7 @@ runVMM isRunningTests' isHomestead preExistingSuicideList callDepth' env availab
                          callDepth=callDepth',
                          vmGasRemaining=availableGas,
                          suicideList=preExistingSuicideList} $
-      runEitherT f
+      runExceptT f
 
   case result of
       (Left e, vmState') -> do
@@ -969,7 +969,7 @@ getFromSelector sel isRunningTests' b codeHash = do
 
   stateRoot <- getStateRoot
   setStateDBStateRoot (blockDataStateRoot b)
-  let env = 
+  let env =
         Environment{ -- this is all dummy information....  getSource should be a very simple function that unconditionally returns a single string
           envGasPrice=1,
           envBlockHeader=BlockData{

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Memory.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Memory.hs
@@ -17,7 +17,7 @@ module Blockchain.VM.Memory (
 
 import           Control.Monad
 import           Control.Monad.Trans
-import           Control.Monad.Trans.Either
+import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.State    hiding (state)
 import qualified Data.ByteString              as B
 import qualified Data.ByteString.Base16       as B16
@@ -93,7 +93,7 @@ setNewMaxSize newSize' = do
   if vmGasRemaining state < gasCharge
      then do
           setGasRemaining 0
-          left OutOfGasException
+          throwE OutOfGasException
     else do
     when (newSize > fromIntegral oldSize) $ do
       liftIO $ writeIORef (mSize $ memory state) (fromInteger newSize)

--- a/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
@@ -9,7 +9,7 @@ import           Control.Monad
 import           Control.Monad.Logger
 import           Control.Monad.Stats
 import           Control.Monad.Trans
-import           Control.Monad.Trans.Either
+import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Resource
 import           Control.Monad.Trans.State
 import qualified Data.ByteString                    as B
@@ -34,8 +34,8 @@ import           Blockchain.VM.VMState
 import           Blockchain.VMContext
 import           Blockchain.VM.VMException
 
-type VMM = EitherT VMException (StateT VMState (StatsT (ResourceT (LoggingT IO))))
---type VMM2 = EitherT VMException (StateT VMState (ResourceT IO))
+type VMM = ExceptT VMException (StateT VMState (StatsT (ResourceT (LoggingT IO))))
+--type VMM2 = ExceptT VMException (StateT VMState (ResourceT IO))
 
 --TODO- Do I really need this?  Is it bad that it is undefined?
 instance MonadResource VMM where

--- a/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
@@ -37,14 +37,6 @@ import           Blockchain.VM.VMException
 type VMM = ExceptT VMException (StateT VMState (StatsT (ResourceT (LoggingT IO))))
 --type VMM2 = ExceptT VMException (StateT VMState (ResourceT IO))
 
---TODO- Do I really need this?  Is it bad that it is undefined?
-instance MonadResource VMM where
-  liftResourceT = error "liftResourceT undefined for VMM"
-
--- todo: what the actual fuck
-instance MonadLogger VMM where
-    monadLoggerLog = monadLoggerLog
-
 instance HasMemAddressStateDB VMM where
   getAddressStateDBMap = do
       cxt <- lift get
@@ -112,7 +104,7 @@ pop = do
     VMState{stack=val:rest} -> do
                 lift $ put state'{stack=rest}
                 return $ fromWord256 val
-    _ -> left StackTooSmallException
+    _ -> throwE StackTooSmallException
 
 localState :: (VMState -> VMState) -> VMM a -> VMM a
 localState f mv = do
@@ -127,12 +119,12 @@ getStackItem i = do
   state' <- lift get
   if length (stack state') > fromIntegral i
     then return $ fromWord256 (stack state' !! i)
-    else left StackTooSmallException
+    else throwE StackTooSmallException
 
 push::Word256Storable a=>a->VMM ()
 push val = do
   state' <- lift get
-  when (length (stack state') > 1023) $ left StackTooLarge
+  when (length (stack state') > 1023) $ throwE StackTooLarge
   lift $ put state'{stack = toWord256 val:stack state'}
 
 addDebugCallCreate::DebugCallCreate->VMM ()
@@ -207,25 +199,25 @@ useGas gas = do
   case vmGasRemaining state' - gas of
     x | x < 0 -> do
       lift $ put state'{vmGasRemaining=0}
-      left OutOfGasException
+      throwE OutOfGasException
     x -> lift $ put state'{vmGasRemaining=x}
 
 addGas::Integer->VMM ()
 addGas gas = do
   state' <- lift get
   case vmGasRemaining state' + gas of
-    x | x < 0 -> left OutOfGasException
+    x | x < 0 -> throwE OutOfGasException
     x -> lift $ put state'{vmGasRemaining=x}
 
 pay'::String->Address->Address->Integer->VMM ()
 pay' reason from to val = do
   success <- pay reason from to val
-  unless success $ left InsufficientFunds
+  unless success $ throwE InsufficientFunds
 
 addToBalance'::Address->Integer->VMM ()
 addToBalance' address' val = do
   success <- addToBalance address' val
-  unless success $ left InsufficientFunds
+  unless success $ throwE InsufficientFunds
 
 getStorageKeyVal::Word256->VMM Word256
 getStorageKeyVal key = do

--- a/core-strato/fast-ecrecover/src/Blockchain/FastECRecover.hs
+++ b/core-strato/fast-ecrecover/src/Blockchain/FastECRecover.hs
@@ -8,7 +8,6 @@ import qualified BlockApps.ECRecover.IntegerFormat as F
 import qualified Blockchain.ExtendedECDSA          as D
 import qualified Blockchain.ExtWord                as E
 import qualified Data.Binary                       as A
-import qualified Data.ByteString                   as B
 import qualified Data.ByteString.Lazy              as G
 import qualified Network.Haskoin.Internals         as C
 

--- a/core-strato/stack.yaml
+++ b/core-strato/stack.yaml
@@ -59,22 +59,9 @@ extra-lib-dirs:
 - /usr/local/lib
 
 ghc-options:
-  ethereum-discovery:      -Wall -Werror
-  ethereum-encryption:     -Wall -Werror
-  merkle-patricia-db:      -Wall -Werror
-  strato-init:             -Wall -Werror
-  strato-p2p:              -Wall -Werror
-  strato-redis-blockdb:    -Wall -Werror
-  blockapps-tools:         -Wall -Werror
-  strato-index:            -Wall -Werror
-  strato-api:              -fno-warn-orphans
-  blockapps-tools:         -Wall -Werror
-  strato-index:            -Wall -Werror
-  strato-sequencer:        -Wall -Werror
-  strato-adit:             -Wall -Werror
-  strato-conf:             -Wall -Werror -fno-warn-inline-rule-shadowing
-  blockapps-data:          -Wall -Werror
-  ethereum-vm:             -Wall -Werror -fno-warn-warnings-deprecations
+  "$locals": -Wall -Werror
+  strato-api: -Wall -Werror -fno-warn-orphans
+  strato-conf: -Wall -Werror -fno-warn-inline-rule-shadowing
 
 docker:
   enable: true

--- a/core-strato/strato-api/src/Foundation.hs
+++ b/core-strato/strato-api/src/Foundation.hs
@@ -25,7 +25,7 @@ import           Yesod.Raml.Routes
 import           Blockchain.DB.SQLDB
 
 debug :: c -> String -> c
-debug = flip trace
+debug = const
 
 timeFormat :: String
 timeFormat = "%Y-%m-%dT%T.%q"

--- a/core-strato/strato-api/src/Foundation.hs
+++ b/core-strato/strato-api/src/Foundation.hs
@@ -24,9 +24,6 @@ import           Yesod.Raml.Routes
 
 import           Blockchain.DB.SQLDB
 
-debug :: c -> String -> c
-debug = const
-
 timeFormat :: String
 timeFormat = "%Y-%m-%dT%T.%q"
 
@@ -36,9 +33,8 @@ stringToDate s = time where
     picos = (P.init (T.unpack s)) ++ replicate 9 '0'
 
 instance PathPiece UTCTime where
-    toPathPiece t = T.pack $ show t `debug` "PathPieceTo"
-    fromPathPiece s = Just time `debug` ("PathPiece: " ++ show time) where
-       time = stringToDate s `debug` ("PathPieceFrom: " ++ show s)
+    toPathPiece t = T.pack $ show t
+    fromPathPiece s = Just . stringToDate $ s
 
 
 -- | The foundation datatype for your application. This can be a good place to

--- a/core-strato/strato-api/src/Import.hs
+++ b/core-strato/strato-api/src/Import.hs
@@ -3,4 +3,4 @@ module Import
     ) where
 
 import           Foundation          as Import
-import           Import.NoFoundation as Import hiding (Handler)
+import           Import.NoFoundation as Import

--- a/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
+++ b/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
@@ -25,11 +25,8 @@ import           Blockchain.Util
 
 import           Control.Monad
 import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Class                   (lift)
 import           Control.Monad.Trans.Resource
 import qualified Data.Map                                    as Map
-import Data.Time.Clock
-import Data.Time.Clock.POSIX
 
 import           Blockchain.Strato.StateDiff
 
@@ -59,8 +56,8 @@ createAccount blockNumber codeSource codeContractName addressDiffs = do
         name' = codeContractName $ codeHash diff
     return $ addrRef address diff src name'
   addrIDs <- SQL.insertMany newAccounts
-  
-  newStorage <- 
+
+  newStorage <-
     forM (zip addressDiffs addrIDs) $ \(addressDiff, addrID) -> do
       let (_, diff) = addressDiff
       return [Storage addrID k v | (k, Value v) <- Map.toList $ storage diff]

--- a/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Event.hs
+++ b/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Event.hs
@@ -5,15 +5,12 @@ module Blockchain.Strato.StateDiff.Event
     ) where
 
 import           Data.Aeson
-import           Data.Aeson.Types                (typeMismatch)
 import           Data.Binary
 import           Data.Binary.Put                 (putLazyByteString)
-import qualified Data.HashMap.Strict             as H
 import           Data.Map                        (Map)
 import qualified Data.Map                        as Map
 import qualified Data.Text                       as T
 
-import           Blockchain.Format
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.StateDiff
 

--- a/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Kafka.hs
+++ b/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Kafka.hs
@@ -14,7 +14,6 @@ import           Control.Monad                     (liftM)
 import           Data.Aeson
 import qualified Data.ByteString.Lazy              as L
 import qualified Data.Map                          as Map
-import           Data.Maybe                        (catMaybes)
 import qualified Network.Kafka                     as K
 import qualified Network.Kafka.Producer            as KW
 import qualified Network.Kafka.Protocol            as KP
@@ -23,7 +22,6 @@ import           Blockchain.KafkaTopics            (lookupTopic)
 
 import           Blockchain.Strato.StateDiff
 import           Blockchain.Strato.StateDiff.Event
-import           Blockchain.Stream.Raw             (fetchBytes, setDefaultKafkaState)
 
 stateDiffTopicName :: KP.TopicName
 stateDiffTopicName = lookupTopic "statediff"

--- a/core-strato/strato-statediff/strato-statediff.cabal
+++ b/core-strato/strato-statediff/strato-statediff.cabal
@@ -49,4 +49,4 @@ library
                       , OverloadedStrings
                       , TypeFamilies
                       , ViewPatterns
-  ghc-options:        -Wall -Werror -fno-warn-warnings-deprecations -fno-warn-orphans -fno-warn-unused-imports
+  ghc-options:        -Wall -Werror -fno-warn-orphans -fno-warn-unused-imports

--- a/core-strato/test-suite/test/Blockchain/VM/TestEthereum.hs
+++ b/core-strato/test-suite/test/Blockchain/VM/TestEthereum.hs
@@ -14,7 +14,7 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.Trans
-import           Control.Monad.Trans.Either
+import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.State
 import           Data.Aeson
 import qualified Data.ByteString                             as B
@@ -206,7 +206,7 @@ runTest test = do
 
         (result, vmState1) <- lift $
           flip runStateT vmState0{vmGasRemaining=getNumber $ gas' exec, debugCallCreates=Just []} $
-          runEitherT $ do
+          runExceptT $ do
             runCodeFromStart
 
             vmState2 <- lift get
@@ -247,7 +247,7 @@ runTest test = do
         signedTransaction' <- liftIO $ withSource Haskoin.devURandom t
         let signedTransaction = txToOutputTx signedTransaction'
         result <-
-          runEitherT $ addTransaction True (blockBlockData $ block) (currentGasLimit $ env test) signedTransaction
+          runExceptT $ addTransaction True (blockBlockData $ block) (currentGasLimit $ env test) signedTransaction
 
         flushMemStorageDB
         flushMemAddressStateDB

--- a/core-strato/test-suite/test/Blockchain/VM/TestEthereum.hs
+++ b/core-strato/test-suite/test/Blockchain/VM/TestEthereum.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# OPTIONS -fno-warn-deprecations #-}
 
 module Blockchain.VM.TestEthereum
     ( runAllTests


### PR DESCRIPTION
Additionally, enable -Wall -Werror with a wildcard so that it hits all the packages that were missing, and fix the redundant import problems that it uncovered