### PR TITLE
Discover in PBFT until network is fully connected

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -181,7 +181,15 @@ function doInit {
     tail -f /dev/null
   fi
 
-  sed -i 's/minAvailablePeers:.*/minAvailablePeers: '"$numMinPeers"'/' .ethereumH/ethconf.yaml
+
+  if [[ -n "${validators}" ]]; then
+    # Keep active discovery until all other validators are peers
+    echo "Overriding minAvailablePeers with number of consensus peers"
+    actualMinPeers=$( echo "${validators}" | tr -cd , | wc -c )
+  else
+    actualMinPeers=$numMinPeers
+  fi
+  sed -i 's/minAvailablePeers:.*/minAvailablePeers: '"$actualMinPeers"'/' .ethereumH/ethconf.yaml
 
   echo "Creating a random coinbase"
   mkCoinbase


### PR DESCRIPTION
Once number of peers >= numMinPeers, discovery stops. Currently SGS defaults numMinPeers to 0, which means that bootnodes aren't sharing neighbors with their clients. Previously the default was 5 peers, but that did not work consistently as it relied on the fragile premises that either most peers connect to the boot node simultaneously, or that when this peer is connected a majority are already known to the boot node.