### PR TITLE
Action processing

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
@@ -4,22 +4,23 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
-module BlockApps.Bloc22.Server.Utils where
+module BlockApps.Bloc22.Server.Utils
+  ( getBatchBlocTxStatus
+  , accumStateT
+  , partitionWith
+  , binRuntimeToCodeHash
+  , emptyTxParams
+  ) where
 
-import           Control.Concurrent
 import           Control.Monad                    (forM)
-import           Control.Monad.IO.Class
-import           Control.Monad.Loops
 import           Control.Monad.Trans.State.Strict
 import qualified Data.ByteString.Base16           as BS16
 import           Data.Foldable                    (toList)
-import           Data.Functor.Identity            (runIdentity)
 import qualified Data.Map.Strict                  as Map
 import           Data.Maybe
 import qualified Data.Sequence                    as Q
 import qualified Data.Text                        as Text
 import qualified Data.Text.Encoding               as Text
-import           Servant.Client
 
 import           BlockApps.Bloc22.API.Users
 import           BlockApps.Bloc22.API.Utils
@@ -27,27 +28,6 @@ import           BlockApps.Bloc22.Monad
 import           BlockApps.Ethereum         hiding (Transaction (..))
 import           BlockApps.Strato.Client
 import           BlockApps.Strato.Types
-
-waitNewBlock :: Maybe ChainId -> ClientM ()
-waitNewBlock chainId = do
-  blockNum <- lastBlockNum
-  liftIO $ print blockNum
-  untilM_
-    (liftIO $ putStrLn "checking condition" >> threadDelay 1000000)
-    (do
-      liftIO $ putStrLn "getting last block number"
-      blockNum' <- lastBlockNum
-      liftIO $ print blockNum'
-      return $ blockNum' /= blockNum)
-  where
-    lastBlockNum
-      = blockdataNumber
-      . blockBlockData
-      . withoutNext
-      . head <$> getBlocksLast 0 chainId
-
-maybeTxResult :: Maybe ChainId -> Keccak256 -> Bloc (Maybe TransactionResult)
-maybeTxResult chainId hash = listToMaybe <$> blocStrato (getTxResult hash chainId)
 
 maybeTxBatchResult :: Maybe ChainId -> [Keccak256] -> Bloc [Maybe TransactionResult]
 maybeTxBatchResult chainId hashes = maybeHeads <$> (blocStrato (postTxResultBatch chainId hashes))
@@ -57,23 +37,6 @@ maybeTxBatchResult chainId hashes = maybeHeads <$> (blocStrato (postTxResultBatc
             Nothing -> Nothing
             Just trs -> listToMaybe trs
 
-
-maybeTx :: Maybe ChainId -> Keccak256 -> Bloc (Maybe Transaction)
-maybeTx chainId hash = do
-  mtx <- blocStrato $ listToMaybe <$> getTxsFilter txsFilterParams{qtHash = Just hash, qtChainId = chainId}
-  case mtx of
-    Just tx -> return $ Just $ withoutNext tx
-    Nothing -> return Nothing
-
-getBlocTxStatus :: Maybe ChainId -> Keccak256 -> Bloc (BlocTransactionStatus, Maybe TransactionResult)
-getBlocTxStatus chainId hash = do
-  mtxr <- maybeTxResult chainId hash
-  case mtxr of
-    Nothing -> return (Pending,mtxr)
-    Just txr -> do
-      case transactionresultMessage txr of
-        "Success!" -> return (Success,mtxr)
-        _          -> return (Failure,mtxr)
 
 getBatchBlocTxStatus :: Maybe ChainId -> [Keccak256] -> Bloc [(BlocTransactionStatus, Maybe TransactionResult)]
 getBatchBlocTxStatus chainId hashes = do
@@ -93,18 +56,10 @@ binRuntimeToCodeHash :: Text.Text -> Keccak256
 binRuntimeToCodeHash = keccak256 . fst . BS16.decode . Text.encodeUtf8
 
 accumStateT :: Monad m => s -> [a] -> (a -> StateT s m b) -> m [b]
-accumStateT _ [] _ = pure []
-accumStateT s (a:as) run = do
-  (b,s') <- runStateT (run a) s
-  (b:) <$> accumStateT s' as run
-
-buildStateT :: Monad m => s -> [a] -> (a -> StateT s m ()) -> m s
-buildStateT s [] _ = pure s
-buildStateT s (a:as) run = do
-  s' <- execStateT (run a) s
-  buildStateT s' as run
+accumStateT s as f = evalStateT (mapM f as) s
 
 partitionWith :: Ord k => (a -> k) -> [a] -> [(k,[a])]
-partitionWith f as = map (fmap toList) . Map.toList . runIdentity $ buildStateT Map.empty as $ \a -> do
-  let k = f a
-  modify $ Map.alter (Just . (Q.|> a) . fromMaybe Q.empty) k
+partitionWith f = Map.toList
+                . Map.map toList
+                . Map.fromListWith (<>)
+                . map (\a -> (f a, Q.singleton a))

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -14,12 +14,13 @@
 module Slipstream.Processor where
 
 import Control.Arrow ((&&&))
+import Control.Applicative
 import Control.Monad.Except
-import Control.Monad.Log    hiding (Handler)
-import Control.Monad.Reader
+import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.State.Strict hiding (state)
 import Control.Monad.Trans.Class (lift)
 import qualified Data.Aeson as JSON
+import Data.Bifunctor (second)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
@@ -33,7 +34,6 @@ import qualified Data.Map as Map
 import Data.Monoid ((<>))
 import Data.Maybe
 import qualified Data.Text as T
-import Data.Traversable (for)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import Database.PostgreSQL.Typed (PGConnection)
@@ -67,6 +67,15 @@ todoToMap = \case
   BS.ActionEVMDiff m -> m
   BS.ActionSolidVMDiff _ -> error "TODO(tim): Processing not implemented for SolidVM"
 
+diffNull :: BS.ActionDataDiff -> Bool
+diffNull (BS.ActionEVMDiff m) = Map.null m
+diffNull (BS.ActionSolidVMDiff m) = Map.null m
+
+mergeDiffs :: BS.ActionDataDiff -> BS.ActionDataDiff -> BS.ActionDataDiff
+mergeDiffs (BS.ActionEVMDiff lhs) (BS.ActionEVMDiff rhs) = BS.ActionEVMDiff $ lhs <> rhs
+mergeDiffs (BS.ActionSolidVMDiff lhs) (BS.ActionSolidVMDiff rhs) = BS.ActionSolidVMDiff $ lhs <> rhs
+mergeDiffs lhs rhs = error $ "Invalid diff combination: " ++ show (lhs, rhs)
+
 data BatchedInserts = BatchedInserts
   { indexInsert     :: ProcessedContract
   , historyInserts  :: [ProcessedContract]
@@ -84,10 +93,7 @@ toAction x =
 
 enterBloc2 :: BlocEnv -> Bloc x -> IO x
 enterBloc2 env x = do
-  ret <-
-    runExceptT
-    $ flip runLoggingT (filterPrintLog $ logLevel env)
-    $ flip runReaderT env $ runBloc x
+  ret <- runBlocToIO env x
 
   case ret of
    Left e -> error $ show e
@@ -100,7 +106,7 @@ hasContract::Action->Bool
 hasContract = (/= emptyHash) . actionCodeHash
 
 matters :: Action -> Bool
-matters Action{..} = (actionType == Create) || (not . Map.null $ todoToMap actionStorage)
+matters Action{..} = (actionType == Create) || (not $ diffNull actionStorage)
 
 on2 :: (b -> b -> c) -> ((a -> a -> b), (a -> a -> b)) -> a -> a -> c
 on2 f p = curry ((uncurry f) . ((uncurry (fst p)) &&& (uncurry (snd p))))
@@ -121,12 +127,10 @@ groupSimilarActions as = go as [] []
 
 -- assumes all Actions in the list are for the same (Address, Maybe ChainId) pair
 combineActions :: [Action] -> Action
-combineActions []     = error "combineActions: called with an empty list"
-combineActions [x]    = x
-combineActions (x:xs) = let y = combineActions xs
-                         in merge x y
+combineActions [] = error "cannot combine 0 actions"
+combineActions (x:xs) = foldr merge x xs
   where
-    merge a b = b { actionStorage  = BS.ActionEVMDiff $ (Map.union `on` todoToMap . actionStorage) b a
+    merge a b = b { actionStorage  = (mergeDiffs `on` actionStorage) b a
                   , actionMetadata = (Map.union `on` actionMetadata) b a
                   }
 
@@ -182,19 +186,22 @@ getFunctionCallValues xabi input' output' =
                (typemap output' otypes)
    in (fname,imap,omap)
 
-processedContract :: Text
-                  -> Text
-                  -> Text
+data ABIID = ABIID { aiAbi :: Text
+                   , aiName :: Text
+                   , aiChain :: Text
+                   } deriving (Eq, Show)
+
+processedContract :: ABIID
                   -> Map.Map Text Value
                   -> Action
                   -> ProcessedContract
-processedContract abi name chain state Action{..} =
+processedContract ABIID{..} state Action{..} =
   ProcessedContract
     { address = actionAddress
     , codehash = actionCodeHash
-    , abi = abi
-    , contractName = name
-    , chain = chain
+    , abi = aiAbi
+    , contractName = aiName
+    , chain = aiChain
     , contractData = state
     , blockHash = actionBlockHash
     , blockTimestamp = actionBlockTimestamp
@@ -205,13 +212,11 @@ processedContract abi name chain state Action{..} =
     }
 
 makeFunctionInserts :: Xabi
-                    -> Text
-                    -> Text
-                    -> Text
+                    -> ABIID
                     -> Map.Map Text Value
                     -> Action
                     -> Bloc [ProcessedContract]
-makeFunctionInserts xabi abi name chain state Action{..} =
+makeFunctionInserts xabi ABIID{..} state Action{..} =
   forM actionCallData $ \CallData{..} -> do
     let ibytes = _input
         obytes = fromMaybe B.empty _output
@@ -225,9 +230,9 @@ makeFunctionInserts xabi abi name chain state Action{..} =
     pure $ ProcessedContract
       { address = actionAddress
       , codehash = actionCodeHash
-      , abi = abi
-      , contractName = name
-      , chain = chain
+      , abi = aiAbi
+      , contractName = aiName
+      , chain = aiChain
       , contractData = state
       , blockHash = actionBlockHash
       , blockTimestamp = actionBlockTimestamp
@@ -240,6 +245,82 @@ makeFunctionInserts xabi abi name chain state Action{..} =
           , functioncalldataOutput = o
           }
       }
+
+detailsForRow :: Action -> Bloc (Maybe (Int32, ContractDetails))
+detailsForRow row = liftM2 (<|>)
+  (runMaybeT $ do
+    let md = actionMetadata row
+    let lookupT k m = MaybeT . return $ Map.lookup k m
+    src <- lookupT "src" md
+    name <- lookupT "name" md
+    detailsMap <- lift $ compileContract src
+    lookupT name detailsMap)
+  (getContractDetailsByCodeHash $ actionCodeHash row)
+
+adjustGlobals :: IORef Globals -> Action -> ContractDetails -> Bloc ()
+adjustGlobals gref row details = do
+  let go m (k,f) = for_ (Map.lookup k $ actionMetadata row) $ \v -> do
+                let contracts = filter (not . T.null) $ T.splitOn "," v
+                forM_ contracts $ \c -> for_ (fmap (contractdetailsCodeHash . snd) $ Map.lookup c m) $ f gref
+  detailsMap <- compileContract $ contractdetailsSrc details -- won't actually recompile the contract
+  mapM_ (go detailsMap) $ [("history", addToHistoryList)
+                          ,("nohistory", removeFromHistoryList)
+                          ,("noindex", addToNoIndexList)
+                          ,("index", removeFromNoIndexList)
+                          ,("functionhistory", addToFunctionHistoryList)
+                          ,("nofunctionhistory", removeFromFunctionHistoryList)
+                          ]
+
+ensureContractInstance :: Int32 -> Action -> Bloc ()
+ensureContractInstance cmId row = do
+  let addr = actionAddress row
+      chainId = actionTxChainId row
+  (mInstance :: Maybe Int32) <- fmap listToMaybe . blocQuery $
+    contractInstancesByCodeHash (actionCodeHash row) addr chainId
+  when (isNothing mInstance) . void $
+    insertContractInstance cmId addr chainId
+
+readPreviousState :: IORef Globals -> Address -> Maybe ChainId -> Contract -> Bloc [(Text, Value)]
+readPreviousState gref addr chainId cont = do
+  let default' = SVR.decodeValues 0 (typeDefs cont) (mainStruct cont) (const 0) 0
+  fromMaybe default' <$> getContractState gref addr chainId
+
+
+rowToInsert :: IORef Globals -> ABIID -> Action -> Contract -> [(Text, Value)] -> Bloc ProcessedContract
+rowToInsert gref abiid row cont oldState = do
+  let cache = flip Map.lookup . todoToMap $ actionStorage row
+      newState = SVR.decodeCacheValues
+                  (typeDefs cont)
+                  (mainStruct cont)
+                  cache
+                  0
+                  oldState
+  setContractState gref (actionAddress row) (actionTxChainId row) newState
+  return $ processedContract abiid (Map.fromList $ newState) row
+
+rowToHistories :: IORef Globals -> ABIID -> Action -> [Action] -> Contract -> ContractDetails -> [(Text, Value)] -> Bloc ([ProcessedContract], [ProcessedContract])
+rowToHistories gref abiid row actions cont details oldState = do
+  hist <- isHistoric gref $ actionCodeHash row
+  second join . unzip <$> if not hist
+    then pure []
+    else accumStateT oldState actions $ \hRow -> do
+      let hCache = flip Map.lookup . todoToMap $ actionStorage hRow
+      modify $ SVR.decodeCacheValues
+               (typeDefs cont)
+               (mainStruct cont)
+               hCache
+               0
+      newMap <- gets Map.fromList
+      let hInsert = processedContract abiid newMap hRow
+      functionHist <- isFunctionHistoric gref $ actionCodeHash hRow
+      fInserts <- if not functionHist
+                    then pure []
+                    else lift $ makeFunctionInserts
+                                  (contractdetailsXabi details)
+                                  abiid
+                                  newMap
+                                  hRow
+      pure (hInsert, fInserts)
 
 processTheMessages :: BlocEnv -> PGConnection -> IORef Globals -> [B.ByteString] -> IO ()
 processTheMessages env conn g messages = do
@@ -265,78 +346,28 @@ processTheMessages env conn g messages = do
       recordCombinedAction row
       liftIO . infoM "processTheMessages" . T.unpack . formatAction $ row
 
-      let md = actionMetadata row
-      mcd <- getContractDetailsByCodeHash $ actionCodeHash row
-      mDetails <- withNothing mcd $ do
-        fmap join . for (Map.lookup "src" md) $ \src -> do
-          detailsMap <- compileContract src
-          fmap join . for (Map.lookup "name" md) $ \name -> do
-            traverse pure $ Map.lookup name detailsMap
-
-      if isNothing mDetails
-        then pure . Left $ "No details found for code hash "
+      mDetails <- detailsForRow row
+      case mDetails of
+        Nothing -> pure . Left $ "No details found for code hash "
                         <> (T.pack . show $ actionCodeHash row)
                         <> " and no 'src' field found in actionMetadata"
-        else do
-          let Just (cmId,details) = mDetails
-              strAbi = T.replace "\'" "\'\'" . decodeUtf8 . BL.toStrict . JSON.encode $ contractdetailsXabi details
-              strName = T.replace "\"" "" $ contractdetailsName details
+        Just (cmId, details) -> do
+          let abiid = ABIID
+                { aiAbi = T.replace "\'" "\'\'" . decodeUtf8 . BL.toStrict
+                        . JSON.encode $ contractdetailsXabi details
+                , aiName = T.replace "\"" "" $ contractdetailsName details
+                , aiChain = maybe "" (T.pack . chainIdString) $ actionTxChainId row
+                }
               cont = either error id . xAbiToContract $ contractdetailsXabi details
-              chain = maybe "" (T.pack . chainIdString) $ actionTxChainId row
-              cache = flip Map.lookup . todoToMap $ actionStorage row
-              updateGlobal m (k,f) = for_ (Map.lookup k $ actionMetadata row) $ \v -> do
-                let contracts = filter (not . T.null) $ T.splitOn "," v
-                forM_ contracts $ \c -> for_ (fmap (contractdetailsCodeHash . snd) $ Map.lookup c m) $ f g
 
-          detailsMap <- compileContract $ contractdetailsSrc details -- won't actually recompile the contract
-          mapM_ (updateGlobal detailsMap) $ [("history", addToHistoryList)
-                                            ,("nohistory", removeFromHistoryList)
-                                            ,("noindex", addToNoIndexList)
-                                            ,("index", removeFromNoIndexList)
-                                            ,("functionhistory", addToFunctionHistoryList)
-                                            ,("nofunctionhistory", removeFromFunctionHistoryList)
-                                            ]
+          adjustGlobals g row details
 
-          (mInstance :: Maybe Int32) <- fmap listToMaybe . blocQuery $
-            contractInstancesByCodeHash (actionCodeHash row) addr chainId
-          when (isNothing mInstance) . void $
-            insertContractInstance cmId addr chainId
-          let default' = SVR.decodeValues 0 (typeDefs cont) (mainStruct cont) (const 0) 0
-              cState = getContractState g addr chainId
-          oldState <- fromMaybe default' <$> cState
-          let newState = SVR.decodeCacheValues
-                          (typeDefs cont)
-                          (mainStruct cont)
-                          cache
-                          0
-                          oldState
-          setContractState g addr chainId newState
-          let indexContract = processedContract strAbi strName chain (Map.fromList $ newState) row
+          ensureContractInstance cmId row
 
-          hist <- isHistoric g $ actionCodeHash row
-          (hs,fhs) <- unzip <$> if hist
-            then accumStateT oldState actions $ \hRow -> do
-              let hCache = flip Map.lookup . todoToMap $ actionStorage hRow
-              modify $ SVR.decodeCacheValues
-                       (typeDefs cont)
-                       (mainStruct cont)
-                       hCache
-                       0
-              newMap <- gets Map.fromList
-              let hInsert = processedContract strAbi strName chain newMap hRow
-              functionHist <- isFunctionHistoric g $ actionCodeHash hRow
-              fInserts <- if functionHist
-                            then lift $ makeFunctionInserts
-                                          (contractdetailsXabi details)
-                                          strAbi
-                                          strName
-                                          chain
-                                          newMap
-                                          hRow
-                            else pure []
-              pure (hInsert, fInserts)
-            else pure []
-          pure . Right . BatchedInserts indexContract hs $ join fhs
+          oldState <- readPreviousState g addr chainId cont
+          indexContract <- rowToInsert g abiid row cont oldState
+          (hs, fhs) <- rowToHistories g abiid row actions cont details oldState
+          pure . Right $ BatchedInserts indexContract hs fhs
 
   forM_ (lefts inserts) $ errorM "processTheMessages" . T.unpack
 

--- a/blockapps-haskell/slipstream/tests/Main.hs
+++ b/blockapps-haskell/slipstream/tests/Main.hs
@@ -2,7 +2,7 @@ import Spec (spec)
 import Test.Hspec.Runner
 
 predicate :: Path -> Bool
-predicate ("OutputData":_, _) = True
+predicate (_:_, _) = True
 predicate _ = False
 
 main :: IO ()

--- a/blockapps-haskell/slipstream/tests/OutputDataSpec.hs
+++ b/blockapps-haskell/slipstream/tests/OutputDataSpec.hs
@@ -97,7 +97,6 @@ spec = do
     transaction_function_name = excluded.transaction_function_name,
     "owners" = excluded."owners";|]
 
-
   describe "Array serialization with history enabled" $ do
     it "should create JSON entries" $ do
       let testAdd = Address $ fst . head . readHex $ "ADDRESS"


### PR DESCRIPTION
This change was motivated to fit `processTheMessages` on a single screen, and to break out the storage decoding to make it more testable. The easy migrations for SolidVM aware decoding are made, but it does not yet attempt to parse the storage diff. 

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/1474/pipeline