### PR TITLE
Revert 9385cf1e

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -111,13 +111,15 @@ function newnode {
   echo "Starting strato-txr-indexer"
   runBackgroundProcess strato-txr-indexer +RTS -N1 >> logs/strato-txr-indexer 2>&1
 
-
+  if [ -n "${brokenRefundReenable}" ]; then
+    breFlag="--brokenRefundReenable=${brokenRefundReenable}"
+  fi
   echo "Starting vm-runner"
   runBackgroundProcess vm-runner --useSyncMode=$useSyncMode --miner=$miningAlgorithm --maxTxsPerBlock=$maxTxsPerBlock \
                          --diffPublish=$diffPublish --sqlDiff=$sqlDiff --createTransactionResults=true \
                          --miningVerification=$verifyBlocks --difficultyBomb=$difficultyBomb \
                          --trace=$evmTraceMode --debug=$evmDebugMode --minLogLevel=$evmMinLogLevel \
-                         "${tbFlag}" +RTS "${vmRunnerRTSOPTs:-}" -N1 >> logs/vm-runner 2>&1
+                         "${tbFlag}" "${breFlag}" +RTS "${vmRunnerRTSOPTs:-}" -N1 >> logs/vm-runner 2>&1
 
   echo "Starting strato-api"
   HOST=0.0.0.0 PORT=3000 APPROOT="" FETCH_LIMIT=2000 NODEKEY=$apiKey \

--- a/core-strato/vm-tools/src/Blockchain/Data/ExecResults.hs
+++ b/core-strato/vm-tools/src/Blockchain/Data/ExecResults.hs
@@ -38,7 +38,7 @@ instance NFData ExecResults
 calculateReturned :: Transaction -> ExecResults -> Integer
 calculateReturned t er =
   let realRefund = min (erRefund er) ((transactionGasLimit t - erRemainingTxGas er) `div` 2)
-  in realRefund + erRemainingTxGas er
+  in realRefund + erRefund er
 
 
 evmErrorResults :: Integer -> VMException -> ExecResults

--- a/core-strato/vm-tools/src/Blockchain/Data/ExecResults.hs
+++ b/core-strato/vm-tools/src/Blockchain/Data/ExecResults.hs
@@ -18,6 +18,7 @@ import           Blockchain.Strato.Model.Action
 import           Blockchain.Data.Address
 import           Blockchain.Data.Log
 import           Blockchain.Data.Transaction
+import           Blockchain.VMOptions
 
 data ExecResults =
   ExecResults {
@@ -38,7 +39,10 @@ instance NFData ExecResults
 calculateReturned :: Transaction -> ExecResults -> Integer
 calculateReturned t er =
   let realRefund = min (erRefund er) ((transactionGasLimit t - erRemainingTxGas er) `div` 2)
-  in realRefund + erRefund er
+      addend = if flags_brokenRefundReenable
+                 then erRefund er
+                 else erRemainingTxGas er
+  in realRefund + addend
 
 
 evmErrorResults :: Integer -> VMException -> ExecResults

--- a/core-strato/vm-tools/src/Blockchain/VMOptions.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMOptions.hs
@@ -7,6 +7,7 @@ module Blockchain.VMOptions (
   flags_trace,
   flags_svmTrace,
   flags_altGenBlock,
+  flags_brokenRefundReenable,
   flags_createTransactionResults,
   flags_sqlDiff,
   flags_diffPublish,
@@ -30,6 +31,8 @@ defineFlag "trace" "none" "Style of tracing. \n\
  \ evmProfile -> Profile runtimes labeled by opcode, emitted to the log \n\
  \ evmMetrics -> Profile runtimes labeled by opcode, collected by prometheus"
 defineFlag "altGenBlock" False "use the alternate stablenet genesis block"
+defineFlag "brokenRefundReenable" (False::Bool) "Whether to turn on spec incompatible refunds\
+  \ See STRATO-1411 or strato-platform/pull/745 for details"
 defineFlag "createTransactionResults" False "stores transaction results in the SQL DB"
 defineFlag "sqlDiff" True "runs sqlDiff and updates account state and storage in SQL DB"
 defineFlag "diffPublish" False "publishes all state changes to kafka"
@@ -38,4 +41,5 @@ defineFlag "miningVerification" True "Flag to turn mining verification or/off"
 defineFlag "transactionRootVerification" False "Flag to turn transaction root verification or/off"
 defineFlag "startingBlock" (-1::Integer) "block in kafka to start running the VM on"
 defineFlag "svmTrace" (True::Bool) "Whether to have verbose logging in SolidVM"
+
 defineEQFlag "miner" [| Instant :: MinerType |] "MINER" "What mining algorithm"

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -125,6 +125,7 @@ services:
     - blockstanbulSkipCheck=${blockstanbulSkipCheck}
     - blockTime=${blockTime}
     - bootnode=${bootnode}
+    - brokenRefundReenable=${brokenRefundReenable}
     - connectionTimeout=${connectionTimeout}
     - debugFail=${debugFail}
     - evmDebugMode=${evmDebugMode}


### PR DESCRIPTION
9385cf1e fixed a bug that was introduced in edfeef0481. However,
edfeef0 is in version 4.2 and 9385cf1e is not. Changing the refund
behavior causes stateroot mismatches during upgrade to 4.3 or 4.4 
because nodes in a mixed version network compute different
balances for the refunds