### PR TITLE
Sequencer split

### DIFF
--- a/core-strato/strato-sequencer/package.yaml
+++ b/core-strato/strato-sequencer/package.yaml
@@ -48,6 +48,7 @@ dependencies:
   - aeson
   - async
   - prometheus-client
+  - transformers
   - warp
   - servant-client
   - wai-extra

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -296,15 +296,7 @@ transformFullTransactions pairs = do
             lookupTxBlocks tHash >>= \case
               Nothing -> $logInfoS "transformFullTransactions" . T.pack $ "Transaction " ++ format tHash ++ " has not been put in a block."
               Just bHash -> lookupDependentTxs bHash >>= \case
-                Nothing ->
-                  error $ concat
-                    [ "lookupDependentTxs: transaction "
-                    , format tHash
-                    , " claims to depend on block "
-                    , format bHash
-                    , ", but the block is not listed in the registry."
-                    ]
-                Just depTxs | not (S.member tHash depTxs) ->
+                depTxs | not (S.member tHash depTxs) ->
                   error $ concat
                     [ "lookupDependentTxs: transaction "
                     , format tHash
@@ -314,7 +306,7 @@ transformFullTransactions pairs = do
                     , "Dependent transactions: "
                     , (show . map format $ S.toList depTxs)
                     ]
-                Just depTxs | depTxs == S.singleton tHash -> do
+                depTxs | depTxs == S.singleton tHash -> do
                   $logInfoS "transformFullTransactions" . T.pack $ concat
                     [ "Transaction "
                     , format tHash
@@ -325,7 +317,7 @@ transformFullTransactions pairs = do
                   clearDependentTxs bHash
                   mBlock <- witnessedBlock bHash
                   traverse_ runBlock mBlock
-                Just depTxs -> do
+                depTxs -> do
                   $logInfoS "transformFullTransactions" . T.pack $ concat
                     [ "Transaction "
                     , format tHash
@@ -424,7 +416,7 @@ hydrateAndEmit = awaitForever $ \case
           else
             logHydrate $ "Transaction hash " ++ format th ++ " is not missing"
     depTXs <- lift . lookupDependentTxs $ bHash
-    if isNothing depTXs || (S.null $ fromJust depTXs)
+    if S.null depTXs
       then do
         logHydrate $ "Block hash " ++ format bHash ++ " has no dependent transactions. Hydrating and emitting to VM"
         hydratedBlock <- lift . hydrateBlock $ ob
@@ -432,7 +424,7 @@ hydrateAndEmit = awaitForever $ \case
         yield $ OEBlock hydratedBlock
       else do
         logHydrate $ "Block hash " ++ format bHash ++ " has dependent transactions. Inserting them into GetTransactions list"
-        lift . for_ depTXs $ mapM_ insertGetTransactionsDB
+        lift $ mapM_ insertGetTransactionsDB depTXs
   oe -> yield oe
 
 transformBlocks :: [IngestBlock] -> SequencerM ()
@@ -473,17 +465,15 @@ transformGenesis chains = forM_ chains $ \ig -> do
             lookupTxBlocks tHash >>= \case
               Nothing -> return ()
               Just bHash -> lookupDependentTxs bHash >>= \case
-                Nothing ->
-                  error $ "lookupDependentTxs: transaction " ++ format tHash ++ " claims to depend on block " ++ format bHash ++ ", but the block is missing from the registry."
-                Just depTxs | not (S.member tHash depTxs) ->
+                depTxs | not (S.member tHash depTxs) ->
                   error $ "lookupDependentTxs: transaction " ++ format tHash ++ " claims to depend on block " ++ format bHash ++ ", but it's missing from the block's dependent transaction set. Dependent transactions: " ++ (show . map format $ S.toList depTxs)
-                Just depTxs | depTxs == S.singleton tHash -> do
+                depTxs | depTxs == S.singleton tHash -> do
                   $logInfoS "transformGenesis" . T.pack $ "Transaction " ++ format tHash ++ " is the only dependent transaction in block " ++ format bHash
                   removeTxBlock tHash
                   clearDependentTxs bHash
                   mBlock <- witnessedBlock bHash
                   mapM_ runBlock mBlock
-                Just depTxs -> do
+                depTxs -> do
                   $logInfoS "transformGenesis" . T.pack $ "Transaction " ++ format tHash ++ " is a dependent transaction in block " ++ format bHash ++ ", but there are others. Inserting them into MissingTxDB and GetTransactions list"
                   removeTxBlock tHash
                   let depTxs' = S.delete tHash depTxs

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -404,8 +404,6 @@ hydrateAndEmit = awaitForever $ \case
             th = SHA th'
             ch = SHA ch'
         lift $ runPrivateHashTX th ch
-        tr <- gets _txHashRegistry
-        logHydrate $ "TX Hash Registry: " ++ show tr
         logHydrate $ "Looking up transaction hash " ++ format th ++ " in MissingTxDB"
         missing <- lift . isMissingTX $ th
         if missing

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -19,7 +19,7 @@ import           Control.Monad.IO.Class                    (liftIO)
 import           Data.ByteString.Char8                     (pack)
 import           Data.ByteString.Base16                    as B16
 import           Data.Foldable                             (for_, toList, traverse_)
-import           Data.Maybe                                (catMaybes, fromJust, isJust)
+import           Data.Maybe
 import qualified Data.Set                                  as S
 import qualified Data.Text                                 as T
 import           Data.Time.Clock
@@ -203,7 +203,7 @@ checkIfIsMissingTX th ch = lookupChainHash ch >>= \case
     return ()
   Just (_, cid) -> do
     $logInfoS "transformPrivateHashTXs" . T.pack $ "We know this transaction's chain Id. It's " ++ format (SHA cid) ++ ". Inserting into MissingTxDB and GetTransactions list"
-    useChainHash ch cid
+    useChainHash ch
     insertMissingTx th
     insertGetTransactionsDB th
 
@@ -219,7 +219,7 @@ runPrivateHashTX th ch = do
       lookupTransaction th >>= \case
         Just tx -> do
           $logInfoS "runPrivateHashTX" . T.pack $ "We have this transaction's body. It's: " ++ prettyOTx tx
-          useChainHash ch (fromJust . TD.transactionChainId $ otBaseTx tx)
+          useChainHash ch
         Nothing -> do
           $logInfoS "runPrivateHashTX" "We don't have this transaction's body. Looking it up by chain hash"
           checkIfIsMissingTX th ch
@@ -296,16 +296,44 @@ transformFullTransactions pairs = do
             lookupTxBlocks tHash >>= \case
               Nothing -> $logInfoS "transformFullTransactions" . T.pack $ "Transaction " ++ format tHash ++ " has not been put in a block."
               Just bHash -> lookupDependentTxs bHash >>= \case
-                depTxs | not (S.member tHash depTxs) ->
-                  error $ "lookupDependentTxs: transaction " ++ format tHash ++ " claims to depend on block " ++ format bHash ++ ", but it's missing from the block's dependent transaction set. Dependent transactions: " ++ (show . map format $ S.toList depTxs)
-                depTxs | depTxs == S.singleton tHash -> do
-                  $logInfoS "transformFullTransactions" . T.pack $ "Transaction " ++ format tHash ++ " is the only dependent transaction in block " ++ format bHash
+                Nothing ->
+                  error $ concat
+                    [ "lookupDependentTxs: transaction "
+                    , format tHash
+                    , " claims to depend on block "
+                    , format bHash
+                    , ", but the block is not listed in the registry."
+                    ]
+                Just depTxs | not (S.member tHash depTxs) ->
+                  error $ concat
+                    [ "lookupDependentTxs: transaction "
+                    , format tHash
+                    , " claims to depend on block "
+                    , format bHash
+                    , ", but it's missing from the block's dependent transaction set. "
+                    , "Dependent transactions: "
+                    , (show . map format $ S.toList depTxs)
+                    ]
+                Just depTxs | depTxs == S.singleton tHash -> do
+                  $logInfoS "transformFullTransactions" . T.pack $ concat
+                    [ "Transaction "
+                    , format tHash
+                    , " is the only dependent transaction in block "
+                    , format bHash
+                    ]
                   removeTxBlock tHash
                   clearDependentTxs bHash
                   mBlock <- witnessedBlock bHash
                   traverse_ runBlock mBlock
-                depTxs -> do
-                  $logInfoS "transformFullTransactions" . T.pack $ "Transaction " ++ format tHash ++ " is a dependent transaction in block " ++ format bHash ++ ", but there are others. Inserting them into MissingTxDB and GetTransactions list"
+                Just depTxs -> do
+                  $logInfoS "transformFullTransactions" . T.pack $ concat
+                    [ "Transaction "
+                    , format tHash
+                    , " is a dependent transaction in block "
+                    , format bHash
+                    , ", but there are others. "
+                    , "Inserting them into MissingTxDB and GetTransactions list"
+                    ]
                   removeTxBlock tHash
                   let depTxs' = S.delete tHash depTxs
                   mapM_ insertMissingTx depTxs'
@@ -392,8 +420,8 @@ hydrateAndEmit = awaitForever $ \case
             lift $ insertDependentTx bHash th
           else
             logHydrate $ "Transaction hash " ++ format th ++ " is not missing"
-    depTXS <- lift . lookupDependentTxs $ bHash
-    if S.null depTXS
+    depTXs <- lift . lookupDependentTxs $ bHash
+    if isNothing depTXs || (S.null $ fromJust depTXs)
       then do
         logHydrate $ "Block hash " ++ format bHash ++ " has no dependent transactions. Hydrating and emitting to VM"
         hydratedBlock <- lift . hydrateBlock $ ob
@@ -401,7 +429,7 @@ hydrateAndEmit = awaitForever $ \case
         yield $ OEBlock hydratedBlock
       else do
         logHydrate $ "Block hash " ++ format bHash ++ " has dependent transactions. Inserting them into GetTransactions list"
-        lift $ mapM_ insertGetTransactionsDB depTXS
+        lift . for_ depTXs $ mapM_ insertGetTransactionsDB
   oe -> yield oe
 
 transformBlocks :: [IngestBlock] -> SequencerM ()
@@ -429,7 +457,7 @@ transformGenesis chains = forM_ chains $ \ig -> do
     False -> do
       $logInfoS "transformGenesis" "We haven't seen this chain before. Inserting into SeenChainDB and emitting to VM"
       insertChainInfo cId cInfo
-      insertSeenChain cId
+      insertSeenChain cId cInfo
       markForVM $ OEGenesis og
       lookupMissingChainTxs cId >>= \case
         [] -> return ()
@@ -443,15 +471,17 @@ transformGenesis chains = forM_ chains $ \ig -> do
             lookupTxBlocks tHash >>= \case
               Nothing -> return ()
               Just bHash -> lookupDependentTxs bHash >>= \case
-                depTxs | not (S.member tHash depTxs) ->
+                Nothing ->
+                  error $ "lookupDependentTxs: transaction " ++ format tHash ++ " claims to depend on block " ++ format bHash ++ ", but the block is missing from the registry."
+                Just depTxs | not (S.member tHash depTxs) ->
                   error $ "lookupDependentTxs: transaction " ++ format tHash ++ " claims to depend on block " ++ format bHash ++ ", but it's missing from the block's dependent transaction set. Dependent transactions: " ++ (show . map format $ S.toList depTxs)
-                depTxs | depTxs == S.singleton tHash -> do
+                Just depTxs | depTxs == S.singleton tHash -> do
                   $logInfoS "transformGenesis" . T.pack $ "Transaction " ++ format tHash ++ " is the only dependent transaction in block " ++ format bHash
                   removeTxBlock tHash
                   clearDependentTxs bHash
                   mBlock <- witnessedBlock bHash
                   mapM_ runBlock mBlock
-                depTxs -> do
+                Just depTxs -> do
                   $logInfoS "transformGenesis" . T.pack $ "Transaction " ++ format tHash ++ " is a dependent transaction in block " ++ format bHash ++ ", but there are others. Inserting them into MissingTxDB and GetTransactions list"
                   removeTxBlock tHash
                   let depTxs' = S.delete tHash depTxs

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -38,6 +38,7 @@ import           Blockchain.Sequencer.DB.GetChainsDB
 import           Blockchain.Sequencer.DB.GetTransactionsDB
 import           Blockchain.Sequencer.DB.MissingChainDB
 import           Blockchain.Sequencer.DB.MissingTxDB
+import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.PrivateTxDB
 import           Blockchain.Sequencer.DB.SeenChainDB
 import           Blockchain.Sequencer.DB.SeenHashDB
@@ -211,11 +212,11 @@ runPrivateHashTX :: SHA -> SHA -> SequencerM ()
 runPrivateHashTX th ch = do
   $logInfoS "runPrivateHashTX" . T.pack $ "Transforming transaction " ++ format th ++ " with chain hash " ++ format ch
   lookupSeenTxHash th >>= \case
-    True -> do
+    Just _ -> do
       $logInfoS "runPrivateHashTX" "Transaction hash seen before!"
-    False -> do
+    Nothing -> do
       $logInfoS "runPrivateHashTX" "Transaction hash not seen before! Inserting it into SeenTxHashDB"
-      insertSeenTxHash th
+      insertSeenTxHash th ch
       lookupTransaction th >>= \case
         Just tx -> do
           $logInfoS "runPrivateHashTX" . T.pack $ "We have this transaction's body. It's: " ++ prettyOTx tx
@@ -279,15 +280,14 @@ transformFullTransactions pairs = do
             let tHash = txHash ptx
             removeMissingTx tHash
             lookupSeenTxHash tHash >>= \case
-              True -> do
+              Just _ -> do
                 $logInfoS "transformFullTransactions" . T.pack $ "We have seen this transaction's PrivateHashTX before."
-              False -> do
+              Nothing -> do
                 insertPrivateHash ptx
                 when (otOrigin ptx == TO.API) $ do
                   cHash <- getNewChainHash chainId
-                  insertSeenTxHash tHash
+                  insertSeenTxHash tHash cHash
                   $logInfoS "transformFullTransactions" . T.pack $ "Created chain hash " ++ format cHash ++ " for transaction " ++ format tHash
-                  removeMissingTx tHash
                   let SHA th' = tHash
                       SHA ch' = cHash
                       phtx = ptx{otBaseTx = TD.PrivateHashTX th' ch'}
@@ -405,12 +405,15 @@ hydrateAndEmit = awaitForever $ \case
     let bHash = blockHeaderHash $ obBlockData ob
         logHydrate = $logInfoS "hydrateAndEmit" . T.pack
     logHydrate $ prettyOBlock ob
+    lift . repsertBlockHashEntry_ bHash $ return . fromMaybe (blockHashEntry ob)
     forM_ (obReceiptTransactions ob) $ \tx ->
       when (isPrivateHashTX tx) $ do
         let TD.PrivateHashTX th' ch' = otBaseTx tx
             th = SHA th'
             ch = SHA ch'
         lift $ runPrivateHashTX th ch
+        tr <- gets _txHashRegistry
+        logHydrate $ "TX Hash Registry: " ++ show tr
         logHydrate $ "Looking up transaction hash " ++ format th ++ " in MissingTxDB"
         missing <- lift . isMissingTX $ th
         if missing
@@ -457,7 +460,6 @@ transformGenesis chains = forM_ chains $ \ig -> do
     False -> do
       $logInfoS "transformGenesis" "We haven't seen this chain before. Inserting into SeenChainDB and emitting to VM"
       insertChainInfo cId cInfo
-      insertSeenChain cId cInfo
       markForVM $ OEGenesis og
       lookupMissingChainTxs cId >>= \case
         [] -> return ()

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/ChainHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/ChainHashDB.hs
@@ -17,22 +17,22 @@ import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.SeenChainDB
 import           Blockchain.Sequencer.DB.Metrics
 
-lookupChainHash :: HasRegistry m => SHA -> m (Maybe (Bool, Word256))
+lookupChainHash :: HasPrivateHashDB m => SHA -> m (Maybe (Bool, Word256))
 lookupChainHash cHash = fmap (_used &&& _onChainId) <$> getChainHashEntry cHash
 
-insertChainHash :: HasRegistry m => SHA -> Word256 -> m ()
+insertChainHash :: HasPrivateHashDB m => SHA -> Word256 -> m ()
 insertChainHash cHash chainId = insertChainHashEntry cHash $ chainHashEntry chainId
 
-useChainHash :: HasRegistry m => SHA -> m ()
+useChainHash :: HasPrivateHashDB m => SHA -> m ()
 useChainHash cHash = modifyChainHashEntryState_ cHash $ used .= True
 
-getChainBuffer :: HasRegistry m => Word256 -> m (CircularBuffer SHA)
+getChainBuffer :: HasPrivateHashDB m => Word256 -> m (CircularBuffer SHA)
 getChainBuffer chainId = maybe emptyCircularBuffer _chainHashes <$> getChainIdEntry chainId
 
-lookupChainBuffer :: HasRegistry m => Word256 -> m (CircularBuffer SHA)
+lookupChainBuffer :: HasPrivateHashDB m => Word256 -> m (CircularBuffer SHA)
 lookupChainBuffer = getChainBuffer
 
-insertChainBufferEntry :: HasRegistry m => Word256 -> SHA -> m ()
+insertChainBufferEntry :: HasPrivateHashDB m => Word256 -> SHA -> m ()
 insertChainBufferEntry chainId cHash = modifyChainIdEntryState_ chainId $ do
   CircularBuffer cap sz q <- use chainHashes
   liftIO $ withLabel chainBuffer (fromString (show chainId)) (flip setGauge (fromIntegral sz))
@@ -42,7 +42,7 @@ insertChainBufferEntry chainId cHash = modifyChainIdEntryState_ chainId $ do
            Q.EmptyL -> chainHashes .= CircularBuffer cap 1 (q Q.|> cHash)
            (_ Q.:< q') -> chainHashes .= CircularBuffer cap sz (q' Q.|> cHash)
 
-getNewChainHash :: HasRegistry m => Word256 -> m SHA
+getNewChainHash :: HasPrivateHashDB m => Word256 -> m SHA
 getNewChainHash chainId = do
   CircularBuffer cap sz q <- getChainBuffer chainId
   case Q.viewl q of
@@ -54,7 +54,7 @@ getNewChainHash chainId = do
         then useChainHash h >> return h
         else getNewChainHash chainId
 
-insertChainInfo :: HasRegistry m => Word256 -> ChainInfo -> m ()
+insertChainInfo :: HasPrivateHashDB m => Word256 -> ChainInfo -> m ()
 insertChainInfo chainId cInfo = do
   let h = hash . rlpSerialize $ rlpEncode cInfo
   insertSeenChain chainId cInfo

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/ChainHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/ChainHashDB.hs
@@ -6,9 +6,9 @@ import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.RLP
 import           Blockchain.SHA
 
+import           Control.Arrow                ((&&&))
+import           Control.Lens
 import           Control.Monad.IO.Class
-import           Data.Map.Strict              (Map)
-import qualified Data.Map.Strict              as M
 import qualified Data.Sequence                as Q
 import           Data.String
 import           Prometheus
@@ -17,64 +17,46 @@ import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.SeenChainDB
 import           Blockchain.Sequencer.DB.Metrics
 
-getChainHashMap :: HasPrivateHashDB m => m (Map SHA (Bool, Word256))
-getChainHashMap = chainHashMap <$> getPrivateHashDB
+lookupChainHash :: HasRegistry m => SHA -> m (Maybe (Bool, Word256))
+lookupChainHash cHash = fmap (_used &&& _onChainId) <$> getChainHashEntry cHash
 
-putChainHashMap :: HasPrivateHashDB m => Map SHA (Bool, Word256) -> m ()
-putChainHashMap m = getPrivateHashDB >>= \db -> putPrivateHashDB db{ chainHashMap = m }
+insertChainHash :: HasRegistry m => SHA -> Word256 -> m ()
+insertChainHash cHash chainId = insertChainHashEntry cHash $ chainHashEntry chainId
 
-lookupChainHash :: HasPrivateHashDB m => SHA -> m (Maybe (Bool, Word256))
-lookupChainHash h = M.lookup h <$> getChainHashMap
+useChainHash :: HasRegistry m => SHA -> m ()
+useChainHash cHash = modifyChainHashEntryState_ cHash $ used .= True
 
-insertChainHash :: HasPrivateHashDB m => SHA -> Word256 -> m ()
-insertChainHash h cid = do
-  liftIO $ withLabel chainMetrics "chain_hash" incCounter
-  getChainHashMap >>= putChainHashMap . M.insert h (False, cid)
+getChainBuffer :: HasRegistry m => Word256 -> m (CircularBuffer SHA)
+getChainBuffer chainId = maybe emptyCircularBuffer _chainHashes <$> getChainIdEntry chainId
 
-useChainHash :: HasPrivateHashDB m => SHA -> Word256 -> m ()
-useChainHash h cid = getChainHashMap >>= putChainHashMap . M.alter (\_ -> Just (True, cid)) h
+lookupChainBuffer :: HasRegistry m => Word256 -> m (CircularBuffer SHA)
+lookupChainBuffer = getChainBuffer
 
-getChainBuffers :: HasPrivateHashDB m => m (Map Word256 (CircularBuffer SHA))
-getChainBuffers = chainBuffers <$> getPrivateHashDB
+insertChainBufferEntry :: HasRegistry m => Word256 -> SHA -> m ()
+insertChainBufferEntry chainId cHash = modifyChainIdEntryState_ chainId $ do
+  CircularBuffer cap sz q <- use chainHashes
+  liftIO $ withLabel chainBuffer (fromString (show chainId)) (flip setGauge (fromIntegral sz))
+  if sz < cap
+    then chainHashes .= CircularBuffer cap (sz + 1) (q Q.|> cHash)
+    else case Q.viewl q of
+           Q.EmptyL -> chainHashes .= CircularBuffer cap 1 (q Q.|> cHash)
+           (_ Q.:< q') -> chainHashes .= CircularBuffer cap sz (q' Q.|> cHash)
 
-putChainBuffers :: HasPrivateHashDB m => Map Word256 (CircularBuffer SHA) -> m ()
-putChainBuffers m = getPrivateHashDB >>= \db -> putPrivateHashDB db{ chainBuffers = m }
-
-lookupChainBuffer :: HasPrivateHashDB m => Word256 -> m (CircularBuffer SHA)
-lookupChainBuffer cid = maybe emptyCircularBuffer id . M.lookup cid <$> getChainBuffers
-
-insertChainBuffer :: HasPrivateHashDB m => Word256 -> CircularBuffer SHA -> m ()
-insertChainBuffer cid buf = getChainBuffers >>= putChainBuffers . M.insert cid buf
-
-createChainBuffer :: HasPrivateHashDB m => Word256 -> m ()
-createChainBuffer = flip insertChainBuffer emptyCircularBuffer
-
-insertChainBufferEntry :: HasPrivateHashDB m => Word256 -> SHA -> m ()
-insertChainBufferEntry cid h = do
-  CircularBuffer cap sz q <- lookupChainBuffer cid
-  let cb = if sz < cap
-             then CircularBuffer cap (sz + 1) (q Q.|> h)
-             else case Q.viewl q of
-                    Q.EmptyL -> CircularBuffer cap 1 (q Q.|> h)
-                    (_ Q.:< q') -> CircularBuffer cap sz (q' Q.|> h)
-  liftIO $ withLabel chainBuffer (fromString (show cid)) (flip setGauge (fromIntegral sz))
-  insertChainBuffer cid cb
-
-getNewChainHash :: HasPrivateHashDB m => Word256 -> m SHA
-getNewChainHash cid = do
-  CircularBuffer cap sz q <- lookupChainBuffer cid
+getNewChainHash :: HasRegistry m => Word256 -> m SHA
+getNewChainHash chainId = do
+  CircularBuffer cap sz q <- getChainBuffer chainId
   case Q.viewl q of
-    Q.EmptyL -> error $ "getNewChainHash: Empty chain buffer for chainId " ++ show cid
+    Q.EmptyL -> error $ "getNewChainHash: Empty chain buffer for chainId " ++ show chainId
     (h Q.:< q') -> do
-      insertChainBuffer cid (CircularBuffer cap (sz - 1) q')
-      Just (used, _) <- lookupChainHash h
-      if not used
-        then useChainHash h cid >> return h
-        else getNewChainHash cid
+      modifyChainIdEntryState_ chainId $ chainHashes .= CircularBuffer cap (sz - 1) q'
+      Just (used', _) <- lookupChainHash h
+      if not used'
+        then useChainHash h >> return h
+        else getNewChainHash chainId
 
-insertChainInfo :: HasPrivateHashDB m => Word256 -> ChainInfo -> m ()
-insertChainInfo cId cInfo = do
+insertChainInfo :: HasRegistry m => Word256 -> ChainInfo -> m ()
+insertChainInfo chainId cInfo = do
   let h = hash . rlpSerialize $ rlpEncode cInfo
-  insertSeenChain cId
-  insertChainHash h cId
-  insertChainBufferEntry cId h
+  insertSeenChain chainId cInfo
+  insertChainHash h chainId
+  insertChainBufferEntry chainId h

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/DependentTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/DependentTxDB.hs
@@ -26,8 +26,8 @@ insertDependentTxs bHash tHashes = do
       Nothing -> error $ "insertDependentTXs: Block hash " ++ format bHash ++ " not found"
       Just b -> return $ (dependentTXs %~ S.union tHashes) b
 
-lookupDependentTxs :: HasPrivateHashDB m => SHA -> m (Maybe (Set SHA))
-lookupDependentTxs bHash = fmap _dependentTXs <$> getBlockHashEntry bHash
+lookupDependentTxs :: HasPrivateHashDB m => SHA -> m (Set SHA)
+lookupDependentTxs bHash = maybe S.empty _dependentTXs <$> getBlockHashEntry bHash
 
 clearDependentTxs :: HasPrivateHashDB m => SHA -> m ()
 clearDependentTxs bHash = do

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/DependentTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/DependentTxDB.hs
@@ -1,41 +1,37 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Blockchain.Sequencer.DB.DependentTxDB where
 
+import           Blockchain.Format
 import           Blockchain.SHA
 
+import           Control.Lens           ((%~), (%=))
+import           Control.Monad          (mapM_)
 import           Control.Monad.IO.Class
-import           Data.Map.Strict              (Map)
-import qualified Data.Map.Strict              as M
-import           Data.Maybe                   (fromMaybe)
-import qualified Data.Set                     as S
+import           Data.Foldable          (traverse_)
+import           Data.Set               (Set)
+import qualified Data.Set               as S
 import           Prometheus
 
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 
-getDependentTxDB :: HasPrivateHashDB m => m (Map SHA (S.Set SHA))
-getDependentTxDB = dependentTxDB <$> getPrivateHashDB
-
-putDependentTxDB :: HasPrivateHashDB m => Map SHA (S.Set SHA) -> m ()
-putDependentTxDB m = getPrivateHashDB >>= \db -> putPrivateHashDB db{ dependentTxDB = m }
-
-lookupDependentTxs :: HasPrivateHashDB m => SHA -> m (S.Set SHA)
-lookupDependentTxs bHash = fromMaybe S.empty . M.lookup bHash <$> getDependentTxDB
-
-insertDependentTx :: HasPrivateHashDB m => SHA -> SHA -> m ()
+insertDependentTx :: HasRegistry m => SHA -> SHA -> m ()
 insertDependentTx bHash tHash = do
   liftIO $ withLabel txMetrics "dependent_tx" incCounter
-  m <- getDependentTxDB
-  case M.lookup bHash m of
-    Nothing -> putDependentTxDB (M.insert bHash (S.singleton tHash) m)
-    Just ths -> putDependentTxDB (M.insert bHash (S.insert tHash ths) m)
+  modifyBlockHashEntryState_ bHash $ dependentTXs %= S.insert tHash
 
-insertDependentTxs :: HasPrivateHashDB m => SHA -> S.Set SHA -> m ()
-insertDependentTxs bHash ths = do
-  liftIO $ withLabel txMetrics "dependent_tx" (flip unsafeAddCounter . fromIntegral . S.size $ ths)
-  getDependentTxDB >>= putDependentTxDB . M.insert bHash ths
+insertDependentTxs :: HasRegistry m => SHA -> Set SHA -> m ()
+insertDependentTxs bHash tHashes = do
+  liftIO $ withLabel txMetrics "dependent_tx" (flip unsafeAddCounter . fromIntegral . S.size $ tHashes)
+  repsertBlockHashEntry_ bHash $ \entry -> do
+    case entry of
+      Nothing -> error $ "insertDependentTXs: Block hash " ++ format bHash ++ " not found"
+      Just b -> return $ (dependentTXs %~ S.union tHashes) b
 
-clearDependentTxs :: HasPrivateHashDB m => SHA -> m ()
+lookupDependentTxs :: HasRegistry m => SHA -> m (Maybe (Set SHA))
+lookupDependentTxs bHash = fmap _dependentTXs <$> getBlockHashEntry bHash
+
+clearDependentTxs :: HasRegistry m => SHA -> m ()
 clearDependentTxs bHash = do
   liftIO $ withLabel txMetrics "dependent_tx_removed" incCounter
-  getDependentTxDB >>= putDependentTxDB . M.delete bHash
+  traverse_ (mapM_ removeTransaction . _dependentTXs) =<< getBlockHashEntry bHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/DependentTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/DependentTxDB.hs
@@ -4,10 +4,8 @@ module Blockchain.Sequencer.DB.DependentTxDB where
 import           Blockchain.Format
 import           Blockchain.SHA
 
-import           Control.Lens           ((%~), (%=))
-import           Control.Monad          (mapM_)
+import           Control.Lens
 import           Control.Monad.IO.Class
-import           Data.Foldable          (traverse_)
 import           Data.Set               (Set)
 import qualified Data.Set               as S
 import           Prometheus
@@ -34,4 +32,4 @@ lookupDependentTxs bHash = fmap _dependentTXs <$> getBlockHashEntry bHash
 clearDependentTxs :: HasPrivateHashDB m => SHA -> m ()
 clearDependentTxs bHash = do
   liftIO $ withLabel txMetrics "dependent_tx_removed" incCounter
-  traverse_ (mapM_ removeTransaction . _dependentTXs) =<< getBlockHashEntry bHash
+  modifyBlockHashEntryState_ bHash $ dependentTXs .= S.empty

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/DependentTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/DependentTxDB.hs
@@ -15,12 +15,12 @@ import           Prometheus
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 
-insertDependentTx :: HasRegistry m => SHA -> SHA -> m ()
+insertDependentTx :: HasPrivateHashDB m => SHA -> SHA -> m ()
 insertDependentTx bHash tHash = do
   liftIO $ withLabel txMetrics "dependent_tx" incCounter
   modifyBlockHashEntryState_ bHash $ dependentTXs %= S.insert tHash
 
-insertDependentTxs :: HasRegistry m => SHA -> Set SHA -> m ()
+insertDependentTxs :: HasPrivateHashDB m => SHA -> Set SHA -> m ()
 insertDependentTxs bHash tHashes = do
   liftIO $ withLabel txMetrics "dependent_tx" (flip unsafeAddCounter . fromIntegral . S.size $ tHashes)
   repsertBlockHashEntry_ bHash $ \entry -> do
@@ -28,10 +28,10 @@ insertDependentTxs bHash tHashes = do
       Nothing -> error $ "insertDependentTXs: Block hash " ++ format bHash ++ " not found"
       Just b -> return $ (dependentTXs %~ S.union tHashes) b
 
-lookupDependentTxs :: HasRegistry m => SHA -> m (Maybe (Set SHA))
+lookupDependentTxs :: HasPrivateHashDB m => SHA -> m (Maybe (Set SHA))
 lookupDependentTxs bHash = fmap _dependentTXs <$> getBlockHashEntry bHash
 
-clearDependentTxs :: HasRegistry m => SHA -> m ()
+clearDependentTxs :: HasPrivateHashDB m => SHA -> m ()
 clearDependentTxs bHash = do
   liftIO $ withLabel txMetrics "dependent_tx_removed" incCounter
   traverse_ (mapM_ removeTransaction . _dependentTXs) =<< getBlockHashEntry bHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingChainDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingChainDB.hs
@@ -4,38 +4,30 @@ module Blockchain.Sequencer.DB.MissingChainDB where
 import           Blockchain.ExtWord           (Word256)
 import           Blockchain.SHA
 
+import           Control.Lens
+import           Control.Monad                (mapM_)
 import           Control.Monad.IO.Class
-import           Data.Map.Strict              (Map)
-import qualified Data.Map.Strict              as M
-import           Data.Maybe                   (fromMaybe)
+import           Data.Foldable                (traverse_)
+import qualified Data.Set                     as S
 import           Prometheus
 
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 
-getMissingChainsDB :: HasPrivateHashDB m => m (Map Word256 [SHA])
-getMissingChainsDB = missingChainDB <$> getPrivateHashDB
+lookupMissingChainTxs :: HasRegistry m => Word256 -> m [SHA]
+lookupMissingChainTxs chainId = maybe [] (S.toList . _missingTXs) <$> getChainIdEntry chainId
 
-putMissingChainsDB :: HasPrivateHashDB m => Map Word256 [SHA] -> m ()
-putMissingChainsDB m = getPrivateHashDB >>= \db -> putPrivateHashDB db{ missingChainDB = m }
-
-lookupMissingChainTxs :: HasPrivateHashDB m => Word256 -> m [SHA]
-lookupMissingChainTxs chainId = fromMaybe [] . M.lookup chainId <$> getMissingChainsDB
-
-insertMissingChainTx :: HasPrivateHashDB m => Word256 -> SHA -> m ()
+insertMissingChainTx :: HasRegistry m => Word256 -> SHA -> m ()
 insertMissingChainTx chainId th = do
   liftIO $ withLabel chainMetrics "missing_chain_tx" incCounter
-  m <- getMissingChainsDB
-  case M.lookup chainId m of
-    Nothing -> putMissingChainsDB (M.insert chainId [th] m)
-    Just ths -> putMissingChainsDB (M.insert chainId (th:ths) m)
+  modifyChainIdEntryState_ chainId $ missingTXs %= S.insert th
 
-insertMissingChainTxs :: HasPrivateHashDB m => Word256 -> [SHA] -> m ()
+insertMissingChainTxs :: HasRegistry m => Word256 -> [SHA] -> m ()
 insertMissingChainTxs chainId ths = do
   liftIO $ withLabel chainMetrics "missing_chain_tx" (flip unsafeAddCounter . fromIntegral . length $ ths)
-  getMissingChainsDB >>= putMissingChainsDB . M.insert chainId ths
+  modifyChainIdEntryState_ chainId $ missingTXs .= S.fromList ths
 
-clearMissingChainTxs :: HasPrivateHashDB m => Word256 -> m ()
+clearMissingChainTxs :: HasRegistry m => Word256 -> m ()
 clearMissingChainTxs chainId = do
   liftIO $ withLabel chainMetrics "missing_chain_tx_removed" incCounter
-  getMissingChainsDB >>= putMissingChainsDB . M.delete chainId
+  traverse_ (mapM_ removeTransaction . _missingTXs) =<< getChainIdEntry chainId

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingChainDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingChainDB.hs
@@ -14,20 +14,20 @@ import           Prometheus
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 
-lookupMissingChainTxs :: HasRegistry m => Word256 -> m [SHA]
+lookupMissingChainTxs :: HasPrivateHashDB m => Word256 -> m [SHA]
 lookupMissingChainTxs chainId = maybe [] (S.toList . _missingTXs) <$> getChainIdEntry chainId
 
-insertMissingChainTx :: HasRegistry m => Word256 -> SHA -> m ()
+insertMissingChainTx :: HasPrivateHashDB m => Word256 -> SHA -> m ()
 insertMissingChainTx chainId th = do
   liftIO $ withLabel chainMetrics "missing_chain_tx" incCounter
   modifyChainIdEntryState_ chainId $ missingTXs %= S.insert th
 
-insertMissingChainTxs :: HasRegistry m => Word256 -> [SHA] -> m ()
+insertMissingChainTxs :: HasPrivateHashDB m => Word256 -> [SHA] -> m ()
 insertMissingChainTxs chainId ths = do
   liftIO $ withLabel chainMetrics "missing_chain_tx" (flip unsafeAddCounter . fromIntegral . length $ ths)
   modifyChainIdEntryState_ chainId $ missingTXs .= S.fromList ths
 
-clearMissingChainTxs :: HasRegistry m => Word256 -> m ()
+clearMissingChainTxs :: HasPrivateHashDB m => Word256 -> m ()
 clearMissingChainTxs chainId = do
   liftIO $ withLabel chainMetrics "missing_chain_tx_removed" incCounter
   traverse_ (mapM_ removeTransaction . _missingTXs) =<< getChainIdEntry chainId

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingTxDB.hs
@@ -11,7 +11,7 @@ import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 
 isMissingTX :: HasRegistry m => SHA -> m Bool
-isMissingTX tHash = maybe False (isJust . _outputTx) <$> getTxHashEntry tHash
+isMissingTX tHash = maybe False (isNothing . _outputTx) <$> getTxHashEntry tHash
 
 insertMissingTx :: HasRegistry m => SHA -> m ()
 insertMissingTx tHash = do
@@ -22,4 +22,4 @@ insertMissingTx tHash = do
 removeMissingTx :: HasRegistry m => SHA -> m ()
 removeMissingTx tHash = do
   liftIO $ withLabel txMetrics "missing_tx_removed" incCounter
-  removeTransaction tHash
+  removeMissingTxEntry tHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingTxDB.hs
@@ -4,27 +4,22 @@ module Blockchain.Sequencer.DB.MissingTxDB where
 import           Blockchain.SHA
 
 import           Control.Monad.IO.Class
-import qualified Data.Set                     as S
+import           Data.Maybe
 import           Prometheus
 
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 
-getMissingTxsDB :: HasPrivateHashDB m => m (S.Set SHA)
-getMissingTxsDB = missingTxs <$> getPrivateHashDB
+isMissingTX :: HasRegistry m => SHA -> m Bool
+isMissingTX tHash = maybe False (isJust . _outputTx) <$> getTxHashEntry tHash
 
-putMissingTxsDB :: HasPrivateHashDB m => S.Set SHA -> m ()
-putMissingTxsDB txs = getPrivateHashDB >>= \db -> putPrivateHashDB db{ missingTxs = txs }
-
-isMissingTX :: HasPrivateHashDB m => SHA -> m Bool
-isMissingTX tx = S.member tx <$> getMissingTxsDB
-
-insertMissingTx :: HasPrivateHashDB m => SHA -> m ()
-insertMissingTx tx = do
+insertMissingTx :: HasRegistry m => SHA -> m ()
+insertMissingTx tHash = do
   liftIO $ withLabel txMetrics "missing_tx" incCounter
-  getMissingTxsDB >>= putMissingTxsDB . S.insert tx
+  alterTxHashEntry_ tHash $
+    return . Just . fromMaybe emptyTxHashEntry
 
-removeMissingTx :: HasPrivateHashDB m => SHA -> m ()
-removeMissingTx tx = do
+removeMissingTx :: HasRegistry m => SHA -> m ()
+removeMissingTx tHash = do
   liftIO $ withLabel txMetrics "missing_tx_removed" incCounter
-  getMissingTxsDB >>= putMissingTxsDB . S.delete tx
+  removeTransaction tHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/MissingTxDB.hs
@@ -10,16 +10,16 @@ import           Prometheus
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 
-isMissingTX :: HasRegistry m => SHA -> m Bool
+isMissingTX :: HasPrivateHashDB m => SHA -> m Bool
 isMissingTX tHash = maybe False (isNothing . _outputTx) <$> getTxHashEntry tHash
 
-insertMissingTx :: HasRegistry m => SHA -> m ()
+insertMissingTx :: HasPrivateHashDB m => SHA -> m ()
 insertMissingTx tHash = do
   liftIO $ withLabel txMetrics "missing_tx" incCounter
   alterTxHashEntry_ tHash $
     return . Just . fromMaybe emptyTxHashEntry
 
-removeMissingTx :: HasRegistry m => SHA -> m ()
+removeMissingTx :: HasPrivateHashDB m => SHA -> m ()
 removeMissingTx tHash = do
   liftIO $ withLabel txMetrics "missing_tx_removed" incCounter
   removeMissingTxEntry tHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateHashDB.hs
@@ -91,7 +91,7 @@ makeLenses ''ChainIdEntry
 chainIdEntry :: ChainInfo -> ChainIdEntry
 chainIdEntry cInfo = ChainIdEntry cInfo emptyCircularBuffer S.empty
 
-class MonadResource m => HasRegistry m where
+class MonadResource m => HasPrivateHashDB m where
   generateChainHashes :: OutputTx -> m [SHA]
   alterBlockHashEntry :: SHA     -> (Maybe BlockHashEntry -> m (Maybe BlockHashEntry)) -> m (Maybe BlockHashEntry)
   alterTxHashEntry    :: SHA     -> (Maybe TxHashEntry    -> m (Maybe TxHashEntry)   ) -> m (Maybe TxHashEntry)
@@ -101,163 +101,163 @@ class MonadResource m => HasRegistry m where
 ffor :: (Applicative f, Monad t, Traversable t) => t a -> (a -> f (t b)) -> f (t b)
 ffor t = fmap join . for t
 
-updateBlockHashEntry :: HasRegistry m => SHA -> (BlockHashEntry -> m (Maybe BlockHashEntry)) -> m (Maybe BlockHashEntry)
+updateBlockHashEntry :: HasPrivateHashDB m => SHA -> (BlockHashEntry -> m (Maybe BlockHashEntry)) -> m (Maybe BlockHashEntry)
 updateBlockHashEntry bHash = alterBlockHashEntry bHash . flip ffor
 
-updateBlockHashEntryState :: HasRegistry m => SHA -> StateT BlockHashEntry m (Maybe BlockHashEntry) -> m (Maybe BlockHashEntry)
+updateBlockHashEntryState :: HasPrivateHashDB m => SHA -> StateT BlockHashEntry m (Maybe BlockHashEntry) -> m (Maybe BlockHashEntry)
 updateBlockHashEntryState bHash = updateBlockHashEntry bHash . evalStateT
 
-modifyBlockHashEntry :: HasRegistry m => SHA -> (BlockHashEntry -> m BlockHashEntry) -> m BlockHashEntry
+modifyBlockHashEntry :: HasPrivateHashDB m => SHA -> (BlockHashEntry -> m BlockHashEntry) -> m BlockHashEntry
 modifyBlockHashEntry bHash f = fmap fromJust $ updateBlockHashEntry bHash (fmap Just . f)
 
-modifyBlockHashEntryState :: HasRegistry m => SHA -> StateT BlockHashEntry m () -> m BlockHashEntry
+modifyBlockHashEntryState :: HasPrivateHashDB m => SHA -> StateT BlockHashEntry m () -> m BlockHashEntry
 modifyBlockHashEntryState bHash = modifyBlockHashEntry bHash . execStateT
 
-repsertBlockHashEntry :: HasRegistry m => SHA -> (Maybe BlockHashEntry -> m BlockHashEntry) -> m BlockHashEntry
+repsertBlockHashEntry :: HasPrivateHashDB m => SHA -> (Maybe BlockHashEntry -> m BlockHashEntry) -> m BlockHashEntry
 repsertBlockHashEntry bHash f = fmap fromJust $ alterBlockHashEntry bHash (fmap Just . f)
 
-insertBlockHashEntry :: HasRegistry m => SHA -> BlockHashEntry -> m ()
+insertBlockHashEntry :: HasPrivateHashDB m => SHA -> BlockHashEntry -> m ()
 insertBlockHashEntry bHash bhe = alterBlockHashEntry_ bHash (return . const (Just bhe))
 
-getBlockHashEntry :: HasRegistry m => SHA -> m (Maybe BlockHashEntry)
+getBlockHashEntry :: HasPrivateHashDB m => SHA -> m (Maybe BlockHashEntry)
 getBlockHashEntry bHash = alterBlockHashEntry bHash return
 
-alterBlockHashEntry_ :: HasRegistry m => SHA -> (Maybe BlockHashEntry -> m (Maybe BlockHashEntry)) -> m ()
+alterBlockHashEntry_ :: HasPrivateHashDB m => SHA -> (Maybe BlockHashEntry -> m (Maybe BlockHashEntry)) -> m ()
 alterBlockHashEntry_ bHash = void . alterBlockHashEntry bHash
 
-updateBlockHashEntry_ :: HasRegistry m => SHA -> (BlockHashEntry -> m (Maybe BlockHashEntry)) -> m ()
+updateBlockHashEntry_ :: HasPrivateHashDB m => SHA -> (BlockHashEntry -> m (Maybe BlockHashEntry)) -> m ()
 updateBlockHashEntry_ bHash = void . updateBlockHashEntry bHash
 
-updateBlockHashEntryState_ :: HasRegistry m => SHA -> StateT BlockHashEntry m (Maybe BlockHashEntry) -> m ()
+updateBlockHashEntryState_ :: HasPrivateHashDB m => SHA -> StateT BlockHashEntry m (Maybe BlockHashEntry) -> m ()
 updateBlockHashEntryState_ bHash = void . updateBlockHashEntryState bHash
 
-modifyBlockHashEntry_ :: HasRegistry m => SHA -> (BlockHashEntry -> m BlockHashEntry) -> m ()
+modifyBlockHashEntry_ :: HasPrivateHashDB m => SHA -> (BlockHashEntry -> m BlockHashEntry) -> m ()
 modifyBlockHashEntry_ bHash = void . modifyBlockHashEntry bHash
 
-modifyBlockHashEntryState_ :: HasRegistry m => SHA -> StateT BlockHashEntry m () -> m ()
+modifyBlockHashEntryState_ :: HasPrivateHashDB m => SHA -> StateT BlockHashEntry m () -> m ()
 modifyBlockHashEntryState_ bHash = void . modifyBlockHashEntryState bHash
 
-repsertBlockHashEntry_ :: HasRegistry m => SHA -> (Maybe BlockHashEntry -> m BlockHashEntry) -> m ()
+repsertBlockHashEntry_ :: HasPrivateHashDB m => SHA -> (Maybe BlockHashEntry -> m BlockHashEntry) -> m ()
 repsertBlockHashEntry_ bHash = void . repsertBlockHashEntry bHash
 
-updateTxHashEntry :: HasRegistry m => SHA -> (TxHashEntry -> m (Maybe TxHashEntry)) -> m (Maybe TxHashEntry)
+updateTxHashEntry :: HasPrivateHashDB m => SHA -> (TxHashEntry -> m (Maybe TxHashEntry)) -> m (Maybe TxHashEntry)
 updateTxHashEntry tHash = alterTxHashEntry tHash . flip ffor
 
-updateTxHashEntryState :: HasRegistry m => SHA -> StateT TxHashEntry m (Maybe TxHashEntry) -> m (Maybe TxHashEntry)
+updateTxHashEntryState :: HasPrivateHashDB m => SHA -> StateT TxHashEntry m (Maybe TxHashEntry) -> m (Maybe TxHashEntry)
 updateTxHashEntryState tHash = updateTxHashEntry tHash . evalStateT
 
-modifyTxHashEntry :: HasRegistry m => SHA -> (TxHashEntry -> m TxHashEntry) -> m TxHashEntry
+modifyTxHashEntry :: HasPrivateHashDB m => SHA -> (TxHashEntry -> m TxHashEntry) -> m TxHashEntry
 modifyTxHashEntry tHash f = fmap fromJust $ updateTxHashEntry tHash (fmap Just . f)
 
-modifyTxHashEntryState :: HasRegistry m => SHA -> StateT TxHashEntry m () -> m TxHashEntry
+modifyTxHashEntryState :: HasPrivateHashDB m => SHA -> StateT TxHashEntry m () -> m TxHashEntry
 modifyTxHashEntryState tHash = modifyTxHashEntry tHash . execStateT
 
-repsertTxHashEntry :: HasRegistry m => SHA -> (Maybe TxHashEntry -> m TxHashEntry) -> m TxHashEntry
+repsertTxHashEntry :: HasPrivateHashDB m => SHA -> (Maybe TxHashEntry -> m TxHashEntry) -> m TxHashEntry
 repsertTxHashEntry tHash f = fmap fromJust $ alterTxHashEntry tHash (fmap Just . f)
 
-insertTxHashEntry :: HasRegistry m => SHA -> TxHashEntry -> m ()
+insertTxHashEntry :: HasPrivateHashDB m => SHA -> TxHashEntry -> m ()
 insertTxHashEntry tHash the = alterTxHashEntry_ tHash (return . const (Just the))
 
-getTxHashEntry :: HasRegistry m => SHA -> m (Maybe TxHashEntry)
+getTxHashEntry :: HasPrivateHashDB m => SHA -> m (Maybe TxHashEntry)
 getTxHashEntry tHash = alterTxHashEntry tHash return
 
-alterTxHashEntry_ :: HasRegistry m => SHA -> (Maybe TxHashEntry -> m (Maybe TxHashEntry)) -> m ()
+alterTxHashEntry_ :: HasPrivateHashDB m => SHA -> (Maybe TxHashEntry -> m (Maybe TxHashEntry)) -> m ()
 alterTxHashEntry_ tHash = void . alterTxHashEntry tHash
 
-updateTxHashEntry_ :: HasRegistry m => SHA -> (TxHashEntry -> m (Maybe TxHashEntry)) -> m ()
+updateTxHashEntry_ :: HasPrivateHashDB m => SHA -> (TxHashEntry -> m (Maybe TxHashEntry)) -> m ()
 updateTxHashEntry_ tHash = void . updateTxHashEntry tHash
 
-updateTxHashEntryState_ :: HasRegistry m => SHA -> StateT TxHashEntry m (Maybe TxHashEntry) -> m ()
+updateTxHashEntryState_ :: HasPrivateHashDB m => SHA -> StateT TxHashEntry m (Maybe TxHashEntry) -> m ()
 updateTxHashEntryState_ tHash = void . updateTxHashEntryState tHash
 
-modifyTxHashEntry_ :: HasRegistry m => SHA -> (TxHashEntry -> m TxHashEntry) -> m ()
+modifyTxHashEntry_ :: HasPrivateHashDB m => SHA -> (TxHashEntry -> m TxHashEntry) -> m ()
 modifyTxHashEntry_ tHash = void . modifyTxHashEntry tHash
 
-modifyTxHashEntryState_ :: HasRegistry m => SHA -> StateT TxHashEntry m () -> m ()
+modifyTxHashEntryState_ :: HasPrivateHashDB m => SHA -> StateT TxHashEntry m () -> m ()
 modifyTxHashEntryState_ tHash = void . modifyTxHashEntryState tHash
 
-repsertTxHashEntry_ :: HasRegistry m => SHA -> (Maybe TxHashEntry -> m TxHashEntry) -> m ()
+repsertTxHashEntry_ :: HasPrivateHashDB m => SHA -> (Maybe TxHashEntry -> m TxHashEntry) -> m ()
 repsertTxHashEntry_ tHash = void . repsertTxHashEntry tHash
 
-updateChainHashEntry :: HasRegistry m => SHA -> (ChainHashEntry -> m (Maybe ChainHashEntry)) -> m (Maybe ChainHashEntry)
+updateChainHashEntry :: HasPrivateHashDB m => SHA -> (ChainHashEntry -> m (Maybe ChainHashEntry)) -> m (Maybe ChainHashEntry)
 updateChainHashEntry cHash = alterChainHashEntry cHash . flip ffor
 
-updateChainHashEntryState :: HasRegistry m => SHA -> StateT ChainHashEntry m (Maybe ChainHashEntry) -> m (Maybe ChainHashEntry)
+updateChainHashEntryState :: HasPrivateHashDB m => SHA -> StateT ChainHashEntry m (Maybe ChainHashEntry) -> m (Maybe ChainHashEntry)
 updateChainHashEntryState cHash = updateChainHashEntry cHash . evalStateT
 
-modifyChainHashEntry :: HasRegistry m => SHA -> (ChainHashEntry -> m ChainHashEntry) -> m ChainHashEntry
+modifyChainHashEntry :: HasPrivateHashDB m => SHA -> (ChainHashEntry -> m ChainHashEntry) -> m ChainHashEntry
 modifyChainHashEntry cHash f = fmap fromJust $ updateChainHashEntry cHash (fmap Just . f)
 
-modifyChainHashEntryState :: HasRegistry m => SHA -> StateT ChainHashEntry m () -> m ChainHashEntry
+modifyChainHashEntryState :: HasPrivateHashDB m => SHA -> StateT ChainHashEntry m () -> m ChainHashEntry
 modifyChainHashEntryState cHash = modifyChainHashEntry cHash . execStateT
 
-repsertChainHashEntry :: HasRegistry m => SHA -> (Maybe ChainHashEntry -> m ChainHashEntry) -> m ChainHashEntry
+repsertChainHashEntry :: HasPrivateHashDB m => SHA -> (Maybe ChainHashEntry -> m ChainHashEntry) -> m ChainHashEntry
 repsertChainHashEntry cHash f = fmap fromJust $ alterChainHashEntry cHash (fmap Just . f)
 
-insertChainHashEntry :: HasRegistry m => SHA -> ChainHashEntry -> m ()
+insertChainHashEntry :: HasPrivateHashDB m => SHA -> ChainHashEntry -> m ()
 insertChainHashEntry cHash che = alterChainHashEntry_ cHash (return . const (Just che))
 
-getChainHashEntry :: HasRegistry m => SHA -> m (Maybe ChainHashEntry)
+getChainHashEntry :: HasPrivateHashDB m => SHA -> m (Maybe ChainHashEntry)
 getChainHashEntry cHash = alterChainHashEntry cHash return
 
-alterChainHashEntry_ :: HasRegistry m => SHA -> (Maybe ChainHashEntry -> m (Maybe ChainHashEntry)) -> m ()
+alterChainHashEntry_ :: HasPrivateHashDB m => SHA -> (Maybe ChainHashEntry -> m (Maybe ChainHashEntry)) -> m ()
 alterChainHashEntry_ cHash = void . alterChainHashEntry cHash
 
-updateChainHashEntry_ :: HasRegistry m => SHA -> (ChainHashEntry -> m (Maybe ChainHashEntry)) -> m ()
+updateChainHashEntry_ :: HasPrivateHashDB m => SHA -> (ChainHashEntry -> m (Maybe ChainHashEntry)) -> m ()
 updateChainHashEntry_ cHash = void . updateChainHashEntry cHash
 
-updateChainHashEntryState_ :: HasRegistry m => SHA -> StateT ChainHashEntry m (Maybe ChainHashEntry) -> m ()
+updateChainHashEntryState_ :: HasPrivateHashDB m => SHA -> StateT ChainHashEntry m (Maybe ChainHashEntry) -> m ()
 updateChainHashEntryState_ cHash = void . updateChainHashEntryState cHash
 
-modifyChainHashEntry_ :: HasRegistry m => SHA -> (ChainHashEntry -> m ChainHashEntry) -> m ()
+modifyChainHashEntry_ :: HasPrivateHashDB m => SHA -> (ChainHashEntry -> m ChainHashEntry) -> m ()
 modifyChainHashEntry_ cHash = void . modifyChainHashEntry cHash
 
-modifyChainHashEntryState_ :: HasRegistry m => SHA -> StateT ChainHashEntry m () -> m ()
+modifyChainHashEntryState_ :: HasPrivateHashDB m => SHA -> StateT ChainHashEntry m () -> m ()
 modifyChainHashEntryState_ cHash = void . modifyChainHashEntryState cHash
 
-repsertChainHashEntry_ :: HasRegistry m => SHA -> (Maybe ChainHashEntry -> m ChainHashEntry) -> m ()
+repsertChainHashEntry_ :: HasPrivateHashDB m => SHA -> (Maybe ChainHashEntry -> m ChainHashEntry) -> m ()
 repsertChainHashEntry_ cHash = void . repsertChainHashEntry cHash
 
-updateChainIdEntry :: HasRegistry m => Word256 -> (ChainIdEntry -> m (Maybe ChainIdEntry)) -> m (Maybe ChainIdEntry)
+updateChainIdEntry :: HasPrivateHashDB m => Word256 -> (ChainIdEntry -> m (Maybe ChainIdEntry)) -> m (Maybe ChainIdEntry)
 updateChainIdEntry cId = alterChainIdEntry cId . flip ffor
 
-updateChainIdEntryState :: HasRegistry m => Word256 -> StateT ChainIdEntry m (Maybe ChainIdEntry) -> m (Maybe ChainIdEntry)
+updateChainIdEntryState :: HasPrivateHashDB m => Word256 -> StateT ChainIdEntry m (Maybe ChainIdEntry) -> m (Maybe ChainIdEntry)
 updateChainIdEntryState cId = updateChainIdEntry cId . evalStateT
 
-modifyChainIdEntry :: HasRegistry m => Word256 -> (ChainIdEntry -> m ChainIdEntry) -> m ChainIdEntry
+modifyChainIdEntry :: HasPrivateHashDB m => Word256 -> (ChainIdEntry -> m ChainIdEntry) -> m ChainIdEntry
 modifyChainIdEntry cId f = fmap fromJust $ updateChainIdEntry cId (fmap Just . f)
 
-modifyChainIdEntryState :: HasRegistry m => Word256 -> StateT ChainIdEntry m () -> m ChainIdEntry
+modifyChainIdEntryState :: HasPrivateHashDB m => Word256 -> StateT ChainIdEntry m () -> m ChainIdEntry
 modifyChainIdEntryState cId = modifyChainIdEntry cId . execStateT
 
-repsertChainIdEntry :: HasRegistry m => Word256 -> (Maybe ChainIdEntry -> m ChainIdEntry) -> m ChainIdEntry
+repsertChainIdEntry :: HasPrivateHashDB m => Word256 -> (Maybe ChainIdEntry -> m ChainIdEntry) -> m ChainIdEntry
 repsertChainIdEntry cId f = fmap fromJust $ alterChainIdEntry cId (fmap Just . f)
 
-insertChainIdEntry :: HasRegistry m => Word256 -> ChainIdEntry -> m ()
+insertChainIdEntry :: HasPrivateHashDB m => Word256 -> ChainIdEntry -> m ()
 insertChainIdEntry cId cie = alterChainIdEntry_ cId (return . const (Just cie))
 
-getChainIdEntry :: HasRegistry m => Word256 -> m (Maybe ChainIdEntry)
+getChainIdEntry :: HasPrivateHashDB m => Word256 -> m (Maybe ChainIdEntry)
 getChainIdEntry cId = alterChainIdEntry cId return
 
-alterChainIdEntry_ :: HasRegistry m => Word256 -> (Maybe ChainIdEntry -> m (Maybe ChainIdEntry)) -> m ()
+alterChainIdEntry_ :: HasPrivateHashDB m => Word256 -> (Maybe ChainIdEntry -> m (Maybe ChainIdEntry)) -> m ()
 alterChainIdEntry_ cId = void . alterChainIdEntry cId
 
-updateChainIdEntry_ :: HasRegistry m => Word256 -> (ChainIdEntry -> m (Maybe ChainIdEntry)) -> m ()
+updateChainIdEntry_ :: HasPrivateHashDB m => Word256 -> (ChainIdEntry -> m (Maybe ChainIdEntry)) -> m ()
 updateChainIdEntry_ cId = void . updateChainIdEntry cId
 
-updateChainIdEntryState_ :: HasRegistry m => Word256 -> StateT ChainIdEntry m (Maybe ChainIdEntry) -> m ()
+updateChainIdEntryState_ :: HasPrivateHashDB m => Word256 -> StateT ChainIdEntry m (Maybe ChainIdEntry) -> m ()
 updateChainIdEntryState_ cId = void . updateChainIdEntryState cId
 
-modifyChainIdEntry_ :: HasRegistry m => Word256 -> (ChainIdEntry -> m ChainIdEntry) -> m ()
+modifyChainIdEntry_ :: HasPrivateHashDB m => Word256 -> (ChainIdEntry -> m ChainIdEntry) -> m ()
 modifyChainIdEntry_ cId = void . modifyChainIdEntry cId
 
-modifyChainIdEntryState_ :: HasRegistry m => Word256 -> StateT ChainIdEntry m () -> m ()
+modifyChainIdEntryState_ :: HasPrivateHashDB m => Word256 -> StateT ChainIdEntry m () -> m ()
 modifyChainIdEntryState_ cId = void . modifyChainIdEntryState cId
 
-repsertChainIdEntry_ :: HasRegistry m => Word256 -> (Maybe ChainIdEntry -> m ChainIdEntry) -> m ()
+repsertChainIdEntry_ :: HasPrivateHashDB m => Word256 -> (Maybe ChainIdEntry -> m ChainIdEntry) -> m ()
 repsertChainIdEntry_ cId = void . repsertChainIdEntry cId
 
-insertHashPairs :: HasRegistry m => SHA -> Map SHA SHA -> m ()
+insertHashPairs :: HasPrivateHashDB m => SHA -> Map SHA SHA -> m ()
 insertHashPairs bHash thchs = repsertBlockHashEntry_ bHash $ \case
   Nothing -> error $ "insertThChPairs: Block hash " ++ format bHash ++ " not found"
   Just bhe -> return . flip execState bhe $ do
@@ -267,7 +267,7 @@ insertHashPairs bHash thchs = repsertBlockHashEntry_ bHash $ \case
         build [] m = m
         build ((th,ch):xs) m = build xs $ M.alter (Just . maybe (S.singleton th) (S.insert th)) ch m
 
-removeMissingTxEntry :: HasRegistry m => SHA -> m ()
+removeMissingTxEntry :: HasPrivateHashDB m => SHA -> m ()
 removeMissingTxEntry tHash = do
   mthe <- getTxHashEntry tHash
   for_ mthe $ \TxHashEntry{_outputTx = otx} ->
@@ -275,7 +275,7 @@ removeMissingTxEntry tHash = do
       modifyChainIdEntryState_ (fromJust $ txChainId tx) $
         missingTXs %= S.delete tHash
 
-removeTransaction :: HasRegistry m => SHA -> m ()
+removeTransaction :: HasPrivateHashDB m => SHA -> m ()
 removeTransaction tHash = updateTxHashEntryState_ tHash $ do
   body <- use outputTx
   for_ body $ \tx ->
@@ -304,8 +304,8 @@ removeTransaction tHash = updateTxHashEntryState_ tHash $ do
         else gets Just
   return Nothing
 
-getChainHashForTxInBlock :: HasRegistry m => SHA -> SHA -> m (Maybe SHA)
+getChainHashForTxInBlock :: HasPrivateHashDB m => SHA -> SHA -> m (Maybe SHA)
 getChainHashForTxInBlock bHash tHash = join . fmap (M.lookup tHash . _txHashMap) <$> getBlockHashEntry bHash
 
-getTxHashSetForChainHashInBlock :: HasRegistry m => SHA -> SHA -> m (Maybe (Set SHA))
+getTxHashSetForChainHashInBlock :: HasPrivateHashDB m => SHA -> SHA -> m (Maybe (Set SHA))
 getTxHashSetForChainHashInBlock bHash cHash = join . fmap (M.lookup cHash . _chainHashMap) <$> getBlockHashEntry bHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateHashDB.hs
@@ -1,34 +1,39 @@
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TemplateHaskell       #-}
+
 module Blockchain.Sequencer.DB.PrivateHashDB where
 
+import           Blockchain.Data.ChainInfo
+import           Blockchain.Data.DataDefs     (BlockData(..))
 import           Blockchain.ExtWord           (Word256)
+import           Blockchain.Format
+import           Blockchain.Strato.Model.Class
 import           Blockchain.Sequencer.Event
 import           Blockchain.SHA
+import           Control.Lens
+import           Control.Monad                (join, void, when)
+import           Control.Monad.Trans.Class    (lift)
 import           Control.Monad.Trans.Resource
+import           Control.Monad.Trans.State
 
+import           Data.Foldable                (for_)
 import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as M
+import           Data.Maybe                   (fromJust)
 import qualified Data.Sequence                as Q
+import           Data.Set                     (Set)
 import qualified Data.Set                     as S
+import           Data.Traversable             (for)
 
-data PrivateHashDB =
-     PrivateHashDB { txHashMap      :: Map SHA OutputTx                 -- TODO: Make these LDB entries
-                   , chainHashMap   :: Map SHA (Bool, Word256)
-                   , chainBuffers   :: Map Word256 (CircularBuffer SHA) -- TODO: Use buffers to remove old entries
-                   , seenChains     :: S.Set Word256
-                   , missingChainDB :: Map Word256 [SHA]
-                   , seenTXs        :: S.Set SHA                        -- set of seen transaction hashes
-                   , missingTxs     :: S.Set SHA                        -- set of transaction hashes for chains we recognize but don't have data for
-                   , dependentTxDB  :: Map SHA (S.Set SHA)              -- map from block hash to dependent transaction hashes
-                   , txBlockDB      :: Map SHA SHA                      -- map from transaction hash to block hash
-                   }
-
-data CircularBuffer a =
-     CircularBuffer { capacity :: Int
-                    , size     :: Int
-                    , queue    :: Q.Seq a
-                    } deriving (Show)
+data CircularBuffer a = CircularBuffer
+  { _capacity :: Int
+  , _size     :: Int
+  , _queue    :: Q.Seq a
+  } deriving (Show)
+makeLenses ''CircularBuffer
 
 maxBufferCapacity :: Int
 maxBufferCapacity = 4096
@@ -36,10 +41,261 @@ maxBufferCapacity = 4096
 emptyCircularBuffer :: CircularBuffer a
 emptyCircularBuffer = CircularBuffer maxBufferCapacity 0 Q.empty
 
-emptyPrivateHashDB :: PrivateHashDB
-emptyPrivateHashDB  = PrivateHashDB M.empty M.empty M.empty S.empty M.empty
-                                    S.empty S.empty M.empty M.empty
+data BlockHashInfo = BlockHashInfo
+  { _bhiTotalDifficulty :: Integer
+  , _bhiBlockNumber     :: Integer
+  }
+makeLenses ''BlockHashInfo
 
-class MonadResource m => HasPrivateHashDB m where
-    getPrivateHashDB :: m PrivateHashDB
-    putPrivateHashDB :: PrivateHashDB -> m ()
+data BlockHashEntry = BlockHashEntry
+  { _blockData    :: BlockData
+  , _dependentTXs :: Set SHA
+  , _txHashMap    :: Map SHA SHA
+  , _chainHashMap :: Map SHA (Set SHA)
+  }
+makeLenses ''BlockHashEntry
+
+blockHashEntry :: BlockData -> BlockHashEntry
+blockHashEntry bData = BlockHashEntry bData S.empty M.empty M.empty
+
+data TxHashEntry = TxHashEntry
+  { _outputTx :: Maybe OutputTx
+  , _inBlock  :: Maybe SHA
+  }
+makeLenses ''TxHashEntry
+
+emptyTxHashEntry :: TxHashEntry
+emptyTxHashEntry = TxHashEntry Nothing Nothing
+
+data ChainHashEntry = ChainHashEntry
+  { _used         :: Bool
+  , _onChainId    :: Word256
+  , _transactions :: Set SHA
+  , _blocks       :: Map SHA BlockHashInfo
+  }
+makeLenses ''ChainHashEntry
+
+chainHashEntry :: Word256 -> ChainHashEntry
+chainHashEntry chainId = ChainHashEntry False chainId S.empty M.empty
+
+data ChainIdEntry = ChainIdEntry
+  { _chainInfo   :: ChainInfo
+  , _chainHashes :: CircularBuffer SHA
+  , _missingTXs  :: Set SHA
+  , _blockHashes :: Map SHA BlockHashInfo
+  }
+makeLenses ''ChainIdEntry
+
+chainIdEntry :: ChainInfo -> ChainIdEntry
+chainIdEntry cInfo = ChainIdEntry cInfo emptyCircularBuffer S.empty M.empty
+
+class MonadResource m => HasRegistry m where
+  generateChainHashes :: OutputTx -> m [SHA]
+  alterBlockHashEntry :: SHA     -> (Maybe BlockHashEntry -> m (Maybe BlockHashEntry)) -> m (Maybe BlockHashEntry)
+  alterTxHashEntry    :: SHA     -> (Maybe TxHashEntry    -> m (Maybe TxHashEntry)   ) -> m (Maybe TxHashEntry)
+  alterChainHashEntry :: SHA     -> (Maybe ChainHashEntry -> m (Maybe ChainHashEntry)) -> m (Maybe ChainHashEntry)
+  alterChainIdEntry   :: Word256 -> (Maybe ChainIdEntry   -> m (Maybe ChainIdEntry)  ) -> m (Maybe ChainIdEntry)
+
+ffor :: (Applicative f, Monad t, Traversable t) => t a -> (a -> f (t b)) -> f (t b)
+ffor t = fmap join . for t
+
+updateBlockHashEntry :: HasRegistry m => SHA -> (BlockHashEntry -> m (Maybe BlockHashEntry)) -> m (Maybe BlockHashEntry)
+updateBlockHashEntry bHash = alterBlockHashEntry bHash . flip ffor
+
+updateBlockHashEntryState :: HasRegistry m => SHA -> StateT BlockHashEntry m (Maybe BlockHashEntry) -> m (Maybe BlockHashEntry)
+updateBlockHashEntryState bHash = updateBlockHashEntry bHash . evalStateT
+
+modifyBlockHashEntry :: HasRegistry m => SHA -> (BlockHashEntry -> m BlockHashEntry) -> m BlockHashEntry
+modifyBlockHashEntry bHash f = fmap fromJust $ updateBlockHashEntry bHash (fmap Just . f)
+
+modifyBlockHashEntryState :: HasRegistry m => SHA -> StateT BlockHashEntry m () -> m BlockHashEntry
+modifyBlockHashEntryState bHash = modifyBlockHashEntry bHash . execStateT
+
+repsertBlockHashEntry :: HasRegistry m => SHA -> (Maybe BlockHashEntry -> m BlockHashEntry) -> m BlockHashEntry
+repsertBlockHashEntry bHash f = fmap fromJust $ alterBlockHashEntry bHash (fmap Just . f)
+
+insertBlockHashEntry :: HasRegistry m => SHA -> BlockHashEntry -> m ()
+insertBlockHashEntry bHash bhe = alterBlockHashEntry_ bHash (return . const (Just bhe))
+
+getBlockHashEntry :: HasRegistry m => SHA -> m (Maybe BlockHashEntry)
+getBlockHashEntry bHash = alterBlockHashEntry bHash return
+
+alterBlockHashEntry_ :: HasRegistry m => SHA -> (Maybe BlockHashEntry -> m (Maybe BlockHashEntry)) -> m ()
+alterBlockHashEntry_ bHash = void . alterBlockHashEntry bHash
+
+updateBlockHashEntry_ :: HasRegistry m => SHA -> (BlockHashEntry -> m (Maybe BlockHashEntry)) -> m ()
+updateBlockHashEntry_ bHash = void . updateBlockHashEntry bHash
+
+updateBlockHashEntryState_ :: HasRegistry m => SHA -> StateT BlockHashEntry m (Maybe BlockHashEntry) -> m ()
+updateBlockHashEntryState_ bHash = void . updateBlockHashEntryState bHash
+
+modifyBlockHashEntry_ :: HasRegistry m => SHA -> (BlockHashEntry -> m BlockHashEntry) -> m ()
+modifyBlockHashEntry_ bHash = void . modifyBlockHashEntry bHash
+
+modifyBlockHashEntryState_ :: HasRegistry m => SHA -> StateT BlockHashEntry m () -> m ()
+modifyBlockHashEntryState_ bHash = void . modifyBlockHashEntryState bHash
+
+repsertBlockHashEntry_ :: HasRegistry m => SHA -> (Maybe BlockHashEntry -> m BlockHashEntry) -> m ()
+repsertBlockHashEntry_ bHash = void . repsertBlockHashEntry bHash
+
+updateTxHashEntry :: HasRegistry m => SHA -> (TxHashEntry -> m (Maybe TxHashEntry)) -> m (Maybe TxHashEntry)
+updateTxHashEntry tHash = alterTxHashEntry tHash . flip ffor
+
+updateTxHashEntryState :: HasRegistry m => SHA -> StateT TxHashEntry m (Maybe TxHashEntry) -> m (Maybe TxHashEntry)
+updateTxHashEntryState tHash = updateTxHashEntry tHash . evalStateT
+
+modifyTxHashEntry :: HasRegistry m => SHA -> (TxHashEntry -> m TxHashEntry) -> m TxHashEntry
+modifyTxHashEntry tHash f = fmap fromJust $ updateTxHashEntry tHash (fmap Just . f)
+
+modifyTxHashEntryState :: HasRegistry m => SHA -> StateT TxHashEntry m () -> m TxHashEntry
+modifyTxHashEntryState tHash = modifyTxHashEntry tHash . execStateT
+
+repsertTxHashEntry :: HasRegistry m => SHA -> (Maybe TxHashEntry -> m TxHashEntry) -> m TxHashEntry
+repsertTxHashEntry tHash f = fmap fromJust $ alterTxHashEntry tHash (fmap Just . f)
+
+insertTxHashEntry :: HasRegistry m => SHA -> TxHashEntry -> m ()
+insertTxHashEntry tHash the = alterTxHashEntry_ tHash (return . const (Just the))
+
+getTxHashEntry :: HasRegistry m => SHA -> m (Maybe TxHashEntry)
+getTxHashEntry tHash = alterTxHashEntry tHash return
+
+alterTxHashEntry_ :: HasRegistry m => SHA -> (Maybe TxHashEntry -> m (Maybe TxHashEntry)) -> m ()
+alterTxHashEntry_ tHash = void . alterTxHashEntry tHash
+
+updateTxHashEntry_ :: HasRegistry m => SHA -> (TxHashEntry -> m (Maybe TxHashEntry)) -> m ()
+updateTxHashEntry_ tHash = void . updateTxHashEntry tHash
+
+updateTxHashEntryState_ :: HasRegistry m => SHA -> StateT TxHashEntry m (Maybe TxHashEntry) -> m ()
+updateTxHashEntryState_ tHash = void . updateTxHashEntryState tHash
+
+modifyTxHashEntry_ :: HasRegistry m => SHA -> (TxHashEntry -> m TxHashEntry) -> m ()
+modifyTxHashEntry_ tHash = void . modifyTxHashEntry tHash
+
+modifyTxHashEntryState_ :: HasRegistry m => SHA -> StateT TxHashEntry m () -> m ()
+modifyTxHashEntryState_ tHash = void . modifyTxHashEntryState tHash
+
+repsertTxHashEntry_ :: HasRegistry m => SHA -> (Maybe TxHashEntry -> m TxHashEntry) -> m ()
+repsertTxHashEntry_ tHash = void . repsertTxHashEntry tHash
+
+updateChainHashEntry :: HasRegistry m => SHA -> (ChainHashEntry -> m (Maybe ChainHashEntry)) -> m (Maybe ChainHashEntry)
+updateChainHashEntry cHash = alterChainHashEntry cHash . flip ffor
+
+updateChainHashEntryState :: HasRegistry m => SHA -> StateT ChainHashEntry m (Maybe ChainHashEntry) -> m (Maybe ChainHashEntry)
+updateChainHashEntryState cHash = updateChainHashEntry cHash . evalStateT
+
+modifyChainHashEntry :: HasRegistry m => SHA -> (ChainHashEntry -> m ChainHashEntry) -> m ChainHashEntry
+modifyChainHashEntry cHash f = fmap fromJust $ updateChainHashEntry cHash (fmap Just . f)
+
+modifyChainHashEntryState :: HasRegistry m => SHA -> StateT ChainHashEntry m () -> m ChainHashEntry
+modifyChainHashEntryState cHash = modifyChainHashEntry cHash . execStateT
+
+repsertChainHashEntry :: HasRegistry m => SHA -> (Maybe ChainHashEntry -> m ChainHashEntry) -> m ChainHashEntry
+repsertChainHashEntry cHash f = fmap fromJust $ alterChainHashEntry cHash (fmap Just . f)
+
+insertChainHashEntry :: HasRegistry m => SHA -> ChainHashEntry -> m ()
+insertChainHashEntry cHash che = alterChainHashEntry_ cHash (return . const (Just che))
+
+getChainHashEntry :: HasRegistry m => SHA -> m (Maybe ChainHashEntry)
+getChainHashEntry cHash = alterChainHashEntry cHash return
+
+alterChainHashEntry_ :: HasRegistry m => SHA -> (Maybe ChainHashEntry -> m (Maybe ChainHashEntry)) -> m ()
+alterChainHashEntry_ cHash = void . alterChainHashEntry cHash
+
+updateChainHashEntry_ :: HasRegistry m => SHA -> (ChainHashEntry -> m (Maybe ChainHashEntry)) -> m ()
+updateChainHashEntry_ cHash = void . updateChainHashEntry cHash
+
+updateChainHashEntryState_ :: HasRegistry m => SHA -> StateT ChainHashEntry m (Maybe ChainHashEntry) -> m ()
+updateChainHashEntryState_ cHash = void . updateChainHashEntryState cHash
+
+modifyChainHashEntry_ :: HasRegistry m => SHA -> (ChainHashEntry -> m ChainHashEntry) -> m ()
+modifyChainHashEntry_ cHash = void . modifyChainHashEntry cHash
+
+modifyChainHashEntryState_ :: HasRegistry m => SHA -> StateT ChainHashEntry m () -> m ()
+modifyChainHashEntryState_ cHash = void . modifyChainHashEntryState cHash
+
+repsertChainHashEntry_ :: HasRegistry m => SHA -> (Maybe ChainHashEntry -> m ChainHashEntry) -> m ()
+repsertChainHashEntry_ cHash = void . repsertChainHashEntry cHash
+
+updateChainIdEntry :: HasRegistry m => Word256 -> (ChainIdEntry -> m (Maybe ChainIdEntry)) -> m (Maybe ChainIdEntry)
+updateChainIdEntry cId = alterChainIdEntry cId . flip ffor
+
+updateChainIdEntryState :: HasRegistry m => Word256 -> StateT ChainIdEntry m (Maybe ChainIdEntry) -> m (Maybe ChainIdEntry)
+updateChainIdEntryState cId = updateChainIdEntry cId . evalStateT
+
+modifyChainIdEntry :: HasRegistry m => Word256 -> (ChainIdEntry -> m ChainIdEntry) -> m ChainIdEntry
+modifyChainIdEntry cId f = fmap fromJust $ updateChainIdEntry cId (fmap Just . f)
+
+modifyChainIdEntryState :: HasRegistry m => Word256 -> StateT ChainIdEntry m () -> m ChainIdEntry
+modifyChainIdEntryState cId = modifyChainIdEntry cId . execStateT
+
+repsertChainIdEntry :: HasRegistry m => Word256 -> (Maybe ChainIdEntry -> m ChainIdEntry) -> m ChainIdEntry
+repsertChainIdEntry cId f = fmap fromJust $ alterChainIdEntry cId (fmap Just . f)
+
+insertChainIdEntry :: HasRegistry m => Word256 -> ChainIdEntry -> m ()
+insertChainIdEntry cId cie = alterChainIdEntry_ cId (return . const (Just cie))
+
+getChainIdEntry :: HasRegistry m => Word256 -> m (Maybe ChainIdEntry)
+getChainIdEntry cId = alterChainIdEntry cId return
+
+alterChainIdEntry_ :: HasRegistry m => Word256 -> (Maybe ChainIdEntry -> m (Maybe ChainIdEntry)) -> m ()
+alterChainIdEntry_ cId = void . alterChainIdEntry cId
+
+updateChainIdEntry_ :: HasRegistry m => Word256 -> (ChainIdEntry -> m (Maybe ChainIdEntry)) -> m ()
+updateChainIdEntry_ cId = void . updateChainIdEntry cId
+
+updateChainIdEntryState_ :: HasRegistry m => Word256 -> StateT ChainIdEntry m (Maybe ChainIdEntry) -> m ()
+updateChainIdEntryState_ cId = void . updateChainIdEntryState cId
+
+modifyChainIdEntry_ :: HasRegistry m => Word256 -> (ChainIdEntry -> m ChainIdEntry) -> m ()
+modifyChainIdEntry_ cId = void . modifyChainIdEntry cId
+
+modifyChainIdEntryState_ :: HasRegistry m => Word256 -> StateT ChainIdEntry m () -> m ()
+modifyChainIdEntryState_ cId = void . modifyChainIdEntryState cId
+
+repsertChainIdEntry_ :: HasRegistry m => Word256 -> (Maybe ChainIdEntry -> m ChainIdEntry) -> m ()
+repsertChainIdEntry_ cId = void . repsertChainIdEntry cId
+
+insertHashPairs :: HasRegistry m => SHA -> Map SHA SHA -> m ()
+insertHashPairs bHash thchs = repsertBlockHashEntry_ bHash $ \case
+  Nothing -> error $ "insertThChPairs: Block hash " ++ format bHash ++ " not found"
+  Just bhe -> return . flip execState bhe $ do
+    txHashMap %= M.union thchs
+    chainHashMap %= build (M.toList thchs)
+  where build :: [(SHA,SHA)] -> Map SHA (Set SHA) -> Map SHA (Set SHA)
+        build [] m = m
+        build ((th,ch):xs) m = build xs $ M.alter (Just . maybe (S.singleton th) (S.insert th)) ch m
+
+removeTransaction :: HasRegistry m => SHA -> m ()
+removeTransaction tHash = updateTxHashEntryState_ tHash $ do
+  body <- use outputTx
+  for_ body $ \tx ->
+    lift . modifyChainIdEntryState_ (fromJust $ txChainId tx) $
+      missingTXs %= S.delete tHash
+  bh <- use inBlock
+  for_ bh $ \bHash ->
+    lift . updateBlockHashEntry bHash . evalStateT $ do
+      depTXs <- dependentTXs <%= S.delete tHash
+      mChash <- use (txHashMap . at tHash)
+      mthchs <- for mChash $ \cHash -> do
+        txHashMap %= M.delete tHash
+        ths <- chainHashMap . at cHash . _Just <%= S.delete tHash
+        chs <- if S.null ths
+                then chainHashMap <%= (M.delete cHash)
+                else use chainHashMap
+        lift . modifyChainHashEntryState_ cHash $ do
+          transactions %= S.delete tHash
+          when (M.null chs) $ blocks %= M.delete bHash
+        return (ths,chs)
+      if S.null depTXs
+        then ffor mthchs $ \(ths,chs) ->
+          if S.null ths && M.null chs
+            then return Nothing
+            else gets Just
+        else gets Just
+  return Nothing
+
+getChainHashForTxInBlock :: HasRegistry m => SHA -> SHA -> m (Maybe SHA)
+getChainHashForTxInBlock bHash tHash = join . fmap (M.lookup tHash . _txHashMap) <$> getBlockHashEntry bHash
+
+getTxHashSetForChainHashInBlock :: HasRegistry m => SHA -> SHA -> m (Maybe (Set SHA))
+getTxHashSetForChainHashInBlock bHash cHash = join . fmap (M.lookup cHash . _chainHashMap) <$> getBlockHashEntry bHash

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateHashDB.hs
@@ -7,7 +7,6 @@
 module Blockchain.Sequencer.DB.PrivateHashDB where
 
 import           Blockchain.Data.ChainInfo
-import           Blockchain.Data.DataDefs     (BlockData(..))
 import           Blockchain.ExtWord           (Word256)
 import           Blockchain.Format
 import           Blockchain.Strato.Model.Class
@@ -41,53 +40,56 @@ maxBufferCapacity = 4096
 emptyCircularBuffer :: CircularBuffer a
 emptyCircularBuffer = CircularBuffer maxBufferCapacity 0 Q.empty
 
-data BlockHashInfo = BlockHashInfo
-  { _bhiTotalDifficulty :: Integer
-  , _bhiBlockNumber     :: Integer
-  }
-makeLenses ''BlockHashInfo
-
 data BlockHashEntry = BlockHashEntry
-  { _blockData    :: BlockData
+  { _outputBlock  :: OutputBlock
   , _dependentTXs :: Set SHA
   , _txHashMap    :: Map SHA SHA
   , _chainHashMap :: Map SHA (Set SHA)
   }
 makeLenses ''BlockHashEntry
 
-blockHashEntry :: BlockData -> BlockHashEntry
-blockHashEntry bData = BlockHashEntry bData S.empty M.empty M.empty
+blockHashEntry :: OutputBlock -> BlockHashEntry
+blockHashEntry ob = BlockHashEntry ob S.empty M.empty M.empty
 
 data TxHashEntry = TxHashEntry
-  { _outputTx :: Maybe OutputTx
-  , _inBlock  :: Maybe SHA
-  }
+  { _outputTx  :: Maybe OutputTx
+  , _chainHash :: Maybe SHA
+  , _inBlock   :: Maybe SHA
+  } deriving (Show)
 makeLenses ''TxHashEntry
 
 emptyTxHashEntry :: TxHashEntry
-emptyTxHashEntry = TxHashEntry Nothing Nothing
+emptyTxHashEntry = TxHashEntry Nothing Nothing Nothing
+
+txHashEntryWithOutputTx :: OutputTx -> TxHashEntry
+txHashEntryWithOutputTx otx = TxHashEntry (Just otx) Nothing Nothing
+
+txHashEntryWithChainHash :: SHA -> TxHashEntry
+txHashEntryWithChainHash cHash = TxHashEntry Nothing (Just cHash) Nothing
+
+txHashEntryWithBlockHash :: SHA -> TxHashEntry
+txHashEntryWithBlockHash bHash = TxHashEntry Nothing Nothing (Just bHash)
 
 data ChainHashEntry = ChainHashEntry
   { _used         :: Bool
   , _onChainId    :: Word256
   , _transactions :: Set SHA
-  , _blocks       :: Map SHA BlockHashInfo
+  , _inBlocks     :: Set SHA
   }
 makeLenses ''ChainHashEntry
 
 chainHashEntry :: Word256 -> ChainHashEntry
-chainHashEntry chainId = ChainHashEntry False chainId S.empty M.empty
+chainHashEntry chainId = ChainHashEntry False chainId S.empty S.empty
 
 data ChainIdEntry = ChainIdEntry
   { _chainInfo   :: ChainInfo
   , _chainHashes :: CircularBuffer SHA
   , _missingTXs  :: Set SHA
-  , _blockHashes :: Map SHA BlockHashInfo
   }
 makeLenses ''ChainIdEntry
 
 chainIdEntry :: ChainInfo -> ChainIdEntry
-chainIdEntry cInfo = ChainIdEntry cInfo emptyCircularBuffer S.empty M.empty
+chainIdEntry cInfo = ChainIdEntry cInfo emptyCircularBuffer S.empty
 
 class MonadResource m => HasRegistry m where
   generateChainHashes :: OutputTx -> m [SHA]
@@ -265,6 +267,14 @@ insertHashPairs bHash thchs = repsertBlockHashEntry_ bHash $ \case
         build [] m = m
         build ((th,ch):xs) m = build xs $ M.alter (Just . maybe (S.singleton th) (S.insert th)) ch m
 
+removeMissingTxEntry :: HasRegistry m => SHA -> m ()
+removeMissingTxEntry tHash = do
+  mthe <- getTxHashEntry tHash
+  for_ mthe $ \TxHashEntry{_outputTx = otx} ->
+    for_ otx $ \tx ->
+      modifyChainIdEntryState_ (fromJust $ txChainId tx) $
+        missingTXs %= S.delete tHash
+
 removeTransaction :: HasRegistry m => SHA -> m ()
 removeTransaction tHash = updateTxHashEntryState_ tHash $ do
   body <- use outputTx
@@ -273,10 +283,10 @@ removeTransaction tHash = updateTxHashEntryState_ tHash $ do
       missingTXs %= S.delete tHash
   bh <- use inBlock
   for_ bh $ \bHash ->
-    lift . updateBlockHashEntry bHash . evalStateT $ do
+    lift . updateBlockHashEntryState_ bHash $ do
       depTXs <- dependentTXs <%= S.delete tHash
       mChash <- use (txHashMap . at tHash)
-      mthchs <- for mChash $ \cHash -> do
+      mPairs <- for mChash $ \cHash -> do
         txHashMap %= M.delete tHash
         ths <- chainHashMap . at cHash . _Just <%= S.delete tHash
         chs <- if S.null ths
@@ -284,10 +294,10 @@ removeTransaction tHash = updateTxHashEntryState_ tHash $ do
                 else use chainHashMap
         lift . modifyChainHashEntryState_ cHash $ do
           transactions %= S.delete tHash
-          when (M.null chs) $ blocks %= M.delete bHash
+          when (M.null chs) $ inBlocks %= S.delete bHash
         return (ths,chs)
       if S.null depTXs
-        then ffor mthchs $ \(ths,chs) ->
+        then ffor mPairs $ \(ths,chs) ->
           if S.null ths && M.null chs
             then return Nothing
             else gets Just

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateHashDB.hs
@@ -101,6 +101,42 @@ class MonadResource m => HasPrivateHashDB m where
 ffor :: (Applicative f, Monad t, Traversable t) => t a -> (a -> f (t b)) -> f (t b)
 ffor t = fmap join . for t
 
+{-
+  GUIDE:
+  All the following functions follow this pattern, for key type K and value type V:
+  - alterX takes a K, a function (Maybe V -> m (Maybe V)), and returns m (Maybe V)
+    - similar to Map.alter, which reads a (maybe non-existent) value from the Map,
+      then either inserts, updates, or deletes it.
+    - if the input value is Nothing, the value doesn't exist in the Map.
+    - if the return value is Nothing, the (k,v) pair is deleted from the Map.
+  - updateX takes a K, a function (V -> m (Maybe V)), and returns m (Maybe V)
+    - similar to Map.update, which takes an existing value for the Map, and either
+      updates or deletes it.
+    - if the return value is Nothing, the (k,v) pair is deleted from the Map.
+    - if the (k,v) pair is not in the Map, the function is not applied.
+  - modifyX takes a K, a function (V -> m V), and returns m V.
+    - similar to State.modify
+    - takes an existing v from the Map, and modifies it with f.
+    - cannot be used to insert or delete items from the Map
+    - if the (k,v) pair is not in the Map, the function is not applied.
+  - repsertX takes a K, a function (Maybe V -> m V), and returns m V.
+    - can be used to insert, modify, or overwrite an existing element of the Map.
+    - cannot be used to delete an item from the Map
+  - insertX takes a K, a V, and returns m ()
+  - getX takes a K, returns m (Maybe V)
+  - updateXState takes a K, a StateT V m (Maybe V) action, and returns m (Maybe V)
+    - same as updateX, but run in the StateT monad
+    - allows for nicer lens operations, and implicit state updates
+    - if the return value of the action is Nothing, the item is deleted from the Map
+    - uses evalStateT
+  - modifyXState takes a K, a StateT V m () action, and returns m V.
+    - same as modifyX, but run in the StateT monad
+    - allows for nicer lens operations, and implicit state updates
+    - action has no return value (m ())
+    - uses execStateT
+  - quiet versions of each function had an underscore appended (e.g. alterX_, modifyXState_)
+-}
+
 updateBlockHashEntry :: HasPrivateHashDB m => SHA -> (BlockHashEntry -> m (Maybe BlockHashEntry)) -> m (Maybe BlockHashEntry)
 updateBlockHashEntry bHash = alterBlockHashEntry bHash . flip ffor
 

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateTxDB.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Blockchain.Sequencer.DB.PrivateTxDB where
 
-import           Blockchain.Data.RLP
 import           Blockchain.SHA
+import           Control.Lens           ((.~))
+import           Control.Monad          (join)
 import           Control.Monad.IO.Class
-import           Data.Map.Strict              (Map)
-import qualified Data.Map.Strict              as M
 import           Prometheus
 
 import           Blockchain.Sequencer.DB.ChainHashDB
@@ -14,28 +13,20 @@ import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.Event
 import           Blockchain.Strato.Model.Class
 
-getTxHashMap :: HasPrivateHashDB m => m (Map SHA OutputTx)
-getTxHashMap = txHashMap <$> getPrivateHashDB
+lookupTransaction :: HasRegistry m => SHA -> m (Maybe OutputTx)
+lookupTransaction tHash = join . fmap _outputTx <$> getTxHashEntry tHash
 
-putTxHashMap :: HasPrivateHashDB m => Map SHA OutputTx -> m ()
-putTxHashMap m = getPrivateHashDB >>= \db -> putPrivateHashDB db{ txHashMap = m }
+insertTransaction :: HasRegistry m => OutputTx -> m ()
+insertTransaction tx = do
+  let tHash = txHash tx
+      otx = Just tx
+  repsertTxHashEntry_ tHash $ return . maybe (TxHashEntry otx Nothing) (outputTx .~ otx)
 
-lookupTransaction :: HasPrivateHashDB m => SHA -> m (Maybe OutputTx)
-lookupTransaction h = M.lookup h <$> getTxHashMap
-
-insertTransaction :: HasPrivateHashDB m => OutputTx -> m ()
-insertTransaction tx = getTxHashMap >>= putTxHashMap . M.insert (txHash tx) tx
-
-insertPrivateHash :: HasPrivateHashDB m => OutputTx -> m ()
+insertPrivateHash :: HasRegistry m => OutputTx -> m ()
 insertPrivateHash tx = case txChainId tx of
   Nothing -> error "insertPrivateHash: Trying to insert a public transaction"
   Just chainId -> do
     liftIO $ withLabel txMetrics "private_hash" incCounter
-    let r = txSigR tx
-        s = txSigS tx
-        rs = hash . rlpSerialize $ RLPArray [rlpEncode r, rlpEncode s]
-        sr = hash . rlpSerialize $ RLPArray [rlpEncode s, rlpEncode r]
-    insertChainHash rs chainId
-    insertChainHash sr chainId
-    insertChainBufferEntry chainId rs
-    insertChainBufferEntry chainId sr
+    cHashes <- generateChainHashes tx
+    mapM_ (flip insertChainHash chainId) cHashes
+    mapM_ (insertChainBufferEntry chainId) cHashes

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateTxDB.hs
@@ -19,14 +19,14 @@ lookupTransaction tHash = join . fmap _outputTx <$> getTxHashEntry tHash
 insertTransaction :: HasRegistry m => OutputTx -> m ()
 insertTransaction tx = do
   let tHash = txHash tx
-      otx = Just tx
-  repsertTxHashEntry_ tHash $ return . maybe (TxHashEntry otx Nothing) (outputTx .~ otx)
+  repsertTxHashEntry_ tHash $ return . maybe (txHashEntryWithOutputTx tx) (outputTx .~ Just tx)
 
 insertPrivateHash :: HasRegistry m => OutputTx -> m ()
 insertPrivateHash tx = case txChainId tx of
   Nothing -> error "insertPrivateHash: Trying to insert a public transaction"
   Just chainId -> do
     liftIO $ withLabel txMetrics "private_hash" incCounter
+    insertTxHashEntry (txHash tx) (txHashEntryWithOutputTx tx)
     cHashes <- generateChainHashes tx
     mapM_ (flip insertChainHash chainId) cHashes
     mapM_ (insertChainBufferEntry chainId) cHashes

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateTxDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/PrivateTxDB.hs
@@ -13,15 +13,15 @@ import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.Event
 import           Blockchain.Strato.Model.Class
 
-lookupTransaction :: HasRegistry m => SHA -> m (Maybe OutputTx)
+lookupTransaction :: HasPrivateHashDB m => SHA -> m (Maybe OutputTx)
 lookupTransaction tHash = join . fmap _outputTx <$> getTxHashEntry tHash
 
-insertTransaction :: HasRegistry m => OutputTx -> m ()
+insertTransaction :: HasPrivateHashDB m => OutputTx -> m ()
 insertTransaction tx = do
   let tHash = txHash tx
   repsertTxHashEntry_ tHash $ return . maybe (txHashEntryWithOutputTx tx) (outputTx .~ Just tx)
 
-insertPrivateHash :: HasRegistry m => OutputTx -> m ()
+insertPrivateHash :: HasPrivateHashDB m => OutputTx -> m ()
 insertPrivateHash tx = case txChainId tx of
   Nothing -> error "insertPrivateHash: Trying to insert a public transaction"
   Just chainId -> do

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenChainDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenChainDB.hs
@@ -1,25 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Blockchain.Sequencer.DB.SeenChainDB where
 
+import           Blockchain.Data.ChainInfo
 import           Blockchain.ExtWord           (Word256)
 
 import           Control.Monad.IO.Class
-import qualified Data.Set                     as S
+import           Data.Maybe                   (isJust)
 import           Prometheus
 
 import           Blockchain.Sequencer.DB.Metrics
 import           Blockchain.Sequencer.DB.PrivateHashDB
 
-getSeenChainsDB :: HasPrivateHashDB m => m (S.Set Word256)
-getSeenChainsDB = seenChains <$> getPrivateHashDB
+lookupSeenChain :: HasRegistry m => Word256 -> m Bool
+lookupSeenChain = fmap isJust . getChainIdEntry
 
-putSeenChainsDB :: HasPrivateHashDB m => S.Set Word256 -> m ()
-putSeenChainsDB m = getPrivateHashDB >>= \db -> putPrivateHashDB db{ seenChains = m }
-
-lookupSeenChain :: HasPrivateHashDB m => Word256 -> m Bool
-lookupSeenChain chainId = S.member chainId <$> getSeenChainsDB
-
-insertSeenChain :: HasPrivateHashDB m => Word256 -> m ()
-insertSeenChain chainId = do
+insertSeenChain :: HasRegistry m => Word256 -> ChainInfo -> m ()
+insertSeenChain chainId cInfo = do
   liftIO $ withLabel chainMetrics "seen_chains" incCounter
-  getSeenChainsDB >>= putSeenChainsDB . S.insert chainId
+  insertChainIdEntry chainId $ chainIdEntry cInfo

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenChainDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenChainDB.hs
@@ -11,10 +11,10 @@ import           Prometheus
 import           Blockchain.Sequencer.DB.Metrics
 import           Blockchain.Sequencer.DB.PrivateHashDB
 
-lookupSeenChain :: HasRegistry m => Word256 -> m Bool
+lookupSeenChain :: HasPrivateHashDB m => Word256 -> m Bool
 lookupSeenChain = fmap isJust . getChainIdEntry
 
-insertSeenChain :: HasRegistry m => Word256 -> ChainInfo -> m ()
+insertSeenChain :: HasPrivateHashDB m => Word256 -> ChainInfo -> m ()
 insertSeenChain chainId cInfo = do
   liftIO $ withLabel chainMetrics "seen_chains" incCounter
   insertChainIdEntry chainId $ chainIdEntry cInfo

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenHashDB.hs
@@ -14,10 +14,10 @@ import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 import           Blockchain.SHA
 
-lookupSeenTxHash :: (HasRegistry m, MonadThrow m) => SHA -> m (Maybe SHA)
+lookupSeenTxHash :: (HasPrivateHashDB m, MonadThrow m) => SHA -> m (Maybe SHA)
 lookupSeenTxHash tHash = join . fmap _chainHash <$> getTxHashEntry tHash
 
-insertSeenTxHash :: HasRegistry m => SHA -> SHA -> m ()
+insertSeenTxHash :: HasPrivateHashDB m => SHA -> SHA -> m ()
 insertSeenTxHash tHash cHash = do
   liftIO $ withLabel txMetrics "seen_tx_hash" incCounter
   repsertTxHashEntry_ tHash $ \case

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenHashDB.hs
@@ -4,26 +4,17 @@ module Blockchain.Sequencer.DB.SeenHashDB where
 
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
-import           Data.Set                   (Set)
-import qualified Data.Set                   as S
+import           Data.Maybe             (isJust)
 import           Prometheus
 
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 import           Blockchain.SHA
 
-getSeenHashDB :: HasPrivateHashDB m => m (Set SHA)
-getSeenHashDB = seenTXs <$> getPrivateHashDB
+lookupSeenTxHash :: (HasRegistry m, MonadThrow m) => SHA -> m Bool
+lookupSeenTxHash tHash = isJust <$> getTxHashEntry tHash
 
-putSeenHashDB :: HasPrivateHashDB m => Set SHA -> m ()
-putSeenHashDB bm = getPrivateHashDB >>= \db -> putPrivateHashDB db{ seenTXs = bm }
-
-lookupSeenTxHash :: (HasPrivateHashDB m, MonadThrow m) => SHA -> m Bool
-lookupSeenTxHash th = do
-  db <- getSeenHashDB
-  return $ th `S.member` db
-
-insertSeenTxHash :: HasPrivateHashDB m => SHA -> m ()
-insertSeenTxHash th = do
+insertSeenTxHash :: HasRegistry m => SHA -> m ()
+insertSeenTxHash tHash = do
   liftIO $ withLabel txMetrics "seen_tx_hash" incCounter
-  getSeenHashDB >>= putSeenHashDB . S.insert th
+  insertTxHashEntry tHash emptyTxHashEntry

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenHashDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/SeenHashDB.hs
@@ -1,20 +1,25 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Blockchain.Sequencer.DB.SeenHashDB where
 
 
+import           Control.Lens           ((.~))
+import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
-import           Data.Maybe             (isJust)
 import           Prometheus
 
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 import           Blockchain.SHA
 
-lookupSeenTxHash :: (HasRegistry m, MonadThrow m) => SHA -> m Bool
-lookupSeenTxHash tHash = isJust <$> getTxHashEntry tHash
+lookupSeenTxHash :: (HasRegistry m, MonadThrow m) => SHA -> m (Maybe SHA)
+lookupSeenTxHash tHash = join . fmap _chainHash <$> getTxHashEntry tHash
 
-insertSeenTxHash :: HasRegistry m => SHA -> m ()
-insertSeenTxHash tHash = do
+insertSeenTxHash :: HasRegistry m => SHA -> SHA -> m ()
+insertSeenTxHash tHash cHash = do
   liftIO $ withLabel txMetrics "seen_tx_hash" incCounter
-  insertTxHashEntry tHash emptyTxHashEntry
+  repsertTxHashEntry_ tHash $ \case
+    Nothing -> return $ txHashEntryWithChainHash cHash
+    Just the -> return $ (chainHash .~ Just cHash) the

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/TxBlockDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/TxBlockDB.hs
@@ -11,15 +11,15 @@ import           Prometheus
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 
-lookupTxBlocks :: HasRegistry m => SHA -> m (Maybe SHA)
+lookupTxBlocks :: HasPrivateHashDB m => SHA -> m (Maybe SHA)
 lookupTxBlocks tHash = join . fmap _inBlock <$> getTxHashEntry tHash
 
-insertTxBlock :: HasRegistry m => SHA -> SHA -> m ()
+insertTxBlock :: HasPrivateHashDB m => SHA -> SHA -> m ()
 insertTxBlock tHash bHash = do
   liftIO $ withLabel txMetrics "tx_blocks" incCounter
   repsertTxHashEntry_ tHash $ return . maybe (txHashEntryWithBlockHash bHash) (inBlock .~ Just bHash)
 
-removeTxBlock :: HasRegistry m => SHA -> m ()
+removeTxBlock :: HasPrivateHashDB m => SHA -> m ()
 removeTxBlock tHash = do
   liftIO $ withLabel txMetrics "tx_blocks_removed" incCounter
   modifyTxHashEntryState_ tHash $ inBlock .= Nothing

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/TxBlockDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/TxBlockDB.hs
@@ -3,29 +3,24 @@ module Blockchain.Sequencer.DB.TxBlockDB where
 
 import           Blockchain.SHA
 
+import           Control.Lens           ((.~),(.=))
+import           Control.Monad          (join)
 import           Control.Monad.IO.Class
-import           Data.Map.Strict              (Map)
-import qualified Data.Map.Strict              as M
 import           Prometheus
 
 import           Blockchain.Sequencer.DB.PrivateHashDB
 import           Blockchain.Sequencer.DB.Metrics
 
-getTxBlockDB :: HasPrivateHashDB m => m (Map SHA SHA)
-getTxBlockDB = txBlockDB <$> getPrivateHashDB
+lookupTxBlocks :: HasRegistry m => SHA -> m (Maybe SHA)
+lookupTxBlocks tHash = join . fmap _inBlock <$> getTxHashEntry tHash
 
-putTxBlockDB :: HasPrivateHashDB m => Map SHA SHA -> m ()
-putTxBlockDB m = getPrivateHashDB >>= \db -> putPrivateHashDB db{ txBlockDB = m }
-
-lookupTxBlocks :: HasPrivateHashDB m => SHA -> m (Maybe SHA)
-lookupTxBlocks tHash = M.lookup tHash <$> getTxBlockDB
-
-insertTxBlock :: HasPrivateHashDB m => SHA -> SHA -> m ()
+insertTxBlock :: HasRegistry m => SHA -> SHA -> m ()
 insertTxBlock tHash bHash = do
   liftIO $ withLabel txMetrics "tx_blocks" incCounter
-  getTxBlockDB >>= putTxBlockDB . M.insert tHash bHash
+  let bh = Just bHash
+  repsertTxHashEntry_ tHash $ return . maybe (TxHashEntry Nothing bh) (inBlock .~ bh)
 
-removeTxBlock :: HasPrivateHashDB m => SHA -> m ()
+removeTxBlock :: HasRegistry m => SHA -> m ()
 removeTxBlock tHash = do
   liftIO $ withLabel txMetrics "tx_blocks_removed" incCounter
-  getTxBlockDB >>= putTxBlockDB . M.delete tHash
+  modifyTxHashEntryState_ tHash $ inBlock .= Nothing

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/TxBlockDB.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/DB/TxBlockDB.hs
@@ -17,8 +17,7 @@ lookupTxBlocks tHash = join . fmap _inBlock <$> getTxHashEntry tHash
 insertTxBlock :: HasRegistry m => SHA -> SHA -> m ()
 insertTxBlock tHash bHash = do
   liftIO $ withLabel txMetrics "tx_blocks" incCounter
-  let bh = Just bHash
-  repsertTxHashEntry_ tHash $ return . maybe (TxHashEntry Nothing bh) (inBlock .~ bh)
+  repsertTxHashEntry_ tHash $ return . maybe (txHashEntryWithBlockHash bHash) (inBlock .~ Just bHash)
 
 removeTxBlock :: HasRegistry m => SHA -> m ()
 removeTxBlock tHash = do

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -41,6 +41,8 @@ import           Conduit
 import           Data.Conduit.TMChan
 import           Data.Foldable                             (toList)
 import           Data.IORef
+import           Data.Map                                  (Map)
+import qualified Data.Map                                  as M
 import qualified Data.Sequence                             as Q
 import qualified Data.Set                                  as S
 import qualified Data.Text                                 as T
@@ -49,6 +51,7 @@ import           Data.Time.Clock
 import           Blockchain.Blockstanbul
 import           Blockchain.Blockstanbul.HTTPAdmin
 import           Blockchain.Constants
+import           Blockchain.Data.RLP
 import           Blockchain.ExtWord                        (Word256)
 import           Blockchain.Sequencer.CablePackage
 import           Blockchain.Sequencer.DB.DependentBlockDB
@@ -59,6 +62,7 @@ import           Blockchain.Sequencer.DB.SeenBlockDB
 import           Blockchain.Sequencer.DB.SeenTransactionDB
 import           Blockchain.Sequencer.Event
 import           Blockchain.SHA
+import           Blockchain.Strato.Model.Class
 import           System.Directory                          (createDirectoryIfMissing)
 
 import qualified Database.LevelDB                          as LDB
@@ -67,7 +71,10 @@ data SequencerContext = SequencerContext
                       { _dependentBlockDB    :: DependentBlockDB
                       , _seenBlockDB         :: SeenBlockDB
                       , _seenTransactionDB   :: SeenTransactionDB
-                      , _privateHashDB       :: PrivateHashDB
+                      , _blockHashRegistry   :: Map SHA BlockHashEntry
+                      , _txHashRegistry      :: Map SHA TxHashEntry
+                      , _chainHashRegistry   :: Map SHA ChainHashEntry
+                      , _chainIdRegistry     :: Map Word256 ChainIdEntry
                       , _getChainsDB         :: S.Set Word256
                       , _getTransactionsDB   :: S.Set SHA
                       , _ldbBatchOps         :: Q.Seq LDB.BatchOp
@@ -109,9 +116,38 @@ instance HasGetTransactionsDB SequencerM where
     getGetTransactionsDB = use getTransactionsDB
     putGetTransactionsDB = assign getTransactionsDB
 
-instance HasPrivateHashDB SequencerM where
-    getPrivateHashDB = use privateHashDB
-    putPrivateHashDB = assign privateHashDB
+instance HasRegistry SequencerM where
+    generateChainHashes tx =
+      let r = txSigR tx
+          s = txSigS tx
+          rs = hash . rlpSerialize $ RLPArray [rlpEncode r, rlpEncode s]
+          sr = hash . rlpSerialize $ RLPArray [rlpEncode s, rlpEncode r]
+       in return [rs,sr]
+
+    -- TODO: Add persistence layer
+    alterBlockHashEntry bHash f = do
+      bhr <- use blockHashRegistry
+      mbhe <- f $ M.lookup bHash bhr
+      blockHashRegistry %= M.alter (const mbhe) bHash
+      return mbhe
+
+    alterTxHashEntry tHash f = do
+      thr <- use txHashRegistry
+      mthe <- f $ M.lookup tHash thr
+      txHashRegistry %= M.alter (const mthe) tHash
+      return mthe
+
+    alterChainHashEntry cHash f = do
+      chr <- use chainHashRegistry
+      mche <- f $ M.lookup cHash chr
+      chainHashRegistry %= M.alter (const mche) cHash
+      return mche
+
+    alterChainIdEntry cId f = do
+      cir <- use chainIdRegistry
+      mcie <- f $ M.lookup cId cir
+      chainIdRegistry %= M.alter (const mcie) cId
+      return mcie
 
 instance HasSeenBlockDB SequencerM where
     getSeenBlockDB = use seenBlockDB
@@ -139,7 +175,10 @@ runSequencerM c mbc m = do
             { _dependentBlockDB    = depBlock
             , _seenBlockDB         = mkSeenBlockDB stxSize
             , _seenTransactionDB   = mkSeenTxDB stxSize
-            , _privateHashDB       = emptyPrivateHashDB
+            , _blockHashRegistry   = M.empty
+            , _txHashRegistry      = M.empty
+            , _chainHashRegistry   = M.empty
+            , _chainIdRegistry     = M.empty
             , _getChainsDB         = S.empty
             , _getTransactionsDB   = S.empty
             , _ldbBatchOps         = Q.empty

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -116,7 +116,7 @@ instance HasGetTransactionsDB SequencerM where
     getGetTransactionsDB = use getTransactionsDB
     putGetTransactionsDB = assign getTransactionsDB
 
-instance HasRegistry SequencerM where
+instance HasPrivateHashDB SequencerM where
     generateChainHashes tx =
       let r = txSigR tx
           s = txSigS tx


### PR DESCRIPTION
Changes to the Sequencer `HasPrivateHashDB` class, making it possible to break blocks up by transactions per private chain, as well as making it generally easier to write utility functions, and a persistence layer on the back-end.