### PR TITLE
runResourceT in a more useful place

### DIFF
--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -12,6 +12,7 @@ module Blockchain.CommunicationConduit
     ) where
 
 import           Blockchain.Output
+import           Control.Monad.IO.Unlift
 import           Control.Monad.State
 import           Control.Monad.Trans.Resource
 import           Crypto.Types.PubKey.ECC
@@ -21,10 +22,12 @@ import           Data.Conduit
 import qualified Data.Conduit.Binary                   as CB
 import qualified Data.Conduit.List                     as CL
 import           Data.Conduit.Network
-import           Data.Conduit.TMChan
+import           Data.Conduit.TQueue
 import           Data.Maybe
 import qualified Data.Text                             as T
+import           Data.Void
 import           UnliftIO.Exception
+import           UnliftIO.STM
 
 import           Network.Kafka                         as K
 
@@ -39,6 +42,7 @@ import           Blockchain.DB.SQLDB
 import           Blockchain.Display
 import           Blockchain.Event
 import           Blockchain.EventException
+import           Blockchain.ExtMergeSources
 import           Blockchain.Frame
 import           Blockchain.Metrics
 import           Blockchain.Options
@@ -66,7 +70,9 @@ mkEthP2PEventSource :: ( Monad m
                     -> K.KafkaState
                     -> [ConduitM () Event m ()]
                     -> m (ConduitM () Event m ())
-mkEthP2PEventSource app inCtx ks extra = (.| CL.iterM recordEvent) <$> mergeSources (
+mkEthP2PEventSource app inCtx ks extra = do
+  canarySource <- mkCanarySource
+  (.| CL.iterM recordEvent) <$> mergeSourcesByForce (
     [ appSource app
         .| ethDecrypt inCtx
         .| bytesToMessages
@@ -74,7 +80,18 @@ mkEthP2PEventSource app inCtx ks extra = (.| CL.iterM recordEvent) <$> mergeSour
         .| CL.map MsgEvt
     , seqEventNotificationSource ks
         .| CL.map NewSeqEvent
+    , canarySource .| CL.map absurd
     ] ++ extra) 4096 -- 🙏
+
+mkCanarySource :: (MonadLogger m, MonadUnliftIO m, MonadResource m) => m (ConduitM () Void m ())
+mkCanarySource = do
+  ender <- toIO $ $logInfoS "canary/exit" "" >> killCanary
+  void . register $ ender
+  q <- atomically newTQueue
+  $logInfoS "canary/enter" ""
+  addCanary
+  -- Wait forever on nothing
+  return $ sourceTQueue q
 
 mkEthP2PEventConduit :: (Monad m, MonadResource m, MonadLogger m)
                      => String

--- a/core-strato/strato-p2p/src/Blockchain/ExtMergeSources.hs
+++ b/core-strato/strato-p2p/src/Blockchain/ExtMergeSources.hs
@@ -21,7 +21,6 @@ import           UnliftIO.Concurrent
 import           UnliftIO.Exception
 import           UnliftIO.STM
 
-import           Blockchain.Metrics
 import           Blockchain.Output
 
 mergeSourcesByForce :: (MonadLogger mi, MonadResource mi, MonadUnliftIO mi, MonadIO mo)
@@ -33,9 +32,8 @@ mergeSourcesByForce sx bound = do
     (chkey, c) <- allocate (atomically $ newTBMChan bound) (atomically . closeTBMChan)
     st <- lift $ askUnliftIO
     regs <- forM sx $ \s -> do
-      register $ (\tid -> uncountFork >> killThread tid) =<< do
-        (liftIO $ forkWithUnmask $ \unmask -> do
-          countFork
+      register . killThread =<< do
+        (liftIO $ forkWithUnmask $ \unmask ->
           (unmask $ unliftIO st $
             runConduit $ s .| sinkTBMChan c)
           `finally` atomically (closeTBMChan c))

--- a/core-strato/strato-p2p/src/Blockchain/ExtMergeSources.hs
+++ b/core-strato/strato-p2p/src/Blockchain/ExtMergeSources.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Blockchain.ExtMergeSources (
+  mergeSourcesByForce
+  ) where
+
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Control.Monad.IO.Unlift
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Resource
+import           Data.Conduit.TMChan          hiding (mergeSources)
+import           Data.Foldable
+
+import           Data.Conduit
+import           UnliftIO.Concurrent
+import           UnliftIO.Exception
+import           UnliftIO.STM
+
+import           Blockchain.Metrics
+import           Blockchain.Output
+
+mergeSourcesByForce :: (MonadLogger mi, MonadResource mi, MonadUnliftIO mi, MonadIO mo)
+                    => [ConduitM () a mi ()] -- sources to merge
+                    -> Int -- ^ bound of the intermediate channel
+                    -> mo (ConduitM () a mi ())
+mergeSourcesByForce sx bound = do
+  return $ do
+    (chkey, c) <- allocate (atomically $ newTBMChan bound) (atomically . closeTBMChan)
+    st <- lift $ askUnliftIO
+    regs <- forM sx $ \s -> do
+      register $ (\tid -> uncountFork >> killThread tid) =<< do
+        (liftIO $ forkWithUnmask $ \unmask -> do
+          countFork
+          (unmask $ unliftIO st $
+            runConduit $ s .| sinkTBMChan c)
+          `finally` atomically (closeTBMChan c))
+    sourceTBMChan c
+    release chkey
+    traverse_ release regs

--- a/core-strato/strato-p2p/src/Blockchain/Metrics.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Metrics.hs
@@ -7,8 +7,6 @@ module Blockchain.Metrics ( recordEvent
                           , recordGossipFinal
                           , addCanary
                           , killCanary
-                          , countFork
-                          , uncountFork
                           ) where
 
 import Control.Monad.IO.Class
@@ -104,15 +102,3 @@ addCanary = liftIO $ incGauge canaryCount
 
 killCanary :: MonadIO m => m ()
 killCanary = liftIO $ decGauge canaryCount
-
-{-# NOINLINE forkCount #-}
-forkCount :: Gauge
-forkCount = unsafeRegister
-          . gauge
-          $ Info "p2p_fork_count" "Number of forks executed by mkEthP2PSource"
-
-countFork :: MonadIO m => m ()
-countFork = liftIO $ incGauge forkCount
-
-uncountFork :: MonadIO m => m ()
-uncountFork = liftIO $ decGauge forkCount

--- a/core-strato/strato-p2p/src/Blockchain/Metrics.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Metrics.hs
@@ -5,6 +5,10 @@ module Blockchain.Metrics ( recordEvent
                           , recordMessage
                           , recordGossipRNG
                           , recordGossipFinal
+                          , addCanary
+                          , killCanary
+                          , countFork
+                          , uncountFork
                           ) where
 
 import Control.Monad.IO.Class
@@ -88,3 +92,27 @@ recordGossipFinal :: (MonadIO m) => Bool -> m Bool
 recordGossipFinal dec = liftIO $ do
   withLabel gossipDecisions (if dec then "approve_final" else "reject_final") incCounter
   return $! dec
+
+{-# NOINLINE canaryCount #-}
+canaryCount :: Gauge
+canaryCount = unsafeRegister
+            . gauge
+            $ Info "p2p_canary_count" "Rough approximation of the number of kafka threads running"
+
+addCanary :: MonadIO m => m ()
+addCanary = liftIO $ incGauge canaryCount
+
+killCanary :: MonadIO m => m ()
+killCanary = liftIO $ decGauge canaryCount
+
+{-# NOINLINE forkCount #-}
+forkCount :: Gauge
+forkCount = unsafeRegister
+          . gauge
+          $ Info "p2p_fork_count" "Number of forks executed by mkEthP2PSource"
+
+countFork :: MonadIO m => m ()
+countFork = liftIO $ incGauge forkCount
+
+uncountFork :: MonadIO m => m ()
+uncountFork = liftIO $ decGauge forkCount

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -56,6 +56,8 @@ runPeer :: (MonadIO m, MonadLogger m, MonadThrow m, MonadUnliftIO m)
         -> CommPort      -- otherServiceCommPort
         -> m ()
 runPeer peer myPriv _ _ = runResourceT $ do
+  ender <- toIO . $logInfoS "runPeer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
+  void $ register ender
   ctx <- initContext flags_maxReturnedHeaders
   runContextM ctx $ do
     let otherPubKey = fromMaybe (error "programmer error: runPeer was called without a pubkey") $ pPeerPubkey peer

--- a/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -16,6 +16,7 @@ import           Blockchain.RLPx
 import           Conduit
 import           Control.Monad
 import           Control.Monad.Trans.Identity
+import           Control.Monad.Trans.Resource
 import           Control.Monad.Trans.State
 import           Blockchain.Output
 import           Crypto.PubKey.ECC.DH
@@ -23,15 +24,16 @@ import           Data.Conduit.Network
 import           Data.Streaming.Network                (appCloseConnection)
 import qualified Data.Text                             as T
 import qualified Database.Persist.Types                as SQL
-import           UnliftIO.Exception
+import           UnliftIO
 
 import           Blockchain.ECIES
 import           Blockchain.EthConf
 import           Blockchain.Options
 import           Blockchain.P2PUtil
 import           Blockchain.Strato.Discovery.Data.Peer
+import qualified Text.Colors                           as C
 
-runEthServer :: (MonadResource m, MonadIO m, MonadLogger m, MonadUnliftIO m)
+runEthServer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
              => PrivateNumber
              -> Int
              -> m ()
@@ -40,8 +42,10 @@ runEthServer myPriv listenPort = do
   let myPubkey = calculatePublic theCurve myPriv
   void . runContextM ctx $ do
     initState <- get
-    lift . runGeneralTCPServer (serverSettings listenPort "*") $ \app -> do
+    lift . runGeneralTCPServer (serverSettings listenPort "*") $ \app -> runResourceT $ do
       let theSockAddr = sockAddrToIP (appSockAddr app)
+      ender <- toIO . $logInfoS "runEthServer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow theSockAddr
+      void $ register ender
       runIdentityT (getPeerByIP theSockAddr) >>= \case
         Nothing -> do
           $logErrorS "runEthServer" . T.pack $ "Didn't see peer in discovery at IP " ++ show theSockAddr ++ ". rejecting violently."
@@ -75,4 +79,4 @@ stratoP2PServer = do
   $logInfoS "stratoP2PServer" $ T.pack $ "connect address: " ++ flags_address
   $logInfoS "stratoP2PServer" $ T.pack $ "listen port:     " ++ show flags_listen
 
-  void . runResourceT $ runEthServer myPriv flags_listen
+  void $ runEthServer myPriv flags_listen


### PR DESCRIPTION
This change has two main components:

Adding a `runResourceT` inside of the fork from the TCP listen. Cleanups need to happen per connection termination, and using the outer `runResourceT` call meant cleanups would only happen when the server terminated.

Reinstating a custom version of `mergeSources`. While the comment is honest:
```
All spawned threads will be removed when source is closed or upon an
exit from ResourceT region. This means that result can only be
used within a runResourceT scope.
```
what it does not do is kill each thread when one exits. This version uses more or less the source for `mergeSources`, but instead of keeping a refcount to know when to close the channel, the channel is closed when any of the sources exit. Then either once the channel is emptied or the `ResourceT` block ends, all spawned threads are killed.