### PR TITLE
Log a pre-crash message at critical

### DIFF
--- a/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
@@ -76,7 +76,7 @@ getTheMessages offset@(K.Offset o) = do
   let errorStatuses = concatMap (^.. _2 . folded . _2) (fetched ^. K.fetchResponseFields)
   case find (/= K.NoError) errorStatuses of
    Just e -> do
-    liftIO . debugM "getTheMessages/kafka_response" . show $ fetched
+    liftIO . criticalM "getTheMessages/kafka_response" . show $ fetched
     let topic = BC.unpack (lookupTopic ^. K.tName ^. K.kString)
     error $ printf "There was a critical Kafka error while fetching messages: %s\ntopic = %s, offset = %d" (show e) topic o
    Nothing -> return ()


### PR DESCRIPTION
It's not very helpful to debug log something that cannot be reproduced reliably