### PR TITLE
Change docker-compose template version to 3

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "3"
 volumes:
   dapps:
     driver: local


### PR DESCRIPTION
Things seem to work fine with newer docker-compose template version which also supports clusterization and Kubernetes template auto-generation. 
Next steps would be to provide the d-c.yaml with all the required parameters to maintain stateful containers correctly on the cluster.