### PR TITLE
Smd privacy

### DIFF
--- a/apex/api/sockets/aggregators/getTransactions.js
+++ b/apex/api/sockets/aggregators/getTransactions.js
@@ -29,7 +29,11 @@ function getTransactions() {
 
 function parseTransactionType(t) {
   if(t.to_address == null) {
-	  return "Contract";
+      if(t.code_or_data.length == 0) {
+	        return "PrivateTX";
+      } else {
+	        return "Contract";
+      }
   }
   else if(t.code_or_data.length == 0) {
 	  return "Transfer";

--- a/apex/api/sockets/aggregators/transactionsType.js
+++ b/apex/api/sockets/aggregators/transactionsType.js
@@ -20,13 +20,13 @@ function getTransactionsType() {
       }
   ).then(function (data) {
     if (data.length) {
-      let typesCounter = {"FunctionCall": 0, "Transfer": 0, "Contract": 0};
+      let typesCounter = {"FunctionCall": 0, "Transfer": 0, "Contract": 0, "PrivateTX": 0};
       data.forEach(tx => {
         let txType;
         if (tx.to_address) {
           txType = tx.code_or_data.length ? 'FunctionCall' : 'Transfer';
         } else {
-          txType = 'Contract';
+            txType = tx.code_or_data.length ? 'Contract' : 'PrivateTX';
         }
         typesCounter[txType] += 1;
       });

--- a/core-strato/blockapps-data/src/Blockchain/Data/BlockDB.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/BlockDB.hs
@@ -193,15 +193,15 @@ putBlocks difficultyBase blocks makeHashOne = do
              toInsert <- lift $ lift $ blk2BlkDataRef dm (b, hash') makeHashOne
              blkDataRefId <- SQL.insert toInsert
              forM_ (blockReceiptTransactions b) $ \tx -> do
-               txID <- updateBlockNumber b $ transactionHash tx
+               txID <- updateBlockNumber b (transactionHash tx) (txChainId tx)
                SQL.insert $ BlockTransaction blkDataRefId txID
              return blkDataRefId
            [bd] -> return $ SQL.entityKey bd
            _ -> error "DB has multiple blocks with the same hash"
 
   where
-    updateBlockNumber b txHash'  = do
-          ret <- SQL.getBy (UniqueTXHash txHash')
+    updateBlockNumber b txHash' cid = do
+          ret <- SQL.getBy (UniqueTXHash txHash' $ fromMaybe 0 cid)
           key <-
             case ret of
              Just x  -> return $ entityKey x

--- a/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.hs
@@ -57,6 +57,8 @@ migrateAll = do
   exec "ALTER TABLE IF EXISTS block_data ALTER COLUMN extra_data TYPE bytea USING extra_data::bytea;"
   exec "ALTER TABLE IF EXISTS block_data_ref ALTER COLUMN extra_data TYPE bytea USING extra_data::bytea;"
   exec "ALTER TABLE IF EXISTS address_state_ref DROP COLUMN IF EXISTS source;"
+  exec "ALTER TABLE IF EXISTS raw_transaction ALTER COLUMN chain_id SET DEFAULT 0;"
+  exec "ALTER TABLE IF EXISTS raw_transaction ALTER COLUMN chain_id SET NOT NULL;"
   migrateAuto
 
 -- todo newtype me

--- a/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.txt
+++ b/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.txt
@@ -64,7 +64,7 @@ RawTransaction
     toAddress Address Maybe
     value Integer sqltype=numeric(1000,0)
     codeOrData BS.ByteString
-    chainId Word256 Maybe
+    chainId Word256
     r Integer
     s Integer
     v Word8
@@ -72,7 +72,7 @@ RawTransaction
     blockNumber Int
     txHash SHA
     origin TXOrigin
-    UniqueTXHash txHash
+    UniqueTXHash txHash chainId
     deriving Eq Generic Read Show
 
 Storage json

--- a/core-strato/blockapps-data/src/Blockchain/Data/Json.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/Json.hs
@@ -16,14 +16,15 @@ import           Blockchain.Data.DataDefs
 import           Blockchain.Data.Transaction
 import           Blockchain.Format
 import           Blockchain.Strato.Model.ExtendedWord (Word256)
+import           Blockchain.Util                      (toMaybe)
 
 import           Data.Aeson
-import           Data.Aeson.Types            (Parser)
-import qualified Data.ByteString             as B
-import qualified Data.ByteString.Base16      as B16
-import qualified Data.Map.Strict             as M
+import           Data.Aeson.Types                     (Parser)
+import qualified Data.ByteString                      as B
+import qualified Data.ByteString.Base16               as B16
+import qualified Data.Map.Strict                      as M
 import           Data.Maybe
-import qualified Data.Text.Encoding          as T
+import qualified Data.Text.Encoding                   as T
 import           Data.Time.Calendar
 import           Data.Time.Clock
 import           Data.Word
@@ -50,7 +51,7 @@ instance ToJSON RawTransaction' where
         "transactionType" .= (show $ rawTransactionSemantics rt),
         "timestamp" .= show t,
         "origin" .= format o
-               ] ++ (("chainId" .=) <$> maybeToList cid)
+               ] ++ (("chainId" .=) <$> maybeToList (toMaybe 0 cid))
                  ++ (("metadata" .=) <$> maybeToList (M.fromList <$> md))
     toJSON (RawTransaction' rt@(RawTransaction t (Address fa) non gp gl Nothing val cod cid r s v md bn h o) next) =
         object $ ["next" .= next, "from" .= showHex fa "", "nonce" .= non, "gasPrice" .= gp, "gasLimit" .= gl,
@@ -63,7 +64,7 @@ instance ToJSON RawTransaction' where
         "transactionType" .= (show $ rawTransactionSemantics rt),
         "timestamp" .= show t,
         "origin" .= format o
-               ] ++ (("chainId" .=) <$> maybeToList cid)
+               ] ++ (("chainId" .=) <$> maybeToList (toMaybe 0 cid))
                  ++ (("metadata" .=) <$> maybeToList (M.fromList <$> md))
 
 parseHexStr :: (Integral a) => Parser String -> Parser a
@@ -104,7 +105,7 @@ instance FromJSON RawTransaction' where
                  (tto :: Maybe Address)
                  (tval :: Integer)
                  (tcd :: B.ByteString)
-                 (cid :: Maybe Word256)
+                 (fromMaybe 0 (cid :: Maybe Word256))
                  (tr :: Integer)
                  (ts :: Integer)
                  (tv :: Word8)

--- a/core-strato/blockapps-data/src/Blockchain/Data/Transaction.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/Transaction.hs
@@ -136,21 +136,24 @@ instance TransactionLike Transaction where
               md        = txMetadata t
 
 rawTX2TX :: RawTransaction -> Transaction
-rawTX2TX (RawTransaction _ _ nonce' gp gl (Just to') val dat cid r s v md _ _ _) = MessageTX nonce' gp gl to' val dat cid r s v (M.fromList <$> md)
-rawTX2TX (RawTransaction _ _ 0 0 0 Nothing 0 init' Nothing h ch 0 Nothing _ _ _) | init' == B.empty = PrivateHashTX (fromInteger h) (fromInteger ch)
-rawTX2TX (RawTransaction _ _ nonce' gp gl Nothing val init' cid r s v md _ _ _) = ContractCreationTX nonce' gp gl val (Code init') cid r s v (M.fromList <$> md)
+rawTX2TX (RawTransaction _ _ nonce' gp gl (Just to') val dat cid r s v md _ _ _) =
+  MessageTX nonce' gp gl to' val dat (toMaybe 0 cid) r s v (M.fromList <$> md)
+rawTX2TX (RawTransaction _ _ 0 0 0 Nothing 0 init' 0 h ch 0 Nothing _ _ _) | init' == B.empty =
+  PrivateHashTX (fromInteger h) (fromInteger ch)
+rawTX2TX (RawTransaction _ _ nonce' gp gl Nothing val init' cid r s v md _ _ _) =
+  ContractCreationTX nonce' gp gl val (Code init') (toMaybe 0 cid) r s v (M.fromList <$> md)
 
 txAndTime2RawTX :: TXOrigin -> Transaction -> Integer -> UTCTime -> RawTransaction
 txAndTime2RawTX origin tx blkNum time =
   case tx of
     (MessageTX nonce' gp gl to' val dat cid r s v md) ->
-        RawTransaction time signer nonce' gp gl (Just to') val dat cid r s v (M.toList <$> md) (fromIntegral blkNum) (txHash tx) origin
+        RawTransaction time signer nonce' gp gl (Just to') val dat (fromMaybe 0 cid) r s v (M.toList <$> md) (fromIntegral blkNum) (txHash tx) origin
     (ContractCreationTX _ _ _ _ (PrecompiledCode _) _ _ _ _ _) ->
         error "Error in call to txAndTime2RawTX: You can't convert a transaction to a raw transaction if the code is a precompiled contract"
     (ContractCreationTX nonce' gp gl val (Code init') cid r s v md) ->
-        RawTransaction time signer nonce' gp gl Nothing val init' cid r s v (M.toList <$> md) (fromIntegral blkNum) (txHash tx) origin
+        RawTransaction time signer nonce' gp gl Nothing val init' (fromMaybe 0 cid) r s v (M.toList <$> md) (fromIntegral blkNum) (txHash tx) origin
     (PrivateHashTX h ch) ->
-        RawTransaction time signer 0 0 0 Nothing 0 B.empty Nothing (fromIntegral h) (fromIntegral ch) 0 Nothing (fromIntegral blkNum) (txHash tx) origin
+        RawTransaction time signer 0 0 0 Nothing 0 B.empty 0 (fromIntegral h) (fromIntegral ch) 0 Nothing (fromIntegral blkNum) (txHash tx) origin
   where
     signer = fromMaybe (Address (-1)) $ whoSignedThisTransaction tx
 

--- a/core-strato/blockapps-util/src/Blockchain/Util.hs
+++ b/core-strato/blockapps-util/src/Blockchain/Util.hs
@@ -19,6 +19,9 @@ import           Data.Time.Clock.POSIX    (POSIXTime, getPOSIXTime)
 
 import qualified Data.Binary              as Binary
 
+toMaybe :: Eq a => a -> a -> Maybe a
+toMaybe a b = if a == b then Nothing else Just b
+
 buildState :: s -> [a] -> (a -> State s ()) -> s
 buildState s [] _ = s
 buildState s (a:as) run =

--- a/core-strato/strato-api/src/Handler/Filters.hs
+++ b/core-strato/strato-api/src/Handler/Filters.hs
@@ -185,7 +185,7 @@ getTransFilter (rawTx)     ("minvalue", v)     = rawTx E.^. RawTransactionValue 
 getTransFilter (rawTx)     ("maxvalue", v)     = rawTx E.^. RawTransactionValue E.<=. E.val (toInteger' v)
 
 getTransFilter (rawTx)     ("blocknumber", v)  = rawTx E.^. RawTransactionBlockNumber E.==. E.val (P.read $ T.unpack v :: Int)
-getTransFilter (rawTx)     ("chainid", v)      = ((rawTx E.^. RawTransactionChainId) E.==. (E.just $ E.val (fromHexText v)))
+getTransFilter (rawTx)     ("chainid", v)      = ((rawTx E.^. RawTransactionChainId) E.==. E.val (fromHexText v))
 getTransFilter _           _                   = P.undefined ("no match in getTransFilter"::String)
 
 getStorageFilter :: (E.Esqueleto query expr backend) => (expr (Entity Storage), expr (Entity AddressStateRef)) -> (Text, Text) -> expr (E.Value Bool)

--- a/core-strato/strato-api/src/Handler/TransactionInfo.hs
+++ b/core-strato/strato-api/src/Handler/TransactionInfo.hs
@@ -137,17 +137,17 @@ getTransactionR = do
                                         E.where_ ((P.foldl1 (E.&&.) $ P.map (getTransFilter (rawTx)) $ getParameters ))
 
                                         let criteria = P.map (getTransFilter rawTx) $ getParameters
-                                        let matchChainId cid = ((rawTx E.^. RawTransactionChainId) E.==. (E.just $ E.val $ fromHexText cid))
-                                        let chainCriteria = case chainIds of
-                                              [] -> [(E.isNothing $ rawTx E.^. RawTransactionChainId)]
+                                            matchChainId cid = ((rawTx E.^. RawTransactionChainId) E.==. (E.val $ fromHexText cid))
+                                            chainCriteria = case chainIds of
+                                              [] -> [rawTx E.^. RawTransactionChainId E.==. E.val 0]
                                               [cid] -> if (T.unpack cid == "main")
-                                                           then [(E.isNothing $ rawTx E.^. RawTransactionChainId)]
+                                                           then [rawTx E.^. RawTransactionChainId E.==. E.val 0]
                                                            else if (T.unpack cid == "all")
                                                                     then []
-                                                                    else [matchChainId cid]             
-                                              cids -> P.map matchChainId cids 
-                                        let otherCriteria = ((rawTx E.^. RawTransactionBlockNumber) E.>=. E.val index') : criteria
-                                        let allCriteria = case chainCriteria of
+                                                                    else [matchChainId cid]
+                                              cids -> P.map matchChainId cids
+                                            otherCriteria = ((rawTx E.^. RawTransactionBlockNumber) E.>=. E.val index') : criteria
+                                            allCriteria = case chainCriteria of
                                                 [] -> [otherCriteria]
                                                 _ -> P.map (\cc -> cc : otherCriteria) chainCriteria
                                         -- FIXME: if more than `limit` transactions per block, we will need to have a tuple as index

--- a/core-strato/strato-api/src/Handler/TxLast.hs
+++ b/core-strato/strato-api/src/Handler/TxLast.hs
@@ -17,9 +17,7 @@ getTxLastR  num = do
         E.from $ \(rawTX `E.InnerJoin` btx `E.InnerJoin` b) -> do
           E.on (b E.^. BlockDataRefId E.==. btx E.^. BlockTransactionBlockDataRefId)
           E.on (btx E.^. BlockTransactionTransaction E.==. rawTX E.^. RawTransactionId)
-          E.where_ $ case chainId of
-                Nothing -> (E.isNothing $ rawTX E.^. RawTransactionChainId)
-                Just c -> ((rawTX E.^. RawTransactionChainId) E.==. (E.just $ E.val c))
+          E.where_ (rawTX E.^. RawTransactionChainId E.==. E.val (fromMaybe 0 chainId))
           E.limit $ P.max 1 $ P.min (fromIntegral num :: Int64) fetchLimit
           E.orderBy [E.desc $ b E.^. BlockDataRefId]
           return rawTX

--- a/smd-ui/src/components/Accounts/accounts.saga.js
+++ b/smd-ui/src/components/Accounts/accounts.saga.js
@@ -174,7 +174,7 @@ export function* faucetAccount(action) {
   try {
     yield call(postFaucet, action.name, action.address);
     yield call(delay, 100)
-    yield put(fetchAccountDetail(action.name, action.address, action.flag));
+    yield put(fetchAccountDetail(action.name, action.address, action.chainId, action.flag));
     if (!action.flag)
       yield put(faucetSuccess());
   }

--- a/smd-ui/src/tests/Accounts/accounts.saga.spec.js
+++ b/smd-ui/src/tests/Accounts/accounts.saga.spec.js
@@ -254,7 +254,7 @@ describe('Accounts: saga', () => {
       const gen = faucetAccount(action);
         expect(gen.next().value).toEqual(call(postFaucet, action.name, action.address));
       expect(gen.next().value).toEqual(call(delay, 100));
-      expect(gen.next().value).toEqual(put(fetchAccountDetail(action.name, action.address, action.flag)));
+      expect(gen.next().value).toEqual(put(fetchAccountDetail(action.name, action.address, undefined, action.flag)));
       expect(gen.throw(error).value).toEqual(put(faucetFailure(error)));
       expect(gen.next().done).toBe(true);
     });


### PR DESCRIPTION
Merging the private chain SMD changes into develop broke the faucet button. Also in this PR, PrivateTXs are distinguished from contract uploads in Apex/SMD, and `RawTransaction`s are uniquely identified by the transaction hash and chain Id, to allow for the PrivateHashTX and the full transaction payload to be stored in the database simultaneously. In will allow us to see the PrivateHashTX in SMD when we're viewing the main chain, and view the full transaction payload when viewing the private chain.