### PR TITLE
Replace instance with $NODE_HOST

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -247,6 +247,8 @@ services:
     - /var/run/docker.sock:/var/run/docker.sock
   prometheus:
     build: .
+    environment:
+      - NODE_HOST=${NODE_HOST}
     image: ${PROMETHEUS_IMAGE:-<REPO_URL>prometheus:<VERSION>}
     volumes:
     - prometheusdata:/prometheus

--- a/prometheus-packager/Dockerfile
+++ b/prometheus-packager/Dockerfile
@@ -6,10 +6,12 @@ COPY console_libraries /usr/share/prometheus/strato_console_libraries
 
 COPY LICENSE NOTICE /prometheus/
 
-ENTRYPOINT ["/bin/prometheus"]
-CMD        ["--config.file=/etc/prometheus/strato_prometheus.yml", \
-            "--storage.tsdb.path=/prometheus", \
-            "--web.console.libraries=/usr/share/prometheus/strato_console_libraries", \
-            "--web.console.templates=/usr/share/prometheus/strato_consoles", \
-            "--web.external-url=http://anything/prometheus", \
-            "--web.route-prefix=/prometheus"]
+ENTRYPOINT sed -i "s/__NODE_HOST_MARKER__/${NODE_HOST:-localhost}/" /etc/prometheus/strato_prometheus.yml && \
+           cat /etc/prometheus/strato_prometheus.yml && \
+           /bin/prometheus \
+                  --config.file=/etc/prometheus/strato_prometheus.yml \
+                  --storage.tsdb.path=/prometheus \
+                  --web.console.libraries=/usr/share/prometheus/strato_console_libraries \
+                  --web.console.templates=/usr/share/prometheus/strato_consoles \
+                  --web.external-url=http://anything/prometheus \
+                  --web.route-prefix=/prometheus

--- a/prometheus-packager/strato_prometheus.yml
+++ b/prometheus-packager/strato_prometheus.yml
@@ -1,20 +1,7 @@
 # Strato Prometheus Configuration
 global:
   scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
-  # scrape_timeout is set to the global default (10s).
-
-# Alertmanager configuration
-alerting:
-  alertmanagers:
-  - static_configs:
-    - targets:
-      # - alertmanager:9093
-
-# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
-rule_files:
-  # - "first_rules.yml"
-  # - "second_rules.yml"
+  evaluation_interval: 60s
 
 # Processes to scrape
 scrape_configs:
@@ -22,28 +9,54 @@ scrape_configs:
     metrics_path: '/prometheus/metrics'
     static_configs:
     - targets: ['localhost:9090']
+    metric_relabel_configs:
+      - target_label: instance
+        replacement: '__NODE_HOST_MARKER__'
+
   - job_name: 'strato-sequencer'
     metrics_path: '/metrics'
     static_configs:
       - targets: ['strato:8050']
+    metric_relabel_configs:
+      - target_label: instance
+        replacement: '__NODE_HOST_MARKER__'
+
+  - job_name: 'strato-api'
+    metrics_path: '/metrics'
+    static_configs:
+    - targets: ['strato:3000']
+    metric_relabel_configs:
+      - target_label: instance
+        replacement: '__NODE_HOST_MARKER__'
+
   - job_name: 'strato-p2p'
+    metrics_path: '/metrics'
     static_configs:
       - targets: ['strato:10248']
-  - job_name: 'ethereum-vm'
+    metric_relabel_configs:
+      - target_label: instance
+        replacement: '__NODE_HOST_MARKER__'
+
+  - job_name: 'vm-runner'
     metrics_path: '/metrics'
     static_configs:
       - targets: ['strato:8000']
+    metric_relabel_configs:
+      - target_label: instance
+        replacement: '__NODE_HOST_MARKER__'
+
   - job_name: 'slipstream'
     metrics_path: '/metrics'
     static_configs:
       - targets: ['bloc:10777']
+    metric_relabel_configs:
+      - target_label: instance
+        replacement: '__NODE_HOST_MARKER__'
 
-#   metric_relabel_configs:
-#   - source_labels: [__name__]
-#     regex: '(prometheus)_(.*)'
-#     replacement: '${2}'
-#     target_label: pool
-#
-#  - source_labels: [__name__]
-#   regex: '(go|time_)'
-#   action: drop
+  - job_name: 'bloc'
+    metrics_path: '/bloc/v2.2/metrics'
+    static_configs:
+      - targets: ['bloc:8000']
+    metric_relabel_configs:
+      - target_label: instance
+        replacement: '__NODE_HOST_MARKER__'


### PR DESCRIPTION
This creates labels like: 
`gregor_p2p_chan_read{exported_instance="strato:8050",exported_job="strato-sequencer",instance="test4.ci.blockapps.net:80",job="test4"}`. I would have preferred to have `gregor_p2p_chain_read{job="strato-sequencer", instance="test4.ci.blockapps.net:80"}` but this is fine for now