### PR TITLE
Kafka md

### DIFF
--- a/blockapps-haskell/slipstream/exec_src/Main.hs
+++ b/blockapps-haskell/slipstream/exec_src/Main.hs
@@ -27,7 +27,7 @@ main = do
 
   let conCreate = "create table if not exists contract (id serial primary key, \"codeHash\" text, contract text, abi text);"
   dbInsert conCreate conn
-  let conAlter =  "alter table contract add column \"chainId\" text;"
+  let conAlter =  "alter table contract add column if not exists \"chainId\" text;"
   dbInsert conAlter conn
 
   let offset = 0 :: K.Offset

--- a/core-strato/blockapps-util/package.yaml
+++ b/core-strato/blockapps-util/package.yaml
@@ -34,5 +34,6 @@ library:
     - http-api-data
     - text
     - unix
+    - unliftio
     - time
     - strato-model

--- a/core-strato/blockapps-util/package.yaml
+++ b/core-strato/blockapps-util/package.yaml
@@ -34,6 +34,5 @@ library:
     - http-api-data
     - text
     - unix
-    - unliftio
     - time
     - strato-model

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -75,6 +75,14 @@ withKafkaViolently k = do
             putKafkaState newS
             return a
 
-
-
-
+withKafkaRetry :: (MonadIO m, HasKafkaState m) => Int -> StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
+withKafkaRetry t k = do
+  s <- getKafkaState
+  (a, newS) <- go s
+  putKafkaState newS
+  return a
+  where go s' = do
+          r <- liftIO . runExceptT $ runStateT k s'
+          case r of
+            Left _ -> (liftIO $ threadDelay (1000*t)) >> go s'
+            Right a -> return a

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -78,14 +78,14 @@ withKafkaViolently k = do
 withKafkaRetry :: (MonadIO m, HasKafkaState m) => Int -> StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
 withKafkaRetry t k = do
   s <- getKafkaState
-  (a, newS) <- go s
+  let go = do
+        r <- liftIO . runExceptT $ runStateT k s
+        case r of
+          Right a -> return a
+          Left _ -> (liftIO $ threadDelay (1000*t)) >> go
+  (a, newS) <- go
   putKafkaState newS
   return a
-  where go s' = do
-          r <- liftIO . runExceptT $ runStateT k s'
-          case r of
-            Left _ -> (liftIO $ threadDelay (1000*t)) >> go s'
-            Right a -> return a
 
 withKafkaRetry1s :: (MonadIO m, HasKafkaState m) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
 withKafkaRetry1s = withKafkaRetry 1000

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -86,3 +86,6 @@ withKafkaRetry t k = do
           case r of
             Left _ -> (liftIO $ threadDelay (1000*t)) >> go s'
             Right a -> return a
+
+withKafkaRetry1s :: (MonadIO m, HasKafkaState m) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
+withKafkaRetry1s = withKafkaRetry 1000

--- a/core-strato/blockapps-util/src/Blockchain/Util.hs
+++ b/core-strato/blockapps-util/src/Blockchain/Util.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module Blockchain.Util where
 
-import           Control.Monad.State.Lazy           (State, execState, get, put)
+import           Control.Monad.State.Lazy (State, execState, get, put)
 import           Data.Bits
 import qualified Data.ByteString          as B
 import           Data.ByteString.Internal

--- a/core-strato/ethereum-vm/src/Blockchain/Bagger.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/Bagger.hs
@@ -53,14 +53,13 @@ class (Monad m, MonadIO m, HasHashDB m, HasStateDB m, HasMemAddressStateDB m, Mo
     txsDroppedCallback :: [TxRejection] -> [SHA] -> m () -- called when a Tx is dropped from/rejected by the pool
     {-# MINIMAL getBaggerState, putBaggerState, runFromStateRoot, rewardCoinbases, newTxRanCallback, updateTxCallback, txsDroppedCallback #-}
 
-    getCheckpointableState :: m (SHA, DD.BlockData, [SHA])
+    getCheckpointableState :: m (SHA, DD.BlockData)
     getCheckpointableState = do
         state <- getBaggerState
         let miningCache = B.miningCache state
             bestSHA     = B.bestBlockSHA miningCache
             bestHeader  = B.bestBlockHeader miningCache
-            txShas      = B.bestBlockTxHashes miningCache
-        return (bestSHA, bestHeader, txShas)
+        return (bestSHA, bestHeader)
 
     updateBaggerState :: (B.BaggerState -> B.BaggerState) -> m ()
     updateBaggerState f = putBaggerState =<< (f <$> getBaggerState)

--- a/core-strato/ethereum-vm/src/Executable/EVMCheckpoint.hs
+++ b/core-strato/ethereum-vm/src/Executable/EVMCheckpoint.hs
@@ -21,16 +21,15 @@ import           Control.Arrow            ((>>>))
 data EVMCheckpoint = EVMCheckpoint {
     checkpointSHA    :: SHA,
     checkpointHead   :: DD.BlockData,
-    checkpointTXs    :: [SHA],
     ctxBestBlockInfo :: ContextBestBlockInfo
 } deriving (Read, Show)
 
 instance RLPSerializable EVMCheckpoint where
-    rlpDecode (RLPArray [sha, header, RLPArray txShas, bbi]) =
-        EVMCheckpoint (rlpDecode sha) (rlpDecode header) (rlpDecode <$> txShas) (rlpDecode bbi)
+    rlpDecode (RLPArray [sha, header, bbi]) =
+        EVMCheckpoint (rlpDecode sha) (rlpDecode header) (rlpDecode bbi)
     rlpDecode _ = error "unexpected RLP object"
-    rlpEncode (EVMCheckpoint sha header txShas bbi) =
-        RLPArray [rlpEncode sha, rlpEncode header, RLPArray (rlpEncode <$> txShas), rlpEncode bbi]
+    rlpEncode (EVMCheckpoint sha header bbi) =
+        RLPArray [rlpEncode sha, rlpEncode header, rlpEncode bbi]
 
 instance RLPSerializable ContextBestBlockInfo where
     rlpDecode (RLPArray [tag, body]) = case rlpDecode tag :: Integer of
@@ -58,10 +57,9 @@ instance RLPSerializable ContextBestBlockInfo where
 
 
 instance Format EVMCheckpoint where -- todo add format instance for ContextBestBlockInfo and show it here as well.
-    format (EVMCheckpoint sha _ txhs _) =
-        "EVMCheckpoint " ++ CL.red (short sha) ++ (' ':count)
+    format (EVMCheckpoint sha _ _) =
+        "EVMCheckpoint " ++ CL.red (short sha)
             where short = take 16 . formatSHAWithoutColor
-                  count = CL.green $ show (length txhs)
 
 toKafkaMetadata :: EVMCheckpoint -> KP.Metadata
 toKafkaMetadata = KP.Metadata . KP.KString . B16.encode . rlpSerialize . rlpEncode

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -180,7 +180,7 @@ getCheckpoint = do
         topic' = show topic
         cg'    = show consumerGroup
     $logInfoS "getCheckpoint" . T.pack $ "Getting checkpoint for " ++ topic' ++ "#0 for " ++ cg'
-    K.withKafkaViolently (K.fetchSingleOffset consumerGroup topic 0) >>= \case
+    K.withKafkaRetry 1000 (K.fetchSingleOffset consumerGroup topic 0) >>= \case
         Left KP.UnknownTopicOrPartition -> initializeCheckpointAndBlockSummary >> getCheckpoint
         Left err -> error $ "Unexpected response when fetching checkpoint: " ++ show err
         Right (ofs, md) -> do

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -181,7 +181,7 @@ getCheckpoint = do
         topic' = show topic
         cg'    = show consumerGroup
     $logInfoS "getCheckpoint" . T.pack $ "Getting checkpoint for " ++ topic' ++ "#0 for " ++ cg'
-    K.withKafkaRetry 1000 (K.fetchSingleOffset consumerGroup topic 0) >>= \case
+    K.withKafkaRetry1s (K.fetchSingleOffset consumerGroup topic 0) >>= \case
         Left KP.UnknownTopicOrPartition -> initializeCheckpointAndBlockSummary >> getCheckpoint
         Left err -> error $ "Unexpected response when fetching checkpoint: " ++ show err
         Right (ofs, md) -> do

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -56,10 +56,10 @@ ethereumVM = void . execContextM $ do
 
     let makeLazyBlocks = lazyBlocks $ quarryConfig ethConf
     Bagger.setCalculateIntrinsicGas calculateIntrinsicGas'
-    (cpOffsetStart, EVMCheckpoint cpHash cpHead cpShas cpBBI) <- getCheckpoint
+    (cpOffsetStart, EVMCheckpoint cpHash cpHead cpBBI) <- getCheckpoint
     putContextBestBlockInfo cpBBI
     bootstrapChainDB cpHash -- TODO: Move main chain genesis block creation to strato-genesis, and move this there too
-    Bagger.processNewBestBlock cpHash cpHead cpShas -- bootstrap Bagger with genesis block
+    Bagger.processNewBestBlock cpHash cpHead [] -- bootstrap Bagger with genesis block
 
     $logInfoS "evm/preLoop" $ T.pack $ "cpOffset = " ++ show cpOffsetStart
     let microtimeCutoff = secondsToMicrotime flags_mempoolLivenessCutoff
@@ -122,7 +122,9 @@ ethereumVM = void . execContextM $ do
         flushTransactionResults
 
         let newOffset = cpOffset + fromIntegral (length seqEvents)
-        setCheckpointNoMetadata newOffset
+        baggerData <- uncurry EVMCheckpoint <$> Bagger.getCheckpointableState
+        checkpointData <- baggerData <$> getContextBestBlockInfo
+        setCheckpoint newOffset checkpointData
 
 insertNewChains :: [OutputEvent] -> ContextM ()
 insertNewChains events = do
@@ -158,11 +160,10 @@ initializeCheckpointAndBlockSummary = do
         header = obBlockData block
         txs    = obReceiptTransactions block
         td     = obTotalDifficulty block
-        txHs   = otHash <$> txs
         txL    = length txs
         uncL   = length (obBlockUncles block)
         cbbi   = ContextBestBlockInfo (sha, header, td, txL, uncL)
-    setCheckpoint 1 (EVMCheckpoint sha header txHs cbbi)
+    setCheckpoint 1 (EVMCheckpoint sha header cbbi)
 
 
 writeBlockSummary :: OutputBlock -> ContextM ()

--- a/core-strato/strato-adit/src/Executable/StratoAdit.hs
+++ b/core-strato/strato-adit/src/Executable/StratoAdit.hs
@@ -13,8 +13,8 @@ module Executable.StratoAdit (
 import           Control.Concurrent.Lifted      hiding (yield, takeMVar, putMVar, newEmptyMVar)
 import           Control.Concurrent.STM
 import           Control.Monad
+import           Control.Monad.Except
 import           Control.Monad.Logger
-import           Control.Monad.State
 import qualified Data.Text                      as T
 import           Network.Kafka
 import           Blockchain.MilenaTools
@@ -129,7 +129,7 @@ stratoAdit = runAditT $ do
     $logInfoS "stratoAdit" "Initing runKafka"
     $logInfoS "stratoAdit" "Will fetch offsets"
 
-    offset <- withKafkaViolently $ getLastOffset LatestTime 0 (lookupTopic "unminedblock")
+    offset <- withKafkaRetry 1000 $ getLastOffset LatestTime 0 (lookupTopic "unminedblock")
     $logInfoS "stratoAdit" . T.pack $ "Will mine starting at " ++ show offset
 
     doConsume (max (offset - 1) 0) c

--- a/core-strato/strato-adit/src/Executable/StratoAdit.hs
+++ b/core-strato/strato-adit/src/Executable/StratoAdit.hs
@@ -129,7 +129,7 @@ stratoAdit = runAditT $ do
     $logInfoS "stratoAdit" "Initing runKafka"
     $logInfoS "stratoAdit" "Will fetch offsets"
 
-    offset <- withKafkaRetry 1000 $ getLastOffset LatestTime 0 (lookupTopic "unminedblock")
+    offset <- withKafkaRetry1s $ getLastOffset LatestTime 0 (lookupTopic "unminedblock")
     $logInfoS "stratoAdit" . T.pack $ "Will mine starting at " ++ show offset
 
     doConsume (max (offset - 1) 0) c

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/ApiIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/ApiIndexer.hs
@@ -120,7 +120,7 @@ kafkaClientIds :: (KafkaClientId, ConsumerGroup)
 kafkaClientIds = ("strato-api-indexer", lookupConsumerGroup "strato-api-indexer")
 
 getKafkaCheckpoint :: IContextM (Offset, IndexerBestBlockInfo)
-getKafkaCheckpoint = withKafkaViolently (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
+getKafkaCheckpoint = withKafkaRetry 1000 (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
     Left UnknownTopicOrPartition -> error "ApiIndexerBestBlock was never initialized in strato-setup!"
     Left err -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
     Right (ofs, Metadata (KString md'))  -> return (ofs, reIBBI . read $ S8.unpack md')
@@ -143,5 +143,5 @@ setKafkaCheckpoint' ofs md =
 getUnprocessedIndexEvents :: IContextM (Offset, [IndexEvent], IndexerBestBlockInfo)
 getUnprocessedIndexEvents = do
     (ofs, md) <- getKafkaCheckpoint
-    evs       <- withKafkaViolently (readIndexEvents ofs)
+    evs       <- withKafkaRetry 1000 (readIndexEvents ofs)
     return (ofs, evs, md)

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/ApiIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/ApiIndexer.hs
@@ -120,7 +120,7 @@ kafkaClientIds :: (KafkaClientId, ConsumerGroup)
 kafkaClientIds = ("strato-api-indexer", lookupConsumerGroup "strato-api-indexer")
 
 getKafkaCheckpoint :: IContextM (Offset, IndexerBestBlockInfo)
-getKafkaCheckpoint = withKafkaRetry 1000 (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
+getKafkaCheckpoint = withKafkaRetry1s (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
     Left UnknownTopicOrPartition -> error "ApiIndexerBestBlock was never initialized in strato-setup!"
     Left err -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
     Right (ofs, Metadata (KString md'))  -> return (ofs, reIBBI . read $ S8.unpack md')
@@ -143,5 +143,5 @@ setKafkaCheckpoint' ofs md =
 getUnprocessedIndexEvents :: IContextM (Offset, [IndexEvent], IndexerBestBlockInfo)
 getUnprocessedIndexEvents = do
     (ofs, md) <- getKafkaCheckpoint
-    evs       <- withKafkaRetry 1000 (readIndexEvents ofs)
+    evs       <- withKafkaRetry1s (readIndexEvents ofs)
     return (ofs, evs, md)

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/P2PIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/P2PIndexer.hs
@@ -47,7 +47,7 @@ kafkaClientIds :: (KafkaClientId, ConsumerGroup)
 kafkaClientIds = ("strato-p2p-indexer", lookupConsumerGroup "strato-p2p-indexer")
 
 getKafkaCheckpoint :: IContextM Offset
-getKafkaCheckpoint = withKafkaViolently (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
+getKafkaCheckpoint = withKafkaRetry 1000 (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
     Left UnknownTopicOrPartition -> setKafkaCheckpoint 0 >> getKafkaCheckpoint
     Left err -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
     Right (ofs, _)  -> return ofs
@@ -62,5 +62,5 @@ setKafkaCheckpoint ofs = do
 getUnprocessedIndexEvents :: IContextM (Offset, [IndexEvent])
 getUnprocessedIndexEvents = do
     ofs <- getKafkaCheckpoint
-    evs <- withKafkaViolently (readIndexEvents ofs)
+    evs <- withKafkaRetry 1000 (readIndexEvents ofs)
     return (ofs, evs)

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/P2PIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/P2PIndexer.hs
@@ -47,7 +47,7 @@ kafkaClientIds :: (KafkaClientId, ConsumerGroup)
 kafkaClientIds = ("strato-p2p-indexer", lookupConsumerGroup "strato-p2p-indexer")
 
 getKafkaCheckpoint :: IContextM Offset
-getKafkaCheckpoint = withKafkaRetry 1000 (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
+getKafkaCheckpoint = withKafkaRetry1s (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
     Left UnknownTopicOrPartition -> setKafkaCheckpoint 0 >> getKafkaCheckpoint
     Left err -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
     Right (ofs, _)  -> return ofs
@@ -62,5 +62,5 @@ setKafkaCheckpoint ofs = do
 getUnprocessedIndexEvents :: IContextM (Offset, [IndexEvent])
 getUnprocessedIndexEvents = do
     ofs <- getKafkaCheckpoint
-    evs <- withKafkaRetry 1000 (readIndexEvents ofs)
+    evs <- withKafkaRetry1s (readIndexEvents ofs)
     return (ofs, evs)

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -106,7 +106,7 @@ kafkaClientIds :: (KafkaClientId, ConsumerGroup)
 kafkaClientIds = ("strato-txr-indexer", lookupConsumerGroup "strato-txr-indexer")
 
 getKafkaCheckpoint :: IContextM Offset
-getKafkaCheckpoint = withKafkaViolently (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
+getKafkaCheckpoint = withKafkaRetry 1000 (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
     Left UnknownTopicOrPartition -> setKafkaCheckpoint 0 >> getKafkaCheckpoint
     Left err -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
     Right (ofs, _)  -> return ofs
@@ -121,5 +121,5 @@ setKafkaCheckpoint ofs = do
 getUnprocessedIndexEvents :: IContextM (Offset, [IndexEvent])
 getUnprocessedIndexEvents = do
     ofs <- getKafkaCheckpoint
-    evs <- withKafkaViolently (readIndexEvents ofs)
+    evs <- withKafkaRetry 1000 (readIndexEvents ofs)
     return (ofs, evs)

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -106,7 +106,7 @@ kafkaClientIds :: (KafkaClientId, ConsumerGroup)
 kafkaClientIds = ("strato-txr-indexer", lookupConsumerGroup "strato-txr-indexer")
 
 getKafkaCheckpoint :: IContextM Offset
-getKafkaCheckpoint = withKafkaRetry 1000 (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
+getKafkaCheckpoint = withKafkaRetry1s (fetchSingleOffset (snd kafkaClientIds) targetTopicName 0) >>= \case
     Left UnknownTopicOrPartition -> setKafkaCheckpoint 0 >> getKafkaCheckpoint
     Left err -> error $ "Unexpected response when fetching offset for " ++ show targetTopicName ++ ": " ++ show err
     Right (ofs, _)  -> return ofs
@@ -121,5 +121,5 @@ setKafkaCheckpoint ofs = do
 getUnprocessedIndexEvents :: IContextM (Offset, [IndexEvent])
 getUnprocessedIndexEvents = do
     ofs <- getKafkaCheckpoint
-    evs <- withKafkaRetry 1000 (readIndexEvents ofs)
+    evs <- withKafkaRetry1s (readIndexEvents ofs)
     return (ofs, evs)

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -457,24 +457,24 @@ readUnseqEvents' :: SequencerM [(KP.Offset, IngestEvent)]
 readUnseqEvents' = do
     offset <- getNextIngestedOffset
     $logInfoS "readUnseqEvents'" . T.pack $ "Fetching unseqevents from " ++ show offset
-    ret <- zip [(offset+1)..] <$> K.withKafkaRetry 1000 (readUnseqEvents offset) -- its really [(nextOffset, eventAtThisOffset)]
+    ret <- zip [(offset+1)..] <$> K.withKafkaRetry1s (readUnseqEvents offset) -- its really [(nextOffset, eventAtThisOffset)]
     tickBy (length ret) ctr_sequencer_kafka_unseq_reads
     return ret
 
 writeSeqVmEvents' :: [OutputEvent] -> SequencerM ()
 writeSeqVmEvents' events = void $ do
-    void $ K.withKafkaRetry 1000 (writeSeqVmEvents events)
+    void $ K.withKafkaRetry1s (writeSeqVmEvents events)
     tickBy (length events) ctr_sequencer_kafka_seq_writes
 
 writeSeqP2pEvents' :: [OutputEvent] -> SequencerM ()
 writeSeqP2pEvents' events = void $ do
-    void $ K.withKafkaRetry 1000 (writeSeqP2pEvents events)
+    void $ K.withKafkaRetry1s (writeSeqP2pEvents events)
     tickBy (length events) ctr_sequencer_kafka_seq_writes
 
 getNextIngestedOffset :: SequencerM KP.Offset
 getNextIngestedOffset = do
   group  <- getKafkaConsumerGroup
-  ret <- K.withKafkaRetry 1000 (K.fetchSingleOffset group unseqEventsTopicName 0) >>= \case
+  ret <- K.withKafkaRetry1s (K.fetchSingleOffset group unseqEventsTopicName 0) >>= \case
     Left KP.UnknownTopicOrPartition -> -- we've never committed an Offset
         setNextIngestedOffset 0 >> getNextIngestedOffset
     Left err -> error $ "Unexpected response when fetching offset for " ++ show unseqEventsTopicName ++ ": " ++ show err

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -457,24 +457,24 @@ readUnseqEvents' :: SequencerM [(KP.Offset, IngestEvent)]
 readUnseqEvents' = do
     offset <- getNextIngestedOffset
     $logInfoS "readUnseqEvents'" . T.pack $ "Fetching unseqevents from " ++ show offset
-    ret <- zip [(offset+1)..] <$> K.withKafkaViolently (readUnseqEvents offset) -- its really [(nextOffset, eventAtThisOffset)]
+    ret <- zip [(offset+1)..] <$> K.withKafkaRetry 1000 (readUnseqEvents offset) -- its really [(nextOffset, eventAtThisOffset)]
     tickBy (length ret) ctr_sequencer_kafka_unseq_reads
     return ret
 
 writeSeqVmEvents' :: [OutputEvent] -> SequencerM ()
 writeSeqVmEvents' events = void $ do
-    void $ K.withKafkaViolently (writeSeqVmEvents events)
+    void $ K.withKafkaRetry 1000 (writeSeqVmEvents events)
     tickBy (length events) ctr_sequencer_kafka_seq_writes
 
 writeSeqP2pEvents' :: [OutputEvent] -> SequencerM ()
 writeSeqP2pEvents' events = void $ do
-    void $ K.withKafkaViolently (writeSeqP2pEvents events)
+    void $ K.withKafkaRetry 1000 (writeSeqP2pEvents events)
     tickBy (length events) ctr_sequencer_kafka_seq_writes
 
 getNextIngestedOffset :: SequencerM KP.Offset
 getNextIngestedOffset = do
   group  <- getKafkaConsumerGroup
-  ret <- K.withKafkaViolently (K.fetchSingleOffset group unseqEventsTopicName 0) >>= \case
+  ret <- K.withKafkaRetry 1000 (K.fetchSingleOffset group unseqEventsTopicName 0) >>= \case
     Left KP.UnknownTopicOrPartition -> -- we've never committed an Offset
         setNextIngestedOffset 0 >> getNextIngestedOffset
     Left err -> error $ "Unexpected response when fetching offset for " ++ show unseqEventsTopicName ++ ": " ++ show err

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -219,8 +219,6 @@ services:
     image: wurstmeister/zookeeper:3.4.6
     restart: always
   kafka:
-    depends_on:
-    - zookeeper
     environment:
       KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ADVERTISED_PORT: 9092

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -96,6 +96,8 @@ services:
     image: redis:3.2
     restart: always
   vault-wrapper:
+    depends_on:
+    - postgres
     environment:
     - postgres_host=postgres
     - postgres_password=${postgres_password:-api}
@@ -149,7 +151,6 @@ services:
     - zkHost=zookeeper
     - blockstanbulBlockPeriodMs=${blockstanbulBlockPeriodMs}
     - blockstanbulRoundPeriodS=${blockstanbulRoundPeriodS}
-
     build: .
     image: ${STRATO_IMAGE:-<REPO_URL>strato:<VERSION>}
     ports:
@@ -218,6 +219,8 @@ services:
     image: wurstmeister/zookeeper:3.4.6
     restart: always
   kafka:
+    depends_on:
+    - zookeeper
     environment:
       KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ADVERTISED_PORT: 9092


### PR DESCRIPTION
Make Strato and Slipstream survive after a docker-compose stop and restart. The main changes are:
- `withKafkaRetry`: Instead of throwing an error if a kafka transaction fails, delay for `t` milliseconds, and try again. This is helpful for containers after a docker restart.
- Reinstating storing `EVMCheckpoint` data in the Kafka checkpoint metadata: This is essentially what was causing the EVM to crash with `ByteString.head: empty ByteString`. It turns out, someone has either tackled this problem before, or had great foresight. We used to store this metadata after each EVM cycle, apparently so the EVM could pick up where it left off in the event of a restart. Unfortunately, it stored the best block's list of transaction hashes, which caused the checkpoint to fail.
- Removing the list of transaction hashes from `EVMCheckpoint`: This was a logically difficult decision, but needed to prevent ingestion tests from crashing, but still allow us to recover from a restart. On a normal start, the checkpoint will be for the genesis block, which has no transactions (hardcoded in Blockchain.Data.GenesisBlock), or the checkpoint will be for the last block run before the restart. The only reason we keep the list of transaction hashes is so the Bagger can know which ones to promote and demote, but after a restart, the Bagger will be empty, so storing the transaction hashes is pointless.
- Slipstream migration: I added `if not exists` to the `chainId` migration, so that Slipstream doesn't crash on restart.