### PR TITLE
Fix strato-api /transacton/last/{integer} endpoint

### DIFF
--- a/core-strato/strato-api/src/Handler/TxLast.hs
+++ b/core-strato/strato-api/src/Handler/TxLast.hs
@@ -14,11 +14,11 @@ getTxLastR  num = do
   addHeader "Access-Control-Allow-Origin" "*"
   tx <- runDB $ E.select $
         E.from $ \(rawTX `E.InnerJoin` btx `E.InnerJoin` b) -> do
-          E.on $ case chainId of
-                Nothing -> (E.isNothing $ rawTX E.^. RawTransactionChainId)
-                Just c -> ((rawTX E.^. RawTransactionChainId) E.==. (E.just $ E.val c))
           E.on (b E.^. BlockDataRefId E.==. btx E.^. BlockTransactionBlockDataRefId)
           E.on (btx E.^. BlockTransactionTransaction E.==. rawTX E.^. RawTransactionId)
+          E.where_ $ case chainId of
+                Nothing -> (E.isNothing $ rawTX E.^. RawTransactionChainId)
+                Just c -> ((rawTX E.^. RawTransactionChainId) E.==. (E.just $ E.val c))
           E.limit $ P.max 1 $ P.min (fromIntegral num :: Int64) fetchLimit
           E.orderBy [E.desc $ b E.^. BlockDataRefId]
           return rawTX


### PR DESCRIPTION
I'm not sure why chainIds were part of the join clause, but it was causing a runtime exception to be thrown