### PR TITLE
Fix a counting issue with historic replay

### DIFF
--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Authentication.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Authentication.hs
@@ -143,7 +143,7 @@ authenticate (IMsg (MsgAuth addr sig) tm) =
   in mAddress == Just addr
 authenticate _ = True -- Non-messages are trusted implicitly
 
-replayHistoricBlock :: S.Set Address  -> Word256 -> Block -> Either String Word256
+replayHistoricBlock :: S.Set Address  -> Word256 -> Block -> Either String ()
 replayHistoricBlock realValidators seqNo blk = do
   -- TODO(tim): This needs to be fixed for validator voting, as the current list
   -- may have diverged from the validators at the time of commit
@@ -156,8 +156,8 @@ replayHistoricBlock realValidators seqNo blk = do
               . mapMaybe (verifyCommitmentSeal (blockHash blk))
               $ _commitment
       blockNo = fromIntegral . blockDataNumber . blockBlockData $ blk
-  unless (seqNo + 1 == blockNo) $
-    Left $ printf "unexpected block number: have %d, wanted %d" blockNo (seqNo + 1)
+  unless (seqNo == blockNo) $
+    Left $ printf "unexpected block number: have %d, wanted %d" blockNo seqNo
   unless (realValidators == S.fromList _validatorList) $
     Left "mismatched validators"
   case mProp of
@@ -169,7 +169,7 @@ replayHistoricBlock realValidators seqNo blk = do
     Left $ "unknown signers: " ++ unexplained
   unless (3 * S.size signers > 2 * S.size realValidators) $
     Left $ printf "not enough commit seals (have %d out of %d)" (S.size signers) (S.size realValidators)
-  Right . fromIntegral $ seqNo + 1
+  Right ()
 
 isHistoricBlock :: Block -> Bool
 isHistoricBlock = (> 32) . B.length . view extraLens

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -250,11 +250,11 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
       -- may have diverged from the validators at the time of commit
       realValidators <- use validators
       seqNo <- use $ view . sequence
-      let eNextSeqNo = replayHistoricBlock realValidators seqNo blk
+      let eAccept = replayHistoricBlock realValidators seqNo blk
           blockNo = blockDataNumber . blockBlockData $ blk
-      case eNextSeqNo of
+      case eAccept of
         Left err -> $logWarnS "blockstanbul" . T.pack . printf "Rejecting historical block #%d: %s" blockNo $ err
-        Right _ -> do
+        Right () -> do
           -- TODO(tim): Does it have a vote to record?
           $logInfoS "blockstanbul" . T.pack . printf "Accepting historical block #%d" $ blockNo
           yield . ToCommit $ blk

--- a/core-strato/blockstanbul/test/AuthenticationSpec.hs
+++ b/core-strato/blockstanbul/test/AuthenticationSpec.hs
@@ -119,18 +119,18 @@ spec = do
       let vals = S.singleton 0xdeadbeef
           blk = addValidators vals testBlock
           got = replayHistoricBlock S.empty 300 blk
-      got `shouldBe` Left "unexpected block number: have 40, wanted 301"
+      got `shouldBe` Left "unexpected block number: have 40, wanted 300"
 
     it "Rejects a block with the wrong validator list" $ do
       let vals = S.map prvKey2Address . S.singleton $ private
           blk = addValidators vals testBlock
-          got = replayHistoricBlock (S.singleton 0xdeadbeef) 39 blk
+          got = replayHistoricBlock (S.singleton 0xdeadbeef) 40 blk
       got `shouldBe` Left "mismatched validators"
 
     it "Rejects a block without a proposer's signature" $ do
       let vals = S.singleton 0xdeadbeef
           blk = addValidators vals testBlock
-          got = replayHistoricBlock vals 39 blk
+          got = replayHistoricBlock vals 40 blk
       got `shouldBe` Left "invalid proposer seal"
 
     it "Rejects a block with a bad proposer's signature" $ do
@@ -138,7 +138,7 @@ spec = do
           blk' = addValidators vals testBlock
       seal <- proposerSeal blk' private
       let blk = addProposerSeal seal blk'
-          got = replayHistoricBlock vals 39 blk
+          got = replayHistoricBlock vals 40 blk
       got `shouldBe` Left "proposer 80976e7d04c8ae9b3a1c08278a5c385e5b0ff446 not a validator"
 
     it "Rejects a block without commit seals" $ do
@@ -146,7 +146,7 @@ spec = do
           blk' = addValidators vals testBlock
       seal <- proposerSeal blk' private
       let blk = addProposerSeal seal blk'
-          got = replayHistoricBlock vals 39 blk
+          got = replayHistoricBlock vals 40 blk
       got `shouldBe` Left "not enough commit seals (have 0 out of 1)"
 
     it "Rejects a block with an unknown seal" $ do
@@ -156,7 +156,7 @@ spec = do
       let blk' = addProposerSeal pSeal blk''
       cSeal <- commitmentSeal (blockHash blk') (head keys)
       let blk = addCommitmentSeals [cSeal] blk'
-          got = replayHistoricBlock vals 39 blk
+          got = replayHistoricBlock vals 40 blk
       got `shouldBe` Left "unknown signers: 807da1d7f5286530d0a71a2e87df146b8fefec96"
 
     it "Accepts a block with 1 validator" $ do
@@ -166,5 +166,5 @@ spec = do
       let blk' = addProposerSeal pSeal blk''
       cSeal <- commitmentSeal (blockHash blk') private
       let blk = addCommitmentSeals [cSeal] blk'
-          got = replayHistoricBlock vals 39 blk
-      got `shouldBe` Right 40
+          got = replayHistoricBlock vals 40 blk
+      got `shouldBe` Right ()


### PR DESCRIPTION
If the sequence number is N, the next block to commit is N+1.
For example, at the start seqno = 0 and block = 1, as block = 0
is the genesis block and does not require consensus. That means
the previous block committed was N.