### PR TITLE
Allow Nothing SourcePtrs

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -135,7 +135,7 @@ pipeline {
               set -x
               echo 'Running local integration tests'
               cd tests
-              npm ci
+              npm install
               npm run test:truchainz
             '''
           }

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -129,6 +129,15 @@ pipeline {
               cd strato-platform/smd-ui
               docker build -f Dockerfile.test .
             '''
+          },
+          'Integration tests' : {
+            sh '''#!/bin/bash -le
+              set -x
+              echo 'Running local integration tests'
+              cd tests
+              npm ci
+              npm run test:truchainz
+            '''
           }
         )
       }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -113,6 +113,15 @@ pipeline {
               cd strato-platform/blockapps-haskell
               ./run_unit_tests.sh
             '''
+          },
+          "Integration tests" : {
+            sh '''#!/bin/bash -le
+              set -x
+              echo 'Running local integration tests'
+              cd tests
+              npm ci
+              npm run test:truchainz
+            '''
           }
         )
       }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -119,7 +119,7 @@ pipeline {
               set -x
               echo 'Running local integration tests'
               cd tests
-              npm ci
+              npm install
               npm run test:truchainz
             '''
           }

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -140,7 +140,7 @@ pipeline {
               set -x
               echo 'Running local integration tests'
               cd tests
-              npm ci
+              npm install
               npm run test:truchainz
             '''
           }

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -134,6 +134,15 @@ pipeline {
               cd smd-ui
               docker build -f Dockerfile.test .
             '''
+          },
+          '(quick) Integration tests' : {
+            sh '''#!/bin/bash -le
+              set -x
+              echo 'Running local integration tests'
+              cd tests
+              npm ci
+              npm run test:truchainz
+            '''
           }
         )
       }

--- a/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
@@ -87,5 +87,6 @@ isContractCreated globalsIORef codeHash = do
 data ContractAndXabi =
   ContractAndXabi {
     contract :: Either String Contract,
-    xabi :: Text
+    xabi :: Text,
+    name :: Text
   } deriving (Show)

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -19,6 +19,7 @@ import qualified Data.Aeson as JSON
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import Data.IORef
+import Data.Foldable
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Pool
@@ -93,23 +94,27 @@ emptyHash :: Text
 emptyHash = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
 
 getContract :: Text -> Text -> Maybe ChainId->Bloc (Either String ContractAndXabi)
-getContract _ "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" _ = return $ (Left "Blank")
+getContract _ "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" _ =
+  return $ (Left "noncontract accounts should have empty statediffs")
 getContract name _ chainId = do
   xabi <- getContractXabi (ContractName name) (Named name) chainId
 
   return $ Right ContractAndXabi {
     contract = xAbiToContract xabi
     , xabi = T.pack . show $ JSON.toJSON xabi
+    , name = name
     }
 
 getContractCompileFullSource :: Address -> Text -> Maybe ChainId->Bloc (Either String ContractAndXabi)
-getContractCompileFullSource _ "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" _ = return $ (Left "Blank")
+getContractCompileFullSource _ "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" _ =
+  return $ (Left "noncontract accounts should have empty statediffs")
 getContractCompileFullSource address _ chainId = do
   contractDetails <- getContractDetailsByAddressOnly address chainId
 
   let ret = ContractAndXabi {
     contract = xAbiToContract $ contractdetailsXabi contractDetails
     , xabi = T.pack . show . JSON.toJSON $ contractdetailsXabi contractDetails
+    , name = contractdetailsName contractDetails
   }
   return $ (Right ret)
 
@@ -207,22 +212,22 @@ processTheMessages messages conn g = do
 
         sourcePtr' <-
           case sourcePtr of
-           Just x -> do
-             storeCachedSourcePtr g codeHash x
-             return x
-           Nothing -> do
-             maybeName <- getCachedSourcePtr g codeHash
-             return $ fromMaybe (error "a contract without a sourcePtr has come to slipstream") maybeName
+            Just x -> do
+              storeCachedSourcePtr g codeHash x
+              return sourcePtr
+            Nothing -> do
+              getCachedSourcePtr g codeHash
 
         maybeCachedContract <- getCachedContract g codeHash
-        sourceIsCreated <- isSourceCreated g $ A.sourceHash sourcePtr'
+        sourceIsCreated <- maybe (return False) (isSourceCreated g . A.sourceHash) sourcePtr'
         let addr = Address . fst . head . readHex . T.unpack $ address
 
         contractMetaData <-
               case (sourceIsCreated, maybeCachedContract) of
                (_, Just cachedContract) -> return cachedContract
                (True, Nothing) -> do
-                 contractOrError <- getContract (A.contractName sourcePtr') codeHash chainId
+                 let name = maybe (error "name missing from sourcePtr") A.contractName sourcePtr'
+                 contractOrError <- getContract name codeHash chainId
                  case contractOrError of
                   Left e -> error e
                   Right c -> do
@@ -230,9 +235,9 @@ processTheMessages messages conn g = do
                     return c
                (False, Nothing) -> do
                  liftIO . warningM "processTheMessages" . show $ "Need to call getContractCompileFullSource (this can be slow): ch:" <>
-                                     tshow codeHash <> ", src:" <> tshow sourcePtr'
+                                     tshow codeHash <> ", addr:" <> tshow addr
                  contractOrError <- getContractCompileFullSource addr codeHash chainId
-                 setSourceCreated g $ A.sourceHash sourcePtr'
+                 traverse_ (setSourceCreated g . A.sourceHash ) sourcePtr'
                  liftIO . infoM "processTheMessages" . show $ "Done fetching the metadata for " <> tshow codeHash
                  case contractOrError of
                   Left e -> error e
@@ -241,8 +246,8 @@ processTheMessages messages conn g = do
                     return c
 
 
-        let strAbi = T.replace "\'" "\'\'" $ xabi contractMetaData
-            strName = T.replace "\"" "" . A.contractName $ sourcePtr'
+        let strAbi = T.replace "\'" "\'\'" . xabi $ contractMetaData
+            strName = T.replace "\"" "" . name $ contractMetaData
             cont = case contract contractMetaData of
                     Left s -> error s
                     Right c -> c

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,7 +7,8 @@
     "test:e2e": "mocha e2e/compile.test.js && mocha e2e/createUser.test.js && mocha e2e/import.constructor.test.js && mocha e2e/import.test.js",
     "test:dataTypes": "mocha regressions/address.test.js && mocha regressions/bool.test.js && mocha regressions/bytes.test.js && mocha regressions/enum.test.js && mocha regressions/string.test.js && mocha regressions/uint.test.js",
     "test:load": "mocha load/stratoLoad.test.js --batchCount 20 --batchSize 20 && mocha load/stratoLoadFactory.test.js --batchCount 20 --batchSize 20",
-    "test:upload": "mocha load/uploadString.test.js --batchCount 10 --batchSize 10 && mocha load/uploadUniqueAddresses.test.js --batchCount 10 --batchSize 10"
+    "test:upload": "mocha load/uploadString.test.js --batchCount 10 --batchSize 10 && mocha load/uploadUniqueAddresses.test.js --batchCount 10 --batchSize 10",
+    "test:truchainz": "mocha e2e/createChain.test.js && mocha e2e/governance.test.js"
   },
   "dependencies": {
     "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#private-chain",


### PR DESCRIPTION
This is inevitible with diffs coming from private chains, as
the source is not available at the site of statediff generation.

Without a sourcePtr, sourceIsCreated is always set to false
and the SourceCreated cache will not be updated. The
other caches will be updated and read as normal