### PR TITLE
Provide concurrent faucets

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -10,6 +10,7 @@ module BlockApps.Bloc22.Server.Users where
 
 import           ClassyPrelude                     ((<>))
 import           Control.Concurrent
+import           Control.Concurrent.Async.Lifted
 import           Control.Arrow
 import           Control.Exception.Lifted          (catch)
 import           Control.Monad
@@ -140,15 +141,15 @@ postUsersKeyStore username (PostUsersKeyStoreRequest password keystore) = do
 postUsersFill :: UserName  -> Address -> Bool -> Bloc BlocTransactionResult
 postUsersFill _ addr resolve = blocTransaction $ do
   when resolve (logWith logNotice "Waiting for faucet transaction to be mined")
-  hash <- blocStrato $ postFaucet addr
+  hashes <- blocStrato $ postFaucet addr
   void . blocModify $ \conn -> runInsertMany conn hashNameTable [
     ( Nothing
-    , constant hash
+    , constant h
     , constant (0 :: Int32)
     , constant (0 :: Int32)
     , constant (Text.decodeUtf8 . BL.toStrict $ Aeson.encode defaultPostTx{posttransactionTo = Just addr})
-    )]
-  getBlocTransactionResult' Nothing hash resolve
+    ) | h <- hashes]
+  getBlocTransactionResult' Nothing hashes resolve
 
 postUsersSend :: UserName -> Address -> Maybe ChainId -> Bool -> PostSendParameters -> Bloc BlocTransactionResult
 postUsersSend userName addr chainId resolve
@@ -184,7 +185,7 @@ postUsersSend' TransferParameters{..} sign = do
       , constant (0 :: Int32)
       , constant (Text.decodeUtf8 . BL.toStrict $ Aeson.encode tx)
       )]
-    getBlocTransactionResult' chainId hash resolve
+    getBlocTransactionResult' chainId [hash] resolve
 
 postUsersContract :: UserName -> Address -> Maybe ChainId -> Bool -> PostUsersContractRequest -> Bloc BlocTransactionResult
 postUsersContract userName addr chainId resolve
@@ -240,7 +241,7 @@ postUsersContract' ContractParameters{..} sign = blocTransaction $ do
     , constant (1 :: Int32)
     , constant contractdetailsName
     )]
-  getBlocTransactionResult' chainId hash resolve
+  getBlocTransactionResult' chainId [hash] resolve
 
 postUsersUploadList :: UserName -> Address -> Maybe ChainId -> Bool -> UploadListRequest -> Bloc [BlocTransactionResult]
 postUsersUploadList userName addr chainId resolve (UploadListRequest pw contracts _resolve) = do
@@ -505,7 +506,7 @@ postUsersContractMethod' FunctionParameters{..} sign = do
       , constant (2 :: Int32)
       , constant funcName
       )]
-    getBlocTransactionResult' chainId hash resolve
+    getBlocTransactionResult' chainId [hash] resolve
 
 data TRD = TRD -- transaction resolution data
        { trdStatus :: BlocTransactionStatus
@@ -534,11 +535,14 @@ data BatchState = BatchState
 emptyBatchState :: BatchState
 emptyBatchState = BatchState [] Map.empty Map.empty Map.empty Map.empty
 
-getBlocTransactionResult' :: Maybe ChainId -> Keccak256 -> Bool -> Bloc BlocTransactionResult
-getBlocTransactionResult' chainId hash resolve =
+getBlocTransactionResult' :: Maybe ChainId -> [Keccak256] -> Bool -> Bloc BlocTransactionResult
+getBlocTransactionResult' _ [] _ = throwError $ AnError "getBlockTransactionResult': no TX hashes"
+getBlocTransactionResult' chainId hashes@(txh:_) resolve =
   if resolve
-    then (getBlocTransactionResult hash chainId True)
-    else return (BlocTransactionResult Pending hash Nothing Nothing)
+    then do
+      promises <- forM hashes $ \h -> async (getBlocTransactionResult h chainId True)
+      snd <$> waitAny promises
+    else return $ BlocTransactionResult Pending txh Nothing Nothing
 
 getBlocTransactionResult :: Keccak256 -> Maybe ChainId -> Bool -> Bloc BlocTransactionResult
 getBlocTransactionResult hash chainId resolve = fmap head $ postBlocTransactionResults chainId resolve [hash]

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/API.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/API.hs
@@ -100,7 +100,7 @@ type API =
     :> Get '[JSON] [Storage]
   :<|> "faucet"
     :> ReqBody '[FormUrlEncoded] Address
-    :> Post '[PlainText] Keccak256
+    :> Post '[JSON] [Keccak256]
   :<|> "chain"
     :> ReqBody '[JSON] ChainInfo
     :> Post '[JSON] ChainId

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
@@ -20,7 +20,6 @@ module BlockApps.Strato.Types
   , ChainId (..)
   , Keccak256 (..)
   , WithNext (..)
-  , FaucetResponse(..)
   , TransactionType (..)
   , Transaction (..)
   , TransactionResult (..)
@@ -46,7 +45,6 @@ import           Data.Aeson
 import           Data.Aeson.Casing
 import           Data.Aeson.Casing.Internal   (dropFPrefix)
 import qualified Data.Binary                  as Binary
-import qualified Data.ByteString.Lazy         as Lazy
 import qualified Data.HashMap.Strict          as HashMap
 import           Data.LargeWord
 import           Data.List.NonEmpty           (NonEmpty)
@@ -59,7 +57,6 @@ import qualified Data.Swagger                 as Sw
 import           Data.Swagger.Internal.Schema (named, sketchSchema)
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
-import qualified Data.Text.Encoding           as Text
 import           Data.Time
 import           Data.Word
 import qualified Generic.Random               as GR
@@ -78,8 +75,6 @@ import           BlockApps.Ethereum           (Hex (..), Address (..), ChainId (
                                                AccountInfo(..), CodeInfo(..),
                                                stringChainId)
 import           BlockApps.Strato.TypeLits
-
-newtype FaucetResponse = FaucetResponse Text deriving (Eq, Generic, Show)
 
 instance (ToHttpApiData a) => ToHttpApiData [a] where
   toUrlPiece = Text.pack . show . map toUrlPiece
@@ -114,11 +109,6 @@ instance ToSchema x => ToSchema (Strung x) where
 
 instance ToSchema x => ToSchema (NonEmpty x) where
   declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy x)
-
-instance ToSchema FaucetResponse where
-  declareNamedSchema proxy = genericDeclareNamedSchema stratoSchemaOptions proxy
-    & mapped.schema.description ?~ "A faucet response url"
-    & mapped.schema.example     ?~ "/account?address=00000000000000000000000000000000deadbeef"
 
 instance ToSchema Transaction where
   declareNamedSchema proxy = genericDeclareNamedSchema stratoSchemaOptions proxy
@@ -403,19 +393,6 @@ instance FromJSON Storage where
 
 instance ToJSON Storage where
   toJSON = genericToJSON (aesonPrefix camelCase)
-
-instance FromJSON FaucetResponse where
-  parseJSON = fmap FaucetResponse . parseJSON
-instance ToJSON FaucetResponse where
-  toJSON (FaucetResponse x) = toJSON x
-
-instance MimeUnrender PlainText FaucetResponse where
-  mimeUnrender _ =
-    return . FaucetResponse . Text.decodeUtf8 . Lazy.toStrict
-
-instance MimeRender PlainText FaucetResponse where
-  mimeRender _ (FaucetResponse x) =
-    Lazy.fromStrict $ Text.encodeUtf8 x
 
 data AbiBin = AbiBin
   { abi        :: Text

--- a/blockapps-haskell/strato/client/src/BlockApps/Strato/Client.hs
+++ b/blockapps-haskell/strato/client/src/BlockApps/Strato/Client.hs
@@ -128,7 +128,7 @@ getAccountsFilter :: AccountsFilterParams -> ClientM [Account]
 getDifficulty :: ClientM Difficulty
 getTotalTx :: ClientM TxCount
 getStorage :: StorageFilterParams -> ClientM [Storage]
-postFaucet :: Address -> ClientM Keccak256
+postFaucet :: Address -> ClientM [Keccak256]
 postChain :: ChainInfo -> ClientM ChainId
 getChain :: [ChainId] -> ClientM [ChainIdChainInfo]
 getTxsFilter
@@ -175,7 +175,7 @@ getTxsFilter
       :<|> getTotalTx'
       :<|> getStorage'
       :<|> postFaucet'
-      :<|> postChain' 
+      :<|> postChain'
       :<|> getChain' =
         client (Proxy @ API)
     uncurryTxsFilterParams f TxsFilterParams{..} = f

--- a/core-strato/ethereum-vm/src/Blockchain/Bagger/TransactionList.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/Bagger/TransactionList.hs
@@ -35,7 +35,7 @@ insertTransaction t tl =
         oldTx  = M.lookup nonce' tl in
             case oldTx of
                 Nothing -> (Nothing, M.insert nonce' t tl)
-                Just existing -> if gasPrice existing >= gasPrice t
+                Just existing -> if gasPrice existing < gasPrice t
                     then (oldTx, M.insert nonce' t tl)
                     else (Just t, tl)
 

--- a/core-strato/run_unit_tests.sh
+++ b/core-strato/run_unit_tests.sh
@@ -12,6 +12,7 @@ TESTS=(
   ethereum-rlp
   ethereum-vm
   merkle-patricia-db
+  strato-api:unittests
   strato-genesis
   strato-init
   strato-p2p

--- a/core-strato/run_unit_tests_long.sh
+++ b/core-strato/run_unit_tests_long.sh
@@ -10,6 +10,7 @@ TESTS=(
   ethereum-discovery
   ethereum-vm
   merkle-patricia-db
+  strato-api:unittests
   strato-genesis
   strato-init
   strato-p2p

--- a/core-strato/strato-api/package.yaml
+++ b/core-strato/strato-api/package.yaml
@@ -121,3 +121,13 @@ tests:
       - hspec-expectations
       - case-insensitive
       - QuickCheck
+
+  unittests:
+    main: Spec.hs
+    source-dirs: unittest
+    dependencies:
+      - strato-api
+      - hspec-core
+      - hspec-expectations-lifted
+      - lifted-async
+      - classy-prelude

--- a/core-strato/strato-api/src/Application.hs
+++ b/core-strato/strato-api/src/Application.hs
@@ -60,6 +60,7 @@ makeFoundation appSettings = do
 
     appHttpManager <- newManager
     appLogger <- newStdoutLoggerSet defaultBufSize >>= makeYesodLogger
+    appFaucetNonce <- newIORef (-1)
 
     -- We need a log function to create a connection pool. We need a connection
     -- pool to create our foundation. And we need our foundation to get a

--- a/core-strato/strato-api/src/Application.hs
+++ b/core-strato/strato-api/src/Application.hs
@@ -60,7 +60,7 @@ makeFoundation appSettings = do
 
     appHttpManager <- newManager
     appLogger <- newStdoutLoggerSet defaultBufSize >>= makeYesodLogger
-    appFaucetNonce <- newIORef (-1)
+    appFaucetNonce <- initialMaxNonce
 
     -- We need a log function to create a connection pool. We need a connection
     -- pool to create our foundation. And we need our foundation to get a

--- a/core-strato/strato-api/src/Foundation.hs
+++ b/core-strato/strato-api/src/Foundation.hs
@@ -44,15 +44,16 @@ data App = App
     , appFaucetNonce :: IORef Integer -- The last maximum nonce given out
     }
 
+initialMaxNonce :: MonadIO m => m (IORef Integer)
+initialMaxNonce = liftIO $ newIORef (-1)
+
 acquireNewMaxNonce :: (MonadIO m, MonadReader App m) => Integer -> m Integer
 acquireNewMaxNonce minNonce = do
   let findNext :: Integer -> (Integer, Integer)
-      -- If this is the first nonce after startup, use the nonce from postgres
-      -- Another node may have jumped ahead of our faucet stream, so
+      -- Another node may have jumped ahead of our faucet stream or we may
+      -- just be starting up, so always give at least the minNonce.
       findNext maxNonce =
-        let next = if maxNonce == -1
-                     then minNonce
-                     else max minNonce $ 1 + maxNonce
+        let next = max minNonce $ 1 + maxNonce
         in (next, next)
   nref <- asks appFaucetNonce
   liftIO $ atomicModifyIORef' nref findNext

--- a/core-strato/strato-api/src/Foundation.hs
+++ b/core-strato/strato-api/src/Foundation.hs
@@ -41,7 +41,21 @@ data App = App
     , appConnPool    :: ConnectionPool -- ^ Database connection pool.
     , appHttpManager :: Manager
     , appLogger      :: Logger
+    , appFaucetNonce :: IORef Integer -- The last maximum nonce given out
     }
+
+acquireNewMaxNonce :: (MonadIO m, MonadReader App m) => Integer -> m Integer
+acquireNewMaxNonce minNonce = do
+  let findNext :: Integer -> (Integer, Integer)
+      -- If this is the first nonce after startup, use the nonce from postgres
+      -- Another node may have jumped ahead of our faucet stream, so
+      findNext maxNonce =
+        let next = if maxNonce == -1
+                     then minNonce
+                     else max minNonce $ 1 + maxNonce
+        in (next, next)
+  nref <- asks appFaucetNonce
+  liftIO $ atomicModifyIORef' nref findNext
 
 instance HasHttpManager App where
     getHttpManager = appHttpManager
@@ -49,6 +63,8 @@ instance HasHttpManager App where
 -- This is where we define all of the routes in our application. For a full
 -- explanation of the syntax, please see:
 -- http://www.yesodweb.com/book/routing-and-handlers
+--
+--
 --
 -- Note that this is really half the story; in Application.hs, mkYesodDispatch
 -- generates the rest of the code. Please see the linked documentation for an

--- a/core-strato/strato-api/src/Handler/Faucet.hs
+++ b/core-strato/strato-api/src/Handler/Faucet.hs
@@ -7,6 +7,7 @@ import qualified Data.Text                      as T
 import qualified Database.Esqueleto             as E
 import qualified Network.Haskoin.Crypto         as H
 import qualified Prelude                        as P
+import Text.Printf
 
 import           Blockchain.Constants
 import           Blockchain.Data.Address
@@ -16,8 +17,9 @@ import           Blockchain.EthConf             (runKafkaConfigured)
 import           Blockchain.Sequencer.Event     (IngestEvent (IETx), IngestTx (..))
 import           Blockchain.Sequencer.Kafka     (writeUnseqEvents)
 import           Blockchain.Strato.Model.Class
-import           Blockchain.Strato.Model.SHA
+import           Blockchain.Strato.Model.Format
 import           Blockchain.Util                (getCurrentMicrotime)
+import           Data.List                      (nub)
 import           Handler.Common
 import           Handler.Filters
 import           Import
@@ -45,14 +47,14 @@ emitKafkaTransactions :: (MonadIO m, MonadLogger m) => [Transaction] -> m ()
 emitKafkaTransactions txs = do
     ts <- liftIO $ getCurrentMicrotime
     let ingestTxs = (\t -> IETx ts (IngestTx API t)) <$> txs
-    $logDebugS "writeUnseqEventsBegin" . T.pack $ "Writing " ++ (show $ length ingestTxs) ++ " faucet tx(s) to unseqevents"    
+    $logDebugS "writeUnseqEventsBegin" . T.pack $ "Writing " ++ (show $ length ingestTxs) ++ " faucet tx(s) to unseqevents"
     rets <- liftIO $ runKafkaConfigured "strato-api" $ writeUnseqEvents ingestTxs
     case rets of
         Left e      -> $logError $ "Could not write txs to Kafka: " Import.++ (T.pack $ show e)
         Right resps -> $logDebug $ "writeUnseqEventsEnd Kafka commit: " Import.++ (T.pack $ show resps)
     return ()
 
-postFaucetR :: Handler Text
+postFaucetR :: Handler Value
 postFaucetR = do
   addHeader "Access-Control-Allow-Origin" "*"
 
@@ -60,32 +62,39 @@ postFaucetR = do
   key' <- maybe (invalidArgs ["No faucet account is defined"]) return key
   liftIO $ putStrLn $ T.pack $ show key'
 
-  nonce <- lookupNonce $ prvKey2Address key'
+  minNonce <- lookupNonce $ prvKey2Address key'
 
-  maybeVal <- lookupPostParam "address"
-  liftIO $ putStrLn $ T.pack $ show maybeVal
-  case maybeVal of
-    Just val -> putTX key' val nonce
+  mAddr <- lookupPostParam "address"
+  toJSON <$> case fmap toAddr mAddr of
+    Just target -> do
+      maxNonce <- acquireNewMaxNonce minNonce
+      $logInfoS "postFaucetR" . T.pack $ printf "%s: [min..max]=[%d,%d]" (format target) minNonce maxNonce
+      mapM (putTX maxNonce key' target) $ nub [maxNonce, minNonce]
     Nothing -> do
       maybeAddrs <- lookupPostParam "addresses"
       liftIO $ putStrLn $ T.pack $ show maybeAddrs
       case maybeAddrs of
         Just addrTLT -> do
           let addrTL = P.read $ T.unpack $ addrTLT
-          faucets <- sequence $ zipWith (putTX key') addrTL $ map (nonce +) [0..]
-          return $ T.pack $ show $ map T.unpack faucets
+          -- TODO(tim): Find a multiple nonce strategy for multiple addresses
+          sequence . zipWith (putTX minNonce key') addrTL $ map (minNonce +) [0..]
         Nothing -> invalidArgs ["Missing 'address' or 'addresses'"]
   where
-    makeTX k a n = do
+    makeTX maxN k a n = do
+      -- We use a declining gas schedule to prevent ejecting faucets that
+      -- might more urgently need a nonce. For example, if faucet(y) is
+      -- given [n] and faucet(x) is given [n, n+1], x's faucet
+      -- should only take nonce n if y's faucet fails. In turn, faucet(z)
+      -- with [n, n+1, n+2] has highest priority for n+2, second priority for n+1,
+      -- and will only take n if both faucet(x) and faucet(y) don't.
+      let gasPrice = 50000000000 - 100000 * (maxN - n)
       liftIO $ putStrLn $ T.pack $ "nonce: " ++ (show n)
-      tx <- liftIO $ H.withSource H.devURandom (createMessageTX n (50000000000) (100000) a (1000*ether) "" Nothing k)
+      tx <- liftIO . H.withSource H.devURandom $
+        createMessageTX n gasPrice 100000 a (1000*ether) "" Nothing k
       liftIO $ putStrLn $ T.pack $ "tx for faucet: " ++ (show tx)
       return tx
-    putTX k v n = do
-      tx <- makeTX k (toAddr v) n
+    putTX maxN k a n = do
+      tx <- makeTX maxN k a n
       _ <- insertTXIfNew API Nothing [tx]
       emitKafkaTransactions [tx]
-
-      return . T.pack . shaToHex . txHash $ tx
-
-
+      return $ txHash tx

--- a/core-strato/strato-api/unittest/Spec.hs
+++ b/core-strato/strato-api/unittest/Spec.hs
@@ -12,7 +12,7 @@ main = hspec spec
 
 runTestM :: ReaderT App IO () -> IO ()
 runTestM mv = do
-  ref <- newIORef (-1)
+  ref <- initialMaxNonce
   runReaderT mv App{appFaucetNonce = ref}
 
 spec :: Spec

--- a/core-strato/strato-api/unittest/Spec.hs
+++ b/core-strato/strato-api/unittest/Spec.hs
@@ -1,0 +1,34 @@
+{-# OPTIONS_GHC -fno-warn-missing-fields #-}
+import ClassyPrelude
+import Control.Concurrent.Async.Lifted
+import Foundation
+
+import Test.Hspec.Core.Runner
+import Test.Hspec.Core.Spec
+import Test.Hspec.Expectations.Lifted
+
+main :: IO ()
+main = hspec spec
+
+runTestM :: ReaderT App IO () -> IO ()
+runTestM mv = do
+  ref <- newIORef (-1)
+  runReaderT mv App{appFaucetNonce = ref}
+
+spec :: Spec
+spec = describe "acquireNewMaxNonce" $ do
+  it "allocates distinct" . runTestM $
+    replicateM 100 (acquireNewMaxNonce 0) `shouldReturn` [0..99]
+
+  it "will give a nonce larger than min nonce" . runTestM $
+    acquireNewMaxNonce 2007 `shouldReturn` 2007
+
+  it "is thread safe" . runTestM $ do
+    nonces <- replicateConcurrently 100 (acquireNewMaxNonce 100)
+    nonces `shouldMatchList` [100..199]
+
+  it "gives the minimum allowable" . runTestM $ do
+    acquireNewMaxNonce 400 `shouldReturn` 400
+    acquireNewMaxNonce 420 `shouldReturn` 420
+    acquireNewMaxNonce 420 `shouldReturn` 421
+    acquireNewMaxNonce 422 `shouldReturn` 422


### PR DESCRIPTION
As part of this, the output from /faucet is changed to always be a json list of tx hashes. I don't conisder this a breaking change, because `text/plain` shouldn't be relied upon as a stable format.

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/561