### PR TITLE
Misc

### DIFF
--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/Selector.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/Selector.hs
@@ -46,6 +46,7 @@ formatArg _ (SimpleType (TypeBytes (Just b))) = "bytes" ++ show b
 formatArg _ (SimpleType TypeBool) = "bool"
 formatArg _ (SimpleType TypeAddress) = "address"
 formatArg _ (SimpleType TypeString) = "string"
+formatArg _ (TypeContract name) = Text.unpack name
 formatArg enumSizes (TypeArrayFixed size x) = formatArg enumSizes x ++"[" ++ show size ++ "]"
 formatArg enumSizes (TypeArrayDynamic x) = formatArg enumSizes x ++"[]"
 formatArg enumSizes (TypeMapping x y) = "mapping(" ++ formatArg enumSizes (SimpleType x) ++ "=>" ++ formatArg enumSizes y ++ ")"
@@ -56,70 +57,3 @@ formatArg enumSizes (TypeEnum label) =
    Just x -> error $ "undefined case in formatArg for enum with more than 255 items: size=" ++ show x
 
 formatArg _ x = error $ "undefined value in formatArg: " ++ show x
-
-
-
-
-
-
-
-
-
-
-{-formatArg _ (SignedInt s) = text "int" <> natural (s * 8)
-formatArg _ (UnsignedInt s) = text "uint" <> natural (s * 8)
-formatArg _ (FixedBytes s) = text "bytes" <> natural s
-formatArg _ DynamicBytes = text "bytes"
-formatArg _ String = text "string"
-formatArg typesL (FixedArray t l) = pretty typesL t <> text "[" <> natural l <> text "]"
-formatArg typesL (DynamicArray t) = pretty typesL t <> text "[]"
-formatArg typesL (Mapping d c) =
-  text "mapping" <+> parens (pretty typesL d <+> text "=>" <+> pretty typesL c)
-formatArg typesL (Typedef name) =
-  case typesL Map.! name of
-    EnumLayout s -> pretty typesL (UnsignedInt s)
-    _ -> text name -}
-
-{-
-
-selector :: SolidityTypesLayout -> Identifier -> [SolidityObjDef] -> [SolidityObjDef] -> String
-selector typesL name args vals = hash4 $ signature typesL name args vals
-  where
-    hash4 bs = concatMap toHex $ BS.unpack $ BS.take 4 $ SHA3.hash 256 bs
-    toHex = zeroPad . flip showHex ""
-    zeroPad [c] = ['0',c]
-    zeroPad x = x
-
-signature :: SolidityTypesLayout -> Identifier -> [SolidityObjDef] -> [SolidityObjDef] -> ByteString
-signature typesL name args _ = encodeUtf8 $ T.pack $ name ++ prettyArgTypes typesL args
-
-prettyArgTypes :: SolidityTypesLayout -> [SolidityObjDef] -> String
-prettyArgTypes typesL args =
-  show $ parens $ hcat $ punctuate (text ",") $
-  mapMaybe (fmap (pretty typesL) . varType) args
-
-varType :: SolidityObjDef -> Maybe SolidityBasicType
-varType (ObjDef _ (SingleValue t) NoValue _ _) = Just t
-varType _ = Nothing
-
-pretty :: SolidityTypesLayout -> SolidityBasicType -> Doc
-pretty _ Boolean = text "bool"
-{-pretty _ Address = text "address"
-pretty _ (SignedInt s) = text "int" <> natural (s * 8)
-pretty _ (UnsignedInt s) = text "uint" <> natural (s * 8)
-pretty _ (FixedBytes s) = text "bytes" <> natural s
-pretty _ DynamicBytes = text "bytes"
-pretty _ String = text "string"
-pretty typesL (FixedArray t l) = pretty typesL t <> text "[" <> natural l <> text "]"
-pretty typesL (DynamicArray t) = pretty typesL t <> text "[]"
-pretty typesL (Mapping d c) =
-  text "mapping" <+> parens (pretty typesL d <+> text "=>" <+> pretty typesL c)
-pretty typesL (Typedef name) =
-  case typesL Map.! name of
-    EnumLayout s -> pretty typesL (UnsignedInt s)
-    _ -> text name -}
-
-natural = integer . toInteger
-
-
--}

--- a/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
@@ -41,7 +41,6 @@ import           Data.Text                        (Text)
 import qualified Data.Text                        as Text
 import qualified Data.Text.Encoding               as Text
 import           Data.Word
-import           Debug.Trace                      (traceShowId)
 import           Text.Printf
 import           Text.Read
 
@@ -161,7 +160,7 @@ decodeCacheValues
   -> [(Text, Value)]
   -> [(Text, Value)]
 decodeCacheValues typeDefs' struct'@Struct{..} cache offset state =
-  zipWith fromMaybe state $ map (decodeCacheValue typeDefs' struct' cache offset) $ traceShowId state
+  zipWith fromMaybe state $ map (decodeCacheValue typeDefs' struct' cache offset) state
 
 decodeCacheValue
   :: TypeDefs
@@ -260,8 +259,9 @@ decodeCacheValue' typeDefs'@TypeDefs{..} cache position@Storage.Position{..} val
           len = fromMaybe vlen $ fromIntegral <$> cache offset
           vals' = if len < vlen
                     then take len vals
-                    else vals ++ replicate (len - vlen) (decodeCacheValue' typeDefs' (const $ Just 0) doesntMatter (error "decodeCacheValue': Evaluating non-existent array element") ty) -- Seems unnecessary, but we need a way to hand over a generic null value
-                      where doesntMatter = Storage.Position 0 0 -- Our cache function is (const $ Just 0), so we don't need to pass in the correct offset
+                    else vals ++ replicate (len - vlen) (decodeValue' typeDefs' (const 0) 0 0 False doesntMatter ty)
+                      -- Our cache function is (Just 0), so we don't need to pass in the correct offset
+                      where doesntMatter = Storage.Position 0 0
           (_, elementSize) = getPositionAndSize typeDefs' (Storage.positionAt 0) ty
           theList = zipWith (\ofs val -> decodeCacheValue' typeDefs' cache ((arrayPosition (toInteger elementSize) ofs) `Storage.addOffset` startingKey) val ty) [0..] vals'
           startingKey = getArrayStartingKey offset

--- a/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
@@ -41,6 +41,7 @@ import           Data.Text                        (Text)
 import qualified Data.Text                        as Text
 import qualified Data.Text.Encoding               as Text
 import           Data.Word
+import           Debug.Trace                      (traceShowId)
 import           Text.Printf
 import           Text.Read
 
@@ -160,7 +161,7 @@ decodeCacheValues
   -> [(Text, Value)]
   -> [(Text, Value)]
 decodeCacheValues typeDefs' struct'@Struct{..} cache offset state =
-  zipWith fromMaybe state $ map (decodeCacheValue typeDefs' struct' cache offset) state
+  zipWith fromMaybe state $ map (decodeCacheValue typeDefs' struct' cache offset) $ traceShowId state
 
 decodeCacheValue
   :: TypeDefs

--- a/blockapps-haskell/solidity/src/BlockApps/XAbiConverter.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/XAbiConverter.hs
@@ -27,25 +27,6 @@ import qualified BlockApps.Solidity.Xabi.Type      as Xabi
 import qualified BlockApps.Storage                 as Storage
 import           BlockApps.SolidityVarReader       (decodeStorageKey)
 
-transformXabi :: Integer -> Xabi -> Map.Map Text Text -> [(Word256, Word256)]
-transformXabi fetchLimit xabi@Xabi{..} vars = do
-  newXabiVars <- for (Map.toList vars) $ \(varName, val) -> do
-    case Map.lookup varName xabiVars of
-      Nothing -> error "Cannot assign value to a nonexiting contract variable"
-      Just Xabi.VarType{..} -> do
-        let initialVal = Just $ Text.unpack val
-            newVarType = Xabi.VarType varTypeAtBytes varTypePublic varTypeConstant initialVal varTypeType
-        return (varName, newVarType)
-  let updateVarVal varName curVal = if (Just curVal) == Map.lookup varName (Map.fromList newXabiVars)
-                                       then Just curVal
-                                       else Map.lookup varName (Map.fromList newXabiVars)
-  _ <- map (\(varName, _) -> Map.updateWithKey updateVarVal varName xabiVars) newXabiVars
-
-  let contract' = case xAbiToContract xabi of
-                    Left x -> error x
-                    Right c -> c
-  decodeStorageKey (typeDefs contract') (mainStruct contract') ["Gov"] 0 0 fetchLimit True
-
 fieldsToStruct::TypeDefs->[((Text, Type), Maybe Text)]->Struct
 fieldsToStruct typeDefs' vars =
   let

--- a/blockapps-haskell/solidity/src/BlockApps/XAbiConverter.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/XAbiConverter.hs
@@ -6,7 +6,6 @@
 module BlockApps.XAbiConverter where
 
 import qualified Data.Bimap                        as Bimap
-import           Data.LargeWord
 import           Data.List
 import qualified Data.Map                          as Map
 import qualified Data.Map.Ordered                  as OMap
@@ -25,7 +24,6 @@ import           BlockApps.Solidity.Xabi
 import qualified BlockApps.Solidity.Xabi.Def       as XabiDef
 import qualified BlockApps.Solidity.Xabi.Type      as Xabi
 import qualified BlockApps.Storage                 as Storage
-import           BlockApps.SolidityVarReader       (decodeStorageKey)
 
 fieldsToStruct::TypeDefs->[((Text, Type), Maybe Text)]->Struct
 fieldsToStruct typeDefs' vars =

--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -1029,11 +1029,12 @@ create isRunningTests' isHomestead preExistingSuicideList b callDepth' sender or
 create' :: VMM Code
 create' = do
 
+  owner <- getEnvVar envOwner
+  storageDiffs %= M.alter (Just . fromMaybe M.empty) owner
+
   runCodeFromStart
 
   vmState <- lift get
-
-  owner <- getEnvVar envOwner
 
   let codeBytes' = fromMaybe B.empty $ returnVal vmState
   when flags_debug $ lift $ $logInfoS "create'" . T.pack $ "Result: " ++ show codeBytes'


### PR DESCRIPTION
For Slipstream to update the state of a contract, there must be a storage diff for that contract in the Action. Until now, contracts with no internal state and contracts initialized with all 0 values would not have their tables created. This is a mild inconvenience in a single-node, but the real problem occurs in a multi-node setting. If there are no storage diffs in a transaction, then no Actions get emitted to Slipstream, and thus the metadata containing the contract source gets lost forever. On peer nodes, this means they don't receive the source, and can never index the contract. In this PR, we add an empty storage diff for the contract as it's being created, thus ensuring an Action will be emitted for it.

Additionally, dynamic array elements were causing decodeCacheValue' to crash, so I replaced the inner call to it with decodeValue'.