### PR TITLE
better docker-compose logging in pipelines

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -58,8 +58,8 @@ pipeline {
           }
           check_bloc
           echo "Restarting docker containers to simulate computer restart..."
-          docker-compose -p strato stop
-          docker-compose -p strato start
+          docker-compose -p strato --log-level ERROR stop
+          docker-compose -p strato --log-level ERROR start
           check_bloc
         '''
       }
@@ -78,7 +78,7 @@ pipeline {
                 set -x
                 docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
                 cd strato-worktree
-                docker-compose -f docker-compose.push.yml push
+                docker-compose --log-level ERROR -f docker-compose.push.yml push 2>&1
               '''
             }
           },

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -149,7 +149,7 @@ pipeline {
               cd strato-worktree
               RELEASE_VERSION=$(<VERSION)
               docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
-              docker-compose -f docker-compose.push.yml push
+              docker-compose --log-level ERROR -f docker-compose.push.yml push 2>&1
 
               # Release to strato-getting-started
               STRATOGS_RELEASE_DETAILS_STABLE="--user blockapps --repo strato-getting-started --tag ${RELEASE_VERSION}"

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -72,8 +72,8 @@ pipeline {
           }
           check_bloc
           echo "Restarting docker containers to simulate computer restart..."
-          docker-compose -p strato stop
-          docker-compose -p strato start
+          docker-compose -p strato --log-level ERROR stop
+          docker-compose -p strato --log-level ERROR start
           check_bloc
         '''
       }
@@ -92,7 +92,7 @@ pipeline {
                 set -x
                 docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
                 cd strato-worktree
-                docker-compose -f docker-compose.push.yml push
+                docker-compose --log-level ERROR -f docker-compose.push.yml push 2>&1
               '''
             }
           },


### PR DESCRIPTION
I found out that docker-compose does not expose the stderr logs to jenkins pipeline so it's hard to investigate the docker-compose push issue