### PR TITLE
Nonviolence

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Stream/VMEvent.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Stream/VMEvent.hs
@@ -76,11 +76,14 @@ class HasVMEventsSink k where
 
 produceVMEventsM :: (HasSQLDB m, HasKafkaState m, MonadIO m) => [VMEvent] -> m Offset
 produceVMEventsM vmEvents = do
-    Right x <- withKafkaViolently . produceMessages $
+    ex <- withKafkaViolently . produceMessages $
         map (TopicAndMessage (lookupTopic "block") . makeMessage . vmEventToBytes) vmEvents
 
-    let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x
-    return offset
+    case ex of
+      Left err -> error $ "produceVMEventsM: Failed to connect to Kafka with: " ++ show err
+      Right x -> do
+        let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x
+        return offset
 
 -- todo: refactor this to consume produceVMEventsM
 produceVMEvents::(HasSQLDB m, MonadIO m)=>[VMEvent]->m Offset

--- a/core-strato/blockapps-data/src/Blockchain/Stream/VMEvent.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Stream/VMEvent.hs
@@ -76,7 +76,7 @@ class HasVMEventsSink k where
 
 produceVMEventsM :: (HasSQLDB m, HasKafkaState m, MonadIO m) => [VMEvent] -> m Offset
 produceVMEventsM vmEvents = do
-    x <- withKafkaViolently . produceMessages $
+    Right x <- withKafkaViolently . produceMessages $
         map (TopicAndMessage (lookupTopic "block") . makeMessage . vmEventToBytes) vmEvents
 
     let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -65,15 +65,15 @@ class HasKafkaState m where
     getKafkaState :: m KafkaState
     putKafkaState :: KafkaState -> m ()
 
-withKafkaViolently :: (MonadIO m, HasKafkaState m) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
+withKafkaViolently :: (MonadIO m, HasKafkaState m) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m (Either KafkaClientError a)
 withKafkaViolently k = do
     s <- getKafkaState
     r <- liftIO . runExceptT $ runStateT k s
     case r of
-        Left err -> error $ show err
+        Left err -> return $ Left err
         Right (a, newS) -> do
             putKafkaState newS
-            return a
+            return $ Right a
 
 
 

--- a/core-strato/blockapps-util/src/Blockchain/Util.hs
+++ b/core-strato/blockapps-util/src/Blockchain/Util.hs
@@ -18,6 +18,10 @@ import           Data.Time.Clock.POSIX    (POSIXTime, getPOSIXTime)
 
 import qualified Data.Binary              as Binary
 
+withRight :: Monad m => Either a b -> (b -> m ()) -> m ()
+withRight (Left _) _ = return ()
+withRight (Right b) f = f b
+
 buildState :: s -> [a] -> (a -> State s ()) -> s
 buildState s [] _ = s
 buildState s (a:as) run =

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -7,12 +7,12 @@ declare -A MONITORED_PIDS
 MONITORING_TIMER=5;
 
 function newnode {
-  initialize=false
+  bootstrap=false
 
   mkdir -p logs/rotation
 
   if [[ ! -d .ethereumH ]]
-  then initialize=true
+  then bootstrap=true
        cleanupDB
        doInit
   fi
@@ -58,7 +58,7 @@ function newnode {
   echo "Starting ethereum-vm"
   runBackgroundProcess ethereum-vm --useSyncMode=$useSyncMode --miner=$miningAlgorithm --maxTxsPerBlock=$maxTxsPerBlock \
                          --diffPublish=$diffPublish --sqlDiff=$sqlDiff --createTransactionResults=true \
-                         --miningVerification=$verifyBlocks --difficultyBomb=$difficultyBomb \
+                         --miningVerification=$verifyBlocks --difficultyBomb=$difficultyBomb --bootstrap=$bootstrap \
                          --trace=$evmTraceMode --debug=$evmDebugMode --minLogLevel=$minLogLevel \
                          --tmpblockstanbul=${tmpblockstanbul:-false} +RTS -N1 >> logs/ethereum-vm 2>&1
 

--- a/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
@@ -686,7 +686,7 @@ calculateAndEmitStateDiffs newBlock oldHeader codeSource codeContractName = when
       when flags_sqlDiff $ commitSqlDiffs diff codeSource' codeContractName'
       when flags_diffPublish $
           let (deletionEvents, creationEvents, updateEvents) = destructStateDiff diff
-          in withKafkaViolently $ do
+          in void . withKafkaViolently $ do
               void $ writeStateDiffEvents deletionEvents
               void $ writeStateDiffEvents creationEvents
               void $ writeStateDiffEvents updateEvents

--- a/core-strato/ethereum-vm/src/Executable/EVMFlags.hs
+++ b/core-strato/ethereum-vm/src/Executable/EVMFlags.hs
@@ -3,6 +3,7 @@ module Executable.EVMFlags where
 
 import           HFlags
 
+defineFlag "bootstrap" True "Whether this is a fresh start or a restart"
 defineFlag "maxTxsPerBlock" (500 :: Integer) "max number of transactions that may be put into a block"
 defineFlag "mempoolLivenessCutoff" (240 :: Integer) "max age of a transaction in seconds that is valid for the mempool"
 defineFlag "useTestnet" False "Change difficulty computation for ethdev testnet"

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -46,7 +46,7 @@ import           Blockchain.Strato.Model.Class
 import qualified Blockchain.Strato.RedisBlockDB        as RBDB
 import           Blockchain.Strato.RedisBlockDB.Models
 
-import           Blockchain.Util                       (getCurrentMicrotime, secondsToMicrotime)
+import           Blockchain.Util                       (getCurrentMicrotime, secondsToMicrotime, withRight)
 
 ethereumVM :: LoggingT IO ()
 ethereumVM = void . execContextM $ do
@@ -109,7 +109,7 @@ ethereumVM = void . execContextM $ do
             $logInfoS "evm/loop/newBlock" "calling Bagger.makeNewBlock"
             newBlock <- Bagger.makeNewBlock
             $logInfoS "evm/loop/newBlock" "calling produceUnminedBlocksM"
-            K.withKafkaViolently (produceUnminedBlocksM [outputBlockToBlock newBlock])
+            void . K.withKafkaViolently $ produceUnminedBlocksM [outputBlockToBlock newBlock]
 
         -- todo: is this the best place to put this?
         flushLogEntries
@@ -175,9 +175,10 @@ getCheckpoint = do
         cg'    = show consumerGroup
     $logInfoS "getCheckpoint" . T.pack $ "Getting checkpoint for " ++ topic' ++ "#0 for " ++ cg'
     K.withKafkaViolently (K.fetchSingleOffset consumerGroup topic 0) >>= \case
-        Left KP.UnknownTopicOrPartition -> initializeCheckpointAndBlockSummary >> getCheckpoint
-        Left err -> error $ "Unexpected response when fetching checkpoint: " ++ show err
-        Right (ofs, md) -> do
+        Left err -> error $ "getCheckpoint: Connection to Kafka failed with: " ++ show err
+        Right (Left KP.UnknownTopicOrPartition) -> initializeCheckpointAndBlockSummary >> getCheckpoint
+        Right (Left err) -> error $ "Unexpected response when fetching checkpoint: " ++ show err
+        Right (Right (ofs, md)) -> do
             let md' = fromKafkaMetadata md
             $logInfoS "getCheckpoint" . T.pack $ show ofs ++ " / " ++ format md'
             return (ofs, md')
@@ -189,9 +190,10 @@ getCheckpointNoMetadata = do
         cg'    = show consumerGroup
     $logInfoS "getCheckpointNoMetadata" . T.pack $ "Getting checkpoint for " ++ topic' ++ "#0 for " ++ cg'
     K.withKafkaViolently (K.fetchSingleOffset consumerGroup topic 0) >>= \case
-        Left KP.UnknownTopicOrPartition -> setCheckpointNoMetadata 1 >> getCheckpointNoMetadata
-        Left err -> error $ "Unexpected response when fetching checkpoint: " ++ show err
-        Right (ofs, _) -> do
+        Left err -> error $ "getCheckpointNoMetadata: Connection to Kafka failed with: " ++ show err
+        Right (Left KP.UnknownTopicOrPartition) -> setCheckpointNoMetadata 1 >> getCheckpointNoMetadata
+        Right (Left err) -> error $ "Unexpected response when fetching checkpoint: " ++ show err
+        Right (Right (ofs, _)) -> do
             return ofs
 
 
@@ -200,21 +202,24 @@ setCheckpoint ofs checkpoint = do
     $logInfoS "setCheckpoint" . T.pack $ "Setting checkpoint to " ++ show ofs ++ " / " ++ format checkpoint
     let kMetadata = toKafkaMetadata checkpoint
     ret  <- K.withKafkaViolently $ K.commitSingleOffset consumerGroup seqVmEventsTopicName 0 ofs kMetadata
-    either (error . show) return ret
+    withRight ret $ either (error . show) return
 
 setCheckpointNoMetadata :: KP.Offset -> ContextM ()
 setCheckpointNoMetadata ofs = do
     $logInfoS "setCheckpointNoMetadata" . T.pack $ "Setting checkpoint to " ++ show ofs
     let emptyMetadata = KP.Metadata $ KP.KString BS.empty
     ret  <- K.withKafkaViolently $ K.commitSingleOffset consumerGroup seqVmEventsTopicName 0 ofs emptyMetadata
-    either (error . show) return ret
+    withRight ret $ either (error . show) return
 
 getUnprocessedKafkaEvents :: KP.Offset -> ContextM [OutputEvent]
 getUnprocessedKafkaEvents offset = do
     $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Fetching sequenced blockchain events with offset " ++ show offset
-    ret <- K.withKafkaViolently (readSeqVmEvents offset)
-    $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Got: " ++ show (length ret) ++ " unprocessed blocks/txs"
-    return ret
+    eRet <- K.withKafkaViolently (readSeqVmEvents offset)
+    case eRet of
+      Left _ -> return [] --TODO: Should this error instead?
+      Right ret -> do
+        $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Got: " ++ show (length ret) ++ " unprocessed blocks/txs"
+        return ret
 
 shouldProcessNewTransactions :: ContextM Bool -- todo: probably shouldn't do it by number, but tdiff.
 shouldProcessNewTransactions =

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -16,6 +16,7 @@ import qualified Data.Map                              as M
 import           Data.Maybe                            (isNothing)
 import qualified Data.ByteString                       as BS
 import qualified Blockchain.MilenaTools                as K
+import qualified Network.Kafka                         as Kafka
 import qualified Network.Kafka.Protocol                as KP
 
 import           Blockchain.BlockChain
@@ -55,15 +56,16 @@ ethereumVM = void . execContextM $ do
 
     let makeLazyBlocks = lazyBlocks $ quarryConfig ethConf
     Bagger.setCalculateIntrinsicGas calculateIntrinsicGas'
-    (cpOffsetStart, EVMCheckpoint cpHash cpHead cpShas cpBBI) <- getCheckpoint
-    putContextBestBlockInfo cpBBI
-    bootstrapChainDB cpHash -- TODO: Move main chain genesis block creation to strato-genesis, and move this there too
-    Bagger.processNewBestBlock cpHash cpHead cpShas -- bootstrap Bagger with genesis block
-
-    $logInfoS "evm/preLoop" $ T.pack $ "cpOffset = " ++ show cpOffsetStart
+    when flags_bootstrap $ do
+      (cpOffsetStart, EVMCheckpoint cpHash cpHead cpShas cpBBI) <- getCheckpoint
+      putContextBestBlockInfo cpBBI
+      bootstrapChainDB cpHash -- TODO: Move main chain genesis block creation to strato-genesis, and move this there too
+      Bagger.processNewBestBlock cpHash cpHead cpShas -- bootstrap Bagger with genesis block
+      $logInfoS "evm/preLoop" $ T.pack $ "cpOffset = " ++ show cpOffsetStart
     let microtimeCutoff = secondsToMicrotime flags_mempoolLivenessCutoff
     forever $ do
-        cpOffset <- getCheckpointNoMetadata
+      eCpOffset <- getCheckpointNoMetadata
+      withRight eCpOffset $ \cpOffset -> do
         $logInfoS "evm/loop" "Getting Blocks/Txs"
         seqEvents <- getUnprocessedKafkaEvents cpOffset
 
@@ -183,18 +185,18 @@ getCheckpoint = do
             $logInfoS "getCheckpoint" . T.pack $ show ofs ++ " / " ++ format md'
             return (ofs, md')
 
-getCheckpointNoMetadata :: ContextM KP.Offset
+getCheckpointNoMetadata :: ContextM (Either Kafka.KafkaClientError KP.Offset)
 getCheckpointNoMetadata = do
     let topic  = seqVmEventsTopicName
         topic' = show topic
         cg'    = show consumerGroup
     $logInfoS "getCheckpointNoMetadata" . T.pack $ "Getting checkpoint for " ++ topic' ++ "#0 for " ++ cg'
     K.withKafkaViolently (K.fetchSingleOffset consumerGroup topic 0) >>= \case
-        Left err -> error $ "getCheckpointNoMetadata: Connection to Kafka failed with: " ++ show err
+        Left err -> return $ Left err
         Right (Left KP.UnknownTopicOrPartition) -> setCheckpointNoMetadata 1 >> getCheckpointNoMetadata
         Right (Left err) -> error $ "Unexpected response when fetching checkpoint: " ++ show err
         Right (Right (ofs, _)) -> do
-            return ofs
+            return $ Right ofs
 
 
 setCheckpoint :: KP.Offset -> EVMCheckpoint -> ContextM ()

--- a/core-strato/strato-adit/src/Executable/StratoAdit.hs
+++ b/core-strato/strato-adit/src/Executable/StratoAdit.hs
@@ -70,9 +70,12 @@ doBlock minerNumber n newNonce = do
     $logDebugS "writeUnseqEventsBegin" . T.pack $ "Writing block number " ++ show number ++ " with " ++ show txLength ++ " txs to unseqevents"
         -- TODO update hash too!
         -- this used to happen through setting the matching blockDataRefHash to blockHash $ theMinedBlock
-    _ <- withKafkaViolently $ writeUnseqEvents [IEBlock $ blockToIngestBlock TO.Quarry theMinedBlock]
-    $logDebugS "writeUnseqEventsEnd" . T.pack $ "Wrote block number " ++ show number ++ " with " ++ show txLength ++ " txs to unseqevents"
-    return ()
+    res <- withKafkaViolently $ writeUnseqEvents [IEBlock $ blockToIngestBlock TO.Quarry theMinedBlock]
+    case res of
+      Left err -> $logErrorS "writeUnseqEventsEnd" . T.pack $ "Connection to Kafka failed with: " ++ show err
+      Right _ -> do
+        $logDebugS "writeUnseqEventsEnd" . T.pack $ "Wrote block number " ++ show number ++ " with " ++ show txLength ++ " txs to unseqevents"
+        return ()
 
 mineBlock :: TMVar Block -> Integer -> Integer -> (Miner, Int) -> AditM ()
 mineBlock mv t i (m@Miner{miner = theMiner}, mi) =
@@ -94,7 +97,8 @@ mineBlock mv t i (m@Miner{miner = theMiner}, mi) =
 doConsume :: Offset -> TMVar Block -> AditM ()
 doConsume offset c = do
     $logInfoS "doConsume" . T.pack $ "Starting fetching blocks " ++ show offset
-    blocks <- withKafkaViolently $ setDefaultKafkaState >> fetchUnminedBlocks offset
+    eBlocks <- withKafkaViolently $ setDefaultKafkaState >> fetchUnminedBlocks offset
+    let blocks = either (const []) id eBlocks
     numPeers <- liftIO $ getActivePeers >>= return . length
 
     case reverse blocks of
@@ -129,7 +133,10 @@ stratoAdit = runAditT $ do
     $logInfoS "stratoAdit" "Initing runKafka"
     $logInfoS "stratoAdit" "Will fetch offsets"
 
-    offset <- withKafkaViolently $ getLastOffset LatestTime 0 (lookupTopic "unminedblock")
-    $logInfoS "stratoAdit" . T.pack $ "Will mine starting at " ++ show offset
+    eOffset <- withKafkaViolently $ getLastOffset LatestTime 0 (lookupTopic "unminedblock")
+    case eOffset of
+      Left err -> error $ "stratoAdit: Kafka connection failed with: " ++ show err
+      Right offset -> do
+        $logInfoS "stratoAdit" . T.pack $ "Will mine starting at " ++ show offset
 
-    doConsume (max (offset - 1) 0) c
+        doConsume (max (offset - 1) 0) c

--- a/core-strato/strato-adit/src/Executable/StratoAdit.hs
+++ b/core-strato/strato-adit/src/Executable/StratoAdit.hs
@@ -133,10 +133,12 @@ stratoAdit = runAditT $ do
     $logInfoS "stratoAdit" "Initing runKafka"
     $logInfoS "stratoAdit" "Will fetch offsets"
 
-    eOffset <- withKafkaViolently $ getLastOffset LatestTime 0 (lookupTopic "unminedblock")
-    case eOffset of
-      Left err -> error $ "stratoAdit: Kafka connection failed with: " ++ show err
-      Right offset -> do
-        $logInfoS "stratoAdit" . T.pack $ "Will mine starting at " ++ show offset
+    offset <- getOffset
+    $logInfoS "stratoAdit" . T.pack $ "Will mine starting at " ++ show offset
 
-        doConsume (max (offset - 1) 0) c
+    doConsume (max (offset - 1) 0) c
+    where getOffset = do
+            eOffset <- withKafkaViolently $ getLastOffset LatestTime 0 (lookupTopic "unminedblock")
+            case eOffset of
+              Right ofs -> return ofs
+              Left _ -> getOffset

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/ApiIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/ApiIndexer.hs
@@ -121,17 +121,19 @@ kafkaClientIds = ("strato-api-indexer", lookupConsumerGroup "strato-api-indexer"
 
 getKafkaCheckpoint :: IContextM (Offset, IndexerBestBlockInfo)
 getKafkaCheckpoint = withKafkaViolently (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
-    Left UnknownTopicOrPartition -> error "ApiIndexerBestBlock was never initialized in strato-setup!"
-    Left err -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
-    Right (ofs, Metadata (KString md'))  -> return (ofs, reIBBI . read $ S8.unpack md')
+    Left err -> error $ "getKafkaCheckpoint: Connection to Kafka failed with: " ++ show err
+    Right (Left UnknownTopicOrPartition) -> error "ApiIndexerBestBlock was never initialized in strato-setup!"
+    Right (Left err) -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
+    Right (Right (ofs, Metadata (KString md'))) -> return (ofs, reIBBI . read $ S8.unpack md')
 
 setKafkaCheckpoint :: Offset -> IndexerBestBlockInfo -> IContextM ()
 setKafkaCheckpoint ofs md = do
     $logInfoS "setKafkaCheckpoint" . T.pack $ "Setting checkpoint to " ++ show ofs ++ " / " ++ show md
     op <- withKafkaViolently (setKafkaCheckpoint' ofs md)
     case op of
-        Left err -> error $ "Client error: " ++ show err
-        Right _  -> return ()
+        Left err -> error $ "setKafkaCheckpoint: Connection to Kafka failed with: " ++ show err
+        Right (Left err) -> error $ "Client error: " ++ show err
+        Right (Right _)  -> return ()
 
 setKafkaCheckpoint' :: (Kafka k) => Offset -> IndexerBestBlockInfo -> k (Either KafkaError ())
 setKafkaCheckpoint' ofs md =
@@ -143,5 +145,7 @@ setKafkaCheckpoint' ofs md =
 getUnprocessedIndexEvents :: IContextM (Offset, [IndexEvent], IndexerBestBlockInfo)
 getUnprocessedIndexEvents = do
     (ofs, md) <- getKafkaCheckpoint
-    evs       <- withKafkaViolently (readIndexEvents ofs)
-    return (ofs, evs, md)
+    eEvs       <- withKafkaViolently (readIndexEvents ofs)
+    case eEvs of
+      Left _ -> return (ofs, [], md) --TODO: should this error instead?
+      Right evs -> return (ofs, evs, md)

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/P2PIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/P2PIndexer.hs
@@ -48,19 +48,23 @@ kafkaClientIds = ("strato-p2p-indexer", lookupConsumerGroup "strato-p2p-indexer"
 
 getKafkaCheckpoint :: IContextM Offset
 getKafkaCheckpoint = withKafkaViolently (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
-    Left UnknownTopicOrPartition -> setKafkaCheckpoint 0 >> getKafkaCheckpoint
-    Left err -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
-    Right (ofs, _)  -> return ofs
+    Left err -> error $ "getKafkaCheckpoint: Connection to Kafka failed with: " ++ show err
+    Right (Left UnknownTopicOrPartition) -> setKafkaCheckpoint 0 >> getKafkaCheckpoint
+    Right (Left err) -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
+    Right (Right (ofs, _))  -> return ofs
 
 setKafkaCheckpoint :: Offset -> IContextM ()
 setKafkaCheckpoint ofs = do
     $logInfoS "setKafkaCheckpoint" . T.pack $ "Setting checkpoint to " ++ show ofs
     withKafkaViolently (commitSingleOffset (snd kafkaClientIds) targetTopicName 0 ofs "") >>= \case
-        Left err -> error $ "Unexpected response when setting checkpoint to " ++ show ofs ++ ": " ++ show err
-        Right () -> return ()
+        Left err -> error $ "setKafkaCheckpoint: Connection to Kafka failed with: " ++ show err
+        Right (Left err) -> error $ "Unexpected response when setting checkpoint to " ++ show ofs ++ ": " ++ show err
+        Right (Right ()) -> return ()
 
 getUnprocessedIndexEvents :: IContextM (Offset, [IndexEvent])
 getUnprocessedIndexEvents = do
     ofs <- getKafkaCheckpoint
-    evs <- withKafkaViolently (readIndexEvents ofs)
-    return (ofs, evs)
+    eEvs <- withKafkaViolently (readIndexEvents ofs)
+    case eEvs of
+      Left _ -> return (ofs, [])
+      Right evs -> return (ofs, evs)

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -107,19 +107,23 @@ kafkaClientIds = ("strato-txr-indexer", lookupConsumerGroup "strato-txr-indexer"
 
 getKafkaCheckpoint :: IContextM Offset
 getKafkaCheckpoint = withKafkaViolently (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
-    Left UnknownTopicOrPartition -> setKafkaCheckpoint 0 >> getKafkaCheckpoint
-    Left err -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
-    Right (ofs, _)  -> return ofs
+    Left err -> error $ "getKafkaCheckpoint: Connection to Kafka failed with: " ++ show err
+    Right (Left UnknownTopicOrPartition) -> setKafkaCheckpoint 0 >> getKafkaCheckpoint
+    Right (Left err) -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
+    Right (Right (ofs, _))  -> return ofs
 
 setKafkaCheckpoint :: Offset -> IContextM ()
 setKafkaCheckpoint ofs = do
     $logInfoS "setKafkaCheckpoint" . T.pack $ "Setting checkpoint to " ++ show ofs
     withKafkaViolently (commitSingleOffset (snd kafkaClientIds) targetTopicName 0 ofs "") >>= \case
-        Left err -> error $ "Unexpected response when setting checkpoint to " ++ show ofs ++ ": " ++ show err
-        Right () -> return ()
+        Left err -> error $ "setKafkaCheckpoint: Connection to Kafka failed with: " ++ show err
+        Right (Left err) -> error $ "Unexpected response when setting checkpoint to " ++ show ofs ++ ": " ++ show err
+        Right (Right ()) -> return ()
 
 getUnprocessedIndexEvents :: IContextM (Offset, [IndexEvent])
 getUnprocessedIndexEvents = do
     ofs <- getKafkaCheckpoint
-    evs <- withKafkaViolently (readIndexEvents ofs)
-    return (ofs, evs)
+    eEvs <- withKafkaViolently (readIndexEvents ofs)
+    case eEvs of
+      Left _ -> return (ofs, [])
+      Right evs -> return (ofs, evs)

--- a/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -26,10 +26,12 @@ seqEventNotificationSource :: ( MonadIO m
                               )
                            => Source m OutputEvent
 seqEventNotificationSource = do
-    ofs' <- lift $ K.withKafkaViolently $ K.getLastOffset K.LatestTime 0 seqP2pEventsTopicName
+    eOfs' <- lift $ K.withKafkaViolently $ K.getLastOffset K.LatestTime 0 seqP2pEventsTopicName
+    let ofs' = either (const 0) id eOfs'
     loop ofs'
     where loop nextOffset = do
-              events <- lift $ K.withKafkaViolently $ readSeqP2pEvents nextOffset
+              eEvents <- lift $ K.withKafkaViolently $ readSeqP2pEvents nextOffset
+              let events = either (const []) id eEvents
               unless (null events) $ do -- stop bloating the logs
                 $logInfoS "seqEventNotify" . T.pack $ "read kafka seqevents @ " ++ show nextOffset
                 forM_ events $ \e -> do

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -480,9 +480,12 @@ readUnseqEvents' :: SequencerM [(KP.Offset, IngestEvent)]
 readUnseqEvents' = do
     offset <- getNextIngestedOffset
     $logInfoS "readUnseqEvents'" . T.pack $ "Fetching unseqevents from " ++ show offset
-    ret <- zip [(offset+1)..] <$> K.withKafkaViolently (readUnseqEvents offset) -- its really [(nextOffset, eventAtThisOffset)]
-    tickBy (length ret) ctr_sequencer_kafka_unseq_reads
-    return ret
+    eRet <- (fmap (zip [(offset+1)..])) <$> K.withKafkaViolently (readUnseqEvents offset) -- its really [(nextOffset, eventAtThisOffset)]
+    case eRet of
+      Left _ -> return [] --TODO: Should this error instead?
+      Right ret -> do
+        tickBy (length ret) ctr_sequencer_kafka_unseq_reads
+        return ret
 
 writeSeqVmEvents' :: [OutputEvent] -> SequencerM ()
 writeSeqVmEvents' events = void $ do
@@ -498,10 +501,11 @@ getNextIngestedOffset :: SequencerM KP.Offset
 getNextIngestedOffset = do
   group  <- getKafkaConsumerGroup
   ret <- K.withKafkaViolently (K.fetchSingleOffset group unseqEventsTopicName 0) >>= \case
-    Left KP.UnknownTopicOrPartition -> -- we've never committed an Offset
+    Left err -> error $ "getNextIngestedOffset: Connection to Kafka failed with: " ++ show err
+    Right (Left KP.UnknownTopicOrPartition) -> -- we've never committed an Offset
         setNextIngestedOffset 0 >> getNextIngestedOffset
-    Left err -> error $ "Unexpected response when fetching offset for " ++ show unseqEventsTopicName ++ ": " ++ show err
-    Right (ofs, _) -> return ofs
+    Right (Left err) -> error $ "Unexpected response when fetching offset for " ++ show unseqEventsTopicName ++ ": " ++ show err
+    Right (Right (ofs, _)) -> return ofs
   tick ctr_sequencer_kafka_checkpoint_reads
   return ret
 
@@ -512,6 +516,7 @@ setNextIngestedOffset newOffset = do
     tick ctr_sequencer_kafka_checkpoint_writes
     op <- K.withKafkaViolently $ K.commitSingleOffset group unseqEventsTopicName 0 newOffset ""
     op & \case
-        Left err ->
+        Left err -> error $ "setNextIngestedOffset: Connection to Kafka failed with: " ++ show err
+        Right (Left err) ->
             error $ "Unexpected response when setting the offset to " ++ show newOffset ++ ": " ++ show err
-        Right () -> return ()
+        Right (Right ()) -> return ()


### PR DESCRIPTION
`withKafkaViolently` would `error` out if the action passed to it failed, even though it was running the action inside `ExceptT`. In this PR, `withKafkaViolently` returns `Either KafkaClientError a`, and allows the caller to determine what to do with it. Should the entire function be in `MonadError`?