### PR TITLE
I am changing a single Show instance to use `Integer` instead of a La…

### DIFF
--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -100,7 +100,7 @@ instance (NFData a, NFData b) => NFData (LargeKey a b) where
 newtype Hex n = Hex { unHex :: n } deriving (Eq, Generic)
 
 instance (Integral n, Show n) => Show (Hex n) where
-  show (Hex n) = showHex n ""
+  show (Hex n) = showHex (toInteger n) ""
 
 instance (Eq n, Num n) => Read (Hex n) where
   readPrec = Hex <$> readP_to_Prec (const readHexP)


### PR DESCRIPTION
…rgeWord `Word256`, because LargeWord is terrible....  A single `showHex` can take up to about 0.3 seconds for LargeWord (if the number size is large enough), and this brought the Vitu tests to a crawl (and timed them out).