### PR TITLE
Build tests for bloch before running them

### DIFF
--- a/blockapps-haskell/Makefile
+++ b/blockapps-haskell/Makefile
@@ -27,6 +27,7 @@ build_solidity: prebuild
 build_haskell: prebuild build_solidity
 	stack setup
 	stack install --local-bin-path=$(FAKEROOT)/usr/bin
+	stack test --no-run-tests
 
 build_deploybase: prebuild
 	cp -f Dockerfile.deploybase /tmp/docker-dummy-bloc


### PR DESCRIPTION
This should hopefully prevent the jenkins problems where it tries to run the bloch and strato tests at the same time, and the bloch tests fail to compile presumably because of a race condition in its compilation

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/256/pipeline