### PR TITLE
Compare using InstSet to [Word256] for jump destinations

### DIFF
--- a/core-strato/blockapps-util/src/Blockchain/Util.hs
+++ b/core-strato/blockapps-util/src/Blockchain/Util.hs
@@ -104,6 +104,10 @@ safeDrop i s | i > fromIntegral (B.length s) = B.empty
 safeDrop i _ | i > 0x7fffffffffffffff = error "error in call to safeDrop: string too long"
 safeDrop i s = B.drop (fromIntegral i) s
 
+safeIntDrop :: Int -> B.ByteString -> B.ByteString
+safeIntDrop i s | i > B.length s = B.empty
+safeIntDrop i s = B.drop i s
+
 
 isContiguous::(Eq a, Num a)=>[a]->Bool
 isContiguous []         = True

--- a/core-strato/ethereum-vm/bench/Microbench.hs
+++ b/core-strato/ethereum-vm/bench/Microbench.hs
@@ -1,13 +1,19 @@
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
 import Criterion.Main
 
 import Data.Bits ((.&.))
 import Data.Word
 import qualified Data.Vector as V
 import qualified Data.Set as S
-import qualified Data.HashSet as H
+import qualified Data.IntSet as I
+-- import qualified Data.HashSet as H
+-- import qualified Data.Hashable as DH
 
-import Network.Haskoin.Crypto.BigWord (Word256(..))
-import Blockchain.VM.VMState
+import Network.Haskoin.Internals (Word256)
+-- import Blockchain.VM.VMState
+
+-- deriving instance DH.Hashable Word256
 
 -- Simulate an out of bounds destination, to see how behavior scales
 exampleDest :: Word256
@@ -22,8 +28,8 @@ vec256Dests = V.fromList . list256Dests
 set256Dests :: Int -> S.Set Word256
 set256Dests = S.fromList . list256Dests
 
-hash256Dests :: Int -> H.HashSet Word256
-hash256Dests = H.fromList . list256Dests
+-- hash256Dests :: Int -> H.HashSet Word256
+-- hash256Dests = H.fromList . list256Dests
 
 list256MembershipTests :: Int -> Benchmark
 list256MembershipTests n = bench ("list word256 " ++ show n)
@@ -37,9 +43,9 @@ set256MembershipTests :: Int -> Benchmark
 set256MembershipTests n = bench ("set word256 " ++ show n)
                         $ nf (S.member exampleDest) (set256Dests n)
 
-hash256MembershipTests :: Int -> Benchmark
-hash256MembershipTests n = bench ("set word256 " ++ show n)
-                         $ nf (H.member exampleDest) (hash256Dests n)
+-- hash256MembershipTests :: Int -> Benchmark
+-- hash256MembershipTests n = bench ("set word256 " ++ show n)
+--                          $ nf (H.member exampleDest) (hash256Dests n)
 
 list64Dests :: Int -> [Word64]
 list64Dests n = map fromIntegral [1..n]
@@ -50,11 +56,18 @@ vec64Dests = V.fromList . list64Dests
 set64Dests :: Int -> S.Set Word64
 set64Dests = S.fromList . list64Dests
 
-hash64Dests :: Int -> H.HashSet Word64
-hash64Dests = H.fromList . list64Dests
+intsetDests :: Int -> I.IntSet
+intsetDests n = I.fromList [0..n]
 
-downgrade :: Word256 -> Word64
+-- hash64Dests :: Int -> H.HashSet Word64
+-- hash64Dests = H.fromList . list64Dests
+
+downgrade :: (Integral a) => Word256 -> a
 downgrade n = fromInteger (toInteger n .&. 0xffffffffffffffff)
+
+intsetMembershipTests :: Int -> Benchmark
+intsetMembershipTests n = bench ("intset " ++ show n)
+                        $ nf (I.member (downgrade exampleDest)) (intsetDests n)
 
 list64MembershipTests :: Int -> Benchmark
 list64MembershipTests n = bench ("list word64 " ++ show n)
@@ -68,14 +81,17 @@ set64MembershipTests :: Int -> Benchmark
 set64MembershipTests n = bench ("set word64 " ++ show n)
                        $ nf (S.member (downgrade exampleDest)) (set64Dests n)
 
-hash64MembershipTests :: Int -> Benchmark
-hash64MembershipTests n = bench ("hash word64 " ++ show n)
-                        $ nf (H.member (downgrade exampleDest)) (hash64Dests n)
+-- hash64MembershipTests :: Int -> Benchmark
+-- hash64MembershipTests n = bench ("hash word64 " ++ show n)
+--                         $ nf (H.member (downgrade exampleDest)) (hash64Dests n)
 
 main :: IO ()
 main = do
-  let jumpSizes = [1, 4, 16, 256]
+  let jumpSizes = [256, 4096, 32768]
   defaultMain $ map list256MembershipTests jumpSizes
              ++ map vec256MembershipTests jumpSizes
              ++ map set256MembershipTests jumpSizes
-             ++ map hash256MembershipTests jumpSizes
+             ++ map list64MembershipTests jumpSizes
+             ++ map vec64MembershipTests jumpSizes
+             ++ map set64MembershipTests jumpSizes
+             ++ map intsetMembershipTests jumpSizes

--- a/core-strato/ethereum-vm/bench/Microbench.hs
+++ b/core-strato/ethereum-vm/bench/Microbench.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
 import Criterion.Main
 
 import Data.Bits ((.&.))
@@ -7,15 +5,9 @@ import Data.Word
 import qualified Data.Vector as V
 import qualified Data.Set as S
 import qualified Data.IntSet as I
--- import qualified Data.HashSet as H
--- import qualified Data.Hashable as DH
 
 import Network.Haskoin.Internals (Word256)
--- import Blockchain.VM.VMState
 
--- deriving instance DH.Hashable Word256
-
--- Simulate an out of bounds destination, to see how behavior scales
 exampleDest :: Word256
 exampleDest = 200000
 
@@ -27,9 +19,6 @@ vec256Dests = V.fromList . list256Dests
 
 set256Dests :: Int -> S.Set Word256
 set256Dests = S.fromList . list256Dests
-
--- hash256Dests :: Int -> H.HashSet Word256
--- hash256Dests = H.fromList . list256Dests
 
 list256MembershipTests :: Int -> Benchmark
 list256MembershipTests n = bench ("list word256 " ++ show n)
@@ -43,10 +32,6 @@ set256MembershipTests :: Int -> Benchmark
 set256MembershipTests n = bench ("set word256 " ++ show n)
                         $ nf (S.member exampleDest) (set256Dests n)
 
--- hash256MembershipTests :: Int -> Benchmark
--- hash256MembershipTests n = bench ("set word256 " ++ show n)
---                          $ nf (H.member exampleDest) (hash256Dests n)
-
 list64Dests :: Int -> [Word64]
 list64Dests n = map fromIntegral [1..n]
 
@@ -58,9 +43,6 @@ set64Dests = S.fromList . list64Dests
 
 intsetDests :: Int -> I.IntSet
 intsetDests n = I.fromList [0..n]
-
--- hash64Dests :: Int -> H.HashSet Word64
--- hash64Dests = H.fromList . list64Dests
 
 downgrade :: (Integral a) => Word256 -> a
 downgrade n = fromInteger (toInteger n .&. 0xffffffffffffffff)
@@ -80,10 +62,6 @@ vec64MembershipTests n = bench ("vec word64 " ++ show n)
 set64MembershipTests :: Int -> Benchmark
 set64MembershipTests n = bench ("set word64 " ++ show n)
                        $ nf (S.member (downgrade exampleDest)) (set64Dests n)
-
--- hash64MembershipTests :: Int -> Benchmark
--- hash64MembershipTests n = bench ("hash word64 " ++ show n)
---                         $ nf (H.member (downgrade exampleDest)) (hash64Dests n)
 
 main :: IO ()
 main = do

--- a/core-strato/ethereum-vm/bench/Microbench.hs
+++ b/core-strato/ethereum-vm/bench/Microbench.hs
@@ -1,0 +1,81 @@
+import Criterion.Main
+
+import Data.Bits ((.&.))
+import Data.Word
+import qualified Data.Vector as V
+import qualified Data.Set as S
+import qualified Data.HashSet as H
+
+import Network.Haskoin.Crypto.BigWord (Word256(..))
+import Blockchain.VM.VMState
+
+-- Simulate an out of bounds destination, to see how behavior scales
+exampleDest :: Word256
+exampleDest = 200000
+
+list256Dests :: Int -> [Word256]
+list256Dests n = map fromIntegral [1..n]
+
+vec256Dests :: Int -> V.Vector Word256
+vec256Dests = V.fromList . list256Dests
+
+set256Dests :: Int -> S.Set Word256
+set256Dests = S.fromList . list256Dests
+
+hash256Dests :: Int -> H.HashSet Word256
+hash256Dests = H.fromList . list256Dests
+
+list256MembershipTests :: Int -> Benchmark
+list256MembershipTests n = bench ("list word256 " ++ show n)
+                         $ nf (elem exampleDest) (list256Dests n)
+
+vec256MembershipTests :: Int -> Benchmark
+vec256MembershipTests n = bench ("vec word256 " ++ show n)
+                        $ nf (V.elem exampleDest) (vec256Dests n)
+
+set256MembershipTests :: Int -> Benchmark
+set256MembershipTests n = bench ("set word256 " ++ show n)
+                        $ nf (S.member exampleDest) (set256Dests n)
+
+hash256MembershipTests :: Int -> Benchmark
+hash256MembershipTests n = bench ("set word256 " ++ show n)
+                         $ nf (H.member exampleDest) (hash256Dests n)
+
+list64Dests :: Int -> [Word64]
+list64Dests n = map fromIntegral [1..n]
+
+vec64Dests :: Int -> V.Vector Word64
+vec64Dests = V.fromList . list64Dests
+
+set64Dests :: Int -> S.Set Word64
+set64Dests = S.fromList . list64Dests
+
+hash64Dests :: Int -> H.HashSet Word64
+hash64Dests = H.fromList . list64Dests
+
+downgrade :: Word256 -> Word64
+downgrade n = fromInteger (toInteger n .&. 0xffffffffffffffff)
+
+list64MembershipTests :: Int -> Benchmark
+list64MembershipTests n = bench ("list word64 " ++ show n)
+                        $ nf (elem (downgrade exampleDest)) (list64Dests n)
+
+vec64MembershipTests :: Int -> Benchmark
+vec64MembershipTests n = bench ("vec word64 " ++ show n)
+                       $ nf (V.elem (downgrade exampleDest)) (vec64Dests n)
+
+set64MembershipTests :: Int -> Benchmark
+set64MembershipTests n = bench ("set word64 " ++ show n)
+                       $ nf (S.member (downgrade exampleDest)) (set64Dests n)
+
+hash64MembershipTests :: Int -> Benchmark
+hash64MembershipTests n = bench ("hash word64 " ++ show n)
+                        $ nf (H.member (downgrade exampleDest)) (hash64Dests n)
+
+main :: IO ()
+main = do
+  let jumpSizes = [1, 4, 16, 256]
+  defaultMain $ map list256MembershipTests jumpSizes
+             ++ map vec256MembershipTests jumpSizes
+             ++ map set256MembershipTests jumpSizes
+             ++ map hash256MembershipTests jumpSizes

--- a/core-strato/ethereum-vm/package.yaml
+++ b/core-strato/ethereum-vm/package.yaml
@@ -111,3 +111,12 @@ tests:
       - ethereum-vm
       - hspec
     ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
+
+benchmarks:
+  microbench:
+    source-dirs: bench/
+    main: Microbench.hs
+    dependencies:
+      - criterion
+      - ethereum-vm
+      - unordered-containers

--- a/core-strato/ethereum-vm/package.yaml
+++ b/core-strato/ethereum-vm/package.yaml
@@ -119,4 +119,5 @@ benchmarks:
     dependencies:
       - criterion
       - ethereum-vm
+      - hashable
       - unordered-containers

--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -421,7 +421,7 @@ runOperation SSTORE = do
 runOperation JUMP = do
   p <- pop
   jumpDests <- getEnvVar envJumpDests
-  let pInt = fromIntegral $ p .&. (0xffffffffffffffff :: Word256)
+  let pInt = fromIntegral . min p $ (0xffffffffffffffff :: Word256)
   if pInt `I.member` jumpDests
     then setPC $ pInt - 1 -- Subtracting 1 to compensate for the pc-increment that occurs every step.
     else throwE InvalidJump
@@ -430,7 +430,7 @@ runOperation JUMPI = do
   p <- pop
   condition <- pop
   jumpDests <- getEnvVar envJumpDests
-  let pInt = fromIntegral $ p .&. (0xffffffffffffffff :: Word256)
+  let pInt = fromIntegral . min p $ (0xffffffffffffffff :: Word256)
   case (pInt `I.member` jumpDests, (0::Word256) /= condition) of
     (_, False) -> return ()
     (True, _)  -> setPC $ pInt - 1

--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -23,6 +23,7 @@ import qualified Data.ByteString                    as B
 import qualified Data.ByteString.Char8              as BC
 import           Data.Char
 import           Data.Function
+import qualified Data.IntSet                        as I
 import qualified Data.Map.Strict                    as M
 import           Data.Maybe
 import qualified Data.Set                           as S
@@ -420,19 +421,19 @@ runOperation SSTORE = do
 runOperation JUMP = do
   p <- pop
   jumpDests <- getEnvVar envJumpDests
-
-  if p `elem` jumpDests
-    then setPC $ fromIntegral p - 1 -- Subtracting 1 to compensate for the pc-increment that occurs every step.
+  let pInt = fromIntegral $ p .&. (0xffffffffffffffff :: Word256)
+  if pInt `I.member` jumpDests
+    then setPC $ pInt - 1 -- Subtracting 1 to compensate for the pc-increment that occurs every step.
     else throwE InvalidJump
 
 runOperation JUMPI = do
   p <- pop
   condition <- pop
   jumpDests <- getEnvVar envJumpDests
-
-  case (p `elem` jumpDests, (0::Word256) /= condition) of
+  let pInt = fromIntegral $ p .&. (0xffffffffffffffff :: Word256)
+  case (pInt `I.member` jumpDests, (0::Word256) /= condition) of
     (_, False) -> return ()
-    (True, _)  -> setPC $ fromIntegral p - 1
+    (True, _)  -> setPC $ pInt - 1
     _          -> throwE InvalidJump
 
 runOperation PC = pushVMStateVar pc
@@ -908,7 +909,7 @@ runCode c = do
 
   when flags_sqlTrace $
     vmTrace $
-      "EVM [ eth | " ++ show (callDepth vmState) ++ " | " ++ formatAddressWithoutColor (envOwner env) ++ " | #" ++ show c ++ " | " ++ map toUpper (showHex4 (pc vmState)) ++ " : " ++ formatOp op ++ " | " ++ show (vmGasRemaining vmState) ++ " | " ++ show (vmGasRemaining result - vmGasRemaining result) ++ " | " ++ show(toInteger memAfter - toInteger memBefore) ++ "x32 ]\n"
+      "EVM [ eth | " ++ show (callDepth vmState) ++ " | " ++ formatAddressWithoutColor (envOwner env) ++ " | #" ++ show c ++ " | " ++ map toUpper (showHex (pc vmState) "") ++ " : " ++ formatOp op ++ " | " ++ show (vmGasRemaining vmState) ++ " | " ++ show (vmGasRemaining result - vmGasRemaining result) ++ " | " ++ show(toInteger memAfter - toInteger memBefore) ++ "x32 ]\n"
 
   when flags_trace $ printTrace (environment result) memBefore memAfter c op vmState result
 

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
@@ -2,7 +2,7 @@
 module Blockchain.VM.Code where
 
 import qualified Data.ByteString              as B
-import           Network.Haskoin.Internals
+import qualified Data.IntSet                  as I
 import           Numeric
 import           Text.PrettyPrint.ANSI.Leijen
 
@@ -13,36 +13,36 @@ import           Blockchain.Util
 import           Blockchain.VM.Opcodes
 
 
-getOperationAt::Code->Word256->(Operation, Word256)
+getOperationAt::Code->CodePointer->(Operation, CodePointer)
 getOperationAt (Code bytes) p        = getOperationAt' bytes p
 getOperationAt (PrecompiledCode _) _ = error "getOperationAt called for precompilded code"
 
-getOperationAt'::B.ByteString->Word256->(Operation, Word256)
-getOperationAt' rom p = opCode2Op $ safeDrop p rom
+getOperationAt'::B.ByteString->Int->(Operation, CodePointer)
+getOperationAt' rom p = opCode2Op $ safeIntDrop p rom
 
-showCode::Word256->Code->String
+showCode::CodePointer->Code->String
 showCode _ (Code bytes) | B.null bytes = ""
 showCode _ (PrecompiledCode x) = CL.blue $ "<PrecompiledCode:" ++ show x ++">"
-showCode lineNumber c@(Code rom) = showHex lineNumber "" ++ " " ++ format (B.pack $ op2OpCode op) ++ " " ++ show (pretty op) ++ "\n" ++  showCode (lineNumber + nextP) (Code (safeDrop nextP rom))
+showCode lineNumber c@(Code rom) = showHex lineNumber "" ++ " " ++ format (B.pack $ op2OpCode op) ++ " " ++ show (pretty op) ++ "\n" ++  showCode (lineNumber + nextP) (Code (safeIntDrop nextP rom))
         where
           (op, nextP) = getOperationAt c 0
 
 formatCode::Code->String
 formatCode = showCode 0
 
-getValidJUMPDESTs::Code->[Word256]
+getValidJUMPDESTs::Code->I.IntSet
 getValidJUMPDESTs (Code bytes) =
-  map fst $ filter ((== JUMPDEST) . snd) $ getOps bytes 0
+  I.fromList $ map fst $ filter ((== JUMPDEST) . snd) $ getOps bytes 0
   where
-    getOps::B.ByteString->Word256->[(Word256, Operation)]
-    getOps bytes' p | p > fromIntegral (B.length bytes') = []
+    getOps::B.ByteString->Int->[(CodePointer, Operation)]
+    getOps bytes' p | p > B.length bytes' = []
     getOps code p = (p, op):getOps code (p+len)
       where
         (op, len) = getOperationAt' code p
 getValidJUMPDESTs (PrecompiledCode _) = error "getValidJUMPDESTs called on precompiled code"
 
 
-codeLength::Code->Int
+codeLength::Code->CodePointer
 codeLength (Code bytes)        = B.length bytes
 codeLength (PrecompiledCode _) = error "codeLength called on precompiled code"
 

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Environment.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Environment.hs
@@ -9,6 +9,7 @@ import           Blockchain.Data.DataDefs
 import           Blockchain.ExtWord
 import           Blockchain.SHA
 import           Data.Map.Strict            (Map)
+import qualified Data.IntSet                as I
 import           Data.Text                  (Text)
 
 data Environment =
@@ -20,7 +21,7 @@ data Environment =
       envSender      :: Address,
       envValue       :: Integer,
       envCode        :: Code,
-      envJumpDests   :: [Word256],
+      envJumpDests   :: I.IntSet,
       envBlockHeader :: BlockData,
       envTxHash      :: SHA,
       envChainId     :: Maybe Word256,

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
@@ -7,10 +7,11 @@ import           Data.Binary
 import qualified Data.ByteString              as B
 import qualified Data.Map                     as M
 import           Data.Maybe
-import           Network.Haskoin.Internals
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 import           Blockchain.Util
+
+type CodePointer = Int
 
 data Operation =
     STOP | ADD | MUL | SUB | DIV | SDIV | MOD | SMOD | ADDMOD | MULMOD | EXP | SIGNEXTEND | NEG |
@@ -194,7 +195,7 @@ opLen::Operation->Int
 opLen (PUSH x) = 1 + length x
 opLen _        = 1
 
-opCode2Op::B.ByteString->(Operation, Word256)
+opCode2Op::B.ByteString->(Operation, CodePointer)
 opCode2Op rom | B.null rom = (STOP, 1) --according to the yellowpaper, should return STOP if outside of the code bytestring
 opCode2Op rom =
   let opcode = B.head rom in --head OK, null weeded out above

--- a/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
@@ -202,12 +202,12 @@ addLog newLog = do
   state' <- lift get
   lift $ put state'{logs=newLog:logs state'}
 
-setPC::Word256->VMM ()
+setPC::Int->VMM ()
 setPC p = do
   state' <- lift get
   lift $ put state'{pc=p}
 
-incrementPC::Word256->VMM ()
+incrementPC::Int->VMM ()
 incrementPC p = do
   state' <- lift get
   lift $ put state'{pc=pc state' + p}

--- a/core-strato/ethereum-vm/src/Blockchain/VM/VMState.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/VMState.hs
@@ -26,6 +26,7 @@ import           Blockchain.ExtWord
 import           Blockchain.Format
 import           Blockchain.Strato.Model.Class
 import           Blockchain.VM.Environment
+import           Blockchain.VM.Opcodes (CodePointer)
 import           Blockchain.VMContext
 import           Blockchain.VM.VMException
 

--- a/core-strato/ethereum-vm/src/Blockchain/VM/VMState.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/VMState.hs
@@ -57,7 +57,7 @@ data VMState =
     dbs              :: Context,
     sqldb            :: Config,
     vmGasRemaining   :: Integer,
-    pc               :: Word256,
+    pc               :: CodePointer,
     memory           :: Memory,
     stack            :: [Word256],
     callDepth        :: Int,

--- a/core-strato/run_unit_tests.sh
+++ b/core-strato/run_unit_tests.sh
@@ -20,6 +20,9 @@ TESTS=(
   strato-sequencer
 )
 
+BENCHES=(
+  ethereum-vm
+)
 # There's a good chance that strato-getting-started is also running, so
 # we change redis's port to avoid a conflict.
 REDIS=$(docker run -d -p 2023:6379 redis:3.2 redis-server --appendonly yes)
@@ -29,6 +32,6 @@ for tst in ${TESTS[@]}; do
   time stack test $tst
 done
 
-for tst in ${TEST_AND_BENCH[@]}; do
-  time stack test $tst
+for tst in ${BENCHES[@]}; do
+  time stack bench $tst
 done


### PR DESCRIPTION
https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/910

Benchmarks are now included in the ethereum-vm package as well. IntSet is the fastest of the data structures compared, and so from that `pc` is changed to `Int` and `jumpDests` is changed to an `IntSet`. 256 bits as a pointer is wasteful until we start running terabytecode