### PR TITLE
Prevent frequent disconnects in PBFT, regardless of round period

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -74,6 +74,9 @@ function newnode {
   if [ -n "${blockstanbulBlockPeriodMs}" ]; then
     bpFlag="--blockstanbul_block_period_ms=${blockstanbulBlockPeriodMs}"
   fi
+  if [ -n "${blockstanbulRoundPeriodS}" ]; then
+    rpFlag="--blockstanbul_round_period_s=${blockstanbulRoundPeriodS}"
+  fi
   if [ -n "${validators}" ]; then
     vsFlag="--validators=${validators}"
   fi

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -46,6 +46,10 @@ function newnode {
          withCushion=$(( 2 * blockstanbulRoundPeriodS ))
          actualTimeout=$(( actualTimeout > withCushion ? actualTimeout : withCushion ))
        fi
+       if [ -n "${validators}" ]; then
+         numValidators=$(( 1 + $( echo "${validators}" | tr -cd , | wc -c) ))
+         maxConn=$(( maxConn >= numValidators ? maxConn : numValidators ))
+       fi
        runBackgroundProcess strato-p2p-client \
           --connectionTimeout=$actualTimeout \
           --cNetworkID=$networkID \

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -20,8 +20,6 @@ function newnode {
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."
 
-  ctFlag="--connectionTimeout=${actualTimeout}"
-
   if $mineBlocks
   then echo "Starting strato-adit"
       aMiner=$miningAlgorithm

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -19,9 +19,8 @@ function newnode {
   fi
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."
-  if [ -n "${connectionTimeout}" ]; then
-    ctFlag="--connectionTimeout=${connectionTimeout}"
-  fi
+
+  ctFlag="--connectionTimeout=${actualTimeout}"
 
   if $mineBlocks
   then echo "Starting strato-adit"
@@ -42,7 +41,19 @@ function newnode {
 
   if $receiveBlocks
   then echo "Starting strato-p2p-client"
-       runBackgroundProcess strato-p2p-client $ctFlag --cNetworkID=$networkID --maxConn=$maxConn --sqlPeers=true --debugFail=${debugFail:-true} --maxReturnedHeaders=$maxReturnedHeaders >> logs/strato-p2p-client 2>&1
+       actualTimeout="${connectionTimeout:-300}"
+       if [ -n "${blockstanbulRoundPeriodS}" ]; then
+         withCushion=$(( 2 * blockstanbulRoundPeriodS ))
+         actualTimeout=$(( actualTimeout > withCushion ? actualTimeout : withCushion ))
+       fi
+       runBackgroundProcess strato-p2p-client \
+          --connectionTimeout=$actualTimeout \
+          --cNetworkID=$networkID \
+          --maxConn=$maxConn \
+          --sqlPeers=true \
+          --debugFail=${debugFail:-true}  \
+          --maxReturnedHeaders=$maxReturnedHeaders \
+          >> logs/strato-p2p-client 2>&1
   fi
 
   evmMinLogLevel=LevelInfo
@@ -60,9 +71,6 @@ function newnode {
   fi
   if [ -n "${blockstanbulBlockPeriodMs}" ]; then
     bpFlag="--blockstanbul_block_period_ms=${blockstanbulBlockPeriodMs}"
-  fi
-  if [ -n "${blockstanbulRoundPeriodS}" ]; then
-    rpFlag="--blockstanbul_round_period_s=${blockstanbulRoundPeriodS}"
   fi
   if [ -n "${validators}" ]; then
     vsFlag="--validators=${validators}"

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -125,6 +125,7 @@ services:
     - blockstanbulRoundPeriodS=${blockstanbulRoundPeriodS}
     - blockTime=${blockTime}
     - bootnode=${bootnode}
+    - maxConn=${maxConn}
     - connectionTimeout=${connectionTimeout}
     - debugFail=${debugFail}
     - evmDebugMode=${evmDebugMode}


### PR DESCRIPTION
No blockstanbulRoundPeriodS: 
`strato-p2p-client --connectionTimeout=300 --cNetworkID=6 --maxConn=20 --sqlPeers=true --debugFail=true --maxReturnedHeaders=1000`

blockstanbulRoundPeriodS = 100: (no change expected);
`strato-p2p-client --connectionTimeout=300 --cNetworkID=6 --maxConn=20 --sqlPeers=true --debugFail=true --maxReturnedHeaders=1000`

blockstanbulRoundPeriodS = 200: 
`strato-p2p-client --connectionTimeout=400 --cNetworkID=6 --maxConn=20 --sqlPeers=true --debugFail=true --maxReturnedHeaders=1000`