### PR TITLE
Increment nonce after assignment

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -14,7 +14,7 @@ import           Control.Concurrent
 import           Control.Concurrent.Async.Lifted
 import           Control.Arrow
 import           Control.Exception.Lifted          (catch)
-import           Control.Lens                      ((<?=), at, use, uses, (+=))
+import           Control.Lens                      ((<?=), at, use, uses, (+=), (<<+=))
 import           Control.Lens.TH
 import           Control.Lens.Tuple                (_1, _2)
 import           Control.Monad
@@ -470,8 +470,9 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
                 inUse <- uses _2 (`S.member` noncesInUse)
                 when inUse $ _2 += 1
                 return inUse
-              use _2
+              _2 <<+= 1
             Just v -> return v
+
           let params = params'{txparamsNonce = Just newNonce }
           mtuple <- use $ _1 . at methodcallContractName
           (mapKey, xabi) <- case mtuple of

--- a/tests/e2e/uploadOrder.test.js
+++ b/tests/e2e/uploadOrder.test.js
@@ -54,6 +54,19 @@ async function set(user, contract, xs) {
   return await co.wrap(rest.callList)(user, txs);
 }
 
+async function setNoNonces(user, contract, xs) {
+  const txs = xs.map(x => {
+    return {
+      contractName: contract.name,
+      contractAddress: contract.address,
+      methodName: 'set',
+      value: 0,
+      args: {'_x': x}
+    }});
+  console.log(`Txs: ${JSON.stringify(txs, null, 2)}`);
+  return await co.wrap(rest.callList)(user, txs);
+}
+
 async function get(user, contract) {
   return await co.wrap(rest.callMethod)(user, contract, "get");
 }
@@ -62,10 +75,19 @@ describe('Nonce upload orders', async () => {
 
   it ('will respect the nonce provided on each tx', async () => {
     const [user, contract] = await upload();
-    console.log(`Setting 4, then setting 300`);
+    console.log(`Setting 300, then 4`);
     await set(user, contract, [4, 300]);
     console.log(`Checking our work`);
     const results = await get(user, contract);
     assert.deepEqual(results, ["300", "4"]);
+  }).timeout(config.timeout);
+
+  it ("won't collide nonces when none are provided", async () => {
+    const [user, contract] = await upload();
+    console.log(`Setting 4, then 300`);
+    await setNoNonces(user, contract, [4, 300]);
+    console.log(`Checking our work`);
+    const results = await get(user, contract);
+    assert.deepEqual(results, ["4", "300"]);
   }).timeout(config.timeout);
 })


### PR DESCRIPTION
The previous PR (https://github.com/blockapps/strato-platform/pull/693/files) introduced a regression, because it only had tests for calllist with supplied nonces and not without. When they were not supplied, the nonce in StateT was never incremented.