### PR TITLE
Leave nonce alone in lazy mining

### DIFF
--- a/core-strato/strato-adit/src/Blockchain/Mining/Instant.hs
+++ b/core-strato/strato-adit/src/Blockchain/Mining/Instant.hs
@@ -10,10 +10,7 @@ instantMiner::Miner
 instantMiner = Miner mineInstant verifyInstant
 
 mineInstant :: Block -> IO (Maybe Integer)
-mineInstant _ = do
-            return $ Just 6
+mineInstant = return . Just . fromIntegral . blockDataNonce . blockBlockData
 
 verifyInstant :: Block -> Bool
-verifyInstant Block{blockBlockData=bd} =
-    nonce == 6
-      where nonce = blockDataNonce bd
+verifyInstant = const True


### PR DESCRIPTION
The nonce is used as a channel for blockstanbul votes, and setting it to 6 erases the previous value