### PR TITLE
Switch to a stretch based apex image

### DIFF
--- a/apex/api/Dockerfile
+++ b/apex/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9-slim
+FROM node:9-stretch
 
 RUN apt-get update && \
     mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \


### PR DESCRIPTION
Jessie has been discontinued, which is what 9-slim was based on.
This caused failures when the apt-get update step had to run:
```
 ---> Running in 865b78a75d28

Get:1 http://security.debian.org jessie/updates InRelease [44.9 kB]

Ign http://deb.debian.org jessie InRelease

Ign http://deb.debian.org jessie-updates InRelease

Get:2 http://deb.debian.org jessie Release.gpg [2420 B]

Ign http://deb.debian.org jessie-updates Release.gpg

Get:3 http://deb.debian.org jessie Release [148 kB]

Ign http://deb.debian.org jessie-updates Release

Err http://deb.debian.org jessie-updates/main amd64 Packages

  

Err http://deb.debian.org jessie-updates/main amd64 Packages

  

Err http://deb.debian.org jessie-updates/main amd64 Packages

  

Err http://deb.debian.org jessie-updates/main amd64 Packages

  

Err http://deb.debian.org jessie-updates/main amd64 Packages

  404  Not Found

Get:4 http://security.debian.org jessie/updates/main amd64 Packages [822 kB]

Get:5 http://deb.debian.org jessie/main amd64 Packages [9098 kB]

Fetched 10.1 MB in 7s (1442 kB/s)

W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found
```