### PR TITLE
Correctly count the number of active peers

### DIFF
--- a/core-strato/ethereum-discovery/package.yaml
+++ b/core-strato/ethereum-discovery/package.yaml
@@ -29,6 +29,7 @@ dependencies:
   - network-uri
   - persistent-postgresql
   - persistent-template
+  - prometheus-client
   - random
   - resourcet
   - split

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -25,6 +25,7 @@ import           Blockchain.Data.PubKey
 import           Blockchain.DB.SQLDB          (withGlobalSQLPool)
 import           Blockchain.MiscJSON          ()
 import           Blockchain.SHA
+import           Blockchain.Strato.Discovery.Metrics
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 PPeer
@@ -105,13 +106,16 @@ getAvailablePeers = try . withGlobalSQLPool $ \sqldb -> do
   fmap (map SQL.entityVal) $ flip SQL.runSqlPool sqldb $
     SQL.selectList [PPeerEnableTime SQL.<. currentTime] []
 
-setPeerActiveState::T.Text->Int->Int->IO (Either SomeException ())
-setPeerActiveState ip _ state = try $ withGlobalSQLPool $ \sqldb -> do
+setPeerActiveState::T.Text->Int->ActivityState->IO (Either SomeException ())
+setPeerActiveState ip _ state = do
+  recordStateChange state
   -- TODO(tim): Reenable port selection
   let port' = 30303
-  flip SQL.runSqlPool sqldb $
-    SQL.updateWhere [PPeerIp SQL.==. ip, PPeerTcpPort SQL.==. port'] [PPeerActiveState SQL.=. state]
-  return ()
+  try $ withGlobalSQLPool $ \sqldb -> do
+    flip SQL.runSqlPool sqldb $
+      SQL.updateWhere [PPeerIp SQL.==. ip, PPeerTcpPort SQL.==. port']
+                      [PPeerActiveState SQL.=. fromEnum state]
+
 
 getActivePeers::IO (Either SomeException [PPeer])
 getActivePeers = try . withGlobalSQLPool $ \sqldb -> do

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -124,7 +124,7 @@ getActivePeers::IO (Either SomeException [PPeer])
 getActivePeers = try . withGlobalSQLPool $ \sqldb -> do
   currentTime <- getCurrentTime
   fmap (map SQL.entityVal) $ flip SQL.runSqlPool sqldb $
-    SQL.selectList [PPeerActiveState SQL.==. 1, PPeerEnableTime SQL.<. currentTime] []
+    SQL.selectList [PPeerActiveState SQL.==. fromEnum Active, PPeerEnableTime SQL.<. currentTime] []
 
 setPeerBondingState::String->Int->Int->IO (Either SomeException ())
 setPeerBondingState ip _ state = try . withGlobalSQLPool $ \sqldb -> do

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -7,7 +7,10 @@
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
 
-module Blockchain.Strato.Discovery.Data.Peer where
+module Blockchain.Strato.Discovery.Data.Peer
+  ( module Blockchain.Strato.Discovery.Metrics
+  , module Blockchain.Strato.Discovery.Data.Peer
+  ) where
 
 import           Control.Exception
 import           Crypto.Types.PubKey.ECC

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Metrics.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Metrics.hs
@@ -3,7 +3,7 @@
 module Blockchain.Strato.Discovery.Metrics
   ( recordStateChange
   , ActivityState(..)
-  , getNumPeers
+  , getSameTypeNumPeers
   ) where
 
 import Control.Monad.IO.Class
@@ -21,5 +21,8 @@ recordStateChange = \case
   Unactive -> subGauge numPeers 1
   Active -> addGauge numPeers 1
 
-getNumPeers :: MonadIO m => m Int
-getNumPeers = floor <$> getGauge numPeers
+-- This will accurately report the number of other client peers if
+-- this is a client thread, or the number of server peers if
+-- this is a server thread. It will not count across types.
+getSameTypeNumPeers :: MonadIO m => m Int
+getSameTypeNumPeers = floor <$> getGauge numPeers

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Metrics.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Metrics.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Blockchain.Strato.Discovery.Metrics
+  ( recordStateChange
+  , ActivityState(..)
+  , getNumPeers
+  ) where
+
+import Control.Monad.IO.Class
+import Prometheus
+
+data ActivityState = Unactive | Active deriving (Eq, Show, Enum, Ord)
+
+numPeers :: Gauge
+numPeers = unsafeRegister
+         . gauge
+         $ Info "disc_num_peers" "Number of active peers at any given time"
+
+recordStateChange :: MonadMonitor m => ActivityState -> m ()
+recordStateChange = \case
+  Unactive -> subGauge numPeers 1
+  Active -> addGauge numPeers 1
+
+getNumPeers :: MonadIO m => m Int
+getNumPeers = floor <$> getGauge numPeers

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -132,7 +132,7 @@ runContextM :: (MonadBaseControl IO m, MonadThrow m, MonadIO m)
             => s
             -> StateT s (ResourceT m) a
             -> m ()
-runContextM s f = void . runResourceT $ recordProcessStart >> runStateT f s
+runContextM s f = void . runResourceT $ runStateT f s
 
 initContext :: (MonadResource m, MonadIO m, MonadBaseControl IO m, MonadLogger m)
             => Int -> m Context

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -43,7 +43,6 @@ import           Blockchain.DB.SQLDB
 import           Blockchain.DBM
 import           Blockchain.EthConf
 import           Blockchain.Options
-import           Blockchain.Metrics
 import           Blockchain.Sequencer.Event            (IngestEvent (..))
 import           Blockchain.Sequencer.Kafka            (writeUnseqEvents, HasUnseqSink(..))
 

--- a/core-strato/strato-p2p/src/Blockchain/Metrics.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Metrics.hs
@@ -3,11 +3,9 @@
 
 module Blockchain.Metrics ( recordEvent
                           , recordMessage
-                          , recordProcessStart) where
+                          ) where
 
-import Control.Monad
 import Control.Monad.IO.Class
-import Control.Monad.Trans.Resource
 import Data.Text
 import Prometheus
 
@@ -34,11 +32,6 @@ p2pEvents = unsafeRegister
           . vector "event_type"
           . counter
           $ Info "p2p_event" "Count of p2p events"
-
-numProcs :: Gauge
-numProcs = unsafeRegister
-         . gauge
-         $ Info "p2p_num_procs" "Number of processes running at any given time"
 
 recordEvent :: (MonadIO m) => Event -> m ()
 recordEvent = \case

--- a/core-strato/strato-p2p/src/Blockchain/Metrics.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Metrics.hs
@@ -77,8 +77,3 @@ recordMessage' msgVect msg = do
                 ChainDetails _ -> "chain_details"
                 GetTransactions _ -> "get_transactions"
   liftIO $ withLabel msgVect label incCounter
-
-recordProcessStart :: MonadResource m => m ()
-recordProcessStart = void $ allocate inc dec
-  where inc = addGauge numProcs 1
-        dec = const $ subGauge numProcs 1

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -68,7 +68,7 @@ runPeer peer myPriv _ _ = runResourceT $ do
         peerAddress = BC.pack . T.unpack $ pPeerIp peer
 
     runTCPClientWithConnectTimeout (clientSettings peerPort peerAddress) 5 $ \app -> do
-        void . liftIO $ setPeerActiveState (pPeerIp peer) (pPeerTcpPort peer) 1
+        void . liftIO $ setPeerActiveState (pPeerIp peer) (pPeerTcpPort peer) Active
 
         (_, (outCtx, inCtx)) <- liftIO $ appSource app $$+ ethCryptConnect myPriv otherPubKey `fuseUpstream` appSink app
 
@@ -80,7 +80,7 @@ runPeer peer myPriv _ _ = runResourceT $ do
              .| eventSink
              .| appSink app
 
-        void . liftIO $ setPeerActiveState (pPeerIp peer) (pPeerTcpPort peer) 0
+        void . liftIO $ setPeerActiveState (pPeerIp peer) (pPeerTcpPort peer) Unactive
         case attempt of
           Right () -> $logDebugS "runPeer" "Peer ran successfully!"
           Left err -> $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err

--- a/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -49,7 +49,7 @@ runEthServer myPriv listenPort = do
             $logErrorS "runEthServer" . T.pack $ "Didn't get pubkey during discovery for peer " ++ show theSockAddr  ++ ". rejecting violently."
             liftIO (appCloseConnection app)
           Just otherPubKey -> do
-            void . liftIO $ setPeerActiveState (pPeerIp p) (pPeerTcpPort p) 1
+            void . liftIO $ setPeerActiveState (pPeerIp p) (pPeerTcpPort p) Active
             (_, (outCtx, inCtx)) <- liftIO $ appSource app $$+ ethCryptAccept myPriv otherPubKey `fuseUpstream` appSink app
             !eventSource <- mkEthP2PEventSource app inCtx []
             let !eventSink = mkEthP2PEventConduit (show $ appSockAddr app) outCtx
@@ -59,7 +59,7 @@ runEthServer myPriv listenPort = do
                 .| eventSink
                 .| appSink app
 
-            void . liftIO $ setPeerActiveState (pPeerIp p) (pPeerTcpPort p) 0
+            void . liftIO $ setPeerActiveState (pPeerIp p) (pPeerTcpPort p) Unactive
             case attempt of
               Right () -> $logDebugS "runEthServer" "Peer ran successfully!"
               Left err -> $logErrorS "runEthServer" . T.pack $ "Peer did not run successfully: " ++ show err
@@ -68,7 +68,7 @@ stratoP2PServer :: LoggingT IO ()
 stratoP2PServer = do
   let PrivKey myPriv = privKey ethConf
 
-  $logInfoS "stratoP2PServer" $ T.pack $ "connect address: " ++ (flags_address)
-  $logInfoS "stratoP2PServer" $ T.pack $ "listen port:     " ++ (show flags_listen)
+  $logInfoS "stratoP2PServer" $ T.pack $ "connect address: " ++ flags_address
+  $logInfoS "stratoP2PServer" $ T.pack $ "listen port:     " ++ show flags_listen
 
   void . runResourceT $ runEthServer myPriv flags_listen


### PR DESCRIPTION
runContextM does not have a 1-1 correspondence to peers, so it is
more accurate to just count it at the source