### PR TITLE
Generate a cabal file matching the previous name

### DIFF
--- a/blockapps-haskell/bloc/exe/.gitignore
+++ b/blockapps-haskell/bloc/exe/.gitignore
@@ -1,1 +1,2 @@
 blockapps-bloc.cabal
+blocExec.cabal

--- a/blockapps-haskell/bloc/exe/package.yaml
+++ b/blockapps-haskell/bloc/exe/package.yaml
@@ -1,4 +1,4 @@
-name:                blockapps-bloc
+name:                blocExec
 version:             0.1.0.0
 category:            Web
 build-type:          Simple
@@ -26,6 +26,7 @@ dependencies:
   - wai-extra
   - warp
 
-executable:
-  source-dirs: app/
-  main: Main.hs
+executables:
+  blockapps-bloc:
+    source-dirs: app/
+    main: Main.hs

--- a/core-strato/ecrecover/src/BlockApps/ECRecover/Pointers.hs
+++ b/core-strato/ecrecover/src/BlockApps/ECRecover/Pointers.hs
@@ -6,8 +6,6 @@ where
 
 import           BlockApps.ECRecover.Prelude
 import qualified Data.ByteString.Internal       as D
-import qualified Data.ByteString.Short          as B
-import qualified Data.ByteString.Short.Internal as A
 import qualified Data.ByteString.Unsafe         as C
 
 
@@ -33,11 +31,11 @@ pokeInteger :: Ptr Word8 -> Int -> Integer -> IO ()
 pokeInteger ptr size integer =
   recur (pred size) (plusPtr ptr (pred size)) integer
   where
-    recur i ptr state =
+    recur i ptr' state =
       if i >= 0
         then do
-          poke ptr chunk
-          recur (pred i) (plusPtr ptr (-1)) nextState
+          poke ptr' chunk
+          recur (pred i) (plusPtr ptr' (-1)) nextState
         else return ()
       where
         chunk =

--- a/core-strato/ecrecover/src/BlockApps/ECRecover/Prelude.hs
+++ b/core-strato/ecrecover/src/BlockApps/ECRecover/Prelude.hs
@@ -8,10 +8,7 @@ where
 import           BasePrelude           as Exports
 
 import           Foreign.C             as Exports
-import           Foreign.ForeignPtr    as Exports
 import           Foreign.Marshal.Alloc as Exports
-import           Foreign.Ptr           as Exports
-import           Foreign.Storable      as Exports
 
 import           Data.ByteString       as Exports (ByteString)
 import           Data.ByteString.Short as Exports (ShortByteString)

--- a/core-strato/ecrecover/tests/Main.hs
+++ b/core-strato/ecrecover/tests/Main.hs
@@ -7,10 +7,9 @@ import qualified Control.Parallel.Strategies       as C
 import qualified Main.Samples                      as B
 import           Test.Tasty
 import           Test.Tasty.HUnit
-import           Test.Tasty.QuickCheck
-import           Test.Tasty.Runners
 
 
+main :: IO ()
 main =
   defaultMain (testGroup "" [bytes, integer])
   where

--- a/core-strato/ecrecover/tests/Main/Samples.hs
+++ b/core-strato/ecrecover/tests/Main/Samples.hs
@@ -1,6 +1,6 @@
 module Main.Samples where
 
-import           Data.ByteString hiding (List)
+import           Data.ByteString
 import           Data.Int
 
 type List = []

--- a/core-strato/ethereum-rlp/test/Main.hs
+++ b/core-strato/ethereum-rlp/test/Main.hs
@@ -2,10 +2,6 @@
 
 module Main where
 
-import Data.Functor
-import Data.List
-import Data.Monoid
-import System.Exit
 import Test.Framework
 import Test.Framework.Providers.HUnit
 import Test.HUnit
@@ -18,8 +14,8 @@ testNumber = do
   assertEqual "rlp encoding failed for small number" (rlpDecode $ rlpDeserialize $ rlpSerialize $ rlpEncode n) n
 
 main::IO ()
-main = 
-  defaultMainWithOpts 
+main =
+  defaultMainWithOpts
   [
    testCase "test RLP number encoding" testNumber
   ] mempty

--- a/core-strato/statsdi/src/Control/Monad/Stats/MTL.hs
+++ b/core-strato/statsdi/src/Control/Monad/Stats/MTL.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TemplateHaskell       #-}
 module Control.Monad.Stats.MTL
     ( MonadStats
-    , StatsT(..)
+    , StatsT
     , runStatsT
     , runNoStatsT
     , tick

--- a/core-strato/statsdi/src/Control/Monad/Stats/Monad.hs
+++ b/core-strato/statsdi/src/Control/Monad/Stats/Monad.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE RecordWildCards       #-}
 module Control.Monad.Stats.Monad
     ( MonadStats
-    , StatsT(..)
+    , StatsT
     , runStatsT
     , runNoStatsT
     , borrowTMVar
@@ -32,10 +32,8 @@ import           Data.ByteString           (ByteString)
 import           Data.ByteString           as ByteString
 import qualified Data.ByteString.Char8     as Char8
 import           Data.Dequeue
-import           Data.HashMap.Strict       (HashMap)
 import qualified Data.HashMap.Strict       as HashMap
 import           Data.IORef
-import           Data.Time                 (NominalDiffTime)
 import           Data.Time.Clock.POSIX     (POSIXTime, getPOSIXTime)
 import qualified Network.Socket            as Socket hiding (recv, recvFrom,
                                                       send, sendTo)
@@ -51,17 +49,14 @@ borrowTMVar tmvar m = do
     liftIO . atomically $ putTMVar tmvar var
     return v
 
-withSocket :: (MonadStats tag m) => proxy tag -> (Socket.Socket -> m ()) -> m ()
-withSocket tag m = withEnvironment tag $ \e -> borrowTMVar (envSocket e) m
-
 withEnvironment :: (MonadStats tag m) => proxy tag -> (StatsTEnvironment -> m ()) -> m ()
 withEnvironment tag f = ask tag >>= \case
     NoStatsTEnvironment -> return ()
     env -> f env
 
 withSTS :: (MonadStats tag m) => proxy tag -> (StatsTState -> StatsTState) -> m ()
-withSTS tag f = withEnvironment tag $ \(StatsTEnvironment (_, _, state)) ->
-    liftIO $ atomicModifyIORef' state (\x -> (f x, ()))
+withSTS tag f = withEnvironment tag $ \(StatsTEnvironment (_, _, state')) ->
+    liftIO $ atomicModifyIORef' state' (\x -> (f x, ()))
 
 tick :: (MonadStats tag m) => proxy tag -> Counter -> m ()
 tick tag = tickBy tag 1
@@ -98,7 +93,7 @@ histoSample tag v Histogram{..} = withEnvironment tag $ \env -> do
     where rendered = renderSimpleMetric histogramName v "|h" histogramTags (Just _histogramSampleRate)
 
 renderTimestamp :: POSIXTime -> ByteString
-renderTimestamp time = ByteString.concat ["|d:", Char8.pack . show $ posixToMillis time]
+renderTimestamp time' = ByteString.concat ["|d:", Char8.pack . show $ posixToMillis time']
 
 renderKeyedField :: ByteString -> Maybe ByteString -> ByteString
 renderKeyedField x = maybe "" (\y -> ByteString.concat [x,y])
@@ -112,7 +107,6 @@ renderSimpleMetric name value kind tags sampleRate env =
                       , allTags
                       ]
     where sampleRateBit = maybe "" (ByteString.append "|@" . Char8.pack . show) sampleRate
-          fullName = ByteString.concat [prefix cfg, name, suffix cfg]
           cfg      = envConfig env
           allTags  = renderAllTags [defaultTags cfg, tags]
 
@@ -176,16 +170,17 @@ mkStatsDSocket cfg = do
           opts' = Nothing
 
 forkStatsThread :: (MonadIO m) => StatsTEnvironment -> m ThreadId
-forkStatsThread env@(StatsTEnvironment (cfg, socket, state)) = do
+forkStatsThread NoStatsTEnvironment = error "cannot fork without statst env"
+forkStatsThread env@(StatsTEnvironment (cfg, socket, _)) = do
     me <- liftIO myThreadId
     liftIO . forkFinally loop $ \e -> do
         borrowTMVar socket $ \s -> do
             isConnected <- Socket.isConnected s
             when isConnected $ Socket.close s
         case e of
-            Left e -> case (fromException e :: Maybe AsyncException) of
+            Left e' -> case (fromException e' :: Maybe AsyncException) of
                 Just ThreadKilled -> return ()
-                _                 -> throwTo me e
+                _                 -> throwTo me e'
             Right () -> return ()
     where loop = forever $ do
               let interval = flushInterval cfg
@@ -195,7 +190,8 @@ forkStatsThread env@(StatsTEnvironment (cfg, socket, state)) = do
               threadDelay (interval * 1000 - fromIntegral (end - start))
 
 reportSamples :: MonadIO m => StatsTEnvironment -> m ()
-reportSamples env@(StatsTEnvironment (cfg, socket, state)) = do
+reportSamples NoStatsTEnvironment = return ()
+reportSamples env@(StatsTEnvironment (_, socket, state')) = do
     (samples, queuedEvents) <- getAndWipeStates
     borrowTMVar socket $ \sock -> do
         forM_ samples (reportSample sock)
@@ -207,13 +203,12 @@ reportSamples env@(StatsTEnvironment (cfg, socket, state)) = do
                                then ByteString.concat [msg' 0, "\n", msg' value]
                                else msg' value
                     msg' v     = renderSimpleMetric (keyName key) v (keyKind key) (keyTags key) sampleRate env
-                    value'     = Char8.pack (show value)
                     sampleRate = if isHistogram key
                                  then Just $ histogramSampleRate key
                                  else Nothing
 
           getAndWipeStates :: (MonadIO m) => m ([(MetricStoreKey, MetricStore)], BankersDequeue ByteString)
-          getAndWipeStates = liftIO . atomicModifyIORef' state $ \(StatsTState m q) ->
+          getAndWipeStates = liftIO . atomicModifyIORef' state' $ \(StatsTState m q) ->
                 (StatsTState HashMap.empty Data.Dequeue.empty, (HashMap.toList m, q))
 
 

--- a/core-strato/statsdi/src/Control/Monad/Stats/TH.hs
+++ b/core-strato/statsdi/src/Control/Monad/Stats/TH.hs
@@ -11,7 +11,6 @@ module Control.Monad.Stats.TH
 import           Control.Monad
 import qualified Data.ByteString.Char8        as Char8
 import           Data.Char
-import           Data.List
 import           Text.ParserCombinators.ReadP
 
 import qualified Language.Haskell.TH          as TH
@@ -82,9 +81,6 @@ satisfiesParser p = predicate . readP_to_S p
 
 isValidMetricName :: String -> Bool
 isValidMetricName = not . null . readP_to_S validateMetricName
-
-isValidTag :: (String, String) -> Bool
-isValidTag (name, val) = isValidTagName name
 
 isValidTagName :: String -> Bool
 isValidTagName name = isValidTagNameForm name && name /= "device"

--- a/core-strato/statsdi/src/Control/Monad/Stats/Types.hs
+++ b/core-strato/statsdi/src/Control/Monad/Stats/Types.hs
@@ -6,11 +6,9 @@
 module Control.Monad.Stats.Types where
 
 import           Control.Concurrent.STM (TMVar)
-import           Control.Monad.Ether
 import           Control.Monad.IO.Class
 import           Data.ByteString        (ByteString)
 import qualified Data.ByteString        as ByteString
-import qualified Data.ByteString.Char8  as Char8
 import           Data.Dequeue
 import           Data.Hashable
 import           Data.HashMap.Strict    (HashMap)
@@ -66,11 +64,11 @@ keyTags (HistogramKey m) = histogramTags m
 keyTags (SetKey m)       = setTags m
 
 keyKind :: MetricStoreKey -> ByteString
-keyKind (CounterKey m)   = "|c"
-keyKind (GaugeKey m)     = "|g"
-keyKind (TimerKey m)     = "|ms"
-keyKind (HistogramKey m) = "|h"
-keyKind (SetKey m)       = "|s"
+keyKind (CounterKey _)   = "|c"
+keyKind (GaugeKey _)     = "|g"
+keyKind (TimerKey _)     = "|ms"
+keyKind (HistogramKey _) = "|h"
+keyKind (SetKey _)       = "|s"
 
 data Counter = Counter { counterName :: !ByteString, counterTags :: !Tags }
     deriving (Eq, Ord, Read, Show, Generic, Typeable)

--- a/core-strato/statsdi/test/Harness.hs
+++ b/core-strato/statsdi/test/Harness.hs
@@ -5,12 +5,9 @@ module Harness
 
 import           Control.Concurrent
 import           Control.Concurrent.STM
-import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Stats
 import           Data.ByteString           (ByteString)
-import qualified Data.ByteString           as ByteString
-import           Data.Time.Clock.POSIX
 import           Network.Socket            hiding (recv)
 import           Network.Socket.ByteString (recv)
 
@@ -22,9 +19,9 @@ harnessLock = unsafePerformIO $ newTMVarIO 0
 
 tQueueToList :: TQueue a -> IO [a]
 tQueueToList = fmap reverse . loop []
-    where loop read q = atomically (tryReadTQueue q) >>= \case
-                Nothing -> return read
-                Just x  -> loop (x:read) q
+    where loop read' q = atomically (tryReadTQueue q) >>= \case
+                Nothing -> return read'
+                Just x  -> loop (x:read') q
 
 listenForUDP :: (MonadIO m) => StatsTConfig -> TMVar [ByteString] -> m ThreadId
 listenForUDP cfg var = liftIO . withSocketsDo $ do
@@ -58,12 +55,12 @@ forkAndListen cfg = do
 runStatsTCapturingOutput :: (MonadIO m) => StatsTConfig -> Int -> StatsT m a ->  m ([ByteString], a)
 runStatsTCapturingOutput c lingerTime m = do
     (tid, var)  <- liftIO $ do
-        atomically $ takeTMVar harnessLock
+        _ <- atomically $ takeTMVar harnessLock
         forkAndListen c
     ret <- runStatsT m c
     liftIO $ do
         threadDelay $ lingerTime * 1000
         killThread tid
         val <- atomically (takeTMVar var)
-        atomically (putTMVar harnessLock 0)
+        _ <- atomically (putTMVar harnessLock 0)
         return (val, ret)

--- a/core-strato/statsdi/test/Spec.hs
+++ b/core-strato/statsdi/test/Spec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# OPTIONS -fno-warn-unused-top-binds #-}
 
 import           Control.Concurrent
 import           Control.Monad
@@ -11,7 +12,6 @@ import           Data.ByteString         (ByteString)
 import qualified Data.ByteString         as ByteString
 import qualified Data.ByteString.Char8   as Char8
 import           Data.Char               (isNumber)
-import           Data.Proxy
 import           Data.Time.Clock.POSIX
 
 import           Harness
@@ -19,10 +19,6 @@ import           Harness
 import           Test.Hspec
 import           Test.Tasty
 import           Test.Tasty.Hspec
-import           Test.Tasty.Options      (OptionDescription (..))
-import           Test.Tasty.Runners      (NumThreads (..))
-
-import Debug.Trace (traceShowId)
 
 -- these tests effectively test the TH for sanity
 -- otherwise the test suite wouldnt even compile
@@ -124,7 +120,8 @@ timerTests = describe "A Timer" $ do
         capture `shouldSatisfy` (not . null)
         capture `shouldSatisfy` (isRoughlyMillis 250 10 . head)
 
-        where isRoughlyMillis target leeway bs = abs (actual - target) <= leeway
+        where isRoughlyMillis :: Int -> Int -> Char8.ByteString -> Bool
+              isRoughlyMillis target leeway bs = abs (actual - target) <= leeway
                     where actual = read pluckedTime
                           pluckedTime = takeWhile isNumber nameStripped
                           nameStripped = drop (ByteString.length (timerName time_test) + 1) (Char8.unpack bs)


### PR DESCRIPTION
Otherwise, cd10 complains that it sees multiple cabal files when switching branches to pre-hpack.

Also, I was mislead by earlier passing CI runs for enabling -Werror globally. Since there were packages that were not being rebuilt, those had the potential for still throwing warnings. With a clean slate, I dug around for more potential warnings and `develop` should be clean after this PR.