### PR TITLE
Byte32 conversion

### DIFF
--- a/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
@@ -64,7 +64,7 @@ valueToSolidityValue (ValueContract (Address addr)) =
   SolidityValueAsString $ Text.pack $ printf "%040x" (fromIntegral addr::Integer)
 valueToSolidityValue (ValueArrayFixed _ values) = SolidityArray $ map valueToSolidityValue values
 valueToSolidityValue (ValueArrayDynamic values) = SolidityArray $ map valueToSolidityValue values
-valueToSolidityValue (SimpleValue (ValueBytes _ bytes)) = SolidityValueAsString $ Text.pack $ BC.unpack bytes
+valueToSolidityValue (SimpleValue (ValueBytes _ bytes)) = SolidityValueAsString $ Text.pack $ BC.unpack $ B16.encode bytes
 valueToSolidityValue (ValueEnum _ _ index)              = SolidityValueAsString $ Text.pack $ show index -- SolidityValueAsString $ name `Text.append` "." `Text.append` value
 valueToSolidityValue (ValueStruct namedItems) =
   SolidityObject $ map (fmap valueToSolidityValue) namedItems

--- a/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
@@ -572,7 +572,7 @@ encodeByteString offset byte size bs =
    in [(offset, byteStringToWord256 bss)]
 
 decodeByteString::Storage->Word256->Int->Int->Value
-decodeByteString storage offset byte size = SimpleValue $ ValueBytes Nothing $ B16.encode $ ByteString.take size $ ByteString.drop (32 - byte - size) $ word256ToByteString $ storage offset
+decodeByteString storage offset byte size = SimpleValue $ ValueBytes Nothing $ ByteString.take size $ ByteString.drop (32 - byte - size) $ word256ToByteString $ storage offset
 
 decodeCacheByteString :: Cache -> Word256 -> Int -> Int -> Value -> Value
 decodeCacheByteString storage offset byte size value = fromMaybe value $ SimpleValue . ValueBytes Nothing . B16.encode . ByteString.take size . ByteString.drop (32 - byte - size) . word256ToByteString <$> storage offset


### PR DESCRIPTION
This branch fixes the encoding bug so that it can return the correct form of bytes32 value from solidity contracts