### PR TITLE
Deepseq enodes to ferret out lurking exceptions

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Data/Enode.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/Enode.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS -fno-warn-orphans #-}
@@ -14,6 +15,7 @@ module Blockchain.Data.Enode (
   ) where
 
 
+import                  Control.DeepSeq
 import                  Data.Bits
 import                  Data.Binary
 import qualified        Data.ByteString             as B
@@ -28,28 +30,24 @@ import                  Network.Socket.Internal
 import                  Blockchain.Data.RLP
 
 
-data IPAddress = IPv4 HostAddress deriving (Show, Read, Eq, Ord, GHCG.Generic)
-
-instance Binary IPAddress where
+data IPAddress = IPv4 HostAddress deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary)
 
 instance RLPSerializable IPAddress where
   rlpEncode (IPv4 addy) = rlpEncode $ toInteger addy
   rlpDecode x = IPv4 (fromInteger $ rlpDecode x)
 
-data Enode = Enode 
+data Enode = Enode
   { pubKey     :: B.ByteString
   , ipAddress  :: IPAddress
   , tcpPort    :: Int
   , udpPort    :: Maybe Int
-  } deriving (Show, Read, Eq, Ord, GHCG.Generic)
-        
-instance Binary Enode where
+  } deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary)
 
 instance RLPSerializable Enode where
-  rlpEncode (Enode pk ip tp up) = 
+  rlpEncode (Enode pk ip tp up) =
     RLPArray [rlpEncode pk, rlpEncode ip, rlpEncode $ toInteger tp, rlpEncode (toInteger <$> up)]
 
-  rlpDecode (RLPArray [a,b,c,d]) = 
+  rlpDecode (RLPArray [a,b,c,d]) =
     Enode (rlpDecode a) (rlpDecode b) (fromInteger $ rlpDecode c) (fromInteger <$> (rlpDecode d))
 
   rlpDecode _ = error "error in rlpDecode for Enode type: bad RLPObject"
@@ -80,25 +78,25 @@ readIP input =
       (b1, temp3) = break (=='.') s1
       b0 = dropWhile (=='.') temp3
 
-      addy = ((read b0) + (((read b1) .&. 0xff) `shiftL` 8) + (((read b2) .&. 0xff) `shiftL` 16) + 
+      addy = ((read b0) + (((read b1) .&. 0xff) `shiftL` 8) + (((read b2) .&. 0xff) `shiftL` 16) +
         (((read b3) .&. 0xff) `shiftL` 24))
   in (IPv4 addy)
 
 showEnode :: Enode -> String
-showEnode (Enode pk ip tp up) = 
-    "enode://" ++ 
+showEnode (Enode pk ip tp up) =
+    "enode://" ++
     (C8.unpack $ B16.encode pk) ++
     "@" ++
     (showIP ip) ++ ":" ++
-    (show tp) ++ uPort 
+    (show tp) ++ uPort
     where
-      uPort = 
+      uPort =
         case up of
           Nothing -> ""
           Just x -> "?discport=" ++ show x
 
 readEnode :: String -> Enode
-readEnode input = 
+readEnode input =
     let suffix = dropWhile (/='/') input
         pksuffix = dropWhile (=='/') suffix
         (pk, temp) = break (=='@') pksuffix
@@ -108,7 +106,7 @@ readEnode input =
         (tcp, temp3) = break (=='?') tcpsuffix
         udpsuffix = dropWhile (/='=') temp3
         udp = dropWhile (=='=') udpsuffix
-        up = 
+        up =
           case udp of
             [] -> Nothing
             _ -> Just (read udp)

--- a/core-strato/strato-index/package.yaml
+++ b/core-strato/strato-index/package.yaml
@@ -17,6 +17,7 @@ dependencies:
   - bytestring
   - clock
   - containers
+  - deepseq
   - format
   - hedis
   - hflags

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -5,17 +5,16 @@
 {-# LANGUAGE TemplateHaskell   #-}
 module Blockchain.Strato.Indexer.TxrIndexer where
 
+import           Control.DeepSeq
 import           Control.Exception
 import           Control.Monad
-import           Blockchain.Output
 import           Control.Monad.IO.Class             (liftIO)
 import           Control.Monad.Trans.Class          (lift)
-import           Control.Exception                  (catch, SomeException)
+import           Control.Exception                  (SomeException)
 import           Data.Binary
 import qualified Data.ByteString                    as BS
 import qualified Data.ByteString.Char8              as C8
 import qualified Data.ByteString.Lazy               as BL
-import           Data.Foldable                      (for_)
 import           Data.Maybe                         (isJust)
 import qualified Data.Text                          as T
 import           Data.Text.Encoding                 (decodeUtf8)
@@ -30,7 +29,8 @@ import qualified Blockchain.Data.LogDB              as LogDB
 import qualified Blockchain.Data.TransactionResult  as TxrDB
 import           Blockchain.EthConf                 (lookupConsumerGroup)
 
-import           Blockchain.Sequencer.Event         (IngestEvent(..))
+import           Blockchain.Output
+import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Kafka
 import           Blockchain.SHA                     (hash)
 import           Blockchain.Strato.Indexer.IContext
@@ -72,12 +72,14 @@ txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
                       let address = decode . BL.fromStrict . BS.take 20 . BS.drop 12 $ logDBTheData l --TODO: unhack
                           enodelen = fromInteger . byteString2Integer . BS.take 32 . BS.drop 64 $ logDBTheData l
                           enode' = T.unpack . decodeUtf8 . BS.take enodelen . BS.drop 96 $ logDBTheData l
-                      mEnode <- liftIO $ (Just <$> evaluate (readEnode enode')) `catch` (\(_ :: SomeException) -> return Nothing)
-                      for_ mEnode $ \enode -> do
-                        $logInfoS "txrIndexer" . T.pack $ "Adding member " ++ (showHex address "") ++ " on chain " ++ showHex chainId ""
-                        lift $ addMember chainId address enode' -- We only need the Text version for Postgres
-                        void . RBDB.withRedisBlockDB $ RBDB.addChainMember chainId address enode
-                        void . withKafkaRetry1s $ writeUnseqEvents [IENewChainMember chainId address enode]
+                      eEnode :: Either SomeException Enode <- liftIO . try . evaluate . force $ readEnode enode'
+                      case eEnode of
+                        Left err -> $logErrorS "txrIndexer" . T.pack $ "failed to parse enode: " ++ show err
+                        Right enode -> do
+                          $logInfoS "txrIndexer" . T.pack $ "Adding member " ++ (showHex address "") ++ " on chain " ++ showHex chainId ""
+                          lift $ addMember chainId address enode' -- We only need the Text version for Postgres
+                          void . RBDB.withRedisBlockDB $ RBDB.addChainMember chainId address enode
+                          void . withKafkaRetry1s $ writeUnseqEvents [IENewChainMember chainId address enode]
                     Just x | SHA x == removeTopic -> do
                       let address = decode . BL.fromStrict . BS.take 20 . BS.drop 12 $ logDBTheData l
                       $logInfoS "txrIndexer" . T.pack $ "Removing member " ++ (showHex address "") ++ " on chain " ++ showHex chainId ""


### PR DESCRIPTION
I managed to crash a node with enode://dev, because the seq did not see
far enough to fail the public key parse.