### PR TITLE
Provide a dataFaucet from strato-api

### DIFF
--- a/core-strato/strato-api/config/routes.txt
+++ b/core-strato/strato-api/config/routes.txt
@@ -1,4 +1,5 @@
 /eth/v1.2/chain ChainR GET POST
+/eth/v1.2/dataFaucet DataFaucetR POST
 /eth/v1.2/faucet FaucetR POST
 /eth/v1.2/stats/difficulty StatDiffR GET
 /eth/v1.2/stats/totaltx StatTxR GET

--- a/core-strato/strato-api/src/Handler/Faucet.hs
+++ b/core-strato/strato-api/src/Handler/Faucet.hs
@@ -2,6 +2,7 @@
 
 module Handler.Faucet where
 
+import qualified Control.Monad                  as CM
 import qualified Data.Binary                    as BN
 import qualified Data.Text                      as T
 import qualified Database.Esqueleto             as E
@@ -11,89 +12,118 @@ import Text.Printf
 
 import           Blockchain.Constants
 import           Blockchain.Data.Address
+import           Blockchain.Data.Code
 import           Blockchain.Data.Transaction
 import           Blockchain.Data.TXOrigin
+import           Blockchain.DB.SQLDB
 import           Blockchain.EthConf             (runKafkaConfigured)
 import           Blockchain.Sequencer.Event     (IngestEvent (IETx), IngestTx (..))
 import           Blockchain.Sequencer.Kafka     (writeUnseqEvents)
 import           Blockchain.Strato.Model.Class
 import           Blockchain.Strato.Model.Format
+import           Blockchain.Strato.Model.SHA
 import           Blockchain.Util                (getCurrentMicrotime)
 import           Data.List                      (nub)
 import           Handler.Common
 import           Handler.Filters
 import           Import
 
+import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as BL
 
-retrievePrvKey :: FilePath -> IO (Maybe H.PrvKey)
-retrievePrvKey path = do
-  keyBytes <- readFile path
-  let intVal = BN.decode $ BL.fromStrict $ keyBytes :: Integer
-  return $ H.makePrvKey intVal
-
+getKey :: Handler H.PrvKey
+getKey = do
+  mKey <- fmap (H.makePrvKey . BN.decode . BL.fromStrict)
+        . liftIO . readFile $ "config" </> "priv"
+  case mKey of
+    Nothing -> invalidArgs ["No faucet account is defined"]
+    Just k -> return k
 
 lookupNonce :: (YesodPersist site, YesodPersistBackend site ~ SqlBackend) => Address -> HandlerT site IO Integer
 lookupNonce addr' = do
   addrSt <- runDB $ E.select $
-                      E.from $ \(accStateRef) -> do
-                      E.where_ ((E.isNothing $ accStateRef E.^. AddressStateRefChainId) E.&&. accStateRef E.^. AddressStateRefAddress E.==. (E.val addr'))
+                      E.from $ \accStateRef -> do
+                      E.where_ (E.isNothing (accStateRef E.^. AddressStateRefChainId)
+                         E.&&. accStateRef E.^. AddressStateRefAddress E.==. E.val addr')
                       return accStateRef
-  case addrSt of
-    []      -> return 0
-    addrSt' -> return $ addressStateRefNonce $ E.entityVal $ P.head $ addrSt'
+  return $ case addrSt of
+    []      -> 0
+    n:_ -> addressStateRefNonce $ E.entityVal n
 
 emitKafkaTransactions :: (MonadIO m, MonadLogger m) => [Transaction] -> m ()
 emitKafkaTransactions txs = do
-    ts <- liftIO $ getCurrentMicrotime
-    let ingestTxs = (\t -> IETx ts (IngestTx API t)) <$> txs
-    $logDebugS "writeUnseqEventsBegin" . T.pack $ "Writing " ++ (show $ length ingestTxs) ++ " faucet tx(s) to unseqevents"
+    ts <- liftIO getCurrentMicrotime
+    let ingestTxs = (IETx ts . IngestTx API)  <$> txs
+    $logDebugS "writeUnseqEventsBegin" . T.pack $ "Writing " ++ show (length ingestTxs) ++ " faucet tx(s) to unseqevents"
     rets <- liftIO $ runKafkaConfigured "strato-api" $ writeUnseqEvents ingestTxs
     case rets of
-        Left e      -> $logError $ "Could not write txs to Kafka: " Import.++ (T.pack $ show e)
-        Right resps -> $logDebug $ "writeUnseqEventsEnd Kafka commit: " Import.++ (T.pack $ show resps)
+        Left e      -> $logError $ "Could not write txs to Kafka: " Import.++ T.pack (show e)
+        Right resps -> $logDebug $ "writeUnseqEventsEnd Kafka commit: " Import.++ T.pack (show resps)
     return ()
+
+emitTransaction :: (MonadIO m, MonadLogger m, HasSQLDB m) => Transaction -> m SHA
+emitTransaction tx = do
+  emitKafkaTransactions [tx]
+  return $ txHash tx
 
 postFaucetR :: Handler Value
 postFaucetR = do
   addHeader "Access-Control-Allow-Origin" "*"
 
-  key <- liftIO $ retrievePrvKey $ "config" </> "priv"
-  key' <- maybe (invalidArgs ["No faucet account is defined"]) return key
-  liftIO $ putStrLn $ T.pack $ show key'
-
-  minNonce <- lookupNonce $ prvKey2Address key'
+  key <- getKey
+  minNonce <- lookupNonce $ prvKey2Address key
 
   mAddr <- lookupPostParam "address"
   toJSON <$> case fmap toAddr mAddr of
     Just target -> do
       maxNonce <- acquireNewMaxNonce minNonce
       $logInfoS "postFaucetR" . T.pack $ printf "%s: [min..max]=[%d,%d]" (format target) minNonce maxNonce
-      mapM (putTX maxNonce key' target) $ nub [maxNonce, minNonce]
+      mapM (putTX maxNonce key target) $ nub [maxNonce, minNonce]
     Nothing -> do
       maybeAddrs <- lookupPostParam "addresses"
       liftIO $ putStrLn $ T.pack $ show maybeAddrs
       case maybeAddrs of
         Just addrTLT -> do
-          let addrTL = P.read $ T.unpack $ addrTLT
+          let addrTL = P.read $ T.unpack addrTLT
           -- TODO(tim): Find a multiple nonce strategy for multiple addresses
-          sequence . zipWith (putTX minNonce key') addrTL $ map (minNonce +) [0..]
+          sequence . zipWith (putTX minNonce key) addrTL $ map (minNonce +) [0..]
         Nothing -> invalidArgs ["Missing 'address' or 'addresses'"]
-  where
-    makeTX maxN k a n = do
-      -- We use a declining gas schedule to prevent ejecting faucets that
-      -- might more urgently need a nonce. For example, if faucet(y) is
-      -- given [n] and faucet(x) is given [n, n+1], x's faucet
-      -- should only take nonce n if y's faucet fails. In turn, faucet(z)
-      -- with [n, n+1, n+2] has highest priority for n+2, second priority for n+1,
-      -- and will only take n if both faucet(x) and faucet(y) don't.
-      let gasPrice = 50000000000 - 100000 * (maxN - n)
-      liftIO $ putStrLn $ T.pack $ "nonce: " ++ (show n)
-      tx <- liftIO . H.withSource H.devURandom $
-        createMessageTX n gasPrice 100000 a (1000*ether) "" Nothing k
-      liftIO $ putStrLn $ T.pack $ "tx for faucet: " ++ (show tx)
-      return tx
-    putTX maxN k a n = do
-      tx <- makeTX maxN k a n
-      emitKafkaTransactions [tx]
-      return $ txHash tx
+    where
+      putTX maxN k a = emitTransaction <=< makeSendTX maxN k a
+
+readInt :: Int -> Maybe Text -> Int
+readInt defaultVal = fromMaybe defaultVal . fmap (P.read . T.unpack)
+
+postDataFaucetR :: Handler Value
+postDataFaucetR = do
+  addHeader "Access-Control-Allow-Origin" "*"
+  key <- getKey
+  minNonce <- lookupNonce $ prvKey2Address key
+  size <- readInt 4096 <$> lookupPostParam "size"
+  countOf <- readInt 1 <$> lookupPostParam "count" :: Handler Int
+  fmap toJSON . CM.replicateM countOf $ do
+    maxN <- acquireNewMaxNonce minNonce
+    tx <- makeSizedTX maxN size key
+    emitTransaction tx
+
+makeSendTX :: MonadIO m => Integer -> H.PrvKey -> Address -> Integer -> m Transaction
+makeSendTX maxN k a n = do
+  -- We use a declining gas schedule to prevent ejecting faucets that
+  -- might more urgently need a nonce. For example, if faucet(y) is
+  -- given [n] and faucet(x) is given [n, n+1], x's faucet
+  -- should only take nonce n if y's faucet fails. In turn, faucet(z)
+  -- with [n, n+1, n+2] has highest priority for n+2, second priority for n+1,
+  -- and will only take n if both faucet(x) and faucet(y) don't.
+  let gasPrice = 50000000000 - 100000 * (maxN - n)
+  liftIO . H.withSource H.devURandom $
+    createMessageTX n gasPrice 100000 a (1000*ether) "" Nothing k
+
+
+makeSizedTX :: MonadIO m => Integer -> Int -> H.PrvKey -> m Transaction
+makeSizedTX nonce size pk =
+  let code = Code $ BS.replicate size 0x0
+      gasPrice = 50000000000
+      gasLimit = 100000
+      val = 0
+      mk = createContractCreationTX nonce gasPrice gasLimit val code Nothing pk
+  in liftIO . H.withSource H.devURandom $ mk

--- a/core-strato/strato-api/src/Handler/Faucet.hs
+++ b/core-strato/strato-api/src/Handler/Faucet.hs
@@ -119,6 +119,8 @@ makeSendTX maxN k a n = do
     createMessageTX n gasPrice 100000 a (1000*ether) "" Nothing k
 
 
+-- TODO(tim): Add a queryparam for contracts with variable length bin-runtimes, rather
+-- than these that have empty bin-runtimes.
 makeSizedTX :: MonadIO m => Integer -> Int -> H.PrvKey -> m Transaction
 makeSizedTX nonce size pk =
   let code = Code $ BS.replicate size 0x0


### PR DESCRIPTION
I've tested it with `curl -F "size=4096" http://localhost/strato-api/eth/v1.2/dataFaucet` and `curl -F "size=4096" -F "count=100" http://localhost/strato-api/eth/v1.2/dataFaucet`: (3 individual faucets are the first block, the next blocks are the pieces of the 100 txs):

```
select block_number, count(*) from raw_transaction group by block_number order by block_number;
 block_number | count
--------------+-------
            1 |     1
            2 |     1
            3 |     1
            4 |     2
            5 |     2
            6 |    10
            7 |    10
            8 |     7
            9 |     8
           10 |     9
           11 |    17
           12 |    13
           13 |    22
(13 rows)

```

```
eth_f048efd7be051d618c17c710ead0ccb26a2db0e3=# select octet_length(code_or_data), count(*) from raw_transaction group by octet_length(code_or_data);
 octet_length | count
--------------+-------
         4096 |   103
(1 row)


eth_f048efd7be051d618c17c710ead0ccb26a2db0e3=# select count(*) from raw_transaction where block_number=-1;
 count
-------
     0
(1 row)
```