### PR TITLE
Made action input and output data ShortByteStrings

### DIFF
--- a/core-strato/ethereum-vm/src/Blockchain/EVM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/EVM.hs
@@ -1160,8 +1160,8 @@ create' = do
               , _callDataOwner       = envOwner
               , _callDataGasPrice    = envGasPrice
               , _callDataValue       = envValue
-              , _callDataInput       = envInputData
-              , _callDataOutput      = returnVal vmState
+              , _callDataInput       = BSS.toShort envInputData
+              , _callDataOutput      = BSS.toShort <$> returnVal vmState
               }
 
 call :: Bool
@@ -1243,8 +1243,8 @@ call' noValueTransfer = do
           , _callDataOwner       = envOwner
           , _callDataGasPrice    = envGasPrice
           , _callDataValue       = envValue
-          , _callDataInput       = envInputData
-          , _callDataOutput      = returnVal vmState
+          , _callDataInput       = BSS.toShort envInputData
+          , _callDataOutput      = BSS.toShort <$> returnVal vmState
           }
 
   return (fromMaybe B.empty $ returnVal vmState)

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Action.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Action.hs
@@ -14,6 +14,7 @@ import           Control.Monad                (liftM2)
 import           Data.Aeson
 import           Data.Aeson.Types
 import qualified Data.ByteString              as B
+import qualified Data.ByteString.Short        as BSS
 import           Data.Function                (on)
 import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as M
@@ -39,8 +40,8 @@ data CallData = CallData
   , _callDataOwner    :: Address
   , _callDataGasPrice :: Integer
   , _callDataValue    :: Integer
-  , _callDataInput    :: B.ByteString
-  , _callDataOutput   :: Maybe B.ByteString
+  , _callDataInput    :: BSS.ShortByteString
+  , _callDataOutput   :: Maybe BSS.ShortByteString
   } deriving (Eq, Show, Generic, NFData)
 makeLenses ''CallData
 
@@ -73,7 +74,7 @@ emptyCallData = CallData
   , _callDataOwner    = Address 0
   , _callDataGasPrice = 0
   , _callDataValue    = 0
-  , _callDataInput    = B.empty
+  , _callDataInput    = BSS.empty
   , _callDataOutput   = Nothing
   }
 


### PR DESCRIPTION
I made the Action input and output data `ShortByteString`s, and saw a moderate improvement to performance. Against the current `STRATO-1292_Memory_Leak` branch, here are some test results:

stratoLoad.test.js --batchSize 40 --batchCount 80
STRATO-1292_Memory_Leak: 28.57 TPS
STRATO-1292_Memory_Leak_Action: 37.21 TPS

stratoLoadCall.test.js --batchSize 40 --batchCount 80 (Uploads one contract and makes 3200 function calls)
STRATO-1292_Memory_Leak: 58.18 TPS
STRATO-1292_Memory_Leak_Action: 72.73 TPS

Memory usage:
STRATO-1292_Memory_Leak:
![vm-runner-19-3-4-5](https://user-images.githubusercontent.com/26780905/53764747-22223c00-3e9c-11e9-914c-3b6db6d3cb80.png)
STRATO-1292_Memory_Leak_Action:
![vm-runner-19-3-4-4](https://user-images.githubusercontent.com/26780905/53764777-36fecf80-3e9c-11e9-9cd2-a1465ebeec9b.png)
