### PR TITLE
Make jumpdest collections more efficient

### DIFF
--- a/core-strato/ethereum-vm/bench/Microbench.hs
+++ b/core-strato/ethereum-vm/bench/Microbench.hs
@@ -7,11 +7,14 @@ import Control.DeepSeq
 import Control.Monad
 import GHC.Generics
 import Data.Bits ((.&.))
+import qualified Data.ByteString as B
 import Data.Word
 import qualified Data.Vector as V
 import qualified Data.Set as S
 import qualified Data.IntSet as I
 
+import Blockchain.Strato.Model.Code
+import Blockchain.VM.Code
 import Network.Haskoin.Internals (Word256)
 import qualified Blockchain.VM.MutableStack as MS
 
@@ -70,6 +73,16 @@ vec64MembershipTests n = bench ("vec word64 " ++ show n)
 set64MembershipTests :: Int -> Benchmark
 set64MembershipTests n = bench ("set word64 " ++ show n)
                        $ nf (S.member (downgrade exampleDest)) (set64Dests n)
+
+-- | Every opcode is a JUMPDEST
+getJumpDestsTime :: Int -> Benchmark
+getJumpDestsTime n = bench ("getJumpDests " ++ show n)
+                   $ nf getValidJUMPDESTs (Code $ B.replicate n 0x5b)
+
+-- | None of the opcodes are a jumpdest
+getJumpDestsMissTime :: Int -> Benchmark
+getJumpDestsMissTime n = bench ("getJumpDestsMissTime" ++ show n)
+                       $ nf getValidJUMPDESTs (Code $ B.replicate n 0x00)
 
 -- Stack benchmarks
 
@@ -143,6 +156,7 @@ main = do
   [s1, s2, s3] <- replicateM 3 defaultStack
 
   let jumpSizes = [256, 4096, 32768]
+  let codeSizes = [10, 100000, 1000000]
   defaultMain
     [ bgroup "Stacks" $
                 map oldStackFullPush stackSizes
@@ -157,4 +171,6 @@ main = do
              ++ map list64MembershipTests jumpSizes
              ++ map vec64MembershipTests jumpSizes
              ++ map set64MembershipTests jumpSizes
-             ++ map intsetMembershipTests jumpSizes]
+             ++ map intsetMembershipTests jumpSizes
+             ++ map getJumpDestsTime codeSizes
+             ++ map getJumpDestsMissTime codeSizes]

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
@@ -1,4 +1,4 @@
-
+{-# LANGUAGE BangPatterns #-}
 module Blockchain.VM.Code where
 
 import qualified Data.ByteString              as B
@@ -30,17 +30,18 @@ showCode lineNumber c@(Code rom) = showHex lineNumber "" ++ " " ++ format (B.pac
 formatCode::Code->String
 formatCode = showCode 0
 
-getValidJUMPDESTs::Code->I.IntSet
-getValidJUMPDESTs (Code bytes) =
-  I.fromList $ map fst $ filter ((== JUMPDEST) . snd) $ getOps bytes 0
-  where
-    getOps::B.ByteString->Int->[(CodePointer, Operation)]
-    getOps bytes' p | p > B.length bytes' = []
-    getOps code p = (p, op):getOps code (p+len)
-      where
-        (op, len) = getOperationAt' code p
+getValidJUMPDESTs :: Code -> I.IntSet
 getValidJUMPDESTs (PrecompiledCode _) = error "getValidJUMPDESTs called on precompiled code"
-
+getValidJUMPDESTs (Code bytes) = I.fromAscList $ go 0
+ where
+  len = B.length bytes
+  go :: Int -> [Int]
+  go !x = if x >= len
+            then []
+            else case B.index bytes x of
+                    0x5b -> x : go (x+1)
+                    op | 0x60 <= op && op <= 0x7f -> go (x + 2 + fromIntegral op - 0x60)
+                       | otherwise -> go (x+1)
 
 codeLength::Code->CodePointer
 codeLength (Code bytes)        = B.length bytes
@@ -50,4 +51,3 @@ compile::[Operation]->Code
 compile x = Code bytes
   where
     bytes = B.pack $ op2OpCode =<< x
-


### PR DESCRIPTION
On code full of JUMPDESTs, its about 4-5x faster.
On code devoid of JUMPDESTs, its about 50x faster.
(Benchmarks taken from two different versions of Code.hs)

```
benchmarking getJumpDests 10
time                 902.7 ns   (862.8 ns .. 955.6 ns)
                     0.983 R²   (0.973 R² .. 0.995 R²)
mean                 899.0 ns   (872.4 ns .. 951.6 ns)
std dev              118.0 ns   (75.95 ns .. 187.7 ns)
variance introduced by outliers: 94% (severely inflated)

benchmarking getJumpDests 100000
time                 9.759 ms   (8.878 ms .. 10.56 ms)
                     0.915 R²   (0.783 R² .. 0.984 R²)
mean                 12.44 ms   (11.69 ms .. 13.39 ms)
std dev              2.211 ms   (1.590 ms .. 3.090 ms)
variance introduced by outliers: 77% (severely inflated)

benchmarking getJumpDests 1000000
time                 135.3 ms   (119.7 ms .. 148.0 ms)
                     0.984 R²   (0.952 R² .. 1.000 R²)
mean                 132.5 ms   (125.4 ms .. 138.1 ms)
std dev              9.017 ms   (7.541 ms .. 10.80 ms)
variance introduced by outliers: 12% (moderately inflated)

benchmarking getJumpDestsMissTime10
time                 631.5 ns   (600.1 ns .. 669.6 ns)
                     0.977 R²   (0.969 R² .. 0.986 R²)
mean                 685.0 ns   (642.3 ns .. 755.7 ns)
std dev              180.7 ns   (123.1 ns .. 264.0 ns)
variance introduced by outliers: 99% (severely inflated)

benchmarking getJumpDestsMissTime100000
time                 5.230 ms   (4.946 ms .. 5.489 ms)
                     0.944 R²   (0.884 R² .. 0.981 R²)
mean                 5.778 ms   (5.453 ms .. 6.201 ms)
std dev              1.136 ms   (760.1 μs .. 1.454 ms)
variance introduced by outliers: 86% (severely inflated)

benchmarking getJumpDestsMissTime1000000
time                 51.44 ms   (43.95 ms .. 56.31 ms)
                     0.964 R²   (0.906 R² .. 0.994 R²)
mean                 56.39 ms   (53.37 ms .. 61.76 ms)
std dev              6.841 ms   (3.682 ms .. 11.02 ms)
variance introduced by outliers: 40% (moderately inflated)
```
to
```
benchmarking getJumpDests 10
time                 184.5 ns   (181.8 ns .. 188.7 ns)
                     0.995 R²   (0.986 R² .. 0.999 R²)
mean                 184.9 ns   (182.1 ns .. 192.6 ns)
std dev              14.09 ns   (5.593 ns .. 27.54 ns)
variance introduced by outliers: 85% (severely inflated)

benchmarking getJumpDests 100000
time                 2.110 ms   (1.967 ms .. 2.255 ms)
                     0.970 R²   (0.953 R² .. 0.985 R²)
mean                 2.046 ms   (1.983 ms .. 2.142 ms)
std dev              254.9 μs   (167.1 μs .. 391.0 μs)
variance introduced by outliers: 78% (severely inflated)

benchmarking getJumpDests 1000000
time                 18.95 ms   (18.15 ms .. 19.80 ms)
                     0.987 R²   (0.975 R² .. 0.996 R²)
mean                 20.04 ms   (19.58 ms .. 20.83 ms)
std dev              1.362 ms   (826.4 μs .. 2.165 ms)
variance introduced by outliers: 27% (moderately inflated)

benchmarking getJumpDestsMissTime10
time                 22.64 ns   (22.00 ns .. 23.56 ns)
                     0.990 R²   (0.981 R² .. 0.999 R²)
mean                 22.61 ns   (22.10 ns .. 23.52 ns)
std dev              2.223 ns   (1.260 ns .. 3.474 ns)
variance introduced by outliers: 92% (severely inflated)

benchmarking getJumpDestsMissTime100000
time                 121.9 μs   (119.9 μs .. 124.4 μs)
                     0.993 R²   (0.988 R² .. 0.997 R²)
mean                 128.8 μs   (123.9 μs .. 140.4 μs)
std dev              24.27 μs   (9.020 μs .. 40.42 μs)
variance introduced by outliers: 94% (severely inflated)

benchmarking getJumpDestsMissTime1000000
time                 1.261 ms   (1.218 ms .. 1.332 ms)
                     0.980 R²   (0.967 R² .. 0.993 R²)
mean                 1.248 ms   (1.220 ms .. 1.296 ms)
std dev              117.9 μs   (81.22 μs .. 168.5 μs)
variance introduced by outliers: 70% (severely inflated)
```