### PR TITLE
Centralize Action, CodeKind, HexStorage

### DIFF
--- a/core-strato/blockapps-datadefs/src/Blockchain/Data/DataDefs.hs
+++ b/core-strato/blockapps-datadefs/src/Blockchain/Data/DataDefs.hs
@@ -35,7 +35,7 @@ import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Strato.Model.SHA
 import           Blockchain.Strato.Model.StateRoot
-import           SolidVM.Model
+import           Blockchain.SolidVM.Model
 
 import           Blockchain.Data.PersistTypes            ()
 import           Blockchain.Data.TransactionResultStatus

--- a/core-strato/blockapps-datadefs/src/Blockchain/Data/PersistTypes.hs
+++ b/core-strato/blockapps-datadefs/src/Blockchain/Data/PersistTypes.hs
@@ -18,7 +18,7 @@ import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Strato.Model.SHA
 import           Blockchain.Strato.Model.StateRoot
-import           SolidVM.Model
+import           Blockchain.SolidVM.Model
 
 derivePersistField "Integer"
 derivePersistField "Point"

--- a/core-strato/blockapps-mpdbs/src/Blockchain/DB/CodeDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/DB/CodeDB.hs
@@ -24,7 +24,7 @@ import qualified Database.LevelDB                   as DB
 
 import           Blockchain.Database.MerklePatricia
 import           Blockchain.SHA
-import           SolidVM.Model
+import           Blockchain.SolidVM.Model
 
 type CodeDB = DB.DB
 

--- a/core-strato/ethereum-vm/src/Blockchain/EVM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/EVM.hs
@@ -44,7 +44,7 @@ import           Text.Printf
 
 
 import qualified Blockchain.Colors                  as CL
-import           Blockchain.Data.Action
+import           Blockchain.Strato.Model.Action
 import           Blockchain.Data.Address
 import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.BlockDB

--- a/core-strato/ethereum-vm/src/Blockchain/EVM/VMState.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/EVM/VMState.hs
@@ -25,7 +25,7 @@ import qualified Data.Vector.Storable.Mutable as V
 import           Data.Word
 import           GHC.Generics
 
-import           Blockchain.Data.Action
+import           Blockchain.Strato.Model.Action
 import           Blockchain.Data.Address
 import           Blockchain.Data.Log
 import           Blockchain.EVM.Environment

--- a/core-strato/strato-api/src/Handler/Filters.hs
+++ b/core-strato/strato-api/src/Handler/Filters.hs
@@ -18,7 +18,7 @@ import           Blockchain.Data.DataDefs
 import           Blockchain.ExtWord
 import           Blockchain.SHA
 import           Blockchain.Util
-import           SolidVM.Model
+import           Blockchain.SolidVM.Model
 
 import           Control.Monad
 import           Data.Set

--- a/core-strato/strato-api/src/Handler/StorageInfo.hs
+++ b/core-strato/strato-api/src/Handler/StorageInfo.hs
@@ -16,7 +16,7 @@ import           Handler.Filters
 import           Import
 
 import           Blockchain.Data.Address
-import           SolidVM.Model
+import           Blockchain.SolidVM.Model
 
 import qualified Database.Esqueleto      as E
 import qualified Prelude                 as P

--- a/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
+++ b/core-strato/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
@@ -24,7 +24,7 @@ import           Numeric
 
 import           Blockchain.Database.MerklePatricia
 
-import qualified Blockchain.Data.Action               as A
+import qualified Blockchain.Strato.Model.Action               as A
 import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.BlockDB
 import           Blockchain.Data.ChainInfo

--- a/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
@@ -26,7 +26,7 @@ import qualified Data.Text                                    as T
 import           System.Directory
 
 import           Blockchain.BackupBlocks
-import qualified Blockchain.Data.Action                       as A
+import qualified Blockchain.Strato.Model.Action                       as A
 import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.BlockDB
 import           Blockchain.Data.DataDefs

--- a/core-strato/strato-model/package.yaml
+++ b/core-strato/strato-model/package.yaml
@@ -6,30 +6,31 @@ build-type:          Simple
 license:             Apache-2.0
 
 dependencies:
+  - QuickCheck
   - aeson
   - ansi-wl-pprint
   - base
   - base16-bytestring
-  - containers
-  - ethereum-rlp
   - binary
+  - blockapps-haskoin
   - bytestring
+  - containers
+  - cpu
   - cryptonite
   - deepseq
+  - ethereum-rlp
+  - fast-keccak256
   - hashable
+  - http-api-data
+  - integer-gmp
   - lens
-  - path-pieces
   - memory
   - nibblestring
-  - blockapps-haskoin
+  - path-pieces
+  - primitive
   - text
   - time
-  - QuickCheck
-  - http-api-data
-  - primitive
-  - cpu
-  - integer-gmp
-  - fast-keccak256
+  - unordered-containers
 
 ghc-options: -Wall -Werror -fno-warn-warnings-deprecations
 

--- a/core-strato/strato-model/src/Blockchain/MiscJSON.hs
+++ b/core-strato/strato-model/src/Blockchain/MiscJSON.hs
@@ -16,3 +16,4 @@ instance ToJSON B.ByteString where
     toJSON  = String . decodeUtf8 .  B16.encode
 
 instance ToJSONKey B.ByteString where
+    toJSONKey = toJSONKeyText (decodeUtf8 . B16.encode)

--- a/core-strato/strato-model/src/Blockchain/SolidVM/Model.hs
+++ b/core-strato/strato-model/src/Blockchain/SolidVM/Model.hs
@@ -1,4 +1,8 @@
-module SolidVM.Model where
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Blockchain.SolidVM.Model where
 
 import Control.DeepSeq
 import Data.Aeson
@@ -11,7 +15,9 @@ import GHC.Generics
 
 import Blockchain.Strato.Model.ExtendedWord (Word256, word256ToBytes)
 
-newtype HexStorage = HexStorage B.ByteString deriving (Eq, Show, Read, Generic, NFData)
+newtype HexStorage = HexStorage B.ByteString
+                   deriving (Eq, Show, Read, Generic)
+                   deriving anyclass NFData
 
 word256ToHexStorage :: Word256 -> HexStorage
 word256ToHexStorage = HexStorage . word256ToBytes

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Action.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Action.hs
@@ -3,14 +3,11 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE TemplateHaskell      #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Blockchain.Data.Action where
+module Blockchain.Strato.Model.Action where
 
-import           Blockchain.Data.Address
-import           Blockchain.ExtWord           (Word256, bytesToWord256)
-import           Blockchain.MiscJSON()
-import           Blockchain.SHA
 import           Control.DeepSeq
 import           Control.Lens                 hiding ((.=))
 import           Control.Monad                (liftM2)
@@ -25,10 +22,11 @@ import           Data.Text                    (Text)
 import           Data.Time
 import           GHC.Generics
 
-import           SolidVM.Model
-
-instance FromJSONKey Address where
-    fromJSONKey = FromJSONKeyTextParser (parseJSON . String)
+import           Blockchain.MiscJSON()
+import           Blockchain.SolidVM.Model
+import           Blockchain.Strato.Model.Address
+import           Blockchain.Strato.Model.ExtendedWord           (Word256, bytesToWord256)
+import           Blockchain.Strato.Model.SHA
 
 data CallType = Create | Delete | Update deriving (Eq, Show, Generic, NFData)
 
@@ -145,6 +143,9 @@ instance FromJSON ActionData where
     dt <- o .: "data"
     return $ ActionData ch ck df dt
   parseJSON o = error $ "parseJSON ActionData: Expected object, got: " ++ show o
+
+instance FromJSONKey Address where
+  fromJSONKey = FromJSONKeyTextParser (parseJSON . String)
 
 data Action = Action
   { _actionBlockHash          :: SHA

--- a/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
+++ b/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
@@ -22,7 +22,7 @@ import           Blockchain.DB.SQLDB
 import           Blockchain.DB.StateDB
 import           Blockchain.ExtWord
 import           Blockchain.SHA
-import           SolidVM.Model
+import           Blockchain.SolidVM.Model
 
 import           Control.Monad
 import           Control.Monad.IO.Class

--- a/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Kafka.hs
+++ b/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff/Kafka.hs
@@ -12,7 +12,7 @@ import qualified Network.Kafka                     as K
 import qualified Network.Kafka.Producer            as KW
 import qualified Network.Kafka.Protocol            as KP
 
-import           Blockchain.Data.Action
+import           Blockchain.Strato.Model.Action
 import           Blockchain.KafkaTopics            (lookupTopic)
 
 stateDiffTopicName :: KP.TopicName

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -44,7 +44,7 @@ import           Text.Printf
 
 import qualified Blockchain.Colors                       as CL
 import           Blockchain.Constants
-import           Blockchain.Data.Action
+import           Blockchain.Strato.Model.Action
 import           Blockchain.Data.Address
 import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.BlockDB

--- a/core-strato/vm-tools/src/Blockchain/Data/ExecResults.hs
+++ b/core-strato/vm-tools/src/Blockchain/Data/ExecResults.hs
@@ -8,7 +8,7 @@ import qualified Data.Set                as S
 import           GHC.Generics
 
 import           Blockchain.VM.VMException
-import           Blockchain.Data.Action
+import           Blockchain.Strato.Model.Action
 import           Blockchain.Data.Address
 import           Blockchain.Data.Log
 import           Blockchain.Data.Transaction


### PR DESCRIPTION
This is one half of #650. It turns out it is not possible to reexport the module in place without confusing git about which Action.hs is being edited, so I rewrote Blockapps.Data.Action references to point directly to strato-model