### PR TITLE
Strato 1151

### DIFF
--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/Contract.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/Contract.hs
@@ -25,7 +25,7 @@ getNextAvailablePosition p _ = p{Storage.offset=Storage.offset p+1, Storage.byte
 
 --Given the next available position, return the actual chosen position and the number of primary bytes used (this doesn't include bytes used at other memory locations, like the content of a large string)
 getPositionAndSize::TypeDefs->Storage.Position->Type->(Storage.Position, Word256)
-getPositionAndSize _ p (SimpleType TypeBool) = (p,1)
+getPositionAndSize _ p (SimpleType TypeBool) = (getNextAvailablePosition p 1, 1)
 
 getPositionAndSize _ p (SimpleType TypeInt8)=(getNextAvailablePosition p 1, 1)
 getPositionAndSize _ p (SimpleType TypeInt16)=(getNextAvailablePosition p 2, 2)

--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/TypeDefs.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/TypeDefs.hs
@@ -13,4 +13,4 @@ data TypeDefs =
   TypeDefs {
     enumDefs::Map Text EnumSet,
     structDefs::Map Text Struct
-    } deriving (Show)  
+    } deriving (Show)

--- a/blockapps-haskell/solidity/src/BlockApps/XAbiConverter.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/XAbiConverter.hs
@@ -60,10 +60,11 @@ fieldsToStruct typeDefs' vars =
      fields=OMap.fromList
             $ (map (\((n,t),c) -> (n, (constantValue c, t))) constants)
             ++ zipWith (\(n, t) p -> (n, (Right p, t))) variables positions,
-     size = fromIntegral $ 32 * Storage.offset positionAfter + fromIntegral (Storage.byte positionAfter)
+     size = fromIntegral $ 32 * Storage.offset positionAfter +  roundUp (Storage.byte positionAfter)
      }
   where
     constantValue mval = maybe (error "fieldsToStruct: You must supply a value to a constant") Left mval
+    roundUp n = if n == 0 then 0 else 32
 
 addPositions::TypeDefs->Storage.Position -> [Type] -> (Storage.Position, [Storage.Position])
 addPositions _ p [] = (p, [])

--- a/blockapps-haskell/solidity/test/BlockApps/XAbiConverterSpec.hs
+++ b/blockapps-haskell/solidity/test/BlockApps/XAbiConverterSpec.hs
@@ -6,22 +6,37 @@ module BlockApps.XAbiConverterSpec where
 
 import           Test.Hspec
 import           Data.Aeson
-import qualified Data.ByteString.Lazy as ByteString
---import           Data.List
+import qualified Data.ByteString.Lazy        as ByteString
+import qualified Data.Map.Strict             as M
 import           Data.Maybe
+import qualified BlockApps.Solidity.Struct   as Struct
+import           BlockApps.Solidity.Type
+import           BlockApps.Solidity.TypeDefs
 import           BlockApps.Solidity.Xabi
---import           BlockApps.Solidity.Xabi.Type
 import           BlockApps.XAbiConverter
 
 import Text.RawString.QQ
 
 spec :: Spec
 spec =
-  describe "Xabi" $
+  describe "Xabi" $ do
     it "should convert a first pass xabi to a contract, then to a second pass xabi" $ do
       let firstPass = fromMaybe undefined $ decode firstPassString
           secondPass = fromMaybe undefined $ decode secondPassString::Xabi
       contractToXabi "MyContract" (either undefined id $ xAbiToContract firstPass) `shouldBe` secondPass
+    it "should derive the correct size of a struct definition ending with a single-byte type" $ do
+      let tdefs = TypeDefs M.empty M.empty
+          fields = [(("exceptionID"   , SimpleType TypeUInt256), Nothing)
+                   ,(("exceptionType" , SimpleType TypeUInt256), Nothing)
+                   ,(("exceptionLevel", SimpleType TypeUInt256), Nothing)
+                   ,(("stateType"     , SimpleType TypeUInt256), Nothing)
+                   ,(("state"         , SimpleType TypeUInt256), Nothing)
+                   ,(("timeoutLength" , SimpleType TypeUInt256), Nothing)
+                   ,(("minValue"      , SimpleType TypeUInt256), Nothing)
+                   ,(("maxValue"      , SimpleType TypeUInt256), Nothing)
+                   ,(("isWarning"     , SimpleType TypeBool   ), Nothing)
+                   ]
+      Struct.size (fieldsToStruct tdefs fields) `shouldBe` fromIntegral (32 * length fields)
 
 secondPassString::ByteString.ByteString
 secondPassString =


### PR DESCRIPTION
Structs ending with a short type (i.e. less than 32 bytes) would cause array offsets to be miscalculated. An example is `struct Z { uint a; uint b; bool c; }`. Interestingly, this miscalculation only happened if the last member of the struct doesn't line up to a 32-byte boundary.