### PR TITLE
Stub out catch-up block functionalitiy for PBFT

### DIFF
--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -219,6 +219,14 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
   when authz $ case ev of
     NewBeneficiary _ (benf,decision,_)  -> do
       pendingvotes %= M.insert benf decision
+    PreviousBlock blk -> do
+      -- TODO(tim): verify this block
+      -- TODO(tim): Does the validator list match the log at that point in time?
+      -- TODO(tim): Has the proposer from that (roundno, validator list) signed it?
+      -- TODO(tim): Have 2/3s of the validators signed it?
+      -- TODO(tim): Does it have a vote to record?
+      -- TODO(tim): Take the sequence number
+      yield . ToCommit $ blk
     NewBlock blk' -> do
       let blk = truncateExtra blk'
       ppl <- use proposal

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
@@ -75,6 +75,7 @@ data InEvent = IMsg {iAuth :: MsgAuth, iMessage :: TrustedMessage}
              -- TODO(tim): CommitResult should have the digest
              | CommitResult (Either Text ())
              | NewBlock Block
+             | PreviousBlock Block
              | NewBeneficiary {bAuth :: MsgAuth, beneficiary :: (Address, Bool,Int)}
              deriving (Eq, Show)
 

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -8,7 +8,8 @@
 {-# LANGUAGE TupleSections     #-}
 module Blockchain.Sequencer where
 
-import           Control.Concurrent
+import           Conduit
+import           Control.Concurrent                        hiding (yield)
 import           Control.Monad.Logger
 import           Control.Monad.Reader
 import           Control.Monad.State
@@ -270,7 +271,8 @@ transformFullTransactions pairs = do
                   mBlock <- witnessedBlock bHash
                   when (isJust mBlock) $ do
                     let Just block = mBlock
-                    hydrateAndEmit block
+                    evs <- hydrateAndEmit block
+                    mapM_ (markForVM . OEBlock) evs
                 depTxs -> do
                   $logInfoS "transformFullTransactions" . T.pack $ "Transaction " ++ format tHash ++ " is a dependent transaction in block " ++ format bHash ++ ", but there are others. Inserting them into MissingTxDB and GetTransactions list"
                   removeTxBlock tHash
@@ -285,66 +287,77 @@ transformTransactions events = forM_ (partitionWith (isPrivateHashTX . itTransac
     then transformPrivateHashTXs pairs
     else transformFullTransactions pairs
 
-hydrateAndEmit :: SequencedBlock -> SequencerM ()
-hydrateAndEmit sb = do
+hydrateAndEmit :: SequencedBlock -> SequencerM [OutputBlock]
+hydrateAndEmit sb = runConduit $ hydrateAndEmit' .| sinkList
+ where
+ hydrateAndEmit' :: Conduit () SequencerM OutputBlock
+ hydrateAndEmit' = do
   t0 <- liftIO $ getTime Realtime
-  readiness <- enqueueIfParentNotEmitted sb
+  readiness <- lift $ enqueueIfParentNotEmitted sb
   t1 <- liftIO $ getTime Realtime
+  let logHydrate = $logInfoS "hydrateAndEmit" . T.pack
   $logDebug . T.pack $ "enqueueIfParentNotEmitted took: " ++ show (toNanoSecs $ t1 - t0)
   case readiness of
+      NotReadyToEmit -> do
+          $logWarnS "transformEvents/emitBlocks" . T.pack $ prettyBlock sb ++ " is not yet ready to emit."
+          lift $ tick ctr_sequencer_blocks_enqueued
       (ReadyToEmit totalPastDifficulty) -> do
-          dryChain <- buildEmissionChain sb totalPastDifficulty -- TODO: buildEmissionChain needs to do all of this so that we don't emit blocks missing transactions prematurely
+          -- TODO: buildEmissionChain needs to do all of this so that we don't emit blocks missing transactions prematurely
+          dryChain <- lift $ buildEmissionChain sb totalPastDifficulty
           if (dryChain /= [])
             then $logInfoS "transformEvents/emitBlocks" . T.pack $ prettyBlock sb ++ " is ready to emit! Emitting it and chain of dependents."
             else $logInfoS "transformEvents/emitBlocks" . T.pack $ prettyBlock sb ++ " is ready to emit, but its emission chain is empty. It was likely already emitted."
-          mapM_ (markForP2P . OEBlock . snd) dryChain
+          mapM_ (lift . markForP2P . OEBlock . snd) dryChain
           ldbOps <- forM dryChain $ \(ldbOp, ob) -> do
             let bHash = blockHeaderHash $ obBlockData ob
-            $logInfoS "hydrateAndEmit" . T.pack $ prettyOBlock ob
+            logHydrate $ prettyOBlock ob
             forM_ (obReceiptTransactions ob) $ \tx -> do
               when (isPrivateHashTX tx) $ do
                 let TD.PrivateHashTX{TD.transactionTxHash = th'} = otBaseTx tx
                     th = SHA th'
-                $logInfoS "hydrateAndEmit" . T.pack $ "Looking up transaction hash " ++ format th ++ " in MissingTxDB"
-                lookupMissingTx th >>= \case
-                  False -> do
-                    $logInfoS "hydrateAndEmit" . T.pack $ "Transaction hash " ++ format th ++ " is not missing"
-                    return ()
-                  True -> do
-                    $logInfoS "hydrateAndEmit" . T.pack $ "Transaction hash " ++ format th ++ " is missing. Inserting into TxBlockDB and DependentTxDB"
-                    insertTxBlock th bHash
-                    insertDependentTx bHash th
-            lookupDependentTxs bHash >>= \case
-              s | s == S.empty -> do
-                $logInfoS "hydrateAndEmit" . T.pack $ "Block hash " ++ format bHash ++ " has no dependent transactions. Hydrating and emitting to VM"
-                hydratedBlock <- hydrateBlock ob
-                tickBy 1 ctr_sequencer_blocks_released
-                markForVM $ OEBlock hydratedBlock
+                logHydrate $ "Looking up transaction hash " ++ format th ++ " in MissingTxDB"
+                missing <- lift . isMissingTX $ th
+                if missing
+                  then do
+                    logHydrate $ "Transaction hash " ++ format th ++ " is missing. Inserting into TxBlockDB and DependentTxDB"
+                    lift $ insertTxBlock th bHash
+                    lift $ insertDependentTx bHash th
+                  else do
+                    logHydrate $ "Transaction hash " ++ format th ++ " is not missing"
+            depTXS <- lift . lookupDependentTxs $ bHash
+            if S.null depTXS
+              then do
+                logHydrate $ "Block hash " ++ format bHash ++ " has no dependent transactions. Hydrating and emitting to VM"
+                hydratedBlock <- lift . hydrateBlock $ ob
+                lift $ tickBy 1 ctr_sequencer_blocks_released
+                yield hydratedBlock
                 return ldbOp
-              s -> do
-                $logInfoS "hydrateAndEmit" . T.pack $ "Block hash " ++ format bHash ++ " has dependent transactions. Inserting them into GetTransactions list"
-                mapM_ insertGetTransactionsDB s
+              else do
+                logHydrate $ "Block hash " ++ format bHash ++ " has dependent transactions. Inserting them into GetTransactions list"
+                lift $ mapM_ insertGetTransactionsDB depTXS
                 return Nothing
-          addLdbBatchOps $ catMaybes ldbOps
-      NotReadyToEmit -> do
-          $logWarnS "transformEvents/emitBlocks" . T.pack $ prettyBlock sb ++ " is not yet ready to emit."
-          tick ctr_sequencer_blocks_enqueued
+          lift . addLdbBatchOps . catMaybes $ ldbOps
 
 transformBlocks :: [IngestBlock] -> SequencerM ()
 transformBlocks = mapM_ $ \ib -> do
-  hasPBFT <- blockstanbulRunning
-  case (hasPBFT, ibOrigin ib) of
-    (True, TO.Quarry) -> blockstanbulSend [NewBlock . ingestBlockToBlock $ ib]
-    -- TODO(tim): external PBFT blocks should have their validators and seals checked
-    (_,_) -> do
-      let mSb = ingestBlockToSequencedBlock ib
-      case mSb of
-        Nothing -> do
-          $logWarnS "transformEvents/emitBlocks" . T.pack $ "Could not ECRecover the pubkey of certain Txs in Block " ++ prettyIBlock ib ++ "; not emitting"
-          tick ctr_sequencer_blocks_ecrfail -- couldnt ecrecover some transactions in this block. block is likely garbage
-        Just sb -> do
-          witnessBlockHash (sbHash sb) sb
-          hydrateAndEmit sb
+  let mSb = ingestBlockToSequencedBlock ib
+  case mSb of
+    Nothing -> do
+      $logWarnS "transformEvents/emitBlocks" . T.pack
+        $ "Could not ECRecover the pubkey of certain Txs in Block " ++ prettyIBlock ib ++ "; not emitting"
+      tick ctr_sequencer_blocks_ecrfail -- couldnt ecrecover some transactions in this block. block is likely garbage
+    Just sb -> do
+      witnessBlockHash (sbHash sb) sb
+      hasPBFT <- blockstanbulRunning
+      wetBlocks <- hydrateAndEmit sb
+      if not hasPBFT
+        then mapM_ (markForVM . OEBlock) wetBlocks
+        else let block = ingestBlockToBlock ib
+                 inEvent = case ibOrigin ib of
+                          TO.Quarry -> NewBlock block
+                          _ -> PreviousBlock block
+                 wetEvents = map (PreviousBlock . outputBlockToBlock) wetBlocks
+             in blockstanbulSend (inEvent:wetEvents)
 
 transformGenesis :: [IngestGenesis] -> SequencerM ()
 transformGenesis chains = forM_ chains $ \ig -> do
@@ -385,7 +398,8 @@ transformGenesis chains = forM_ chains $ \ig -> do
                   mBlock <- witnessedBlock bHash
                   when (isJust mBlock) $ do
                     let Just block = mBlock
-                    hydrateAndEmit block
+                    vmevs <- hydrateAndEmit block
+                    mapM_ (markForVM . OEBlock) vmevs
                 depTxs -> do
                   $logInfoS "transformGenesis" . T.pack $ "Transaction " ++ format tHash ++ " is a dependent transaction in block " ++ format bHash ++ ", but there are others. Inserting them into MissingTxDB and GetTransactions list"
                   removeTxBlock tHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -269,10 +269,7 @@ transformFullTransactions pairs = do
                   removeTxBlock tHash
                   clearDependentTxs bHash
                   mBlock <- witnessedBlock bHash
-                  when (isJust mBlock) $ do
-                    let Just block = mBlock
-                    evs <- hydrateAndEmit block
-                    mapM_ (markForVM . OEBlock) evs
+                  mapM_ hydrateAndEmit mBlock
                 depTxs -> do
                   $logInfoS "transformFullTransactions" . T.pack $ "Transaction " ++ format tHash ++ " is a dependent transaction in block " ++ format bHash ++ ", but there are others. Inserting them into MissingTxDB and GetTransactions list"
                   removeTxBlock tHash
@@ -287,8 +284,19 @@ transformTransactions events = forM_ (partitionWith (isPrivateHashTX . itTransac
     then transformPrivateHashTXs pairs
     else transformFullTransactions pairs
 
-hydrateAndEmit :: SequencedBlock -> SequencerM [OutputBlock]
-hydrateAndEmit sb = runConduit $ hydrateAndEmit' .| sinkList
+hydrateAndEmit :: SequencedBlock -> SequencerM ()
+hydrateAndEmit sb = do
+  wetBlocks <- runConduit $ hydrateAndEmit' .| sinkList
+  hasPBFT <- blockstanbulRunning
+  if not hasPBFT
+    then mapM_ (markForVM . OEBlock) $ wetBlocks
+    else let convert :: OutputBlock -> InEvent
+             convert outBlock = case obOrigin outBlock of
+                                    TO.Quarry -> NewBlock . outputBlockToBlock $ outBlock
+                                    _ -> PreviousBlock . outputBlockToBlock $ outBlock
+         -- Blockstanbul will check that the seals and validators match up before
+         -- announcing it to the network or forwarding to the EVM.
+         in blockstanbulSend . map convert $ wetBlocks
  where
  hydrateAndEmit' :: Conduit () SequencerM OutputBlock
  hydrateAndEmit' = do
@@ -348,16 +356,7 @@ transformBlocks = mapM_ $ \ib -> do
       tick ctr_sequencer_blocks_ecrfail -- couldnt ecrecover some transactions in this block. block is likely garbage
     Just sb -> do
       witnessBlockHash (sbHash sb) sb
-      hasPBFT <- blockstanbulRunning
-      wetBlocks <- hydrateAndEmit sb
-      if not hasPBFT
-        then mapM_ (markForVM . OEBlock) wetBlocks
-        else let block = ingestBlockToBlock ib
-                 inEvent = case ibOrigin ib of
-                          TO.Quarry -> NewBlock block
-                          _ -> PreviousBlock block
-                 wetEvents = map (PreviousBlock . outputBlockToBlock) wetBlocks
-             in blockstanbulSend (inEvent:wetEvents)
+      hydrateAndEmit sb
 
 transformGenesis :: [IngestGenesis] -> SequencerM ()
 transformGenesis chains = forM_ chains $ \ig -> do
@@ -396,10 +395,7 @@ transformGenesis chains = forM_ chains $ \ig -> do
                   removeTxBlock tHash
                   clearDependentTxs bHash
                   mBlock <- witnessedBlock bHash
-                  when (isJust mBlock) $ do
-                    let Just block = mBlock
-                    vmevs <- hydrateAndEmit block
-                    mapM_ (markForVM . OEBlock) vmevs
+                  mapM_ hydrateAndEmit mBlock
                 depTxs -> do
                   $logInfoS "transformGenesis" . T.pack $ "Transaction " ++ format tHash ++ " is a dependent transaction in block " ++ format bHash ++ ", but there are others. Inserting them into MissingTxDB and GetTransactions list"
                   removeTxBlock tHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -331,11 +331,12 @@ hydrateAndEmit sb = do
           tick ctr_sequencer_blocks_enqueued
 
 transformBlocks :: [IngestBlock] -> SequencerM ()
-transformBlocks blocks = do
+transformBlocks = mapM_ $ \ib -> do
   hasPBFT <- blockstanbulRunning
-  if hasPBFT
-    then blockstanbulSend $ map (NewBlock . ingestBlockToBlock) blocks
-    else forM_ blocks $ \ib -> do
+  case (hasPBFT, ibOrigin ib) of
+    (True, TO.Quarry) -> blockstanbulSend [NewBlock . ingestBlockToBlock $ ib]
+    -- TODO(tim): external PBFT blocks should have their validators and seals checked
+    (_,_) -> do
       let mSb = ingestBlockToSequencedBlock ib
       case mSb of
         Nothing -> do

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingTxDB.hs
@@ -13,8 +13,8 @@ getMissingTxsDB = missingTxs <$> getPrivateHashDB
 putMissingTxsDB :: HasPrivateHashDB m => S.Set SHA -> m ()
 putMissingTxsDB txs = getPrivateHashDB >>= \db -> putPrivateHashDB db{ missingTxs = txs }
 
-lookupMissingTx :: HasPrivateHashDB m => SHA -> m Bool
-lookupMissingTx tx = S.member tx <$> getMissingTxsDB
+isMissingTX :: HasPrivateHashDB m => SHA -> m Bool
+isMissingTX tx = S.member tx <$> getMissingTxsDB
 
 insertMissingTx :: HasPrivateHashDB m => SHA -> m ()
 insertMissingTx tx = getMissingTxsDB >>= putMissingTxsDB . S.insert tx


### PR DESCRIPTION
This PR should also make it so that blocks are hydrated when PBFT is running. However, after their hydration they are sent into blockstanbul for it to decide whether it should be forwarded to the VM.