### PR TITLE
Be more generous in accepting proposer seals

### DIFF
--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -6,7 +6,6 @@
 module Blockchain.Blockstanbul.EventLoop where
 
 import Conduit
-import Control.Applicative ((<|>))
 import Control.Lens hiding (view)
 import Control.Monad hiding (sequence)
 import Control.Monad.Logger
@@ -143,7 +142,6 @@ isAuthorized iev = do
   unless authenticated $
     warn $ "Rejecting inevent; message failed authentication: " ++ show iev
   authorized <- authorize iev
-  mLockSender <- use lockSender
   specificAuth <-
     case iev of
       NewBeneficiary (MsgAuth addr sign) (benf, dir, nonc) -> do
@@ -160,20 +158,20 @@ isAuthorized iev = do
             return False
       -- TODO(tim): RoundChange a Preprepare correctly signed by the proposer,
       -- but with incorrect extraData.
-      IMsg (MsgAuth addr _) (Preprepare _ pp) -> do
+      IMsg _ (Preprepare _ pp) -> do
         vals <- use validators
         let payloadVals = S.fromList (getValidatorList pp)
             validatorsMatch = vals == payloadVals
             signatory = verifyProposerSeal pp =<< getProposerSeal pp
-            signerMatches = (mLockSender <|> Just addr) == signatory
-        unless signerMatches $
+            signerExists = signatory `S.member` S.map Just vals
+        unless signerExists $
           warn $ "Rejecting Preprepare; signer " ++ show (format <$> signatory)
-              ++ " is not sender " ++ format addr
+              ++ " is not a known validator"
         unless validatorsMatch $
           warn $ "Rejecting Preprepare; payload validators "
               ++ show (S.map format payloadVals) ++ " are not expected validators "
               ++ show (S.map format vals)
-        return $ signerMatches && validatorsMatch
+        return $ signerExists && validatorsMatch
       IMsg (MsgAuth addr _) (Commit _ di seal) -> do
         let ret = Just addr == verifyCommitmentSeal di seal
         unless ret . warn $ "Rejecting Commit; bad seal"

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module StateMachineSpec where
 
-import Test.Hspec (Spec, describe, it, parallel, pendingWith)
+import Test.Hspec (Spec, describe, it, parallel)
 import Test.Hspec.Expectations.Lifted
 import Test.QuickCheck
 
@@ -468,11 +468,10 @@ spec = parallel $ do
           (lockBlk, omsgs) <- resendLock blk theirPK theirPK
           map oMessage omsgs `shouldBe` [Prepare v (blockHash lockBlk)]
 
-      it "rejects a block if the signer is not the original sender" $ property $ \blk -> do
-        pendingWith "TODO(tim): Reorganize specific auth"
+      it "accepts a block if the signer is not the original sender" $ property $ \blk ->
         runAuthTest $ do
           theirPK <- liftIO $ HK.withSource getEntropy HK.genPrvKey
           v <- use view
           myKey <- use prvkey
-          (_, omsgs) <- resendLock blk theirPK myKey
-          map oMessage omsgs `shouldBe` [RoundChange v]
+          (lockBlk, omsgs) <- resendLock blk theirPK myKey
+          map oMessage omsgs `shouldBe` [Prepare v (blockHash lockBlk)]


### PR DESCRIPTION
From the logs in https://blockappsdev.slack.com/archives/G5E7K3ETX/p1539727000000100,

At the time of block #95, there were 5 nodes out to lunch[0]. During its
initial announcement by 315, 3 nodes become locked on #95: 311, 315, 317
[1]. Quorum in a 20 node network is 14 (note: I had miscounted yesterday
as 13, but 13 * 3 < 2 * 20 < 14 * 3), so to commit any block would
require colloboration between the unlocked and locked nodes. For any
block announced, the locked nodes would require that the sealer of the
block was the original sealer. The unlocked nodes would require that the
sealer of the block is the sender. The stall came from the passage of 20
rounds, as the only acceptable proposer to both factions would be 315
again[2]. In general, progress is not guaranteed as the validator which
nodes have locked on need not be one of the locked nodes.

There are two possible corrections. One is for the reannouncers of a
locked block to unseal and reseal it with their own private key, and for
validators to compare lock replacements on a hash which ignores the
proposer seal. Two is for validators to relax the seal author checking:
instead of comparing against the believed signer (which can be a false
belief if there is disagreement about a lock), just check that the seal
author is any validator.

[0] `for dir in */; do echo $dir; grep "showctx/view.*sequence = 95" $dir/strato-sequencer | wc -l; done`
[1] `grep "21:34:06.8.*showctx/mLockedSender" */strato-sequencer`
[2] `grep "showctx/view.*sequence = 95" strato-sequencer | cut -d \| -f
3,4 | uniq -c`