### PR TITLE
Test for the presence of concurrently uploaded contracts in slipstream

### DIFF
--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -153,6 +153,7 @@ pipeline {
               pushd strato-worktree/tests
               npm install
               npm run test:truchainz
+              npm run test:multicontract
               popd
               pushd strato-worktree/core-strato/strato-init
               ./check_genesis_ingestion.sh

--- a/tests/e2e/multicontract.test.js
+++ b/tests/e2e/multicontract.test.js
@@ -1,0 +1,51 @@
+"use strict";
+const ba = require('blockapps-rest');
+const co = require('co');
+require('co-mocha');
+
+const rest = ba.rest;
+const common = ba.common;
+const util = common.util;
+const BigNumber = common.BigNumber;
+const config = common.config;
+const password = '1234';
+config.apiDebug=true;
+
+// Honestly, past this size bloc can't receive all connections.
+const SIZE=10
+const transactions = [...Array(SIZE).keys()].map(i => {
+  const name = `ScatterUpload_${i}`
+  return { nonce: i, name: name, src: `contract ${name} \{\}` }
+})
+
+async function sleep(timeout) {
+  return new Promise(resolve => setTimeout(resolve, timeout))
+}
+
+describe("Concurrent uploads", function() {
+
+  it('should create multiple contracts and see them all in cirrus', async function () {
+    this.timeout(config.timeout);
+    const user_name= 'multi_contract' + util.uid();
+    const user = await co.wrap(rest.createUser)(user_name, password, false);
+    let balance = new BigNumber(0);
+    while (balance.isZero()) {
+      await sleep(500);
+      balance = await co.wrap(rest.getBalance)(user.address);
+    }
+    console.log(`Balance of ${user_name} is ${balance}`)
+    console.log("Beginning to upload contracts");
+    const upload = co.wrap(rest.uploadContractString)
+    const promises = transactions.map(tx =>
+      upload(user, tx.name, tx.src, undefined, undefined, {nonce: tx.nonce}));
+    let allResults = await Promise.all(promises);
+    console.log(allResults);
+    const query = co.wrap(rest.queryUntil)
+    const qromises = transactions.map(tx =>
+      query(tx.name, results => results.length > 0));
+    let allQueries = await Promise.all(qromises);
+    console.log(allQueries);
+  });
+
+});
+

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,8 @@
     "test:load": "mocha load/stratoLoad.test.js --batchCount 20 --batchSize 20 && mocha load/stratoLoadFactory.test.js --batchCount 20 --batchSize 20",
     "test:loadecho": "mocha load/stratoLoadEcho.test.js --batchCount 20 --batchSize 20 --config config/localhost.config.yaml",
     "test:upload": "mocha load/uploadString.test.js --batchCount 10 --batchSize 10 && mocha load/uploadUniqueAddresses.test.js --batchCount 10 --batchSize 10",
-    "test:truchainz": "mocha e2e/createChain.test.js && mocha e2e/governance.test.js"
+    "test:truchainz": "mocha e2e/createChain.test.js && mocha e2e/governance.test.js",
+    "test:multicontract": "mocha e2e/multicontract.test.js"
   },
   "dependencies": {
     "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#develop",


### PR DESCRIPTION
This test is passing without changes, meaning that my hypothesis that some contracts were being omitted from statediffs were omitted is unsupported. Still, the test is already written and I think it might not be a bad check to have.