### PR TITLE
remove "fixed" post action in test jenkins pipeline

### DIFF
--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -200,17 +200,5 @@ pipeline {
         }
       }
     }
-
-    fixed {
-      script {
-        if (env.PLATFORM_BRANCH_NAME == 'develop') {
-          slackSend(
-              channel: '#engineering',
-              color: 'good',
-              message: "Develop branch build *is fixed after it was failing*: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL} on node ${env.NODE_NAME})"
-          )
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
the jenkins job with branch name specified as build parameter is unable to properly trigger "fixed" status for just 'develop' branch