### PR TITLE
Wait for success on one of the faucets

### DIFF
--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -53,7 +53,7 @@ pipeline {
           cp strato-worktree/docker-compose.yml strato-getting-started/
           cd strato-getting-started
           NODE_HOST=$(</host)
-          NODE_HOST=${NODE_HOST} genesis=smokeTest ./strato.sh -m 1 --single
+          NODE_HOST=${NODE_HOST} genesis=smokeTest loglevel=6 ./strato.sh -m 1 --single
           docker ps
           # Few quick tests
           check_bloc() {

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
@@ -122,6 +122,7 @@ data BlocError
   | Unimplemented Text
   | AlreadyExists Text
   | RuntimeError SomeException
+  | UnavailableError Text
   deriving Show
 
 --------------------------------------------------------------------------------
@@ -173,7 +174,7 @@ enterBloc env x
     reThrowError
       = \case
           StratoError (FailureResponse (Response Status{statusCode=404} _ _ _)) ->
-            err500{errBody = fromString $ unlines
+            err500{errBody = JSON.encode $ unlines
                    [
                      "Error!",
                      "Bloc seems to be improperly configured: Strato page is missing.",
@@ -181,9 +182,9 @@ enterBloc env x
                      "(More information can be found in the Bloc logs.)"
                    ]}
           StratoError (FailureResponse Response{..}) | statusIsClientError responseStatusCode ->
-            err400{errBody= Lazy.Char8.pack $ compensateForTheOddStratoApiFormattingAndPullOutTheMessage responseBody}
+            err400{errBody= JSON.encode $ compensateForTheOddStratoApiFormattingAndPullOutTheMessage responseBody}
           StratoError (ConnectionError _) ->
-            err500{errBody = fromString $ unlines
+            err500{errBody = JSON.encode $ unlines
                    [
                      "Error!",
                      "Bloc can not connect to Strato.",
@@ -192,7 +193,7 @@ enterBloc env x
                      "(More information can be found in the Bloc logs.)"
                    ]}
           StratoError _ ->
-            err500{errBody = fromString $ unlines
+            err500{errBody = JSON.encode $ unlines
                    [
                      "Error!",
                      "Bloc recieved a malformed response from Strato.",
@@ -201,9 +202,9 @@ enterBloc env x
                      "(More information can be found in the Bloc logs.)"
                    ]}
           VaultWrapperError (FailureResponse Response{..}) | statusIsClientError responseStatusCode ->
-            err400{errBody= Lazy.Char8.pack $ compensateForTheOddStratoApiFormattingAndPullOutTheMessage responseBody}
+            err400{errBody= JSON.encode $ compensateForTheOddStratoApiFormattingAndPullOutTheMessage responseBody}
           VaultWrapperError (ConnectionError _) ->
-            err500{errBody = fromString $ unlines
+            err500{errBody = JSON.encode $ unlines
                    [
                      "Error!",
                      "Bloc can not connect to Strato.",
@@ -212,7 +213,7 @@ enterBloc env x
                      "(More information can be found in the Bloc logs.)"
                    ]}
           VaultWrapperError _ ->
-            err500{errBody = fromString $ unlines
+            err500{errBody = JSON.encode $ unlines
                    [
                      "Error!",
                      "Bloc recieved a malformed response from Strato.",
@@ -221,19 +222,20 @@ enterBloc env x
                      "(More information can be found in the Bloc logs.)"
                    ]}
           DBError _ ->
-            err500{errBody = fromString $ unlines
+            err500{errBody = JSON.encode $ unlines
                    [
                      "Internal Error!",
                      "Something is broken in the Bloc Server database.",
                      "Please contact your network administrator to have this problem fixed.",
                      "(More information can be found in the Bloc logs.)"
                    ]}
-          CirrusError err -> err500{errBody = Lazy.Char8.pack (show err)}
-          UserError err -> err400{errBody = fromString $ show err}
-          AlreadyExists err -> err409{errBody = fromString $ show err}
-          CouldNotFind err -> err404{errBody = fromString $ show err}
+          CirrusError err -> err500{errBody = JSON.encode (show err)}
+          UserError err -> err400{errBody = JSON.encode err}
+          AlreadyExists err -> err409{errBody = JSON.encode err}
+          CouldNotFind err -> err404{errBody = JSON.encode err}
+          UnavailableError err -> err503{errBody = JSON.encode err}
           AnError _ ->
-            err500{errBody = fromString $ unlines
+            err500{errBody = JSON.encode $ unlines
                    [
                      "Internal Error!",
                      "Something is broken in the Bloc Server.",
@@ -241,13 +243,13 @@ enterBloc env x
                      "(More information can be found in the Bloc logs.)"
                    ]}
           Unimplemented err ->
-            err501{errBody = fromString $ unlines
+            err501{errBody = JSON.encode $ unlines
                    [
                      "Internal Error!",
                      "You are using a feature of the Bloc Server that has not yet been implemented.",
                      Text.unpack err
                    ]}
-          RuntimeError _ -> err500{errBody = fromString $ unlines
+          RuntimeError _ -> err500{errBody = JSON.encode $ unlines
                    [
                      "Internal Error!",
                      "Something wrong has happened inside of bloc.",

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
@@ -23,7 +23,6 @@ import           Data.Foldable
 import qualified Data.HashMap.Lazy                  as HashMap
 import           Data.Maybe                         (fromMaybe)
 import           Data.Profunctor.Product.Default
-import           Data.String
 import           Data.Text                          (Text)
 import qualified Data.Text                          as Text
 import           Data.Text.Prettyprint.Doc

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -183,6 +183,8 @@ postUsersFill _ addr resolve = blocTransaction $ do
     waitForBalance addr
   logWith logNotice $ "postUsersFill: resolve = " <> Text.pack (show resolve)
   logWith logNotice $ "postUsersFill: result = " <> Text.pack (show result)
+  when (Failure == blocTransactionStatus result) $
+    throwError $ UnavailableError "faucet transaction failed; please try again"
   return result
 
 postUsersSend :: UserName -> Address -> Maybe ChainId -> Bool -> PostSendParameters -> Bloc BlocTransactionResult

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -159,7 +159,10 @@ waitForBalance addr = go 20
   where go :: Int -> Bloc ()
         go ms = do
           when (ms > 30000) . throwError $ CouldNotFind "no user account found"
-          accts <- blocStrato $ getAccountsFilter accountsFilterParams{qaAddress = Just addr}
+          let params = accountsFilterParams{qaAddress = Just addr}
+          accts <- blocStrato $ getAccountsFilter params
+          logWith logNotice $ "waitForBalance req: " <> Text.pack (show params)
+          logWith logNotice $ "waitForBalance resp: " <> Text.pack (show accts)
           when (null accts || accountBalance (head accts) == Strung 0) $ do
             liftIO . threadDelay $ ms * 1000
             go $ 2 * ms
@@ -178,6 +181,8 @@ postUsersFill _ addr resolve = blocTransaction $ do
   result <- getBlocTransactionResult' Nothing hashes resolve
   when (resolve && Success == blocTransactionStatus result) $ do
     waitForBalance addr
+  logWith logNotice $ "postUsersFill: resolve = " <> Text.pack (show resolve)
+  logWith logNotice $ "postUsersFill: result = " <> Text.pack (show result)
   return result
 
 postUsersSend :: UserName -> Address -> Maybe ChainId -> Bool -> PostSendParameters -> Bloc BlocTransactionResult
@@ -765,8 +770,10 @@ getAccountTxParams addr chainId = \case
       Nothing -> getAcctNonce >>= \n -> return params{txparamsNonce = Just n}
   where
     getAcctNonce = do
-      accts <- blocStrato $ getAccountsFilter
-        accountsFilterParams{qaAddress = Just addr, qaChainId = chainId}
+      let params = accountsFilterParams{qaAddress = Just addr, qaChainId = chainId}
+      accts <- blocStrato $ getAccountsFilter params
+      logWith logNotice $ "getAccountNonce req: " <> Text.pack (show params)
+      logWith logNotice $ "getAccountNonce resp: " <> Text.pack (show accts)
       case listToMaybe accts of
         Nothing   -> throwError . UserError $ "User does not have a balance"
         Just acct -> return $ accountNonce acct

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -561,13 +561,20 @@ postUsersContractMethod' FunctionParameters{..} sign = do
 emptyBatchState :: BatchState
 emptyBatchState = BatchState Map.empty Map.empty
 
+-- getBlocTransactionResult' will return only one of the results
+-- when multiple hashes are provided. This is a glass-half-full
+-- function, and if one TX succeeds then the result is a success.
 getBlocTransactionResult' :: Maybe ChainId -> [Keccak256] -> Bool -> Bloc BlocTransactionResult
 getBlocTransactionResult' _ [] _ = throwError $ AnError "getBlockTransactionResult': no TX hashes"
 getBlocTransactionResult' chainId hashes@(txh:_) resolve =
   if resolve
     then do
       promises <- forM hashes $ \h -> async (getBlocTransactionResult h chainId True)
-      snd <$> waitAny promises
+      results <- mapM wait promises
+      logWith logNotice $ "Transaction results: " <> Text.pack (show results)
+      case filter ((== Success) . blocTransactionStatus) results of
+        (winner:_) -> return winner
+        [] -> return $ head results
     else return $ BlocTransactionResult Pending txh Nothing Nothing
 
 getBlocTransactionResult :: Keccak256 -> Maybe ChainId -> Bool -> Bloc BlocTransactionResult


### PR DESCRIPTION
The previous behavior was that the first result returned was the final one. This is not appropriate in the case of /faucet, as it is expected that at least one of the faucets succeeds but not all of them.

Additionally, while I was adding a new error type I changed the response body to JSON. This improves the swagger docs somewhat, as they will only render an error message if it matches the MIME type. This does not address json parse failures, as that error message comes from the MimeUnrender instance for JSON.