### PR TITLE
Allow a Word8 type attached to code in the db

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/DB/CodeDB.hs
+++ b/core-strato/blockapps-data/src/Blockchain/DB/CodeDB.hs
@@ -1,9 +1,11 @@
-
+{-# LANGUAGE OverloadedStrings #-}
 module Blockchain.DB.CodeDB (
   CodeDB,
+  CodeKind(..),
   HasCodeDB(..),
   addCode,
   getCode,
+  getEVMCode,
   codeDBGet,
   codeDBPut
   ) where
@@ -24,21 +26,36 @@ type CodeDB = DB.DB
 class MonadResource m => HasCodeDB m where
   getCodeDB :: m CodeDB
 
-addCode :: (HasCodeDB m, MonadResource m) => B.ByteString -> m ()
-addCode = codeDBPut
+data CodeKind = EVM
+              | SolidVM
+              deriving (Eq, Show, Enum, Ord)
 
-getCode :: (HasCodeDB m, MonadResource m) => SHA -> m (Maybe B.ByteString)
-getCode theHash =
-  codeDBGet (BL.toStrict $ encode $ sha2StateRoot theHash)
+toWord8 :: CodeKind -> Word8
+toWord8 = fromIntegral . fromEnum
 
-codeDBPut :: HasCodeDB m => B.ByteString -> m ()
-codeDBPut code = do
+fromWord8 :: Word8 -> CodeKind
+fromWord8 = toEnum . fromIntegral
+
+addCode :: (HasCodeDB m, MonadResource m) => CodeKind -> B.ByteString -> m ()
+addCode = codeDBPut . toWord8
+
+getCode :: (HasCodeDB m, MonadResource m) => SHA -> m (Maybe (CodeKind, B.ByteString))
+getCode theHash = codeDBGet (BL.toStrict $ encode $ sha2StateRoot theHash)
+
+getEVMCode :: (HasCodeDB m, MonadResource m) => SHA -> m B.ByteString
+getEVMCode hsh = maybe "" snd <$> getCode hsh
+
+codeDBPut :: HasCodeDB m => Word8 -> B.ByteString -> m ()
+codeDBPut kind code = do
   db <- getCodeDB
-  DB.put db def (BL.toStrict $ encode $ hash code) code
+  DB.put db def (BL.toStrict $ encode $ hash code) $ B.cons kind code
 
 
-codeDBGet :: HasCodeDB m => B.ByteString -> m (Maybe B.ByteString)
+codeDBGet :: HasCodeDB m => B.ByteString -> m (Maybe (CodeKind, B.ByteString))
 codeDBGet key = do
   db <- getCodeDB
-  DB.get db def key
-
+  mFullBS <- DB.get db def key
+  return $ do
+    fullBS <- mFullBS
+    (h, t) <- B.uncons fullBS
+    return (fromWord8 h, t)

--- a/core-strato/ethereum-vm/src/Blockchain/VM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/VM.hs
@@ -305,7 +305,7 @@ runOperation EXTCODESIZE = do
   address <- pop
   accountCreationHack address --needed hack to get the tests working
   addressState <- getAddressState address
-  code <- fromMaybe B.empty <$> getCode (addressStateCodeHash addressState)
+  code <- getEVMCode (addressStateCodeHash addressState)
   push $ (fromIntegral (B.length code)::Word256)
 
 runOperation EXTCODECOPY = do
@@ -316,7 +316,7 @@ runOperation EXTCODECOPY = do
   size <- pop
 
   addressState <- getAddressState address
-  code <- fromMaybe B.empty <$> getCode (addressStateCodeHash addressState)
+  code <- getEVMCode (addressStateCodeHash addressState)
   mStoreByteString memOffset (safeTake size $ safeDrop codeOffset $ code)
 
 runOperation RETURNDATASIZE = do
@@ -1130,7 +1130,7 @@ create' = do
   where
     assignCode::B.ByteString->Address->VMM ()
     assignCode codeBytes address = do
-      addCode codeBytes
+      addCode EVM codeBytes
       newAddressState <- getAddressState address
       putAddressState address newAddressState{addressStateCodeHash=hash codeBytes}
     assignDetails = do
@@ -1173,7 +1173,7 @@ call isRunningTests' isHomestead noValueTransfer preExistingSuicideList b callDe
   code <-
     if 0 < codeAddress && codeAddress < 5
     then return $ PrecompiledCode $ fromIntegral codeAddress
-    else Code . fromMaybe B.empty <$> getCode (addressStateCodeHash addressState)
+    else Code <$> getEVMCode (addressStateCodeHash addressState)
 
   let env =
         Environment{

--- a/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
+++ b/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
@@ -136,7 +136,7 @@ parseHex theString =
    _ -> error $ "parseHex: error parsing string: " ++ theString
 
 initializeCodeDB :: (HasCodeDB m, MonadResource m) => [CodeInfo] -> m ()
-initializeCodeDB = mapM_ (addCode . (\(CodeInfo bin _ _) -> bin))
+initializeCodeDB = mapM_ (addCode EVM . (\(CodeInfo bin _ _) -> bin))
 
 chainInfoToGenesisState :: (HasCodeDB m, HasHashDB m, Mem.HasMemAddressStateDB m, HasStateDB m, HasStorageDB m)
                           => ChainInfo

--- a/core-strato/strato-init/src/Blockchain/Setup.hs
+++ b/core-strato/strato-init/src/Blockchain/Setup.hs
@@ -468,7 +468,7 @@ oneTimeSetup genesisBlockName = do
          redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
 
          void . flip runLoggingT printLogMsg $ flip runReaderT (SetupDBs smpdb hdb cdb pool redisBDBPool m1 m2 m3 m4) $ do
-           addCode B.empty --blank code is the default for Accounts, but gets added nowhere else.
+           addCode EVM B.empty --blank code is the default for Accounts, but gets added nowhere else.
            liftIO $ putStrLn $ CL.yellow ">>>> Initializing Genesis Block"
            case (flags_backupmp, flags_backupblocks) of
              (False, False) -> initializeGenesisBlock NoBackup genesisBlockName decodedFaucets

--- a/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff.hs
+++ b/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff.hs
@@ -241,7 +241,8 @@ eventualAccountState
     addressStateCodeHash
     }
   = do
-    code <- lookupCode addressStateCodeHash
+    -- TODO(tim): dispatch storage decoding based on vmkind
+    (_, code) <- lookupCode addressStateCodeHash
     storage <- eventualStorage addressStateContractRoot
     return AccountDiff{
       nonce = Just (Value addressStateNonce),
@@ -315,7 +316,7 @@ retrieveMPDBValue = rlpDecode . rlpDeserialize . rlpDecode
 lookupAddress :: (HasCodeDB m, HasHashDB m, MonadResource m) => [N.Nibble] -> m Address
 lookupAddress (N.pack -> addrHash) = lookupInMPDB "address" getAddressFromHash addrHash
 
-lookupCode :: (HasHashDB m, HasCodeDB m, MonadResource m) => SHA -> m ByteString
+lookupCode :: (HasHashDB m, HasCodeDB m, MonadResource m) => SHA -> m (CodeKind, ByteString)
 lookupCode = lookupInMPDB "contract code" getCode
 
 lookupStorageKey :: (HasCodeDB m, HasHashDB m, MonadResource m) => Key -> m Word256

--- a/core-strato/test-suite/src/Blockchain/VM/TestEthereum.hs
+++ b/core-strato/test-suite/src/Blockchain/VM/TestEthereum.hs
@@ -69,7 +69,7 @@ defineFlag "debugEnabled2" False "enable debugging"
 
 populateAndConvertAddressState :: Maybe Word256 -> Address -> AddressState' -> ContextM AddressState
 populateAndConvertAddressState cid owner addressState' = do
-  addCode . codeBytes . contractCode' $ addressState'
+  addCode EVM . codeBytes . contractCode' $ addressState'
 
   forM_ (M.toList $ storage' addressState') $
     \(key, val) -> putStorageKeyVal' owner (fromIntegral key) (fromIntegral val)
@@ -94,8 +94,7 @@ showHexInt x
 
 getDataAndRevertAddressState::Address->AddressState->ContextM AddressState'
 getDataAndRevertAddressState _ addressState = do
-  theCode <- fromMaybe (error $ "Missing code in getDataAndRevertAddressState: " ++ format addressState) <$>
-             getCode (addressStateCodeHash addressState)
+  theCode <- getEVMCode (addressStateCodeHash addressState)
 
   -- Copied wholesale from Context.hs:getAllStorageKeyVals'
   -- since that function requires an unhashed owner.

--- a/core-strato/vm-runner/src/Blockchain/JsonRpcCommand.hs
+++ b/core-strato/vm-runner/src/Blockchain/JsonRpcCommand.hs
@@ -66,10 +66,8 @@ runJsonRpcCommand c@JRCGetCode{jrcAddress=address, jrcId=id} = do
   bestBlock <- runWithSQL getBestBlock
   setStateDBStateRoot $ blockDataRefStateRoot bestBlock
   addressState <- getAddressState address
-  maybeCode <- getCode $ addressStateCodeHash addressState
-  case maybeCode of
-   Just code -> liftIO $ produceResponse id code
-   Nothing   -> liftIO $ produceResponse id ""
+  code <- getEVMCode (addressStateCodeHash addressState)
+  liftIO $ produceResponse id code
 
 runJsonRpcCommand c@JRCGetTransactionCount{jrcAddress=address, jrcId=id} = do
   liftIO $ putStrLn $ "running command: " ++ show c

--- a/core-strato/vm-runner/test/Spec.hs
+++ b/core-strato/vm-runner/test/Spec.hs
@@ -14,7 +14,6 @@ import           Control.Monad.Logger
 import qualified Data.ByteString         as B
 import qualified Data.ByteString.Char8   as C8
 import qualified Data.ByteString.Base16  as B16
-import           Data.Maybe
 import qualified Data.Set                as S
 import           Data.Either
 import qualified Data.Text.Encoding      as Text
@@ -83,7 +82,7 @@ spec = do
                     Nothing
         addressState <- getAddressState newAddress
         liftIO . putStrLn $ show addressState
-        code <- fromMaybe C8.empty <$> getCode (addressStateCodeHash addressState)
+        code <- getEVMCode (addressStateCodeHash addressState)
         liftIO . putStrLn $ show $ B16.encode code
         call isRunningTests
              isHomestead


### PR DESCRIPTION
https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/1254

This is slightly different from the spec, because the spec suggests augmenting the codehash with a type tag. Since the codehash is only useful as key into the codedb, the value is augmented with the type as well in an easy to parse fashion and there is no concern about backwards compatibility of the AccountInfo