### PR TITLE
Remove transactionRootVerification from VM

### DIFF
--- a/core-strato/ethereum-vm/src/Blockchain/VMOptions.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VMOptions.hs
@@ -31,6 +31,6 @@ defineFlag "sqlDiff" True "runs sqlDiff and updates account state and storage in
 defineFlag "diffPublish" False "publishes all state changes to kafka"
 defineFlag "queryBlocks" (10000::Int) "Number of blocks to query from SQL to process in one batch"
 defineFlag "miningVerification" True "Flag to turn mining verification or/off"
-defineFlag "transactionRootVerification" True "Flag to turn transaction root verification or/off"
+defineFlag "transactionRootVerification" False "Flag to turn transaction root verification or/off"
 defineFlag "startingBlock" (-1::Integer) "block in kafka to start running the VM on"
 defineEQFlag "miner" [| Instant :: MinerType |] "MINER" "What mining algorithm"


### PR DESCRIPTION
This flag makes the VM check the transactions root of a block, which is bad in the case of private chains, since the transactions root will change when all the private transaction data is filled in. However, we check the transactions root of deflated (no private transactions, just private hashes) blocks as they come in from the network, so we're not missing out on any verification. With this change, the `createChain.test.js` test passes for multinode