### PR TITLE
Guard against accidental votes in blockstanbul

### DIFF
--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -17,6 +17,7 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import Prelude hiding (round, sequence)
 import Prometheus
+import System.Exit
 import Text.Printf
 
 import Blockapps.Crossmon
@@ -236,6 +237,8 @@ nextRound nt = do
   use view >>= recordView
   vals <- use validators
   thisR <- use $ view . round
+  when (S.null vals) . liftIO $
+    die "All participants voted out, consensus is stuck."
   let leader = (fromIntegral thisR `mod` S.size vals) `S.elemAt` vals
   proposer .= leader
   proposal .= Nothing

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -77,10 +77,13 @@ spec = parallel $ do
       _ <- sendMessages [Timeout 20]
       use pendingRound `shouldReturn` Just 21
 
-    it "can handle several rounds in succession" $ property $ \blk'' blk2'' as' seal ->
+    it "can handle several rounds in succession" $ withMaxSuccess 10 $ property $ \blk'' blk2'' as' seal ->
       not (null as') ==> runTest $ do
         let as = sortOn sender as'
-        let (blk', blk2') = over both (addProposerSeal seal . truncateExtra) (blk'', blk2'')
+            -- The nonce is set to avoid voting out the sole validator
+            setNonce :: Block -> Block
+            setNonce blk = blk{blockBlockData = (blockBlockData blk){blockDataNonce = 0x24444}}
+        let (blk', blk2') = over both (addProposerSeal seal . truncateExtra . setNonce) (blk'', blk2'')
             blk = setBlockNo 19 blk'
         (v, hsh) <- setupRound blk . map sender $ as
         let ppr = as !! ((fromIntegral . _round $ v) `mod` length as)


### PR DESCRIPTION
These would result in divide-by-zero exceptions when only one validator V existed, the cainbase = V, and the nonce = 0. Nonzero nonces mean no vote outs will occur in this test