### PR TITLE
Use Word256 backed digests in slipstream

### DIFF
--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -30,8 +30,12 @@ module BlockApps.Ethereum
   , stringChainId
     -- * Keccak 256 Hashes
   , Keccak256 (..)
+  , SHA(..)
+  , shaToHex
   , keccak256
   , keccak256lazy
+  , keccak256SHA
+  , shaKeccak256
   , keccak256ByteString
   , byteStringKeccak256
   , keccak256String
@@ -107,6 +111,7 @@ import           Web.FormUrlEncoded     hiding (fieldLabelModifier)
 import qualified Data.LargeWord as LW
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ExtendedWord
+import           Blockchain.Strato.Model.SHA (shaToHex, SHA(..))
 
 
 lastWord64 :: Word256 -> Word64
@@ -314,6 +319,15 @@ newSecKey = fromMaybe err . secKey <$> getEntropy 32
 
 newtype Keccak256 = Keccak256 { digestKeccak256 :: Digest Keccak_256 }
   deriving (Eq,Ord,Show,Generic, NFData)
+
+keccak256SHA :: Keccak256 -> SHA
+keccak256SHA = SHA . bytesToWord256 . ByteArray.convert . digestKeccak256
+
+shaKeccak256 :: SHA -> Keccak256
+shaKeccak256 (SHA hsh) = Keccak256
+                       . fromMaybe (error $ "internal error: shaKeccak256" ++ show hsh)
+                       . digestFromByteString
+                       $ word256ToBytes hsh
 
 keccak256ByteString :: Keccak256 -> ByteString
 keccak256ByteString = ByteArray.convert . digestKeccak256

--- a/blockapps-haskell/slipstream/src/Slipstream/Data/Action.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Data/Action.hs
@@ -74,7 +74,7 @@ instance FromJSON CallData where
   parseJSON o = error $ "parseJSON CallData: Expected object, got: " ++ show o
 
 data ActionData = ActionData
-  { _codeHash     :: Keccak256
+  { _codeHash     :: SHA
   , _codeKind     :: CodeKind
   , _storageDiffs :: BS.ActionDataDiff
   , _callData     :: [CallData]
@@ -101,10 +101,10 @@ instance FromJSON ActionData where
   parseJSON o = error $ "parseJSON ActionData: Expected object, got: " ++ show o
 
 data Action' = Action'
-  { _blockHash          :: Keccak256
+  { _blockHash          :: SHA
   , _blockTimestamp     :: UTCTime
   , _blockNumber        :: Integer
-  , _transactionHash    :: Keccak256
+  , _transactionHash    :: SHA
   , _transactionChainId :: Maybe ChainId
   , _transactionSender  :: Address
   , _actionData         :: Map Address ActionData
@@ -137,14 +137,14 @@ instance FromJSON Action' where
   parseJSON o = error $ "parseJSON Action: Expected object, got: " ++ show o
 
 data Action = Action
-  { actionBlockHash      :: Keccak256
+  { actionBlockHash      :: SHA
   , actionBlockTimestamp :: UTCTime
   , actionBlockNumber    :: Integer
-  , actionTxHash         :: Keccak256
+  , actionTxHash         :: SHA
   , actionTxChainId      :: Maybe ChainId
   , actionTxSender       :: Address
   , actionAddress        :: Address
-  , actionCodeHash       :: Keccak256
+  , actionCodeHash       :: SHA
   , actionStorage        :: BS.ActionDataDiff
   , actionType           :: CallType
   , actionCallData       :: [CallData]

--- a/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
@@ -15,10 +15,10 @@ instance NFData (LRU key val) where
   rnf = (`seq` ()) -- LRU is already pretty strict
 
 
-data Globals = Globals { createdContracts :: S.Set Keccak256 -- list of contacts with a table
-                       , historyList :: S.Set Keccak256
-                       , noIndexList :: S.Set Keccak256
-                       , functionHistoryList :: S.Set Keccak256
+data Globals = Globals { createdContracts :: S.Set SHA -- list of contacts with a table
+                       , historyList :: S.Set SHA
+                       , noIndexList :: S.Set SHA
+                       , functionHistoryList :: S.Set SHA
                        , contractStates :: LRU (Address, Maybe ChainId) [(Text, Value)]
                        , csHandle :: Handle
                        } deriving (Generic, NFData)

--- a/blockapps-haskell/slipstream/src/Slipstream/Events.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Events.hs
@@ -11,7 +11,7 @@ module Slipstream.Events where
 import           Data.Map                 (Map)
 import           Data.Text                (Text)
 import qualified BlockApps.Solidity.Value as V
-import           BlockApps.Ethereum (Keccak256, Address)
+import           BlockApps.Ethereum (Address, SHA)
 import           Data.Time
 import           Slipstream.SolidityValue
 
@@ -27,14 +27,14 @@ data FunctionCallData = FunctionCallData
 
 data ProcessedContract = ProcessedContract
   { address           :: Address
-  , codehash          :: Keccak256
+  , codehash          :: SHA
   , abi               :: Text
   , contractName      :: Text
   , chain             :: Text
-  , blockHash         :: Keccak256
+  , blockHash         :: SHA
   , blockTimestamp    :: UTCTime
   , blockNumber       :: Integer
-  , transactionHash   :: Keccak256
+  , transactionHash   :: SHA
   , transactionSender :: Address
   , functionCallData  :: Maybe FunctionCallData
   , contractData      :: Map Text V.Value

--- a/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
@@ -31,66 +31,66 @@ updateGlobals gref g = do
   recordGlobals g
   writeIORef gref g
 
-setContractCreated :: MonadIO m => IORef Globals -> Keccak256 -> m ()
+setContractCreated :: MonadIO m => IORef Globals -> SHA -> m ()
 setContractCreated globalsIORef codeHash = do
   globals@Globals{..} <- readIORef globalsIORef
   updateGlobals globalsIORef globals{createdContracts=Set.insert codeHash createdContracts}
 
-isContractCreated :: MonadIO m => IORef Globals -> Keccak256 -> m Bool
+isContractCreated :: MonadIO m => IORef Globals -> SHA -> m Bool
 isContractCreated globalsIORef codeHash = do
   Globals{..} <- readIORef globalsIORef
   return $ codeHash `Set.member` createdContracts
 
-isHistoric :: MonadIO m => IORef Globals -> Keccak256 -> m Bool
+isHistoric :: MonadIO m => IORef Globals -> SHA -> m Bool
 isHistoric globalsIORef name = do
   Globals{..} <- readIORef globalsIORef
   return $ name `Set.member` historyList
 
-isFunctionHistoric :: MonadIO m => IORef Globals -> Keccak256 -> m Bool
+isFunctionHistoric :: MonadIO m => IORef Globals -> SHA -> m Bool
 isFunctionHistoric globalsIORef name = do
   Globals{..} <- readIORef globalsIORef
   return $ name `Set.member` functionHistoryList
 
-getHistoryList :: MonadIO m => IORef Globals -> m (Set Keccak256)
+getHistoryList :: MonadIO m => IORef Globals -> m (Set SHA)
 getHistoryList = fmap historyList . readIORef
 
-getFunctionHistoryList :: MonadIO m => IORef Globals -> m (Set Keccak256)
+getFunctionHistoryList :: MonadIO m => IORef Globals -> m (Set SHA)
 getFunctionHistoryList = fmap functionHistoryList . readIORef
 
-addToHistoryList :: MonadIO m => IORef Globals -> Keccak256 -> m ()
+addToHistoryList :: MonadIO m => IORef Globals -> SHA -> m ()
 addToHistoryList g k = do
   globals@Globals{..} <- readIORef g
   updateGlobals g globals{historyList=Set.insert k historyList}
 
-removeFromHistoryList :: MonadIO m => IORef Globals -> Keccak256 -> m ()
+removeFromHistoryList :: MonadIO m => IORef Globals -> SHA -> m ()
 removeFromHistoryList g k = do
   globals@Globals{..} <- readIORef g
   updateGlobals g globals{historyList=Set.delete k historyList}
 
-shouldIndex :: MonadIO m => IORef Globals -> Keccak256 -> m Bool
+shouldIndex :: MonadIO m => IORef Globals -> SHA -> m Bool
 shouldIndex globalsIORef name = do
   Globals{..} <- readIORef globalsIORef
   return . not $ name `Set.member` noIndexList
 
-getNoIndexList :: MonadIO m => IORef Globals -> m (Set Keccak256)
+getNoIndexList :: MonadIO m => IORef Globals -> m (Set SHA)
 getNoIndexList = fmap noIndexList . readIORef
 
-addToNoIndexList :: MonadIO m => IORef Globals -> Keccak256 -> m ()
+addToNoIndexList :: MonadIO m => IORef Globals -> SHA -> m ()
 addToNoIndexList g k = do
   globals@Globals{..} <- readIORef g
   updateGlobals g globals{noIndexList=Set.insert k noIndexList}
 
-removeFromNoIndexList :: MonadIO m => IORef Globals -> Keccak256 -> m ()
+removeFromNoIndexList :: MonadIO m => IORef Globals -> SHA -> m ()
 removeFromNoIndexList g k = do
   globals@Globals{..} <- readIORef g
   updateGlobals g globals{noIndexList=Set.delete k noIndexList}
 
-addToFunctionHistoryList :: MonadIO m => IORef Globals -> Keccak256 -> m ()
+addToFunctionHistoryList :: MonadIO m => IORef Globals -> SHA -> m ()
 addToFunctionHistoryList g k = do
   globals@Globals{..} <- readIORef g
   updateGlobals g globals{functionHistoryList=Set.insert k functionHistoryList}
 
-removeFromFunctionHistoryList :: MonadIO m => IORef Globals -> Keccak256 -> m ()
+removeFromFunctionHistoryList :: MonadIO m => IORef Globals -> SHA -> m ()
 removeFromFunctionHistoryList g k = do
   globals@Globals{..} <- readIORef g
   updateGlobals g globals{functionHistoryList=Set.delete k functionHistoryList}

--- a/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
@@ -247,7 +247,7 @@ insertHistoryTable globalsIORef contracts@(x:_) = do
 insertContractTableQuery :: ProcessedContract -> Text
 insertContractTableQuery ProcessedContract{..} =
   let conVals = wrapAndEscape . map escapeQuotes $
-        [ T.pack $ keccak256String codehash
+        [ T.pack $ shaToHex codehash
         , contractName
         , abi
         , chain
@@ -295,10 +295,10 @@ insertIndexTableQuery contracts@(x:_) =
       transactionFuncName = fromMaybe "" . fmap functioncalldataName . functionCallData
       baseVals = [ tshow . address
                  , chain
-                 , T.pack . keccak256String . blockHash
+                 , T.pack . shaToHex . blockHash
                  , tshow . blockTimestamp
                  , tshow . blockNumber
-                 , T.pack . keccak256String . transactionHash
+                 , T.pack . shaToHex . transactionHash
                  , tshow . transactionSender
                  ]
       tableVals = baseVals ++ [escapeQuotes . transactionFuncName]
@@ -339,10 +339,10 @@ insertHistoryTableQuery contracts@(x:_) =
       transactionFuncName = fromMaybe "" . fmap functioncalldataName . functionCallData
       baseVals = [ tshow . address
                  , chain
-                 , T.pack . keccak256String . blockHash
+                 , T.pack . shaToHex . blockHash
                  , tshow . blockTimestamp
                  , tshow . blockNumber
-                 , T.pack . keccak256String . transactionHash
+                 , T.pack . shaToHex . transactionHash
                  , tshow . transactionSender
                  ]
       tableVals = baseVals ++ [escapeQuotes . transactionFuncName]

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -54,6 +54,8 @@ import BlockApps.XAbiConverter
 import qualified BlockApps.SolidityVarReader as SVR
 
 import qualified Blockchain.Strato.Model.Action as BS
+import Blockchain.Strato.Model.SHA (hash)
+
 
 import Slipstream.Data.Action
 import Slipstream.Events
@@ -99,8 +101,8 @@ enterBloc2 env x = do
    Left e -> error $ show e
    Right v -> return v
 
-emptyHash :: Keccak256
-emptyHash = keccak256 B.empty
+emptyHash :: SHA
+emptyHash = hash B.empty
 
 hasContract::Action->Bool
 hasContract = (/= emptyHash) . actionCodeHash
@@ -255,13 +257,13 @@ detailsForRow row = liftM2 (<|>)
     name <- lookupT "name" md
     detailsMap <- lift $ sourceToContractDetails True src
     lookupT name detailsMap)
-  (getContractDetailsByCodeHash $ actionCodeHash row)
+  (getContractDetailsByCodeHash . shaKeccak256 $ actionCodeHash row)
 
 adjustGlobals :: IORef Globals -> Action -> ContractDetails -> Bloc ()
 adjustGlobals gref row details = do
   let go m (k,f) = for_ (Map.lookup k $ actionMetadata row) $ \v -> do
                 let contracts = filter (not . T.null) $ T.splitOn "," v
-                forM_ contracts $ \c -> for_ (fmap (contractdetailsCodeHash . snd) $ Map.lookup c m) $ f gref
+                forM_ contracts $ \c -> for_ (fmap (keccak256SHA . contractdetailsCodeHash . snd) $ Map.lookup c m) $ f gref
   -- won't actually recompile the contract
   detailsMap <- sourceToContractDetails True $ contractdetailsSrc details
   mapM_ (go detailsMap) $ [("history", addToHistoryList)
@@ -277,7 +279,7 @@ ensureContractInstance cmId row = do
   let addr = actionAddress row
       chainId = actionTxChainId row
   (mInstance :: Maybe Int32) <- fmap listToMaybe . blocQuery $
-    contractInstancesByCodeHash (actionCodeHash row) addr chainId
+    contractInstancesByCodeHash (shaKeccak256 $ actionCodeHash row) addr chainId
   when (isNothing mInstance) . void $
     insertContractInstance cmId addr chainId
 

--- a/blockapps-haskell/slipstream/tests/ActionFidelitySpec.hs
+++ b/blockapps-haskell/slipstream/tests/ActionFidelitySpec.hs
@@ -5,15 +5,15 @@ module ActionFidelitySpec where
 import Data.Aeson
 import Data.Aeson.QQ
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Base16 as B16
 import Data.Either
-import Data.Maybe
 import qualified Data.Map.Strict as M
 import Data.Time.Clock.POSIX
 import Test.QuickCheck
 import Test.Hspec
 
-import BlockApps.Ethereum (stringKeccak256)
 import qualified Blockchain.Strato.Model.Action as BS
+import Blockchain.Strato.Model.ExtendedWord
 import Blockchain.Strato.Model.SHA
 import Blockchain.SolidVM.Model
 import qualified Slipstream.Data.Action as SS
@@ -60,7 +60,7 @@ spec = describe "Action conversions" $ do
      convert a `shouldSatisfy` isRight
 
    it "should be backwards compatible" $ do
-     let forceHash = fromMaybe (error "invalid digest") . stringKeccak256
+     let forceHash = SHA . bytesToWord256 . fst . B16.decode
          oldStyle = [aesonQQ| {
          "chainId": null,
          "data": {

--- a/blockapps-haskell/slipstream/tests/OutputDataSpec.hs
+++ b/blockapps-haskell/slipstream/tests/OutputDataSpec.hs
@@ -14,6 +14,7 @@ import Text.RawString.QQ
 
 import BlockApps.Ethereum --(Keccak256, Address)
 import qualified BlockApps.Solidity.Value as V
+import Blockchain.Strato.Model.SHA (hash)
 import Slipstream.Events
 import Slipstream.Globals
 import Slipstream.GlobalsColdStorage (fakeHandle)
@@ -27,14 +28,14 @@ spec = do
       let testAdd = Address $ fst . head . readHex $ "ADDRESS"
       let input = [ProcessedContract {
             address = testAdd,
-            codehash = keccak256 "<CODEHASH>",
+            codehash = hash "<CODEHASH>",
             abi = "<ABI>",
             contractName = "Vehicle",
             chain = "<CHAIN>",
-            blockHash = keccak256 "<BLOCKHASH>",
+            blockHash = hash "<BLOCKHASH>",
             blockTimestamp = (read "2018-09-16 18:28:52.607875 UTC")::UTCTime,
             blockNumber = 123,
-            transactionHash = keccak256 "<TRANSACTIONHASH>",
+            transactionHash = hash "<TRANSACTIONHASH>",
             transactionSender = testAdd,
             functionCallData = Nothing,
             contractData = M.singleton "owners" $ V.ValueArrayDynamic [
@@ -100,17 +101,17 @@ spec = do
   describe "Array serialization with history enabled" $ do
     it "should create JSON entries" $ do
       let testAdd = Address $ fst . head . readHex $ "ADDRESS"
-          cHash = keccak256 "<CODEHASH>"
+          cHash = hash "<CODEHASH>"
       let input = [ProcessedContract {
              address = testAdd,
              codehash = cHash,
              abi = "<ABI>",
              contractName = "Vehicle",
              chain = "<CHAIN>",
-             blockHash = keccak256 "<BLOCKHASH>",
+             blockHash = hash "<BLOCKHASH>",
              blockTimestamp = (read "2018-09-16 18:28:52.607875 UTC")::UTCTime,
              blockNumber = 123,
-             transactionHash = keccak256 "<TRANSACTIONHASH>",
+             transactionHash = hash "<TRANSACTIONHASH>",
              transactionSender = testAdd,
              functionCallData = Nothing,
              contractData = M.singleton "owners" $ V.ValueArrayDynamic [
@@ -210,14 +211,14 @@ spec = do
       let testAdd = Address $ fst . head . readHex $ "ADDRESS"
       let input = [ProcessedContract {
             address = testAdd,
-            codehash = keccak256 "<CODEHASH>",
+            codehash = hash "<CODEHASH>",
             abi = "<ABI>",
             contractName = "\"Vehicle''",
             chain = "<CHAIN>",
-            blockHash = keccak256 "<BLOCKHASH>",
+            blockHash = hash "<BLOCKHASH>",
             blockTimestamp = (read "2018-09-16 18:28:52.607875 UTC")::UTCTime,
             blockNumber = 123,
-            transactionHash = keccak256 "<TRANSACTIONHASH>",
+            transactionHash = hash "<TRANSACTIONHASH>",
             transactionSender = testAdd,
             functionCallData = Nothing,
             contractData = M.singleton "\"owners\"" $ V.ValueArrayDynamic [


### PR DESCRIPTION
This is not to say that the digests won't eventually be called Keccak256, but
it seems easier to reach gradual convergence on the newtype backend and
then do a global s/SHA/Keccak256 if need be.