### PR TITLE
Upgrade solc to 0.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ docker-compose:
 build_buildbase:
 	mkdir -p $(TMPDIR)
 	blockapps-haskell/pull_solc.sh 0.4.25 $(TMPDIR)/solc-0.4 $(TMPDIR)/license
-	blockapps-haskell/pull_solc.sh 0.5.1 $(TMPDIR)/solc-0.5 $(TMPDIR)/license
+	blockapps-haskell/pull_solc.sh 0.5.2 $(TMPDIR)/solc-0.5 $(TMPDIR)/license
 	ln -f $(TMPDIR)/solc-0.4 $(TMPDIR)/solc
 	cp -f Dockerfile.buildbase $(TMPDIR)
 	docker build --build-arg STACK_RESOLVER=${STACK_RESOLVER} --tag=strato-buildbase:${STACK_RESOLVER} -f ${TMPDIR}/Dockerfile.buildbase ${TMPDIR}

--- a/blockapps-haskell/Makefile
+++ b/blockapps-haskell/Makefile
@@ -23,7 +23,7 @@ $(FAKEROOT)/usr/bin/solc-0.4: prebuild
 	./pull_solc.sh 0.4.25 $@ $(LICENSE_SOURCE_DIR)/solidity-0.4
 
 $(FAKEROOT)/usr/bin/solc-0.5: prebuild
-	./pull_solc.sh 0.5.1 $@ $(LICENSE_SOURCE_DIR)/solidity-0.5
+	./pull_solc.sh 0.5.2 $@ $(LICENSE_SOURCE_DIR)/solidity-0.5
 
 $(FAKEROOT)/usr/bin/solc: $(FAKEROOT)/usr/bin/solc-0.4 $(FAKEROOT)/usr/bin/solc-0.5
 	ln -f $< $@


### PR DESCRIPTION
Of special interest to me in the release notes: `These include faster compilation time but also cheaper contracts in some situations. `

https://github.com/ethereum/solidity/releases/tag/v0.5.2
https://jenkins.blockapps.net/job/STRATO_test/1078/