### PR TITLE
Replace references to SHA3 with ones to Keccak_256

### DIFF
--- a/core-strato/blockapps-tools/exec_src/RLPTool.hs
+++ b/core-strato/blockapps-tools/exec_src/RLPTool.hs
@@ -1,5 +1,4 @@
 
-import qualified Crypto.Hash.SHA3 as SHA3
 import Data.Binary
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BC
@@ -10,6 +9,7 @@ import Blockchain.Data.Address
 import Blockchain.Data.RLP
 import Blockchain.Data.Transaction
 import Blockchain.Format
+import Blockchain.Strato.Model.SHA  (keccak256)
 
 getColumn::Int->[String]->String
 getColumn i inputColumns = inputColumns !! i
@@ -54,11 +54,11 @@ main = do
                                getColumn 1,
                                getColumn 2,
                                getColumn 3,
-                               format . SHA3.hash 256 . fst . B16.decode . BC.pack . getColumn 0
+                               format . keccak256 . fst . B16.decode . BC.pack . getColumn 0
                                ]) contents
 
 
-  
+
 --  putStrLn $ unlines $ map (getOutput [getColumn 0, unlines . map showIt . rlpMap getTransaction . getAtRLPArray 0 . decodeBase16 . getColumn 1]) contents
 --  putStrLn $ unlines $ map (getOutput [getColumn 0, decodeRLP . getAtRLPArray 0 . decodeBase16 . getColumn 1, show . rlpMap getTransaction . getAtRLPArray 0 . decodeBase16 . getColumn 1]) contents
 --  putStrLn $ unlines $ map (getOutput [getColumn 0, decodeRLP . decodeBase16 . getColumn 1]) contents

--- a/core-strato/blockapps-util/src/Blockchain/SHA.hs
+++ b/core-strato/blockapps-util/src/Blockchain/SHA.hs
@@ -8,7 +8,6 @@ module Blockchain.SHA (
   ) where
 
 import           Control.Monad
-import qualified Crypto.Hash.SHA3            as C
 import qualified Data.Aeson                  as JSON
 import           Data.Binary
 import qualified Data.ByteString             as B

--- a/core-strato/ethereum-discovery/ethereum-discovery.cabal
+++ b/core-strato/ethereum-discovery/ethereum-discovery.cabal
@@ -34,6 +34,7 @@ library
                      , resourcet
                      , split
                      , strato-conf
+                     , strato-model
                      , text
                      , time
                      , monad-control

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/P2PUtil.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/P2PUtil.hs
@@ -17,9 +17,8 @@ import           Data.Typeable             (Typeable)
 import           Data.Word                 (Word8)
 
 import           Blockchain.ExtendedECDSA  (ExtendedSignature, extSignMsg)
+import           Blockchain.Strato.Model.SHA (keccak256)
 
-
-import qualified Crypto.Hash.SHA3          as SHA3
 import           Crypto.Types.PubKey.ECC   (Point (..))
 import           Network.Haskoin.Crypto    (Word256)
 import qualified Network.Haskoin.Internals as H
@@ -40,7 +39,7 @@ add :: B.ByteString
     -> B.ByteString
     -> Either DiscoverException B.ByteString
 add acc val
-  | B.length acc == 32 && B.length val == 32 = Right $ SHA3.hash 256 $ val `B.append` acc
+  | B.length acc == 32 && B.length val == 32 = Right $ keccak256 $ val `B.append` acc
   | otherwise = Left $ ByteStringLengthException $ "Expected length 32 summands, got " ++
       show (B.length acc, B.length val)
 

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
@@ -27,7 +27,6 @@ import           Control.Exception
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
-import qualified Crypto.Hash.SHA3                      as SHA3
 import           Crypto.Types.PubKey.ECC
 import           Data.Binary
 import           Data.Bits
@@ -51,6 +50,7 @@ import           Blockchain.ExtWord
 import           Blockchain.Format
 import           Blockchain.SHA
 import           Blockchain.Strato.Discovery.P2PUtil   (DiscoverException (..), hPubKeyToPubKey)
+import           Blockchain.Strato.Model.SHA           (keccak256)
 import           Blockchain.Util
 
 import           Blockchain.Strato.Discovery.Data.Peer
@@ -219,7 +219,7 @@ sendPacket sock prv addr packet = do
       r' = H.sigR signature'
       s' = H.sigS signature'
       theSignature = word256ToBytes (fromIntegral r') ++ word256ToBytes (fromIntegral s') ++ [v']
-      theHash = B.unpack $ SHA3.hash 256 $ B.pack $ theSignature ++ [theType'] ++ theData
+      theHash = B.unpack $ keccak256 $ B.pack $ theSignature ++ [theType'] ++ theData
 
   _ <- liftIO $ NB.sendTo sock ( B.pack $ theHash ++ theSignature ++ [theType'] ++ theData) addr
   return ()
@@ -309,7 +309,7 @@ getServerPubKey myPriv domain port =
           s = H.sigS signature
           theSignature =
             word256ToBytes (fromIntegral r) ++ word256ToBytes (fromIntegral s) ++ [v]
-          theHash = B.unpack $ SHA3.hash 256 $ B.pack $ theSignature ++ [theType] ++ theData
+          theHash = B.unpack $ keccak256 $ B.pack $ theSignature ++ [theType] ++ theData
 
       _ <- NB.send socket' $ B.pack $ theHash ++ theSignature ++ [theType] ++ theData
 
@@ -342,7 +342,7 @@ findNeighbors myPriv domain port =
           s = H.sigS signature
           theSignature =
             word256ToBytes (fromIntegral r) ++ word256ToBytes (fromIntegral s) ++ [v]
-          theHash = B.unpack $ SHA3.hash 256 $ B.pack $ theSignature ++ [theType] ++ theData
+          theHash = B.unpack $ keccak256 $ B.pack $ theSignature ++ [theType] ++ theData
 
       _ <- NB.send socket' $ B.pack $ theHash ++ theSignature ++ [theType] ++ theData
 

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
@@ -66,7 +66,7 @@ connectMe port' = do
                                   (Just (defaultHints {addrFlags = [AI_PASSIVE]}))
                                   Nothing (Just (show port'))
   sock <- liftIO $ socket (addrFamily serveraddr) Datagram defaultProtocol
-  liftIO $ bindSocket sock (addrAddress serveraddr)
+  liftIO $ bind sock (addrAddress serveraddr)
 
   return sock
 

--- a/core-strato/ethereum-discovery/src/Executable/EthereumDiscovery.hs
+++ b/core-strato/ethereum-discovery/src/Executable/EthereumDiscovery.hs
@@ -38,7 +38,7 @@ ethereumDiscovery = do
 
     bracket
       (connectMe $ discoveryPort $ discoveryConfig ethConf)
-      (liftIO . S.sClose)
+      (liftIO . S.close)
       (runEthUDPServer cxt privateKey (discoveryPort $ discoveryConfig ethConf))
 
   return ()

--- a/core-strato/ethereum-encryption/ethereum-encryption.cabal
+++ b/core-strato/ethereum-encryption/ethereum-encryption.cabal
@@ -17,6 +17,7 @@ library
                      , cipher-aes
                      , conduit
                      , conduit-extra
+                     , cryptonite
                      , Crypto
                      , cryptohash
                      , crypto-pubkey
@@ -25,9 +26,11 @@ library
                      , entropy
                      , ethereum-rlp
                      , blockapps-haskoin
+                     , memory
                      , monad-logger
                      , lifted-base
                      , mtl
+                     , strato-model
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall -O2  -fno-warn-warnings-deprecations

--- a/core-strato/ethereum-encryption/src/Blockchain/AESCTR.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/AESCTR.hs
@@ -1,4 +1,4 @@
-
+{-# LANGUAGE PackageImports #-}
 module Blockchain.AESCTR (
   encrypt,
   decrypt,
@@ -6,9 +6,9 @@ module Blockchain.AESCTR (
   aesIV_
   ) where
 
-import           Crypto.Cipher.AES
-import           Data.Bits
-import qualified Data.ByteString   as B
+import "cipher-aes" Crypto.Cipher.AES
+import              Data.Bits
+import qualified    Data.ByteString   as B
 
 
 data AESCTRState = AESCTRState AES AESIV Int

--- a/core-strato/ethereum-encryption/src/Blockchain/ECIES.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/ECIES.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports    #-}
 
 module Blockchain.ECIES (
   decrypt,
@@ -6,22 +7,22 @@ module Blockchain.ECIES (
   theCurve
   ) where
 
-import           Codec.Utils
-import           Control.Monad
-import           Crypto.Cipher.AES
-import           Crypto.Hash.SHA256
-import           Crypto.PubKey.ECC.DH
-import           Crypto.Types.PubKey.ECC
-import           Data.Binary
-import           Data.Binary.Get
-import           Data.Binary.Put
-import           Data.Bits
-import qualified Data.ByteString         as B
-import qualified Data.ByteString.Lazy    as BL
-import           Data.HMAC
-import           System.Entropy
+import                 Codec.Utils
+import                 Control.Monad
+import "cipher-aes"    Crypto.Cipher.AES
+import                 Crypto.Hash.SHA256
+import "crypto-pubkey" Crypto.PubKey.ECC.DH
+import                 Crypto.Types.PubKey.ECC
+import                 Data.Binary
+import                 Data.Binary.Get
+import                 Data.Binary.Put
+import                 Data.Bits
+import qualified       Data.ByteString         as B
+import qualified       Data.ByteString.Lazy    as BL
+import                 Data.HMAC
+import                 System.Entropy
 
-import           Blockchain.ExtWord
+import                 Blockchain.ExtWord
 
 theCurve :: Curve
 theCurve = getCurveByName SEC_p256k1

--- a/core-strato/ethereum-encryption/src/Blockchain/Frame.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/Frame.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports    #-}
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TemplateHaskell   #-}
 module Blockchain.Frame
@@ -9,20 +10,22 @@ module Blockchain.Frame
   , cbSafeTake
   ) where
 
-import qualified Blockchain.AESCTR                 as AES
-import           Blockchain.Error
-import           Blockchain.EthEncryptionException
-import           Control.Exception.Lifted
-import           Control.Monad
-import           Control.Monad.Logger
-import           Crypto.Cipher.AES
-import qualified Crypto.Hash.SHA3                  as SHA3
-import           Data.Bits
-import qualified Data.ByteString                   as B
-import qualified Data.ByteString.Lazy              as BL
-import           Data.Conduit
-import qualified Data.Conduit.Binary               as CB
-import           Data.Maybe
+import qualified    Blockchain.AESCTR                 as AES
+import              Blockchain.Error
+import              Blockchain.EthEncryptionException
+import              Control.Exception.Lifted
+import              Control.Monad
+import              Control.Monad.Logger
+import "cipher-aes" Crypto.Cipher.AES
+import "cryptonite" Crypto.Hash                       (Context, hashUpdate, hashFinalize)
+import              Crypto.Hash.Algorithms            (Keccak_256)
+import              Data.Bits
+import              Data.ByteArray                    (convert)
+import qualified    Data.ByteString                   as B
+import qualified    Data.ByteString.Lazy              as BL
+import              Data.Conduit
+import qualified    Data.Conduit.Binary               as CB
+import              Data.Maybe
 
 bXor :: B.ByteString->B.ByteString->B.ByteString
 bXor x y | B.length x == B.length y = B.pack $ B.zipWith xor x y
@@ -31,27 +34,27 @@ bXor x y = error' $
            show (B.length x) ++ ", length string2 = " ++ show (B.length y)
 
 data EthCryptState = EthCryptState { aesState :: AES.AESCTRState
-                                   , mac      :: SHA3.Ctx
+                                   , mac      :: Context Keccak_256
                                    , key      :: B.ByteString
                                    }
 
 instance Show EthCryptState where
   show = show . key
 
-rawUpdateMac :: SHA3.Ctx
+rawUpdateMac :: Context Keccak_256
              -> B.ByteString
-             -> (SHA3.Ctx, B.ByteString)
+             -> (Context Keccak_256, B.ByteString)
 rawUpdateMac theMac value =
-  let mac' = SHA3.update theMac value
-  in (mac', B.take 16 $ SHA3.finalize mac')
+  let mac' = hashUpdate theMac value
+  in (mac', B.take 16 . convert . hashFinalize $ mac')
 
-updateMac :: SHA3.Ctx
+updateMac :: Context Keccak_256
           -> B.ByteString
           -> B.ByteString
-          -> (SHA3.Ctx, B.ByteString)
+          -> (Context Keccak_256, B.ByteString)
 updateMac theMac theKey value =
   rawUpdateMac theMac $
-    value `bXor` (encryptECB (initAES theKey) (B.take 16 $ SHA3.finalize theMac))
+    value `bXor` (encryptECB (initAES theKey) (B.take 16 . convert . hashFinalize $ theMac))
 
 ethEncrypt :: (MonadLogger m, Monad m)
            => EthCryptState

--- a/core-strato/ethereum-encryption/src/Blockchain/Handshake.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/Handshake.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports    #-}
 
 module Blockchain.Handshake (
   AckMessage(..),
@@ -6,22 +7,22 @@ module Blockchain.Handshake (
   bytesToAckMsg
   ) where
 
-import qualified Crypto.Hash.SHA3          as SHA3
-import           Crypto.PubKey.ECC.DH
-import           Crypto.Types.PubKey.ECC
-import           Data.Binary
-import           Data.Binary.Get
-import           Data.Binary.Put
-import           Data.Bits
-import qualified Data.ByteString           as B
-import qualified Data.ByteString.Lazy      as BL
-import           Data.Maybe
-import qualified Network.Haskoin.Internals as H
+import "crypto-pubkey" Crypto.PubKey.ECC.DH
+import                 Crypto.Types.PubKey.ECC
+import                 Data.Binary
+import                 Data.Binary.Get
+import                 Data.Binary.Put
+import                 Data.Bits
+import qualified       Data.ByteString             as B
+import qualified       Data.ByteString.Lazy        as BL
+import                 Data.Maybe
+import qualified       Network.Haskoin.Internals   as H
 
-import           Blockchain.Data.PubKey
-import qualified Blockchain.ECIES          as ECIES
-import           Blockchain.ExtendedECDSA
-import           Blockchain.ExtWord
+import                 Blockchain.Data.PubKey
+import qualified       Blockchain.ECIES            as ECIES
+import                 Blockchain.ExtendedECDSA
+import                 Blockchain.ExtWord
+import                 Blockchain.Strato.Model.SHA (keccak256)
 
 sigToBytes::ExtendedSignature->[Word8]
 sigToBytes (ExtendedSignature signature yIsOdd) =
@@ -93,7 +94,7 @@ getHandshakeBytes myPriv otherPubKey myNonce = do
     ephemeral =
       fromMaybe (error "malformed signature given to call getHandshakeBytes") $
       getPubKeyFromSignature sig msg
-    hepubk = SHA3.hash 256 $ B.pack $ pubKeyToBytes ephemeral
+    hepubk = keccak256 $ B.pack $ pubKeyToBytes ephemeral
     pubk = B.pack $ pointToBytes myPublic
     theData = B.pack (sigToBytes sig) `B.append`
                 hepubk `B.append`

--- a/core-strato/ethereum-encryption/src/Blockchain/RLPx.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/RLPx.hs
@@ -1,37 +1,40 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
 
 module Blockchain.RLPx (
   ethCryptConnect,
   ethCryptAccept
   ) where
 
-import           Control.Exception
-import           Control.Monad
-import           Control.Monad.IO.Class
-import           Crypto.Cipher.AES
-import qualified Crypto.Hash.SHA3                  as SHA3
-import           Crypto.PubKey.ECC.DH
-import           Crypto.Random
-import           Crypto.Types.PubKey.ECC
-import           Data.Binary
-import           Data.Bits
-import qualified Data.ByteString                   as B
-import qualified Data.ByteString.Lazy              as BL
-import           Data.Conduit
-import qualified Data.Conduit.Binary               as CB
-import           Data.Maybe
-import qualified Network.Haskoin.Internals         as H
+import                 Control.Exception
+import                 Control.Monad
+import                 Control.Monad.IO.Class
+import "cipher-aes"    Crypto.Cipher.AES
+import "cryptonite"    Crypto.Hash                       (hashInitWith, hashUpdate)
+import                 Crypto.Hash.Algorithms            (Keccak_256(..))
+import "crypto-pubkey" Crypto.PubKey.ECC.DH
+import "crypto-random" Crypto.Random
+import                 Crypto.Types.PubKey.ECC
+import                 Data.Binary
+import                 Data.Bits
+import qualified       Data.ByteString                   as B
+import qualified       Data.ByteString.Lazy              as BL
+import                 Data.Conduit
+import qualified       Data.Conduit.Binary               as CB
+import                 Data.Maybe
+import qualified       Network.Haskoin.Internals         as H
 
-import qualified Blockchain.AESCTR                 as AES
-import           Blockchain.Data.PubKey
-import           Blockchain.Data.RLP
-import qualified Blockchain.ECIES                  as ECIES
-import           Blockchain.Error
-import           Blockchain.EthEncryptionException
-import           Blockchain.ExtendedECDSA
-import           Blockchain.ExtWord
-import           Blockchain.Frame
-import           Blockchain.Handshake
+import qualified       Blockchain.AESCTR                 as AES
+import                 Blockchain.Data.PubKey
+import                 Blockchain.Data.RLP
+import qualified       Blockchain.ECIES                  as ECIES
+import                 Blockchain.Error
+import                 Blockchain.EthEncryptionException
+import                 Blockchain.ExtendedECDSA
+import                 Blockchain.ExtWord
+import                 Blockchain.Frame
+import                 Blockchain.Handshake
+import                 Blockchain.Strato.Model.SHA        (keccak256)
 
 intToBytes :: Integer -> [Word8]
 intToBytes x = map (fromIntegral . (x `shiftR`)) [256-8, 256-16..0]
@@ -71,12 +74,12 @@ ethCryptConnect myPriv otherPubKey = do
   return (
           EthCryptState { --encrypt
                           aesState = AES.AESCTRState (initAES frameDecKey) (aesIV_ $ B.replicate 16 0) 0,
-                          mac=SHA3.update (SHA3.init 256) $ (macEncKey `bXor` otherNonce) `B.append` egressCipher,
+                          mac=hashUpdate (hashInitWith Keccak_256) $ (macEncKey `bXor` otherNonce) `B.append` egressCipher,
                           key=macEncKey
           },
           EthCryptState { --decrypt
                           aesState = AES.AESCTRState (initAES frameDecKey) (aesIV_ $ B.replicate 16 0) 0,
-                          mac=SHA3.update (SHA3.init 256) $ (macEncKey `bXor` myNonce) `B.append` ingressCipher,
+                          mac=hashUpdate (hashInitWith Keccak_256) $ (macEncKey `bXor` myNonce) `B.append` ingressCipher,
                           key=macEncKey
           }
          )
@@ -84,7 +87,7 @@ ethCryptConnect myPriv otherPubKey = do
 add :: B.ByteString
     -> B.ByteString
     -> B.ByteString
-add acc val | B.length acc ==32 && B.length val == 32 = SHA3.hash 256 $ val `B.append` acc
+add acc val | B.length acc ==32 && B.length val == 32 = keccak256 $ val `B.append` acc
 add _ _     = error "add called with ByteString of length not 32"
 
 hPubKeyToPubKey :: H.PubKey -> Point
@@ -174,12 +177,12 @@ ethCryptAcceptEIP8 myPriv _ hsBytes eciesMsgIBytes = do
   return (
       EthCryptState { --encrypt
          aesState = AES.AESCTRState (initAES frameDecKey) (aesIV_ $ B.replicate 16 0) 0,
-         mac=SHA3.update (SHA3.init 256) $ (macEncKey `bXor` otherNonce) `B.append` eciesMsgOBytes,
+         mac=hashUpdate (hashInitWith Keccak_256) $ (macEncKey `bXor` otherNonce) `B.append` eciesMsgOBytes,
          key=macEncKey
          },
       EthCryptState { --decrypt
         aesState = AES.AESCTRState (initAES frameDecKey) (aesIV_ $ B.replicate 16 0) 0,
-        mac=SHA3.update (SHA3.init 256) $ (macEncKey `bXor` myNonceBS) `B.append` (BL.toStrict hsBytes),
+        mac=hashUpdate (hashInitWith Keccak_256) $ (macEncKey `bXor` myNonceBS) `B.append` (BL.toStrict hsBytes),
         key=macEncKey
         }
       )
@@ -229,12 +232,12 @@ ethCryptAcceptOld myPriv otherPoint hsBytes eciesMsgIBytes = do
     return $ Just (
       EthCryptState { --encrypt
          aesState = AES.AESCTRState (initAES frameDecKey) (aesIV_ $ B.replicate 16 0) 0,
-         mac=SHA3.update (SHA3.init 256) $ (macEncKey `bXor` otherNonce) `B.append` eciesMsgOBytes,
+         mac=hashUpdate (hashInitWith Keccak_256) $ (macEncKey `bXor` otherNonce) `B.append` eciesMsgOBytes,
          key=macEncKey
          },
       EthCryptState { --decrypt
         aesState = AES.AESCTRState (initAES frameDecKey) (aesIV_ $ B.replicate 16 0) 0,
-        mac=SHA3.update (SHA3.init 256) $ (macEncKey `bXor` myNonceBS) `B.append` (BL.toStrict hsBytes),
+        mac=hashUpdate (hashInitWith Keccak_256) $ (macEncKey `bXor` myNonceBS) `B.append` (BL.toStrict hsBytes),
         key=macEncKey
         }
       )

--- a/core-strato/ethereum-jsonrpc/ethereum-jsonrpc.cabal
+++ b/core-strato/ethereum-jsonrpc/ethereum-jsonrpc.cabal
@@ -29,6 +29,7 @@ executable ethereum-jsonrpc
                      , mtl
                      , random
                      , strato-conf
+                     , strato-model
                      , strato-sequencer
                      , text
                      , unordered-containers

--- a/core-strato/ethereum-jsonrpc/src/Commands.hs
+++ b/core-strato/ethereum-jsonrpc/src/Commands.hs
@@ -6,7 +6,6 @@ module Commands (
 
 import           Control.Monad.Except
 import           Control.Monad.IO.Class
-import qualified Crypto.Hash.SHA3            as SHA3
 import qualified Data.Aeson                  as JSON
 import           Data.Binary
 import qualified Data.ByteString             as B
@@ -37,6 +36,7 @@ import           Blockchain.KafkaTopics
 import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Kafka
 import           Blockchain.SHA
+import           Blockchain.Strato.Model.SHA (keccak256)
 import           Blockchain.Stream.Raw
 
 import qualified APIProxy                    as API
@@ -140,7 +140,7 @@ web3_sha3 = toMethod "web3_sha3" f (Required "value" :+: ())
           case strToByteString val of
            Left err -> throwError $ rpcError (-32602) $ T.pack err
            Right bytes ->
-             return $ "0x" ++ BC.unpack (B16.encode $ SHA3.hash 256 bytes)
+             return $ "0x" ++ BC.unpack (B16.encode $ keccak256 bytes)
 
 net_peerCount::Method Server
 net_peerCount = toMethod "net_peerCount" f ()

--- a/core-strato/ethereum-vm/src/Blockchain/EthashMining.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/EthashMining.hs
@@ -6,7 +6,6 @@ module Blockchain.Mining (
 
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.State
-import qualified Crypto.Hash.SHA3          as SHA3
 import qualified Data.Array.IO             as A
 import qualified Data.Binary               as Bin
 import qualified Data.ByteString           as B
@@ -17,15 +16,11 @@ import           Data.Word
 import           Blockchain.Data.BlockDB
 import           Blockchain.Data.RLP
 import           Blockchain.ExtWord
---import Blockchain.SHA
+import           Blockchain.Strato.Model.SHA (keccak256)
 import           Blockchain.Util
 
---import Cache
 import           Constants
---import Dataset
 import           Hashimoto
-
---import Debug.Trace
 
 
 word32Unpack::B.ByteString->[Word32]
@@ -86,5 +81,5 @@ noncelessBlockData2RLP bd =
       ]
 
 headerHashWithoutNonce::Block->B.ByteString
-headerHashWithoutNonce b = SHA3.hash 256 $ rlpSerialize $ noncelessBlockData2RLP $ blockBlockData b
+headerHashWithoutNonce b = keccak256 $ rlpSerialize $ noncelessBlockData2RLP $ blockBlockData b
 

--- a/core-strato/merkle-patricia-db/merkle-patricia-db.cabal
+++ b/core-strato/merkle-patricia-db/merkle-patricia-db.cabal
@@ -77,6 +77,7 @@ Test-Suite test-merkle-patricia-db
                   , HUnit
                   , containers
                   , blockapps-util
+                  , strato-model
                   , aeson
                   , mtl
                   , hspec

--- a/core-strato/merkle-patricia-db/merkle-patricia-db.cabal
+++ b/core-strato/merkle-patricia-db/merkle-patricia-db.cabal
@@ -39,6 +39,7 @@ library
                  , ansi-wl-pprint
                  , containers
                  , mtl
+                 , strato-model
     exposed-modules: Blockchain.Database.MerklePatricia
                    , Blockchain.Database.MerklePatriciaMem
                    , Blockchain.Database.KeyVal

--- a/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia.hs
+++ b/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia.hs
@@ -26,13 +26,13 @@ module Blockchain.Database.MerklePatricia (
   ) where
 
 import           Control.Monad.Trans.Resource
-import qualified Crypto.Hash.SHA3                            as SHA3
 import           Data.Default
 import           Data.Maybe                                  (isJust)
 import qualified Database.LevelDB                            as DB
 
 import           Blockchain.Data.RLP
 import           Blockchain.Database.MerklePatricia.Internal
+import           Blockchain.Strato.Model.SHA                 (keccak256)
 
 
 -- | Adds a new key/value pair.
@@ -72,7 +72,7 @@ keyExists db key = isJust <$> getKeyVal db key
 
 -- | Returns the StateRoot of the blank database
 blankStateRoot :: StateRoot
-blankStateRoot = StateRoot $ SHA3.hash 256 (rlpSerialize $ rlpEncode (0 :: Integer))
+blankStateRoot = StateRoot $ keccak256 (rlpSerialize $ rlpEncode (0 :: Integer))
 
 -- | Initialize the DB by adding a blank stateroot.
 initializeBlank::MonadResource m=>MPDB -- ^ The object containing the current stateRoot.
@@ -80,5 +80,5 @@ initializeBlank::MonadResource m=>MPDB -- ^ The object containing the current st
 initializeBlank db =
     let bytes = rlpSerialize $ rlpEncode (0::Integer)
     in
-      DB.put (ldb db) def (SHA3.hash 256 bytes) bytes
+      DB.put (ldb db) def (keccak256 bytes) bytes
 

--- a/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/Internal.hs
+++ b/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/Internal.hs
@@ -23,7 +23,6 @@ module Blockchain.Database.MerklePatricia.Internal (
   ) where
 
 import           Control.Monad.Trans.Resource
-import qualified Crypto.Hash.SHA3                             as SHA3
 import qualified Data.ByteString                              as B
 import           Data.Default
 import           Data.Function
@@ -37,6 +36,7 @@ import           Blockchain.Database.MerklePatricia.MPDB
 import           Blockchain.Database.MerklePatricia.NodeData
 import           Blockchain.Database.MerklePatricia.StateRoot
 import           Blockchain.Format
+import           Blockchain.Strato.Model.SHA                  (keccak256)
 
 unsafePutKeyVal::MonadResource m=>MPDB->Key->Val->m MPDB
 unsafePutKeyVal db key val = do
@@ -62,7 +62,7 @@ unsafeDeleteKey db key = do
 
 keyToSafeKey::N.NibbleString->N.NibbleString
 keyToSafeKey key =
-  N.EvenNibbleString $ SHA3.hash 256 keyByteString
+  N.EvenNibbleString $ keccak256 keyByteString
   where
     N.EvenNibbleString keyByteString = key
 
@@ -222,7 +222,7 @@ getNodeData db (PtrRef ptr@(StateRoot p)) = do
 putNodeData::MonadResource m=>MPDB->NodeData->m StateRoot
 putNodeData db nd = do
   let bytes = rlpSerialize $ rlpEncode nd
-      ptr = SHA3.hash 256 bytes
+      ptr = keccak256 bytes
   DB.put (ldb db) def ptr bytes
   return $ StateRoot ptr
 

--- a/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/InternalMem.hs
+++ b/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/InternalMem.hs
@@ -12,7 +12,6 @@ module Blockchain.Database.MerklePatricia.InternalMem (
   keyToSafeKeyMem
   ) where
 
-import qualified Crypto.Hash.SHA3                             as SHA3
 import qualified Data.ByteString                              as B
 import           Data.Function
 import           Data.List
@@ -24,6 +23,7 @@ import           Blockchain.Data.RLP
 import           Blockchain.Database.MerklePatricia.NodeData
 import           Blockchain.Database.MerklePatricia.StateRoot
 import           Blockchain.Format
+import           Blockchain.Strato.Model.SHA                  (keccak256)
 
 type MPMap = Map.Map B.ByteString B.ByteString
 
@@ -55,7 +55,7 @@ unsafeDeleteKeyMem db key = do
 
 keyToSafeKeyMem::N.NibbleString->N.NibbleString
 keyToSafeKeyMem key =
-  N.EvenNibbleString $ SHA3.hash 256 keyByteString
+  N.EvenNibbleString $ keccak256 keyByteString
   where
     N.EvenNibbleString keyByteString = key
 
@@ -222,7 +222,7 @@ getNodeDataMem db (PtrRef ptr@(StateRoot p)) = do
 putNodeDataMem::Monad m=>MPMem->NodeData->m MPMem
 putNodeDataMem db nd = do
   let bytes = rlpSerialize $ rlpEncode nd
-      ptr = SHA3.hash 256 bytes
+      ptr = keccak256 bytes
       map' = Map.insert ptr bytes (mpMap db)
   return $ MPMem { mpMap = map', mpStateRoot = StateRoot ptr }
 

--- a/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/StateRoot.hs
+++ b/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/StateRoot.hs
@@ -10,7 +10,6 @@ module Blockchain.Database.MerklePatricia.StateRoot (
   ) where
 
 import           Control.Monad
-import qualified Crypto.Hash.SHA3       as C
 import           Data.Aeson
 import           Data.Binary
 import qualified Data.ByteString        as B
@@ -53,7 +52,7 @@ instance RLPSerializable StateRoot where
 
 -- | The stateRoot of the empty database.
 emptyTriePtr::StateRoot
-emptyTriePtr = StateRoot $ C.hash 256 $ rlpSerialize $ rlpEncode (0::Integer)
+emptyTriePtr = StateRoot $ keccak256 $ rlpSerialize $ rlpEncode (0::Integer)
 
 sha2StateRoot::SHA->StateRoot
 sha2StateRoot (SHA x) = StateRoot $ B.pack $ word256ToBytes x

--- a/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/StateRoot.hs
+++ b/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/StateRoot.hs
@@ -26,7 +26,7 @@ import           Blockchain.SHA
 
 import           GHC.Generics
 
--- | Internal nodes are indexed in the underlying database by their 256-bit SHA3 hash.
+-- | Internal nodes are indexed in the underlying database by their keccak256-bit hash.
 -- This types represents said hash.
 --
 -- The stateRoot is of this type,

--- a/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatriciaMem.hs
+++ b/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatriciaMem.hs
@@ -5,13 +5,13 @@ module Blockchain.Database.MerklePatriciaMem (
   MPMem(..)
   ) where
 
-import qualified Crypto.Hash.SHA3                               as SHA3
 import qualified Data.Map                                       as Map
 import           Data.Maybe                                     (isJust)
 
 import           Blockchain.Data.RLP
 import           Blockchain.Database.MerklePatricia.InternalMem
 import           Blockchain.Database.MerklePatricia.StateRoot
+import           Blockchain.Strato.Model.SHA                    (keccak256)
 
 putKeyValMem::Monad m=>MPMem
            ->Key
@@ -49,7 +49,7 @@ initializeBlankMem =
         bytes = rlpSerialize theRLP
     in
       MPMem {
-        mpMap = Map.insert (SHA3.hash 256 bytes) bytes Map.empty,
+        mpMap = Map.insert (keccak256 bytes) bytes Map.empty,
         mpStateRoot = StateRoot bytes
       }
 

--- a/core-strato/miner-ethash/miner-ethash.cabal
+++ b/core-strato/miner-ethash/miner-ethash.cabal
@@ -20,6 +20,7 @@ library
                        binary,
                        bytestring,
                        cryptohash,
+                       strato-model,
                        time
   ghc-options:         -Wall -O2
   hs-source-dirs:      src

--- a/core-strato/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Cache.hs
+++ b/core-strato/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Cache.hs
@@ -22,7 +22,7 @@ type Cache = A.UArray (Word32, Word32) Word32
 mkCache :: Integer -> B.ByteString -> IO Cache
 mkCache cSize seed = do
   let n = cSize `div` hashBytes
-      v = initDataSet n $ SHA3.hash 512 seed
+      v = initDataSet n $ keccak512 seed
   mv <- MA.unsafeThawIOUArray v
   mix mv
   return v
@@ -31,7 +31,7 @@ mkCache cSize seed = do
 for _ in range(CACHE_ROUNDS):
         for i in range(n):
             v = o[i][0] % n
-            o[i] = sha3_512(map(xor, o[(i-1+n) % n], o[v]))
+            o[i] = keccak512(map(xor, o[(i-1+n) % n], o[v]))
 
 -}
 
@@ -60,10 +60,10 @@ mix mx = do
       m2 <- fmap repair $ sequence $ map (MA.readArray mx . ((i-1+n) `mod` n,)) [0..15]
       sequence $
         map (\(k, val) -> MA.writeArray mx (i,k) val) $
-        zip [0..15] $ shatter $ SHA3.hash 512 $ xorBS m1 m2
+        zip [0..15] $ shatter $ keccak512 $ xorBS m1 m2
 
 initDataSet::Integer->B.ByteString->Cache
 initDataSet n | n > toInteger (maxBound::Word32) =
   error "initDataSet called for value too large, you can no longer use Word32 for cache index"
-initDataSet n = A.listArray ((0,0), (fromIntegral n-1,15)) . concat . map shatter . iterate (SHA3.hash 512)
+initDataSet n = A.listArray ((0,0), (fromIntegral n-1,15)) . concat . map shatter . iterate keccak512
 

--- a/core-strato/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Cache.hs
+++ b/core-strato/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Cache.hs
@@ -7,7 +7,6 @@ module Blockchain.Strato.Mining.Ethash.Cache (
   ) where
 
 import           Control.Monad
-import qualified Crypto.Hash.SHA3                          as SHA3
 import qualified Data.Array.IO                             as MA
 import qualified Data.Array.IO.Internals                   as MA
 import qualified Data.Array.Unboxed                        as A
@@ -16,6 +15,7 @@ import           Data.Word
 
 import           Blockchain.Strato.Mining.Ethash.Constants
 import           Blockchain.Strato.Mining.Ethash.Util
+import           Blockchain.Strato.Model.SHA               (keccak512)
 
 type Cache = A.UArray (Word32, Word32) Word32
 

--- a/core-strato/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Dataset.hs
+++ b/core-strato/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Dataset.hs
@@ -8,7 +8,6 @@ module Blockchain.Strato.Mining.Ethash.Dataset (
   ) where
 
 import           Control.Monad
-import qualified Crypto.Hash.SHA3                          as SHA3
 import qualified Data.Array.Base                           as A
 import qualified Data.Array.IO                             as A
 import           Data.Bits
@@ -17,6 +16,7 @@ import           Data.Word
 import           Blockchain.Strato.Mining.Ethash.Cache
 import           Blockchain.Strato.Mining.Ethash.Constants
 import           Blockchain.Strato.Mining.Ethash.Util
+import           Blockchain.Strato.Model.SHA               (keccak512)
 
 
 type Slice = A.IOUArray Word32 Word32
@@ -37,14 +37,14 @@ calcDatasetItem cache i = do
   A.writeArray mix 0 =<< (fmap (xor i) $ A.readArray mix 0)
 
   mixBytes' <- sequence $ map (A.readArray mix) [0..15]
-  let theHash = shatter $ SHA3.hash 512 $ repair mixBytes'
+  let theHash = shatter $ keccak512 $ repair mixBytes'
   sequence_ $ map (uncurry $ A.writeArray mix) $ zip [0..] theHash
 
   forM_ [0..fromIntegral $ datasetParents-1] $ \j ->
     cacheFunc cache i j mix
 
   mixBytes'' <- sequence $ map (A.readArray mix) [0..15]
-  let theHash' = shatter $ SHA3.hash 512 $ repair mixBytes''
+  let theHash' = shatter $ keccak512 $ repair mixBytes''
   sequence_ $ map (uncurry $ A.writeArray mix) $ zip [0..] theHash'
 
   return mix

--- a/core-strato/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Hashimoto.hs
+++ b/core-strato/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Hashimoto.hs
@@ -3,7 +3,6 @@
 module Blockchain.Strato.Mining.Ethash.Hashimoto where
 
 import           Control.Monad
-import qualified Crypto.Hash.SHA3                          as SHA3
 import qualified Data.Array.IO                             as MA
 import           Data.Binary.Get
 import           Data.Binary.Put
@@ -15,6 +14,7 @@ import           Data.Word
 import           Blockchain.Strato.Mining.Ethash.Constants
 import           Blockchain.Strato.Mining.Ethash.Dataset
 import           Blockchain.Strato.Mining.Ethash.Util
+import           Blockchain.Strato.Model.SHA               (keccak256, keccak512)
 
 --import Debug.Trace
 
@@ -54,7 +54,7 @@ wordPack = B.concat . fmap (BL.toStrict . runPut . putWord32le)
 hashimoto::B.ByteString->B.ByteString->Int->(Word32->IO Slice)->IO (B.ByteString, B.ByteString)
 hashimoto header nonce fullSize' dataset = do
   let mixhashes = mixBytes `div` hashBytes
-      s = SHA3.hash 512 $ header `B.append` B.reverse nonce
+      s = keccak512 $ header `B.append` B.reverse nonce
 
   mix <- MA.newArray (0,31) 0
 
@@ -73,7 +73,7 @@ hashimoto header nonce fullSize' dataset = do
         return $ v1 `fnv` v2 `fnv`  v3 `fnv` v4
 
   cmix <- fmap repair $ sequence $ map f2 [0,4..31]
-  return (cmix, SHA3.hash 256 (s `B.append` cmix))
+  return (cmix, keccak256 (s `B.append` cmix))
 
 
 f::(Word32->IO Slice, Int, Integer, B.ByteString)->Word32->MA.IOUArray Word32 Word32->IO ()

--- a/core-strato/stack.yaml
+++ b/core-strato/stack.yaml
@@ -59,9 +59,9 @@ extra-lib-dirs:
 - /usr/local/lib
 
 ghc-options:
-  ethereum-discovery:      -Wall -Werror -fno-warn-warnings-deprecations
+  ethereum-discovery:      -Wall -Werror
   ethereum-encryption:     -Wall -Werror -fno-warn-warnings-deprecations
-  merkle-patricia-db:      -Wall -Werror -fno-warn-warnings-deprecations
+  merkle-patricia-db:      -Wall -Werror
   strato-init:             -Wall -Werror -fno-warn-warnings-deprecations
   strato-p2p:              -Wall -Werror -fno-warn-warnings-deprecations
   strato-redis-blockdb:    -Wall -Werror -fno-warn-warnings-deprecations
@@ -74,7 +74,7 @@ ghc-options:
   strato-adit:             -Wall -Werror -fno-warn-warnings-deprecations
   strato-conf:             -Wall -Werror -fno-warn-warnings-deprecations -fno-warn-inline-rule-shadowing
   blockapps-data:          -Wall -Werror
-  ethereum-vm:             -Wall -Werror -fno-warn-warnings-deprecations
+  ethereum-vm:             -Wall -Werror
 
 docker:
   enable: true

--- a/core-strato/stack.yaml
+++ b/core-strato/stack.yaml
@@ -62,19 +62,19 @@ ghc-options:
   ethereum-discovery:      -Wall -Werror
   ethereum-encryption:     -Wall -Werror -fno-warn-warnings-deprecations
   merkle-patricia-db:      -Wall -Werror
-  strato-init:             -Wall -Werror -fno-warn-warnings-deprecations
-  strato-p2p:              -Wall -Werror -fno-warn-warnings-deprecations
-  strato-redis-blockdb:    -Wall -Werror -fno-warn-warnings-deprecations
-  blockapps-tools:         -Wall -Werror -fno-warn-warnings-deprecations
+  strato-init:             -Wall -Werror
+  strato-p2p:              -Wall -Werror
+  strato-redis-blockdb:    -Wall -Werror
+  blockapps-tools:         -Wall -Werror
   strato-index:            -Wall -Werror
   strato-api:              -fno-warn-orphans
   blockapps-tools:         -Wall -Werror
-  strato-index:            -Wall -Werror -fno-warn-warnings-deprecations
-  strato-sequencer:        -Wall -Werror -fno-warn-warnings-deprecations
-  strato-adit:             -Wall -Werror -fno-warn-warnings-deprecations
-  strato-conf:             -Wall -Werror -fno-warn-warnings-deprecations -fno-warn-inline-rule-shadowing
+  strato-index:            -Wall -Werror
+  strato-sequencer:        -Wall -Werror
+  strato-adit:             -Wall -Werror
+  strato-conf:             -Wall -Werror -fno-warn-inline-rule-shadowing
   blockapps-data:          -Wall -Werror
-  ethereum-vm:             -Wall -Werror
+  ethereum-vm:             -Wall -Werror -fno-warn-warnings-deprecations
 
 docker:
   enable: true

--- a/core-strato/stack.yaml
+++ b/core-strato/stack.yaml
@@ -60,7 +60,7 @@ extra-lib-dirs:
 
 ghc-options:
   ethereum-discovery:      -Wall -Werror
-  ethereum-encryption:     -Wall -Werror -fno-warn-warnings-deprecations
+  ethereum-encryption:     -Wall -Werror
   merkle-patricia-db:      -Wall -Werror
   strato-init:             -Wall -Werror
   strato-p2p:              -Wall -Werror

--- a/core-strato/strato-init/src/Blockchain/BackupMP.hs
+++ b/core-strato/strato-init/src/Blockchain/BackupMP.hs
@@ -6,14 +6,11 @@ module Blockchain.BackupMP (
 
 import           Control.Monad
 import           Control.Monad.IO.Class
-import qualified Crypto.Hash.SHA3                   as SHA3
 import qualified Data.ByteString                    as B
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Lazy               as BL
 import qualified Data.ByteString.Lazy.Char8         as BLC
 import qualified Database.LevelDB                   as LDB
---import Network.Kafka
---import Network.Kafka.Producer
 import           Numeric
 
 import           Blockchain.Data.BlockDB
@@ -22,11 +19,10 @@ import           Blockchain.DB.CodeDB
 import           Blockchain.DB.HashDB
 import           Blockchain.DB.SQLDB
 import           Blockchain.DB.StateDB
---import Blockchain.EthConf
---import Blockchain.KafkaTopics
 import           Blockchain.Data.RLP
 import qualified Blockchain.Database.MerklePatricia as MPDB
 import           Blockchain.SHA
+import           Blockchain.Strato.Model.SHA        (keccak256)
 import           Blockchain.Stream.VMEvent
 
 addBlock::(HasSQLDB m)=>BL.ByteString->m ()
@@ -38,19 +34,19 @@ addBlock blockData = do
 addStateDB::LDB.MonadResource m=>LDB.DB->BL.ByteString->m ()
 addStateDB db stateDBData = do
   let val = decodeWithCheck $ BL.toStrict stateDBData
-  LDB.put db LDB.defaultWriteOptions (SHA3.hash 256 val) val
+  LDB.put db LDB.defaultWriteOptions (keccak256 val) val
   return ()
 
 addCode'::LDB.MonadResource m=>LDB.DB->BL.ByteString->m ()
 addCode' db codeData = do
   let val = decodeWithCheck $ BL.toStrict codeData
-  LDB.put db LDB.defaultWriteOptions (SHA3.hash 256 val) val
+  LDB.put db LDB.defaultWriteOptions (keccak256 val) val
   return ()
 
 addHash'::LDB.MonadResource m=>LDB.DB->BL.ByteString->m ()
 addHash' db hashData = do
   let val = decodeWithCheck $ BL.toStrict hashData
-  LDB.put db LDB.defaultWriteOptions (SHA3.hash 256 val) val
+  LDB.put db LDB.defaultWriteOptions (keccak256 val) val
   return ()
 
 

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -10,8 +10,6 @@ module Blockchain.Strato.Model.Address
     ) where
 
 import           Control.Monad
-import qualified Crypto.Hash.SHA3                     as C
--- import           Data.Binary
 import           Data.Maybe                           (fromMaybe)
 import           Numeric
 
@@ -19,6 +17,7 @@ import           Blockchain.Data.RLP
 import qualified Blockchain.Strato.Model.Colors       as CL
 import           Blockchain.Strato.Model.Format
 import           Blockchain.Strato.Model.ExtendedWord (Word160, word160ToBytes)
+import           Blockchain.Strato.Model.SHA          (keccak256)
 import           Blockchain.Strato.Model.Util
 
 import qualified Data.Aeson                           as AS
@@ -49,7 +48,7 @@ newtype Address = Address Word160 deriving (Show, Eq, Read, Enum, Real, Bounded,
 
 prvKey2Address :: PrvKey -> Address
 prvKey2Address prvKey =
-  Address $ fromInteger $ byteString2Integer $ C.hash 256 $ BL.toStrict $ encode x `BL.append` encode y
+  Address $ fromInteger $ byteString2Integer $ keccak256 $ BL.toStrict $ encode x `BL.append` encode y
   --B16.encode $ hash 256 $ BL.toStrict $ encode x `BL.append` encode y
   where
     point = pubKeyPoint $ derivePubKey prvKey
@@ -58,7 +57,7 @@ prvKey2Address prvKey =
 
 pubKey2Address :: PubKey -> Address
 pubKey2Address pubKey =
-  Address $ fromInteger $ byteString2Integer $ C.hash 256 $ BL.toStrict $ encode x `BL.append` encode y
+  Address $ fromInteger $ byteString2Integer $ keccak256 $ BL.toStrict $ encode x `BL.append` encode y
   --B16.encode $ hash 256 $ BL.toStrict $ encode x `BL.append` encode y
   where
     x = fromMaybe (error "getX failed in prvKey2Address") $ getX point

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/SHA.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/SHA.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# OPTIONS -fno-warn-warnings-deprecations #-}
 module Blockchain.Strato.Model.SHA where
 
 import           Blockchain.Strato.Model.ExtendedWord (Word256, word256ToBytes)
 import           Blockchain.Strato.Model.Util
 import           Control.Monad                        (replicateM)
-import qualified Crypto.Hash.SHA3                     as SuperProprietaryWrongFuckingHash
+import           Crypto.Hash                          (Digest, hash)
+import           Crypto.Hash.Algorithms               (Keccak_256)
 import qualified Data.Aeson                           as Ae
 import qualified Data.Aeson.Encoding                  as Enc
 import           Data.Binary
+import           Data.ByteArray                       (convert)
 import qualified Data.ByteString                      as B
 import qualified Data.ByteString.Base16               as B16
 import qualified Data.ByteString.Char8                as S8
@@ -49,4 +50,7 @@ shaFromHex :: String -> SHA
 shaFromHex = SHA . fst . head . readHex
 
 superProprietaryStratoSHAHash :: S8.ByteString -> SHA
-superProprietaryStratoSHAHash = SHA . fromIntegral . byteString2Integer . SuperProprietaryWrongFuckingHash.hash 256
+superProprietaryStratoSHAHash = SHA . fromIntegral . byteString2Integer . keccak256
+
+keccak256 :: S8.ByteString -> S8.ByteString
+keccak256 bs = convert (hash bs :: Digest Keccak_256)

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/SHA.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/SHA.hs
@@ -5,7 +5,7 @@ import           Blockchain.Strato.Model.ExtendedWord (Word256, word256ToBytes)
 import           Blockchain.Strato.Model.Util
 import           Control.Monad                        (replicateM)
 import           Crypto.Hash                          (Digest, hash)
-import           Crypto.Hash.Algorithms               (Keccak_256)
+import           Crypto.Hash.Algorithms               (Keccak_256, Keccak_512)
 import qualified Data.Aeson                           as Ae
 import qualified Data.Aeson.Encoding                  as Enc
 import           Data.Binary
@@ -54,3 +54,6 @@ superProprietaryStratoSHAHash = SHA . fromIntegral . byteString2Integer . keccak
 
 keccak256 :: S8.ByteString -> S8.ByteString
 keccak256 bs = convert (hash bs :: Digest Keccak_256)
+
+keccak512 :: S8.ByteString -> S8.ByteString
+keccak512 bs = convert (hash bs :: Digest Keccak_512)

--- a/core-strato/strato-model/strato-model.cabal
+++ b/core-strato/strato-model/strato-model.cabal
@@ -25,9 +25,10 @@ library
                       , ethereum-rlp
                       , binary
                       , bytestring
+                      , cryptonite
                       , path-pieces
+                      , memory
                       , nibblestring
-                      , cryptohash
                       , blockapps-haskoin
                       , text
                       , time
@@ -44,7 +45,7 @@ library
                       , LambdaCase
                       , RecordWildCards
                       , FunctionalDependencies
-  ghc-options:        -Wall -Werror -fno-warn-warnings-deprecations
+  ghc-options:        -Wall -Werror
 
 test-suite strato-model-test
     type: exitcode-stdio-1.0

--- a/core-strato/strato-p2p/src/Blockchain/Mining.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Mining.hs
@@ -6,7 +6,6 @@ module Blockchain.Mining (
 
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.State
-import qualified Crypto.Hash.SHA3          as SHA3
 import qualified Data.Array.IO             as A
 import qualified Data.Binary               as Bin
 import qualified Data.ByteString           as B
@@ -18,15 +17,11 @@ import           Blockchain.Context
 import           Blockchain.Data.BlockDB
 import           Blockchain.Data.RLP
 import           Blockchain.ExtWord
---import Blockchain.SHA
+import           Blockchain.Strato.Model.SHA (keccak256)
 import           Blockchain.Util
 
---import Cache
 import           Constants
---import Dataset
 import           Hashimoto
-
---import Debug.Trace
 
 
 word32Unpack::B.ByteString->[Word32]
@@ -87,5 +82,5 @@ noncelessBlockData2RLP bd =
       ]
 
 headerHashWithoutNonce::Block->B.ByteString
-headerHashWithoutNonce b = SHA3.hash 256 $ rlpSerialize $ noncelessBlockData2RLP $ blockBlockData b
+headerHashWithoutNonce b = keccak256 $ rlpSerialize $ noncelessBlockData2RLP $ blockBlockData b
 

--- a/core-strato/strato-p2p/src/Blockchain/P2PUtil.hs
+++ b/core-strato/strato-p2p/src/Blockchain/P2PUtil.hs
@@ -50,7 +50,7 @@ sockAddrToIP :: S.SockAddr -> String
 sockAddrToIP (S.SockAddrInet6 _ _ host _) = show host
 sockAddrToIP s@S.SockAddrInet{}           = takeWhile (/=':') (show s)
 sockAddrToIP (S.SockAddrUnix str)         = str
-sockAddrToIP (S.SockAddrCan addr)         = show addr -- the guy who wanted to run us on RasPi can now do it with CANBus
+sockAddrToIP _ = error "unsupported socket type"
 
 looksLikeHostname :: String -> Bool
 looksLikeHostname = stringToIAddr >>> \case

--- a/core-strato/test-suite/test-suite.cabal
+++ b/core-strato/test-suite/test-suite.cabal
@@ -32,6 +32,7 @@ executable test-suite-exe
                  , monad-logger
                  , mtl
                  , nibblestring
+                 , strato-model
                  , strato-sequencer
                  , text
                  , time

--- a/core-strato/test-suite/test/Blockchain/VM/TestEthereum.hs
+++ b/core-strato/test-suite/test/Blockchain/VM/TestEthereum.hs
@@ -16,7 +16,6 @@ import           Control.Monad.Logger
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Either
 import           Control.Monad.Trans.State
-import qualified Crypto.Hash.SHA3                            as SHA3
 import           Data.Aeson
 import qualified Data.ByteString                             as B
 import qualified Data.ByteString.Lazy                        as BL
@@ -50,6 +49,7 @@ import           Blockchain.DB.StorageDB
 import           Blockchain.ExtWord
 import           Blockchain.Format
 import           Blockchain.Sequencer.Event
+import           Blockchain.Strato.Model.SHA                 (keccak256)
 import           Blockchain.SHA
 import           Blockchain.Util
 import           Blockchain.VM
@@ -260,7 +260,7 @@ runTest test = do
 
   afterAddressStates <- addressStates
 
-  let hashInteger = byteString2Integer . nibbleString2ByteString . N.EvenNibbleString . (SHA3.hash 256) . nibbleString2ByteString . N.pack . (N.byte2Nibbles =<<) . word256ToBytes . fromIntegral
+  let hashInteger = byteString2Integer . nibbleString2ByteString . N.EvenNibbleString . keccak256 . nibbleString2ByteString . N.pack . (N.byte2Nibbles =<<) . word256ToBytes . fromIntegral
   let postTest = M.toList $
                  flip M.map (post test) $
                  \s' -> s'{storage' = M.mapKeys hashInteger (storage' s')}


### PR DESCRIPTION
This removes almost all of the need for deprecation suppressions. Where necessary, use the functions supplied in cryptonite's Crypto.Hash. However, a drop-in replacement for `sha3 256 :: ByteString -> ByteString` is written in `keccak256` to minimize disruption at most callsites that just want simple hashing behavior.