### PR TITLE
Avoid 20% idle CPU usage on the sequencer

### DIFF
--- a/core-strato/strato-sequencer/package.yaml
+++ b/core-strato/strato-sequencer/package.yaml
@@ -54,6 +54,7 @@ dependencies:
   - wai-middleware-prometheus
   - deepseq
   - exceptions
+  - unliftio
 
 ghc-options: -Wall -O2 -threaded
 

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -10,7 +10,7 @@ module Blockchain.Sequencer where
 import           ClassyPrelude                             (atomically)
 import           Conduit
 import           Control.Concurrent                        hiding (yield)
-import           Control.Concurrent.STM.TMChan
+import           Control.Concurrent.STM.TQueue
 import           Control.Monad.Logger
 import           Control.Monad.Reader
 import           Control.Monad.State
@@ -98,8 +98,8 @@ readEventsInBufferedWindow src = do
   $logInfoS "sequencer/events" "Reading from fused channels..."
   dt <- asks maxUsPerIter
   uch <- asks $ unseqEvents . cablePackage
-  top <- atomically . tryPeekTMChan $ uch
-  $logDebugS "sequencer/events" . T.pack . show $ "top event is: " ++ show top
+  top <- atomically . tryPeekTQueue $ uch
+  $logDebugS "sequencer/events" . T.pack $ "top event is: " ++ show top
   -- There may be WaitTerminateds left over from the last iteration
   -- This will block indefinitely if there are no real messages to process,
   -- so `src` must be the only source of input to this thread.
@@ -539,9 +539,9 @@ prettyOTx OutputTx{otOrigin=o, otBaseTx=t} = prefix t ++ " via " ++ shortOrigin 
 writeSeqVmEvents :: [OutputEvent] -> SequencerM ()
 writeSeqVmEvents events = do
     ch <- asks (seqVMEvents . cablePackage)
-    atomically . mapM_ (writeTMChan ch) $ events
+    atomically . mapM_ (writeTQueue ch) $ events
 
 writeSeqP2pEvents :: [OutputEvent] -> SequencerM ()
 writeSeqP2pEvents events = do
     ch <- asks (seqP2PEvents . cablePackage)
-    atomically . mapM_ (writeTMChan ch) $ events
+    atomically . mapM_ (writeTQueue ch) $ events

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/CablePackage.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/CablePackage.hs
@@ -5,14 +5,14 @@ import Blockchain.Sequencer.Event
 
 
 data CablePackage = CablePackage
-                  { unseqEvents :: TMChan IngestEvent
-                  , seqP2PEvents :: TMChan OutputEvent
-                  , seqVMEvents :: TMChan OutputEvent
+                  { unseqEvents :: TQueue IngestEvent
+                  , seqP2PEvents :: TQueue OutputEvent
+                  , seqVMEvents :: TQueue OutputEvent
                   }
 
 newCablePackage :: STM CablePackage
 newCablePackage = do
-  a <- newTMChan
-  b <- newTMChan
-  c <- newTMChan
+  a <- newTQueue
+  b <- newTQueue
+  c <- newTQueue
   return $ CablePackage a b c

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -21,16 +21,15 @@ module Blockchain.Sequencer.Gregor
   , writeSeqVmEvents
   ) where
 
-import           ClassyPrelude              (atomically, TMChan, writeTMChan, STM,
-                                             tryReadTMChan, tryPeekTMChan)
-import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async.Lifted (race_)
+import           Control.Concurrent.STM (orElse, flushTQueue)
 import           Control.Lens               hiding (op)
 import           Control.Monad.State
 import           Control.Monad.Logger
 import           Control.Monad.Trans.Resource
 import qualified Data.Text as T
 import qualified Prometheus as P
+import           UnliftIO.STM
 
 import qualified Blockchain.EthConf                        as EC
 import qualified Blockchain.MilenaTools     as K
@@ -53,9 +52,9 @@ data GregorConfig = GregorConfig
 data GregorContext = GregorContext
                      { _gregorKafkaState :: K.KafkaState
                      , _gregorConsumerGroup :: KP.ConsumerGroup
-                     , _gregorUnseq :: TMChan IngestEvent
-                     , _gregorSeqP2P :: TMChan OutputEvent
-                     , _gregorSeqVM :: TMChan OutputEvent
+                     , _gregorUnseq :: TQueue IngestEvent
+                     , _gregorSeqP2P :: TQueue OutputEvent
+                     , _gregorSeqVM :: TQueue OutputEvent
                      }
 makeLenses ''GregorContext
 
@@ -140,8 +139,8 @@ unseqReader = forever . timeAction gregorUnseqTiming $ do
   P.withLabel gregorLoop "unseq_events" P.incCounter
   $logInfoS "gregor" . T.pack $ "Fetched " ++ show (length inEvents) ++ " unseq events"
   ch <- use gregorUnseq
-  atomically . forM_ inEvents $ writeTMChan ch . snd
-  hd <- atomically $ tryPeekTMChan ch
+  atomically . forM_ inEvents $ writeTQueue ch . snd
+  hd <- atomically $ tryPeekTQueue ch
   $logDebugS "gregor/unseqchHead" . T.pack . show $ hd
   P.unsafeAddCounter gregorUnseqWrite (fromIntegral (length inEvents))
   unless (null inEvents) $ do
@@ -150,10 +149,10 @@ unseqReader = forever . timeAction gregorUnseqTiming $ do
 
 seqWriters :: GregorM ()
 seqWriters = forever . timeAction gregorSeqTiming $ do
-  vmch <- use gregorSeqVM
-  p2pch <- use gregorSeqP2P
+  vmq <- use gregorSeqVM
+  p2pq <- use gregorSeqP2P
   events <- atomically $
-    fmap Left (blockDrainTMChan vmch) `orElse` fmap Right (blockDrainTMChan p2pch)
+    fmap Left (blockFlushTQueue vmq) `orElse` fmap Right (blockFlushTQueue p2pq)
 
   case events of
     Right vmevs -> do
@@ -166,16 +165,8 @@ seqWriters = forever . timeAction gregorSeqTiming $ do
       writeSeqP2pEvents p2pevs
 
 -- Will only read if at least one element is in the channel.
-blockDrainTMChan :: TMChan a -> STM [a]
-blockDrainTMChan ch = do
-  first <- readTMChan ch
-  rest <- drainTMChan ch
-  return (first:rest)
-
-drainTMChan :: TMChan a -> STM [a]
-drainTMChan ch = do
-  mmx <- tryReadTMChan ch
-  case mmx of
-    Nothing -> return []
-    Just Nothing -> return []
-    Just (Just x) -> (x:) <$> drainTMChan ch
+blockFlushTQueue :: TQueue a -> STM [a]
+blockFlushTQueue ch = do
+  first <- readTQueue ch
+  rest <- flushTQueue ch
+  return $! first:rest

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -153,13 +153,13 @@ seqWriters = forever . timeAction gregorSeqTiming $ do
   p2pq <- use gregorSeqP2P
   events <- atomically $
     fmap Left (blockFlushTQueue vmq) `orElse` fmap Right (blockFlushTQueue p2pq)
-
+  $logDebugS "gregor/seqWriter" . T.pack . show $ events
   case events of
-    Right vmevs -> do
+    Left vmevs -> do
       P.withLabel gregorLoop "seq_vm_events" P.incCounter
       P.unsafeAddCounter gregorVMRead (fromIntegral $ length vmevs)
       writeSeqVmEvents vmevs
-    Left p2pevs -> do
+    Right p2pevs -> do
       P.withLabel gregorLoop "seq_p2p_events" P.incCounter
       P.unsafeAddCounter gregorP2PRead (fromIntegral $ length p2pevs)
       writeSeqP2pEvents p2pevs

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -164,9 +164,9 @@ seqWriters = forever . timeAction gregorSeqTiming $ do
       P.unsafeAddCounter gregorP2PRead (fromIntegral $ length p2pevs)
       writeSeqP2pEvents p2pevs
 
--- Will only read if at least one element is in the channel.
+-- Will only read if at least one element is in the queue.
 blockFlushTQueue :: TQueue a -> STM [a]
 blockFlushTQueue ch = do
   first <- readTQueue ch
   rest <- flushTQueue ch
-  return $! first:rest
+  return $ first:rest

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -151,18 +151,26 @@ unseqReader = forever . timeAction gregorUnseqTiming $ do
 seqWriters :: GregorM ()
 seqWriters = forever . timeAction gregorSeqTiming $ do
   vmch <- use gregorSeqVM
-  vmevs <- atomically $ drainTMChan vmch
-  unless (null vmevs) $ do
-    P.withLabel gregorLoop "seq_vm_events" P.incCounter
-    P.unsafeAddCounter gregorVMRead (fromIntegral $ length vmevs)
-    writeSeqVmEvents vmevs
   p2pch <- use gregorSeqP2P
-  p2pevs <- atomically $ drainTMChan p2pch
-  unless (null p2pevs) $ do
-    P.withLabel gregorLoop "seq_p2p_events" P.incCounter
-    P.unsafeAddCounter gregorP2PRead (fromIntegral $ length p2pevs)
-    writeSeqP2pEvents p2pevs
-  liftIO $ threadDelay 1000 -- 1ms
+  events <- atomically $
+    fmap Left (blockDrainTMChan vmch) `orElse` fmap Right (blockDrainTMChan p2pch)
+
+  case events of
+    Right vmevs -> do
+      P.withLabel gregorLoop "seq_vm_events" P.incCounter
+      P.unsafeAddCounter gregorVMRead (fromIntegral $ length vmevs)
+      writeSeqVmEvents vmevs
+    Left p2pevs -> do
+      P.withLabel gregorLoop "seq_p2p_events" P.incCounter
+      P.unsafeAddCounter gregorP2PRead (fromIntegral $ length p2pevs)
+      writeSeqP2pEvents p2pevs
+
+-- Will only read if at least one element is in the channel.
+blockDrainTMChan :: TMChan a -> STM [a]
+blockDrainTMChan ch = do
+  first <- readTMChan ch
+  rest <- drainTMChan ch
+  return (first:rest)
 
 drainTMChan :: TMChan a -> STM [a]
 drainTMChan ch = do

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -39,6 +39,7 @@ import           Control.Monad.Trans.Resource
 
 import           Conduit
 import           Data.Conduit.TMChan
+import           Data.Conduit.TQueue
 import           Data.Foldable                             (toList)
 import           Data.IORef
 import qualified Data.Sequence                             as Q
@@ -222,7 +223,7 @@ fuseChannels = do
   loop <- use loopTimeout
   let debugLog = (.| iterMC ($logDebugS "fuseChannels" . T.pack . show))
   (debugLog . transPipe lift) <$> mergeSources
-               [ sourceTMChan unseq .| mapC UnseqEvent
+               [ sourceTQueue unseq .| mapC UnseqEvent
                , sourceTMChan votes .| mapC VoteMade
                , sourceTMChan timers .| mapC TimerFire
                , sourceTMChan loop .| mapC (const WaitTerminated)]

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -16,6 +16,7 @@ import           Numeric                             (showHex)
 import           Conduit
 import           Control.Concurrent
 import           Control.Concurrent.STM.TMChan
+import           Control.Concurrent.STM.TQueue
 import           Control.Exception                   (finally)
 import           Control.Monad
 import           Control.Monad.Logger
@@ -102,8 +103,8 @@ withTemporaryDepBlockDB pbft genesisBlock m = do
     setCurrentDirectory "../" -- for ethconf to be happy
     createDirectoryIfMissing True fullPath
     pkg <- atomically newCablePackage
-    vch <- atomically newTMChan
-    tch <- atomically newTMChan
+    vch <- atomically newTChan
+    tch <- atomically newTChan
     let
         cfg  = SequencerConfig { depBlockDBCacheSize   = 0
                                , depBlockDBPath        = fullPath
@@ -293,11 +294,11 @@ spec = do
     describe "fuseChannels" $ do
       it "should multiplex event types" $ withMaxSuccess 5 $ property $ \vote rn iev -> runTestM $ do
         tch <- asks blockstanbulTimeouts
-        atomically . writeTMChan tch $ rn
+        atomically . writeTChan tch $ rn
         uch <- asks $ unseqEvents . cablePackage
-        atomically . writeTMChan uch $ iev
+        atomically . writeTQueue uch $ iev
         vch <- asks blockstanbulBeneficiary
-        atomically . writeTMChan vch $ vote
+        atomically . writeTChan vch $ vote
         src0 <- newResumableSource <$> fuseChannels
         (src1, ev1) <- src0 $$++ headC
         (src2, ev2) <- src1 $$++ headC
@@ -307,16 +308,16 @@ spec = do
     describe "sequencer" $ do
       it "should be able to run in a test" $ withMaxSuccess 5 $ property $ \iev -> runTestM $ do
         uch <- asks $ unseqEvents . cablePackage
-        atomically . writeTMChan uch $ iev
+        atomically . writeTQueue uch $ iev
         src <- newResumableSource <$> fuseChannels
         void $ oneSequencerIter src
 
       it "should not only return 1 event if multiple are pending" . runTestM $ do
         tch <- asks blockstanbulTimeouts
         atomically $ do
-          writeTMChan tch 20
-          writeTMChan tch 34
-          writeTMChan tch 92
+          writeTChan tch 20
+          writeTChan tch 34
+          writeTChan tch 92
         src <- newResumableSource <$> fuseChannels
         (_, evs) <- readEventsInBufferedWindow src
         evs `shouldMatchList` map TimerFire [20, 34, 92]
@@ -368,7 +369,7 @@ spec = do
         uch <- asks blockstanbulTimeouts
         void . liftIO . forkIO $ do
           threadDelay 5000
-          atomically . writeTMChan uch $ 987
+          atomically . writeTChan uch $ 987
         (_, evs) <- readEventsInBufferedWindow src
         evs `shouldMatchList` [TimerFire 987]
 

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -103,8 +103,8 @@ withTemporaryDepBlockDB pbft genesisBlock m = do
     setCurrentDirectory "../" -- for ethconf to be happy
     createDirectoryIfMissing True fullPath
     pkg <- atomically newCablePackage
-    vch <- atomically newTChan
-    tch <- atomically newTChan
+    vch <- atomically newTMChan
+    tch <- atomically newTMChan
     let
         cfg  = SequencerConfig { depBlockDBCacheSize   = 0
                                , depBlockDBPath        = fullPath
@@ -294,11 +294,11 @@ spec = do
     describe "fuseChannels" $ do
       it "should multiplex event types" $ withMaxSuccess 5 $ property $ \vote rn iev -> runTestM $ do
         tch <- asks blockstanbulTimeouts
-        atomically . writeTChan tch $ rn
+        atomically . writeTMChan tch $ rn
         uch <- asks $ unseqEvents . cablePackage
         atomically . writeTQueue uch $ iev
         vch <- asks blockstanbulBeneficiary
-        atomically . writeTChan vch $ vote
+        atomically . writeTMChan vch $ vote
         src0 <- newResumableSource <$> fuseChannels
         (src1, ev1) <- src0 $$++ headC
         (src2, ev2) <- src1 $$++ headC
@@ -315,9 +315,9 @@ spec = do
       it "should not only return 1 event if multiple are pending" . runTestM $ do
         tch <- asks blockstanbulTimeouts
         atomically $ do
-          writeTChan tch 20
-          writeTChan tch 34
-          writeTChan tch 92
+          writeTMChan tch 20
+          writeTMChan tch 34
+          writeTMChan tch 92
         src <- newResumableSource <$> fuseChannels
         (_, evs) <- readEventsInBufferedWindow src
         evs `shouldMatchList` map TimerFire [20, 34, 92]
@@ -369,7 +369,7 @@ spec = do
         uch <- asks blockstanbulTimeouts
         void . liftIO . forkIO $ do
           threadDelay 5000
-          atomically . writeTChan uch $ 987
+          atomically . writeTMChan uch $ 987
         (_, evs) <- readEventsInBufferedWindow src
         evs `shouldMatchList` [TimerFire 987]
 


### PR DESCRIPTION
The STM waits are much more efficient than polling every 1ms.
https://jenkins.blockapps.net/job/STRATO_test/962