### PR TITLE
Retain constructor information when creating Xabi

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -224,7 +224,7 @@ postContractsCompile = blocTransaction . fmap concat . traverse compileOneContra
     compileOneContract PostCompileRequest{..} = do
       idsAndDetails <- compileContract postcompilerequestSource
       for (toList idsAndDetails) $ \ (_,details) -> do
-        let eBlockappsjsXabi = completeXabi . contractdetailsXabi $ details
+        let eBlockappsjsXabi = uncurry completeXabi $ (contractdetailsName &&& contractdetailsXabi) details
         case eBlockappsjsXabi of
           Left msg -> throwError $
             AnError (Text.append "Xabi conversion to Blockapps-js Xabi failed, "  (Text.pack msg))
@@ -237,7 +237,7 @@ postContractsXabi PostXabiRequest{..} =
    let xabis :: Either String (Map.Map Text Xabi)
        xabis = do
          partialXabis <- Map.fromList <$> parseXabi "src" (Text.unpack postxabirequestSrc)
-         traverse completeXabi partialXabis
+         Map.traverseWithKey completeXabi partialXabis
    in case xabis of
         Left msg -> throwError . AnError .
             ("contract compilation for xabi failed: " <>) . Text.pack $msg
@@ -248,11 +248,11 @@ completeContractDetailXabi :: ContractDetails -> ContractDetails
 completeContractDetailXabi cd =
   let eXabi = xAbiToContract $ contractdetailsXabi cd in
   case eXabi of
-    Right xabi -> cd { contractdetailsXabi = contractToXabi xabi }
+    Right xabi -> cd { contractdetailsXabi = contractToXabi (contractdetailsName cd) xabi }
     Left _ -> cd
 
 
-completeXabi :: Xabi -> Either String Xabi
-completeXabi xabi = do
+completeXabi :: Text -> Xabi -> Either String Xabi
+completeXabi name xabi = do
   c <- xAbiToContract xabi
-  return $ contractToXabi c
+  return $ contractToXabi name c

--- a/blockapps-haskell/solidity/src/BlockApps/XAbiConverter.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/XAbiConverter.hs
@@ -244,7 +244,7 @@ xAbiToContract contractXabi@Xabi{..} = mdo
     return ((name, var'), Text.pack <$> (Xabi.varTypeConstant var >>= \b -> if b then Xabi.varTypeInitialValue var else Nothing))
 
   funcs <-
-    for (Map.toList xabiFuncs) $ \(name, func) -> do
+    for (Map.toList $ Map.union xabiFuncs xabiConstr) $ \(name, func) -> do
       theFunction <- funcToType contractXabi name func
       return ((name, theFunction), Nothing)
 
@@ -257,8 +257,8 @@ xAbiToContract contractXabi@Xabi{..} = mdo
 --------------------------------------------
 --Inverse Conversion
 
-contractToXabi::Contract->Xabi
-contractToXabi Contract{..} =
+contractToXabi :: Text -> Contract -> Xabi
+contractToXabi cName Contract{..} =
   let
     functions =
       Map.fromList
@@ -277,11 +277,13 @@ contractToXabi Contract{..} =
     isFunction::Type->Bool
     isFunction TypeFunction{} = True
     isFunction _ = False
+    isConstructor k = const (k == cName)
+    (constructors, funcs) = Map.partitionWithKey isConstructor functions
 
   in
     Xabi{
-      xabiFuncs = functions,
-      xabiConstr = Map.empty,
+      xabiFuncs = funcs,
+      xabiConstr = constructors,
       xabiVars = Map.fromList $ map (fmap $ fieldToVarType typeDefs) vars,
       xabiTypes = Map.empty,
       xabiModifiers = Map.empty,

--- a/blockapps-haskell/solidity/test/BlockApps/XAbiConverterSpec.hs
+++ b/blockapps-haskell/solidity/test/BlockApps/XAbiConverterSpec.hs
@@ -8,7 +8,6 @@ import           Test.Hspec
 import           Data.Aeson
 import qualified Data.ByteString.Lazy as ByteString
 --import           Data.List
-import qualified Data.Map as Map
 import           Data.Maybe
 import           BlockApps.Solidity.Xabi
 --import           BlockApps.Solidity.Xabi.Type
@@ -20,11 +19,9 @@ spec :: Spec
 spec =
   describe "Xabi" $
     it "should convert a first pass xabi to a contract, then to a second pass xabi" $ do
-      pendingWith "bork test"
       let firstPass = fromMaybe undefined $ decode firstPassString
           secondPass = fromMaybe undefined $ decode secondPassString::Xabi
-      --We don't yet put constructors in the contract to xabi conversion, so I remove this field for the test.
-      contractToXabi (either undefined id $ xAbiToContract firstPass) `shouldBe` secondPass{xabiConstr=Map.empty}
+      contractToXabi "MyContract" (either undefined id $ xAbiToContract firstPass) `shouldBe` secondPass
 
 secondPassString::ByteString.ByteString
 secondPassString =
@@ -101,46 +98,49 @@ secondPassString =
          }
       },
       "constr":{
-         "_author":{
-            "type":"Address",
-            "index":1
-         },
-         "_userOwner":{
-            "type":"Address",
-            "index":0
-         },
-         "_hash":{
-            "type":"Bytes",
-            "index":2,
-            "bytes":32
-         },
-         "_contents":{
-            "dynamic":true,
-            "type":"String",
-            "index":4
-         },
-         "_tags":{
-            "dynamic":true,
-            "entry":{
-               "type":"Bytes",
-               "bytes":32
+         "MyContract":{
+            "args":{
+              "_author":{
+                  "type":"Address",
+                  "index":1
+              },
+              "_userOwner":{
+                  "type":"Address",
+                  "index":0
+              },
+              "_hash":{
+                  "type":"Bytes",
+                  "index":2,
+                  "bytes":32
+              },
+              "_contents":{
+                  "dynamic":true,
+                  "type":"String",
+                  "index":4
+              },
+              "_tags":{
+                  "dynamic":true,
+                  "entry":{
+                    "type":"Bytes",
+                    "bytes":32
+                  },
+                  "type":"Array",
+                  "index":3
+              }
             },
-            "type":"Array",
-            "index":3
+            "vals":{}
          }
       },
       "vars":{
          "hash":{
             "atBytes":160,
             "type":"Bytes",
-            "bytes":32,
-            "public":true
+            "bytes":32
          },
          "contents":{
             "atBytes":192,
             "dynamic":true,
-            "type":"String",
-            "public":true
+            "type":"String"
          },
          "readers":{
             "atBytes":32,
@@ -151,23 +151,19 @@ secondPassString =
             "key":{
                "type":"Address"
             },
-            "type":"Mapping",
-            "public":true
+            "type":"Mapping"
          },
          "owner":{
             "atBytes":0,
-            "type":"Address",
-            "public":true
+            "type":"Address"
          },
          "author":{
             "atBytes":96,
-            "type":"Address",
-            "public":true
+            "type":"Address"
          },
          "userOwner":{
             "atBytes":64,
-            "type":"Address",
-            "public":true
+            "type":"Address"
          },
          "tags":{
             "atBytes":128,
@@ -176,8 +172,7 @@ secondPassString =
                "type":"Bytes",
                "bytes":32
             },
-            "type":"Array",
-            "public":true
+            "type":"Array"
          }
       }
    }
@@ -279,34 +274,37 @@ firstPassString =
          }
       },
       "constr":{
-         "_author":{
-            "type":"Address",
-            "index":1
-         },
-         "_userOwner":{
-            "type":"Address",
-            "index":0
-         },
-         "_hash":{
-            "dynamic":false,
-            "type":"Bytes",
-            "index":2,
-            "bytes":32
-         },
-         "_contents":{
-            "dynamic":true,
-            "type":"String",
-            "index":4
-         },
-         "_tags":{
-            "dynamic":true,
-            "entry":{
-               "dynamic":false,
-               "type":"Bytes",
-               "bytes":32
+         "MyContract":{
+            "args":{
+              "_author":{
+                  "type":"Address",
+                  "index":1
+              },
+              "_userOwner":{
+                  "type":"Address",
+                  "index":0
+              },
+              "_hash":{
+                  "type":"Bytes",
+                  "index":2,
+                  "bytes":32
+              },
+              "_contents":{
+                  "dynamic":true,
+                  "type":"String",
+                  "index":4
+              },
+              "_tags":{
+                  "dynamic":true,
+                  "entry":{
+                    "type":"Bytes",
+                    "bytes":32
+                  },
+                  "type":"Array",
+                  "index":3
+              }
             },
-            "type":"Array",
-            "index":3
+            "vals":{}
          }
       },
       "vars":{


### PR DESCRIPTION
In SMD's `CreateContract` modal, the text boxes for constructor arguments have been missing for awhile, since the constructor list gets dropped by `completeXabi`.