### PR TITLE
Attempt decoding EVM storage when none available

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -145,18 +145,20 @@ getContractsState contract@(ContractName contractName) contractId chainId mName 
   let storage = translateStorageMap storage'
 
   ret <- case (storage', mName) of
-    ([], _) -> return []
     (Storage{storageKind=SolidVM}:_, Nothing) -> return .
         decodeSolidVMValues $ map (\Storage{storageKV=SolidVMEntry k v} -> (k, v)) storage'
     (Storage{storageKind=SolidVM}:_, Just name) ->
        error $ "unimplemented: range based solidVM queries" ++ Text.unpack name
-    (Storage{storageKind=EVM}:_, Nothing) ->
-      let vals = decodeValues fetchLimit (typeDefs contract') (mainStruct contract') storage 0
-          solVals = map (fmap valueToSolidityValue) vals
-      in return solVals
-    (Storage{storageKind=EVM}:_, Just name) ->
+    -- Treat this potentially empty storage as the EVM, even though it could be on SolidVM.
+    -- This may still be useful to return enums and constants in EVM, and should hopefully
+    -- still return [] for [] on SolidVM.
+    (_, Just name) ->
       let vals = decodeValuesFromList (typeDefs contract') (mainStruct contract') storage 0
                  ofs cnt mLength [name]
+          solVals = map (fmap valueToSolidityValue) vals
+      in return solVals
+    (_, Nothing) ->
+      let vals = decodeValues fetchLimit (typeDefs contract') (mainStruct contract') storage 0
           solVals = map (fmap valueToSolidityValue) vals
       in return solVals
   $logDebugS "getContractsState/storage" $ Text.unlines

--- a/tests/e2e/createChain.test.js
+++ b/tests/e2e/createChain.test.js
@@ -8,11 +8,11 @@ const util = common.util;
 const BigNumber = common.BigNumber;
 const constants = common.constants;
 const assert = common.assert;
-const config = common.config; 
+const config = common.config;
 const password = '1234';
 
 const label = 'My chain label';
-const src = 'contract Governance { }';
+const src = 'contract Governance { uint constant TEN = 10; }';
 const args = {};
 const members = [{
     address: "00000000000000000000000000000000deadbeef"
@@ -95,6 +95,13 @@ describe("Create Chain", function() {
     console.log('###CHAININFO###',chainInfo);
     assert.isDefined(chainInfo, "should exist");
     assert.deepEqual(label, chainInfo.label, "chain labels should be identical");
+
+    const chainAddress = '0000000000000000000000000000000000000100';
+
+    // Despite not running the constructor, bloch will at least
+    // return the constants and functions.
+    const state = yield api.bloc.state('Governance', chainAddress, chainId);
+    assert.hasAnyKeys(state, ['TEN']);
 
     for(var i=0; i < 10; i++) {
       const txResult = yield rest.send(alice, bob, 123456, false, null, chainId);


### PR DESCRIPTION
This should help partially with the HT3 issue about NaNs in summary reports for new chains. The numbers will still discard the results from constructors, but 0 is a reasonable number to give for a brand new chain in a few cases.