### PR TITLE
Tail the crashing processes logs into container logs

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -122,7 +122,8 @@ function newnode {
       for monitored_pid in "${!MONITORED_PIDS[@]}"; do
         # if process with pid does not exist
         if ! (ps -p ${monitored_pid} > /dev/null); then
-          echo "Process ${MONITORED_PIDS[${monitored_pid}]} with pid ${monitored_pid} crashed - killing all monitored processes but keeping the container running..."
+          DEAD_PROCESS=${MONITORED_PIDS[${monitored_pid}]}
+          echo "Process ${DEAD_PROCESS} with pid ${monitored_pid} crashed - killing all monitored processes but keeping the container running..."
           # Kill all the rest of monitored processes
           for pid_to_kill in "${!MONITORED_PIDS[@]}"; do
             if ps -p ${pid_to_kill} > /dev/null; then
@@ -131,6 +132,11 @@ function newnode {
               echo "done"
             fi
           done
+          FILE_NAME="/var/lib/strato/logs/$(echo ${DEAD_PROCESS} | cut -d ' ' -f 1)"
+          echo "Tail of logs for crashed process:"
+          echo "+tail -n 20 ${FILE_NAME}"
+          tail -n 20 $FILE_NAME
+          echo "End of logs."
           echo "STRATO IS DOWN: Process with pid ${monitored_pid} crashed so all background processes were killed. Check /var/lib/strato/logs/ in the container"
           # Keep container running idle
           tail -f /dev/null


### PR DESCRIPTION
This removes a step of indirection for determining the problem, as in many cases `docker logs strato_strato_1` will explain why the crash happened, as oppose to pointing to the next log to look at.

In this case, there is no explanation as I `kill`ed strato-sequencer: 
```Configuring log maintenance
process pid:: 97 (command: cleanupLogs)
Monitoring the background processes. Making checks every 5 sec. If you don't see any error messages below - all processes are healthy...
+ cleanupLogs
+ true
+ sleep 900
Process strato-sequencer   --validators=["16ce1643692f8d22a290991b61c44d1d7ef64254"] --blockstanbul=true   --minLogLevel=LevelInfo +RTS  -N1 with pid 91 crashed - killing all monitored processes but keeping the container running...
killing process strato-p2p-indexer +RTS -N1 (pid: 93)
done
killing process strato-api-indexer +RTS -N1 (pid: 92)
done
killing process strato-p2p --connectionTimeout=300 --sqlPeers=true --debugFail=true --maxConn=20 --maxReturnedHeaders=1000 --networkID=6 --txGossipFanout=3 (pid: 90)
done
killing process cleanupLogs (pid: 97)
done
killing process strato-api +RTS -N1 (pid: 96)
done
killing process vm-runner --useSyncMode=false --miner=Instant --maxTxsPerBlock=500 --diffPublish=true --sqlDiff=true --createTransactionResults=true --miningVerification=false --difficultyBomb=false --trace=false --debug=false --minLogLevel=LevelInfo --blockstanbul=true +RTS  -N1 (pid: 95)
done
killing process strato-txr-indexer +RTS -N1 (pid: 94)
done
killing process logserver --directory /var/lib/strato/logs --uri_root=/logs/strato/ (pid: 83)
done
killing process strato-adit --useSyncMode=false --minQuorumSize=1 --threads=1 --aMiner=Instant (pid: 84)
done
killing process ethereum-discover (pid: 85)
done
Tail of logs for crashed process:
[2019-03-12 14:41:47.782933059 UTC]  INFO | ThreadId 7     | showctx/view                        | View (round = 6, sequence = 0)
[2019-03-12 14:41:47.783003314 UTC]  INFO | ThreadId 7     | showctx/proposer                    | 16ce1643692f8d22a290991b61c44d1d7ef64254
[2019-03-12 14:41:47.783198332 UTC]  INFO | ThreadId 7     | showctx/validators                  | ["16ce1643692f8d22a290991b61c44d1d7ef64254"]
[2019-03-12 14:41:47.783277775 UTC]  INFO | ThreadId 7     | showctx/mBlockNumber                | Nothing
[2019-03-12 14:41:47.783334503 UTC]  INFO | ThreadId 7     | showctx/mLockedBlockNo              | Nothing
[2019-03-12 14:41:47.783391193 UTC]  INFO | ThreadId 7     | showctx/mLockedSender               | Nothing
[2019-03-12 14:41:47.783499506 UTC]       src/Blockchain/Blockstanbul/EventLoop.hs:414 |  WARN | ThreadId 7     | blockstanbul                        | Round 6 timed out
[2019-03-12 14:41:47.78358829 UTC]  INFO | ThreadId 7     | blockstanbul/roundchange            | timeout
[2019-03-12 14:41:47.787869173 UTC]  INFO | ThreadId 7     | blockstanbul/OutShortLog            | ROUNDCHANGE View (round = 7, sequence = 0) 16ce1643692f8d22a290991b61c44d1d7ef64254
[2019-03-12 14:41:47.791738992 UTC]  INFO | ThreadId 7     | blockstanbul/InShortLog             | ROUNDCHANGE View (round = 7, sequence = 0) 16ce1643692f8d22a290991b61c44d1d7ef64254
[2019-03-12 14:41:47.791862029 UTC]  INFO | ThreadId 7     | showctx/view                        | View (round = 6, sequence = 0)
[2019-03-12 14:41:47.79193479 UTC]  INFO | ThreadId 7     | showctx/proposer                    | 16ce1643692f8d22a290991b61c44d1d7ef64254
[2019-03-12 14:41:47.792013219 UTC]  INFO | ThreadId 7     | showctx/validators                  | ["16ce1643692f8d22a290991b61c44d1d7ef64254"]
[2019-03-12 14:41:47.792094586 UTC]  INFO | ThreadId 7     | showctx/mBlockNumber                | Nothing
[2019-03-12 14:41:47.792156327 UTC]  INFO | ThreadId 7     | showctx/mLockedBlockNo              | Nothing
[2019-03-12 14:41:47.792268631 UTC]  INFO | ThreadId 7     | showctx/mLockedSender               | Nothing
[2019-03-12 14:41:47.798841382 UTC]  INFO | ThreadId 7     | blockstanbul/OutShortLog            | RESET_TIMER 7
[2019-03-12 14:41:47.803540392 UTC]  INFO | ThreadId 7     | blockstanbul/OutShortLog            | MAKE_BLOCK_COMMAND
[2019-03-12 14:41:47.803813324 UTC]  INFO | ThreadId 7     | checkForUnseq                       | Applied pending LDB writes
[2019-03-12 14:41:47.803903476 UTC]  INFO | ThreadId 7     | sequencer/events                    | Reading from fused channels...
End of logs.
STRATO IS DOWN: Process with pid 91 crashed so all background processes were killed. Check /var/lib/strato/logs/ in the container

