### PR TITLE
Encode all 32 bytes of Word256 in strato

### DIFF
--- a/core-strato/strato-model/src/Blockchain/Strato/Model/ExtendedWord.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/ExtendedWord.hs
@@ -83,8 +83,11 @@ instance RLPSerializable Word512 where
     rlpDecode x             = error ("Missing case in rlp2Word512: " ++ show x)
 
 instance RLPSerializable Word256 where
-    rlpEncode = rlpEncode . toInteger
-    rlpDecode = fromInteger . rlpDecode
+    rlpEncode val = RLPString $ BL.toStrict $ encode val
+
+    rlpDecode (RLPString s) | B.null s = 0
+    rlpDecode (RLPString s) | B.length s <= 32 = decode $ BL.fromStrict s
+    rlpDecode x             = error ("Missing case in rlp2Word256: " ++ show x)
 
 instance RLPSerializable Word128 where
     rlpEncode val = RLPString $ BL.toStrict $ encode val


### PR DESCRIPTION
Chain IDs with a most-significant byte of 0x00 were getting serialized incorrectly, causing Strato to derive the wrong address during ecrecovery. This is why there were random, infrequent transaction failures due to insufficient balance on private chains