### PR TITLE
Use standard Word256 RLP encoding for ChainId

### DIFF
--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -315,7 +315,7 @@ instance ToCapture (Capture "chainid" ChainId) where
   toCapture _ = DocCapture "chainid" "a private chain Id"
 
 instance RLPEncodable ChainId where
-  rlpEncode chainId = rlpEncode . fst . Base16.decode . Char8.pack $ chainIdString chainId
+  rlpEncode (ChainId n) = rlpEncode $ toInteger n
   rlpDecode obj = ChainId . fromInteger <$> rlpDecode obj
 
 instance ToParam (QueryParam "chainid" ChainId) where


### PR DESCRIPTION
Instead of changing the RLP instance for all Word256s, I'm instead just changing `ChainId`'s instance to use the same instance as `Word256`. This is the same encoding that `Wei` and `Nonce` use, which are also newtypes over `Word256`.

This PR replaces https://github.com/blockapps/strato-platform/pull/601