### PR TITLE
Use an associative array for the monitored pids

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-MONITORED_PIDS=()
+declare -A MONITORED_PIDS
 MONITORING_TIMER=5;
 
 function newnode {
@@ -71,15 +71,15 @@ function newnode {
   echo "Monitoring the background processes..."
   while sleep ${MONITORING_TIMER}; do
     # check status for every monitored process
-    for monitored_pid in "${MONITORED_PIDS[@]}"; do
+    for monitored_pid in "${!MONITORED_PIDS[@]}"; do
       # if process with pid does not exist
       if ! (ps -p ${monitored_pid} > /dev/null); then
-        echo "Process with pid ${monitored_pid} crashed - killing all monitored processes but keeping the container running..."
+        echo "Process ${MONITORED_PIDS[${monitored_pid}]} with pid ${monitored_pid} crashed - killing all monitored processes but keeping the container running..."
         # Kill all the rest of monitored processes
-        for pid_to_kill in "${MONITORED_PIDS[@]}"; do
-          if [ ${pid_to_kill} -ne ${monitored_pid} ]; then
-            echo "killing process ${pid_to_kill}..."
-            kill -9 ${pid_to_kill}
+        for pid_to_kill in "${!MONITORED_PIDS[@]}"; do
+          if ps -p ${pid_to_kill} > /dev/null; then
+            echo "killing process ${MONITORED_PIDS[${pid_to_kill}]} (pid: ${pid_to_kill})"
+            kill -9 ${pid_to_kill} || true
             echo "done"
           fi
         done
@@ -148,7 +148,7 @@ function cleanupLogs {
 function runBackgroundProcess {
   $@ &
   proc_pid=$!
-  MONITORED_PIDS+=(${proc_pid})
+  MONITORED_PIDS[${proc_pid}]=$@
   echo "process pid:: $proc_pid (command: $@)"
   disown %
 }


### PR DESCRIPTION
This provides more local information about which process is being killed, than having to scroll up and see which PID it was assigned (new style):
```
+ sleep 900
Process strato-p2p-client --cNetworkID=6 --maxConn=20 --sqlPeers=true --debugFail=true with pid 101 crashed - killing all monitored processes but keeping the container running...
killing process strato-p2p-client --cNetworkID=6 --maxConn=20 --sqlPeers=true --debugFail=true (pid: 101)
/var/lib/doit.sh: line 82: kill: (101) - No such process
done
killing process ethereum-discover (pid: 100)
done
/var/lib/doit.sh: line 82: kill: (100) - No such process
killing process strato-api-indexer +RTS -N1 (pid: 103)
done
/var/lib/doit.sh: line 82: kill: (103) - No such process
killing process strato-api +RTS -N1 (pid: 107)
done
/var/lib/doit.sh: line 82: kill: (107) - No such process
STRATO IS DOWN: Process with pid 101 crashed so all background processes were killed. Check /var/lib/strato/logs/
```
Additionally, this adds `|| true` after the `kill` command because it would fail if the process had already stopped (old style):
```+ sleep 900
Process with pid 21 crashed - killing all monitored processes but keeping the container running...
killing process 19...
done
killing process 20...
done
/var/lib/doit.sh: line 82: kill: (22) - No such process
killing process 22...
```