### PR TITLE
Accumulate writes to storage during execution

### DIFF
--- a/core-strato/ethereum-vm/package.yaml
+++ b/core-strato/ethereum-vm/package.yaml
@@ -13,6 +13,7 @@ github: blockapps/strato-platform/core-strato/ethereum-vm
 
 dependencies:
   - base >= 4 && < 5
+  - aeson-pretty
   - ansi-wl-pprint
   - array
   - base16-bytestring

--- a/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
@@ -28,15 +28,18 @@ import qualified Control.Monad.State                     as State
 import           Control.Monad.Stats                     hiding (Success)
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Except
+import           Data.Aeson.Encode.Pretty                (encodePretty)
 import qualified Data.ByteString                         as B
 import qualified Data.ByteString.Base16                  as B16
 import qualified Data.ByteString.Char8                   as BC
+import qualified Data.ByteString.Lazy                    as BL
 import           Data.IORef                              (newIORef, readIORef, writeIORef)
 import           Data.List
 import qualified Data.Map                                as M
 import           Data.Maybe
 import qualified Data.Set                                as S
 import qualified Data.Text                               as T
+import           Data.Text.Encoding                      (decodeUtf8)
 import           Data.Time.Clock
 import           Data.Time.Clock.POSIX
 import           Blockchain.MilenaTools                  (withKafkaViolently)
@@ -98,6 +101,7 @@ import           Blockchain.Strato.StateDiff.Kafka
 
 import           Blockchain.Strato.Indexer.Kafka         (writeIndexEvents)
 import           Blockchain.Strato.Indexer.Model         (IndexEvent (..))
+
 
 -- has to be here unfortunately, or else BlockChain.hs puts a circular dependency on VMContext.hs
 instance Bagger.MonadBagger ContextM where
@@ -411,6 +415,7 @@ addTransaction isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=bt,otSign
                                        , erTrace              = theTrace newVMState'
                                        , erLogs               = logs newVMState'
                                        , erNewContractAddress = if isContractCreationTX bt then Just theAddress else Nothing
+                                       , erStorageDiffs       = _storageDiffs newVMState'
                                        , erException          = Just e
                                        }
                 Right _ -> do
@@ -429,6 +434,7 @@ addTransaction isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=bt,otSign
                                        , erTrace              = theTrace newVMState'
                                        , erLogs               = logs newVMState'
                                        , erNewContractAddress = if isContractCreationTX bt then Just theAddress else Nothing
+                                       , erStorageDiffs       = _storageDiffs newVMState'
                                        , erException          = Nothing
                                        }
         else do
@@ -442,6 +448,7 @@ addTransaction isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=bt,otSign
                                , erTrace=[] --error "theTrace not set" -- seriously?
                                , erLogs=[]
                                , erNewContractAddress=Nothing
+                               , erStorageDiffs = M.empty
                                , erException = Just Blockchain.VM.VMException.InsufficientFunds
                                }
 
@@ -535,6 +542,7 @@ outputTransactionResult b hashFunction mined (TxRunResult OutputTx{otHash=theHas
               Right erResult -> filterM (fmap not . NoCache.addressStateExists) $ moveToFront $ erNewContractAddress erResult
 
       let ranBlockHash = hashFunction b
+          sDiffs = either (const M.empty) erStorageDiffs result
           mkLogEntry Log{..} = LogDB ranBlockHash theHash chainId address (topics `indexMaybe` 0) (topics `indexMaybe` 1) (topics `indexMaybe` 2) (topics `indexMaybe` 3) logData bloom
       enqueueLogEntries $ mkLogEntry <$> theLogs
       enqueueInsertTransactionResult $
@@ -547,7 +555,7 @@ outputTransactionResult b hashFunction mined (TxRunResult OutputTx{otHash=theHas
                                , transactionResultEtherUsed        = etherUsed
                                , transactionResultContractsCreated = intercalate "," $ map formatAddress newAddresses
                                , transactionResultContractsDeleted = intercalate "," $ map formatAddress $ S.toList $ (beforeAddresses S.\\ afterAddresses) `S.union` (afterDeletes S.\\ beforeDeletes)
-                               , transactionResultStateDiff        = "" --BC.unpack $ BL.toStrict $ Aeson.encode addrDiff
+                               , transactionResultStateDiff        = T.unpack . decodeUtf8 . BL.toStrict $ encodePretty sDiffs
                                , transactionResultTime             = realToFrac deltaT
                                , transactionResultNewStorage       = ""
                                , transactionResultDeletedStorage   = ""

--- a/core-strato/ethereum-vm/src/Blockchain/Data/ExecResults.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/Data/ExecResults.hs
@@ -3,10 +3,12 @@ module Blockchain.Data.ExecResults (
   ) where
 
 import qualified Data.ByteString         as B
+import qualified Data.Map.Strict         as M
 
 import           Blockchain.VM.VMException
 import           Blockchain.Data.Address
 import           Blockchain.Data.Log
+import           Blockchain.ExtWord        (Word256)
 
 data ExecResults =
   ExecResults {
@@ -16,5 +18,6 @@ data ExecResults =
     erTrace              :: [String],
     erLogs               :: [Log],
     erNewContractAddress :: Maybe Address,
+    erStorageDiffs       :: M.Map Address (M.Map Word256 Word256),
     erException          :: Maybe VMException
     } deriving (Show)

--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -12,6 +12,7 @@ module Blockchain.VM
 import           Prelude                            hiding (EQ, GT, LT)
 import qualified Prelude                            as Ordering (Ordering (..))
 
+import           Control.Lens                       ((%=))
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
@@ -25,6 +26,7 @@ import qualified Data.ByteString.Char8              as BC
 import qualified Data.ByteString.Base16             as B16
 import           Data.Char
 import           Data.Function
+import qualified Data.Map.Strict                    as M
 import           Data.Maybe
 import qualified Data.Set                           as S
 import qualified Data.Text                          as T
@@ -412,6 +414,9 @@ runOperation SSTORE = do
   val <- pop::VMM Word256
 
   putStorageKeyVal p val --putStorageKeyVal will delete value if val=0
+
+  owner <- getEnvVar envOwner
+  storageDiffs %= M.alter (Just . M.insert p val . fromMaybe M.empty) owner
 
 --TODO- refactor so that I don't have to use this -1 hack
 runOperation JUMP = do
@@ -1218,6 +1223,7 @@ create_debugWrapper block owner value initCodeBytes = do
           forM_ (reverse $ logs finalVMState) addLog
           state' <- lift get
           lift $ put state'{suicideList = suicideList finalVMState}
+          storageDiffs %= M.unionWith M.union (_storageDiffs finalVMState)
           addToRefund (refund finalVMState)
 
           return $ Just newAddress
@@ -1252,6 +1258,7 @@ nestedRun_debugWrapper noValueTransfer gas receiveAddress (Address address') sen
           forM_ (reverse $ logs finalVMState) addLog
           state' <- lift get
           lift $ put state'{suicideList = suicideList finalVMState}
+          storageDiffs %= M.unionWith M.union (_storageDiffs finalVMState)
           when flags_debug $
             lift $ $logInfoS "nestedRun_debugWrapper" $ T.pack $ "Refunding: " ++ show (vmGasRemaining finalVMState)
           useGas (- vmGasRemaining finalVMState)

--- a/core-strato/ethereum-vm/src/Blockchain/VM/VMState.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/VMState.hs
@@ -1,14 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
 
 module Blockchain.VM.VMState (
   VMState(..),
+  storageDiffs,
   Memory(..),
   startingState,
   DebugCallCreate(..),
   ) where
 
+import           Control.Lens                 hiding (Context)
 import           Control.Monad
 import qualified Data.ByteString              as B
 import           Data.IORef
+import qualified Data.Map.Strict              as M
 import qualified Data.Set                     as S
 import qualified Data.Vector.Storable.Mutable as V
 import           Data.Word
@@ -68,11 +72,14 @@ data VMState =
 
     writable         :: Bool, -- Whether to throw on attempted changes to storage
 
+    _storageDiffs    :: M.Map Address (M.Map Word256 Word256),
+
     --These last two variable are only used for the Ethereum tests.
     isRunningTests   :: Bool,
     debugCallCreates :: Maybe [DebugCallCreate]
 
     }
+makeLenses ''VMState
 
 
 instance Format VMState where
@@ -103,6 +110,7 @@ startingState isRunningTests' isHomestead env dbs' = do
                logs=[],
                environment=env,
                suicideList=S.empty,
+               _storageDiffs = M.empty,
 
                --only used for running ethereum tests
                isRunningTests=isRunningTests',

--- a/core-strato/test-suite/test/Blockchain/VM/TestEthereum.hs
+++ b/core-strato/test-suite/test/Blockchain/VM/TestEthereum.hs
@@ -254,7 +254,7 @@ runTest test = do
         flushMemAddressStateDB
 
         case result of
-            Right (ExecResults remGas _ retVal _ rLogs _ _) -> do
+            Right (ExecResults remGas _ retVal _ rLogs _ _ _) -> do
               return ( Right (), retVal, remGas, rLogs, Just [], Nothing)
             Left _ -> do
               return (Right (), Nothing, 0, [], Just [], Nothing)


### PR DESCRIPTION
We will use transaction results to build the audit trail, since one block's stateDiff can include many state changes bundled together. However, doing a stateDiff per transaction is _very_ expensive. In this PR, I've built a map that accumulates storage key/value each time `SSTORE` is called. Additionally, since multiple contracts can be mutated in one transaction, each mutated contract gets its own map. To make this a full stateDiff, we'll also need to reflect changes in account balance, nonce, and whether the account is part of the self destruct list. 