### PR TITLE
Dont mistake SHA 0 as a missing hash

### DIFF
--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -172,7 +172,7 @@ handleEvents mode peer = awaitForever $ \case
             -- check if blockheaders we recieved have parents.
             parentsInDB :: [(SHA, Maybe BlockHeader)] <- RBDB.withRedisBlockDB . RBDB.getHeaders $ parentHash <$> headers
             let existingParents = [(sha, x) | (sha, Just x) <- parentsInDB]
-            let missingParents  = [sha | (sha, Nothing) <- parentsInDB]
+            let missingParents  = [sha | (sha, Nothing) <- parentsInDB, sha /= SHA 0]
             unless (null missingParents) $ do
                  bestBlock <- RBDB.withRedisBlockDB RBDB.getBestBlockInfo
                  let fetchNumber = numFromRedis bestBlock + 1


### PR DESCRIPTION
Upgraded nodes 2 and 3 keep requesting block headers because they're missing block hash 0. Obviously, no node has a block with that hash, so they'll never stop requesting block headers.