### PR TITLE
Cut down verbosity on log messages

### DIFF
--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -460,7 +460,7 @@ sendMessages wms = do
 sendAllMessages :: (MonadIO m, MonadLogger m, HasBlockstanbulContext m) => [InEvent] -> m [OutEvent]
 sendAllMessages wms = do
   out <- sendMessages wms
-  $logDebugS "sendAllMessages" . T.pack $ formatList out
+  $logDebugS "sendAllMessages" . T.pack $ format out
   case mapMaybe loopback out of
              [] -> return out
              wms' -> (out ++) <$> sendAllMessages wms'

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -460,7 +460,7 @@ sendMessages wms = do
 sendAllMessages :: (MonadIO m, MonadLogger m, HasBlockstanbulContext m) => [InEvent] -> m [OutEvent]
 sendAllMessages wms = do
   out <- sendMessages wms
-  $logDebugS "sendAllMessages" . T.pack . show $ out
+  $logDebugS "sendAllMessages" . T.pack . show . map format $ out
   case mapMaybe loopback out of
              [] -> return out
              wms' -> (out ++) <$> sendAllMessages wms'

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -460,7 +460,7 @@ sendMessages wms = do
 sendAllMessages :: (MonadIO m, MonadLogger m, HasBlockstanbulContext m) => [InEvent] -> m [OutEvent]
 sendAllMessages wms = do
   out <- sendMessages wms
-  $logDebugS "sendAllMessages" . T.pack . show . map format $ out
+  $logDebugS "sendAllMessages" . T.pack $ formatList out
   case mapMaybe loopback out of
              [] -> return out
              wms' -> (out ++) <$> sendAllMessages wms'

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
@@ -47,6 +47,12 @@ data TrustedMessage = Preprepare View Block
                     | RoundChange {roundchangeView :: View }
                     deriving (Eq, Show, Generic)
 
+instance Format TrustedMessage where
+  format (Preprepare v theBlock) = CL.blue "PRE_PREPARE " ++ format v ++ " " ++ format (blockHash theBlock)
+  format (Prepare v theSHA) = CL.blue "PREPARE " ++ format v ++ " " ++ format theSHA
+  format (Commit v theSHA _) = CL.blue "COMMIT " ++ format v ++ " " ++ format theSHA
+  format (RoundChange v) = CL.blue "ROUNDCHANGE " ++ format v
+
 data MessageKind = PreprepareK | PrepareK | CommitK | RoundChangeK deriving (Eq, Show, Enum, Generic)
 
 categorize :: TrustedMessage -> MessageKind
@@ -81,11 +87,7 @@ derive makeArbitrary ''TrustedMessage
 derive makeArbitrary ''WireMessage
 
 instance Format WireMessage where
-  format (WireMessage (MsgAuth s _) (Preprepare v theBlock)) = CL.blue "PRE_PREPARE " ++ format v ++ " " ++ format s ++ "\n" ++ format theBlock
-  format (WireMessage (MsgAuth s _) (Prepare v theSHA)) = CL.blue "PREPARE " ++ format v ++ " " ++ format s ++ " " ++ format theSHA
-  format (WireMessage (MsgAuth s _) (Commit v theSHA _)) = CL.blue "COMMIT " ++ format v ++ " " ++ format s ++ " " ++ format theSHA
-  format (WireMessage (MsgAuth s _) (RoundChange v)) = CL.blue "ROUNDCHANGE " ++ format v ++ " " ++ format s
-
+  format (WireMessage (MsgAuth s _) msg) = format msg ++ " " ++ format s
 
 preprepareCode, prepareCode, commitCode, roundchangeCode :: Integer
 preprepareCode = 0
@@ -103,8 +105,13 @@ data InEvent = IMsg {iAuth :: MsgAuth, iMessage :: TrustedMessage}
              deriving (Eq, Show)
 
 instance Format InEvent where
-  format (IMsg a m) = format $ WireMessage a m
-  format x = show x
+  format (IMsg (MsgAuth s _) msg) = "IMsg " ++ format msg ++ " " ++ format s
+  format (Timeout rn) = "Timeout " ++ format rn
+  format (CommitResult (Left text)) = unpack $ "CommitResult Error: " <> text
+  format (CommitResult (Right sha)) = "CommitResult Success: " ++ format sha
+  format (UnannouncedBlock blk) = "UnannouncedBlock " ++ format (blockHash blk)
+  format (PreviousBlock blk) = "PreviousBlock " ++ format (blockHash blk)
+  format (NewBeneficiary (MsgAuth s _) ben) = "NewBeneficiary " ++ show ben ++ " " ++ format s
 
 data OutEvent = OMsg {oAuth :: MsgAuth, oMessage :: TrustedMessage}
               | ToCommit Block
@@ -116,6 +123,14 @@ data OutEvent = OMsg {oAuth :: MsgAuth, oMessage :: TrustedMessage}
               | GapFound {have :: Integer, require :: Integer, peer :: Address}
               | LeadFound {weHave :: Integer, theyHave :: Integer, peer :: Address}
               deriving (Eq, Show, Generic)
+
+instance Format OutEvent where
+  format (OMsg (MsgAuth s _) msg) = "OMsg " ++ format msg ++ " " ++ format s
+  format (ToCommit blk) = "ToCommit " ++ format (blockHash blk)
+  format MakeBlockCommand = "MakeBlockCommand"
+  format (ResetTimer rn) = "ResetTimer " ++ format rn
+  format (GapFound we they p) = "GapFound " ++ show (we, they, p)
+  format (LeadFound we they p) = "LeadFound " ++ show (we, they, p)
 
 blkNum :: Block -> String
 blkNum = show . blockDataNumber . blockBlockData
@@ -145,10 +160,6 @@ outShortLog loc oev = $logInfoS loc . pack $
     ResetTimer rn -> CL.blue "RESET_TIMER " ++ show rn
     GapFound h r p -> CL.blue "GAP_FOUND " ++ format p ++ " " ++ show h ++ " " ++ show r
     LeadFound h r p -> CL.blue "LEAD_FOUND " ++ format p ++ " " ++ show h ++ " " ++ show r
-
-instance Format OutEvent where
-  format (OMsg a m) = format $ WireMessage a m
-  format x = show x
 
 instance NFData OutEvent
 

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -46,6 +46,12 @@ data SeqLoopEvent = TimerFire PBFT.RoundNumber
                   | WaitTerminated
                   deriving (Eq, Show, GHCG.Generic)
 
+instance Format SeqLoopEvent where
+  format (TimerFire rn) = "TimerFire " ++ format rn
+  format (VoteMade vote) = "VoteMade " ++ show vote
+  format (UnseqEvent ev) = "UnseqEvent " ++ format ev
+  format WaitTerminated = "WaitTerminated"
+
 data IngestEvent = IETx Timestamp IngestTx
                  | IEBlock IngestBlock
                  | IEGenesis IngestGenesis
@@ -344,10 +350,10 @@ instance Format IngestBlock where
              format bd ++
              (if null receipts
               then "        (no transactions)\n"
-              else tab (intercalate "\n    " (format <$> receipts))) ++
+              else tab (show $ length receipts)) ++
              (if null uncles
               then "        (no uncles)"
-              else tab ("Uncles:" ++ tab ("\n" ++ intercalate "\n    " (format <$> uncles)))))
+              else tab (show $ length uncles)))
 
 instance Format OutputBlock where
     format b@OutputBlock { obOrigin              = origin
@@ -361,10 +367,10 @@ instance Format OutputBlock where
              format bd ++
              (if null receipts
               then "        (no transactions)\n"
-              else tab (intercalate "\n    " (format <$> receipts))) ++
+              else tab (show $ length receipts)) ++
              (if null uncles
               then "        (no uncles)"
-              else tab ("Uncles:" ++ tab ("\n" ++ intercalate "\n    " (format <$> uncles)))))
+              else tab (show $ length uncles)))
 
 instance Format OutputTx where
     format OutputTx{ otOrigin = origin

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -122,12 +122,13 @@ data OutputEvent = OETx Timestamp OutputTx
                  deriving (Eq, Show, GHCG.Generic)
 
 instance Format OutputEvent where
-  format (OETx ts o)       = show ts ++ " " ++ format o
-  format (OEBlock o)       = format o
-  format (OEGenesis o)     = show o
-  format (OEGetChain cids) = "[" ++ (intercalate "," $ map (format . SHA) cids) ++ "]"
-  format (OEGetTx shas)    = "[" ++ (intercalate "," $ map format shas) ++ "]"
-  format x                 = show x
+  format (OETx ts o)        = show ts ++ " " ++ format o
+  format (OEBlock o)        = format o
+  format (OEGenesis o)      = show o
+  format (OEGetChain cids)  = "[" ++ (intercalate "," $ map (format . SHA) cids) ++ "]"
+  format (OEGetTx shas)     = "[" ++ (intercalate "," $ map format shas) ++ "]"
+  format (OEBlockstanbul o) = format o
+  format x                  = show x
 
 data OutputTx = OutputTx { otOrigin :: TO.TXOrigin
                          , otHash   :: SHA
@@ -378,13 +379,13 @@ instance Format OutputTx where
                    , otBaseTx = base
                    } =
            CL.red("OutputTx from address " ++ format signer)
-                ++ tab (" via " ++ format origin ++ "\n" ++ format base)
+                ++ tab (" via " ++ format origin ++ "\n" ++ format (txHash base))
 
 instance Format IngestTx where
     format IngestTx{ itOrigin      = origin
                    , itTransaction = base
                    } =
-           CL.red("IngestTx via " ++ format origin ++ "\n" ++ tab (format base))
+           CL.red("IngestTx via " ++ format origin ++ "\n" ++ tab (format $ txHash base))
 
 -- todo: can we get away with this? seems like there'd be overhead recomputing
 -- todo: otSigner

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Format.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Format.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
-module Blockchain.Strato.Model.Format (
-  Format(..)
+module Blockchain.Strato.Model.Format
+  ( Format(..)
+  , formatList
   ) where
 
 import qualified Data.ByteString        as B
@@ -24,3 +25,6 @@ instance Format N.NibbleString where
 
 instance (Format a, Format b) => Format (a, b) where
   format (x, y) = "(" ++ format x ++ ", " ++ format y ++ ")"
+
+formatList :: Format a => [a] -> String
+formatList = show . map format

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Format.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Format.hs
@@ -3,7 +3,6 @@
 
 module Blockchain.Strato.Model.Format
   ( Format(..)
-  , formatList
   ) where
 
 import qualified Data.ByteString        as B
@@ -26,5 +25,5 @@ instance Format N.NibbleString where
 instance (Format a, Format b) => Format (a, b) where
   format (x, y) = "(" ++ format x ++ ", " ++ format y ++ ")"
 
-formatList :: Format a => [a] -> String
-formatList = show . map format
+instance Format a => Format [a] where
+  format = show . map format

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -55,9 +55,6 @@ import           Blockchain.Strato.Model.SHA
 
 import           Blockchain.Util
 
-formatList :: Format a => [a] -> T.Text
-formatList = T.concat . map (T.pack . format)
-
 logFF :: MonadLogger m => T.Text -> String -> m ()
 logFF str = $logInfoS str . T.pack
 -- replace with this when debugging tests
@@ -85,11 +82,11 @@ oneSequencerIter src = timeAction seqLoopTiming $ do
   vmEvs <- drainVM
   unless (null vmEvs) $ do
     writeSeqVmEvents vmEvs
-    $logDebugS "sequencer" . T.pack $ "Wrote " ++ show (length vmEvs) ++ " SeqEvents to VM"
+    $logDebugS "sequencer" . T.pack $ "Wrote " ++ formatList vmEvs ++ " SeqEvents to VM"
   p2pEvs <- drainP2P
   unless (null p2pEvs) $ do
     writeSeqP2pEvents p2pEvs
-    $logDebugS "sequencer" . T.pack $ "Wrote " ++ show (length p2pEvs) ++ " SeqEvents to P2P"
+    $logDebugS "sequencer" . T.pack $ "Wrote " ++ formatList p2pEvs ++ " SeqEvents to P2P"
   return src'
 
 clearAll :: SequencerM ()
@@ -115,7 +112,7 @@ readEventsInBufferedWindow src = do
   (src'', events) <- src' $$++ takeWhileC (/= WaitTerminated)
                           .| takeC maxEvents
                           .| sinkList
-  $logDebugS "sequencer/events" $ formatList events
+  $logDebugS "sequencer/events" . T.pack $ formatList events
   logF . printf "read %d events from fused channels" $ length events
   return (src'', events)
 
@@ -180,7 +177,7 @@ blockstanbulSend' msg = do
         [b] -> sendAllMessages [CommitResult . Right . blockHash $ b]
         bs -> error $ "can send at most 1 block at a time: " ++ show bs
   mapM_ createNewTimer [rn | ResetTimer rn <- resp]
-  $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ show (map blockHash blocks)
+  $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ formatList (map blockHash blocks)
   let getSequencedBlock = ingestBlockToSequencedBlock . blockToIngestBlock TO.Blockstanbul
       rewriteBlock b = do
         let msb = getSequencedBlock b
@@ -200,9 +197,9 @@ blockstanbulSend' msg = do
     now <- liftIO getCurrentTime
     when (now < tNext) $
       liftIO . threadDelay . round $ 1e6 * diffUTCTime tNext now
-  $logDebugS "seq/pbft/send_p2p" $ formatList p2pevs
+  $logDebugS "seq/pbft/send_p2p" . T.pack $ formatList p2pevs
   mapM_ markForP2P p2pevs
-  $logDebugS "seq/pbft/send_vm" $ formatList vmevs
+  $logDebugS "seq/pbft/send_vm" . T.pack $ formatList vmevs
   return vmevs
 
 transformPrivateHashTXs :: [(Timestamp, IngestTx)] -> SequencerM ()

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -82,11 +82,11 @@ oneSequencerIter src = timeAction seqLoopTiming $ do
   vmEvs <- drainVM
   unless (null vmEvs) $ do
     writeSeqVmEvents vmEvs
-    $logDebugS "sequencer" . T.pack $ "Wrote " ++ show vmEvs ++ " SeqEvents to VM"
+    $logDebugS "sequencer" . T.pack $ "Wrote " ++ show (length vmEvs) ++ " SeqEvents to VM"
   p2pEvs <- drainP2P
   unless (null p2pEvs) $ do
     writeSeqP2pEvents p2pEvs
-    $logDebugS "sequencer" . T.pack $ "Wrote " ++ show p2pEvs ++ " SeqEvents to P2P"
+    $logDebugS "sequencer" . T.pack $ "Wrote " ++ show (length p2pEvs) ++ " SeqEvents to P2P"
   return src'
 
 clearAll :: SequencerM ()
@@ -177,7 +177,7 @@ blockstanbulSend' msg = do
         [b] -> sendAllMessages [CommitResult . Right . blockHash $ b]
         bs -> error $ "can send at most 1 block at a time: " ++ show bs
   mapM_ createNewTimer [rn | ResetTimer rn <- resp]
-  $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ show blocks
+  $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ show (map blockHash blocks)
   let getSequencedBlock = ingestBlockToSequencedBlock . blockToIngestBlock TO.Blockstanbul
       rewriteBlock b = do
         let msb = getSequencedBlock b

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -55,6 +55,9 @@ import           Blockchain.Strato.Model.SHA
 
 import           Blockchain.Util
 
+formatList :: Format a => [a] -> T.Text
+formatList = T.concat . map (T.pack . format)
+
 logFF :: MonadLogger m => T.Text -> String -> m ()
 logFF str = $logInfoS str . T.pack
 -- replace with this when debugging tests
@@ -112,7 +115,7 @@ readEventsInBufferedWindow src = do
   (src'', events) <- src' $$++ takeWhileC (/= WaitTerminated)
                           .| takeC maxEvents
                           .| sinkList
-  $logDebugS "sequencer/events" . T.pack . show $ events
+  $logDebugS "sequencer/events" $ formatList events
   logF . printf "read %d events from fused channels" $ length events
   return (src'', events)
 
@@ -197,9 +200,9 @@ blockstanbulSend' msg = do
     now <- liftIO getCurrentTime
     when (now < tNext) $
       liftIO . threadDelay . round $ 1e6 * diffUTCTime tNext now
-  $logDebugS "seq/pbft/send_p2p" . T.pack . show $ p2pevs
+  $logDebugS "seq/pbft/send_p2p" $ formatList p2pevs
   mapM_ markForP2P p2pevs
-  $logDebugS "seq/pbft/send_vm" . T.pack . show $ vmevs
+  $logDebugS "seq/pbft/send_vm" $ formatList vmevs
   return vmevs
 
 transformPrivateHashTXs :: [(Timestamp, IngestTx)] -> SequencerM ()

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -82,11 +82,11 @@ oneSequencerIter src = timeAction seqLoopTiming $ do
   vmEvs <- drainVM
   unless (null vmEvs) $ do
     writeSeqVmEvents vmEvs
-    $logDebugS "sequencer" . T.pack $ "Wrote " ++ formatList vmEvs ++ " SeqEvents to VM"
+    $logDebugS "sequencer" . T.pack $ "Wrote " ++ format vmEvs ++ " SeqEvents to VM"
   p2pEvs <- drainP2P
   unless (null p2pEvs) $ do
     writeSeqP2pEvents p2pEvs
-    $logDebugS "sequencer" . T.pack $ "Wrote " ++ formatList p2pEvs ++ " SeqEvents to P2P"
+    $logDebugS "sequencer" . T.pack $ "Wrote " ++ format p2pEvs ++ " SeqEvents to P2P"
   return src'
 
 clearAll :: SequencerM ()
@@ -112,7 +112,7 @@ readEventsInBufferedWindow src = do
   (src'', events) <- src' $$++ takeWhileC (/= WaitTerminated)
                           .| takeC maxEvents
                           .| sinkList
-  $logDebugS "sequencer/events" . T.pack $ formatList events
+  $logDebugS "sequencer/events" . T.pack $ format events
   logF . printf "read %d events from fused channels" $ length events
   return (src'', events)
 
@@ -177,7 +177,7 @@ blockstanbulSend' msg = do
         [b] -> sendAllMessages [CommitResult . Right . blockHash $ b]
         bs -> error $ "can send at most 1 block at a time: " ++ show bs
   mapM_ createNewTimer [rn | ResetTimer rn <- resp]
-  $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ formatList (map blockHash blocks)
+  $logDebugS "seq/pbft/send" . T.pack $ "Pre-rewrite: " ++ format (map blockHash blocks)
   let getSequencedBlock = ingestBlockToSequencedBlock . blockToIngestBlock TO.Blockstanbul
       rewriteBlock b = do
         let msb = getSequencedBlock b
@@ -197,9 +197,9 @@ blockstanbulSend' msg = do
     now <- liftIO getCurrentTime
     when (now < tNext) $
       liftIO . threadDelay . round $ 1e6 * diffUTCTime tNext now
-  $logDebugS "seq/pbft/send_p2p" . T.pack $ formatList p2pevs
+  $logDebugS "seq/pbft/send_p2p" . T.pack $ format p2pevs
   mapM_ markForP2P p2pevs
-  $logDebugS "seq/pbft/send_vm" . T.pack $ formatList vmevs
+  $logDebugS "seq/pbft/send_vm" . T.pack $ format vmevs
   return vmevs
 
 transformPrivateHashTXs :: [(Timestamp, IngestTx)] -> SequencerM ()

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -38,6 +38,7 @@ import           Blockchain.Sequencer.CablePackage
 import           Blockchain.Sequencer.Event
 import qualified Blockchain.Sequencer.Kafka as SK
 import           Blockchain.Sequencer.Metrics
+import           Blockchain.Strato.Model.Format
 import qualified Network.Kafka              as K
 import qualified Network.Kafka.Protocol     as KP
 
@@ -141,7 +142,7 @@ unseqReader = forever . timeAction gregorUnseqTiming $ do
   ch <- use gregorUnseq
   atomically . forM_ inEvents $ writeTQueue ch . snd
   hd <- atomically $ tryPeekTQueue ch
-  $logDebugS "gregor/unseqchHead" . T.pack . show $ hd
+  $logDebugS "gregor/unseqchHead" . T.pack . show . fmap format $ hd
   P.unsafeAddCounter gregorUnseqWrite (fromIntegral (length inEvents))
   unless (null inEvents) $ do
     let ofs = maximum . map fst $ inEvents

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -153,7 +153,7 @@ seqWriters = forever . timeAction gregorSeqTiming $ do
   p2pq <- use gregorSeqP2P
   events <- atomically $
     fmap Left (blockFlushTQueue vmq) `orElse` fmap Right (blockFlushTQueue p2pq)
-  $logDebugS "gregor/seqWriter" . T.pack . show $ events
+  $logDebugS "gregor/seqWriter" . T.pack . show $ length events
   case events of
     Left vmevs -> do
       P.withLabel gregorLoop "seq_vm_events" P.incCounter

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -142,7 +142,7 @@ unseqReader = forever . timeAction gregorUnseqTiming $ do
   ch <- use gregorUnseq
   atomically . forM_ inEvents $ writeTQueue ch . snd
   hd <- atomically $ tryPeekTQueue ch
-  $logDebugS "gregor/unseqchHead" . T.pack . show . fmap format $ hd
+  $logDebugS "gregor/unseqchHead" $ maybe "empty" (T.pack . format) hd
   P.unsafeAddCounter gregorUnseqWrite (fromIntegral (length inEvents))
   unless (null inEvents) $ do
     let ofs = maximum . map fst $ inEvents

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -64,6 +64,7 @@ import           Blockchain.Sequencer.DB.SeenTransactionDB
 import           Blockchain.Sequencer.Event
 import           Blockchain.SHA
 import           Blockchain.Strato.Model.Class
+import           Blockchain.Strato.Model.Format
 import           System.Directory                          (createDirectoryIfMissing)
 
 import qualified Database.LevelDB                          as LDB
@@ -258,7 +259,7 @@ fuseChannels = do
   votes <- asks blockstanbulBeneficiary
   timers <- asks blockstanbulTimeouts
   loop <- use loopTimeout
-  let debugLog = (.| iterMC ($logDebugS "fuseChannels" . T.pack . show))
+  let debugLog = (.| iterMC ($logDebugS "fuseChannels" . T.pack . format))
   (debugLog . transPipe lift) <$> mergeSources
                [ sourceTQueue unseq .| mapC UnseqEvent
                , sourceTMChan votes .| mapC VoteMade


### PR DESCRIPTION
Instead of completely removing the logs, I've changed the format to print hashes instead of full payloads for transactions and blocks. When seqDebugMode is off, I'm still able to get 28 TPS in 4-node PBFT with the TicketFactory contract