### PR TITLE
slipstream db creation on startup and cleanup on restart

### DIFF
--- a/blockapps-haskell/Dockerfile.deploybase
+++ b/blockapps-haskell/Dockerfile.deploybase
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 RUN apt-get -y update                                          && \
     apt-get install -y libleveldb-dev libpq-dev libpcre3-dev autoconf libblas-dev \
                        liblapack-dev libsodium-dev netbase netcat-openbsd libstdc++6 \
-                       locales curl supervisor                 && \
+                       locales curl supervisor postgresql-client && \
     apt-get autoremove                                         && \
     rm -rf /var/lib/apt/lists/*                                && \
     apt-get clean                                              && \

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -23,6 +23,7 @@ slipstream:
 
 strato-server:
 no vars/flags set
+
 bloc:
 stratoHost="${stratoHost}"
 --stratourl=\$stratoRoot="${stratoRoot}"
@@ -52,16 +53,26 @@ while true; do
     sleep 0.5
 done
 
+until nc -z $kafkaHost $kafkaPort >&/dev/null
+do  echo "Waiting for Kafka to become available"
+    sleep 1
+done
+
+
+PSQL_CONNECTION_PARAMS="-h ${postgres_host} -p ${postgres_port} -U ${postgres_user}"
+if PGPASSWORD=${postgres_password} psql ${PSQL_CONNECTION_PARAMS} -lqt | cut -d \| -f 1 | grep -qw ${postgres_slipstream_db}; then
+    # slipstream database exists - drop it to create the new one
+    PGPASSWORD=${postgres_password} dropdb ${PSQL_CONNECTION_PARAMS} ${postgres_slipstream_db}
+fi
+# Create the database for slipstream
+PGPASSWORD=${postgres_password} createdb ${PSQL_CONNECTION_PARAMS} ${postgres_slipstream_db}
+
+
 mkdir logs
 
 # TODO: refactor using the process monitoring from core-strato's doit.sh
 
 /usr/bin/blockapps-strato-server >> logs/strato-server 2>&1 &
-
-until nc -z $kafkaHost $kafkaPort >&/dev/null
-do  echo "Waiting for Kafka to become available"
-    sleep 1
-done
 
 /usr/bin/slipstream --pghost="$postgres_host" --pgport="$postgres_port" --pguser="$postgres_user" --password="$postgres_password" \
             --database="$postgres_slipstream_db"  --stratourl="$stratoRoot" \

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -58,17 +58,19 @@ do  echo "Waiting for Kafka to become available"
     sleep 1
 done
 
-
 PSQL_CONNECTION_PARAMS="-h ${postgres_host} -p ${postgres_port} -U ${postgres_user}"
-if PGPASSWORD=${postgres_password} psql ${PSQL_CONNECTION_PARAMS} -lqt | cut -d \| -f 1 | grep -qw ${postgres_slipstream_db}; then
-    # slipstream database exists - drop it to create the new one
-    PGPASSWORD=${postgres_password} dropdb ${PSQL_CONNECTION_PARAMS} ${postgres_slipstream_db}
+# Check if this container was initialized before
+if [ ! -f initialized ]; then
+    # drop slipstream db if already exists
+    PGPASSWORD=${postgres_password} dropdb ${PSQL_CONNECTION_PARAMS} --if-exists ${postgres_slipstream_db}
+    # Create the database for slipstream
+    PGPASSWORD=${postgres_password} createdb ${PSQL_CONNECTION_PARAMS} ${postgres_slipstream_db}
+    # Create logs directory
+    mkdir logs
+    # Create the 'initialized' sentinel file
+    date '+%Y-%m-%d %H:%M:%S' > initialized
+
 fi
-# Create the database for slipstream
-PGPASSWORD=${postgres_password} createdb ${PSQL_CONNECTION_PARAMS} ${postgres_slipstream_db}
-
-
-mkdir logs
 
 # TODO: refactor using the process monitoring from core-strato's doit.sh
 

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -140,8 +140,10 @@ services:
     restart: always
   postgrest:
     depends_on:
+    - bloc
     - postgres
     environment:
+    - blocHost=bloc:8000
     - PG_ENV_POSTGRES_DB=cirrus
     - PG_ENV_POSTGRES_HOST=postgres
     - PG_ENV_POSTGRES_PASSWORD=${postgres_password:-api}
@@ -152,7 +154,6 @@ services:
     restart: always
   postgres:
     environment:
-    - POSTGRES_DB=cirrus
     - POSTGRES_PASSWORD=${postgres_password:-api}
     image: postgres:9.6
     volumes:

--- a/postgrest-packager/Dockerfile
+++ b/postgrest-packager/Dockerfile
@@ -15,7 +15,7 @@ ENV POSTGREST_SOURCE=http://github.com/begriffs/postgrest/releases/download \
     DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y tar xz-utils wget postgresql-client && \
+    apt-get install -y tar xz-utils wget postgresql-client curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     wget "$POSTGREST_SOURCE/$POSTGREST_VERSION/$POSTGREST_FILE" && \

--- a/postgrest-packager/doit.sh
+++ b/postgrest-packager/doit.sh
@@ -3,6 +3,15 @@
 set -e
 set -x
 
+# Checking for bloc to be running to avoid using the slipstream database before it was initialized in bloc's doit.sh
+blocRoot=http://${blocHost}/bloc/v2.2
+echo 'Waiting for bloc to be available...'
+until curl --silent --output /dev/null --fail --location ${blocRoot}
+do
+  sleep 1
+done
+echo 'bloc is available'
+
 echo "the pg host and port are: ${PG_ENV_POSTGRES_HOST} ${PG_PORT_5432_TCP_PORT}"
 
 until PGPASSWORD=${PG_ENV_POSTGRES_PASSWORD:-""} psql -h "${PG_ENV_POSTGRES_HOST}" -p ${PG_PORT_5432_TCP_PORT} -U "postgres" -c '\q'; do


### PR DESCRIPTION
Creating slipstream db with script in slipstream’s (bloc) container instead of creating it when running postgres.
Drop and re-create slipstream db if already exists (for STRATO node upgrade case)