### PR TITLE
Allow governance contract to inherit from others

### DIFF
--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Chain.hs
@@ -39,6 +39,7 @@ import           BlockApps.Strato.TypeLits
 --------------------------------------------------------------------------------
 data ChainInput  = ChainInput
   { chaininputSrc      :: Text
+  , chaininputContract :: Maybe Text
   , chaininputLabel    :: Text
   , chaininputBalances :: NamedMap "address" Address "balance" Integer
   , chaininputArgs     :: Map Text ArgValue
@@ -66,7 +67,7 @@ instance FromJSON ChainInput where
   parseJSON = genericParseJSON (aesonPrefix camelCase)
 
 instance ToJSON ChainInput where
-  toJSON = genericToJSON (aesonPrefix camelCase) 
+  toJSON = genericToJSON (aesonPrefix camelCase)
 
 exampleSrc :: Text
 exampleSrc = "contract Governance { enum Rule { AUTO_APPROVE, TWO_VOTES_IN, MAJORITY_RULES } Rule addRule; Rule removeRule; Rule terminateRule; event MemberAdded (address member, string enode); event MemberRemoved (address member); event ChainTerminated(); struct MemberVotes { address member; uint votes; } MemberVotes[] addVotes; MemberVotes[] removeVotes; uint terminateVotes; function voteToAdd(address m, string e) { MemberAdded(m,e); } function voteToRemove(address m) { MemberRemoved(m); } function voteToTerminate() { terminateVotes++; if (satisfiesRule(terminateRule, terminateVotes)) { ChainTerminated(); } } function satisfiesRule(Rule rule, uint votes) returns (bool) { if (rule == Rule.AUTO_APPROVE) { return true; } else if (rule == Rule.TWO_VOTES_IN) { return votes >= 2; } else { return true; } } }";
@@ -80,6 +81,7 @@ exampleEnode2 = "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d8
 exChainInput :: ChainInput
 exChainInput = ChainInput
     { chaininputSrc = exampleSrc
+    , chaininputContract = Just "Governance"
     , chaininputLabel = "my chain"
     , chaininputBalances = map fromTuple [
          (Address 0x5815b9975001135697b5739956b9a6c87f1c575c, (20000000 :: Integer))

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -34,7 +34,7 @@ governanceAddress :: Address
 governanceAddress = Address 0x100
 
 postChainInfo :: ChainInput -> Bloc ChainId
-postChainInfo (ChainInput src lbl balances chaininputArgs members) = do
+postChainInfo (ChainInput src cname lbl balances chaininputArgs members) = do
   when (null members) $ throwError $ UserError "Private chains must include at least one member"
   when (sum (nmap2' balances) == 0) $ throwError $ UserError "At least one account must have a non-zero balance"
   idsAndDetails <- if (Text.null src)
@@ -43,7 +43,10 @@ postChainInfo (ChainInput src lbl balances chaininputArgs members) = do
   mContract <- case Map.toList idsAndDetails of
             [] -> return Nothing
             [(_, x)] -> return $ Just x
-            _ -> throwError $ UserError "Multiple governance contracts are not allowed"
+            _ -> case cname of
+                   Nothing -> throwError $ UserError "When you upload multiple contracts, you need to specify which contract should be uploaded to the chain in the 'contract' key of the given data"
+                   Just name -> fmap Just $ blocMaybe "Could not find contract name in compilation details"
+                                      $ Map.lookup name idsAndDetails
   (cAcctInfo, codeInfo) <- case mContract of
       Nothing -> return ([],[])
       Just (_, ContractDetails{..}) -> do


### PR DESCRIPTION
This was a request from Samrit for the Wings project. When the governance contract inherited from base contracts, the POST /chain endpoint rejected the request. To allow for this, I've added an optional `contract` field to the `ChainInput` type, similar to what we do for regular contract uploads. I've also made the corresponding changes to blockapps-rest.