### PR TITLE
Api metadata

### DIFF
--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Transaction.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Transaction.hs
@@ -75,6 +75,7 @@ instance ToSample PostBlocTransactionRequest where
       [BlocTransfer $ TransferPayload
         (Address 0x12345678)
         (Strung 600)
+        (Just $ Map.fromList [("purpose","groceries")])
       ]
       (Just (TxParams (Just $ Gas 1000000) (Just $ Wei 1) (Just $ Nonce 0)))
 
@@ -90,6 +91,7 @@ instance ToSchema PostBlocTransactionRequest where
                  [BlocTransfer $ TransferPayload
                    (Address 0x12345678)
                    (Strung 600)
+                   (Just $ Map.fromList [("purpose","groceries")])
                  ]
                  (Just (TxParams (Just $ Gas 1000000) (Just $ Wei 1) (Just $ Nonce 0)))
 
@@ -117,11 +119,13 @@ data ContractPayload = ContractPayload
   , contractpayloadContract :: Maybe Text
   , contractpayloadArgs     :: Maybe (Map Text ArgValue)
   , contractpayloadValue    :: Maybe (Strung Natural)
+  , contractpayloadMetadata :: Maybe (Map Text Text)
   } deriving (Eq, Show, Generic)
 
 data TransferPayload = TransferPayload
   { transferpayloadToAddress :: Address
   , transferpayloadValue     :: Strung Natural
+  , transferpayloadMetadata  :: Maybe (Map Text Text)
   } deriving (Eq, Show, Generic)
 
 data FunctionPayload = FunctionPayload
@@ -130,6 +134,7 @@ data FunctionPayload = FunctionPayload
   , functionpayloadMethod          :: Text
   , functionpayloadArgs            :: Map Text ArgValue
   , functionpayloadValue           :: Maybe (Strung Natural)
+  , functionpayloadMetadata        :: Maybe (Map Text Text)
   } deriving (Eq, Show, Generic)
 
 instance ToJSON ContractPayload where
@@ -158,6 +163,7 @@ instance ToSchema BlocTransactionPayload where
         , contractpayloadContract = Nothing
         , contractpayloadArgs     = Just $ Map.fromList [("_x", ArgInt 1)]
         , contractpayloadValue    = Nothing
+        , contractpayloadMetadata = Nothing
         }
 
 instance ToSchema ContractPayload where
@@ -172,6 +178,7 @@ instance ToSchema ContractPayload where
         , contractpayloadContract = Nothing
         , contractpayloadArgs     = Just $ Map.fromList [("_x", ArgInt 1)]
         , contractpayloadValue    = Nothing
+        , contractpayloadMetadata = Nothing
         }
 
 instance ToSchema TransferPayload where
@@ -184,6 +191,7 @@ instance ToSchema TransferPayload where
       ex = TransferPayload
         { transferpayloadToAddress = Address (0xdeadbeef)
         , transferpayloadValue = Strung 1000000
+        , transferpayloadMetadata = Nothing
         }
 
 instance ToSchema FunctionPayload where
@@ -199,4 +207,5 @@ instance ToSchema FunctionPayload where
         , functionpayloadMethod          = "set"
         , functionpayloadArgs            = Map.fromList [("_x", ArgInt 5)]
         , functionpayloadValue           = Nothing
+        , functionpayloadMetadata = Nothing
         }

--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Users.hs
@@ -253,6 +253,7 @@ data PostSendParameters = PostSendParameters
   , sendValue     :: Strung Natural
   , sendPassword  :: Password
   , sendTxParams  :: Maybe TxParams
+  , sendMetadata  :: Maybe (Map Text Text)
   } deriving (Eq, Show, Generic)
 
 instance Arbitrary PostSendParameters where arbitrary = GR.genericArbitrary GR.uniform
@@ -269,6 +270,7 @@ instance ToSample PostSendParameters where
     , sendValue = Strung 10
     , sendPassword = "securePassword"
     , sendTxParams = Nothing
+    , sendMetadata = Nothing
     }
 
 instance ToSchema PostSendParameters where
@@ -282,6 +284,7 @@ instance ToSchema PostSendParameters where
         , sendValue = Strung 100000000
         , sendPassword = "securePassword"
         , sendTxParams = Nothing
+        , sendMetadata = Nothing
         }
 
 data TransferParameters = TransferParameters
@@ -289,6 +292,7 @@ data TransferParameters = TransferParameters
   , toAddress   :: Address
   , value       :: Strung Natural
   , txParams    :: Maybe TxParams
+  , metadata    :: Maybe (Map Text Text)
   , chainId     :: Maybe ChainId
   , resolve     :: Bool
   } deriving (Eq, Show, Generic)
@@ -311,6 +315,7 @@ data PostUsersContractRequest = PostUsersContractRequest
   , postuserscontractrequestArgs     :: Maybe (Map Text ArgValue)
   , postuserscontractrequestTxParams :: Maybe TxParams
   , postuserscontractrequestValue    :: Maybe (Strung Natural)
+  , postuserscontractrequestMetadata :: Maybe (Map Text Text)
   } deriving (Eq,Show,Generic)
 
 instance Arbitrary PostUsersContractRequest where arbitrary = GR.genericArbitrary GR.uniform
@@ -332,6 +337,7 @@ instance ToSample PostUsersContractRequest where
     , postuserscontractrequestArgs = Nothing
     , postuserscontractrequestTxParams = Nothing
     , postuserscontractrequestValue = Just $ Strung 10
+    , postuserscontractrequestMetadata = Nothing
     }
 
 instance ToSchema PostUsersContractRequest where
@@ -341,6 +347,7 @@ instance ToSchema PostUsersContractRequest where
     contractNameSchema <- declareSchemaRef (Proxy :: Proxy (Maybe Text))
     argsSchema <- declareSchemaRef (Proxy :: Proxy (Maybe (Map Text ArgValue)))
     txParamsSchema <- declareSchemaRef (Proxy :: Proxy (Maybe TxParams))
+    metadataSchema <- declareSchemaRef (Proxy :: Proxy (Maybe (Map Text Text)))
     return $ NamedSchema (Just "Post Users Contract Request")
       ( mempty
         & type_ .~ SwaggerObject
@@ -351,6 +358,7 @@ instance ToSchema PostUsersContractRequest where
             , ("args", argsSchema)
             , ("txParams", txParamsSchema)
             , ("value", textSchema & mapped.description ?~ "Contract value in Eth")
+            , ("metadata", metadataSchema)
             ]
         & required .~ [ "src"
                       , "password"
@@ -366,6 +374,7 @@ instance ToSchema PostUsersContractRequest where
             , postuserscontractrequestArgs = Nothing
             , postuserscontractrequestTxParams = Nothing
             , postuserscontractrequestValue = Nothing
+            , postuserscontractrequestMetadata = Nothing
             }
       )
 
@@ -376,6 +385,7 @@ data ContractParameters = ContractParameters
   , args     :: Maybe (Map Text ArgValue)
   , value    :: Maybe (Strung Natural)
   , txParams :: Maybe TxParams
+  , metadata :: Maybe (Map Text Text)
   , chainId  :: Maybe ChainId
   , resolve  :: Bool
   }
@@ -418,6 +428,7 @@ instance ToSchema UploadListRequest where
         , uploadlistcontractArgs = Map.fromList [("accountType", ArgString "Checking"), ("balance",ArgInt 10)]
         , uploadlistcontractTxParams = Nothing
         , uploadlistcontractValue = Nothing
+        , uploadlistcontractMetadata = Nothing
         }
       ex :: UploadListRequest
       ex = UploadListRequest "SecretPassword" [exContract1] True
@@ -427,6 +438,7 @@ data UploadListContract = UploadListContract
   , uploadlistcontractArgs         :: Map Text ArgValue
   , uploadlistcontractTxParams     :: Maybe TxParams
   , uploadlistcontractValue        :: Maybe (Strung Natural)
+  , uploadlistcontractMetadata     :: Maybe (Map Text Text)
   } deriving (Eq,Show,Generic)
 
 instance Arbitrary UploadListContract where arbitrary = GR.genericArbitrary GR.uniform
@@ -448,6 +460,7 @@ instance ToSchema UploadListContract where
         , uploadlistcontractArgs = Map.fromList [("user", ArgString "Bob"), ("age",ArgInt 1)]
         , uploadlistcontractTxParams = Just $ TxParams (Just $ Gas 123) (Just $ Wei 345) Nothing
         , uploadlistcontractValue = Nothing
+        , uploadlistcontractMetadata = Nothing
         }
 
 newtype PostUsersUploadListResponse = PostUsersUploadListResponse
@@ -500,6 +513,7 @@ data PostUsersContractMethodRequest = PostUsersContractMethodRequest
   , postuserscontractmethodArgs     :: Map Text ArgValue
   , postuserscontractmethodValue    :: Maybe (Strung Natural)
   , postuserscontractmethodTxParams :: Maybe TxParams
+  , postuserscontractmethodMetadata :: Maybe (Map Text Text)
   } deriving (Eq,Show,Generic)
 
 instance Arbitrary PostUsersContractMethodRequest where arbitrary = GR.genericArbitrary GR.uniform
@@ -527,6 +541,7 @@ instance ToSchema PostUsersContractMethodRequest where
     pwSchema <- declareSchemaRef (Proxy :: Proxy Password)
     argsSchema <- declareSchemaRef (Proxy :: Proxy (Map Text ArgValue))
     txParamsSchema <- declareSchemaRef (Proxy :: Proxy (Maybe TxParams))
+    metadataSchema <- declareSchemaRef (Proxy :: Proxy (Maybe (Map Text Text)))
     return $ NamedSchema (Just "Post Users Contract Method Request")
       ( mempty
         & type_ .~ SwaggerObject
@@ -536,6 +551,7 @@ instance ToSchema PostUsersContractMethodRequest where
             , ("args", argsSchema)
             , ("value", textSchema & mapped.description ?~ "Method value in Eth")
             , ("txParams", txParamsSchema)
+            , ("metadata", metadataSchema)
             ]
         & required .~ [ "password", "method", "args" ]
         & description ?~ "Post Users Contract Method Request"
@@ -545,6 +561,7 @@ instance ToSchema PostUsersContractMethodRequest where
             , postuserscontractmethodArgs = Map.empty
             , postuserscontractmethodValue = Just $ Strung 0
             , postuserscontractmethodTxParams = Nothing
+            , postuserscontractmethodMetadata = Nothing
             }
       )
 
@@ -571,6 +588,7 @@ data FunctionParameters = FunctionParameters
   , args         :: Map Text ArgValue
   , value        :: Maybe (Strung Natural)
   , txParams     :: Maybe TxParams
+  , metadata     :: Maybe (Map Text Text)
   , chainId      :: Maybe ChainId
   , resolve      :: Bool
   }
@@ -621,12 +639,14 @@ instance ToSchema PostSendListRequest where
         , sendtransactionValue = Strung 1000000000000000
         , sendtransactionTxParams = Just (TxParams (Just $ Gas 123) (Just $ Wei 345)
             (Just $ Nonce 9876))
+        , sendtransactionMetadata = (Just $ Map.fromList [("purpose","groceries")])
         }
 
 data SendTransaction = SendTransaction
   { sendtransactionToAddress :: Address
   , sendtransactionValue     :: Strung Natural
   , sendtransactionTxParams  :: Maybe TxParams
+  , sendtransactionMetadata  :: Maybe (Map Text Text)
   } deriving (Eq,Show,Generic)
 
 instance Arbitrary SendTransaction where arbitrary = GR.genericArbitrary GR.uniform
@@ -677,6 +697,7 @@ instance ToSchema SendTransaction where
         , sendtransactionValue = Strung 100000000000000
         , sendtransactionTxParams = Just (TxParams (Just $ Gas 123) (Just $ Wei 345)
             (Just $ Nonce 9876))
+        , sendtransactionMetadata = (Just $ Map.fromList [("purpose","groceries")])
         }
 
 data TransferListParameters = TransferListParameters
@@ -784,7 +805,8 @@ methodErroredExample =
        , methodcallArgs = Map.fromList [("user", ArgString "Bob"), ("age", ArgInt 52)]
        , methodcallMethodName = "getHoroscope"
        , methodcallContractAddress = Address 0xdeadbeef
-       , methodcallContractName = "HorroscopeApp"
+       , methodcallContractName = "HoroscopeApp"
+       , methodcallMetadata = Nothing
        }
 
 
@@ -833,7 +855,8 @@ instance ToSchema PostMethodListRequest where
         , methodcallArgs = Map.fromList [("user", ArgString "Bob"), ("age", ArgInt 52)]
         , methodcallMethodName = "getHoroscope"
         , methodcallContractAddress = Address 0xdeadbeef
-        , methodcallContractName = "HorroscopeApp"
+        , methodcallContractName = "HoroscopeApp"
+        , methodcallMetadata = Nothing
         }
 
 data MethodCall = MethodCall
@@ -843,6 +866,7 @@ data MethodCall = MethodCall
   , methodcallArgs            :: Map Text ArgValue
   , methodcallValue           :: Strung Natural
   , methodcallTxParams        :: Maybe TxParams
+  , methodcallMetadata        :: Maybe (Map Text Text)
   } deriving (Eq,Show,Generic)
 
 instance Arbitrary MethodCall where arbitrary = GR.genericArbitrary GR.uniform
@@ -867,6 +891,7 @@ instance ToSchema MethodCall where
         , methodcallMethodName = "getHoroscope"
         , methodcallContractAddress = Address 0xdeadbeef
         , methodcallContractName = "HoroscopeApp"
+        , methodcallMetadata = Nothing
         }
 
 data FunctionListParameters = FunctionListParameters

--- a/blockapps-haskell/bloc/bloc22/client/test/BlockApps/Bloc22/API/E2ESpec.hs
+++ b/blockapps-haskell/bloc/bloc22/client/test/BlockApps/Bloc22/API/E2ESpec.hs
@@ -74,7 +74,7 @@ spec =
       threadDelay 4000000
       let
         weiToSend = 100
-        postSendParameters = PostSendParameters address2 (Strung weiToSend) pw testTxParams
+        postSendParameters = PostSendParameters address2 (Strung weiToSend) pw testTxParams Nothing
       postSendEither <- getResolvedTx testConfig $ runClientM (postUsersSend userName1 address1 Nothing True postSendParameters) (ClientEnv mgr blocUrl)
       postSendEither `shouldSatisfy` isRight
       threadDelay 4000000
@@ -107,6 +107,7 @@ spec =
           , postuserscontractrequestArgs = Nothing
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList [("src",simpleStorageSrc),("name", simpleStorageContractName)]
           }
       eAccts1 <- runClientM (getAccountsFilter params1) (ClientEnv mgr stratoUrl)
       eAccts1 `shouldSatisfy` isRight
@@ -151,6 +152,7 @@ spec =
           , postuserscontractmethodArgs = Map.singleton "x" (ArgInt 3)
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherSet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestSet)
@@ -166,6 +168,7 @@ spec =
           , postuserscontractmethodArgs = Map.empty
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherGet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestGet)
@@ -225,6 +228,7 @@ spec =
                   , postuserscontractrequestArgs = args
                   , postuserscontractrequestTxParams = testTxParams
                   , postuserscontractrequestValue = Just $ Strung 0
+                  , postuserscontractrequestMetadata = Just $ Map.fromList [("src",src),("name",Text.pack ctName)]
                   }
             let clientMethod = postUsersContract
                                un
@@ -308,6 +312,7 @@ spec =
           , postuserscontractrequestArgs = Nothing
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList [("src",simpleStorageAddressSrc),("name",simpleStorageAddressContractName)]
           }
       eAccts1 <- runClientM (getAccountsFilter params1) (ClientEnv mgr stratoUrl)
       eAccts1 `shouldSatisfy` isRight
@@ -353,6 +358,7 @@ spec =
           , postuserscontractmethodArgs = Map.singleton "x" (ArgString "deadbeef")
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherSet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestSet)
@@ -368,6 +374,7 @@ spec =
           , postuserscontractmethodArgs = Map.empty
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherGet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestGet)
@@ -418,6 +425,10 @@ spec =
           , postuserscontractrequestArgs = Nothing
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src",simpleStorageBytes32ArraySrc)
+              ,("name",simpleStorageBytes32ArrayContractName)
+              ]
           }
       _ <- runClientM (postContractsCompile [postCompileRequest]) (ClientEnv mgr blocUrl)
       eAccts1 <- runClientM (getAccountsFilter params1) (ClientEnv mgr stratoUrl)
@@ -466,6 +477,7 @@ spec =
           , postuserscontractmethodArgs = Map.singleton "x" (ArgArray [ArgString arg1, ArgString arg2])
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherSet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestSet)
@@ -481,6 +493,7 @@ spec =
           , postuserscontractmethodArgs = Map.empty
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherGet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestGet)
@@ -553,6 +566,7 @@ spec =
           , postuserscontractrequestArgs = Just storeArgs
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList [("src", simpleStorageBytes32ArraySrc),("name",simpleStorageBytes32ArrayContractName)]
           }
       _ <- runClientM (postContractsCompile [postCompileRequest]) (ClientEnv mgr blocUrl)
       eAccts1 <- runClientM (getAccountsFilter params1) (ClientEnv mgr stratoUrl)
@@ -577,6 +591,7 @@ spec =
           , postuserscontractrequestArgs = Nothing
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Nothing
+          , postuserscontractrequestMetadata = Nothing
           }
         sameName2ContractRequest = PostUsersContractRequest
           { postuserscontractrequestSrc = sameName2Src
@@ -585,6 +600,7 @@ spec =
           , postuserscontractrequestArgs = Nothing
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Nothing
+          , postuserscontractrequestMetadata = Nothing
           }
       Right (BlocTransactionResult _ _ _ (Just (Upload sameName1Details))) <- getResolvedTx testConfig $ runClientM
         (postUsersContract userName userAddress Nothing True sameName1ContractRequest)
@@ -629,6 +645,8 @@ spec =
           , postuserscontractrequestArgs = Just $ Map.singleton "x" (ArgInt 3)
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", simpleConstructorSrc),("name",simpleConstructorName)]
           }
       eAccts1 <- runClientM (getAccountsFilter params1) (ClientEnv mgr stratoUrl)
       eAccts1 `shouldSatisfy` isRight
@@ -688,6 +706,8 @@ spec =
           , postuserscontractrequestArgs = Just $ Map.singleton "x" (ArgArray (Vector.fromList [ArgInt 3,ArgInt 2,ArgInt 3]))
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", simpleConstructorSrc),("name", testArrayStatName)]
           }
       eAccts1 <- runClientM
         (getAccountsFilter params1)
@@ -724,6 +744,8 @@ spec =
           , postuserscontractrequestArgs = Just $ Map.singleton "x" (ArgArray (Vector.fromList (fmap ArgInt [1,2,3,4,5,6,7,8])))
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", simpleConstructorSrc),("name", testArrayStatName)]
           }
       eAccts1 <- runClientM
         (getAccountsFilter params1)
@@ -759,6 +781,8 @@ spec =
           , postuserscontractrequestArgs = Just . Map.singleton "x" $ ArgString "416c6c207468617420697320676f6c6420646f6573206e6f7420676c69747465722c204e6f7420616c6c2074686f73652077686f2077616e64657220617265206c6f73743b20546865206f6c642074686174206973207374726f6e6720646f6573206e6f74207769746865722c204465657020726f6f747320617265206e6f742072656163686564206279207468652066726f73742e2046726f6d2074686520617368657320612066697265207368616c6c20626520776f6b656e2c2041206c696768742066726f6d2074686520736861646f7773207368616c6c20737072696e673b2052656e65776564207368616c6c2062652074686520626c6164652074686174207761732062726f6b656e2c205468652063726f776e6c65737320616761696e207368616c6c206265206b696e672e"
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", simpleConstructorSrc),("name", testArrayStatName)]
           }
       eAccts1 <- runClientM
         (getAccountsFilter params1)
@@ -798,6 +822,8 @@ spec =
           ]
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", simpleConstructorSrc),("name", testArrayStatName)]
           }
       eAccts1 <- runClientM
         (getAccountsFilter params1)
@@ -842,6 +868,8 @@ spec =
           ]
           , postuserscontractrequestTxParams = txParamsComplex
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", simpleConstructorSrc),("name", testArrayStatName)]
           }
       eAccts1 <- runClientM
         (getAccountsFilter params1)
@@ -877,6 +905,8 @@ spec =
           , postuserscontractrequestArgs = Nothing
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", simpleTupleSrc),("name", simpleTupleContractName)]
           }
       eAccts1 <- runClientM (getAccountsFilter params1) (ClientEnv mgr stratoUrl)
       eAccts1 `shouldSatisfy` isRight
@@ -928,6 +958,7 @@ spec =
           , postuserscontractmethodArgs = [("argVal1", ArgInt argVal1), ("argVal2", ArgInt argVal2)]
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherSet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestSet)
@@ -943,6 +974,7 @@ spec =
           , postuserscontractmethodArgs = Map.empty
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherGet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestGet)
@@ -995,6 +1027,8 @@ spec =
           , postuserscontractrequestArgs = Just [("b", ArgString "81a76550480e6e3d9a4df17b9f3683b66ceda988390a73c1446c427173bf6a89")]
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", testSrc'),("name", testContractName')]
           }
       eAccts1 <- runClientM (getAccountsFilter params1) (ClientEnv mgr stratoUrl)
       eAccts1 `shouldSatisfy` isRight
@@ -1031,6 +1065,7 @@ spec =
           , postuserscontractmethodArgs = argVal
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherSet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestSet)
@@ -1049,6 +1084,7 @@ spec =
           , postuserscontractmethodArgs = Map.empty
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherGet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractName contractAddr Nothing True postUsersContractMethodRequestGet)
@@ -1082,6 +1118,8 @@ spec =
           , postuserscontractrequestArgs = Nothing
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", testSrc'),("name", testContractName')]
           }
       eAccts1 <- runClientM (getAccountsFilter params1) (ClientEnv mgr stratoUrl)
       eAccts1 `shouldSatisfy` isRight
@@ -1106,6 +1144,7 @@ spec =
           , postuserscontractmethodArgs = Map.empty
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherGet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractNameDeployer contractAddr Nothing True postUsersContractMethodRequestGet)
@@ -1136,6 +1175,7 @@ spec =
           , postuserscontractmethodArgs = argVal
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherSet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 storageName (fromJust . stringAddress . Text.unpack $ storageAddr) Nothing True postUsersContractMethodRequestSet)
@@ -1172,6 +1212,8 @@ spec =
           , postuserscontractrequestArgs = Nothing
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", iamBlob),("name", iamName)]
           }
       _ <- runClientM (postContractsCompile [postCompileRequest]) (ClientEnv mgr blocUrl)
       eAccts2 <- runClientM (getAccountsFilter paramsIAM) (ClientEnv mgr stratoUrl)
@@ -1197,7 +1239,7 @@ spec =
       let
         Right bobAddr = postBobEither
         args = Map.singleton "userKey" . ArgString . Text.pack . addressString $ bobAddr
-        contrMethodReq = PostUsersContractMethodRequest pw "createIdentityAgent" args (Just $ Strung 0) Nothing
+        contrMethodReq = PostUsersContractMethodRequest pw "createIdentityAgent" args (Just $ Strung 0) Nothing Nothing
       identityAgentEither <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod iamUsername iamUserAddr (ContractName "IdentityAccessManager") iamAddr Nothing True contrMethodReq)
         (ClientEnv mgr blocUrl)
@@ -1218,7 +1260,7 @@ spec =
             )
           , ("_contents" , ArgString "Account Data should be able to be as long as you want ideally 12343432442431")
           ]
-        storeMethodReq = PostUsersContractMethodRequest pw "writeDataToStorage" storeArgs (Just $ Strung 0) Nothing
+        storeMethodReq = PostUsersContractMethodRequest pw "writeDataToStorage" storeArgs (Just $ Strung 0) Nothing Nothing
       storeEither <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod iamUsername iamUserAddr cName (fromJust . stringAddress . Text.unpack $ storeAddr) Nothing True storeMethodReq)
         (ClientEnv mgr blocUrl)
@@ -1250,6 +1292,8 @@ spec =
               [("_hash",arghash),("_contents",argcontents)]
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Just $ Map.fromList
+              [("src", returnTupleSrc),("name", testContractName')]
           }
       eAccts1 <- runClientM (getAccountsFilter params1) (ClientEnv mgr stratoUrl)
       eAccts1 `shouldSatisfy` isRight
@@ -1274,6 +1318,7 @@ spec =
           , postuserscontractmethodArgs = Map.empty
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       postUsersContractMethodEitherGet <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName1 addr1 contractNameDeployer contractAddr Nothing True postUsersContractMethodRequestGet)

--- a/blockapps-haskell/bloc/bloc22/client/test/BlockApps/Bloc22/API/MultiNodeSpec.hs
+++ b/blockapps-haskell/bloc/bloc22/client/test/BlockApps/Bloc22/API/MultiNodeSpec.hs
@@ -321,6 +321,7 @@ createContractOnMulti src cn args config@TestConfig{..} = do
       , postuserscontractrequestArgs = args
       , postuserscontractrequestTxParams = testTxParams
       , postuserscontractrequestValue = Just $ Strung 0
+      , postuserscontractrequestMetadata = Just $ Map.fromList [("src",src),("name",cn)]
       }
   result <- fromEither =<< (getResolvedTxMulti config $ runClientM (postUsersContract userName addr Nothing False postUsersContractRequest) blocclient)
   result `shouldSatisfy` (== Success) . blocTransactionStatus
@@ -344,6 +345,7 @@ callMethodLocal method cAddr contractName methodArgs config@TestConfig{..} =
         , postuserscontractmethodArgs = methodArgs
         , postuserscontractmethodValue = Just $ Strung 0
         , postuserscontractmethodTxParams = testTxParams
+        , postuserscontractmethodMetadata = Nothing
         }
   in fromEither =<<
      ( getResolvedTx config $
@@ -380,6 +382,7 @@ callMethodListLocal method cAddr contractName args config@TestConfig{..} =
             , methodcallArgs = args
             , methodcallValue = Strung 0
             , methodcallTxParams = testTxParams
+            , methodcallMetadata = Nothing
             }
         }
   in getResolvedBatchTx config $

--- a/blockapps-haskell/bloc/bloc22/client/test/BlockApps/Bloc22/API/UsersSpec.hs
+++ b/blockapps-haskell/bloc/bloc22/client/test/BlockApps/Bloc22/API/UsersSpec.hs
@@ -73,8 +73,8 @@ spec = do
   describe "postUsersSend" $ do
     it "should send ethers to another address" $ \ testConfig@TestConfig {..} -> do
       let
-        postSendParameters = PostSendParameters toUserAddress (Strung 100) pw testTxParams
-        postSendParametersBad = PostSendParameters (Address 0xddb9fa06155e06d3fcf274b8e0a6680d0dc95370) (Strung 100) "12345" testTxParams
+        postSendParameters = PostSendParameters toUserAddress (Strung 100) pw testTxParams Nothing
+        postSendParametersBad = PostSendParameters (Address 0xddb9fa06155e06d3fcf274b8e0a6680d0dc95370) (Strung 100) "12345" testTxParams Nothing
       Right result <- getResolvedTx testConfig $ runClientM (postUsersSend userName userAddress Nothing False postSendParameters) (ClientEnv mgr blocUrl)
       let
         Send postTransaction = fromJust $ blocTransactionData result
@@ -84,7 +84,7 @@ spec = do
 
     it "should send ethers to another address with low nonce" $ \ testConfig@TestConfig {..} -> do
       let
-        postSendParameters = PostSendParameters toUserAddress (Strung 100) pw testTxParamsLowNonce
+        postSendParameters = PostSendParameters toUserAddress (Strung 100) pw testTxParamsLowNonce Nothing
       Right result <- getResolvedTx testConfig $ runClientM (postUsersSend userName userAddress Nothing False postSendParameters) (ClientEnv mgr blocUrl)
       result `shouldSatisfy` (== Failure) . blocTransactionStatus
       putStrLn $ show result
@@ -99,6 +99,7 @@ spec = do
           , postuserscontractrequestArgs = Nothing
           , postuserscontractrequestTxParams = testTxParams
           , postuserscontractrequestValue = Just $ Strung 0
+          , postuserscontractrequestMetadata = Nothing
           }
       Right result <- getResolvedTx testConfig $ runClientM (postUsersContract userName userAddress Nothing False postUsersContractRequest) (ClientEnv mgr blocUrl)
       result `shouldSatisfy` (== Success) . blocTransactionStatus
@@ -119,6 +120,7 @@ spec = do
             , uploadlistcontractArgs = Map.empty
             , uploadlistcontractTxParams = testTxParams
             , uploadlistcontractValue = Nothing
+            , uploadlistcontractMetadata = Nothing
             }
           ]
         uploadListRequest = UploadListRequest
@@ -144,6 +146,7 @@ spec = do
           , postuserscontractmethodArgs = Map.empty
           , postuserscontractmethodValue = Just $ Strung 0
           , postuserscontractmethodTxParams = testTxParams
+          , postuserscontractmethodMetadata = Nothing
           }
       Right result <- getResolvedTx testConfig $ runClientM
         (postUsersContractMethod userName userAddress contractName contractAddress Nothing False postUsersContractMethodRequest)
@@ -161,6 +164,7 @@ spec = do
               { sendtransactionToAddress = toUserAddress
               , sendtransactionValue = Strung 100
               , sendtransactionTxParams = testTxParams
+              , sendtransactionMetadata = Nothing
               }
           }
       eResults <- runClientM
@@ -186,6 +190,7 @@ spec = do
               , methodcallArgs = Map.empty
               , methodcallValue = Strung 0
               , methodcallTxParams = testTxParams
+              , methodcallMetadata = Nothing
               }
           }
       eResults <- runClientM

--- a/blockapps-haskell/bloc/bloc22/client/test/Spec.hs
+++ b/blockapps-haskell/bloc/bloc22/client/test/Spec.hs
@@ -99,6 +99,7 @@ setup = do
       , uploadlistcontractArgs = Map.empty
       , uploadlistcontractTxParams = testTxParams testConfig
       , uploadlistcontractValue = Nothing
+      , uploadlistcontractMetadata = Nothing
       }
     uploadListRequest = UploadListRequest
       { uploadlistPassword = pw testConfig

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
@@ -47,6 +47,7 @@ postBlocTransaction mUserName mUserId chainId resolve (PostBlocTransactionReques
                         (transferpayloadToAddress p)
                         (transferpayloadValue p)
                         txParams
+                        (transferpayloadMetadata p)
                         chainId
                         resolve
             fmap (:[]) $ postUsersSend' btp (callSignature userName userId)
@@ -54,7 +55,7 @@ postBlocTransaction mUserName mUserId chainId resolve (PostBlocTransactionReques
             p <- mapM fromTransfer xs
             let btlp = TransferListParameters
                         addr
-                        (map (\(TransferPayload t v) -> SendTransaction t v txParams) p)
+                        (map (\(TransferPayload t v m) -> SendTransaction t v txParams m) p)
                         chainId
                         resolve
             postUsersSendList' btlp (callSignature userName userId)
@@ -69,6 +70,7 @@ postBlocTransaction mUserName mUserId chainId resolve (PostBlocTransactionReques
                         (contractpayloadArgs p)
                         (contractpayloadValue p)
                         txParams
+                        (contractpayloadMetadata p)
                         chainId
                         resolve
             fmap (:[]) $ postUsersContract' bcp (callSignature userName userId)
@@ -76,7 +78,7 @@ postBlocTransaction mUserName mUserId chainId resolve (PostBlocTransactionReques
             p <- mapM fromContract xs
             let bclp = ContractListParameters
                         addr
-                        (map (\(ContractPayload _ c a v) -> UploadListContract (fromJust c) (fromMaybe Map.empty a) txParams v) p)
+                        (map (\(ContractPayload _ c a v m) -> UploadListContract (fromJust c) (fromMaybe Map.empty a) txParams v m) p)
                         chainId
                         resolve
             postUsersUploadList' bclp (callSignature userName userId)
@@ -92,6 +94,7 @@ postBlocTransaction mUserName mUserId chainId resolve (PostBlocTransactionReques
                         (functionpayloadArgs p)
                         (functionpayloadValue p)
                         txParams
+                        (functionpayloadMetadata p)
                         chainId
                         resolve
             fmap (:[]) $ postUsersContractMethod' bfp (callSignature userName userId)
@@ -99,7 +102,7 @@ postBlocTransaction mUserName mUserId chainId resolve (PostBlocTransactionReques
             p <- mapM fromFunction xs
             let bflp = FunctionListParameters
                         addr
-                        (map (\(FunctionPayload (ContractName n) a m r v) -> MethodCall n a m r (fromMaybe (Strung 0) v) txParams) p)
+                        (map (\(FunctionPayload (ContractName n) a m r v md) -> MethodCall n a m r (fromMaybe (Strung 0) v) txParams md) p)
                         chainId
                         resolve
             postUsersContractMethodList' bflp (callSignature userName userId)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -152,13 +152,14 @@ postUsersFill _ addr resolve = blocTransaction $ do
 
 postUsersSend :: UserName -> Address -> Maybe ChainId -> Bool -> PostSendParameters -> Bloc BlocTransactionResult
 postUsersSend userName addr chainId resolve
-  (PostSendParameters toAddr value password mTxParams) = do
+  (PostSendParameters toAddr value password mTxParams md) = do
     sk <- getAccountSecKey userName password addr
     let btp = TransferParameters
                 addr
                 toAddr
                 value
                 mTxParams
+                md
                 chainId
                 resolve
     postUsersSend' btp (return . signTransaction sk)
@@ -166,7 +167,7 @@ postUsersSend userName addr chainId resolve
 postUsersSend' :: TransferParameters -> Signer -> Bloc BlocTransactionResult
 postUsersSend' TransferParameters{..} sign = do
     params <- getAccountTxParams fromAddress chainId txParams
-    tx <- signAndPrepare sign fromAddress Nothing $
+    tx <- signAndPrepare sign fromAddress metadata $
       TransactionHeader
         (Just toAddress)
         fromAddress
@@ -187,7 +188,7 @@ postUsersSend' TransferParameters{..} sign = do
 
 postUsersContract :: UserName -> Address -> Maybe ChainId -> Bool -> PostUsersContractRequest -> Bloc BlocTransactionResult
 postUsersContract userName addr chainId resolve
-  (PostUsersContractRequest src password maybeContract args mTxParams value) = do
+  (PostUsersContractRequest src password maybeContract args mTxParams value md) = do
   sk <- getAccountSecKey userName password addr
   let bcp = ContractParameters
               addr
@@ -196,6 +197,7 @@ postUsersContract userName addr chainId resolve
               args
               value
               mTxParams
+              md
               chainId
               resolve
   postUsersContract' bcp (return . signTransaction sk)
@@ -216,11 +218,11 @@ postUsersContract' ContractParameters{..} sign = blocTransaction $ do
      Just contract' -> (,) contract' <$> blocMaybe "Could not find global contract metadataId" (Map.lookup contract' idsAndDetails)
   let
     (bin,leftOver) = Base16.decode $ Text.encodeUtf8 contractdetailsBin
-    metadata = Just $ Map.fromList [("src", src),("name", cName)]
+    metadata' = Just $ fromMaybe Map.empty metadata `Map.union` Map.fromList [("src", src),("name", cName)]
   unless (ByteString.null leftOver) $ throwError $ AnError "Couldn't decode binary"
   mFunctionId <- getConstructorId cmId
   argsBin <- buildArgumentByteString (fmap (fmap argValueToText) args) mFunctionId
-  tx <- signAndPrepare sign fromAddr metadata $
+  tx <- signAndPrepare sign fromAddr metadata' $
     TransactionHeader
       Nothing
       fromAddr
@@ -255,10 +257,10 @@ postUsersUploadList' ContractListParameters{..} sign = do
   if (null contracts)
     then return []
     else do
-      let UploadListContract _ _ mtp _ = head contracts
+      let UploadListContract _ _ mtp _ _ = head contracts
       params <- getAccountTxParams fromAddr chainId mtp
       (namesCmIdsTxs,_) <- forStateT (Map.empty, Map.empty, Map.empty) (zip contracts [0..]) $
-        \(UploadListContract name args _ value,nonceIncr) -> do
+        \(UploadListContract name args _ value md,nonceIncr) -> do
           (names, cmIds, fIds) <- get
           (bin, src, cmId, names') <- case Map.lookup name names of
             Just (b, src, cm) -> return (b, src, cm, names)
@@ -282,8 +284,8 @@ postUsersUploadList' ContractListParameters{..} sign = do
                 xabiArgs' <- lift $ getXabiFunctionsArgsQuery functionId
                 return (xabiArgs', Map.insert functionId xabiArgs' fIds)
           argsBin <- lift $ constructArgValues (Just (fmap argValueToText args)) xabiArgs
-          let metadata = Just $ Map.fromList [("src",src),("name",name)]
-          tx <- lift . signAndPrepare sign fromAddr metadata $
+          let metadata' = Just $ fromMaybe Map.empty md `Map.union`Map.fromList [("src",src),("name",name)]
+          tx <- lift . signAndPrepare sign fromAddr metadata' $
               TransactionHeader
                 Nothing
                 fromAddr
@@ -323,20 +325,20 @@ postUsersSendList' TransferListParameters{..} sign = do
   if null txs
     then return []
     else do
-      let SendTransaction _ _ mtp = head txs
+      let SendTransaction _ _ mtp _ = head txs
       params <- getAccountTxParams fromAddr chainId mtp
-      txHeaders <- zipWithM
-        (\(SendTransaction toAddr (Strung value) _) i -> do
-            return $ TransactionHeader
-              (Just toAddr)
-              fromAddr
-              params
-              (Wei $ fromIntegral value)
-              (ByteString.empty)
-              i
-              chainId
+      txs' <- zipWithM
+        (\(SendTransaction toAddr (Strung value) _ md) i -> do
+            let header = TransactionHeader
+                  (Just toAddr)
+                  fromAddr
+                  params
+                  (Wei $ fromIntegral value)
+                  (ByteString.empty)
+                  i
+                  chainId
+            signAndPrepare sign fromAddr md header
         ) txs [0..]
-      txs' <- mapM (signAndPrepare sign fromAddr Nothing) txHeaders
       hashes <- blocStrato $ postTxList txs'
       void . blocModify $ \conn -> runInsertMany conn hashNameTable
         [( Nothing
@@ -413,7 +415,7 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
               zxcv <- lift $ getXabiFunctionsArgsQuery functionId
               return (zxcv, Map.insert functionId zxcv fIds)
           argsBin <- lift $ constructArgValues (Just (fmap argValueToText methodcallArgs)) xabiArgs
-          tx <- lift . signAndPrepare sign fromAddr Nothing $
+          tx <- lift . signAndPrepare sign fromAddr methodcallMetadata $
             TransactionHeader
               (Just methodcallContractAddress)
               fromAddr
@@ -455,7 +457,7 @@ postUsersContractMethod
   contractAddr
   chainId
   resolve
-  (PostUsersContractMethodRequest password funcName args value mTxParams) = do
+  (PostUsersContractMethodRequest password funcName args value mTxParams md) = do
     sk <- getAccountSecKey userName password userAddr
     let bfp = FunctionParameters
                 userAddr
@@ -465,6 +467,7 @@ postUsersContractMethod
                 args
                 value
                 mTxParams
+                md
                 chainId
                 resolve
     postUsersContractMethod' bfp (return . signTransaction sk)
@@ -484,7 +487,7 @@ postUsersContractMethod' FunctionParameters{..} sign = do
        _ -> throwError . UserError $ "Contract doesn't have a method named '" <> funcName <> "'"
     functionId <- getFunctionId cmId funcName
     argsBin <- buildArgumentByteString (Just (fmap argValueToText args)) (Just functionId)
-    tx <- signAndPrepare sign fromAddr Nothing $
+    tx <- signAndPrepare sign fromAddr metadata $
       TransactionHeader
         (Just contractAddr)
         fromAddr

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -15,8 +15,6 @@ isPublic=false
    isPublic=true
  fi
 
-echo "History list: $historyList"
-
 echo "Environment variables:
 slipstream:
 --pghost=\$postgres_host="${postgres_host}"
@@ -109,7 +107,7 @@ echo "Bloc is up - running slipstream now..."
 
 runBackgroundProcess /usr/bin/slipstream --pghost="$postgres_host" --pgport="$postgres_port" --pguser="$postgres_user" --password="$postgres_password" \
            --database="$postgres_slipstream_db"  --stratourl="$stratoRoot" --vaultwrapperurl="$vaultWrapperRoot" \
-           --kafkahost="$kafkaHost" --kafkaport="$kafkaPort" --historyList="$historyList" &>> logs/slipstream
+           --kafkahost="$kafkaHost" --kafkaport="$kafkaPort" &>> logs/slipstream
 
 set +x
 if [ "${PROCESS_MONITORING}" = true ] ; then

--- a/blockapps-haskell/slipstream/exec_src/Main.hs
+++ b/blockapps-haskell/slipstream/exec_src/Main.hs
@@ -19,6 +19,7 @@ import System.IO
 import System.Log.Logger
 
 import Slipstream.MessageConsumer
+import Slipstream.Options()
 import Slipstream.OutputData
 
 

--- a/blockapps-haskell/slipstream/exec_src/Main.hs
+++ b/blockapps-haskell/slipstream/exec_src/Main.hs
@@ -11,9 +11,6 @@
 
 import Data.Default
 import Data.IORef
-import Data.List.Split ( splitOn )
-import qualified Data.Set as Set
-import qualified Data.Text as T
 import Database.PostgreSQL.Typed
 import HFlags
 import Network.Kafka
@@ -21,9 +18,7 @@ import qualified Network.Kafka.Protocol as K hiding (Message)
 import System.IO
 import System.Log.Logger
 
-import Slipstream.Globals
 import Slipstream.MessageConsumer
-import Slipstream.Options
 import Slipstream.OutputData
 
 
@@ -46,9 +41,8 @@ main = do
   let offset = 0 :: K.Offset
   let kafkaID = "slipstream" :: KafkaClientId
   let state = mkConfiguredKafkaState kafkaID
-  let histories = Set.fromList . map T.pack . filter (not . null) $ splitOn "," flags_historyList
 
-  cachedContractsIORef <- newIORef def{historyList = histories}
+  cachedContractsIORef <- newIORef def
 
   msg <- runKafka state $ (getAndProcessMessages conn cachedContractsIORef offset)
 

--- a/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
@@ -18,8 +18,8 @@ import           BlockApps.Ethereum
 data Globals =
   Globals {
     createdContracts :: Set Keccak256, -- list of contracts that have had their tables made
-    historyList :: Set Text,
-    noIndexList :: Set Text,
+    historyList :: Set Keccak256,
+    noIndexList :: Set Keccak256,
     contractStates :: Map (Address,Maybe ChainId) [(Text,Value)]
     }
 
@@ -46,24 +46,52 @@ isContractCreated globalsIORef codeHash = do
   return $ codeHash `Set.member` createdContracts
 
 isHistoric :: MonadIO m =>
-              IORef Globals -> Text -> m Bool
+              IORef Globals -> Keccak256 -> m Bool
 isHistoric globalsIORef name = do
   Globals{..} <- liftIO $ readIORef globalsIORef
   return $ name `Set.member` historyList
 
 getHistoryList :: MonadIO m =>
-                  IORef Globals -> m (Set Text)
+                  IORef Globals -> m (Set Keccak256)
 getHistoryList = fmap historyList . liftIO . readIORef
 
+addToHistoryList :: MonadIO m =>
+                  IORef Globals -> Keccak256 -> m ()
+addToHistoryList g k = do
+  globals@Globals{..} <- liftIO $ readIORef g
+  liftIO $ writeIORef g
+    globals{historyList=Set.insert k historyList}
+
+removeFromHistoryList :: MonadIO m =>
+                  IORef Globals -> Keccak256 -> m ()
+removeFromHistoryList g k = do
+  globals@Globals{..} <- liftIO $ readIORef g
+  liftIO $ writeIORef g
+    globals{historyList=Set.delete k historyList}
+
 shouldIndex :: MonadIO m =>
-              IORef Globals -> Text -> m Bool
+              IORef Globals -> Keccak256 -> m Bool
 shouldIndex globalsIORef name = do
   Globals{..} <- liftIO $ readIORef globalsIORef
   return . not $ name `Set.member` noIndexList
 
 getNoIndexList :: MonadIO m =>
-                  IORef Globals -> m (Set Text)
+                  IORef Globals -> m (Set Keccak256)
 getNoIndexList = fmap noIndexList . liftIO . readIORef
+
+addToNoIndexList :: MonadIO m =>
+                  IORef Globals -> Keccak256 -> m ()
+addToNoIndexList g k = do
+  globals@Globals{..} <- liftIO $ readIORef g
+  liftIO $ writeIORef g
+    globals{noIndexList=Set.insert k noIndexList}
+
+removeFromNoIndexList :: MonadIO m =>
+                  IORef Globals -> Keccak256 -> m ()
+removeFromNoIndexList g k = do
+  globals@Globals{..} <- liftIO $ readIORef g
+  liftIO $ writeIORef g
+    globals{noIndexList=Set.delete k noIndexList}
 
 getContractState :: MonadIO m =>
                      IORef Globals -> Address -> Maybe ChainId -> m (Maybe [(Text,Value)])

--- a/blockapps-haskell/slipstream/src/Slipstream/Options.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Options.hs
@@ -15,6 +15,5 @@ defineFlag "stratourl" ("http://strato-int.centralus.cloudapp.azure.com/strato-a
 defineFlag "vaultwrapperurl" ("http://strato-int.centralus.cloudapp.azure.com/strato/v2.3"::String) "URL of the Vault Wrapper server Bloc will connect to"
 defineFlag "kafkahost" ("kafka" :: String) "Kafka host"
 defineFlag "kafkaport" (9092 :: Int) "Kafka port"
-defineFlag "historyList" ("" :: String) "List of contract with enabled history"
 defineFlag "stateFetchLimit" (100::Integer) "The maximum number of array entries to return from the state route"
 -- defineFlag "cirrusurl" ("http://postgrest:3001"::String) "URL of the Cirrus server Bloc will connect to"

--- a/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
@@ -131,7 +131,7 @@ createInserts globalsIORef = do
     globals <- readIORef globalsIORef
     let contractAlreadyCreated = hashVal `Set.member` createdContracts globals
     let tableName = contractName firstContract
-    history <- isHistoric globalsIORef tableName
+    history <- isHistoric globalsIORef hashVal
 
     let list = Map.toList $ Map.map valueToSolidityValue $ Map.filter isFunction $ contractData firstContract
     let comma = if null list
@@ -199,7 +199,7 @@ createInserts globalsIORef = do
       let hist = T.concat ["insert into \"", tableName, "_history\" ", keySt, " values ", inserts, ";"]
       yield hist
 
-    index <- shouldIndex globalsIORef tableName
+    index <- shouldIndex globalsIORef hashVal
     when index $ do
       let ins = T.concat
             [ "insert into \""

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -22,6 +22,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.Either (lefts,rights)
 import Data.Int (Int32)
 import Data.IORef
+import Data.Foldable (for_)
 import Data.Function
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -181,6 +182,17 @@ processTheMessages messages conn g = do
                 cont = either error id . xAbiToContract $ contractdetailsXabi details
                 chain = maybe "" (T.pack . flip showHex "" . unChainId) actionTxChainId
                 cache = maybe (const Nothing) (\s -> fmap unHex . flip Map.lookup s . Hex) actionStorage
+                updateGlobal m (k,f) = for_ (Map.lookup k =<< actionMetadata) $ \v -> do
+                  let contracts = filter (not . T.null) $ T.splitOn "," v
+                  forM_ contracts $ \c -> for_ (fmap (contractdetailsCodeHash . snd) $ Map.lookup c m) $ f g
+
+            detailsMap <- compileContract $ contractdetailsSrc details -- won't actually recompile the contract
+            mapM_ (updateGlobal detailsMap) $ [("history", addToHistoryList)
+                                              ,("nohistory", removeFromHistoryList)
+                                              ,("noindex", addToNoIndexList)
+                                              ,("index", removeFromNoIndexList)
+                                              ]
+
             (mInstance :: Maybe Int32) <- fmap listToMaybe . blocQuery $
               contractInstancesByCodeHash actionCodeHash actionAddress actionTxChainId
             when (isNothing mInstance) . void $ insertContractInstance cmId actionAddress actionTxChainId

--- a/blockapps-haskell/slipstream/tests/Test.hs
+++ b/blockapps-haskell/slipstream/tests/Test.hs
@@ -75,9 +75,10 @@ main = hspec $ do
   describe "Array serialization with history enabled" $ do
     it "should create JSON entries" $ do
       let testAdd = Address $ fst . head . readHex $ "ADDRESS"
+          cHash = keccak256 "<CODEHASH>"
       let input = [ProcessedContract {
              address = testAdd,
-             codehash = keccak256 "<CODEHASH>",
+             codehash = cHash,
              abi = "<ABI>",
              contractName = "Vehicle",
              chain = "<CHAIN>",
@@ -91,7 +92,7 @@ main = hspec $ do
                   ("number", V.SimpleValue $ V.valueUInt 18199984780605),
                   ("hash", V.SimpleValue $ V.ValueString "Owner_hash_181999847806006")]]
             }]
-      g <- newIORef def{historyList = Set.singleton "Vehicle"}
+      g <- newIORef def{historyList = Set.singleton cHash}
       runConduit (yield input .| createInserts g .| sinkList)
         `shouldReturn` [
           "insert into contract (\"codeHash\", contract, abi, \"chainId\") values ('dd993a7bf0018419be434b8232c93936b65b1ebf663006e2f906c333427b1402', 'Vehicle', '<ABI>', '<CHAIN>') ON CONFLICT DO NOTHING;",

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -77,7 +77,6 @@ services:
     - strato
     - vault-wrapper
     environment:
-    - historyList=${historyList}
     - loglevel=${loglevel}
     - kafkaHost=kafka
     - kafkaPort=9092


### PR DESCRIPTION
Allow arbitrary metadata maps to be passed in through transactional Bloc endpoints, excluding /fill, although this could be added if desired. Also, instead of passing a static history list into Slipstream via the command line, contracts can be marked for history, nohistory, index, and noindex, via the transaction metadata. The defaults are nohistory and index, i.e. index the contract, but don't track it's history.