### PR TITLE
Split StorageDB into specific and generic layers

### DIFF
--- a/core-strato/blockapps-data/package.yaml
+++ b/core-strato/blockapps-data/package.yaml
@@ -81,8 +81,11 @@ tests:
     dependencies:
       - aeson-diff
       - blockapps-data
+      - directory
       - hspec
+      - hspec-expectations-lifted
       - HUnit
+      - unix
       - unordered-containers
       - vector
     ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N

--- a/core-strato/blockapps-data/src/Blockchain/DB/RawStorageDB.hs
+++ b/core-strato/blockapps-data/src/Blockchain/DB/RawStorageDB.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Blockchain.DB.RawStorageDB (
+  HasRawStorageDB(..),
+  putRawStorageKeyVal',
+  getRawStorageKeyVal',
+  getAllRawStorageKeyVals',
+  flushRawStorageTxDBToBlockDB,
+  flushMemRawStorageDB
+ ) where
+
+import           Control.Monad.State
+import           Control.Monad.Trans.Resource
+import qualified Data.ByteString                             as B
+import qualified Data.Map                                    as M
+import qualified Database.LevelDB                            as DB
+
+import           Blockchain.Data.Address
+import           Blockchain.Data.AddressStateDB
+import           Blockchain.Data.RLP
+import qualified Blockchain.Database.MerklePatricia          as MP
+import qualified Blockchain.Database.MerklePatricia.Internal as MP
+import           Blockchain.DB.HashDB
+import           Blockchain.DB.MemAddressStateDB
+import           Blockchain.DB.StateDB
+import qualified Data.NibbleString                           as N
+
+class MonadResource m => HasRawStorageDB m where
+  getRawStorageTxDB     :: m (DB.DB, M.Map (Address, B.ByteString) B.ByteString)
+  putRawStorageTxMap    :: M.Map (Address, B.ByteString) B.ByteString -> m ()
+  getRawStorageBlockDB  :: m (DB.DB, M.Map (Address, B.ByteString) B.ByteString)
+  putRawStorageBlockMap :: M.Map (Address, B.ByteString) B.ByteString -> m ()
+
+type FullRawStorage m = (HasMemAddressStateDB m, HasRawStorageDB m, HasStateDB m, HasHashDB m)
+
+putRawStorageKeyVal' :: FullRawStorage m => Address -> B.ByteString -> B.ByteString -> m ()
+putRawStorageKeyVal' = putRawStorageKeyValMC
+
+getRawStorageKeyVal' :: FullRawStorage m => Address -> B.ByteString -> m B.ByteString
+getRawStorageKeyVal' = getRawStorageKeyValMC
+
+getAllRawStorageKeyVals' :: FullRawStorage m => Address -> m [(MP.Key, B.ByteString)]
+getAllRawStorageKeyVals' = getAllRawStorageKeyValsMC
+
+--The following are the memory cache versions of the functions
+
+putRawStorageKeyValMC :: FullRawStorage m => Address -> B.ByteString -> B.ByteString -> m ()
+putRawStorageKeyValMC owner key val = do
+  theMap <- fmap snd getRawStorageTxDB
+  putRawStorageTxMap $ M.insert (owner, key) val theMap
+
+getRawStorageKeyValMC :: FullRawStorage m => Address -> B.ByteString -> m B.ByteString
+getRawStorageKeyValMC owner key = do
+  theMap <- fmap snd getRawStorageTxDB
+  case M.lookup (owner, key) theMap of
+   Just val -> return val
+   Nothing  -> do
+     theBMap <- fmap snd getRawStorageBlockDB
+     case M.lookup (owner, key) theBMap of
+       Just val' -> return val'
+       Nothing -> getRawStorageKeyValDB owner key
+
+getAllRawStorageKeyValsMC :: FullRawStorage m  => Address -> m [(MP.Key, B.ByteString)]
+getAllRawStorageKeyValsMC = getAllRawStorageKeyValsDB
+
+flushRawStorageTxDBToBlockDB :: FullRawStorage m => m ()
+flushRawStorageTxDBToBlockDB = do
+  txMap <- snd <$> getRawStorageTxDB
+  blkMap <- snd <$> getRawStorageBlockDB
+  putRawStorageBlockMap $ txMap `M.union` blkMap
+  putRawStorageTxMap M.empty
+
+flushMemRawStorageDB :: FullRawStorage m => m ()
+flushMemRawStorageDB = do
+  flushRawStorageTxDBToBlockDB
+  theMap <- fmap snd getRawStorageBlockDB
+  forM_ (M.toList theMap) $ \((address, key), val) ->
+     putRawStorageKeyValDB address key val
+  putRawStorageBlockMap M.empty
+
+
+--The following are the DB versions of the functions
+
+-- TODO(tim): This is kind of ugly, because it makes the assumption that the
+-- return values another layer of RLP. I think it would be cleaner to treat ""
+-- as the default bytestring, but that would break stateroot compatibility for
+-- the word256 based storage.
+{-# NOINLINE blankVal #-}
+blankVal :: B.ByteString
+blankVal = rlpSerialize $ RLPString ""
+
+putRawStorageKeyValDB :: FullRawStorage m => Address -> B.ByteString -> B.ByteString -> m ()
+putRawStorageKeyValDB owner key val =
+  if val == blankVal
+    then do --when val=0, we actually delete the key from the database
+      addressState <- getAddressState owner
+      db <- fmap fst getRawStorageBlockDB
+      let mpdb = MP.MPDB{MP.ldb=db, MP.stateRoot=addressStateContractRoot addressState}
+      newContractRoot <- fmap MP.stateRoot
+                       $ MP.deleteKey mpdb (N.EvenNibbleString key)
+      putAddressState owner addressState{addressStateContractRoot=newContractRoot}
+    else do
+      hashDBPut storageKeyNibbles
+      addressState <- getAddressState owner
+      db <- fmap fst getRawStorageBlockDB
+      let mpdb = MP.MPDB{MP.ldb=db, MP.stateRoot=addressStateContractRoot addressState}
+      newContractRoot <- fmap MP.stateRoot
+                       $ MP.putKeyVal mpdb storageKeyNibbles (rlpEncode val)
+      putAddressState owner addressState{addressStateContractRoot=newContractRoot}
+ where storageKeyNibbles = N.EvenNibbleString key
+
+getRawStorageKeyValDB :: FullRawStorage m => Address -> B.ByteString -> m B.ByteString
+getRawStorageKeyValDB owner key = do
+  addressState <- getAddressState owner
+  db <- fmap fst getRawStorageBlockDB
+  let mpdb = MP.MPDB{MP.ldb=db, MP.stateRoot=addressStateContractRoot addressState}
+  maybe blankVal rlpDecode <$> MP.getKeyVal mpdb (N.EvenNibbleString key)
+
+getAllRawStorageKeyValsDB :: FullRawStorage m => Address -> m [(MP.Key, B.ByteString)]
+getAllRawStorageKeyValsDB owner = do
+  addressState <- getAddressState owner
+  db <- fmap fst getRawStorageBlockDB
+  let mpdb = MP.MPDB{MP.ldb=db, MP.stateRoot=addressStateContractRoot addressState}
+  kvs <- MP.unsafeGetAllKeyVals mpdb
+  return $ map (fmap rlpDecode) kvs

--- a/core-strato/blockapps-data/src/Blockchain/DB/StorageDB.hs
+++ b/core-strato/blockapps-data/src/Blockchain/DB/StorageDB.hs
@@ -1,6 +1,6 @@
-
+{-# LANGUAGE ConstraintKinds #-}
 module Blockchain.DB.StorageDB (
-  HasStorageDB(..),
+  HasStorageDB,
   putStorageKeyVal',
   getStorageKeyVal',
   getAllStorageKeyVals',
@@ -8,123 +8,44 @@ module Blockchain.DB.StorageDB (
   flushMemStorageDB
   ) where
 
-import           Control.Monad.State
-import           Control.Monad.Trans.Resource
-import qualified Data.Map                                    as M
-import qualified Database.LevelDB                            as DB
+import           Data.Bifunctor                              (second)
+import qualified Data.ByteString                             as B
 
 import           Blockchain.Data.Address
-import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.RLP
 import qualified Blockchain.Database.MerklePatricia          as MP
-import qualified Blockchain.Database.MerklePatricia.Internal as MP
 import           Blockchain.DB.HashDB
 import           Blockchain.DB.MemAddressStateDB
+import           Blockchain.DB.RawStorageDB
 import           Blockchain.DB.StateDB
 import           Blockchain.ExtWord
-import qualified Data.NibbleString                           as N
 
-class MonadResource m => HasStorageDB m where
-  getStorageTxDB     :: m (DB.DB, M.Map (Address, Word256) Word256)
-  putStorageTxMap    :: M.Map (Address, Word256) Word256 -> m ()
-  getStorageBlockDB  :: m (DB.DB, M.Map (Address, Word256) Word256)
-  putStorageBlockMap :: M.Map (Address, Word256) Word256 -> m ()
+-- A thin layer around raw storage db for clients who expect to work on
+-- keys and values of Word256
+type HasStorageDB = HasRawStorageDB
 
+type FullStorage m = (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m)
 
+toKey :: Word256 -> B.ByteString
+toKey = word256ToBytes
 
-putStorageKeyVal' :: (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m) =>
-                  Address -> Word256 -> Word256 -> m ()
-putStorageKeyVal' = putStorageKeyValMC
+toVal :: Word256 -> B.ByteString
+toVal = rlpSerialize  . rlpEncode
 
-getStorageKeyVal' :: (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m) =>
-                   Address -> Word256 -> m Word256
-getStorageKeyVal' = getStorageKeyValMC
+fromVal :: B.ByteString -> Word256
+fromVal = rlpDecode . rlpDeserialize
 
-getAllStorageKeyVals' :: (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m) =>
-                       Address -> m [(MP.Key, Word256)]
-getAllStorageKeyVals' = getAllStorageKeyValsMC
+putStorageKeyVal' :: FullStorage m => Address -> Word256 -> Word256 -> m ()
+putStorageKeyVal' addr key val = putRawStorageKeyVal' addr (toKey key) (toVal val)
 
---The following are the memory cache versions of the functions
+getStorageKeyVal' :: FullStorage m => Address -> Word256 -> m Word256
+getStorageKeyVal' addr key = fromVal <$> getRawStorageKeyVal' addr (toKey key)
 
-putStorageKeyValMC :: (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m) =>
-                  Address -> Word256 -> Word256 -> m ()
-putStorageKeyValMC owner key val = do
-  theMap <- fmap snd getStorageTxDB
-  putStorageTxMap $ M.insert (owner, key) val theMap
+getAllStorageKeyVals' :: FullStorage m => Address -> m [(MP.Key, Word256)]
+getAllStorageKeyVals' addr = map (second fromVal) <$> getAllRawStorageKeyVals' addr
 
-getStorageKeyValMC :: (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m) =>
-                   Address -> Word256 -> m Word256
-getStorageKeyValMC owner key = do
-  theMap <- fmap snd getStorageTxDB
-  case M.lookup (owner, key) theMap of
-   Just val -> return val
-   Nothing  -> do
-     theBMap <- fmap snd getStorageBlockDB
-     case M.lookup (owner, key) theBMap of
-       Just val' -> return val'
-       Nothing -> getStorageKeyValDB owner key
+flushStorageTxDBToBlockDB :: FullStorage m => m ()
+flushStorageTxDBToBlockDB = flushRawStorageTxDBToBlockDB
 
-getAllStorageKeyValsMC :: (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m) =>
-                       Address -> m [(MP.Key, Word256)]
-getAllStorageKeyValsMC = getAllStorageKeyValsDB
-
-flushStorageTxDBToBlockDB :: (HasMemAddressStateDB m, HasStateDB m, HasStorageDB m, HasHashDB m) =>
-                          m ()
-flushStorageTxDBToBlockDB = do
-  txMap <- snd <$> getStorageTxDB
-  blkMap <- snd <$> getStorageBlockDB
-  putStorageBlockMap $ txMap `M.union` blkMap
-  putStorageTxMap M.empty
-
-flushMemStorageDB :: (HasMemAddressStateDB m, HasStateDB m, HasStorageDB m, HasHashDB m) =>
-                   m ()
-flushMemStorageDB = do
-  flushStorageTxDBToBlockDB
-  theMap <- fmap snd getStorageBlockDB
-  forM_ (M.toList theMap) $ \((address, key), val) ->
-     putStorageKeyValDB address key val
-  putStorageBlockMap M.empty
-
-
---The following are the DB versions of the functions
-
-
-putStorageKeyValDB :: (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m) =>
-                  Address -> Word256 -> Word256 -> m ()
-putStorageKeyValDB owner key 0 = do --when val=0, we actually delete the key from the database
-  addressState <- getAddressState owner
-  db <- fmap fst getStorageBlockDB
-  let mpdb = MP.MPDB{MP.ldb=db, MP.stateRoot=addressStateContractRoot addressState}
-  newContractRoot <- fmap MP.stateRoot
-                   $ MP.deleteKey mpdb (N.EvenNibbleString $ word256ToBytes key)
-  putAddressState owner addressState{addressStateContractRoot=newContractRoot}
-
-putStorageKeyValDB owner key val = do
-  hashDBPut storageKeyNibbles
-  addressState <- getAddressState owner
-  db <- fmap fst getStorageBlockDB
-  let mpdb = MP.MPDB{MP.ldb=db, MP.stateRoot=addressStateContractRoot addressState}
-  newContractRoot <- fmap MP.stateRoot
-                   $ MP.putKeyVal mpdb storageKeyNibbles (rlpEncode $ rlpSerialize $ rlpEncode val)
-  putAddressState owner addressState{addressStateContractRoot=newContractRoot}
-  where storageKeyNibbles = N.EvenNibbleString $ word256ToBytes key
-
-getStorageKeyValDB :: (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m) =>
-                   Address -> Word256 -> m Word256
-getStorageKeyValDB owner key = do
-  addressState <- getAddressState owner
-  db <- fmap fst getStorageBlockDB
-  let mpdb = MP.MPDB{MP.ldb=db, MP.stateRoot=addressStateContractRoot addressState}
-  maybeVal <- MP.getKeyVal mpdb (N.EvenNibbleString $ word256ToBytes key)
-  case maybeVal of
-    Nothing -> return 0
-    Just x  -> return $ fromInteger $ rlpDecode $ rlpDeserialize $ rlpDecode x
-
-getAllStorageKeyValsDB :: (HasMemAddressStateDB m, HasStorageDB m, HasStateDB m, HasHashDB m) =>
-                       Address -> m [(MP.Key, Word256)]
-getAllStorageKeyValsDB owner = do
-  addressState <- getAddressState owner
-  db <- fmap fst getStorageBlockDB
-  let mpdb = MP.MPDB{MP.ldb=db, MP.stateRoot=addressStateContractRoot addressState}
-  kvs <- MP.unsafeGetAllKeyVals mpdb
-  return $ map (fmap $ fromInteger . rlpDecode . rlpDeserialize . rlpDecode) kvs
+flushMemStorageDB :: FullStorage m => m ()
+flushMemStorageDB = flushMemRawStorageDB

--- a/core-strato/blockapps-data/test/Spec.hs
+++ b/core-strato/blockapps-data/test/Spec.hs
@@ -28,6 +28,7 @@ import           Blockchain.Strato.Model.SHA
 import           Blockchain.Data.Json
 import           Blockchain.Data.Transaction
 
+import           StorageSpec
 import           Test.QuickCheck
 
 main :: IO()
@@ -56,6 +57,7 @@ main = hspec $ do
     eventualHashIdempotency
     eventualFromIdempotency
     directComparison
+  storageSpec
 
 rlpRT :: (RLPSerializable a) => a -> a
 rlpRT = rlpDecode . rlpDeserialize . rlpSerialize . rlpEncode

--- a/core-strato/blockapps-data/test/StorageSpec.hs
+++ b/core-strato/blockapps-data/test/StorageSpec.hs
@@ -1,0 +1,60 @@
+module StorageSpec (storageSpec) where
+
+import Test.Hspec
+
+storageSpec :: Spec
+storageSpec = do
+  describe "StorageDB" $ do
+    it "can run a test" $ do
+      "ok" `shouldBe` "ok"
+
+    -- type SMap = M.Map (Address, Word256) Word256
+-- type AMap = M.Map Address AddressStateModification
+
+-- data CachedStorage = CS
+  -- { _sdb :: DB.DB
+  -- , _sdbsr :: MP.StateRoot
+  -- , _hdb :: HashDB
+  -- , _stx :: SMap
+  -- , _sbs :: SMap
+  -- , _atx :: AMap
+  -- , _abs :: AMap
+  -- } deriving (Generic, NFData)
+-- makeLenses ''CachedStorage
+
+-- type StorM = StateT CachedStorage (ResourceT IO)
+
+-- instance HasStorageDB StorM where
+  -- getStorageTxDB = liftM2 (,) (use sdb) (use stx)
+  -- putStorageTxMap = assign stx
+  -- getStorageBlockDB = liftM2 (,) (use sdb) (use sbs)
+  -- putStorageBlockMap = assign sbs
+
+-- instance HasMemAddressStateDB StorM where
+  -- getAddressStateTxDBMap = use atx
+  -- putAddressStateTxDBMap = assign atx
+  -- getAddressStateBlockDBMap = use abs
+  -- putAddressStateBlockDBMap = assign abs
+
+-- instance HasStateDB StorM where
+  -- getStateDB = liftM2 MP.MPDB (use sdb) (use sdbsr)
+  -- setStateDBStateRoot = assign sdbsr
+
+-- instance HasHashDB StorM where
+  -- getHashDB = use hdb
+
+-- initialEnv :: IO (FilePath, CachedStorage)
+-- initialEnv = do
+  -- tmpdir <- mkdtemp "/tmp/initial_env"
+  -- let ldbOptions = DB.defaultOptions { DB.createIfMissing = True }
+    --   openDB b = DBB.open (tmpdir ++ b) ldbOptions
+  -- s <- openDB stateDBPath
+  -- h <- openDB hashDBPath
+  -- let st = CS s MP.emptyTriePtr h M.empty M.empty M.empty M.empty
+  -- fmap (tmpdir,) . runResourceT . flip execStateT st $ do
+    -- MP.initializeBlank =<< getStateDB
+
+-- benchStorM :: NFData a => String -> StorM a -> Benchmark
+-- benchStorM name a = envWithCleanup initialEnv (\ ~(p, _) -> removePathForcibly p)
+    --                                           (\ ~(_, s) -> bench name . nfIO $ runStorM s a)
+

--- a/core-strato/blockapps-data/test/StorageSpec.hs
+++ b/core-strato/blockapps-data/test/StorageSpec.hs
@@ -12,6 +12,7 @@ import Control.Lens
 import Control.Monad
 import Control.Monad.Trans.State
 import Control.Monad.Trans.Resource
+import qualified Data.ByteString as B
 import qualified Data.Map as M
 import qualified Blockchain.Database.MerklePatricia as MP
 import qualified Database.LevelDB as DB
@@ -29,13 +30,14 @@ import Blockchain.Data.Address
 import Blockchain.Data.AddressStateDB
 import Blockchain.DB.HashDB
 import Blockchain.DB.MemAddressStateDB
+import Blockchain.DB.RawStorageDB
 import Blockchain.DB.StateDB
 import Blockchain.DB.StorageDB
 import Blockchain.ExtWord
 import Blockchain.Strato.Model.SHA
 import qualified Data.NibbleString as N
 
-type SMap = M.Map (Address, Word256) Word256
+type SMap = M.Map (Address, B.ByteString) B.ByteString
 type AMap = M.Map Address AddressStateModification
 
 data CachedStorage = CS
@@ -51,11 +53,11 @@ makeLenses ''CachedStorage
 
 type StorM = StateT CachedStorage (ResourceT IO)
 
-instance HasStorageDB StorM where
-  getStorageTxDB = liftM2 (,) (use sdb) (use stx)
-  putStorageTxMap = assign stx
-  getStorageBlockDB = liftM2 (,) (use sdb) (use sbs)
-  putStorageBlockMap = assign sbs
+instance HasRawStorageDB StorM where
+  getRawStorageTxDB = liftM2 (,) (use sdb) (use stx)
+  putRawStorageTxMap = assign stx
+  getRawStorageBlockDB = liftM2 (,) (use sdb) (use sbs)
+  putRawStorageBlockMap = assign sbs
 
 instance HasMemAddressStateDB StorM where
   getAddressStateTxDBMap = use atx

--- a/core-strato/blockapps-data/test/StorageSpec.hs
+++ b/core-strato/blockapps-data/test/StorageSpec.hs
@@ -1,60 +1,149 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 module StorageSpec (storageSpec) where
 
-import Test.Hspec
+import Control.DeepSeq
+import Control.Lens
+import Control.Monad
+import Control.Monad.Trans.State
+import Control.Monad.Trans.Resource
+import qualified Data.Map as M
+import qualified Blockchain.Database.MerklePatricia as MP
+import qualified Database.LevelDB as DB
+import qualified Database.LevelDB.Base as DBB
+import GHC.Generics
+import Prelude hiding (abs)
+import System.Posix.Temp
+import System.Directory
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Expectations.Lifted
+import UnliftIO.Exception
+
+import Blockchain.Constants
+import Blockchain.Data.Address
+import Blockchain.Data.AddressStateDB
+import Blockchain.DB.HashDB
+import Blockchain.DB.MemAddressStateDB
+import Blockchain.DB.StateDB
+import Blockchain.DB.StorageDB
+import Blockchain.ExtWord
+import Blockchain.Strato.Model.SHA
+import qualified Data.NibbleString as N
+
+type SMap = M.Map (Address, Word256) Word256
+type AMap = M.Map Address AddressStateModification
+
+data CachedStorage = CS
+  { _sdb :: DB.DB
+  , _sdbsr :: MP.StateRoot
+  , _hdb :: HashDB
+  , _stx :: SMap
+  , _sbs :: SMap
+  , _atx :: AMap
+  , _abs :: AMap
+  } deriving (Generic, NFData)
+makeLenses ''CachedStorage
+
+type StorM = StateT CachedStorage (ResourceT IO)
+
+instance HasStorageDB StorM where
+  getStorageTxDB = liftM2 (,) (use sdb) (use stx)
+  putStorageTxMap = assign stx
+  getStorageBlockDB = liftM2 (,) (use sdb) (use sbs)
+  putStorageBlockMap = assign sbs
+
+instance HasMemAddressStateDB StorM where
+  getAddressStateTxDBMap = use atx
+  putAddressStateTxDBMap = assign atx
+  getAddressStateBlockDBMap = use abs
+  putAddressStateBlockDBMap = assign abs
+
+instance HasStateDB StorM where
+  getStateDB = liftM2 MP.MPDB (use sdb) (use sdbsr)
+  setStateDBStateRoot = assign sdbsr
+
+instance HasHashDB StorM where
+  getHashDB = use hdb
+
+initialEnv :: IO (FilePath, CachedStorage)
+initialEnv = do
+  tmpdir <- mkdtemp "/tmp/storage_spec"
+  let ldbOptions = DB.defaultOptions { DB.createIfMissing = True }
+      openDB b = DBB.open (tmpdir ++ b) ldbOptions
+  s <- openDB stateDBPath
+  h <- openDB hashDBPath
+  let st = CS s MP.emptyTriePtr h M.empty M.empty M.empty M.empty
+  fmap (tmpdir,) . runResourceT . flip execStateT st $ do
+    MP.initializeBlank =<< getStateDB
+
+runStorM :: StorM a -> IO a
+runStorM mv = bracket initialEnv
+                       (removePathForcibly . fst)
+                       (runResourceT . evalStateT mv . snd)
 
 storageSpec :: Spec
 storageSpec = do
   describe "StorageDB" $ do
-    it "can run a test" $ do
-      "ok" `shouldBe` "ok"
+    it "gets its puts" . runStorM $ do
+      getStorageKeyVal' 0x776 0x999 `shouldReturn` 0x0
+      putStorageKeyVal' 0x776 0x999 0x1234567890ab
+      getStorageKeyVal' 0x776 0x999 `shouldReturn` 0x1234567890ab
 
-    -- type SMap = M.Map (Address, Word256) Word256
--- type AMap = M.Map Address AddressStateModification
+    it "gets its puts after a partial flush" . runStorM $ do
+      putStorageKeyVal' 0x1 0x2 0x3
+      flushStorageTxDBToBlockDB
+      use stx `shouldReturn` M.empty
+      getStorageKeyVal' 0x1 0x2 `shouldReturn` 0x3
+      putStorageKeyVal' 0x1 0x2 0x77777
+      getStorageKeyVal' 0x1 0x2 `shouldReturn` 0x77777
 
--- data CachedStorage = CS
-  -- { _sdb :: DB.DB
-  -- , _sdbsr :: MP.StateRoot
-  -- , _hdb :: HashDB
-  -- , _stx :: SMap
-  -- , _sbs :: SMap
-  -- , _atx :: AMap
-  -- , _abs :: AMap
-  -- } deriving (Generic, NFData)
--- makeLenses ''CachedStorage
+    it "gets its puts after a full flush" . runStorM $ do
+      putStorageKeyVal' 0x1 0x2 0x3
+      flushMemStorageDB
+      use stx `shouldReturn` M.empty
+      use sbs `shouldReturn` M.empty
+      getStorageKeyVal' 0x1 0x2 `shouldReturn` 0x3
 
--- type StorM = StateT CachedStorage (ResourceT IO)
+    it "getAll returns nothing before a flush" . runStorM $ do
+      putStorageKeyVal' 0x1 0x2 0x3
+      putStorageKeyVal' 0x1 0x3 0x4
+      putStorageKeyVal' 0x1 0x4 0x5
+      putStorageKeyVal' 0x1 0x3 0x6
+      getAllStorageKeyVals' 0x1 `shouldReturn` []
 
--- instance HasStorageDB StorM where
-  -- getStorageTxDB = liftM2 (,) (use sdb) (use stx)
-  -- putStorageTxMap = assign stx
-  -- getStorageBlockDB = liftM2 (,) (use sdb) (use sbs)
-  -- putStorageBlockMap = assign sbs
+    it "getAll puts after a flush" . runStorM $ do
+      putStorageKeyVal' 0x1 0x2 0x3
+      putStorageKeyVal' 0x1 0x3 0x4
+      putStorageKeyVal' 0x1 0x4 0x5
+      putStorageKeyVal' 0x1 0x3 0x6
+      flushMemStorageDB
+      use stx `shouldReturn` M.empty
+      use sbs `shouldReturn` M.empty
+      let toKey = N.EvenNibbleString . keccak256 . word256ToBytes
+      kvs <- getAllStorageKeyVals' 0x1
+      kvs `shouldMatchList` [ (toKey 2, 3)
+                            , (toKey 3, 6)
+                            , (toKey 4, 5)
+                            ]
 
--- instance HasMemAddressStateDB StorM where
-  -- getAddressStateTxDBMap = use atx
-  -- putAddressStateTxDBMap = assign atx
-  -- getAddressStateBlockDBMap = use abs
-  -- putAddressStateBlockDBMap = assign abs
+    it "put 0 should not change the state root" . runStorM $ do
+      want <- addressStateContractRoot <$> getAddressState 0x1234
+      want `shouldBe` "V\232\US\ETB\ESC\204U\166\255\131E\230\146\192\248n[H\224\ESC\153l\173\192\SOHb/\181\227c\180!"
+      putStorageKeyVal' 0x1234 0x3 0x0
+      flushMemStorageDB
+      got <- addressStateContractRoot <$> getAddressState 0x1234
+      want `shouldBe` got
 
--- instance HasStateDB StorM where
-  -- getStateDB = liftM2 MP.MPDB (use sdb) (use sdbsr)
-  -- setStateDBStateRoot = assign sdbsr
 
--- instance HasHashDB StorM where
-  -- getHashDB = use hdb
-
--- initialEnv :: IO (FilePath, CachedStorage)
--- initialEnv = do
-  -- tmpdir <- mkdtemp "/tmp/initial_env"
-  -- let ldbOptions = DB.defaultOptions { DB.createIfMissing = True }
-    --   openDB b = DBB.open (tmpdir ++ b) ldbOptions
-  -- s <- openDB stateDBPath
-  -- h <- openDB hashDBPath
-  -- let st = CS s MP.emptyTriePtr h M.empty M.empty M.empty M.empty
-  -- fmap (tmpdir,) . runResourceT . flip execStateT st $ do
-    -- MP.initializeBlank =<< getStateDB
-
--- benchStorM :: NFData a => String -> StorM a -> Benchmark
--- benchStorM name a = envWithCleanup initialEnv (\ ~(p, _) -> removePathForcibly p)
-    --                                           (\ ~(_, s) -> bench name . nfIO $ runStorM s a)
-
+    it "put 1 should change the state root" . runStorM $ do
+      want <- addressStateContractRoot <$> getAddressState 0x222
+      putStorageKeyVal' 0x1234 0x3 0x44
+      flushMemStorageDB
+      got <- addressStateContractRoot <$> getAddressState 0x1234
+      want `shouldNotBe` got
+      got `shouldBe` "E\RS\164\USe\177\214\249m\186\SI\248\136\\\215\137\172\231\135q\224;\178TWg\SUB\147n\134. "

--- a/core-strato/ethereum-vm/package.yaml
+++ b/core-strato/ethereum-vm/package.yaml
@@ -5,6 +5,7 @@ author: Jamshid
 maintainer:    jamshidnh@gmail.com
 synopsis: A Haskell version of an Ethereum EVM
 category:      Data Structures
+license: Apache-2.0
 description:
     The client described in the Ethereum Yellowpaper
 

--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -56,8 +56,8 @@ import           Blockchain.DB.BlockSummaryDB
 import           Blockchain.DB.CodeDB
 import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.DB.ModifyStateDB
+import           Blockchain.DB.RawStorageDB
 import           Blockchain.DB.StateDB
-import           Blockchain.DB.StorageDB
 import           Blockchain.ExtWord
 import           Blockchain.Format
 import           Blockchain.SHA
@@ -1014,7 +1014,7 @@ runVMM isRunningTests' isHomestead preExistingSuicideList callDepth env availabl
           return (Left e, vmState'{logs=[]})
       (_, stateAfter) -> do
           setStateDBStateRoot $ MP.stateRoot $ contextStateDB $ dbs $ stateAfter
-          putStorageTxMap $ contextStorageTxMap $ dbs stateAfter
+          putRawStorageTxMap $ contextStorageTxMap $ dbs stateAfter
           putAddressStateTxDBMap $ contextAddressStateTxDBMap $ dbs stateAfter
 
           when flags_debug . lift .lift $ $logInfoS "runVMM/Right" "VM has finished running"
@@ -1278,7 +1278,7 @@ create_debugWrapper block owner value initCodeBytes = do
       ((result, finalVMState), finalDBs) <- runEm callEm
 
       setStateDBStateRoot $ MP.stateRoot $ contextStateDB $ finalDBs
-      putStorageTxMap $ contextStorageTxMap finalDBs
+      putRawStorageTxMap $ contextStorageTxMap finalDBs
       putAddressStateTxDBMap $ contextAddressStateTxDBMap finalDBs
       gr <- liftIO . readGasRemaining $ finalVMState
       setGasRemaining gr
@@ -1334,7 +1334,7 @@ nestedRun_debugWrapper noValueTransfer gas receiveAddress (Address address) send
       runEm callEm
 
   setStateDBStateRoot $ MP.stateRoot $ contextStateDB $ finalDBs
-  putStorageTxMap $ contextStorageTxMap finalDBs
+  putRawStorageTxMap $ contextStorageTxMap finalDBs
   putAddressStateTxDBMap $ contextAddressStateTxDBMap finalDBs
 
 

--- a/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM/VMM.hs
@@ -60,6 +60,7 @@ import           Blockchain.DB.CodeDB
 import           Blockchain.DB.HashDB
 import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.DB.ModifyStateDB
+import           Blockchain.DB.RawStorageDB
 import           Blockchain.DB.StateDB
 import           Blockchain.DB.StorageDB
 import           Blockchain.ExtWord
@@ -105,19 +106,19 @@ instance HasChainDB VMM where
     vmState <- lift get
     lift $ put vmState{dbs=(dbs vmState){contextGenesisRoot = sr}}
 
-instance HasStorageDB VMM where
-    getStorageTxDB = do
+instance HasRawStorageDB VMM where
+    getRawStorageTxDB = do
       cxt <- lift get
       return (MP.ldb $ contextStateDB $ dbs cxt, --storage uses the state db also
               contextStorageTxMap $ dbs cxt)
-    putStorageTxMap theMap = do
+    putRawStorageTxMap theMap = do
       cxt <- lift get
       lift $ put cxt{dbs=(dbs cxt){contextStorageTxMap=theMap}}
-    getStorageBlockDB = do
+    getRawStorageBlockDB = do
       cxt <- lift get
       return (MP.ldb $ contextStateDB $ dbs cxt, --storage uses the state db also
               contextStorageBlockMap $ dbs cxt)
-    putStorageBlockMap theMap = do
+    putRawStorageBlockMap theMap = do
       cxt <- lift get
       lift $ put cxt{dbs=(dbs cxt){contextStorageBlockMap=theMap}}
 

--- a/core-strato/strato-init/src/Blockchain/Setup.hs
+++ b/core-strato/strato-init/src/Blockchain/Setup.hs
@@ -45,16 +45,15 @@ import qualified Blockchain.Database.MerklePatricia as MP
 import           Blockchain.DB.CodeDB
 import           Blockchain.DB.HashDB
 import           Blockchain.DB.MemAddressStateDB
+import           Blockchain.DB.RawStorageDB
 import           Blockchain.DB.SQLDB
 import           Blockchain.DB.StateDB
-import           Blockchain.DB.StorageDB
 import           Blockchain.EthConf
 import           Blockchain.KafkaTopics
 import           Blockchain.Output
 import           Blockchain.PrivateKeyConf
 import qualified Blockchain.Strato.RedisBlockDB     as RBDB
 import           Blockchain.Strato.Model.Address
-import           Blockchain.Strato.Model.ExtendedWord
 
 import qualified Executable.EthDiscoverySetup       as EthDiscovery
 
@@ -89,8 +88,8 @@ data SetupDBs =
     codeDB  :: CodeDB,
     sqlDB   :: SQLDB,
     redisDB :: Redis.Connection,
-    localStorageTx :: IORef (Map.Map (Address, Word256) Word256),
-    localStorageBlock :: IORef (Map.Map (Address, Word256) Word256),
+    localStorageTx :: IORef (Map.Map (Address, B.ByteString) B.ByteString),
+    localStorageBlock :: IORef (Map.Map (Address, B.ByteString) B.ByteString),
     localAddressStateTx :: IORef (Map.Map Address AddressStateModification),
     localAddressStateBlock :: IORef (Map.Map Address AddressStateModification)
     }
@@ -102,21 +101,21 @@ instance HasStateDB SetupDBM where
     dbref <- asks stateDB
     liftIO $ atomicModifyIORef' dbref (\s -> (s{MP.stateRoot=sr}, ()))
 
-instance HasStorageDB SetupDBM where
-  getStorageTxDB = do
+instance HasRawStorageDB SetupDBM where
+  getRawStorageTxDB = do
     cxt <- ask --storage and states use the same database!
     db <- liftIO . readIORef . stateDB $ cxt
     lst <- liftIO . readIORef .localStorageTx $ cxt
     return (MP.ldb db, lst)
-  putStorageTxMap theMap = do
+  putRawStorageTxMap theMap = do
     lstref <- asks localStorageTx
     liftIO $ atomicWriteIORef lstref theMap
-  getStorageBlockDB = do
+  getRawStorageBlockDB = do
     cxt <- ask
     db <- liftIO . readIORef . stateDB $ cxt
     lsb <- liftIO . readIORef . localStorageBlock $ cxt
     return (MP.ldb db, lsb)
-  putStorageBlockMap theMap = do
+  putRawStorageBlockMap theMap = do
     lsbref <- asks localStorageBlock
     liftIO $ atomicWriteIORef lsbref theMap
 

--- a/core-strato/vm-tools/src/Blockchain/VMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMContext.hs
@@ -36,6 +36,7 @@ import           Control.Monad.Logger
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Control.Monad.Trans.Resource
+import qualified Data.ByteString                    as B
 import           Data.Foldable                      (toList)
 import qualified Data.Map                           as M
 import qualified Data.Sequence                      as Q
@@ -67,11 +68,11 @@ import           Blockchain.DB.ChainDB
 import           Blockchain.DB.CodeDB
 import           Blockchain.DB.HashDB
 import           Blockchain.DB.MemAddressStateDB
+import           Blockchain.DB.RawStorageDB
 import           Blockchain.DB.SQLDB
 import           Blockchain.DB.StateDB
 import           Blockchain.DB.StorageDB
 import           Blockchain.EthConf
-import           Blockchain.ExtWord
 import qualified Blockchain.Strato.Indexer.Kafka    as IK
 import qualified Blockchain.Strato.Indexer.Model    as IM
 import           Blockchain.Strato.Model.SHA
@@ -97,8 +98,8 @@ data Context = Context { contextStateDB                :: MP.MPDB
                        , contextBlockSummaryDB         :: BlockSummaryDB
                        , contextAddressStateTxDBMap    :: M.Map Address AddressStateModification
                        , contextAddressStateBlockDBMap :: M.Map Address AddressStateModification
-                       , contextStorageTxMap           :: M.Map (Address, Word256) Word256
-                       , contextStorageBlockMap        :: M.Map (Address, Word256) Word256
+                       , contextStorageTxMap           :: M.Map (Address, B.ByteString) B.ByteString
+                       , contextStorageBlockMap        :: M.Map (Address, B.ByteString) B.ByteString
                        , contextBlockHashRoot          :: MP.StateRoot
                        , contextGenesisRoot            :: MP.StateRoot
                        , contextBaggerState            :: !BaggerState
@@ -175,19 +176,19 @@ instance HasMemAddressStateDB ContextM where
     cxt <- get
     put $ cxt{contextAddressStateBlockDBMap=theMap}
 
-instance HasStorageDB ContextM where
-  getStorageTxDB = do
+instance HasRawStorageDB ContextM where
+  getRawStorageTxDB = do
     cxt <- get
     return (MP.ldb $ contextStateDB cxt, --storage and states use the same database!
             contextStorageTxMap cxt)
-  putStorageTxMap theMap = do
+  putRawStorageTxMap theMap = do
     cxt <- get
     put cxt{contextStorageTxMap=theMap}
-  getStorageBlockDB = do
+  getRawStorageBlockDB = do
     cxt <- get
     return (MP.ldb $ contextStateDB cxt, --storage and states use the same database!
             contextStorageBlockMap cxt)
-  putStorageBlockMap theMap = do
+  putRawStorageBlockMap theMap = do
     cxt <- get
     put cxt{contextStorageBlockMap=theMap}
 
@@ -319,8 +320,8 @@ getNewAddress address = do
 
 purgeStorageMap :: HasStorageDB m => Address -> m ()
 purgeStorageMap address = do
-  (_, storageMap) <- getStorageTxDB
-  putStorageTxMap $ M.filterWithKey (\(a,_) _ -> a /= address) storageMap
+  (_, storageMap) <- getRawStorageTxDB
+  putRawStorageTxMap $ M.filterWithKey (\(a,_) _ -> a /= address) storageMap
 
 getContextBestBlockInfo :: ContextM ContextBestBlockInfo
 getContextBestBlockInfo = contextBestBlockInfo <$> get


### PR DESCRIPTION
This should not introduce a behavioral change, it just separates the word256ToBytes and rlp serialization calls out of the storage decision logic. It could be taken one step farther to process RLP Values, but I think this makes clear that there are two layers of RLP in use for classic EVM storage: RLP encoded Word256s are then encoded again as RLPStrings.

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/1248