### PR TITLE
Benchmark Merkle Patricia

### DIFF
--- a/core-strato/merkle-patricia-db/bench/MPBench.hs
+++ b/core-strato/merkle-patricia-db/bench/MPBench.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+import Control.DeepSeq
+import Control.Monad
+import Criterion.Main
+import qualified Data.ByteString as B
+import qualified Data.NibbleString as N
+import Data.Word
+import qualified Database.LevelDB as DB
+import qualified Database.LevelDB.Base as DBB
+import System.Directory
+import System.Posix.Temp
+import Test.QuickCheck
+import Text.Printf
+
+import Blockchain.Data.RLP
+import qualified Blockchain.Database.MerklePatricia as MP
+import qualified Blockchain.Database.MerklePatricia.Internal as MPI
+import Blockchain.Strato.Model.ExtendedWord (word256ToBytes)
+
+defaultKey :: N.NibbleString
+defaultKey = N.EvenNibbleString $ B.replicate 32 0x0
+
+defaultRLP :: RLPObject
+defaultRLP = RLPScalar 0x45
+
+instance Arbitrary N.NibbleString where
+  arbitrary = (N.EvenNibbleString . word256ToBytes) <$> arbitrary
+
+nenv :: Int -> IO (FilePath, MP.MPDB)
+nenv n = do
+  tmpdir <- mkdtemp "/tmp/mp_bench"
+  db <- DBB.open (tmpdir ++ "/test.ldb") DB.defaultOptions {DB.createIfMissing = True}
+  let mp = MP.MPDB{MP.ldb=db, MP.stateRoot=MP.blankStateRoot}
+  MP.initializeBlank mp
+  kvs <- makeRandomKeys n
+  mp' <- foldM (\m (k, v) -> MP.putKeyVal m k v) mp kvs
+  return (tmpdir, mp')
+
+makeRandomKeys :: Int -> IO [(MP.Key, MP.Val)]
+makeRandomKeys = fmap (fmap (, defaultRLP)) . generate . vector
+
+benchMP :: NFData a => IO (FilePath, MP.MPDB) -> String -> (MP.MPDB -> IO a) -> Benchmark
+benchMP mkenv name a = envWithCleanup mkenv (\ ~(p, _) -> removePathForcibly p)
+                                            (\ ~(_, mp) -> bench name . nfIO $ a mp)
+
+
+getBench :: Int -> Benchmark
+getBench n = benchMP (nenv n) (printf "getKeyVal - %d" n)
+           $ \mp -> MP.getKeyVal mp defaultKey
+
+putBench :: Int -> Benchmark
+putBench n = benchMP (nenv n) (printf "putKeyVal - %d" n)
+           $ \mp -> MP.putKeyVal mp defaultKey defaultRLP
+
+deleteBench :: Int -> Benchmark
+deleteBench n = benchMP (nenv n) (printf "deleteKey - %d" n)
+              $ \mp -> MP.deleteKey mp defaultKey
+
+existsBench :: Int -> Benchmark
+existsBench n = benchMP (nenv n) (printf "keyExists - %d" n)
+              $ \mp -> MP.keyExists mp defaultKey
+
+
+main :: IO ()
+main = defaultMain [getBench 0, getBench 10000, getBench 100000
+                   , putBench 0, putBench 10000, putBench 100000
+                   , deleteBench 0, deleteBench 10000, deleteBench 100000
+                   , existsBench 0, existsBench 10000, existsBench 100000
+                   ]

--- a/core-strato/merkle-patricia-db/package.yaml
+++ b/core-strato/merkle-patricia-db/package.yaml
@@ -46,3 +46,15 @@ tests:
       - HUnit
       - hspec
       - hspec-contrib
+
+benchmarks:
+  mpbench:
+    main: MPBench.hs
+    source-dirs: bench/
+    dependencies:
+      - criterion
+      - directory
+      - merkle-patricia-db
+      - directory
+      - unix
+      - QuickCheck

--- a/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia.hs
+++ b/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia.hs
@@ -25,7 +25,7 @@ module Blockchain.Database.MerklePatricia (
   initializeBlank, blankStateRoot
   ) where
 
-import           Control.Monad.Trans.Resource
+import           Control.Monad.IO.Class
 import           Data.Default
 import           Data.Maybe                                  (isJust)
 import qualified Database.LevelDB                            as DB
@@ -36,14 +36,14 @@ import           Blockchain.Strato.Model.SHA                 (keccak256)
 
 
 -- | Adds a new key/value pair.
-putKeyVal::MonadResource m=>MPDB -- ^ The object containing the current stateRoot.
+putKeyVal::MonadIO m=>MPDB -- ^ The object containing the current stateRoot.
            ->Key -- ^ Key of the data to be inserted.
            ->Val -- ^ Value of the new data
            ->m MPDB -- ^ The object containing the stateRoot to the data after the insert.
 putKeyVal db = unsafePutKeyVal db . keyToSafeKey
 
 -- | Retrieves all key/value pairs whose key starts with the given parameter.
-getKeyVal::MonadResource m=>MPDB -- ^ Object containing the current stateRoot.
+getKeyVal::MonadIO m=>MPDB -- ^ Object containing the current stateRoot.
          -> Key -- ^ Key of the data to be inserted.
          -> m (Maybe Val) -- ^ The requested value.
 getKeyVal db key = do
@@ -59,13 +59,13 @@ getKeyVal db key = do
 --
 -- Note that the key/value pair will still be present in the history, and
 -- can be accessed by using an older 'MPDB' object.
-deleteKey::MonadResource m=>MPDB -- ^ The object containing the current stateRoot.
+deleteKey::MonadIO m=>MPDB -- ^ The object containing the current stateRoot.
          ->Key -- ^ The key to be deleted.
          ->m MPDB -- ^ The object containing the stateRoot to the data after the delete.
 deleteKey db = unsafeDeleteKey db . keyToSafeKey
 
 -- | Returns True is a key exists.
-keyExists::MonadResource m=>MPDB -- ^ The object containing the current stateRoot.
+keyExists::MonadIO m=>MPDB -- ^ The object containing the current stateRoot.
          ->Key -- ^ The key to be deleted.
          ->m Bool -- ^ True if the key exists
 keyExists db key = isJust <$> getKeyVal db key
@@ -75,10 +75,9 @@ blankStateRoot :: StateRoot
 blankStateRoot = StateRoot $ keccak256 (rlpSerialize $ rlpEncode (0 :: Integer))
 
 -- | Initialize the DB by adding a blank stateroot.
-initializeBlank::MonadResource m=>MPDB -- ^ The object containing the current stateRoot.
+initializeBlank:: MonadIO m => MPDB -- ^ The object containing the current stateRoot.
                ->m ()
 initializeBlank db =
     let bytes = rlpSerialize $ rlpEncode (0::Integer)
     in
       DB.put (ldb db) def (keccak256 bytes) bytes
-

--- a/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/Internal.hs
+++ b/core-strato/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/Internal.hs
@@ -22,7 +22,8 @@ module Blockchain.Database.MerklePatricia.Internal (
   prependToKey
   ) where
 
-import           Control.Monad.Trans.Resource
+
+import           Control.Monad.IO.Class
 import qualified Data.ByteString                              as B
 import           Data.Default
 import           Data.Function
@@ -38,22 +39,22 @@ import           Blockchain.Database.MerklePatricia.StateRoot
 import           Blockchain.Format
 import           Blockchain.Strato.Model.SHA                  (keccak256)
 
-unsafePutKeyVal::MonadResource m=>MPDB->Key->Val->m MPDB
+unsafePutKeyVal::MonadIO m=>MPDB->Key->Val->m MPDB
 unsafePutKeyVal db key val = do
   dbNodeData <- getNodeData db (PtrRef $ stateRoot db)
   dbPutNodeData <- putKV_NodeData db key val dbNodeData
   p <- putNodeData db dbPutNodeData
   return db{stateRoot=p}
 
-unsafeGetKeyVals::MonadResource m=>MPDB->Key->m [(Key, Val)]
+unsafeGetKeyVals::MonadIO m=>MPDB->Key->m [(Key, Val)]
 unsafeGetKeyVals db =
   let dbNodeRef = PtrRef $ stateRoot db
   in getKeyVals_NodeRef db dbNodeRef
 
-unsafeGetAllKeyVals::MonadResource m=>MPDB->m [(Key, Val)]
+unsafeGetAllKeyVals::MonadIO m=>MPDB->m [(Key, Val)]
 unsafeGetAllKeyVals db = unsafeGetKeyVals db N.empty
 
-unsafeDeleteKey::MonadResource m=>MPDB->Key->m MPDB
+unsafeDeleteKey::MonadIO m=>MPDB->Key->m MPDB
 unsafeDeleteKey db key = do
   dbNodeData <- getNodeData db (PtrRef $ stateRoot db)
   dbDeleteNodeData <- deleteKey_NodeData db key dbNodeData
@@ -68,7 +69,7 @@ keyToSafeKey key =
 
 -----
 
-putKV_NodeData::MonadResource m=>MPDB->Key->Val->NodeData->m NodeData
+putKV_NodeData::MonadIO m=>MPDB->Key->Val->NodeData->m NodeData
 
 putKV_NodeData _ key val EmptyNodeData =
   return $ ShortcutNodeData key (Right val)
@@ -116,7 +117,6 @@ putKV_NodeData db key1 val1 (ShortcutNodeData key2 val2)
       nodeAfterCommonBeforePut <- newShortcut db (N.pack suffix2) val2
       nodeAfterCommon <- putKV_NodeRef db (N.pack suffix1) val1 nodeAfterCommonBeforePut
       return $ ShortcutNodeData (N.pack commonPrefix) $ Left nodeAfterCommon
-
   | otherwise = do
       tailNode1 <- newShortcut db (N.tail key1) $ Right val1
       tailNode2 <- newShortcut db (N.tail key2) val2
@@ -127,7 +127,7 @@ putKV_NodeData db key1 val1 (ShortcutNodeData key2 val2)
 
 -----
 
-getKeyVals_NodeData::MonadResource m=>MPDB->NodeData->Key->m [(Key, Val)]
+getKeyVals_NodeData::MonadIO m=>MPDB->NodeData->Key->m [(Key, Val)]
 
 getKeyVals_NodeData _ EmptyNodeData _ = return []
 
@@ -156,7 +156,7 @@ getKeyVals_NodeData _ ShortcutNodeData{nextNibbleString=s, nextVal=Right val} ke
 
 -----
 
-deleteKey_NodeData::MonadResource m=>MPDB->Key->NodeData->m NodeData
+deleteKey_NodeData::MonadIO m=>MPDB->Key->NodeData->m NodeData
 
 deleteKey_NodeData _ _ EmptyNodeData = return EmptyNodeData
 
@@ -186,27 +186,27 @@ deleteKey_NodeData db key1 nd@(ShortcutNodeData key2 (Left ref))
 
 -----
 
-putKV_NodeRef::MonadResource m=>MPDB->Key->Val->NodeRef->m NodeRef
+putKV_NodeRef::MonadIO m=>MPDB->Key->Val->NodeRef->m NodeRef
 putKV_NodeRef db key val nodeRef = do
   nodeData <- getNodeData db nodeRef
   newNodeData <- putKV_NodeData db key val nodeData
   nodeData2NodeRef db newNodeData
 
 
-getKeyVals_NodeRef::MonadResource m=>MPDB->NodeRef->Key->m [(Key, Val)]
+getKeyVals_NodeRef::MonadIO m=>MPDB->NodeRef->Key->m [(Key, Val)]
 getKeyVals_NodeRef db ref key = do
   nodeData <- getNodeData db ref
   getKeyVals_NodeData db nodeData key
 
 --TODO- This is looking like a lift, I probably should make NodeRef some sort of Monad....
 
-deleteKey_NodeRef::MonadResource m=>MPDB->Key->NodeRef->m NodeRef
+deleteKey_NodeRef::MonadIO m=>MPDB->Key->NodeRef->m NodeRef
 deleteKey_NodeRef db key nodeRef =
   nodeData2NodeRef db =<< deleteKey_NodeData db key =<< getNodeData db nodeRef
 
 -----
 
-getNodeData::MonadResource m=>MPDB->NodeRef->m NodeData
+getNodeData::MonadIO m=>MPDB->NodeRef->m NodeData
 getNodeData _ (SmallRef x) = return $ rlpDecode $ rlpDeserialize x
 getNodeData db (PtrRef ptr@(StateRoot p)) = do
   bytes <-
@@ -217,9 +217,9 @@ getNodeData db (PtrRef ptr@(StateRoot p)) = do
     where
       bytes2NodeData::B.ByteString->NodeData
       bytes2NodeData bytes | B.null bytes = EmptyNodeData
-      bytes2NodeData bytes = rlpDecode $ rlpDeserialize $ B.pack $ B.unpack bytes
+      bytes2NodeData bytes = rlpDecode . rlpDeserialize $ bytes
 
-putNodeData::MonadResource m=>MPDB->NodeData->m StateRoot
+putNodeData::MonadIO m=>MPDB->NodeData->m StateRoot
 putNodeData db nd = do
   let bytes = rlpSerialize $ rlpEncode nd
       ptr = keccak256 bytes
@@ -239,7 +239,7 @@ putNodeData db nd = do
 -- the whole database.  The delete function only will "break" the
 -- canonical structure locally, so deep recursion isn't required.
 
-simplify_NodeData::MonadResource m=>MPDB->NodeData->m NodeData
+simplify_NodeData::MonadIO m=>MPDB->NodeData->m NodeData
 simplify_NodeData _ EmptyNodeData = return EmptyNodeData
 simplify_NodeData db nd@(ShortcutNodeData key (Left ref)) = do
   refNodeData <- getNodeData db ref
@@ -255,11 +255,11 @@ simplify_NodeData _ x = return x
 
 -----
 
-newShortcut::MonadResource m=>MPDB->Key->Either NodeRef Val->m NodeRef
+newShortcut::MonadIO m=>MPDB->Key->Either NodeRef Val->m NodeRef
 newShortcut _ "" (Left ref) = return ref
 newShortcut db key val      = nodeData2NodeRef db $ ShortcutNodeData key val
 
-nodeData2NodeRef::MonadResource m=>MPDB->NodeData->m NodeRef
+nodeData2NodeRef::MonadIO m=>MPDB->NodeData->m NodeRef
 nodeData2NodeRef db nodeData =
   case rlpSerialize $ rlpEncode nodeData of
     bytes | B.length bytes < 32 -> return $ SmallRef bytes


### PR DESCRIPTION
In addition to the benchmarks, there are two changes:

+ MonadResource is only necessary on calls that open leveldb. Everything else only requires MonadIO
+ There was a useless `B.unpack . B.pack`. Removing this sped up operations 2x for large trees

Before:
```
Benchmark mpbench: RUNNING...
benchmarking getKeyVal - 0
time                 1.444 μs   (1.417 μs .. 1.500 μs)
                     0.996 R²   (0.989 R² .. 1.000 R²)
mean                 1.428 μs   (1.418 μs .. 1.462 μs)
std dev              55.00 ns   (8.821 ns .. 116.4 ns)
variance introduced by outliers: 53% (severely inflated)

benchmarking getKeyVal - 10000
time                 30.93 μs   (30.71 μs .. 31.24 μs)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 31.15 μs   (30.86 μs .. 31.83 μs)
std dev              1.395 μs   (678.4 ns .. 2.511 μs)
variance introduced by outliers: 51% (severely inflated)

benchmarking getKeyVal - 100000
time                 43.30 μs   (43.04 μs .. 43.64 μs)
                     0.999 R²   (0.997 R² .. 0.999 R²)
mean                 44.56 μs   (43.91 μs .. 46.91 μs)
std dev              3.667 μs   (1.574 μs .. 7.123 μs)
variance introduced by outliers: 77% (severely inflated)

benchmarking putKeyVal - 0
time                 9.852 μs   (9.724 μs .. 9.960 μs)
                     0.991 R²   (0.968 R² .. 0.999 R²)
mean                 51.02 μs   (9.906 μs .. 215.4 μs)
std dev              269.4 μs   (302.9 ns .. 573.0 μs)
variance introduced by outliers: 99% (severely inflated)

benchmarking putKeyVal - 10000
time                 176.6 μs   (172.5 μs .. 180.9 μs)
                     0.997 R²   (0.996 R² .. 0.999 R²)
mean                 174.5 μs   (172.5 μs .. 176.9 μs)
std dev              7.687 μs   (6.412 μs .. 9.062 μs)
variance introduced by outliers: 43% (moderately inflated)

benchmarking putKeyVal - 100000
time                 278.7 μs   (270.7 μs .. 285.0 μs)
                     0.994 R²   (0.992 R² .. 0.997 R²)
mean                 268.7 μs   (263.4 μs .. 274.6 μs)
std dev              19.03 μs   (16.04 μs .. 23.48 μs)
variance introduced by outliers: 65% (severely inflated)

benchmarking deleteKey - 0
time                 7.229 μs   (7.155 μs .. 7.298 μs)
                     0.993 R²   (0.976 R² .. 1.000 R²)
mean                 30.80 μs   (7.276 μs .. 148.3 μs)
std dev              152.4 μs   (143.3 ns .. 349.7 μs)
variance introduced by outliers: 99% (severely inflated)

benchmarking deleteKey - 10000
time                 152.6 μs   (150.0 μs .. 156.2 μs)
                     0.996 R²   (0.991 R² .. 0.999 R²)
mean                 153.3 μs   (151.7 μs .. 156.4 μs)
std dev              7.205 μs   (4.573 μs .. 12.33 μs)
variance introduced by outliers: 47% (moderately inflated)

benchmarking deleteKey - 100000
time                 173.5 μs   (170.4 μs .. 177.7 μs)
                     0.995 R²   (0.992 R² .. 0.997 R²)
mean                 177.0 μs   (173.5 μs .. 181.8 μs)
std dev              13.25 μs   (10.87 μs .. 17.02 μs)
variance introduced by outliers: 69% (severely inflated)

benchmarking keyExists - 0
time                 1.688 μs   (1.666 μs .. 1.716 μs)
                     0.992 R²   (0.977 R² .. 1.000 R²)
mean                 12.40 μs   (1.688 μs .. 65.96 μs)
std dev              71.06 μs   (23.12 ns .. 163.6 μs)
variance introduced by outliers: 99% (severely inflated)

benchmarking keyExists - 10000
time                 27.68 μs   (27.60 μs .. 27.76 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 27.96 μs   (27.77 μs .. 28.20 μs)
std dev              711.9 ns   (510.7 ns .. 1.066 μs)
variance introduced by outliers: 25% (moderately inflated)

benchmarking keyExists - 100000
time                 43.25 μs   (43.05 μs .. 43.51 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 43.61 μs   (43.30 μs .. 44.13 μs)
std dev              1.330 μs   (855.3 ns .. 2.152 μs)
variance introduced by outliers: 31% (moderately inflated)

Benchmark mpbench: FINISH
Completed 2 action(s).
```

After:
```
Running 1 benchmarks...
Benchmark mpbench: RUNNING...
benchmarking getKeyVal - 0
time                 1.427 μs   (1.422 μs .. 1.433 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.435 μs   (1.427 μs .. 1.449 μs)
std dev              31.88 ns   (21.44 ns .. 51.90 ns)
variance introduced by outliers: 27% (moderately inflated)

benchmarking getKeyVal - 10000
time                 16.81 μs   (16.74 μs .. 16.88 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 16.82 μs   (16.76 μs .. 16.92 μs)
std dev              252.4 ns   (203.2 ns .. 341.7 ns)
variance introduced by outliers: 11% (moderately inflated)

benchmarking getKeyVal - 100000
time                 21.74 μs   (21.48 μs .. 22.10 μs)
                     0.998 R²   (0.996 R² .. 1.000 R²)
mean                 21.69 μs   (21.56 μs .. 21.95 μs)
std dev              644.6 ns   (372.2 ns .. 1.196 μs)
variance introduced by outliers: 32% (moderately inflated)

benchmarking putKeyVal - 0
time                 9.991 μs   (9.866 μs .. 10.13 μs)
                     0.993 R²   (0.976 R² .. 0.999 R²)
mean                 158.7 μs   (9.976 μs .. 753.7 μs)
std dev              963.8 μs   (315.3 ns .. 2.047 ms)
variance introduced by outliers: 99% (severely inflated)

benchmarking putKeyVal - 10000
time                 171.3 μs   (168.2 μs .. 174.4 μs)
                     0.995 R²   (0.992 R² .. 0.997 R²)
mean                 176.0 μs   (171.6 μs .. 181.5 μs)
std dev              16.02 μs   (13.40 μs .. 19.87 μs)
variance introduced by outliers: 77% (severely inflated)

benchmarking putKeyVal - 100000
time                 159.1 μs   (155.2 μs .. 165.5 μs)
                     0.992 R²   (0.986 R² .. 0.997 R²)
mean                 164.4 μs   (160.6 μs .. 170.0 μs)
std dev              15.86 μs   (12.19 μs .. 19.74 μs)
variance introduced by outliers: 79% (severely inflated)

benchmarking deleteKey - 0
time                 7.635 μs   (7.401 μs .. 7.966 μs)
                     0.982 R²   (0.964 R² .. 0.994 R²)
mean                 47.26 μs   (7.577 μs .. 245.4 μs)
std dev              256.8 μs   (572.8 ns .. 589.4 μs)
variance introduced by outliers: 99% (severely inflated)

benchmarking deleteKey - 10000
time                 109.1 μs   (108.4 μs .. 109.9 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 110.0 μs   (108.9 μs .. 111.4 μs)
std dev              4.095 μs   (3.063 μs .. 5.292 μs)
variance introduced by outliers: 37% (moderately inflated)

benchmarking deleteKey - 100000
time                 134.9 μs   (132.6 μs .. 137.4 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 134.3 μs   (132.6 μs .. 136.3 μs)
std dev              6.100 μs   (5.049 μs .. 7.516 μs)
variance introduced by outliers: 46% (moderately inflated)

benchmarking keyExists - 0
time                 1.669 μs   (1.647 μs .. 1.690 μs)
                     0.993 R²   (0.978 R² .. 1.000 R²)
mean                 5.999 μs   (1.648 μs .. 23.40 μs)
std dev              28.51 μs   (25.95 ns .. 60.64 μs)
variance introduced by outliers: 100% (severely inflated)

benchmarking keyExists - 10000
time                 19.80 μs   (19.70 μs .. 19.92 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 19.97 μs   (19.84 μs .. 20.26 μs)
std dev              640.1 ns   (334.4 ns .. 1.179 μs)
variance introduced by outliers: 36% (moderately inflated)

benchmarking keyExists - 100000
time                 25.07 μs   (24.77 μs .. 25.44 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 26.26 μs   (25.75 μs .. 27.29 μs)
std dev              2.381 μs   (1.413 μs .. 4.124 μs)
variance introduced by outliers: 82% (severely inflated)

Benchmark mpbench: FINISH
Completed 4 action(s).
```