### PR TITLE
de-bork

### DIFF
--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -125,7 +125,8 @@ handleMsgClientConduit myId peer = do
                 void $ RBDB.withRedisBlockDB (RBDB.updateWorldBestBlockInfo peerBestHash 0 peerTD) -- we set to 0 cause we dont necessarily know the number yet
                 lastBlockNumber <- liftIO getBestKafkaBlockNumber
                 Just (ChainBlock firstBlock:_) <- liftIO $ fetchVMEventsIO 0
-                yield $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) (blockDataNumber $ blockBlockData firstBlock))) flags_maxReturnedHeaders 0 Forward
+                mrh <- gets maxReturnedHeaders
+                yield $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) (blockDataNumber $ blockBlockData firstBlock))) mrh 0 Forward
                 stampActionTimestamp
         other -> assertHandshake other
     handleEvents (if flags_debugFail then Fail else Log) peer

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -59,7 +59,8 @@ data Context =
         vmEventsSink        :: forall m . (MonadIO m, K.HasKafkaState m, HasSQLDB m) => Conduit [VMEvent] m Void,
         blockHeaders        :: [BlockHeader],
         actionTimestamp     :: Maybe UTCTime,
-        connectionTimeout   :: Int
+        connectionTimeout   :: Int,
+        maxReturnedHeaders  :: Int
     }
 
 type ContextM = StateT Context (ResourceT (LoggingT IO))
@@ -124,8 +125,8 @@ runContextM :: (MonadBaseControl IO m )
 runContextM s f = void . runResourceT $ runStateT f s
 
 initContext :: (MonadResource m, MonadIO m, MonadBaseControl IO m, MonadLogger m)
-            => m Context
-initContext = do
+            => Int -> m Context
+initContext maxHeaders = do
   dbs <- openDBs
   redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
   return Context { actionTimestamp = Nothing
@@ -137,6 +138,7 @@ initContext = do
                  , vmEventsSink=mapM_C (void . produceVMEventsM) .| sinkNull
                  , vmTrace=[]
                  , connectionTimeout=flags_connectionTimeout
+                 , maxReturnedHeaders = maxHeaders
                  }
 
 

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -41,7 +41,6 @@ import           Blockchain.DBM
 import           Blockchain.EventModel
 import           Blockchain.EventException
 import           Blockchain.Format
-import           Blockchain.Options
 import           Blockchain.SHA
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Stream.VMEvent
@@ -239,7 +238,8 @@ handleEvents mode peer = awaitForever $ \case
         lift $ putBlockHeaders remainingHeaders
         if null remainingHeaders
             then when (newCount > 0) $ do
-                yield $ GetBlockHeaders (BlockHash $ headerHash $ last headers) flags_maxReturnedHeaders 0 Forward
+                mrh <- gets maxReturnedHeaders
+                yield $ GetBlockHeaders (BlockHash $ headerHash $ last headers) mrh 0 Forward
                 stampActionTimestamp
             else do
                 yield $ GetBlockBodies (map headerHash remainingHeaders)
@@ -379,7 +379,8 @@ syncFetch :: (MonadIO m, RBDB.HasRedisBlockDB m, MonadState Context m, MonadLogg
 syncFetch d num = do
     blockHeaders' <- lift getBlockHeaders -- get blockHeaders from Context
     when (null blockHeaders') $ do
-        yield $ GetBlockHeaders (BlockNumber num) flags_maxReturnedHeaders 0 d
+        mrh <- gets maxReturnedHeaders
+        yield $ GetBlockHeaders (BlockNumber num) mrh 0 d
         stampActionTimestamp
 
 shouldSend :: PPeer -> Origin.TXOrigin -> Bool

--- a/core-strato/strato-p2p/src/Blockchain/ServOptions.hs
+++ b/core-strato/strato-p2p/src/Blockchain/ServOptions.hs
@@ -9,4 +9,5 @@ defineFlag "l:listen" (30303 :: Int) "Listen on port"
 defineFlag "runUDPServer" True "Turn the UDP server on/off"
 defineFlag "networkID" (1::Int) "Turn the UDP server on/off"
 defineFlag "name" ("Indiana Jones" :: String) "Who to greet."
+defineFlag "maxReturnedHeaders" (1000 :: Int) "Number of headers to return from a GetBlockHeaders request" -- todo: seriously???
 

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -52,7 +52,7 @@ runPeer :: (MonadIO m, MonadBaseControl IO m, MonadLogger m, MonadThrow m)
         -> CommPort      -- otherServiceCommPort
         -> m ()
 runPeer peer myPriv _ _ = runResourceT $ do
-  ctx <- initContext
+  ctx <- initContext flags_maxReturnedHeaders
   runContextM ctx $ do
     let otherPubKey = fromMaybe (error "programmer error: runPeer was called without a pubkey") $ pPeerPubkey peer
         myPublic    = calculatePublic theCurve myPriv

--- a/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -34,7 +34,7 @@ runEthServer :: (MonadResource m, MonadIO m, MonadBaseControl IO m, MonadLogger 
              -> Int
              -> m ()
 runEthServer myPriv listenPort = do
-  ctx <- initContext
+  ctx <- initContext flags_maxReturnedHeaders
   let myPubkey = calculatePublic theCurve myPriv
   void . runContextM ctx . runGeneralTCPServer (serverSettings listenPort "*") $ \app -> do
     let theSockAddr = sockAddrToIP (appSockAddr app)

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -58,6 +58,7 @@ testContext = do
                  , vmEventsSink=sinkNull
                  , vmTrace=[]
                  , connectionTimeout=60
+                 , maxReturnedHeaders=1000
                  })
 
 testPeer :: DataPeer.PPeer


### PR DESCRIPTION
Apparently the p2p client and server have different sets of HFlags, so instead of referencing the flag directly, include it in the context.