### PR TITLE
Repurpose the connection timeout to create a watchdog

### DIFF
--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -12,6 +12,7 @@ description:
 github: blockapps/strato-platform/core-strato/strato-p2p
 
 dependencies:
+  - alarmclock
   - array
   - async
   - base >= 4 && < 5

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -16,6 +16,7 @@ import           Control.Monad.IO.Unlift
 import           Control.Monad.State
 import           Control.Monad.Trans.Resource
 import           Crypto.Types.PubKey.ECC
+import           Data.Bits                             (shiftL)
 import qualified Data.ByteString                       as B
 import qualified Data.ByteString.Char8                 as BC
 import           Conduit
@@ -28,6 +29,7 @@ import           Data.List.Split
 import           Data.Maybe
 import qualified Data.Text                             as T
 import           Data.Void
+import           Text.Printf
 import           UnliftIO.Concurrent                   hiding (yield)
 import           UnliftIO.Exception
 import           UnliftIO.STM
@@ -263,7 +265,14 @@ bytesToMessages = forever $ do
     objBytes <- getRLPData
     yield $ obj2WireMessage word $ rlpDeserialize objBytes
 
+maxMessageSize :: Int
+maxMessageSize = 1 `shiftL` 24
+
 messageToBytes :: Monad m => ConduitM Message B.ByteString m ()
 messageToBytes = mapC $ \msg ->
   let (theWord, o) = wireMessage2Obj msg
-  in theWord `B.cons` rlpSerialize o
+      bs = theWord `B.cons` rlpSerialize o
+  in if B.length bs >= maxMessageSize
+        then error $ printf "messageToBytes: message (%s...) too large for TCP send (%d >= %d)"
+                            (take 50 $ show msg) (B.length bs) maxMessageSize
+        else bs

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -28,6 +28,7 @@ import           Data.List.Split
 import           Data.Maybe
 import qualified Data.Text                             as T
 import           Data.Void
+import           UnliftIO.Concurrent                   hiding (yield)
 import           UnliftIO.Exception
 import           UnliftIO.STM
 
@@ -57,6 +58,7 @@ import           Blockchain.Strato.RedisBlockDB.Models
 import           Blockchain.Stream.VMEvent
 import           Blockchain.TimerSource
 import           Blockchain.Util
+import           Blockchain.Watchdog
 
 ethVersion :: Int
 ethVersion = 62
@@ -65,8 +67,7 @@ ethVersion = 62
 blockstanbulVersion :: Int
 blockstanbulVersion = 1
 
-mkEthP2PEventSource :: ( Monad m
-                       , MonadResource m
+mkEthP2PEventSource :: ( MonadResource m
                        , MonadLogger m
                        , MonadUnliftIO m
                        )
@@ -76,17 +77,22 @@ mkEthP2PEventSource :: ( Monad m
                     -> m (ConduitM () Event m ())
 mkEthP2PEventSource app inCtx ks = do
   canarySource <- mkCanarySource
-  (.| CL.iterM recordEvent) <$> mergeSourcesByForce (
+  tid <- myThreadId
+  recvWatchdog <- mkWatchdog tid $ fromIntegral flags_connectionTimeout
+  merged <- mergeSourcesByForce (
     [ appSource app
         .| ethDecrypt inCtx
         .| bytesToMessages
         .| CL.iterM (displayMessage Inbound (show $ appSockAddr app))
         .| CL.map MsgEvt
+        .| CL.iterM (const $ petWatchdog recvWatchdog)
     , seqEventNotificationSource ks
         .| CL.map NewSeqEvent
     , canarySource .| CL.map absurd
     , timerSource
     ]) 4096 -- 🙏
+  return $ merged
+        .| CL.iterM recordEvent
 
 mkCanarySource :: (MonadLogger m, MonadUnliftIO m, MonadResource m) => m (ConduitM () Void m ())
 mkCanarySource = do
@@ -98,16 +104,19 @@ mkCanarySource = do
   -- Wait forever on nothing
   return $ sourceTQueue q
 
-mkEthP2PEventConduit :: (MonadResource m, MonadLogger m)
+mkEthP2PEventConduit :: (MonadResource m, MonadLogger m, MonadUnliftIO m)
                      => String
                      -> EthCryptState
-                     -> ConduitM (Either P2PCNC Message) BC.ByteString m ()
-mkEthP2PEventConduit str outCtx =
-     debounceTxSends
-  .| CL.iterM recordMessage
-  .| CL.iterM (displayMessage Outbound str)
-  .| messageToBytes
-  .| ethEncrypt outCtx
+                     -> m (ConduitM (Either P2PCNC Message) BC.ByteString m ())
+mkEthP2PEventConduit str outCtx = do
+  tid <- myThreadId
+  sendWatchdog <- mkWatchdog tid $ fromIntegral flags_connectionTimeout
+  return $ debounceTxSends
+        .| CL.iterM recordMessage
+        .| CL.iterM (displayMessage Outbound str)
+        .| CL.iterM (const $ petWatchdog sendWatchdog)
+        .| messageToBytes
+        .| ethEncrypt outCtx
 
 debounceTxSends :: MonadIO m => ConduitT (Either P2PCNC Message) Message m ()
 debounceTxSends = do

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -82,6 +82,7 @@ mkEthP2PEventSource app inCtx ks = do
   merged <- mergeSourcesByForce (
     [ appSource app
         .| ethDecrypt inCtx
+        .| CL.iterM (recordTraffic Inbound)
         .| bytesToMessages
         .| CL.iterM (displayMessage Inbound (show $ appSockAddr app))
         .| CL.map MsgEvt
@@ -116,6 +117,7 @@ mkEthP2PEventConduit str outCtx = do
         .| CL.iterM (displayMessage Outbound str)
         .| CL.iterM (const $ petWatchdog sendWatchdog)
         .| messageToBytes
+        .| CL.iterM (recordTraffic Outbound)
         .| ethEncrypt outCtx
 
 debounceTxSends :: MonadIO m => ConduitT (Either P2PCNC Message) Message m ()

--- a/core-strato/strato-p2p/src/Blockchain/ExtMergeSources.hs
+++ b/core-strato/strato-p2p/src/Blockchain/ExtMergeSources.hs
@@ -13,10 +13,9 @@ import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Resource
+import           Data.Conduit
 import           Data.Conduit.TMChan          hiding (mergeSources)
 import           Data.Foldable
-
-import           Data.Conduit
 import           UnliftIO.Concurrent
 import           UnliftIO.Exception
 import           UnliftIO.STM

--- a/core-strato/strato-p2p/src/Blockchain/Metrics.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Metrics.hs
@@ -11,6 +11,8 @@ module Blockchain.Metrics ( recordEvent
                           , recordException
                           , recordQueuedTxs
                           , recordEmptyQueue
+                          , recordWatchdogPet
+                          , recordWatchdogWake
                           ) where
 
 import Control.Exception
@@ -134,3 +136,16 @@ recordQueuedTxs = liftIO . addGauge txQueueDepth . fromIntegral . Prelude.length
 
 recordEmptyQueue :: MonadIO m => m ()
 recordEmptyQueue = liftIO $ setGauge txQueueDepth 0
+
+{-# NOINLINE watchdogActions #-}
+watchdogActions :: Vector Text Counter
+watchdogActions = unsafeRegister
+                . vector "action"
+                . counter
+                $ Info "p2p_watchdog_actions" "Number of wakes/pets that the watchdog has endured"
+
+recordWatchdogPet :: MonadIO m => m ()
+recordWatchdogPet = liftIO $ withLabel watchdogActions "pet" incCounter
+
+recordWatchdogWake :: MonadIO m => m ()
+recordWatchdogWake = liftIO $ withLabel watchdogActions "wake" incCounter

--- a/core-strato/strato-p2p/src/Blockchain/Metrics.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Metrics.hs
@@ -13,14 +13,17 @@ module Blockchain.Metrics ( recordEvent
                           , recordEmptyQueue
                           , recordWatchdogPet
                           , recordWatchdogWake
+                          , recordTraffic
                           ) where
 
 import Control.Exception
 import Control.Monad.IO.Class
+import qualified Data.ByteString as B
 import Data.Text
 import Data.Typeable
 import Prometheus
 
+import Blockchain.Display (MsgDirection(..))
 import Blockchain.EventModel
 import Blockchain.Data.Wire
 import Blockchain.Strato.Discovery.Data.Peer (PPeer(..))
@@ -149,3 +152,18 @@ recordWatchdogPet = liftIO $ withLabel watchdogActions "pet" incCounter
 
 recordWatchdogWake :: MonadIO m => m ()
 recordWatchdogWake = liftIO $ withLabel watchdogActions "wake" incCounter
+
+
+{-# NOINLINE traffic #-}
+traffic :: Vector (Text, Text) Counter
+traffic = unsafeRegister
+        . vector ("direction", "type")
+        . counter
+        $ Info "p2p_traffic" "Number and lengths of inbound/outbound messages"
+
+
+recordTraffic :: MonadIO m => MsgDirection -> B.ByteString -> m ()
+recordTraffic dir msg = liftIO $ do
+  let dirLabel = if dir == Inbound then "recv" else "send"
+  withLabel traffic (dirLabel, "count") incCounter
+  withLabel traffic (dirLabel, "bytes") $ \c -> unsafeAddCounter c (fromIntegral $ B.length msg)

--- a/core-strato/strato-p2p/src/Blockchain/Watchdog.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Watchdog.hs
@@ -1,0 +1,46 @@
+module Blockchain.Watchdog where
+
+import Control.Concurrent
+import Control.Concurrent.AlarmClock
+import Control.Exception
+import Control.Monad
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Resource
+import Data.Time
+import UnliftIO.STM
+
+import Blockchain.Metrics
+
+-- Watchdogs are used to check that particular threads don't hang
+-- indefinitely. In particular each p2p connection should be
+-- sending and receiving one ROUND_CHANGE per blockstanbulRoundPeriodS, so
+-- if the sending/receiving threads are stalled for a multiple of that it
+-- indicates an unhealthy connection.
+data Watchdog = Watchdog (TVar Bool)
+
+data WatchdogBite = WatchdogBite ThreadId NominalDiffTime deriving (Show)
+
+instance Exception WatchdogBite where
+
+-- mkWatchdog will bite the passed in `mtid` when `interval` has
+-- elapsed without a pet.
+mkWatchdog :: MonadResource m => ThreadId -> NominalDiffTime -> m Watchdog
+mkWatchdog mtid interval = do
+  hasBeenPet <- atomically $ newTVar True
+  let checkForPet :: AlarmClock UTCTime -> UTCTime -> IO ()
+      checkForPet this now = do
+        recordWatchdogWake
+        lastValue <- atomically $ swapTVar hasBeenPet False
+        if lastValue
+          then liftIO . setAlarm this $ addUTCTime interval now
+          else throwTo mtid $ WatchdogBite mtid interval
+
+  when (interval > 0) $ do
+    (_, alarm) <- allocate (liftIO $ newAlarmClock' checkForPet) destroyAlarmClock
+    liftIO $ setAlarmNow alarm
+  return $ Watchdog hasBeenPet
+
+petWatchdog :: MonadUnliftIO m => Watchdog -> m ()
+petWatchdog (Watchdog hasBeenPet) = do
+  recordWatchdogPet
+  atomically $ writeTVar hasBeenPet True

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -77,11 +77,11 @@ runPeer peer myPriv _ _ = runResourceT $ do
         (_, (outCtx, inCtx)) <- liftIO $ appSource app $$+ ethCryptConnect myPriv otherPubKey `fuseUpstream` appSink app
 
         !eventSource <- mkEthP2PEventSource app inCtx (contextKafkaState initState)
-        let !eventSink = mkEthP2PEventConduit (show $ appSockAddr app) outCtx
+        !eventSink <- mkEthP2PEventConduit (show $ appSockAddr app) outCtx
         attempt :: Either SomeException () <- try . runConduit . evalStateLC initState $
                   transPipe lift eventSource
                .| handleMsgClientConduit myPublic peer
-               .| eventSink
+               .| transPipe lift eventSink
                .| appSink app
 
         void . liftIO $ setPeerActiveState (pPeerIp peer) (pPeerTcpPort peer) Unactive

--- a/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -60,11 +60,11 @@ runEthServer myPriv listenPort = do
               void . liftIO $ setPeerActiveState (pPeerIp p) (pPeerTcpPort p) Active
               (_, (outCtx, inCtx)) <- liftIO $ appSource app $$+ ethCryptAccept myPriv otherPubKey `fuseUpstream` appSink app
               !eventSource <- mkEthP2PEventSource app inCtx (contextKafkaState initState)
-              let !eventSink = mkEthP2PEventConduit (show $ appSockAddr app) outCtx
+              !eventSink <- mkEthP2PEventConduit (show $ appSockAddr app) outCtx
               (attempt :: Either SomeException ()) <- try . runConduit . evalStateLC initState $
                      transPipe lift eventSource
                   .| handleMsgServerConduit myPubkey p
-                  .| eventSink
+                  .| transPipe lift eventSink
                   .| appSink app
 
               void . liftIO $ setPeerActiveState (pPeerIp p) (pPeerTcpPort p) Unactive


### PR DESCRIPTION
If a connection becomes stuck, an exception is thrown and a new connection can be established