### PR TITLE
Private chain named tuples

### DIFF
--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/TypeLits.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/TypeLits.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE KindSignatures        #-}
@@ -19,9 +20,11 @@ import           Data.Aeson
 import           Data.Aeson.Types    (Parser)
 import           Data.Proxy
 import qualified Data.Text           as Text
+import           GHC.Generics
 import           GHC.TypeLits
 
 data NamedTuple (k :: Symbol) a (v :: Symbol) b = NamedTuple (a,b)
+  deriving (Eq, Ord, Show, Generic)
 
 type NamedTupleParser k a v b = Parser (NamedTuple k a v b)
 

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/TypeLits.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/TypeLits.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+module BlockApps.Strato.TypeLits
+  ( NamedTuple(..)
+  , NamedTupleParser
+  , NamedMap
+  , NamedMapParser
+  , IsTuple(..)
+  , module GHC.TypeLits
+  ) where
+
+import           Control.Applicative (liftA2)
+import           Data.Aeson
+import           Data.Aeson.Types    (Parser)
+import           Data.Proxy
+import qualified Data.Text           as Text
+import           GHC.TypeLits
+
+data NamedTuple (k :: Symbol) a (v :: Symbol) b = NamedTuple (a,b)
+
+type NamedTupleParser k a v b = Parser (NamedTuple k a v b)
+
+type NamedMap k a v b = [NamedTuple k a v b]
+
+type NamedMapParser k a v b = Parser (NamedMap k a v b)
+
+class IsTuple t a b where
+  fromTuple :: (a,b) -> t
+  toTuple :: t -> (a,b)
+
+instance IsTuple (NamedTuple k a v b) a b where
+  fromTuple = NamedTuple
+  toTuple (NamedTuple t) = t
+
+instance forall k a v b. (KnownSymbol k, KnownSymbol v, ToJSON a, ToJSON b) => ToJSON (NamedTuple k a v b) where
+  toJSON (NamedTuple (a,b)) =
+    object [ (Text.pack $ symbolVal (Proxy :: Proxy k)) .= toJSON a
+           , (Text.pack $ symbolVal (Proxy :: Proxy v)) .= toJSON b
+           ]
+
+instance forall k a v b. (KnownSymbol k, KnownSymbol v, FromJSON a, FromJSON b) => FromJSON (NamedTuple k a v b) where
+  parseJSON (Object o) = NamedTuple
+                     <$> liftA2 (,)
+                         (o .: (Text.pack $ symbolVal (Proxy :: Proxy k)))
+                         (o .: (Text.pack $ symbolVal (Proxy :: Proxy v)))
+  parseJSON o          = error $ "parseJSON NamedTuple: expected object, got " ++ show o

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
 
+{-# OPTIONS_GHC -fno-warn-missing-methods #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module BlockApps.Strato.Types
@@ -40,13 +41,12 @@ module BlockApps.Strato.Types
   , CodeInfo (..)
   , AccountInfo (..)
   , ChainInfo (..)
-  , AccountBalance (..)
   , ChainIdChainInfo
   ) where
 
 import           Control.Applicative
 import           Control.Lens                 (mapped, (&), (.~), (?~))
-import           Data.Aeson                   
+import           Data.Aeson
 import           Data.Aeson.Casing
 import           Data.Aeson.Casing.Internal   (dropFPrefix)
 import qualified Data.Aeson.TH                as AT
@@ -82,6 +82,7 @@ import           BlockApps.Ethereum           (Address (..), ChainId (..),
                                                addressString, keccak256,
                                                keccak256lazy, stringAddress,
                                                stringChainId)
+import           BlockApps.Strato.TypeLits
 
 instance (Arbitrary a, Arbitrary b) => Arbitrary (LargeKey a b) where
   arbitrary = LargeKey <$> arbitrary <*> arbitrary
@@ -596,15 +597,29 @@ instance ToSchema AccountInfo where
     & mapped.schema.description ?~ "AccountInfo"
     & mapped.schema.example     ?~ "/account?address=00000000000000000000000000000000deadbeef"
 
+type AccountBalance = NamedTuple "address" Address "balance" Integer
+instance KnownSymbol "address" where
+instance KnownSymbol "balance" where
+
+instance ToSchema AccountBalance where
+  declareNamedSchema proxy = genericDeclareNamedSchema stratoSchemaOptions proxy
+    & mapped.schema.description ?~ "Account balances"
+    & mapped.schema.example ?~ toJSON ex
+    where
+      ex = exampleAccountBalances
+
+exampleAccountBalances :: [AccountBalance]
+exampleAccountBalances = map fromTuple [ (Address 0x5815b9975001135697b5739956b9a6c87f1c575c, (20000000 :: Integer))
+                                       , (Address 0x93fdd1d21502c4f87295771253f5b71d897d911c, (999999 :: Integer))]
 
 data ChainInfo = ChainInfo
   {  chainLabel      :: Text
   ,  addRule         :: Text
   ,  removeRule      :: Text
   ,  members         :: [Text]
-  ,  ciAccountBalance  :: [AccountBalance] 
-  } 
-  deriving (Eq, Read, Show, Generic)
+  ,  ciAccountBalance :: [AccountBalance]
+  }
+  deriving (Eq, Show, Generic)
 
 exampleChainInfo :: ChainInfo
 exampleChainInfo = ChainInfo
@@ -613,7 +628,7 @@ exampleChainInfo = ChainInfo
   ,  addRule = "majorityRules"
   ,  removeRule = "majorityRules"
   ,  members = ["enode://6d8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@171.16.0.4:30303", "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@172.16.0.5:30303?discport=30303"]
-  ,  ciAccountBalance = [AccountBalance "5815b9975001135697b5739956b9a6c87f1c575c" 20000000, AccountBalance "93fdd1d21502c4f87295771253f5b71d897d911c" 999999]
+  ,  ciAccountBalance = exampleAccountBalances
   }
 
 instance ToSchema ChainInfo where
@@ -632,39 +647,14 @@ instance FromJSON ChainInfo where
   parseJSON x = error $ "couldn't parse JSON for chain info: " ++ show x
 
 instance ToJSON ChainInfo where
-  toJSON x = 
+  toJSON x =
     object [
        "chainLabel" .= chainLabel x
     ,  "addRule" .= addRule x
     ,  "removeRule" .= removeRule x
-    ,  "members" .= members x 
-    ,  "accountBalance" .= ciAccountBalance x  
+    ,  "members" .= members x
+    ,  "accountBalance" .= ciAccountBalance x
     ]
-
-data AccountBalance = AccountBalance {
-  address :: Text,
-  balance :: Integer
-} deriving (Eq, Read, Show, Generic)
-
-instance ToJSON AccountBalance where
-  toEncoding x = 
-    pairs (
-      "address" .= address x <>
-      "balance" .= balance x
-    )
-
-instance FromJSON AccountBalance where
-  parseJSON (Object o) =
-    AccountBalance <$>
-    o .: "address" <*>
-    o .: "balance"
-  parseJSON x = error $ "couldn't parse JSON for Account Balance: " ++ show x
-
-instance ToSchema AccountBalance
-
-instance ToHttpApiData AccountBalance where
-  toUrlPiece = Text.pack . show
-
 
 data ChainIdChainInfo = ChainIdChainInfo (ChainId, ChainInfo) deriving (Eq, Show, Generic)
 

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
@@ -80,8 +80,7 @@ import           Text.Read.Lex
 import           BlockApps.Ethereum           (Address (..), ChainId (..),
                                                Keccak256 (..), Nonce (..),
                                                addressString, keccak256,
-                                               keccak256lazy, stringAddress,
-                                               stringChainId)
+                                               keccak256lazy, stringAddress)
 import           BlockApps.Strato.TypeLits
 
 instance (Arbitrary a, Arbitrary b) => Arbitrary (LargeKey a b) where
@@ -656,17 +655,14 @@ instance ToJSON ChainInfo where
     ,  "accountBalance" .= ciAccountBalance x
     ]
 
-data ChainIdChainInfo = ChainIdChainInfo (ChainId, ChainInfo) deriving (Eq, Show, Generic)
+type ChainIdChainInfo = NamedTuple "id" ChainId "info" ChainInfo
+instance KnownSymbol "id" where
+instance KnownSymbol "info" where
 
 instance ToSchema ChainIdChainInfo where
   declareNamedSchema proxy = genericDeclareNamedSchema stratoSchemaOptions proxy
-    & mapped.schema.description ?~ "(ChainId, ChainInfo)"
+    & mapped.schema.description ?~ "ChainId and ChainInfo pair"
     & mapped.schema.example ?~ toJSON ex
     where
       ex :: ChainIdChainInfo
-      ex = ChainIdChainInfo (fromJust $ stringChainId "ec41a0a4da1f33ee9a757f4fd27c2a1a57313353375860388c66edc562ddc781"
-        , exampleChainInfo)
-
-instance FromJSON ChainIdChainInfo
-
-instance ToJSON ChainIdChainInfo
+      ex = fromTuple (ChainId 0xec41a0a4da1f33ee9a757f4fd27c2a1a57313353375860388c66edc562ddc781, exampleChainInfo)

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
@@ -638,21 +638,21 @@ instance ToSchema ChainInfo where
 instance FromJSON ChainInfo where
   parseJSON (Object o) =
     ChainInfo <$>
-    o .: "chainLabel" <*>
+    o .: "label" <*>
     o .: "addRule" <*>
     o .: "removeRule" <*>
     o .: "members" <*>
-    o .: "accountBalance"
+    o .: "balances"
   parseJSON x = error $ "couldn't parse JSON for chain info: " ++ show x
 
 instance ToJSON ChainInfo where
   toJSON x =
     object [
-       "chainLabel" .= chainLabel x
+       "label" .= chainLabel x
     ,  "addRule" .= addRule x
     ,  "removeRule" .= removeRule x
     ,  "members" .= members x
-    ,  "accountBalance" .= ciAccountBalance x
+    ,  "balances" .= ciAccountBalance x
     ]
 
 type ChainIdChainInfo = NamedTuple "id" ChainId "info" ChainInfo

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
@@ -42,20 +42,20 @@ instance Arbitrary ChainInfo where
 instance FromJSON ChainInfo where
   parseJSON (Object o) =
     ChainInfo <$>
-    o .: "chainLabel" <*>
+    o .: "label" <*>
     o .: "addRule" <*>
     o .: "removeRule" <*>
     o .: "members" <*>
-    (map toTuple <$> ((o .: "accountBalance") :: NamedMapParser "address" Address "balance" Integer))
+    (map toTuple <$> ((o .: "balances") :: NamedMapParser "address" Address "balance" Integer))
   parseJSON x = error $ "couldn't parse JSON for chain info: " ++ show x
 
 instance ToJSON ChainInfo where
   toJSON (ChainInfo cl ar rr ms ab) =
-    object [ "chainLabel" .= cl
+    object [ "label" .= cl
            , "addRule" .= ar
            , "removeRule" .= rr
            , "members" .= ms
-           , "accountBalance" .= ((map fromTuple ab) :: NamedMap "address" Address "balance" Integer)
+           , "balances" .= ((map fromTuple ab) :: NamedMap "address" Address "balance" Integer)
            ]
 
 instance KnownSymbol "address" where

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
@@ -7,24 +7,21 @@
 
 module Blockchain.Data.ChainInfo
   ( ChainInfo (..)
-  , ChainIdChainInfo (..)
   ) where
 
-import           Data.Aeson
-
 import           Blockchain.Data.ArbitraryInstances()
-import           Blockchain.Data.RLP
-import           Blockchain.ExtWord              (Word256)
-import           Blockchain.Strato.Model.Address
 import           Blockchain.Data.Enode
+import           Blockchain.Data.RLP
+import           Blockchain.Strato.Model.Address
 import           Blockchain.TypeLits
-import qualified GHC.Generics                              as GHCG
-import           Data.Monoid ((<>))
-import qualified Data.Text                       as T
-import           Data.Text.Encoding              (encodeUtf8, decodeUtf8)
+
+import           Data.Aeson
+import qualified Data.Text                            as T
+import           Data.Text.Encoding                   (encodeUtf8, decodeUtf8)
+
+import qualified GHC.Generics                         as GHCG
 
 import           Test.QuickCheck.Arbitrary
-import           Control.Applicative
 
 data ChainInfo = ChainInfo {
     chainLabel      :: String,
@@ -80,19 +77,3 @@ instance RLPSerializable ChainInfo where
       (rlpDecode <$> ms)
       (rlpDecode <$> ab)
   rlpDecode o = error $ "rlpDecode ChainInfo: Expected 5 element RLPArray, got " ++ show o
-
-newtype ChainIdChainInfo = ChainIdChainInfo {
-    unChainIdChainInfo :: (Word256, ChainInfo)
-} deriving (Eq, Read, Show, GHCG.Generic)
-
-instance FromJSON ChainIdChainInfo where
-  parseJSON (Object a) =
-    ChainIdChainInfo <$> liftA2 (,) (a .: "chainId") (a .: "chainInfo")
-  parseJSON x = error $ "couldn't parse JSON for (chainId, chainInfo): " ++ show x
-
-instance ToJSON ChainIdChainInfo where
-  toEncoding (ChainIdChainInfo (cid, cinfo)) =
-    pairs (
-      "chainId" .= cid <>
-      "chainInfo" .= cinfo
-    )

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
@@ -1,9 +1,12 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DeriveGeneric     #-}
+{-# OPTIONS -fno-warn-missing-methods #-}
+{-# OPTIONS -fno-warn-orphans         #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DeriveGeneric            #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE OverloadedStrings        #-}
 
 module Blockchain.Data.ChainInfo
-  ( AccountBalance(..)
-  , ChainInfo (..)
+  ( ChainInfo (..)
   , ChainIdChainInfo (..)
   ) where
 
@@ -14,6 +17,7 @@ import           Blockchain.Data.RLP
 import           Blockchain.ExtWord              (Word256)
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Data.Enode
+import           Blockchain.TypeLits
 import qualified GHC.Generics                              as GHCG
 import           Data.Monoid ((<>))
 import qualified Data.Text                       as T
@@ -21,20 +25,6 @@ import           Data.Text.Encoding              (encodeUtf8, decodeUtf8)
 
 import           Test.QuickCheck.Arbitrary
 import           Control.Applicative
-
-newtype AccountBalance = AccountBalance {
-    unAccountBalance :: (Address, Integer)
-} deriving (Eq, Read, Show, GHCG.Generic)
-
-instance FromJSON AccountBalance where
-  parseJSON (Object a) = AccountBalance <$> liftA2 (,) (a .: "address") (a .: "balance")    
-  parseJSON x = error $ "couldn't parse JSON for account balance: " ++ show x
-
-instance ToJSON AccountBalance where
-  toJSON (AccountBalance (addr, bal)) =
-      object [ "address" .= addr
-             , "balance" .= bal
-             ]
 
 data ChainInfo = ChainInfo {
     chainLabel      :: String,
@@ -59,7 +49,7 @@ instance FromJSON ChainInfo where
     o .: "addRule" <*>
     o .: "removeRule" <*>
     o .: "members" <*>
-    (map unAccountBalance <$> (o .: "accountBalance"))
+    (map toTuple <$> ((o .: "accountBalance") :: NamedMapParser "address" Address "balance" Integer))
   parseJSON x = error $ "couldn't parse JSON for chain info: " ++ show x
 
 instance ToJSON ChainInfo where
@@ -68,8 +58,11 @@ instance ToJSON ChainInfo where
            , "addRule" .= ar
            , "removeRule" .= rr
            , "members" .= ms
-           , "accountBalance" .= (map AccountBalance ab)
+           , "accountBalance" .= ((map fromTuple ab) :: NamedMap "address" Address "balance" Integer)
            ]
+
+instance KnownSymbol "address" where
+instance KnownSymbol "balance" where
 
 instance RLPSerializable ChainInfo where
   rlpEncode ci = RLPArray

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfoDB.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfoDB.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS -fno-warn-missing-methods #-}
+{-# OPTIONS -fno-warn-orphans         #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE RecordWildCards          #-}
 
 module Blockchain.Data.ChainInfoDB where
 
@@ -9,6 +13,7 @@ import qualified Database.Persist.Postgresql        as SQL
 
 import           Blockchain.Data.ChainInfo
 import           Blockchain.ExtWord                 (Word256)
+import           Blockchain.TypeLits
 
 import           Blockchain.DB.SQLDB
 
@@ -17,7 +22,7 @@ import           Blockchain.Data.Enode
 import           Control.Monad.Trans.Resource
 import           Data.Maybe
 
-getChainInfo :: (HasSQLDB m) => Word256 -> m (Maybe (Word256, ChainInfo))
+getChainInfo :: (HasSQLDB m) => Word256 -> m (Maybe (NamedTuple "id" Word256 "info" ChainInfo))
 getChainInfo chainId = do
   db <- getSQLDB
   runResourceT . flip SQL.runSqlPool db $ do
@@ -39,34 +44,34 @@ getChainInfo chainId = do
           --   E.where_ (abRef E.^. AccountInfoRefChainId E.==. E.val chainInfoRefId)
           -- cInfos <- E.select . E.from $ \ciRef -> do
           --   E.where_ (abRef E.^. CodeInfoRefChainId E.==. E.val chainInfoRefId)
-          return . Just $ (chainId,  
-                           ChainInfo
-                             chainInfoRefChainLabel
-                             chainInfoRefAddRule
-                             chainInfoRefRemoveRule
-                             (map name members)
-                             (map anb accts))
+          return . Just . fromTuple $ (chainId,
+                                       ChainInfo
+                                         chainInfoRefChainLabel
+                                         chainInfoRefAddRule
+                                         chainInfoRefRemoveRule
+                                         (map name members)
+                                         (map anb accts))
           where name = readEnode . chainMemberRefName . entityVal
                 anb  = (address &&& balance) . entityVal
                 address = chainAccountBalanceRefAddress
                 balance = chainAccountBalanceRefBalance
 
-getChainInfos :: (HasSQLDB m) => [Word256] -> m [(Word256, ChainInfo)]
+getChainInfos :: (HasSQLDB m) => [Word256] -> m (NamedMap "id" Word256 "info" ChainInfo)
 getChainInfos chainIds = do
   cids <- case chainIds of
               [] -> do
                   db <- getSQLDB
-                  runResourceT . flip SQL.runSqlPool db $ do  
+                  runResourceT . flip SQL.runSqlPool db $ do
                       chains <- E.select . E.from $ \cRef -> do
                           return cRef
                       case chains of
                           [] -> return []
                           cs -> return $ map (chainInfoRefChainId . E.entityVal) cs
               cIds -> return cIds
-  chainInfos <- mapM getChainInfo cids      
+  chainInfos <- mapM getChainInfo cids
   let cInfos = sequence $ filter isJust chainInfos
-  case cInfos of 
-      Nothing -> return [] 
+  case cInfos of
+      Nothing -> return []
       Just cis -> return cis
 
 putChainInfo :: (HasSQLDB m) => Word256 -> ChainInfo -> m (Key ChainInfoRef)
@@ -78,3 +83,6 @@ putChainInfo chainId ChainInfo{..} = do
     insertMany_ $ map (ChainMemberRef chainInfoRefId . showEnode) members
     insertMany_ $ map (uncurry (ChainAccountBalanceRef chainInfoRefId)) accountBalance
     return chainInfoRefId
+
+instance KnownSymbol "id" where
+instance KnownSymbol "info" where

--- a/core-strato/blockapps-util/blockapps-util.cabal
+++ b/core-strato/blockapps-util/blockapps-util.cabal
@@ -17,6 +17,7 @@ library
                      , Blockchain.MiscJSON
                      , Blockchain.Output
                      , Blockchain.SHA
+                     , Blockchain.TypeLits
                      , Blockchain.Util
   build-depends:       base
                      , aeson

--- a/core-strato/blockapps-util/src/Blockchain/TypeLits.hs
+++ b/core-strato/blockapps-util/src/Blockchain/TypeLits.hs
@@ -1,26 +1,51 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
-module Blockchain.TypeLits where
+module Blockchain.TypeLits
+  ( NamedTuple(..)
+  , NamedTupleParser
+  , NamedMap
+  , NamedMapParser
+  , IsTuple(..)
+  , module GHC.TypeLits
+  ) where
 
-import GHC.TypeLits
-import Data.Aeson
+import           Control.Applicative (liftA2)
+import           Data.Aeson
+import           Data.Aeson.Types    (Parser)
+import           Data.Proxy
+import qualified Data.Text           as Text
+import           GHC.TypeLits
 
 data NamedTuple (k :: Symbol) a (v :: Symbol) b = NamedTuple (a,b)
 
--- class IsTuple t a b where
---   fromTuple :: (a,b) -> t
---   toTuple :: t -> (a,b)
+type NamedTupleParser k a v b = Parser (NamedTuple k a v b)
 
--- instance IsTuple (NamedTuple a b) where
---   fromTuple = NamedTuple
---   toTuple (NamedTuple t) = t
+type NamedMap k a v b = [NamedTuple k a v b]
+
+type NamedMapParser k a v b = Parser (NamedMap k a v b)
+
+class IsTuple t a b where
+  fromTuple :: (a,b) -> t
+  toTuple :: t -> (a,b)
+
+instance IsTuple (NamedTuple k a v b) a b where
+  fromTuple = NamedTuple
+  toTuple (NamedTuple t) = t
 
 instance forall k a v b. (KnownSymbol k, KnownSymbol v, ToJSON a, ToJSON b) => ToJSON (NamedTuple k a v b) where
   toJSON (NamedTuple (a,b)) =
-    object [ (Text.pack (symbolVal (Proxy :: Proxy k))) .= toJSON a
-           , (Text.pack (symbolVal (Proxy :: Proxy v))) .= toJSON b
+    object [ (Text.pack $ symbolVal (Proxy :: Proxy k)) .= toJSON a
+           , (Text.pack $ symbolVal (Proxy :: Proxy v)) .= toJSON b
            ]
 
--- TODO: Figure out FromJSON
+instance forall k a v b. (KnownSymbol k, KnownSymbol v, FromJSON a, FromJSON b) => FromJSON (NamedTuple k a v b) where
+  parseJSON (Object o) = NamedTuple
+                     <$> liftA2 (,)
+                         (o .: (Text.pack $ symbolVal (Proxy :: Proxy k)))
+                         (o .: (Text.pack $ symbolVal (Proxy :: Proxy v)))
+  parseJSON o          = error $ "parseJSON NamedTuple: expected object, got " ++ show o

--- a/core-strato/blockapps-util/src/Blockchain/TypeLits.hs
+++ b/core-strato/blockapps-util/src/Blockchain/TypeLits.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Blockchain.TypeLits where
+
+import GHC.TypeLits
+import Data.Aeson
+
+data NamedTuple (k :: Symbol) a (v :: Symbol) b = NamedTuple (a,b)
+
+-- class IsTuple t a b where
+--   fromTuple :: (a,b) -> t
+--   toTuple :: t -> (a,b)
+
+-- instance IsTuple (NamedTuple a b) where
+--   fromTuple = NamedTuple
+--   toTuple (NamedTuple t) = t
+
+instance forall k a v b. (KnownSymbol k, KnownSymbol v, ToJSON a, ToJSON b) => ToJSON (NamedTuple k a v b) where
+  toJSON (NamedTuple (a,b)) =
+    object [ (Text.pack (symbolVal (Proxy :: Proxy k))) .= toJSON a
+           , (Text.pack (symbolVal (Proxy :: Proxy v))) .= toJSON b
+           ]
+
+-- TODO: Figure out FromJSON

--- a/tests/package.json
+++ b/tests/package.json
@@ -10,7 +10,7 @@
     "test:upload": "mocha load/uploadString.test.js --batchCount 10 --batchSize 10 && mocha load/uploadUniqueAddresses.test.js --batchCount 10 --batchSize 10"
   },
   "dependencies": {
-    "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#private-chain",
+    "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#private-chain-new-names",
     "chai": "^4.0.2",
     "co": "^4.6.0",
     "co-mocha": "^1.2.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -10,7 +10,7 @@
     "test:upload": "mocha load/uploadString.test.js --batchCount 10 --batchSize 10 && mocha load/uploadUniqueAddresses.test.js --batchCount 10 --batchSize 10"
   },
   "dependencies": {
-    "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#private-chain-new-names",
+    "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#private-chain",
     "chai": "^4.0.2",
     "co": "^4.6.0",
     "co-mocha": "^1.2.0",


### PR DESCRIPTION
I was thinking about how we made `newtype` wrappers for tuples so we could customize their JSON representations, and figured there was a generic way to do this. With `NamedTuple`, you can define the JSON tags at the type level, so you don't have to write the JSON boilerplate for each tuple type. I also updated blockapps-rest with these changes :grin: 