### PR TITLE
Remove happy installs, doesn't seem to be necessary anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,6 @@ build_buildbase:
 	blockapps-haskell/pull_solc.sh 0.4.24 $(TMPDIR) $(TMPDIR)/license
 	cp -f Dockerfile.buildbase $(TMPDIR)
 	docker build --build-arg STACK_RESOLVER=${STACK_RESOLVER} --tag=strato-buildbase:${STACK_RESOLVER} -f ${TMPDIR}/Dockerfile.buildbase ${TMPDIR}
-	stack exec -- stack install happy-1.19.8
 
 test:
 	@echo ${VERSION}

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ sudo ./b2 install
 
 None library dependencies
 
-#### Known issue with 'happy' lib when building on host (non-docker-enabled stack)
+#### (Should no longer occur): Known issue with 'happy' lib when building on host (non-docker-enabled stack)
 
 Also we need to explicitly install `happy` library on the host:
 ```

--- a/core-strato/Makefile
+++ b/core-strato/Makefile
@@ -19,15 +19,11 @@ prebuild:
 
 build_haskell: prebuild
 	stack setup
-	# installing happy-1.19.8 explicitly to avoid the error while building 3rd party lib "language-javascript-0.6.0.11" - remove when migrated to compiler ghc-8.2.2 in stack.yaml
-	stack install --local-bin-path=$(FAKEROOT)/usr/bin happy-1.19.8
 	stack install --local-bin-path=$(FAKEROOT)/usr/bin
-	stack test --no-run-tests test-suite \
+	stack test --no-run-tests test-suite
 
 build_haskell_profiled: prebuild build_buildbase
 	stack setup
-	# installing happy-1.19.8 explicitly to avoid the error while building 3rd party lib "language-javascript-0.6.0.11" - remove when migrated to compiler ghc-8.2.2 in stack.yaml
-	stack install --local-bin-path=$(FAKEROOT)/usr/bin happy-1.19.8
 	stack install --profile --work-dir .stack-work-profile --local-bin-path=$(FAKEROOT)/usr/bin
 	stack test    --profile --work-dir .stack-work-profile --no-run-tests test-suite
 


### PR DESCRIPTION
https://jenkins.blockapps.net/job/STRATO_test/762/.
I also was able to build in multinode308:/sp2 from a fresh install of solc