### PR TITLE
Change OutputBlock ordering from totalDifficulty to blockNumber

### DIFF
--- a/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -425,7 +425,7 @@ instance BlockLike DD.BlockData OutputTx OutputBlock where
     blockTransactions = obReceiptTransactions
     blockUncleHeaders = obBlockUncles
 
-    blockOrdering = obTotalDifficulty
+    blockOrdering = DD.blockDataNumber . obBlockData
     buildBlock = OutputBlock TO.Morphism 0
 
 derive makeArbitrary ''IngestEvent


### PR DESCRIPTION
Using totalDifficulty as a function for block ordering is fine with PoW, but does not work for PBFT. This is causing private chain syncing to not work properly on multinode PBFT. However, using block number fixes the problem