### PR TITLE
Do not assume that the world has moved forward

### DIFF
--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -353,10 +353,6 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
         yield =<< signMessage pk (RoundChange vn)
       when (3 * sameRNCount > 2 * total) $ do
         next <- use pendingRound
-        when (_sequence v < _sequence vn) $ do
-          -- Assume that we have missed the commit of the locked block, because
-          -- the rest of the nodes have moved on.
-          clearLock
         case next of
           Nothing -> error "TODO(tim): a round was voted on without existing"
           Just r -> nextRound (Round r)

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -421,23 +421,15 @@ spec = parallel $ do
       runTest $ do
         setBlock blk
         me <- selfAddr
-        next <- uses view (over round (+1))
-        resp <- sendMessages [IMsg (MsgAuth me sig) $ RoundChange next]
+        roundPlus1 <- uses view (over round (+1))
+        let roundAndSequencePlus1 = over sequence (+1) roundPlus1
+        resp <- sendMessages [IMsg (MsgAuth me sig) $ RoundChange roundAndSequencePlus1]
         let omsgs = [o | o@(OMsg _ _) <- resp]
             other = resp \\ omsgs
-        map oMessage omsgs `shouldBe` [RoundChange next, Preprepare next blk]
-        other `shouldBe` [ResetTimer $ _round next]
+        map oMessage omsgs `shouldBe` [RoundChange roundAndSequencePlus1,
+                                       Preprepare roundPlus1 blk]
+        other `shouldBe` [ResetTimer $ _round roundPlus1]
 
-    it "clears the lock after a future round change" $ property $ \blk sig ->
-      runTest $ do
-        setBlock blk
-        me <- selfAddr
-        next <- uses view (over round (+1) . over sequence (+1))
-        resp <- sendMessages [IMsg (MsgAuth me sig) $ RoundChange next]
-        let omsgs = [o | o@(OMsg _ _) <- resp]
-            other = resp \\ omsgs
-        map oMessage omsgs `shouldBe` [RoundChange next]
-        other `shouldMatchList` [ResetTimer $ _round next, MakeBlockCommand]
     describe "Authentication" $ do
       let resendLock :: Block -> HK.PrvKey -> HK.PrvKey
                      -> StateT BlockstanbulContext (NoLoggingT IO) (Block, [OutEvent])


### PR DESCRIPTION
If the world actually has moved forward, a replay will bring the
block that was committed back to this node and the lock can
be cleared in the normal fashion