### PR TITLE
public /health endpoint with rate limit and caching

### DIFF
--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -41,6 +41,9 @@ http {
 
     absolute_redirect off;
 
+    limit_req_zone $binary_remote_addr zone=healthcheck:5m rate=5r/s;
+    proxy_cache_path /tmp/nginx-cache levels=1:2 keys_zone=strato_short_term_cache:1m max_size=5m inactive=1s use_temp_path=off;
+  
     server {
       listen 80;
       listen 443 ssl;                                                       #TEMPLATE_MARK_SSL
@@ -122,6 +125,15 @@ http {
         return 302 /apex-api/;
       }
 
+      # Publicly available node health endpoint
+      location /health {
+        limit_req zone=healthcheck burst=20;
+        limit_req_status 429;
+        proxy_cache strato_short_term_cache;
+        proxy_cache_valid any 1s;
+        proxy_pass http://apex:3001/health;
+      }
+      
       location /apex-api/ {
         rewrite_by_lua_file lua/openid.lua;                                 #TEMPLATE_MARK_OAUTH  #TEMPLATE_MARK_OAUTH_STRATO_43_AND_ABOVE
         proxy_set_header Accept-Encoding "";


### PR DESCRIPTION
rate limit: one IP can call the endpoint every 200ms; with the max queue of 20 calls exceeding the rate - otherwise response HTTP 429 Too Many Requests

cache - health data cache is valid for 1 sec (to avoid calling apex api and fetching the health from db more frequently)
