### PR TITLE
Append output to strato-sequencer logs

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -75,7 +75,7 @@ function newnode {
   fi
   NODEKEY=${blockstanbulPrivateKey:-} runBackgroundProcess strato-sequencer \
     "${bpFlag}" "${rpFlag}" "${vsFlag}" "${tbFlag}" "${evsFlag}" "${usFlag}" \
-    --minLogLevel=$seqMinLogLevel &> logs/strato-sequencer
+    --minLogLevel=$seqMinLogLevel &>> logs/strato-sequencer
 
   echo "Starting strato-api-indexer"
   runBackgroundProcess strato-api-indexer +RTS -N1 >> logs/strato-api-indexer 2>&1


### PR DESCRIPTION
When using `>`, `truncate -s 0` will not prevent the apparent file size from decreasing because the logging process will write at the same file offset: 
```
~ ❯❯❯ xxd /tmp/log
00000000: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000010: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000020: 0000 0000 7468 6973 2069 7320 6d6f 7265  ....this is more
00000030: 2074 6578 740a                            text.

```
https://blockapps.atlassian.net/browse/STRATO-1188