### PR TITLE
InsertXabi in parallel

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -14,6 +14,7 @@ module BlockApps.Bloc22.Database.Queries where
 
 import           Control.Arrow
 import           Control.Concurrent              (threadDelay)
+import           Control.Concurrent.Async.Lifted
 import           Control.Monad
 import           Control.Monad.Except
 import           Crypto.Hash
@@ -1151,8 +1152,12 @@ compileContract source' = do
         , contractdetailsXabi = xabi
         , contractdetailsChainId = Nothing
         }
+      details' = Map.toList details
 
-  metadataIds <- flip Map.traverseWithKey details $ \ contrName (detail@ContractDetails{..}) -> do
+  -- WARNING: forConcurrently will discard any BlocError that is created during
+  -- this block. The monadic state diverges for each thread, and rather than be
+  -- rejoined it is discarded.
+  metadataIds' <- forConcurrently details' $ \(contrName, detail@ContractDetails{..}) -> do
     let
       xcodeHash = keccak256 (Text.encodeUtf8 contractdetailsBin)
     contrId <- createContractQuery contrName
@@ -1163,7 +1168,8 @@ compileContract source' = do
       contractdetailsCodeHash
       xcodeHash
     insertXabi metadataId contrName contractdetailsXabi
-    return (metadataId,detail)
+    return (contrName, (metadataId,detail))
+  let metadataIds = Map.fromList metadataIds'
 
   for_ metadataIds $ \ (leftmetadataId,_) ->
     for_ metadataIds $ \ (rightmetadataId,_) -> blocModify $


### PR DESCRIPTION
This is trading safety in the name of performance, as BlocErrors created by the threads will not propagate up to the parent. I'd be happy to accept a change that figures out the `lift`s which would make the callbacks only ReaderT and LoggingT, but I'm not willing to descend into that labyrinth myself.