### PR TITLE
Use chainId for storage queries in Slipstream

### DIFF
--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -133,7 +133,9 @@ storageToList BA.Storage {BA.storageKey=k, BA.storageValue=v} = (T.pack $ show k
 
 addStorageIfNeeded::Action->Bloc Action
 addStorageIfNeeded action'@A.Action{..} | actionType == A.Update = do
-  storage' <- blocStrato $ getStorage storageFilterParams{ qsAddress = Just . Address . fst . head . readHex $ T.unpack address }
+  storage' <- blocStrato $ getStorage storageFilterParams{ qsAddress = Just . Address . fst . head . readHex $ T.unpack address
+                                                         , qsChainId = chainId
+                                                         }
   return $ action'{A.storage = Just . Map.fromList $ map storageToList storage'}
 addStorageIfNeeded action = return action
 


### PR DESCRIPTION
Not sure how this appeared to work before. I think maybe we only saw `Create`s for private chains, and never saw what happened with `Update`s