### PR TITLE
Filter out governance address in NonContract list

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -14,7 +14,7 @@ import           Control.Monad.Except
 import           Crypto.Random.Entropy
 import qualified Data.Map.Ordered                  as OMap
 import qualified Data.Map.Strict                   as Map
-import           Data.Maybe                        (fromMaybe, isJust)
+import           Data.Maybe                        (catMaybes, fromMaybe, isJust)
 import           Data.Text                         (Text)
 import qualified Data.Text                         as Text
 import           Opaleye                           hiding (not, null, index, sum)
@@ -88,7 +88,9 @@ postChainInfo (ChainInput src cname lbl balances chaininputArgs members mmd) = d
               codeInfo' = CodeInfo contractdetailsBinRuntime src contractdetailsName
           return ([contractAcctInfo],[codeInfo']) -- Perhaps in the future, we can support multiple contracts
   nonce <- byteStringToWord256 <$> liftIO (getEntropy 32)
-  let nonContractAcctInfo = nmap NonContract balances
+  let maybeNonContract a b | a == governanceAddress = Nothing
+                           | otherwise = Just $ NonContract a b
+      nonContractAcctInfo = catMaybes $ nmap maybeNonContract balances
       acctInfo = cAcctInfo ++ nonContractAcctInfo
       chainInfo = ChainInfo
         (UnsignedChainInfo lbl


### PR DESCRIPTION
Without this change, supplying a balance to the governance contract results in two entries in the AccountInfo list for the governance contract: one as a `ContractWithStorage`, and one as a `NonContract`, thus resulting in strange behavior when calling the governance contract afterwards.