### PR TITLE
Unify Slipstream and Strato's Action types

### DIFF
--- a/blockapps-haskell/slipstream/src/Slipstream/Data/Action.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Data/Action.hs
@@ -9,16 +9,14 @@
     , GeneralizedNewtypeDeriving
     , FlexibleInstances
 #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Slipstream.Data.Action where
+module Slipstream.Data.Action
+  ( module Blockchain.Strato.Model.Action
+  , module Slipstream.Data.Action
+  ) where
 
 import           BlockApps.Ethereum
 import           Control.DeepSeq
-import           Control.Lens            hiding ((.=))
-import qualified Data.Aeson.Encoding     as AesonEnc
-import           Data.Aeson.Types
-import           Data.ByteString         (ByteString)
 import           Data.Map.Strict         (Map)
 import qualified Data.Map.Strict         as M
 import           Data.Maybe              (fromMaybe,listToMaybe)
@@ -27,116 +25,11 @@ import qualified Data.Text               as T
 import           Data.Time
 import           GHC.Generics
 
-import qualified Blockchain.Strato.Model.Action as BS
-import           Blockchain.SolidVM.Model
+import           Blockchain.Strato.Model.Action ( Action(..), ActionData(..), ActionDataDiff(..)
+                                                , CallType(..), CallData(..))
 
-instance (Integral a, Show a) => ToJSONKey (Hex a) where
-  toJSONKey = ToJSONKeyText f g
-    where f x = T.pack $ show x
-          g x = AesonEnc.text . T.pack $ show x
 
-instance FromJSONKey (Hex Word256) where
-    fromJSONKey = FromJSONKeyTextParser (parseJSON . String)
-
-data CallType = Create | Delete | Update deriving (Eq, Show, Generic, NFData, ToJSON, FromJSON)
-
-data CallData = CallData
-  { _callType    :: CallType
-  , _sender      :: Address
-  , _owner       :: Address
-  , _gasPrice    :: Integer
-  , _value       :: Integer
-  , _input       :: ByteString
-  , _output      :: Maybe ByteString
-  } deriving (Eq, Show, Generic, NFData)
-makeLenses ''CallData
-
-instance ToJSON CallData where
-  toJSON CallData{..} = object
-    [ "type"    .= _callType
-    , "sender"  .= _sender
-    , "owner"   .= _owner
-    , "gasPrice".= _gasPrice
-    , "value"   .= _value
-    , "input"   .= _input
-    , "output"  .= _output
-    ]
-
-instance FromJSON CallData where
-  parseJSON (Object o) = CallData
-    <$> (o .: "type")
-    <*> (o .: "sender")
-    <*> (o .: "owner")
-    <*> (o .: "gasPrice")
-    <*> (o .: "value")
-    <*> (o .: "input")
-    <*> (o .:? "output")
-  parseJSON o = error $ "parseJSON CallData: Expected object, got: " ++ show o
-
-data ActionData = ActionData
-  { _codeHash     :: CodePtr
-  , _codeKind     :: CodeKind
-  , _storageDiffs :: BS.ActionDataDiff
-  , _callData     :: [CallData]
-  } deriving (Eq, Show, Generic, NFData)
-makeLenses ''ActionData
-
-instance ToJSON ActionData where
-  toJSON ActionData{..} = object
-    [ "codeHash" .= _codeHash
-    , "codeKind" .= _codeKind
-    , "diff"     .= _storageDiffs
-    , "data"     .= _callData
-    ]
-
-instance FromJSON ActionData where
-  parseJSON (Object o) = do
-    ch <- o .: "codeHash"
-    ck <- o .:? "codeKind" .!= EVM
-    df <- (case ck of
-      EVM -> explicitParseField BS.parseDiffEVM
-      SolidVM -> explicitParseField BS.parseDiffSolidVM) o "diff"
-    dt <- o .: "data"
-    return $ ActionData ch ck df dt
-  parseJSON o = error $ "parseJSON ActionData: Expected object, got: " ++ show o
-
-data Action' = Action'
-  { _blockHash          :: SHA
-  , _blockTimestamp     :: UTCTime
-  , _blockNumber        :: Integer
-  , _transactionHash    :: SHA
-  , _transactionChainId :: Maybe ChainId
-  , _transactionSender  :: Address
-  , _actionData         :: Map Address ActionData
-  , _metadata           :: Maybe (Map Text Text)
-  } deriving (Eq, Show, Generic, NFData)
-makeLenses ''Action'
-
-instance ToJSON Action' where
-  toJSON Action'{..} = object
-    [ "blockHash"       .= _blockHash
-    , "blockTimestamp"  .= _blockTimestamp
-    , "blockNumber"     .= _blockNumber
-    , "transactionHash" .= _transactionHash
-    , "chainId"         .= _transactionChainId
-    , "sender"          .= _transactionSender
-    , "data"            .= _actionData
-    , "metadata"        .= _metadata
-    ]
-
-instance FromJSON Action' where
-  parseJSON (Object o) = Action'
-    <$> (o .: "blockHash")
-    <*> (o .: "blockTimestamp")
-    <*> (o .: "blockNumber")
-    <*> (o .: "transactionHash")
-    <*> (o .:? "chainId")
-    <*> (o .: "sender")
-    <*> (o .: "data")
-    <*> (o .: "metadata")
-  parseJSON o = error $ "parseJSON Action: Expected object, got: " ++ show o
-
-data Action = Action
+data AggregateAction = AggregateAction
   { actionBlockHash      :: SHA
   , actionBlockTimestamp :: UTCTime
   , actionBlockNumber    :: Integer
@@ -145,33 +38,33 @@ data Action = Action
   , actionTxSender       :: Address
   , actionAddress        :: Address
   , actionCodeHash       :: CodePtr
-  , actionStorage        :: BS.ActionDataDiff
+  , actionStorage        :: ActionDataDiff
   , actionType           :: CallType
   , actionCallData       :: [CallData]
   , actionMetadata       :: Map Text Text
   } deriving (Show, Generic, NFData)
 
-flatten :: Action' -> [Action]
-flatten Action'{..} = flip map (M.toList _actionData) $
-  \(address, ActionData{..}) ->
-    let t = maybe Create _callType $ listToMaybe _callData -- It's a Create because I said so
-     in Action
-          { actionBlockHash      = _blockHash
-          , actionBlockTimestamp = _blockTimestamp
-          , actionBlockNumber    = _blockNumber
-          , actionTxHash         = _transactionHash
-          , actionTxChainId      = _transactionChainId
-          , actionTxSender       = _transactionSender
+flatten :: Action -> [AggregateAction]
+flatten Action{..} = flip map (M.toList _actionData) $
+  \(address, ActionData{..}) -> -- It's a Create because I said so
+    let t = maybe Create _callDataType $ listToMaybe _actionDataCallData
+     in AggregateAction
+          { actionBlockHash      = _actionBlockHash
+          , actionBlockTimestamp = _actionBlockTimestamp
+          , actionBlockNumber    = _actionBlockNumber
+          , actionTxHash         = _actionTransactionHash
+          , actionTxChainId      = ChainId <$> _actionTransactionChainId
+          , actionTxSender       = _actionTransactionSender
           , actionAddress        = address
-          , actionCodeHash       = _codeHash
-          , actionStorage        = _storageDiffs
+          , actionCodeHash       = _actionDataCodeHash
+          , actionStorage        = _actionDataStorageDiffs
           , actionType           = t
-          , actionCallData       = _callData
-          , actionMetadata       = fromMaybe M.empty _metadata
+          , actionCallData       = _actionDataCallData
+          , actionMetadata       = fromMaybe M.empty _actionMetadata
           }
 
-formatAction :: Action -> Text
-formatAction Action{..} = T.concat
+formatAction :: AggregateAction -> Text
+formatAction AggregateAction{..} = T.concat
   [ tshow actionType
   , ", blockHash: "
   , tshow actionBlockHash
@@ -189,8 +82,8 @@ formatAction Action{..} = T.concat
   , tshow actionAddress
   , " with "
   , tshow (case actionStorage of
-      BS.ActionEVMDiff m -> M.size m
-      BS.ActionSolidVMDiff m -> M.size m)
+      ActionEVMDiff m -> M.size m
+      ActionSolidVMDiff m -> M.size m)
   , " items\n"
   , "    codeHash = "
   , tshow actionCodeHash

--- a/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
@@ -86,7 +86,7 @@ recordGlobals g = liftIO $ do
 recordKafkaMessages :: MonadIO m => [a] -> m ()
 recordKafkaMessages = liftIO . void . addCounter kafkaCount . fromIntegral . length
 
-recordActionOn :: MonadIO m => T.Text -> Action -> m ()
+recordActionOn :: MonadIO m => T.Text -> AggregateAction -> m ()
 recordActionOn stage act = do
   let kind = case actionType act of
               Create -> "create"
@@ -95,10 +95,10 @@ recordActionOn stage act = do
   liftIO $ withLabel actionCount (stage, kind) incCounter
   recordMaxBlockNumber "slipstream_processor" . actionBlockNumber $ act
 
-recordAction :: MonadIO m => Action -> m ()
+recordAction :: MonadIO m => AggregateAction -> m ()
 recordAction = recordActionOn "raw"
 
-recordCombinedAction :: MonadIO m => Action -> m ()
+recordCombinedAction :: MonadIO m => AggregateAction -> m ()
 recordCombinedAction = recordActionOn "combined"
 
 incNumTables :: MonadIO m => m ()

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -27,6 +27,7 @@ import Data.Bifunctor (second)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Short as SB
 import Data.Either (lefts, rights)
 import Data.Int (Int32)
 import Data.IORef
@@ -84,7 +85,7 @@ data BatchedInserts = BatchedInserts
   , functionInserts :: [ProcessedContract]
   } deriving (Show)
 
-toAction :: BL.ByteString -> Action'
+toAction :: BL.ByteString -> Action
 toAction x =
  case JSON.eitherDecode x of
   Left e -> error $ show e
@@ -98,17 +99,16 @@ enterBloc2 env x = do
    Left e -> error $ show e
    Right v -> return v
 
+{-# NOINLINE emptyHash #-}
 emptyHash :: SHA
 emptyHash = hash B.empty
 
-hasContract::Action->Bool
-hasContract = (/= EVMCode emptyHash) . actionCodeHash
-
-matters :: Action -> Bool
-matters Action{..} = (actionType == Create) || (not $ diffNull actionStorage)
+matters :: AggregateAction -> Bool
+matters AggregateAction{..} = (actionType == Create || (not $ diffNull actionStorage))
+                           && (codePtrToSHA actionCodeHash /= emptyHash)
 
 -- assumes all Actions in the list are for the same (Address, Maybe ChainId) pair
-combineActions :: [Action] -> Action
+combineActions :: [AggregateAction] -> AggregateAction
 combineActions [] = error "cannot combine 0 actions"
 combineActions (x:xs) = foldr merge x xs
   where
@@ -116,7 +116,7 @@ combineActions (x:xs) = foldr merge x xs
                   , actionMetadata = (Map.union `on` actionMetadata) b a
                   }
 
-splitActions :: [Action] -> [((Address, Maybe ChainId), [Action])]
+splitActions :: [AggregateAction] -> [((Address, Maybe ChainId), [AggregateAction])]
 splitActions = partitionWith (actionAddress &&& actionTxChainId)
 
 functionDetailsFromContract :: Contract -> ByteString -> (Text, ([(Text, Type)],[(Maybe Text, Type)]))
@@ -172,9 +172,9 @@ data ABIID = ABIID { aiAbi :: Text
 
 processedContract :: ABIID
                   -> Map.Map Text Value
-                  -> Action
+                  -> AggregateAction
                   -> ProcessedContract
-processedContract ABIID{..} state Action{..} =
+processedContract ABIID{..} state AggregateAction{..} =
   ProcessedContract
     { address = actionAddress
     , codehash = actionCodeHash
@@ -193,12 +193,12 @@ processedContract ABIID{..} state Action{..} =
 makeFunctionInserts :: Xabi
                     -> ABIID
                     -> Map.Map Text Value
-                    -> Action
+                    -> AggregateAction
                     -> Bloc [ProcessedContract]
-makeFunctionInserts xabi ABIID{..} state Action{..} =
+makeFunctionInserts xabi ABIID{..} state AggregateAction{..} =
   forM actionCallData $ \CallData{..} -> do
-    let ibytes = _input
-        obytes = fromMaybe B.empty _output
+    let ibytes = SB.fromShort $ _callDataInput
+        obytes = SB.fromShort $ fromMaybe SB.empty _callDataOutput
         (f',i,o) = getFunctionCallValues xabi ibytes obytes
         f = if T.null f'
               then if actionType == Create
@@ -230,9 +230,9 @@ lookupT k = MaybeT . return . Map.lookup k
 
 -- Note: This could be reshaped to remove the bloch dependency, as
 -- we only care about the ABI from `sourceToContractDetails` and
--- not the metadata id. Additinally, at some point this must
+-- not the metadata id. Additionally, at some point this must
 -- offload to disk.
-getCachedSolidVMDetails :: IORef Globals -> Action -> Bloc (Maybe (Text, Text))
+getCachedSolidVMDetails :: IORef Globals -> AggregateAction -> Bloc (Maybe (Text, Text))
 getCachedSolidVMDetails g row = liftM2 (<|>)
   (getSolidVMABIs g codePtr)
   (runMaybeT $ do
@@ -244,7 +244,7 @@ getCachedSolidVMDetails g row = liftM2 (<|>)
   )
  where codePtr = actionCodeHash row
 
-detailsForRow :: Action -> Bloc (Maybe (Int32, ContractDetails))
+detailsForRow :: AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
 detailsForRow row = liftM2 (<|>)
   (getContractDetailsByCodeHash . shaKeccak256 . codePtrToSHA $ actionCodeHash row)
   (runMaybeT $ do
@@ -254,7 +254,7 @@ detailsForRow row = liftM2 (<|>)
     detailsMap <- lift $ sourceToContractDetails True src
     lookupT name detailsMap)
 
-adjustGlobals :: IORef Globals -> Action -> ContractDetails -> Bloc ()
+adjustGlobals :: IORef Globals -> AggregateAction -> ContractDetails -> Bloc ()
 adjustGlobals gref row details = do
   let go m (k,f) = runMaybeT $ do
         v <- lookupT k $ actionMetadata row
@@ -274,7 +274,7 @@ adjustGlobals gref row details = do
                           ,("nofunctionhistory", removeFromFunctionHistoryList)
                           ]
 
-ensureContractInstance :: Int32 -> Action -> Bloc ()
+ensureContractInstance :: Int32 -> AggregateAction -> Bloc ()
 ensureContractInstance cmId row = do
   let addr = actionAddress row
       chainId = actionTxChainId row
@@ -292,7 +292,8 @@ readPreviousSolidVMState :: IORef Globals -> Address -> Maybe ChainId -> Bloc [(
 readPreviousSolidVMState gref addr chainId = fromMaybe [] <$> getContractState gref addr chainId
 
 
-rowToInsert :: IORef Globals -> ABIID -> Action -> Contract -> [(Text, Value)] -> Bloc ProcessedContract
+rowToInsert :: IORef Globals -> ABIID -> AggregateAction -> Contract -> [(Text, Value)]
+            -> Bloc ProcessedContract
 rowToInsert gref abiid row cont oldState = do
   let newState = case actionStorage row of
                     BS.ActionEVMDiff mp -> SVR.decodeCacheValues cont (flip Map.lookup mp) oldState
@@ -300,7 +301,9 @@ rowToInsert gref abiid row cont oldState = do
   setContractState gref (actionAddress row) (actionTxChainId row) newState
   return $ processedContract abiid (Map.fromList $ newState) row
 
-rowToHistories :: IORef Globals -> ABIID -> Action -> [Action] -> Contract -> ContractDetails -> [(Text, Value)] -> Bloc ([ProcessedContract], [ProcessedContract])
+rowToHistories :: IORef Globals -> ABIID -> AggregateAction -> [AggregateAction] -> Contract
+               -> ContractDetails -> [(Text, Value)]
+               -> Bloc ([ProcessedContract], [ProcessedContract])
 rowToHistories gref abiid row actions cont details oldState = do
   hist <- isHistoric gref $ actionCodeHash row
   second join . unzip <$> if not hist
@@ -323,14 +326,13 @@ rowToHistories gref abiid row actions cont details oldState = do
 
 -- Prioritizing with-source actions prevents the issue where updates to contracts
 -- at different addresses are lost because the schema has not been seen yet.
-withSourceFirst :: (a, [Action]) -> Down Bool
+withSourceFirst :: (a, [AggregateAction]) -> Down Bool
 withSourceFirst = Down . any (Map.member "src" . actionMetadata) . snd
 
-parseActions :: [B.ByteString] -> [((Address, Maybe ChainId), [Action])]
+parseActions :: [B.ByteString] -> [((Address, Maybe ChainId), [AggregateAction])]
 parseActions = sortOn withSourceFirst
              . splitActions
              . filter matters
-             . filter hasContract
              . concatMap (flatten . toAction . BL.fromStrict)
 
 processTheMessages :: BlocEnv -> PGConnection -> IORef Globals -> [B.ByteString] -> LoggingT IO ()

--- a/blockapps-haskell/slipstream/tests/ActionFidelitySpec.hs
+++ b/blockapps-haskell/slipstream/tests/ActionFidelitySpec.hs
@@ -18,7 +18,7 @@ import Blockchain.Strato.Model.SHA
 import Blockchain.SolidVM.Model
 import qualified Slipstream.Data.Action as SS
 
-convert :: BS.Action -> Either String SS.Action'
+convert :: BS.Action -> Either String SS.Action -- 🤔
 convert = eitherDecode . encode
 
 emptyEVMData :: BS.ActionData
@@ -104,15 +104,15 @@ spec = describe "Action conversions" $ do
          }
        }|]
 
-     eitherDecode (encode oldStyle) `shouldBe` Right (SS.Action'
-        { SS._blockHash = forceHash "53fe605019e925357f1077cf753b17384e56379fa4dca1064cbb5e956d76e32f"
-        , SS._blockTimestamp = posixSecondsToUTCTime 1550858759
-        , SS._blockNumber = 9
-        , SS._transactionHash = forceHash "3d5069c6b8f6e3922f8a98bef4f23c2d73794403172c12d6915d51ad47a9e827"
-        , SS._transactionChainId = Nothing
-        , SS._transactionSender = 0xc2191df3032cb8ee72e37ab6bbc4e83f92b9911c
+     eitherDecode (encode oldStyle) `shouldBe` Right (SS.Action
+        { SS._actionBlockHash = forceHash "53fe605019e925357f1077cf753b17384e56379fa4dca1064cbb5e956d76e32f"
+        , SS._actionBlockTimestamp = posixSecondsToUTCTime 1550858759
+        , SS._actionBlockNumber = 9
+        , SS._actionTransactionHash = forceHash "3d5069c6b8f6e3922f8a98bef4f23c2d73794403172c12d6915d51ad47a9e827"
+        , SS._actionTransactionChainId = Nothing
+        , SS._actionTransactionSender = 0xc2191df3032cb8ee72e37ab6bbc4e83f92b9911c
         , SS._actionData = M.singleton 0x2f6ff9d4a35c07f7b630fe1ce039bc45559b5fb6 $ SS.ActionData
-          { SS._storageDiffs = BS.ActionEVMDiff . M.fromList $
+          { SS._actionDataStorageDiffs = BS.ActionEVMDiff . M.fromList $
             [ (0, 0x5c703a07)
             , (1, 0x76696e5f305f300000000000000000000000000000000000000000000000000e)
             , (2, 0x73305f305f30000000000000000000000000000000000000000000000000000c)
@@ -120,17 +120,17 @@ spec = describe "Action conversions" $ do
             , (4, 0x73325f305f30000000000000000000000000000000000000000000000000000c)
             , (5, 0x73335f305f30000000000000000000000000000000000000000000000000000c)
             ]
-          , SS._codeHash = EVMCode $ forceHash "86bc2e2a375e6ea377ae90026248f472fbeaa1354ef4424f568d01f3a48ab5b9"
-          , SS._codeKind = EVM
-          , SS._callData = [SS.CallData
-            { SS._callType = SS.Create
-            , SS._sender = 0xc2191df3032cb8ee72e37ab6bbc4e83f92b9911c
-            , SS._owner = 0x2f6ff9d4a35c07f7b630fe1ce039bc45559b5fb6
-            , SS._gasPrice = 1
-            , SS._value = 0
-            , SS._input = ""
-            , SS._output = Just "\x60\x80\x60"
+          , SS._actionDataCodeHash = EVMCode $ forceHash "86bc2e2a375e6ea377ae90026248f472fbeaa1354ef4424f568d01f3a48ab5b9"
+          , SS._actionDataCodeKind = EVM
+          , SS._actionDataCallData = [SS.CallData
+            { SS._callDataType = SS.Create
+            , SS._callDataSender = 0xc2191df3032cb8ee72e37ab6bbc4e83f92b9911c
+            , SS._callDataOwner = 0x2f6ff9d4a35c07f7b630fe1ce039bc45559b5fb6
+            , SS._callDataGasPrice = 1
+            , SS._callDataValue = 0
+            , SS._callDataInput = ""
+            , SS._callDataOutput = Just "\x60\x80\x60"
             }]
           }
-        , SS._metadata = Just . M.fromList $ [("name", "Vehicle"), ("src", "contract Vehicle {}")]
+        , SS._actionMetadata = Just . M.fromList $ [("name", "Vehicle"), ("src", "contract Vehicle {}")]
       })

--- a/tests/e2e/slipstream.test.js
+++ b/tests/e2e/slipstream.test.js
@@ -62,4 +62,29 @@ contract Y {
     console.log(`indexX returned ${JSON.stringify(indexX, null, 2)}`);
     assert.equal(indexX[0].z, "7624", "z");
   }).timeout(config.timeout);
+
+
+  const Counter = `
+contract Z {
+  uint public count = 0;
+  function incr() public {
+    count++;
+  }
+}
+`;
+  it("Will index updates to a contract", async () => {
+    const [user, contract] = await upload("Z", Counter);
+    let indexZ = await co.wrap(rest.waitQuery)("Z", 1);
+    assert.equal(indexZ.length, 1, JSON.stringify(indexZ, null, 2));
+    console.log(`Initial index: ${JSON.stringify(indexZ, null, 2)}`);
+    let res = await co.wrap(rest.callMethod)(user, contract, "incr");
+    console.log(`Incr result 1: ${JSON.stringify(res, null, 2)}`);
+    indexZ = await co.wrap(rest.waitQuery)("Z?count=eq.1", 1);
+    console.log(`Second index: ${JSON.stringify(indexZ, null, 2)}`);
+    res = await co.wrap(rest.callMethod)(user, contract, "incr");
+    console.log(`Incr result 2: ${JSON.stringify(res, null, 2)}`);
+    indexZ = await co.wrap(rest.waitQuery)("Z?count=eq.2", 1);
+    console.log(`Last index: ${JSON.stringify(indexZ, null, 2)}`);
+  }).timeout(config.timeout);
+
 });


### PR DESCRIPTION
What was previous Slipstream's Action is renamed to AggregateAction, but there might be a better choice for it. The accessors could be confusing as they still overlap with the Strato lenses, but the alternative I first thought of (aaCodeHash) was worse.

https://jenkins.blockapps.net/job/STRATO_test/1496/