### PR TITLE
some more pipeline enhancements

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -1,6 +1,6 @@
 pipeline {
   agent {
-    label "cd10"
+    label "test"
   }
   options { disableConcurrentBuilds() }
   stages {
@@ -13,7 +13,6 @@ pipeline {
           docker rmi -f $(docker images -aq) || true
           docker images -a
           rm -rf ~/.stack
-          rm -rf strato-platform
           git worktree remove -f strato-worktree
           git wortkree add strato-worktree develop
           git workree list

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -18,7 +18,6 @@ pipeline {
           sh '''#!/bin/bash -le
             set -x
             if [ "$BUILD_TYPE" == "full" ]; then
-              rm -rf strato-platform
               git worktree remove -f strato-worktree
               git worktree add strato-worktree develop
               cd strato-worktree


### PR DESCRIPTION
use `test` label for nightly build to make sure we are not depend on a machine + make some kind of a round-robbing to clean the environments on the test machines ~once a week, and rebuild on them from scratch (and avoid diskdrives to be full)