### PR TITLE
Archive benchmark pages in nightly builds

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -113,6 +113,7 @@ pipeline {
               cd strato-worktree/core-strato
               ./run_unit_tests_long.sh
             '''
+            archiveArtifacts artifacts: "strato-worktree/core-strato/*.html"
           },
 
           'Bloch tests': {


### PR DESCRIPTION
These are self contained html files with graphs of the benchmarks that ran. Currently there are
blockapps-haskoin.html
blockstanbul.html
ethereum-rlp.html
strato-sequencer.html
![benchmarks](https://user-images.githubusercontent.com/1399455/48144989-dfe74600-e27f-11e8-836c-ff0b8d1f3cc6.png)

These pages are about 2MB at present:
```du -h core-strato/*html
820K    core-strato/blockapps-haskoin.html
384K    core-strato/blockstanbul.html
348K    core-strato/ethereum-rlp.html
248K    core-strato/strato-sequencer.html
```