### PR TITLE
Private chain blocks

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/DB/ChainDB.hs
+++ b/core-strato/blockapps-data/src/Blockchain/DB/ChainDB.hs
@@ -117,8 +117,7 @@ putBlockHeaderInChainDB b = do
     mChainRoot <- getChainRoot p
     case mChainRoot of
       Nothing -> error $ "putBlockHeaderInChainDB: No parent block with hash " ++ format p ++ " found"
-      Just chainRoot -> do
-        putChainBlockHashInfo h p chainRoot
+      Just chainRoot -> putChainBlockHashInfo h p chainRoot
 
 getChainRoot :: (HasStateDB m, HasChainDB m) => SHA -> m (Maybe MP.StateRoot)
 getChainRoot = fmap (fmap snd) . getChainBlockHashInfo

--- a/core-strato/blockapps-data/src/Blockchain/DB/ChainDB.hs
+++ b/core-strato/blockapps-data/src/Blockchain/DB/ChainDB.hs
@@ -6,13 +6,16 @@ module Blockchain.DB.ChainDB (
   , putBlockHeaderInChainDB
   , getChainRoot
   , getGenesisStateRoot
-  , putGenesisStateRoot
+  , putChainGenesisInfo
   , withBlockchain
   ) where
 
+import           Control.Monad                        (join, when)
 import           Control.Monad.Trans.Resource
 
+import           Data.Maybe                           (isNothing)
 import qualified Data.NibbleString                    as N
+import           Data.Traversable                     (for)
 import           Data.Word                            (Word8)
 
 import qualified Blockchain.Database.MerklePatricia   as MP
@@ -58,14 +61,14 @@ import qualified Database.LevelDB                     as DB
 |                          /\                                                   |
 |                         /  \                                                  |
 |                        /\  /\                                                 |
-|                (block hash, chain root)                                       |
+|         (block hash, (parent hash, chain root))                               |
 | Finally, all known chains that haven't been transacted upon will be stored    |
 | in a trie, keyed by chain id, with value being the chain's genesis state:     |
 |                     genesis root                                              |
 |                          /\                                                   |
 |                         /  \                                                  |
 |                        /\  /\                                                 |
-|             (chain id, genesis state root)                                    |
+|  (chain id, (creation block hash, genesis state root))                        |
 | It's important to note that each block hash may have a unique chain root,     |
 | but the genesis root only gets updated when the VM receives a new             |
 | OEGenesis message.                                                            |
@@ -86,22 +89,6 @@ class Monad m => HasChainDB m where
   putBlockHashRoot    :: MP.StateRoot -> m ()
   getGenesisRoot      :: m MP.StateRoot
   putGenesisRoot      :: MP.StateRoot -> m ()
-  getCurrentBlockHash :: m SHA
-  putCurrentBlockHash :: SHA -> m ()
-  getCurrentChainId   :: m (Maybe Word256)
-  putCurrentChainId   :: Maybe Word256 -> m ()
-
-forJust :: Applicative f => Maybe a -> b -> (a -> f b) -> f b
-forJust m b f =
-  case m of
-    Nothing -> pure b
-    Just a -> f a
-
-forNothing :: Applicative f => Maybe a -> (a -> b) -> f b -> f b
-forNothing m f b =
-  case m of
-    Nothing -> b
-    Just a -> pure (f a)
 
 getLDB :: HasStateDB m => m DB.DB
 getLDB = MP.ldb <$> getStateDB
@@ -119,61 +106,75 @@ putkv :: (RLPSerializable a, MonadResource m) => MP.MPDB -> N.NibbleString -> a 
 putkv db k = (fmap MP.stateRoot) . MP.putKeyVal db k . rlpEncode
 
 bootstrapChainDB :: (HasStateDB m, HasChainDB m) => SHA -> m ()
-bootstrapChainDB genesisHash = putChainRoot genesisHash MP.emptyTriePtr
+bootstrapChainDB genesisHash = putChainBlockHashInfo genesisHash (SHA 0) MP.emptyTriePtr
 
 putBlockHeaderInChainDB :: (BlockHeaderLike h, HasStateDB m, HasChainDB m) => h -> m ()
 putBlockHeaderInChainDB b = do
   let p = blockHeaderParentHash b
       h = blockHeaderHash b
-  mChainRoot <- getChainRoot p
-  case mChainRoot of
-    Nothing -> error $ "putBlockHeaderInChainDB: No parent block with hash " ++ format p ++ " found"
-    Just chainRoot -> putChainRoot h chainRoot
+  mExistingChainRoot <- getChainRoot h     -- if we've seen this block before,
+  when (isNothing mExistingChainRoot) $ do -- its chain root will already exist
+    mChainRoot <- getChainRoot p
+    case mChainRoot of
+      Nothing -> error $ "putBlockHeaderInChainDB: No parent block with hash " ++ format p ++ " found"
+      Just chainRoot -> do
+        putChainBlockHashInfo h p chainRoot
 
 getChainRoot :: (HasStateDB m, HasChainDB m) => SHA -> m (Maybe MP.StateRoot)
-getChainRoot (SHA h) = do
+getChainRoot = fmap (fmap snd) . getChainBlockHashInfo
+
+getChainBlockHashInfo :: (HasStateDB m, HasChainDB m) => SHA -> m (Maybe (SHA, MP.StateRoot))
+getChainBlockHashInfo (SHA h) = do
   bhdb <- MP.MPDB <$> getLDB <*> getBlockHashRoot
   getkv bhdb (word256ToMPKey h)
 
-putChainRoot :: (HasStateDB m, HasChainDB m) => SHA -> MP.StateRoot -> m ()
-putChainRoot (SHA h) sr = do
+putChainBlockHashInfo :: (HasStateDB m, HasChainDB m) => SHA -> SHA -> MP.StateRoot -> m ()
+putChainBlockHashInfo (SHA h) parentHash sr = do
   bhdb <- MP.MPDB <$> getLDB <*> getBlockHashRoot
-  newBlockHashRoot <- putkv bhdb (word256ToMPKey h) sr
+  newBlockHashRoot <- putkv bhdb (word256ToMPKey h) (parentHash, sr)
   putBlockHashRoot newBlockHashRoot
 
 getGenesisStateRoot :: (HasStateDB m, HasChainDB m) => Word256 -> m (Maybe MP.StateRoot)
-getGenesisStateRoot cid = do
+getGenesisStateRoot = fmap (fmap snd) . getChainGenesisInfo
+
+getChainGenesisInfo :: (HasStateDB m, HasChainDB m) => Word256 -> m (Maybe (SHA, MP.StateRoot))
+getChainGenesisInfo cid = do
   gdb <- MP.MPDB <$> getLDB <*> getGenesisRoot
   getkv gdb (word256ToMPKey cid)
 
-putGenesisStateRoot :: (HasStateDB m, HasChainDB m) => Word256 -> MP.StateRoot -> m ()
-putGenesisStateRoot cid sr = do
+putChainGenesisInfo :: (HasStateDB m, HasChainDB m) => Word256 -> SHA -> MP.StateRoot -> m ()
+putChainGenesisInfo chainId creationBlock stateRoot = do
   gdb <- MP.MPDB <$> getLDB <*> getGenesisRoot
-  newGenesisRoot <- putkv gdb (word256ToMPKey cid) sr
+  newGenesisRoot <- putkv gdb (word256ToMPKey chainId) (creationBlock, stateRoot)
   putGenesisRoot newGenesisRoot
 
 getChainStateRoot :: (HasStateDB m, HasChainDB m) => Word256 -> SHA -> m (Maybe MP.StateRoot)
 getChainStateRoot chainId bHash = do
-  mChainRoot <- getChainRoot bHash
-  (mStateRoot :: Maybe (Word256, MP.StateRoot))
-    <- forJust mChainRoot Nothing $ \chainRoot -> do
-      cdb <- flip MP.MPDB chainRoot <$> getLDB
-      getkv cdb (word256ToMPKey chainId)
-  forNothing mStateRoot (Just . snd) $ do
-    mGenStateRoot <- getGenesisStateRoot chainId
-    forJust mGenStateRoot Nothing $ \genStateRoot -> do
-      putChainStateRoot chainId bHash genStateRoot
-      return $ Just genStateRoot
+  mChainRoot <- getChainBlockHashInfo bHash
+  fmap join . for mChainRoot $ \(parentHash, chainRoot) -> do
+    cdb <- flip MP.MPDB chainRoot <$> getLDB
+    mStateRoot <- getkv cdb (word256ToMPKey chainId)
+    case mStateRoot of
+      Just (_ :: Word256, stateRoot) -> return $ Just stateRoot
+      Nothing -> do
+        mGenStateRoot <- getChainGenesisInfo chainId
+        fmap join . for mGenStateRoot $ \(creationBlock, genStateRoot) -> do
+          mStateRoot' <- if parentHash == creationBlock
+            then return $ Just genStateRoot
+            else getChainStateRoot chainId parentHash
+          for mStateRoot' $ \stateRoot -> do
+            putChainStateRoot chainId bHash stateRoot
+            return stateRoot
 
 putChainStateRoot :: (HasStateDB m, HasChainDB m) => Word256 -> SHA -> MP.StateRoot -> m ()
 putChainStateRoot chainId bHash stateRoot = do
-  mChainRoot <- getChainRoot bHash
+  mChainRoot <- getChainBlockHashInfo bHash
   case mChainRoot of
     Nothing -> error $ "putChainStateRoot: Attempting to set chain root for block hash " ++ format bHash ++ ", but it doesn't exist"
-    Just chainRoot -> do
+    Just (parentHash, chainRoot) -> do
       cdb <- flip MP.MPDB chainRoot <$> getLDB
       newChainRoot <- putkv cdb (word256ToMPKey chainId) (chainId, stateRoot)
-      putChainRoot bHash newChainRoot
+      putChainBlockHashInfo bHash parentHash newChainRoot
 
 withBlockchain :: (HasStateDB m, HasChainDB m) => SHA -> Maybe Word256 -> m a -> m a
 withBlockchain bh cid f = do

--- a/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
@@ -94,14 +94,6 @@ instance HasChainDB VMM where
   putGenesisRoot sr = do
     vmState <- lift get
     lift $ put vmState{dbs=(dbs vmState){contextGenesisRoot = sr}}
-  getCurrentBlockHash = lift $ fmap (contextCurrentBlockHash . dbs) get
-  putCurrentBlockHash bh = do
-    vmState <- lift get
-    lift $ put vmState{dbs=(dbs vmState){contextCurrentBlockHash = bh}}
-  getCurrentChainId = lift $ fmap (contextCurrentChainId . dbs) get
-  putCurrentChainId cid = do
-    vmState <- lift get
-    lift $ put vmState{dbs=(dbs vmState){contextCurrentChainId = cid}}
 
 instance HasStorageDB VMM where
     getStorageTxDB = do

--- a/core-strato/ethereum-vm/src/Blockchain/VMContext.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VMContext.hs
@@ -86,8 +86,6 @@ data Context = Context { contextStateDB                :: MP.MPDB
                        , contextStorageBlockMap        :: M.Map (Address, Word256) Word256
                        , contextBlockHashRoot          :: MP.StateRoot
                        , contextGenesisRoot            :: MP.StateRoot
-                       , contextCurrentBlockHash       :: SHA
-                       , contextCurrentChainId         :: Maybe Word256
                        , contextBaggerState            :: !BaggerState
                        , contextKafkaState             :: K.KafkaState
                        , contextBestBlockInfo          :: ContextBestBlockInfo
@@ -224,8 +222,6 @@ runContextM f = do
                        M.empty
                        MP.emptyTriePtr
                        MP.emptyTriePtr
-                       (SHA 0)
-                       Nothing
                        defaultBaggerState
                        initialKafkaState
                        Unspecified

--- a/core-strato/ethereum-vm/src/Blockchain/VMContext.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VMContext.hs
@@ -141,14 +141,6 @@ instance HasChainDB ContextM where
   putGenesisRoot sr = do
     cxt <- get
     put cxt{contextGenesisRoot = sr}
-  getCurrentBlockHash = contextCurrentBlockHash <$> get
-  putCurrentBlockHash bh = do
-    cxt <- get
-    put cxt{contextCurrentBlockHash = bh}
-  getCurrentChainId = contextCurrentChainId <$> get
-  putCurrentChainId cid = do
-    cxt <- get
-    put cxt{contextCurrentChainId = cid}
 
 instance K.HasKafkaState ContextM where
     getKafkaState = contextKafkaState <$> get

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -47,6 +47,7 @@ import qualified Blockchain.Bagger.BaggerState         as B
 import           Blockchain.Strato.Indexer.Kafka       (writeIndexEvents)
 import           Blockchain.Strato.Indexer.Model       (IndexEvent (..))
 import           Blockchain.Strato.Model.Class
+import           Blockchain.Strato.Model.SHA
 import qualified Blockchain.Strato.RedisBlockDB        as RBDB
 import           Blockchain.Strato.RedisBlockDB.Models
 import           Blockchain.Strato.StateDiff.Kafka     (writeActionJSONToKafka)
@@ -148,6 +149,10 @@ ethereumVM = void . execContextM $ do
 insertNewChains :: [OutputEvent] -> ContextM ()
 insertNewChains events = do
   let newChainInfos = [c | OEGenesis (OutputGenesis _ c) <- events]
+  bbi <- getContextBestBlockInfo
+  let bestSha = case bbi of
+        Unspecified -> SHA 0
+        ContextBestBlockInfo (sha,_,_,_,_) -> sha
 
   newChains <- forM newChainInfos $ \(cId, cInfo) -> do
     sr <- chainInfoToGenesisState cInfo
@@ -156,7 +161,7 @@ insertNewChains events = do
       Just _ -> return [] -- error $ "ethereumVM.getGenesisStateRoot: chain "
       Nothing -> do
         initializeChainDBs cId cInfo sr -- only needed to update Postgres with chain info for API calls
-        putGenesisStateRoot cId sr >> return [(cId, cInfo)]
+        putChainGenesisInfo cId bestSha sr >> return [(cId, cInfo)]
 
   void . K.withKafkaViolently . writeIndexEvents . map (uncurry NewChainInfo) $ concat newChains
 

--- a/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
+++ b/core-strato/ethereum-vm/src/Executable/EthereumVM.hs
@@ -149,10 +149,6 @@ ethereumVM = void . execContextM $ do
 insertNewChains :: [OutputEvent] -> ContextM ()
 insertNewChains events = do
   let newChainInfos = [c | OEGenesis (OutputGenesis _ c) <- events]
-  bbi <- getContextBestBlockInfo
-  let bestSha = case bbi of
-        Unspecified -> SHA 0
-        ContextBestBlockInfo (sha,_,_,_,_) -> sha
 
   newChains <- forM newChainInfos $ \(cId, cInfo) -> do
     sr <- chainInfoToGenesisState cInfo
@@ -161,7 +157,7 @@ insertNewChains events = do
       Just _ -> return [] -- error $ "ethereumVM.getGenesisStateRoot: chain "
       Nothing -> do
         initializeChainDBs cId cInfo sr -- only needed to update Postgres with chain info for API calls
-        putChainGenesisInfo cId bestSha sr >> return [(cId, cInfo)]
+        putChainGenesisInfo cId (SHA 0) sr >> return [(cId, cInfo)]
 
   void . K.withKafkaViolently . writeIndexEvents . map (uncurry NewChainInfo) $ concat newChains
 

--- a/core-strato/ethereum-vm/test/Spec.hs
+++ b/core-strato/ethereum-vm/test/Spec.hs
@@ -87,8 +87,6 @@ runContextM' f = do
                         M.empty
                         MP.emptyTriePtr
                         MP.emptyTriePtr
-                        (SHA 0)
-                        Nothing
                         defaultBaggerState
                         (error "Kafka not initialized") --initialKafkaState
                         Unspecified

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -524,7 +524,7 @@ spec = do
         let ietx = IETx 0 . IngestTx TO.Morphism
         checkForUnseq [ietx tx1, ietx tx2]
         vmevs' <- drainVM
-        let otxs' = obReceiptTransactions $ head [b | OEBlock b <- vmevs']
-        length otxs' `shouldBe` 2
-        txType (otxs' !! 0) `shouldBe` Message
-        txType (otxs' !! 1) `shouldBe` Message
+        let obs' = [b | OEBlock b <- vmevs']
+        length obs' `shouldBe` 3
+        mapM_ ((`shouldBe` 1) . length . obReceiptTransactions) obs'
+        mapM_ ((`shouldBe` Message) . txType . head . obReceiptTransactions) obs'

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -480,3 +480,51 @@ spec = do
         let otxs' = obReceiptTransactions $ head [b | OEBlock b <- vmevs']
         length otxs' `shouldBe` 1
         txType (head otxs') `shouldBe` Message
+
+      it "should split block up by chain Id" . runPBFTTestMWithGenesis $ \h -> do
+        -- chain 1
+        let chainId1 = 0x12345678
+            cInfo1 = ChainInfo "my test chain 1" [] [] M.empty
+            chainDetails1 = IEGenesis (IngestGenesis TO.Morphism (chainId1, cInfo1))
+            chainHash1 = unSHA . superProprietaryStratoSHAHash . rlpSerialize $ rlpEncode cInfo1
+        tx1 <- liftIO . HK.withSource HK.devURandom $ do
+          pk <- HK.genPrvKey
+          createChainMessageTX 0 1 1 (Address 0xdeadbeef) 0 BS.empty (Just chainId1) Nothing pk
+        let hashTx1 = PrivateHashTX (unSHA $ txHash tx1) chainHash1
+
+        -- chain 2
+        let chainId2 = 0x9abcdef0
+            cInfo2 = ChainInfo "my test chain 2" [] [] M.empty
+            chainDetails2 = IEGenesis (IngestGenesis TO.Morphism (chainId2, cInfo2))
+            chainHash2 = unSHA . superProprietaryStratoSHAHash . rlpSerialize $ rlpEncode cInfo2
+        tx2 <- liftIO . HK.withSource HK.devURandom $ do
+          pk <- HK.genPrvKey
+          createChainMessageTX 0 1 1 (Address 0xdeadbeef) 0 BS.empty (Just chainId2) Nothing pk
+        let hashTx2 = PrivateHashTX (unSHA $ txHash tx2) chainHash2
+
+        let b' = makeBlockWithTransactions [hashTx1, hashTx2]
+            blk = Block (blockBlockData b'){ blockDataParentHash = h
+                                           , blockDataNumber = 1
+                                           }
+                        (blockReceiptTransactions b')
+                        (blockBlockUncles b')
+            iev = IEBlock . blockToIngestBlock TO.Morphism $ blk
+        checkForUnseq [chainDetails1, chainDetails2]
+        checkForUnseq [iev]
+        vmevs <- drainVM
+        let obs = [b | OEBlock b <- vmevs]
+        obs `shouldBe` []
+        p2pevs <- drainP2P
+        let bs = [b | OEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        length bs `shouldBe` 1
+        let txs = blockReceiptTransactions $ head bs
+        length txs `shouldBe` 2
+        txType (txs !! 0) `shouldBe` PrivateHash
+        txType (txs !! 1) `shouldBe` PrivateHash
+        let ietx = IETx 0 . IngestTx TO.Morphism
+        checkForUnseq [ietx tx1, ietx tx2]
+        vmevs' <- drainVM
+        let otxs' = obReceiptTransactions $ head [b | OEBlock b <- vmevs']
+        length otxs' `shouldBe` 2
+        txType (otxs' !! 0) `shouldBe` Message
+        txType (otxs' !! 1) `shouldBe` Message

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -482,6 +482,8 @@ spec = do
         txType (head otxs') `shouldBe` Message
 
       it "should split block up by chain Id" . runPBFTTestMWithGenesis $ \h -> do
+        liftIO $ pendingWith "TODO: reinstate once sequencer splits up blocks"
+
         -- chain 1
         let chainId1 = 0x12345678
             cInfo1 = ChainInfo "my test chain 1" [] [] M.empty


### PR DESCRIPTION
Allows the VM to run private chain transactions in old blocks by retroactively inserting the chain's state root into the ChainDB trie