### PR TITLE
Remove Xabi tables and consolidate Opaleye queries

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Create.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Create.hs
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS contracts_metadata(
   code_hash bytea NOT NULL,
   xcode_hash bytea NOT NULL,
   src_hash bytea NOT NULL,
+  xabi bytea NOT NULL,
   FOREIGN KEY (contract_id) REFERENCES contracts(id)
 );
 |]

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Create.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Create.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes       #-}
-
+{-# LANGUAGE QuasiQuotes       #-} 
 module BlockApps.Bloc22.Database.Create where
 
 import           Database.PostgreSQL.Simple
@@ -94,17 +93,6 @@ CREATE TABLE IF NOT EXISTS contracts_instance(
   timestamp timestamptz NOT NULL DEFAULT now(),
   chainid bytea NOT NULL,
   FOREIGN KEY (contract_metadata_id) REFERENCES contracts_metadata(id)
-);
-|]
-
-contractsLookupTable :: Query
-contractsLookupTable = [sql|
-CREATE TABLE IF NOT EXISTS contracts_lookup(
-  contract_metadata_id int NOT NULL REFERENCES contracts_metadata(id),
-  linked_metadata_id int NOT NULL REFERENCES contracts_metadata(id),
-  PRIMARY KEY (contract_metadata_id, linked_metadata_id),
-  FOREIGN KEY (contract_metadata_id) REFERENCES contracts_metadata(id),
-  FOREIGN KEY (linked_metadata_id) REFERENCES contracts_metadata(id)
 );
 |]
 
@@ -228,7 +216,6 @@ createTables = mconcat
   , contractsMetaDataTable
   , hashNameTable
   , contractsInstanceTable
-  , contractsLookupTable
   , xabiFunctionsTable
   , xabiTypesTable
   , xabiFunctionArgumentsTable

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Create.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Create.hs
@@ -69,7 +69,8 @@ CREATE TABLE IF NOT EXISTS contracts_metadata(
   xcode_hash bytea NOT NULL,
   src_hash bytea NOT NULL,
   xabi bytea NOT NULL,
-  FOREIGN KEY (contract_id) REFERENCES contracts(id)
+  FOREIGN KEY (contract_id) REFERENCES contracts(id),
+  CONSTRAINT uc_contracts_metadata UNIQUE (code_hash, src_hash)
 );
 |]
 

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Migration.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Migration.hs
@@ -40,6 +40,7 @@ migrations = [ (Throw, createTables)
              , (Throw, contractsSourceTable)
              , (Throw, addSrcHashColumn)
              , (Throw, alterValueColumn)
+             , (Throw, addXabiColumn)
              ]
 
 getSchemaVersion :: Query
@@ -72,3 +73,6 @@ addSrcHashColumn = [sql| ALTER TABLE contracts_metadata ADD COLUMN IF NOT EXISTS
 
 alterValueColumn :: Query
 alterValueColumn = [sql| ALTER TABLE xabi_variables ALTER COLUMN value TYPE text; |]
+
+addXabiColumn :: Query
+addXabiColumn = [sql| ALTER TABLE contracts_metadata ADD COLUMN IF NOT EXISTS xabi bytea; |]

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -11,7 +11,6 @@
 
 module BlockApps.Bloc22.Database.Queries where
 
-
 import           ClassyPrelude                   ((<>))
 import           Control.Arrow
 import           Control.Concurrent              (threadDelay)
@@ -40,8 +39,6 @@ import           Data.Traversable
 import           Database.PostgreSQL.Simple      (Connection)
 import           GHC.Stack
 import           Opaleye                         hiding (not, null, index)
-import qualified Opaleye                         (not)
-
 
 import           BlockApps.Bloc22.API.Utils
 import           BlockApps.Bloc22.Crypto
@@ -54,8 +51,6 @@ import           BlockApps.SolidityVarReader     (byteStringToWord256, word256To
 import           BlockApps.Solidity.Contract
 import           BlockApps.Solidity.Parse.Parser
 import           BlockApps.Solidity.Xabi
-import qualified BlockApps.Solidity.Xabi.Def     as Xabi.Def
-import qualified BlockApps.Solidity.Xabi.Type    as Xabi
 import           BlockApps.Strato.Types
 import           BlockApps.XAbiConverter
 
@@ -733,148 +728,6 @@ getContractsContractLatestQuery contractName = limit 1 $ proc () -> do
       contractDetailsJoinTable -< ()
   restrict -< name .== constant contractName
   returnA -< (b,br,ch,xch,name,src,cmId,xabi)
-{- |
-SELECT
-  XF.id
- ,XF.name
- ,XF.selector
-FROM xabi_functions XF
-WHERE XF.is_constructor = false AND XF.contract_metadata_id = $1;
--}
-getXabiFunctionsQuery :: HasCallStack =>
-                         Int32 -> Bloc (Map Text Func)
-getXabiFunctionsQuery cmId = do
-  funcsWithIds <- fmap Map.fromList . blocQuery $ proc () -> do
-    (xfId,contractmetadataId,isConstr,name,mut) <-
-      queryTable xabiFunctionsTable -< ()
-    restrict -< contractmetadataId .== constant cmId .&& Opaleye.not isConstr
-    returnA -< (name,(xfId, mut))
-  for funcsWithIds $ \ (xfId, mut) -> do --TODO remove the selector from the DB
-    args <- getXabiFunctionsArgsQuery xfId
-    let
-      valMap valList = Map.fromList
-        [ ( "#" <> Text.pack (show (Xabi.indexedTypeIndex val)), val)
-        | val <- valList
-        ]
-    vals <- valMap <$> getXabiFunctionsReturnValuesQuery xfId
-    return  Func { funcArgs = args
-                 , funcVals = vals
-                 , funcContents = Nothing
-                 , funcStateMutability = mut
-                 , funcVisibility = Nothing
-                 , funcModifiers = Nothing
-                 }
-
-{- |
-SELECT
-  XF.id
- ,XF.name
- ,XF.selector
-FROM xabi_functions XF
-WHERE XF.is_constructor = false AND XF.contract_metadata_id = $1;
--}
-getXabiConstrQuery :: HasCallStack =>
-                         Int32 -> Bloc (Maybe Func)
-getXabiConstrQuery cmId = do
-  funcsWithIds <- blocQueryMaybe $ proc () -> do
-    (xfId,contractmetadataId,isConstr,name, _) <-
-      queryTable xabiFunctionsTable -< ()
-    restrict -< contractmetadataId .== constant cmId .&& isConstr
-    returnA -< (name,xfId)
-  for funcsWithIds $ \(_ :: Text, xfId) -> do
-    args <- getXabiFunctionsArgsQuery xfId
-    let
-      valMap valList = Map.fromList
-        [ ( "#" <> Text.pack (show (Xabi.indexedTypeIndex val)), val)
-        | val <- valList
-        ]
-    vals <- valMap <$> getXabiFunctionsReturnValuesQuery xfId
-    return $ Func { funcArgs = args
-                  , funcVals = vals
-                  , funcStateMutability = Nothing
-                  , funcContents = Nothing
-                  , funcVisibility = Nothing
-                  , funcModifiers = Nothing
-                  }
-
-{- |
-SELECT
-  ,XFA.name
-  ,XFA.index
-  ,XT.type
-  ,XT.typedef
-  ,XT.is_dynamic
-  ,XT.bytes
-  ,XTE.type as entry_type
-  ,XTE.bytes as entry_bytes
-FROM xabi_function_arguments XFA
-JOIN xabi_types XT
-  ON XT.id = XFA.type_id
-LEFT OUTER JOIN xabi_types XTE
-  ON XTE.id = XT.entry_type_id
-WHERE XFA.function_id = $1;
--}
-getXabiFunctionsArgsQuery
-  :: Int32
-  -> Bloc (Map Text Xabi.IndexedType)
-getXabiFunctionsArgsQuery funcId = do
-  argsWithIds <- fmap Map.fromList . blocQuery $ proc () -> do
-    (_,functionId,tyid,name,index) <-
-      queryTable xabiFunctionArgumentsTable -< ()
-    restrict -< functionId .== constant funcId
-    returnA -< (name,(index,tyid))
-  for argsWithIds $ \ (index,tyid) -> do
-    ty <- getXabiType tyid
-    return $ Xabi.IndexedType index ty
-
-{- |
-SELECT
-  (CASE WHEN XFR.name IS NULL THEN '#' + CAST(XFR.index AS VARCHAR(20)) ELSE XFR.name END) as name
-  ,XFR.index
-  ,XT.type
-  ,XT.typedef
-  ,XT.is_dynamic
-  ,XT.bytes
-  ,XTE.type as entry_type
-  ,XTE.bytes as entry_bytes
-FROM xabi_function_return XFR
-JOIN xabi_types XT
-  ON XT.id = XFR.type_id
-LEFT OUTER JOIN xabi_types XTE
-  ON XTE.id = XT.entry_type_id
-WHERE XFR.function_id = $1;"
--}
-getXabiFunctionsReturnValuesQuery :: HasCallStack =>
-                                     Int32 -> Bloc [Xabi.IndexedType]
-getXabiFunctionsReturnValuesQuery funcId = do
-  valsWithIds <- blocQuery $ proc () -> do
-    (_,functionId,index,tyid) <-
-      queryTable xabiFunctionReturnsTable -< ()
-    restrict -< functionId .== constant funcId
-    returnA -< (index,tyid)
-  for valsWithIds $ \ (index,tyid) -> do
-    ty <- getXabiType tyid
-    return $ Xabi.IndexedType index ty
-
-{- |
-SELECT
-   XV.name
-  ,XV.at_bytes
-  ,XV.type_id
-FROM
-  xabi_variables XV
-WHERE XV.contract_metadata_id = $1;
--}
-getXabiVariablesQuery :: Int32 -> Bloc (Map Text Xabi.VarType)
-getXabiVariablesQuery cmId = do
-  varsWithIds <- fmap Map.fromList . blocQuery $ proc () -> do
-    (_,cmid,typeid,name,atbytes,ispublic,isconstant,value)
-      <- queryTable xabiVariablesTable -< ()
-    restrict -< cmid .== constant cmId
-    returnA -< (name,(atbytes,ispublic,isconstant,value,typeid))
-  for varsWithIds $ \ (atbytes,ispublic,isconstant, value,typeid) -> do
-    ty <- getXabiType typeid
-    return $ Xabi.VarType atbytes (Just ispublic) (Just isconstant) value ty
 
 serializeXabi :: Xabi -> ByteString
 serializeXabi = toStrict . encode
@@ -1167,87 +1020,6 @@ compileContractFromScratch source = do
     return (metadataId,detail)
 
   return metadataIds
-
-getXabiType :: HasCallStack =>
-               Int32 -> Bloc Xabi.Type
-getXabiType typeId = do
-  (xtty,xttd,xtdy,xtsi,xtby,xtlen,xtetid,xtvtid,xtktid)
-    <- blocQuery1 "getXabiType" $ proc () -> do
-      (xtid,xtty,xttd,xtdy,xtsi,xtby,xtlen,xtet,xtvt,xtkt)
-        <- queryTable xabiTypesTable -< ()
-      restrict -< xtid .== constant typeId
-      returnA -< (xtty,xttd,xtdy,xtsi,xtby,xtlen,xtet,xtvt,xtkt)
-  case xtty::Text of
-    "Int" ->
-      return $ Xabi.Int (Just xtsi) xtby
-    "String" ->
-      return $ Xabi.String (Just xtdy)
-    "Bytes" ->
-      return $ Xabi.Bytes (Just xtdy) xtby
-    "Bool" ->
-      return Xabi.Bool
-    "Address" ->
-      return Xabi.Address
-    "Struct" -> do
-      xttd' <- blocMaybe "Missing typedef in type Struct" xttd
-      return $ Xabi.Struct xtby xttd'
-    "Enum" -> do
-      xttd' <- blocMaybe "Missing typedef in type Enum" xttd
-      return $ Xabi.Enum xtby xttd' Nothing
-    "Array" -> do
-      xtetid' <- blocMaybe "Missing entry type id in type Array" xtetid
-      xtet <- getXabiType xtetid'
-      return $ Xabi.Array xtet (fmap fromIntegral (xtlen :: Maybe Int32))
-    "Contract" -> do
-      xttd' <- blocMaybe "Missing typedef in type Struct" xttd
-      return $ Xabi.Contract xttd'
-    "Mapping" -> do
-      xtktid' <- blocMaybe "Missing key type id in type Mapping" xtktid
-      xtvtid' <- blocMaybe "Missing value type id in type Mapping" xtvtid
-      xtkt <- getXabiType xtktid'
-      xtvt <- getXabiType xtvtid'
-      return $ Xabi.Mapping (Just xtdy) xtkt xtvt
-    "Label" -> do
-      xttd' <- blocMaybe "Missing typedef in type Enum" xttd
-      return $ Xabi.Label $ Text.unpack xttd'
-    _ -> throwError $ DBError "Could not match type"
-
-getXabiStructFields :: Int32 -> Bloc [(Text, Xabi.FieldType)]
-getXabiStructFields typeDefId = do
-  fieldsWithIds <- blocQuery $ proc () -> do
-    (_,name,atbytes,tdid,ftid)
-      <- queryTable xabiStructFieldsTable -< ()
-    restrict -< tdid .== constant typeDefId
-    returnA -< (name,(atbytes,ftid))
-  for fieldsWithIds $ \ (name,(atbytes,ftid)) -> do
-    ty <- getXabiType ftid
-    return (name, Xabi.FieldType atbytes ty)
-
-getXabiEnumNames :: Int32 -> Bloc [Text]
-getXabiEnumNames typeDefId = blocQuery $ proc () -> do
-  (_,name,_,tdid) <-
-    orderBy (asc (\ (_,_,value,_) -> value))
-      (queryTable xabiEnumNamesTable) -< ()
-  restrict -< tdid .== constant typeDefId
-  returnA -< name
-
-getXabiTypeDefs :: Int32 -> Bloc (Map Text Xabi.Def.Def)
-getXabiTypeDefs metadataId = do
-  typedefsWithIds <- fmap Map.fromList . blocQuery $ proc () -> do
-    (tdid,name,cmid,ty,by) <- queryTable xabiTypeDefsTable -< ()
-    restrict -< cmid .== constant metadataId
-    returnA -< (name,(tdid,ty,by))
-  for typedefsWithIds $ \ (tdid,ty,by::Int32) -> case ty of
-      "Struct" -> do
-        fields <- getXabiStructFields tdid
-        return $ Xabi.Def.Struct fields (fromIntegral by)
-      "Enum" -> do
-        names <- getXabiEnumNames tdid
-        return $ Xabi.Def.Enum names (fromIntegral by)
-      "Contract" ->
-        return $ Xabi.Def.Contract $ fromIntegral by
-      _ -> throwError $ DBError $
-        "Invalid type def. Expected Struct or Enum, saw " <> ty
 
 getContractXabiByMetadataId :: HasCallStack => Int32 -> Bloc Xabi
 getContractXabiByMetadataId cmId = do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -34,6 +34,7 @@ import           Data.Text                       (Text)
 import qualified Data.Text                       as Text
 import qualified Data.Text.Encoding              as Text
 import           Data.Traversable
+import           Data.Tuple                      (swap)
 import           Database.PostgreSQL.Simple      (Connection)
 import           GHC.Stack
 import           Opaleye                         hiding (not, null, index)
@@ -685,6 +686,18 @@ createContractQuery contractName = do
       [(Nothing, constant contractName)]
       fst
 
+createContractBatchQuery :: [Text] -> Bloc (Map Text Int32)
+createContractBatchQuery names = do
+  cidMap <- fmap Map.fromList . blocQuery $ proc () -> do
+    (cId,name) <- queryTable contractsTable -< ()
+    restrict -< in_ (map constant names) name
+    returnA -< (name, cId)
+  let new = filter (isNothing . flip Map.lookup cidMap) names
+      inserts = map (\n -> (Nothing, constant n)) new
+  newCids <- fmap Map.fromList . blocModify $ \conn ->
+    runInsertManyReturning conn contractsTable inserts swap
+  return $ Map.union newCids cidMap
+
 insertContractSourceQuery
   :: Text
   -> Bloc (Int32, Keccak256)
@@ -724,6 +737,24 @@ insertContractMetaDataQuery
       , constant (serializeXabi xabi)
       )]
       (\ (contractmetadataId,_,_,_,_,_,_,_) -> contractmetadataId)
+
+insertContractMetaDataBatchQuery
+  :: Keccak256
+  -> [(Int32, ContractDetails)]
+  -> Bloc (Map Int32 Int32)
+insertContractMetaDataBatchQuery srcHash details = blocModify $ \ conn ->
+  let inserts = flip map details $ \(contractId, ContractDetails{..}) ->
+        ( Nothing
+        , constant contractId
+        , constant (Text.encodeUtf8 contractdetailsBin)
+        , constant (Text.encodeUtf8 contractdetailsBinRuntime)
+        , constant contractdetailsCodeHash
+        , constant $ keccak256 (Text.encodeUtf8 contractdetailsBin)
+        , constant srcHash
+        , constant (serializeXabi contractdetailsXabi)
+        )
+   in Map.fromList <$> runInsertManyReturning conn contractsMetaDataTable inserts
+        (\(contractmetadataId,cId,_,_,_,_,_,_) -> (cId,contractmetadataId))
 
 instance QueryRunnerColumnDefault PGBytea Address where
   queryRunnerColumnDefault = queryRunnerColumn id
@@ -858,21 +889,11 @@ compileContractFromScratch source = do
         }
 
   (_,srcHash) <- insertContractSourceQuery source
-  metadataIds <- flip Map.traverseWithKey details $ \ contrName (detail@ContractDetails{..}) -> do
-    let
-      xcodeHash = keccak256 (Text.encodeUtf8 contractdetailsBin)
-    contrId <- createContractQuery contrName
-    metadataId <- insertContractMetaDataQuery
-      contrId
-      contractdetailsBin
-      contractdetailsBinRuntime
-      contractdetailsCodeHash
-      xcodeHash
-      srcHash
-      contractdetailsXabi
-    return (metadataId,detail)
-
-  return metadataIds
+  contractIdMap <- createContractBatchQuery $ Map.keys details
+  let idDetails = Map.elems $ Map.intersectionWith (,) contractIdMap details
+  mdIdMap <- insertContractMetaDataBatchQuery srcHash idDetails
+  let cmIdDetails = Map.elems . Map.intersectionWith (,) mdIdMap $ Map.fromList idDetails
+  return . Map.fromList $ map ((contractdetailsName . snd) &&& id) cmIdDetails
 
 getContractXabiByMetadataId :: HasCallStack => Int32 -> Bloc Xabi
 getContractXabiByMetadataId cmId = do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -636,7 +636,12 @@ getContractDetailsAndMetadataId (ContractName contractName) contractId chainId =
       Unnamed addr -> do
         tuple <- fmap listToMaybe . blocQuery $
           getContractsContractByAddressQuery contractName addr chainId
-        for tuple $ detailsWith (Just (Unnamed addr)) chainId
+        case tuple of
+          Just t -> Just <$> detailsWith (Just (Unnamed addr)) chainId t
+          Nothing -> do
+            tuple' <- blocQueryMaybe $
+              getContractsContractLatestQuery contractName
+            for tuple' $ detailsWith (Just (Unnamed addr)) chainId
       Named name -> if contractName == name
         then do
           tuple <- fmap listToMaybe . blocQuery $

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -21,11 +21,12 @@ import           Crypto.Hash
 import qualified Crypto.Saltine.Class            as Saltine
 import qualified Crypto.Saltine.Core.SecretBox   as SecretBox
 import           Crypto.Secp256k1
-import           Data.Aeson                      (Result(..),fromJSON)
+import           Data.Aeson                      (Result(..), fromJSON, decode, encode)
 import qualified Data.ByteArray                  as ByteArray
 import           Data.ByteString                 (ByteString)
 import qualified Data.ByteString                 as BS
 import qualified Data.ByteString.Char8           as Char8
+import           Data.ByteString.Lazy            (fromStrict)
 import           Data.Foldable
 import           Data.Int                        (Int32, Int64)
 import           Data.Map.Strict                 (Map)
@@ -155,15 +156,16 @@ contractsJoinTable :: Query
   , Column PGBytea
   , Column PGBytea
   , Column PGBytea
+  , Column PGBytea
   )
 contractsJoinTable = joinF
-  (\ (_,_,a,ts, cid) (cmId,n,src,b,br,ch,xch) -> (cmId,n,src,a,ts,b,br,ch,xch,cid))
-  (\ (_,contractmetadataId,_,_,_) (cmId,_,_,_,_,_,_) -> cmId .== contractmetadataId)
+  (\ (_,_,a,ts, cid) (cmId,n,src,b,br,ch,xch,xabi) -> (cmId,n,src,a,ts,b,br,ch,xch,cid,xabi))
+  (\ (_,contractmetadataId,_,_,_) (cmId,_,_,_,_,_,_,_) -> cmId .== contractmetadataId)
   (queryTable contractsInstanceTable) $ joinF
-    (\ (_,n) (cmId,_,b,br,ch,xch,src) -> (cmId,n,src,b,br,ch,xch))
-    (\ (cid,_) (_,contractId,_,_,_,_,_) -> cid .== contractId)
+    (\ (_,n) (cmId,_,b,br,ch,xch,src,xabi) -> (cmId,n,src,b,br,ch,xch,xabi))
+    (\ (cid,_) (_,contractId,_,_,_,_,_,_) -> cid .== contractId)
     (queryTable contractsTable) $ joinF
-      (\ (cmId,cid,b,br,ch,xch,_,_) (_,_,src) -> (cmId,cid,b,br,ch,xch,src))
+      (\ (cmId,cid,b,br,ch,xch,_,xabi) (_,_,src) -> (cmId,cid,b,br,ch,xch,src,xabi))
       (\ (_,_,_,_,_,_,sh,_) (_,sh',_) -> sh .== sh')
       (queryTable contractsMetaDataTable)
       (queryTable contractsSourceTable)
@@ -177,12 +179,13 @@ contractDetailsJoinTable :: Query
   , Column PGText
   , Column PGText
   , Column PGInt4
+  , Column PGBytea
   )
 contractDetailsJoinTable = joinF
-  (\ (_,name) (cmId,_,b,br,ch,xch,sh,src) -> (b,br,ch,xch,sh,name,src,cmId))
-  (\ (cId,_) (_,contractId,_,_,_,_,_,_) -> cId .== contractId)
+  (\ (_,name) (cmId,_,b,br,ch,xch,sh,src,xabi) -> (b,br,ch,xch,sh,name,src,cmId,xabi))
+  (\ (cId,_) (_,contractId,_,_,_,_,_,_,_) -> cId .== contractId)
   (queryTable contractsTable) $ joinF
-    (\ (cmId,cid,b,br,ch,xch,sh,_) (_,_,src) -> (cmId,cid,b,br,ch,xch,sh,src))
+    (\ (cmId,cid,b,br,ch,xch,sh,xabi) (_,_,src) -> (cmId,cid,b,br,ch,xch,sh,src,xabi))
     (\ (_,_,_,_,_,_,sh,_) (_,sh',_) -> sh .== sh')
     (queryTable contractsMetaDataTable)
     (queryTable contractsSourceTable)
@@ -202,9 +205,10 @@ contractByAddress
     , Column PGBytea
     , Column PGBytea
     , Column PGBytea
+    , Column PGBytea
     )
 contractByAddress contractName contractAddress chainId = proc () -> do
-  contract@(_,name,_,addr,_,_,_,_,_,cid) <- contractsJoinTable -< ()
+  contract@(_,name,_,addr,_,_,_,_,_,cid,_) <- contractsJoinTable -< ()
   restrict -< name .== constant contractName
   restrict -< addr .== constant contractAddress
   restrict -< cid .== constant chainId
@@ -221,9 +225,10 @@ contractByCodeHash
     , Column PGText
     , Column PGText
     , Column PGInt4
+    , Column PGBytea
     )
 contractByCodeHash codeHash = proc () -> do
-  contract@(_,_,ch,_,_,_,_,_) <- contractDetailsJoinTable -< ()
+  contract@(_,_,ch,_,_,_,_,_,_) <- contractDetailsJoinTable -< ()
   restrict -< ch .== constant codeHash
   returnA -< contract
 
@@ -238,9 +243,10 @@ contractByMetadataId
     , Column PGText
     , Column PGText
     , Column PGInt4
+    , Column PGBytea
     )
 contractByMetadataId metadataId = proc () -> do
-  contract@(_,_,_,_,_,_,_,cmId) <- contractDetailsJoinTable -< ()
+  contract@(_,_,_,_,_,_,_,cmId,_) <- contractDetailsJoinTable -< ()
   restrict -< cmId .== constant metadataId
   returnA -< contract
 
@@ -250,7 +256,7 @@ contractInstancesByCodeHash
   -> Maybe ChainId
   -> Query (Column PGInt4)
 contractInstancesByCodeHash codeHash address chainId = proc () -> do
-  (cmId,_,_,addr,_,_,_,ch,_,cid) <- contractsJoinTable -< ()
+  (cmId,_,_,addr,_,_,_,ch,_,cid,_) <- contractsJoinTable -< ()
   restrict -< ch .== constant codeHash
   restrict -< addr .== constant address
   restrict -< cid .== constant chainId
@@ -267,15 +273,16 @@ contractBySourceHash
     , Column PGText
     , Column PGText
     , Column PGInt4
+    , Column PGBytea
     )
 contractBySourceHash srcHash = proc () -> do
-  contract@(_,_,_,_,sh,_,_,_) <- contractDetailsJoinTable -< ()
+  contract@(_,_,_,_,sh,_,_,_,_) <- contractDetailsJoinTable -< ()
   restrict -< sh .== constant srcHash
   returnA -< contract
 
 contractNameFromAddress :: Address -> Maybe ChainId -> Query (Column PGText)
 contractNameFromAddress contractAddress chainId = proc () -> do
-  (_,name,_,addr,_,_,_,_,_,cid) <- contractsJoinTable -< ()
+  (_,name,_,addr,_,_,_,_,_,cid,_) <- contractsJoinTable -< ()
   restrict -< addr .== constant contractAddress
   restrict -< cid .== constant chainId
   returnA -< name
@@ -295,21 +302,22 @@ linkedContractsJoinTable :: Query
   , Column PGText
   , Column PGText
   , Column PGInt4
+  , Column PGBytea
   )
 linkedContractsJoinTable = joinF
-  (\ (_,name2) (name,src,cm2Id,_,b,br,ch,xch) -> (b,br,ch,xch,name,name2,src,cm2Id))
-  (\ (c2Id,_) (_,_,_,contractId2,_,_,_,_) -> c2Id .== contractId2)
+  (\ (_,name2) (name,src,cm2Id,_,b,br,ch,xch,xabi) -> (b,br,ch,xch,name,name2,src,cm2Id,xabi))
+  (\ (c2Id,_) (_,_,_,contractId2,_,_,_,_,_) -> c2Id .== contractId2)
   (queryTable contractsTable) $ joinF
-    (\ (cm2Id,contractId2,_,_,_,_,_,_) (name,src,_,b,br,ch,xch) -> (name,src,cm2Id,contractId2,b,br,ch,xch))
-    (\ (cm2Id,_,_,_,_,_,_,_) (_,_,linkedmetadataId,_,_,_,_) -> cm2Id .== linkedmetadataId)
+    (\ (cm2Id,contractId2,_,_,_,_,_,_) (name,src,_,b,br,ch,xch,xabi) -> (name,src,cm2Id,contractId2,b,br,ch,xch,xabi))
+    (\ (cm2Id,_,_,_,_,_,_,_) (_,_,linkedmetadataId,_,_,_,_,_) -> cm2Id .== linkedmetadataId)
     (queryTable contractsMetaDataTable) $ joinF
-      (\ (_,linkedmetadataId) (name,src,_,b,br,ch,xch) -> (name,src,linkedmetadataId,b,br,ch,xch))
-      (\ (contractmetadataId,_) (_,_,cmId,_,_,_,_) -> contractmetadataId .== cmId)
+      (\ (_,linkedmetadataId) (name,src,_,b,br,ch,xch,xabi) -> (name,src,linkedmetadataId,b,br,ch,xch,xabi))
+      (\ (contractmetadataId,_) (_,_,cmId,_,_,_,_,_) -> contractmetadataId .== cmId)
       (queryTable contractsLookupTable) $ joinF
-        (\ (_,name) (cmId,_,b,br,ch,xch,src) -> (name,src,cmId,b,br,ch,xch))
-        (\ (cid,_) (_,contractId,_,_,_,_,_) -> cid .== contractId)
+        (\ (_,name) (cmId,_,b,br,ch,xch,src,xabi) -> (name,src,cmId,b,br,ch,xch,xabi))
+        (\ (cid,_) (_,contractId,_,_,_,_,_,_) -> cid .== contractId)
         (queryTable contractsTable) $ joinF
-          (\ (cmId,cid,b,br,ch,xch,_,_) (_,_,src)-> (cmId,cid,b,br,ch,xch,src))
+          (\ (cmId,cid,b,br,ch,xch,_,xabi) (_,_,src)-> (cmId,cid,b,br,ch,xch,src,xabi))
           (\ (_,_,_,_,_,_,sh,_) (_,sh',_)-> sh .== sh')
           (queryTable contractsMetaDataTable)
           (queryTable contractsSourceTable)
@@ -322,8 +330,8 @@ SELECT CI.address FROM contracts_instance CI
 -}
 getSearchContractQuery :: Text -> Query (Column PGBytea, Column PGBytea)
 getSearchContractQuery contractName = proc () -> do
-  (_,name,_,addr,_,_,_,_,_,cid) <-
-    orderBy (desc (\(_,_,_,_,timestamp,_,_,_,_,_) -> timestamp))
+  (_,name,_,addr,_,_,_,_,_,cid,_) <-
+    orderBy (desc (\(_,_,_,_,timestamp,_,_,_,_,_,_) -> timestamp))
       contractsJoinTable -< ()
   restrict -< name .== constant contractName
   returnA -< (addr,cid)
@@ -346,7 +354,7 @@ getContractsAddressesQuery :: Maybe ChainId -> Query
   , Column PGBytea
   )
 getContractsAddressesQuery chainId = proc () -> do
-  (_,name,_,addr,timestamp,_,_,_,_,cid) <- contractsJoinTable -< ()
+  (_,name,_,addr,timestamp,_,_,_,_,cid,_) <- contractsJoinTable -< ()
   restrict -< cid .== constant chainId
   returnA -< (name,addr,timestamp,cid)
 
@@ -375,8 +383,8 @@ getContractsNamesAsAddressesQuery :: Maybe ChainId -> Query
   )
 getContractsNamesAsAddressesQuery chainId = proc () -> do
   (n1,n2,ts,cid) <- joinF
-    (\ (_,_,_,timestamp,cid) (_,_,_,_,name,name2,_,_) -> (name,name2,timestamp,cid))
-    (\ (_,contractmetadataId,_,_,_) (_,_,_,_,_,_,_,cm2Id) -> contractmetadataId .== cm2Id)
+    (\ (_,_,_,timestamp,cid) (_,_,_,_,name,name2,_,_,_) -> (name,name2,timestamp,cid))
+    (\ (_,contractmetadataId,_,_,_) (_,_,_,_,_,_,_,cm2Id,_) -> contractmetadataId .== cm2Id)
     (queryTable contractsInstanceTable)
     linkedContractsJoinTable
     -< ()
@@ -395,7 +403,7 @@ WHERE C.name=$1;
 -}
 getContractsDataAddressesQuery :: Text -> Query (Column PGBytea, Column PGBytea)
 getContractsDataAddressesQuery contractName = proc () -> do
-  (_,name,_,addr,_,_,_,_,_,cid) <- contractsJoinTable -< ()
+  (_,name,_,addr,_,_,_,_,_,cid,_) <- contractsJoinTable -< ()
   restrict -< name .== constant contractName
   returnA -< (addr,cid)
 
@@ -430,7 +438,7 @@ getContractsDataNamesQuery contractName =
       restrict -< name .== constant contractName
       returnA -< name
     differentName = proc () -> do
-      (_,_,_,_,name,name2,_,_) <- linkedContractsJoinTable -< ()
+      (_,_,_,_,name,name2,_,_,_) <- linkedContractsJoinTable -< ()
       restrict -< name .== constant contractName
       returnA -< name2
     latest = proc () -> do
@@ -471,7 +479,7 @@ getContractDetailsByAddressOnly contractAddr chainId = do
 
 getContractSourceByCodeHash :: Keccak256 -> Query (Column PGText)
 getContractSourceByCodeHash codeHash = proc () -> do
-  (_,_,src,_,_,_,_,ch,_,_) <- contractsJoinTable -< ()
+  (_,_,src,_,_,_,_,ch,_,_,_) <- contractsJoinTable -< ()
   restrict -< ch .== constant codeHash
   returnA -< src
 
@@ -528,7 +536,7 @@ getContractsMetaDataIdByAddressQuery
   -> Query (Column PGInt4)
 getContractsMetaDataIdByAddressQuery contractName contractAddress chainId =
   proc () -> do
-    (cmId,_,_,_,_,_,_,_,_,_) <-
+    (cmId,_,_,_,_,_,_,_,_,_,_) <-
       contractByAddress contractName contractAddress chainId -< ()
     returnA -< cmId
 
@@ -562,12 +570,13 @@ getContractsContractByAddressQuery
       , Column PGText
       , Column PGText
       , Column PGInt4
+      , Column PGBytea
     ) )
 getContractsContractByAddressQuery contractName contractAddress chainId =
   limit 1 $ proc () -> do
-    (cmId,name,src,addr,_,bin,binRuntime,codeHash,xcodeHash,cid) <-
+    (cmId,name,src,addr,_,bin,binRuntime,codeHash,xcodeHash,cid,xabi) <-
       contractByAddress contractName contractAddress chainId -< ()
-    returnA -< (addr,cid,(bin,binRuntime,codeHash,xcodeHash,name,src,cmId))
+    returnA -< (addr,cid,(bin,binRuntime,codeHash,xcodeHash,name,src,cmId,xabi))
 
 getContractsContractByCodeHashQuery
   :: Keccak256
@@ -580,6 +589,7 @@ getContractsContractByCodeHashQuery
     , Column PGText
     , Column PGText
     , Column PGInt4
+    , Column PGBytea
     )
 getContractsContractByCodeHashQuery codeHash =
   limit 1 $ proc () -> do
@@ -607,7 +617,7 @@ getContractsMetaDataIdByNameQuery
   -> Query (Column PGInt4)
 getContractsMetaDataIdByNameQuery contractName1 contractName2 =
   limit 1 . orderBy (desc id) $ proc () -> do
-    (_,_,_,_,name1,name2,_,cm2Id) <- linkedContractsJoinTable -< ()
+    (_,_,_,_,name1,name2,_,cm2Id,_) <- linkedContractsJoinTable -< ()
     restrict -< name1 .== constant contractName1
     restrict -< name2 .== constant contractName2
     returnA -< cm2Id
@@ -641,13 +651,14 @@ getContractsContractByNameQuery
     , Column PGText
     , Column PGText
     , Column PGInt4
+    , Column PGBytea
     )
 getContractsContractByNameQuery contractName1 contractName2 =
   limit 1 $ proc () -> do
-    (b,br,ch,xch,name1,name2,src,cm2Id) <- linkedContractsJoinTable -< ()
+    (b,br,ch,xch,name1,name2,src,cm2Id,xabi) <- linkedContractsJoinTable -< ()
     restrict -< name1 .== constant contractName1
     restrict -< name2 .== constant contractName2
-    returnA -< (b,br,ch,xch,name2,src,cm2Id)
+    returnA -< (b,br,ch,xch,name2,src,cm2Id,xabi)
 
 {- |
 SELECT CM.id
@@ -693,12 +704,13 @@ getContractsContractBySameNameQuery
     , Column PGText
     , Column PGText
     , Column PGInt4
+    , Column PGBytea
     )
 getContractsContractBySameNameQuery contractName =
   limit 1 $ proc () -> do
-    (b,br,ch,xch,_,name,src,cmId) <- contractDetailsJoinTable -< ()
+    (b,br,ch,xch,_,name,src,cmId,xabi) <- contractDetailsJoinTable -< ()
     restrict -< name .== constant contractName
-    returnA -< (b,br,ch,xch,name,src,cmId)
+    returnA -< (b,br,ch,xch,name,src,cmId,xabi)
 
 {- |
 SELECT CM.id
@@ -713,7 +725,7 @@ LIMIT 1;
 -}
 getContractsMetaDataIdByLatestQuery :: Text -> Query (Column PGInt4)
 getContractsMetaDataIdByLatestQuery contractName = limit 1 $ proc () -> do
-  (_,_,_,_,_,_,cmId) <-
+  (_,_,_,_,_,_,cmId,_) <-
     getContractsContractLatestQuery contractName -< ()
   returnA -< cmId
 
@@ -743,13 +755,14 @@ getContractsContractLatestQuery
     , Column PGText
     , Column PGText
     , Column PGInt4
+    , Column PGBytea
     )
 getContractsContractLatestQuery contractName = limit 1 $ proc () -> do
-  (b,br,ch,xch,_,name,src,cmId) <-
-    orderBy (desc (\ (_,_,_,_,_,_,_,cmId) -> cmId))
+  (b,br,ch,xch,_,name,src,cmId,xabi) <-
+    orderBy (desc (\ (_,_,_,_,_,_,_,cmId,_) -> cmId))
       contractDetailsJoinTable -< ()
   restrict -< name .== constant contractName
-  returnA -< (b,br,ch,xch,name,src,cmId)
+  returnA -< (b,br,ch,xch,name,src,cmId,xabi)
 {- |
 SELECT
   XF.id
@@ -909,11 +922,16 @@ getXabiVariableNamesQuery metadataId = proc () -> do
   restrict -< cmid .== constant metadataId
   returnA -< varName
 
+decodeXabiJSON :: ByteString -> Bloc Xabi
+decodeXabiJSON xabi' = case decode (fromStrict xabi') of
+  Nothing -> throwError $ DBError "Corrupted Xabi stored in database"
+  Just x -> return x
+
 getContractDetailsByMetadataId :: Int32 -> MaybeNamed Address -> Maybe ChainId -> Bloc ContractDetails
 getContractDetailsByMetadataId cmId addr chainId = do
-  xabi <- getContractXabiByMetadataId cmId
-  (bin,binRuntime,codeHash,_ :: ByteString,_ :: Keccak256,name,src,_ :: Int32) <-
+  (bin,binRuntime,codeHash,_ :: ByteString,_ :: Keccak256,name,src,_ :: Int32,xabi') <-
     blocQuery1 "getContractDetailsByMetadataId" $ contractByMetadataId cmId
+  xabi <- decodeXabiJSON xabi'
   return ContractDetails
     { contractdetailsBin = Text.decodeUtf8 bin
     , contractdetailsAddress = Just addr
@@ -926,11 +944,11 @@ getContractDetailsByMetadataId cmId addr chainId = do
     }
 
 getContractDetails :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc ContractDetails
-getContractDetails contract@(ContractName contractName) contractId chainId = do
-    xabi <- getContractXabi contract contractId chainId
+getContractDetails (ContractName contractName) contractId chainId = do
     let
-      detailsWith detailsAddr cid (bin,binRuntime,codeHash,_ :: ByteString,name,src,_ :: Int32) =
-        ContractDetails
+      detailsWith detailsAddr cid (bin,binRuntime,codeHash,_ :: ByteString,name,src,_ :: Int32,xabi') = do
+        xabi <- decodeXabiJSON xabi'
+        return ContractDetails
           { contractdetailsBin = Text.decodeUtf8 bin
           , contractdetailsAddress = detailsAddr
           , contractdetailsBinRuntime = Text.decodeUtf8 binRuntime
@@ -944,26 +962,26 @@ getContractDetails contract@(ContractName contractName) contractId chainId = do
       Named "Latest" -> do
         tuple <- blocQuery1 "getContractDetails/latest" $
           getContractsContractLatestQuery contractName
-        return $ detailsWith Nothing chainId tuple
+        detailsWith Nothing chainId tuple
       Unnamed addr -> do
         (addr',cid,tuple) <- blocQuery1 "getContractDetails/unnamed" $
           getContractsContractByAddressQuery contractName addr chainId
-        return $ detailsWith (Just (Unnamed addr')) cid tuple
+        detailsWith (Just (Unnamed addr')) cid tuple
       Named name -> if contractName == name
         then do
           tuple <- blocQuery1 "getContractDetails/named" $
             getContractsContractBySameNameQuery name
-          return $ detailsWith (Just (Named name)) chainId tuple
+          detailsWith (Just (Named name)) chainId tuple
         else do
           tuple <- blocQuery1 "getContractDetails/otherNamed" $
             getContractsContractByNameQuery contractName name
-          return $ detailsWith (Just (Named name)) chainId tuple
+          detailsWith (Just (Named name)) chainId tuple
 
 getContractDetailsByCodeHash :: Keccak256 -> Bloc (Maybe (Int32, ContractDetails))
 getContractDetailsByCodeHash codeHash = do
     mDetails <- fmap listToMaybe . blocQuery $ getContractsContractByCodeHashQuery codeHash
-    for mDetails $ \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId) -> do
-      xabi <- getContractXabiByMetadataId cmId
+    for mDetails $ \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId,xabi') -> do
+      xabi <- decodeXabiJSON xabi'
       return (cmId, ContractDetails
         { contractdetailsBin = Text.decodeUtf8 bin
         , contractdetailsAddress = Nothing
@@ -1022,9 +1040,10 @@ insertContractMetaDataQuery
   -> Keccak256
   -> Keccak256
   -> Keccak256
+  -> Xabi
   -> Bloc Int32
 insertContractMetaDataQuery
-  contractId bin binRuntime codeHash xcodeHash srcHash = blocModify1 $ \ conn ->
+  contractId bin binRuntime codeHash xcodeHash srcHash xabi = blocModify1 $ \ conn ->
     runInsertManyReturning conn contractsMetaDataTable [
       ( Nothing
       , constant contractId
@@ -1033,7 +1052,7 @@ insertContractMetaDataQuery
       , constant codeHash
       , constant xcodeHash
       , constant srcHash
-      , constant BS.empty
+      , constant (encode xabi)
       )]
       (\ (contractmetadataId,_,_,_,_,_,_,_) -> contractmetadataId)
 
@@ -1231,8 +1250,8 @@ compileContract source = do
   if null details
     then compileContractFromScratch source
     else fmap Map.fromList . forM details $
-      \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId) -> do
-        xabi <- getContractXabiByMetadataId cmId
+      \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId,xabi') -> do
+        xabi <- decodeXabiJSON xabi'
         return (name,(cmId, ContractDetails
           { contractdetailsBin = Text.decodeUtf8 bin
           , contractdetailsAddress = Nothing
@@ -1284,6 +1303,7 @@ compileContractFromScratch source = do
       contractdetailsCodeHash
       xcodeHash
       srcHash
+      contractdetailsXabi
     insertXabi metadataId contrName contractdetailsXabi
     return (metadataId,detail)
 

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -1208,25 +1208,6 @@ insertXabi metadataId contractName Xabi{..} = do
   void $ insertXabiVariables metadataId xabiVars
   void $ insertXabiTypeDefs metadataId xabiTypes
 
-insertContract
-  :: Text
-  -> Text
-  -> Text
-  -> Text
-  -> Text
-  -> Xabi
-  -> Bloc Int32
-insertContract parentContr contr bin binRuntime src xabi = do
-  let
-    codeHash = binRuntimeToCodeHash binRuntime
-    xcodeHash = keccak256 (Text.encodeUtf8 bin)
-  contrId <- createContractQuery contr
-  (_,srcHash) <- insertContractSourceQuery src
-  metadataId <- insertContractMetaDataQuery
-    contrId bin binRuntime codeHash xcodeHash srcHash
-  insertXabi metadataId parentContr xabi
-  return metadataId
-
 insertContractInstance
   :: Int32
   -> Address
@@ -1700,20 +1681,6 @@ getContractXabiAndMetadataId (ContractName contractName) contractId chainId = do
     Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr chainId
   xabi <- getContractXabiByMetadataId metadataId
   return (metadataId, xabi)
-
-getContractMetadataAndBin :: Text -> Bloc (Int32, ByteString)
-getContractMetadataAndBin contract = blocTransaction $ do
-  cmIds_bins <- blocQuery $ proc () -> do
-    (cmId,name,bin) <- joinF
-      (\ (cmId,_,bin,_,_,_,_) (_,name) -> (cmId,name,bin))
-      (\ (_,contractId,_,_,_,_,_) (cid,_) -> cid .== contractId)
-      (queryTable contractsMetaDataTable)
-      (queryTable contractsTable) -< ()
-    restrict -< name .== constant contract
-    returnA -< (cmId,bin)
-  blocMaybe
-    "No contract metadata id found. Likely, contract did not compile successfully"
-    (listToMaybe cmIds_bins)
 
 getConstructorId :: Int32 -> Bloc (Maybe Int32)
 getConstructorId cmId = do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -28,7 +28,7 @@ import qualified Data.ByteString                 as BS
 import qualified Data.ByteString.Char8           as Char8
 import           Data.ByteString.Lazy            (fromStrict)
 import           Data.Foldable
-import           Data.Int                        (Int32, Int64)
+import           Data.Int                        (Int32)
 import           Data.Map.Strict                 (Map)
 import qualified Data.Map.Strict                 as Map
 import           Data.Maybe
@@ -41,7 +41,7 @@ import           Data.Traversable
 import           Database.PostgreSQL.Simple      (Connection)
 import           GHC.Stack
 import           Opaleye                         hiding (not, null, index)
-import qualified Opaleye                         (not, null)
+import qualified Opaleye                         (not)
 
 
 import           BlockApps.Bloc22.API.Utils
@@ -483,43 +483,6 @@ getContractSourceByCodeHash codeHash = proc () -> do
   restrict -< ch .== constant codeHash
   returnA -< src
 
-insertXabiFunctionArg
-  :: Int32
-  -> Map Text Xabi.IndexedType
-  -> Bloc Int64
-insertXabiFunctionArg funcId args = do
-  argsWithIds <- for args $ \ (Xabi.IndexedType index xt) -> do
-    xtid <- insertXabiType xt
-    return (index,xtid)
-  blocModify $ \conn ->
-    runInsertMany conn xabiFunctionArgumentsTable
-      [ ( Nothing
-        , constant funcId
-        , constant xtid
-        , constant name
-        , constant index
-        )
-      | (name,(index,xtid)) <- Map.toList argsWithIds
-      ]
-
-insertXabiFunctionRet
-  :: Int32
-  -> [Xabi.IndexedType]
-  -> Bloc Int64
-insertXabiFunctionRet funcId vals = do
-  valIds <- for vals $ \ (Xabi.IndexedType index xt) -> do
-    xtid <- insertXabiType xt
-    return (index,xtid)
-  blocModify $ \conn ->
-    runInsertMany conn xabiFunctionReturnsTable
-      [ ( Nothing
-        , constant funcId
-        , constant index
-        , constant xtid
-        )
-      | (index,xtid) <- valIds
-      ]
-
 {- |
 SELECT CM.id
 FROM contracts_metadata CM
@@ -827,14 +790,6 @@ getXabiConstrQuery cmId = do
                   , funcModifiers = Nothing
                   }
 
-getXabiFunctionNamesQuery :: Int32 -> Query ( Column PGText)
-getXabiFunctionNamesQuery metadataId = proc () -> do
-  (_,cmid,isc,name,_) <-
-    queryTable xabiFunctionsTable -< ()
-  restrict -< cmid .== constant metadataId .&& Opaleye.not isc
-  returnA -< name
-
-
 {- |
 SELECT
   ,XFA.name
@@ -913,14 +868,6 @@ getXabiVariablesQuery cmId = do
   for varsWithIds $ \ (atbytes,ispublic,isconstant, value,typeid) -> do
     ty <- getXabiType typeid
     return $ Xabi.VarType atbytes (Just ispublic) (Just isconstant) value ty
-
-
-getXabiVariableNamesQuery :: Int32 -> Query ( Column PGText )
-getXabiVariableNamesQuery metadataId = proc () -> do
-  (_,cmid,_,varName,_,_,_,_) <-
-    queryTable xabiVariablesTable -< ()
-  restrict -< cmid .== constant metadataId
-  returnA -< varName
 
 deserializeXabi :: ByteString -> Bloc Xabi
 deserializeXabi = decodeXabiJSON
@@ -1151,89 +1098,6 @@ instance Default Constant (Maybe ChainId) (Column PGBytea) where
                 Nothing -> BS.empty
                 Just cid -> word256ToByteString $ unChainId cid
 
-insertXabiVariables
-  :: Int32
-  -> Map Text Xabi.VarType
-  -> Bloc Int64
-insertXabiVariables metadataId vars = do
-  varsWithIds <- for (Map.toList vars) $ \ (name,Xabi.VarType atBytes ispublic isconstant value xt) -> do
-    varIds :: [Int32] <- blocQuery $ proc () -> do
-      (vId,cmId,_,vname,_,_,_,_) <- queryTable xabiVariablesTable -< ()
-      restrict -< cmId .== constant metadataId
-        .&& vname .== constant name
-      returnA -< vId
-    if null varIds
-    then do
-      xtid <- insertXabiType xt
-      return $ Just (name,atBytes,ispublic,isconstant,value,xtid)
-    else
-      return Nothing
-  blocModify $ \conn ->
-    runInsertMany conn xabiVariablesTable
-      [ ( Nothing
-        , constant metadataId
-        , constant xtid
-        , constant name
-        , constant atBytes
-        , constant (fromMaybe False ispublic)
-        , constant (fromMaybe False isconstant)
-        , constant value
-        )
-      | Just (name,atBytes,ispublic,isconstant,value,xtid) <- varsWithIds
-      ]
-
-{- |
-INSERT INTO xabi_functions
-  (contract_metadata_id,name,selector,is_constructor)
-  VALUES ($1,$2,$3,$4) RETURNING id;
--}
-insertXabiFunction
-  :: Int32
-  -> (Text, Func)
-  -> Bloc ()
-insertXabiFunction metadataId (name,Func{..}) = do
-  funcIds :: [Int32] <- blocQuery $ proc () -> do
-    (fId,cmId,_,fname,_) <- queryTable xabiFunctionsTable -< ()
-    restrict -< cmId .== constant metadataId
-      .&& fname .== constant name
-    returnA -< fId
-  when (null funcIds) $ do
-    funcId <- blocModify1 $ \ conn -> runInsertManyReturning conn xabiFunctionsTable [
-      ( Nothing
-      , constant metadataId
-      , constant False
-      , constant name
-      , constant funcStateMutability
-      )]
-      (\ (xfId,_,_,_,_) -> xfId)
-    void $ insertXabiFunctionArg funcId funcArgs
-    void $ insertXabiFunctionRet funcId (toList funcVals)
-
-insertXabiConstr
-  :: Int32
-  -> Text
-  -> Map Text Xabi.IndexedType
-  -> Bloc ()
-insertXabiConstr metadataId contractName constrArgs = unless (Map.null constrArgs) $ do
-  funcId <- blocModify1 $ \ conn -> runInsertManyReturning conn xabiFunctionsTable [
-    ( Nothing
-    , constant metadataId
-    , constant True
-    , constant contractName
-    , constant (Nothing :: Maybe StateMutability)
-    )]
-    (\ (xfId,_,_,_, _) -> xfId)
-  void $ insertXabiFunctionArg funcId constrArgs
-
-insertXabi :: Int32 -> Text -> Xabi -> Bloc ()
-insertXabi metadataId contractName Xabi{..} = do
-  traverse_ (insertXabiFunction metadataId) (Map.toList xabiFuncs)
-  case xabiConstr of
-    Just constr -> insertXabiConstr metadataId contractName (funcArgs constr)
-    Nothing -> return ()
-  void $ insertXabiVariables metadataId xabiVars
-  void $ insertXabiTypeDefs metadataId xabiTypes
-
 insertContractInstance
   :: Int32
   -> Address
@@ -1318,210 +1182,6 @@ compileContractFromScratch source = do
 
   return metadataIds
 
-insertXabiType :: Xabi.Type -> Bloc Int32
-insertXabiType = \case
-  Xabi.Int signed bytes ->
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Int"::Text)
-        , Opaleye.null
-        , constant False
-        , constant $ fromMaybe False signed
-        , constant bytes
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-  Xabi.String dynamic ->
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("String"::Text)
-        , Opaleye.null
-        , constant $ fromMaybe False dynamic
-        , constant False
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-  Xabi.Bytes dynamic bytes ->
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Bytes"::Text)
-        , Opaleye.null
-        , constant $ fromMaybe False dynamic
-        , constant False
-        , constant bytes
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-  Xabi.Bool ->
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Bool"::Text)
-        , Opaleye.null
-        , constant False
-        , constant False
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-  Xabi.Address ->
-    blocModify1 $ \ conn->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Address"::Text)
-        , Opaleye.null
-        , constant False
-        , constant False
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-  Xabi.Struct bytes typedef ->
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Struct"::Text)
-        , constant $ Just typedef
-        , constant False
-        , constant False
-        , constant bytes
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-    -- parentTypeId <- blocModify1 $ \ conn -> do
-    --   runInsertManyReturning conn xabiTypesTable [
-    --     ( Nothing
-    --     , constant ("Struct"::Text)
-    --     , constant $ Just typedef
-    --     , constant False
-    --     , constant False
-    --     , constant bytes
-    --     , Opaleye.null
-    --     , Opaleye.null
-    --     , Opaleye.null
-    --     , Opaleye.null
-    --     )]
-    --     (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-    -- void $ blocModify $ \ conn -> do
-    --   runInsertMany conn xabiStructFieldsTable
-    --     [ ( Nothing
-    --       , constant name
-    --       , constant atby
-    --       , constant parentTypeId
-    --       , constant tyid
-    --       )
-    --     | (name,(atby,tyid)) <- Map.toList fieldsWithIds]
-    -- return parentTypeId
-  Xabi.Enum bytes typedef _ ->
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Enum"::Text)
-        , constant $ Just typedef
-        , constant False
-        , constant False
-        , constant bytes
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-    -- void $ blocModify $ \ conn -> do
-    --   runInsertMany conn xabiEnumNamesTable
-    --     [ ( Nothing
-    --       , constant name
-    --       , constant value
-    --       , constant tyid
-    --       )
-    --     | (name,value) <- zip names [(0::Int32)..]]
-    -- return tyid
-  Xabi.Array entry len -> do
-    entryId <- insertXabiType entry
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Array"::Text)
-        , Opaleye.null
-        , constant $ isNothing len
-        , constant False
-        , Opaleye.null
-        , constant (fmap fromIntegral len :: Maybe Int32)
-        , constant $ Just entryId
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-  Xabi.Contract typedef ->
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Contract"::Text)
-        , constant $ Just typedef
-        , constant False
-        , constant False
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-  Xabi.Mapping dynamic key value -> do
-    keyId <- insertXabiType key
-    valueId <- insertXabiType value
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Mapping"::Text)
-        , Opaleye.null
-        , constant $ fromMaybe False dynamic
-        , constant False
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , constant $ Just valueId
-        , constant $ Just keyId
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-  Xabi.Label name ->
-    blocModify1 $ \conn ->
-      runInsertManyReturning conn xabiTypesTable [
-        ( Nothing
-        , constant ("Label"::Text)
-        , constant $ Just name
-        , constant False
-        , constant False
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        , Opaleye.null
-        )]
-        (\ (xtid,_,_,_,_,_,_,_,_,_) -> xtid)
-
 getXabiType :: HasCallStack =>
                Int32 -> Bloc Xabi.Type
 getXabiType typeId = do
@@ -1577,22 +1237,6 @@ getXabiStructFields typeDefId = do
     ty <- getXabiType ftid
     return (name, Xabi.FieldType atbytes ty)
 
-insertXabiStructFields :: Int32 ->  [(Text, Xabi.FieldType)] -> Bloc Int64
-insertXabiStructFields typeDefId fields = do
-  fieldsWithIds <- for fields $ \ (name,(Xabi.FieldType atBytes xt)) -> do
-    xtid <- insertXabiType xt
-    return (name,(atBytes,xtid))
-  blocModify $ \ conn ->
-    runInsertMany conn xabiStructFieldsTable
-      [ ( Nothing
-        , constant name
-        , constant atBytes
-        , constant typeDefId
-        , constant xtid
-        )
-      | (name,(atBytes,xtid)) <- fieldsWithIds
-      ]
-
 getXabiEnumNames :: Int32 -> Bloc [Text]
 getXabiEnumNames typeDefId = blocQuery $ proc () -> do
   (_,name,_,tdid) <-
@@ -1600,17 +1244,6 @@ getXabiEnumNames typeDefId = blocQuery $ proc () -> do
       (queryTable xabiEnumNamesTable) -< ()
   restrict -< tdid .== constant typeDefId
   returnA -< name
-
-insertXabiEnumNames :: Int32 -> [Text] -> Bloc Int64
-insertXabiEnumNames typeDefId names = blocModify $ \ conn ->
-  runInsertMany conn xabiEnumNamesTable
-    [ ( Nothing
-      , constant name
-      , constant value
-      , constant typeDefId
-      )
-    | (name,value) <- zip names [0::Int32 ..]
-    ]
 
 getXabiTypeDefs :: Int32 -> Bloc (Map Text Xabi.Def.Def)
 getXabiTypeDefs metadataId = do
@@ -1629,32 +1262,6 @@ getXabiTypeDefs metadataId = do
         return $ Xabi.Def.Contract $ fromIntegral by
       _ -> throwError $ DBError $
         "Invalid type def. Expected Struct or Enum, saw " <> ty
-
-insertXabiTypeDefs :: Int32 -> Map Text Xabi.Def.Def -> Bloc ()
-insertXabiTypeDefs metadataId typeDefs = do
-  typeDefIds <- fmap Map.fromList . blocModify $ \ conn -> do
-    let
-      tyOf :: Xabi.Def.Def -> Text
-      tyOf = \case
-        Xabi.Def.Enum _ _ -> "Enum"
-        Xabi.Def.Struct _ _ -> "Struct"
-        Xabi.Def.Contract _ -> "Contract"
-      byOf :: Xabi.Def.Def -> Int32
-      byOf = fromIntegral . Xabi.Def.bytes
-    runInsertManyReturning conn xabiTypeDefsTable
-      [ ( Nothing
-        , constant name
-        , constant metadataId
-        , constant (tyOf enumOrStruct)
-        , constant (byOf enumOrStruct)
-        )
-      | (name,enumOrStruct) <- Map.toList typeDefs
-      ]
-      (\ (tdId,name,_,_,_) -> (name,tdId))
-  for_ (Map.intersectionWith (,) typeDefs typeDefIds) $ \case
-    (Xabi.Def.Struct fields _, tdId) -> insertXabiStructFields tdId fields
-    (Xabi.Def.Enum names _, tdId) -> insertXabiEnumNames tdId names
-    (Xabi.Def.Contract _, _) -> return 0
 
 getContractXabiByMetadataId :: HasCallStack => Int32 -> Bloc Xabi
 getContractXabiByMetadataId metadataId = do
@@ -1708,36 +1315,3 @@ getContractXabiAndMetadataId (ContractName contractName) contractId chainId = do
     Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr chainId
   xabi <- getContractXabiByMetadataId metadataId
   return (metadataId, xabi)
-
-getConstructorId :: Int32 -> Bloc (Maybe Int32)
-getConstructorId cmId = do
-  functionIds <- blocQuery $ proc () -> do
-    (xfId,contractMetaDataId,isConstr,_,_)
-      <- queryTable xabiFunctionsTable -< ()
-    restrict -< contractMetaDataId .== constant cmId .&& isConstr
-    returnA -< xfId
-  return $ listToMaybe functionIds
-
-getFunctionId :: Int32 -> Text -> Bloc Int32
-getFunctionId cmId funcName = blocQuery1 "getFunctionId" $ proc () -> do
-  (xfId,contractMetaDataId,isConstr,name,_)
-    <- queryTable xabiFunctionsTable -< ()
-  restrict -< contractMetaDataId .== constant cmId
-    .&& name .== constant funcName
-    .&& Opaleye.not isConstr
-  returnA -< xfId
-
-getEnumValues :: Int32 -> Text -> Bloc [(Text,Int)]
-getEnumValues cmId enumName = blocQuery $
-  orderBy (asc snd) $ proc () -> do
-    (name,enumValue,enumIndex,contractMetaDataId,ty) <- joinTable -< ()
-    restrict -< contractMetaDataId .== constant cmId
-      .&& name .== constant enumName
-      .&& ty .== constant ("Enum" :: Text)
-    returnA -< (enumValue,enumIndex)
-  where
-    joinTable = joinF
-      (\ (_,name,contractMetaDataId,ty,_) (_,enumValue,enumIndex,_) -> (name,enumValue,enumIndex,contractMetaDataId,ty))
-      (\ (tdId,_,_,_,_) (_,_,_,typedefId) -> tdId .== typedefId)
-      (queryTable xabiTypeDefsTable)
-      (queryTable xabiEnumNamesTable)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -1310,7 +1310,6 @@ compileContractFromScratch source = do
       xcodeHash
       srcHash
       contractdetailsXabi
-    insertXabi metadataId contrName contractdetailsXabi
     return (metadataId,detail)
 
   for_ metadataIds $ \ (leftmetadataId,_) ->

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -1659,16 +1659,17 @@ insertXabiTypeDefs metadataId typeDefs = do
 
 getContractXabiByMetadataId :: HasCallStack => Int32 -> Bloc Xabi
 getContractXabiByMetadataId metadataId = do
-  funcs <- getXabiFunctionsQuery metadataId
-  constr <- getXabiConstrQuery metadataId
-  vars <- getXabiVariablesQuery metadataId
-  typeDefs <- getXabiTypeDefs metadataId
-  -- TODO: Add modifiers table and pull modifiers from there
-  return xabiEmpty{ xabiFuncs = funcs
-                  , xabiConstr = constr
-                  , xabiVars = vars
-                  , xabiTypes = typeDefs
-                  }
+  (   _ :: ByteString
+    , _ :: ByteString
+    , _ :: Keccak256
+    , _ :: ByteString
+    , _ :: Keccak256
+    , _ :: Text
+    , _ :: Text
+    , _ :: Int32
+    , xabi'
+    ) <- blocQuery1 "getContractDetailsByMetadataId" $ contractByMetadataId metadataId
+  deserializeXabi xabi'
 
 getContractContractByMetadataId :: HasCallStack => Int32 -> Bloc Contract
 getContractContractByMetadataId metadataId = getContractRetry 0

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -1305,13 +1305,3 @@ getContractXabi (ContractName contractName) contractId chainId = do
     Named _ -> blocQuery1 "getContractXabi" $ getContractsMetaDataId contractName contractId chainId
     Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr chainId
   getContractXabiByMetadataId metadataId
-
-getContractXabiAndMetadataId :: HasCallStack =>
-                   ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc (Int32, Xabi)
-getContractXabiAndMetadataId (ContractName contractName) contractId chainId = do
-  metadataId <- case contractId of
-    Named _ -> blocQuery1 "getContractXabiAndMetadataId" $
-      getContractsMetaDataId contractName contractId chainId
-    Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr chainId
-  xabi <- getContractXabiByMetadataId metadataId
-  return (metadataId, xabi)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -421,53 +421,13 @@ getContractsDataNamesQuery contractName =
       restrict -< name .== constant contractName
       returnA -< constant ("Latest"::Text)
 
-getContractsMetaDataId :: Text -> MaybeNamed Address -> Maybe ChainId -> Bloc Int32
-getContractsMetaDataId contractName mContractId chainId = case mContractId of
-  Unnamed contractAddress ->
-    getContractsMetaDataIdExhaustive contractName contractAddress chainId
-  Named name -> blocQuery1 "getContractsMetaDataId" $
-    if name == "Latest"
-      then getContractsMetaDataIdByLatestQuery contractName
-      else if contractName == name
-        then getContractsMetaDataIdBySameNameQuery contractName
-        else getContractsMetaDataIdByNameQuery contractName name
-
-getContractsMetaDataIdExhaustive :: Text -> Address -> Maybe ChainId -> Bloc Int32
-getContractsMetaDataIdExhaustive contractName contractAddr chainId = do
-  cmIdsByAddress <- byAddress
-  cmIdsByLatest <- byLatest
-  cmIdsBySameName <- bySameName
-  let cmIds = cmIdsByAddress ++ cmIdsByLatest ++ cmIdsBySameName
-  case cmIds of
-    [] -> throwError $ UserError "getContractsMetaDataIdExhaustive: couldn't find contract metadata id"
-    cmId:_ -> return cmId
-  where
-    byAddress = blocQuery $ getContractsMetaDataIdByAddressQuery contractName contractAddr chainId
-    byLatest = blocQuery $ getContractsMetaDataIdByLatestQuery contractName
-    bySameName = blocQuery $ getContractsMetaDataIdBySameNameQuery contractName
+getContractsMetaDataId :: Text -> MaybeNamed Address -> Maybe ChainId -> Bloc (Maybe Int32)
+getContractsMetaDataId name contractId = fmap (fmap fst) . getContractDetailsAndMetadataId (ContractName name) contractId
 
 getContractDetailsByAddressOnly :: Address -> Maybe ChainId -> Bloc (Maybe ContractDetails)
 getContractDetailsByAddressOnly contractAddr chainId = do
   mName <- fmap listToMaybe . blocQuery $ contractNameFromAddress contractAddr chainId
   fmap join . for mName $ \name -> getContractDetails (ContractName name) (Unnamed contractAddr) chainId
-
-{- |
-SELECT CM.id
-FROM contracts_metadata CM
-JOIN contracts C
-  ON C.id = CM.contract_id
-JOIN contracts_instance CI
-  ON CI.contract_metadata_id = CM.id
-WHERE C.name=$1 AND CI.address=$2;
--}
-getContractsMetaDataIdByAddressQuery
-  :: Text
-  -> Address
-  -> Maybe ChainId
-  -> Query (Column PGInt4)
-getContractsMetaDataIdByAddressQuery contractName contractAddress chainId =
-  getContractsContractByAddressQuery contractName contractAddress chainId
-    >>> arr (\(_,_,_,_,_,_,cmId,_) -> cmId)
 
 {- |
 SELECT
@@ -524,30 +484,6 @@ getContractsContractByCodeHashQuery codeHash =
     returnA -< details
 
 {- |
-SELECT CM2.id
-FROM contracts_metadata CM
-JOIN contracts C
-  ON C.id = CM.contract_id
-JOIN contracts_lookup CL
-  ON CL.contract_metadata_id = CM.id
-JOIN contracts_metadata CM2
-  ON CM2.id = CL.linked_metadata_id
-JOIN contracts C2
-  ON C2.id = CM2.contract_id
-WHERE C.name = $1 AND C2.name=$2
-ORDER BY CM2.id DESC
-LIMIT 1;
--}
-getContractsMetaDataIdByNameQuery
-  :: Text
-  -> Text
-  -> Query (Column PGInt4)
-getContractsMetaDataIdByNameQuery name1 name2 =
-  limit 1 . orderBy (desc id) $
-    getContractsContractByNameQuery name1 name2
-      >>> arr (\(_,_,_,_,_,_,cm2Id,_) -> cm2Id)
-
-{- |
 SELECT
    CM2.bin
  , CM2.bin_runtime
@@ -584,21 +520,6 @@ getContractsContractByNameQuery contractName1 contractName2 = proc () -> do
   returnA -< (b,br,ch,xch,name2,src,cm2Id,xabi)
 
 {- |
-SELECT CM.id
-FROM contracts_metadata CM
-JOIN contracts C
-  ON C.id = CM.contract_id
-WHERE C.name = $1
-ORDER BY CM.id DESC
-LIMIT 1;
--}
-getContractsMetaDataIdBySameNameQuery :: Text -> Query (Column PGInt4)
-getContractsMetaDataIdBySameNameQuery contractName =
-  limit 1 . orderBy (desc id) $
-    getContractsContractBySameNameQuery contractName
-      >>> arr (\(_,_,_,_,_,_,cmId,_) -> cmId)
-
-{- |
 SELECT
    CM.bin
  , CM.bin_runtime
@@ -625,23 +546,6 @@ getContractsContractBySameNameQuery contractName = proc () -> do
   (b,br,ch,xch,_,name,src,cmId,xabi) <- contractDetailsJoinTable -< ()
   restrict -< name .== constant contractName
   returnA -< (b,br,ch,xch,name,src,cmId,xabi)
-
-{- |
-SELECT CM.id
-FROM contracts_metadata CM
-JOIN contracts C
-  ON C.id = CM.contract_id
-JOIN contracts_instance CI
-  ON CI.contract_metadata_id = CM.id
-WHERE C.name = $1
-ORDER BY CI.timestamp DESC
-LIMIT 1;
--}
-getContractsMetaDataIdByLatestQuery :: Text -> Query (Column PGInt4)
-getContractsMetaDataIdByLatestQuery contractName = limit 1 $ proc () -> do
-  (_,_,_,_,_,_,cmId,_) <-
-    getContractsContractLatestQuery contractName -< ()
-  returnA -< cmId
 
 {- |
 SELECT

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -27,7 +27,6 @@ import           Data.ByteString                 (ByteString)
 import qualified Data.ByteString                 as BS
 import qualified Data.ByteString.Char8           as Char8
 import           Data.ByteString.Lazy            (fromStrict, toStrict)
-import           Data.Foldable
 import           Data.Int                        (Int32)
 import           Data.Map.Strict                 (Map)
 import qualified Data.Map.Strict                 as Map
@@ -159,16 +158,10 @@ contractsJoinTable :: Query
   , Column PGBytea
   )
 contractsJoinTable = joinF
-  (\ (_,_,a,ts, cid) (cmId,n,src,b,br,ch,xch,xabi) -> (cmId,n,src,a,ts,b,br,ch,xch,cid,xabi))
-  (\ (_,contractmetadataId,_,_,_) (cmId,_,_,_,_,_,_,_) -> cmId .== contractmetadataId)
-  (queryTable contractsInstanceTable) $ joinF
-    (\ (_,n) (cmId,_,b,br,ch,xch,src,xabi) -> (cmId,n,src,b,br,ch,xch,xabi))
-    (\ (cid,_) (_,contractId,_,_,_,_,_,_) -> cid .== contractId)
-    (queryTable contractsTable) $ joinF
-      (\ (cmId,cid,b,br,ch,xch,_,xabi) (_,_,src) -> (cmId,cid,b,br,ch,xch,src,xabi))
-      (\ (_,_,_,_,_,_,sh,_) (_,sh',_) -> sh .== sh')
-      (queryTable contractsMetaDataTable)
-      (queryTable contractsSourceTable)
+  (\ (_,_,a,ts, cid) (b,br,ch,xch,_,n,src,cmId,xabi) -> (cmId,n,src,a,ts,b,br,ch,xch,cid,xabi))
+  (\ (_,contractmetadataId,_,_,_) (_,_,_,_,_,_,_,cmId,_) -> cmId .== contractmetadataId)
+  (queryTable contractsInstanceTable)
+  contractDetailsJoinTable
 
 contractDetailsJoinTable :: Query
   ( Column PGBytea
@@ -305,22 +298,13 @@ linkedContractsJoinTable :: Query
   , Column PGBytea
   )
 linkedContractsJoinTable = joinF
-  (\ (_,name2) (name,src,cm2Id,_,b,br,ch,xch,xabi) -> (b,br,ch,xch,name,name2,src,cm2Id,xabi))
-  (\ (c2Id,_) (_,_,_,contractId2,_,_,_,_,_) -> c2Id .== contractId2)
+  (\ (_,name2) (b,br,ch,xch,name,src,cm2Id,_,xabi) -> (b,br,ch,xch,name,name2,src,cm2Id,xabi))
+  (\ (c2Id,_) (_,_,_,_,_,_,_,contractId2,_) -> c2Id .== contractId2)
   (queryTable contractsTable) $ joinF
-    (\ (cm2Id,contractId2,_,_,_,_,_,_) (name,src,_,b,br,ch,xch,xabi) -> (name,src,cm2Id,contractId2,b,br,ch,xch,xabi))
-    (\ (cm2Id,_,_,_,_,_,_,_) (_,_,linkedmetadataId,_,_,_,_,_) -> cm2Id .== linkedmetadataId)
-    (queryTable contractsMetaDataTable) $ joinF
-      (\ (_,linkedmetadataId) (name,src,_,b,br,ch,xch,xabi) -> (name,src,linkedmetadataId,b,br,ch,xch,xabi))
-      (\ (contractmetadataId,_) (_,_,cmId,_,_,_,_,_) -> contractmetadataId .== cmId)
-      (queryTable contractsLookupTable) $ joinF
-        (\ (_,name) (cmId,_,b,br,ch,xch,src,xabi) -> (name,src,cmId,b,br,ch,xch,xabi))
-        (\ (cid,_) (_,contractId,_,_,_,_,_,_) -> cid .== contractId)
-        (queryTable contractsTable) $ joinF
-          (\ (cmId,cid,b,br,ch,xch,_,xabi) (_,_,src)-> (cmId,cid,b,br,ch,xch,src,xabi))
-          (\ (_,_,_,_,_,_,sh,_) (_,sh',_)-> sh .== sh')
-          (queryTable contractsMetaDataTable)
-          (queryTable contractsSourceTable)
+    (\ (cm2Id,contractId2,_,_,_,_,_,_) (b,br,ch,xch,_,name,src,_,xabi) -> (b,br,ch,xch,name,src,cm2Id,contractId2,xabi))
+    (\ (_,_,_,_,_,_,sh',_) (_,_,_,_,sh,_,_,_,_) -> sh' .== sh)
+    (queryTable contractsMetaDataTable)
+    contractDetailsJoinTable
 
 {- |
 SELECT CI.address FROM contracts_instance CI
@@ -477,12 +461,6 @@ getContractDetailsByAddressOnly contractAddr chainId = do
     [] -> throwError $ UserError "getContractDetailsByAddressOnly: couldn't find contract metadata id"
     name:_ -> getContractDetails (ContractName name) (Unnamed contractAddr) chainId
 
-getContractSourceByCodeHash :: Keccak256 -> Query (Column PGText)
-getContractSourceByCodeHash codeHash = proc () -> do
-  (_,_,src,_,_,_,_,ch,_,_,_) <- contractsJoinTable -< ()
-  restrict -< ch .== constant codeHash
-  returnA -< src
-
 {- |
 SELECT CM.id
 FROM contracts_metadata CM
@@ -578,12 +556,9 @@ getContractsMetaDataIdByNameQuery
   :: Text
   -> Text
   -> Query (Column PGInt4)
-getContractsMetaDataIdByNameQuery contractName1 contractName2 =
-  limit 1 . orderBy (desc id) $ proc () -> do
-    (_,_,_,_,name1,name2,_,cm2Id,_) <- linkedContractsJoinTable -< ()
-    restrict -< name1 .== constant contractName1
-    restrict -< name2 .== constant contractName2
-    returnA -< cm2Id
+getContractsMetaDataIdByNameQuery name1 name2 =
+  limit 1 . orderBy (desc id) $
+    byNameQuery name1 name2 >>> arr (\(_,_,_,_,_,_,cm2Id,_) -> cm2Id)
 
 {- |
 SELECT
@@ -617,11 +592,43 @@ getContractsContractByNameQuery
     , Column PGBytea
     )
 getContractsContractByNameQuery contractName1 contractName2 =
-  limit 1 $ proc () -> do
-    (b,br,ch,xch,name1,name2,src,cm2Id,xabi) <- linkedContractsJoinTable -< ()
-    restrict -< name1 .== constant contractName1
-    restrict -< name2 .== constant contractName2
-    returnA -< (b,br,ch,xch,name2,src,cm2Id,xabi)
+  limit 1 $ byNameQuery contractName1 contractName2
+
+{- |
+SELECT
+   CM2.bin
+ , CM2.bin_runtime
+ , CM2.code_hash
+ , C2.name
+FROM contracts_metadata CM
+JOIN contracts C
+  ON C.id = CM.contract_id
+JOIN contracts_lookup CL
+  ON CL.contract_metadata_id = CM.id
+JOIN contracts_metadata CM2
+  ON CM2.id = CL.linked_metadata_id
+JOIN contracts C2
+  ON C2.id = CM2.contract_id
+WHERE C.name = $1 AND C2.name=$2
+-}
+byNameQuery
+  :: Text
+  -> Text
+  -> Query
+    ( Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGText
+    , Column PGText
+    , Column PGInt4
+    , Column PGBytea
+    )
+byNameQuery contractName1 contractName2 = proc () -> do
+  (b,br,ch,xch,name1,name2,src,cm2Id,xabi) <- linkedContractsJoinTable -< ()
+  restrict -< name1 .== constant contractName1
+  restrict -< name2 .== constant contractName2
+  returnA -< (b,br,ch,xch,name2,src,cm2Id,xabi)
 
 {- |
 SELECT CM.id
@@ -1012,26 +1019,6 @@ insertContractMetaDataQuery
       )]
       (\ (contractmetadataId,_,_,_,_,_,_,_) -> contractmetadataId)
 
-{- |
-INSERT INTO contracts_lookup (contract_metadata_id, linked_metadata_id)
-SELECT $1,$2  WHERE NOT EXISTS
-(SELECT contract_metadata_id, linked_metadata_id FROM contracts_lookup
-WHERE contract_metadata_id = $1 AND linked_metadata_id = $2);
--}
-insertContractLookup :: Int32 -> Int32 -> Connection -> IO ()
-insertContractLookup metadataId linkedId conn = do
-  rows <- runQuery conn $ proc () -> do
-    row@(contractmetadataId,linkedmetadataId) <-
-      queryTable contractsLookupTable -< ()
-    restrict -< contractmetadataId .== constant metadataId
-      .&& linkedmetadataId .== constant linkedId
-    returnA -< row
-  when (null (rows::[(Int32,Int32)])) . void $
-    runInsertMany conn contractsLookupTable
-      [(constant metadataId,constant linkedId)]
-
-
-
 instance QueryRunnerColumnDefault PGBytea Address where
   queryRunnerColumnDefault = queryRunnerColumn id
     (fromMaybe (error "could not decode address") . stringAddress . Char8.unpack)
@@ -1179,10 +1166,6 @@ compileContractFromScratch source = do
       contractdetailsXabi
     return (metadataId,detail)
 
-  for_ metadataIds $ \ (leftmetadataId,_) ->
-    for_ metadataIds $ \ (rightmetadataId,_) -> blocModify $
-      insertContractLookup leftmetadataId rightmetadataId
-
   return metadataIds
 
 getXabiType :: HasCallStack =>
@@ -1267,18 +1250,10 @@ getXabiTypeDefs metadataId = do
         "Invalid type def. Expected Struct or Enum, saw " <> ty
 
 getContractXabiByMetadataId :: HasCallStack => Int32 -> Bloc Xabi
-getContractXabiByMetadataId metadataId = do
-  (   _ :: ByteString
-    , _ :: ByteString
-    , _ :: Keccak256
-    , _ :: ByteString
-    , _ :: Keccak256
-    , _ :: Text
-    , _ :: Text
-    , _ :: Int32
-    , xabi'
-    ) <- blocQuery1 "getContractDetailsByMetadataId" $ contractByMetadataId metadataId
+getContractXabiByMetadataId cmId = do
+  xabi' <- blocQuery1 "getContractXabiByMetadataId" . fmap ninth $ contractByMetadataId cmId
   deserializeXabi xabi'
+  where ninth (_,_,_,_,_,_,_,_,x) = x
 
 getContractContractByMetadataId :: HasCallStack => Int32 -> Bloc Contract
 getContractContractByMetadataId metadataId = getContractRetry 0

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -11,9 +11,7 @@
 
 module BlockApps.Bloc22.Database.Queries where
 
-import           ClassyPrelude                   ((<>))
 import           Control.Arrow
-import           Control.Concurrent              (threadDelay)
 import           Control.Monad
 import           Control.Monad.Except
 import           Crypto.Hash
@@ -48,11 +46,9 @@ import           BlockApps.Bloc22.Monad
 import           BlockApps.Bloc22.Server.Utils
 import           BlockApps.Ethereum
 import           BlockApps.SolidityVarReader     (byteStringToWord256, word256ToByteString)
-import           BlockApps.Solidity.Contract
 import           BlockApps.Solidity.Parse.Parser
 import           BlockApps.Solidity.Xabi
 import           BlockApps.Strato.Types
-import           BlockApps.XAbiConverter
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
 
@@ -425,15 +421,16 @@ getContractsDataNamesQuery contractName =
       restrict -< name .== constant contractName
       returnA -< constant ("Latest"::Text)
 
-getContractsMetaDataId :: Text -> MaybeNamed Address -> Maybe ChainId -> Query (Column PGInt4)
+getContractsMetaDataId :: Text -> MaybeNamed Address -> Maybe ChainId -> Bloc Int32
 getContractsMetaDataId contractName mContractId chainId = case mContractId of
-  Named "Latest" ->
-    getContractsMetaDataIdByLatestQuery contractName
   Unnamed contractAddress ->
-    getContractsMetaDataIdByAddressQuery contractName contractAddress chainId
-  Named name -> if contractName == name
-    then getContractsMetaDataIdBySameNameQuery contractName
-    else getContractsMetaDataIdByNameQuery contractName name
+    getContractsMetaDataIdExhaustive contractName contractAddress chainId
+  Named name -> blocQuery1 "getContractsMetaDataId" $
+    if name == "Latest"
+      then getContractsMetaDataIdByLatestQuery contractName
+      else if contractName == name
+        then getContractsMetaDataIdBySameNameQuery contractName
+        else getContractsMetaDataIdByNameQuery contractName name
 
 getContractsMetaDataIdExhaustive :: Text -> Address -> Maybe ChainId -> Bloc Int32
 getContractsMetaDataIdExhaustive contractName contractAddr chainId = do
@@ -471,10 +468,8 @@ getContractsMetaDataIdByAddressQuery
   -> Maybe ChainId
   -> Query (Column PGInt4)
 getContractsMetaDataIdByAddressQuery contractName contractAddress chainId =
-  proc () -> do
-    (cmId,_,_,_,_,_,_,_,_,_,_) <-
-      contractByAddress contractName contractAddress chainId -< ()
-    returnA -< cmId
+  getContractsContractByAddressQuery contractName contractAddress chainId
+    >>> arr (\(_,_,(_,_,_,_,_,_,cmId,_)) -> cmId)
 
 {- |
 SELECT
@@ -553,7 +548,8 @@ getContractsMetaDataIdByNameQuery
   -> Query (Column PGInt4)
 getContractsMetaDataIdByNameQuery name1 name2 =
   limit 1 . orderBy (desc id) $
-    byNameQuery name1 name2 >>> arr (\(_,_,_,_,_,_,cm2Id,_) -> cm2Id)
+    getContractsContractByNameQuery name1 name2
+      >>> arr (\(_,_,_,_,_,_,cm2Id,_) -> cm2Id)
 
 {- |
 SELECT
@@ -571,7 +567,6 @@ JOIN contracts_metadata CM2
 JOIN contracts C2
   ON C2.id = CM2.contract_id
 WHERE C.name = $1 AND C2.name=$2
-LIMIT 1;
 -}
 getContractsContractByNameQuery
   :: Text
@@ -586,40 +581,7 @@ getContractsContractByNameQuery
     , Column PGInt4
     , Column PGBytea
     )
-getContractsContractByNameQuery contractName1 contractName2 =
-  limit 1 $ byNameQuery contractName1 contractName2
-
-{- |
-SELECT
-   CM2.bin
- , CM2.bin_runtime
- , CM2.code_hash
- , C2.name
-FROM contracts_metadata CM
-JOIN contracts C
-  ON C.id = CM.contract_id
-JOIN contracts_lookup CL
-  ON CL.contract_metadata_id = CM.id
-JOIN contracts_metadata CM2
-  ON CM2.id = CL.linked_metadata_id
-JOIN contracts C2
-  ON C2.id = CM2.contract_id
-WHERE C.name = $1 AND C2.name=$2
--}
-byNameQuery
-  :: Text
-  -> Text
-  -> Query
-    ( Column PGBytea
-    , Column PGBytea
-    , Column PGBytea
-    , Column PGBytea
-    , Column PGText
-    , Column PGText
-    , Column PGInt4
-    , Column PGBytea
-    )
-byNameQuery contractName1 contractName2 = proc () -> do
+getContractsContractByNameQuery contractName1 contractName2 = proc () -> do
   (b,br,ch,xch,name1,name2,src,cm2Id,xabi) <- linkedContractsJoinTable -< ()
   restrict -< name1 .== constant contractName1
   restrict -< name2 .== constant contractName2
@@ -636,16 +598,9 @@ LIMIT 1;
 -}
 getContractsMetaDataIdBySameNameQuery :: Text -> Query (Column PGInt4)
 getContractsMetaDataIdBySameNameQuery contractName =
-  limit 1 . orderBy (desc id) $ proc () -> do
-    (cmId,name) <- joinTable -< ()
-    restrict -< name .== constant contractName
-    returnA -< cmId
-  where
-    joinTable = joinF
-      (\ (cmId,_,_,_,_,_,_,_) (_,name) -> (cmId,name))
-      (\ (_,contractId,_,_,_,_,_,_) (cId,_) -> cId .== contractId)
-      (queryTable contractsMetaDataTable)
-      (queryTable contractsTable)
+  limit 1 . orderBy (desc id) $
+    getContractsContractBySameNameQuery contractName
+      >>> arr (\(_,_,_,_,_,_,cmId,_) -> cmId)
 
 {- |
 SELECT
@@ -657,7 +612,6 @@ FROM contracts_metadata CM
 JOIN contracts C
   ON C.id = CM.contract_id
 WHERE C.name = $1
-LIMIT 1;
 -}
 getContractsContractBySameNameQuery
   :: Text
@@ -671,11 +625,10 @@ getContractsContractBySameNameQuery
     , Column PGInt4
     , Column PGBytea
     )
-getContractsContractBySameNameQuery contractName =
-  limit 1 $ proc () -> do
-    (b,br,ch,xch,_,name,src,cmId,xabi) <- contractDetailsJoinTable -< ()
-    restrict -< name .== constant contractName
-    returnA -< (b,br,ch,xch,name,src,cmId,xabi)
+getContractsContractBySameNameQuery contractName = proc () -> do
+  (b,br,ch,xch,_,name,src,cmId,xabi) <- contractDetailsJoinTable -< ()
+  restrict -< name .== constant contractName
+  returnA -< (b,br,ch,xch,name,src,cmId,xabi)
 
 {- |
 SELECT CM.id
@@ -780,16 +733,16 @@ getContractDetailsAndMetadataId (ContractName contractName) contractId chainId =
           getContractsContractLatestQuery contractName
         detailsWith Nothing chainId tuple
       Unnamed addr -> do
-        (addr',cid,tuple) <- blocQuery1 "getContractDetails/unnamed" $
+        (addr',cid,tuple) <- blocQuery1 "getContractDetails/unnamed" . limit 1 $
           getContractsContractByAddressQuery contractName addr chainId
         detailsWith (Just (Unnamed addr')) cid tuple
       Named name -> if contractName == name
         then do
-          tuple <- blocQuery1 "getContractDetails/named" $
+          tuple <- blocQuery1 "getContractDetails/named" . limit 1 $
             getContractsContractBySameNameQuery name
           detailsWith (Just (Named name)) chainId tuple
         else do
-          tuple <- blocQuery1 "getContractDetails/otherNamed" $
+          tuple <- blocQuery1 "getContractDetails/otherNamed" . limit 1 $
             getContractsContractByNameQuery contractName name
           detailsWith (Just (Named name)) chainId tuple
 
@@ -1027,31 +980,7 @@ getContractXabiByMetadataId cmId = do
   deserializeXabi xabi'
   where ninth (_,_,_,_,_,_,_,_,x) = x
 
-getContractContractByMetadataId :: HasCallStack => Int32 -> Bloc Contract
-getContractContractByMetadataId metadataId = getContractRetry 0
-  where
-  -- Impatient clients may have submitted a contract and immediately issued
-  -- a function call against it. Here we give a basic defense against it.
-  -- A much nicer way to handle that is to return cookies to the client
-  -- after writes, and use that cookie on subsequent calls to block until
-  -- their write will be visible.
-  -- In the case of a true failure, the total sleep is (2^10 - 1)* 5ms = 5s
-      sleep t = liftIO . threadDelay . (1000*) $ t
-      getContractRetry :: Int -> Bloc Contract
-      getContractRetry t = do
-        x <- getContractXabiByMetadataId metadataId
-        case xAbiToContract x of
-          Right c -> return c
-          Left err ->
-            if t < 5000
-              then sleep t >> getContractRetry (1 + 2 * t)
-              else throwError . UserError $
-                    "getContractContractByMetadataId: invalid types in contract: " <> (Text.pack . show $ err)
-
 getContractXabi :: HasCallStack =>
                    ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc Xabi
-getContractXabi (ContractName contractName) contractId chainId = do
-  metadataId <- case contractId of
-    Named _ -> blocQuery1 "getContractXabi" $ getContractsMetaDataId contractName contractId chainId
-    Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr chainId
-  getContractXabiByMetadataId metadataId
+getContractXabi contractName contractId =
+  fmap contractdetailsXabi . getContractDetails contractName contractId

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -944,11 +944,14 @@ getContractDetailsByMetadataId cmId addr chainId = do
     }
 
 getContractDetails :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc ContractDetails
-getContractDetails (ContractName contractName) contractId chainId = do
+getContractDetails name contractId = fmap snd . getContractDetailsAndMetadataId name contractId
+
+getContractDetailsAndMetadataId :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc (Int32, ContractDetails)
+getContractDetailsAndMetadataId (ContractName contractName) contractId chainId = do
     let
-      detailsWith detailsAddr cid (bin,binRuntime,codeHash,_ :: ByteString,name,src,_ :: Int32,xabi') = do
+      detailsWith detailsAddr cid (bin,binRuntime,codeHash,_ :: ByteString,name,src,cmId,xabi') = do
         xabi <- decodeXabiJSON xabi'
-        return ContractDetails
+        return (cmId, ContractDetails
           { contractdetailsBin = Text.decodeUtf8 bin
           , contractdetailsAddress = detailsAddr
           , contractdetailsBinRuntime = Text.decodeUtf8 binRuntime
@@ -957,7 +960,7 @@ getContractDetails (ContractName contractName) contractId chainId = do
           , contractdetailsSrc = src
           , contractdetailsXabi = xabi
           , contractdetailsChainId = cid
-          }
+          })
     case contractId of
       Named "Latest" -> do
         tuple <- blocQuery1 "getContractDetails/latest" $

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -922,6 +922,9 @@ getXabiVariableNamesQuery metadataId = proc () -> do
   restrict -< cmid .== constant metadataId
   returnA -< varName
 
+deserializeXabi :: ByteString -> Bloc Xabi
+deserializeXabi = decodeXabiJSON
+
 decodeXabiJSON :: ByteString -> Bloc Xabi
 decodeXabiJSON xabi' = case decode (fromStrict xabi') of
   Nothing -> throwError $ DBError "Corrupted Xabi stored in database"
@@ -931,7 +934,7 @@ getContractDetailsByMetadataId :: Int32 -> MaybeNamed Address -> Maybe ChainId -
 getContractDetailsByMetadataId cmId addr chainId = do
   (bin,binRuntime,codeHash,_ :: ByteString,_ :: Keccak256,name,src,_ :: Int32,xabi') <-
     blocQuery1 "getContractDetailsByMetadataId" $ contractByMetadataId cmId
-  xabi <- decodeXabiJSON xabi'
+  xabi <- deserializeXabi xabi'
   return ContractDetails
     { contractdetailsBin = Text.decodeUtf8 bin
     , contractdetailsAddress = Just addr
@@ -950,7 +953,7 @@ getContractDetailsAndMetadataId :: ContractName -> MaybeNamed Address -> Maybe C
 getContractDetailsAndMetadataId (ContractName contractName) contractId chainId = do
     let
       detailsWith detailsAddr cid (bin,binRuntime,codeHash,_ :: ByteString,name,src,cmId,xabi') = do
-        xabi <- decodeXabiJSON xabi'
+        xabi <- deserializeXabi xabi'
         return (cmId, ContractDetails
           { contractdetailsBin = Text.decodeUtf8 bin
           , contractdetailsAddress = detailsAddr
@@ -984,7 +987,7 @@ getContractDetailsByCodeHash :: Keccak256 -> Bloc (Maybe (Int32, ContractDetails
 getContractDetailsByCodeHash codeHash = do
     mDetails <- fmap listToMaybe . blocQuery $ getContractsContractByCodeHashQuery codeHash
     for mDetails $ \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId,xabi') -> do
-      xabi <- decodeXabiJSON xabi'
+      xabi <- deserializeXabi xabi'
       return (cmId, ContractDetails
         { contractdetailsBin = Text.decodeUtf8 bin
         , contractdetailsAddress = Nothing
@@ -1254,7 +1257,7 @@ compileContract source = do
     then compileContractFromScratch source
     else fmap Map.fromList . forM details $
       \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId,xabi') -> do
-        xabi <- decodeXabiJSON xabi'
+        xabi <- deserializeXabi xabi'
         return (name,(cmId, ContractDetails
           { contractdetailsBin = Text.decodeUtf8 bin
           , contractdetailsAddress = Nothing

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -446,12 +446,10 @@ getContractsMetaDataIdExhaustive contractName contractAddr chainId = do
     byLatest = blocQuery $ getContractsMetaDataIdByLatestQuery contractName
     bySameName = blocQuery $ getContractsMetaDataIdBySameNameQuery contractName
 
-getContractDetailsByAddressOnly :: Address -> Maybe ChainId -> Bloc ContractDetails
+getContractDetailsByAddressOnly :: Address -> Maybe ChainId -> Bloc (Maybe ContractDetails)
 getContractDetailsByAddressOnly contractAddr chainId = do
-  mName <- blocQuery $ contractNameFromAddress contractAddr chainId
-  case mName of
-    [] -> throwError $ UserError "getContractDetailsByAddressOnly: couldn't find contract metadata id"
-    name:_ -> getContractDetails (ContractName name) (Unnamed contractAddr) chainId
+  mName <- fmap listToMaybe . blocQuery $ contractNameFromAddress contractAddr chainId
+  fmap join . for mName $ \name -> getContractDetails (ContractName name) (Unnamed contractAddr) chainId
 
 {- |
 SELECT CM.id
@@ -469,7 +467,7 @@ getContractsMetaDataIdByAddressQuery
   -> Query (Column PGInt4)
 getContractsMetaDataIdByAddressQuery contractName contractAddress chainId =
   getContractsContractByAddressQuery contractName contractAddress chainId
-    >>> arr (\(_,_,(_,_,_,_,_,_,cmId,_)) -> cmId)
+    >>> arr (\(_,_,_,_,_,_,cmId,_) -> cmId)
 
 {- |
 SELECT
@@ -494,20 +492,18 @@ getContractsContractByAddressQuery
   -> Query
     ( Column PGBytea
     , Column PGBytea
-    , ( Column PGBytea
-      , Column PGBytea
-      , Column PGBytea
-      , Column PGBytea
-      , Column PGText
-      , Column PGText
-      , Column PGInt4
-      , Column PGBytea
-    ) )
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGText
+    , Column PGText
+    , Column PGInt4
+    , Column PGBytea
+    )
 getContractsContractByAddressQuery contractName contractAddress chainId =
   limit 1 $ proc () -> do
-    (cmId,name,src,addr,_,bin,binRuntime,codeHash,xcodeHash,cid,xabi) <-
+    (cmId,name,src,_,_,bin,binRuntime,codeHash,xcodeHash,_,xabi) <-
       contractByAddress contractName contractAddress chainId -< ()
-    returnA -< (addr,cid,(bin,binRuntime,codeHash,xcodeHash,name,src,cmId,xabi))
+    returnA -< (bin,binRuntime,codeHash,xcodeHash,name,src,cmId,xabi)
 
 getContractsContractByCodeHashQuery
   :: Keccak256
@@ -709,10 +705,10 @@ getContractDetailsByMetadataId cmId addr chainId = do
     , contractdetailsChainId = chainId
     }
 
-getContractDetails :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc ContractDetails
-getContractDetails name contractId = fmap snd . getContractDetailsAndMetadataId name contractId
+getContractDetails :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc (Maybe ContractDetails)
+getContractDetails name contractId = fmap (fmap snd) . getContractDetailsAndMetadataId name contractId
 
-getContractDetailsAndMetadataId :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc (Int32, ContractDetails)
+getContractDetailsAndMetadataId :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc (Maybe (Int32, ContractDetails))
 getContractDetailsAndMetadataId (ContractName contractName) contractId chainId = do
     let
       detailsWith detailsAddr cid (bin,binRuntime,codeHash,_ :: ByteString,name,src,cmId,xabi') = do
@@ -729,22 +725,22 @@ getContractDetailsAndMetadataId (ContractName contractName) contractId chainId =
           })
     case contractId of
       Named "Latest" -> do
-        tuple <- blocQuery1 "getContractDetails/latest" $
+        tuple <- blocQueryMaybe $
           getContractsContractLatestQuery contractName
-        detailsWith Nothing chainId tuple
+        for tuple $ detailsWith Nothing chainId
       Unnamed addr -> do
-        (addr',cid,tuple) <- blocQuery1 "getContractDetails/unnamed" . limit 1 $
+        tuple <- fmap listToMaybe . blocQuery $
           getContractsContractByAddressQuery contractName addr chainId
-        detailsWith (Just (Unnamed addr')) cid tuple
+        for tuple $ detailsWith (Just (Unnamed addr)) chainId
       Named name -> if contractName == name
         then do
-          tuple <- blocQuery1 "getContractDetails/named" . limit 1 $
+          tuple <- fmap listToMaybe . blocQuery $
             getContractsContractBySameNameQuery name
-          detailsWith (Just (Named name)) chainId tuple
+          for tuple $ detailsWith (Just (Named name)) chainId
         else do
-          tuple <- blocQuery1 "getContractDetails/otherNamed" . limit 1 $
+          tuple <- fmap listToMaybe . blocQuery $
             getContractsContractByNameQuery contractName name
-          detailsWith (Just (Named name)) chainId tuple
+          for tuple $ detailsWith (Just (Named name)) chainId
 
 getContractDetailsByCodeHash :: Keccak256 -> Bloc (Maybe (Int32, ContractDetails))
 getContractDetailsByCodeHash codeHash = do
@@ -981,6 +977,6 @@ getContractXabiByMetadataId cmId = do
   where ninth (_,_,_,_,_,_,_,_,x) = x
 
 getContractXabi :: HasCallStack =>
-                   ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc Xabi
+                   ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc (Maybe Xabi)
 getContractXabi contractName contractId =
-  fmap contractdetailsXabi . getContractDetails contractName contractId
+  fmap (fmap contractdetailsXabi) . getContractDetails contractName contractId

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -26,7 +26,7 @@ import qualified Data.ByteArray                  as ByteArray
 import           Data.ByteString                 (ByteString)
 import qualified Data.ByteString                 as BS
 import qualified Data.ByteString.Char8           as Char8
-import           Data.ByteString.Lazy            (fromStrict)
+import           Data.ByteString.Lazy            (fromStrict, toStrict)
 import           Data.Foldable
 import           Data.Int                        (Int32)
 import           Data.Map.Strict                 (Map)
@@ -869,6 +869,9 @@ getXabiVariablesQuery cmId = do
     ty <- getXabiType typeid
     return $ Xabi.VarType atbytes (Just ispublic) (Just isconstant) value ty
 
+serializeXabi :: Xabi -> ByteString
+serializeXabi = toStrict . encode
+
 deserializeXabi :: ByteString -> Bloc Xabi
 deserializeXabi = decodeXabiJSON
 
@@ -1005,7 +1008,7 @@ insertContractMetaDataQuery
       , constant codeHash
       , constant xcodeHash
       , constant srcHash
-      , constant (encode xabi)
+      , constant (serializeXabi xabi)
       )]
       (\ (contractmetadataId,_,_,_,_,_,_,_) -> contractmetadataId)
 

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -163,8 +163,8 @@ contractsJoinTable = joinF
     (\ (_,n) (cmId,_,b,br,ch,xch,src) -> (cmId,n,src,b,br,ch,xch))
     (\ (cid,_) (_,contractId,_,_,_,_,_) -> cid .== contractId)
     (queryTable contractsTable) $ joinF
-      (\ (cmId,cid,b,br,ch,xch,_) (_,_,src) -> (cmId,cid,b,br,ch,xch,src))
-      (\ (_,_,_,_,_,_,sh) (_,sh',_) -> sh .== sh')
+      (\ (cmId,cid,b,br,ch,xch,_,_) (_,_,src) -> (cmId,cid,b,br,ch,xch,src))
+      (\ (_,_,_,_,_,_,sh,_) (_,sh',_) -> sh .== sh')
       (queryTable contractsMetaDataTable)
       (queryTable contractsSourceTable)
 
@@ -182,8 +182,8 @@ contractDetailsJoinTable = joinF
   (\ (_,name) (cmId,_,b,br,ch,xch,sh,src) -> (b,br,ch,xch,sh,name,src,cmId))
   (\ (cId,_) (_,contractId,_,_,_,_,_,_) -> cId .== contractId)
   (queryTable contractsTable) $ joinF
-    (\ (cmId,cid,b,br,ch,xch,sh) (_,_,src) -> (cmId,cid,b,br,ch,xch,sh,src))
-    (\ (_,_,_,_,_,_,sh) (_,sh',_) -> sh .== sh')
+    (\ (cmId,cid,b,br,ch,xch,sh,_) (_,_,src) -> (cmId,cid,b,br,ch,xch,sh,src))
+    (\ (_,_,_,_,_,_,sh,_) (_,sh',_) -> sh .== sh')
     (queryTable contractsMetaDataTable)
     (queryTable contractsSourceTable)
 
@@ -300,8 +300,8 @@ linkedContractsJoinTable = joinF
   (\ (_,name2) (name,src,cm2Id,_,b,br,ch,xch) -> (b,br,ch,xch,name,name2,src,cm2Id))
   (\ (c2Id,_) (_,_,_,contractId2,_,_,_,_) -> c2Id .== contractId2)
   (queryTable contractsTable) $ joinF
-    (\ (cm2Id,contractId2,_,_,_,_,_) (name,src,_,b,br,ch,xch) -> (name,src,cm2Id,contractId2,b,br,ch,xch))
-    (\ (cm2Id,_,_,_,_,_,_) (_,_,linkedmetadataId,_,_,_,_) -> cm2Id .== linkedmetadataId)
+    (\ (cm2Id,contractId2,_,_,_,_,_,_) (name,src,_,b,br,ch,xch) -> (name,src,cm2Id,contractId2,b,br,ch,xch))
+    (\ (cm2Id,_,_,_,_,_,_,_) (_,_,linkedmetadataId,_,_,_,_) -> cm2Id .== linkedmetadataId)
     (queryTable contractsMetaDataTable) $ joinF
       (\ (_,linkedmetadataId) (name,src,_,b,br,ch,xch) -> (name,src,linkedmetadataId,b,br,ch,xch))
       (\ (contractmetadataId,_) (_,_,cmId,_,_,_,_) -> contractmetadataId .== cmId)
@@ -309,8 +309,8 @@ linkedContractsJoinTable = joinF
         (\ (_,name) (cmId,_,b,br,ch,xch,src) -> (name,src,cmId,b,br,ch,xch))
         (\ (cid,_) (_,contractId,_,_,_,_,_) -> cid .== contractId)
         (queryTable contractsTable) $ joinF
-          (\ (cmId,cid,b,br,ch,xch,_) (_,_,src)-> (cmId,cid,b,br,ch,xch,src))
-          (\ (_,_,_,_,_,_,sh) (_,sh',_)-> sh .== sh')
+          (\ (cmId,cid,b,br,ch,xch,_,_) (_,_,src)-> (cmId,cid,b,br,ch,xch,src))
+          (\ (_,_,_,_,_,_,sh,_) (_,sh',_)-> sh .== sh')
           (queryTable contractsMetaDataTable)
           (queryTable contractsSourceTable)
 
@@ -666,8 +666,8 @@ getContractsMetaDataIdBySameNameQuery contractName =
     returnA -< cmId
   where
     joinTable = joinF
-      (\ (cmId,_,_,_,_,_,_) (_,name) -> (cmId,name))
-      (\ (_,contractId,_,_,_,_,_) (cId,_) -> cId .== contractId)
+      (\ (cmId,_,_,_,_,_,_,_) (_,name) -> (cmId,name))
+      (\ (_,contractId,_,_,_,_,_,_) (cId,_) -> cId .== contractId)
       (queryTable contractsMetaDataTable)
       (queryTable contractsTable)
 
@@ -1033,8 +1033,9 @@ insertContractMetaDataQuery
       , constant codeHash
       , constant xcodeHash
       , constant srcHash
+      , constant BS.empty
       )]
-      (\ (contractmetadataId,_,_,_,_,_,_) -> contractmetadataId)
+      (\ (contractmetadataId,_,_,_,_,_,_,_) -> contractmetadataId)
 
 {- |
 INSERT INTO contracts_lookup (contract_metadata_id, linked_metadata_id)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries/Deprecated.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries/Deprecated.hs
@@ -1,0 +1,370 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE Arrows                #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TupleSections         #-}
+
+module BlockApps.Bloc22.Database.Queries.Deprecated where
+
+import           ClassyPrelude                   ((<>))
+import           Control.Arrow
+import           Control.Concurrent              (threadDelay)
+import           Control.Monad
+import           Control.Monad.Except
+import           Crypto.Hash
+import qualified Crypto.Saltine.Class            as Saltine
+import qualified Crypto.Saltine.Core.SecretBox   as SecretBox
+import           Crypto.Secp256k1
+import           Data.Aeson                      (Result(..), fromJSON, decode, encode)
+import qualified Data.ByteArray                  as ByteArray
+import           Data.ByteString                 (ByteString)
+import qualified Data.ByteString                 as BS
+import qualified Data.ByteString.Char8           as Char8
+import           Data.ByteString.Lazy            (fromStrict, toStrict)
+import           Data.Int                        (Int32)
+import           Data.Map.Strict                 (Map)
+import qualified Data.Map.Strict                 as Map
+import           Data.Maybe
+import           Data.Profunctor
+import           Data.Profunctor.Product.Default
+import           Data.Text                       (Text)
+import qualified Data.Text                       as Text
+import qualified Data.Text.Encoding              as Text
+import           Data.Traversable
+import           Database.PostgreSQL.Simple      (Connection)
+import           GHC.Stack
+import           Opaleye                         hiding (not, null, index)
+import qualified Opaleye                         (not)
+
+
+import           BlockApps.Bloc22.API.Utils
+import           BlockApps.Bloc22.Crypto
+import           BlockApps.Bloc22.Database.Tables
+import           BlockApps.Bloc22.Database.Solc
+import           BlockApps.Bloc22.Monad
+import           BlockApps.Bloc22.Server.Utils
+import           BlockApps.Ethereum
+import           BlockApps.SolidityVarReader     (byteStringToWord256, word256ToByteString)
+import           BlockApps.Solidity.Contract
+import           BlockApps.Solidity.Parse.Parser
+import           BlockApps.Solidity.Xabi
+import qualified BlockApps.Solidity.Xabi.Def     as Xabi.Def
+import qualified BlockApps.Solidity.Xabi.Type    as Xabi
+import           BlockApps.Strato.Types
+import           BlockApps.XAbiConverter
+
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+
+{- |
+SELECT
+  XF.id
+ ,XF.name
+ ,XF.selector
+FROM xabi_functions XF
+WHERE XF.is_constructor = false AND XF.contract_metadata_id = $1;
+-}
+getXabiFunctionsQuery :: HasCallStack =>
+                         Int32 -> Bloc (Map Text Func)
+getXabiFunctionsQuery cmId = do
+  funcsWithIds <- fmap Map.fromList . blocQuery $ proc () -> do
+    (xfId,contractmetadataId,isConstr,name,mut) <-
+      queryTable xabiFunctionsTable -< ()
+    restrict -< contractmetadataId .== constant cmId .&& Opaleye.not isConstr
+    returnA -< (name,(xfId, mut))
+  for funcsWithIds $ \ (xfId, mut) -> do --TODO remove the selector from the DB
+    args <- getXabiFunctionsArgsQuery xfId
+    let
+      valMap valList = Map.fromList
+        [ ( "#" <> Text.pack (show (Xabi.indexedTypeIndex val)), val)
+        | val <- valList
+        ]
+    vals <- valMap <$> getXabiFunctionsReturnValuesQuery xfId
+    return  Func { funcArgs = args
+                 , funcVals = vals
+                 , funcContents = Nothing
+                 , funcStateMutability = mut
+                 , funcVisibility = Nothing
+                 , funcModifiers = Nothing
+                 }
+
+{- |
+SELECT
+  XF.id
+ ,XF.name
+ ,XF.selector
+FROM xabi_functions XF
+WHERE XF.is_constructor = false AND XF.contract_metadata_id = $1;
+-}
+getXabiConstrQuery :: HasCallStack =>
+                         Int32 -> Bloc (Maybe Func)
+getXabiConstrQuery cmId = do
+  funcsWithIds <- blocQueryMaybe $ proc () -> do
+    (xfId,contractmetadataId,isConstr,name, _) <-
+      queryTable xabiFunctionsTable -< ()
+    restrict -< contractmetadataId .== constant cmId .&& isConstr
+    returnA -< (name,xfId)
+  for funcsWithIds $ \(_ :: Text, xfId) -> do
+    args <- getXabiFunctionsArgsQuery xfId
+    let
+      valMap valList = Map.fromList
+        [ ( "#" <> Text.pack (show (Xabi.indexedTypeIndex val)), val)
+        | val <- valList
+        ]
+    vals <- valMap <$> getXabiFunctionsReturnValuesQuery xfId
+    return $ Func { funcArgs = args
+                  , funcVals = vals
+                  , funcStateMutability = Nothing
+                  , funcContents = Nothing
+                  , funcVisibility = Nothing
+                  , funcModifiers = Nothing
+                  }
+
+{- |
+SELECT
+  ,XFA.name
+  ,XFA.index
+  ,XT.type
+  ,XT.typedef
+  ,XT.is_dynamic
+  ,XT.bytes
+  ,XTE.type as entry_type
+  ,XTE.bytes as entry_bytes
+FROM xabi_function_arguments XFA
+JOIN xabi_types XT
+  ON XT.id = XFA.type_id
+LEFT OUTER JOIN xabi_types XTE
+  ON XTE.id = XT.entry_type_id
+WHERE XFA.function_id = $1;
+-}
+getXabiFunctionsArgsQuery
+  :: Int32
+  -> Bloc (Map Text Xabi.IndexedType)
+getXabiFunctionsArgsQuery funcId = do
+  argsWithIds <- fmap Map.fromList . blocQuery $ proc () -> do
+    (_,functionId,tyid,name,index) <-
+      queryTable xabiFunctionArgumentsTable -< ()
+    restrict -< functionId .== constant funcId
+    returnA -< (name,(index,tyid))
+  for argsWithIds $ \ (index,tyid) -> do
+    ty <- getXabiType tyid
+    return $ Xabi.IndexedType index ty
+
+{- |
+SELECT
+  (CASE WHEN XFR.name IS NULL THEN '#' + CAST(XFR.index AS VARCHAR(20)) ELSE XFR.name END) as name
+  ,XFR.index
+  ,XT.type
+  ,XT.typedef
+  ,XT.is_dynamic
+  ,XT.bytes
+  ,XTE.type as entry_type
+  ,XTE.bytes as entry_bytes
+FROM xabi_function_return XFR
+JOIN xabi_types XT
+  ON XT.id = XFR.type_id
+LEFT OUTER JOIN xabi_types XTE
+  ON XTE.id = XT.entry_type_id
+WHERE XFR.function_id = $1;"
+-}
+getXabiFunctionsReturnValuesQuery :: HasCallStack =>
+                                     Int32 -> Bloc [Xabi.IndexedType]
+getXabiFunctionsReturnValuesQuery funcId = do
+  valsWithIds <- blocQuery $ proc () -> do
+    (_,functionId,index,tyid) <-
+      queryTable xabiFunctionReturnsTable -< ()
+    restrict -< functionId .== constant funcId
+    returnA -< (index,tyid)
+  for valsWithIds $ \ (index,tyid) -> do
+    ty <- getXabiType tyid
+    return $ Xabi.IndexedType index ty
+
+{- |
+SELECT
+   XV.name
+  ,XV.at_bytes
+  ,XV.type_id
+FROM
+  xabi_variables XV
+WHERE XV.contract_metadata_id = $1;
+-}
+getXabiVariablesQuery :: Int32 -> Bloc (Map Text Xabi.VarType)
+getXabiVariablesQuery cmId = do
+  varsWithIds <- fmap Map.fromList . blocQuery $ proc () -> do
+    (_,cmid,typeid,name,atbytes,ispublic,isconstant,value)
+      <- queryTable xabiVariablesTable -< ()
+    restrict -< cmid .== constant cmId
+    returnA -< (name,(atbytes,ispublic,isconstant,value,typeid))
+  for varsWithIds $ \ (atbytes,ispublic,isconstant, value,typeid) -> do
+    ty <- getXabiType typeid
+    return $ Xabi.VarType atbytes (Just ispublic) (Just isconstant) value ty
+
+instance QueryRunnerColumnDefault PGBytea Address where
+  queryRunnerColumnDefault = queryRunnerColumn id
+    (fromMaybe (error "could not decode address") . stringAddress . Char8.unpack)
+    queryRunnerColumnDefault
+instance Default Constant Address (Column PGBytea) where
+  def = lmap (Char8.pack . addressString) def
+
+instance QueryRunnerColumnDefault PGBytea SecretBox.Nonce where
+  queryRunnerColumnDefault = queryRunnerColumn id
+    (fromMaybe (error "could not decode nonce") . Saltine.decode)
+    queryRunnerColumnDefault
+instance Default Constant SecretBox.Nonce (Column PGBytea) where
+  def = lmap Saltine.encode def
+
+instance Default Constant PubKey (Column PGBytea) where
+  def = lmap (exportPubKey False) def
+
+instance QueryRunnerColumnDefault PGBytea PubKey where
+  queryRunnerColumnDefault =
+     queryRunnerColumn id toPubKey queryRunnerColumnDefault
+     where toPubKey :: ByteString -> PubKey
+           toPubKey = fromMaybe (error "could not import pubkey") . importPubKey
+
+instance Default Constant UserName (Column PGText) where
+  def = lmap getUserName def
+
+instance Default Constant StateMutability (Column PGText) where
+  def = lmap tShow def
+
+instance QueryRunnerColumnDefault PGText StateMutability where
+  queryRunnerColumnDefault = queryRunnerColumn id
+    (fromMaybe (error "could not decode mutability") . tRead)
+    queryRunnerColumnDefault
+
+instance QueryRunnerColumnDefault PGBytea Keccak256 where
+  queryRunnerColumnDefault =
+    queryRunnerColumn id toKecc queryRunnerColumnDefault
+    where
+      toKecc :: ByteString -> Keccak256
+      toKecc
+        = Keccak256
+        . fromMaybe (error "could not decode hash")
+        . digestFromByteString
+
+instance Default Constant Keccak256 (Column PGBytea) where
+  def = lmap fromKecc def
+    where
+      fromKecc :: Keccak256 -> ByteString
+      fromKecc (Keccak256 digest) = ByteArray.convert digest
+
+instance QueryRunnerColumnDefault PGBytea (Maybe ChainId) where
+  queryRunnerColumnDefault =
+    queryRunnerColumn id toChainId queryRunnerColumnDefault
+    where
+      toChainId :: ByteString -> Maybe ChainId
+      toChainId bs
+        = if BS.null bs
+            then Nothing
+            else Just
+               . ChainId
+               . byteStringToWord256
+               $ bs
+
+instance Default Constant (Maybe ChainId) (Column PGBytea) where
+  def = lmap fromChainId def
+        where fromChainId = \case
+                Nothing -> BS.empty
+                Just cid -> word256ToByteString $ unChainId cid
+
+getXabiType :: HasCallStack =>
+               Int32 -> Bloc Xabi.Type
+getXabiType typeId = do
+  (xtty,xttd,xtdy,xtsi,xtby,xtlen,xtetid,xtvtid,xtktid)
+    <- blocQuery1 "getXabiType" $ proc () -> do
+      (xtid,xtty,xttd,xtdy,xtsi,xtby,xtlen,xtet,xtvt,xtkt)
+        <- queryTable xabiTypesTable -< ()
+      restrict -< xtid .== constant typeId
+      returnA -< (xtty,xttd,xtdy,xtsi,xtby,xtlen,xtet,xtvt,xtkt)
+  case xtty::Text of
+    "Int" ->
+      return $ Xabi.Int (Just xtsi) xtby
+    "String" ->
+      return $ Xabi.String (Just xtdy)
+    "Bytes" ->
+      return $ Xabi.Bytes (Just xtdy) xtby
+    "Bool" ->
+      return Xabi.Bool
+    "Address" ->
+      return Xabi.Address
+    "Struct" -> do
+      xttd' <- blocMaybe "Missing typedef in type Struct" xttd
+      return $ Xabi.Struct xtby xttd'
+    "Enum" -> do
+      xttd' <- blocMaybe "Missing typedef in type Enum" xttd
+      return $ Xabi.Enum xtby xttd' Nothing
+    "Array" -> do
+      xtetid' <- blocMaybe "Missing entry type id in type Array" xtetid
+      xtet <- getXabiType xtetid'
+      return $ Xabi.Array xtet (fmap fromIntegral (xtlen :: Maybe Int32))
+    "Contract" -> do
+      xttd' <- blocMaybe "Missing typedef in type Struct" xttd
+      return $ Xabi.Contract xttd'
+    "Mapping" -> do
+      xtktid' <- blocMaybe "Missing key type id in type Mapping" xtktid
+      xtvtid' <- blocMaybe "Missing value type id in type Mapping" xtvtid
+      xtkt <- getXabiType xtktid'
+      xtvt <- getXabiType xtvtid'
+      return $ Xabi.Mapping (Just xtdy) xtkt xtvt
+    "Label" -> do
+      xttd' <- blocMaybe "Missing typedef in type Enum" xttd
+      return $ Xabi.Label $ Text.unpack xttd'
+    _ -> throwError $ DBError "Could not match type"
+
+getXabiStructFields :: Int32 -> Bloc [(Text, Xabi.FieldType)]
+getXabiStructFields typeDefId = do
+  fieldsWithIds <- blocQuery $ proc () -> do
+    (_,name,atbytes,tdid,ftid)
+      <- queryTable xabiStructFieldsTable -< ()
+    restrict -< tdid .== constant typeDefId
+    returnA -< (name,(atbytes,ftid))
+  for fieldsWithIds $ \ (name,(atbytes,ftid)) -> do
+    ty <- getXabiType ftid
+    return (name, Xabi.FieldType atbytes ty)
+
+getXabiEnumNames :: Int32 -> Bloc [Text]
+getXabiEnumNames typeDefId = blocQuery $ proc () -> do
+  (_,name,_,tdid) <-
+    orderBy (asc (\ (_,_,value,_) -> value))
+      (queryTable xabiEnumNamesTable) -< ()
+  restrict -< tdid .== constant typeDefId
+  returnA -< name
+
+getXabiTypeDefs :: Int32 -> Bloc (Map Text Xabi.Def.Def)
+getXabiTypeDefs metadataId = do
+  typedefsWithIds <- fmap Map.fromList . blocQuery $ proc () -> do
+    (tdid,name,cmid,ty,by) <- queryTable xabiTypeDefsTable -< ()
+    restrict -< cmid .== constant metadataId
+    returnA -< (name,(tdid,ty,by))
+  for typedefsWithIds $ \ (tdid,ty,by::Int32) -> case ty of
+      "Struct" -> do
+        fields <- getXabiStructFields tdid
+        return $ Xabi.Def.Struct fields (fromIntegral by)
+      "Enum" -> do
+        names <- getXabiEnumNames tdid
+        return $ Xabi.Def.Enum names (fromIntegral by)
+      "Contract" ->
+        return $ Xabi.Def.Contract $ fromIntegral by
+      _ -> throwError $ DBError $
+        "Invalid type def. Expected Struct or Enum, saw " <> ty
+
+getContractXabiDeprecated :: HasCallStack =>
+                   ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc Xabi
+getContractXabiDeprecated (ContractName contractName) contractId chainId = do
+  metadataId <- case contractId of
+    Named _ -> blocQuery1 "getContractXabi" $ getContractsMetaDataId contractName contractId chainId
+    Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr chainId
+  funcs <- getXabiFunctionsQuery metadataId
+  constr <- getXabiConstrQuery metadataId
+  vars <- getXabiVariablesQuery metadataId
+  typeDefs <- getXabiTypeDefs metadataId
+  return xabiEmpty{ xabiFuncs = funcs
+                  , xabiConstr = constr
+                  , xabiVars = vars
+                  , xabiTypes = typeDefs
+                  }

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries/Deprecated.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries/Deprecated.hs
@@ -262,9 +262,7 @@ getXabiTypeDefs metadataId = do
 getContractXabiDeprecated :: HasCallStack =>
                    ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc Xabi
 getContractXabiDeprecated (ContractName contractName) contractId chainId = do
-  metadataId <- case contractId of
-    Named _ -> blocQuery1 "getContractXabi" $ getContractsMetaDataId contractName contractId chainId
-    Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr chainId
+  metadataId <- getContractsMetaDataId contractName contractId chainId
   funcs <- getXabiFunctionsQuery metadataId
   constr <- getXabiConstrQuery metadataId
   vars <- getXabiVariablesQuery metadataId

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries/Deprecated.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries/Deprecated.hs
@@ -262,13 +262,16 @@ getXabiTypeDefs metadataId = do
 getContractXabiDeprecated :: HasCallStack =>
                    ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc Xabi
 getContractXabiDeprecated (ContractName contractName) contractId chainId = do
-  metadataId <- getContractsMetaDataId contractName contractId chainId
-  funcs <- getXabiFunctionsQuery metadataId
-  constr <- getXabiConstrQuery metadataId
-  vars <- getXabiVariablesQuery metadataId
-  typeDefs <- getXabiTypeDefs metadataId
-  return xabiEmpty{ xabiFuncs = funcs
-                  , xabiConstr = constr
-                  , xabiVars = vars
-                  , xabiTypes = typeDefs
-                  }
+  mCmId <- getContractsMetaDataId contractName contractId chainId
+  case mCmId of
+    Nothing -> return xabiEmpty
+    Just cmId -> do
+      funcs <- getXabiFunctionsQuery cmId
+      constr <- getXabiConstrQuery cmId
+      vars <- getXabiVariablesQuery cmId
+      typeDefs <- getXabiTypeDefs cmId
+      return xabiEmpty{ xabiFuncs = funcs
+                      , xabiConstr = constr
+                      , xabiVars = vars
+                      , xabiTypes = typeDefs
+                      }

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries/Deprecated.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries/Deprecated.hs
@@ -13,50 +13,25 @@ module BlockApps.Bloc22.Database.Queries.Deprecated where
 
 import           ClassyPrelude                   ((<>))
 import           Control.Arrow
-import           Control.Concurrent              (threadDelay)
-import           Control.Monad
 import           Control.Monad.Except
-import           Crypto.Hash
-import qualified Crypto.Saltine.Class            as Saltine
-import qualified Crypto.Saltine.Core.SecretBox   as SecretBox
-import           Crypto.Secp256k1
-import           Data.Aeson                      (Result(..), fromJSON, decode, encode)
-import qualified Data.ByteArray                  as ByteArray
-import           Data.ByteString                 (ByteString)
-import qualified Data.ByteString                 as BS
-import qualified Data.ByteString.Char8           as Char8
-import           Data.ByteString.Lazy            (fromStrict, toStrict)
 import           Data.Int                        (Int32)
 import           Data.Map.Strict                 (Map)
 import qualified Data.Map.Strict                 as Map
-import           Data.Maybe
-import           Data.Profunctor
-import           Data.Profunctor.Product.Default
 import           Data.Text                       (Text)
 import qualified Data.Text                       as Text
-import qualified Data.Text.Encoding              as Text
 import           Data.Traversable
-import           Database.PostgreSQL.Simple      (Connection)
 import           GHC.Stack
 import           Opaleye                         hiding (not, null, index)
 import qualified Opaleye                         (not)
 
-
 import           BlockApps.Bloc22.API.Utils
-import           BlockApps.Bloc22.Crypto
+import           BlockApps.Bloc22.Database.Queries
 import           BlockApps.Bloc22.Database.Tables
-import           BlockApps.Bloc22.Database.Solc
 import           BlockApps.Bloc22.Monad
-import           BlockApps.Bloc22.Server.Utils
 import           BlockApps.Ethereum
-import           BlockApps.SolidityVarReader     (byteStringToWord256, word256ToByteString)
-import           BlockApps.Solidity.Contract
-import           BlockApps.Solidity.Parse.Parser
 import           BlockApps.Solidity.Xabi
 import qualified BlockApps.Solidity.Xabi.Def     as Xabi.Def
 import qualified BlockApps.Solidity.Xabi.Type    as Xabi
-import           BlockApps.Strato.Types
-import           BlockApps.XAbiConverter
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
 
@@ -202,75 +177,6 @@ getXabiVariablesQuery cmId = do
   for varsWithIds $ \ (atbytes,ispublic,isconstant, value,typeid) -> do
     ty <- getXabiType typeid
     return $ Xabi.VarType atbytes (Just ispublic) (Just isconstant) value ty
-
-instance QueryRunnerColumnDefault PGBytea Address where
-  queryRunnerColumnDefault = queryRunnerColumn id
-    (fromMaybe (error "could not decode address") . stringAddress . Char8.unpack)
-    queryRunnerColumnDefault
-instance Default Constant Address (Column PGBytea) where
-  def = lmap (Char8.pack . addressString) def
-
-instance QueryRunnerColumnDefault PGBytea SecretBox.Nonce where
-  queryRunnerColumnDefault = queryRunnerColumn id
-    (fromMaybe (error "could not decode nonce") . Saltine.decode)
-    queryRunnerColumnDefault
-instance Default Constant SecretBox.Nonce (Column PGBytea) where
-  def = lmap Saltine.encode def
-
-instance Default Constant PubKey (Column PGBytea) where
-  def = lmap (exportPubKey False) def
-
-instance QueryRunnerColumnDefault PGBytea PubKey where
-  queryRunnerColumnDefault =
-     queryRunnerColumn id toPubKey queryRunnerColumnDefault
-     where toPubKey :: ByteString -> PubKey
-           toPubKey = fromMaybe (error "could not import pubkey") . importPubKey
-
-instance Default Constant UserName (Column PGText) where
-  def = lmap getUserName def
-
-instance Default Constant StateMutability (Column PGText) where
-  def = lmap tShow def
-
-instance QueryRunnerColumnDefault PGText StateMutability where
-  queryRunnerColumnDefault = queryRunnerColumn id
-    (fromMaybe (error "could not decode mutability") . tRead)
-    queryRunnerColumnDefault
-
-instance QueryRunnerColumnDefault PGBytea Keccak256 where
-  queryRunnerColumnDefault =
-    queryRunnerColumn id toKecc queryRunnerColumnDefault
-    where
-      toKecc :: ByteString -> Keccak256
-      toKecc
-        = Keccak256
-        . fromMaybe (error "could not decode hash")
-        . digestFromByteString
-
-instance Default Constant Keccak256 (Column PGBytea) where
-  def = lmap fromKecc def
-    where
-      fromKecc :: Keccak256 -> ByteString
-      fromKecc (Keccak256 digest) = ByteArray.convert digest
-
-instance QueryRunnerColumnDefault PGBytea (Maybe ChainId) where
-  queryRunnerColumnDefault =
-    queryRunnerColumn id toChainId queryRunnerColumnDefault
-    where
-      toChainId :: ByteString -> Maybe ChainId
-      toChainId bs
-        = if BS.null bs
-            then Nothing
-            else Just
-               . ChainId
-               . byteStringToWord256
-               $ bs
-
-instance Default Constant (Maybe ChainId) (Column PGBytea) where
-  def = lmap fromChainId def
-        where fromChainId = \case
-                Nothing -> BS.empty
-                Just cid -> word256ToByteString $ unChainId cid
 
 getXabiType :: HasCallStack =>
                Int32 -> Bloc Xabi.Type

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Tables.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Tables.hs
@@ -156,18 +156,6 @@ contractsInstanceTable = Table "contracts_instance" $ p5
   , required "chainid"
   )
 
-contractsLookupTable :: Table
-  ( Column PGInt4
-  , Column PGInt4
-  )
-  ( Column PGInt4
-  , Column PGInt4
-  )
-contractsLookupTable = Table "contracts_lookup" $ p2
-  ( required "contract_metadata_id"
-  , required "linked_metadata_id"
-  )
-
 xabiFunctionsTable :: Table
   ( Maybe (Column PGInt4)
   , Column PGInt4

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Tables.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Tables.hs
@@ -113,6 +113,7 @@ contractsMetaDataTable :: Table
   , Column PGBytea
   , Column PGBytea
   , Column PGBytea
+  , Column PGBytea
   )
   ( Column PGInt4
   , Column PGInt4
@@ -121,8 +122,9 @@ contractsMetaDataTable :: Table
   , Column PGBytea
   , Column PGBytea
   , Column PGBytea
+  , Column PGBytea
   )
-contractsMetaDataTable = Table "contracts_metadata" $ p7
+contractsMetaDataTable = Table "contracts_metadata" $ p8
   ( optional "id"
   , required "contract_id"
   , required "bin"
@@ -130,6 +132,7 @@ contractsMetaDataTable = Table "contracts_metadata" $ p7
   , required "code_hash"
   , required "xcode_hash"
   , required "src_hash"
+  , required "xabi"
   )
 
 contractsInstanceTable :: Table

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -17,7 +17,6 @@ import qualified Data.Map.Strict                   as Map
 import           Data.Maybe                        (fromMaybe, isJust)
 import           Data.Text                         (Text)
 import qualified Data.Text                         as Text
-import           Opaleye                           hiding (not, null, index, sum)
 
 import           BlockApps.Bloc22.API.Chain
 import           BlockApps.Bloc22.Monad
@@ -33,7 +32,6 @@ import           BlockApps.Strato.Client           as Strato
 import           BlockApps.Strato.TypeLits
 import           BlockApps.Strato.Types            hiding (Transaction (..))
 import           BlockApps.Bloc22.Database.Queries
-import           BlockApps.Bloc22.Database.Tables
 import           BlockApps.XAbiConverter           (xAbiToContract)
 
 governanceAddress :: Address
@@ -104,15 +102,7 @@ postChainInfo (ChainInput src cname lbl balances chaininputArgs members mmd) = d
   chainId <- blocStrato $ Strato.postChain chainInfo
   when (isJust mContract) $ do
     let Just (cmId, _) = mContract
-    void . blocModify $ \conn -> runInsertMany conn contractsInstanceTable
-      [
-      ( Nothing
-      , constant cmId
-      , constant governanceAddress
-      , Nothing
-      , constant (Just chainId)
-      )
-      ]
+    void $ insertContractInstance cmId governanceAddress (Just chainId)
   return chainId
 
 getChainInfo :: [ChainId] -> Bloc [ChainIdChainOutput]

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -69,7 +69,16 @@ getContractsData (ContractName contractName) = blocTransaction $ do
   return $ map (Unnamed . fst) addresses ++ map Named names
 
 getContractsContract :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc ContractDetails
-getContractsContract name addr = getContractDetails name addr
+getContractsContract name addr chainId =
+  let err = UserError $ Text.concat
+              [ "getContractsContract: Couldn't find contract details for "
+              , Text.pack $ show name
+              , " at address "
+              , Text.pack $ show addr
+              , " on chain "
+              , maybe "Main" (Text.pack . show) chainId
+              ]
+   in maybe (throwError err) return =<< getContractDetails name addr chainId
 
 translateStorageMap :: [T.Storage] -> S.Storage
 translateStorageMap storage' =
@@ -86,12 +95,15 @@ getContractsState :: ContractName
                   -> Bool
                   -> Bloc GetContractsStateResponses -- state-translation
 getContractsState contract@(ContractName contractName) contractId chainId mName mCount mOffset mLength = do
-  eitherErrorOrContract' <- toUserError
-    (Text.pack $ "Couldn't find " ++ Text.unpack contractName ++ " with ID " ++ show contractId)
-      $ xAbiToContract <$> getContractXabi contract contractId chainId
-
-  contract' <-
-    either (throwError . UserError . Text.pack) return eitherErrorOrContract'
+  let err = UserError $ Text.concat
+              [ "getContractsState: Couldn't find "
+              , contractName
+              , "with ID "
+              , Text.pack $ show contractId
+              ]
+  mXabi <- getContractXabi contract contractId chainId
+  eitherErrorOrContract' <- maybe (throwError err) (return . xAbiToContract) mXabi
+  contract' <- either (throwError . UserError . Text.pack) return eitherErrorOrContract'
 
   address <- case contractId of
     Unnamed addr -> return addr
@@ -156,26 +168,56 @@ getContractsState contract@(ContractName contractName) contractId chainId mName 
 
 getContractsDetails :: Address -> Maybe ChainId -> Bloc ContractDetails
 getContractsDetails contractAddress chainId = do
-  toUserError
-    (Text.pack $ "Couldn't get contract details for address " ++ show contractAddress)
-    (getContractDetailsByAddressOnly contractAddress chainId >>= return . completeContractDetailXabi)
+  let err = UserError $ Text.concat
+              [ "getContractsDetails: couldn't find contract details for address "
+              , Text.pack $ addressString contractAddress
+              , " on chain "
+              , maybe "Main" (Text.pack . show) chainId
+              ]
+  mdetails <- getContractDetailsByAddressOnly contractAddress chainId
+  maybe (throwError err) (return . completeContractDetailXabi) mdetails
 
 getContractsFunctions :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc [FunctionName]
 getContractsFunctions contractName contractId chainId = blocTransaction $ do
-  xabi <- getContractXabi contractName contractId chainId
-  return . map FunctionName . Map.keys $ xabiFuncs xabi
+  let err = UserError $ Text.concat
+              [ "getContractsFunctions: couldn't find contract details for "
+              , Text.pack $ show contractName
+              , " at address "
+              , Text.pack $ show contractId
+              , " on chain "
+              , maybe "Main" (Text.pack . show) chainId
+              ]
+  mXabi <- getContractXabi contractName contractId chainId
+  maybe (throwError err) (return . map FunctionName . Map.keys . xabiFuncs) mXabi
 
 getContractsSymbols :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc [SymbolName]
 getContractsSymbols contractName contractId chainId = blocTransaction $ do
-  xabi <- getContractXabi contractName contractId chainId
-  return . map SymbolName . Map.keys $ xabiVars xabi
+  let err = UserError $ Text.concat
+              [ "getContractsSymbols: couldn't find contract details for "
+              , Text.pack $ show contractName
+              , " at address "
+              , Text.pack $ show contractId
+              , " on chain "
+              , maybe "Main" (Text.pack . show) chainId
+              ]
+  mXabi <- getContractXabi contractName contractId chainId
+  maybe (throwError err) (return . map SymbolName . Map.keys . xabiVars) mXabi
 
 getContractsEnum :: ContractName -> MaybeNamed Address -> EnumName -> Maybe ChainId -> Bloc [EnumValue]
-getContractsEnum contractName contractId (EnumName enumName) chainId =
+getContractsEnum contractName contractId (EnumName enumName) chainId = do
+  let err = UserError $ Text.concat
+              [ "getContractsEnum: couldn't find contract details for "
+              , Text.pack $ show contractName
+              , " at address "
+              , Text.pack $ show contractId
+              , " on chain "
+              , maybe "Main" (Text.pack . show) chainId
+              ]
   blocTransaction $ do
-    xabi <- getContractXabi contractName contractId chainId
-    let enums = concat [names | (n, Enum names _) <- Map.toList (xabiTypes xabi), n == enumName]
-    return $ map EnumValue enums
+    mXabi <- getContractXabi contractName contractId chainId
+    flip (maybe (throwError err)) mXabi $ \xabi ->
+      let enums = concat [names | (n, Enum names _) <- Map.toList (xabiTypes xabi), n == enumName]
+      in return $ map EnumValue enums
 
 getContractsStateMapping :: ContractName
                          -> MaybeNamed Address
@@ -185,7 +227,14 @@ getContractsStateMapping :: ContractName
                          -> Bloc GetContractsStateMappingResponse
                          -- state-translation
 getContractsStateMapping contract@(ContractName contractName) contractId (SymbolName mappingName) keyName chainId = do
-  eitherErrorOrContract <- xAbiToContract <$> getContractXabi contract contractId chainId
+  let err = UserError $ Text.concat
+              [ "getContractsStateMapping: Couldn't find "
+              , contractName
+              , "with ID "
+              , Text.pack $ show contractId
+              ]
+  mXabi <- getContractXabi contract contractId chainId
+  eitherErrorOrContract <- maybe (throwError err) (return . xAbiToContract) mXabi
 
   contract' <- either (throwError . UserError . Text.pack) return eitherErrorOrContract
   metadataId <- getContractsMetaDataId contractName contractId chainId
@@ -216,7 +265,7 @@ getContractsStateMapping contract@(ContractName contractName) contractId (Symbol
     ]
 
   case ret of
-   Left err -> throwError $ UserError $ Text.pack err
+   Left e -> throwError . UserError $ Text.pack e
    Right val -> return $ Map.fromList [(mappingName, Map.fromList [(keyName, val)])]
 
 getContractsStates :: ContractName -> Bloc [GetContractsStatesResponse] -- state-translation

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -162,24 +162,19 @@ getContractsDetails contractAddress chainId = do
     (getContractDetailsByAddressOnly contractAddress chainId >>= return . completeContractDetailXabi)
 
 getContractsFunctions :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc [FunctionName]
-getContractsFunctions (ContractName contractName) contractId chainId = blocTransaction $ do
-  metadataId <- blocQuery1 "getContractsFunctions" $ getContractsMetaDataId contractName contractId chainId
-  xabi <- getContractXabiByMetadataId metadataId
+getContractsFunctions contractName contractId chainId = blocTransaction $ do
+  xabi <- getContractXabi contractName contractId chainId
   return . map FunctionName . Map.keys $ xabiFuncs xabi
 
 getContractsSymbols :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc [SymbolName]
-getContractsSymbols (ContractName contractName) contractId chainId = blocTransaction $ do
-  metadataId <- blocQuery1 "getContractsSymbols" $ getContractsMetaDataId contractName contractId chainId
-  xabi <- getContractXabiByMetadataId metadataId
+getContractsSymbols contractName contractId chainId = blocTransaction $ do
+  xabi <- getContractXabi contractName contractId chainId
   return . map SymbolName . Map.keys $ xabiVars xabi
 
 getContractsEnum :: ContractName -> MaybeNamed Address -> EnumName -> Maybe ChainId -> Bloc [EnumValue]
-getContractsEnum (ContractName contractName) contractId (EnumName enumName) chainId =
+getContractsEnum contractName contractId (EnumName enumName) chainId =
   blocTransaction $ do
-    metadataId <- case contractId of
-      Named _ -> blocQuery1 "getContractsEnum" $ getContractsMetaDataId contractName contractId chainId
-      Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr chainId
-    xabi <- getContractXabiByMetadataId metadataId
+    xabi <- getContractXabi contractName contractId chainId
     let enums = concat [names | (n, Enum names _) <- Map.toList (xabiTypes xabi), n == enumName]
     return $ map EnumValue enums
 

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -101,19 +101,18 @@ getContractsState contract@(ContractName contractName) contractId chainId mName 
               , "with ID "
               , Text.pack $ show contractId
               ]
-  mXabi <- getContractXabi contract contractId chainId
-  eitherErrorOrContract' <- maybe (throwError err) (return . xAbiToContract) mXabi
+  (cmId, details) <- maybe (throwError err) return =<< getContractDetailsAndMetadataId contract contractId chainId
+  let eitherErrorOrContract' = xAbiToContract $ contractdetailsXabi details
   contract' <- either (throwError . UserError . Text.pack) return eitherErrorOrContract'
 
   address <- case contractId of
     Unnamed addr -> return addr
     Named "Latest" -> do
-      metadataId <- getContractsMetaDataId contractName contractId chainId
       blocQuery1 "getContractsState/instances" $ proc () -> do
         (_,cmId',addr,_,_) <-
           (limit 1 . orderBy (desc (\(_,_,_,time,_) -> time)))
             (queryTable contractsInstanceTable) -< ()
-        restrict -< cmId' .== constant (metadataId::Int32)
+        restrict -< cmId' .== constant cmId
         returnA -< addr
     Named somethingElse -> blocError $ UserError $
       "Expected address or \"Latest\": saw " <> somethingElse
@@ -233,11 +232,10 @@ getContractsStateMapping contract@(ContractName contractName) contractId (Symbol
               , "with ID "
               , Text.pack $ show contractId
               ]
-  mXabi <- getContractXabi contract contractId chainId
-  eitherErrorOrContract <- maybe (throwError err) (return . xAbiToContract) mXabi
+  (metadataId, details) <- maybe (throwError err) return =<< getContractDetailsAndMetadataId contract contractId chainId
+  let eitherErrorOrContract = xAbiToContract $ contractdetailsXabi details
 
   contract' <- either (throwError . UserError . Text.pack) return eitherErrorOrContract
-  metadataId <- getContractsMetaDataId contractName contractId chainId
   address <- case contractId of
               Unnamed addr -> return addr
               Named "Latest" -> blocQuery1 "getContractsStateMapping/instances" $ proc () -> do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -34,6 +34,7 @@ import           BlockApps.Ethereum
 import           BlockApps.Solidity.Contract
 import           BlockApps.Solidity.Parse.Parser (parseXabi)
 import           BlockApps.Solidity.Xabi
+import           BlockApps.Solidity.Xabi.Def
 import           BlockApps.SolidityVarReader
 import           BlockApps.Storage               as S
 import           BlockApps.Strato.Client
@@ -163,14 +164,14 @@ getContractsDetails contractAddress chainId = do
 getContractsFunctions :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc [FunctionName]
 getContractsFunctions (ContractName contractName) contractId chainId = blocTransaction $ do
   metadataId <- blocQuery1 "getContractsFunctions" $ getContractsMetaDataId contractName contractId chainId
-  funcs <- blocQuery $ getXabiFunctionNamesQuery metadataId
-  return $ map FunctionName funcs
+  xabi <- getContractXabiByMetadataId metadataId
+  return . map FunctionName . Map.keys $ xabiFuncs xabi
 
 getContractsSymbols :: ContractName -> MaybeNamed Address -> Maybe ChainId -> Bloc [SymbolName]
 getContractsSymbols (ContractName contractName) contractId chainId = blocTransaction $ do
   metadataId <- blocQuery1 "getContractsSymbols" $ getContractsMetaDataId contractName contractId chainId
-  vars <- blocQuery $ getXabiVariableNamesQuery metadataId
-  return $ map SymbolName vars
+  xabi <- getContractXabiByMetadataId metadataId
+  return . map SymbolName . Map.keys $ xabiVars xabi
 
 getContractsEnum :: ContractName -> MaybeNamed Address -> EnumName -> Maybe ChainId -> Bloc [EnumValue]
 getContractsEnum (ContractName contractName) contractId (EnumName enumName) chainId =
@@ -178,7 +179,9 @@ getContractsEnum (ContractName contractName) contractId (EnumName enumName) chai
     metadataId <- case contractId of
       Named _ -> blocQuery1 "getContractsEnum" $ getContractsMetaDataId contractName contractId chainId
       Unnamed contractAddr -> getContractsMetaDataIdExhaustive contractName contractAddr chainId
-    map (EnumValue . fst) <$> getEnumValues metadataId enumName
+    xabi <- getContractXabiByMetadataId metadataId
+    let enums = concat [names | (n, Enum names _) <- Map.toList (xabiTypes xabi), n == enumName]
+    return $ map EnumValue enums
 
 getContractsStateMapping :: ContractName
                          -> MaybeNamed Address

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -96,8 +96,7 @@ getContractsState contract@(ContractName contractName) contractId chainId mName 
   address <- case contractId of
     Unnamed addr -> return addr
     Named "Latest" -> do
-      metadataId <- blocQuery1 "getContractsState/metadataid" $
-        getContractsMetaDataId contractName contractId chainId
+      metadataId <- getContractsMetaDataId contractName contractId chainId
       blocQuery1 "getContractsState/instances" $ proc () -> do
         (_,cmId',addr,_,_) <-
           (limit 1 . orderBy (desc (\(_,_,_,time,_) -> time)))
@@ -188,12 +187,8 @@ getContractsStateMapping :: ContractName
 getContractsStateMapping contract@(ContractName contractName) contractId (SymbolName mappingName) keyName chainId = do
   eitherErrorOrContract <- xAbiToContract <$> getContractXabi contract contractId chainId
 
-  contract' <-
-    either (throwError . UserError . Text.pack) return eitherErrorOrContract
-
-  metadataId <- blocQuery1 "getContractsStateMapping/metadata" $
-    getContractsMetaDataId contractName contractId chainId
-
+  contract' <- either (throwError . UserError . Text.pack) return eitherErrorOrContract
+  metadataId <- getContractsMetaDataId contractName contractId chainId
   address <- case contractId of
               Unnamed addr -> return addr
               Named "Latest" -> blocQuery1 "getContractsStateMapping/instances" $ proc () -> do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -98,7 +98,7 @@ getContractsState contract@(ContractName contractName) contractId chainId mName 
   let err = UserError $ Text.concat
               [ "getContractsState: Couldn't find "
               , contractName
-              , "with ID "
+              , " with ID "
               , Text.pack $ show contractId
               ]
   (cmId, details) <- maybe (throwError err) return =<< getContractDetailsAndMetadataId contract contractId chainId

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -14,7 +14,7 @@ import           Control.Concurrent
 import           Control.Concurrent.Async.Lifted
 import           Control.Arrow
 import           Control.Exception.Lifted          (catch)
-import           Control.Lens                      ((%=), (<?=), at, use)
+import           Control.Lens                      ((<?=), at, use)
 import           Control.Lens.TH
 import           Control.Monad
 import           Control.Monad.Except
@@ -87,18 +87,8 @@ data TRD = TRD -- transaction resolution data
   , trdResult :: Maybe TransactionResult
   }
 
-data ContractCreationData = ContractCreationData
-  { metadataId :: Int32
-  , transactionHash :: Keccak256
-  , contractName :: ContractName
-  , contractChainId :: Maybe ChainId
-  , transactionResult :: Maybe TransactionResult
-  , batchIndex :: Integer
-  }
-
 data BatchState = BatchState
-  { _contractsList      :: [(Address, ContractCreationData)]
-  , _contractDetailsMap :: Map.Map ContractName ContractDetails
+  { _contractDetailsMap :: Map.Map ContractName ContractDetails
   , _functionXabiMap    :: Map.Map Int32 Xabi
   }
 makeLenses ''BatchState
@@ -528,7 +518,7 @@ postUsersContractMethod' FunctionParameters{..} sign = do
     getBlocTransactionResult' chainId [hash] resolve
 
 emptyBatchState :: BatchState
-emptyBatchState = BatchState [] Map.empty Map.empty
+emptyBatchState = BatchState Map.empty Map.empty
 
 getBlocTransactionResult' :: Maybe ChainId -> [Keccak256] -> Bool -> Bloc BlocTransactionResult
 getBlocTransactionResult' _ [] _ = throwError $ AnError "getBlockTransactionResult': no TX hashes"
@@ -550,81 +540,66 @@ getBatchBlocTransactionResult' chainId hashes resolve = do
       forM hashes $ \h -> return (BlocTransactionResult Pending h Nothing Nothing)
 
 postBlocTransactionResults :: Maybe ChainId -> Bool -> [Keccak256] -> Bloc [BlocTransactionResult]
-postBlocTransactionResults chainId resolve hashes = do
-  let resolutions' = zipWith (\h i -> TRD Pending h i Nothing) hashes [0..]
-  resolutions <- recurseTRDs chainId (0 :: Int) resolve resolutions' -- recursively batch resolve transactions
-  evalAndReturn resolutions -- evaluate transaction results
-
-merge :: [a] -> [a] -> (a -> a -> Bool) -> [a]
-merge [] ps _ = ps
-merge ds [] _ = ds
-merge (d:ds) (p:ps) c =
-  if c d p
-    then (d : merge ds (p:ps) c)
-    else (p : merge (d:ds) ps c)
+postBlocTransactionResults chainId resolve hashes = recurseTRDs chainId resolve hashes >>= evalAndReturn
 
 recurseTRDs :: Maybe ChainId
-        -> Int
-        -> Bool
-        -> [TRD]
-        -> Bloc [TRD]
-recurseTRDs chainId num resolve list = do
-  let his = map (arr trdHash &&& arr trdIndex) list
-  statusAndMtxrs <- flip zip his <$> getBatchBlocTxStatus chainId (map fst his)
-  let (pending', done) = partitionEithers $
-                  flip map statusAndMtxrs
-                    (\((s,r),(h,i)) ->
-                       if s == Pending
-                         then Left $ TRD s h i r
-                         else Right $ TRD s h i r)
-  pending <- if not resolve || null pending'
-    then return pending'
-    else
-      if num >= 60
+            -> Bool
+            -> [Keccak256]
+            -> Bloc [TRD]
+recurseTRDs chainId resolve hashes = go 0 (toPending hashes)
+  where
+    go :: Int -> [TRD] -> Bloc [TRD]
+    go num list = do
+      let his = map (trdHash &&& trdIndex) list
+      statusAndMtxrs <- flip zip his <$> getBatchBlocTxStatus chainId (map fst his)
+      let (pending', done) = partitionEithers $
+                      flip map statusAndMtxrs
+                        (\((s,r),(h,i)) ->
+                          if s == Pending
+                            then Left $ TRD s h i r
+                            else Right $ TRD s h i r)
+      pending <- if not resolve || null pending'
         then return pending'
-        else do
-          logWith logNotice . Text.pack $
-            "Polling BlocTransactionStatus for transaction hashes: " ++ (show $ map trdHash pending')
-          void . liftIO $ threadDelay 1000000
-          recurseTRDs chainId (num + 1) resolve pending'
-  return $ merge pending done (\(TRD _ _ i _) (TRD _ _ j _) -> i < j)
+        else
+          if num >= 60
+            then return pending'
+            else do
+              logWith logNotice . Text.pack $
+                "Polling BlocTransactionStatus for transaction hashes: " ++ (show $ map trdHash pending')
+              void . liftIO $ threadDelay 1000000
+              go (num + 1) pending'
+      return $ merge pending done (\(TRD _ _ i _) (TRD _ _ j _) -> i < j)
+
+    toPending :: [Keccak256] -> [TRD]
+    toPending = zipWith (\i h -> TRD Pending h i Nothing) [0..]
+
+    merge :: [a] -> [a] -> (a -> a -> Bool) -> [a]
+    merge [] ps _ = ps
+    merge ds [] _ = ds
+    merge (d:ds) (p:ps) c =
+      if c d p
+        then (d : merge ds (p:ps) c)
+        else (p : merge (d:ds) ps c)
 
 evalAndReturn :: [TRD] -> Bloc [BlocTransactionResult]
-evalAndReturn list = do
-  (mbtrs,state) <- forStateT emptyBatchState list $
-    \(TRD status hash index mtxr) -> do
-      case status of
-        Pending -> return . Just $ (BlocTransactionResult Pending hash Nothing Nothing, index)
-        Failure -> return . Just $ (BlocTransactionResult Failure hash mtxr Nothing, index)
+evalAndReturn list = fmap fst . forStateT emptyBatchState list $
+    \(TRD status hash _ mtxr) -> case status of
+        Pending -> return $ BlocTransactionResult Pending hash Nothing Nothing
+        Failure -> return $ BlocTransactionResult Failure hash mtxr Nothing
         Success -> do
           (cmId,ttype,tdata)::(Int32,Int32,Text) <- lift $ blocQuery1 "evalAndReturn" $ contractByTxHash hash
           case ttype of
-            0 -> return . Just $ (BlocTransactionResult Success hash mtxr (Just . Send . fromJust . Aeson.decode . BL.fromStrict $ Text.encodeUtf8 tdata), index)
-            1 -> contractResult hash mtxr cmId tdata index
-            2 -> functionResult hash mtxr cmId tdata index
+            0 -> return $ BlocTransactionResult Success hash mtxr (Just . Send . fromJust . Aeson.decode . BL.fromStrict $ Text.encodeUtf8 tdata)
+            1 -> contractResult hash mtxr cmId tdata
+            2 -> functionResult hash mtxr cmId tdata
             _ -> error $ "Unexpected transaction type: got" ++ show ttype
-  let jbtrs = [btr | Just btr <- mbtrs]
-      cl = reverse $ _contractsList state
-  (nbtrs,_) <- do
-    forStateT state cl $
-      \(addr', ContractCreationData cmId hash name chainId mtxr index) -> do
-        mdetails <- use (contractDetailsMap . at name)
-        details <- case mdetails of
-          Just details' -> return details'{contractdetailsAddress = Just (Unnamed addr')}
-          Nothing -> do
-            details' <- lift $ getContractDetailsByMetadataId cmId (Unnamed addr') chainId
-            contractDetailsMap . at name <?= details'
-        return $ (BlocTransactionResult Success hash mtxr (Just $ Upload details), index)
-  let btrs = map fst $ merge jbtrs nbtrs (\r1 r2 -> snd r1 < snd r2)
-  return btrs
 
 contractResult :: Keccak256
                -> Maybe TransactionResult
                -> Int32
                -> Text
-               -> Integer
-               -> StateT BatchState Bloc (Maybe (BlocTransactionResult, Integer))
-contractResult hash mtxr cmId name index = do
+               -> StateT BatchState Bloc BlocTransactionResult
+contractResult hash mtxr cmId name = do
   let
     Just txResult = mtxr
     chainId = transactionresultChainId txResult
@@ -643,25 +618,20 @@ contractResult hash mtxr cmId name index = do
       stratoMsg  -> lift $ throwError $ UserError stratoMsg
     Just addr' -> do
       let cn = ContractName name
-      mcds <- lift $ getContractDetails cn (Unnamed addr') chainId
-      case mcds of
+      mdetails <- use $ contractDetailsMap . at cn
+      details <- case mdetails of
+        Just details' -> return details'{contractdetailsAddress = Just (Unnamed addr')}
         Nothing -> do
-          contractsList %= ((addr', ContractCreationData cmId hash (ContractName name) chainId mtxr index):)
-          return Nothing
-        Just cds -> do
-          mdetails <- use $ contractDetailsMap . at cn
-          details <- case mdetails of
-            Just details' -> return details'{contractdetailsAddress = Just (Unnamed addr')}
-            Nothing -> contractDetailsMap . at cn <?= cds
-          return $ Just (BlocTransactionResult Success hash mtxr (Just $ Upload details), index)
+          cds <- lift $ getContractDetailsByMetadataId cmId (Unnamed addr') chainId
+          contractDetailsMap . at cn <?= cds
+      return $ BlocTransactionResult Success hash mtxr (Just $ Upload details)
 
 functionResult :: Keccak256
                -> Maybe TransactionResult
                -> Int32
                -> Text
-               -> Integer
-               -> StateT BatchState Bloc (Maybe (BlocTransactionResult, Integer))
-functionResult hash mtxr cmId funcName index = do
+               -> StateT BatchState Bloc BlocTransactionResult
+functionResult hash mtxr cmId funcName = do
   let Just txResult = mtxr
   mxabi <- use $ functionXabiMap . at cmId
   xabi <- case mxabi of
@@ -683,7 +653,7 @@ functionResult hash mtxr cmId funcName index = do
   case transactionresultMessage txResult of
     "Success!" -> do
       formattedResponse <- lift $ blocMaybe ("Failed to parse response: " <> txResp) mFormattedResponse
-      return $ Just (BlocTransactionResult Success hash mtxr (Just $ Call formattedResponse), index)
+      return $ BlocTransactionResult Success hash mtxr (Just $ Call formattedResponse)
     stratoMsg  -> lift $ throwError $ UserError stratoMsg
 
 convertEnumTypeToInt :: Type -> Type

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -13,6 +13,7 @@ import           Control.Concurrent
 import           Control.Concurrent.Async.Lifted
 import           Control.Arrow
 import           Control.Exception.Lifted          (catch)
+import           Control.Lens                      ((<?=), at, use)
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.Log
@@ -260,30 +261,20 @@ postUsersUploadList' ContractListParameters{..} sign = do
     else do
       let UploadListContract _ _ mtp _ _ = head contracts
       params <- getAccountTxParams fromAddr chainId mtp
-      (namesCmIdsTxs,_) <- forStateT (Map.empty, Map.empty, Map.empty) (zip contracts [0..]) $
+      (namesCmIdsTxs,_) <- forStateT Map.empty (zip contracts [0..]) $
         \(UploadListContract name args _ value md,nonceIncr) -> do
-          (names, cmIds, fIds) <- get
-          (bin, src, cmId, names') <- case Map.lookup name names of
-            Just (b, src, cm) -> return (b, src, cm, names)
+          mtuple <- use $ at name
+          (bin, src, cmId, xabi) <- case mtuple of
+            Just (b, src, cmId', x) -> return (b, src, cmId', x)
             Nothing -> do
-              (b16,src,cm) <- lift $ blocQuery1 "postUsersUploadList'" $ proc () -> do
-                (bin16,_,_,_,_,src,cmId',_) <- getContractsContractLatestQuery name -< ()
-                returnA -< (bin16,src,cmId')
+              (b16,src,(cmId' :: Int32),x') <- lift $ blocQuery1 "postUsersUploadList'" $ proc () -> do
+                (bin16,_,_,_,_,src,cmId',x'') <- getContractsContractLatestQuery name -< ()
+                returnA -< (bin16,src,cmId',x'')
               let (b, leftOver) = Base16.decode b16
               unless (ByteString.null leftOver) $ throwError $ AnError "Couldn't decode binary"
-              return (b, src, cm, Map.insert name (b, src, cm) names)
-          (mFunctionId, cmIds') <- case Map.lookup cmId cmIds of
-            Just fId -> return (fId, cmIds)
-            Nothing -> do
-              fId <- lift $ getConstructorId cmId
-              return (fId, Map.insert cmId fId cmIds)
-          (xabiArgs, fIds') <- case mFunctionId of
-            Nothing -> return (Map.empty, fIds)
-            Just functionId -> case Map.lookup functionId fIds of
-              Just xabiArgs' -> return (xabiArgs', fIds)
-              Nothing -> do
-                xabiArgs' <- lift $ getXabiFunctionsArgsQuery functionId
-                return (xabiArgs', Map.insert functionId xabiArgs' fIds)
+              x <- lift $ decodeXabiJSON x'
+              at name <?= (b, src, cmId', x)
+          let xabiArgs = maybe Map.empty funcArgs $ xabiConstr xabi
           argsBin <- lift $ constructArgValues (Just (fmap argValueToText args)) xabiArgs
           let metadata' = Just $ fromMaybe Map.empty md `Map.union`Map.fromList [("src",src),("name",name)]
           tx <- lift . signAndPrepare sign fromAddr metadata' $
@@ -295,7 +286,6 @@ postUsersUploadList' ContractListParameters{..} sign = do
                 (bin <> argsBin)
                 nonceIncr
                 chainId
-          put (names', cmIds', fIds')
           return ((name,cmId),tx)
       let
         txs = map snd namesCmIdsTxs

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -222,8 +222,8 @@ postUsersContract' ContractParameters{..} sign = blocTransaction $ do
     (bin,leftOver) = Base16.decode $ Text.encodeUtf8 contractdetailsBin
     metadata' = Just $ fromMaybe Map.empty metadata `Map.union` Map.fromList [("src", src),("name", cName)]
   unless (ByteString.null leftOver) $ throwError $ AnError "Couldn't decode binary"
-  mFunctionId <- getConstructorId cmId
-  argsBin <- buildArgumentByteString (fmap (fmap argValueToText) args) mFunctionId
+  let xabiArgs = maybe Map.empty funcArgs $ xabiConstr contractdetailsXabi
+  argsBin <- constructArgValues (fmap (fmap argValueToText) args) xabiArgs
   tx <- signAndPrepare sign fromAddr metadata' $
     TransactionHeader
       Nothing

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -377,34 +377,27 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
     else do
       let mc = head txs
       params <- getAccountTxParams fromAddr chainId $ methodcallTxParams mc
-      (txsCmIdsFuncNames,_) <- forStateT (Map.empty, Map.empty, Map.empty) (zip txs [0..]) $
+      txsCmIdsFuncNames <- fmap fst . forStateT Map.empty (zip txs [0..]) $
         \ (MethodCall{..},nonceIncr) -> do
-          (names, cmIds, fIds) <- get
-          (mapKey, names') <- case Map.lookup methodcallContractName names of
-            Just cmId -> return (cmId, names)
+          mtuple <- use $ at methodcallContractName
+          (mapKey, xabi) <- case mtuple of
+            Just (cmId, x) -> return (cmId, x)
             Nothing -> do
-              (mapKey' :: Int32) <- lift $ blocQuery1 "postUsersContractMethodList'" $ proc () -> do
-                (_,_,_,_,_,_,cmId,_) <- getContractsContractLatestQuery methodcallContractName -< ()
-                returnA -< cmId
-              return (mapKey', Map.insert methodcallContractName mapKey' names)
-          (contract', cmIds') <- case Map.lookup mapKey cmIds of
-            Just entry -> return (entry, cmIds)
-            Nothing -> do
-              mapValue <- lift $ getContractContractByMetadataId mapKey
-              return (mapValue, Map.insert mapKey mapValue cmIds)
+              (mapKey' :: Int32,x') <- lift $ blocQuery1 "postUsersContractMethodList'" $ proc () -> do
+                (_,_,_,_,_,_,cmId,x'') <- getContractsContractLatestQuery methodcallContractName -< ()
+                returnA -< (cmId,x'')
+              x <- lift $ decodeXabiJSON x'
+              at methodcallContractName <?= (mapKey', x)
+          contract' <- case xAbiToContract xabi of
+            Left err -> throwError . AnError $ Text.pack err
+            Right c -> return c
           let maybeFunc = OMap.lookup methodcallMethodName (fields $ C.mainStruct contract')
 
           sel <-
             case maybeFunc of
              Just (_, TypeFunction selector _ _) -> return selector
              _ -> lift $ throwError . UserError $ "Contract doesn't have a method named '" <> methodcallMethodName <> "'"
-
-          functionId <- lift $ getFunctionId mapKey methodcallMethodName
-          (xabiArgs, fIds') <- case Map.lookup functionId fIds of
-            Just xabiArgs' -> return (xabiArgs', fIds)
-            Nothing -> do
-              zxcv <- lift $ getXabiFunctionsArgsQuery functionId
-              return (zxcv, Map.insert functionId zxcv fIds)
+          let xabiArgs = maybe Map.empty funcArgs . Map.lookup methodcallMethodName $ xabiFuncs xabi
           argsBin <- lift $ constructArgValues (Just (fmap argValueToText methodcallArgs)) xabiArgs
           tx <- lift . signAndPrepare sign fromAddr methodcallMetadata $
             TransactionHeader
@@ -415,7 +408,6 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
               (sel <> argsBin)
               nonceIncr
               chainId
-          put (names', cmIds', fIds')
           -- resultXabiTypes <- getXabiFunctionsReturnValuesQuery functionId
           return (tx,mapKey,methodcallMethodName)
       let txs' = [tx | (tx,_,_) <- txsCmIdsFuncNames]

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -272,7 +272,7 @@ postUsersUploadList' ContractListParameters{..} sign = do
                 returnA -< (bin16,src,cmId',x'')
               let (b, leftOver) = Base16.decode b16
               unless (ByteString.null leftOver) $ throwError $ AnError "Couldn't decode binary"
-              x <- lift $ decodeXabiJSON x'
+              x <- lift $ deserializeXabi x'
               at name <?= (b, src, cmId', x)
           let xabiArgs = maybe Map.empty funcArgs $ xabiConstr xabi
           argsBin <- lift $ constructArgValues (Just (fmap argValueToText args)) xabiArgs
@@ -386,7 +386,7 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
               (mapKey' :: Int32,x') <- lift $ blocQuery1 "postUsersContractMethodList'" $ proc () -> do
                 (_,_,_,_,_,_,cmId,x'') <- getContractsContractLatestQuery methodcallContractName -< ()
                 returnA -< (cmId,x'')
-              x <- lift $ decodeXabiJSON x'
+              x <- lift $ deserializeXabi x'
               at methodcallContractName <?= (mapKey', x)
           contract' <- case xAbiToContract xabi of
             Left err -> throwError . AnError $ Text.pack err

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
 
@@ -13,12 +14,13 @@ import           Control.Concurrent
 import           Control.Concurrent.Async.Lifted
 import           Control.Arrow
 import           Control.Exception.Lifted          (catch)
-import           Control.Lens                      ((<?=), at, use)
+import           Control.Lens                      ((%=), (<?=), at, use)
+import           Control.Lens.TH
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.Log
 import           Control.Monad.Reader
-import           Control.Monad.Trans.State.Lazy    (StateT(..), get, put, runStateT)
+import           Control.Monad.Trans.State.Lazy    (StateT(..), runStateT)
 import           Crypto.Secp256k1
 import qualified Data.Aeson                        as Aeson
 import           Data.ByteString                   (ByteString)
@@ -77,6 +79,29 @@ data TransactionHeader = TransactionHeader
   }
 
 type Signer = UnsignedTransaction -> Bloc Transaction
+
+data TRD = TRD -- transaction resolution data
+  { trdStatus :: BlocTransactionStatus
+  , trdHash   :: Keccak256
+  , trdIndex  :: Integer
+  , trdResult :: Maybe TransactionResult
+  }
+
+data ContractCreationData = ContractCreationData
+  { metadataId :: Int32
+  , transactionHash :: Keccak256
+  , contractName :: ContractName
+  , contractChainId :: Maybe ChainId
+  , transactionResult :: Maybe TransactionResult
+  , batchIndex :: Integer
+  }
+
+data BatchState = BatchState
+  { _contractsList      :: [(Address, ContractCreationData)]
+  , _contractDetailsMap :: Map.Map ContractName ContractDetails
+  , _functionXabiMap    :: Map.Map Int32 Xabi
+  }
+makeLenses ''BatchState
 
 forStateT :: Monad m => s -> [a] -> (a -> StateT s m b) -> m ([b],s)
 forStateT s [] _ = return ([],s)
@@ -495,32 +520,8 @@ postUsersContractMethod' FunctionParameters{..} sign = do
       )]
     getBlocTransactionResult' chainId [hash] resolve
 
-data TRD = TRD -- transaction resolution data
-       { trdStatus :: BlocTransactionStatus
-       , trdHash   :: Keccak256
-       , trdIndex  :: Integer
-       , trdResult :: Maybe TransactionResult
-       }
-
-data ContractCreationData = ContractCreationData
-       { metadataId :: Int32
-       , transactionHash :: Keccak256
-       , contractName :: ContractName
-       , contractChainId :: Maybe ChainId
-       , transactionResult :: Maybe TransactionResult
-       , batchIndex :: Integer
-       }
-
-data BatchState = BatchState
-       { contractsList      :: [(Address, ContractCreationData)]
-       , contractDetailsMap :: Map.Map ContractName ContractDetails
-       , functionIdMap      :: Map.Map (Int32, Text) Int32
-       , functionXabiMap    :: Map.Map Int32 Xabi
-       , functionReturnMap  :: Map.Map Int32 [Type]
-       }
-
 emptyBatchState :: BatchState
-emptyBatchState = BatchState [] Map.empty Map.empty Map.empty Map.empty
+emptyBatchState = BatchState [] Map.empty Map.empty
 
 getBlocTransactionResult' :: Maybe ChainId -> [Keccak256] -> Bool -> Bloc BlocTransactionResult
 getBlocTransactionResult' _ [] _ = throwError $ AnError "getBlockTransactionResult': no TX hashes"
@@ -581,8 +582,7 @@ recurseTRDs chainId num resolve list = do
           recurseTRDs chainId (num + 1) resolve pending'
   return $ merge pending done (\(TRD _ _ i _) (TRD _ _ j _) -> i < j)
 
-evalAndReturn :: [TRD]
-              -> Bloc [BlocTransactionResult]
+evalAndReturn :: [TRD] -> Bloc [BlocTransactionResult]
 evalAndReturn list = do
   (mbtrs,state) <- forStateT emptyBatchState list $
     \(TRD status hash index mtxr) -> do
@@ -597,18 +597,16 @@ evalAndReturn list = do
             2 -> functionResult hash mtxr cmId tdata index
             _ -> error $ "Unexpected transaction type: got" ++ show ttype
   let jbtrs = [btr | Just btr <- mbtrs]
-      cl = contractsList state
+      cl = reverse $ _contractsList state
   (nbtrs,_) <- do
     forStateT state cl $
       \(addr', ContractCreationData cmId hash name chainId mtxr index) -> do
-        st <- get
-        let cds = contractDetailsMap st
-        (details, cds') <- case Map.lookup name cds of
-          Just details' -> return (details'{contractdetailsAddress = Just (Unnamed addr')}, cds)
+        mdetails <- use (contractDetailsMap . at name)
+        details <- case mdetails of
+          Just details' -> return details'{contractdetailsAddress = Just (Unnamed addr')}
           Nothing -> do
             details' <- lift $ getContractDetailsByMetadataId cmId (Unnamed addr') chainId
-            return (details', Map.insert name details' cds)
-        put st{contractDetailsMap = cds'}
+            contractDetailsMap . at name <?= details'
         return $ (BlocTransactionResult Success hash mtxr (Just $ Upload details), index)
   let btrs = map fst $ merge jbtrs nbtrs (\r1 r2 -> snd r1 < snd r2)
   return btrs
@@ -640,23 +638,18 @@ contractResult hash mtxr cmId name index = do
       xs::[Int32] <- lift $ blocQuery $ proc () -> do
         (cmId',_,_,_,_,_,_,_,_,_,_) <- contractByAddress name addr' chainId -< ()
         returnA -< cmId'
-      if (isNothing $ listToMaybe xs)
+      if isNothing $ listToMaybe xs
         then do
-          st <- get
-          put st{contractsList =
-                  (contractsList st) ++ [(addr', ContractCreationData cmId hash (ContractName name) chainId mtxr index)]
-                }
+          contractsList %= ((addr', ContractCreationData cmId hash (ContractName name) chainId mtxr index):)
           return Nothing
         else do
-          st <- get
-          let cds = contractDetailsMap st
-              cn  = ContractName name
-          (details, cds') <- case Map.lookup cn cds of
-            Just details' -> return (details'{contractdetailsAddress = Just (Unnamed addr')}, cds)
+          let cn  = ContractName name
+          mdetails <- use $ contractDetailsMap . at cn
+          details <- case mdetails of
+            Just details' -> return details'{contractdetailsAddress = Just (Unnamed addr')}
             Nothing -> do
               details' <- lift $ getContractDetails cn (Unnamed addr') chainId
-              return (details', Map.insert cn details' cds)
-          put st{contractDetailsMap = cds'}
+              contractDetailsMap . at cn <?= details'
           return $ Just (BlocTransactionResult Success hash mtxr (Just $ Upload details), index)
 
 functionResult :: Keccak256
@@ -667,37 +660,23 @@ functionResult :: Keccak256
                -> StateT BatchState Bloc (Maybe (BlocTransactionResult, Integer))
 functionResult hash mtxr cmId funcName index = do
   let Just txResult = mtxr
-  state <- get
-  (functionId, state') <- case Map.lookup (cmId,funcName) (functionIdMap state) of
-    Just fid -> return (fid, state)
-    Nothing -> do
-      fid <- lift $ getFunctionId cmId funcName
-      return (fid,state{functionIdMap = Map.insert (cmId,funcName) fid (functionIdMap state)})
-  (xabi, state'') <- case Map.lookup cmId (functionXabiMap state') of
-    Just xabi' -> return (xabi', state')
+  mxabi <- use $ functionXabiMap . at cmId
+  xabi <- case mxabi of
+    Just xabi' -> return xabi'
     Nothing -> do
       xabi' <- lift $ getContractXabiByMetadataId cmId
-      return (xabi', state'{functionXabiMap = Map.insert cmId xabi' (functionXabiMap state')})
-  (mappedResultTypes, state''') <- case Map.lookup functionId (functionReturnMap state'') of
-    Just types -> return (types, state'')
-    Nothing -> do
-      resultXabiTypes <- lift $ getXabiFunctionsReturnValuesQuery functionId
-      let
-        orderedResultIndexedXT = sortOn Xabi.indexedTypeIndex resultXabiTypes
-      orderedResultTypes <- lift $
-        for orderedResultIndexedXT $ \Xabi.IndexedType{..} ->
-          either (throwError . UserError . Text.pack) return $
-            xabiTypeToType xabi indexedTypeType
-      let
-        types' = map convertEnumTypeToInt orderedResultTypes
-      return (types', state''{functionReturnMap = Map.insert functionId types' (functionReturnMap state'')})
-  let
-    txResp = transactionresultResponse txResult
+      functionXabiMap . at cmId <?= xabi'
+  let resultXabiTypes = maybe [] (Map.elems . funcVals) . Map.lookup funcName $ xabiFuncs xabi
+      orderedResultIndexedXT = sortOn Xabi.indexedTypeIndex resultXabiTypes
+  orderedResultTypes <- lift $
+    for orderedResultIndexedXT $ \Xabi.IndexedType{..} ->
+      either (throwError . UserError . Text.pack) return $
+        xabiTypeToType xabi indexedTypeType
+  let mappedResultTypes = map convertEnumTypeToInt orderedResultTypes
+      txResp = transactionresultResponse txResult
     -- TODO::(map convertEnumTypeToInt orderedResultTypes) is currenlty a
     -- workaround for enums
-    mFormattedResponse =
-      convertResultResToVals txResp mappedResultTypes
-  put state'''
+      mFormattedResponse = convertResultResToVals txResp mappedResultTypes
   case transactionresultMessage txResult of
     "Success!" -> do
       formattedResponse <- lift $ blocMaybe ("Failed to parse response: " <> txResp) mFormattedResponse

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -458,18 +458,23 @@ postUsersContractMethod
 postUsersContractMethod' :: FunctionParameters -> Signer -> Bloc BlocTransactionResult
 postUsersContractMethod' FunctionParameters{..} sign = do
     params <- getAccountTxParams fromAddr chainId txParams
-    cmId <- getContractsMetaDataIdExhaustive contractName contractAddr chainId
 
-    contract' <- getContractContractByMetadataId cmId
+    (cmId,xabi) <- fmap contractdetailsXabi <$> getContractDetailsAndMetadataId
+                  (ContractName contractName)
+                  (Unnamed contractAddr)
+                  chainId
+    contract' <- case xAbiToContract xabi of
+      Left err -> throwError . AnError $ Text.pack err
+      Right c -> return c
 
     let maybeFunc = OMap.lookup funcName (fields $ C.mainStruct contract')
+        xabiArgs = maybe Map.empty funcArgs . Map.lookup funcName $ xabiFuncs xabi
 
     sel <-
       case maybeFunc of
        Just (_, TypeFunction selector _ _) -> return selector
        _ -> throwError . UserError $ "Contract doesn't have a method named '" <> funcName <> "'"
-    functionId <- getFunctionId cmId funcName
-    argsBin <- buildArgumentByteString (Just (fmap argValueToText args)) (Just functionId)
+    argsBin <- constructArgValues (Just (fmap argValueToText args)) xabiArgs
     tx <- signAndPrepare sign fromAddr metadata $
       TransactionHeader
         (Just contractAddr)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -267,7 +267,7 @@ postUsersUploadList' ContractListParameters{..} sign = do
             Just (b, src, cm) -> return (b, src, cm, names)
             Nothing -> do
               (b16,src,cm) <- lift $ blocQuery1 "postUsersUploadList'" $ proc () -> do
-                (bin16,_,_,_,_,src,cmId') <- getContractsContractLatestQuery name -< ()
+                (bin16,_,_,_,_,src,cmId',_) <- getContractsContractLatestQuery name -< ()
                 returnA -< (bin16,src,cmId')
               let (b, leftOver) = Base16.decode b16
               unless (ByteString.null leftOver) $ throwError $ AnError "Couldn't decode binary"
@@ -394,7 +394,7 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
             Just cmId -> return (cmId, names)
             Nothing -> do
               (mapKey' :: Int32) <- lift $ blocQuery1 "postUsersContractMethodList'" $ proc () -> do
-                (_,_,_,_,_,_,cmId) <- getContractsContractLatestQuery methodcallContractName -< ()
+                (_,_,_,_,_,_,cmId,_) <- getContractsContractLatestQuery methodcallContractName -< ()
                 returnA -< cmId
               return (mapKey', Map.insert methodcallContractName mapKey' names)
           (contract', cmIds') <- case Map.lookup mapKey cmIds of
@@ -651,7 +651,7 @@ contractResult hash mtxr cmId name index = do
       stratoMsg  -> lift $ throwError $ UserError stratoMsg
     Just addr' -> do
       xs::[Int32] <- lift $ blocQuery $ proc () -> do
-        (cmId',_,_,_,_,_,_,_,_,_) <- contractByAddress name addr' chainId -< ()
+        (cmId',_,_,_,_,_,_,_,_,_,_) <- contractByAddress name addr' chainId -< ()
         returnA -< cmId'
       if (isNothing $ listToMaybe xs)
         then do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -695,13 +695,6 @@ convertResultResToVals txResp responseTypes =
   let byteResp = fst (Base16.decode (Text.encodeUtf8 txResp))
   in map valueToSolidityValue <$> bytestringToValues byteResp responseTypes
 
-buildArgumentByteString :: Maybe (Map Text Text) -> Maybe Int32 -> Bloc ByteString
-buildArgumentByteString args mFunctionId = case mFunctionId of
-  Nothing -> return ByteString.empty
-  Just functionId -> do
-    argNamesTypes <- getXabiFunctionsArgsQuery functionId
-    constructArgValues args argNamesTypes
-
 constructArgValues :: Maybe (Map Text Text) -> Map Text Xabi.IndexedType -> Bloc ByteString
 constructArgValues args argNamesTypes = do
     let

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -561,7 +561,7 @@ recurseTRDs chainId resolve hashes = go 0 (toPending hashes)
       pending <- if not resolve || null pending'
         then return pending'
         else
-          if num >= 60
+          if num >= 600
             then return pending'
             else do
               logWith logNotice . Text.pack $

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -566,7 +566,7 @@ recurseTRDs chainId resolve hashes = go 0 (toPending hashes)
             else do
               logWith logNotice . Text.pack $
                 "Polling BlocTransactionStatus for transaction hashes: " ++ (show $ map trdHash pending')
-              void . liftIO $ threadDelay 1000000
+              void . liftIO $ threadDelay 100000
               go (num + 1) pending'
       return $ merge pending done (\(TRD _ _ i _) (TRD _ _ j _) -> i < j)
 

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -484,12 +484,19 @@ postUsersContractMethod' :: FunctionParameters -> Signer -> Bloc BlocTransaction
 postUsersContractMethod' FunctionParameters{..} sign = do
     params <- getAccountTxParams fromAddr chainId txParams
 
-    (cmId,xabi) <- fmap contractdetailsXabi <$> getContractDetailsAndMetadataId
-                  (ContractName contractName)
-                  (Unnamed contractAddr)
-                  chainId
+    let err = UserError $ Text.concat
+                [ "postUsersContractMethod': Couldn't find contract details for "
+                , contractName
+                , " at address "
+                , Text.pack $ addressString contractAddr
+                ]
+    (cmId,xabi) <- maybe (throwError err) (return . fmap contractdetailsXabi) =<<
+      getContractDetailsAndMetadataId
+        (ContractName contractName)
+        (Unnamed contractAddr)
+        chainId
     contract' <- case xAbiToContract xabi of
-      Left err -> throwError . AnError $ Text.pack err
+      Left e -> throwError . AnError $ Text.pack e
       Right c -> return c
 
     let maybeFunc = OMap.lookup funcName (fields $ C.mainStruct contract')
@@ -635,21 +642,17 @@ contractResult hash mtxr cmId name index = do
           Nothing -> lift $ throwError $ UserError "Transaction succeeded, but contract was neither created, nor destroyed"
       stratoMsg  -> lift $ throwError $ UserError stratoMsg
     Just addr' -> do
-      xs::[Int32] <- lift $ blocQuery $ proc () -> do
-        (cmId',_,_,_,_,_,_,_,_,_,_) <- contractByAddress name addr' chainId -< ()
-        returnA -< cmId'
-      if isNothing $ listToMaybe xs
-        then do
+      let cn = ContractName name
+      mcds <- lift $ getContractDetails cn (Unnamed addr') chainId
+      case mcds of
+        Nothing -> do
           contractsList %= ((addr', ContractCreationData cmId hash (ContractName name) chainId mtxr index):)
           return Nothing
-        else do
-          let cn  = ContractName name
+        Just cds -> do
           mdetails <- use $ contractDetailsMap . at cn
           details <- case mdetails of
             Just details' -> return details'{contractdetailsAddress = Just (Unnamed addr')}
-            Nothing -> do
-              details' <- lift $ getContractDetails cn (Unnamed addr') chainId
-              contractDetailsMap . at cn <?= details'
+            Nothing -> contractDetailsMap . at cn <?= cds
           return $ Just (BlocTransactionResult Success hash mtxr (Just $ Upload details), index)
 
 functionResult :: Keccak256

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -148,10 +148,10 @@ functionDetailsFromContract contract selector' =
       $ OMap.assocs
         (fields $ mainStruct contract)
 
-getFunctionDetailsFromSelector :: Int32 -> ByteString -> Bloc (Text, ([(Text,Type)],[(Maybe Text, Type)]))
-getFunctionDetailsFromSelector cmId sel' = do
-  contract' <- getContractContractByMetadataId cmId
-  return $ functionDetailsFromContract contract' sel'
+getFunctionDetailsFromSelector :: Xabi -> ByteString -> (Text, ([(Text,Type)],[(Maybe Text, Type)]))
+getFunctionDetailsFromSelector xabi sel' = case xAbiToContract xabi of
+  Left err -> error $ "getFunctionDetailsFromSelector: " ++ err
+  Right contract' -> functionDetailsFromContract contract' sel'
 
 convertEnumTypeToInt :: Type -> Type
 convertEnumTypeToInt = \case
@@ -163,12 +163,12 @@ convertEnumTypeToInt = \case
 convertByteStringToVals :: ByteString -> [Type] -> Maybe [SolidityValue]
 convertByteStringToVals byteResp responseTypes = map valueToSolidityValue <$> bytestringToValues byteResp responseTypes
 
-getFunctionCallValues :: Int32 -> ByteString -> ByteString -> Bloc (Text, [(Text, SolidityValue)], [(Text, SolidityValue)])
-getFunctionCallValues cmId input' output' = do
+getFunctionCallValues :: Xabi -> ByteString -> ByteString -> (Text, [(Text, SolidityValue)], [(Text, SolidityValue)])
+getFunctionCallValues xabi input' output' =
   let sel = B.take 4 input'
       data' = B.drop 4 input'
-  (fname,(itypes,otypes)) <- getFunctionDetailsFromSelector cmId sel
-  let typemap bs = uncurry zip
+      (fname,(itypes,otypes)) = getFunctionDetailsFromSelector xabi sel
+      typemap bs = uncurry zip
                    . fmap ( fromMaybe (repeat (SolidityValueAsString ""))
                      . convertByteStringToVals bs
                      . map convertEnumTypeToInt
@@ -178,7 +178,7 @@ getFunctionCallValues cmId input' output' = do
                (\i (n,v) -> (fromMaybe (T.pack $ '#':show i) n, v))
                ([0..] :: [Integer])
                (typemap output' otypes)
-  return (fname,imap,omap)
+   in (fname,imap,omap)
 
 processedContract :: Text
                   -> Text
@@ -202,19 +202,19 @@ processedContract abi name chain state Action{..} =
     , functionCallData = Nothing
     }
 
-makeFunctionInserts :: Int32
+makeFunctionInserts :: Xabi
                     -> Text
                     -> Text
                     -> Text
                     -> Map.Map Text Value
                     -> Action
                     -> Bloc [ProcessedContract]
-makeFunctionInserts cmId abi name chain state Action{..} =
+makeFunctionInserts xabi abi name chain state Action{..} =
   forM actionCallData $ \CallData{..} -> do
     let ibytes = _input
         obytes = fromMaybe B.empty _output
-    (f',i,o) <- getFunctionCallValues cmId ibytes obytes
-    let f = if T.null f'
+        (f',i,o) = getFunctionCallValues xabi ibytes obytes
+        f = if T.null f'
               then if actionType == Create
                     then "constructor"
                     else "fallback"
@@ -361,7 +361,13 @@ processTheMessages messages conn g = do
               let hInsert = processedContract strAbi strName chain newMap hRow
               functionHist <- isFunctionHistoric g $ actionCodeHash hRow
               fInserts <- if functionHist
-                            then lift $ makeFunctionInserts cmId strAbi strName chain newMap hRow
+                            then lift $ makeFunctionInserts
+                                          (contractdetailsXabi details)
+                                          strAbi
+                                          strName
+                                          chain
+                                          newMap
+                                          hRow
                             else pure []
               pure (hInsert, fInserts)
             else pure []


### PR DESCRIPTION
Contract Xabi is now stored as a single, JSON-serialized column in the `contracts_metadata` table. All endpoints interacting with the Xabi now must deserialized the entire blob instead of retrieving the specific piece from the database. However, this appears to not affect performance negatively on contracts "Wings-size" or smaller. Instead, there is a significant positive effect on performance for contract ingestion. With these changes, I've observed the following improvements in project deployment times:
Project: Old -> New
BlockApps-BA: 19s -> 14s 
HT3: 32s -> 16s
Wings: 50s -> 31s
Additionally, I removed the `contracts_lookup` table, as its purpose is achieved by the `src_hash` column of the `contracts_metadata` table. I also created batch queries for insertion into the `contracts` and `contracts_metadata` table. This improves ingestion of large sets of dependent contracts, such as the HT3 AdminInterface contract dependencies.
Finally, there is currently no migration from the old Xabi tables to the new Xabi column. Should this be required, I'll write it. However, it has been suggested that node upgrades should happen incrementally, by wiping and re-syncing a node with the rest of the network.