### PR TITLE
Always give a unique nonce to each to_address

### DIFF
--- a/core-strato/strato-api/src/Foundation.hs
+++ b/core-strato/strato-api/src/Foundation.hs
@@ -58,7 +58,7 @@ acquireNewMaxNonce minNonce = do
       -- Another node may have jumped ahead of our faucet stream or we may
       -- just be starting up, so always give at least the minNonce.
       findNext maxNonce =
-        let next = max minNonce $ 1 + maxNonce
+        let next = 1 + max minNonce maxNonce
         in (next, next)
   nref <- asks appFaucetNonce
   liftIO $ atomicModifyIORef' nref findNext

--- a/core-strato/strato-api/src/Handler/Faucet.hs
+++ b/core-strato/strato-api/src/Handler/Faucet.hs
@@ -23,7 +23,6 @@ import           Blockchain.Strato.Model.Class
 import           Blockchain.Strato.Model.Format
 import           Blockchain.Strato.Model.SHA
 import           Blockchain.Util                (getCurrentMicrotime)
-import           Data.List                      (nub)
 import           Handler.Common
 import           Handler.Filters
 import           Import
@@ -75,7 +74,7 @@ postFaucetR = do
     Just target -> do
       maxNonce <- acquireNewMaxNonce minNonce
       $logInfoS "postFaucetR" . T.pack $ printf "%s: [min..max]=[%d,%d]" (format target) minNonce maxNonce
-      mapM (putTX maxNonce key target) $ nub [maxNonce, minNonce]
+      mapM (putTX maxNonce key target) [maxNonce, minNonce]
     Nothing -> do
       maybeAddrs <- lookupPostParam "addresses"
       liftIO $ putStrLn $ T.pack $ show maybeAddrs

--- a/core-strato/strato-api/unittest/Spec.hs
+++ b/core-strato/strato-api/unittest/Spec.hs
@@ -18,17 +18,17 @@ runTestM mv = do
 spec :: Spec
 spec = describe "acquireNewMaxNonce" $ do
   it "allocates distinct" . runTestM $
-    replicateM 100 (acquireNewMaxNonce 0) `shouldReturn` [0..99]
+    replicateM 100 (acquireNewMaxNonce 0) `shouldReturn` [1..100]
 
-  it "will give a nonce larger than min nonce" . runTestM $
-    acquireNewMaxNonce 2007 `shouldReturn` 2007
+  it "will give a nonce strictly larger than min nonce" . runTestM $
+    acquireNewMaxNonce 2007 `shouldReturn` 2008
 
   it "is thread safe" . runTestM $ do
-    nonces <- replicateConcurrently 100 (acquireNewMaxNonce 100)
+    nonces <- replicateConcurrently 100 (acquireNewMaxNonce 99)
     nonces `shouldMatchList` [100..199]
 
   it "gives the minimum allowable" . runTestM $ do
-    acquireNewMaxNonce 400 `shouldReturn` 400
-    acquireNewMaxNonce 420 `shouldReturn` 420
+    acquireNewMaxNonce 400 `shouldReturn` 401
     acquireNewMaxNonce 420 `shouldReturn` 421
-    acquireNewMaxNonce 422 `shouldReturn` 422
+    acquireNewMaxNonce 420 `shouldReturn` 422
+    acquireNewMaxNonce 422 `shouldReturn` 423


### PR DESCRIPTION
It's currently possible that faucets can be dropped when they are the first to be created for a block.
Running faucet scripts until confirmation can lead to missed addreses, in about every ~200 blocks:
```26977 tim        20   0 97912 28304 10240 S  0.0  0.4  0:10.30 python3 /home/tim/bin/fauceter.py multinode23.ci.blockapps.net 1073
27911 tim        20   0 97912 28508 10440 S  0.7  0.4  0:10.12 python3 /home/tim/bin/fauceter.py multinode23.ci.blockapps.net 1109
 3544 tim        20   0 97908 28448 10396 S  0.7  0.4  0:08.49 python3 /home/tim/bin/fauceter.py multinode23.ci.blockapps.net 1396
11496 tim        20   0 97912 28464 10396 S  0.7  0.4  0:06.96 python3 /home/tim/bin/fauceter.py multinode23.ci.blockapps.net 1629
22378 tim        20   0 97908 28192 10140 S  0.7  0.4  0:05.51 python3 /home/tim/bin/fauceter.py multinode23.ci.blockapps.net 2004
23241 tim        20   0 97912 28776 10708 S  0.7  0.4  0:05.50 python3 /home/tim/bin/fauceter.py multinode23.ci.blockapps.net 2037
```
The reason for this is that the first faucet for a block is given the next available nonce, but so is every other faucet for that block. Most of the time this is fine because of the higher gas price, but it is possible that the later TX reaches a peer and is enblocked first:
```
eth_e779e7156cf444469055ce499966cf2b8a5e7f1a=# select to_address, from_address, block_number from raw_transaction where nonce = 830;
 to_address |               from_address               | block_number
------------+------------------------------------------+--------------
 1073       | 4c5233b10246aa027e666a203e08f294bfc7fa7f |           -1
 1075       | 275292fe27f6bdc05e7fd4ca40e0e34f58e9a7fc |           -1
 1072       | 4c5233b10246aa027e666a203e08f294bfc7fa7f |          845
 1074       | 275292fe27f6bdc05e7fd4ca40e0e34f58e9a7fc |          845
(4 rows)


eth_e779e7156cf444469055ce499966cf2b8a5e7f1a=# select nonce from raw_transaction where to_address = '1072';
 nonce
-------
   830
   831
(2 rows)

```