### PR TITLE
Revert the ordering of detailsForRow

### DIFF
--- a/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
@@ -205,12 +205,7 @@ createIndexTable globalsIORef contract = do
       contractAlreadyCreated = hashVal `Set.member` createdContracts globals
 
   --When contract hasn't been written to "contract" table and indexing table doesn't exist
-  $logDebugLS "createIndexTable" $
-    T.intercalate " " [ "In createIndexTable,"
-                      , tshow hashVal
-                      , "contractAlreadyCreated ="
-                      , tshow contractAlreadyCreated
-                      ]
+  $logDebugLS "createIndexTable/contractAlreadyCreated" (hashVal, contractAlreadyCreated)
   unless contractAlreadyCreated $ do
     incNumTables
     yield $ insertContractTableQuery contract

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -12,7 +12,10 @@
     , TupleSections
 #-}
 
-module Slipstream.Processor (processTheMessages) where
+module Slipstream.Processor
+  ( processTheMessages
+  , parseActions -- For testing
+  ) where
 
 import Control.Arrow ((&&&))
 import Control.Applicative
@@ -29,7 +32,7 @@ import Data.Either (lefts, rights)
 import Data.Int (Int32)
 import Data.IORef
 import Data.Function
-import Data.List (sortBy)
+import Data.List (sortOn)
 import qualified Data.Map.Ordered as OMap
 import qualified Data.Map as Map
 import Data.Monoid ((<>))
@@ -244,13 +247,13 @@ getCachedSolidVMDetails g row = liftM2 (<|>)
 
 detailsForRow :: Action -> Bloc (Maybe (Int32, ContractDetails))
 detailsForRow row = liftM2 (<|>)
+  (getContractDetailsByCodeHash . shaKeccak256 . codePtrToSHA $ actionCodeHash row)
   (runMaybeT $ do
     let md = actionMetadata row
     src <- lookupT "src" md
     name <- lookupT "name" md
     detailsMap <- lift $ sourceToContractDetails True src
     lookupT name detailsMap)
-  (getContractDetailsByCodeHash . shaKeccak256 . codePtrToSHA $ actionCodeHash row)
 
 adjustGlobals :: IORef Globals -> Action -> ContractDetails -> Bloc ()
 adjustGlobals gref row details = do
@@ -324,15 +327,17 @@ rowToHistories gref abiid row actions cont details oldState = do
 withSourceFirst :: (a, [Action]) -> Down Bool
 withSourceFirst = Down . any (Map.member "src" . actionMetadata) . snd
 
+parseActions :: [B.ByteString] -> [((Address, Maybe ChainId), [Action])]
+parseActions = sortOn withSourceFirst
+             . splitActions
+             . filter matters
+             . filter hasContract
+             . concatMap (flatten . toAction . BL.fromStrict)
+
 processTheMessages :: BlocEnv -> PGConnection -> IORef Globals -> [B.ByteString] -> LoggingT IO ()
 processTheMessages env conn g messages = do
 
-  let changes = sortBy (compare `on` withSourceFirst)
-              . splitActions
-              . filter matters
-              . filter hasContract
-              . join
-              $ map (flatten . toAction . BL.fromStrict) messages
+  let changes = parseActions messages
 
   unless (null messages) $
     $logDebugS "processTheMessages" . T.pack . unlines . map show $ messages
@@ -365,7 +370,6 @@ processTheMessages env conn g messages = do
                     , aiChain = maybe "" (T.pack . chainIdString) $ actionTxChainId row
                     }
                   cont = either error id . xAbiToContract $ contractdetailsXabi details
-
               adjustGlobals g row details
 
               ensureContractInstance cmId row

--- a/blockapps-haskell/slipstream/tests/ProcessorSpec.hs
+++ b/blockapps-haskell/slipstream/tests/ProcessorSpec.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module ProcessorSpec where
+
+import qualified Data.ByteString as B
+import Test.Hspec
+import Text.RawString.QQ
+
+import BlockApps.Ethereum
+import Slipstream.Processor
+
+messageToSplit :: B.ByteString
+messageToSplit = [r|
+{
+  "chainId": null,
+  "data": {
+    "95b0195a59bdb49db4c8ffacbd93dc67857fbe82": {
+      "diff": {
+        "0000000000000000000000000000000000000000000000000000000000000000": "0000000000000000000000000000000000000000000000000000000000001dc8"
+      },
+      "data": [
+        {
+          "gasPrice": 1,
+          "sender": "eb6b5070bad6eb2efec046fb00179395ee308608",
+          "value": 0,
+          "input": "",
+          "owner": "95b0195a59bdb49db4c8ffacbd93dc67857fbe82",
+          "output": "608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063c5d7802e146044575b600080fd5b348015604f57600080fd5b506056606c565b6040518082815260200191505060405180910390f35b600054815600a165627a7a72305820639e7d28b71a1ef617bf71da6ad97c06640d12a4d4778298c9d027fdf29cc1c00029",
+          "type": "Create"
+        }
+      ],
+      "codeHash": {
+        "kind": "EVM",
+        "digest": "794bb2542a58e85323a2d871316b5b2ce24fd089d22ab6e1ab3608927ea7b189"
+      },
+      "codeKind": "EVM"
+    },
+    "eb6b5070bad6eb2efec046fb00179395ee308608": {
+      "diff": {
+        "0000000000000000000000000000000000000000000000000000000000000000": "00000000000000000000000095b0195a59bdb49db4c8ffacbd93dc67857fbe82"
+      },
+      "data": [
+        {
+          "gasPrice": 1,
+          "sender": "d18abf689702c2c4b00ca666fd2e38f87d4944e9",
+          "value": 0,
+          "input": "",
+          "owner": "eb6b5070bad6eb2efec046fb00179395ee308608",
+          "output": "6080604052600080fd00a165627a7a7230582090e070e4b8b3df7093ff1a80d3cb4ba05124a560a39709332610169c318757e30029",
+          "type": "Create"
+        }
+      ],
+      "codeHash": {
+        "kind": "EVM",
+        "digest": "2d04e92a4bf8c25d551bbc54cf020e4396c99f14c1d4f3f7cd18788cca84fb11"
+      },
+      "codeKind": "EVM"
+    }
+  },
+  "sender": "d18abf689702c2c4b00ca666fd2e38f87d4944e9",
+  "blockHash": "1c3347ba8d9ccd9279df945107abc9385f16d31f6671cfc744234d504d517df7",
+  "transactionHash": "c4a10600b73d11db293d047f7b3c8cf6bd4d5b37e581134f09eaa02bb4071943",
+  "blockTimestamp": "2019-04-11T14:40:59Z",
+  "blockNumber": 3,
+  "metadata": {
+    "name": "Y",
+    "src": "\ncontract X {\n  uint public z = 7624;\n}\n\ncontract Y {\n  X x;\n  constructor() public {\n    x = new X();\n  }\n}\n"
+  }
+}
+|]
+
+spec :: Spec
+spec = do
+
+  it "can create multiple actions from a single message" $ do
+    -- The ActionDatas have different codehashes, and so should be processed indepedently
+    map fst (parseActions [messageToSplit]) `shouldBe`
+      [ (Address 0x95b0195a59bdb49db4c8ffacbd93dc67857fbe82, Nothing)
+      , (Address 0xeb6b5070bad6eb2efec046fb00179395ee308608, Nothing)]

--- a/tests/e2e/slipstream.test.js
+++ b/tests/e2e/slipstream.test.js
@@ -42,4 +42,24 @@ contract StringArray {
 
   }).timeout(config.timeout);
 
+  const newContract = `
+contract X {
+  uint public z = 7624;
+}
+
+contract Y {
+  X x;
+  constructor() public {
+    x = new X();
+  }
+}
+`;
+  it("can index contracts recursively constructed", async () => {
+    const [user, contract] = await upload("Y", newContract);
+    const indexY = await co.wrap(rest.waitQuery)("Y", 1);
+    assert.equal(indexY.length, 1, JSON.stringify(indexY, null, 2));
+    const indexX = await co.wrap(rest.waitQuery)("X", 1);
+    console.log(`indexX returned ${JSON.stringify(indexX, null, 2)}`);
+    assert.equal(indexX[0].z, "7624", "z");
+  }).timeout(config.timeout);
 });


### PR DESCRIPTION
I had misunderstood the original implementation, and thought that
if the source is present, it should be compiled and inserted. What
happens instead with the current ordering is that multiple ActionDatas
share a metadata, and so if contract `Y` calls `new X()` both of them
are labeled as `Y`s. In hindsight, it should have been obvious that
it should have been structurally similar to `getCachedSolidVMDetails`.

This change includes one test that actually discriminates on this
problem (in slipstream.test.js) and one test from a dead end of
my investigations (ProcessorSpec.hs).