### PR TITLE
Chain history

### DIFF
--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Chain.hs
@@ -44,6 +44,7 @@ data ChainInput  = ChainInput
   , chaininputBalances :: NamedMap "address" Address "balance" Integer
   , chaininputArgs     :: Map Text ArgValue
   , chaininputMembers  :: NamedMap "address" Address "enode" Text
+  , chaininputMetadata :: Maybe (Map Text Text)
   } deriving (Eq, Show, Generic)
 
 instance ToSchema (NamedTuple "address" Address "balance" Integer) where
@@ -91,6 +92,7 @@ exChainInput = ChainInput
          (Address 0x5815b9975001135697b5739956b9a6c87f1c575c, exampleEnode1)
        , (Address 0x93fdd1d21502c4f87295771253f5b71d897d911c, exampleEnode2)
        ]
+    , chaininputMetadata = Just $ Map.fromList [("history","Governance")]
     }
 
 instance ToSample ChainInput where

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -13,7 +13,7 @@ module BlockApps.Bloc22.Server.Chain where
 import           Control.Monad.Except
 import           Crypto.Random.Entropy
 import qualified Data.Map.Strict                   as Map
-import           Data.Maybe                        (isJust)
+import           Data.Maybe                        (fromMaybe, isJust)
 import qualified Data.Text                         as Text
 import           Opaleye                           hiding (not, null, index, sum)
 
@@ -35,7 +35,7 @@ governanceAddress :: Address
 governanceAddress = Address 0x100
 
 postChainInfo :: ChainInput -> Bloc ChainId
-postChainInfo (ChainInput src cname lbl balances chaininputArgs members) = do
+postChainInfo (ChainInput src cname lbl balances chaininputArgs members mmd) = do
   when (null members) $ throwError $ UserError "Private chains must include at least one member"
   when (sum (nmap2' balances) == 0) $ throwError $ UserError "At least one account must have a non-zero balance"
   idsAndDetails <- if (Text.null src)
@@ -68,7 +68,7 @@ postChainInfo (ChainInput src cname lbl balances chaininputArgs members) = do
                            Nothing
                            creationBlockHash
                            nonce
-                           Map.empty
+                           (fromMaybe Map.empty mmd)
         )
         Nothing
   chainId <- blocStrato $ Strato.postChain chainInfo

--- a/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
+++ b/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
@@ -220,7 +220,7 @@ initializeChainDBs chainId (ChainInfo UnsignedChainInfo{..} _) sRoot = do
         let cHash = hash $ codeInfoCode ci
             md    = Map.fromList [("src",codeInfoSource ci),("name",codeInfoName ci)]
          in (cHash, md)
-      getMetadata = fmap (Map.union chainMetadata) . flip Map.lookup metadatas
+      getMetadata = fmap (`Map.union` chainMetadata) . flip Map.lookup metadatas
       toAction a d = A.Action
         { A._actionBlockHash = creationBlock
         , A._actionBlockTimestamp = posixSecondsToUTCTime 0

--- a/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
+++ b/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
@@ -220,9 +220,9 @@ initializeChainDBs chainId (ChainInfo UnsignedChainInfo{..} _) sRoot = do
         let cHash = hash $ codeInfoCode ci
             md    = Map.fromList [("src",codeInfoSource ci),("name",codeInfoName ci)]
          in (cHash, md)
-      getMetadata = flip Map.lookup metadatas
+      getMetadata = fmap (Map.union chainMetadata) . flip Map.lookup metadatas
       toAction a d = A.Action
-        { A._actionBlockHash = SHA 0
+        { A._actionBlockHash = creationBlock
         , A._actionBlockTimestamp = posixSecondsToUTCTime 0
         , A._actionBlockNumber = 0
         , A._actionTransactionHash = SHA chainId


### PR DESCRIPTION
Allow history of the governance contract to be turned on by including metadata in the POST /chain route