### PR TITLE
New chain info

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -11,6 +11,7 @@
 module BlockApps.Bloc22.Server.Chain where
 
 import           Control.Monad.Except
+import           Crypto.Random.Entropy
 import qualified Data.Map.Strict                   as Map
 import           Data.Maybe                        (isJust)
 import qualified Data.Text                         as Text
@@ -56,9 +57,20 @@ postChainInfo (ChainInput src cname lbl balances chaininputArgs members) = do
               contractAcctInfo = ContractWithStorage governanceAddress (0::Integer) contractdetailsCodeHash storage
               codeInfo' = CodeInfo contractdetailsBinRuntime src contractdetailsName
           return ([contractAcctInfo],[codeInfo']) -- Perhaps in the future, we can support multiple contracts
+  nonce <- byteStringToWord256 <$> liftIO (getEntropy 32)
   let nonContractAcctInfo = nmap NonContract balances
       acctInfo = cAcctInfo ++ nonContractAcctInfo
-      chainInfo = ChainInfo lbl acctInfo codeInfo members
+      chainInfo = ChainInfo
+        (UnsignedChainInfo lbl
+                           acctInfo
+                           codeInfo
+                           members
+                           Nothing
+                           creationBlockHash
+                           (Hex nonce)
+                           Map.empty
+        )
+        Nothing
   chainId <- blocStrato $ Strato.postChain chainInfo
   when (isJust mContract) $ do
     let Just (cmId, _) = mContract
@@ -81,7 +93,7 @@ getChainInfo chainIds = do
       convertChainInfo :: ChainIdChainInfo -> ChainIdChainOutput
       convertChainInfo chp = do
         let chtup = (toTuple chp :: (ChainId, ChainInfo))
-        let chinfo =  snd chtup
+        let chinfo =  chainInfo $ snd chtup
         let getAddrBalance acct = case acct of
                                     NonContract a b -> (a, b)
                                     ContractNoStorage a b _ -> (a, b)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -67,7 +67,7 @@ postChainInfo (ChainInput src cname lbl balances chaininputArgs members) = do
                            members
                            Nothing
                            creationBlockHash
-                           (Hex nonce)
+                           nonce
                            Map.empty
         )
         Nothing

--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -100,6 +100,23 @@ instance (Arbitrary a, Arbitrary b) => Arbitrary (LargeKey a b) where
 instance (NFData a, NFData b) => NFData (LargeKey a b) where
   rnf (LargeKey a b) = rnf a `seq` rnf b `seq` ()
 
+instance ToSchema Word256 where
+  declareNamedSchema _ = return $
+    NamedSchema (Just "LargeWord")
+      ( mempty
+        & type_ .~ SwaggerString
+        & example ?~ "ec41a0a4da1f33ee9a757f4fd27c2a1a57313353375860388c66edc562ddc781"
+        & description ?~ "Fixed-size words of > 64 bits" )
+
+instance ToJSON Word256 where toJSON = toJSON . show256
+
+instance FromJSON Word256 where
+  parseJSON value = do
+    string <- parseJSON value
+    case fmap fromInteger (readMaybe $ "0x" ++ string) of
+      Nothing      -> fail $ "Could not decode Word256: " <> string
+      Just word256 -> return word256
+
 newtype Hex n = Hex { unHex :: n } deriving (Eq, Generic, Ord)
 
 instance (Integral n, Show n) => Show (Hex n) where

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
@@ -36,7 +36,10 @@ module BlockApps.Strato.Types
   , AbiBin (..)
   , exampleTxResult
   , ChainInfo (..)
+  , UnsignedChainInfo (..)
+  , ChainSignature (..)
   , ChainIdChainInfo
+  , creationBlockHash
   ) where
 
 import           Control.Applicative
@@ -49,6 +52,7 @@ import qualified Data.HashMap.Strict          as HashMap
 import           Data.LargeWord
 import           Data.List.NonEmpty           (NonEmpty)
 import           Data.Map.Strict              (Map)
+import qualified Data.Map.Strict              as M
 import           Data.Maybe
 import           Data.Monoid                  ((<>))
 import           Data.Proxy
@@ -71,6 +75,7 @@ import           Text.Read
 import           BlockApps.Ethereum           (Hex (..), Address (..), ChainId (..),
                                                Keccak256 (..), Nonce (..),
                                                addressString, keccak256,
+                                               stringKeccak256,
                                                keccak256lazy, stringAddress,
                                                AccountInfo(..), CodeInfo(..),
                                                stringChainId)
@@ -476,30 +481,102 @@ instance ToJSON BatchTransactionResult where
 instance FromJSON BatchTransactionResult where
     parseJSON = fmap BatchTransactionResult . parseJSON
 
-data ChainInfo = ChainInfo
-  {  chainLabel    :: Text
-  ,  accountInfo   :: [AccountInfo]
-  ,  codeInfo      :: [CodeInfo]
-  ,  members       :: NamedMap "address" Address "enode" Text
+data UnsignedChainInfo = UnsignedChainInfo
+  { chainLabel    :: !Text
+  , accountInfo   :: ![AccountInfo]
+  , codeInfo      :: ![CodeInfo]
+  , members       :: !(NamedMap "address" Address "enode" Text)
+  , parentChain   :: !(Maybe ChainId)
+  , creationBlock :: !Keccak256
+  , chainNonce    :: !(Hex Word256)
+  , chainMetadata :: !(Map Text Text)
   } deriving (Eq, Show, Generic)
 
+exampleUnsignedChainInfo :: UnsignedChainInfo
+exampleUnsignedChainInfo = UnsignedChainInfo
+  { chainLabel = "myChain"
+  , accountInfo =
+      [ (NonContract (Address 0x5815b9975001135697b5739956b9a6c87f1c575c) (2000 :: Integer))
+      , (NonContract (Address 0x93fdd1d21502c4f87295771253f5b71d897d911c) (400000 :: Integer))
+      ]
+  , codeInfo = []
+  , members = map fromTuple
+      [ ( Address 0x5815b9975001135697b5739956b9a6c87f1c575c
+        , "enode://6d8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@171.16.0.4:30303"
+          :: Text
+        )
+      , ( Address 0x93fdd1d21502c4f87295771253f5b71d897d911c
+        , "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@172.16.0.5:30303?discport=30303"
+          :: Text
+        )
+      ]
+  , parentChain = Nothing
+  , creationBlock = creationBlockHash
+  , chainNonce = Hex 0x5a5e4ac0d5b1d8cde2662075ee00ecd2da47faae2729252c92237057c6e5b32a
+  , chainMetadata = M.empty
+  }
+
+instance ToSchema UnsignedChainInfo where
+  declareNamedSchema proxy = genericDeclareNamedSchema stratoSchemaOptions proxy
+    & mapped.schema.description ?~ "UnsignedChainInfo"
+
+data ChainSignature = ChainSignature
+  { chainR        :: !(Hex Word256)
+  , chainS        :: !(Hex Word256)
+  , chainV        :: !(Hex Word8)
+  } deriving (Eq, Show, Generic)
+
+exampleChainSignature :: ChainSignature
+exampleChainSignature = ChainSignature
+  { chainR = Hex 0
+  , chainS = Hex 0
+  , chainV = Hex 0x1b
+  }
+
+instance ToSchema ChainSignature where
+  declareNamedSchema proxy = genericDeclareNamedSchema stratoSchemaOptions proxy
+    & mapped.schema.description ?~ "ChainSignature"
+    & mapped.schema.example ?~ toJSON exampleChainSignature
+
+instance FromJSON ChainSignature where
+  parseJSON (Object o) = ChainSignature
+    <$> (o .: "r")
+    <*> (o .: "s")
+    <*> (o .: "v")
+  parseJSON x = error $ "couldn't parse JSON for chain info: " ++ show x
+
+instance ToJSON ChainSignature where
+  toJSON (ChainSignature r s v) =
+    object [ "r" .= r
+           , "s" .= s
+           , "v" .= v
+           ]
+
+data ChainInfo = ChainInfo
+  { chainInfo      :: !(UnsignedChainInfo)
+  , chainSignature :: !(Maybe ChainSignature)
+  } deriving (Eq, Show, Generic)
+
+creationBlockHash :: Keccak256
+creationBlockHash = fromJust $
+  stringKeccak256 "0000000000000000000000000000000000000000000000000000000000000000"
 
 instance ToSchema (NamedTuple "address" Address "enode" Text) where
   declareNamedSchema proxy = genericDeclareNamedSchema stratoSchemaOptions proxy
     & mapped.schema.description ?~ "address and enode pair"
-    & mapped.schema.example ?~ toJSON ((NamedTuple (Address 0x5815b9975001135697b5739956b9a6c87f1c575c, "enode://6d8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@171.16.0.4:30303" :: Text)) :: NamedTuple "address" Address "enode" Text)
+    & mapped.schema.example ?~ toJSON
+      ((NamedTuple
+        ( Address 0x5815b9975001135697b5739956b9a6c87f1c575c
+        , "enode://6d8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@171.16.0.4:30303"
+          :: Text
+        )
+       ) :: NamedTuple "address" Address "enode" Text
+      )
 
 exampleChainInfo :: ChainInfo
 exampleChainInfo = ChainInfo
-  {
-     chainLabel = "myChain"
-  ,  accountInfo = [
-       (NonContract (Address 0x5815b9975001135697b5739956b9a6c87f1c575c) (2000 :: Integer))
-     , (NonContract (Address 0x93fdd1d21502c4f87295771253f5b71d897d911c) (400000 :: Integer))
-     ]
-  ,  codeInfo = []
-  ,  members = map fromTuple [(Address 0x5815b9975001135697b5739956b9a6c87f1c575c, "enode://6d8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@171.16.0.4:30303" :: Text)
-               , (Address 0x93fdd1d21502c4f87295771253f5b71d897d911c, "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@172.16.0.5:30303?discport=30303" :: Text)]
+  { chainInfo = exampleUnsignedChainInfo
+  , chainSignature = Just exampleChainSignature
   }
 
 instance ToSchema ChainInfo where
@@ -513,17 +590,26 @@ instance FromJSON ChainInfo where
     as <- o .: "accountInfo"
     cs <- o .: "codeInfo"
     ms <- o .: "members"
-    return $ ChainInfo l as cs ms
+    pc <- o .:? "parentChain"
+    cb <- o .: "creationBlock"
+    cn <- o .: "nonce"
+    md <- o .: "metadata"
+    sig <- o .:? "signature"
+    return $ ChainInfo (UnsignedChainInfo l as cs ms pc cb cn md) sig
   parseJSON x = error $ "couldn't parse JSON for chain info: " ++ show x
 
 instance ToJSON ChainInfo where
-  toJSON x =
-    object [
-       "label" .= chainLabel x
-    ,  "accountInfo" .= accountInfo x
-    ,  "codeInfo" .= codeInfo x
-    ,  "members" .= members x
-    ]
+  toJSON (ChainInfo (UnsignedChainInfo cl ai ci ms pc cb cn md) sig) =
+    object [ "label" .= cl
+           , "accountInfo" .= ai
+           , "codeInfo" .= ci
+           , "members" .= ms
+           , "parentChain" .= pc
+           , "creationBlock" .= cb
+           , "nonce" .= cn
+           , "metadata" .= md
+           , "signature" .= sig
+           ]
 
 type ChainIdChainInfo = NamedTuple "id" ChainId "info" ChainInfo
 

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
@@ -488,7 +488,7 @@ data UnsignedChainInfo = UnsignedChainInfo
   , members       :: !(NamedMap "address" Address "enode" Text)
   , parentChain   :: !(Maybe ChainId)
   , creationBlock :: !Keccak256
-  , chainNonce    :: !(Hex Word256)
+  , chainNonce    :: !Word256
   , chainMetadata :: !(Map Text Text)
   } deriving (Eq, Show, Generic)
 
@@ -512,7 +512,7 @@ exampleUnsignedChainInfo = UnsignedChainInfo
       ]
   , parentChain = Nothing
   , creationBlock = creationBlockHash
-  , chainNonce = Hex 0x5a5e4ac0d5b1d8cde2662075ee00ecd2da47faae2729252c92237057c6e5b32a
+  , chainNonce = 0x5a5e4ac0d5b1d8cde2662075ee00ecd2da47faae2729252c92237057c6e5b32a
   , chainMetadata = M.empty
   }
 
@@ -521,8 +521,8 @@ instance ToSchema UnsignedChainInfo where
     & mapped.schema.description ?~ "UnsignedChainInfo"
 
 data ChainSignature = ChainSignature
-  { chainR        :: !(Hex Word256)
-  , chainS        :: !(Hex Word256)
+  { chainR        :: !(Hex Natural)
+  , chainS        :: !(Hex Natural)
   , chainV        :: !(Hex Word8)
   } deriving (Eq, Show, Generic)
 
@@ -592,7 +592,7 @@ instance FromJSON ChainInfo where
     ms <- o .: "members"
     pc <- o .:? "parentChain"
     cb <- o .: "creationBlock"
-    cn <- o .: "nonce"
+    cn <- (o .: "nonce")
     md <- o .: "metadata"
     sig <- o .:? "signature"
     return $ ChainInfo (UnsignedChainInfo l as cs ms pc cb cn md) sig

--- a/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
+++ b/blockapps-haskell/strato/api/src/BlockApps/Strato/Types.hs
@@ -539,18 +539,10 @@ instance ToSchema ChainSignature where
     & mapped.schema.example ?~ toJSON exampleChainSignature
 
 instance FromJSON ChainSignature where
-  parseJSON (Object o) = ChainSignature
-    <$> (o .: "r")
-    <*> (o .: "s")
-    <*> (o .: "v")
-  parseJSON x = error $ "couldn't parse JSON for chain info: " ++ show x
+  parseJSON = genericParseJSON (aesonPrefix camelCase)
 
 instance ToJSON ChainSignature where
-  toJSON (ChainSignature r s v) =
-    object [ "r" .= r
-           , "s" .= s
-           , "v" .= v
-           ]
+  toJSON = genericToJSON (aesonPrefix camelCase)
 
 data ChainInfo = ChainInfo
   { chainInfo      :: !(UnsignedChainInfo)

--- a/core-strato/blockapps-data/src/Blockchain/Data/ArbitraryInstances.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ArbitraryInstances.hs
@@ -177,24 +177,6 @@ instance Arbitrary AccountInfo where
       <$> arbitrary
       <*> arbitrary `suchThat` (>=0)
 
-instance Arbitrary ChainSignature where
-  arbitrary = ChainSignature
-    <$> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-
-instance Arbitrary UnsignedChainInfo where
-  arbitrary = UnsignedChainInfo
-    <$> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-
-instance Arbitrary ChainInfo where
-  arbitrary = ChainInfo
-    <$> arbitrary
-    <*> arbitrary
+derive makeArbitrary ''ChainSignature
+derive makeArbitrary ''UnsignedChainInfo
+derive makeArbitrary ''ChainInfo

--- a/core-strato/blockapps-data/src/Blockchain/Data/ArbitraryInstances.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ArbitraryInstances.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString.Internal           as IB
 import qualified Data.Map                           as M    hiding (map, filter)
 import qualified Data.Text                          as T
 import           Data.Time
+import           Data.Word
 
 import           System.IO.Unsafe                   (unsafePerformIO)
 
@@ -23,6 +24,7 @@ import           Blockchain.Data.Enode
 import           Blockchain.Data.Transaction
 import           Blockchain.Data.TXOrigin
 import           Blockchain.Database.MerklePatricia hiding (stateRoot)
+import           Blockchain.ExtWord
 import           Blockchain.SHA
 import           Blockchain.Util
 
@@ -180,8 +182,15 @@ instance Arbitrary AccountInfo where
 
 instance Arbitrary ChainInfo where
   arbitrary = do
-    cl <- arbitrary :: Gen String
+    cl <- arbitrary :: Gen T.Text
     ai <- arbitrary :: Gen [AccountInfo]
     ci <- arbitrary :: Gen [CodeInfo]
     mb <- arbitrary :: Gen (M.Map Address Enode)
-    return (ChainInfo cl ai ci mb)
+    pc <- arbitrary :: Gen (Maybe Word256)
+    cb <- arbitrary :: Gen SHA
+    cn <- arbitrary :: Gen Word256
+    md <- arbitrary :: Gen (M.Map T.Text T.Text)
+    r <- arbitrary :: Gen Word256
+    s <- arbitrary :: Gen Word256
+    v <- arbitrary :: Gen Word8
+    return (ChainInfo cl ai ci mb pc cb cn md r s v)

--- a/core-strato/blockapps-data/src/Blockchain/Data/ArbitraryInstances.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ArbitraryInstances.hs
@@ -9,10 +9,8 @@ import           Test.QuickCheck
 import           Data.ByteString.Arbitrary
 import qualified Data.ByteString                    as B
 import qualified Data.ByteString.Internal           as IB
-import qualified Data.Map                           as M    hiding (map, filter)
 import qualified Data.Text                          as T
 import           Data.Time
-import           Data.Word
 
 import           System.IO.Unsafe                   (unsafePerformIO)
 
@@ -24,7 +22,6 @@ import           Blockchain.Data.Enode
 import           Blockchain.Data.Transaction
 import           Blockchain.Data.TXOrigin
 import           Blockchain.Database.MerklePatricia hiding (stateRoot)
-import           Blockchain.ExtWord
 import           Blockchain.SHA
 import           Blockchain.Util
 
@@ -180,17 +177,24 @@ instance Arbitrary AccountInfo where
       <$> arbitrary
       <*> arbitrary `suchThat` (>=0)
 
+instance Arbitrary ChainSignature where
+  arbitrary = ChainSignature
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+
+instance Arbitrary UnsignedChainInfo where
+  arbitrary = UnsignedChainInfo
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+
 instance Arbitrary ChainInfo where
-  arbitrary = do
-    cl <- arbitrary :: Gen T.Text
-    ai <- arbitrary :: Gen [AccountInfo]
-    ci <- arbitrary :: Gen [CodeInfo]
-    mb <- arbitrary :: Gen (M.Map Address Enode)
-    pc <- arbitrary :: Gen (Maybe Word256)
-    cb <- arbitrary :: Gen SHA
-    cn <- arbitrary :: Gen Word256
-    md <- arbitrary :: Gen (M.Map T.Text T.Text)
-    r <- arbitrary :: Gen Word256
-    s <- arbitrary :: Gen Word256
-    v <- arbitrary :: Gen Word8
-    return (ChainInfo cl ai ci mb pc cb cn md r s v)
+  arbitrary = ChainInfo
+    <$> arbitrary
+    <*> arbitrary

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveGeneric            #-}
 {-# LANGUAGE FlexibleInstances        #-}
 {-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE RecordWildCards          #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
 
 module Blockchain.Data.ChainInfo
@@ -29,18 +30,19 @@ import qualified Data.ByteString                      as B
 import qualified Data.ByteString.Base16               as B16
 import qualified Data.ByteString.Char8                as C8
 import qualified Data.JsonStream.Parser               as JS
-import qualified Data.Map                             as M      hiding (map, filter)
+import qualified Data.Map.Strict                      as M      hiding (map, filter)
 import qualified Data.Text                            as T
 import           Data.Text.Encoding                   (encodeUtf8, decodeUtf8)
 import qualified Data.Vector                          as V
+import           Data.Word
 
 import qualified GHC.Generics                         as GHCG
 
 
 data CodeInfo = CodeInfo
-  { codeInfoCode   :: B.ByteString
-  , codeInfoSource :: T.Text
-  , codeInfoName   :: T.Text
+  { codeInfoCode   :: !B.ByteString
+  , codeInfoSource :: !T.Text
+  , codeInfoName   :: !T.Text
   } deriving (Show, Read, Eq, GHCG.Generic)
 
 instance FromJSON CodeInfo where
@@ -72,9 +74,9 @@ instance RLPSerializable CodeInfo where
   rlpDecode (RLPArray [a,b,c]) = CodeInfo (rlpDecode a) (decodeUtf8 $ rlpDecode b) (decodeUtf8 $ rlpDecode c)
   rlpDecode _ = error ("Error in rlpDecode for CodeInfo: bad RLPObject")
 
-data AccountInfo = NonContract Address Integer
-                 | ContractNoStorage Address Integer SHA
-                 | ContractWithStorage Address Integer SHA [(Word256, Word256)]
+data AccountInfo = NonContract !Address !Integer
+                 | ContractNoStorage !Address !Integer !SHA
+                 | ContractWithStorage !Address !Integer !SHA ![(Word256, Word256)]
    deriving (Show, Eq, Read, GHCG.Generic)
 
 instance FromJSON AccountInfo where
@@ -138,10 +140,17 @@ instance RLPSerializable AccountInfo where
 
 
 data ChainInfo = ChainInfo {
-    chainLabel      :: String,
-    accountInfo     :: [AccountInfo],
-    codeInfo        :: [CodeInfo],
-    members         :: M.Map Address Enode
+  chainLabel    :: !T.Text,
+  accountInfo   :: ![AccountInfo],
+  codeInfo      :: ![CodeInfo],
+  members       :: !(M.Map Address Enode),
+  parentChain   :: !(Maybe Word256),
+  creationBlock :: !SHA,
+  chainNonce    :: !Word256,
+  chainMetadata :: !(M.Map T.Text T.Text),
+  chainR        :: !Word256,
+  chainS        :: !Word256,
+  chainV        :: !Word8
 } deriving (Eq, Show, Read, GHCG.Generic)
 
 instance FromJSON ChainInfo where
@@ -150,31 +159,59 @@ instance FromJSON ChainInfo where
     as <- o .: "accountInfo"
     cs <- o .: "codeInfo"
     ms <- ((o .: "members") :: NamedMapParser "address" Address "enode" Enode)
-    return $ ChainInfo l as cs (M.fromList $ map toTuple ms)
+    pc <- o .:? "parentChain"
+    cb <- o .: "creationBlock"
+    cn <- o .: "chainNonce"
+    md <- o .: "chainMetadata"
+    r <- o .: "r"
+    s <- o .: "s"
+    v <- o .: "v"
+    return $ ChainInfo l as cs (M.fromList $ map toTuple ms) pc cb cn md r s v
   parseJSON x = error $ "couldn't parse JSON for chain info: " ++ show x
 
 instance ToJSON ChainInfo where
-  toJSON (ChainInfo cl ai ci ms) =
+  toJSON (ChainInfo cl ai ci ms pc cb cn md r s v) =
     object [ "label" .= cl
            , "accountInfo" .= ai
            , "codeInfo" .= ci
            , "members" .= ((map fromTuple (M.toList ms)) :: NamedMap "address" Address "enode" Enode)
+           , "parentChain" .= pc
+           , "creationBlock" .= cb
+           , "chainNonce" .= cn
+           , "chainMetadata" .= md
+           , "r" .= r
+           , "s" .= s
+           , "v" .= v
            ]
 
 instance RLPSerializable ChainInfo where
-  rlpEncode ci = RLPArray
-    [ rlpEncode . encodeUtf8 . T.pack $ chainLabel ci
-    , RLPArray . map rlpEncode $ accountInfo ci
-    , RLPArray . map rlpEncode $ codeInfo ci
-    , rlpEncode $ members ci
+  rlpEncode ChainInfo{..} = RLPArray
+    [ rlpEncode $ encodeUtf8 chainLabel
+    , RLPArray $ map rlpEncode accountInfo
+    , RLPArray $ map rlpEncode codeInfo
+    , rlpEncode members
+    , rlpEncode parentChain
+    , rlpEncode creationBlock
+    , rlpEncode chainNonce
+    , rlpEncode chainMetadata
+    , rlpEncode chainR
+    , rlpEncode chainS
+    , rlpEncode $ toInteger chainV
     ]
-  rlpDecode (RLPArray [cl, RLPArray ai, RLPArray coi, ms]) =
+  rlpDecode (RLPArray [cl, RLPArray ai, RLPArray coi, ms, pc, cb, cn, md, r, s, v]) =
     ChainInfo
-      (T.unpack . decodeUtf8 $ rlpDecode cl)
+      (decodeUtf8 $ rlpDecode cl)
       (rlpDecode <$> ai)
       (rlpDecode <$> coi)
       (rlpDecode ms)
-  rlpDecode o = error $ "rlpDecode ChainInfo: Expected 4 element RLPArray, got " ++ show o
+      (rlpDecode pc)
+      (rlpDecode cb)
+      (rlpDecode cn)
+      (rlpDecode md)
+      (rlpDecode r)
+      (rlpDecode s)
+      (fromInteger $ rlpDecode v)
+  rlpDecode o = error $ "rlpDecode ChainInfo: Expected 11 element RLPArray, got " ++ show o
 
 
 accountExtractor :: JS.Parser [AccountInfo]

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
@@ -8,10 +8,12 @@
 {-# LANGUAGE ScopedTypeVariables      #-}
 
 module Blockchain.Data.ChainInfo
-  ( ChainInfo (..),
-    AccountInfo (..),
-    CodeInfo (..),
-    accountExtractor
+  ( ChainInfo (..)
+  , UnsignedChainInfo(..)
+  , ChainSignature(..)
+  , AccountInfo (..)
+  , CodeInfo (..)
+  , accountExtractor
   ) where
 
 
@@ -138,20 +140,55 @@ instance RLPSerializable AccountInfo where
   rlpDecode (RLPArray [a,b]) = NonContract (rlpDecode a) (rlpDecode b)
   rlpDecode _ = error ("Error in rlpDecode for AccountInfo: bad RLPObject")
 
+data ChainSignature = ChainSignature
+  { chainR :: !Word256
+  , chainS :: !Word256
+  , chainV :: !Word8
+  } deriving (Eq, Show, GHCG.Generic)
 
-data ChainInfo = ChainInfo {
-  chainLabel    :: !T.Text,
-  accountInfo   :: ![AccountInfo],
-  codeInfo      :: ![CodeInfo],
-  members       :: !(M.Map Address Enode),
-  parentChain   :: !(Maybe Word256),
-  creationBlock :: !SHA,
-  chainNonce    :: !Word256,
-  chainMetadata :: !(M.Map T.Text T.Text),
-  chainR        :: !Word256,
-  chainS        :: !Word256,
-  chainV        :: !Word8
-} deriving (Eq, Show, Read, GHCG.Generic)
+instance FromJSON ChainSignature where
+  parseJSON (Object o) = do
+    r <- o .: "r"
+    s <- o .: "s"
+    v <- o .: "v"
+    return $ ChainSignature r s v
+  parseJSON x = error $ "couldn't parse JSON for chain signature: " ++ show x
+
+instance ToJSON ChainSignature where
+  toJSON (ChainSignature r s v) =
+    object [ "r" .= r
+           , "s" .= s
+           , "v" .= v
+           ]
+
+instance RLPSerializable ChainSignature where
+  rlpEncode ChainSignature{..} = RLPArray
+    [ rlpEncode chainR
+    , rlpEncode chainS
+    , rlpEncode $ toInteger chainV
+    ]
+  rlpDecode (RLPArray [r, s, v]) =
+    ChainSignature
+      (rlpDecode r)
+      (rlpDecode s)
+      (fromInteger $ rlpDecode v)
+  rlpDecode o = error $ "rlpDecode ChainSignature: Expected 3 element RLPArray, got " ++ show o
+
+data UnsignedChainInfo = UnsignedChainInfo
+  { chainLabel     :: !T.Text
+  , accountInfo    :: ![AccountInfo]
+  , codeInfo       :: ![CodeInfo]
+  , members        :: !(M.Map Address Enode)
+  , parentChain    :: !(Maybe Word256)
+  , creationBlock  :: !SHA
+  , chainNonce     :: !Word256
+  , chainMetadata  :: !(M.Map T.Text T.Text)
+  } deriving (Eq, Show, GHCG.Generic)
+
+data ChainInfo = ChainInfo
+  { chainInfo      :: !UnsignedChainInfo
+  , chainSignature :: !(Maybe ChainSignature)
+  } deriving (Eq, Show, GHCG.Generic)
 
 instance FromJSON ChainInfo where
   parseJSON (Object o) = do
@@ -161,31 +198,27 @@ instance FromJSON ChainInfo where
     ms <- ((o .: "members") :: NamedMapParser "address" Address "enode" Enode)
     pc <- o .:? "parentChain"
     cb <- o .: "creationBlock"
-    cn <- o .: "chainNonce"
-    md <- o .: "chainMetadata"
-    r <- o .: "r"
-    s <- o .: "s"
-    v <- o .: "v"
-    return $ ChainInfo l as cs (M.fromList $ map toTuple ms) pc cb cn md r s v
+    cn <- o .: "nonce"
+    md <- o .: "metadata"
+    sig <- o .:? "signature"
+    return $ ChainInfo (UnsignedChainInfo l as cs (M.fromList $ map toTuple ms) pc cb cn md) sig
   parseJSON x = error $ "couldn't parse JSON for chain info: " ++ show x
 
 instance ToJSON ChainInfo where
-  toJSON (ChainInfo cl ai ci ms pc cb cn md r s v) =
+  toJSON (ChainInfo (UnsignedChainInfo cl ai ci ms pc cb cn md) sig) =
     object [ "label" .= cl
            , "accountInfo" .= ai
            , "codeInfo" .= ci
            , "members" .= ((map fromTuple (M.toList ms)) :: NamedMap "address" Address "enode" Enode)
            , "parentChain" .= pc
            , "creationBlock" .= cb
-           , "chainNonce" .= cn
-           , "chainMetadata" .= md
-           , "r" .= r
-           , "s" .= s
-           , "v" .= v
+           , "nonce" .= cn
+           , "metadata" .= md
+           , "signature" .= sig
            ]
 
-instance RLPSerializable ChainInfo where
-  rlpEncode ChainInfo{..} = RLPArray
+instance RLPSerializable UnsignedChainInfo where
+  rlpEncode UnsignedChainInfo{..} = RLPArray
     [ rlpEncode $ encodeUtf8 chainLabel
     , RLPArray $ map rlpEncode accountInfo
     , RLPArray $ map rlpEncode codeInfo
@@ -194,12 +227,9 @@ instance RLPSerializable ChainInfo where
     , rlpEncode creationBlock
     , rlpEncode chainNonce
     , rlpEncode chainMetadata
-    , rlpEncode chainR
-    , rlpEncode chainS
-    , rlpEncode $ toInteger chainV
     ]
-  rlpDecode (RLPArray [cl, RLPArray ai, RLPArray coi, ms, pc, cb, cn, md, r, s, v]) =
-    ChainInfo
+  rlpDecode (RLPArray [cl, RLPArray ai, RLPArray coi, ms, pc, cb, cn, md]) =
+    UnsignedChainInfo
       (decodeUtf8 $ rlpDecode cl)
       (rlpDecode <$> ai)
       (rlpDecode <$> coi)
@@ -208,11 +238,17 @@ instance RLPSerializable ChainInfo where
       (rlpDecode cb)
       (rlpDecode cn)
       (rlpDecode md)
-      (rlpDecode r)
-      (rlpDecode s)
-      (fromInteger $ rlpDecode v)
-  rlpDecode o = error $ "rlpDecode ChainInfo: Expected 11 element RLPArray, got " ++ show o
+  rlpDecode o = error $ "rlpDecode UnsignedChainInfo: Expected 8 element RLPArray, got " ++ show o
 
+instance RLPSerializable ChainInfo where
+  rlpEncode (ChainInfo uci sig) =
+    let RLPArray xs = rlpEncode uci
+     in RLPArray (xs ++ [rlpEncode sig])
+  rlpDecode (RLPArray xs) =
+    ChainInfo
+      (rlpDecode . RLPArray $ take 8 xs)
+      (rlpDecode $ xs !! 8)
+  rlpDecode o = error $ "rlpDecode ChainInfo: Expected 9 element RLPArray, got " ++ show o
 
 accountExtractor :: JS.Parser [AccountInfo]
 accountExtractor = many ("accountInfo" JS..: JS.arrayOf acctInfo)

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
@@ -32,7 +32,7 @@ import qualified Data.ByteString                      as B
 import qualified Data.ByteString.Base16               as B16
 import qualified Data.ByteString.Char8                as C8
 import qualified Data.JsonStream.Parser               as JS
-import qualified Data.Map.Strict                      as M      hiding (map, filter)
+import qualified Data.Map.Strict                      as M
 import qualified Data.Text                            as T
 import           Data.Text.Encoding                   (encodeUtf8, decodeUtf8)
 import qualified Data.Vector                          as V
@@ -226,7 +226,7 @@ instance RLPSerializable UnsignedChainInfo where
     , rlpEncode parentChain
     , rlpEncode creationBlock
     , rlpEncode chainNonce
-    , rlpEncode chainMetadata
+    , rlpEncode . M.mapKeys encodeUtf8 $ M.map encodeUtf8 chainMetadata
     ]
   rlpDecode (RLPArray [cl, RLPArray ai, RLPArray coi, ms, pc, cb, cn, md]) =
     UnsignedChainInfo
@@ -237,7 +237,7 @@ instance RLPSerializable UnsignedChainInfo where
       (rlpDecode pc)
       (rlpDecode cb)
       (rlpDecode cn)
-      (rlpDecode md)
+      (M.mapKeys decodeUtf8 . M.map decodeUtf8 $ rlpDecode md)
   rlpDecode o = error $ "rlpDecode UnsignedChainInfo: Expected 8 element RLPArray, got " ++ show o
 
 instance RLPSerializable ChainInfo where

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE OverloadedStrings        #-}
 {-# LANGUAGE RecordWildCards          #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StrictData               #-}
 
 module Blockchain.Data.ChainInfo
   ( ChainInfo (..)
@@ -42,9 +43,9 @@ import qualified GHC.Generics                         as GHCG
 
 
 data CodeInfo = CodeInfo
-  { codeInfoCode   :: !B.ByteString
-  , codeInfoSource :: !T.Text
-  , codeInfoName   :: !T.Text
+  { codeInfoCode   :: B.ByteString
+  , codeInfoSource :: T.Text
+  , codeInfoName   :: T.Text
   } deriving (Show, Read, Eq, GHCG.Generic)
 
 instance FromJSON CodeInfo where
@@ -76,9 +77,9 @@ instance RLPSerializable CodeInfo where
   rlpDecode (RLPArray [a,b,c]) = CodeInfo (rlpDecode a) (decodeUtf8 $ rlpDecode b) (decodeUtf8 $ rlpDecode c)
   rlpDecode _ = error ("Error in rlpDecode for CodeInfo: bad RLPObject")
 
-data AccountInfo = NonContract !Address !Integer
-                 | ContractNoStorage !Address !Integer !SHA
-                 | ContractWithStorage !Address !Integer !SHA ![(Word256, Word256)]
+data AccountInfo = NonContract Address Integer
+                 | ContractNoStorage Address Integer SHA
+                 | ContractWithStorage Address Integer SHA [(Word256, Word256)]
    deriving (Show, Eq, Read, GHCG.Generic)
 
 instance FromJSON AccountInfo where
@@ -141,9 +142,9 @@ instance RLPSerializable AccountInfo where
   rlpDecode _ = error ("Error in rlpDecode for AccountInfo: bad RLPObject")
 
 data ChainSignature = ChainSignature
-  { chainR :: !Word256
-  , chainS :: !Word256
-  , chainV :: !Word8
+  { chainR :: Word256
+  , chainS :: Word256
+  , chainV :: Word8
   } deriving (Eq, Show, GHCG.Generic)
 
 instance FromJSON ChainSignature where
@@ -175,19 +176,19 @@ instance RLPSerializable ChainSignature where
   rlpDecode o = error $ "rlpDecode ChainSignature: Expected 3 element RLPArray, got " ++ show o
 
 data UnsignedChainInfo = UnsignedChainInfo
-  { chainLabel     :: !T.Text
-  , accountInfo    :: ![AccountInfo]
-  , codeInfo       :: ![CodeInfo]
-  , members        :: !(M.Map Address Enode)
-  , parentChain    :: !(Maybe Word256)
-  , creationBlock  :: !SHA
-  , chainNonce     :: !Word256
-  , chainMetadata  :: !(M.Map T.Text T.Text)
+  { chainLabel     :: T.Text
+  , accountInfo    :: [AccountInfo]
+  , codeInfo       :: [CodeInfo]
+  , members        :: (M.Map Address Enode)
+  , parentChain    :: (Maybe Word256)
+  , creationBlock  :: SHA
+  , chainNonce     :: Word256
+  , chainMetadata  :: (M.Map T.Text T.Text)
   } deriving (Eq, Show, GHCG.Generic)
 
 data ChainInfo = ChainInfo
-  { chainInfo      :: !UnsignedChainInfo
-  , chainSignature :: !(Maybe ChainSignature)
+  { chainInfo      :: UnsignedChainInfo
+  , chainSignature :: (Maybe ChainSignature)
   } deriving (Eq, Show, GHCG.Generic)
 
 instance FromJSON ChainInfo where

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfoDB.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfoDB.hs
@@ -52,12 +52,23 @@ getChainInfo chainId = do
           cInfos <- E.select . E.from $ \ciRef -> do
             E.where_ (ciRef E.^. CodeInfoRefChainInfoId E.==. E.val chainInfoRefId)
             return ciRef
+          mds <- E.select . E.from $ \cmdRef -> do
+            E.where_ (cmdRef E.^. ChainMetadataRefChainInfoId E.==. E.val chainInfoRefId)
+            return cmdRef
           return . Just . fromTuple $ (chainId,
                                        ChainInfo
-                                         chainInfoRefChainLabel
+                                         (T.pack chainInfoRefChainLabel)
                                          (map ai aInfos)
                                          (map ci cInfos)
-                                         (M.fromList (map makePairs members)))
+                                         (M.fromList (map makePairs members))
+                                         chainInfoRefParentChain
+                                         chainInfoRefCreationBlock
+                                         chainInfoRefChainNonce
+                                         (M.fromList $ map md mds)
+                                         (fromInteger chainInfoRefR)
+                                         (fromInteger chainInfoRefS)
+                                         chainInfoRefV
+                                      )
           where makePairs = (chainMemberRefAddress &&& (readEnode . chainMemberRefName)) . entityVal
                 ai = \aInfo ->
                         let AccountInfoRef{..} = entityVal aInfo
@@ -83,6 +94,9 @@ getChainInfo chainId = do
                               codeInfoRefEvmByteCode
                               (T.pack codeInfoRefContractCode)
                               (T.pack codeInfoRefContractName)
+                md = \metadata ->
+                        let ChainMetadataRef{..} = entityVal metadata
+                         in (T.pack chainMetadataRefKey, T.pack chainMetadataRefValue)
 
 getChainInfos :: (HasSQLDB m) => [Word256] -> m (NamedMap "id" Word256 "info" ChainInfo)
 getChainInfos chainIds = do
@@ -106,7 +120,14 @@ putChainInfo :: (HasSQLDB m) => Word256 -> ChainInfo -> m (Key ChainInfoRef)
 putChainInfo chainId ChainInfo{..} = do
   db <- getSQLDB
   runResourceT . flip SQL.runSqlPool db $ do
-    let chainInfoRef = ChainInfoRef chainId chainLabel
+    let chainInfoRef = ChainInfoRef chainId
+                                    (T.unpack chainLabel)
+                                    parentChain
+                                    creationBlock
+                                    chainNonce
+                                    (toInteger chainR)
+                                    (toInteger chainS)
+                                    chainV
     cirId <- E.insert chainInfoRef
     insertMany_ $ map (parseAInfo cirId) accountInfo
     insertMany_ $ map (parseCInfo cirId) codeInfo

--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfoDB.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfoDB.hs
@@ -12,6 +12,7 @@ import           Control.Arrow                      ((&&&))
 import           Control.Monad                      (when)
 import           Control.Monad.Logger
 import           Control.Monad.Trans.Resource
+import           Data.Foldable                      (traverse_)
 import qualified Data.Map                           as M        (fromList, toList)
 import           Data.Maybe
 import qualified Data.Text                          as T
@@ -55,20 +56,24 @@ getChainInfo chainId = do
           mds <- E.select . E.from $ \cmdRef -> do
             E.where_ (cmdRef E.^. ChainMetadataRefChainInfoId E.==. E.val chainInfoRefId)
             return cmdRef
-          return . Just . fromTuple $ (chainId,
-                                       ChainInfo
-                                         (T.pack chainInfoRefChainLabel)
-                                         (map ai aInfos)
-                                         (map ci cInfos)
-                                         (M.fromList (map makePairs members))
-                                         chainInfoRefParentChain
-                                         chainInfoRefCreationBlock
-                                         chainInfoRefChainNonce
-                                         (M.fromList $ map md mds)
-                                         (fromInteger chainInfoRefR)
-                                         (fromInteger chainInfoRefS)
-                                         chainInfoRefV
-                                      )
+          sig <- fmap listToMaybe . E.select . E.from $ \csRef -> do
+            E.where_ (csRef E.^. ChainSignatureRefChainInfoId E.==. E.val chainInfoRefId)
+            return csRef
+          return . Just . fromTuple $
+            ( chainId
+            , ChainInfo
+               (UnsignedChainInfo
+                 (T.pack chainInfoRefChainLabel)
+                 (map ai aInfos)
+                 (map ci cInfos)
+                 (M.fromList (map makePairs members))
+                 chainInfoRefParentChain
+                 chainInfoRefCreationBlock
+                 chainInfoRefChainNonce
+                 (M.fromList $ map md mds)
+               )
+               (fmap csig sig)
+            )
           where makePairs = (chainMemberRefAddress &&& (readEnode . chainMemberRefName)) . entityVal
                 ai = \aInfo ->
                         let AccountInfoRef{..} = entityVal aInfo
@@ -97,6 +102,12 @@ getChainInfo chainId = do
                 md = \metadata ->
                         let ChainMetadataRef{..} = entityVal metadata
                          in (T.pack chainMetadataRefKey, T.pack chainMetadataRefValue)
+                csig = \sig ->
+                          let ChainSignatureRef{..} = entityVal sig
+                           in ChainSignature
+                                (fromInteger chainSignatureRefR)
+                                (fromInteger chainSignatureRefS)
+                                chainSignatureRefV
 
 getChainInfos :: (HasSQLDB m) => [Word256] -> m (NamedMap "id" Word256 "info" ChainInfo)
 getChainInfos chainIds = do
@@ -117,7 +128,7 @@ getChainInfos chainIds = do
       Just cis -> return cis
 
 putChainInfo :: (HasSQLDB m) => Word256 -> ChainInfo -> m (Key ChainInfoRef)
-putChainInfo chainId ChainInfo{..} = do
+putChainInfo chainId (ChainInfo UnsignedChainInfo{..} csig) = do
   db <- getSQLDB
   runResourceT . flip SQL.runSqlPool db $ do
     let chainInfoRef = ChainInfoRef chainId
@@ -125,13 +136,12 @@ putChainInfo chainId ChainInfo{..} = do
                                     parentChain
                                     creationBlock
                                     chainNonce
-                                    (toInteger chainR)
-                                    (toInteger chainS)
-                                    chainV
     cirId <- E.insert chainInfoRef
     insertMany_ $ map (parseAInfo cirId) accountInfo
     insertMany_ $ map (parseCInfo cirId) codeInfo
     insertMany_ $ map (parseMember cirId) (M.toList members)
+    insertMany_ $ map (parseMetadata cirId) (M.toList chainMetadata)
+    traverse_ insert_ $ fmap (parseSignature cirId) csig
     return cirId
       where
         parseAInfo chid aInfo =
@@ -143,6 +153,14 @@ putChainInfo chainId ChainInfo{..} = do
           CodeInfoRef ch bc (T.unpack cc) (T.unpack cn)
         parseMember chi (ad, en) =
           ChainMemberRef chi (showEnode en) ad
+        parseMetadata chi (k, v) =
+          ChainMetadataRef chi (T.unpack k) (T.unpack v)
+        parseSignature chi ChainSignature{..} =
+          ChainSignatureRef
+            chi
+            (toInteger chainR)
+            (toInteger chainS)
+            chainV
 
 addMember :: (HasSQLDB m) => Word256 -> Address -> String -> m ()
 addMember chainId address enode = do

--- a/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.hs
@@ -59,6 +59,9 @@ migrateAll = do
   exec "ALTER TABLE IF EXISTS address_state_ref DROP COLUMN IF EXISTS source;"
   exec "ALTER TABLE IF EXISTS raw_transaction ALTER COLUMN chain_id SET DEFAULT 0;"
   exec "ALTER TABLE IF EXISTS raw_transaction ALTER COLUMN chain_id SET NOT NULL;"
+  exec "ALTER TABLE IF EXISTS chain_info_ref ADD COLUMN IF NOT EXISTS parent_chain varchar;"
+  exec "ALTER TABLE IF EXISTS chain_info_ref ADD COLUMN IF NOT EXISTS creation_block varchar;"
+  exec "ALTER TABLE IF EXISTS chain_info_ref ADD COLUMN IF NOT EXISTS chain_nonce varchar;"
   migrateAuto
 
 -- todo newtype me

--- a/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.txt
+++ b/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.txt
@@ -155,13 +155,19 @@ LogDB
 ChainInfoRef
     chainId Word256
     chainLabel String
-    deriving Eq Generic Read Show
+    parentChain Word256 Maybe
+    creationBlock SHA
+    chainNonce Word256
+    r Integer
+    s Integer
+    v Word8
+    deriving Eq Generic Show
 
 ChainMemberRef
     chainInfoId ChainInfoRefId
     name String
     address Address
-    deriving Eq Generic Read Show
+    deriving Eq Generic Show
 
 AccountInfoRef
     chainInfoId ChainInfoRefId
@@ -169,11 +175,17 @@ AccountInfoRef
     balance Integer
     codeHash SHA Maybe
     map [MapPair] Maybe
-    deriving Eq Generic Read Show
+    deriving Eq Generic Show
 
 CodeInfoRef
     chainInfoId ChainInfoRefId
     evmByteCode BS.ByteString
     contractCode String
     contractName String
-    deriving Eq Generic Read Show
+    deriving Eq Generic Show
+
+ChainMetadataRef
+    chainInfoId ChainInfoRefId
+    key String
+    value String
+    deriving Eq Generic Show

--- a/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.txt
+++ b/core-strato/blockapps-data/src/Blockchain/Data/DataDefs.txt
@@ -158,6 +158,10 @@ ChainInfoRef
     parentChain Word256 Maybe
     creationBlock SHA
     chainNonce Word256
+    deriving Eq Generic Show
+
+ChainSignatureRef
+    chainInfoId ChainInfoRefId
     r Integer
     s Integer
     v Word8

--- a/core-strato/strato-api/src/Handler/ChainInfo.hs
+++ b/core-strato/strato-api/src/Handler/ChainInfo.hs
@@ -10,21 +10,18 @@ import qualified Data.Map                       as M
 import qualified Data.Set                       as S
 import qualified Data.Text                      as T
 
-import           Blockchain.SHA
-import           Blockchain.Data.TXOrigin
-import           Blockchain.EthConf             (runKafkaConfigured)
-import           Blockchain.Sequencer.Event     (IngestEvent (IEGenesis), IngestGenesis (..))
-import           Blockchain.Sequencer.Kafka     (writeUnseqEvents)
-import           Import                         hiding (hash)
-import           Numeric                        (showHex)
-
 import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.ChainInfoDB
-import           Blockchain.TypeLits
-import           System.Entropy
-import           Blockchain.Util
+import           Blockchain.Data.TXOrigin
+import           Blockchain.EthConf             (runKafkaConfigured)
 import           Blockchain.ExtWord             (Word256)
+import           Blockchain.Sequencer.Event     (IngestEvent (IEGenesis), IngestGenesis (..))
+import           Blockchain.Sequencer.Kafka     (writeUnseqEvents)
+import           Blockchain.SHA
+
 import           Handler.Filters
+import           Import                         hiding (hash)
+import           Numeric                        (showHex)
 
 emitKafkaTransactions :: (MonadIO m, MonadLogger m) => [(Word256, ChainInfo)] -> m ()
 emitKafkaTransactions gs = do
@@ -43,7 +40,7 @@ postChainR = do
 
   ci <- parseJsonBody :: Handler (Result ChainInfo)
   case ci of
-    Success gen@(ChainInfo _ acin cdin mb) -> do
+    Success gen@(ChainInfo _ acin cdin mb _ _ _ _ _ _ _) -> do
     -- add more checks?
       when (length acin == 0) $ invalidArgs ["account info is empty"]
       when (M.size mb == 0) $ invalidArgs ["member list is empty"]
@@ -55,23 +52,22 @@ postChainR = do
       case accountCodeHashes S.\\ codeCodeHashes of
         s | s /= S.empty -> invalidArgs ["Each contract code hash in accountInfo must match a corresponding code hash in codeInfo."]
           | otherwise -> do
-            liftIO $ putStrLn $ T.pack $ show gen
-            bytes <- liftIO $ getEntropy 32
-            let cid = fromInteger $ byteString2Integer bytes
+            $logDebugS "postChainR" . T.pack $ show gen
+            let SHA cid = rlpHash gen
             emitKafkaTransactions [(cid, gen)]
             return . String . T.pack $ showHex cid ""
     _ -> invalidArgs ["could not parse the args"]
 
 getChainR :: Handler Value
 getChainR = do
-  chainIds <- lookupGetParams "chainid" 
+  chainIds <- lookupGetParams "chainid"
   addHeader "Access-Control-Allow-Origin" "*"
-  cInfos <- case chainIds of 
+  cInfos <- case chainIds of
       [] -> getChainInfos []
       [cid] -> if (T.unpack cid == "all")
                    then getChainInfos []
                    else getChainInfos [fromHexText cid]
       cids -> getChainInfos $ fmap fromHexText cids
   case cInfos of
-      [] -> returnJson ([]::NamedMap "id" Word256 "info" ChainInfo)
+      [] -> notFound
       cis -> returnJson cis

--- a/core-strato/strato-api/src/Handler/ChainInfo.hs
+++ b/core-strato/strato-api/src/Handler/ChainInfo.hs
@@ -40,7 +40,7 @@ postChainR = do
 
   ci <- parseJsonBody :: Handler (Result ChainInfo)
   case ci of
-    Success gen@(ChainInfo _ acin cdin mb _ _ _ _ _ _ _) -> do
+    Success gen@(ChainInfo (UnsignedChainInfo _ acin cdin mb _ _ _ _) _) -> do
     -- add more checks?
       when (length acin == 0) $ invalidArgs ["account info is empty"]
       when (M.size mb == 0) $ invalidArgs ["member list is empty"]

--- a/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
+++ b/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
@@ -142,8 +142,8 @@ chainInfoToGenesisState :: (HasCodeDB m, HasHashDB m, Mem.HasMemAddressStateDB m
                           => ChainInfo
                           -> m StateRoot
 chainInfoToGenesisState ci = do
-    initializeCodeDB (codeInfo ci)
-    initializeStateDB (accountInfo ci)
+    initializeCodeDB (codeInfo $ chainInfo ci)
+    initializeStateDB (accountInfo $ chainInfo ci)
     stateRoot <$> getStateDB
 
 zipSourceInfo :: [AccountInfo] -> [CodeInfo] -> [(AccountInfo, CodeInfo)]
@@ -203,7 +203,7 @@ initializeChainDBs :: ( MonadResource m
                    -> ChainInfo
                    -> StateRoot
                    -> t m ()
-initializeChainDBs chainId ChainInfo{..} sRoot = do
+initializeChainDBs chainId (ChainInfo UnsignedChainInfo{..} _) sRoot = do
   genAddrStates <- getAllAddressStates
   accountDiffs <- mapM eventualAccountState . Map.fromList $ genAddrStates
   let diff = StateDiff {

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/Model.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/Model.hs
@@ -19,7 +19,7 @@ data IndexEvent = RanBlock OutputBlock
                 | UpdateTxResult (SHA, SHA, SHA, Bool) -- Deprecated
                 | NewChainInfo Word256 ChainInfo
                 | IndexTransaction Timestamp OutputTx
-                deriving (Eq, Read, Show)
+                deriving (Eq, Show)
 
 instance Binary LogDB
 instance Binary TransactionResult

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -76,16 +76,18 @@ txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
                         lift $ addMember chainId address enode' -- We only need the Text version for Postgres
                         mChainInfo <- RBDB.withRedisBlockDB $ RBDB.getChainInfo chainId
                         when (isJust mChainInfo) $ do
-                          let Just (cInfo@ChainInfo{members=ms}) = mChainInfo
-                          void . RBDB.withRedisBlockDB $ RBDB.putChainInfo chainId cInfo{members = Map.insert address enode ms}
+                          let Just (ChainInfo (cInfo@UnsignedChainInfo{members=ms}) sig) = mChainInfo
+                          void . RBDB.withRedisBlockDB $
+                            RBDB.putChainInfo chainId $ ChainInfo cInfo{members = Map.insert address enode ms} sig
                     Just x | SHA x == removeTopic -> do
                       let address = decode . BL.fromStrict . BS.take 20 . BS.drop 12 $ logDBTheData l
                       $logInfoS "txrIndexer" . T.pack $ "Removing member " ++ (showHex address "") ++ " on chain " ++ showHex chainId ""
                       lift $ removeMember chainId address
                       mChainInfo <- RBDB.withRedisBlockDB $ RBDB.getChainInfo chainId
                       when (isJust mChainInfo) $ do
-                        let Just (cInfo@ChainInfo{members=ms}) = mChainInfo
-                        void . RBDB.withRedisBlockDB $ RBDB.putChainInfo chainId cInfo{members = Map.delete address ms}
+                        let Just (ChainInfo (cInfo@UnsignedChainInfo{members=ms}) sig) = mChainInfo
+                        void . RBDB.withRedisBlockDB $
+                          RBDB.putChainInfo chainId $ ChainInfo cInfo{members = Map.delete address ms} sig
                     Just x | SHA x == terminateTopic -> do
                       $logInfoS "txrIndexer" . T.pack $ "Terminating chain " ++ showHex chainId ""
                       lift $ terminateChain chainId

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/SHA.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/SHA.hs
@@ -64,3 +64,6 @@ keccak256 bs = convert (hash bs :: Digest Keccak_256)
 
 keccak512 :: S8.ByteString -> S8.ByteString
 keccak512 bs = convert (hash bs :: Digest Keccak_512)
+
+rlpHash :: RLPSerializable a => a -> SHA
+rlpHash = superProprietaryStratoSHAHash . rlpSerialize . rlpEncode

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -330,7 +330,7 @@ handleEvents peer = awaitForever $ \case
               mCInfo <- RBDB.withRedisBlockDB $ RBDB.getChainInfo cid'
               case mCInfo of
                 Nothing -> return False
-                Just cInfo -> do
+                Just (ChainInfo cInfo _) -> do
                   let pIp = readIP $ T.unpack (pPeerIp peer)
                       ipList = ipAddress <$> members cInfo
                   return $ pIp `elem` ipList
@@ -341,11 +341,11 @@ handleEvents peer = awaitForever $ \case
               $logInfoS "handleEvents/OETx" $ T.pack $ "sending Transaction " ++ format (otHash tx) ++ " for chainID " ++ show cId
               $logDebugS "NewSeqEvent.tx" . T.pack $ "the transaction was: " ++ format tx
               yield $ Transactions [otBaseTx tx]
-      OEGenesis (OutputGenesis og (cId, cInfo)) -> do
+      OEGenesis (OutputGenesis og (cId, cInfo@(ChainInfo uci _))) -> do
         when (shouldSend peer og) $ do
-          $logInfoS "NewSeqEvent.genesis" . T.pack $ "yielding new chain: " ++ show cId ++ " with " ++ show cInfo
+          $logInfoS "NewSeqEvent.genesis" . T.pack $ "yielding new chain: " ++ show cId ++ " with " ++ show uci
           let pIp = readIP $ T.unpack (pPeerIp peer)
-          let ipList = ipAddress <$> members cInfo
+          let ipList = ipAddress <$> members uci
           let match = find (==pIp) ipList
 
           case match of
@@ -442,7 +442,7 @@ shouldSendGossip peer txo = recordGossipFinal
 -- check that the peer is authorized to receive these chain details, by verifying that their
 -- IPaddress is associated with one of the Enodes in the chain's member list
 checkPeerIsMember :: PPeer -> ChainInfo -> Bool
-checkPeerIsMember peer ci =
+checkPeerIsMember peer (ChainInfo ci _) =
   case match of
     Nothing -> False
     Just _ -> True

--- a/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
+++ b/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
@@ -69,7 +69,7 @@ newtype RedisHeader    = RedisHeader   BHD.BlockHeader deriving (Eq, Read, Show,
 newtype RedisTx        = RedisTx       TXD.Transaction deriving (Eq, Read, Show, RLPSerializable, TransactionLike)
 newtype RedisTxs       = RedisTxs      [RedisTx]       deriving (Eq, Read, Show, RedisDBValuable)
 newtype RedisUncles    = RedisUncles   [RedisHeader]   deriving (Eq, Read, Show, RedisDBValuable)
-newtype RedisChainInfo = RedisChainInfo ChainInfo      deriving (Eq, Read, Show, RLPSerializable)
+newtype RedisChainInfo = RedisChainInfo ChainInfo      deriving (Eq, Show, RLPSerializable)
 data RedisBestBlock = RedisBestBlock { bestBlockHash            :: SHA
                                      , bestBlockNumber          :: Integer          -- todo: BlockNumber
                                      , bestBlockTotalDifficulty :: Integer -- todo: TotalDifficulty

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/BinaryInstances.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/BinaryInstances.hs
@@ -15,17 +15,38 @@ import           Data.ByteString             ()
 
 instance Binary CI.ChainInfo where
     put gi = sequence_ $ map ($ gi) $
-        [ put. CI.chainLabel
-        , put. CI.accountInfo
-        , put. CI.codeInfo
-        , put. CI.members
+        [ put . CI.chainLabel
+        , put . CI.accountInfo
+        , put . CI.codeInfo
+        , put . CI.members
+        , put . CI.parentChain
+        , put . CI.creationBlock
+        , put . CI.chainNonce
+        , put . CI.chainMetadata
         ]
     get = do
-        chainLabel      <- get
-        accountInfo        <- get
-        codeInfo        <- get
-        members         <- get
-        return $ CI.ChainInfo chainLabel accountInfo codeInfo members
+        chainLabel    <- get
+        accountInfo   <- get
+        codeInfo      <- get
+        members       <- get
+        parentChain   <- get
+        creationBlock <- get
+        chainNonce    <- get
+        chainMetadata <- get
+        chainR        <- get
+        chainS        <- get
+        chainV        <- get
+        return $ CI.ChainInfo chainLabel
+                              accountInfo
+                              codeInfo
+                              members
+                              parentChain
+                              creationBlock
+                              chainNonce
+                              chainMetadata
+                              chainR
+                              chainS
+                              chainV
 
 instance Binary CI.CodeInfo where
   put (CI.CodeInfo bs s1 s2) = put bs >> put s1 >> put s2

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/BinaryInstances.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/BinaryInstances.hs
@@ -13,40 +13,41 @@ import           Blockchain.SHA              ()
 
 import           Data.ByteString             ()
 
+instance Binary CI.ChainSignature where
+    put gi = sequence_ . map ($ gi) $
+        [ put . CI.chainR
+        , put . CI.chainS
+        , put . CI.chainV
+        ]
+    get = CI.ChainSignature
+          <$> get
+          <*> get
+          <*> get
+
 instance Binary CI.ChainInfo where
     put gi = sequence_ $ map ($ gi) $
-        [ put . CI.chainLabel
-        , put . CI.accountInfo
-        , put . CI.codeInfo
-        , put . CI.members
-        , put . CI.parentChain
-        , put . CI.creationBlock
-        , put . CI.chainNonce
-        , put . CI.chainMetadata
+        [ put . CI.chainLabel     . CI.chainInfo
+        , put . CI.accountInfo    . CI.chainInfo
+        , put . CI.codeInfo       . CI.chainInfo
+        , put . CI.members        . CI.chainInfo
+        , put . CI.parentChain    . CI.chainInfo
+        , put . CI.creationBlock  . CI.chainInfo
+        , put . CI.chainNonce     . CI.chainInfo
+        , put . CI.chainMetadata  . CI.chainInfo
+        , put . CI.chainSignature
         ]
-    get = do
-        chainLabel    <- get
-        accountInfo   <- get
-        codeInfo      <- get
-        members       <- get
-        parentChain   <- get
-        creationBlock <- get
-        chainNonce    <- get
-        chainMetadata <- get
-        chainR        <- get
-        chainS        <- get
-        chainV        <- get
-        return $ CI.ChainInfo chainLabel
-                              accountInfo
-                              codeInfo
-                              members
-                              parentChain
-                              creationBlock
-                              chainNonce
-                              chainMetadata
-                              chainR
-                              chainS
-                              chainV
+    get = CI.ChainInfo
+          <$> (CI.UnsignedChainInfo
+              <$> get
+              <*> get
+              <*> get
+              <*> get
+              <*> get
+              <*> get
+              <*> get
+              <*> get
+              )
+          <*> get
 
 instance Binary CI.CodeInfo where
   put (CI.CodeInfo bs s1 s2) = put bs >> put s1 >> put s2

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/BinaryInstances.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/BinaryInstances.hs
@@ -14,44 +14,9 @@ import           Blockchain.SHA              ()
 import           Data.ByteString             ()
 
 instance Binary CI.ChainSignature where
-    put gi = sequence_ . map ($ gi) $
-        [ put . CI.chainR
-        , put . CI.chainS
-        , put . CI.chainV
-        ]
-    get = CI.ChainSignature
-          <$> get
-          <*> get
-          <*> get
-
+instance Binary CI.UnsignedChainInfo where
 instance Binary CI.ChainInfo where
-    put gi = sequence_ $ map ($ gi) $
-        [ put . CI.chainLabel     . CI.chainInfo
-        , put . CI.accountInfo    . CI.chainInfo
-        , put . CI.codeInfo       . CI.chainInfo
-        , put . CI.members        . CI.chainInfo
-        , put . CI.parentChain    . CI.chainInfo
-        , put . CI.creationBlock  . CI.chainInfo
-        , put . CI.chainNonce     . CI.chainInfo
-        , put . CI.chainMetadata  . CI.chainInfo
-        , put . CI.chainSignature
-        ]
-    get = CI.ChainInfo
-          <$> (CI.UnsignedChainInfo
-              <$> get
-              <*> get
-              <*> get
-              <*> get
-              <*> get
-              <*> get
-              <*> get
-              <*> get
-              )
-          <*> get
-
 instance Binary CI.CodeInfo where
-  put (CI.CodeInfo bs s1 s2) = put bs >> put s1 >> put s2
-  get = CI.CodeInfo <$> get <*> get <*> get
 
 instance Binary CI.AccountInfo where
   put (CI.NonContract a n) = putWord8 0 >> put a >> put n

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Event.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Event.hs
@@ -82,7 +82,7 @@ data IngestBlock = IngestBlock { ibOrigin              :: TO.TXOrigin
 
 data IngestGenesis = IngestGenesis { igOrigin          :: TO.TXOrigin
                                    , igGenesisInfo     :: (Word256, ChainInfo)
-                                   } deriving (Eq, Read, Show, GHCG.Generic)
+                                   } deriving (Eq, Show, GHCG.Generic)
 
 data SequencedBlock = SequencedBlock { sbOrigin              :: TO.TXOrigin
                                      , sbHash                :: SHA
@@ -136,7 +136,7 @@ data OutputBlock = OutputBlock { obOrigin              :: TO.TXOrigin
 
 data OutputGenesis = OutputGenesis { ogOrigin          :: TO.TXOrigin
                                    , ogGenesisInfo     :: (Word256, ChainInfo)
-                                   } deriving (Eq, Read, Show, GHCG.Generic)
+                                   } deriving (Eq, Show, GHCG.Generic)
 
 ingestGenesisToOutputGenesis :: IngestGenesis -> OutputGenesis
 ingestGenesisToOutputGenesis (IngestGenesis o g) = OutputGenesis o g

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -404,7 +404,9 @@ spec = do
 
       it "should create a PrivateHashTX for a private transaction" . runTestM $ do
         let chainId = 0x12345678
-            cInfo = ChainInfo "my test chain" [] [] M.empty
+            cInfo = ChainInfo
+                      (UnsignedChainInfo "my test chain" [] [] M.empty Nothing (SHA 0) 0 M.empty)
+                      Nothing
             chainDetails = IEGenesis (IngestGenesis TO.Morphism (chainId, cInfo))
         ptx <- liftIO . HK.withSource HK.devURandom $ do
           pk <- HK.genPrvKey
@@ -422,7 +424,9 @@ spec = do
 
       it "should run Blockstanbul with private transactions" . runPBFTTestMWithGenesis $ \h -> do
         let chainId = 0x12345678
-            cInfo = ChainInfo "my test chain" [] [] M.empty
+            cInfo = ChainInfo
+                      (UnsignedChainInfo "my test chain" [] [] M.empty Nothing (SHA 0) 0 M.empty)
+                      Nothing
             chainDetails = IEGenesis (IngestGenesis TO.Morphism (chainId, cInfo))
             chainHash = unSHA . superProprietaryStratoSHAHash . rlpSerialize $ rlpEncode cInfo
         tx <- liftIO . HK.withSource HK.devURandom $ do
@@ -451,7 +455,9 @@ spec = do
 
       it "should run Blockstanbul with delayed private transactions" . runPBFTTestMWithGenesis $ \h -> do
         let chainId = 0x12345678
-            cInfo = ChainInfo "my test chain" [] [] M.empty
+            cInfo = ChainInfo
+                      (UnsignedChainInfo "my test chain" [] [] M.empty Nothing (SHA 0) 0 M.empty)
+                      Nothing
             chainDetails = IEGenesis (IngestGenesis TO.Morphism (chainId, cInfo))
             chainHash = unSHA . superProprietaryStratoSHAHash . rlpSerialize $ rlpEncode cInfo
         tx <- liftIO . HK.withSource HK.devURandom $ do
@@ -487,7 +493,9 @@ spec = do
 
         -- chain 1
         let chainId1 = 0x12345678
-            cInfo1 = ChainInfo "my test chain 1" [] [] M.empty
+            cInfo1 = ChainInfo
+                      (UnsignedChainInfo "my test chain" [] [] M.empty Nothing (SHA 0) 0 M.empty)
+                      Nothing
             chainDetails1 = IEGenesis (IngestGenesis TO.Morphism (chainId1, cInfo1))
             chainHash1 = unSHA . superProprietaryStratoSHAHash . rlpSerialize $ rlpEncode cInfo1
         tx1 <- liftIO . HK.withSource HK.devURandom $ do
@@ -497,7 +505,9 @@ spec = do
 
         -- chain 2
         let chainId2 = 0x9abcdef0
-            cInfo2 = ChainInfo "my test chain 2" [] [] M.empty
+            cInfo2 = ChainInfo
+                      (UnsignedChainInfo "my test chain" [] [] M.empty Nothing (SHA 0) 0 M.empty)
+                      Nothing
             chainDetails2 = IEGenesis (IngestGenesis TO.Morphism (chainId2, cInfo2))
             chainHash2 = unSHA . superProprietaryStratoSHAHash . rlpSerialize $ rlpEncode cInfo2
         tx2 <- liftIO . HK.withSource HK.devURandom $ do

--- a/tests/e2e/createChain.test.js
+++ b/tests/e2e/createChain.test.js
@@ -31,6 +31,37 @@ const balances = [
 
 describe("Create Chain", function() {
 
+  it('should create 100 new chains', function* () {
+    this.timeout(config.timeout);
+    const uid = util.uid();
+    const alicename = 'Alice' + uid;
+    const bobname = 'Bob' + uid;
+    // create user
+    const isAsync = true;
+    const alice = yield rest.createUser(alicename, password, isAsync);
+    const bob   = yield rest.createUser(bobname, password, isAsync);
+    assert.isDefined(alice, "should exist");
+    assert.isDefined(alice.address, "should be defined");
+    assert.notEqual(alice.address, 0, "should be a nonzero address");
+    assert.isDefined(bob, "should exist");
+    assert.isDefined(bob.address, "should be defined");
+    assert.notEqual(bob.address, 0, "should be a nonzero address");
+
+    const bals = [{ address: alice.address, balance: 1000000000000000000000}
+                 ,{ address: bob.address, balance: 0}
+                 ];
+    const mems = [{address: alice.address, enode: members[0].enode}
+                 ,{address: bob.address, enode: members[1].enode}
+		 ];
+    for(var i = 0; i < 100; i++) {
+    const chainId = yield rest.createChain(label, mems, bals, src, args);
+    console.log('###CHAINID###',chainId);
+    assert.isDefined(chainId, "should exist");
+    assert.notEqual(chainId, '', "should be a nonzero address");
+    }
+
+  });
+
   it('should create a new chain and query the chain details', function* () {
     this.timeout(config.timeout);
     const uid = util.uid();


### PR DESCRIPTION
Changes to the `ChainInfo` type:
1. Added `creationBlock` field, which corresponds to some block hash in the recent history of the canonical chain, after which the chain was created. In the future, peers will verify that the chain's `creationBlock` field is within a certain number of ancestors of the chain head before electing to transact upon the chain. This will also allows us to implement "branch chains", which branch for the parent chain's state at `creationBlock`, rather than define their own genesis state. For now, we just use `SHA 0`.
2. Added `chainNonce` field, which is a random number generated by the chain's creator to prevent identical chain ID, given that the rest of the chain information between two chains is identical.
3. Added `parentChain` field, which will be used to create a hierarchy of chains in the future, similar to Plasma. For now, this field is always `Nothing`, corresponding to the main chain.
4. Added `chainMetadata` field, which isn't used for anything at the moment, but allows for additional capabilities to be built in without chainging the datatype in the future.
5. Added `chainSignature` field, which can be used by the chain creator to sign the chain info, enabling verification of chain authenticity (desired by WIngs). This field is optional to remain backwards compatible with blockapps-rest and the API. I'll be adding routes to Bloc to allow for chain signing for Bloc users and OAuth users.
6. The `ChainId` is now the hash of the entire `ChainInfo` record, and the initial chain hash (used to be the hash of the `ChainInfo`) will be the hash of the `ChainId`, so that the `ChainId` does not appear on the main chain.