### PR TITLE
Contract instances

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -227,6 +227,18 @@ contractByCodeHash codeHash = proc () -> do
   restrict -< ch .== constant codeHash
   returnA -< contract
 
+contractInstancesByCodeHash
+  :: Keccak256
+  -> Address
+  -> Maybe ChainId
+  -> Query (Column PGInt4)
+contractInstancesByCodeHash codeHash address chainId = proc () -> do
+  (cmId,_,_,addr,_,_,_,ch,_,cid) <- contractsJoinTable -< ()
+  restrict -< ch .== constant codeHash
+  restrict -< addr .== constant address
+  restrict -< cid .== constant chainId
+  returnA -< cmId
+
 contractBySourceHash
   :: Keccak256
   -> Query
@@ -914,12 +926,12 @@ getContractDetails contract@(ContractName contractName) contractId chainId = do
             getContractsContractByNameQuery contractName name
           return $ detailsWith (Just (Named name)) chainId tuple
 
-getContractDetailsByCodeHash :: Keccak256 -> Bloc (Maybe ContractDetails)
+getContractDetailsByCodeHash :: Keccak256 -> Bloc (Maybe (Int32, ContractDetails))
 getContractDetailsByCodeHash codeHash = do
     mDetails <- fmap listToMaybe . blocQuery $ getContractsContractByCodeHashQuery codeHash
     for mDetails $ \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId) -> do
       xabi <- getContractXabiByMetadataId cmId
-      return ContractDetails
+      return (cmId, ContractDetails
         { contractdetailsBin = Text.decodeUtf8 bin
         , contractdetailsAddress = Nothing
         , contractdetailsBinRuntime = Text.decodeUtf8 binr
@@ -928,7 +940,7 @@ getContractDetailsByCodeHash codeHash = do
         , contractdetailsSrc = src
         , contractdetailsXabi = xabi
         , contractdetailsChainId = Nothing
-        }
+        })
 
 {- |
 WITH contract_id AS (
@@ -1181,6 +1193,22 @@ insertContract parentContr contr bin binRuntime src xabi = do
     contrId bin binRuntime codeHash xcodeHash srcHash
   insertXabi metadataId parentContr xabi
   return metadataId
+
+insertContractInstance
+  :: Int32
+  -> Address
+  -> Maybe ChainId
+  -> Bloc Int32
+insertContractInstance cmId address chainId = blocModify1 $ \conn -> runInsertManyReturning conn contractsInstanceTable
+  [
+  ( Nothing
+  , constant cmId
+  , constant address
+  , Nothing
+  , constant chainId
+  )
+  ]
+  (\ (contractInstanceId,_,_,_,_) -> contractInstanceId)
 
 compileContract :: Text -> Bloc (Map Text (Int32, ContractDetails))
 compileContract source = do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -227,6 +227,23 @@ contractByCodeHash codeHash = proc () -> do
   restrict -< ch .== constant codeHash
   returnA -< contract
 
+contractByMetadataId
+  :: Int32
+  -> Query
+    ( Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGText
+    , Column PGText
+    , Column PGInt4
+    )
+contractByMetadataId metadataId = proc () -> do
+  contract@(_,_,_,_,_,_,_,cmId) <- contractDetailsJoinTable -< ()
+  restrict -< cmId .== constant metadataId
+  returnA -< contract
+
 contractInstancesByCodeHash
   :: Keccak256
   -> Address
@@ -891,6 +908,20 @@ getXabiVariableNamesQuery metadataId = proc () -> do
   restrict -< cmid .== constant metadataId
   returnA -< varName
 
+getContractDetailsByMetadataId :: Int32 -> MaybeNamed Address -> Maybe ChainId -> Bloc ContractDetails
+getContractDetailsByMetadataId cmId addr chainId = do
+  xabi <- getContractXabiByMetadataId cmId
+  (bin,binRuntime,codeHash,_ :: ByteString,_ :: Keccak256,name,src,_ :: Int32) <- blocQuery1 $ contractByMetadataId cmId
+  return ContractDetails
+    { contractdetailsBin = Text.decodeUtf8 bin
+    , contractdetailsAddress = Just addr
+    , contractdetailsBinRuntime = Text.decodeUtf8 binRuntime
+    , contractdetailsCodeHash = codeHash
+    , contractdetailsName = name
+    , contractdetailsSrc = src
+    , contractdetailsXabi = xabi
+    , contractdetailsChainId = chainId
+    }
 
 getContractDetails :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc ContractDetails
 getContractDetails contract@(ContractName contractName) contractId chainId = do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -606,13 +606,13 @@ evalAndReturn list = do
       cl = contractsList state
   (nbtrs,_) <- do
     forStateT state cl $
-      \(addr', ContractCreationData _ hash name chainId mtxr index) -> do
+      \(addr', ContractCreationData cmId hash name chainId mtxr index) -> do
         st <- get
         let cds = contractDetailsMap st
         (details, cds') <- case Map.lookup name cds of
           Just details' -> return (details'{contractdetailsAddress = Just (Unnamed addr')}, cds)
           Nothing -> do
-            details' <- lift $ getContractDetails name (Unnamed addr') chainId
+            details' <- lift $ getContractDetailsByMetadataId cmId (Unnamed addr') chainId
             return (details', Map.insert name details' cds)
         put st{contractDetailsMap = cds'}
         return $ (BlocTransactionResult Success hash mtxr (Just $ Upload details), index)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -605,16 +605,6 @@ evalAndReturn list = do
   let jbtrs = [btr | Just btr <- mbtrs]
       cl = contractsList state
   (nbtrs,_) <- do
-    void . blocModify $ \conn -> runInsertMany conn contractsInstanceTable
-      [
-      ( Nothing
-      , constant cmId
-      , constant addr'
-      , Nothing
-      , constant chainId
-      )
-      | (addr', ContractCreationData cmId _ _ chainId _ _) <- cl
-      ]
     forStateT state cl $
       \(addr', ContractCreationData _ hash name chainId mtxr index) -> do
         st <- get

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -20,6 +20,7 @@ import qualified Data.Aeson as JSON
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import Data.Either (lefts,rights)
+import Data.Int (Int32)
 import Data.IORef
 import Data.Function
 import Data.Map (Map)
@@ -167,19 +168,22 @@ processTheMessages messages conn g = do
           fmap join . for (Map.lookup "src" md) $ \src -> do
             detailsMap <- compileContract src
             fmap join . for (Map.lookup "name" md) $ \name -> do
-              traverse (pure . snd) $ Map.lookup name detailsMap
+              traverse pure $ Map.lookup name detailsMap
 
         if isNothing mDetails
           then return . Left $ "No details found for code hash "
                             <> (T.pack $ show actionCodeHash)
                             <> " and no 'src' field found in actionMetadata"
           else do
-            let Just details = mDetails
+            let Just (cmId,details) = mDetails
                 strAbi = T.replace "\'" "\'\'" . decodeUtf8 . BL.toStrict . JSON.encode $ contractdetailsXabi details
                 strName = T.replace "\"" "" $ contractdetailsName details
                 cont = either error id . xAbiToContract $ contractdetailsXabi details
                 chain = maybe "" (T.pack . flip showHex "" . unChainId) actionTxChainId
                 cache = maybe (const Nothing) (\s -> fmap unHex . flip Map.lookup s . Hex) actionStorage
+            (mInstance :: Maybe Int32) <- fmap listToMaybe . blocQuery $
+              contractInstancesByCodeHash actionCodeHash actionAddress actionTxChainId
+            when (isNothing mInstance) . void $ insertContractInstance cmId actionAddress actionTxChainId
             fetchLimit <- asks stateFetchLimit
             oldState <- fromMaybe (decodeValues fetchLimit (typeDefs cont) (mainStruct cont) (const 0) 0)
                           <$> getContractState g actionAddress actionTxChainId


### PR DESCRIPTION
Slipstream used to ask Bloc for the details of a contract. If Bloc didn't have them, it would pull the contract source out of Strato, compile it, and store the details, including an entry in the `contractsInstance` table, for the specific address requested. Now, Slipstream is a lot smarter, and no longer relies on Bloc for this information (it still uses the Bloc DB for contract metadata info, but that's about it). All of a sudden, contracts don't show up in SMD on other nodes, because Bloc never creates entries in the `contractsInstance` table for them. In this PR, Slipstream performs this task for all new contracts, so other nodes will still be able to see and interact with all the contracts.