### PR TITLE
Report correctly which transaction evicted which

### DIFF
--- a/core-strato/ethereum-vm/src/Blockchain/Bagger.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/Bagger.hs
@@ -271,12 +271,12 @@ promoteTx tx@OutputTx{otSigner=signer} = do
     state <- getBaggerState
     $logInfoS "Bagger.promoteTx" "pulling from mempool"
     let txShas = B.bestBlockTxHashes (B.miningCache state)
-        !(evicted, state') = B.addToPending tx state
+        !(evicted, kept, state') = B.addToPending tx state
     putBaggerState state'
     forM_ evicted $ \e -> do
         removeFromSeen e
         logDiscard' "promoteTx" signer e
-        txsDroppedCallback [LessLucrative Promotion Pending tx e] txShas
+        txsDroppedCallback [LessLucrative Promotion Pending kept e] txShas
     addToPromotionCache tx
 
 demoteUnexecutables :: MonadBagger m => m ()

--- a/core-strato/ethereum-vm/src/Blockchain/Bagger/BaggerState.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/Bagger/BaggerState.hs
@@ -91,11 +91,12 @@ defaultMiningCache  = MiningCache { bestBlockSHA          = SHA 0
                                   , startTimestamp        = posixSecondsToUTCTime 0
                                   }
 
-addToATL :: OutputTx -> ATL -> (Maybe OutputTx, ATL)
+addToATL :: OutputTx -> ATL -> (Maybe OutputTx, OutputTx, ATL)
 addToATL t atl =
     case M.lookup signer atl of
-        Nothing  -> (Nothing, M.insert signer (singletonTransactionList t) atl)
-        Just txs -> let (oldTx, newTL) = insertTransaction t txs in (oldTx, M.insert signer newTL atl)
+        Nothing  -> (Nothing, t, M.insert signer (singletonTransactionList t) atl)
+        Just txs -> let (oldTx, newTx, newTL) = insertTransaction t txs
+                    in  (oldTx, newTx, M.insert signer newTL atl)
     where signer = otSigner t
 
 modifyATL :: Alternative a => (TransactionList -> (a OutputTx, TransactionList)) -> Address -> ATL -> (a OutputTx, ATL)
@@ -119,11 +120,15 @@ calculateIntrinsicGasAtNextBlock :: BaggerState -> OutputTx -> Integer
 calculateIntrinsicGasAtNextBlock BaggerState{ miningCache = MiningCache { bestBlockHeader = bh }, calculateIntrinsicGas = cig } =
     cig (DD.blockDataNumber bh + 1)
 
-addToPending :: OutputTx -> BaggerState -> (Maybe OutputTx, BaggerState)
-addToPending t s@BaggerState{pending = p} = let (oldTx, newATL) = addToATL t p in (oldTx, s { pending = newATL })
+addToPending :: OutputTx -> BaggerState -> (Maybe OutputTx, OutputTx, BaggerState)
+addToPending t s@BaggerState{pending = p} =
+   let (oldTx, newTx, newATL) = addToATL t p
+   in  (oldTx, newTx, s { pending = newATL })
 
 addToQueued :: OutputTx -> BaggerState -> (Maybe OutputTx, BaggerState)
-addToQueued t s@BaggerState{queued = q} = let (oldTx, newATL) = addToATL t q in (oldTx, s { queued = newATL })
+addToQueued t s@BaggerState{queued = q} =
+  let (oldTx, _, newATL) = addToATL t q
+  in (oldTx, s { queued = newATL })
 
 addToSeen :: OutputTx -> BaggerState -> BaggerState
 addToSeen t@OutputTx{otHash=sha} s@BaggerState{seen = seen'} = s { seen = M.insert sha t seen' }

--- a/core-strato/ethereum-vm/src/Blockchain/Bagger/TransactionList.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/Bagger/TransactionList.hs
@@ -29,15 +29,15 @@ singletonTransactionList t = M.singleton (transactionNonce $ otBaseTx t) t
 
 -- should replace TXs with identical nonces but different gas cost to one with higher gas cost
 -- returns (Maybe <txThatWasReplaced/txToDropFromSeen>, newTransactionList)
-insertTransaction :: OutputTx -> TransactionList -> (Maybe OutputTx, TransactionList)
+insertTransaction :: OutputTx -> TransactionList -> (Maybe OutputTx, OutputTx, TransactionList)
 insertTransaction t tl =
     let nonce' = nonce t
         oldTx  = M.lookup nonce' tl in
             case oldTx of
-                Nothing -> (Nothing, M.insert nonce' t tl)
+                Nothing -> (Nothing, t, M.insert nonce' t tl)
                 Just existing -> if gasPrice existing < gasPrice t
-                    then (oldTx, M.insert nonce' t tl)
-                    else (Just t, tl)
+                    then (oldTx, t, M.insert nonce' t tl)
+                    else (Just t, existing, tl)
 
 trimBelowNonce :: Integer -> TransactionList -> ([OutputTx], TransactionList)
 trimBelowNonce nonce' tl = let (lt, gte) = M.partitionWithKey (\k _ -> k < nonce') tl in (M.elems lt, gte)

--- a/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/BlockChain.hs
@@ -136,7 +136,7 @@ instance Bagger.MonadBagger ContextM where
 
     -- todo batch insert results
     txsDroppedCallback rejections bestBlockShas = forM_ rejections $ \rejection -> do
-        let (message, _, _, theHash) = baggerRejectionToTransactionResultBits rejection
+        let (message, theHash) = baggerRejectionToTransactionResultBits rejection
         -- if a tx is dropped from Queued during demotion, it means it was likely culled during the demotion as the
         -- new best block we just mined came in
         let isRecentlyRan = theHash `elem` bestBlockShas
@@ -161,16 +161,16 @@ instance Bagger.MonadBagger ContextM where
                                        , transactionResultChainId          = transactionChainId . otBaseTx $ rejectedTx rejection
                                        }
 
-baggerRejectionToTransactionResultBits :: TxRejection -> (String, BaggerStage, BaggerTxQueue, SHA) -- pretty, queue, txHash
+baggerRejectionToTransactionResultBits :: TxRejection -> (String, SHA) -- pretty, txHash
 baggerRejectionToTransactionResultBits rejection = case rejection of
     NonceTooLow    s q expected OutputTx{otHash=hash, otBaseTx=bt} ->
-        (p' s q ++ "tx nonce (expected: " ++ show expected ++ ", actual: " ++ show (transactionNonce bt) ++ ")", s, q, hash)
+        (p' s q ++ "tx nonce (expected: " ++ show expected ++ ", actual: " ++ show (transactionNonce bt) ++ ")", hash)
     BalanceTooLow  s q needed actual OutputTx{otHash=hash} ->
-        (p' s q ++ "account balance (expected: " ++ show needed ++ ", actual: " ++ show actual ++ ")", s, q, hash)
+        (p' s q ++ "account balance (expected: " ++ show needed ++ ", actual: " ++ show actual ++ ")", hash)
     GasLimitTooLow s q _ OutputTx{otHash=hash} ->
-        (p' s q ++ "tx gas limit", s, q, hash)
+        (p' s q ++ "tx gas limit", hash)
     LessLucrative  s q OutputTx{otHash=hashBetter} OutputTx{otHash=hashWorse} ->
-        (p s q ++ formatSHAWithoutColor hashBetter ++ " being a more lucrative transaction", s, q, hashWorse)
+        (p s q ++ formatSHAWithoutColor hashBetter ++ " being a more lucrative transaction", hashWorse)
 
     where p stage queue = "Rejected from mempool at " ++ show stage ++ "/" ++ show queue ++ " due to "
           p' s q        = p s q ++ "low "


### PR DESCRIPTION
If `tx` is less lucrative than the `existing`, it may be rejected. Then the result was recorded as `LessLucrative Promoted Pending tx tx`. This changes it to always report the superior transaction when a conflict arises.

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/652