### PR TITLE
Attach an empty storage diff on create

### DIFF
--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -1029,11 +1029,12 @@ create isRunningTests' isHomestead preExistingSuicideList b callDepth' sender or
 create' :: VMM Code
 create' = do
 
+  owner <- getEnvVar envOwner
+  storageDiffs %= M.alter (Just . fromMaybe M.empty) owner
+
   runCodeFromStart
 
   vmState <- lift get
-
-  owner <- getEnvVar envOwner
 
   let codeBytes' = fromMaybe B.empty $ returnVal vmState
   when flags_debug $ lift $ $logInfoS "create'" . T.pack $ "Result: " ++ show codeBytes'


### PR DESCRIPTION
For Slipstream to update the state of a contract, there must be a storage diff for that contract in the Action. Until now, contracts with no internal state and contracts initialized with all 0 values would not have their tables created. This is a mild inconvenience in a single-node, but the real problem occurs in a multi-node setting. If there are no storage diffs in a transaction, then no Actions get emitted to Slipstream, and thus the metadata containing the contract source gets lost forever. On peer nodes, this means they don't receive the source, and can never index the contract. In this PR, we add an empty storage diff for the contract as it's being created, thus ensuring an Action will be emitted for it.