### PR TITLE
Make `address` optional in Bloc `/transaction`

### DIFF
--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Transaction.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Transaction.hs
@@ -54,7 +54,7 @@ type PostBlocTransaction = "transaction"
   :> Post '[JSON] [BlocTransactionResult]
 
 data PostBlocTransactionRequest = PostBlocTransactionRequest
-  { postbloctransactionrequestAddress  :: Address
+  { postbloctransactionrequestAddress  :: Maybe Address
   , postbloctransactionrequestTxs      :: [BlocTransactionPayload]
   , postbloctransactionrequestTxParams :: Maybe TxParams
   } deriving (Eq, Show, Generic)
@@ -71,7 +71,7 @@ instance FromJSON PostBlocTransactionRequest where
 instance ToSample PostBlocTransactionRequest where
   toSamples _ = singleSample $
     PostBlocTransactionRequest
-      (Address 0xdeadbeef)
+      (Just $ Address 0xdeadbeef)
       [BlocTransfer $ TransferPayload
         (Address 0x12345678)
         (Strung 600)
@@ -86,7 +86,7 @@ instance ToSchema PostBlocTransactionRequest where
     where
       ex :: PostBlocTransactionRequest
       ex = PostBlocTransactionRequest
-                 (Address 0xdeadbeef)
+                 (Just $ Address 0xdeadbeef)
                  [BlocTransfer $ TransferPayload
                    (Address 0x12345678)
                    (Strung 600)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
@@ -29,76 +29,80 @@ import           BlockApps.VaultWrapper.Client
 import           BlockApps.VaultWrapper.Types
 
 postBlocTransaction :: Maybe Text -> Maybe Text -> Maybe ChainId -> Bool -> PostBlocTransactionRequest -> Bloc [BlocTransactionResult]
-postBlocTransaction mUserName mUserId chainId resolve (PostBlocTransactionRequest addr txs' txParams) = do
+postBlocTransaction mUserName mUserId chainId resolve (PostBlocTransactionRequest mAddr txs' txParams) = do
   case (mUserName, mUserId) of
     (Nothing, _) -> error "Did not find X-USER-UNIQUE-NAME in the header"
     (Just _, Nothing) -> error "Did not find X-USER-ID in the header"
-    (Just userName, Just userId) -> fmap join . forM (partitionWith transactionType txs') $ \(ttype, txs) -> case ttype of
-      TRANSFER -> case txs of
-        [] -> return []
-        [x] -> do
-          p <- fromTransfer x
-          let btp = TransferParameters
-                      addr
-                      (transferpayloadToAddress p)
-                      (transferpayloadValue p)
-                      txParams
-                      chainId
-                      resolve
-          fmap (:[]) $ postUsersSend' btp (callSignature userName userId)
-        xs -> do
-          p <- mapM fromTransfer xs
-          let btlp = TransferListParameters
-                      addr
-                      (map (\(TransferPayload t v) -> SendTransaction t v txParams) p)
-                      chainId
-                      resolve
-          postUsersSendList' btlp (callSignature userName userId)
-      CONTRACT -> case txs of
-        [] -> return []
-        [x] -> do
-          p <- fromContract x
-          let bcp = ContractParameters
-                      addr
-                      (contractpayloadSrc p)
-                      (contractpayloadContract p)
-                      (contractpayloadArgs p)
-                      (contractpayloadValue p)
-                      txParams
-                      chainId
-                      resolve
-          fmap (:[]) $ postUsersContract' bcp (callSignature userName userId)
-        xs -> do
-          p <- mapM fromContract xs
-          let bclp = ContractListParameters
-                      addr
-                      (map (\(ContractPayload _ c a v) -> UploadListContract (fromJust c) (fromMaybe Map.empty a) txParams v) p)
-                      chainId
-                      resolve
-          postUsersUploadList' bclp (callSignature userName userId)
-      FUNCTION -> case txs of
-        [] -> return []
-        [x] -> do
-          p <- fromFunction x
-          let bfp = FunctionParameters
-                      addr
-                      ((\(ContractName c) -> c) $ functionpayloadContractName p)
-                      (functionpayloadContractAddress p)
-                      (functionpayloadMethod p)
-                      (functionpayloadArgs p)
-                      (functionpayloadValue p)
-                      txParams
-                      chainId
-                      resolve
-          fmap (:[]) $ postUsersContractMethod' bfp (callSignature userName userId)
-        xs -> do
-          p <- mapM fromFunction xs
-          let bflp = FunctionListParameters
-                      addr
-                      (map (\(FunctionPayload (ContractName n) a m r v) -> MethodCall n a m r (fromMaybe (Strung 0) v) txParams) p)
-                      chainId
-                      resolve
-          postUsersContractMethodList' bflp (callSignature userName userId)
+    (Just userName, Just userId) -> do
+      addr <- case mAddr of
+        Nothing -> fmap unStatusAndAddress . blocVaultWrapper $ getKey mUserName mUserId
+        Just addr' -> return addr'
+      fmap join . forM (partitionWith transactionType txs') $ \(ttype, txs) -> case ttype of
+        TRANSFER -> case txs of
+          [] -> return []
+          [x] -> do
+            p <- fromTransfer x
+            let btp = TransferParameters
+                        addr
+                        (transferpayloadToAddress p)
+                        (transferpayloadValue p)
+                        txParams
+                        chainId
+                        resolve
+            fmap (:[]) $ postUsersSend' btp (callSignature userName userId)
+          xs -> do
+            p <- mapM fromTransfer xs
+            let btlp = TransferListParameters
+                        addr
+                        (map (\(TransferPayload t v) -> SendTransaction t v txParams) p)
+                        chainId
+                        resolve
+            postUsersSendList' btlp (callSignature userName userId)
+        CONTRACT -> case txs of
+          [] -> return []
+          [x] -> do
+            p <- fromContract x
+            let bcp = ContractParameters
+                        addr
+                        (contractpayloadSrc p)
+                        (contractpayloadContract p)
+                        (contractpayloadArgs p)
+                        (contractpayloadValue p)
+                        txParams
+                        chainId
+                        resolve
+            fmap (:[]) $ postUsersContract' bcp (callSignature userName userId)
+          xs -> do
+            p <- mapM fromContract xs
+            let bclp = ContractListParameters
+                        addr
+                        (map (\(ContractPayload _ c a v) -> UploadListContract (fromJust c) (fromMaybe Map.empty a) txParams v) p)
+                        chainId
+                        resolve
+            postUsersUploadList' bclp (callSignature userName userId)
+        FUNCTION -> case txs of
+          [] -> return []
+          [x] -> do
+            p <- fromFunction x
+            let bfp = FunctionParameters
+                        addr
+                        ((\(ContractName c) -> c) $ functionpayloadContractName p)
+                        (functionpayloadContractAddress p)
+                        (functionpayloadMethod p)
+                        (functionpayloadArgs p)
+                        (functionpayloadValue p)
+                        txParams
+                        chainId
+                        resolve
+            fmap (:[]) $ postUsersContractMethod' bfp (callSignature userName userId)
+          xs -> do
+            p <- mapM fromFunction xs
+            let bflp = FunctionListParameters
+                        addr
+                        (map (\(FunctionPayload (ContractName n) a m r v) -> MethodCall n a m r (fromMaybe (Strung 0) v) txParams) p)
+                        chainId
+                        resolve
+            postUsersContractMethodList' bflp (callSignature userName userId)
   where fromTransfer = \case
           BlocTransfer t -> return t
           _ -> throwError $ UserError "Could not decode transfer arguments from body"

--- a/blockapps-haskell/vault-wrapper/api/src/BlockApps/VaultWrapper/API.hs
+++ b/blockapps-haskell/vault-wrapper/api/src/BlockApps/VaultWrapper/API.hs
@@ -6,7 +6,6 @@ module BlockApps.VaultWrapper.API where
 import           Data.Text                    (Text)
 import           Servant.API
 
-import           BlockApps.Ethereum           (Address(..))
 import           BlockApps.VaultWrapper.Types
 
 type API =
@@ -15,7 +14,11 @@ type API =
   :<|> "key"
     :> Header "X-USER-UNIQUE-NAME" Text -- Guess what? Our version of Servant is too old to make headers Required!
     :> Header "X-USER-ID" Text
-    :> Post '[JSON] Address
+    :> Get '[JSON] StatusAndAddress
+  :<|> "key"
+    :> Header "X-USER-UNIQUE-NAME" Text -- Guess what? Our version of Servant is too old to make headers Required!
+    :> Header "X-USER-ID" Text
+    :> Post '[JSON] StatusAndAddress
   :<|> "signature"
     :> Header "X-USER-UNIQUE-NAME" Text
     :> Header "X-USER-ID" Text

--- a/blockapps-haskell/vault-wrapper/api/src/BlockApps/VaultWrapper/Types.hs
+++ b/blockapps-haskell/vault-wrapper/api/src/BlockApps/VaultWrapper/Types.hs
@@ -1,13 +1,15 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module BlockApps.VaultWrapper.Types where
 
 import           Data.Aeson
 import           Data.LargeWord          (Word256)
+import           Data.Text               (Text)
 import           Data.Word               (Word8)
 import           GHC.Generics
 
-import           BlockApps.Ethereum      (Hex(..))
+import           BlockApps.Ethereum      (Hex(..), Address(..))
 
 data SignatureDetails = SignatureDetails
   { r :: Hex Word256
@@ -27,3 +29,17 @@ userData = UserData . Hex
 
 instance ToJSON UserData
 instance FromJSON UserData
+
+--------------------------------------------------------------------------
+
+newtype StatusAndAddress = StatusAndAddress { unStatusAndAddress :: Address } deriving (Show, Generic)
+
+instance ToJSON StatusAndAddress where
+  toJSON (StatusAndAddress a) = object
+                              [ "status" .= ("success" :: Text) -- hey, don't blame me, this is part of the spec
+                              , "address" .= a
+                              ]
+
+instance FromJSON StatusAndAddress where
+  parseJSON (Object o) = StatusAndAddress <$> (o .: "address")
+  parseJSON o = error $ "parseJSON StatusAndAddress: expected object, but got " ++ show o

--- a/blockapps-haskell/vault-wrapper/client/src/BlockApps/VaultWrapper/Client.hs
+++ b/blockapps-haskell/vault-wrapper/client/src/BlockApps/VaultWrapper/Client.hs
@@ -2,6 +2,7 @@
 
 module BlockApps.VaultWrapper.Client
   ( getPing
+  , getKey
   , postKey
   , postSignature
   ) where
@@ -11,11 +12,11 @@ import           Data.Text                    (Text)
 import           Servant.API
 import           Servant.Client
 
-import           BlockApps.Ethereum           (Address(..))
 import           BlockApps.VaultWrapper.API
 import           BlockApps.VaultWrapper.Types
 
 getPing :: ClientM String
-postKey :: Maybe Text -> Maybe Text -> ClientM Address
+getKey :: Maybe Text -> Maybe Text -> ClientM StatusAndAddress
+postKey :: Maybe Text -> Maybe Text -> ClientM StatusAndAddress
 postSignature :: Maybe Text -> Maybe Text -> UserData -> ClientM SignatureDetails
-getPing :<|> postKey :<|> postSignature = client (Proxy @ API)
+getPing :<|> getKey :<|> postKey :<|> postSignature = client (Proxy @ API)


### PR DESCRIPTION
The `address` field in `PostBlocTransactionRequest` was required to fetch the account nonce before signing a transaction. However, now we have Vault Wrapper's `GET /key` endpoint, and can lookup the address ourselves. Instead of removing the `address` field entirely, we leave it as an optional parameter, as it prevents the extra call to Vault Wrapper.