### PR TITLE
Don't Faucet from validator in late arrival

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -92,6 +92,9 @@ function newnode {
   echo ${blockstanbulAdmins}
   if [ -n "${blockstanbulSkipCheck}" ]; then
     scFlag="--blockstanbul_skip_check=${blockstanbulSkipCheck}"
+    apiKey=
+  else
+    apiKey="${blockstanbulPrivateKey:-}"
   fi
 
   NODEKEY=${blockstanbulPrivateKey:-} runBackgroundProcess strato-sequencer \
@@ -117,7 +120,7 @@ function newnode {
                          "${tbFlag}" +RTS "${vmRunnerRTSOPTs:-}" -N1 >> logs/vm-runner 2>&1
 
   echo "Starting strato-api"
-  HOST=0.0.0.0 PORT=3000 APPROOT="" FETCH_LIMIT=2000 NODEKEY=${blockstanbulPrivateKey:-} \
+  HOST=0.0.0.0 PORT=3000 APPROOT="" FETCH_LIMIT=2000 NODEKEY=$apiKey \
     runBackgroundProcess strato-api +RTS -N1 >> logs/strato-api 2>&1
 
   echo "Configuring log maintenance"


### PR DESCRIPTION
When an address is voted in, it won't have a balance from the genesis
block. Leaving it as the faucet address would break fauceting from that
node.