### PR TITLE
Batch TXS on send from p2p

### DIFF
--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -57,6 +57,7 @@ dependencies:
   - random
   - resourcet
   - SafeSemaphore
+  - split
   - stm
   - stm-conduit
   - streaming-commons

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -18,11 +18,13 @@ import           Control.Monad.Trans.Resource
 import           Crypto.Types.PubKey.ECC
 import qualified Data.ByteString                       as B
 import qualified Data.ByteString.Char8                 as BC
-import           Data.Conduit
+import           Conduit
 import qualified Data.Conduit.Binary                   as CB
+import           Data.Conduit.Combinators              (yieldMany)
 import qualified Data.Conduit.List                     as CL
 import           Data.Conduit.Network
 import           Data.Conduit.TQueue
+import           Data.List.Split
 import           Data.Maybe
 import qualified Data.Text                             as T
 import           Data.Void
@@ -34,9 +36,10 @@ import           Network.Kafka                         as K
 import           Blockchain.Constants                  hiding (ethVersion)
 import           Blockchain.Context
 import           Blockchain.Data.Block
+import           Blockchain.Data.Control               (P2PCNC(..))
 import           Blockchain.Data.DataDefs
 import           Blockchain.Data.RLP
-import           Blockchain.Data.Wire
+import           Blockchain.Data.Wire                  as W
 import           Blockchain.DB.DetailsDB               hiding (getBestBlockHash)
 import           Blockchain.DB.SQLDB
 import           Blockchain.Display
@@ -96,12 +99,24 @@ mkCanarySource = do
 mkEthP2PEventConduit :: (Monad m, MonadResource m, MonadLogger m)
                      => String
                      -> EthCryptState
-                     -> ConduitM Message BC.ByteString m ()
+                     -> ConduitM (Either P2PCNC Message) BC.ByteString m ()
 mkEthP2PEventConduit str outCtx =
-     CL.iterM recordMessage
+     debounceTxSends
+  .| CL.iterM recordMessage
   .| CL.iterM (displayMessage Outbound str)
   .| messageToBytes
   .| ethEncrypt outCtx
+
+debounceTxSends :: MonadIO m => ConduitT (Either P2PCNC Message) Message m ()
+debounceTxSends = do
+  txq <- atomically newTQueue
+  awaitForever $ \case
+    Right (W.Transactions txs) -> do
+      atomically $ mapM_ (writeTQueue txq) txs
+    Right other -> yield other
+    Left TXQueueTimeout -> do
+      txs <- atomically $ flushTQueue txq
+      yieldMany . map W.Transactions $ chunksOf 100 txs
 
 handleMsgClientConduit :: ( MonadIO (StateT Context m)
                           , MonadResource m
@@ -111,10 +126,10 @@ handleMsgClientConduit :: ( MonadIO (StateT Context m)
                           )
                        => Point
                        -> PPeer
-                       -> ConduitM Event Message (StateT Context m) ()
+                       -> ConduitM Event (Either P2PCNC Message) (StateT Context m) ()
 handleMsgClientConduit myId peer = do
     $logDebugS "handleMsgClientConduit" $ T.pack $ "<waving hand emoji>"
-    yield Hello { version = 4
+    yield $ Right Hello { version = 4
                       , clientId = stratoVersionString
                       , capability = [ ETH . fromIntegral $ ethVersion
                                      , IST . fromIntegral $ blockstanbulVersion
@@ -129,7 +144,7 @@ handleMsgClientConduit myId peer = do
                 Nothing -> error "we don't have a local BestBlock"
                 Just (RedisBestBlock hash _ tdiff) -> do
                     genHash <- lift . runWithSQL $ getGenesisBlockHash
-                    yield Status {
+                    yield $ Right Status {
                         protocolVersion = fromIntegral ethVersion,
                         networkID       = computeNetworkID,
                         totalDifficulty = fromIntegral tdiff,
@@ -145,8 +160,8 @@ handleMsgClientConduit myId peer = do
                 lastBlockNumber <- liftIO getBestKafkaBlockNumber
                 Just (ChainBlock firstBlock:_) <- liftIO $ fetchVMEventsIO 0
                 mrh <- gets maxReturnedHeaders
-                yield $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) (blockDataNumber $ blockBlockData firstBlock))) mrh 0 Forward
-                yield $ GetChainDetails []
+                yield . Right $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) (blockDataNumber $ blockBlockData firstBlock))) mrh 0 Forward
+                yield . Right $ GetChainDetails []
                 handleGetChainDetails peer []
                 stampActionTimestamp
         other -> assertHandshake other
@@ -160,7 +175,7 @@ handleMsgServerConduit :: (MonadIO (StateT Context m)
                          )
                  => Point
                  -> PPeer
-                 -> ConduitM Event Message (StateT Context m) ()
+                 -> ConduitM Event (Either P2PCNC Message) (StateT Context m) ()
 handleMsgServerConduit myPubkey peer = do
     $logDebugS "handleMsgServerConduit" $ T.pack $ "about to parse message"
     awaitMsg >>= \case
@@ -173,7 +188,7 @@ handleMsgServerConduit myPubkey peer = do
                 port = 0,
                 nodeId = myPubkey
             }
-            yield helloMsg'
+            yield $ Right helloMsg'
         other -> assertHandshake $ other
     awaitMsg >>= \case
         Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash} -> do
@@ -184,7 +199,7 @@ handleMsgServerConduit myPubkey peer = do
                     genHash <- lift . runWithSQL $ getGenesisBlockHash
                     when (genHash /= peerGH) $ error "peer has a different genesis block than we do!"
                     void $ RBDB.withRedisBlockDB (RBDB.updateWorldBestBlockInfo peerBestHash 0 peerTD) -- we set to 0 cause we dont necessarily know the number yet
-                    yield Status {
+                    yield $ Right Status {
                         protocolVersion=fromIntegral ethVersion,
                         networkID=computeNetworkID,
                         totalDifficulty= fromIntegral tdiff,
@@ -194,11 +209,11 @@ handleMsgServerConduit myPubkey peer = do
         other -> assertHandshake other
     handleEvents peer
 
-awaitMsg :: (MonadIO m) => ConduitM Event Message m (Maybe Message)
+awaitMsg :: (MonadIO m) => ConduitM Event (Either P2PCNC Message) m (Maybe Message)
 awaitMsg = await >>= \case
     Just (MsgEvt msg) -> return (Just msg)
-    Nothing              -> return Nothing
-    _                    -> awaitMsg
+    Nothing           -> return Nothing
+    _                 -> awaitMsg
 
 assertHandshake :: (MonadLogger m, MonadIO m)
                 => Maybe Message
@@ -234,11 +249,6 @@ bytesToMessages = forever $ do
     yield $ obj2WireMessage word $ rlpDeserialize objBytes
 
 messageToBytes :: Monad m => ConduitM Message B.ByteString m ()
-messageToBytes = do
-    maybeMsg <- await
-    case maybeMsg of
-     Nothing -> return ()
-     Just msg -> do
-        let (theWord, o) = wireMessage2Obj msg
-        yield $ theWord `B.cons` rlpSerialize o
-        messageToBytes
+messageToBytes = mapC $ \msg ->
+  let (theWord, o) = wireMessage2Obj msg
+  in theWord `B.cons` rlpSerialize o

--- a/core-strato/strato-p2p/src/Blockchain/Data/Control.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Data/Control.hs
@@ -1,0 +1,5 @@
+module Blockchain.Data.Control (
+  P2PCNC(..)
+) where
+
+data P2PCNC = TXQueueTimeout deriving (Show, Eq)

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -39,6 +39,7 @@ import           Blockchain.Context
 import           Blockchain.Data.BlockDB
 import           Blockchain.Data.BlockHeader
 import           Blockchain.Data.ChainInfo
+import           Blockchain.Data.Control               (P2PCNC(..))
 import           Blockchain.Data.Enode
 import           Blockchain.Data.PubKey
 import           Blockchain.Data.Transaction
@@ -102,17 +103,23 @@ peerString peer = key ++ "@" ++ T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcp
         p2s (Just p) = BS8.unpack . BC16.encode $ pointToBytes p
         p2s _        = ""
 
+yieldR :: Monad m => a -> ConduitT i (Either e a) m ()
+yieldR = yield . Right
+
+yieldL :: Monad m => e -> ConduitT i (Either e a) m ()
+yieldL = yield . Left
+
 handleEvents :: ( MonadIO m
                 , MonadResource m
                 , RBDB.HasRedisBlockDB m
                 , SK.HasUnseqSink m
                 , MonadState Context m
                 , MonadLogger m
-                ) => PPeer -> ConduitM Event Message m ()
+                ) => PPeer -> ConduitM Event (Either P2PCNC Message) m ()
 handleEvents peer = awaitForever $ \case
     MsgEvt Hello{}  -> error "A hello message appeared after the handshake"
     MsgEvt Status{} -> error "A status message appeared after the handshake"
-    MsgEvt Ping     -> yield Pong
+    MsgEvt Ping     -> yieldR Pong
 
     MsgEvt (Transactions txs) -> do
         stampActionTimestamp
@@ -161,20 +168,20 @@ handleEvents peer = awaitForever $ \case
       when (null chain) $
         $logInfoS "handleEvents/GetBlockHeaders" $ T.pack $ "Warning: A peer requested blocks starting at #" ++ show start ++ ", but we don't have these in our canonical chain.... I don't know what to do, so I am returning a blank response. This may indicate something unhealthy in the network."
 
-      yield . BlockHeaders . skipEntries skip' $ snd <$> chain
+      yieldR . BlockHeaders . skipEntries skip' $ snd <$> chain
 
     MsgEvt (GetBlockHeaders (BlockHash start) max' skip' dir) -> do
       stampActionTimestamp
       maybeHeader :: Maybe BlockHeader <- RBDB.withRedisBlockDB $ RBDB.getHeader start
       case maybeHeader of
-        Nothing    -> yield (BlockBodies [])
+        Nothing    -> yieldR (BlockBodies [])
         Just head' -> do
           let num = blockHeaderBlockNumber head'
           start' <- case dir of
             Reverse -> return $ if num > fromIntegral max' then num - (fromIntegral max') else 1
             Forward -> return num
           chain <- RBDB.withRedisBlockDB $ RBDB.getCanonicalHeaderChain start' max'
-          yield . BlockHeaders . skipEntries skip' $ snd <$> chain
+          yieldR . BlockHeaders . skipEntries skip' $ snd <$> chain
 
     MsgEvt (BlockHeaders headers) -> do
         stampActionTimestamp
@@ -214,7 +221,7 @@ handleEvents peer = awaitForever $ \case
 
             lift $ putBlockHeaders neededHeaders
             $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "putBlockHeaders called with length " ++ show (length neededHeaders)
-            yield . GetBlockBodies $ headerHash <$> neededHeaders
+            yieldR . GetBlockBodies $ headerHash <$> neededHeaders
             stampActionTimestamp
 
     -- todo: seems like geth and parity will send bodies on a best-effort, skipping shas they doesnt have
@@ -229,13 +236,13 @@ handleEvents peer = awaitForever $ \case
     -- todo: someone else or us at a later time
     MsgEvt (GetBlockBodies [])   -> do
       stampActionTimestamp
-      yield (BlockBodies []) -- todo parity bans peers when they do this. should we?
+      yieldR (BlockBodies []) -- todo parity bans peers when they do this. should we?
     MsgEvt (GetBlockBodies shas) -> do
       stampActionTimestamp
       getUntilMissing shas [] [] >>= (\(bodies, pshas) -> do
-          yield . BlockBodies . Prelude.reverse $ map toBody bodies
+          yieldR . BlockBodies . Prelude.reverse $ map toBody bodies
           ptxs <- fmap catMaybes . RBDB.withRedisBlockDB $ mapM RBDB.getPrivateTransactions pshas
-          unless (null ptxs) . yield $ Transactions ptxs)
+          unless (null ptxs) . yieldR $ Transactions ptxs)
         where getUntilMissing :: (RBDB.HasRedisBlockDB m, MonadIO m)
                               => [SHA] -> [Block] -> [SHA] -> m ([Block],[SHA])
               getUntilMissing []     bodies pshas = return (bodies, pshas)
@@ -270,10 +277,10 @@ handleEvents peer = awaitForever $ \case
         if null remainingHeaders
             then when (newCount > 0) $ do
                 mrh <- gets maxReturnedHeaders
-                yield $ GetBlockHeaders (BlockHash $ headerHash $ last headers) mrh 0 Forward
+                yieldR $ GetBlockHeaders (BlockHash $ headerHash $ last headers) mrh 0 Forward
                 stampActionTimestamp
             else do
-                yield $ GetBlockBodies (map headerHash remainingHeaders)
+                yieldR $ GetBlockBodies (map headerHash remainingHeaders)
                 stampActionTimestamp
     MsgEvt (Blockstanbul wm) -> do
       stampActionTimestamp
@@ -295,7 +302,7 @@ handleEvents peer = awaitForever $ \case
       ptrs <- fmap catMaybes . lift . RBDB.withRedisBlockDB $ mapM RBDB.getPrivateTransactions trHashes
       mems <- lift . RBDB.withRedisBlockDB $ mapM (RBDB.getChainMembers . fromJust . txChainId) ptrs
       let trMems = zip ptrs mems
-      yield . Transactions . map fst $ filter ((checkPeerIsMember peer) . snd) trMems
+      yieldR . Transactions . map fst $ filter ((checkPeerIsMember peer) . snd) trMems
 
     MsgEvt (Disconnect _) -> do
             $logInfoS "handleEvents/Disconnect" $ T.pack $ "Disconnect event received in Event handler"
@@ -311,7 +318,7 @@ handleEvents peer = awaitForever $ \case
               $logInfoS "NewSeqEvent.block" . T.pack $ "World TDiff: " ++ show worldTDiff
               when (obTotalDifficulty b >= worldTDiff) $ do
                 $logInfoS "NewSeqEvent.block" . T.pack $ "yielding new block: " ++ show (blockDataNumber . blockBlockData . outputBlockToBlock $ b)
-                yield $ NewBlock (outputBlockToBlock b) (obTotalDifficulty b)
+                yieldR $ NewBlock (outputBlockToBlock b) (obTotalDifficulty b)
       OETx _ tx -> do
         whenM (shouldSendGossip peer $ otOrigin tx) $ do
           let cId = txChainId tx
@@ -328,7 +335,7 @@ handleEvents peer = awaitForever $ \case
             else do
               $logInfoS "handleEvents/OETx" $ T.pack $ "sending Transaction " ++ format (otHash tx) ++ " for chainID " ++ show cId
               $logDebugS "NewSeqEvent.tx" . T.pack $ "the transaction was: " ++ format tx
-              yield $ Transactions [otBaseTx tx]
+              yieldR $ Transactions [otBaseTx tx]
       OEGenesis (OutputGenesis og (cId, cInfo@(ChainInfo uci _))) -> do
         when (shouldSend peer og) $ do
           $logInfoS "NewSeqEvent.genesis" . T.pack $ "yielding new chain: " ++ show cId ++ " with " ++ show uci
@@ -339,11 +346,11 @@ handleEvents peer = awaitForever $ \case
           if match
             then do
               $logInfoS "handleEvents/OEGenesis" $ T.pack $ "sending ChainDetails for chainID " ++ (show cId)
-              yield $ ChainDetails [(cId, cInfo)]
+              yieldR $ ChainDetails [(cId, cInfo)]
             else do
               $logInfoS "handleEvents/OEGenesis" $ T.pack $ "peer requesting chain details is not authorized for chainID " ++ (show cId)
-      OEGetChain chainIds -> yield $ GetChainDetails chainIds
-      OEGetTx shas -> yield $ GetTransactions shas
+      OEGetChain chainIds -> yieldR $ GetChainDetails chainIds
+      OEGetTx shas -> yieldR $ GetTransactions shas
       OENewChainMember cId _ _ -> do
         let formatted = format $ SHA cId
         $logInfoS "handleEvents/OENewChainMember" $ T.pack $ "New member added to chain " ++ formatted
@@ -351,17 +358,17 @@ handleEvents peer = awaitForever $ \case
         when (checkPeerIsMember peer mems) $ do
           $logInfoS "handleEvents/OENewChainMember" $ T.pack $ "Emitting chain details for chain " ++ formatted
           mcInfo <- lift . RBDB.withRedisBlockDB $ RBDB.getChainInfo cId
-          for_ ((cId,) <$> mcInfo) $ yield . ChainDetails . (:[])
+          for_ ((cId,) <$> mcInfo) $ yieldR . ChainDetails . (:[])
       OEBlockstanbul msg -> do
         let outbound = Blockstanbul msg
         $logDebugS "handleEvents/OEBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
-        yield outbound
+        yieldR outbound
       OEAskForBlocks start end p -> do
         ss <- shouldSendToPeer p
         when ss $ do
           let outbound = GetBlockHeaders (BlockNumber start) (fromIntegral $ end - start + 1) 0 Forward
           $logDebugS "handleEvents/OEAskForBlocks" . T.pack $ "Outgoing message: " ++ show outbound
-          yield outbound
+          yieldR outbound
       OEPushBlocks start end p -> do
         ss <- shouldSendToPeer p
         when ss $ do
@@ -372,7 +379,7 @@ handleEvents peer = awaitForever $ \case
               "Blockstanbul believes we have blocks for [%d..%d], they are not found in redis" start end
           let outbound = BlockHeaders . map snd $ chain
           $logDebugS "handleEvents/OEPushBlocks" . T.pack $ "Outgoing message: " ++ show outbound
-          yield outbound
+          yieldR outbound
       OEJsonRpcCommand _ -> $logErrorS "handleEvents/OEJsonRpcCommand" "The impossible happened"
       OECreateBlockCommand -> $logErrorS "handleEvents/OECreateBlockCommand" "何"
       OEVoteToMake{} -> $logErrorS "handleEvents/OEVoteToMake" "absurd"
@@ -386,16 +393,17 @@ handleEvents peer = awaitForever $ \case
                 maxTime <- gets (fromIntegral . connectionTimeout)
                 liftIO $ setTitle $ "timer: " ++ show (maxTime - diffTime)
                 when (diffTime > maxTime) $ do
-                    yield $ Disconnect UselessPeer
+                    yieldR $ Disconnect UselessPeer
                     liftIO $ setTitle "timer timed out!"
                     error "Peer did not respond"
             Nothing -> do
               $logInfoS "TimerEvt" $ T.pack "Timestamp is not set"
               return ()
+        yieldL TXQueueTimeout
 
     AbortEvt reason -> do
       $logInfoS "handleEvents/AbortEvt" . T.pack $ "Received AbortEvt: " ++ reason
-      yield $ Disconnect AlreadyConnected
+      yieldR $ Disconnect AlreadyConnected
     event -> liftIO . error $ "unrecognized event: " ++ show event
 
 handleGetChainDetails :: ( MonadIO m
@@ -407,7 +415,7 @@ handleGetChainDetails :: ( MonadIO m
                          )
                       => PPeer
                       -> [Word256]
-                      -> ConduitM Event Message m ()
+                      -> ConduitM Event (Either P2PCNC Message) m ()
 handleGetChainDetails peer cids' = do
   cids <- case cids' of
             [] -> RBDB.withRedisBlockDB $ RBDB.getIPChains (peerIPAddress peer)
@@ -421,7 +429,7 @@ handleGetChainDetails peer cids' = do
   unless (null filteredPairs) $ do
     cInfos <- lift . RBDB.withRedisBlockDB $ mapM RBDB.getChainInfo cids
     let finalPairs = map (fmap fromJust) . filter (isJust . snd) $ zip cids cInfos
-    yield $ ChainDetails finalPairs
+    yieldR $ ChainDetails finalPairs
     stampActionTimestamp
     $logInfoS "handleGetChainDetails" $ T.pack $ "the following (ChainId, ChainInfo) pairs were returned " ++
       (intercalate "\n" $ show <$> finalPairs)
@@ -434,12 +442,12 @@ numFromRedis = \case
 -- todo: we should take blockNumber as argument here instead of just looking for
 -- bestBlock to prevent us from getting stuck
 syncFetch :: (MonadIO m, RBDB.HasRedisBlockDB m, MonadState Context m, MonadLogger m)
-          => Direction -> Integer -> ConduitM Event Message m ()
+          => Direction -> Integer -> ConduitM Event (Either P2PCNC Message) m ()
 syncFetch d num = do
     blockHeaders' <- lift getBlockHeaders -- get blockHeaders from Context
     when (null blockHeaders') $ do
         mrh <- gets maxReturnedHeaders
-        yield $ GetBlockHeaders (BlockNumber num) mrh 0 d
+        yieldR $ GetBlockHeaders (BlockNumber num) mrh 0 d
         stampActionTimestamp
 
 shouldSend :: PPeer -> Origin.TXOrigin -> Bool

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -18,6 +18,7 @@ import Blockchain.Context
 import Blockchain.Data.ArbitraryInstances()
 import qualified Blockchain.Data.Blockchain as DataBlock
 import qualified Blockchain.Data.DataDefs as DataDefs
+import Blockchain.Data.Control
 import Blockchain.Data.Wire
 import Blockchain.Event
 import Blockchain.Output
@@ -97,11 +98,11 @@ spec = do
   describe "handleEvents" $ do
     it "should pong a ping" $
       runTestPeer . const $ do
-        runConduit $ yield (MsgEvt Ping) .| handleEvents testPeer .| sinkList `L.shouldReturn` [Pong]
+        runConduit $ yield (MsgEvt Ping) .| handleEvents testPeer .| sinkList `L.shouldReturn` [Right Pong]
     it "should return empty BlockBodies to empty BlockHeaders" $
       runTestPeer . const $ do
         runConduit $ yield (MsgEvt (BlockHeaders [])) .| handleEvents testPeer .| sinkList
-          `L.shouldReturn` [GetBlockBodies []]
+          `L.shouldReturn` [Right $ GetBlockBodies []]
     it "should forward blockstanbul messages" $ property $ \wm ->
       let addr = blockstanbulSender wm
       in addr /= 0 && addr /= 0xa ==> runTestPeer $ \ch -> do
@@ -123,6 +124,13 @@ spec = do
         runConduit $ yield (NewSeqEvent (OEBlockstanbul wm))
                       .| handleEvents testPeer
                       .| sinkList
-            `L.shouldReturn` [Blockstanbul wm]
+            `L.shouldReturn` [Right $ Blockstanbul wm]
         -- We should not mistake internal messages as the peers
         shouldSendToPeer 0xa `L.shouldReturn` True
+
+    it "should forward a timer to a TXQueue timeout" $ do
+      runTestPeer . const $ do
+        runConduit $ yield TimerEvt
+                      .| handleEvents testPeer
+                      .| sinkList
+            `L.shouldReturn` [Left TXQueueTimeout]


### PR DESCRIPTION
This makes transaction exchange more efficient by reducing the number of messages. In previous versions of strato, high volumes of transaction starved PBFT messages from being able to complete in a timely manner, but with batched sends PBFT is able to make progress even in the face of high transaction throughput.

I was hoping that this would be an opportunity to use `Control.Debounce`, but unfortunately the conduit architecture makes that hard. I think its possible, `debounceTxSends` would instead provide a sink connected to `handleMsgClientConduit` and a source for `eventSink`, and queue Transactions until a debounced flush moved them to the channel behind the provided source. This would have better latency if it could send a lone transaction immediately and only queue for batches, rather than sending on a fixed interval