### PR TITLE
Strato 1410 health

### DIFF
--- a/apex/api/config/app.config.js
+++ b/apex/api/config/app.config.js
@@ -36,6 +36,7 @@ module.exports = {
   healthCheck: {
       requestTimeout: 1 * 1000,
       pollFrequency: 15 * 1000,
+      pollTimeoutsForUnhealthy: 3, // number of timed out polls in a row to consider node unhealthy
       cleanFrequency: 5 * 60 * 1000, //clean db every 5 mins
       retention_hours: 1 * 24,
       progressWindow: 10 * 60 * 1000

--- a/apex/api/config/app.config.js
+++ b/apex/api/config/app.config.js
@@ -36,7 +36,6 @@ module.exports = {
   healthCheck: {
       requestTimeout: 1 * 1000,
       pollFrequency: 15 * 1000,
-      maxResponseRange: 1 * 1000,
       cleanFrequency: 5 * 60 * 1000, //clean db every 5 mins
       retention_hours: 1 * 24,
       progressWindow: 10 * 60 * 1000

--- a/apex/api/controllers/health.js
+++ b/apex/api/controllers/health.js
@@ -71,12 +71,7 @@ module.exports = {
         const currentTime = Date.now();
 
         if (healthInfo && stallInfo){
-            const nodeUp = ((currentTime - healthInfo.dataValues.latestCheckTimestamp) < config.healthCheck.maxResponseRange);
-            if (!nodeUp) {
-               const currentStatus = [false, 'Node'];
-               await nodeHealthCheck.updateCurrentHealth(currentStatus);
-            }
-            healthStatus = healthInfo.dataValues.latestHealthStatus && nodeUp;
+            healthStatus = healthInfo.dataValues.latestHealthStatus;
             stallStatus = stallInfo.dataValues.latestHealthStatus;
             uptime = (healthStatus) ? currentTime - healthInfo.dataValues.lastFailureTimestamp : 0;
             isInc = stallInfo.dataValues.isBlocksValidInc;

--- a/apex/api/controllers/health.js
+++ b/apex/api/controllers/health.js
@@ -1,6 +1,7 @@
 const BlockDataRef = require('../models/strato/eth/blockDataRef');
 const models = require('../models');
 const nodeHealthCheck = require('../daemons/node-health-check')
+const config = require('../config/app.config');
 
 module.exports = {
   ping: function (req, res) {

--- a/apex/api/controllers/health.js
+++ b/apex/api/controllers/health.js
@@ -1,5 +1,6 @@
 const BlockDataRef = require('../models/strato/eth/blockDataRef');
 const models = require('../models');
+const nodeHealthCheck = require('../daemons/node-health-check')
 
 module.exports = {
   ping: function (req, res) {
@@ -69,7 +70,12 @@ module.exports = {
         const currentTime = Date.now();
 
         if (healthInfo && stallInfo){
-            healthStatus = healthInfo.dataValues.latestHealthStatus;
+            const nodeUp = ((currentTime - healthInfo.dataValues.latestCheckTimestamp) < config.healthCheck.maxResponseRange);
+            if (!nodeUp) {
+               const currentStatus = [false, 'Node'];
+               await nodeHealthCheck.updateCurrentHealth(currentStatus);
+            }
+            healthStatus = healthInfo.dataValues.latestHealthStatus && nodeUp;
             stallStatus = stallInfo.dataValues.latestHealthStatus;
             uptime = (healthStatus) ? currentTime - healthInfo.dataValues.lastFailureTimestamp : 0;
             isInc = stallInfo.dataValues.isBlocksValidInc;

--- a/apex/api/daemons/node-health-check.js
+++ b/apex/api/daemons/node-health-check.js
@@ -82,7 +82,8 @@ function compareTimeStamp(obj) {
                 winston.warn(`Jobs are updated? The following prometheus job is not in the check list required: `, loc);
             }
 
-            ret[name] = true;
+            value = formatPromethusTimestamp(elem.value[0]);
+            ret[name] = (Math.abs(timeNow - value) < config.healthCheck.maxResponseRange) && (elem.value[1] == 1) ? true : false;
         } else {
             winston.info(`Metric format is updated; need to update its handling`);
         }

--- a/apex/api/daemons/node-health-check.js
+++ b/apex/api/daemons/node-health-check.js
@@ -31,6 +31,7 @@ function queryHealthStatus() {
     return new Promise(async (resolve, _void) => {
         try {
             const metricsResult = await getHealthPrometheus();
+            await checkLatest();
             const healthStatus = await compareTimeStamp(metricsResult);
             const overallStatus = await updateHealthStat(healthStatus);
             await updateCurrentHealth(overallStatus);
@@ -83,7 +84,7 @@ function compareTimeStamp(obj) {
             }
 
             value = formatPromethusTimestamp(elem.value[0]);
-            ret[name] = (Math.abs(timeNow - elem.value[0]) < config.healthCheck.maxResponseRange/1000 ) && (elem.value[1] == 1) ? true : false;
+            ret[name] = (Math.abs(timeNow - elem.value[0]) < config.healthCheck.pollFrequency*3 /1000 ) && (elem.value[1] == 1) ? true : false;
         } else {
             winston.info(`Metric format is updated; need to update its handling`);
         }
@@ -141,6 +142,35 @@ async function updateCurrentHealth(overallStat) {
 
 function formatPromethusTimestamp(timestamp) {
     return ( timestamp.toString().split('.')[0])
+}
+
+async function checkLatest() {
+  const healthInfo = await models.CurrentHealth.findOne({
+    where: {
+      processName: "HealthStat"
+    },
+    attributes: [
+      'latestHealthStatus',
+      'latestCheckTimestamp',
+      'lastFailureTimestamp'
+    ],
+    raw: true,
+  }).catch(err => next(err));
+
+
+  const currentTime = Date.now();
+  if (healthInfo) {
+
+    console.log("currentTime", currentTime)
+    console.log("latestC", healthInfo.latestCheckTimestamp )
+    console.log("pollf", config.healthCheck.pollFrequency * 3)
+
+    const nodeUp = ((currentTime - healthInfo.latestCheckTimestamp) < config.healthCheck.pollFrequency * 3);
+    if (!nodeUp) {
+      const currentStatus = [false, 'Last Check Not Recent'];
+      await updateCurrentHealth(currentStatus);
+    }
+  }
 }
 
 module.exports = {

--- a/apex/api/daemons/node-health-check.js
+++ b/apex/api/daemons/node-health-check.js
@@ -84,7 +84,7 @@ function compareTimeStamp(obj) {
             }
 
             value = formatPromethusTimestamp(elem.value[0]);
-            ret[name] = (Math.abs(timeNow - elem.value[0]) < config.healthCheck.pollFrequency*3 /1000 ) && (elem.value[1] == 1) ? true : false;
+            ret[name] = (Math.abs(timeNow - elem.value[0]) < config.healthCheck.pollFrequency * config.healthCheck.pollTimeoutsForUnhealthy /1000 ) && (elem.value[1] == 1) ? true : false;
         } else {
             winston.info(`Metric format is updated; need to update its handling`);
         }
@@ -160,7 +160,7 @@ async function checkLatest() {
 
   const currentTime = Date.now();
   if (healthInfo) {
-    const nodeUp = ((currentTime - healthInfo.latestCheckTimestamp) < config.healthCheck.pollFrequency * 3);
+    const nodeUp = ((currentTime - healthInfo.latestCheckTimestamp) < config.healthCheck.pollFrequency * config.healthCheck.pollTimeoutsForUnhealthy);
     if (!nodeUp) {
       const currentStatus = [false, 'Last Check Not Recent'];
       await updateCurrentHealth(currentStatus);

--- a/apex/api/daemons/node-health-check.js
+++ b/apex/api/daemons/node-health-check.js
@@ -160,11 +160,6 @@ async function checkLatest() {
 
   const currentTime = Date.now();
   if (healthInfo) {
-
-    console.log("currentTime", currentTime)
-    console.log("latestC", healthInfo.latestCheckTimestamp )
-    console.log("pollf", config.healthCheck.pollFrequency * 3)
-
     const nodeUp = ((currentTime - healthInfo.latestCheckTimestamp) < config.healthCheck.pollFrequency * 3);
     if (!nodeUp) {
       const currentStatus = [false, 'Last Check Not Recent'];

--- a/apex/api/daemons/node-health-check.js
+++ b/apex/api/daemons/node-health-check.js
@@ -83,7 +83,7 @@ function compareTimeStamp(obj) {
             }
 
             value = formatPromethusTimestamp(elem.value[0]);
-            ret[name] = (Math.abs(timeNow - value) < config.healthCheck.maxResponseRange) && (elem.value[1] == 1) ? true : false;
+            ret[name] = (Math.abs(timeNow - elem.value[0]) < config.healthCheck.maxResponseRange/1000 ) && (elem.value[1] == 1) ? true : false;
         } else {
             winston.info(`Metric format is updated; need to update its handling`);
         }

--- a/apex/api/models/currentHealth.js
+++ b/apex/api/models/currentHealth.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(sequelize, DataTypes) {
-    let CurrentHealth = sequelize.define('CurrentHealth', {
+    const CurrentHealth = sequelize.define('CurrentHealth', {
         processName : {type: DataTypes.STRING, defaultValue: false, allowNull: false},
         latestHealthStatus : {type: DataTypes.BOOLEAN, allowNull: false},
         latestCheckTimestamp: {

--- a/apex/api/models/healthStat.js
+++ b/apex/api/models/healthStat.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(sequelize, DataTypes) {
-    let HealthStat = sequelize.define('HealthStat', {
+    const HealthStat = sequelize.define('HealthStat', {
         processName: {type: DataTypes.STRING, allowNull: true},
         HealthStatus: {type: DataTypes.BOOLEAN, allowNull: true},
         timestamp: {

--- a/apex/api/models/stallStat.js
+++ b/apex/api/models/stallStat.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(sequelize, DataTypes) {
-    let StallStat = sequelize.define('StallStat', {
+    const StallStat = sequelize.define('StallStat', {
         blockType: {type: DataTypes.STRING, allowNull: true},
         blockCount: {type: DataTypes.INTEGER, allowNull: true},
         timestamp: {type: DataTypes.DATE, allowNull: true}

--- a/apex/api/test/health.test.js
+++ b/apex/api/test/health.test.js
@@ -65,7 +65,7 @@ describe('Tests - Node-level Health Check', function () {
     let testObj = sampleResponse2;
     const currentTime = Date.now();
     testObj.data.result.forEach((elem) => {
-      elem.value[0] = (currentTime - config.healthCheck.pollFrequency * 3)/1000;
+      elem.value[0] = (currentTime - config.healthCheck.pollFrequency * config.healthCheck.pollTimeoutsForUnhealthy)/1000;
     })
     const res = nodeHealthCheckJs.compareTimeStamp(testObj);
     const stat = await nodeHealthCheckJs.updateHealthStat(res);

--- a/apex/api/test/health.test.js
+++ b/apex/api/test/health.test.js
@@ -5,161 +5,206 @@ const models = require('../models');
 const nodeHealthCheckJs = require('../daemons/node-health-check')
 const stallCheckJs = require('../daemons/stall-check')
 const sampleResponse = require('./testdata/prometheusFailResponse')
-const sampleResponse2 = require('./testdata/prometheusCorrectResponse')
+const sampleResp2FileName = './testdata/prometheusCorrectResponse'
+const sampleResponse2 = require(sampleResp2FileName)
 const config = require('../config/app.config');
-const ba = require('blockapps-rest')
+const ba = require('blockapps-rest');
+const fs = require('fs')
 
-const { assert } = ba.common
+const {assert} = ba.common
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 const timeout = config.healthCheck.pollFrequency;
 
 describe('Tests - Node-level Health Check', function () {
-    this.timeout(timeout);
+  this.timeout(timeout);
+  before(async function () {
 
-    it('HealthStat update - FAILURE', async function () {
-        let testObj = sampleResponse;
-        const res = nodeHealthCheckJs.compareTimeStamp(testObj);
-        const stat = await nodeHealthCheckJs.updateHealthStat(res);
-        await nodeHealthCheckJs.updateCurrentHealth(stat);
-        assert.equal(stat[0], false, "Unhealthy");
-        assert.equal(stat[1].sort().toString(), Object.values(nodeHealthCheckJs.neededJobs).sort().toString(), 'Errored Processes')
-        let entriesAdded;
-        for (let i = 0; i < 2; i++) {
-            entriesAdded = await models.HealthStat.findAll({
-                attributes: ['processName', 'HealthStatus'],
-                limit: 4,
-                order: [ [ 'createdAt', 'DESC' ]],
-        })};
-
-        entriesAdded.forEach((elem) => {
-            assert.equal(elem.dataValues.HealthStatus, false, `${elem.dataValues.processName} Status`);
-         })
-        const currentStat = await models.CurrentHealth.findOne({
-            where: {
-                processName: "HealthStat",
-            },
-        });
-        const currentTime = Date.now();
-        assert.equal(currentStat.dataValues.latestHealthStatus, false, `Health Stat`)
-        assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp' )
-
-        assert.equal(Math.abs(currentStat.dataValues.lastFailureTimestamp - currentStat.dataValues.latestCheckTimestamp) < config.healthCheck.requestTimeout, true, 'Last Failure Timestamp' )
-
+    const currentTime = Date.now();
+    sampleResponse2.data.result.forEach((elem) => {
+      elem.value[0] = currentTime / 1000;
     })
 
-    it('HealthStat update - SUCCESS', async function () {
-        let testObj = sampleResponse2;
-        const res = nodeHealthCheckJs.compareTimeStamp(testObj);
-        const stat = await nodeHealthCheckJs.updateHealthStat(res);
-        await nodeHealthCheckJs.updateCurrentHealth(stat);
-        assert.equal(stat[0], true, "Healthy");
-        assert.equal(stat[1].concat().toString(), [].toString(), "Errored Processes")
-        let entriesAdded;
-        for (let i = 0; i < 2; i++) {
-            entriesAdded = await models.HealthStat.findAll({
-                limit: 4,
-                order: [ [ 'createdAt', 'DESC' ]],
-            })};
-        entriesAdded.forEach((elem) => {
-            assert.equal(elem.dataValues.HealthStatus, true, `${elem.dataValues.processName} Status`);
-        })
-        const currentStat = await models.CurrentHealth.findOne({
-            where: {
-                processName: "HealthStat",
-            },
-        });
-        assert.equal(currentStat.dataValues.latestHealthStatus, true, `Current Health`)
-        const currentTime = Date.now();
-        assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp' )
-        assert.equal((currentStat.dataValues.lastFailureTimestamp < currentStat.dataValues.latestCheckTimestamp), true, 'Last Failure Timestamp' )
+  })
 
+  it('HealthStat update - FAILURE', async function () {
+    let testObj = sampleResponse;
+    const res = nodeHealthCheckJs.compareTimeStamp(testObj);
+    const stat = await nodeHealthCheckJs.updateHealthStat(res);
+    await nodeHealthCheckJs.updateCurrentHealth(stat);
+    assert.equal(stat[0], false, "Unhealthy");
+    assert.equal(stat[1].sort().toString(), Object.values(nodeHealthCheckJs.neededJobs).sort().toString(), 'Errored Processes')
+    let entriesAdded;
+    for (let i = 0; i < 2; i++) {
+      entriesAdded = await models.HealthStat.findAll({
+        attributes: ['processName', 'HealthStatus'],
+        limit: 4,
+        order: [['createdAt', 'DESC']],
+      })
+    }
+    ;
+
+    entriesAdded.forEach((elem) => {
+      assert.equal(elem.dataValues.HealthStatus, false, `${elem.dataValues.processName} Status`);
     })
+    const currentStat = await models.CurrentHealth.findOne({
+      where: {
+        processName: "HealthStat",
+      },
+    });
+    const currentTime = Date.now();
+    assert.equal(currentStat.dataValues.latestHealthStatus, false, `Health Stat`)
+    assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp')
 
-    it('StallStat update -- FAILURE', async function () {
+    assert.equal(Math.abs(currentStat.dataValues.lastFailureTimestamp - currentStat.dataValues.latestCheckTimestamp) < config.healthCheck.requestTimeout, true, 'Last Failure Timestamp')
 
-        const lastV = 0;
-        const lastP = 1;
-        const thisV = 0;
-        const checkRes = await stallCheckJs.getCurrentHealth(lastP, lastV, thisV);
-        assert.equal(checkRes[0], false, "Unhealthy");
-        await stallCheckJs.updateCurrentHealth(checkRes);
-        let currentStat;
-        for (let i = 0; i < 3; i++) {
-            currentStat = await models.CurrentHealth.findOne({
-                where: {
-                    processName: "StallStat",
-                },
-        })};
-        assert.equal(currentStat.dataValues.latestHealthStatus, false, 'Current Health')
-        assert.equal(currentStat.dataValues.isBlocksValidInc, false, 'isInc')
-        assert.equal(currentStat.dataValues.isLastPending, true, 'isPending')
-        const currentTime = Date.now();
-        assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp' )
+  })
 
-        assert.equal(Math.abs(currentStat.dataValues.lastFailureTimestamp - currentStat.dataValues.latestCheckTimestamp) < config.healthCheck.requestTimeout, true, 'Last Failure Timestamp' )
-
+  it('HealthStat update - FAILURE - Data not recent', async function () {
+    let testObj = sampleResponse2;
+    const currentTime = Date.now();
+    testObj.data.result.forEach((elem) => {
+      elem.value[0] = (currentTime - config.healthCheck.maxResponseRange)/1000;
     })
+    const res = nodeHealthCheckJs.compareTimeStamp(testObj);
+    const stat = await nodeHealthCheckJs.updateHealthStat(res);
+    await nodeHealthCheckJs.updateCurrentHealth(stat);
+    assert.equal(stat[0], false, "Unhealthy");
+    assert.equal(stat[1].sort().toString(), Object.values(nodeHealthCheckJs.neededJobs).sort().toString(), 'Errored Processes')
+    let entriesAdded;
+    for (let i = 0; i < 2; i++) {
+      entriesAdded = await models.HealthStat.findAll({
+        attributes: ['processName', 'HealthStatus'],
+        limit: 4,
+        order: [['createdAt', 'DESC']],
+      })
+    };
 
-    it('StallStat update -- SUCCESS', async function () {
+  })
 
-        const lastV = 0;
-        const lastP = 1;
-        const thisV = 1;
-        const checkRes = await stallCheckJs.getCurrentHealth(lastP, lastV, thisV);
-        assert.equal(checkRes[0], true, "Healthy");
-        await stallCheckJs.updateCurrentHealth(checkRes);
-        let currentStat;
-        for (let i = 0; i < 3; i++) {
-            currentStat = await models.CurrentHealth.findOne({
-                where: {
-                    processName: "StallStat",
-                },
-            })};
-
-        assert.equal(currentStat.dataValues.latestHealthStatus, true, 'Current Health')
-        assert.equal(currentStat.dataValues.isBlocksValidInc, true, 'isInc')
-        assert.equal(currentStat.dataValues.isLastPending, true, 'isPending')
-        const currentTime = Date.now();
-        assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp' )
-
-        assert.equal((currentStat.dataValues.lastFailureTimestamp < currentStat.dataValues.latestCheckTimestamp), true, 'Last Failure Timestamp' )
-
+  it('HealthStat update - SUCCESS', async function () {
+    let testObj = sampleResponse2;
+    const currentTime = Date.now();
+    testObj.data.result.forEach((elem) => {
+      elem.value[0] = currentTime/1000;
     })
-
-    it('StallStat update -- SUCCESS - Zero pending', async function () {
-
-        const lastV = 0;
-        const lastP = 0;
-        const thisV = 0;
-        const checkRes = await stallCheckJs.getCurrentHealth(lastP, lastV, thisV);
-        assert.equal(checkRes[0], true, "Healthy");
-        await stallCheckJs.updateCurrentHealth(checkRes);
-        let currentStat;
-        for (let i = 0; i < 3; i++) {
-            currentStat = await models.CurrentHealth.findOne({
-                where: {
-                    processName: "StallStat",
-                },
-            })};
-        assert.equal(currentStat.dataValues.latestHealthStatus, true, 'Current Health')
-        assert.equal(currentStat.dataValues.isBlocksValidInc, false, 'isInc')
-        assert.equal(currentStat.dataValues.isLastPending, false, 'isPending')
-        const currentTime = Date.now();
-        assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp' )
-
-        assert.equal((currentStat.dataValues.lastFailureTimestamp < currentStat.dataValues.latestCheckTimestamp), true, 'Last Failure Timestamp' )
-
+    const res = nodeHealthCheckJs.compareTimeStamp(testObj);
+    const stat = await nodeHealthCheckJs.updateHealthStat(res);
+    await nodeHealthCheckJs.updateCurrentHealth(stat);
+    assert.equal(stat[0], true, "Healthy");
+    assert.equal(stat[1].concat().toString(), [].toString(), "Errored Processes")
+    let entriesAdded;
+    for (let i = 0; i < 2; i++) {
+      entriesAdded = await models.HealthStat.findAll({
+        limit: 4,
+        order: [['createdAt', 'DESC']],
+      })
+    }
+    ;
+    entriesAdded.forEach((elem) => {
+      assert.equal(elem.dataValues.HealthStatus, true, `${elem.dataValues.processName} Status`);
     })
+    const currentStat = await models.CurrentHealth.findOne({
+      where: {
+        processName: "HealthStat",
+      },
+    });
+    assert.equal(currentStat.dataValues.latestHealthStatus, true, `Current Health`)
+    assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp')
+    assert.equal((currentStat.dataValues.lastFailureTimestamp < currentStat.dataValues.latestCheckTimestamp), true, 'Last Failure Timestamp')
+
+  })
+
+  it('StallStat update -- FAILURE', async function () {
+
+    const lastV = 0;
+    const lastP = 1;
+    const thisV = 0;
+    const checkRes = await stallCheckJs.getCurrentHealth(lastP, lastV, thisV);
+    assert.equal(checkRes[0], false, "Unhealthy");
+    await stallCheckJs.updateCurrentHealth(checkRes);
+    let currentStat;
+    for (let i = 0; i < 3; i++) {
+      currentStat = await models.CurrentHealth.findOne({
+        where: {
+          processName: "StallStat",
+        },
+      })
+    }
+    ;
+    assert.equal(currentStat.dataValues.latestHealthStatus, false, 'Current Health')
+    assert.equal(currentStat.dataValues.isBlocksValidInc, false, 'isInc')
+    assert.equal(currentStat.dataValues.isLastPending, true, 'isPending')
+    const currentTime = Date.now();
+    assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp')
+
+    assert.equal(Math.abs(currentStat.dataValues.lastFailureTimestamp - currentStat.dataValues.latestCheckTimestamp) < config.healthCheck.requestTimeout, true, 'Last Failure Timestamp')
+
+  })
+
+  it('StallStat update -- SUCCESS', async function () {
+
+    const lastV = 0;
+    const lastP = 1;
+    const thisV = 1;
+    const checkRes = await stallCheckJs.getCurrentHealth(lastP, lastV, thisV);
+    assert.equal(checkRes[0], true, "Healthy");
+    await stallCheckJs.updateCurrentHealth(checkRes);
+    let currentStat;
+    for (let i = 0; i < 3; i++) {
+      currentStat = await models.CurrentHealth.findOne({
+        where: {
+          processName: "StallStat",
+        },
+      })
+    }
+    ;
+
+    assert.equal(currentStat.dataValues.latestHealthStatus, true, 'Current Health')
+    assert.equal(currentStat.dataValues.isBlocksValidInc, true, 'isInc')
+    assert.equal(currentStat.dataValues.isLastPending, true, 'isPending')
+    const currentTime = Date.now();
+    assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp')
+
+    assert.equal((currentStat.dataValues.lastFailureTimestamp < currentStat.dataValues.latestCheckTimestamp), true, 'Last Failure Timestamp')
+
+  })
+
+  it('StallStat update -- SUCCESS - Zero pending', async function () {
+
+    const lastV = 0;
+    const lastP = 0;
+    const thisV = 0;
+    const checkRes = await stallCheckJs.getCurrentHealth(lastP, lastV, thisV);
+    assert.equal(checkRes[0], true, "Healthy");
+    await stallCheckJs.updateCurrentHealth(checkRes);
+    let currentStat;
+    for (let i = 0; i < 3; i++) {
+      currentStat = await models.CurrentHealth.findOne({
+        where: {
+          processName: "StallStat",
+        },
+      })
+    }
+    ;
+    assert.equal(currentStat.dataValues.latestHealthStatus, true, 'Current Health')
+    assert.equal(currentStat.dataValues.isBlocksValidInc, false, 'isInc')
+    assert.equal(currentStat.dataValues.isLastPending, false, 'isPending')
+    const currentTime = Date.now();
+    assert.equal(Math.abs(currentStat.dataValues.latestCheckTimestamp - currentTime) < config.healthCheck.requestTimeout, true, 'Current Timestamp')
+
+    assert.equal((currentStat.dataValues.lastFailureTimestamp < currentStat.dataValues.latestCheckTimestamp), true, 'Last Failure Timestamp')
+
+  })
 
 
-    it('Websocket Emission', function* () {
+  it('Websocket Emission', function* () {
 
 
-    })
+  })
 
-    it('API endpoints', async function () {
+  it('API endpoints', async function () {
 
-    })
+  })
 })

--- a/apex/api/test/health.test.js
+++ b/apex/api/test/health.test.js
@@ -65,7 +65,7 @@ describe('Tests - Node-level Health Check', function () {
     let testObj = sampleResponse2;
     const currentTime = Date.now();
     testObj.data.result.forEach((elem) => {
-      elem.value[0] = (currentTime - config.healthCheck.maxResponseRange)/1000;
+      elem.value[0] = (currentTime - config.healthCheck.pollFrequency * 3)/1000;
     })
     const res = nodeHealthCheckJs.compareTimeStamp(testObj);
     const stat = await nodeHealthCheckJs.updateHealthStat(res);

--- a/smd-ui/src/lib/formatSeconds.js
+++ b/smd-ui/src/lib/formatSeconds.js
@@ -1,6 +1,6 @@
 export function sec2Date(sec){
     if (sec == 0){
-        return "Unhealthy";
+        return " ";
     }
     let seconds = sec;
     const days = Math.floor(seconds / (3600*24));


### PR DESCRIPTION
Added a check into daemon/node-health-check so that ./strato --stop and ./strato --start will save the new lastFailuteTimestamp, uptime will start from 0.

There is a 15 seconds gap when the strato is restarted, where the uptime was still incrementing from the previous uptime. This is the pollFrequency of node health daemon.