### PR TITLE
Sanitize peer string before formatting, to avoid

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Data/TXOrigin.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/TXOrigin.hs
@@ -43,5 +43,5 @@ instance Binary TXOrigin where
 
 instance Format TXOrigin where
     format (BlockHash sha) = "BlockHash " ++ shaToHex sha
-    format (PeerString p ) = "Peer " ++ p
+    format (PeerString p ) = "Peer " ++ show p
     format               x = show x


### PR DESCRIPTION
printing control characters.