### PR TITLE
Fix refunding error causing stateroot mismatches

### DIFF
--- a/core-strato/vm-tools/src/Blockchain/Data/ExecResults.hs
+++ b/core-strato/vm-tools/src/Blockchain/Data/ExecResults.hs
@@ -38,7 +38,7 @@ instance NFData ExecResults
 calculateReturned :: Transaction -> ExecResults -> Integer
 calculateReturned t er =
   let realRefund = min (erRefund er) ((transactionGasLimit t - erRemainingTxGas er) `div` 2)
-  in realRefund + erRemainingTxGas er
+  in realRefund + reRefund er
 
 
 evmErrorResults :: Integer -> VMException -> ExecResults


### PR DESCRIPTION
Adding logging for refund:
4.2: `Refunding: 0`
develop: `Refunding: 3950000000000000`
branch sr: `Refunding: 0` 