### PR TITLE
Prefer txparams from tx when available

### DIFF
--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -156,6 +156,7 @@ pipeline {
               npm run test:truchainz
               npm run test:multicontract
               npm run test:solidvm
+              npm run test:uploadOrder
               popd
               pushd strato-worktree/core-strato/strato-init
               ./check_genesis_ingestion.sh

--- a/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/api/src/BlockApps/Bloc22/API/Users.hs
@@ -708,7 +708,7 @@ data TransferListParameters = TransferListParameters
   , txs      :: [SendTransaction]
   , chainId  :: Maybe ChainId
   , resolve  :: Bool
-  }
+  } deriving (Show, Eq)
 
 --------------------------------------------------------------------------------
 

--- a/blockapps-haskell/bloc/bloc22/server/package.yaml
+++ b/blockapps-haskell/bloc/bloc22/server/package.yaml
@@ -31,6 +31,7 @@ dependencies:
   - contravariant
   - cryptonite
   - directory
+  - extra
   - filepath
   - bytestring
   - base16-bytestring

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -14,10 +14,12 @@ import           Control.Concurrent
 import           Control.Concurrent.Async.Lifted
 import           Control.Arrow
 import           Control.Exception.Lifted          (catch)
-import           Control.Lens                      ((<?=), at, use)
+import           Control.Lens                      ((<?=), at, use, uses, (+=))
 import           Control.Lens.TH
+import           Control.Lens.Tuple                (_1, _2)
 import           Control.Monad
 import           Control.Monad.Except
+import           Control.Monad.Extra
 import           Control.Monad.Log
 import           Control.Monad.Reader
 import           Control.Monad.Trans.State.Lazy    (StateT(..), runStateT)
@@ -38,6 +40,7 @@ import qualified Data.Map.Ordered                  as OMap
 import           Data.Maybe
 import           Data.RLP
 import           Data.Set                          (isSubsetOf)
+import qualified Data.Set                          as S
 import           Data.Text                         (Text)
 import qualified Data.Text                         as Text
 import qualified Data.Text.Encoding                as Text
@@ -302,7 +305,7 @@ postUsersContractSolidVM' ContractParameters{..} sign = blocTransaction $ do
   (_, argsAsSource) <- constructArgValuesAndSource (fmap (fmap argValueToText) args) xabiArgs
 
   let metadata' = Just $ fromMaybe Map.empty metadata `Map.union` Map.fromList [("name", cName), ("args", argsAsSource)]
-  
+
   tx <- signAndPrepare sign fromAddr metadata' $
     TransactionHeader
       Nothing
@@ -314,7 +317,7 @@ postUsersContractSolidVM' ContractParameters{..} sign = blocTransaction $ do
       chainId
   logWith logNotice ("tx is: " <> Text.pack (show tx))
   hash <- blocStrato $ postTx tx
-  void . blocModify $ \conn -> runInsertMany conn hashNameTable [  
+  void . blocModify $ \conn -> runInsertMany conn hashNameTable [
     ( Nothing
     , constant hash
     , constant cmId
@@ -355,7 +358,7 @@ postUsersUploadList' ContractListParameters{..} sign = do
               at name <?= (b, src, cmId', x)
           let xabiArgs = maybe Map.empty funcArgs $ xabiConstr xabi
           argsBin <- lift $ constructArgValues (Just (fmap argValueToText args)) xabiArgs
-          let metadata' = Just $ fromMaybe Map.empty md `Map.union`Map.fromList [("src",src),("name",name)]
+          let metadata' = Just $ fromMaybe Map.empty md `Map.union` Map.fromList [("src",src),("name",name)]
           tx <- lift . signAndPrepare sign fromAddr metadata' $
               TransactionHeader
                 Nothing
@@ -454,11 +457,23 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
   if null txs
     then return []
     else do
-      let mc = head txs
-      params <- getAccountTxParams fromAddr chainId $ methodcallTxParams mc
-      txsCmIdsFuncNames <- fmap fst . forStateT Map.empty (zip txs [0..]) $
-        \ (MethodCall{..},nonceIncr) -> do
-          mtuple <- use $ at methodcallContractName
+      let noncesInUse = S.fromList . mapMaybe (txparamsNonce <=< methodcallTxParams) $ txs
+      nonce <- if S.size noncesInUse == length txs
+                  then return . Nonce . error $ "internal error: unused nonce when already specified" ++ show txs
+                  else getAccountNonce fromAddr chainId
+      txsCmIdsFuncNames <- fmap fst . forStateT (Map.empty, nonce) txs $
+        \(MethodCall{..}) -> do
+          let params' = fromMaybe emptyTxParams methodcallTxParams
+          newNonce <- case txparamsNonce params' of
+            Nothing -> do
+              whileM $ do
+                inUse <- uses _2 (`S.member` noncesInUse)
+                when inUse $ _2 += 1
+                return inUse
+              use _2
+            Just v -> return v
+          let params = params'{txparamsNonce = Just newNonce }
+          mtuple <- use $ _1 . at methodcallContractName
           (mapKey, xabi) <- case mtuple of
             Just (cmId, x) -> return (cmId, x)
             Nothing -> do
@@ -466,7 +481,7 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
                 (_,_,_,_,_,_,cmId,x'') <- getContractsContractLatestQuery methodcallContractName -< ()
                 returnA -< (cmId,x'')
               x <- lift $ deserializeXabi x'
-              at methodcallContractName <?= (mapKey', x)
+              _1 . at methodcallContractName <?= (mapKey', x)
           contract' <- case xAbiToContract xabi of
             Left err -> throwError . AnError $ Text.pack err
             Right c -> return c
@@ -490,7 +505,7 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
               params
               (Wei (fromIntegral $ unStrung methodcallValue))
               (sel <> argsBin)
-              nonceIncr
+              0 -- Nonce specified directly in params
               chainId
           -- resultXabiTypes <- getXabiFunctionsReturnValuesQuery functionId
           return (tx,mapKey,methodcallMethodName)
@@ -560,7 +575,7 @@ postUsersContractMethod' FunctionParameters{..} sign = do
 
     let maybeFunc = OMap.lookup funcName (fields $ C.mainStruct contract')
         xabiArgs = maybe Map.empty funcArgs . Map.lookup funcName $ xabiFuncs xabi
-        
+
     sel <-
       case maybeFunc of
        Just (_, TypeFunction selector _ _) -> return selector
@@ -571,7 +586,7 @@ postUsersContractMethod' FunctionParameters{..} sign = do
           Map.insert "funcName" funcName
           $ Map.insert "args" argsAsSource
           $ fromMaybe Map.empty metadata
-   
+
     tx <- signAndPrepare sign fromAddr (Just metadataWithCallInfo) $
       TransactionHeader
         (Just contractAddr)
@@ -798,7 +813,7 @@ getArgValues argsMap argNamesTypes = do
         throwError (UserError ("argument names don't match: " <> argNames1 <> " " <> argNames2))
       else sequence $ Map.intersectionWith determineValue argsMap argNamesTypes
     return $ map snd (sortOn fst (toList argsVals))
-  
+
 constructArgValues :: Maybe (Map Text Text) -> Map Text Xabi.IndexedType -> Bloc ByteString
 constructArgValues args argNamesTypes = do
     case args of
@@ -827,21 +842,23 @@ constructArgValuesAndSource args argNamesTypes = do
           )
 
 getAccountTxParams :: Address -> Maybe ChainId -> Maybe TxParams -> Bloc TxParams
-getAccountTxParams addr chainId = \case
-  Nothing -> getAcctNonce >>= \n -> return emptyTxParams{txparamsNonce = Just n}
-  Just params@TxParams{..} ->
-    case txparamsNonce of
-      Just _ -> return params
-      Nothing -> getAcctNonce >>= \n -> return params{txparamsNonce = Just n}
-  where
-    getAcctNonce = do
-      let params = accountsFilterParams{qaAddress = Just addr, qaChainId = chainId}
-      accts <- blocStrato $ getAccountsFilter params
-      logWith logNotice $ "getAccountNonce req: " <> Text.pack (show params)
-      logWith logNotice $ "getAccountNonce resp: " <> Text.pack (show accts)
-      case listToMaybe accts of
-        Nothing   -> throwError . UserError $ "User does not have a balance"
-        Just acct -> return $ accountNonce acct
+getAccountTxParams addr chainId mTxParams = do
+  let params = fromMaybe emptyTxParams mTxParams
+  case txparamsNonce params of
+    Nothing -> do
+      n <- getAccountNonce addr chainId
+      return params{txparamsNonce = Just n}
+    Just{} -> return params
+
+getAccountNonce :: Address -> Maybe ChainId -> Bloc Nonce
+getAccountNonce addr chainId = do
+  let params = accountsFilterParams{qaAddress = Just addr, qaChainId = chainId}
+  accts <- blocStrato $ getAccountsFilter params
+  logWith logNotice $ "getAccountNonce req: " <> Text.pack (show params)
+  logWith logNotice $ "getAccountNonce resp: " <> Text.pack (show accts)
+  case listToMaybe accts of
+    Nothing   -> throwError . UserError $ "User does not have a balance"
+    Just acct -> return $ accountNonce acct
 
 getAccountSecKey :: UserName -> Password -> Address -> Bloc SecKey
 getAccountSecKey userName password addr = do

--- a/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
+++ b/blockapps-haskell/ethereum/src/BlockApps/Ethereum.hs
@@ -1,7 +1,9 @@
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 {-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLists       #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -232,7 +234,8 @@ deriveAddress = keccak256Address . ByteString.drop 1 . exportPubKey False
 --------------------------------------------------------------------------------
 
 newtype ChainId = ChainId { unChainId :: Word256 }
-  deriving (Eq, Ord, Generic, Bounded, NFData, Binary.Binary)
+  deriving (Eq, Ord, Generic, Bounded)
+  deriving anyclass (NFData, Binary.Binary)
 
 instance Show ChainId where show = chainIdString
 
@@ -318,7 +321,8 @@ newSecKey = fromMaybe err . secKey <$> getEntropy 32
 --------------------------------------------------------------------------------
 
 newtype Keccak256 = Keccak256 { digestKeccak256 :: Digest Keccak_256 }
-  deriving (Eq,Ord,Show,Generic, NFData)
+  deriving (Eq,Ord,Show,Generic)
+  deriving anyclass (NFData)
 
 keccak256SHA :: Keccak256 -> SHA
 keccak256SHA = SHA . bytesToWord256 . ByteArray.convert . digestKeccak256
@@ -617,7 +621,10 @@ data BlockHeader = BlockHeader
   , blockHeaderChainId          :: Maybe Word256
   } deriving (Eq,Show,Generic)
 
-newtype Nonce = Nonce Word256 deriving (Eq,Show,Generic, NFData)
+newtype Nonce = Nonce Word256
+               deriving (Eq, Show, Generic)
+               deriving newtype (Num, Ord)
+               deriving anyclass (NFData)
 
 instance ToJSON Nonce where
   toJSON (Nonce n) = toJSON $ toInteger n
@@ -645,7 +652,9 @@ instance RLPEncodable Nonce where
 incrNonce :: Nonce -> Nonce
 incrNonce (Nonce n) = Nonce (n+1)
 
-newtype Wei = Wei Word256 deriving (Eq,Show,Generic, NFData)
+newtype Wei = Wei Word256
+  deriving (Eq,Show,Generic)
+  deriving anyclass (NFData)
 
 -- --TODO- this might be unsafe, since it could lead to an overflow.  A Word256 * 10^18 certainly can be much higer than a Word256
 -- eth::Word256->Wei
@@ -674,7 +683,9 @@ instance RLPEncodable Wei where
   rlpEncode (Wei n) = rlpEncode $ toInteger n
   rlpDecode obj = Wei . fromInteger <$> rlpDecode obj
 
-newtype Gas = Gas Integer deriving (Eq,Show,Generic,NFData)
+newtype Gas = Gas Integer
+  deriving (Eq,Show,Generic)
+  deriving anyclass (NFData)
 
 instance Arbitrary Gas where arbitrary = Gas <$> arbitrary
 

--- a/tests/e2e/uploadOrder.test.js
+++ b/tests/e2e/uploadOrder.test.js
@@ -1,0 +1,71 @@
+"use strict";
+const ba = require('blockapps-rest');
+const co = require('co');
+const config = ba.common.config;
+const rest = ba.rest6;
+const assert = ba.common.assert;
+const util = ba.common.util;
+config.apiDebug=true;
+const nonceOrder = `
+contract NonceOrder {
+    uint a = 0;
+    uint b = 0;
+
+    function set(uint _x) public {
+      if (a == 0) {
+        a = _x;
+        return;
+      }
+      b = _x;
+    }
+
+    function get() public returns (uint, uint) {
+      return (a, b);
+    }
+}
+`;
+
+
+async function upload() {
+  const username = 'NonceOrder_User_' + util.uid();
+  const password = '23456';
+  const user = await co.wrap(rest.createUser)(username, password);
+  await co.wrap(rest.fill)(user, true);
+  console.log(`User ${user.name}@${user.address} uploading a NonceOrder`);
+  return [user, await co.wrap(rest.uploadContractString)(user, 'NonceOrder', nonceOrder)];
+}
+
+async function set(user, contract, xs) {
+  let { nonce } = await co.wrap(rest.getNonce)(user);
+  nonce += xs.length;
+  // Set nonces in reverse list order
+  const txs = xs.map(x => {
+    nonce--;
+    console.log(`nonce is ${nonce}`);
+    return {
+      contractName: contract.name,
+      contractAddress: contract.address,
+      methodName: 'set',
+      value: 0,
+      args: {'_x': x},
+      txParams: { nonce }
+    }});
+  console.log(`Txs: ${JSON.stringify(txs, null, 2)}`);
+  return await co.wrap(rest.callList)(user, txs);
+}
+
+async function get(user, contract) {
+  return await co.wrap(rest.callMethod)(user, contract, "get");
+}
+
+describe('Nonce upload orders', async () => {
+
+  it ('will respect the nonce provided on each tx', async () => {
+    const [user, contract] = await upload();
+    console.log(`Setting 4, then setting 300`);
+    await set(user, contract, [4, 300]);
+    console.log(`Checking our work`);
+    const results = await get(user, contract);
+    assert.deepEqual(results, ["300", "4"]);
+  }).timeout(config.timeout);
+})

--- a/tests/package.json
+++ b/tests/package.json
@@ -13,7 +13,8 @@
     "test:upload": "mocha load/uploadString.test.js --batchCount 10 --batchSize 10 && mocha load/uploadUniqueAddresses.test.js --batchCount 10 --batchSize 10",
     "test:upload10k": "mocha load/uploadString.test.js --batchCount 100 --batchSize 100",
     "test:truchainz": "mocha e2e/createChain.test.js && mocha e2e/governance.test.js",
-    "test:multicontract": "mocha e2e/multicontract.test.js"
+    "test:multicontract": "mocha e2e/multicontract.test.js",
+    "test:uploadOrder": "mocha e2e/uploadOrder.test.js"
   },
   "dependencies": {
     "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#6fe2bc46dadb5e5af1a6027ddf5fb52492fa2c4f",


### PR DESCRIPTION
This makes calllist more robust to reordering of the transaction list, and prevents
unsurprising behavior when the txparams set in blockapps-rest are ignored.
sendlist and uploadlist were not changed because they are commutative already
unless the uploader is precalculating the upload addresses for concurrent
txs.

https://jenkins.blockapps.net/job/STRATO_test/1507/
https://blockapps.atlassian.net/browse/STRATO-1375