### PR TITLE
remove the default empty value for env var in yml

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -118,7 +118,7 @@ services:
     - backupblocks=${backupblocks}
     - blockstanbul=${blockstanbul}
     - blockstanbulBlockPeriodMs=${blockstanbulBlockPeriodMs}
-    - blockstanbulPrivateKey=${blockstanbulPrivateKey:-}
+    - blockstanbulPrivateKey=${blockstanbulPrivateKey}
     - blockstanbulRoundPeriodS=${blockstanbulRoundPeriodS}
     - blockTime=${blockTime}
     - bootnode=${bootnode}


### PR DESCRIPTION
Some earlier docker-compose versions complain about this format of setting the empty var in docker-compose.yml