### PR TITLE
Removed Specified Branch

### DIFF
--- a/apex/api/package.json
+++ b/apex/api/package.json
@@ -16,7 +16,7 @@
     "aws-sdk": "2.254.1",
     "bcrypt": "1.0.3",
     "big-integer": "^1.6.26",
-    "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#slipstream-updates",
+    "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git",
     "body-parser": "1.18.2",
     "chai": "4.1.2",
     "chai-http": "3.0.0",


### PR DESCRIPTION
The slipstream-updates branch should be merged at some point, then this config won't have to point to the specific branch.

Link to changes: https://github.com/blockapps/blockapps-rest/commit/42e7a7c2a8d268971eb88fdd4c8a890834a13f71