### PR TITLE
Serve text/plain on the logserver

### DIFF
--- a/logserver/exec_src/LogServer.hs
+++ b/logserver/exec_src/LogServer.hs
@@ -43,7 +43,7 @@ main = do
   unless (null unknown) . putStrLn $ "Unknown flags: " ++ show unknown
   let settings = defaultFileServerSettings flags_directory
       rawApp = staticApp settings
-             { ssGetMimeType = const (return "application/json")
+             { ssGetMimeType = const (return "text/plain")
              , ssListing = Just jsonList
              }
       app = prometheus def . logStdoutDev $ rawApp

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -244,12 +244,14 @@ http {
         auth_basic "Restricted";                 #TEMPLATE_MARK_LOGS
         auth_basic_user_file auth.htpasswd;      #TEMPLATE_MARK_LOGS
         proxy_pass http://strato:7065/;          #TEMPLATE_MARK_LOGS
+        add_header Content-Type text/plain;      #TEMPLATE_MARK_LOGS
       }                                          #TEMPLATE_MARK_LOGS
                                                  #TEMPLATE_MARK_LOGS
       location /logs/bloc/ {                     #TEMPLATE_MARK_LOGS
         auth_basic "Restricted";                 #TEMPLATE_MARK_LOGS
         auth_basic_user_file auth.htpasswd;      #TEMPLATE_MARK_LOGS
         proxy_pass http://bloc:7065/;            #TEMPLATE_MARK_LOGS
+        add_header Content-Type text/plain;      #TEMPLATE_MARK_LOGS
       }                                          #TEMPLATE_MARK_LOGS
                                                  #TEMPLATE_MARK_LOGS
       location /strato-api/eth/v1.2/docs {


### PR DESCRIPTION
This overrides the text/html that is hardcoded by the static file server, and
is unnecessary on the logfiles themselves
```
$ curl -I -u admin:admin localhost/logs/strato/
HTTP/1.1 200 OK
Server: openresty/1.13.6.1
Date: Tue, 12 Feb 2019 19:39:59 GMT
Content-Type: text/html; charset=utf-8
Connection: keep-alive
Content-Type: text/plain

$ curl -I -u admin:admin localhost/logs/strato/strato-api
HTTP/1.1 200 OK
Server: openresty/1.13.6.1
Date: Tue, 12 Feb 2019 19:40:07 GMT
Content-Type: text/plain
Content-Length: 1150
Connection: keep-alive
Last-Modified: Tue, 12 Feb 2019 19:37:58 GMT
Accept-Ranges: bytes
last-modified: Tue, 12 Feb 2019 19:37:58 GMT
Content-Type: text/plain

```

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/1250/pipeline