### PR TITLE
Oauth users

### DIFF
--- a/vault-wrapper/Strato/Strato23/api/src/Strato/Strato23/API/Key.hs
+++ b/vault-wrapper/Strato/Strato23/api/src/Strato/Strato23/API/Key.hs
@@ -17,6 +17,7 @@ import           Strato.Strato23.API.Types
 type GetKey = "key"
             :> Header' '[Required, Strict] "X-USER-UNIQUE-NAME" Text
             :> Header' '[Required, Strict] "X-USER-ID" Text
+            :> QueryParam "username" Text
             :> Get '[JSON] StatusAndAddress
 
 type PostKey = "key"

--- a/vault-wrapper/Strato/Strato23/api/src/Strato/Strato23/Crypto.hs
+++ b/vault-wrapper/Strato/Strato23/api/src/Strato/Strato23/Crypto.hs
@@ -14,9 +14,11 @@ import qualified Crypto.Saltine.Core.SecretBox     as SecretBox
 import qualified Crypto.Saltine.Internal.ByteSizes as Saltine
 import           Crypto.Secp256k1
 import           Data.ByteString                   (ByteString)
+import qualified Data.ByteString                   as BS
 import           Data.Maybe
 import           Data.Text                         (Text)
 import qualified Data.Text.Encoding                as Text
+import           Strato.Strato23.API
 
 newtype Password = Password ByteString
   deriving (Eq,Show)
@@ -34,6 +36,7 @@ data KeyStore = KeyStore
   { keystoreSalt          :: ByteString
   , keystoreAcctNonce     :: SecretBox.Nonce
   , keystoreAcctEncSecKey :: ByteString
+  , keystoreAcctAddress   :: Address
   } deriving (Eq, Show)
 
 decryptSecKey
@@ -52,6 +55,9 @@ decryptSecKey (Password pw) salt nonce encSecKey = do
       , Scrypt.p = 1
       , Scrypt.outputLength = Saltine.secretBoxKey
       }
+
+deriveAddress :: SecKey -> Address
+deriveAddress = keccak256Address . BS.drop 1 . exportPubKey False . derivePubKey
 
 newKeyStore :: MonadIO io => Password -> io KeyStore
 newKeyStore (Password pw) = liftIO $ do
@@ -73,10 +79,12 @@ newKeyStore (Password pw) = liftIO $ do
     encKey = fromMaybe err . Saltine.decode $
       Scrypt.generate scryptParams pw salt
     encAcctSk = SecretBox.secretbox encKey acctNonce (getSecKey acctSk)
+    acctAddr = deriveAddress acctSk
   return KeyStore
     { keystoreSalt = salt
     , keystoreAcctNonce = acctNonce
     , keystoreAcctEncSecKey = encAcctSk
+    , keystoreAcctAddress = acctAddr
     }
 
 newSecKey :: IO SecKey

--- a/vault-wrapper/Strato/Strato23/client/src/Strato/Strato23/Client.hs
+++ b/vault-wrapper/Strato/Strato23/client/src/Strato/Strato23/Client.hs
@@ -15,7 +15,7 @@ import           Strato.Strato23.API
 getPing :: ClientM String
 getPing = client (Proxy @ GetPing)
 
-getKey :: Text -> Text -> ClientM StatusAndAddress
+getKey :: Text -> Text -> Maybe Text -> ClientM StatusAndAddress
 getKey = client (Proxy @ GetKey)
 
 postKey :: Text -> Text -> ClientM StatusAndAddress

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Create.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Create.hs
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS users(
   salt bytea NOT NULL,
   nonce bytea NOT NULL,
   enc_sec_key bytea NOT NULL,
-  address bytea NOT NULL,
+  address bytea NOT NULL
 );
 |]
 

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Create.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Create.hs
@@ -20,7 +20,8 @@ CREATE TABLE IF NOT EXISTS users(
   x_user_unique_name varchar(512) NOT NULL UNIQUE,
   salt bytea NOT NULL,
   nonce bytea NOT NULL,
-  enc_sec_key bytea NOT NULL
+  enc_sec_key bytea NOT NULL,
+  address bytea NOT NULL,
 );
 |]
 

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Migrations.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Migrations.hs
@@ -31,6 +31,7 @@ updateMigrationNumber conn = execute conn updateSchemaVersion (Only $ length mig
 migrations :: [(MigrationErrorBehavior, Query)]
 migrations = [ (Throw, createTables)
              , (Throw, insertSchemaVersion)
+             , (Throw, insertAddress)
              ]
 
 getSchemaVersion :: Query
@@ -41,3 +42,6 @@ insertSchemaVersion = [sql| INSERT INTO vault_wrapper_schema_version VALUES (1,1
 
 updateSchemaVersion :: Query
 updateSchemaVersion = [sql| UPDATE vault_wrapper_schema_version SET schema_version=? WHERE id=1; |]
+
+insertAddress :: Query
+insertAddress = [sql| ALTER TABLE users ADD COLUMN IF NOT EXISTS address bytea; |]

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Queries.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Queries.hs
@@ -14,6 +14,7 @@ module Strato.Strato23.Database.Queries where
 import           Control.Arrow
 import qualified Crypto.Saltine.Class            as Saltine
 import qualified Crypto.Saltine.Core.SecretBox   as SecretBox
+import qualified Data.ByteString.Char8           as C8
 import           Data.Int                        (Int32)
 import           Data.Maybe                      (fromMaybe, listToMaybe)
 import           Data.Profunctor
@@ -22,19 +23,20 @@ import           Data.Text                       (Text)
 import           Database.PostgreSQL.Simple      (Connection)
 import           Opaleye                         hiding (not, null, index)
 
+import           Strato.Strato23.API
 import           Strato.Strato23.Crypto
 import           Strato.Strato23.Database.Tables
 
-getUserKeyQuery :: Text -> Query (Column PGBytea, Column PGBytea, Column PGBytea)
+getUserKeyQuery :: Text -> Query (Column PGBytea, Column PGBytea, Column PGBytea, Column PGBytea)
 getUserKeyQuery username = proc () -> do
-  (_, name, salt, nonce, encSecKey) <- queryTable usersTable -< ()
+  (_, name, salt, nonce, encSecKey, address) <- queryTable usersTable -< ()
   restrict -< name .== constant username
-  returnA -< (salt, nonce, encSecKey)
+  returnA -< (salt, nonce, encSecKey, address)
 
 postUserKeyQuery :: Text -> KeyStore -> Connection -> IO Bool
 postUserKeyQuery userName KeyStore{..} conn = do
   (userIds :: [Int32]) <- runQuery conn $ proc () -> do
-    (userId,name,_,_,_) <- queryTable usersTable -< ()
+    (userId,name,_,_,_,_) <- queryTable usersTable -< ()
     restrict -< name .== constant userName
     returnA -< userId
   case listToMaybe userIds of
@@ -46,8 +48,16 @@ postUserKeyQuery userName KeyStore{..} conn = do
         , constant keystoreSalt
         , constant keystoreAcctNonce
         , constant keystoreAcctEncSecKey
+        , constant keystoreAcctAddress
         )]
       return True
+
+instance QueryRunnerColumnDefault PGBytea Address where
+  queryRunnerColumnDefault = queryRunnerColumn id
+    (fromMaybe (error "could not decode address") . stringAddress . C8.unpack)
+    queryRunnerColumnDefault
+instance Default Constant Address (Column PGBytea) where
+  def = lmap (C8.pack . addressString) def
 
 instance QueryRunnerColumnDefault PGBytea SecretBox.Nonce where
   queryRunnerColumnDefault = queryRunnerColumn id

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Tables.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Database/Tables.hs
@@ -21,17 +21,20 @@ usersTable :: Table
   , Column PGBytea
   , Column PGBytea
   , Column PGBytea
+  , Column PGBytea
   )
   ( Column PGInt4
   , Column PGText
   , Column PGBytea
   , Column PGBytea
   , Column PGBytea
+  , Column PGBytea
   )
-usersTable = Table "users" $ p5
+usersTable = Table "users" $ p6
   ( optional "id"
   , required "x_user_unique_name"
   , required "salt"
   , required "nonce"
   , required "enc_sec_key"
+  , required "address"
   )

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Key.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Key.hs
@@ -4,6 +4,7 @@
 
 module Strato.Strato23.Server.Key where
 
+import           Data.Maybe                       (fromMaybe, isJust)
 import           Data.Text                        (Text)
 import           Strato.Strato23.API
 import           Strato.Strato23.Crypto
@@ -11,12 +12,15 @@ import           Strato.Strato23.Monad
 import           Strato.Strato23.Database.Queries
 
 getKey :: Text -> Text -> Maybe Text -> VaultM StatusAndAddress
-getKey userName userId _ = do
-  (salt, nonce, encKey, (_ :: Address)) <- toUserError ("User " <> userName <> " doesn't exist")
-                         . vaultQuery1 $ getUserKeyQuery userName
-  case decryptSecKey (textPassword userId) salt nonce encKey of
-    Nothing -> vaultWrapperError $ UserError "X-USER-ID does not match entry for X-USER-UNIQUE-NAME"
-    Just pKey -> return . StatusAndAddress $ deriveAddress pKey
+getKey headerUserName userId queryParamUserName = do
+  let userName = fromMaybe headerUserName queryParamUserName
+  (salt, nonce, encKey, addr) <- toUserError ("User " <> userName <> " doesn't exist")
+                               . vaultQuery1 $ getUserKeyQuery userName
+  if isJust queryParamUserName          -- decrypt and derive the address if query param
+    then return $ StatusAndAddress addr -- not specified, to guarantee correctness
+    else case decryptSecKey (textPassword userId) salt nonce encKey of
+      Nothing -> vaultWrapperError $ UserError "X-USER-ID does not match entry for X-USER-UNIQUE-NAME"
+      Just pKey -> return . StatusAndAddress $ deriveAddress pKey
 
 postKey :: Text -> Text -> VaultM StatusAndAddress
 postKey userName userId = do

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Key.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Key.hs
@@ -10,8 +10,8 @@ import           Strato.Strato23.Crypto
 import           Strato.Strato23.Monad
 import           Strato.Strato23.Database.Queries
 
-getKey :: Text -> Text -> VaultM StatusAndAddress
-getKey userName userId = do
+getKey :: Text -> Text -> Maybe Text -> VaultM StatusAndAddress
+getKey userName userId _ = do
   (salt, nonce, encKey, (_ :: Address)) <- toUserError ("User " <> userName <> " doesn't exist")
                          . vaultQuery1 $ getUserKeyQuery userName
   case decryptSecKey (textPassword userId) salt nonce encKey of

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Key.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Key.hs
@@ -1,22 +1,18 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Strato.Strato23.Server.Key where
 
-import           Crypto.Secp256k1
-import qualified Data.ByteString                  as BS
 import           Data.Text                        (Text)
 import           Strato.Strato23.API
 import           Strato.Strato23.Crypto
 import           Strato.Strato23.Monad
 import           Strato.Strato23.Database.Queries
 
-deriveAddress :: SecKey -> Address
-deriveAddress = keccak256Address . BS.drop 1 . exportPubKey False . derivePubKey
-
 getKey :: Text -> Text -> VaultM StatusAndAddress
 getKey userName userId = do
-  (salt, nonce, encKey) <- toUserError ("User " <> userName <> " doesn't exist")
+  (salt, nonce, encKey, (_ :: Address)) <- toUserError ("User " <> userName <> " doesn't exist")
                          . vaultQuery1 $ getUserKeyQuery userName
   case decryptSecKey (textPassword userId) salt nonce encKey of
     Nothing -> vaultWrapperError $ UserError "X-USER-ID does not match entry for X-USER-UNIQUE-NAME"

--- a/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Signature.hs
+++ b/vault-wrapper/Strato/Strato23/server/src/Strato/Strato23/Server/Signature.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Strato.Strato23.Server.Signature where
 
@@ -19,7 +20,7 @@ postSignature userName userId (UserData (Hex msgHash)) = do
   mpk <- vaultTransaction
         . vaultQueryMaybe
         $ getUserKeyQuery userName
-  (salt,nonce,pKey) <- case mpk of
+  (salt,nonce,pKey,(_ :: Address)) <- case mpk of
     Just pk -> return pk
     Nothing -> do
       _ <- postKey userName userId


### PR DESCRIPTION
Allow the GET /key route to be queryable by username. Currently, GET /key still requires the OAuth headers, even with `username` specified. However, if `username` is specified, these credentials are not checked. If `username` is not specified, the handler will try to decrypt the user's secret key and derive the address. If desired, the headers can be dropped altogether, and the lookups can all be done unauthenticated.