### PR TITLE
Try/catch around description assignment in jenkins

### DIFF
--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -10,7 +10,11 @@ pipeline {
       steps {
         wrap([$class: 'BuildUser']) {
           script {
-            currentBuild.description = "origin/${env.PLATFORM_BRANCH_NAME} // ${BUILD_USER_FIRST_NAME}"
+            try {
+              currentBuild.description = "origin/${env.PLATFORM_BRANCH_NAME} // ${BUILD_USER_FIRST_NAME}"
+            } catch (Exception e) {
+              currentBuild.description = "origin/${env.PLATFORM_BRANCH_NAME} // anon"
+            }
           }
         }
         sh '''#!/bin/bash -le


### PR DESCRIPTION
When builds are triggered with the build root token plugin, there is no BUILD_USER_FIRST_NAME (as far as I can tell).

See https://jenkins.blockapps.net/job/STRATO_test_build/321/