### PR TITLE
Allow slipstream to be marked as an unimportant process

### DIFF
--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -53,7 +53,7 @@ pipeline {
           cp strato-worktree/docker-compose.yml strato-getting-started/
           cd strato-getting-started
           NODE_HOST=$(</host)
-          NODE_HOST=${NODE_HOST} genesis=smokeTest loglevel=6 ./strato.sh -m 1 --single
+          NODE_HOST=${NODE_HOST} genesis=smokeTest loglevel=6 SLIPSTREAM_OPTIONAL=false ./strato.sh -m 1 --single
           docker ps
           # Few quick tests
           check_bloc() {

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -108,9 +108,17 @@ until curl localhost:8000 &> /dev/null; do
 done
 echo "Bloc is up - running slipstream now..."
 
-runBackgroundProcess /usr/bin/slipstream --pghost="$postgres_host" --pgport="$postgres_port" --pguser="$postgres_user" --password="$postgres_password" \
-           --database="$postgres_slipstream_db"  --stratourl="$stratoRoot" --vaultwrapperurl="$vaultWrapperRoot" \
-           --kafkahost="$kafkaHost" --kafkaport="$kafkaPort" --debug="${SLIPSTREAM_DEBUG:-false}" &>> logs/slipstream
+SLIPSTREAM_CMD="/usr/bin/slipstream --pghost=${postgres_host} --pgport=${postgres_port} \
+  --pguser=${postgres_user} --password=${postgres_password} --database=${postgres_slipstream_db} \
+  --stratourl=${stratoRoot} --vaultwrapperurl=${vaultWrapperRoot}  \
+  --kafkahost=${kafkaHost} --kafkaport=${kafkaPort} --debug=${SLIPSTREAM_DEBUG:-false}"
+
+if [ ${SLIPSTREAM_OPTIONAL:-true} = true ]; then
+  $SLIPSTREAM_CMD &>> logs/slipstream &
+else
+  runBackgroundProcess $SLIPSTREAM_CMD &>> logs/slipstream
+fi
+
 
 set +x
 if [ "${PROCESS_MONITORING}" = true ] ; then

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -80,6 +80,7 @@ services:
     - postgres_slipstream_db=cirrus
     - postgres_user=postgres
     - PROCESS_MONITORING=${PROCESS_MONITORING}
+    - SLIPSTREAM_OPTIONAL=${SLIPSTREAM_OPTIONAL}
     - SLIPSTREAM_DEBUG=${SLIPSTREAM_DEBUG}
     - SMD_MODE=${SMD_MODE}
     - ssl=${ssl:-false}


### PR DESCRIPTION
By default, the bloc container will stop if slipstream crashes. If slipstream is not necessary for the application, this environment variable makes it easy to relaunch without actually fixing slipstream