### PR TITLE
Improve extraction of PUSH payloads from bytestrings

### DIFF
--- a/core-strato/ethereum-vm/bench/CodeBench.hs
+++ b/core-strato/ethereum-vm/bench/CodeBench.hs
@@ -1,15 +1,8 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MagicHash #-}
-{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
-{-# OPTIONS_GHC -fno-warn-missing-fields #-}
-import Control.Monad
 import Criterion.Main
 import qualified Data.ByteString        as B
 
 import Blockchain.Data.Code
 import Blockchain.VM.Code
-
-import Test.Hspec
 
 {-# NOINLINE exampleCode #-}
 exampleCode :: Code
@@ -40,40 +33,9 @@ benchExtract25Fast :: Benchmark
 benchExtract25Fast = bench "extract25 fast"
                    $ nf (fastExtractQuad exampleCode 128) 25
 
-spec :: Spec
-spec = do
-  describe "push1" $ do
-    it "can extract 1 byte" $ do
-       fastExtractByte exampleCode 0 `shouldBe` defaultExtract exampleCode 0 1
-       fastExtractByte exampleCode 1 `shouldBe` defaultExtract exampleCode 1 1
-       fastExtractByte exampleCode 2 `shouldBe` defaultExtract exampleCode 2 1
-       map (fastExtractByte exampleCode) [0..255] `shouldBe` map (\x -> defaultExtract exampleCode x 1) [0..255]
-
-  describe "push low" $ do
-    it "can push 3 bytes" $ do
-      forM_ [0, 1, 7, 128] $ \n ->
-        fastExtractSingle exampleCode n 3 `shouldBe` defaultExtract exampleCode n 3
-    it "can push 7 bytes" $ do
-      forM_ [0, 1, 0xbb] $ \n ->
-        fastExtractSingle exampleCode n 7 `shouldBe` defaultExtract exampleCode n 7
-
-  describe "push high" $ do
-    it "can push 25 bytes" $ do
-      fastExtractQuad exampleCode 1 25 `shouldBe` defaultExtract exampleCode 1 25
-    it "can push 31 bytes" $ do
-      fastExtractQuad exampleCode 0 31 `shouldBe` defaultExtract exampleCode 0 31
-      fastExtractQuad exampleCode 1 31 `shouldBe` defaultExtract exampleCode 1 31
-      fastExtractQuad exampleCode 2 31 `shouldBe` defaultExtract exampleCode 2 31
-    it "can push 32 bytes" $ do
-      fastExtractQuad exampleCode 0 32 `shouldBe`  defaultExtract exampleCode 0 32
-      fastExtractQuad exampleCode 1 32 `shouldBe`  defaultExtract exampleCode 1 32
-      fastExtractQuad exampleCode 2 32 `shouldBe`  defaultExtract exampleCode 2 32
-      fastExtractQuad exampleCode 64 32 `shouldBe` defaultExtract exampleCode 64 32
-
 
 main :: IO ()
 main = do
-  hspec spec
   defaultMain [benchExtract1Slow, benchExtract1Fast,
                benchExtract3Slow, benchExtract3Fast,
                benchExtract25Slow, benchExtract25Fast]

--- a/core-strato/ethereum-vm/bench/CodeBench.hs
+++ b/core-strato/ethereum-vm/bench/CodeBench.hs
@@ -1,12 +1,11 @@
 import Criterion.Main
 import qualified Data.ByteString        as B
 
-import Blockchain.Data.Code
 import Blockchain.VM.Code
 
 {-# NOINLINE exampleCode #-}
-exampleCode :: Code
-exampleCode = Code $ B.pack $ [0..255]
+exampleCode :: B.ByteString
+exampleCode = B.pack $ [0..255]
 
 
 benchExtract1Slow :: Benchmark

--- a/core-strato/ethereum-vm/bench/CodeBench.hs
+++ b/core-strato/ethereum-vm/bench/CodeBench.hs
@@ -4,23 +4,10 @@
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
 import Control.Monad
 import Criterion.Main
-import Data.Bits
 import qualified Data.ByteString        as B
-import qualified Data.ByteString.Unsafe as BU
-import Data.Primitive.ByteArray
-import Foreign.Ptr
-import Foreign.Storable
-import GHC.Exts
-import GHC.Integer.GMP.Internals (Integer(..), BigNat(..))
-import GHC.Word
-import System.Endian
-import System.IO.Unsafe
-
-import Network.Haskoin.Internals (BigWord(..))
 
 import Blockchain.Data.Code
-import Blockchain.Strato.Model.ExtendedWord
-import Blockchain.Util
+import Blockchain.VM.Code
 
 import Test.Hspec
 
@@ -28,55 +15,6 @@ import Test.Hspec
 exampleCode :: Code
 exampleCode = Code $ B.pack $ [0..255]
 
--- Unoptimized push, for 8-24 bytes that are too infrequently seen
--- to bother writing a specialization.
-defaultExtract :: Code -> Int -> Int -> Word256
--- TODO(tim): Use fastBytesToWord256 once available
-defaultExtract (Code bs) off len = fromIntegral
-                                 . bytes2Integer
-                                 . B.unpack
-                                 . B.take len
-                                 . B.drop off
-                                 $ bs
-defaultExtract _ _ _ = error "precompiled contracts cannot slice code"
-
-fastExtractByte :: Code -> Int -> Word256
-fastExtractByte (Code !code) !off = let !(W8# b#) = BU.unsafeIndex code off
-                                 in BigWord (S# (word2Int# b#))
-fastExtractByte _ _ = error "cannot slice out of precompiled"
-
--- Used to push 2-7 bytes
-fastExtractSingle :: Code -> Int -> Int -> Word256
-fastExtractSingle (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
-  let !offPtr = castPtr ptr :: Ptr Word64
-      !delta = 64 - (8 * len)
-  -- This may read past the end of the bytestring, but if the read is allowed
-  -- those garbage bytes are truncated by the shift.
-  !rawBits <- peekByteOff offPtr off
-  let !(W64# w#) = toBE64 rawBits `shiftR` delta
-  return $! BigWord (S# (word2Int# w#))
-fastExtractSingle _ _ _ = error "cannot slice out of precompiled"
-
--- Used to push 25-32 bytes
-fastExtractQuad :: Code -> Int -> Int -> Word256
-fastExtractQuad (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
-  let !offPtr = castPtr (plusPtr ptr (off + len)) :: Ptr Word64
-  dst <- newByteArray 32
-  ll <- peekElemOff offPtr (-1)
-  lh <- peekElemOff offPtr (-2)
-  hl <- peekElemOff offPtr (-3)
-  -- This might be a violation: we read before the beginning of the bytestring.
-  -- However if the read is allowed, the garbage bytes are masked off.
-  hh <- peekElemOff offPtr (-4)
-
-  writeByteArray dst 0 $! toBE64 ll
-  writeByteArray dst 1 $! toBE64 lh
-  writeByteArray dst 2 $! toBE64 hl
-  let !mask = bit (8 * (len - 24)) - 1
-  writeByteArray dst 3 $! toBE64 hh .&. mask
-  !(ByteArray ba#) <- unsafeFreezeByteArray dst
-  return (BigWord (Jp# (BN# ba#)))
-fastExtractQuad _ _ _ = error "cannot slice out of precompiled"
 
 benchExtract1Slow :: Benchmark
 benchExtract1Slow = bench "extract1 slow"

--- a/core-strato/ethereum-vm/bench/CodeBench.hs
+++ b/core-strato/ethereum-vm/bench/CodeBench.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MagicHash #-}
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+{-# OPTIONS_GHC -fno-warn-missing-fields #-}
+import Control.Monad
+import Criterion.Main
+import Data.Bits
+import qualified Data.ByteString        as B
+import qualified Data.ByteString.Unsafe as BU
+import Data.Primitive.ByteArray
+import Foreign.Ptr
+import Foreign.Storable
+import GHC.Exts
+import GHC.Integer.GMP.Internals (Integer(..), BigNat(..))
+import GHC.Word
+import System.Endian
+import System.IO.Unsafe
+
+import Network.Haskoin.Internals (BigWord(..))
+
+import Blockchain.Data.Code
+import Blockchain.Strato.Model.ExtendedWord
+import Blockchain.Util
+
+import Test.Hspec
+
+{-# NOINLINE exampleCode #-}
+exampleCode :: Code
+exampleCode = Code $ B.pack $ [0..255]
+
+-- Unoptimized push, for 8-24 bytes that are too infrequently seen
+-- to bother writing a specialization.
+defaultExtract :: Code -> Int -> Int -> Word256
+-- TODO(tim): Use fastBytesToWord256 once available
+defaultExtract (Code bs) off len = fromIntegral
+                                 . bytes2Integer
+                                 . B.unpack
+                                 . B.take len
+                                 . B.drop off
+                                 $ bs
+defaultExtract _ _ _ = error "precompiled contracts cannot slice code"
+
+fastExtractByte :: Code -> Int -> Word256
+fastExtractByte (Code !code) !off = let !(W8# b#) = BU.unsafeIndex code off
+                                 in BigWord (S# (word2Int# b#))
+fastExtractByte _ _ = error "cannot slice out of precompiled"
+
+-- Used to push 2-7 bytes
+fastExtractSingle :: Code -> Int -> Int -> Word256
+fastExtractSingle (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
+  let !offPtr = castPtr ptr :: Ptr Word64
+      !delta = 64 - (8 * len)
+  -- This may read past the end of the bytestring, but if the read is allowed
+  -- those garbage bytes are truncated by the shift.
+  !rawBits <- peekByteOff offPtr off
+  let !(W64# w#) = toBE64 rawBits `shiftR` delta
+  return $! BigWord (S# (word2Int# w#))
+fastExtractSingle _ _ _ = error "cannot slice out of precompiled"
+
+-- Used to push 25-32 bytes
+fastExtractQuad :: Code -> Int -> Int -> Word256
+fastExtractQuad (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
+  let !offPtr = castPtr (plusPtr ptr (off + len)) :: Ptr Word64
+  dst <- newByteArray 32
+  ll <- peekElemOff offPtr (-1)
+  lh <- peekElemOff offPtr (-2)
+  hl <- peekElemOff offPtr (-3)
+  -- This might be a violation: we read before the beginning of the bytestring.
+  -- However if the read is allowed, the garbage bytes are masked off.
+  hh <- peekElemOff offPtr (-4)
+
+  writeByteArray dst 0 $! toBE64 ll
+  writeByteArray dst 1 $! toBE64 lh
+  writeByteArray dst 2 $! toBE64 hl
+  let !mask = bit (8 * (len - 24)) - 1
+  writeByteArray dst 3 $! toBE64 hh .&. mask
+  !(ByteArray ba#) <- unsafeFreezeByteArray dst
+  return (BigWord (Jp# (BN# ba#)))
+fastExtractQuad _ _ _ = error "cannot slice out of precompiled"
+
+benchExtract1Slow :: Benchmark
+benchExtract1Slow = bench "extract1 slow"
+                  $ nf (defaultExtract exampleCode 128) 1
+
+benchExtract1Fast :: Benchmark
+benchExtract1Fast = bench "extract1 fast"
+                  $ nf (fastExtractByte exampleCode) 128
+
+benchExtract3Slow :: Benchmark
+benchExtract3Slow = bench "extract3 slow"
+                  $ nf (defaultExtract exampleCode 128) 3
+
+benchExtract3Fast :: Benchmark
+benchExtract3Fast = bench "extract3 fast"
+                  $ nf (fastExtractSingle exampleCode 0) 3
+
+benchExtract25Slow :: Benchmark
+benchExtract25Slow = bench "extract25 slow"
+                   $ nf (defaultExtract exampleCode 128) 25
+
+benchExtract25Fast :: Benchmark
+benchExtract25Fast = bench "extract25 fast"
+                   $ nf (fastExtractQuad exampleCode 128) 25
+
+spec :: Spec
+spec = do
+  describe "push1" $ do
+    it "can extract 1 byte" $ do
+       fastExtractByte exampleCode 0 `shouldBe` defaultExtract exampleCode 0 1
+       fastExtractByte exampleCode 1 `shouldBe` defaultExtract exampleCode 1 1
+       fastExtractByte exampleCode 2 `shouldBe` defaultExtract exampleCode 2 1
+       map (fastExtractByte exampleCode) [0..255] `shouldBe` map (\x -> defaultExtract exampleCode x 1) [0..255]
+
+  describe "push low" $ do
+    it "can push 3 bytes" $ do
+      forM_ [0, 1, 7, 128] $ \n ->
+        fastExtractSingle exampleCode n 3 `shouldBe` defaultExtract exampleCode n 3
+    it "can push 7 bytes" $ do
+      forM_ [0, 1, 0xbb] $ \n ->
+        fastExtractSingle exampleCode n 7 `shouldBe` defaultExtract exampleCode n 7
+
+  describe "push high" $ do
+    it "can push 25 bytes" $ do
+      fastExtractQuad exampleCode 1 25 `shouldBe` defaultExtract exampleCode 1 25
+    it "can push 31 bytes" $ do
+      fastExtractQuad exampleCode 0 31 `shouldBe` defaultExtract exampleCode 0 31
+      fastExtractQuad exampleCode 1 31 `shouldBe` defaultExtract exampleCode 1 31
+      fastExtractQuad exampleCode 2 31 `shouldBe` defaultExtract exampleCode 2 31
+    it "can push 32 bytes" $ do
+      fastExtractQuad exampleCode 0 32 `shouldBe`  defaultExtract exampleCode 0 32
+      fastExtractQuad exampleCode 1 32 `shouldBe`  defaultExtract exampleCode 1 32
+      fastExtractQuad exampleCode 2 32 `shouldBe`  defaultExtract exampleCode 2 32
+      fastExtractQuad exampleCode 64 32 `shouldBe` defaultExtract exampleCode 64 32
+
+
+main :: IO ()
+main = do
+  hspec spec
+  defaultMain [benchExtract1Slow, benchExtract1Fast,
+               benchExtract3Slow, benchExtract3Fast,
+               benchExtract25Slow, benchExtract25Fast]

--- a/core-strato/ethereum-vm/bench/ExtractBench.hs
+++ b/core-strato/ethereum-vm/bench/ExtractBench.hs
@@ -1,7 +1,7 @@
 import Criterion.Main
 import qualified Data.ByteString        as B
 
-import Blockchain.VM.Code
+import Blockchain.VM.Opcodes
 
 {-# NOINLINE exampleCode #-}
 exampleCode :: B.ByteString

--- a/core-strato/ethereum-vm/package.yaml
+++ b/core-strato/ethereum-vm/package.yaml
@@ -128,8 +128,21 @@ benchmarks:
   microbench:
     source-dirs: bench/
     main: Microbench.hs
+    other-modules: []
     dependencies:
       - criterion
       - ethereum-vm
       - hashable
       - unordered-containers
+
+  codebench:
+    source-dirs: bench/
+    main: CodeBench.hs
+    other-modules: []
+    dependencies:
+      - cpu
+      - criterion
+      - ethereum-vm
+      - hspec
+      - integer-gmp
+      - primitive

--- a/core-strato/ethereum-vm/package.yaml
+++ b/core-strato/ethereum-vm/package.yaml
@@ -138,9 +138,9 @@ benchmarks:
       - hashable
       - unordered-containers
 
-  codebench:
+  extractbench:
     source-dirs: bench/
-    main: CodeBench.hs
+    main: ExtractBench.hs
     other-modules: []
     dependencies:
       - criterion

--- a/core-strato/ethereum-vm/package.yaml
+++ b/core-strato/ethereum-vm/package.yaml
@@ -30,6 +30,7 @@ dependencies:
   - classy-prelude
   - clockwork
   - containers
+  - cpu
   - cross-monitoring
   - cryptohash
   - deepseq
@@ -43,6 +44,7 @@ dependencies:
   - ghc
   - hedis
   - hflags
+  - integer-gmp
   - lens
   - leveldb-haskell
   - merkle-patricia-db
@@ -53,6 +55,7 @@ dependencies:
   - persistent-postgresql
   - persistent-sqlite
   - postgresql-simple
+  - primitive
   - prometheus-client
   - resourcet
   - strato-adit
@@ -140,9 +143,6 @@ benchmarks:
     main: CodeBench.hs
     other-modules: []
     dependencies:
-      - cpu
       - criterion
       - ethereum-vm
       - hspec
-      - integer-gmp
-      - primitive

--- a/core-strato/ethereum-vm/package.yaml
+++ b/core-strato/ethereum-vm/package.yaml
@@ -145,4 +145,3 @@ benchmarks:
     dependencies:
       - criterion
       - ethereum-vm
-      - hspec

--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -431,8 +431,7 @@ runOperation GAS = push =<< readGasRemaining =<< lift get
 
 runOperation JUMPDEST = return ()
 
-runOperation (PUSH vals) =
-  push $ (fromIntegral (bytes2Integer vals)::Word256)
+runOperation (PUSH vals) = push vals
 
 runOperation DUP1 = dupn 1
 runOperation DUP2 = dupn 2
@@ -725,6 +724,7 @@ runOperation SUICIDE = do
 
 runOperation (MalformedOpcode opcode) = do
   when flags_debug $ lift $ $logInfoS "runOp/MalformedOpcode" . T.pack $ CL.red ("Malformed Opcode: " ++ showHex opcode "")
+  $logInfoS "runOperation/malformed" . T.pack $ show opcode
   throwE MalformedOpcodeException
 
 runOperation x = error $ "Missing case in runOperation: " ++ show x
@@ -846,7 +846,7 @@ opGasPriceAndRefund x = return (opGasPrice x, 0)
 --Glogtopic 1 Paid for each topic of a LOG operation.
 
 formatOp::Operation->String
-formatOp (PUSH x) = "PUSH" ++ show (length x) -- ++ show x
+formatOp (PUSH x) = "PUSH " ++ show x
 formatOp x        = show x
 
 

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
@@ -1,28 +1,16 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MagicHash    #-}
 module Blockchain.VM.Code where
 
-import           Data.Bits
 import qualified Data.ByteString              as B
-import qualified Data.ByteString.Unsafe       as BU
 import qualified Data.IntSet                  as I
-import           Data.Primitive.ByteArray
-import           Foreign.Ptr
-import           Foreign.Storable
-import           GHC.Exts
-import           GHC.Integer.GMP.Internals (Integer(..), BigNat(..))
-import           GHC.Word
 import           Numeric
-import           System.Endian
-import           System.IO.Unsafe
 import           Text.PrettyPrint.ANSI.Leijen
 
 import qualified Blockchain.Colors            as CL
 import           Blockchain.Data.Code
 import           Blockchain.Format
-import           Blockchain.Util
 import           Blockchain.VM.Opcodes
-import           Network.Haskoin.Internals (BigWord(..), Word256)
+import           Blockchain.Util
 
 
 getOperationAt::Code->CodePointer->(Operation, CodePointer)
@@ -63,49 +51,3 @@ compile::[Operation]->Code
 compile x = Code bytes
   where
     bytes = B.pack $ op2OpCode =<< x
-
--- Unoptimized push, for 8-24 bytes that are too infrequently seen
--- to bother writing a specialization.
-defaultExtract :: B.ByteString -> Int -> Int -> Word256
--- TODO(tim): Use fastBytesToWord256 once available
-defaultExtract bs off len = fromIntegral
-                                 . bytes2Integer
-                                 . B.unpack
-                                 . B.take len
-                                 . B.drop off
-                                 $ bs
-
-fastExtractByte :: B.ByteString-> Int -> Word256
-fastExtractByte !code !off = let !(W8# b#) = BU.unsafeIndex code off
-                             in BigWord (S# (word2Int# b#))
-
--- Used to push 2-7 bytes
-fastExtractSingle :: B.ByteString-> Int -> Int -> Word256
-fastExtractSingle !code !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
-  let !offPtr = castPtr ptr :: Ptr Word64
-      !delta = 64 - (8 * len)
-  -- This may read past the end of the bytestring, but if the read is allowed
-  -- those garbage bytes are truncated by the shift.
-  !rawBits <- peekByteOff offPtr off
-  let !(W64# w#) = toBE64 rawBits `shiftR` delta
-  return $! BigWord (S# (word2Int# w#))
-
--- Used to push 25-32 bytes
-fastExtractQuad :: B.ByteString -> Int -> Int -> Word256
-fastExtractQuad !code !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
-  let !offPtr = castPtr (plusPtr ptr (off + len)) :: Ptr Word64
-  !dst <- newByteArray 32
-  !ll <- peekElemOff offPtr (-1)
-  !lh <- peekElemOff offPtr (-2)
-  !hl <- peekElemOff offPtr (-3)
-  -- This might be a violation: we read before the beginning of the bytestring.
-  -- However if the read is allowed, the garbage bytes are masked off.
-  !hh <- peekElemOff offPtr (-4)
-
-  writeByteArray dst 0 $! toBE64 ll
-  writeByteArray dst 1 $! toBE64 lh
-  writeByteArray dst 2 $! toBE64 hl
-  let !mask = bit (8 * (len - 24)) - 1
-  writeByteArray dst 3 $! toBE64 hh .&. mask
-  !(ByteArray ba#) <- unsafeFreezeByteArray dst
-  return (BigWord (Jp# (BN# ba#)))

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
@@ -1,9 +1,20 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MagicHash    #-}
 module Blockchain.VM.Code where
 
+import           Data.Bits
 import qualified Data.ByteString              as B
+import qualified Data.ByteString.Unsafe       as BU
 import qualified Data.IntSet                  as I
+import           Data.Primitive.ByteArray
+import           Foreign.Ptr
+import           Foreign.Storable
+import           GHC.Exts
+import           GHC.Integer.GMP.Internals (Integer(..), BigNat(..))
+import           GHC.Word
 import           Numeric
+import           System.Endian
+import           System.IO.Unsafe
 import           Text.PrettyPrint.ANSI.Leijen
 
 import qualified Blockchain.Colors            as CL
@@ -11,6 +22,7 @@ import           Blockchain.Data.Code
 import           Blockchain.Format
 import           Blockchain.Util
 import           Blockchain.VM.Opcodes
+import           Network.Haskoin.Internals (BigWord(..), Word256)
 
 
 getOperationAt::Code->CodePointer->(Operation, CodePointer)
@@ -51,3 +63,53 @@ compile::[Operation]->Code
 compile x = Code bytes
   where
     bytes = B.pack $ op2OpCode =<< x
+
+-- Unoptimized push, for 8-24 bytes that are too infrequently seen
+-- to bother writing a specialization.
+defaultExtract :: Code -> Int -> Int -> Word256
+-- TODO(tim): Use fastBytesToWord256 once available
+defaultExtract (Code bs) off len = fromIntegral
+                                 . bytes2Integer
+                                 . B.unpack
+                                 . B.take len
+                                 . B.drop off
+                                 $ bs
+defaultExtract _ _ _ = error "precompiled contracts cannot slice code"
+
+fastExtractByte :: Code -> Int -> Word256
+fastExtractByte (Code !code) !off = let !(W8# b#) = BU.unsafeIndex code off
+                                    in BigWord (S# (word2Int# b#))
+fastExtractByte _ _ = error "cannot slice out of precompiled"
+
+-- Used to push 2-7 bytes
+fastExtractSingle :: Code -> Int -> Int -> Word256
+fastExtractSingle (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
+  let !offPtr = castPtr ptr :: Ptr Word64
+      !delta = 64 - (8 * len)
+  -- This may read past the end of the bytestring, but if the read is allowed
+  -- those garbage bytes are truncated by the shift.
+  !rawBits <- peekByteOff offPtr off
+  let !(W64# w#) = toBE64 rawBits `shiftR` delta
+  return $! BigWord (S# (word2Int# w#))
+fastExtractSingle _ _ _ = error "cannot slice out of precompiled"
+
+-- Used to push 25-32 bytes
+fastExtractQuad :: Code -> Int -> Int -> Word256
+fastExtractQuad (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
+  let !offPtr = castPtr (plusPtr ptr (off + len)) :: Ptr Word64
+  dst <- newByteArray 32
+  ll <- peekElemOff offPtr (-1)
+  lh <- peekElemOff offPtr (-2)
+  hl <- peekElemOff offPtr (-3)
+  -- This might be a violation: we read before the beginning of the bytestring.
+  -- However if the read is allowed, the garbage bytes are masked off.
+  hh <- peekElemOff offPtr (-4)
+
+  writeByteArray dst 0 $! toBE64 ll
+  writeByteArray dst 1 $! toBE64 lh
+  writeByteArray dst 2 $! toBE64 hl
+  let !mask = bit (8 * (len - 24)) - 1
+  writeByteArray dst 3 $! toBE64 hh .&. mask
+  !(ByteArray ba#) <- unsafeFreezeByteArray dst
+  return (BigWord (Jp# (BN# ba#)))
+fastExtractQuad _ _ _ = error "cannot slice out of precompiled"

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
@@ -66,24 +66,22 @@ compile x = Code bytes
 
 -- Unoptimized push, for 8-24 bytes that are too infrequently seen
 -- to bother writing a specialization.
-defaultExtract :: Code -> Int -> Int -> Word256
+defaultExtract :: B.ByteString -> Int -> Int -> Word256
 -- TODO(tim): Use fastBytesToWord256 once available
-defaultExtract (Code bs) off len = fromIntegral
+defaultExtract bs off len = fromIntegral
                                  . bytes2Integer
                                  . B.unpack
                                  . B.take len
                                  . B.drop off
                                  $ bs
-defaultExtract _ _ _ = error "precompiled contracts cannot slice code"
 
-fastExtractByte :: Code -> Int -> Word256
-fastExtractByte (Code !code) !off = let !(W8# b#) = BU.unsafeIndex code off
-                                    in BigWord (S# (word2Int# b#))
-fastExtractByte _ _ = error "cannot slice out of precompiled"
+fastExtractByte :: B.ByteString-> Int -> Word256
+fastExtractByte !code !off = let !(W8# b#) = BU.unsafeIndex code off
+                             in BigWord (S# (word2Int# b#))
 
 -- Used to push 2-7 bytes
-fastExtractSingle :: Code -> Int -> Int -> Word256
-fastExtractSingle (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
+fastExtractSingle :: B.ByteString-> Int -> Int -> Word256
+fastExtractSingle !code !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
   let !offPtr = castPtr ptr :: Ptr Word64
       !delta = 64 - (8 * len)
   -- This may read past the end of the bytestring, but if the read is allowed
@@ -91,19 +89,18 @@ fastExtractSingle (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCStri
   !rawBits <- peekByteOff offPtr off
   let !(W64# w#) = toBE64 rawBits `shiftR` delta
   return $! BigWord (S# (word2Int# w#))
-fastExtractSingle _ _ _ = error "cannot slice out of precompiled"
 
 -- Used to push 25-32 bytes
-fastExtractQuad :: Code -> Int -> Int -> Word256
-fastExtractQuad (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
+fastExtractQuad :: B.ByteString -> Int -> Int -> Word256
+fastExtractQuad !code !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
   let !offPtr = castPtr (plusPtr ptr (off + len)) :: Ptr Word64
-  dst <- newByteArray 32
-  ll <- peekElemOff offPtr (-1)
-  lh <- peekElemOff offPtr (-2)
-  hl <- peekElemOff offPtr (-3)
+  !dst <- newByteArray 32
+  !ll <- peekElemOff offPtr (-1)
+  !lh <- peekElemOff offPtr (-2)
+  !hl <- peekElemOff offPtr (-3)
   -- This might be a violation: we read before the beginning of the bytestring.
   -- However if the read is allowed, the garbage bytes are masked off.
-  hh <- peekElemOff offPtr (-4)
+  !hh <- peekElemOff offPtr (-4)
 
   writeByteArray dst 0 $! toBE64 ll
   writeByteArray dst 1 $! toBE64 lh
@@ -112,4 +109,3 @@ fastExtractQuad (Code !code) !off !len = unsafePerformIO . BU.unsafeUseAsCString
   writeByteArray dst 3 $! toBE64 hh .&. mask
   !(ByteArray ba#) <- unsafeFreezeByteArray dst
   return (BigWord (Jp# (BN# ba#)))
-fastExtractQuad _ _ _ = error "cannot slice out of precompiled"

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Code.hs
@@ -14,11 +14,8 @@ import           Blockchain.Util
 
 
 getOperationAt::Code->CodePointer->(Operation, CodePointer)
-getOperationAt (Code bytes) p        = getOperationAt' bytes p
+getOperationAt (Code bytes) p        = opCode2Op bytes p
 getOperationAt (PrecompiledCode _) _ = error "getOperationAt called for precompilded code"
-
-getOperationAt'::B.ByteString->Int->(Operation, CodePointer)
-getOperationAt' rom p = opCode2Op $ safeIntDrop p rom
 
 showCode::CodePointer->Code->String
 showCode _ (Code bytes) | B.null bytes = ""

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
@@ -1,15 +1,27 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE BangPatterns #-}
 module Blockchain.VM.Opcodes where
 
 import           Prelude                      hiding (EQ, GT, LT)
 
-import           Data.Binary
+import           Data.Bits
 import qualified Data.ByteString              as B
+import qualified Data.ByteString.Unsafe       as BU
 import           Data.Data
+import           Data.Primitive.ByteArray
+import           Foreign.Ptr
+import           Foreign.Storable
+import           GHC.Exts
+import           GHC.Integer.GMP.Internals (Integer(..), BigNat(..))
+import           GHC.Word
+import           System.Endian
+import           System.IO.Unsafe
 import qualified Data.Map                     as M
 import           Data.Maybe
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
+import           Network.Haskoin.Internals (BigWord(..), Word256)
 import           Blockchain.Util
 
 type CodePointer = Int
@@ -208,4 +220,49 @@ opCode2Op rom =
              $ M.lookup opcode code2OpMap in
     (op, 1)
 
+-- Unoptimized extraction, for 8-24 bytes that are too infrequently seen
+-- to bother writing a specialization.
+defaultExtract :: B.ByteString -> Int -> Int -> Word256
+-- TODO(tim): Use fastBytesToWord256 once available
+defaultExtract bs off len = fromIntegral
+                                 . bytes2Integer
+                                 . B.unpack
+                                 . B.take len
+                                 . B.drop off
+                                 $ bs
 
+-- Used to push 1 byte
+fastExtractByte :: B.ByteString-> Int -> Word256
+fastExtractByte !code !off = let !(W8# b#) = BU.unsafeIndex code off
+                             in BigWord (S# (word2Int# b#))
+
+-- Used to push 2-7 bytes
+fastExtractSingle :: B.ByteString-> Int -> Int -> Word256
+fastExtractSingle !code !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
+  let !offPtr = castPtr ptr :: Ptr Word64
+      !delta = 64 - (8 * len)
+  -- This may read past the end of the bytestring, but if the read is allowed
+  -- those garbage bytes are truncated by the shift.
+  !rawBits <- peekByteOff offPtr off
+  let !(W64# w#) = toBE64 rawBits `shiftR` delta
+  return $! BigWord (S# (word2Int# w#))
+
+-- Used to push 25-32 bytes
+fastExtractQuad :: B.ByteString -> Int -> Int -> Word256
+fastExtractQuad !code !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
+  let !offPtr = castPtr (plusPtr ptr (off + len)) :: Ptr Word64
+  !dst <- newByteArray 32
+  !ll <- peekElemOff offPtr (-1)
+  !lh <- peekElemOff offPtr (-2)
+  !hl <- peekElemOff offPtr (-3)
+  -- This might be a violation: we read before the beginning of the bytestring.
+  -- However if the read is allowed, the garbage bytes are masked off.
+  !hh <- peekElemOff offPtr (-4)
+
+  writeByteArray dst 0 $! toBE64 ll
+  writeByteArray dst 1 $! toBE64 lh
+  writeByteArray dst 2 $! toBE64 hl
+  let !mask = bit (8 * (len - 24)) - 1
+  writeByteArray dst 3 $! toBE64 hh .&. mask
+  !(ByteArray ba#) <- unsafeFreezeByteArray dst
+  return (BigWord (Jp# (BN# ba#)))

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
@@ -23,6 +23,7 @@ import           Data.Maybe
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 import           Network.Haskoin.Internals (BigWord(..), Word256)
+import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Util
 
 type CodePointer = Int
@@ -52,7 +53,7 @@ data Operation =
 
 instance Pretty Operation where
   pretty x@JUMPDEST    = text $ "------" ++ show x
-  pretty (PUSH _)      = error "TODO(tim): pretty Operation"
+  pretty (PUSH v)      = text $ "PUSH " ++ show v
   pretty x             = text $ show x
 
 data OPData = OPData Word8 Operation Int Int String
@@ -194,17 +195,13 @@ code2OpMap::M.Map Word8 Operation
 code2OpMap=M.fromList $ (\(OPData opcode op _ _ _) -> (opcode, op)) <$> opDatas
 
 op2OpCode::Operation->[Word8]
-op2OpCode (PUSH _) = error "TODO(tim): op2OpCode"
+op2OpCode (PUSH v) = 0x7f:word256ToBytes v -- This preserves semantics, but it will print a different opcode than was actually in the code
 op2OpCode (DATA bytes) = B.unpack bytes
 op2OpCode (MalformedOpcode byte) = [byte]
 op2OpCode op =
   case M.lookup op op2CodeMap of
     Just x  -> [x]
     Nothing -> error $ "op is missing in op2CodeMap: " ++ show op
-
-opLen::Operation->Int
-opLen (PUSH _) = error "TODO(tim): opLen"
-opLen _        = 1
 
 opCode2Op::B.ByteString -> Int -> (Operation, CodePointer)
 opCode2Op rom !idx | idx >= B.length rom = (STOP, 1) --according to the yellowpaper, should return STOP if outside of the code bytestring

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TupleSections #-}
 module Blockchain.VM.Opcodes where
 
 import           Prelude                      hiding (EQ, GT, LT)
@@ -33,7 +34,7 @@ data Operation =
     ADDRESS | BALANCE | ORIGIN | CALLER | CALLVALUE | CALLDATALOAD | CALLDATASIZE | CALLDATACOPY | CODESIZE | CODECOPY | GASPRICE | EXTCODESIZE | EXTCODECOPY | RETURNDATASIZE | RETURNDATACOPY |
     BLOCKHASH | COINBASE | TIMESTAMP | NUMBER | DIFFICULTY | GASLIMIT |
     POP | MLOAD | MSTORE | MSTORE8 | SLOAD | SSTORE | JUMP | JUMPI | PC | MSIZE | GAS | JUMPDEST |
-    PUSH [Word8] |
+    PUSH Word256 |
     DUP1 | DUP2 | DUP3 | DUP4 |
     DUP5 | DUP6 | DUP7 | DUP8 |
     DUP9 | DUP10 | DUP11 | DUP12 |
@@ -51,7 +52,7 @@ data Operation =
 
 instance Pretty Operation where
   pretty x@JUMPDEST    = text $ "------" ++ show x
-  pretty x@(PUSH vals) = text $ show x ++ " --" ++ show (bytes2Integer vals)
+  pretty (PUSH _)      = error "TODO(tim): pretty Operation"
   pretty x             = text $ show x
 
 data OPData = OPData Word8 Operation Int Int String
@@ -193,10 +194,7 @@ code2OpMap::M.Map Word8 Operation
 code2OpMap=M.fromList $ (\(OPData opcode op _ _ _) -> (opcode, op)) <$> opDatas
 
 op2OpCode::Operation->[Word8]
-op2OpCode (PUSH theList) | length theList <= 32 && not (null theList) =
-  0x5F + fromIntegral (length theList):theList
-op2OpCode (PUSH []) = error "PUSH needs at least one word"
-op2OpCode (PUSH x) = error $ "PUSH can only take up to 32 words: " ++ show x
+op2OpCode (PUSH _) = error "TODO(tim): op2OpCode"
 op2OpCode (DATA bytes) = B.unpack bytes
 op2OpCode (MalformedOpcode byte) = [byte]
 op2OpCode op =
@@ -205,20 +203,20 @@ op2OpCode op =
     Nothing -> error $ "op is missing in op2CodeMap: " ++ show op
 
 opLen::Operation->Int
-opLen (PUSH x) = 1 + length x
+opLen (PUSH _) = error "TODO(tim): opLen"
 opLen _        = 1
 
-opCode2Op::B.ByteString->(Operation, CodePointer)
-opCode2Op rom | B.null rom = (STOP, 1) --according to the yellowpaper, should return STOP if outside of the code bytestring
-opCode2Op rom =
-  let opcode = B.head rom in --head OK, null weeded out above
-  if opcode >= 0x60 && opcode <= 0x7f
-  then (PUSH $ B.unpack $ safeTake (fromIntegral $ opcode-0x5F) $ B.tail rom, fromIntegral $ opcode - 0x5E)
-  else
---    let op = fromMaybe (error $ "code is missing in code2OpMap: 0x" ++ showHex (B.head rom) "")
-    let op = fromMaybe (MalformedOpcode opcode)
-             $ M.lookup opcode code2OpMap in
-    (op, 1)
+opCode2Op::B.ByteString -> Int -> (Operation, CodePointer)
+opCode2Op rom !idx | idx > B.length rom = (STOP, 1) --according to the yellowpaper, should return STOP if outside of the code bytestring
+opCode2Op rom !idx =
+  let opcode = BU.unsafeIndex rom idx in
+  if opcode < 0x60 || opcode > 0x7f
+    then (,1) . fromMaybe (MalformedOpcode opcode) . M.lookup opcode $ code2OpMap
+  else case fromIntegral (opcode - 0x59) of
+    1 -> (PUSH $! fastExtractByte rom (idx + 1), 2)
+    len | len <= 7 -> (PUSH $! fastExtractSingle rom (idx+1) len, len+1)
+        | len >= 25 -> (PUSH $! fastExtractQuad rom (idx+1) len, len+1)
+        | otherwise -> (PUSH $! defaultExtract rom (idx+1) len, len+1)
 
 -- Unoptimized extraction, for 8-24 bytes that are too infrequently seen
 -- to bother writing a specialization.
@@ -252,6 +250,7 @@ fastExtractQuad :: B.ByteString -> Int -> Int -> Word256
 fastExtractQuad !code !off !len = unsafePerformIO . BU.unsafeUseAsCString code $ \ptr -> do
   let !offPtr = castPtr (plusPtr ptr (off + len)) :: Ptr Word64
   !dst <- newByteArray 32
+  fillByteArray dst 0 32 0x0
   !ll <- peekElemOff offPtr (-1)
   !lh <- peekElemOff offPtr (-2)
   !hl <- peekElemOff offPtr (-3)

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
@@ -207,27 +207,27 @@ opLen (PUSH _) = error "TODO(tim): opLen"
 opLen _        = 1
 
 opCode2Op::B.ByteString -> Int -> (Operation, CodePointer)
-opCode2Op rom !idx | idx > B.length rom = (STOP, 1) --according to the yellowpaper, should return STOP if outside of the code bytestring
+opCode2Op rom !idx | idx >= B.length rom = (STOP, 1) --according to the yellowpaper, should return STOP if outside of the code bytestring
 opCode2Op rom !idx =
   let opcode = BU.unsafeIndex rom idx in
   if opcode < 0x60 || opcode > 0x7f
     then (,1) . fromMaybe (MalformedOpcode opcode) . M.lookup opcode $ code2OpMap
-  else case fromIntegral (opcode - 0x59) of
-    1 -> (PUSH $! fastExtractByte rom (idx + 1), 2)
-    len | len <= 7 -> (PUSH $! fastExtractSingle rom (idx+1) len, len+1)
-        | len >= 25 -> (PUSH $! fastExtractQuad rom (idx+1) len, len+1)
-        | otherwise -> (PUSH $! defaultExtract rom (idx+1) len, len+1)
+    else case fromIntegral (opcode - 0x5f) of
+          1 -> (PUSH $! fastExtractByte rom (idx + 1), 2)
+          len | len <= 7 -> (PUSH $! fastExtractSingle rom (idx+1) len, len+1)
+              | len >= 25 -> (PUSH $! fastExtractQuad rom (idx+1) len, len+1)
+              | otherwise -> (PUSH $! defaultExtract rom (idx+1) len, len+1)
 
 -- Unoptimized extraction, for 8-24 bytes that are too infrequently seen
 -- to bother writing a specialization.
 defaultExtract :: B.ByteString -> Int -> Int -> Word256
 -- TODO(tim): Use fastBytesToWord256 once available
 defaultExtract bs off len = fromIntegral
-                                 . bytes2Integer
-                                 . B.unpack
-                                 . B.take len
-                                 . B.drop off
-                                 $ bs
+                          . bytes2Integer
+                          . B.unpack
+                          . B.take len
+                          . B.drop off
+                          $ bs
 
 -- Used to push 1 byte
 fastExtractByte :: B.ByteString-> Int -> Word256

--- a/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/Opcodes.hs
@@ -24,7 +24,6 @@ import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 import           Network.Haskoin.Internals (BigWord(..), Word256)
 import           Blockchain.Strato.Model.ExtendedWord
-import           Blockchain.Util
 
 type CodePointer = Int
 
@@ -195,7 +194,8 @@ code2OpMap::M.Map Word8 Operation
 code2OpMap=M.fromList $ (\(OPData opcode op _ _ _) -> (opcode, op)) <$> opDatas
 
 op2OpCode::Operation->[Word8]
-op2OpCode (PUSH v) = 0x7f:word256ToBytes v -- This preserves semantics, but it will print a different opcode than was actually in the code
+-- This preserves semantics, but it will print a different opcode than was actually in the code
+op2OpCode (PUSH v) = 0x7f:B.unpack (fastWord256ToBytes v)
 op2OpCode (DATA bytes) = B.unpack bytes
 op2OpCode (MalformedOpcode byte) = [byte]
 op2OpCode op =
@@ -218,13 +218,8 @@ opCode2Op rom !idx =
 -- Unoptimized extraction, for 8-24 bytes that are too infrequently seen
 -- to bother writing a specialization.
 defaultExtract :: B.ByteString -> Int -> Int -> Word256
--- TODO(tim): Use fastBytesToWord256 once available
-defaultExtract bs off len = fromIntegral
-                          . bytes2Integer
-                          . B.unpack
-                          . B.take len
-                          . B.drop off
-                          $ bs
+defaultExtract bs off len = let slice = B.take len . B.drop off $ bs
+                            in fastBytesToWord256 $ B.replicate (32 - B.length slice) 0x0 <> slice
 
 -- Used to push 1 byte
 fastExtractByte :: B.ByteString-> Int -> Word256

--- a/core-strato/ethereum-vm/test/Spec.hs
+++ b/core-strato/ethereum-vm/test/Spec.hs
@@ -29,8 +29,8 @@ import           Blockchain.Data.Code
 import           Blockchain.Output    (printLogMsg)
 import           Blockchain.Strato.Model.SHA
 import           Blockchain.VM
-import           Blockchain.VM.Code
 import qualified Blockchain.VM.MutableStack as MS
+import           Blockchain.VM.Opcodes
 import           Blockchain.VM.VMState hiding (isRunningTests)
 import           Blockchain.VMContext
 import           Blockchain.VMOptions()

--- a/core-strato/ethereum-vm/test/Spec.hs
+++ b/core-strato/ethereum-vm/test/Spec.hs
@@ -41,8 +41,8 @@ import           Executable.EVMFlags ()
 --noLog _ _ _ _ = return ()
 
 {-# NOINLINE exampleCode #-}
-exampleCode :: Code
-exampleCode = Code $ B.pack $ [0..255]
+exampleCode :: B.ByteString
+exampleCode = B.pack $ [0..255]
 
 main :: IO ()
 main = do

--- a/core-strato/ethereum-vm/test/Spec.hs
+++ b/core-strato/ethereum-vm/test/Spec.hs
@@ -11,6 +11,7 @@ import           HFlags
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
+import qualified Data.ByteString         as B
 import qualified Data.ByteString.Char8   as C8
 import qualified Data.ByteString.Base16  as B16
 import           Data.Maybe
@@ -28,6 +29,7 @@ import           Blockchain.Data.Code
 import           Blockchain.Output    (printLogMsg)
 import           Blockchain.Strato.Model.SHA
 import           Blockchain.VM
+import           Blockchain.VM.Code
 import qualified Blockchain.VM.MutableStack as MS
 import           Blockchain.VM.VMState hiding (isRunningTests)
 import           Blockchain.VMContext
@@ -37,6 +39,10 @@ import           Executable.EVMFlags ()
 
 --noLog :: Loc -> LogSource -> LogLevel -> LogStr -> IO ()
 --noLog _ _ _ _ = return ()
+
+{-# NOINLINE exampleCode #-}
+exampleCode :: Code
+exampleCode = Code $ B.pack $ [0..255]
 
 main :: IO ()
 main = do
@@ -177,3 +183,32 @@ spec = do
       MS.toList s `shouldReturn` [5, 4, 3]
       MS.pop s `shouldReturn` Just 5
       MS.toList s `shouldReturn` [4, 3]
+
+  describe "Code" $ do
+    describe "extract byte" $ do
+      it "can extract 1 byte" $ do
+         fastExtractByte exampleCode 0 `shouldBe` defaultExtract exampleCode 0 1
+         fastExtractByte exampleCode 1 `shouldBe` defaultExtract exampleCode 1 1
+         fastExtractByte exampleCode 2 `shouldBe` defaultExtract exampleCode 2 1
+         map (fastExtractByte exampleCode) [0..255] `shouldBe` map (\x -> defaultExtract exampleCode x 1) [0..255]
+
+    describe "extract single word" $ do
+      it "can extract 3 bytes" $ do
+        forM_ [0, 1, 7, 128] $ \n ->
+          fastExtractSingle exampleCode n 3 `shouldBe` defaultExtract exampleCode n 3
+      it "can extract 7 bytes" $ do
+        forM_ [0, 1, 0xbb] $ \n ->
+          fastExtractSingle exampleCode n 7 `shouldBe` defaultExtract exampleCode n 7
+
+    describe "extract four words" $ do
+      it "can extract 25 bytes" $ do
+        fastExtractQuad exampleCode 1 25 `shouldBe` defaultExtract exampleCode 1 25
+      it "can extract 31 bytes" $ do
+        fastExtractQuad exampleCode 0 31 `shouldBe` defaultExtract exampleCode 0 31
+        fastExtractQuad exampleCode 1 31 `shouldBe` defaultExtract exampleCode 1 31
+        fastExtractQuad exampleCode 2 31 `shouldBe` defaultExtract exampleCode 2 31
+      it "can extract 32 bytes" $ do
+        fastExtractQuad exampleCode 0 32 `shouldBe`  defaultExtract exampleCode 0 32
+        fastExtractQuad exampleCode 1 32 `shouldBe`  defaultExtract exampleCode 1 32
+        fastExtractQuad exampleCode 2 32 `shouldBe`  defaultExtract exampleCode 2 32
+        fastExtractQuad exampleCode 64 32 `shouldBe` defaultExtract exampleCode 64 32


### PR DESCRIPTION
```
Benchmark extractbench: RUNNING...
benchmarking extract1 slow
time                 64.82 ns   (64.72 ns .. 64.90 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 64.74 ns   (64.68 ns .. 64.83 ns)
std dev              257.0 ps   (207.5 ps .. 337.5 ps)

benchmarking extract1 fast
time                 10.79 ns   (10.78 ns .. 10.82 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.82 ns   (10.80 ns .. 10.84 ns)
std dev              55.96 ps   (42.85 ps .. 74.68 ps)

benchmarking extract3 slow
time                 217.2 ns   (216.9 ns .. 217.6 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 218.1 ns   (217.7 ns .. 218.7 ns)
std dev              1.593 ns   (1.165 ns .. 2.230 ns)

benchmarking extract3 fast
time                 14.93 ns   (14.91 ns .. 14.95 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 14.95 ns   (14.93 ns .. 15.01 ns)
std dev              111.1 ps   (64.87 ps .. 194.2 ps)

benchmarking extract25 slow
time                 2.480 μs   (2.473 μs .. 2.488 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.480 μs   (2.471 μs .. 2.488 μs)
std dev              28.93 ns   (24.52 ns .. 34.55 ns)

benchmarking extract25 fast
time                 21.05 ns   (20.64 ns .. 21.51 ns)
                     0.998 R²   (0.997 R² .. 1.000 R²)
mean                 20.74 ns   (20.64 ns .. 20.94 ns)
std dev              464.4 ps   (138.3 ps .. 793.0 ps)
variance introduced by outliers: 35% (moderately inflated)

Benchmark extractbench: FINISH
Completed 2 action(s).
```
