### PR TITLE
Only announce blocks with the correct parent and block number

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Data/Block.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/Block.hs
@@ -2,7 +2,8 @@
 module Blockchain.Data.Block (
   Block(..),
   blockDataLens,
-  extraLens
+  extraLens,
+  setBlockNo
   ) where
 
 import Control.DeepSeq
@@ -26,6 +27,9 @@ makeLensesFor [("blockBlockData", "blockDataLens")] ''Block
 
 extraLens :: Lens' Block BS.ByteString
 extraLens = blockDataLens . extraDataLens
+
+setBlockNo :: Integer -> Block -> Block
+setBlockNo n blk = blk{blockBlockData = (blockBlockData blk){blockDataNumber = n}}
 
 instance Binary Block where
 instance NFData Block

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/BenchmarkLib.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/BenchmarkLib.hs
@@ -14,6 +14,7 @@ import qualified Network.Haskoin.Crypto as HK
 
 import Blockchain.Blockstanbul
 import Blockchain.Data.Block
+import Blockchain.Data.DataDefs
 import Blockchain.Data.Code
 import Blockchain.Data.Json
 import Blockchain.Data.TransactionDef
@@ -50,4 +51,5 @@ benchContext =
 
 makeBlock :: Int -> Int -> Block
 makeBlock txcount txsize =
-  genesisBlock{blockReceiptTransactions = replicate txcount (oneTX txsize)}
+  genesisBlock{blockReceiptTransactions = replicate txcount (oneTX txsize),
+               blockBlockData = (blockBlockData genesisBlock){blockDataNumber = 41}}

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/BenchmarkLib.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/BenchmarkLib.hs
@@ -14,7 +14,6 @@ import qualified Network.Haskoin.Crypto as HK
 
 import Blockchain.Blockstanbul
 import Blockchain.Data.Block
-import Blockchain.Data.DataDefs
 import Blockchain.Data.Code
 import Blockchain.Data.Json
 import Blockchain.Data.TransactionDef
@@ -50,6 +49,5 @@ benchContext =
   in  newContext (View 200 40) [prvKey2Address pk] [] pk
 
 makeBlock :: Int -> Int -> Block
-makeBlock txcount txsize =
-  genesisBlock{blockReceiptTransactions = replicate txcount (oneTX txsize),
-               blockBlockData = (blockBlockData genesisBlock){blockDataNumber = 41}}
+makeBlock txcount txsize = setBlockNo 41
+  genesisBlock{blockReceiptTransactions = replicate txcount (oneTX txsize)}

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -12,6 +12,7 @@ import Control.Monad.Logger
 import Control.Monad.State.Class
 import qualified Data.Map as M
 import Data.Maybe
+import Data.Monoid ((<>))
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Prelude hiding (round, sequence)
@@ -64,6 +65,7 @@ data BlockstanbulContext = BlockstanbulContext {
   , _blockLock :: Maybe Block
   , _lockSender :: Maybe Address
   , _authSenders :: M.Map Address Int
+  , _lastParent :: Maybe SHA
 }
 
 makeLenses ''BlockstanbulContext
@@ -107,6 +109,7 @@ newContext v as senderlist pk =
      , _blockLock = Nothing
      , _lockSender = Nothing
      , _authSenders = generateNonceMap senderlist
+     , _lastParent = Nothing
      }
 
 selfAddr :: (StateMachineM m) => m Address
@@ -181,6 +184,17 @@ isAuthorized iev = do
               then authorized && authenticated && specificAuth
               else authorized
 
+assertChainConsistency :: HK.Word256 -> Maybe SHA -> Block -> Either T.Text ()
+assertChainConsistency seqNo wantParent blk = do
+  let blkData = blockBlockData blk
+      blkNo = fromIntegral . blockDataNumber $ blkData
+      gotParent = blockDataParentHash blkData
+  unless (seqNo + 1 == blkNo) .
+    Left . T.pack $ printf "Rejecting block; block #%d is not required #%d" blkNo (seqNo +1)
+  when (isJust wantParent && wantParent /= Just gotParent) .
+    Left . T.pack $ "Rejecting block; parent hash " ++ format gotParent ++ " is not required " ++
+                    format (fromMaybe (error "assertChainConsistency") wantParent)
+  Right ()
 
 generateNonceMap :: [Address] -> M.Map Address Int
 generateNonceMap = M.fromList . flip zip (repeat 0)
@@ -253,7 +267,8 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
       let eNextSeqNo = replayHistoricBlock realValidators seqNo blk
           blockNo = blockDataNumber . blockBlockData $ blk
       case eNextSeqNo of
-        Left err -> $logWarnS "blockstanbul" . T.pack . printf "Rejecting historical block #%d: %s" blockNo $ err
+        Left err -> $logWarnS "blockstanbul" . T.pack
+                    . printf "Rejecting historical block #%d: %s" blockNo $ err
         Right _ -> do
           -- TODO(tim): Does it have a vote to record?
           $logInfoS "blockstanbul" . T.pack . printf "Accepting historical block #%d" $ blockNo
@@ -279,8 +294,20 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
         let sealedBlk = addProposerSeal pseal blockWithVs
         mLocked <- use blockLock
         let realSealed = fromMaybe sealedBlk mLocked
-        proposal .= Just realSealed
-        yield =<< signMessage pk (Preprepare v realSealed)
+        wantParent <- use lastParent
+        seqNo <- use (view . sequence)
+        case assertChainConsistency seqNo wantParent realSealed of
+          Left err -> do
+            $logWarnS "blockstanbul" $ "Retrying to build block: " <> err
+            when (isJust mLocked) $ do
+              -- TODO(tim): It may make sense to crash here, but it's also possible that
+              -- peers will be able to commit the lock and historic replay of it
+              -- could absolve us.
+              $logErrorS "blockstanbul" "Lock has wrong block number cannot commit"
+            yield MakeBlockCommand
+          Right () -> do
+            proposal .= Just realSealed
+            yield =<< signMessage pk (Preprepare v realSealed)
     IMsg auth (Preprepare v' pp) -> do
       pr <- use proposer
       mBlockLock <- use blockLock
@@ -376,9 +403,10 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
       $logInfoS "blockstanbul/roundchange" "commit failure (how...)"
       clearLock
       roundChange
-    CommitResult (Right ()) -> do
-      $logInfoS "blockstanbul" "Successful block commit"
+    CommitResult (Right hsh) -> do
+      $logInfoS "blockstanbul" . T.pack $ "Successful block commit of " ++ format hsh
       s <- use $ view . sequence
+      lastParent .= Just hsh
       clearLock
       -- TODO(tim): More guards should be put in place to see that not just the view but
       -- also the block numbers are in ascending order.

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -65,6 +65,8 @@ data BlockstanbulContext = BlockstanbulContext {
   , _blockLock :: Maybe Block
   , _lockSender :: Maybe Address
   , _authSenders :: M.Map Address Int
+  -- TODO(tim): Initialize _lastParent with the genesis block and
+  -- make it required
   , _lastParent :: Maybe SHA
 }
 

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -303,7 +303,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
               -- TODO(tim): It may make sense to crash here, but it's also possible that
               -- peers will be able to commit the lock and historic replay of it
               -- could absolve us.
-              $logErrorS "blockstanbul" "Lock has wrong block number cannot commit"
+              $logErrorS "blockstanbul" "Lock has wrong block number; cannot commit"
             yield MakeBlockCommand
           Right () -> do
             proposal .= Just realSealed
@@ -405,11 +405,11 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
       roundChange
     CommitResult (Right hsh) -> do
       $logInfoS "blockstanbul" . T.pack $ "Successful block commit of " ++ format hsh
-      s <- use $ view . sequence
       lastParent .= Just hsh
       clearLock
       -- TODO(tim): More guards should be put in place to see that not just the view but
       -- also the block numbers are in ascending order.
+      s <- use $ view . sequence
       nextRound . Sequence $ s+1
 
 class (Monad m) => HasBlockstanbulContext m where

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -327,23 +327,29 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
                 yield $ LeadFound (intSeq v) (intSeq v')
               roundChange
            | isJust mBlockLock && Just pp /= mBlockLock -> do
-              $logWarnS "blockstanbul/ppl" . T.pack $
-                printf "Rejecting proposal: block does not match lock"
+              $logWarnS "blockstanbul/ppl" "Rejecting proposal: block does not match lock"
               $logInfoS "blockstanbul/roundchange" "lock mismatch"
               roundChange
            | otherwise -> do
-               blockcount += 1
-               proposal .= Just pp
-               pk <- use prvkey
-               case extractBeneficiary pp of
-                 Nothing -> return()
-                 Just (bnef,vot) -> do
-                   -- insert the vote into map
-                   val <- uses voted $M.lookup bnef
-                   let unwrapVal = fromMaybe M.empty val
-                   let nval = M.insert pr vot unwrapVal
-                   voted %= M.insert bnef nval
-               yield =<< signMessage pk (Prepare v (blockHash pp))
+              wantParent <- use lastParent
+              case assertChainConsistency (_sequence v) wantParent pp of
+                Left err -> do
+                  $logWarnS "blockstanbul/ppl" $ "Rejecting proposal: " <> err
+                  $logInfoS "blockstanbul/roundchange" "chain inconsistency"
+                  roundChange
+                Right () -> do
+                  blockcount += 1
+                  proposal .= Just pp
+                  pk <- use prvkey
+                  case extractBeneficiary pp of
+                    Nothing -> return()
+                    Just (bnef,vot) -> do
+                      -- insert the vote into map
+                      val <- uses voted $M.lookup bnef
+                      let unwrapVal = fromMaybe M.empty val
+                      let nval = M.insert pr vot unwrapVal
+                      voted %= M.insert bnef nval
+                  yield =<< signMessage pk (Prepare v (blockHash pp))
     IMsg auth (Prepare v' di) -> when (v <= v') $ do
       ps <- prepared <%= M.insert (sender auth) di
       total <- poolSize
@@ -407,8 +413,6 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
       $logInfoS "blockstanbul" . T.pack $ "Successful block commit of " ++ format hsh
       lastParent .= Just hsh
       clearLock
-      -- TODO(tim): More guards should be put in place to see that not just the view but
-      -- also the block numbers are in ascending order.
       s <- use $ view . sequence
       nextRound . Sequence $ s+1
 

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
@@ -91,7 +91,7 @@ roundchangeCode = 3
 data InEvent = IMsg {iAuth :: MsgAuth, iMessage :: TrustedMessage}
              | Timeout RoundNumber
              -- TODO(tim): CommitResult should have the digest
-             | CommitResult (Either Text ())
+             | CommitResult (Either Text SHA)
              | UnannouncedBlock Block
              | PreviousBlock Block
              | NewBeneficiary {bAuth :: MsgAuth, beneficiary :: (Address, Bool,Int)}

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -98,7 +98,7 @@ spec = parallel $ do
         length xsp `shouldBe` 1
         xsp `shouldBe` [ToCommit blk]
         -- Pretend that in this interval, the block was committed
-        sendMessages [CommitResult (Right ())] `shouldReturn` []
+        sendMessages [CommitResult (Right (blockHash blk))] `shouldReturn` []
         -- The proposer *shouldn't* change, because the round number is the same
         let nextPpr = as !! ((1 + fromIntegral (_round v)) `mod` length as)
         use proposer `shouldReturn` sender ppr
@@ -139,7 +139,7 @@ spec = parallel $ do
         void $ sendMessages $ [IMsg ppr $ Preprepare v blk]
                            ++ [IMsg a $ Prepare v hsh | a <- as]
                            ++ [IMsg a $ Commit v hsh seal | a <- as]
-                           ++ [CommitResult (Right ())]
+                           ++ [CommitResult (Right (blockHash blk))]
         use view `shouldReturn` over sequence (+1) v
         use proposal `shouldReturn` Nothing
 
@@ -354,12 +354,41 @@ spec = parallel $ do
         use view `shouldReturn` next
 
   describe "An UnannouncedBlock message" $ do
+    let selfElected = do
+          me <- selfAddr
+          proposer .= me
+          validators .= S.singleton me
+
+    it "requires a matching block number" $ property $ \blk' ->
+      runTest $ do
+        let blk = over extraLens (BS.take 32)
+                    blk'{blockBlockData = (blockBlockData blk'){blockDataNumber = 17}}
+        selfElected
+        sendMessages [UnannouncedBlock blk] `shouldReturn` [MakeBlockCommand]
+
+    it "requires a matching hash if known" $ property $ \blk' ->
+      runTest $ do
+        let blk = over extraLens (BS.take 32)
+                    blk'{blockBlockData = (blockBlockData blk'){blockDataNumber = 19}}
+        selfElected
+        lastParent .= Just (SHA 0x999992)
+        sendMessages [UnannouncedBlock blk] `shouldReturn` [MakeBlockCommand]
+
+    it "accepts a block if the parent hash matches" $ property $ \blk' ->
+      runTest $ do
+        let blk = over extraLens (BS.take 32)
+                    blk'{blockBlockData = (blockBlockData blk'){
+                      blockDataNumber = 19,
+                      blockDataParentHash = SHA 0x999992}}
+        selfElected
+        lastParent .= Just (SHA 0x999992)
+        sendMessages [UnannouncedBlock blk] `shouldNotReturn` [MakeBlockCommand]
+
     it "seals the block" $ property $ \blk'' ->
       runTest $ do
-        let blk = over extraLens (BS.take 32) blk''
-        me <- selfAddr
-        validators .= S.singleton me
-        proposer .= me
+        let blk = over extraLens (BS.take 32) $
+                    blk''{blockBlockData = (blockBlockData blk''){blockDataNumber = 19}}
+        selfElected
         v <- use view
         omsgs <- sendMessages [UnannouncedBlock blk]
         let [Preprepare v' blk'] = map oMessage omsgs
@@ -370,14 +399,16 @@ spec = parallel $ do
         let parsedExtra = cookRawExtra . L.view extraLens $ blk'
         L.view vanity parsedExtra `shouldBe` initData
         let Just ist = _istanbul parsedExtra
+        me <- selfAddr
         L.view validatorList ist `shouldBe` [me]
         L.view commitment ist `shouldBe` []
         L.view proposedSig ist `shouldSatisfy`
           (== Just me) . (>>= verifyProposerSeal blk')
 
   describe "Block locks" $ do
-    it "takes priority over UnannouncedBlocks" $ property $ \lock blk ->
+    it "takes priority over UnannouncedBlocks" $ property $ \lock' blk ->
       runTest $ do
+        let lock = lock'{blockBlockData = (blockBlockData lock'){blockDataNumber = 19}}
         me <- selfAddr
         validators .= S.singleton me
         proposer .= me
@@ -407,8 +438,9 @@ spec = parallel $ do
         use blockLock `shouldReturn` Nothing
 
         blockLock .= Just blk
-        _ <- sendMessages [CommitResult (Right ())]
+        _ <- sendMessages [CommitResult (Right (blockHash blk))]
         use blockLock `shouldReturn` Nothing
+        use lastParent `shouldReturn` Just (blockHash blk)
 
     it "Sets a lock after prepare consensus is reached" $ property $ \auth blk ->
       runTest $ do
@@ -425,7 +457,7 @@ spec = parallel $ do
     it "requests a new block after success" $ property $ \blk ->
       runTest $ do
         setBlock blk
-        sendMessages [CommitResult (Right ())] `shouldReturn` [MakeBlockCommand]
+        sendMessages [CommitResult (Right (blockHash blk))] `shouldReturn` [MakeBlockCommand]
 
     it "re-issues the lock after round change" $ property $ \blk sig ->
       runTest $ do

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -69,19 +69,19 @@ spec = parallel $ do
         got <- sendMessages [Timeout 20, CommitResult (Left  "invalid hash")]
         map (_round . roundchangeView . oMessage) got `shouldBe` [21, 21]
 
-    it "ignores stale timeouts" $ do
-      runTest $ do
-        sendMessages [Timeout 10] `shouldReturn` []
+    it "ignores stale timeouts" .  runTest $
+      sendMessages [Timeout 10] `shouldReturn` []
     it "sets the pending round after a timeout" $ property $ \a1 a2 ->
       runTest $ do
       validators .= S.fromList [a1, a2]
       _ <- sendMessages [Timeout 20]
       use pendingRound `shouldReturn` Just 21
 
-    it "can handle several rounds in succession" $ property $ \blk' blk2' as' seal ->
+    it "can handle several rounds in succession" $ property $ \blk'' blk2'' as' seal ->
       not (null as') ==> runTest $ do
         let as = sortOn sender as'
-        let (blk, blk2) = over both (addProposerSeal seal . truncateExtra) (blk', blk2')
+        let (blk', blk2') = over both (addProposerSeal seal . truncateExtra) (blk'', blk2'')
+            blk = blk'{blockBlockData = (blockBlockData blk'){blockDataNumber = 19}}
         (v, hsh) <- setupRound blk . map sender $ as
         let ppr = as !! ((fromIntegral . _round $ v) `mod` length as)
         proposer .= sender ppr
@@ -104,7 +104,9 @@ spec = parallel $ do
         use proposer `shouldReturn` sender ppr
         v2 <- use view
         v2 `shouldBe` over sequence (+1) v
-        -- TODO(tim): blk2 should probably have blk as a parent
+        let blk2 = blk2'{blockBlockData = (blockBlockData blk2'){
+                          blockDataNumber = 20,
+                          blockDataParentHash = hsh}}
         let hsh2 = blockHash blk2
         omsgs3 <- sendMessages [IMsg nextPpr $ Preprepare v2 blk2, IMsg ppr $ Preprepare v2 blk2]
         map oMessage omsgs3 `shouldMatchList`
@@ -146,7 +148,8 @@ spec = parallel $ do
   describe "A preprepare message" $ do
     it "sets the current proposal in response a preprepare message" $ property $ \auth blk' ->
       runTest $ do
-        let blk = truncateExtra blk'
+        let blk = truncateExtra blk'{
+                    blockBlockData = (blockBlockData blk'){blockDataNumber = 19}}
         proposer .= sender auth
         validators .= S.fromList [sender auth]
         pk <- use prvkey
@@ -480,7 +483,8 @@ spec = parallel $ do
             me <- selfAddr
             let them = prvKey2Address theirPK
                 vals = S.fromList [me, them]
-                blk' = truncateExtra blk
+                blk' = truncateExtra blk{
+                         blockBlockData = (blockBlockData blk){blockDataNumber = 19}}
                 blk'' = addValidators vals blk'
             validators .= vals
             proposer .= me

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -81,7 +81,7 @@ spec = parallel $ do
       not (null as') ==> runTest $ do
         let as = sortOn sender as'
         let (blk', blk2') = over both (addProposerSeal seal . truncateExtra) (blk'', blk2'')
-            blk = blk'{blockBlockData = (blockBlockData blk'){blockDataNumber = 19}}
+            blk = setBlockNo 19 blk'
         (v, hsh) <- setupRound blk . map sender $ as
         let ppr = as !! ((fromIntegral . _round $ v) `mod` length as)
         proposer .= sender ppr
@@ -148,8 +148,7 @@ spec = parallel $ do
   describe "A preprepare message" $ do
     it "sets the current proposal in response a preprepare message" $ property $ \auth blk' ->
       runTest $ do
-        let blk = truncateExtra blk'{
-                    blockBlockData = (blockBlockData blk'){blockDataNumber = 19}}
+        let blk = truncateExtra . setBlockNo 19 $ blk'
         proposer .= sender auth
         validators .= S.fromList [sender auth]
         pk <- use prvkey
@@ -364,15 +363,13 @@ spec = parallel $ do
 
     it "requires a matching block number" $ property $ \blk' ->
       runTest $ do
-        let blk = over extraLens (BS.take 32)
-                    blk'{blockBlockData = (blockBlockData blk'){blockDataNumber = 17}}
+        let blk = over extraLens (BS.take 32) . setBlockNo 17 $ blk'
         selfElected
         sendMessages [UnannouncedBlock blk] `shouldReturn` [MakeBlockCommand]
 
     it "requires a matching hash if known" $ property $ \blk' ->
       runTest $ do
-        let blk = over extraLens (BS.take 32)
-                    blk'{blockBlockData = (blockBlockData blk'){blockDataNumber = 19}}
+        let blk = over extraLens (BS.take 32) . setBlockNo 19 $ blk'
         selfElected
         lastParent .= Just (SHA 0x999992)
         sendMessages [UnannouncedBlock blk] `shouldReturn` [MakeBlockCommand]
@@ -389,8 +386,7 @@ spec = parallel $ do
 
     it "seals the block" $ property $ \blk'' ->
       runTest $ do
-        let blk = over extraLens (BS.take 32) $
-                    blk''{blockBlockData = (blockBlockData blk''){blockDataNumber = 19}}
+        let blk = over extraLens (BS.take 32) . setBlockNo 19 $ blk''
         selfElected
         v <- use view
         omsgs <- sendMessages [UnannouncedBlock blk]
@@ -411,7 +407,7 @@ spec = parallel $ do
   describe "Block locks" $ do
     it "takes priority over UnannouncedBlocks" $ property $ \lock' blk ->
       runTest $ do
-        let lock = lock'{blockBlockData = (blockBlockData lock'){blockDataNumber = 19}}
+        let lock = setBlockNo 19 lock'
         me <- selfAddr
         validators .= S.singleton me
         proposer .= me
@@ -483,13 +479,11 @@ spec = parallel $ do
             me <- selfAddr
             let them = prvKey2Address theirPK
                 vals = S.fromList [me, them]
-                blk' = truncateExtra blk{
-                         blockBlockData = (blockBlockData blk){blockDataNumber = 19}}
-                blk'' = addValidators vals blk'
+                blk' = addValidators vals . truncateExtra . setBlockNo 19 $ blk
             validators .= vals
             proposer .= me
-            pSeal <- proposerSeal blk'' pk
-            let lockBlk = addProposerSeal pSeal blk''
+            pSeal <- proposerSeal blk' pk
+            let lockBlk = addProposerSeal pSeal blk'
             myKey <- use prvkey
             OMsg auth wm <- signMessage myKey $ Preprepare v lockBlk
 

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -159,11 +159,13 @@ blockstanbulSend msgs = do
     resp' <- sendAllMessages msgs
     let blocks = [b | ToCommit b <- resp']
     resp <- (resp'++) <$>
-        if null blocks
-            then return []
+        case blocks of
+          [] -> return []
+          [b] ->
             -- TODO(tim): Block insertion can potentially fail, so there
             -- should be feedback here
-            else sendAllMessages [CommitResult (Right ())]
+            sendAllMessages [CommitResult . Right . blockHash $ b]
+          bs -> error $ "must commit at most one block at a time: " ++ show bs
     mapM_ createNewTimer [rn | ResetTimer rn <- resp]
     $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ show blocks
     let rewriteBlock = fmap (OEBlock . flip sequencedBlockToOutputBlock 1)

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -29,7 +29,7 @@ import           Blockchain.Blockstanbul.EventLoop
 import qualified Blockchain.Blockstanbul.HTTPAdmin as API
 import           Blockchain.Blockstanbul.Messages hiding (round)
 import           Blockchain.Data.Address
-import           Blockchain.Data.BlockDB
+import           Blockchain.Data.Block
 import           Blockchain.Data.RLP
 import qualified Blockchain.Data.TXOrigin as TO
 import           Blockchain.Format
@@ -315,9 +315,7 @@ spec = do
         evs `shouldMatchList` map TimerFire [10..19]
 
       it "should forward new blocks to blockstanbul" . runPBFTTestM $ do
-        let blk' = makeBlock 1 1
-            blk = blk'{blockBlockData = (blockBlockData blk'){blockDataNumber = 1} }
-            iev = IEBlock . blockToIngestBlock TO.Morphism $ blk
+        let iev = IEBlock . blockToIngestBlock TO.Morphism . setBlockNo 1 $ makeBlock 1 1
         checkForUnseq [iev]
         p2pevs <- drainP2P
         let pbftEvs = [m | OEBlockstanbul (WireMessage _ m) <- p2pevs]
@@ -327,20 +325,18 @@ spec = do
 
       it "should replay old blocks in blockstanbul" . runPBFTTestM $ do
         ctx <- fromMaybe (error "context required for PBFT") <$> getBlockstanbulContext
-        let blk = makeBlock 2 1
-            blk' = addValidators (_validators ctx) blk{
-                      blockBlockData = (blockBlockData blk){blockDataNumber = 1}}
-        pseal <- proposerSeal blk' (_prvkey ctx)
-        let blk'' = addProposerSeal pseal blk'
-        cseal <- commitmentSeal (blockHash blk'') (_prvkey ctx)
-        let blk''' = addCommitmentSeals [cseal] blk''
-            iev = IEBlock . blockToIngestBlock TO.Morphism $ blk'''
+        let blk = addValidators (_validators ctx) . setBlockNo 1 $ makeBlock 2 1
+        pseal <- proposerSeal blk (_prvkey ctx)
+        let blk' = addProposerSeal pseal blk
+        cseal <- commitmentSeal (blockHash blk') (_prvkey ctx)
+        let blk'' = addCommitmentSeals [cseal] blk'
+            iev = IEBlock . blockToIngestBlock TO.Morphism $ blk''
         putBlockstanbulContext ctx
         checkForUnseq [iev]
         drainP2P `shouldReturn` []
         vmevs <- drainVM
         vmevs `shouldContain` [OECreateBlockCommand]
-        map outputBlockToBlock [oblk | OEBlock oblk <- vmevs] `shouldMatchList` [blk''']
+        map outputBlockToBlock [oblk | OEBlock oblk <- vmevs] `shouldMatchList` [blk'']
         ctx' <- fromMaybe (error "context required for pbft") <$> getBlockstanbulContext
         _view ctx' `shouldBe` View 0 1
 

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -315,7 +315,9 @@ spec = do
         evs `shouldMatchList` map TimerFire [10..19]
 
       it "should forward new blocks to blockstanbul" . runPBFTTestM $ do
-        let iev = IEBlock . blockToIngestBlock TO.Morphism $ makeBlock 1 1
+        let blk' = makeBlock 1 1
+            blk = blk'{blockBlockData = (blockBlockData blk'){blockDataNumber = 1} }
+            iev = IEBlock . blockToIngestBlock TO.Morphism $ blk
         checkForUnseq [iev]
         p2pevs <- drainP2P
         let pbftEvs = [m | OEBlockstanbul (WireMessage _ m) <- p2pevs]


### PR DESCRIPTION
This change has two parts:

Only generate PRE_PREPAREs which descend from the previously committed block
Only accept PRE_PREPAREs ...