### PR TITLE
Src cache

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Create.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Create.hs
@@ -55,7 +55,8 @@ contractsSourceTable = [sql|
 CREATE TABLE IF NOT EXISTS contracts_source(
   id serial PRIMARY KEY,
   src_hash bytea NOT NULL,
-  src text NOT NULL
+  src text NOT NULL,
+  deployed boolean NOT NULL
 );
 |]
 

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Migration.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Migration.hs
@@ -39,6 +39,7 @@ migrations = [ (Throw, createTables)
              , (Throw, addChainIdColumn)
              , (Throw, contractsSourceTable)
              , (Throw, addSrcHashColumn)
+             , (Throw, addDeployedColumn)
              ]
 
 getSchemaVersion :: Query
@@ -68,3 +69,6 @@ addChainIdColumn = [sql| ALTER TABLE contracts_instance ADD COLUMN IF NOT EXISTS
 
 addSrcHashColumn :: Query
 addSrcHashColumn = [sql| ALTER TABLE contracts_metadata ADD COLUMN IF NOT EXISTS src_hash bytea; |]
+
+addDeployedColumn :: Query
+addDeployedColumn = [sql| ALTER TABLE contracts_source ADD COLUMN IF NOT EXISTS deployed boolean default FALSE;; |]

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -964,12 +964,12 @@ getContractDetails contract@(ContractName contractName) contractId chainId = do
             getContractsContractByNameQuery contractName name
           return $ detailsWith (Just (Named name)) chainId tuple
 
-getContractDetailsByCodeHash :: Keccak256 -> Bloc (Maybe (Int32, ContractDetails))
+getContractDetailsByCodeHash :: Keccak256 -> Bloc (Maybe (Keccak256,(Int32, ContractDetails)))
 getContractDetailsByCodeHash codeHash = do
     mDetails <- fmap listToMaybe . blocQuery $ getContractsContractByCodeHashQuery codeHash
-    for mDetails $ \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId) -> do
+    for mDetails $ \(bin,binr,ch,_ :: ByteString,srcHash,name,src,cmId) -> do
       xabi <- getContractXabiByMetadataId cmId
-      return (cmId, ContractDetails
+      return (srcHash,(cmId, ContractDetails
         { contractdetailsBin = Text.decodeUtf8 bin
         , contractdetailsAddress = Nothing
         , contractdetailsBinRuntime = Text.decodeUtf8 binr
@@ -978,7 +978,7 @@ getContractDetailsByCodeHash codeHash = do
         , contractdetailsSrc = src
         , contractdetailsXabi = xabi
         , contractdetailsChainId = Nothing
-        })
+        }))
 
 {- |
 WITH contract_id AS (
@@ -1003,18 +1003,18 @@ createContractQuery contractName = do
       [(Nothing, constant contractName)]
       fst
 
-isDeployedQuery :: Text -> Query (Column PGBool) -- TODO: is it more efficient to
-isDeployedQuery contractSrc = proc () -> do      --       compare source hash?
-  (_,_,src,deployed) <- queryTable contractsSourceTable -< ()
-  restrict -< src .== constant contractSrc
+isDeployedQuery :: Keccak256 -> Query (Column PGBool)
+isDeployedQuery srcHash = proc () -> do
+  (_,sh,_,deployed) <- queryTable contractsSourceTable -< ()
+  restrict -< sh .== constant srcHash
   returnA -< deployed
 
-setDeployedQuery :: Text -> Bloc Int64
-setDeployedQuery contractSrc = do
+setDeployedQuery :: Keccak256 -> Bloc Int64
+setDeployedQuery srcHash = do
   blocModify $ \conn ->
     runUpdateEasy conn contractsSourceTable
       (\(sid,sh,src,_) -> (sid,sh,src, constant True))
-      (\(_,_,src,_) -> src .== constant contractSrc)
+      (\(_,sh,_,_) -> sh .== constant srcHash)
 
 insertContractSourceQuery
   :: Text
@@ -1262,24 +1262,30 @@ insertContractInstance cmId address chainId = blocModify1 $ \conn -> runInsertMa
   ]
   (\ (contractInstanceId,_,_,_,_) -> contractInstanceId)
 
-compileContract :: Text -> Bloc (Map Text (Int32, ContractDetails))
+compileContract :: Text -> Bloc (Keccak256, Map Text (Int32, ContractDetails))
 compileContract source = do
-  details <- blocQuery . contractBySourceHash . keccak256 $ Text.encodeUtf8 source
-  if null details
-    then compileContractFromScratch source
-    else fmap Map.fromList . forM details $
-      \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId) -> do
-        xabi <- getContractXabiByMetadataId cmId
-        return (name,(cmId, ContractDetails
-          { contractdetailsBin = Text.decodeUtf8 bin
-          , contractdetailsAddress = Nothing
-          , contractdetailsBinRuntime = Text.decodeUtf8 binr
-          , contractdetailsCodeHash = ch
-          , contractdetailsName = name
-          , contractdetailsSrc = src
-          , contractdetailsXabi = xabi
-          , contractdetailsChainId = Nothing
-          }))
+  let srcHash = keccak256 $ Text.encodeUtf8 source
+  details <- detailsFromSourceHash srcHash
+  (srcHash,) <$> if Map.null details
+                   then compileContractFromScratch source
+                   else return details
+
+detailsFromSourceHash :: Keccak256 -> Bloc (Map Text (Int32, ContractDetails))
+detailsFromSourceHash srcHash = do
+  details <- blocQuery $ contractBySourceHash srcHash
+  fmap Map.fromList . forM details $
+    \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId) -> do
+      xabi <- getContractXabiByMetadataId cmId
+      return (name,(cmId, ContractDetails
+        { contractdetailsBin = Text.decodeUtf8 bin
+        , contractdetailsAddress = Nothing
+        , contractdetailsBinRuntime = Text.decodeUtf8 binr
+        , contractdetailsCodeHash = ch
+        , contractdetailsName = name
+        , contractdetailsSrc = src
+        , contractdetailsXabi = xabi
+        , contractdetailsChainId = Nothing
+        }))
 
 compileContractFromScratch :: Text -> Bloc (Map Text (Int32, ContractDetails))
 compileContractFromScratch source = do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -163,8 +163,8 @@ contractsJoinTable = joinF
     (\ (_,n) (cmId,_,b,br,ch,xch,src) -> (cmId,n,src,b,br,ch,xch))
     (\ (cid,_) (_,contractId,_,_,_,_,_) -> cid .== contractId)
     (queryTable contractsTable) $ joinF
-      (\ (cmId,cid,b,br,ch,xch,_) (_,_,src) -> (cmId,cid,b,br,ch,xch,src))
-      (\ (_,_,_,_,_,_,sh) (_,sh',_) -> sh .== sh')
+      (\ (cmId,cid,b,br,ch,xch,_) (_,_,src,_) -> (cmId,cid,b,br,ch,xch,src))
+      (\ (_,_,_,_,_,_,sh) (_,sh',_,_) -> sh .== sh')
       (queryTable contractsMetaDataTable)
       (queryTable contractsSourceTable)
 
@@ -182,8 +182,8 @@ contractDetailsJoinTable = joinF
   (\ (_,name) (cmId,_,b,br,ch,xch,sh,src) -> (b,br,ch,xch,sh,name,src,cmId))
   (\ (cId,_) (_,contractId,_,_,_,_,_,_) -> cId .== contractId)
   (queryTable contractsTable) $ joinF
-    (\ (cmId,cid,b,br,ch,xch,sh) (_,_,src) -> (cmId,cid,b,br,ch,xch,sh,src))
-    (\ (_,_,_,_,_,_,sh) (_,sh',_) -> sh .== sh')
+    (\ (cmId,cid,b,br,ch,xch,sh) (_,_,src,_) -> (cmId,cid,b,br,ch,xch,sh,src))
+    (\ (_,_,_,_,_,_,sh) (_,sh',_,_) -> sh .== sh')
     (queryTable contractsMetaDataTable)
     (queryTable contractsSourceTable)
 
@@ -309,8 +309,8 @@ linkedContractsJoinTable = joinF
         (\ (_,name) (cmId,_,b,br,ch,xch,src) -> (name,src,cmId,b,br,ch,xch))
         (\ (cid,_) (_,contractId,_,_,_,_,_) -> cid .== contractId)
         (queryTable contractsTable) $ joinF
-          (\ (cmId,cid,b,br,ch,xch,_) (_,_,src)-> (cmId,cid,b,br,ch,xch,src))
-          (\ (_,_,_,_,_,_,sh) (_,sh',_)-> sh .== sh')
+          (\ (cmId,cid,b,br,ch,xch,_) (_,_,src,_)-> (cmId,cid,b,br,ch,xch,src))
+          (\ (_,_,_,_,_,_,sh) (_,sh',_,_)-> sh .== sh')
           (queryTable contractsMetaDataTable)
           (queryTable contractsSourceTable)
 
@@ -996,6 +996,19 @@ createContractQuery contractName = do
       [(Nothing, constant contractName)]
       fst
 
+isDeployedQuery :: Text -> Query (Column PGBool)
+isDeployedQuery src = proc () -> do
+  let srcHash = (keccak256 $ Text.encodeUtf8 src)
+  (_,sh,_,deployed) <- queryTable contractsSourceTable -< ()
+  restrict -< sh .== constant srcHash
+  returnA -< deployed
+
+setDeployedQuery :: Keccak256 -> Bloc Int64
+setDeployedQuery srcHash = blocModify $ \conn ->
+  runUpdateEasy conn contractsSourceTable
+    (\(sid,sh,src,_) -> (sid,sh,src, constant True))
+    (\(_,sh,_,_) -> sh .== constant srcHash)
+
 insertContractSourceQuery
   :: Text
   -> Bloc (Int32, Keccak256)
@@ -1006,8 +1019,9 @@ insertContractSourceQuery src = do
       ( Nothing
       , constant srcHash
       , constant src
+      , constant False
       )]
-      (\ (csId,sh,_) -> (csId,sh))
+      (\ (csId,sh,_,_) -> (csId,sh))
 
 {- |
 Insert metadata into contract metadata table if metadata table does not contain codehash

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -155,15 +155,16 @@ contractsJoinTable :: Query
   , Column PGBytea
   , Column PGBytea
   , Column PGBytea
+  , Column PGBytea
   )
 contractsJoinTable = joinF
-  (\ (_,_,a,ts, cid) (cmId,n,src,b,br,ch,xch) -> (cmId,n,src,a,ts,b,br,ch,xch,cid))
-  (\ (_,contractmetadataId,_,_,_) (cmId,_,_,_,_,_,_) -> cmId .== contractmetadataId)
+  (\ (_,_,a,ts, cid) (cmId,n,src,b,br,ch,xch,sh) -> (cmId,n,src,a,ts,b,br,ch,xch,sh,cid))
+  (\ (_,contractmetadataId,_,_,_) (cmId,_,_,_,_,_,_,_) -> cmId .== contractmetadataId)
   (queryTable contractsInstanceTable) $ joinF
-    (\ (_,n) (cmId,_,b,br,ch,xch,src) -> (cmId,n,src,b,br,ch,xch))
-    (\ (cid,_) (_,contractId,_,_,_,_,_) -> cid .== contractId)
+    (\ (_,n) (cmId,_,b,br,ch,xch,sh,src) -> (cmId,n,src,b,br,ch,xch,sh))
+    (\ (cid,_) (_,contractId,_,_,_,_,_,_) -> cid .== contractId)
     (queryTable contractsTable) $ joinF
-      (\ (cmId,cid,b,br,ch,xch,_) (_,_,src,_) -> (cmId,cid,b,br,ch,xch,src))
+      (\ (cmId,cid,b,br,ch,xch,_) (_,sh,src,_) -> (cmId,cid,b,br,ch,xch,sh,src))
       (\ (_,_,_,_,_,_,sh) (_,sh',_,_) -> sh .== sh')
       (queryTable contractsMetaDataTable)
       (queryTable contractsSourceTable)
@@ -202,9 +203,10 @@ contractByAddress
     , Column PGBytea
     , Column PGBytea
     , Column PGBytea
+    , Column PGBytea
     )
 contractByAddress contractName contractAddress chainId = proc () -> do
-  contract@(_,name,_,addr,_,_,_,_,_,cid) <- contractsJoinTable -< ()
+  contract@(_,name,_,addr,_,_,_,_,_,_,cid) <- contractsJoinTable -< ()
   restrict -< name .== constant contractName
   restrict -< addr .== constant contractAddress
   restrict -< cid .== constant chainId
@@ -250,7 +252,7 @@ contractInstancesByCodeHash
   -> Maybe ChainId
   -> Query (Column PGInt4)
 contractInstancesByCodeHash codeHash address chainId = proc () -> do
-  (cmId,_,_,addr,_,_,_,ch,_,cid) <- contractsJoinTable -< ()
+  (cmId,_,_,addr,_,_,_,ch,_,_,cid) <- contractsJoinTable -< ()
   restrict -< ch .== constant codeHash
   restrict -< addr .== constant address
   restrict -< cid .== constant chainId
@@ -275,7 +277,7 @@ contractBySourceHash srcHash = proc () -> do
 
 contractNameFromAddress :: Address -> Maybe ChainId -> Query (Column PGText)
 contractNameFromAddress contractAddress chainId = proc () -> do
-  (_,name,_,addr,_,_,_,_,_,cid) <- contractsJoinTable -< ()
+  (_,name,_,addr,_,_,_,_,_,_,cid) <- contractsJoinTable -< ()
   restrict -< addr .== constant contractAddress
   restrict -< cid .== constant chainId
   returnA -< name
@@ -291,25 +293,26 @@ linkedContractsJoinTable :: Query
   , Column PGBytea
   , Column PGBytea
   , Column PGBytea
+  , Column PGBytea
   , Column PGText
   , Column PGText
   , Column PGText
   , Column PGInt4
   )
 linkedContractsJoinTable = joinF
-  (\ (_,name2) (name,src,cm2Id,_,b,br,ch,xch) -> (b,br,ch,xch,name,name2,src,cm2Id))
-  (\ (c2Id,_) (_,_,_,contractId2,_,_,_,_) -> c2Id .== contractId2)
+  (\ (_,name2) (name,src,cm2Id,_,b,br,ch,xch,sh) -> (b,br,ch,xch,sh,name,name2,src,cm2Id))
+  (\ (c2Id,_) (_,_,_,contractId2,_,_,_,_,_) -> c2Id .== contractId2)
   (queryTable contractsTable) $ joinF
-    (\ (cm2Id,contractId2,_,_,_,_,_) (name,src,_,b,br,ch,xch) -> (name,src,cm2Id,contractId2,b,br,ch,xch))
-    (\ (cm2Id,_,_,_,_,_,_) (_,_,linkedmetadataId,_,_,_,_) -> cm2Id .== linkedmetadataId)
+    (\ (cm2Id,contractId2,_,_,_,_,_) (name,src,_,b,br,ch,xch,sh) -> (name,src,cm2Id,contractId2,b,br,ch,xch,sh))
+    (\ (cm2Id,_,_,_,_,_,_) (_,_,linkedmetadataId,_,_,_,_,_) -> cm2Id .== linkedmetadataId)
     (queryTable contractsMetaDataTable) $ joinF
-      (\ (_,linkedmetadataId) (name,src,_,b,br,ch,xch) -> (name,src,linkedmetadataId,b,br,ch,xch))
-      (\ (contractmetadataId,_) (_,_,cmId,_,_,_,_) -> contractmetadataId .== cmId)
+      (\ (_,linkedmetadataId) (name,src,_,b,br,ch,xch,sh) -> (name,src,linkedmetadataId,b,br,ch,xch,sh))
+      (\ (contractmetadataId,_) (_,_,cmId,_,_,_,_,_) -> contractmetadataId .== cmId)
       (queryTable contractsLookupTable) $ joinF
-        (\ (_,name) (cmId,_,b,br,ch,xch,src) -> (name,src,cmId,b,br,ch,xch))
-        (\ (cid,_) (_,contractId,_,_,_,_,_) -> cid .== contractId)
+        (\ (_,name) (cmId,_,b,br,ch,xch,sh,src) -> (name,src,cmId,b,br,ch,xch,sh))
+        (\ (cid,_) (_,contractId,_,_,_,_,_,_) -> cid .== contractId)
         (queryTable contractsTable) $ joinF
-          (\ (cmId,cid,b,br,ch,xch,_) (_,_,src,_)-> (cmId,cid,b,br,ch,xch,src))
+          (\ (cmId,cid,b,br,ch,xch,_) (_,sh,src,_)-> (cmId,cid,b,br,ch,xch,sh,src))
           (\ (_,_,_,_,_,_,sh) (_,sh',_,_)-> sh .== sh')
           (queryTable contractsMetaDataTable)
           (queryTable contractsSourceTable)
@@ -322,8 +325,8 @@ SELECT CI.address FROM contracts_instance CI
 -}
 getSearchContractQuery :: Text -> Query (Column PGBytea, Column PGBytea)
 getSearchContractQuery contractName = proc () -> do
-  (_,name,_,addr,_,_,_,_,_,cid) <-
-    orderBy (desc (\(_,_,_,_,timestamp,_,_,_,_,_) -> timestamp))
+  (_,name,_,addr,_,_,_,_,_,_,cid) <-
+    orderBy (desc (\(_,_,_,_,timestamp,_,_,_,_,_,_) -> timestamp))
       contractsJoinTable -< ()
   restrict -< name .== constant contractName
   returnA -< (addr,cid)
@@ -346,7 +349,7 @@ getContractsAddressesQuery :: Query
   , Column PGBytea
   )
 getContractsAddressesQuery = proc () -> do
-  (_,name,_,addr,timestamp,_,_,_,_,cid) <- contractsJoinTable -< ()
+  (_,name,_,addr,timestamp,_,_,_,_,_,cid) <- contractsJoinTable -< ()
   returnA -< (name,addr,timestamp,cid)
 
 {- |
@@ -373,8 +376,8 @@ getContractsNamesAsAddressesQuery :: Query
   , Column PGBytea
   )
 getContractsNamesAsAddressesQuery = joinF
-  (\ (_,_,_,timestamp,cid) (_,_,_,_,name,name2,_,_) -> (name,name2,timestamp,cid))
-  (\ (_,contractmetadataId,_,_,_) (_,_,_,_,_,_,_,cm2Id) -> contractmetadataId .== cm2Id)
+  (\ (_,_,_,timestamp,cid) (_,_,_,_,_,name,name2,_,_) -> (name,name2,timestamp,cid))
+  (\ (_,contractmetadataId,_,_,_) (_,_,_,_,_,_,_,_,cm2Id) -> contractmetadataId .== cm2Id)
   (queryTable contractsInstanceTable)
   linkedContractsJoinTable
 
@@ -390,7 +393,7 @@ WHERE C.name=$1;
 -}
 getContractsDataAddressesQuery :: Text -> Query (Column PGBytea, Column PGBytea)
 getContractsDataAddressesQuery contractName = proc () -> do
-  (_,name,_,addr,_,_,_,_,_,cid) <- contractsJoinTable -< ()
+  (_,name,_,addr,_,_,_,_,_,_,cid) <- contractsJoinTable -< ()
   restrict -< name .== constant contractName
   returnA -< (addr,cid)
 
@@ -425,7 +428,7 @@ getContractsDataNamesQuery contractName =
       restrict -< name .== constant contractName
       returnA -< name
     differentName = proc () -> do
-      (_,_,_,_,name,name2,_,_) <- linkedContractsJoinTable -< ()
+      (_,_,_,_,_,name,name2,_,_) <- linkedContractsJoinTable -< ()
       restrict -< name .== constant contractName
       returnA -< name2
     latest = proc () -> do
@@ -466,7 +469,7 @@ getContractDetailsByAddressOnly contractAddr chainId = do
 
 getContractSourceByCodeHash :: Keccak256 -> Query (Column PGText)
 getContractSourceByCodeHash codeHash = proc () -> do
-  (_,_,src,_,_,_,_,ch,_,_) <- contractsJoinTable -< ()
+  (_,_,src,_,_,_,_,ch,_,_,_) <- contractsJoinTable -< ()
   restrict -< ch .== constant codeHash
   returnA -< src
 
@@ -523,7 +526,7 @@ getContractsMetaDataIdByAddressQuery
   -> Query (Column PGInt4)
 getContractsMetaDataIdByAddressQuery contractName contractAddress chainId =
   proc () -> do
-    (cmId,_,_,_,_,_,_,_,_,_) <-
+    (cmId,_,_,_,_,_,_,_,_,_,_) <-
       contractByAddress contractName contractAddress chainId -< ()
     returnA -< cmId
 
@@ -554,15 +557,16 @@ getContractsContractByAddressQuery
       , Column PGBytea
       , Column PGBytea
       , Column PGBytea
+      , Column PGBytea
       , Column PGText
       , Column PGText
       , Column PGInt4
     ) )
 getContractsContractByAddressQuery contractName contractAddress chainId =
   limit 1 $ proc () -> do
-    (cmId,name,src,addr,_,bin,binRuntime,codeHash,xcodeHash,cid) <-
+    (cmId,name,src,addr,_,bin,binRuntime,codeHash,xcodeHash,srcHash,cid) <-
       contractByAddress contractName contractAddress chainId -< ()
-    returnA -< (addr,cid,(bin,binRuntime,codeHash,xcodeHash,name,src,cmId))
+    returnA -< (addr,cid,(bin,binRuntime,codeHash,xcodeHash,srcHash,name,src,cmId))
 
 getContractsContractByCodeHashQuery
   :: Keccak256
@@ -602,7 +606,7 @@ getContractsMetaDataIdByNameQuery
   -> Query (Column PGInt4)
 getContractsMetaDataIdByNameQuery contractName1 contractName2 =
   limit 1 . orderBy (desc id) $ proc () -> do
-    (_,_,_,_,name1,name2,_,cm2Id) <- linkedContractsJoinTable -< ()
+    (_,_,_,_,_,name1,name2,_,cm2Id) <- linkedContractsJoinTable -< ()
     restrict -< name1 .== constant contractName1
     restrict -< name2 .== constant contractName2
     returnA -< cm2Id
@@ -633,16 +637,17 @@ getContractsContractByNameQuery
     , Column PGBytea
     , Column PGBytea
     , Column PGBytea
+    , Column PGBytea
     , Column PGText
     , Column PGText
     , Column PGInt4
     )
 getContractsContractByNameQuery contractName1 contractName2 =
   limit 1 $ proc () -> do
-    (b,br,ch,xch,name1,name2,src,cm2Id) <- linkedContractsJoinTable -< ()
+    (b,br,ch,xch,sh,name1,name2,src,cm2Id) <- linkedContractsJoinTable -< ()
     restrict -< name1 .== constant contractName1
     restrict -< name2 .== constant contractName2
-    returnA -< (b,br,ch,xch,name2,src,cm2Id)
+    returnA -< (b,br,ch,xch,sh,name2,src,cm2Id)
 
 {- |
 SELECT CM.id
@@ -685,15 +690,16 @@ getContractsContractBySameNameQuery
     , Column PGBytea
     , Column PGBytea
     , Column PGBytea
+    , Column PGBytea
     , Column PGText
     , Column PGText
     , Column PGInt4
     )
 getContractsContractBySameNameQuery contractName =
   limit 1 $ proc () -> do
-    (b,br,ch,xch,_,name,src,cmId) <- contractDetailsJoinTable -< ()
+    (b,br,ch,xch,sh,name,src,cmId) <- contractDetailsJoinTable -< ()
     restrict -< name .== constant contractName
-    returnA -< (b,br,ch,xch,name,src,cmId)
+    returnA -< (b,br,ch,xch,sh,name,src,cmId)
 
 {- |
 SELECT CM.id
@@ -708,7 +714,7 @@ LIMIT 1;
 -}
 getContractsMetaDataIdByLatestQuery :: Text -> Query (Column PGInt4)
 getContractsMetaDataIdByLatestQuery contractName = limit 1 $ proc () -> do
-  (_,_,_,_,_,_,cmId) <-
+  (_,_,_,_,_,_,_,cmId) <-
     getContractsContractLatestQuery contractName -< ()
   returnA -< cmId
 
@@ -735,16 +741,17 @@ getContractsContractLatestQuery
     , Column PGBytea
     , Column PGBytea
     , Column PGBytea
+    , Column PGBytea
     , Column PGText
     , Column PGText
     , Column PGInt4
     )
 getContractsContractLatestQuery contractName = limit 1 $ proc () -> do
-  (b,br,ch,xch,_,name,src,cmId) <-
+  (b,br,ch,xch,sh,name,src,cmId) <-
     orderBy (desc (\ (_,_,_,_,_,_,_,cmId) -> cmId))
       contractDetailsJoinTable -< ()
   restrict -< name .== constant contractName
-  returnA -< (b,br,ch,xch,name,src,cmId)
+  returnA -< (b,br,ch,xch,sh,name,src,cmId)
 {- |
 SELECT
   XF.id
@@ -927,7 +934,7 @@ getContractDetails :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Blo
 getContractDetails contract@(ContractName contractName) contractId chainId = do
     xabi <- getContractXabi contract contractId chainId
     let
-      detailsWith detailsAddr cid (bin,binRuntime,codeHash,_ :: ByteString,name,src,_ :: Int32) =
+      detailsWith detailsAddr cid (bin,binRuntime,codeHash,_ :: ByteString,_ :: ByteString,name,src,_ :: Int32) =
         ContractDetails
           { contractdetailsBin = Text.decodeUtf8 bin
           , contractdetailsAddress = detailsAddr

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -996,18 +996,18 @@ createContractQuery contractName = do
       [(Nothing, constant contractName)]
       fst
 
-isDeployedQuery :: Text -> Query (Column PGBool)
-isDeployedQuery src = proc () -> do
-  let srcHash = (keccak256 $ Text.encodeUtf8 src)
-  (_,sh,_,deployed) <- queryTable contractsSourceTable -< ()
-  restrict -< sh .== constant srcHash
+isDeployedQuery :: Text -> Query (Column PGBool) -- TODO: is it more efficient to
+isDeployedQuery contractSrc = proc () -> do      --       compare source hash?
+  (_,_,src,deployed) <- queryTable contractsSourceTable -< ()
+  restrict -< src .== constant contractSrc
   returnA -< deployed
 
-setDeployedQuery :: Keccak256 -> Bloc Int64
-setDeployedQuery srcHash = blocModify $ \conn ->
-  runUpdateEasy conn contractsSourceTable
-    (\(sid,sh,src,_) -> (sid,sh,src, constant True))
-    (\(_,sh,_,_) -> sh .== constant srcHash)
+setDeployedQuery :: Text -> Bloc Int64
+setDeployedQuery contractSrc = do
+  blocModify $ \conn ->
+    runUpdateEasy conn contractsSourceTable
+      (\(sid,sh,src,_) -> (sid,sh,src, constant True))
+      (\(_,_,src,_) -> src .== constant contractSrc)
 
 insertContractSourceQuery
   :: Text

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Tables.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Tables.hs
@@ -94,15 +94,18 @@ contractsSourceTable :: Table
   ( Maybe (Column PGInt4)
   , Column PGBytea
   , Column PGText
+  , Column PGBool
   )
   ( Column PGInt4
   , Column PGBytea
   , Column PGText
+  , Column PGBool
   )
-contractsSourceTable = Table "contracts_source" $ p3
+contractsSourceTable = Table "contracts_source" $ p4
   ( optional "id"
   , required "src_hash"
   , required "src"
+  , required "deployed"
   )
 
 contractsMetaDataTable :: Table

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -37,9 +37,9 @@ postChainInfo :: ChainInput -> Bloc ChainId
 postChainInfo (ChainInput src cname lbl balances chaininputArgs members) = do
   when (null members) $ throwError $ UserError "Private chains must include at least one member"
   when (sum (nmap2' balances) == 0) $ throwError $ UserError "At least one account must have a non-zero balance"
-  idsAndDetails <- if (Text.null src)
+  idsAndDetails <- if Text.null src
                      then return Map.empty
-                     else compileContract src
+                     else snd <$> compileContract src
   mContract <- case Map.toList idsAndDetails of
             [] -> return Nothing
             [(_, x)] -> return $ Just x

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -231,7 +231,7 @@ postContractsCompile :: [PostCompileRequest] -> Bloc [PostCompileResponse]
 postContractsCompile = blocTransaction . fmap concat . traverse compileOneContract
   where
     compileOneContract PostCompileRequest{..} = do
-      idsAndDetails <- compileContract postcompilerequestSource
+      idsAndDetails <- snd <$> compileContract postcompilerequestSource
       for (toList idsAndDetails) $ \ (_,details) -> do
         let eBlockappsjsXabi = uncurry completeXabi $ (contractdetailsName &&& contractdetailsXabi) details
         case eBlockappsjsXabi of

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -33,7 +33,7 @@ import qualified Data.Map.Strict                   as Map
 import qualified Data.Map.Ordered                  as OMap
 import           Data.Maybe
 import           Data.RLP
-import           Data.Set                          (isSubsetOf)
+import qualified Data.Set                          as Set
 import           Data.Text                         (Text)
 import qualified Data.Text                         as Text
 import qualified Data.Text.Encoding                as Text
@@ -264,9 +264,9 @@ postUsersUploadList' ContractListParameters{..} sign = do
     else do
       let UploadListContract _ _ mtp _ _ = head contracts
       params <- getAccountTxParams fromAddr chainId mtp
-      (namesCmIdsTxs,_) <- forStateT (Map.empty, Map.empty, Map.empty) (zip contracts [0..]) $
+      (namesCmIdsTxs,_) <- forStateT (Map.empty, Map.empty, Map.empty, Set.empty) (zip contracts [0..]) $
         \(UploadListContract name args _ value md,nonceIncr) -> do
-          (names, cmIds, fIds) <- get
+          (names, cmIds, fIds, srcs) <- get
           (bin, src, cmId, names') <- case Map.lookup name names of
             Just (b, src, cm) -> return (b, src, cm, names)
             Nothing -> do
@@ -289,7 +289,11 @@ postUsersUploadList' ContractListParameters{..} sign = do
                 xabiArgs' <- lift $ getXabiFunctionsArgsQuery functionId
                 return (xabiArgs', Map.insert functionId xabiArgs' fIds)
           argsBin <- lift $ constructArgValues (Just (fmap argValueToText args)) xabiArgs
-          isDeployed <- lift . fmap (fromMaybe False) . blocQueryMaybe $ isDeployedQuery src
+          (isDeployed, srcs') <- if src `Set.member` srcs
+                          then return (True, srcs)
+                          else do
+                            isDep' <- lift . fmap (fromMaybe False) . blocQueryMaybe $ isDeployedQuery src
+                            return (isDep', Set.insert src srcs)
           let metadata' = Just . Map.union (fromMaybe Map.empty md) $
                             if isDeployed
                               then Map.empty
@@ -303,7 +307,7 @@ postUsersUploadList' ContractListParameters{..} sign = do
                 (bin <> argsBin)
                 nonceIncr
                 chainId
-          put (names', cmIds', fIds')
+          put (names', cmIds', fIds', srcs')
           return ((name,cmId),tx)
       let
         txs = map snd namesCmIdsTxs
@@ -788,7 +792,7 @@ constructArgValues args argNamesTypes = do
           then return ByteString.empty
           else throwError (UserError "no arguments provided to function.")
       Just argsMap -> do
-        argsVals <- if not (Map.keysSet argNamesTypes `isSubsetOf` Map.keysSet argsMap)
+        argsVals <- if not (Map.keysSet argNamesTypes `Set.isSubsetOf` Map.keysSet argsMap)
           then do
             let
               argNames1 = "(" <> Text.intercalate ", " (Map.keys argNamesTypes) <> ")"

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -207,7 +207,7 @@ postUsersContract' :: ContractParameters -> Signer -> Bloc BlocTransactionResult
 postUsersContract' ContractParameters{..} sign = blocTransaction $ do
   params <- getAccountTxParams fromAddr chainId txParams
   --TODO: check what happens with mismatching args
-  idsAndDetails <- compileContract src
+  (srcHash,idsAndDetails) <- compileContract src
   logWith logNotice ("constructor arguments: " <> Text.pack (show args))
   (cName,(cmId,ContractDetails{..})) <-
     case contract of
@@ -217,7 +217,7 @@ postUsersContract' ContractParameters{..} sign = blocTransaction $ do
          [x] -> return x
          _ -> throwError $ UserError "When you upload multiple contracts, you need to specify which contract should be uploaded to the chain in the 'contract' key of the given data"
      Just contract' -> (,) contract' <$> blocMaybe "Could not find global contract metadataId" (Map.lookup contract' idsAndDetails)
-  isDeployed <- fromMaybe False <$> blocQueryMaybe (isDeployedQuery src)
+  isDeployed <- fromMaybe False <$> blocQueryMaybe (isDeployedQuery srcHash)
   let
     (bin,leftOver) = Base16.decode $ Text.encodeUtf8 contractdetailsBin
     metadata' = Just . Map.union (fromMaybe Map.empty metadata) $
@@ -266,16 +266,16 @@ postUsersUploadList' ContractListParameters{..} sign = do
       params <- getAccountTxParams fromAddr chainId mtp
       (namesCmIdsTxs,_) <- forStateT (Map.empty, Map.empty, Map.empty, Set.empty) (zip contracts [0..]) $
         \(UploadListContract name args _ value md,nonceIncr) -> do
-          (names, cmIds, fIds, srcs) <- get
-          (bin, src, cmId, names') <- case Map.lookup name names of
-            Just (b, src, cm) -> return (b, src, cm, names)
+          (names, cmIds, fIds, srcHashes) <- get
+          (bin, src, srcHash, cmId, names') <- case Map.lookup name names of
+            Just (b, src, sh, cm) -> return (b, src, sh, cm, names)
             Nothing -> do
-              (b16,src,cm) <- lift $ blocQuery1 $ proc () -> do
-                (bin16,_,_,_,_,_,src,cmId') <- getContractsContractLatestQuery name -< ()
-                returnA -< (bin16,src,cmId')
+              (b16,src,sh,cm) <- lift $ blocQuery1 $ proc () -> do
+                (bin16,_,_,_,sh,_,src,cmId') <- getContractsContractLatestQuery name -< ()
+                returnA -< (bin16,src,sh,cmId')
               let (b, leftOver) = Base16.decode b16
               unless (ByteString.null leftOver) $ throwError $ AnError "Couldn't decode binary"
-              return (b, src, cm, Map.insert name (b, src, cm) names)
+              return (b, src, sh, cm, Map.insert name (b, src, sh, cm) names)
           (mFunctionId, cmIds') <- case Map.lookup cmId cmIds of
             Just fId -> return (fId, cmIds)
             Nothing -> do
@@ -289,11 +289,11 @@ postUsersUploadList' ContractListParameters{..} sign = do
                 xabiArgs' <- lift $ getXabiFunctionsArgsQuery functionId
                 return (xabiArgs', Map.insert functionId xabiArgs' fIds)
           argsBin <- lift $ constructArgValues (Just (fmap argValueToText args)) xabiArgs
-          (isDeployed, srcs') <- if src `Set.member` srcs
-                          then return (True, srcs)
+          (isDeployed, srcHashes') <- if srcHash `Set.member` srcHashes
+                          then return (True, srcHashes)
                           else do
-                            isDep' <- lift . fmap (fromMaybe False) . blocQueryMaybe $ isDeployedQuery src
-                            return (isDep', Set.insert src srcs)
+                            isDep' <- lift . fmap (fromMaybe False) . blocQueryMaybe $ isDeployedQuery srcHash
+                            return (isDep', Set.insert srcHash srcHashes)
           let metadata' = Just . Map.union (fromMaybe Map.empty md) $
                             if isDeployed
                               then Map.empty
@@ -307,7 +307,7 @@ postUsersUploadList' ContractListParameters{..} sign = do
                 (bin <> argsBin)
                 nonceIncr
                 chainId
-          put (names', cmIds', fIds', srcs')
+          put (names', cmIds', fIds', srcHashes')
           return ((name,cmId),tx)
       let
         txs = map snd namesCmIdsTxs

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -271,7 +271,7 @@ postUsersUploadList' ContractListParameters{..} sign = do
             Just (b, src, cm) -> return (b, src, cm, names)
             Nothing -> do
               (b16,src,cm) <- lift $ blocQuery1 $ proc () -> do
-                (bin16,_,_,_,_,src,cmId') <- getContractsContractLatestQuery name -< ()
+                (bin16,_,_,_,_,_,src,cmId') <- getContractsContractLatestQuery name -< ()
                 returnA -< (bin16,src,cmId')
               let (b, leftOver) = Base16.decode b16
               unless (ByteString.null leftOver) $ throwError $ AnError "Couldn't decode binary"
@@ -406,7 +406,7 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
             Just cmId -> return (cmId, names)
             Nothing -> do
               (mapKey' :: Int32) <- lift $ blocQuery1 $ proc () -> do
-                (_,_,_,_,_,_,cmId) <- getContractsContractLatestQuery methodcallContractName -< ()
+                (_,_,_,_,_,_,_,cmId) <- getContractsContractLatestQuery methodcallContractName -< ()
                 returnA -< cmId
               return (mapKey', Map.insert methodcallContractName mapKey' names)
           (contract', cmIds') <- case Map.lookup mapKey cmIds of
@@ -663,7 +663,7 @@ contractResult hash mtxr cmId name index = do
       stratoMsg  -> lift $ throwError $ UserError stratoMsg
     Just addr' -> do
       xs::[Int32] <- lift $ blocQuery $ proc () -> do
-        (cmId',_,_,_,_,_,_,_,_,_) <- contractByAddress name addr' chainId -< ()
+        (cmId',_,_,_,_,_,_,_,_,_,_) <- contractByAddress name addr' chainId -< ()
         returnA -< cmId'
       if (isNothing $ listToMaybe xs)
         then do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -217,9 +217,13 @@ postUsersContract' ContractParameters{..} sign = blocTransaction $ do
          [x] -> return x
          _ -> throwError $ UserError "When you upload multiple contracts, you need to specify which contract should be uploaded to the chain in the 'contract' key of the given data"
      Just contract' -> (,) contract' <$> blocMaybe "Could not find global contract metadataId" (Map.lookup contract' idsAndDetails)
+  isDeployed <- fromMaybe False <$> blocQueryMaybe (isDeployedQuery src)
   let
     (bin,leftOver) = Base16.decode $ Text.encodeUtf8 contractdetailsBin
-    metadata' = Just $ fromMaybe Map.empty metadata `Map.union` Map.fromList [("src", src),("name", cName)]
+    metadata' = Just . Map.union (fromMaybe Map.empty metadata) $
+                  if isDeployed
+                    then Map.empty
+                    else Map.fromList [("src", src),("name", cName)]
   unless (ByteString.null leftOver) $ throwError $ AnError "Couldn't decode binary"
   mFunctionId <- getConstructorId cmId
   argsBin <- buildArgumentByteString (fmap (fmap argValueToText) args) mFunctionId
@@ -285,7 +289,11 @@ postUsersUploadList' ContractListParameters{..} sign = do
                 xabiArgs' <- lift $ getXabiFunctionsArgsQuery functionId
                 return (xabiArgs', Map.insert functionId xabiArgs' fIds)
           argsBin <- lift $ constructArgValues (Just (fmap argValueToText args)) xabiArgs
-          let metadata' = Just $ fromMaybe Map.empty md `Map.union`Map.fromList [("src",src),("name",name)]
+          isDeployed <- lift . fmap (fromMaybe False) . blocQueryMaybe $ isDeployedQuery src
+          let metadata' = Just . Map.union (fromMaybe Map.empty md) $
+                            if isDeployed
+                              then Map.empty
+                              else Map.fromList [("src",src),("name",name)]
           tx <- lift . signAndPrepare sign fromAddr metadata' $
               TransactionHeader
                 Nothing

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
@@ -96,9 +96,13 @@ buildState s (a:as) run =
    in buildState s' as run
 
 partitionWith :: Ord k => (a -> k) -> [a] -> [(k,[a])]
-partitionWith f as = Map.toList . buildState Map.empty as $ \a -> do
-  s <- get
-  let k = f a
-  case Map.lookup k s of
-    Nothing -> put (Map.insert k [a] s)
-    Just _  -> put (Map.update (Just . (++ [a])) k s)
+partitionWith f as =
+  map (fmap reverse)
+  . Map.toList
+  . buildState Map.empty as
+  $ \a -> do
+    s <- get
+    let k = f a
+    case Map.lookup k s of
+      Nothing -> put (Map.insert k [a] s)
+      Just _  -> put (Map.update (Just . (++ [a])) k s)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
@@ -105,4 +105,4 @@ partitionWith f as =
     let k = f a
     case Map.lookup k s of
       Nothing -> put (Map.insert k [a] s)
-      Just _  -> put (Map.update (Just . (++ [a])) k s)
+      Just _  -> put (Map.update (Just . (a:)) k s)

--- a/blockapps-haskell/slipstream/src/Slipstream/Data/Action.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Data/Action.hs
@@ -69,7 +69,7 @@ formatAction Action{..} = T.concat
   , tshow actionCodeHash
   , "\n"
   , "    storage   = "
-  , tshow actionStorage
+  , tshow $ fmap M.size actionStorage
   , "\n"
   , "    metadata  = "
   , tshow actionMetadata

--- a/blockapps-haskell/slipstream/src/Slipstream/Data/Action.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Data/Action.hs
@@ -14,15 +14,18 @@
 
 module Slipstream.Data.Action where
 
-import            BlockApps.Ethereum
-import            Data.Map.Strict         (Map)
-import qualified  Data.Map.Strict         as M
-import            Data.Text               (Text)
-import qualified  Data.Text               as T
-import            Data.Time
-import            Data.LargeWord          (Word256)
-import            Data.Aeson
-import            GHC.Generics
+import           BlockApps.Ethereum
+import           BlockApps.SolidityVarReader (byteStringToWord256)
+import qualified Data.ByteString.Base16      as B16
+import qualified Data.ByteString.Char8       as C8
+import           Data.Map.Strict             (Map)
+import qualified Data.Map.Strict             as M
+import           Data.Text                   (Text)
+import qualified Data.Text                   as T
+import           Data.Time
+import           Data.LargeWord              (Word256)
+import           Data.Aeson
+import           GHC.Generics
 
 data ActionType = Create | Delete | Update deriving (Eq,Show, Generic)
 
@@ -36,11 +39,33 @@ data Action = Action
   , actionTxSender        :: Address
   , actionAddress         :: Address
   , actionCodeHash        :: Keccak256
-  , actionStorage         :: Maybe (Map (Hex Word256) (Hex Word256))
+  , actionStorage         :: Maybe (Map Word256 Word256)
   , actionMetadata        :: Maybe (Map Text Text)
   } deriving (Show, Generic)
 
-instance FromJSON Action
+instance FromJSON Action where
+  parseJSON (Object o ) = Action
+    <$> (o .: "actionType")
+    <*> (o .: "actionBlockHash")
+    <*> (o .: "actionBlockTimestamp")
+    <*> (o .: "actionBlockNumber")
+    <*> (o .: "actionTxHash")
+    <*> (o .: "actionTxChainId")
+    <*> (o .: "actionTxSender")
+    <*> (o .: "actionAddress")
+    <*> (o .: "actionCodeHash")
+    <*> (fmap decodeStorage <$> (o .:? "actionStorage"))
+    <*> (o .:? "actionMetadata")
+  parseJSON o = error $ "parseJSON failed for Action: expected Object, got: " ++ show o
+
+decodeStorage :: Map Text Text -> Map Word256 Word256
+decodeStorage = M.mapKeys hexToWord256 . M.map hexToWord256
+  where hexToWord256 = byteStringToWord256
+                     . fst
+                     . B16.decode
+                     . C8.pack
+                     . T.unpack
+
 instance FromJSON ActionType
 instance FromJSONKey (Hex Word256) where
     fromJSONKey = FromJSONKeyTextParser (parseJSON . String)

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -169,14 +169,14 @@ processTheMessages messages conn g = do
           fmap join . for (Map.lookup "src" md) $ \src -> do
             detailsMap <- compileContract src
             fmap join . for (Map.lookup "name" md) $ \name -> do
-              traverse pure $ Map.lookup name detailsMap
+              traverse pure $ traverse (Map.lookup name) detailsMap
 
         if isNothing mDetails
           then return . Left $ "No details found for code hash "
                             <> (T.pack $ show actionCodeHash)
                             <> " and no 'src' field found in actionMetadata"
           else do
-            let Just (cmId,details) = mDetails
+            let Just (srcHash,(cmId,details)) = mDetails
                 strAbi = T.replace "\'" "\'\'" . decodeUtf8 . BL.toStrict . JSON.encode $ contractdetailsXabi details
                 strName = T.replace "\"" "" $ contractdetailsName details
                 cont = either error id . xAbiToContract $ contractdetailsXabi details
@@ -186,8 +186,8 @@ processTheMessages messages conn g = do
                   let contracts = filter (not . T.null) $ T.splitOn "," v
                   forM_ contracts $ \c -> for_ (fmap (contractdetailsCodeHash . snd) $ Map.lookup c m) $ f g
 
-            void . setDeployedQuery $ contractdetailsSrc details
-            detailsMap <- compileContract $ contractdetailsSrc details -- won't actually recompile the contract
+            void $ setDeployedQuery srcHash
+            detailsMap <- detailsFromSourceHash srcHash
             mapM_ (updateGlobal detailsMap) $ [("history", addToHistoryList)
                                               ,("nohistory", removeFromHistoryList)
                                               ,("noindex", addToNoIndexList)

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -79,10 +79,10 @@ emptyHash = keccak256 B.empty
 hasContract::Action->Bool
 hasContract = (/= emptyHash) . actionCodeHash
 
-storageToList :: BA.Storage -> (Hex Word256, Hex Word256)
-storageToList BA.Storage {BA.storageKey=k, BA.storageValue=v} = (k, v)
+storageToList :: BA.Storage -> (Word256, Word256)
+storageToList BA.Storage {BA.storageKey=Hex k, BA.storageValue=Hex v} = (k, v)
 
-addStorageIfNeeded::Action -> Bloc (Map (Hex Word256) (Hex Word256))
+addStorageIfNeeded::Action -> Bloc (Map Word256 Word256)
 addStorageIfNeeded Action{..} | actionType /= Update = return $ fromMaybe Map.empty actionStorage
                               | otherwise = do
   storage' <- blocStrato $ getStorage storageFilterParams { qsAddress = Just actionAddress
@@ -181,7 +181,7 @@ processTheMessages messages conn g = do
                 strName = T.replace "\"" "" $ contractdetailsName details
                 cont = either error id . xAbiToContract $ contractdetailsXabi details
                 chain = maybe "" (T.pack . flip showHex "" . unChainId) actionTxChainId
-                cache = maybe (const Nothing) (\s -> fmap unHex . flip Map.lookup s . Hex) actionStorage
+                cache = maybe (const Nothing) (\s -> flip Map.lookup s) actionStorage
                 updateGlobal m (k,f) = for_ (Map.lookup k =<< actionMetadata) $ \v -> do
                   let contracts = filter (not . T.null) $ T.splitOn "," v
                   forM_ contracts $ \c -> for_ (fmap (contractdetailsCodeHash . snd) $ Map.lookup c m) $ f g

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -186,6 +186,7 @@ processTheMessages messages conn g = do
                   let contracts = filter (not . T.null) $ T.splitOn "," v
                   forM_ contracts $ \c -> for_ (fmap (contractdetailsCodeHash . snd) $ Map.lookup c m) $ f g
 
+            void . setDeployedQuery $ contractdetailsSrc details
             detailsMap <- compileContract $ contractdetailsSrc details -- won't actually recompile the contract
             mapM_ (updateGlobal detailsMap) $ [("history", addToHistoryList)
                                               ,("nohistory", removeFromHistoryList)

--- a/core-strato/blockapps-util/src/Blockchain/Util.hs
+++ b/core-strato/blockapps-util/src/Blockchain/Util.hs
@@ -26,12 +26,16 @@ buildState s (a:as) run =
    in buildState s' as run
 
 partitionWith :: Ord k => (a -> k) -> [a] -> [(k,[a])]
-partitionWith f as = M.toList . buildState M.empty as $ \a -> do
-  s <- get
-  let k = f a
-  case M.lookup k s of
-    Nothing -> put (M.insert k [a] s)
-    Just _  -> put (M.update (Just . (++ [a])) k s)
+partitionWith f as =
+  map (fmap reverse)
+  . M.toList
+  . buildState M.empty as
+  $ \a -> do
+    s <- get
+    let k = f a
+    case M.lookup k s of
+      Nothing -> put (M.insert k [a] s)
+      Just _  -> put (M.update (Just . (a:)) k s)
 
 showHex4 :: Word256 -> String
 showHex4 i = replicate (4 - length rawOutput) '0' ++ rawOutput


### PR DESCRIPTION
Once a source blob has been included in a block, it doesn't need to be included again. Therefore, we can reduce data transmission by omitting the source code for contracts that have already been uploaded.