### PR TITLE
Sever other connections before dropping the db

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -8,7 +8,7 @@ MONITORING_TIMER=5;
 
 function newnode {
   initialize=false
-  
+
   mkdir -p logs/rotation
 
   if [[ ! -d .ethereumH ]]
@@ -92,7 +92,12 @@ function newnode {
 }
 
 function cleanupDB {
-  db_conn_params="-U $pgUser -h $pgHost"
+  db_conn_params="-U ${pgUser} -h ${pgHost}"
+  PGPASSWORD=$pgPass psql ${db_conn_params} -c "
+    SELECT pg_terminate_backend(pg_stat_activity.pid)
+    FROM pg_stat_activity
+    WHERE pg_stat_activity.datname like '%eth_%';"
+
   PGPASSWORD=$pgPass psql ${db_conn_params} -c "copy (select datname from pg_database where datname like '%eth_%') to stdout" | while read line; do
     echo "dropping the old db: $line"
     PGPASSWORD=$pgPass dropdb ${db_conn_params} "$line"


### PR DESCRIPTION
Before:
```
+ cleanupDB
+ db_conn_params='-U postgres -h postgres'
+ read line
+ PGPASSWORD=api
+ psql -U postgres -h postgres -c 'copy (select datname from pg_database where datname like '\''%eth_%'\'') to stdout'
+ echo 'dropping the old db: eth_17df200692290f7c354c6e7bac0db1b084e7885d'
dropping the old db: eth_17df200692290f7c354c6e7bac0db1b084e7885d
+ PGPASSWORD=api
+ dropdb -U postgres -h postgres eth_17df200692290f7c354c6e7bac0db1b084e7885d
dropdb: database removal failed: ERROR:  database "eth_17df200692290f7c354c6e7bac0db1b084e7885d" is being accessed by other users
DETAIL:  There is 1 other session using the database.
```

After: 
```
+ cleanupDB
+ db_conn_params='-U postgres -h postgres'
+ PGPASSWORD=api
+ psql -U postgres -h postgres -c '
    SELECT pg_terminate_backend(pg_stat_activity.pid)
    FROM pg_stat_activity
    WHERE pg_stat_activity.datname like '\''%eth_%'\'';'
 pg_terminate_backend 
----------------------
 t
 t
(2 rows)

+ read line
+ PGPASSWORD=api
+ psql -U postgres -h postgres -c 'copy (select datname from pg_database where datname like '\''%eth_%'\'') to stdout'
dropping the old db: eth_038c4059b6122137f25ee50b8bd2952e3f25d34d
+ echo 'dropping the old db: eth_038c4059b6122137f25ee50b8bd2952e3f25d34d'
+ PGPASSWORD=api
+ dropdb -U postgres -h postgres eth_038c4059b6122137f25ee50b8bd2952e3f25d34d
+ read line
+ doInit
```