### PR TITLE
Serve /{bloc,strato}/logs

### DIFF
--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -95,6 +95,8 @@ function runBackgroundProcess {
   disown %
 }
 
+runBackgroundProcess /usr/bin/logserver --directory=/logs --uri_path=/bloch/logs &>> logs/logserver
+
 runBackgroundProcess /usr/bin/blockapps-strato-server >> logs/strato-server 2>&1
 
 runBackgroundProcess /usr/bin/blockapps-bloc --pghost="$postgres_host" --pgport="$postgres_port" --pguser="$postgres_user" --password="$postgres_password" \

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -95,7 +95,7 @@ function runBackgroundProcess {
   disown %
 }
 
-runBackgroundProcess /usr/bin/logserver "--directory=${PWD}/logs" --uri_path=/bloch/logs &>> logs/logserver
+runBackgroundProcess /usr/bin/logserver "--directory=${PWD}/logs" --uri_root=/bloc/logs/ &>> logs/logserver
 
 runBackgroundProcess /usr/bin/blockapps-strato-server >> logs/strato-server 2>&1
 

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -95,9 +95,7 @@ function runBackgroundProcess {
   disown %
 }
 
-if [[ "${SERVE_LOGS}" == true ]]; then
-  runBackgroundProcess /usr/bin/logserver "--directory=${PWD}/logs" --uri_root=/bloc/logs/ &>> logs/logserver
-fi
+runBackgroundProcess /usr/bin/logserver "--directory=${PWD}/logs" --uri_root=/bloc/logs/ &>> logs/logserver
 
 runBackgroundProcess /usr/bin/blockapps-strato-server >> logs/strato-server 2>&1
 

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -95,7 +95,7 @@ function runBackgroundProcess {
   disown %
 }
 
-runBackgroundProcess /usr/bin/logserver "--directory=${PWD}/logs" --uri_root=/bloc/logs/ &>> logs/logserver
+runBackgroundProcess /usr/bin/logserver "--directory=${PWD}/logs" --uri_root=/logs/bloc/ &>> logs/logserver
 
 runBackgroundProcess /usr/bin/blockapps-strato-server >> logs/strato-server 2>&1
 

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -95,7 +95,7 @@ function runBackgroundProcess {
   disown %
 }
 
-runBackgroundProcess /usr/bin/logserver --directory=/logs --uri_path=/bloch/logs &>> logs/logserver
+runBackgroundProcess /usr/bin/logserver "--directory=${PWD}/logs" --uri_path=/bloch/logs &>> logs/logserver
 
 runBackgroundProcess /usr/bin/blockapps-strato-server >> logs/strato-server 2>&1
 

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -95,7 +95,9 @@ function runBackgroundProcess {
   disown %
 }
 
-runBackgroundProcess /usr/bin/logserver "--directory=${PWD}/logs" --uri_root=/bloc/logs/ &>> logs/logserver
+if [[ "${SERVE_LOGS}" == true ]]; then
+  runBackgroundProcess /usr/bin/logserver "--directory=${PWD}/logs" --uri_root=/bloc/logs/ &>> logs/logserver
+fi
 
 runBackgroundProcess /usr/bin/blockapps-strato-server >> logs/strato-server 2>&1
 

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -19,7 +19,7 @@ function newnode {
   fi
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."
-  runBackgroundProcess logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &>> logs/logserver &
+  runBackgroundProcess logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &>> logs/logserver
 
   if $mineBlocks
   then echo "Starting strato-adit"

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -19,7 +19,7 @@ function newnode {
   fi
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."
-  runBackgroundProcess logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &>> logs/logserver
+  runBackgroundProcess logserver --directory "${PWD}/logs" --uri_root=/logs/strato/ &>> logs/logserver
 
   if $mineBlocks
   then echo "Starting strato-adit"

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -19,7 +19,9 @@ function newnode {
   fi
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."
-  runBackgroundProcess logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &>> logs/logserver
+  if [[ "${SERVE_LOGS}" == true ]]; then
+    runBackgroundProcess logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &>> logs/logserver
+  fi
 
   if $mineBlocks
   then echo "Starting strato-adit"

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -19,7 +19,7 @@ function newnode {
   fi
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."
-  logserver -d "${PWD}/logs" &> logs/logserver &
+  logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &> logs/logserver &
 
   if $mineBlocks
   then echo "Starting strato-adit"

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -19,7 +19,7 @@ function newnode {
   fi
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."
-  logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &> logs/logserver &
+  runBackgroundProcess logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &>> logs/logserver &
 
   if $mineBlocks
   then echo "Starting strato-adit"

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -19,6 +19,7 @@ function newnode {
   fi
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."
+  logserver -d "${PWD}/logs" &> logs/logserver &
 
   if $mineBlocks
   then echo "Starting strato-adit"

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -19,9 +19,7 @@ function newnode {
   fi
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."
-  if [[ "${SERVE_LOGS}" == true ]]; then
-    runBackgroundProcess logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &>> logs/logserver
-  fi
+  runBackgroundProcess logserver --directory "${PWD}/logs" --uri_root=/strato/logs/ &>> logs/logserver
 
   if $mineBlocks
   then echo "Starting strato-adit"

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -86,7 +86,6 @@ services:
     - postgres_slipstream_db=cirrus
     - postgres_user=postgres
     - PROCESS_MONITORING=${PROCESS_MONITORING}
-    - SERVE_LOGS=${SERVE_LOGS}
     - SLIPSTREAM_DEBUG=${SLIPSTREAM_DEBUG}
     - SMD_MODE=${SMD_MODE}
     - ssl=${ssl:-false}
@@ -151,7 +150,6 @@ services:
     - redisBDBNumber=${redisBDBNumber}
     - redisHost=redis
     - redisPort=6379
-    - SERVE_LOGS=${SERVE_LOGS}
     - seqDebugMode=${seqDebugMode}
     - seqMaxEventsPerIter=${seqMaxEventsPerIter}
     - seqMaxUsPerIter=${seqMaxUsPerIter}
@@ -207,6 +205,7 @@ services:
     - OAUTH_JWT_VALIDATION_DISCOVERY_URL=${OAUTH_JWT_VALIDATION_DISCOVERY_URL}
     - OAUTH_JWT_USERNAME_PROPERTY=${OAUTH_JWT_USERNAME_PROPERTY}
     - SMD_MODE=${SMD_MODE}
+    - SERVE_LOGS=${SERVE_LOGS}
     - ssl=${ssl:-false}
     - sslCertFileType=${sslCertFileType:-crt}
     - STRATO_GS_MODE=${STRATO_GS_MODE}

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -86,6 +86,7 @@ services:
     - postgres_slipstream_db=cirrus
     - postgres_user=postgres
     - PROCESS_MONITORING=${PROCESS_MONITORING}
+    - SERVE_LOGS=${SERVE_LOGS}
     - SLIPSTREAM_DEBUG=${SLIPSTREAM_DEBUG}
     - SMD_MODE=${SMD_MODE}
     - ssl=${ssl:-false}
@@ -150,6 +151,7 @@ services:
     - redisBDBNumber=${redisBDBNumber}
     - redisHost=redis
     - redisPort=6379
+    - SERVE_LOGS=${SERVE_LOGS}
     - seqDebugMode=${seqDebugMode}
     - seqMaxEventsPerIter=${seqMaxEventsPerIter}
     - seqMaxUsPerIter=${seqMaxUsPerIter}

--- a/logserver/exec_src/LogServer.hs
+++ b/logserver/exec_src/LogServer.hs
@@ -14,7 +14,7 @@ import Network.Wai.Middleware.RequestLogger
 import WaiAppStatic.Types
 
 defineFlag "d:directory" ("/var/lib/strato/logs" :: String) "Directory to serve the files from"
-defineFlag "u:uri_root" ("/strato/logs/" :: T.Text) "Prefix to add in front of any URIs"
+defineFlag "u:uri_root" ("/logs/strato/" :: T.Text) "Prefix to add in front of any URIs"
 $(return [])
 
 jsonList :: Pieces -> Folder -> IO Builder

--- a/logserver/exec_src/LogServer.hs
+++ b/logserver/exec_src/LogServer.hs
@@ -1,15 +1,41 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 
+import Blaze.ByteString.Builder
 import Control.Monad
+import qualified Data.Aeson.Encode.Pretty as Ae
+import qualified Data.Map as M
+import qualified Data.Text as T
 import HFlags
 import Network.Wai.Application.Static
 import Network.Wai.Handler.Warp
 import Network.Wai.Middleware.Prometheus
 import Network.Wai.Middleware.RequestLogger
+import WaiAppStatic.Types
 
 defineFlag "d:directory" ("/var/lib/strato/logs" :: String) "Directory to serve the files from"
+defineFlag "u:uri_root" ("/strato/logs/" :: T.Text) "Prefix to add in front of any URIs"
 $(return [])
+
+jsonList :: Pieces -> Folder -> IO Builder
+jsonList pieces (Folder elems) = do
+  -- TODO(tim): These pieces maybe should be used as a prefix for the URIs
+  print pieces
+  return . fromLazyByteString . Ae.encodePretty . map (either renderFolder renderFile) $ elems
+  where renderFolder :: FolderName -> M.Map T.Text T.Text
+        renderFolder dirname = M.fromList
+           [ ("type", "directory")
+           , ("name", fromPiece dirname)
+           , ("uri",  flags_uri_root <> fromPiece dirname)
+           ]
+
+        renderFile :: File -> M.Map T.Text T.Text
+        renderFile file = M.fromList
+          [ ("type", "file")
+          , ("name", fromPiece $ fileName file)
+          , ("uri", flags_uri_root <> fromPiece (fileName file))
+          , ("size", T.pack . show . fileGetSize $ file)
+          ]
 
 main :: IO ()
 main = do
@@ -17,7 +43,9 @@ main = do
   unless (null unknown) . putStrLn $ "Unknown flags: " ++ show unknown
   let settings = defaultFileServerSettings flags_directory
       rawApp = staticApp settings
-             { ssGetMimeType = const (return "text/plain")}
+             { ssGetMimeType = const (return "text/plain")
+             , ssListing = Just jsonList
+             }
       app = prometheus def . logStdoutDev $ rawApp
   putStrLn $ "Serving directory " ++ flags_directory
   run 7065 app

--- a/logserver/exec_src/LogServer.hs
+++ b/logserver/exec_src/LogServer.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+import Control.Monad
+import HFlags
+import Network.Wai.Application.Static
+import Network.Wai.Handler.Warp
+import Network.Wai.Middleware.Prometheus
+import Network.Wai.Middleware.RequestLogger
+
+defineFlag "d:directory" ("/var/lib/strato/logs" :: String) "Directory to serve the files from"
+$(return [])
+
+main :: IO ()
+main = do
+  unknown <- $initHFlags "Strato Log Server"
+  unless (null unknown) . putStrLn $ "Unknown flags: " ++ show unknown
+  let settings = defaultFileServerSettings flags_directory
+      rawApp = staticApp settings
+             { ssGetMimeType = const (return "text/plain")}
+      app = prometheus def . logStdoutDev $ rawApp
+  putStrLn $ "Serving directory " ++ flags_directory
+  run 7065 app

--- a/logserver/exec_src/LogServer.hs
+++ b/logserver/exec_src/LogServer.hs
@@ -43,7 +43,7 @@ main = do
   unless (null unknown) . putStrLn $ "Unknown flags: " ++ show unknown
   let settings = defaultFileServerSettings flags_directory
       rawApp = staticApp settings
-             { ssGetMimeType = const (return "text/plain")
+             { ssGetMimeType = const (return "application/json")
              , ssListing = Just jsonList
              }
       app = prometheus def . logStdoutDev $ rawApp

--- a/logserver/package.yaml
+++ b/logserver/package.yaml
@@ -1,0 +1,15 @@
+name: logserver
+synopsis: static file server for /var/lib/strato/logs
+github: blockapps/strato-platform/core-strato/logserver
+
+executables:
+  logserver:
+    source-dirs: exec_src/
+    main: LogServer.hs
+    dependencies:
+      - base
+      - hflags
+      - wai-app-static
+      - wai-extra
+      - wai-middleware-prometheus
+      - warp

--- a/logserver/package.yaml
+++ b/logserver/package.yaml
@@ -7,8 +7,12 @@ executables:
     source-dirs: exec_src/
     main: LogServer.hs
     dependencies:
+      - aeson-pretty
       - base
+      - blaze-builder
+      - containers
       - hflags
+      - text
       - wai-app-static
       - wai-extra
       - wai-middleware-prometheus

--- a/nginx-packager/docker-run.sh
+++ b/nginx-packager/docker-run.sh
@@ -96,6 +96,10 @@ if [ ! -f /usr/local/openresty/nginx/conf/nginx.conf ]; then
     sed -i '/#TEMPLATE_MARK_BLOCKSTANBUL/d' /tmp/nginx.conf
   fi
 
+  if [ "$SERVE_LOGS" != true ]; then
+    sed -i '/#TEMPLATE_MARK_LOGS/d' /tmp/nginx.conf
+  fi
+
   # Set the Bloc API timeout
   BLOC_TIMEOUT=$((blockTime * BLOCK_TIME_MULTIPLIER_FOR_TIMEOUT))
   if [ ${BLOC_TIMEOUT} -lt ${MIN_TIMEOUT_BLOCKCHAIN_ENDPOINTS} ]
@@ -119,10 +123,10 @@ if [ ! -f /usr/local/openresty/nginx/conf/nginx.conf ]; then
     sed -i 's*<CLIENT_SECRET_PLACEHOLDER>*'"$OAUTH_CLIENT_SECRET"'*g' /tmp/openid-auth.lua
 
     if [ "$ssl" = true ] ; then
-      sed -i 's/<IS_SSL_PLACEHOLDER_YES_NO>/yes/g' /tmp/openid-auth.lua   
-      sed -i 's/<REDIRECT_URI_SCHEME_PLACEHOLDER_HTTP_HTTPS>/https/g' /tmp/openid-auth.lua   
+      sed -i 's/<IS_SSL_PLACEHOLDER_YES_NO>/yes/g' /tmp/openid-auth.lua
+      sed -i 's/<REDIRECT_URI_SCHEME_PLACEHOLDER_HTTP_HTTPS>/https/g' /tmp/openid-auth.lua
     else
-      sed -i 's/<IS_SSL_PLACEHOLDER_YES_NO>/no/g' /tmp/openid-auth.lua   
+      sed -i 's/<IS_SSL_PLACEHOLDER_YES_NO>/no/g' /tmp/openid-auth.lua
       sed -i 's/<REDIRECT_URI_SCHEME_PLACEHOLDER_HTTP_HTTPS>/http/g' /tmp/openid-auth.lua
     fi
   fi

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -230,7 +230,6 @@ http {
         return 301 /docs/?url=/bloc/v2.2/swagger.json;
       }
 
-
       location /prometheus {
         auth_basic "Restricted";
         auth_basic_user_file auth.htpasswd;
@@ -241,18 +240,18 @@ http {
         proxy_set_header X-NginX-Proxy true;
       }
 
-      location /strato/logs/ {
-        auth_basic "Restricted";
-        auth_basic_user_file auth.htpasswd;
-        proxy_pass http://strato:7065/;
-      }
-
-      location /bloc/logs/ {
-        auth_basic "Restricted";
-        auth_basic_user_file auth.htpasswd;
-        proxy_pass http://bloc:7065/;
-      }
-
+      location /strato/logs/ {                   #TEMPLATE_MARK_LOGS
+        auth_basic "Restricted";                 #TEMPLATE_MARK_LOGS
+        auth_basic_user_file auth.htpasswd;      #TEMPLATE_MARK_LOGS
+        proxy_pass http://strato:7065/;          #TEMPLATE_MARK_LOGS
+      }                                          #TEMPLATE_MARK_LOGS
+                                                 #TEMPLATE_MARK_LOGS
+      location /bloc/logs/ {                     #TEMPLATE_MARK_LOGS
+        auth_basic "Restricted";                 #TEMPLATE_MARK_LOGS
+        auth_basic_user_file auth.htpasswd;      #TEMPLATE_MARK_LOGS
+        proxy_pass http://bloc:7065/;            #TEMPLATE_MARK_LOGS
+      }                                          #TEMPLATE_MARK_LOGS
+                                                 #TEMPLATE_MARK_LOGS
       location /strato-api/eth/v1.2/docs {
         auth_basic "Restricted";
         auth_basic_user_file auth.htpasswd;

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -230,6 +230,7 @@ http {
         return 301 /docs/?url=/bloc/v2.2/swagger.json;
       }
 
+
       location /prometheus {
         auth_basic "Restricted";
         auth_basic_user_file auth.htpasswd;
@@ -238,6 +239,12 @@ http {
         proxy_set_header Host $host;
         proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
         proxy_set_header X-NginX-Proxy true;
+      }
+
+      location /strato/logs {
+        auth_basic "Restricted";
+        auth_basic_user_file auth.htpasswd;
+        proxy_pass http://strato:7065/;
       }
 
       location /strato-api/eth/v1.2/docs {

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -247,6 +247,12 @@ http {
         proxy_pass http://strato:7065/;
       }
 
+      location /bloc/logs {
+        auth_basic "Restricted"
+        auth_basic_user_file auth.htpasswd;
+        proxy_pass http://bloc:7065/;
+      }
+
       location /strato-api/eth/v1.2/docs {
         auth_basic "Restricted";
         auth_basic_user_file auth.htpasswd;

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -240,13 +240,13 @@ http {
         proxy_set_header X-NginX-Proxy true;
       }
 
-      location /strato/logs/ {                   #TEMPLATE_MARK_LOGS
+      location /logs/strato/ {                   #TEMPLATE_MARK_LOGS
         auth_basic "Restricted";                 #TEMPLATE_MARK_LOGS
         auth_basic_user_file auth.htpasswd;      #TEMPLATE_MARK_LOGS
         proxy_pass http://strato:7065/;          #TEMPLATE_MARK_LOGS
       }                                          #TEMPLATE_MARK_LOGS
                                                  #TEMPLATE_MARK_LOGS
-      location /bloc/logs/ {                     #TEMPLATE_MARK_LOGS
+      location /logs/bloc/ {                     #TEMPLATE_MARK_LOGS
         auth_basic "Restricted";                 #TEMPLATE_MARK_LOGS
         auth_basic_user_file auth.htpasswd;      #TEMPLATE_MARK_LOGS
         proxy_pass http://bloc:7065/;            #TEMPLATE_MARK_LOGS

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -241,14 +241,14 @@ http {
         proxy_set_header X-NginX-Proxy true;
       }
 
-      location /strato/logs {
+      location /strato/logs/ {
         auth_basic "Restricted";
         auth_basic_user_file auth.htpasswd;
         proxy_pass http://strato:7065/;
       }
 
-      location /bloc/logs {
-        auth_basic "Restricted"
+      location /bloc/logs/ {
+        auth_basic "Restricted";
         auth_basic_user_file auth.htpasswd;
         proxy_pass http://bloc:7065/;
       }

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,6 +47,7 @@ packages:
 - core-strato/privacy/
 - shared-util/cross-monitoring/
 - clockwork
+- logserver
 - location:
     git: https://github.com/echatav/secp256k1-haskell/
     commit: c27236f93ba2af4da0865558e2dedf2d8643cd8c


### PR DESCRIPTION
```
$ curl localhost/bloc/logs
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>openresty/1.13.6.1</center>
</body>
</html>
$ curl localhost/bloc/logs/
<html>
<head><title>401 Authorization Required</title></head>
<body bgcolor="white">
<center><h1>401 Authorization Required</h1></center>
<hr><center>openresty/1.13.6.1</center>
</body>
</html>
$ curl -u admin:admin localhost/bloc/logs/
[
    {
        "size": "254",
        "uri": "/bloch/logs/strato-server",
        "name": "strato-server",
        "type": "file"
    },
    {
        "size": "374",
        "uri": "/bloch/logs/logserver",
        "name": "logserver",
        "type": "file"
    },
    {
        "size": "1311",
        "uri": "/bloch/logs/slipstream",
        "name": "slipstream",
        "type": "file"
    },
    {
        "size": "2886",
        "uri": "/bloch/logs/bloc",
        "name": "bloc",
        "type": "file"
    }
]%                                                                                                       
$ curl -u admin:admin localhost/bloc/logs/logserver
+ proc_pid=72
+ MONITORED_PIDS[${proc_pid}]='/usr/bin/logserver --directory=//logs --uri_root=/bloch/logs/'
+ echo 'process pid:: 72 (command: /usr/bin/logserver' --directory=//logs '--uri_root=/bloch/logs/)'
process pid:: 72 (command: /usr/bin/logserver --directory=//logs --uri_root=/bloch/logs/)
+ disown %
+ /usr/bin/logserver --directory=//logs --uri_root=/bloch/logs/
Serving directory //logs
[]
GET /
  Accept: */*
  Status: 200 OK 0.000343252s
GET /logserver
  Accept: */*
  Status: 200 OK 0.00006661s
$ curl -u admin:admin localhost/bloc/logs/bloc | head
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6792  100  + proc_pid=74 0      0      0 --:--:-- --:--:-- --:--:--     0
+ MONITORED_PIDS[${proc_pid}]='/usr/bin/blockapps-bloc --pghost=postgres --pgport=5432 --pguser=postgres --password=api --stratourl=http://strato:3000/eth/v1.2 --vaultwrapperurl=http://vault-wrapper:8000/strato/v2.3 --loglevel=4 +RTS -N1'
+ /usr/bin/blockapps-bloc --pghost=postgres --pgport=5432 --pguser=postgres --password=api --stratourl=http://strato:3000/eth/v1.2 --vaultwrapperurl=http://vault-wrapper:8000/strato/v2.3 --loglevel=4 +RTS -N1
+ echo 'process pid:: 74 (command: /usr/bin/blockapps-bloc' --pghost=postgres --pgport=5432 --pguser=postgres --password=api --stratourl=http://strato:3000/eth/v1.2 --vaultwrapperurl=http://vault-wrapper:8000/strato/v2.3 --loglevel=4 +RTS '-N1)'
process pid:: 74 (command: /usr/bin/blockapps-bloc --pghost=postgres --pgport=5432 --pguser=postgres --password=api --stratourl=http://strato:3000/eth/v1.2 --vaultwrapperurl=http://vault-wrapper:8000/strato/v2.3 --loglevel=4 +RTS -N1)
+ disown %
██████╗ ██╗      ██████╗  ███6██╗
7██╔══██╗██║     ██╔═══██╗██╔════╝
9██████╔╝██║     ██║   ██║██║
2██╔══██╗██║     ██║   ██║██║
    0     0   964k      0 --:--:-- --:--:-- --:--:-- 1105k
(23) Failed writing body

```