### PR TITLE
Wait less in PBFT

### DIFF
--- a/core-strato/ethereum-vm/package.yaml
+++ b/core-strato/ethereum-vm/package.yaml
@@ -31,6 +31,7 @@ dependencies:
   - extra
   - hedis
   - hflags
+  - lens
   - leveldb-haskell
   - merkle-patricia-db
   - monad-logger

--- a/core-strato/ethereum-vm/src/Blockchain/VMContext.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VMContext.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
@@ -17,9 +18,11 @@ module Blockchain.VMContext
     , purgeStorageMap
     , getContextBestBlockInfo
     , putContextBestBlockInfo
+    , contextBlockRequested
     ) where
 
 
+import           Control.Lens                       hiding (Context(..))
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.State
@@ -63,6 +66,9 @@ import           Blockchain.VMOptions
 
 import           Executable.EVMFlags
 
+data ContextBestBlockInfo = Unspecified | ContextBestBlockInfo (SHA, BlockData, Integer, Int, Int)
+    deriving (Eq, Read, Show)
+
 data Context = Context { contextStateDB             :: MP.MPDB
                        , contextHashDB              :: HashDB
                        , contextCodeDB              :: CodeDB
@@ -82,7 +88,9 @@ data Context = Context { contextStateDB             :: MP.MPDB
                        , contextUpdateTxResultQueue :: [(SHA,SHA,SHA,MiningStatus)]
                        , contextLogDBQueue          :: [LogDB]
                        , contextHasBlockstanbul     :: Bool
+                       , _contextBlockRequested      :: Bool
                        }
+makeLenses ''Context
 
 type ContextM = StateT Context (StatsT (ResourceT (LoggingT IO)))
 
@@ -134,8 +142,6 @@ instance HasMemLogDB ContextM where
     _ <- K.withKafkaViolently $ IK.writeIndexEvents (IM.LogDBEntry <$> toWrite)
     put $ ctx { contextLogDBQueue = [] }
 
-data ContextBestBlockInfo = Unspecified | ContextBestBlockInfo (SHA, BlockData, Integer, Int, Int)
-    deriving (Eq, Read, Show)
 
 instance HasStateDB ContextM where
   getStateDB = contextStateDB <$> get
@@ -231,7 +237,8 @@ runContextM f = do
                         Unspecified
                         redisPool
                         [] [] []
-                        flags_blockstanbul)
+                        flags_blockstanbul
+                        False)
 
 
 evalContextM :: (MonadIO m, MonadBaseControl IO m, MonadThrow m) => StateT Context (StatsT (ResourceT m)) a -> m a

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -7,6 +7,7 @@ module Executable.EthereumVM (
   ethereumVM
 ) where
 
+import           Control.Lens                          ((.=), (||=), use)
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
@@ -93,16 +94,21 @@ ethereumVM = void . execContextM $ do
             writeBlockSummary b
         addBlocks blocks
 
+        contextBlockRequested ||= (OECreateBlockCommand `elem` seqEvents)
         -- todo: perhaps we shouldnt even add TXs to the mempool, it might make for a VERY large checkpoint
         -- todo: which may fail
         isCaughtUp <- shouldProcessNewTransactions
         state <- Bagger.getBaggerState
         pbft <- gets contextHasBlockstanbul
+        reqd <- use contextBlockRequested
         let pending = B.pending state
-        let shouldOutputBlocks = isCaughtUp && (
+            hasTxs = not (null poolableNewTxs) || not (M.null pending)
+            shouldOutputBlocks = isCaughtUp && hasTxs && (
               if pbft
-                then OECreateBlockCommand `elem` seqEvents
-                else not makeLazyBlocks || not (null poolableNewTxs) || not (M.null pending))
+                then reqd
+                else not makeLazyBlocks)
+        when (pbft && shouldOutputBlocks) $
+          contextBlockRequested .= False
         $logDebugS "evm/loop/newBlock" $ T.pack $ "Queued: " ++ show (length poolableNewTxs)
         $logDebugS "evm/loop/newBlock" $ T.pack $ "Pending: " ++ show (length pending)
         when shouldOutputBlocks $ do

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -106,7 +106,7 @@ ethereumVM = void . execContextM $ do
             shouldOutputBlocks = isCaughtUp && (
               if pbft
                 then reqd && hasTxs
-                else not makeLazyBlocks || hasTxs
+                else not makeLazyBlocks || hasTxs)
         when (pbft && shouldOutputBlocks) $
           contextBlockRequested .= False
         $logDebugS "evm/loop/newBlock" $ T.pack $ "Queued: " ++ show (length poolableNewTxs)

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -103,10 +103,10 @@ ethereumVM = void . execContextM $ do
         reqd <- use contextBlockRequested
         let pending = B.pending state
             hasTxs = not (null poolableNewTxs) || not (M.null pending)
-            shouldOutputBlocks = isCaughtUp && hasTxs && (
+            shouldOutputBlocks = isCaughtUp && (
               if pbft
-                then reqd
-                else not makeLazyBlocks)
+                then reqd && hasTxs
+                else not makeLazyBlocks || hasTxs
         when (pbft && shouldOutputBlocks) $
           contextBlockRequested .= False
         $logDebugS "evm/loop/newBlock" $ T.pack $ "Queued: " ++ show (length poolableNewTxs)

--- a/core-strato/ethereum-vm/test/Spec.hs
+++ b/core-strato/ethereum-vm/test/Spec.hs
@@ -87,7 +87,8 @@ runContextM' f = do
                         Unspecified
                         (error "Redis not initialized") --redisPool
                         [] [] []
-                        False)
+                        False False)
+
 
 
 spec :: Spec

--- a/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
@@ -254,7 +254,7 @@ bootstrapSequencer gb = do
                                             , syncWrites            = False
                                             , bootstrapDoEmit       = True
                                             , statsConfig           = Nothing
-                                            , blockstanbulBlockPeriodμs = 0
+                                            , blockstanbulBlockPeriod = 0
                                             , blockstanbulRoundPeriod = 0
                                             }
     runLoggingT (runSequencerM dummySequencerCfg Nothing (bootstrap gb)) printLogMsg

--- a/core-strato/strato-sequencer/exec-src/Main.hs
+++ b/core-strato/strato-sequencer/exec-src/Main.hs
@@ -57,7 +57,7 @@ main = do
     , syncWrites            = flags_syncwrites
     , bootstrapDoEmit       = True
     , statsConfig           = EC.statsConfig EC.ethConf
-    , blockstanbulBlockPeriodμs = 1000 * flags_blockstanbul_block_period_ms
+    , blockstanbulBlockPeriod = fromIntegral flags_blockstanbul_block_period_ms / 1000.0
     , blockstanbulRoundPeriod = fromIntegral flags_blockstanbul_round_period_s
   }
   runLoggingT (runSequencerM cfg mCtx sequencer) printLogMsg

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -21,6 +21,7 @@ import           Data.Function                             ((&))
 import           Data.Maybe                                (catMaybes, fromMaybe, fromJust, isJust, mapMaybe)
 import qualified Data.Set                                  as S
 import qualified Data.Text                                 as T
+import           Data.Time.Clock
 
 import           Blockchain.Blockstanbul
 
@@ -89,12 +90,6 @@ sequencer = do
       markForP2P . OEGetTx $ toList txHashes
     vmEvs <- drainVM
     unless (null vmEvs) $ do
-      when (OECreateBlockCommand `elem` vmEvs) $ do
-        $logDebugS "sequencer" "sleeping OECreateBlockCommand"
-        -- TODO(tim): This delay is to ensure that the timestamp on the
-        -- block is more than a block period away from the last. The
-        -- threadDelay can instead sleep for max(blockperiod - (now - last_timestamp), 0)
-        liftIO . threadDelay =<< asks blockstanbulBlockPeriodμs
       writeSeqVmEvents' vmEvs
       $logDebugS "sequencer" . T.pack $ "Wrote " ++ show vmEvs ++ " SeqEvents to VM"
     p2pEvs <- drainP2P
@@ -155,6 +150,14 @@ blockstanbulSend msgs = do
         creates = [OECreateBlockCommand | MakeBlockCommand <- resp]
         vmevs = creates ++ mapMaybe rewriteBlock blocks
         p2pevs = [OEBlockstanbul (WireMessage a m) | OMsg a m <- resp]
+    unless (null blocks) $ do
+      let tLast = blockHeaderTimestamp . BDB.blockBlockData . head $ blocks
+      dt <- asks blockstanbulBlockPeriod
+      let tNext = addUTCTime dt tLast
+      now <- liftIO getCurrentTime
+      when (now < tNext) $
+       liftIO . threadDelay . round $ 1e6 * diffUTCTime tNext now
+
     $logDebugS "seq/pbft/send_vm" . T.pack . show $ vmevs
     mapM_ markForVM vmevs
     $logDebugS "seq/pbft/send_p2p" . T.pack . show $ p2pevs

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -93,7 +93,7 @@ data SequencerConfig =
                      , syncWrites            :: Bool
                      , bootstrapDoEmit       :: Bool
                      , statsConfig           :: Maybe StatsConf
-                     , blockstanbulBlockPeriodμs :: Int
+                     , blockstanbulBlockPeriod :: NominalDiffTime
                      , blockstanbulRoundPeriod :: NominalDiffTime
                      }
 

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -62,7 +62,7 @@ withTemporaryDepBlockDB genesisBlock m = do
                                , syncWrites            = False
                                , bootstrapDoEmit       = False
                                , statsConfig           = Nothing
-                               , blockstanbulBlockPeriodμs = 0
+                               , blockstanbulBlockPeriod = 0
                                , blockstanbulRoundPeriod = 10000000
                                }
 


### PR DESCRIPTION
This PR comprises two changes:
- Rather then have the EVM obey Blockstanbul unconditionally, it will only create a block if one has been requested and if there are TXs available. 
- Rather than sleep for 1s after every CreateBlockCommand, only sleep if
 + We are in the process of committing a block
 + That block has a timestamp which is more recent than 1 block period ago