### PR TITLE
Constrain vm mem

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -117,12 +117,16 @@ function newnode {
   if [ -n "${svmDev}" ]; then
     svdFlag="--svmDev=${svmDev}"
   fi
+  if [ -n "${seqEventsBatchSize}" ]; then
+    sebFlag="--seqEventsBatchSize=${seqEventsBatchSize}"
+  fi
+
   echo "Starting vm-runner"
   runBackgroundProcess vm-runner --useSyncMode=$useSyncMode --miner=$miningAlgorithm --maxTxsPerBlock=$maxTxsPerBlock \
                          --diffPublish=$diffPublish --sqlDiff=$sqlDiff --createTransactionResults=true \
                          --miningVerification=$verifyBlocks --difficultyBomb=$difficultyBomb \
                          --trace=$evmTraceMode --debug=$evmDebugMode --minLogLevel=$evmMinLogLevel \
-                         "${tbFlag}" "${breFlag}" "${svdFlag}" +RTS "${vmRunnerRTSOPTs:-}" -N1 &>> logs/vm-runner
+                         "${tbFlag}" "${breFlag}" "${sebFlag}" "${svdFlag}" +RTS "${vmRunnerRTSOPTs:-}" -N1 &>> logs/vm-runner
 
   echo "Starting strato-api"
   HOST=0.0.0.0 PORT=3000 APPROOT="" FETCH_LIMIT=2000 NODEKEY=$apiKey \

--- a/core-strato/vm-runner/package.yaml
+++ b/core-strato/vm-runner/package.yaml
@@ -51,6 +51,7 @@ dependencies:
   - wai-middleware-prometheus
   - warp
   - async
+  - unliftio
   - util
   - blockstanbul # This dependency doesn't appear to be used at all, except for one symbol that doesn't exist.
                  # To avoid breaking builds, please leave this here: https://blockapps.atlassian.net/browse/OPS-65
@@ -80,7 +81,9 @@ tests:
       - aeson
       - data-default
       - ethereum-vm
+      - vm-runner
       - hspec
+      - hspec-expectations-lifted
     ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
 
 benchmarks:

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -18,9 +18,11 @@ module Blockchain.BlockChain
     , outputTransactionResult
     , runCodeForTransaction
     , calculateIntrinsicGas'
+    , compactDiffs -- For testing
   ) where
 
 import           Control.Arrow                           ((&&&))
+import           Control.Lens.Operators
 import           Control.Monad
 import           Control.Monad.IO.Class
 import qualified Control.Monad.State                     as State
@@ -29,7 +31,6 @@ import           Control.Monad.Trans.Except
 import qualified Data.ByteString                         as B
 import qualified Data.ByteString.Short                   as BSS
 import           Data.Either.Extra
-import           Data.IORef
 import           Data.List
 import qualified Data.Map                                as M
 import           Data.Maybe
@@ -40,6 +41,7 @@ import           Blockchain.MilenaTools                  (withKafkaViolently)
 import           Prometheus                                as P
 import           Text.PrettyPrint.ANSI.Leijen            (pretty)
 import           Text.Printf
+import           UnliftIO.IORef
 
 import           Blockchain.Constants
 import           Blockchain.Strato.Model.Action
@@ -194,18 +196,28 @@ addBlocks blocks' = do
       didReplaceBest   <- liftIO (newIORef False)
       ranPrivateTxs    <- liftIO (newIORef S.empty)
       replacedBest     <- liftIO (newIORef (error "addBlocks.replacedBest: evaluating uninitialized BestBlockInfo!"))
-      actions <- forM filtered $ \block -> timeit ("Block #" ++ show (blockDataNumber . obBlockData $ block) ++ " (" ++ show (length . obReceiptTransactions $ block) ++ " TXs) insertion") timerToUse $ do
-        actions <- addBlock block
-        (didReplaceThisTime, ranPriv, replacedBits) <- replaceBestIfBetter block
-        when didReplaceThisTime . liftIO $ do
+      (actions, srLog') <- flip State.runStateT [] $ forM filtered $ \block ->
+          let blockNo = blockDataNumber $! obBlockData block
+              txCount = length $! obReceiptTransactions block
+          in timeit (printf "Block #%d (%d TXs insertion)" blockNo txCount) timerToUse $ do
+        actions <- lift $ addBlock block
+        (didReplaceThisTime, ranPriv, replacedBits@(hsh, num, _)) <- lift $ replaceBestIfBetter block
+        when didReplaceThisTime $ do
           writeIORef didReplaceBest True
           writeIORef replacedBest (block, replacedBits)
+          -- Gather a chain of better block stateroots. The last one found should be the best block,
+          -- and the intermediate ones increase the granularity at which we can compute a sequence
+          -- of diffs. The number of blocks to skip between stateroots is determined by the cost of
+          -- the diff between them, which is estimated by the number of transactions.
+          id %= ((blockDataStateRoot $ obBlockData block, hsh, num, txCount):)
         unless (S.null ranPriv) . liftIO $ do
           modifyIORef' ranPrivateTxs (S.union ranPriv)
           drb <- liftIO (readIORef didReplaceBest)
           unless drb $ do
             writeIORef replacedBest (block, replacedBits)
         return actions
+      let srLog = reverse srLog'
+      $logDebugLS "addBlocks/srLog" srLog
       didReplaceBest' <- liftIO (readIORef didReplaceBest)
       ranPrivateTxs' <- liftIO (readIORef ranPrivateTxs)
       timeit "writeIndexEvents1 " timerToUse $ void . withKafkaViolently $ writeIndexEvents (RanBlock <$> blocks') -- emit all blocks to the indexers
@@ -214,9 +226,10 @@ addBlocks blocks' = do
         (theBlock, nbb) <- liftIO (readIORef replacedBest)
         timeit "writeIndexEvents2 " timerToUse $ void . withKafkaViolently $ writeIndexEvents [NewBestBlock nbb]
         timeit "calculateAndEmitStateDiffs " timerToUse $
-          calculateAndEmitStateDiffs theBlock
+          calculateAndEmitStateDiffs srLog
                                      (if didReplaceBest' then Just oldHeader else Nothing)
                                      ranPrivateTxs'
+                                     theBlock
       return $ concat actions
 
   where
@@ -677,23 +690,21 @@ splitCreateDiffs =
         srch = map ch . join . map sequence . map sr
      in S.toList . S.fromList . srch
 
-calculateAndEmitStateDiffs :: (TransactionLike t, Format b, BlockLike BlockData t b) -- todo: generalize commitSqlDiffs etc. to take all BlockHeaderLikes
-                           => b
+calculateAndEmitStateDiffs :: [(MP.StateRoot, SHA, Integer, Int)]
                            -> Maybe BlockData
                            -> S.Set Word256
+                           -> OutputBlock
                            -> ContextM ()
-calculateAndEmitStateDiffs newBlock mOldPubHeader chainIds = when flags_sqlDiff $ do
+calculateAndEmitStateDiffs srLog mOldPubHeader chainIds newBlock = when flags_sqlDiff $ do
+    diffs <- case mOldPubHeader of
+      Nothing -> return []
+      Just oldHeader -> do
+        let base = MP.StateRoot $ blockHeaderStateRoot oldHeader
+        calculateBatchedDiffs base srLog
+    $logInfoS "calculateAndEmitStateDiffs" . T.pack $ "Calculating ChainDiffs for: " ++ show (S.map (format . SHA) chainIds)
     let newHeader    = blockHeader newBlock
         newHash      = blockHash newBlock
-        newStateRoot = MP.StateRoot (blockHeaderStateRoot newHeader)
         newNumber    = blockHeaderOrdering newHeader
-    diffs <- case mOldPubHeader of
-      Just oldHeader -> do
-        let oldStateRoot = MP.StateRoot $ blockHeaderStateRoot oldHeader
-        $logInfoS "calculateAndEmitStateDiffs" . T.pack $ "Calculating StateDiff from: " ++ format oldStateRoot ++ "\nto: " ++ format newStateRoot
-        (:[]) <$> stateDiff Nothing newNumber newHash oldStateRoot newStateRoot
-      Nothing -> return []
-    $logInfoS "calculateAndEmitStateDiffs" . T.pack $ "Calculating ChainDiffs for: " ++ show (S.map (format . SHA) chainIds)
     chainDiffs <- chainDiff newNumber newHash $ S.toList chainIds
 
     $logInfoS "calculateAndEmitStateDiffs" "Calculating all new code hashes"
@@ -701,3 +712,35 @@ calculateAndEmitStateDiffs newBlock mOldPubHeader chainIds = when flags_sqlDiff 
     let allDiffs = diffs ++ chainDiffs
 
     forM_ allDiffs $ lift . commitSqlDiffs
+
+diffMaxCost :: Int
+diffMaxCost = 500
+
+type PreDiff = (MP.StateRoot, SHA, Integer, Int)
+type ToDiff = (MP.StateRoot, MP.StateRoot, SHA, Integer)
+
+promote :: MP.StateRoot -> PreDiff -> ToDiff
+promote base (next, hsh, num, _) = (base, next, hsh, num)
+
+cost :: PreDiff -> Int
+cost (_, _, _, c) = c
+
+compactDiffs :: MP.StateRoot -> [PreDiff] -> [ToDiff]
+compactDiffs _ [] = error "should not be called on an empty list"
+compactDiffs base (p:ps) = go (cost p) (promote base p) ps
+  where go :: Int -> ToDiff -> [PreDiff] -> [ToDiff]
+        go _ lastPending [] = [lastPending]
+        go pendingCost pending@(pendingBase, pendingNext, _, _) (c:cs) =
+          -- If we can fit this PreDiff in, we augment it to the pending ToDiff.
+          -- Otherwise, we emit and create a new ToDiff
+          if pendingCost + cost c > diffMaxCost
+            then pending:go (cost c) (promote pendingNext c) cs
+            else go (pendingCost + cost c) (promote pendingBase c) cs
+
+calculateBatchedDiffs :: MP.StateRoot -> [(MP.StateRoot, SHA, Integer, Int)] -> ContextM [SD.StateDiff]
+calculateBatchedDiffs base = mapM go . compactDiffs base
+  where go :: (MP.StateRoot, MP.StateRoot, SHA, Integer) -> ContextM SD.StateDiff
+        go (src, dst, hsh, num) = do
+          $logInfoS "calculateAndEmitStateDiffs" . T.pack $
+              "Calculating StateDiff from: " ++ format src ++ "\nto: " ++ format dst
+          stateDiff Nothing num hsh src dst

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -148,6 +148,7 @@ ethereumVM = void . execContextM $ do
         loopTimeit "flushLogEntries" $ flushLogEntries
         loopTimeit "flushTransactionResults" $ flushTransactionResults
         loopTimeit "writeActionJSONToKafka" $ void . K.withKafkaViolently $ writeActionJSONToKafka actions
+        loopTimeit "compactContextM" $ compactContextM
 
         let newOffset = cpOffset + fromIntegral (length seqEvents)
         baggerData <- uncurry EVMCheckpoint <$> Bagger.getCheckpointableState
@@ -253,8 +254,11 @@ getUnprocessedKafkaEvents :: KP.Offset -> ContextM [OutputEvent]
 getUnprocessedKafkaEvents offset = do
     $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Fetching sequenced blockchain events with offset " ++ show offset
     ret <- K.withKafkaViolently (readSeqVmEvents offset)
-    $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Got: " ++ show (length ret) ++ " unprocessed blocks/txs"
-    return ret
+    let ret' = if flags_seqEventsBatchSize > 0
+                 then take flags_seqEventsBatchSize ret
+                 else ret
+    $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Got: " ++ show (length ret') ++ " unprocessed blocks/txs"
+    return ret'
 
 shouldProcessNewTransactions :: ContextM Bool -- todo: probably shouldn't do it by number, but tdiff.
 shouldProcessNewTransactions =

--- a/core-strato/vm-runner/test/Spec.hs
+++ b/core-strato/vm-runner/test/Spec.hs
@@ -4,24 +4,25 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 import           Prelude hiding (print)
-import           ClassyPrelude (print)
 
 import           Test.Hspec
+import qualified Test.Hspec.Expectations.Lifted as L
+import           Test.Hspec.Runner
 import           HFlags
 import           Control.Monad
 import           Control.Monad.IO.Class
 import qualified Data.ByteString         as B
-import qualified Data.ByteString.Char8   as C8
 import qualified Data.ByteString.Base16  as B16
 import qualified Data.ByteString.Short   as BSS
 import           Data.Maybe
 import qualified Data.Set                as S
-import qualified Data.Text.Encoding      as Text
 
+import           Blockchain.BlockChain (compactDiffs)
 import qualified Blockchain.Blockstanbul.BenchmarkLib as BML
 import           Blockchain.Data.Address
 import           Blockchain.Data.AddressStateDB
 import qualified Blockchain.Data.Block as BDB
+import           Blockchain.Database.MerklePatricia as MP
 import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.DB.CodeDB
 import           Blockchain.Data.Code
@@ -31,13 +32,11 @@ import qualified Blockchain.EVM.MutableStack as MS
 import           Blockchain.EVM.Opcodes
 import           Blockchain.Output
 import           Blockchain.Strato.Model.SHA
+import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.VMContext
 import           Blockchain.VMOptions()
 
 import           Executable.EVMFlags ()
-
---noLog :: Loc -> LogSource -> LogLevel -> LogStr -> IO ()
---noLog _ _ _ _ = return ()
 
 {-# NOINLINE exampleCode #-}
 exampleCode :: B.ByteString
@@ -46,13 +45,16 @@ exampleCode = B.pack $ [0..255]
 main :: IO ()
 main = do
   void $ $initHFlags "Yeah Buddy"
-  hspec spec
+  let predicate :: Path -> Bool
+      predicate (_:_, _) = True
+      predicate _ = False
+  hspecWith (configAddFilter predicate defaultConfig) spec
 
 spec :: Spec
 spec = do
   describe "monad transformer over map tests" $ do
     it "stateT get its puts for a map" $ do
-      (execResults,_) <- runLoggingT $ runTestContextM $ do
+      (execResults,_) <- runNoLoggingT $ runTestContextM $ do
         let
           isRunningTests = False
           isHomestead = False
@@ -62,7 +64,7 @@ spec = do
           newAddress = (Address 0xdeadbeef)
           txValue = 0
           txGasPrice = 10000000
-          (i,_) = B16.decode "606060405234610000575b5b5b6101748061001b6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063ec6306431461003e575b610000565b346100005761004b6100d4565b604051808060200182810382528381815181526020019150805190602001908083836000831461009a575b80518252602083111561009a57602082019150602081019050602083039250610076565b505050905090810190601f1680156100c65780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6020604051908101604052806000815250606060405190810160405280602f81526020017f636f6e7472616374204c6f7474657279207b0a0a0966756e6374696f6e204c6f81526020017f74746572792829207b0a097d0a0a7d000000000000000000000000000000000081525090505b905600a165627a7a72305820b42b9b4bfc4b8e1dca667748b387dad2822afdf716ae22a127a0150b31ce7a960029"
+          (i,"") = B16.decode "606060405234610000575b5b5b6101748061001b6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063ec6306431461003e575b610000565b346100005761004b6100d4565b604051808060200182810382528381815181526020019150805190602001908083836000831461009a575b80518252602083111561009a57602082019150602081019050602083039250610076565b505050905090810190601f1680156100c65780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6020604051908101604052806000815250606060405190810160405280602f81526020017f636f6e7472616374204c6f7474657279207b0a0a0966756e6374696f6e204c6f81526020017f74746572792829207b0a097d0a0a7d000000000000000000000000000000000081525090505b905600a165627a7a72305820b42b9b4bfc4b8e1dca667748b387dad2822afdf716ae22a127a0150b31ce7a960029"
           txInit = Code i
 
         _ <- create isRunningTests
@@ -81,12 +83,19 @@ spec = do
                     Nothing
                     Nothing
         addressState <- getAddressState newAddress
-        liftIO . putStrLn $ show addressState
+        addressState `L.shouldBe` AddressState
+           { addressStateNonce = 0
+           , addressStateBalance = 0
+           , addressStateCodeHash = EVMCode (SHA 0x1b2d3c7f0269f98c8e9b627cc564b7d23a2c0c0501518d83e757c518135b7e51)
+           , addressStateContractRoot = MP.StateRoot $ word256ToBytes 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+           , addressStateChainId = Nothing
+           }
+
         code <- getEVMCode $
                 case addressStateCodeHash addressState of
                   EVMCode x -> x
                   _ -> error "vm-runner tests only support EVMCode"
-        liftIO . putStrLn $ show $ B16.encode code
+        code `L.shouldBe` B.drop 27 i -- I'd like this better if I knew why 27 was the offset of the payload, but disassembling wasn't helpful
         call isRunningTests
              isHomestead
              True
@@ -105,17 +114,46 @@ spec = do
              Nothing
              Nothing
       erException execResults `shouldSatisfy` isNothing
-      print $ erTrace execResults
-      print $ erException execResults
-      print $ B16.encode "ec630643"
+      erTrace execResults `shouldBe` []
+      B16.encode "ec630643" `shouldBe` "6563363330363433" -- I have no idea why this is tested
       case erReturnVal execResults of
         Nothing -> liftIO $ putStrLn "No return value"
         Just short -> do
           let code = BSS.fromShort short
-          print code
-          print . fst . B16.decode $ code
-          print . Text.decodeUtf8 $ code
-          print . C8.takeWhile (/= '\0') . C8.drop 64 $ code
+          code `shouldBe` mconcat [ B.replicate 31 0x0, B.singleton 0x20
+                                  , B.replicate 31 0x0, B.singleton 0x2f
+                                  , "contract Lottery {\n\n\tfunction Lottery() {\n\t}\n\n}", B.replicate 17 0x0
+                                  ]
+
+  describe "BatchedDiffs" $ do
+    let toRoot = MP.StateRoot . word256ToBytes
+        base = toRoot 0
+        costForN :: Int -> Word256 -> (MP.StateRoot, SHA, Integer, Int)
+        costForN c n = (toRoot n, SHA n, fromIntegral n, c)
+
+    it "will leave a single block alone, no matter the cost" $ do
+      let want = [(base, toRoot 1, SHA 1, 1)]
+      compactDiffs base [costForN 0 1] `shouldBe` want
+      compactDiffs base [costForN 10000 1] `shouldBe` want
+
+    it "will group small blocks together" $ do
+      compactDiffs base (map (costForN 1) [1..50]) `shouldBe`
+        [(base, toRoot 50, SHA 50, 50)]
+
+    it "will separate huge blocks" $ do
+      compactDiffs base [costForN 10000 1, costForN 10000 2] `shouldBe`
+        [ (base, toRoot 1, SHA 1, 1)
+        , (toRoot 1, toRoot 2, SHA 2, 2)]
+
+    it "will combine moderately sized blocks" $ do
+      -- Assume that maxCost is 500, so 10 blocks per diff
+      let input = map (costForN 50) [1..30]
+      compactDiffs base input `shouldBe`
+        [(base, toRoot 10, SHA 10, 10)
+        ,(toRoot 10, toRoot 20, SHA 20, 20)
+        ,(toRoot 20, toRoot 30, SHA 30, 30)
+        ]
+
   describe "Mutable Stack" $ do
     it "can push elements" $ do
       s <- MS.empty :: IO (MS.MutableStack Int)

--- a/core-strato/vm-tools/src/Blockchain/VMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMContext.hs
@@ -28,6 +28,7 @@ module Blockchain.VMContext
     , queuePendingVote
     , peekPendingVote
     , clearPendingVote
+    , compactContextM
     ) where
 
 
@@ -294,7 +295,7 @@ runContextM f = do
           redisPool <- liftIO $ Redis.checkedConnect lookupRedisBlockDBConfig
           let initialKafkaState = mkConfiguredKafkaState "ethereum-vm"
           runStateT f (Context
-                       MP.MPDB{MP.ldb=sdb, MP.stateRoot=error "stateroot not set"}
+                       MP.MPDB{MP.ldb=sdb, MP.stateRoot=MP.emptyTriePtr}
                        hdb
                        cdb
                        blksumdb
@@ -383,3 +384,6 @@ clearPendingVote b = do
         Just i -> Q.deleteAt i ctxCoinbaseQ
         Nothing -> ctxCoinbaseQ
   put ctx { contextCoinbaseQueue = newCoinbaseQ}
+
+compactContextM :: ContextM ()
+compactContextM = modify' force

--- a/core-strato/vm-tools/src/Executable/EVMFlags.hs
+++ b/core-strato/vm-tools/src/Executable/EVMFlags.hs
@@ -12,3 +12,4 @@ defineFlag "useSyncMode" False "Whether or not to wait for P2P world state to ge
 defineFlag "ldbCacheSize" (33554432 {- 32 MiB -} :: Int) "size in bytes of LDB block cache per namespace (0 = default of 8MB)"
 defineFlag "ldbBlockSize" (4096     {-  4 KiB-}  :: Int) "size in bytes of LDB block packing per namespace (default is 4096)"
 defineFlag "blockstanbul" (False :: Bool) "Blockstanbul enabling flag"
+defineFlag "seqEventsBatchSize" (-1::Int) "Number of events to read from seq_events per loop"

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -151,6 +151,7 @@ services:
     - redisHost=redis
     - redisPort=6379
     - seqDebugMode=${seqDebugMode}
+    - seqEventsBatchSize=${seqEventsBatchSize}
     - seqMaxEventsPerIter=${seqMaxEventsPerIter}
     - seqMaxUsPerIter=${seqMaxUsPerIter}
     - seqRTSOPTs=${seqRTSOPTs}


### PR DESCRIPTION
By limiting the number of txs in between stateroots of a diff, the max memory usage of the VM is significantly lower. Without the limit, syncing the multinode10x chain took 14.6G on `tim-machine` and would kill the `vm-runner` process on a multinode machine. With the limit, the sync took 6G and was able to sync successfully (both memory figures are system totals)

