### PR TITLE
Archive docker-compose.yml after build in test pipeline

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -25,6 +25,7 @@ pipeline {
           cd strato-platform
           REPO=private make all
         '''
+        archive "strato-platform/docker-compose.yml"
       }
     }
 
@@ -131,7 +132,6 @@ pipeline {
 
   post {
     success {
-      archive "strato-platform/docker-compose.yml"
       slackSend (
         color: 'good',
         message: "Build Successful: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})"

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -27,6 +27,7 @@ pipeline {
           set -x
           REPO=private make all
         '''
+        archive "docker-compose.yml"
       }
     }
 
@@ -131,7 +132,6 @@ pipeline {
 
   post {
     success {
-      archive "docker-compose.yml"
       slackSend (
         color: 'good',
         message: "Build Successful: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})"


### PR DESCRIPTION
I haven't done the same for the release pipeline, to make
it harder to accidentally release a bad docker-compose.yml.
But a lot of times, I would want a copy of a bad docker-compose.yml
locally so I can try to deploy or run the tests and diagnose what
failed.