### PR TITLE
Fixed UnsignedTransaction RLP

### DIFF
--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -516,7 +516,7 @@ signTransaction sk u@UnsignedTransaction{..} = Transaction
   , transactionGasLimit = unsignedTransactionGasLimit
   , transactionTo = unsignedTransactionTo
   , transactionValue = unsignedTransactionValue
-  , transactionV = testV + 27
+  , transactionV = testV + 0x1b
   , transactionR = r
   , transactionS = s
   , transactionInitOrData = unsignedTransactionInitOrData
@@ -552,7 +552,7 @@ recoverTransaction :: Transaction -> Maybe PubKey
 recoverTransaction t@Transaction{transactionR = r, transactionS = s, transactionV = v} = do
   let
     message = rlpMsg $ unsignTransaction t
-    v' = v - 27
+    v' = v - 0x1b
     compactRecSig = CompactRecSig r s v'
   recSig <- importCompactRecSig compactRecSig
   recover recSig message

--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -464,31 +464,33 @@ data UnsignedTransaction = UnsignedTransaction
   } deriving (Eq,Show,Generic)
 
 instance RLPEncodable UnsignedTransaction where
-  rlpEncode UnsignedTransaction{..} = rlpEncode Transaction
-    { transactionNonce = unsignedTransactionNonce
-    , transactionGasPrice = unsignedTransactionGasPrice
-    , transactionGasLimit = unsignedTransactionGasLimit
-    , transactionTo = unsignedTransactionTo
-    , transactionValue = unsignedTransactionValue
-    , transactionInitOrData = unsignedTransactionInitOrData
-    , transactionChainId = unsignedTransactionChainId
-    , transactionV = 0
-    , transactionR = 0
-    , transactionS = 0
-    }
-  rlpDecode x = do
-    Transaction{..} <- rlpDecode x
-    if (transactionV,transactionR,transactionS) /= (0,0,0)
-      then Left "rlpDecode UnsignedTransaction: expected v,r,s = 0"
-      else return UnsignedTransaction
-        { unsignedTransactionNonce = transactionNonce
-        , unsignedTransactionGasPrice = transactionGasPrice
-        , unsignedTransactionGasLimit = transactionGasLimit
-        , unsignedTransactionTo = transactionTo
-        , unsignedTransactionValue = transactionValue
-        , unsignedTransactionInitOrData = transactionInitOrData
-        , unsignedTransactionChainId = transactionChainId
-        }
+  rlpEncode UnsignedTransaction{..} = Array $
+    [ rlpEncode unsignedTransactionNonce
+    , rlpEncode unsignedTransactionGasPrice
+    , rlpEncode unsignedTransactionGasLimit
+    , rlpEncode unsignedTransactionTo
+    , rlpEncode unsignedTransactionValue
+    , rlpEncode unsignedTransactionInitOrData
+    ] ++ (maybeToList $ fmap rlpEncode unsignedTransactionChainId)
+  rlpDecode (Array [n, gp, gl, to', va, iod, cid]) =
+    UnsignedTransaction
+      <$> rlpDecode n
+      <*> rlpDecode gp
+      <*> rlpDecode gl
+      <*> rlpDecode to'
+      <*> rlpDecode va
+      <*> rlpDecode iod
+      <*> (Just <$> rlpDecode cid)
+  rlpDecode (Array [n, gp, gl, to', va, iod]) =
+    UnsignedTransaction
+      <$> rlpDecode n
+      <*> rlpDecode gp
+      <*> rlpDecode gl
+      <*> rlpDecode to'
+      <*> rlpDecode va
+      <*> rlpDecode iod
+      <*> pure Nothing
+  rlpDecode x = Left $ "rlpDecode Transaction: Got " ++ show x
 
 rlpMsg :: RLPEncodable x => x -> Msg
 rlpMsg
@@ -505,7 +507,7 @@ rlpHash
   . rlpEncode
 
 signTransaction :: SecKey -> UnsignedTransaction -> Transaction
-signTransaction sk UnsignedTransaction{..} = Transaction
+signTransaction sk u@UnsignedTransaction{..} = Transaction
   { transactionNonce = unsignedTransactionNonce
   , transactionGasPrice = unsignedTransactionGasPrice
   , transactionGasLimit = unsignedTransactionGasLimit
@@ -521,45 +523,34 @@ signTransaction sk UnsignedTransaction{..} = Transaction
     CompactRecSig r s testV =
       exportCompactRecSig
       . signRecMsg sk
-      . rlpMsg
-      . Array
-      $ [ rlpEncode unsignedTransactionNonce
-        , rlpEncode unsignedTransactionGasPrice
-        , rlpEncode unsignedTransactionGasLimit
-        , rlpEncode unsignedTransactionTo
-        , rlpEncode unsignedTransactionValue
-        , rlpEncode unsignedTransactionInitOrData
-        ] ++ (maybeToList $ fmap rlpEncode unsignedTransactionChainId)
+      $ rlpMsg u
+
+unsignTransaction :: Transaction -> UnsignedTransaction
+unsignTransaction Transaction{..} = UnsignedTransaction
+  { unsignedTransactionNonce = transactionNonce
+  , unsignedTransactionGasPrice = transactionGasPrice
+  , unsignedTransactionGasLimit = transactionGasLimit
+  , unsignedTransactionTo = transactionTo
+  , unsignedTransactionValue = transactionValue
+  , unsignedTransactionInitOrData = transactionInitOrData
+  , unsignedTransactionChainId = transactionChainId
+  }
 
 verifyTransaction :: PubKey -> Transaction -> Bool
-verifyTransaction pk Transaction{..} =
+verifyTransaction pk t@Transaction{transactionR = r, transactionS = s} =
   let
-    message = rlpMsg . Array $
-      [ rlpEncode transactionNonce
-      , rlpEncode transactionGasPrice
-      , rlpEncode transactionGasLimit
-      , rlpEncode transactionTo
-      , rlpEncode transactionValue
-      , rlpEncode transactionInitOrData
-      ] ++ (maybeToList $ fmap rlpEncode transactionChainId)
+    message = rlpMsg $ unsignTransaction t
   in
-    case importCompactSig (CompactSig transactionR transactionS) of
+    case importCompactSig (CompactSig r s) of
       Nothing  -> False
       Just sig -> verifySig pk sig message
 
 recoverTransaction :: Transaction -> Maybe PubKey
-recoverTransaction Transaction{..} = do
+recoverTransaction t@Transaction{transactionR = r, transactionS = s, transactionV = v} = do
   let
-    message = rlpMsg . Array $
-      [ rlpEncode transactionNonce
-      , rlpEncode transactionGasPrice
-      , rlpEncode transactionGasLimit
-      , rlpEncode transactionTo
-      , rlpEncode transactionValue
-      , rlpEncode transactionInitOrData
-      ] ++ (maybeToList $ fmap rlpEncode transactionChainId)
-    testV = transactionV - 27
-    compactRecSig = CompactRecSig transactionR transactionS testV
+    message = rlpMsg $ unsignTransaction t
+    v' = v - 27
+    compactRecSig = CompactRecSig r s v'
   recSig <- importCompactRecSig compactRecSig
   recover recSig message
 

--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -463,6 +463,9 @@ data UnsignedTransaction = UnsignedTransaction
   , unsignedTransactionChainId    :: Maybe ChainId
   } deriving (Eq,Show,Generic)
 
+instance Arbitrary UnsignedTransaction where
+  arbitrary = genericArbitrary uniform
+
 instance RLPEncodable UnsignedTransaction where
   rlpEncode UnsignedTransaction{..} = Array $
     [ rlpEncode unsignedTransactionNonce

--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -427,7 +427,7 @@ instance RLPEncodable Transaction where
     , rlpEncode transactionR
     , rlpEncode transactionS
     ] ++ (maybeToList $ fmap rlpEncode transactionChainId)
-  rlpDecode (Array [n, gp, gl, to', va, iod, v', r', s', cid]) =
+  rlpDecode (Array (n:gp:gl:to':va:iod:v':r':s':rest)) =
     Transaction
       <$> rlpDecode n
       <*> rlpDecode gp
@@ -435,19 +435,10 @@ instance RLPEncodable Transaction where
       <*> rlpDecode to'
       <*> rlpDecode va
       <*> rlpDecode iod
-      <*> (Just <$> rlpDecode cid)
-      <*> rlpDecode v'
-      <*> rlpDecode r'
-      <*> rlpDecode s'
-  rlpDecode (Array [n, gp, gl, to', va, iod, v', r', s']) =
-    Transaction
-      <$> rlpDecode n
-      <*> rlpDecode gp
-      <*> rlpDecode gl
-      <*> rlpDecode to'
-      <*> rlpDecode va
-      <*> rlpDecode iod
-      <*> pure Nothing
+      <*> (case rest of
+             [] -> pure Nothing
+             [cid] -> Just <$> rlpDecode cid
+             x -> Left $ "rlpDecode Transaction: Too many entries, got: " ++ show x)
       <*> rlpDecode v'
       <*> rlpDecode r'
       <*> rlpDecode s'
@@ -475,7 +466,7 @@ instance RLPEncodable UnsignedTransaction where
     , rlpEncode unsignedTransactionValue
     , rlpEncode unsignedTransactionInitOrData
     ] ++ (maybeToList $ fmap rlpEncode unsignedTransactionChainId)
-  rlpDecode (Array [n, gp, gl, to', va, iod, cid]) =
+  rlpDecode (Array (n:gp:gl:to':va:iod:rest)) =
     UnsignedTransaction
       <$> rlpDecode n
       <*> rlpDecode gp
@@ -483,17 +474,11 @@ instance RLPEncodable UnsignedTransaction where
       <*> rlpDecode to'
       <*> rlpDecode va
       <*> rlpDecode iod
-      <*> (Just <$> rlpDecode cid)
-  rlpDecode (Array [n, gp, gl, to', va, iod]) =
-    UnsignedTransaction
-      <$> rlpDecode n
-      <*> rlpDecode gp
-      <*> rlpDecode gl
-      <*> rlpDecode to'
-      <*> rlpDecode va
-      <*> rlpDecode iod
-      <*> pure Nothing
-  rlpDecode x = Left $ "rlpDecode Transaction: Got " ++ show x
+      <*> (case rest of
+             [] -> pure Nothing
+             [cid] -> Just <$> rlpDecode cid
+             x -> Left $ "rlpDecode UnsignedTransaction: Too many entries, got: " ++ show x)
+  rlpDecode x = Left $ "rlpDecode UnsignedTransaction: Got " ++ show x
 
 rlpMsg :: RLPEncodable x => x -> Msg
 rlpMsg

--- a/blockapps-haskell/ethereum/test/BlockApps/EthereumSpec.hs
+++ b/blockapps-haskell/ethereum/test/BlockApps/EthereumSpec.hs
@@ -64,7 +64,7 @@ spec = modifyMaxSuccess (const 10) $ do
       let t = signTransaction p u
           pub = derivePubKey p
       t `shouldSatisfy` verifyTransaction (derivePubKey p)
-      t `shouldSatisfy` (== Just pub) . recoverTransaction
+      recoverTransaction t `shouldBe` Just pub
     it "correctly signs transaction (1)" $ do
       let
         unsigned1' = UnsignedTransaction

--- a/blockapps-haskell/ethereum/test/BlockApps/EthereumSpec.hs
+++ b/blockapps-haskell/ethereum/test/BlockApps/EthereumSpec.hs
@@ -53,12 +53,18 @@ spec = modifyMaxSuccess (const 10) $ do
         Address 0x13978aee95f38490e9769c39b2773ed763d9cd5f
 
   let
-    Right unsigned1 = rlpDeserialize . fst $ Base16.decode "eb8085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc1000080808080"
+    Right unsigned1 = rlpDeserialize . fst $ Base16.decode "e88085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc1000080"
     Right signed1 = rlpDeserialize . fst $ Base16.decode "f86b8085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc10000801ba0eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4a014a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1"
-    Right unsigned2 = rlpDeserialize . fst $ Base16.decode "f83f8085e8d4a510008227108080af6025515b525b600a37f260003556601b596020356000355760015b525b54602052f260255860005b525b54602052f2808080"
+    Right unsigned2 = rlpDeserialize . fst $ Base16.decode "f83c8085e8d4a510008227108080af6025515b525b600a37f260003556601b596020356000355760015b525b54602052f260255860005b525b54602052f2"
     Right signed2 = rlpDeserialize . fst $ Base16.decode "f87f8085e8d4a510008227108080af6025515b525b600a37f260003556601b596020356000355760015b525b54602052f260255860005b525b54602052f21ba05afed0244d0da90b67cf8979b0f246432a5112c0d31e8d5eedd2bc17b171c694a0bb1035c834677c2e1185b8dc90ca6d1fa585ab3d7ef23707e1a497a98e752d1b"
 
   describe "sign transaction" $ do
+    prop "Public keys can be recovered after signing" $ \u -> do
+      p <- newSecKey
+      let t = signTransaction p u
+          pub = derivePubKey p
+      t `shouldSatisfy` verifyTransaction (derivePubKey p)
+      t `shouldSatisfy` (== Just pub) . recoverTransaction
     it "correctly signs transaction (1)" $ do
       let
         unsigned1' = UnsignedTransaction

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Signature.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Signature.hs
@@ -35,4 +35,4 @@ postSignature userName userId (UserData (Hex msgHash)) = do
         return $ SignatureDetails
                   (Hex $ getCompactRecSigR sig)
                   (Hex $ getCompactRecSigS sig)
-                  (Hex $ getCompactRecSigV sig)
+                  (Hex $ 0x1b + getCompactRecSigV sig)


### PR DESCRIPTION
Due to an incorrect RLP instance for `UnsignedTransaction`, and some hand-crafted code to correctly encode them when signing, transactions signed via the new `/signature` route were unrecoverable