### PR TITLE
Revisionist history

### DIFF
--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -352,15 +352,13 @@ processTheMessages messages conn g = do
           hist <- isHistoric g $ actionCodeHash row
           (hs,fhs) <- unzip <$> if hist
             then accumStateT oldState actions $ \hRow -> do
-              st <- get
-              let newSt = SVR.decodeCacheValues
-                          (typeDefs cont)
-                          (mainStruct cont)
-                          cache
-                          0
-                          st
-                  newMap = Map.fromList newSt
-              put newSt
+              let hCache = flip Map.lookup $ actionStorage hRow
+              modify $ SVR.decodeCacheValues
+                       (typeDefs cont)
+                       (mainStruct cont)
+                       cache
+                       0
+              newMap <- Map.fromList <$> get
               let hInsert = processedContract strAbi strName chain newMap hRow
               functionHist <- isFunctionHistoric g $ actionCodeHash hRow
               fInserts <- if functionHist

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -358,7 +358,7 @@ processTheMessages messages conn g = do
                        (mainStruct cont)
                        hCache
                        0
-              newMap <- Map.fromList <$> get
+              newMap <- gets Map.fromList
               let hInsert = processedContract strAbi strName chain newMap hRow
               functionHist <- isFunctionHistoric g $ actionCodeHash hRow
               fInserts <- if functionHist

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -356,7 +356,7 @@ processTheMessages messages conn g = do
               modify $ SVR.decodeCacheValues
                        (typeDefs cont)
                        (mainStruct cont)
-                       cache
+                       hCache
                        0
               newMap <- Map.fromList <$> get
               let hInsert = processedContract strAbi strName chain newMap hRow


### PR DESCRIPTION
I introduced a bug while making the Slipstream optimizations where individual history actions were using the storage map for the big, combined action, thus aliasing the intermediate state changes