### PR TITLE
Use the status from cmd, not from tee 

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -2,6 +2,7 @@
 
 set -e
 set -x
+set -o pipefail
 
 declare -A MONITORED_PIDS
 MONITORING_TIMER=5;

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -2,7 +2,6 @@
 
 set -e
 set -x
-set -o pipefail
 
 declare -A MONITORED_PIDS
 MONITORING_TIMER=5;
@@ -129,7 +128,7 @@ function doInit {
   echo "strato-setup command: $cmd"
   # logging to stdout and log file:
   $cmd 2>&1 | tee logs/strato-setup
-  if [ $? -ne 0 ]; then
+  if [ ${PIPESTATUS[0]} -ne 0 ]; then
     echo "STRATO SETUP FAILED: see /var/lib/strato/logs/strato-setup for details"
     tail -f /dev/null
   fi


### PR DESCRIPTION
So that failures are detected accurately