### PR TITLE
Use gossip to limit the TX overload

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -42,6 +42,10 @@ function newnode {
     numValidators=$(( 1 + $( echo "${validators}" | tr -cd , | wc -c) ))
     maxConn=$(( maxConn >= numValidators ? maxConn : numValidators ))
   fi
+  if [ -n "${blockstanbul}" || -n "${txGossipFanout}" ]; then
+    txgFlag="--txGossipFanout=${txGossipFanout:-3}"
+  fi
+
   echo "Starting strato-p2p"
   runBackgroundProcess strato-p2p \
      --connectionTimeout=$actualTimeout \
@@ -50,6 +54,7 @@ function newnode {
      --maxConn=$maxConn \
      --maxReturnedHeaders=$maxReturnedHeaders \
      --networkID=$networkID \
+     ${txgFlag} \
      &>> logs/strato-p2p
 
   evmMinLogLevel=LevelInfo

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Metrics.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Metrics.hs
@@ -3,7 +3,7 @@
 module Blockchain.Strato.Discovery.Metrics
   ( recordStateChange
   , ActivityState(..)
-  , getSameTypeNumPeers
+  , getNumPeersMem
   ) where
 
 import Control.Monad.IO.Class
@@ -21,8 +21,5 @@ recordStateChange = \case
   Unactive -> subGauge numPeers 1
   Active -> addGauge numPeers 1
 
--- This will accurately report the number of other client peers if
--- this is a client thread, or the number of server peers if
--- this is a server thread. It will not count across types.
-getSameTypeNumPeers :: MonadIO m => m Int
-getSameTypeNumPeers = floor <$> getGauge numPeers
+getNumPeersMem :: MonadIO m => m Int
+getNumPeersMem = floor <$> getGauge numPeers

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - ethereum-discovery
   - ethereum-encryption
   - ethereum-rlp
+  - ghc
   - blockapps-haskoin
   - hflags
   - iproute
@@ -50,6 +51,7 @@ dependencies:
   - network
   - persistent
   - prometheus-client
+  - random
   - resourcet
   - SafeSemaphore
   - stm

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -45,6 +45,7 @@ import           Blockchain.Data.Wire
 import           Blockchain.EventModel
 import           Blockchain.EventException
 import           Blockchain.Format
+import           Blockchain.Options
 import           Blockchain.SHA
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Stream.VMEvent
@@ -426,17 +427,13 @@ shouldSend peer txo = case txo of
     Origin.Blockstanbul -> False
 
 shouldSendGossip :: MonadIO m => PPeer -> Origin.TXOrigin -> m Bool
-shouldSendGossip peer txo =
-  if not (shouldSend peer txo)
-    then return False
-    else case txo of
-            -- On average, we expect to send to 3 peers if this came
-            -- from a peer.
-            Origin.PeerString{} -> do
-              rangeEnd <- getNumPeersMem
-              rng <- liftIO $ randomRIO (1, rangeEnd)
-              return $ rangeEnd <= 3 || rng <= 3
-            _ -> return True
+shouldSendGossip peer txo = (shouldSend peer txo &&) . (flags_txGossipFanout /= -1 ||) <$>
+  case txo of
+    Origin.PeerString{} -> do
+      rangeEnd <- getNumPeersMem
+      rng <- liftIO $ randomRIO (1, rangeEnd)
+      return $ rangeEnd <= flags_txGossipFanout || rng <= flags_txGossipFanout
+    _ -> return True
 
 -- check that the peer is authorized to receive these chain details, by verifying that their
 -- IPaddress is associated with one of the Enodes in the chain's member list

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -435,7 +435,7 @@ shouldSendGossip peer txo =
             Origin.PeerString{} -> do
               rangeEnd <- getNumPeersMem
               rng <- liftIO $ randomRIO (1, rangeEnd)
-              return $ rng <= 3
+              return $ rangeEnd <= 3 || rng <= 3
             _ -> return True
 
 -- check that the peer is authorized to receive these chain details, by verifying that their

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -27,6 +27,8 @@ import qualified Data.ByteString.Base16                as BC16
 import qualified Data.ByteString.Char8                 as BS8
 import qualified Data.Text                             as T
 import           Data.Time.Clock
+import           MonadUtils
+import           System.Random
 import           Text.Printf
 
 import           Blockchain.Blockstanbul               (blockstanbulSender)
@@ -317,7 +319,7 @@ handleEvents peer = awaitForever $ \case
                 $logInfoS "NewSeqEvent.block" . T.pack $ "yielding new block: " ++ show (blockDataNumber . blockBlockData . outputBlockToBlock $ b)
                 yield $ NewBlock (outputBlockToBlock b) (obTotalDifficulty b)
       OETx _ tx -> do
-        when (shouldSend peer $ otOrigin tx) $ do
+        whenM (shouldSendGossip peer $ otOrigin tx) $ do
           let cId = txChainId tx
           match <- case cId of
             Nothing -> return True
@@ -413,7 +415,7 @@ syncFetch d num = do
         stampActionTimestamp
 
 shouldSend :: PPeer -> Origin.TXOrigin -> Bool
-shouldSend peer tx = case tx of
+shouldSend peer txo = case txo of
     Origin.PeerString ps -> ps /= peerString peer
     Origin.API           -> True
     Origin.BlockHash _   -> False
@@ -422,6 +424,19 @@ shouldSend peer tx = case tx of
     Origin.Morphism      -> -- probably means it was converted, see if this is a problem
         trace "NewTx of type Morphism came in. Should this even happen?" True
     Origin.Blockstanbul -> False
+
+shouldSendGossip :: MonadIO m => PPeer -> Origin.TXOrigin -> m Bool
+shouldSendGossip peer txo =
+  if not (shouldSend peer txo)
+    then return False
+    else case txo of
+            -- On average, we expect to send to 3 peers if this came
+            -- from a peer.
+            Origin.PeerString{} -> do
+              rangeEnd <- getNumPeersMem
+              rng <- liftIO $ randomRIO (1, rangeEnd)
+              return $ rng <= 3
+            _ -> return True
 
 -- check that the peer is authorized to receive these chain details, by verifying that their
 -- IPaddress is associated with one of the Enodes in the chain's member list

--- a/core-strato/strato-p2p/src/Blockchain/Options.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Options.hs
@@ -17,6 +17,9 @@ defineFlag "debugFail" True "Fail on errors we're not supposed to reach. If fals
 defineFlag "maxConn" (20::Int) "Maximum number of client connections."
 defineFlag "connectionTimeout" (300 :: Int) "Number of seconds to tolerate a useless peer"
 defineFlag "maxReturnedHeaders" (1000 :: Int) "Number of headers to return from a GetBlockHeaders request" -- todo: seriously???
+defineFlag "txGossipFanout" (-1::Int) "Maxmimum number of peers to forward transactions to. Only\
+                                      \ applicable for transactions received from peers, not\
+                                      \ originating on this node."
 
 computeNetworkID :: Int
 computeNetworkID = if flags_networkID == -1


### PR DESCRIPTION
![immediate_block_progress](https://user-images.githubusercontent.com/1399455/48030540-63d5ec80-e11f-11e8-9b41-975c96fd7592.png)
![ratio_of_incoming_to_outbound](https://user-images.githubusercontent.com/1399455/48030548-69cbcd80-e11f-11e8-9c11-720bf4f1cda0.png)

Running on ClonePBFTLoadTest, instead of stalling while it processes transactions there is a constant slope for the blocks counter. You can see as well from the graphs that even though 41k transacitons came in on seqevents, 9k were sent out. That's a reasonable approximation to 1/5