### PR TITLE
Manually revert https://github.com/blockapps/strato-platform/pull/466

### DIFF
--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/BenchmarkLib.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/BenchmarkLib.hs
@@ -2,7 +2,6 @@
 module Blockchain.Blockstanbul.BenchmarkLib
   ( benchContext
   , makeBlock
-  , makeBlockWithTransactions
   , oneTX
   ) where
 
@@ -52,7 +51,3 @@ benchContext =
 makeBlock :: Int -> Int -> Block
 makeBlock txcount txsize = setBlockNo 41
   genesisBlock{blockReceiptTransactions = replicate txcount (oneTX txsize)}
-
-makeBlockWithTransactions :: [Transaction] -> Block
-makeBlockWithTransactions txs =
-  genesisBlock{blockReceiptTransactions = txs}

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -18,12 +18,11 @@ import           Control.Monad.IO.Class                    (liftIO)
 
 import           Data.ByteString.Char8                     (pack)
 import           Data.ByteString.Base16                    as B16
-import           Data.Foldable                             (toList, traverse_)
-import           Data.Maybe                                (catMaybes, fromJust, isJust)
+import           Data.Foldable                             (toList)
+import           Data.Maybe                                (catMaybes, fromJust, isJust, mapMaybe)
 import qualified Data.Set                                  as S
 import qualified Data.Text                                 as T
 import           Data.Time.Clock
-import           Data.Traversable                          (for)
 import           Prometheus                                as P
 import           Text.Printf
 
@@ -156,77 +155,67 @@ bootstrapBlockstanbul = do
   createFirstTimer
 
 blockstanbulSend :: [InEvent] -> SequencerM ()
-blockstanbulSend = mapM_ (mapM_ markForVM <=< blockstanbulSend')
+blockstanbulSend msgs = do
+    resp' <- sendAllMessages msgs
+    let blocks = [b | ToCommit b <- resp']
+    resp <- (resp'++) <$>
+        case blocks of
+          [] -> return []
+          -- TODO(tim): Block insertion can potentially fail, so there
+          -- should be feedback here
+          [b] -> sendAllMessages [CommitResult . Right . blockHash $ b]
+          bs -> error $ "can send at most 1 block at a time: " ++ show bs
+    mapM_ createNewTimer [rn | ResetTimer rn <- resp]
+    $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ show blocks
+    let rewriteBlock = fmap (OEBlock . flip sequencedBlockToOutputBlock 1)
+                     . ingestBlockToSequencedBlock
+                     . blockToIngestBlock TO.Blockstanbul
+        creates = [OECreateBlockCommand | MakeBlockCommand <- resp]
+        vmevs = creates ++ mapMaybe rewriteBlock blocks
+        p2pevs = [OEBlockstanbul (WireMessage a m) | OMsg a m <- resp]
+              ++ [OEAskForBlocks (h+1) n | GapFound h n <- resp]
 
-blockstanbulSend' :: InEvent -> SequencerM [OutputEvent]
-blockstanbulSend' msg = do
-  resp' <- sendAllMessages [msg]
-  let blocks = [b | ToCommit b <- resp']
-  resp <- (resp'++) <$>
-    case blocks of
-      [] -> return []
-      [b] ->
-        -- TODO(tim): Block insertion can potentially fail, so there
-        -- should be feedback here
-        sendAllMessages [CommitResult . Right . blockHash $ b]
-      bs -> error $ "must commit at most one block at a time: " ++ show bs
-  mapM_ createNewTimer [rn | ResetTimer rn <- resp]
-  $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ show blocks
-  let getSequencedBlock = ingestBlockToSequencedBlock . blockToIngestBlock TO.Blockstanbul
-      rewriteBlock b = do
-        let msb = getSequencedBlock b
-        for msb $ \sb -> do
-          witnessBlockHash (blockHeaderHash $ sbBlockData sb) sb
-          return . OEBlock $ sequencedBlockToOutputBlock sb 1
-      creates = [OECreateBlockCommand | MakeBlockCommand <- resp]
-  rBlocks <- fmap catMaybes $ mapM rewriteBlock blocks
-  let vmevs = creates ++ rBlocks
-      p2pevs = [OEBlockstanbul (WireMessage a m) | OMsg a m <- resp]
-            ++ [OEAskForBlocks (h+1) n | GapFound h n <- resp]
-            ++ [OEPushBlocks (l+1) h | LeadFound h l <- resp]
-  unless (null blocks) $ do
-    let tLast = blockHeaderTimestamp . BDB.blockBlockData . head $ blocks
-    dt <- asks blockstanbulBlockPeriod
-    let tNext = addUTCTime dt tLast
-    now <- liftIO getCurrentTime
-    when (now < tNext) $
-      liftIO . threadDelay . round $ 1e6 * diffUTCTime tNext now
-  $logDebugS "seq/pbft/send_vm" . T.pack . show $ vmevs
-  $logDebugS "seq/pbft/send_p2p" . T.pack . show $ p2pevs
-  mapM_ markForP2P p2pevs
-  return vmevs
 
-checkIfIsMissingTX :: SHA -> SHA -> SequencerM ()
-checkIfIsMissingTX th ch = lookupChainHash ch >>= \case
-  Nothing -> do
-    $logInfoS "checkIfIsMissingTX" "We don't know this transaction's chain Id. Oh well..."
-    return ()
-  Just (_, cid) -> do
-    $logInfoS "transformPrivateHashTXs" . T.pack $ "We know this transaction's chain Id. It's " ++ format (SHA cid) ++ ". Inserting into MissingTxDB and GetTransactions list"
-    useChainHash ch cid
-    insertMissingTx th
-    insertGetTransactionsDB th
+    unless (null blocks) $ do
+      let tLast = blockHeaderTimestamp . BDB.blockBlockData . head $ blocks
+      dt <- asks blockstanbulBlockPeriod
+      let tNext = addUTCTime dt tLast
+      now <- liftIO getCurrentTime
+      when (now < tNext) $
+       liftIO . threadDelay . round $ 1e6 * diffUTCTime tNext now
 
-runPrivateHashTX :: SHA -> SHA -> SequencerM ()
-runPrivateHashTX th ch = do
-  $logInfoS "runPrivateHashTX" . T.pack $ "Transforming transaction " ++ format th ++ " with chain hash " ++ format ch
+    $logDebugS "seq/pbft/send_vm" . T.pack . show $ vmevs
+    mapM_ markForVM vmevs
+    $logDebugS "seq/pbft/send_p2p" . T.pack . show $ p2pevs
+    mapM_ markForP2P p2pevs
+
+transformPrivateHashTXs :: [(Timestamp, IngestTx)] -> SequencerM ()
+transformPrivateHashTXs pairs = forM_ pairs $ \(_, IngestTx _ (TD.PrivateHashTX th' ch')) -> do
+  $logInfoS "transformPrivateHashTXs" . T.pack $ "Transforming transaction " ++ format (SHA th') ++ " with chain hash " ++ format (SHA ch')
+  let th = SHA th'
+      ch = SHA ch'
   lookupSeenTxHash th >>= \case
     Just _ -> do
-      $logInfoS "runPrivateHashTX" "Transaction hash seen before!"
+      $logInfoS "transformPrivateHashTXs" "Transaction hash seen before!"
       return ()
     Nothing -> do
-      $logInfoS "runPrivateHashTX" "Transaction hash not seen before! Inserting it into SeenTxHashDB"
+      $logInfoS "transformPrivateHashTXs" "Transaction hash not seen before! Inserting it into SeenTxHashDB"
       insertSeenTxHash th ch
       lookupTransaction th >>= \case
         Just tx -> do
-          $logInfoS "runPrivateHashTX" . T.pack $ "We have this transaction's body. It's: " ++ prettyOTx tx
+          $logInfoS "transformPrivateHashTXs" . T.pack $ "We have this transaction's body. It's: " ++ prettyOTx tx
           useChainHash ch (fromJust . TD.transactionChainId $ otBaseTx tx)
         Nothing -> do
-          $logInfoS "runPrivateHashTX" "We don't have this transaction's body. Looking it up by chain hash"
-          checkIfIsMissingTX th ch
-
-transformPrivateHashTXs :: [(Timestamp, IngestTx)] -> SequencerM ()
-transformPrivateHashTXs pairs = forM_ pairs $ \(_, IngestTx _ (TD.PrivateHashTX th' ch')) -> runPrivateHashTX (SHA th') (SHA ch')
+          $logInfoS "transformPrivateHashTXs" "We don't have this transaction's body. Looking it up by chain hash"
+          lookupChainHash ch >>= \case
+            Nothing -> do
+              $logInfoS "transformPrivateHashTXs" "We don't know this transaction's chain Id. Oh well..."
+              return ()
+            Just (_, cid) -> do
+              $logInfoS "transformPrivateHashTXs" . T.pack $ "We know this transaction's chain Id. It's " ++ format (SHA cid) ++ ". Inserting into MissingTxDB and GetTransactions list"
+              useChainHash ch cid
+              insertMissingTx th
+              insertGetTransactionsDB th
 
 transformFullTransactions :: [(Timestamp, IngestTx)] -> SequencerM ()
 transformFullTransactions pairs = do
@@ -254,7 +243,6 @@ transformFullTransactions pairs = do
         mapM_ (markForP2P . pairToOETx) txs
       else forM_ (partitionWith (TD.transactionChainId . otBaseTx . snd) txs) $ \(Just chainId, ptxs) -> do
         $logInfoS "transformFullTransactions" . T.pack $ "Transforming " ++ show (length txs) ++ "private transactions on chain " ++ format (SHA chainId)
-        mapM_ (insertTransaction . snd) ptxs
         lookupSeenChain chainId >>= \case
           False -> do
             $logInfoS "transformFullTransactions" . T.pack $ "We haven't seen the details for chain " ++ format (SHA chainId) ++ ". Inserting all transactions into MissingChainTxDB and inserting the chain Id into the GetChains list"
@@ -263,7 +251,6 @@ transformFullTransactions pairs = do
           True -> forM_ ptxs $ \(ts, ptx) -> do
             $logInfoS "transformFullTransactions" . T.pack $ "We know the details for chain " ++ format (SHA chainId) ++ ". Inserting " ++ prettyOTx ptx ++ "into PrivateHashDB"
             let tHash = txHash ptx
-            removeMissingTx tHash
             cHash <- lookupSeenTxHash tHash >>= \case
               Just ch -> do
                 $logInfoS "transformFullTransactions" . T.pack $ "We have this transaction's chain hash. It's: " ++ format ch
@@ -291,7 +278,7 @@ transformFullTransactions pairs = do
                   removeTxBlock tHash
                   clearDependentTxs bHash
                   mBlock <- witnessedBlock bHash
-                  traverse_ runBlock mBlock
+                  mapM_ hydrateAndEmit mBlock
                 depTxs -> do
                   $logInfoS "transformFullTransactions" . T.pack $ "Transaction " ++ format tHash ++ " is a dependent transaction in block " ++ format bHash ++ ", but there are others. Inserting them into MissingTxDB and GetTransactions list"
                   removeTxBlock tHash
@@ -306,90 +293,70 @@ transformTransactions events = forM_ (partitionWith (isPrivateHashTX . itTransac
     then transformPrivateHashTXs pairs
     else transformFullTransactions pairs
 
-runBlockWithConsensus :: SequencedBlock -> SequencerM ()
-runBlockWithConsensus sb = mapM_ markForVM =<< runConduit (expandBlock sb .| runConsensus .| hydrateAndEmit .| sinkList)
-
-runBlock :: SequencedBlock -> SequencerM ()
-runBlock sb = mapM_ markForVM =<< runConduit (expandBlock sb .| dropLefts .| mapC OEBlock .| hydrateAndEmit .| sinkList)
-
-expandBlock :: SequencedBlock -> ConduitM () (Either SequencedBlock OutputBlock) SequencerM ()
-expandBlock sb = do
+hydrateAndEmit :: SequencedBlock -> SequencerM ()
+hydrateAndEmit sb = do
+  wetBlocks <- runConduit $ hydrateAndEmit' .| sinkList
+  hasPBFT <- blockstanbulRunning
+  if not hasPBFT
+    then mapM_ (markForVM . OEBlock) wetBlocks
+    else let convert :: BDB.Block -> InEvent
+             convert blk = if isHistoricBlock blk
+                             then PreviousBlock blk
+                             else UnannouncedBlock blk
+         -- Blockstanbul will check that the seals and validators match up before
+         -- announcing it to the network or forwarding to the EVM.
+         in blockstanbulSend . map convert $ if null wetBlocks
+                                               then [sequencedBlockToBlock sb]
+                                               else map outputBlockToBlock wetBlocks
+ where
+ hydrateAndEmit' :: ConduitM () OutputBlock SequencerM ()
+ hydrateAndEmit' = do
+  let logHydrate = $logInfoS "hydrateAndEmit" . T.pack
   readiness <- lift $ enqueueIfParentNotEmitted sb
   case readiness of
-    NotReadyToEmit -> do
-      $logWarnS "expandBlock" . T.pack $ prettyBlock sb ++ " is not yet ready to emit."
-      lift $ P.incCounter seqBlocksEnqueued
-    (ReadyToEmit totalPastDifficulty) -> do
-      -- TODO: buildEmissionChain needs to do all of this so that we don't emit blocks missing transactions prematurely
-      (ldbOps, dryChain) <- lift . fmap unzip $ buildEmissionChain sb totalPastDifficulty
-      lift . addLdbBatchOps . catMaybes $ ldbOps
-      if dryChain /= []
-        then do
-          $logInfoS "expandBlock" . T.pack $ prettyBlock sb ++ " is ready to emit! Emitting it and chain of dependents."
-          yieldMany $ map Right dryChain
-        else do
-          $logInfoS "expandBlock" . T.pack $ prettyBlock sb ++ " is ready to emit, but its emission chain is empty. It was likely already emitted."
-          yield $ Left sb
+      NotReadyToEmit -> do
+          $logWarnS "transformEvents/emitBlocks" . T.pack $ prettyBlock sb ++ " is not yet ready to emit."
+          lift $ P.incCounter seqBlocksEnqueued
+      (ReadyToEmit totalPastDifficulty) -> do
+          -- TODO: buildEmissionChain needs to do all of this so that we don't emit blocks missing transactions prematurely
+          dryChain <- lift $ buildEmissionChain sb totalPastDifficulty
+          if dryChain /= []
+            then $logInfoS "transformEvents/emitBlocks" . T.pack $ prettyBlock sb ++ " is ready to emit! Emitting it and chain of dependents."
+            else $logInfoS "transformEvents/emitBlocks" . T.pack $ prettyBlock sb ++ " is ready to emit, but its emission chain is empty. It was likely already emitted."
+          hasPBFT <- lift blockstanbulRunning
+          unless hasPBFT $
+            mapM_ (lift . markForP2P . OEBlock . snd) dryChain
+          ldbOps <- forM dryChain $ \(ldbOp, ob) -> do
+            let bHash = blockHeaderHash $ obBlockData ob
+            logHydrate $ prettyOBlock ob
+            forM_ (obReceiptTransactions ob) $ \tx ->
+              when (isPrivateHashTX tx) $ do
+                let TD.PrivateHashTX{TD.transactionTxHash = th'} = otBaseTx tx
+                    th = SHA th'
+                logHydrate $ "Looking up transaction hash " ++ format th ++ " in MissingTxDB"
+                missing <- lift . isMissingTX $ th
+                if missing
+                  then do
+                    logHydrate $ "Transaction hash " ++ format th ++ " is missing. Inserting into TxBlockDB and DependentTxDB"
+                    lift $ insertTxBlock th bHash
+                    lift $ insertDependentTx bHash th
+                  else
+                    logHydrate $ "Transaction hash " ++ format th ++ " is not missing"
+            depTXS <- lift . lookupDependentTxs $ bHash
+            if S.null depTXS
+              then do
+                logHydrate $ "Block hash " ++ format bHash ++ " has no dependent transactions. Hydrating and emitting to VM"
+                hydratedBlock <- lift . hydrateBlock $ ob
+                lift $ P.incCounter seqBlocksReleased
+                yield hydratedBlock
 
-dropLefts :: Monad m => ConduitM (Either a b) b m ()
-dropLefts = awaitForever $ \case
-  Right b -> yield b
-  _ -> return ()
+                return ldbOp
+              else do
+                logHydrate $ "Block hash " ++ format bHash ++ " has dependent transactions. Inserting them into GetTransactions list"
+                lift $ mapM_ insertGetTransactionsDB depTXS
+                return Nothing
 
-runConsensus :: ConduitM (Either SequencedBlock OutputBlock) OutputEvent SequencerM ()
-runConsensus = awaitForever $ \eob -> do
-  hasPBFT <- lift $ blockstanbulRunning
-  if not hasPBFT
-    then case eob of
-      Left _ -> return ()
-      Right ob -> do
-        let oeBlock = OEBlock ob
-        lift $ markForP2P oeBlock
-        yield oeBlock
-    else do
-      let convert :: BDB.Block -> InEvent
-          convert blk = if isHistoricBlock blk
-                          then PreviousBlock blk
-                          else UnannouncedBlock blk
-          route (Left sb) = sequencedBlockToBlock sb
-          route (Right ob) = outputBlockToBlock ob
-          -- Blockstanbul will check that the seals and validators match up before
-          -- announcing it to the network or forwarding to the EVM.
-      oes <- lift . blockstanbulSend' . convert $ route eob
-      yieldMany oes
-
-hydrateAndEmit :: ConduitM OutputEvent OutputEvent SequencerM ()
-hydrateAndEmit = awaitForever $ \case
-  OEBlock ob -> do
-    let bHash = blockHeaderHash $ obBlockData ob
-        logHydrate = $logInfoS "hydrateAndEmit" . T.pack
-    logHydrate $ prettyOBlock ob
-    forM_ (obReceiptTransactions ob) $ \tx ->
-      when (isPrivateHashTX tx) $ do
-        let TD.PrivateHashTX th' ch' = otBaseTx tx
-            th = SHA th'
-            ch = SHA ch'
-        lift $ runPrivateHashTX th ch
-        logHydrate $ "Looking up transaction hash " ++ format th ++ " in MissingTxDB"
-        missing <- lift . isMissingTX $ th
-        if missing
-          then do
-            logHydrate $ "Transaction hash " ++ format th ++ " is missing. Inserting into TxBlockDB and DependentTxDB"
-            lift $ insertTxBlock th bHash
-            lift $ insertDependentTx bHash th
-          else
-            logHydrate $ "Transaction hash " ++ format th ++ " is not missing"
-    depTXS <- lift . lookupDependentTxs $ bHash
-    if S.null depTXS
-      then do
-        logHydrate $ "Block hash " ++ format bHash ++ " has no dependent transactions. Hydrating and emitting to VM"
-        hydratedBlock <- lift . hydrateBlock $ ob
-        lift $ P.incCounter seqBlocksReleased
-        yield $ OEBlock hydratedBlock
-      else do
-        logHydrate $ "Block hash " ++ format bHash ++ " has dependent transactions. Inserting them into GetTransactions list"
-        lift $ mapM_ insertGetTransactionsDB depTXS
-  oe -> yield oe
+          lift . addLdbBatchOps . catMaybes $ ldbOps
 
 transformBlocks :: [IngestBlock] -> SequencerM ()
 transformBlocks = mapM_ $ \ib -> do
@@ -400,8 +367,9 @@ transformBlocks = mapM_ $ \ib -> do
         $ "Could not ECRecover the pubkey of certain Txs in Block " ++ prettyIBlock ib ++ "; not emitting"
       P.incCounter seqBlocksEcrfail -- couldnt ecrecover some transactions in this block. block is likely garbage
     Just sb -> do
-      witnessBlockHash (blockHeaderHash $ sbBlockData sb) sb -- TODO: this is for PoW, but we should figure out how to move it into `runConsensus`
-      runBlockWithConsensus sb
+      witnessBlockHash (sbHash sb) sb
+      hydrateAndEmit sb
+
 
 transformGenesis :: [IngestGenesis] -> SequencerM ()
 transformGenesis chains = forM_ chains $ \ig -> do
@@ -440,7 +408,7 @@ transformGenesis chains = forM_ chains $ \ig -> do
                   removeTxBlock tHash
                   clearDependentTxs bHash
                   mBlock <- witnessedBlock bHash
-                  mapM_ runBlock mBlock
+                  mapM_ hydrateAndEmit mBlock
                 depTxs -> do
                   $logInfoS "transformGenesis" . T.pack $ "Transaction " ++ format tHash ++ " is a dependent transaction in block " ++ format bHash ++ ", but there are others. Inserting them into MissingTxDB and GetTransactions list"
                   removeTxBlock tHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -173,7 +173,8 @@ blockstanbulSend msgs = do
         creates = [OECreateBlockCommand | MakeBlockCommand <- resp]
         vmevs = creates ++ mapMaybe rewriteBlock blocks
         p2pevs = [OEBlockstanbul (WireMessage a m) | OMsg a m <- resp]
-              ++ [OEAskForBlocks (h+1) n | GapFound h n <- resp]
+              ++ [OEAskForBlocks (h+1) l | GapFound h l <- resp]
+              ++ [OEPushBlocks (l+1) h | LeadFound h l <- resp]
 
 
     unless (null blocks) $ do

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -23,6 +23,7 @@ import           Data.Maybe                                (catMaybes, fromJust,
 import qualified Data.Set                                  as S
 import qualified Data.Text                                 as T
 import           Data.Time.Clock
+import           Data.Traversable                          (for)
 import           Prometheus                                as P
 import           Text.Printf
 
@@ -172,10 +173,13 @@ blockstanbulSend' msg = do
   mapM_ createNewTimer [rn | ResetTimer rn <- resp]
   $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ show blocks
   let getSequencedBlock = ingestBlockToSequencedBlock . blockToIngestBlock TO.Blockstanbul
-      sbs = catMaybes $ map getSequencedBlock blocks
-      rBlocks = map (OEBlock . flip sequencedBlockToOutputBlock 1) sbs
+      rewriteBlock b = do
+        let msb = getSequencedBlock b
+        for msb $ \sb -> do
+          witnessBlockHash (blockHeaderHash $ sbBlockData sb) sb
+          return . OEBlock $ sequencedBlockToOutputBlock sb 1
       creates = [OECreateBlockCommand | MakeBlockCommand <- resp]
-  mapM_ witnessBlockHash sbs
+  rBlocks <- fmap catMaybes $ mapM rewriteBlock blocks
   let vmevs = creates ++ rBlocks
       p2pevs = [OEBlockstanbul (WireMessage a m) | OMsg a m <- resp]
             ++ [OEAskForBlocks (h+1) n | GapFound h n <- resp]
@@ -187,9 +191,9 @@ blockstanbulSend' msg = do
     now <- liftIO getCurrentTime
     when (now < tNext) $
       liftIO . threadDelay . round $ 1e6 * diffUTCTime tNext now
+  $logDebugS "seq/pbft/send_vm" . T.pack . show $ vmevs
   $logDebugS "seq/pbft/send_p2p" . T.pack . show $ p2pevs
   mapM_ markForP2P p2pevs
-  $logDebugS "seq/pbft/send_vm" . T.pack . show $ vmevs
   return vmevs
 
 checkIfIsMissingTX :: SHA -> SHA -> SequencerM ()
@@ -198,7 +202,7 @@ checkIfIsMissingTX th ch = lookupChainHash ch >>= \case
     $logInfoS "checkIfIsMissingTX" "We don't know this transaction's chain Id. Oh well..."
     return ()
   Just (_, cid) -> do
-    $logInfoS "transformPrivateHashTXs" . T.pack $ "We know the chain Id for transaction " ++ format th ++ ". It's " ++ format (SHA cid) ++ ". Inserting into MissingTxDB and GetTransactions list"
+    $logInfoS "transformPrivateHashTXs" . T.pack $ "We know this transaction's chain Id. It's " ++ format (SHA cid) ++ ". Inserting into MissingTxDB and GetTransactions list"
     useChainHash ch cid
     insertMissingTx th
     insertGetTransactionsDB th
@@ -303,10 +307,10 @@ transformTransactions events = forM_ (partitionWith (isPrivateHashTX . itTransac
     else transformFullTransactions pairs
 
 runBlockWithConsensus :: SequencedBlock -> SequencerM ()
-runBlockWithConsensus sb = runConduit (expandBlock sb .| runConsensus .| hydrateAndEmit .| mapM_C markForVM)
+runBlockWithConsensus sb = mapM_ markForVM =<< runConduit (expandBlock sb .| runConsensus .| hydrateAndEmit .| sinkList)
 
 runBlock :: SequencedBlock -> SequencerM ()
-runBlock sb = runConduit (expandBlock sb .| dropLefts .| mapC OEBlock .| hydrateAndEmit .| mapM_C markForVM)
+runBlock sb = mapM_ markForVM =<< runConduit (expandBlock sb .| dropLefts .| mapC OEBlock .| hydrateAndEmit .| sinkList)
 
 expandBlock :: SequencedBlock -> ConduitM () (Either SequencedBlock OutputBlock) SequencerM ()
 expandBlock sb = do
@@ -396,7 +400,7 @@ transformBlocks = mapM_ $ \ib -> do
         $ "Could not ECRecover the pubkey of certain Txs in Block " ++ prettyIBlock ib ++ "; not emitting"
       P.incCounter seqBlocksEcrfail -- couldnt ecrecover some transactions in this block. block is likely garbage
     Just sb -> do
-      witnessBlockHash sb -- TODO: this is for PoW, but we should figure out how to move it into `runConsensus`
+      witnessBlockHash (blockHeaderHash $ sbBlockData sb) sb -- TODO: this is for PoW, but we should figure out how to move it into `runConsensus`
       runBlockWithConsensus sb
 
 transformGenesis :: [IngestGenesis] -> SequencerM ()

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateTxDB.hs
@@ -32,6 +32,7 @@ insertPrivateHash tx = case txChainId tx of
         h = txHash tx
         rs = hash . rlpSerialize $ RLPArray [rlpEncode r, rlpEncode s]
         sr = hash . rlpSerialize $ RLPArray [rlpEncode s, rlpEncode r]
+    insertTransaction tx
     insertChainHash rs chainId
     insertChainHash sr chainId
     chainHash <- getChainHash chainId

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenBlockDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenBlockDB.hs
@@ -2,7 +2,6 @@ module Blockchain.Sequencer.DB.SeenBlockDB where
 
 import           Blockchain.Sequencer.Event    (SequencedBlock(..))
 import           Blockchain.SHA
-import           Blockchain.Strato.Model.Class
 
 import           Control.Monad.Trans.Resource
 
@@ -35,9 +34,8 @@ class (MonadResource m) => HasSeenBlockDB m where
     witnessedBlock :: SHA -> m (Maybe SequencedBlock)
     witnessedBlock sha = (M.lookup sha . seen) <$> getSeenBlockDB
 
-    witnessBlockHash :: SequencedBlock -> m ()
-    witnessBlockHash bd = do
-        let sha = blockHeaderHash $ sbBlockData bd
+    witnessBlockHash :: SHA -> SequencedBlock -> m ()
+    witnessBlockHash sha bd = do
         stxdb     <- getSeenBlockDB
         let withClear = stxdb { operations = operations stxdb + 1
                               , clearQueue = clearQueue stxdb Q.|> sha

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenHashDB.hs
@@ -5,6 +5,7 @@ import           Blockchain.SHA
 
 import           Data.Bimap                   (Bimap)
 import qualified Data.Bimap                   as B
+
 import           Blockchain.Sequencer.DB.PrivateHashDB
 
 getSeenHashDB :: HasPrivateHashDB m => m (Bimap SHA SHA)

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Blockchain.Sequencer.SequencerSpec where
 
+
 import           ClassyPrelude                       (atomically)
-import qualified Data.ByteString                     as BS
 import           Data.IORef
-import           Data.Maybe                          (fromMaybe, isNothing)
+import           Data.Maybe                          (isNothing, fromMaybe)
 import           Data.Time.Clock.POSIX
-import qualified Data.Map                            as M
+import           Data.Map                            as M (singleton,lookup)
 import           Data.ByteString.Base16              as B16
 import           Numeric                             (showHex)
 
@@ -22,19 +21,17 @@ import           Control.Monad.Logger
 import           Control.Concurrent.Async             as Async
 import           Control.Monad.Reader
 import           Control.Monad.State.Class
+
 import           Blockchain.Blockstanbul
 import           Blockchain.Blockstanbul.Authentication
-import           Blockchain.Blockstanbul.BenchmarkLib (makeBlock, makeBlockWithTransactions)
+import           Blockchain.Blockstanbul.BenchmarkLib (makeBlock)
 import           Blockchain.Blockstanbul.EventLoop
 import qualified Blockchain.Blockstanbul.HTTPAdmin as API
 import           Blockchain.Blockstanbul.Messages hiding (round)
 import           Blockchain.Data.Address
 import           Blockchain.Data.Block
 import           Blockchain.Data.BlockDB
-import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.RLP
-import           Blockchain.Data.Transaction         (createChainMessageTX)
-import           Blockchain.Data.TransactionDef
 import qualified Blockchain.Data.TXOrigin as TO
 import           Blockchain.Format
 import           Blockchain.Output
@@ -60,6 +57,7 @@ import           Test.QuickCheck
 
 import           System.Directory                    (createDirectoryIfMissing, getCurrentDirectory,
                                                       removeDirectoryRecursive, setCurrentDirectory)
+
 
 fromLeft :: a -> Either a b -> a
 fromLeft _ (Left a) = a
@@ -366,62 +364,3 @@ spec = do
           atomically . writeTMChan uch $ 987
         (_, evs) <- readEventsInBufferedWindow src
         evs `shouldMatchList` [TimerFire 987]
-
-      it "should run Blockstanbul with private transactions" . runPBFTTestMWithGenesis $ \h -> do
-        let chainId = 0x12345678
-            cInfo = ChainInfo "my test chain" [] [] M.empty
-            chainDetails = IEGenesis (IngestGenesis TO.Morphism (chainId, cInfo))
-            chainHash = unSHA . superProprietaryStratoSHAHash . rlpSerialize $ rlpEncode cInfo
-        tx <- liftIO . HK.withSource HK.devURandom $ do
-          pk <- HK.genPrvKey
-          createChainMessageTX 0 1 1 (Address 0xdeadbeef) 0 BS.empty (Just chainId) Nothing pk
-        let hashTx = PrivateHashTX (unSHA $ txHash tx) chainHash
-        let b' = makeBlockWithTransactions [hashTx]
-            blk = b'{blockBlockData = (blockBlockData b') {
-                      blockDataParentHash = h,
-                      blockDataNumber = 1}}
-            iev = IEBlock . blockToIngestBlock TO.Morphism $ blk
-        checkForUnseq [chainDetails]
-        checkForUnseq [IETx 0 (IngestTx TO.Morphism tx)]
-        checkForUnseq [iev]
-        p2pevs <- drainP2P
-        let bs = [b | OEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
-        length bs `shouldBe` 1
-        let txs = blockReceiptTransactions $ head bs
-        length txs `shouldBe` 1
-        txType (head txs) `shouldBe` PrivateHash
-        vmevs <- drainVM
-        let otxs = obReceiptTransactions $ head [b | OEBlock b <- vmevs]
-        length otxs `shouldBe` 1
-        txType (head otxs) `shouldBe` Message
-
-      it "should run Blockstanbul with delayed private transactions" . runPBFTTestMWithGenesis $ \h -> do
-        let chainId = 0x12345678
-            cInfo = ChainInfo "my test chain" [] [] M.empty
-            chainDetails = IEGenesis (IngestGenesis TO.Morphism (chainId, cInfo))
-            chainHash = unSHA . superProprietaryStratoSHAHash . rlpSerialize $ rlpEncode cInfo
-        tx <- liftIO . HK.withSource HK.devURandom $ do
-          pk <- HK.genPrvKey
-          createChainMessageTX 0 1 1 (Address 0xdeadbeef) 0 BS.empty (Just chainId) Nothing pk
-        let hashTx = PrivateHashTX (unSHA $ txHash tx) chainHash
-        let b' = makeBlockWithTransactions [hashTx]
-            blk = b'{blockBlockData = (blockBlockData b'){
-                      blockDataParentHash = h,
-                      blockDataNumber = 1}}
-            iev = IEBlock . blockToIngestBlock TO.Morphism $ blk
-        checkForUnseq [chainDetails]
-        checkForUnseq [iev]
-        vmevs <- drainVM
-        let obs = [b | OEBlock b <- vmevs]
-        obs `shouldBe` []
-        p2pevs <- drainP2P
-        let bs = [b | OEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
-        length bs `shouldBe` 1
-        let txs = blockReceiptTransactions $ head bs
-        length txs `shouldBe` 1
-        txType (head txs) `shouldBe` PrivateHash
-        checkForUnseq [IETx 0 (IngestTx TO.Morphism tx)]
-        vmevs' <- drainVM
-        let otxs' = obReceiptTransactions $ head [b | OEBlock b <- vmevs']
-        length otxs' `shouldBe` 1
-        txType (head otxs') `shouldBe` Message


### PR DESCRIPTION
I'm not sure what happened, as I thought I had tested f0bed02 on gcp-multinode2x. However, re-testing it consistently has the same problem: the first block is confirmed, and the second block is stalled by `expandBlock`:
```
ethereum-vm:Block #1[2018-10-23 21:10:32.689608 UTC]  INFO | ThreadId 5     | setParentStateRoot                  | Inserting block #1 (10e832de6b9129a75b817cc2dacc18e1fdc8ac2d34446e4f7ee725e9d3cd8a91).
strato-adit:[2018-10-23 21:10:32.209025 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #1
strato-adit:[2018-10-23 21:10:36.940827 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:11:57.370636 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:13:17.79403 UTC ]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:14:38.17422 UTC ]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:15:58.524708 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:17:18.890881 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:18:39.265587 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:19:59.609223 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:21:19.972237 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:22:40.352885 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:24:00.695366 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:25:21.070921 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:26:41.437638 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-adit:[2018-10-23 21:28:01.763569 UTC]  INFO | ThreadId 1     | doConsume                           | putTMVar w/ block #2
strato-p2p-client:Block #1 10e832de6b9129a75b817cc2dacc18e1fdc8ac2d34446e4f7ee725e9d3cd8a91
strato-sequencer:[2018-10-23 21:10:32.259124 UTC]  INFO | ThreadId 8     | expandBlock                         | Block #1/92e0b4806c8d8a1c46fd8281f40fb8365a5dea7f66df64729a3e2d509e38ee27 (via Quarry, 1 txs) is ready to emit! Emitting it and chain of dependents.
strato-sequencer:Block #1 10e832de6b9129a75b817cc2dacc18e1fdc8ac2d34446e4f7ee725e9d3cd8a91
strato-sequencer:[2018-10-23 21:10:36.983947 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:11:57.411174 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:13:17.824824 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:14:38.214898 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:15:58.550541 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:17:18.929753 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:18:39.295427 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:19:59.645404 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:21:20.009721 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:22:40.422029 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:24:00.724123 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:25:21.099327 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:26:41.474011 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
strato-sequencer:[2018-10-23 21:28:01.802202 UTC]                    src/Blockchain/Sequencer.hs:318 |  WARN | ThreadId 8     | expandBlock                         | Block #2/e4f8336a92e00a6d181e44636f5c2a3bab76d679622e0c3417b32c9ca9cb073d (via Quarry, 1 txs) is not yet ready to emit.
```

See https://blockappsdev.slack.com/archives/CD4JLDGJ2/p1540331488000100 for more logs.