### PR TITLE
Revert to a StateT based partitionWith

### DIFF
--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Users.hs
@@ -902,4 +902,4 @@ data FunctionListParameters = FunctionListParameters
   , txs      :: [MethodCall]
   , chainId  :: Maybe ChainId
   , resolve  :: Bool
-  }
+  } deriving (Show, Eq)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
@@ -15,10 +15,9 @@ module BlockApps.Bloc22.Server.Utils
 import           Control.Monad                    (forM)
 import           Control.Monad.Trans.State.Strict
 import qualified Data.ByteString.Base16           as BS16
-import           Data.Foldable                    (toList)
+import           Data.Functor.Identity
 import qualified Data.Map.Strict                  as Map
 import           Data.Maybe
-import qualified Data.Sequence                    as Q
 import qualified Data.Text                        as Text
 import qualified Data.Text.Encoding               as Text
 
@@ -58,8 +57,9 @@ binRuntimeToCodeHash = keccak256 . fst . BS16.decode . Text.encodeUtf8
 accumStateT :: Monad m => s -> [a] -> (a -> StateT s m b) -> m [b]
 accumStateT s as f = evalStateT (mapM f as) s
 
-partitionWith :: Ord k => (a -> k) -> [a] -> [(k,[a])]
-partitionWith f = Map.toList
-                . Map.map toList
-                . Map.fromListWith (<>)
-                . map (\a -> (f a, Q.singleton a))
+buildStateT :: Monad m => s -> [a] -> (a -> StateT s m ()) -> m s
+buildStateT s as f = execStateT (mapM_ f as) s
+
+partitionWith :: Ord k => (a -> k) -> [a] -> [(k, [a])]
+partitionWith f as = Map.toList . fmap reverse . runIdentity . buildStateT Map.empty as $ \a ->
+  modify $ Map.alter (Just . (a:) . fromMaybe []) (f a)

--- a/blockapps-haskell/bloc/bloc22/server/test/Spec.hs
+++ b/blockapps-haskell/bloc/bloc22/server/test/Spec.hs
@@ -5,7 +5,9 @@ module Main where
 import           Test.Hspec
 
 import qualified Database.Spec as DB
+import qualified UtilsSpec as US
 
 main :: IO ()
 main = hspec $ do
   DB.spec
+  US.spec

--- a/blockapps-haskell/bloc/bloc22/server/test/UtilsSpec.hs
+++ b/blockapps-haskell/bloc/bloc22/server/test/UtilsSpec.hs
@@ -1,0 +1,13 @@
+module UtilsSpec where
+
+import Test.Hspec
+
+import BlockApps.Bloc22.Server.Utils
+
+spec :: Spec
+spec = describe "Utils" $ do
+  it "should be stable on values" $ do
+    let input = [(1, 2), (1, 4)] :: [(Int, Int)]
+        output = [(1, [(1, 2), (1, 4)])] :: [(Int, [(Int, Int)])]
+    partitionWith fst input `shouldBe` output
+


### PR DESCRIPTION
The version using Map.fromListWith suffered from an ambiguity in the order
of <>, leading to reversing the order of the txs once partitioned