### PR TITLE
Fund validators in PBFT

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -107,7 +107,8 @@ function newnode {
                          "${tbFlag}" +RTS -N1 >> logs/ethereum-vm 2>&1
 
   echo "Starting strato-api"
-  HOST=0.0.0.0 PORT=3000 APPROOT="" FETCH_LIMIT=2000 runBackgroundProcess strato-api +RTS -N1 >> logs/strato-api 2>&1
+  HOST=0.0.0.0 PORT=3000 APPROOT="" FETCH_LIMIT=2000 NODEKEY=${blockstanbulPrivateKey:-} \
+    runBackgroundProcess strato-api +RTS -N1 >> logs/strato-api 2>&1
 
   echo "Configuring log maintenance"
   runBackgroundProcess cleanupLogs

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -42,7 +42,7 @@ function newnode {
     numValidators=$(( 1 + $( echo "${validators}" | tr -cd , | wc -c) ))
     maxConn=$(( maxConn >= numValidators ? maxConn : numValidators ))
   fi
-  if [ -n "${blockstanbul}" || -n "${txGossipFanout}" ]; then
+  if [[ -n "${blockstanbul}" || -n "${txGossipFanout}" ]]; then
     txgFlag="--txGossipFanout=${txGossipFanout:-3}"
   fi
 
@@ -157,11 +157,14 @@ function cleanupDB {
 function doInit {
   export blockTime=${blockTime:-13}
   export minBlockDifficulty=${minBlockDifficulty:-131072}
+  if [[ -n "${extraFaucets}" || -n "${validators}" ]]; then
+    xfFlag="--extraFaucets=${extraFaucets:-$validators}"
+  fi
   cmd="strato-setup --pguser=$pgUser --password=$pgPass --genesisBlockName=$genesis --kafka=./kafka-topics.sh \
                     --pghost=$pgHost --kafkahost=$kafkaHost --zkhost=$zkHost --lazyblocks=$lazyBlocks \
                     --redisHost=$redisBDBHost --redisPort=$redisBDBPort --redisDBNumber=$redisBDBNumber \
                     --addBootnodes=$addBootnodes $stratoBootnode \
-                    --blockTime=$blockTime --minBlockDifficulty=$minBlockDifficulty"
+                    --blockTime=$blockTime --minBlockDifficulty=$minBlockDifficulty $xfFlag"
 # For backup_restore; the environment var is set during strato-admin.sh invocation.
 # Required: Backup file to be accessible to strato container at /tmp/backup
   if [[ $backupblocks ]] ; then

--- a/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
@@ -94,15 +94,19 @@ readSupplementaryAccounts genesisBlockName = do
 getGenesisBlockAndPopulateInitialMPs :: (MonadIO m, HasCodeDB m, HasHashDB m, Mem.HasMemAddressStateDB m,
                                          HasStateDB m, HasStorageDB m)
                                      => String
+                                     -> [Ad.Address]
                                      -> m ([(AccountInfo, CodeInfo)], Block)
-getGenesisBlockAndPopulateInitialMPs genesisBlockName = do
+getGenesisBlockAndPopulateInitialMPs genesisBlockName extraFaucets = do
     theJSONString <- liftIO . BLC.readFile $ genesisBlockName ++ "Genesis.json"
     let genesis = JS.parseLazyByteString genesisParser theJSONString
         theJSON = case genesis of
                       [x] -> x
                       _ -> error $ "invalid genesis: " ++ show genesis
+        faucetBalance = 0x1000000000000000000000000000000000000000000000000000000000000
+        faucetAccounts = map (flip NonContract faucetBalance) extraFaucets
+        theJSON' = theJSON{genesisInfoAccountInfo = faucetAccounts ++ (genesisInfoAccountInfo theJSON)}
     extraAccounts <- liftIO . readSupplementaryAccounts $ genesisBlockName
-    genesisInfoToGenesisBlock theJSON genesisBlockName extraAccounts
+    genesisInfoToGenesisBlock theJSON' genesisBlockName extraAccounts
 
 data BackupType = NoBackup | BlockBackup | MPBackup
 
@@ -118,19 +122,20 @@ initializeGenesisBlock :: ( MonadResource m
                           )
                        => BackupType
                        -> String
+                       -> [Ad.Address]
                        -> m ()
-initializeGenesisBlock backupType genesisBlockName = do
+initializeGenesisBlock backupType genesisBlockName extraFaucets = do
     $logInfoS "initgen" "Begin of initgen"
     (srcInfo, genesisBlock, obGB) <-
         case backupType of
             NoBackup -> do
-                (si, gb) <- getGenesisBlockAndPopulateInitialMPs genesisBlockName
+                (si, gb) <- getGenesisBlockAndPopulateInitialMPs genesisBlockName extraFaucets
                 _ <- produceVMEvents [ChainBlock gb]
                 obGB <- liftIO $ bootstrapSequencer gb
                 putGenesisHash $ blockHash gb
                 return (si, gb, obGB)
             BlockBackup -> do
-                (si, gb) <- getGenesisBlockAndPopulateInitialMPs genesisBlockName
+                (si, gb) <- getGenesisBlockAndPopulateInitialMPs genesisBlockName extraFaucets
                 _ <- produceVMEvents [ChainBlock gb]
                 obGB <- liftIO $ bootstrapSequencer gb
                 backupBlocks

--- a/core-strato/strato-init/src/Blockchain/Setup.hs
+++ b/core-strato/strato-init/src/Blockchain/Setup.hs
@@ -15,6 +15,7 @@ import           Control.Monad.Logger
 import           Control.Monad.Trans.Reader
 import           Control.Monad.Trans.Resource
 import           Control.Monad.Trans.State
+import qualified Data.Aeson                         as Ae
 import qualified Data.ByteString                    as B
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Char8              as C
@@ -78,6 +79,8 @@ defineFlag "minBlockDifficulty" (131072  ::  Integer) "Minimum block difficulty"
 defineFlag "R:redisHost" ("localhost"  ::  String) "Redis BlockDB hostname"
 defineFlag "redisPort" (6379  ::  Int) "Redis BlockDB port"
 defineFlag "redisDBNumber" (0  ::  Integer) "Redis database number"
+
+defineFlag "extraFaucets" ("[]" :: String) "JSON encoded list of other faucets to initialize"
 
 data SetupDBs =
   SetupDBs {
@@ -222,6 +225,9 @@ defaultConfig =
       quarryConfig       = defaultQuarryConfig,
       discoveryConfig    = defaultDiscoveryConfig
     }
+
+decodedFaucets :: [Address]
+decodedFaucets = fromMaybe [] . Ae.decodeStrict . C.pack $ flags_extraFaucets
 
 defaultPeers :: [(String,Int)]
 defaultPeers =
@@ -461,7 +467,7 @@ oneTimeSetup genesisBlockName = do
            addCode B.empty --blank code is the default for Accounts, but gets added nowhere else.
            liftIO $ putStrLn $ CL.yellow ">>>> Initializing Genesis Block"
            case (flags_backupmp, flags_backupblocks) of
-             (False, False) -> initializeGenesisBlock NoBackup genesisBlockName
+             (False, False) -> initializeGenesisBlock NoBackup genesisBlockName decodedFaucets
              (True, True)   -> error "You can't choose --backupmp and --backupblocks at the same time"
-             (False, True)  -> initializeGenesisBlock BlockBackup genesisBlockName
-             (True, False)  -> initializeGenesisBlock MPBackup genesisBlockName
+             (False, True)  -> initializeGenesisBlock BlockBackup genesisBlockName decodedFaucets
+             (True, False)  -> initializeGenesisBlock MPBackup genesisBlockName decodedFaucets


### PR DESCRIPTION
This behavior can be enabled in non-PBFT by setting `extraFaucets='["deadbeef"]'` and disabled in PBFT by explicitly setting `extraFaucets='[]'`. That variable is not yet exposed in the docker-compose because I'm waiting to see if that is actually a necessary feature. As far as I know, clients don't typically have a problem with the infinite faucet lying around and so I wouldn't anticipate them objecting to infinity * n.
However, if we have clients that expect to upgrade a production PBFT network (I don't think we do yet), this change will cause trouble for them with mismatched genesis blocks. 

The next step is to pass the NODEKEY to strato-api to federate funding of users.