### PR TITLE
Include a dummy CallData in genesis block Actions

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Data/Action.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/Action.hs
@@ -14,7 +14,7 @@ import           Blockchain.SHA
 import           Control.DeepSeq
 import           Control.Lens                 hiding ((.=))
 import           Data.Aeson
-import           Data.ByteString              (ByteString)
+import           Data.ByteString              (ByteString, empty)
 import           Data.Function                (on)
 import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as M
@@ -62,6 +62,17 @@ instance FromJSON CallData where
     <*> (o .: "input")
     <*> (o .:? "output")
   parseJSON o = error $ "parseJSON CallData: Expected object, got: " ++ show o
+
+emptyCallData :: CallData
+emptyCallData = CallData
+  { _callDataType     = Create
+  , _callDataSender   = Address 0
+  , _callDataOwner    = Address 0
+  , _callDataGasPrice = 0
+  , _callDataValue    = 0
+  , _callDataInput    = empty
+  , _callDataOutput   = Nothing
+  }
 
 data ActionData = ActionData
   { _actionDataCodeHash     :: SHA

--- a/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
+++ b/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
@@ -232,7 +232,7 @@ initializeChainDBs chainId ChainInfo{..} sRoot = do
                            A.ActionData
                              (codeHash d)
                              (Map.map fromDiff $ storage d)
-                             []
+                             [A.emptyCallData]
         , A._actionMetadata = getMetadata (codeHash d)
         }
       fromDiff (Value v) = v

--- a/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
@@ -14,9 +14,9 @@ import           Control.Monad
 import           Control.Monad.Logger
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource
-import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Char8 as C8
-import qualified Data.ByteString.Lazy.Char8 as BLC
+import qualified Data.ByteString.Base16                       as B16
+import qualified Data.ByteString.Char8                        as C8
+import qualified Data.ByteString.Lazy.Char8                   as BLC
 import           Data.Either                                  (isLeft)
 import           Data.Map.Strict                              (Map)
 import           Data.Maybe
@@ -199,7 +199,7 @@ populateStorageDBs getMetadata genesisBlock genesisChainId = do
                                 A.ActionData
                                   (codeHash d)
                                   (Map.map fromDiff $ storage d)
-                                  []
+                                  [A.emptyCallData]
             , A._actionMetadata = getMetadata (codeHash d)
             }
           fromDiff :: Diff Word256 'Eventual -> Word256


### PR DESCRIPTION
The reason why genesis block contracts are not being indexed now is because I made the CallData lists empty for genesis blocks. When Actions are processed by Slipstream, they are used to create a ProcessedContract record for each CallData in the list, so by including a dummy CallData in the genesis block's Actions, Slipstream will be able to insert its data.