### PR TITLE
Use worktrees to avoid a second networked fetch request

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -16,6 +16,7 @@ pipeline {
           rm -rf strato-platform
           git worktree remove -f strato-worktree
           git wortkree add strato-worktree develop
+          git workree list
         '''
       }
     }

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -14,7 +14,8 @@ pipeline {
           docker images -a
           rm -rf ~/.stack
           rm -rf strato-platform
-          git clone https://github.com/blockapps/strato-platform -b develop
+          git worktree remove -f strato-worktree
+          git wortkree add strato-worktree
         '''
       }
     }
@@ -23,7 +24,7 @@ pipeline {
       steps {
         sh '''#!/bin/bash -le
           set -x
-          cd strato-platform
+          cd strato-worktree
           REPO=private make all
         '''
       }
@@ -35,7 +36,7 @@ pipeline {
           set -x
           rm -rf strato-getting-started
           git clone https://github.com/blockapps/strato-getting-started
-          cp strato-platform/docker-compose.yml strato-getting-started/
+          cp strato-worktree/docker-compose.yml strato-getting-started/
           cd strato-getting-started
           NODE_HOST=cd10.eastus.cloudapp.azure.com
           NODE_HOST=${NODE_HOST} ./strato.sh -m 1 --single
@@ -72,11 +73,11 @@ pipeline {
             withCredentials([
               usernamePassword(credentialsId: 'docker-aws-registry-login', passwordVariable: 'DOCKER_PASSWD', usernameVariable: 'DOCKER_USER')
             ]) {
-              archiveArtifacts artifacts: "strato-platform/docker-compose.yml"
+              archiveArtifacts artifacts: "strato-worktree/docker-compose.yml"
               sh '''#!/bin/bash -le
                 set -x
                 docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
-                cd strato-platform
+                cd strato-worktree
                 docker-compose -f docker-compose.push.yml push
               '''
             }
@@ -109,7 +110,7 @@ pipeline {
             sh '''#!/bin/bash -le
               set -x
               echo "Running core-strato unit tests"
-              cd strato-platform/core-strato
+              cd strato-worktree/core-strato
               ./run_unit_tests_long.sh
             '''
           },
@@ -118,7 +119,7 @@ pipeline {
             sh '''#!/bin/bash -le
               set -x
               echo 'Running BlockApps Haskell tests'
-              cd strato-platform/blockapps-haskell
+              cd strato-worktree/blockapps-haskell
               ./run_unit_tests.sh
             '''
           },
@@ -127,7 +128,7 @@ pipeline {
             sh '''#!/bin/bash -le
               set -x
               echo 'Running SMD tests'
-              cd strato-platform/smd-ui
+              cd strato-worktree/smd-ui
               docker build -f Dockerfile.test .
             '''
           },

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -15,7 +15,7 @@ pipeline {
           rm -rf ~/.stack
           rm -rf strato-platform
           git worktree remove -f strato-worktree
-          git wortkree add strato-worktree
+          git wortkree add strato-worktree develop
         '''
       }
     }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -28,6 +28,7 @@ pipeline {
               rm -rf docker-compose.push.yml docker-compose.yml
               git checkout ${REFSPEC}
             fi
+            git worktree list
             docker rm -f $(docker ps -aq) || true; docker system prune -f --volumes
             docker ps
           '''

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -19,13 +19,13 @@ pipeline {
             set -x
             if [ "$BUILD_TYPE" == "full" ]; then
               rm -rf strato-platform
-              git clone https://github.com/blockapps/strato-platform -b develop
-              cd strato-platform
+              git worktree remove -f strato-worktree
+              git worktree add strato-worktree develop
+              cd strato-worktree
               git checkout ${REFSPEC}
             else
-              cd strato-platform
+              cd strato-worktree
               rm -rf docker-compose.push.yml docker-compose.yml
-              git fetch
               git checkout ${REFSPEC}
             fi
             docker rm -f $(docker ps -aq) || true; docker system prune -f --volumes
@@ -40,7 +40,7 @@ pipeline {
         withEnv(["RELEASE_VERSION=${env.RELEASE_VERSION}"]) {
           sh '''#!/bin/bash -le
             set -x
-            cd strato-platform
+            cd strato-worktree
             echo ${RELEASE_VERSION} > VERSION
             REPO=public make all
             '''
@@ -54,7 +54,7 @@ pipeline {
           set -x
           rm -rf strato-getting-started
           git clone https://github.com/blockapps/strato-getting-started
-          cp strato-platform/docker-compose.yml strato-getting-started/
+          cp strato-worktree/docker-compose.yml strato-getting-started/
           cd strato-getting-started
           NODE_HOST=strato-int.centralus.cloudapp.azure.com
           NODE_HOST=${NODE_HOST} ./strato.sh -m 1 --single
@@ -103,14 +103,14 @@ pipeline {
             sh '''#!/bin/bash -le
               set -x
               echo "Running core-strato unit tests"
-              cd strato-platform/core-strato
+              cd strato-worktree/core-strato
               ./run_unit_tests.sh
             '''},
           "Bloch tests": {
             sh '''#!/bin/bash -le
               set -x
               echo 'Running BlockApps Haskell tests to verify the build to be healthy'
-              cd strato-platform/blockapps-haskell
+              cd strato-worktree/blockapps-haskell
               ./run_unit_tests.sh
             '''
           },
@@ -136,7 +136,7 @@ pipeline {
           ]) {
             sh '''#!/bin/bash -le
               set -x
-              cd strato-platform
+              cd strato-worktree
               RELEASE_VERSION=$(<VERSION)
               docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
               docker-compose -f docker-compose.push.yml push

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -17,25 +17,19 @@ pipeline {
           }
         }
         withEnv(["PLATFORM_BRANCH_NAME=${env.PLATFORM_BRANCH_NAME}"]) {
-          withCredentials([
-              usernamePassword(credentialsId: 'blockapps-cd-github', passwordVariable: 'GH_PASSWD', usernameVariable: 'GH_USER')
-          ]) {
-            sh '''#!/bin/bash -le
-              set -x
-              docker rm -f $(docker ps -aq) || true; docker system prune -f --volumes
-              if [ -d "strato-platform" ]; then
-                cd strato-platform
-                git checkout -f
-                git pull https://$GH_USER:$GH_PASSWD@github.com/blockapps/strato-platform
-                git fetch origin
-                git checkout ${PLATFORM_BRANCH_NAME}
-                git reset --hard origin/${PLATFORM_BRANCH_NAME}
-                cd ..
-              else
-                git clone https://$GH_USER:$GH_PASSWD@github.com/blockapps/strato-platform -b ${PLATFORM_BRANCH_NAME}
-              fi
-            '''
-          }
+          sh '''#!/bin/bash -le
+            set -x
+            docker rm -f $(docker ps -aq) || true; docker system prune -f --volumes
+            if [ -d "strato-worktree" ]; then
+              cd strato-worktree
+              git checkout ${PLATFORM_BRANCH_NAME}
+              git reset --hard remotes/origin/${PLATFORM_BRANCH_NAME}
+              cd ..
+            else
+              git worktree add strato-worktree remotes/origin/${PLATFORM_BRANCH_NAME}
+            fi
+            git worktree list
+          '''
         }
       }
     }
@@ -44,7 +38,7 @@ pipeline {
       steps {
         sh '''#!/bin/bash -le
           set -x
-          cd strato-platform
+          cd strato-worktree
           REPO=private make all
         '''
       }
@@ -56,7 +50,7 @@ pipeline {
           set -x
           rm -rf strato-getting-started
           git clone https://github.com/blockapps/strato-getting-started
-          cp strato-platform/docker-compose.yml strato-getting-started/
+          cp strato-worktree/docker-compose.yml strato-getting-started/
           cd strato-getting-started
           NODE_HOST=$(</host)
           NODE_HOST=${NODE_HOST} ./strato.sh -m 1 --single
@@ -93,11 +87,11 @@ pipeline {
             withCredentials([
               usernamePassword(credentialsId: 'docker-aws-registry-login', passwordVariable: 'DOCKER_PASSWD', usernameVariable: 'DOCKER_USER')
             ]) {
-              archiveArtifacts artifacts: "strato-platform/docker-compose.yml"
+              archiveArtifacts artifacts: "strato-worktree/docker-compose.yml"
               sh '''#!/bin/bash -le
                 set -x
                 docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
-                cd strato-platform
+                cd strato-worktree
                 docker-compose -f docker-compose.push.yml push
               '''
             }
@@ -130,7 +124,7 @@ pipeline {
             sh '''#!/bin/bash -le
               set -x
               echo "Running core-strato unit tests"
-              cd strato-platform/core-strato
+              cd strato-worktree/core-strato
               ./run_unit_tests.sh
             '''
           },
@@ -139,7 +133,7 @@ pipeline {
             sh '''#!/bin/bash -le
               set -x
               echo 'Running BlockApps Haskell tests'
-              cd strato-platform/blockapps-haskell
+              cd strato-worktree/blockapps-haskell
               ./run_unit_tests.sh
             '''
           },
@@ -148,7 +142,7 @@ pipeline {
             sh '''#!/bin/bash -le
               set -x
               echo 'Running SMD tests'
-              cd strato-platform/smd-ui
+              cd strato-worktree/smd-ui
               docker build -f Dockerfile.test .
             '''
           },
@@ -156,7 +150,7 @@ pipeline {
             sh '''#!/bin/bash -le
               set -x
               echo 'Running local integration tests'
-              cd strato-platform/tests
+              cd strato-worktree/tests
               npm install
               npm run test:truchainz
             '''


### PR DESCRIPTION
A worktree is a copy of the repo it's started from, but this copy shares the object database of its parent repo. What this means is that it does not need credentials, because its looking at files on the same filesystem. 

To achieve same branch name and same commit hash, it combines `git checkout <br> && git reset --hard origin/<br>`.
`git worktree list` in the logs will show the commit and branch of STRATO_test and STRATO_test/strato-worktree: 
```
+ '[' -d strato-worktree ']'
+ cd strato-worktree
+ git checkout worktree-fetch
Already on 'worktree-fetch'
Your branch is behind 'origin/worktree-fetch' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch)
+ git reset --hard remotes/origin/worktree-fetch
HEAD is now at 0ee426a List worktrees
+ cd ..
+ git worktree list
/datadrive/jenkins/workspace/STRATO_test                  0ee426a (detached HEAD)
/datadrive/jenkins/workspace/STRATO_test/strato-worktree  0ee426a [worktree-fetch]
```