### PR TITLE
Blockstanbul Tuning

### DIFF
--- a/core-strato/blockapps-haskoin/Network/Haskoin/Crypto/BigWord.hs
+++ b/core-strato/blockapps-haskoin/Network/Haskoin/Crypto/BigWord.hs
@@ -68,6 +68,7 @@ import Data.Aeson
 import Data.Ratio (numerator, denominator)
 import qualified Data.ByteString as BS (head, length, reverse)
 import qualified Data.Text as T (pack, unpack)
+import Text.Printf
 
 import Network.Haskoin.Crypto.Curve
 import Network.Haskoin.Crypto.NumberTheory
@@ -108,6 +109,9 @@ newtype BigWord n = BigWord { getBigWordInteger :: Integer }
 
 instance NFData (BigWord n) where
     rnf (BigWord n) = rnf n
+
+instance PrintfArg (BigWord n) where
+  formatArg (BigWord n) = formatArg n
 
 inverseP :: FieldP -> FieldP
 inverseP (BigWord i) = fromInteger $ mulInverse i curveP

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -21,6 +21,7 @@ import Blockchain.Blockstanbul.Authentication
 import Blockchain.Blockstanbul.Messages
 import Blockchain.Blockstanbul.Voting
 import Blockchain.ExtendedECDSA
+import Blockchain.Format
 import Blockchain.SHA
 import qualified Network.Haskoin.Crypto as HK
 
@@ -61,17 +62,16 @@ makeLenses ''BlockstanbulContext
 
 debugShowCtx :: StateMachineM m => m ()
 debugShowCtx = do
-  let debugLog :: (StateMachineM m2, Show a) => T.Text -> LensLike' (Const (m2 ())) BlockstanbulContext a-> m2 ()
-      debugLog loc lns = join . uses lns $ $logDebugS loc . T.pack . show
-  debugLog "showctx/view" view
-  debugLog "showctx/proposer" proposer
-  debugLog "showctx/validators" validators
-  debugLog "showctx/prepared" prepared
-  debugLog "showctx/committed" committed
-  debugLog "showctx/hasPrepared" hasPrepared
-  debugLog "showctx/roundChanged" roundChanged
-  mNumber <- uses proposal $ fmap (blockDataNumber . blockBlockData)
-  $logDebugS "showctx/mBlockNumber" . T.pack . show $ mNumber
+  let debugLog :: (StateMachineM m2) => T.Text -> LensLike' (Const (m2 ())) BlockstanbulContext a -> (a -> String) -> m2 ()
+      debugLog loc lns f = join . uses lns $ $logDebugS loc . T.pack . f
+  debugLog "showctx/view" view format
+  debugLog "showctx/proposer" proposer format
+  debugLog "showctx/validators" validators (show . map format)
+  debugLog "showctx/prepared" prepared show
+  debugLog "showctx/committed" committed show
+  debugLog "showctx/hasPrepared" hasPrepared show
+  debugLog "showctx/roundChanged" roundChanged show
+  debugLog "showctx/mBlockNumber" proposal (show . fmap (blockDataNumber . blockBlockData))
 
 newContext :: View -> [Address] -> HK.PrvKey -> BlockstanbulContext
 newContext v as pk =

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -56,7 +56,22 @@ data BlockstanbulContext = BlockstanbulContext {
   , _prvkey :: HK.PrvKey
   , _blockcount :: Int
 }
+
 makeLenses ''BlockstanbulContext
+
+debugShowCtx :: StateMachineM m => m ()
+debugShowCtx = do
+  let debugLog :: (StateMachineM m2, Show a) => T.Text -> LensLike' (Const (m2 ())) BlockstanbulContext a-> m2 ()
+      debugLog loc lns = join . uses lns $ $logDebugS loc . T.pack . show
+  debugLog "showctx/view" view
+  debugLog "showctx/proposer" proposer
+  debugLog "showctx/validators" validators
+  debugLog "showctx/prepared" prepared
+  debugLog "showctx/committed" committed
+  debugLog "showctx/hasPrepared" hasPrepared
+  debugLog "showctx/roundChanged" roundChanged
+  mNumber <- uses proposal $ fmap (blockDataNumber . blockBlockData)
+  $logDebugS "showctx/mBlockNumber" . T.pack . show $ mNumber
 
 newContext :: View -> [Address] -> HK.PrvKey -> BlockstanbulContext
 newContext v as pk =
@@ -65,7 +80,7 @@ newContext v as pk =
                  (a:_) -> a
   in BlockstanbulContext
      { _view = v
-     , _authenticator = const True
+     , _authenticator = const True -- TODO(tim): Authenticate
      , _proposal = Nothing
      , _proposer = prop
      , _validators = as
@@ -138,6 +153,7 @@ nextRound nt = do
 
 eventLoop :: (MonadIO m, MonadLogger m) => BlockstanbulContext -> ConduitM InEvent OutEvent m BlockstanbulContext
 eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
+  debugShowCtx
   authz <- lift $ isAuthorized ev
   v <- use view
   when authz $ case ev of

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -13,6 +13,7 @@ import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Text as T
 import Prelude hiding (round, sequence)
+import Text.Printf
 
 import Blockchain.Data.Address
 import Blockchain.Data.BlockDB
@@ -116,7 +117,9 @@ nextRound nt = do
   validators .= updateValidator val vot
   case nt of
     Sequence s -> view . sequence .= s
-    Round r -> view . round .= r
+    Round r -> do
+      view . round .= r
+      yield $ ResetTimer r
   vals <- use validators
   thisR <- use $ view . round
   let leader = vals !! (fromIntegral thisR `mod` length vals)
@@ -132,8 +135,6 @@ nextRound nt = do
   hasCommitted .= False
   hasPrepared .= False
   pendingRound .= Nothing
-
-  yield ResetTimer
 
 eventLoop :: (MonadIO m, MonadLogger m) => BlockstanbulContext -> ConduitM InEvent OutEvent m BlockstanbulContext
 eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
@@ -223,9 +224,15 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
           Nothing -> error "TODO(tim): a round was voted on without existing"
           Just r -> nextRound (Round r)
       return ()
-    Timeout -> do
-      $logWarnS "blockstanbul" "Round timed out"
-      roundChange
+    Timeout r' -> do
+      case r' `compare` _round v of
+        LT ->
+          let msg = printf "Ignoring stale timeout for %v (now %v)" r' (_round v)
+          in $logDebugS "blockstanbul" . T.pack $ msg
+        EQ -> do
+          $logWarnS "blockstanbul" . T.pack $ printf "Round %v timed out" r'
+          roundChange
+        GT -> error $ printf "We're in a time loop: %v was received at now=%v" r' (_round v)
     CommitResult (Left err) -> do
       $logWarnS "blockstanbul" err
       roundChange

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -265,6 +265,10 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
         yield =<< signMessage pk (RoundChange vn)
       when (3 * sameRNCount > 2 * total) $ do
         next <- use pendingRound
+        when (_sequence v < _sequence vn) $ do
+          -- Assume that we have missed the commit of the locked block, because
+          -- the rest of the nodes have moved on.
+          blockLock .= Nothing
         case next of
           Nothing -> error "TODO(tim): a round was voted on without existing"
           Just r -> nextRound (Round r)

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -56,6 +56,8 @@ data BlockstanbulContext = BlockstanbulContext {
   -- The nodekey for this validator
   , _prvkey :: HK.PrvKey
   , _blockcount :: Int
+  -- Block locking: a safety mechanism to prevent partial commits
+  , _blockLock :: Maybe Block
 }
 
 makeLenses ''BlockstanbulContext
@@ -66,7 +68,7 @@ debugShowCtx = do
       debugLog loc lns f = join . uses lns $ $logDebugS loc . T.pack . f
   debugLog "showctx/view" view format
   debugLog "showctx/proposer" proposer (printf "%x")
-  debugLog "showctx/validators" validators (show . map (printf "%x"))
+  debugLog "showctx/validators" validators (show . map (printf "%x" :: Address -> String))
   debugLog "showctx/prepared" prepared show
   debugLog "showctx/committed" committed show
   debugLog "showctx/hasPrepared" hasPrepared show
@@ -94,6 +96,7 @@ newContext v as pk =
      , _pendingvotes = M.empty
      , _prvkey = pk
      , _blockcount = 0
+     , _blockLock = Nothing
      }
 
 selfAddr :: (StateMachineM m) => m Address
@@ -142,7 +145,13 @@ nextRound nt = do
   proposal .= Nothing
   self <- selfAddr
   when (leader == self) $ do
-    yield MakeBlockCommand
+    lock <- use blockLock
+    case lock of
+      Nothing -> yield MakeBlockCommand
+      Just lb -> do
+        pk <- use prvkey
+        v <- use view
+        yield =<< signMessage pk (Preprepare v lb)
   prepared .= M.empty
   committed .= M.empty
   roundChanged .= M.empty
@@ -178,34 +187,44 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
         let blockWithVs = addValidators vs editedBlk
         pseal <- proposerSeal blockWithVs pk
         let sealedBlk = addProposerSeal pseal blockWithVs
-        proposal .= Just sealedBlk
-        yield =<< signMessage pk (Preprepare v sealedBlk)
+        mLocked <- use blockLock
+        let realSealed = fromMaybe sealedBlk mLocked
+        proposal .= Just realSealed
+        yield =<< signMessage pk (Preprepare v realSealed)
     IMsg auth (Preprepare v' pp) -> do
       pr <- use proposer
       if (sender auth /= pr)
         then $logWarnS "blockstanbul/ppl" . T.pack $
                 printf "Rejecting proposal: proposer %x is not %x" (sender auth) pr
-        else
-          if v /= v'
+        else do
+          mBlockLock <- use blockLock
+          if (isJust mBlockLock && Just pp /= mBlockLock)
             then do
-              $logDebugS "blockstanbul/roundchange" . T.pack $
-                 "view mismatch (us, sender): " ++ format (v, v')
               $logWarnS "blockstanbul/ppl" . T.pack $
-                printf "Rejecting proposal: " ++ format v' ++ " is not " ++ format v
+                printf "Rejecting proposal: block does not match lock"
+              $logDebugS "blockstanbul/roundchange" "lock mismatch"
               roundChange
-            else do
-               blockcount += 1
-               proposal .= Just pp
-               pk <- use prvkey
-               case extractBeneficiary pp of
-                 Nothing -> return()
-                 Just (bnef,vot) -> do
-                   -- insert the vote into map
-                   val <- uses voted $M.lookup bnef
-                   let unwrapVal = fromMaybe M.empty val
-                   let nval = M.insert pr vot unwrapVal
-                   voted %= M.insert bnef nval
-               yield =<< signMessage pk (Prepare v (blockHash pp))
+            else
+              if v /= v'
+                then do
+                  $logDebugS "blockstanbul/roundchange" . T.pack $
+                     "view mismatch (us, sender): " ++ format (v, v')
+                  $logWarnS "blockstanbul/ppl" . T.pack $
+                    printf "Rejecting proposal: " ++ format v' ++ " is not " ++ format v
+                  roundChange
+                else do
+                   blockcount += 1
+                   proposal .= Just pp
+                   pk <- use prvkey
+                   case extractBeneficiary pp of
+                     Nothing -> return()
+                     Just (bnef,vot) -> do
+                       -- insert the vote into map
+                       val <- uses voted $M.lookup bnef
+                       let unwrapVal = fromMaybe M.empty val
+                       let nval = M.insert pr vot unwrapVal
+                       voted %= M.insert bnef nval
+                   yield =<< signMessage pk (Prepare v (blockHash pp))
     IMsg auth (Prepare v' di) -> when (v <= v') $ do
       ps <- prepared <%= M.insert (sender auth) di
       total <- uses validators length
@@ -214,6 +233,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
       hasSent <- use hasPrepared
       when (3 * sameVoteCount > 2 * total && sameHash && not hasSent) $ do
         hasPrepared .= True
+        (blockLock .=) =<< (use proposal)
         pk <- use prvkey
         seal <- commitmentSeal di pk
         yield =<< signMessage pk (Commit v di seal)
@@ -262,10 +282,12 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
     CommitResult (Left err) -> do
       $logWarnS "blockstanbul" err
       $logDebugS "blockstanbul/roundchange" "commit failure (how...)"
+      blockLock .= Nothing
       roundChange
     CommitResult (Right ()) -> do
       $logDebugS "blockstanbul" "Successful block commit"
       s <- use $ view . sequence
+      blockLock .= Nothing
       nextRound . Sequence $ s+1
 
 class (Monad m) => HasBlockstanbulContext m where

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -166,22 +166,30 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
         yield =<< signMessage pk (Preprepare v sealedBlk)
     IMsg auth (Preprepare v' pp) -> do
       pr <- use proposer
-      when (sender auth == pr) $ do
-        if v == v'
-          then do
-            blockcount += 1
-            proposal .= Just pp
-            pk <- use prvkey
-            case extractBeneficiary pp of
-              Nothing -> return()
-              Just (bnef,vot) -> do
-            -- insert the vote into map
-                val <- uses voted $M.lookup bnef
-                let unwrapVal = fromMaybe M.empty val
-                let nval = M.insert pr vot unwrapVal
-                voted %= M.insert bnef nval
-            yield =<< signMessage pk (Prepare v (blockHash pp))
-          else roundChange
+      if (sender auth /= pr)
+        then $logWarnS "blockstanbul/ppl" . T.pack $
+                printf "Rejecting proposal: proposer %x is not %x" (sender auth) pr
+        else
+          if v /= v'
+            then do
+              $logDebugS "blockstanbul/roundchange" . T.pack $
+                 "view mismatch (us, sender): " ++ format (v, v')
+              $logWarnS "blockstanbul/ppl" . T.pack $
+                printf "Rejecting proposal: " ++ format v' ++ " is not " ++ format v
+              roundChange
+            else do
+               blockcount += 1
+               proposal .= Just pp
+               pk <- use prvkey
+               case extractBeneficiary pp of
+                 Nothing -> return()
+                 Just (bnef,vot) -> do
+                   -- insert the vote into map
+                   val <- uses voted $M.lookup bnef
+                   let unwrapVal = fromMaybe M.empty val
+                   let nval = M.insert pr vot unwrapVal
+                   voted %= M.insert bnef nval
+               yield =<< signMessage pk (Prepare v (blockHash pp))
     IMsg auth (Prepare v' di) -> when (v <= v') $ do
       ps <- prepared <%= M.insert (sender auth) di
       total <- uses validators length
@@ -217,6 +225,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
       when (3 * sameRNCount > total && Just rn > sentRN) $ do
         pendingRound .= Just rn
         pk <- use prvkey
+        $logDebugS "blockstanbul/roundchange" "agreed change"
         yield =<< signMessage pk (RoundChange vn)
       when (3 * sameRNCount > 2 * total) $ do
         next <- use pendingRound
@@ -231,10 +240,12 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
           in $logDebugS "blockstanbul" . T.pack $ msg
         EQ -> do
           $logWarnS "blockstanbul" . T.pack $ printf "Round %v timed out" r'
+          $logDebugS "blockstanbul/roundchange" "timeout"
           roundChange
         GT -> error $ printf "We're in a time loop: %v was received at now=%v" r' (_round v)
     CommitResult (Left err) -> do
       $logWarnS "blockstanbul" err
+      $logDebugS "blockstanbul/roundchange" "commit failure (how...)"
       roundChange
     CommitResult (Right ()) -> do
       $logDebugS "blockstanbul" "Successful block commit"

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -74,6 +74,7 @@ debugShowCtx = do
   debugLog "showctx/hasPrepared" hasPrepared show
   debugLog "showctx/roundChanged" roundChanged show
   debugLog "showctx/mBlockNumber" proposal (show . fmap (blockDataNumber . blockBlockData))
+  debugLog "showctx/mLockedBlockNo" blockLock (show . fmap (blockDataNumber . blockBlockData))
 
 newContext :: View -> [Address] -> HK.PrvKey -> BlockstanbulContext
 newContext v as pk =

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -118,6 +118,7 @@ roundChange :: (StateMachineM m) => Conduit InEvent m OutEvent
 roundChange = do
   nextView <- uses view (over round (+1))
   pk <- use prvkey
+  pendingRound .= Just (_round nextView)
   yield =<< signMessage pk (RoundChange nextView)
 
 nextRound :: (StateMachineM m) => NextType -> Conduit InEvent m OutEvent

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -65,8 +65,8 @@ debugShowCtx = do
   let debugLog :: (StateMachineM m2) => T.Text -> LensLike' (Const (m2 ())) BlockstanbulContext a -> (a -> String) -> m2 ()
       debugLog loc lns f = join . uses lns $ $logDebugS loc . T.pack . f
   debugLog "showctx/view" view format
-  debugLog "showctx/proposer" proposer format
-  debugLog "showctx/validators" validators (show . map format)
+  debugLog "showctx/proposer" proposer (printf "%x")
+  debugLog "showctx/validators" validators (show . map (printf "%x"))
   debugLog "showctx/prepared" prepared show
   debugLog "showctx/committed" committed show
   debugLog "showctx/hasPrepared" hasPrepared show

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -53,7 +53,7 @@ data BlockstanbulContext = BlockstanbulContext {
   , _pendingvotes :: M.Map Address Bool
   -- The nodekey for this validator
   , _prvkey :: HK.PrvKey
-  , _blockcount :: Int 
+  , _blockcount :: Int
 }
 makeLenses ''BlockstanbulContext
 
@@ -132,6 +132,8 @@ nextRound nt = do
   hasCommitted .= False
   hasPrepared .= False
   pendingRound .= Nothing
+
+  yield ResetTimer
 
 eventLoop :: (MonadIO m, MonadLogger m) => BlockstanbulContext -> ConduitM InEvent OutEvent m BlockstanbulContext
 eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
@@ -11,6 +11,7 @@ import Data.DeriveTH
 import Data.Text
 import GHC.Generics
 import Test.QuickCheck
+import Text.Printf
 
 import Blockchain.Data.RLP
 import Blockchain.ExtWord
@@ -28,6 +29,9 @@ data View = View {
   _sequence :: SequenceNumber
 } deriving (Eq, Show, Ord, Generic)
 makeLenses ''View
+
+instance Format View where
+  format (View r s) = printf "View (round = %d, sequence = %d)" r s
 
 data MsgAuth = MsgAuth {
   sender :: Address,

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
@@ -77,6 +77,7 @@ data InEvent = IMsg {iAuth :: MsgAuth, iMessage :: TrustedMessage}
 data OutEvent = OMsg {oAuth :: MsgAuth, oMessage :: TrustedMessage}
               | ToCommit Block
               | MakeBlockCommand
+              | ResetTimer
               deriving (Eq, Show)
 
 getHash :: TrustedMessage -> Word256

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
@@ -67,7 +67,7 @@ commitCode = 2
 roundchangeCode = 3
 
 data InEvent = IMsg {iAuth :: MsgAuth, iMessage :: TrustedMessage}
-             | Timeout
+             | Timeout RoundNumber
              -- TODO(tim): CommitResult should have the digest
              | CommitResult (Either Text ())
              | NewBlock Block
@@ -77,7 +77,7 @@ data InEvent = IMsg {iAuth :: MsgAuth, iMessage :: TrustedMessage}
 data OutEvent = OMsg {oAuth :: MsgAuth, oMessage :: TrustedMessage}
               | ToCommit Block
               | MakeBlockCommand
-              | ResetTimer
+              | ResetTimer RoundNumber
               deriving (Eq, Show)
 
 getHash :: TrustedMessage -> Word256

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -399,3 +399,14 @@ spec = parallel $ do
             other = resp \\ omsgs
         map oMessage omsgs `shouldBe` [RoundChange next, Preprepare next blk]
         other `shouldBe` [ResetTimer $ _round next]
+
+    it "clears the lock after a future round change" $ property $ \blk sig ->
+      runTest $ do
+        setBlock blk
+        me <- selfAddr
+        next <- uses view (over round (+1) . over sequence (+1))
+        resp <- sendMessages [IMsg (MsgAuth me sig) $ RoundChange next]
+        let omsgs = [o | o@(OMsg _ _) <- resp]
+            other = resp \\ omsgs
+        map oMessage omsgs `shouldBe` [RoundChange next]
+        other `shouldMatchList` [ResetTimer $ _round next, MakeBlockCommand]

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -64,6 +64,11 @@ spec = parallel $ do
     it "ignores stale timeouts" $ do
       runTest $ do
         sendMessages [Timeout 10] `shouldReturn` []
+    it "sets the pending round after a timeout" $ property $ \a1 a2 ->
+      runTest $ do
+      validators .= [a1, a2]
+      _ <- sendMessages [Timeout 20]
+      use pendingRound `shouldReturn` Just 21
 
     it "can handle several rounds in succession" $ property $ \blk' blk2' as seal ->
       not (null as) ==> runTest $ do

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -58,8 +58,12 @@ spec = parallel $ do
   describe "The blockstanbul event loop" $ do
     it "requests a round changes round in response to a timeout or insertion failure" $
       runTest $ do
-        got <- sendMessages [Timeout, CommitResult (Left  "invalid hash")]
+        got <- sendMessages [Timeout 20, CommitResult (Left  "invalid hash")]
         map (_round . roundchangeView . oMessage) got `shouldBe` [21, 21]
+
+    it "ignores stale timeouts" $ do
+      runTest $ do
+        sendMessages [Timeout 10] `shouldReturn` []
 
     it "can handle several rounds in succession" $ property $ \blk' blk2' as seal ->
       not (null as) ==> runTest $ do
@@ -80,7 +84,7 @@ spec = parallel $ do
         length xsp `shouldBe` 1
         xsp `shouldBe` [ToCommit blk]
         -- Pretend that in this interval, the block was committed
-        sendMessages [CommitResult (Right ())] `shouldReturn` [ResetTimer]
+        sendMessages [CommitResult (Right ())] `shouldReturn` []
         -- The proposer *shouldn't* change, because the round number is the same
         let nextPpr = as !! ((1 + fromIntegral (_round v)) `mod` length as)
         use proposer `shouldReturn` sender ppr
@@ -110,7 +114,7 @@ spec = parallel $ do
         let omsgs5 = [o | o@(OMsg _ _) <- omsgs5']
             rest5 = omsgs5' \\ omsgs5
         map oMessage omsgs5 `shouldBe` [RoundChange next]
-        rest5 `shouldBe` [ResetTimer]
+        rest5 `shouldBe` [ResetTimer 21]
         use view `shouldReturn` over round (+1) v2
         use proposer `shouldReturn` sender nextPpr
 
@@ -298,7 +302,7 @@ spec = parallel $ do
         use roundChanged `shouldReturn` M.fromList [(sender a1, roundNext), (sender a2, roundNext)]
         use view `shouldReturn` curView
         -- 3 votes will do it
-        sendMessages [IMsg a3 $ RoundChange next] `shouldReturn` [ResetTimer]
+        sendMessages [IMsg a3 $ RoundChange next] `shouldReturn` [ResetTimer 24]
         use pendingRound `shouldReturn` Nothing
         use roundChanged `shouldReturn` M.empty
         use view `shouldReturn` next

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -80,7 +80,7 @@ spec = parallel $ do
         length xsp `shouldBe` 1
         xsp `shouldBe` [ToCommit blk]
         -- Pretend that in this interval, the block was committed
-        sendMessages [CommitResult (Right ())] `shouldReturn` []
+        sendMessages [CommitResult (Right ())] `shouldReturn` [ResetTimer]
         -- The proposer *shouldn't* change, because the round number is the same
         let nextPpr = as !! ((1 + fromIntegral (_round v)) `mod` length as)
         use proposer `shouldReturn` sender ppr
@@ -106,8 +106,11 @@ spec = parallel $ do
         -- Lets abort this round
         next <- uses view (over round (+1))
         let aborts = map (\a -> IMsg a $ RoundChange next) as
-        omsgs5 <- sendMessages aborts
+        omsgs5' <- sendMessages aborts
+        let omsgs5 = [o | o@(OMsg _ _) <- omsgs5']
+            rest5 = omsgs5' \\ omsgs5
         map oMessage omsgs5 `shouldBe` [RoundChange next]
+        rest5 `shouldBe` [ResetTimer]
         use view `shouldReturn` over round (+1) v2
         use proposer `shouldReturn` sender nextPpr
 
@@ -295,7 +298,7 @@ spec = parallel $ do
         use roundChanged `shouldReturn` M.fromList [(sender a1, roundNext), (sender a2, roundNext)]
         use view `shouldReturn` curView
         -- 3 votes will do it
-        sendMessages [IMsg a3 $ RoundChange next] `shouldReturn` []
+        sendMessages [IMsg a3 $ RoundChange next] `shouldReturn` [ResetTimer]
         use pendingRound `shouldReturn` Nothing
         use roundChanged `shouldReturn` M.empty
         use view `shouldReturn` next

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -336,3 +336,66 @@ spec = parallel $ do
         L.view commitment ist `shouldBe` []
         L.view proposedSig ist `shouldSatisfy`
           (== Just me) . (>>= verifyProposerSeal blk')
+
+  describe "Block locks" $ do
+    it "takes priority over NewBlocks" $ property $ \lock blk ->
+      runTest $ do
+        me <- selfAddr
+        validators .= [me]
+        proposer .= me
+        blockLock .= Just lock
+        omsgs <- sendMessages [NewBlock blk]
+        let [Preprepare v' blk'] = map oMessage omsgs
+        blk' `shouldBe` lock
+        v <- use view
+        v' `shouldBe` v
+
+    it "round changes a preprepare that doesn't match the lock" $ property $ \lock blk a ->
+      runTest $ do
+        validators .= [sender a]
+        proposer .= sender a
+        blockLock .= Just lock
+        v <- use view
+        omsgs <- sendMessages [IMsg a $ Preprepare v blk]
+        next <- uses view (over round (+1))
+        map oMessage omsgs `shouldBe` [RoundChange next]
+
+    it "Resets the lock after a commit result -- positive or negative" $ property $ \blk as ->
+      runTest $ do
+        me <- selfAddr
+        validators .= me:as
+        blockLock .= Just blk
+        _ <- sendMessages [CommitResult (Left "oops")]
+        use blockLock `shouldReturn` Nothing
+
+        blockLock .= Just blk
+        _ <- sendMessages [CommitResult (Right ())]
+        use blockLock `shouldReturn` Nothing
+
+    it "Sets a lock after prepare consensus is reached" $ property $ \auth blk ->
+      runTest $ do
+        (curView, di) <- setupRound blk [sender auth]
+        _ <- sendMessages [IMsg auth $ Prepare curView di]
+        use blockLock `shouldReturn` Just blk
+
+    let setBlock blk = do
+          me <- selfAddr
+          validators .= [me]
+          proposal .= Just blk
+          blockLock .= Just blk
+
+    it "requests a new block after success" $ property $ \blk ->
+      runTest $ do
+        setBlock blk
+        sendMessages [CommitResult (Right ())] `shouldReturn` [MakeBlockCommand]
+
+    it "re-issues the lock after round change" $ property $ \blk sig ->
+      runTest $ do
+        setBlock blk
+        me <- selfAddr
+        next <- uses view (over round (+1))
+        resp <- sendMessages [IMsg (MsgAuth me sig) $ RoundChange next]
+        let omsgs = [o | o@(OMsg _ _) <- resp]
+            other = resp \\ omsgs
+        map oMessage omsgs `shouldBe` [RoundChange next, Preprepare next blk]
+        other `shouldBe` [ResetTimer $ _round next]

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -43,16 +43,16 @@ function newnode {
   fi
 
   echo "Starting strato-sequencer"
-  if [ -n ${tmpblockstanbul} ]; then
+  if [ -n "${tmpblockstanbul}" ]; then
     tbFlag="--tmpblockstanbul=${tmpblockstanbul}"
   fi
-  if [ -n ${blockstanbulBlockPeriodMs} ]; then
+  if [ -n "${blockstanbulBlockPeriodMs}" ]; then
     bpFlag="--blockstanbul_block_period_ms=${blockstanbulBlockPeriodMs}"
   fi
-  if [ -n ${blockstanbulRoundPeriodS} ]; then
+  if [ -n "${blockstanbulRoundPeriodS}" ]; then
     rpFlag="--blockstanbul_round_period_s=${blockstanbulRoundPeriodS}"
   fi
-  if [ -n ${validators} ]; then
+  if [ -n "${validators}" ]; then
     vsFlag="--validators=${validators}"
   fi
   NODEKEY=${blockstanbulPrivateKey:-} runBackgroundProcess strato-sequencer "${bpFlag}" "${rpFlag}" "${vsFlag}" ${tbFlag} --minLogLevel=$minLogLevel &> logs/strato-sequencer

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -43,7 +43,19 @@ function newnode {
   fi
 
   echo "Starting strato-sequencer"
-  NODEKEY=${blockstanbulPrivateKey:-} runBackgroundProcess strato-sequencer --minLogLevel=$minLogLevel --tmpblockstanbul=${tmpblockstanbul:-false} --validators=${validators:-[]} >> logs/strato-sequencer 2>&1
+  if [ -n ${tmpblockstanbul} ]; then
+    tbFlag="--tmpblockstanbul=${tmpblockstanbul}"
+  fi
+  if [ -n ${blockstanbulBlockPeriodMs} ]; then
+    bpFlag="--blockstanbul_block_period_ms=${blockstanbulBlockPeriodMs}"
+  fi
+  if [ -n ${blockstanbulRoundPeriodS} ]; then
+    rpFlag="--blockstanbul_round_period_s=${blockstanbulRoundPeriodS}"
+  fi
+  if [ -n ${validators} ]; then
+    vsFlag="--validators=${validators}"
+  fi
+  NODEKEY=${blockstanbulPrivateKey:-} runBackgroundProcess strato-sequencer "${bpFlag}" "${rpFlag}" "${vsFlag}" ${tbFlag} --minLogLevel=$minLogLevel &> logs/strato-sequencer
 
   echo "Starting strato-api-indexer"
   runBackgroundProcess strato-api-indexer +RTS -N1 >> logs/strato-api-indexer 2>&1

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -37,9 +37,13 @@ function newnode {
        runBackgroundProcess strato-p2p-client --cNetworkID=$networkID --maxConn=$maxConn --sqlPeers=true --debugFail=${debugFail:-true} >> logs/strato-p2p-client 2>&1
   fi
 
-  minLogLevel=LevelInfo
+  evmMinLogLevel=LevelInfo
   if [ "${evmDebugMode}" = true ] ; then
-      minLogLevel=LevelDebug
+     evmMinLogLevel=LevelDebug
+  fi
+  seqMinLogLevel=LevelInfo
+  if [ "${seqDebugMode}" = true ] ; then
+     seqMinLogLevel=LevelDebug
   fi
 
   echo "Starting strato-sequencer"
@@ -55,7 +59,7 @@ function newnode {
   if [ -n "${validators}" ]; then
     vsFlag="--validators=${validators}"
   fi
-  NODEKEY=${blockstanbulPrivateKey:-} runBackgroundProcess strato-sequencer "${bpFlag}" "${rpFlag}" "${vsFlag}" ${tbFlag} --minLogLevel=$minLogLevel &> logs/strato-sequencer
+  NODEKEY=${blockstanbulPrivateKey:-} runBackgroundProcess strato-sequencer "${bpFlag}" "${rpFlag}" "${vsFlag}" ${tbFlag} --minLogLevel=$seqMinLogLevel &> logs/strato-sequencer
 
   echo "Starting strato-api-indexer"
   runBackgroundProcess strato-api-indexer +RTS -N1 >> logs/strato-api-indexer 2>&1
@@ -71,7 +75,7 @@ function newnode {
   runBackgroundProcess ethereum-vm --useSyncMode=$useSyncMode --miner=$miningAlgorithm --maxTxsPerBlock=$maxTxsPerBlock \
                          --diffPublish=$diffPublish --sqlDiff=$sqlDiff --createTransactionResults=true \
                          --miningVerification=$verifyBlocks --difficultyBomb=$difficultyBomb \
-                         --trace=$evmTraceMode --debug=$evmDebugMode --minLogLevel=$minLogLevel \
+                         --trace=$evmTraceMode --debug=$evmDebugMode --minLogLevel=$evmMinLogLevel \
                          --tmpblockstanbul=${tmpblockstanbul:-false} +RTS -N1 >> logs/ethereum-vm 2>&1
 
   echo "Starting strato-api"

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -53,7 +53,7 @@ jamshidBirth = posixSecondsToUTCTime 0
 createPeer :: String -> Either String PPeer
 createPeer peerString = buildPeer <$> parseEnode peerString
 
--- TODO(tim): Re-enable configurable ports for a peer
+-- TODO(tim): Reenable port selection
 buildPeer :: (Maybe String, String, Int) -> PPeer
 buildPeer (pubKeyMaybe, ip, _) =
     PPeer {
@@ -104,7 +104,9 @@ getAvailablePeers = withGlobalSQLPool $ \sqldb -> do
     SQL.selectList [PPeerEnableTime SQL.<. currentTime] []
 
 setPeerActiveState::T.Text->Int->Int->IO ()
-setPeerActiveState ip port' state = withGlobalSQLPool $ \sqldb -> do
+setPeerActiveState ip _ state = withGlobalSQLPool $ \sqldb -> do
+  -- TODO(tim): Reenable port selection
+  let port' = 30303
   flip SQL.runSqlPool sqldb $
     SQL.updateWhere [PPeerIp SQL.==. ip, PPeerTcpPort SQL.==. port'] [PPeerActiveState SQL.=. state]
   return ()
@@ -116,7 +118,9 @@ getActivePeers = withGlobalSQLPool $ \sqldb -> do
     SQL.selectList [PPeerActiveState SQL.==. 1, PPeerEnableTime SQL.<. currentTime] []
 
 setPeerBondingState::String->Int->Int->IO ()
-setPeerBondingState ip port' state = withGlobalSQLPool $ \sqldb -> do
+setPeerBondingState ip _ state = withGlobalSQLPool $ \sqldb -> do
+  -- TODO(tim): Reenable port selection
+  let port' = 30303
   flip SQL.runSqlPool sqldb $
     SQL.updateWhere [PPeerIp SQL.==. T.pack ip, PPeerUdpPort SQL.==. port'] [PPeerBondState SQL.=. state]
   return ()
@@ -158,14 +162,18 @@ defaultPeer = PPeer{
   }
 
 disablePeerForSeconds::PPeer->Int->IO ()
-disablePeerForSeconds peer seconds = withGlobalSQLPool $ \sqldb -> do
+disablePeerForSeconds peer' seconds = withGlobalSQLPool $ \sqldb -> do
+  -- TODO(tim): Reenable port selection
+  let peer = peer'{pPeerTcpPort = 30303, pPeerUdpPort=30303}
   currentTime <- getCurrentTime
   flip SQL.runSqlPool sqldb $
     SQL.updateWhere [PPeerIp SQL.==. pPeerIp peer, PPeerTcpPort SQL.==. pPeerTcpPort peer] [PPeerEnableTime SQL.=. fromIntegral seconds `addUTCTime` currentTime]
   return ()
 
 disableUDPPeerForSeconds::PPeer->Int->IO ()
-disableUDPPeerForSeconds peer seconds = withGlobalSQLPool $ \sqldb -> do
+disableUDPPeerForSeconds peer' seconds = withGlobalSQLPool $ \sqldb -> do
+  -- TODO(tim): Reenable port selection
+  let peer = peer'{pPeerTcpPort=30303}
   currentTime <- getCurrentTime
   flip SQL.runSqlPool sqldb $
     SQL.updateWhere [PPeerIp SQL.==. pPeerIp peer, PPeerTcpPort SQL.==. pPeerTcpPort peer] [PPeerUdpEnableTime SQL.=. fromIntegral seconds `addUTCTime` currentTime]

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -53,13 +53,14 @@ jamshidBirth = posixSecondsToUTCTime 0
 createPeer :: String -> Either String PPeer
 createPeer peerString = buildPeer <$> parseEnode peerString
 
+-- TODO(tim): Re-enable configurable ports for a peer
 buildPeer :: (Maybe String, String, Int) -> PPeer
-buildPeer (pubKeyMaybe, ip, port') =
+buildPeer (pubKeyMaybe, ip, _) =
     PPeer {
         pPeerPubkey = stringToPoint <$> pubKeyMaybe,
         pPeerIp = T.pack ip,
-        pPeerUdpPort = port', --TODO think about this....  Should the UDP port be the same as the TCP port by default?
-        pPeerTcpPort = port',
+        pPeerUdpPort = 30303, --TODO think about this....  Should the UDP port be the same as the TCP port by default?
+        pPeerTcpPort = 30303,
         pPeerNumSessions = 0,
         pPeerLastTotalDifficulty = 0,
         pPeerLastMsg  = T.pack "msg",

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
@@ -146,7 +146,9 @@ instance RLPSerializable Neighbor where
   rlpDecode x = error $ "unsupported rlp in rlpDecode for Neighbor: " ++ show x
 
 peerToNeighbor :: PPeer -> Either DiscoverException Neighbor
-peerToNeighbor p = do
+peerToNeighbor p' = do
+  -- TODO(tim): Reenable port selection
+  let p = p'{pPeerUdpPort=30303, pPeerTcpPort=30303}
   pubKey <- note NoPublicKeyException (pPeerPubkey p)
   let endpoint = Endpoint (stringToIAddr $ T.unpack $ pPeerIp p)
                           (fromIntegral $ pPeerUdpPort p)
@@ -283,16 +285,20 @@ data UDPException = UDPTimeout deriving (Show)
 instance Exception UDPException where
 
 getSocket :: HostName -> PortNumber -> IO Socket
-getSocket domain port = do
+getSocket domain _ = do
+  -- TODO(tim): Reenable port selection
+  let port = 30303 :: Int
   (serveraddr:_) <- getAddrInfo Nothing (Just domain) (Just $ show port)
   s <- socket (addrFamily serveraddr) Datagram defaultProtocol
   _ <- connect s (addrAddress serveraddr)
   return s
 
 getServerPubKey :: H.PrvKey -> String -> PortNumber -> IO (Either SomeException Point)
-getServerPubKey myPriv domain port =
+getServerPubKey myPriv domain _ =
     withSocketsDo $ bracket (getSocket domain port) close (talk myPriv)
   where
+    -- TODO(tim): Reenable port selection
+    port = 30303
     talk :: H.PrvKey -> Socket -> IO (Either SomeException Point)
     talk prvKey' socket' = do
       timestamp <- fmap round getPOSIXTime
@@ -323,9 +329,11 @@ getServerPubKey myPriv domain port =
         Right (Just x) -> return $ fmapL SomeException $ hPubKeyToPubKey x
 
 findNeighbors::H.PrvKey -> String -> PortNumber -> IO ()
-findNeighbors myPriv domain port =
+findNeighbors myPriv domain _ =
     withSocketsDo $ bracket (getSocket domain port) close (talk myPriv)
   where
+    -- TODO(tim): Reenable port selection
+    port = 30303
     talk :: H.PrvKey -> Socket -> IO ()
     talk prvKey' socket' = do
       let (theType, theRLP) =

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
@@ -54,13 +54,15 @@ runEthUDPServer :: ( MonadIO m
                 -> Int
                 -> Socket
                 -> m ()
-runEthUDPServer ctx myPriv portNum sock =
+runEthUDPServer ctx myPriv _ sock =
   void . runResourceT $ runStateT (udpHandshakeServer myPriv sock portNum) ctx
+     where portNum = 30303 -- TODO(tim): Reenable port selection
 
 connectMe :: (MonadIO m, MonadLogger m)
           => Int
           -> m Socket
-connectMe port' = do
+connectMe _ = do
+  let port' = 30303 :: Int -- TODO(tim): Reenable port selection
   (serveraddr:_) <- liftIO $ getAddrInfo
                                   (Just (defaultHints {addrFlags = [AI_PASSIVE]}))
                                   Nothing (Just (show port'))
@@ -95,10 +97,12 @@ attemptBond :: (MonadIO m, MonadLogger m)
             -> Socket
             -> Int
             -> m ()
-attemptBond prv sock portNum = do
+attemptBond prv sock _ = do
+  let portNum = 30303 :: Int
   unbondedPeers <- liftIO getUnbondedPeers
   when (length unbondedPeers /= 0) $
-    forM_ unbondedPeers $ \p -> do
+    forM_ unbondedPeers $ \p' -> do
+      let p = p'{pPeerUdpPort = 30303, pPeerTcpPort=30303} -- TODO(tim): Reenable port selection
       (peeraddr : _) <- liftIO $ getAddrInfo
                                    Nothing
                                    (Just $ T.unpack $ pPeerIp p)
@@ -131,7 +135,8 @@ udpHandshakeServer :: ( HasSQLDB m
                    -> Socket
                    -> Int
                    -> m ()
-udpHandshakeServer prv sock portNum = do
+udpHandshakeServer prv sock _ = do
+    let portNum = 30303 -- TODO(tim): Reenable port selection
     _ <- addPeersIfNeeded prv sock
     _ <- attemptBond prv sock portNum
     maybePacketData <- liftIO $ timeout 10000000 $ NB.recvFrom sock 1280
@@ -148,10 +153,11 @@ udpHandshakeServer prv sock portNum = do
         _ <- $logInfoS "udpHandshakeServer/handler" $ T.pack $ CL.cyan "receiving " ++ " (" ++ show addr ++ " " ++ BC.unpack (B.take 10 $ B16.encode $ B.pack $ pointToBytes otherPubKey) ++ "....) " ++ format packet
         handleValidPacket prv sock addr otherPort packet otherPubKey
     argValidator :: B.ByteString -> SockAddr -> Either DiscoverException (NodeDiscoveryPacket, ECC.Point, PortNumber)
-    argValidator msg addr = do
+    argValidator msg _ = do
       (packet, otherPubkey) <- dataToPacket msg
       validOtherPubKey <- hPubKeyToPubKey otherPubkey
-      otherPort <- getAddrPort addr
+      -- otherPort <- getAddrPort addr
+      let otherPort = 30303 -- TODO(tim): Reenable port selection
       return (packet, validOtherPubKey, otherPort)
 
 handleValidPacket :: ( HasSQLDB m
@@ -168,7 +174,8 @@ handleValidPacket :: ( HasSQLDB m
                   -> NodeDiscoveryPacket
                   -> ECC.Point
                   -> m ()
-handleValidPacket prv sock addr portNum packet otherPubKey = case packet of
+                                                       -- TODO(tim): Reenable port selection
+handleValidPacket prv sock addr _ packet otherPubKey = let portNum = 30303 :: Int in case packet of
     Ping{} -> do
         addPeer'
         time <- liftIO $ round `fmap` getPOSIXTime
@@ -186,18 +193,19 @@ handleValidPacket prv sock addr portNum packet otherPubKey = case packet of
         peers <- getPeersClosestTo targetPubkey (T.pack ip) otherPubKey
         let theNeighbors = (\p -> Neighbor (mkEndpoint p) (mkNodeId p)) <$> peers
         sendPacket sock prv addr $ Neighbors theNeighbors nextTime
-
-          where mkEndpoint PPeer{..} = Endpoint (stringToIAddr $ T.unpack pPeerIp) (fromIntegral pPeerUdpPort) (fromIntegral pPeerTcpPort)
+                -- TODO(tim): Reenable port selection
+          where mkEndpoint PPeer{..} = Endpoint (stringToIAddr $ T.unpack pPeerIp) 30303 30303
                 mkNodeId             = pointToNodeID . fromJust . pPeerPubkey
 
 
-    Neighbors neighbors _ -> forM_ neighbors $ \(Neighbor (Endpoint addr' udpPort tcpPort) nodeID) -> do
+                                                          -- TODO(tim): Reenable port selection
+    Neighbors neighbors _ -> forM_ neighbors $ \(Neighbor (Endpoint addr' _ _) nodeID) -> do
         $logDebugS "handleValidPacket/Neighbors" . T.pack $ "Got new neighbors: " ++ show neighbors
         curTime <- liftIO getCurrentTime
         let peer = PPeer { pPeerPubkey = Just $ nodeIDToPoint nodeID
                          , pPeerIp = T.pack $ format addr'
-                         , pPeerUdpPort = fromIntegral udpPort
-                         , pPeerTcpPort = fromIntegral tcpPort
+                         , pPeerUdpPort = 30303
+                         , pPeerTcpPort = 30303
                          , pPeerNumSessions = 0
                          , pPeerLastTotalDifficulty = 0
                          , pPeerLastMsg  = T.pack "msg"
@@ -213,9 +221,11 @@ handleValidPacket prv sock addr portNum packet otherPubKey = case packet of
   where addPeer' = do
           curTime <- liftIO getCurrentTime
           let ip   = sockAddrToIP addr
+              portNum = 30303 :: Int
               peer = PPeer { pPeerPubkey = Just otherPubKey
                           , pPeerIp = T.pack ip
                           , pPeerUdpPort = fromIntegral portNum
+                          -- TODO(tim): This TODO may be the cause of the trouble
                           , pPeerTcpPort = fromIntegral portNum --TODO- put correct TCP port in here
                           ,  pPeerNumSessions = 0
                           ,  pPeerLastTotalDifficulty = 0
@@ -230,7 +240,8 @@ handleValidPacket prv sock addr portNum packet otherPubKey = case packet of
                           }
           void $ addPeer peer
 
-getAddrPort :: SockAddr -> Either DiscoverException PortNumber
-getAddrPort (SockAddrInet portNumber _)      = Right portNumber
-getAddrPort (SockAddrInet6 portNumber _ _ _) = Right portNumber
-getAddrPort s                                = Left . MissingPortException $ "No port number: " ++ show s
+-- TODO(tim): Reenable port selection
+-- getAddrPort :: SockAddr -> Either DiscoverException PortNumber
+-- getAddrPort (SockAddrInet portNumber _)      = Right portNumber
+-- getAddrPort (SockAddrInet6 portNumber _ _ _) = Right portNumber
+-- getAddrPort s                                = Left . MissingPortException $ "No port number: " ++ show s

--- a/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
@@ -197,5 +197,7 @@ bootstrapSequencer gb = do
                                             , syncWrites            = False
                                             , bootstrapDoEmit       = True
                                             , statsConfig           = Nothing
+                                            , blockstanbulBlockPeriodμs = 0
+                                            , blockstanbulRoundPeriod = 0
                                             }
     runLoggingT (runSequencerM dummySequencerCfg Nothing (bootstrap gb)) printLogMsg

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -49,7 +49,6 @@ newtype Address = Address Word160 deriving (Show, Eq, Read, Enum, Real, Bounded,
 instance PrintfArg Address where
   formatArg (Address word) = formatArg word
 
-
 prvKey2Address :: PrvKey -> Address
 prvKey2Address prvKey =
   Address $ fromInteger $ byteString2Integer $ keccak256 $ BL.toStrict $ encode x `BL.append` encode y

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -34,6 +34,7 @@ import           Network.Haskoin.Crypto               hiding (Address, Word160)
 import           Network.Haskoin.Internals            hiding (Address, Word160)
 -- import           Text.PrettyPrint.ANSI.Leijen         hiding ((<$>))
 import qualified Text.PrettyPrint.ANSI.Leijen         as Lei
+import           Text.Printf
 import           Web.PathPieces
 
 import           GHC.Generics
@@ -44,6 +45,10 @@ instance RLPSerializable Address where
   rlpDecode x             = error ("Malformed rlp object sent to rlp2Address: " ++ show x)
 
 newtype Address = Address Word160 deriving (Show, Eq, Read, Enum, Real, Bounded, Num, Ord, Generic, Integral)
+
+instance PrintfArg Address where
+  formatArg (Address word) = formatArg word
+
 
 prvKey2Address :: PrvKey -> Address
 prvKey2Address prvKey =

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Format.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Format.hs
@@ -21,3 +21,6 @@ instance Format B.ByteString where
 instance Format N.NibbleString where
   format (N.EvenNibbleString bs)  = format bs
   format (N.OddNibbleString n bs) = showHex n "" ++ format bs
+
+instance (Format a, Format b) => Format (a, b) where
+  format (x, y) = "(" ++ format x ++ ", " ++ format y ++ ")"

--- a/core-strato/strato-sequencer/exec-src/Flags.hs
+++ b/core-strato/strato-sequencer/exec-src/Flags.hs
@@ -8,8 +8,6 @@ import           HFlags
 -- core flags
 defineFlag "q:txdedupwindow" (2000 :: Int) "Transaction window to deduplicate any given Tx (i.e., after N transactions have passed, a previously seen Tx can be reemitted)"
 
--- TODO(tim): This should instead specify validators, a private key file, and perhaps a starting view
-defineFlag "tmpblockstanbul" (False :: Bool) "Whether to run blockstanbul"
 
 -- leveldb related flags
 defineFlag "b:depblockdbpath" (dbDir "h" ++ sequencerDependentBlockDBPath) "Where to store/load the dependent block db"
@@ -21,4 +19,10 @@ defineFlag "k:kafkaclientid" defaultKafkaClientId' "KafkaClientId (for runKafkaC
 
 defineFlag "kafkaaddress" ("" :: String) "Alternate kafka instance to connect to."
 
+-- blockstanbul related flags
+-- TODO(tim): This should instead specify validators, a private key file, and perhaps a starting view
+defineFlag "tmpblockstanbul" (False :: Bool) "Whether to run blockstanbul"
 defineFlag "validators" ("[]" :: String) "JSON encoded addresses of validators"
+defineFlag "blockstanbul_block_period_ms" (1000 :: Int) "Minimum delay between block creations"
+defineFlag "blockstanbul_round_period_s" (10 :: Int)
+  "Maximum seconds that one validator will remain the proposer"

--- a/core-strato/strato-sequencer/exec-src/Main.hs
+++ b/core-strato/strato-sequencer/exec-src/Main.hs
@@ -57,5 +57,7 @@ main = do
     , syncWrites            = flags_syncwrites
     , bootstrapDoEmit       = True
     , statsConfig           = EC.statsConfig EC.ethConf
+    , blockstanbulBlockPeriodμs = 1000 * 1000 * flags_blockstanbul_block_period_ms
+    , blockstanbulRoundPeriod = fromIntegral flags_blockstanbul_round_period_s
   }
   runLoggingT (runSequencerM cfg mCtx sequencer) printLogMsg

--- a/core-strato/strato-sequencer/exec-src/Main.hs
+++ b/core-strato/strato-sequencer/exec-src/Main.hs
@@ -57,7 +57,7 @@ main = do
     , syncWrites            = flags_syncwrites
     , bootstrapDoEmit       = True
     , statsConfig           = EC.statsConfig EC.ethConf
-    , blockstanbulBlockPeriodμs = 1000 * 1000 * flags_blockstanbul_block_period_ms
+    , blockstanbulBlockPeriodμs = 1000 * flags_blockstanbul_block_period_ms
     , blockstanbulRoundPeriod = fromIntegral flags_blockstanbul_round_period_s
   }
   runLoggingT (runSequencerM cfg mCtx sequencer) printLogMsg

--- a/core-strato/strato-sequencer/package.yaml
+++ b/core-strato/strato-sequencer/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - time
   - statsdi
   - stm
+  - stm-chans
   - conduit-combinators
   - blockstanbul
   - lens
@@ -73,5 +74,7 @@ tests:
       - derive
       - hflags
       - hspec
+      - hspec-core
       - hspec-contrib
       - strato-sequencer
+      - hspec-expectations-lifted

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -65,7 +65,7 @@ sequencer = do
   forever $ do
     $logDebugS "seq/loop/start" ""
     v <- currentView
-    $logDebugS "seq/blockstanbul" . T.pack $ "View: " ++ show v
+    $logDebugS "seq/blockstanbul" . T.pack $ "View: " ++ format v
     blockstanbulSend . map Timeout =<< drainTimeouts
     inEvents <- readUnseqEvents'
     $logInfoS "sequencer" . T.pack $ "Fetched " ++ show (length inEvents) ++ " events)"

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -72,18 +72,16 @@ blockPeriodμs = 1000000
 roundTimeout :: NominalDiffTime
 roundTimeout = 10
 
-createBlockstanbulRoundTimer :: IO (TMVar Bool)
-createBlockstanbulRoundTimer = do
+createNewTimer :: SequencerM ()
+createNewTimer = do
   var <- atomically $ newTMVar False
   let act :: AlarmClock UTCTime -> IO ()
-      act alarm' = do
-        _ <- atomically $ swapTMVar var True
-        next <- addUTCTime roundTimeout <$> getCurrentTime
-        setAlarm alarm' next
-  alarm <- newAlarmClock act :: IO (AlarmClock UTCTime)
-  next <- addUTCTime roundTimeout <$> getCurrentTime
+      act _ = atomically $ swapTMVar var True
+  alert <- liftIO $ newAlarmClock act
+  dt <- view blockstanbulRoundTimeout
+  next <- addUTCTime dt <$> liftIO getCurrentTime
   setAlarm alarm next
-  return var
+  blockstanbulTimeout .= var
 
 sequencer :: SequencerM ()
 sequencer = do
@@ -95,6 +93,7 @@ sequencer = do
     $logDebugS "seq/loop/start" ""
     v <- currentView
     $logDebugS "seq/blockstanbul" . T.pack $ "View: " ++ show v
+    timer <- use blockstanbulTimeout
     timedOut <- atomically $ swapTMVar timer False
     when timedOut $ do
       blockstanbulSend [Timeout]
@@ -172,7 +171,7 @@ blockstanbulSend msgs = do
             -- TODO(tim): Block insertion can potentially fail, so there
             -- should be feedback here
             else sendAllMessages [CommitResult (Right ())]
-
+    when (ResetTimer `elem` resp) createNewTimer
     $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ show blocks
     let rewriteBlock = fmap OEBlock
                      . fmap (flip sequencedBlockToOutputBlock 1)

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -8,17 +8,12 @@
 {-# LANGUAGE TupleSections     #-}
 module Blockchain.Sequencer where
 
-import           ClassyPrelude                             (atomically)
-
 import           Control.Concurrent
-import           Control.Concurrent.AlarmClock
-import           Control.Concurrent.STM.TMVar
 import           Control.Monad.Logger
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Control.Monad.Stats                       hiding (prefix)
 import           Control.Monad.IO.Class                    (liftIO)
-import           Data.Time.Clock
 import           System.Clock
 
 import           Data.Foldable                             (toList)
@@ -64,39 +59,14 @@ import           Blockchain.Strato.Model.SHA
 
 import           Blockchain.Util
 
-
--- TODO(tim): Make these flag configurable
-blockPeriodμs :: Int
-blockPeriodμs = 1000000
-
-roundTimeout :: NominalDiffTime
-roundTimeout = 10
-
-createNewTimer :: SequencerM ()
-createNewTimer = do
-  var <- atomically $ newTMVar False
-  let act :: AlarmClock UTCTime -> IO ()
-      act _ = atomically $ swapTMVar var True
-  alert <- liftIO $ newAlarmClock act
-  dt <- view blockstanbulRoundTimeout
-  next <- addUTCTime dt <$> liftIO getCurrentTime
-  setAlarm alarm next
-  blockstanbulTimeout .= var
-
 sequencer :: SequencerM ()
 sequencer = do
-  -- TODO(tim): Pipe time window in through a flag
-  timer <- liftIO $ createBlockstanbulRoundTimer
-  -- Bootstrap the block generation
-  writeSeqVmEvents' [OECreateBlockCommand]
+  bootstrapBlockstanbul
   forever $ do
     $logDebugS "seq/loop/start" ""
     v <- currentView
     $logDebugS "seq/blockstanbul" . T.pack $ "View: " ++ show v
-    timer <- use blockstanbulTimeout
-    timedOut <- atomically $ swapTMVar timer False
-    when timedOut $ do
-      blockstanbulSend [Timeout]
+    blockstanbulSend . map Timeout =<< drainTimeouts
     inEvents <- readUnseqEvents'
     $logInfoS "sequencer" . T.pack $ "Fetched " ++ show (length inEvents) ++ " events)"
     clearLdbBatchOps
@@ -124,7 +94,7 @@ sequencer = do
         -- TODO(tim): This delay is to ensure that the timestamp on the
         -- block is more than a block period away from the last. The
         -- threadDelay can instead sleep for max(blockperiod - (now - last_timestamp), 0)
-        liftIO $ threadDelay blockPeriodμs
+        liftIO . threadDelay =<< asks blockstanbulBlockPeriodμs
       writeSeqVmEvents' vmEvs
       $logDebugS "sequencer" . T.pack $ "Wrote " ++ show vmEvs ++ " SeqEvents to VM"
     p2pEvs <- drainP2P
@@ -161,6 +131,11 @@ bootstrap BDB.Block{BDB.blockBlockData = bd, BDB.blockReceiptTransactions = txs,
                   writeSeqP2pEvents' [OEBlock shortCircuit]  -- todo handle the error :)
               return shortCircuit
 
+bootstrapBlockstanbul :: SequencerM ()
+bootstrapBlockstanbul = do
+  writeSeqVmEvents' [OECreateBlockCommand]
+  createFirstTimer
+
 blockstanbulSend :: [InEvent] -> SequencerM ()
 blockstanbulSend msgs = do
     resp' <- sendAllMessages msgs
@@ -171,7 +146,7 @@ blockstanbulSend msgs = do
             -- TODO(tim): Block insertion can potentially fail, so there
             -- should be feedback here
             else sendAllMessages [CommitResult (Right ())]
-    when (ResetTimer `elem` resp) createNewTimer
+    mapM_ createNewTimer [rn | ResetTimer rn <- resp]
     $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ show blocks
     let rewriteBlock = fmap OEBlock
                      . fmap (flip sequencedBlockToOutputBlock 1)

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -70,6 +70,7 @@ data SequencerContext = SequencerContext
                       , _p2pEvents           :: Q.Seq OutputEvent
                       , _sequencerKafkaState :: K.KafkaState
                       , _blockstanbulContext :: Maybe BlockstanbulContext
+                      , _blockstanbulTimeout :: TMVar Bool
                       }
 makeLenses ''SequencerContext
 
@@ -84,6 +85,8 @@ data SequencerConfig =
                      , syncWrites            :: Bool
                      , bootstrapDoEmit       :: Bool
                      , statsConfig           :: Maybe StatsConf
+                     , blockstanbulBlockPeriodμs :: Int
+                     , blockstanbulRoundTimeout :: NominalDiffTime
                      }
 
 type SequencerM  = StateT SequencerContext (ReaderT SequencerConfig (StatsT (ResourceT (LoggingT IO))))

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -18,8 +18,15 @@ module Blockchain.Sequencer.Monad (
   , addLdbBatchOps
   , drainP2P
   , drainVM
+  , createFirstTimer
+  , createNewTimer
+  , drainTimeouts
 ) where
 
+import           ClassyPrelude                             (atomically, STM)
+import           Prelude                                   hiding (round)
+import           Control.Concurrent.AlarmClock
+import           Control.Concurrent.STM.TMChan
 import           Control.Lens
 import           Control.Monad.Logger
 import           Control.Monad.Reader
@@ -30,6 +37,7 @@ import           Control.Monad.Trans.Resource
 import           Data.Foldable                             (toList)
 import qualified Data.Sequence                             as Q
 import qualified Data.Set                                  as S
+import           Data.Time.Clock
 
 import           Blockchain.Blockstanbul
 import           Blockchain.Constants
@@ -70,7 +78,7 @@ data SequencerContext = SequencerContext
                       , _p2pEvents           :: Q.Seq OutputEvent
                       , _sequencerKafkaState :: K.KafkaState
                       , _blockstanbulContext :: Maybe BlockstanbulContext
-                      , _blockstanbulTimeout :: TMVar Bool
+                      , _blockstanbulTimeouts :: TMChan RoundNumber
                       }
 makeLenses ''SequencerContext
 
@@ -86,7 +94,7 @@ data SequencerConfig =
                      , bootstrapDoEmit       :: Bool
                      , statsConfig           :: Maybe StatsConf
                      , blockstanbulBlockPeriodμs :: Int
-                     , blockstanbulRoundTimeout :: NominalDiffTime
+                     , blockstanbulRoundPeriod :: NominalDiffTime
                      }
 
 type SequencerM  = StateT SequencerContext (ReaderT SequencerConfig (StatsT (ResourceT (LoggingT IO))))
@@ -137,6 +145,7 @@ runSequencerM c mbc m = do
         let kState = case mAddr of
                          Nothing -> EC.mkConfiguredKafkaState kClId
                          Just addr -> K.mkKafkaState kClId addr
+        ch <- atomically $ newTMChan
 
         runStateT m SequencerContext
             { _dependentBlockDB    = depBlock
@@ -150,6 +159,7 @@ runSequencerM c mbc m = do
             , _p2pEvents           = Q.empty
             , _sequencerKafkaState = kState
             , _blockstanbulContext = mbc
+            , _blockstanbulTimeouts = ch
             }
     return $ fst a
 
@@ -167,6 +177,32 @@ drainP2P = fmap toList $ p2pEvents <<.= Q.empty
 
 drainVM :: SequencerM [OutputEvent]
 drainVM = fmap toList $ vmEvents <<.= Q.empty
+
+createFirstTimer :: SequencerM ()
+createFirstTimer = do
+  v <- currentView
+  createNewTimer . _round $ v
+
+createNewTimer :: RoundNumber -> SequencerM ()
+createNewTimer rn = do
+  ch <- use blockstanbulTimeouts
+  let act :: AlarmClock UTCTime -> IO ()
+      act _ = atomically $ writeTMChan ch rn
+  alarm <- liftIO $ newAlarmClock act
+  dt <- asks blockstanbulRoundPeriod
+  next <- addUTCTime dt <$> liftIO getCurrentTime
+  liftIO $ setAlarm alarm next
+
+drainTMChan :: TMChan a -> STM [a]
+drainTMChan ch = do
+  mmx <- tryReadTMChan ch
+  case mmx of
+    Nothing -> return []
+    Just Nothing -> return []
+    Just (Just x) -> (x:) <$> drainTMChan ch
+
+drainTimeouts :: SequencerM [RoundNumber]
+drainTimeouts = join $ uses blockstanbulTimeouts (atomically . drainTMChan)
 
 clearLdbBatchOps :: SequencerM ()
 clearLdbBatchOps = modify (\st -> st{_ldbBatchOps = Q.empty})

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/EventSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/EventSpec.hs
@@ -14,44 +14,38 @@ import           Blockchain.Sequencer.Event
 main :: IO ()
 main = hspec spec
 
+binaryFidelity :: (Eq a, Show a, Binary a) => a -> Expectation
+binaryFidelity x = decode (encode x) `shouldBe` x
+
 spec :: Spec
 spec = parallel $ do
     describe "Transaction" $ do
-        it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: TX.Transaction)
-
+        it "should be serializable and deserializable" $ property $
+            \x -> binaryFidelity (x :: TX.Transaction)
     describe "BlockData" $ do
-        it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: DD.BlockData)
-
+        it "should be serializable and deserializable" $ property $
+            \x -> binaryFidelity (x :: DD.BlockData)
     describe "AccountInfo" $ do
-        it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: CI.AccountInfo)
-
+        it "should be serializable and deserializable" $ property $
+            \x -> binaryFidelity (x :: CI.AccountInfo)
     describe "CodeInfo" $ do
-        it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: CI.CodeInfo)
-
+        it "should be serializable and deserializable" $ property $
+            \x -> binaryFidelity (x :: CI.CodeInfo)
     describe "ChainInfo" $ do
-        it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: CI.ChainInfo)
-
+        it "should be serializable and deserializable" $ property $
+            \x -> binaryFidelity (x :: CI.ChainInfo)
     describe "IngestTx" $ do
         it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: IngestTx)
-
+            \x -> binaryFidelity (x :: IngestTx)
     describe "IngestBlock" $ do
         it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: IngestBlock)
-
+            \x -> binaryFidelity (x :: IngestBlock)
     describe "SequencedBlock" $ do
         it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: SequencedBlock)
-
+            \x -> binaryFidelity (x :: SequencedBlock)
     describe "OutputTx" $ do
         it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: OutputTx)
-
+            \x -> binaryFidelity (x :: OutputTx)
     describe "OutputBlock" $ do
         it "should be serializable and deserializable" $ property $ do
-            \x -> (decode . encode) x == (x :: OutputBlock)
+            \x -> binaryFidelity (x :: OutputBlock)

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/OrderValidator.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/OrderValidator.hs
@@ -17,7 +17,7 @@ import qualified Blockchain.Colors          as CL
 import           Blockchain.Format
 import           Blockchain.Util            (tab)
 
-class OrderValidateable t where
+class Show t => OrderValidateable t where
     getBlockHash   :: t -> SHA
     getParentHash  :: t -> SHA
     getBlockNumber :: t -> Integer
@@ -40,11 +40,11 @@ data OrderValidateable t => OrderValidatorState t =
     OrderValidatorState { seenBlocks   :: Map.Map SHA Integer
                         , unseenBlocks :: [t]
                         , runState     :: ValidationResult t
-                        }
+                        } deriving (Show)
 
 type OrderValidatorM t = StateT (OrderValidatorState t) IO
 
-instance (Show t, Format t, OrderValidateable t) => Format (OrderValidatorState t) where
+instance (Format t, OrderValidateable t) => Format (OrderValidatorState t) where
     format (OrderValidatorState sb usb rs) =
         if (isValid' rs) then CL.green body else CL.red body
             where body =    ("runState -> " ++ (show rs) ++ "\n")

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -151,7 +151,9 @@ spec = do
             length dedupedOut `shouldBe` length dedupedOut
 
     describe "SequencerM" $ do
-      it "queues events" $ property $ \evs1 evs2 -> runTestM $ do
+      -- TODO: Benchmark more tightly.
+      -- This is amazingly slow for how little it appears to be doing.
+      it "queues events" $ withMaxSuccess 5 $ property $ \evs1 evs2 -> runTestM $ do
         drainVM `shouldReturn` []
         drainP2P `shouldReturn` []
         mapM_ markForVM evs1

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -161,9 +161,10 @@ spec = do
         drainP2P `shouldReturn` evs2
         drainP2P `shouldReturn` []
 
-    it "queues timeouts" $ runTestM $ do
-      let input = [20, 45, 30]
-      local (\cfg -> cfg{blockstanbulRoundPeriod=0}) $ do
-        mapM_ createNewTimer input
-      liftIO $ threadDelay 200 -- Who are you to judge?
-      drainTimeouts `shouldReturn` input
+      it "queues timeouts" $ runTestM $ do
+        let input = [20, 45, 30]
+        local (\cfg -> cfg{blockstanbulRoundPeriod=0}) $ do
+          mapM_ createNewTimer input
+        liftIO $ threadDelay 200 -- Who are you to judge?
+        out <- drainTimeouts
+        out `shouldMatchList` input

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -5,8 +5,11 @@ import           Data.Maybe                          (isNothing)
 import           Data.Time.Clock.POSIX
 import           Numeric                             (showHex)
 
+import           Control.Concurrent
 import           Control.Exception                   (finally)
+import           Control.Monad
 import           Control.Monad.Logger
+import           Control.Monad.Reader
 
 import           Blockchain.Format
 import           Blockchain.Output
@@ -20,7 +23,8 @@ import           Blockchain.Strato.Model.Class       (txChainId)
 import qualified Data.ByteString.Char8               as C8
 import qualified Network.Kafka.Protocol              as KP
 
-import           Test.Hspec
+import           Test.Hspec.Core.Spec
+import           Test.Hspec.Expectations.Lifted
 import           Test.Hspec.Contrib.HUnit            ()
 import           Test.HUnit
 import           Test.QuickCheck
@@ -33,6 +37,11 @@ stripTransactionsAndUncles b = b { ibReceiptTransactions = [], ibBlockUncles = [
 
 dedupWindow :: Int
 dedupWindow = 100
+
+runTestM :: SequencerM a -> IO ()
+runTestM m = do
+  gb <- makeGenesisBlock
+  void $ withTemporaryDepBlockDB gb m
 
 withTemporaryDepBlockDB :: IngestBlock -> SequencerM a -> IO a
 withTemporaryDepBlockDB genesisBlock m = do
@@ -53,6 +62,8 @@ withTemporaryDepBlockDB genesisBlock m = do
                                , syncWrites            = False
                                , bootstrapDoEmit       = False
                                , statsConfig           = Nothing
+                               , blockstanbulBlockPeriodμs = 0
+                               , blockstanbulRoundPeriod = 10000000
                                }
 
     runLoggingT (runSequencerM cfg Nothing (bootstrap (ingestBlockToBlock genesisBlock) >> m)) printLogMsg
@@ -91,7 +102,7 @@ spec = do
               oes <- drainVM
               return [block | OEBlock block <- oes ]
             ret <- validateOrder gb outBlocks
-            assertBool (format ret) $ isValid ret
+            ret `shouldSatisfy` isValid
 
         it "transformEvents should output blocks in partial order based on parent hash when input is out of order" $ do
             gb <- makeGenesisBlock
@@ -102,7 +113,7 @@ spec = do
               oes <- drainVM
               return [block | OEBlock block <- oes ]
             ret <- validateOrder gb outBlocks
-            assertBool (format ret) $ isValid ret
+            ret `shouldSatisfy` isValid
 
         it "should not deduplicate incoming transactions that are unique" $ do
             gb <- makeGenesisBlock
@@ -118,8 +129,7 @@ spec = do
             dedupedOut <- withTemporaryDepBlockDB gb $ do
               splitEvents dedupedIn
               drainVM
-            assertBool ((show . length $ dedupedIn) ++ " /= " ++ (show . length $ dedupedOut)) $
-                length dedupedIn == (length dedupedOut)
+            length dedupedOut `shouldBe` length dedupedIn
 
         it ("should allow duplicate incoming transactions that come in after a specified window (" ++ show dedupWindow ++ " txs)") $ do
             gb <- makeGenesisBlock
@@ -138,5 +148,22 @@ spec = do
               splitEvents replicatedIn
               oes <- drainVM
               return [o | o@(OETx _ _) <- oes]
-            assertBool ((show . length $ replicatedIn) ++ " /= " ++ (show . length $ dedupedOut)) $
-                length replicatedIn == (length dedupedOut)
+            length dedupedOut `shouldBe` length dedupedOut
+
+    describe "SequencerM" $ do
+      it "queues events" $ property $ \evs1 evs2 -> runTestM $ do
+        drainVM `shouldReturn` []
+        drainP2P `shouldReturn` []
+        mapM_ markForVM evs1
+        mapM_ markForP2P evs2
+        drainVM `shouldReturn` evs1
+        drainVM `shouldReturn` []
+        drainP2P `shouldReturn` evs2
+        drainP2P `shouldReturn` []
+
+    it "queues timeouts" $ runTestM $ do
+      let input = [20, 45, 30]
+      local (\cfg -> cfg{blockstanbulRoundPeriod=0}) $ do
+        mapM_ createNewTimer input
+      liftIO $ threadDelay 200 -- Who are you to judge?
+      drainTimeouts `shouldReturn` input

--- a/core-strato/strato-sequencer/test/Main.hs
+++ b/core-strato/strato-sequencer/test/Main.hs
@@ -6,7 +6,10 @@ import   Test.Hspec.Runner
 
 import   qualified Spec
 
+predicate :: Path -> Bool
+predicate _ = True
+
 main :: IO ()
 main = do
   _ <- $initHFlags "Sequencer unit tests"
-  hspec Spec.spec
+  hspecWith (configAddFilter predicate defaultConfig) Spec.spec

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -106,6 +106,7 @@ services:
     - bootnode=${bootnode}
     - debugFail=${debugFail}
     - evmDebugMode=${evmDebugMode}
+    - seqDebugMode=${seqDebugMode}
     - evmTraceMode=${evmTraceMode}
     - genesis=${genesis}
     - genesisBlock=${genesisBlock}

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -134,6 +134,9 @@ services:
     - useSyncMode=${useSyncMode}
     - validators=${validators:-}
     - zkHost=zookeeper
+    - blockstanbulBlockPeriodMs=${blockstanbulBlockPeriodMs}
+    - blockstanbulRoundPeriodS=${blockstanbulRoundPeriodS}
+
     build: .
     image: ${STRATO_IMAGE:-<REPO_URL>strato:<VERSION>}
     ports:


### PR DESCRIPTION
There are a few different strands to this PR:
- More useful debug logging
- Forcing discovery ports to always be 30303
- Implementation of block locking:
  + A block is locked when quorum is reached on a Prepare message. If the round times out before it is committed, the next proposer is expected to repropose the same block: if the proposer is aware of the lock it will, and if validators are aware of the lock they will RoundChange other blocks.
- A more sensible implementation of round timers
  + Each timer is given the number of the round it is tracking
  + If a timer goes off after a round has ended, it is ignored
  + Timers are initialized at the start of each round, rather than at fixed 10s intervals.