### PR TITLE
Use -f instead of --force (-f added in git 2.18)

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -13,7 +13,7 @@ pipeline {
           docker rmi -f $(docker images -aq) || true
           docker images -a
           rm -rf ~/.stack
-          git worktree remove -f strato-worktree
+          git worktree remove --force strato-worktree
           git wortkree add strato-worktree develop
           git workree list
         '''

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -18,7 +18,7 @@ pipeline {
           sh '''#!/bin/bash -le
             set -x
             if [ "$BUILD_TYPE" == "full" ]; then
-              git worktree remove -f strato-worktree
+              git worktree remove --force strato-worktree
               git worktree add strato-worktree develop
               cd strato-worktree
               git checkout ${REFSPEC}


### PR DESCRIPTION
https://jenkins.blockapps.net/job/STRATO_develop_nightly_build/

However, some agents seem to have an even older version of `git`, but I can't tell which ones those are. Some say:
```blockapps@test5:/tmp/tst$ git worktree remove -f q
error: unknown switch `f'
usage: git worktree add [<options>] <path> [<commit-ish>]
   or: git worktree list [<options>]
   or: git worktree lock [<options>] <path>
   or: git worktree move <worktree> <new-path>
   or: git worktree prune [<options>]
   or: git worktree remove [<options>] <worktree>
   or: git worktree unlock <path>

    --force               force removing even if the worktree is dirty
```
Others say: ```+ git worktree remove -f strato-worktree
usage: git worktree add [<options>] <path> [<branch>]
   or: git worktree prune [<options>]
   or: git worktree list [<options>]```
