### PR TITLE
Chaindb alter

### DIFF
--- a/core-strato/blockapps-data/package.yaml
+++ b/core-strato/blockapps-data/package.yaml
@@ -42,6 +42,7 @@ dependencies:
   - leveldb-haskell
   - lifted-base
   - merkle-patricia-db
+  - monad-alter
   - monad-control
   - mtl
   - network

--- a/core-strato/blockapps-data/src/Blockchain/Stream/VMEvent.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Stream/VMEvent.hs
@@ -23,6 +23,7 @@ module Blockchain.Stream.VMEvent (
 ) where
 
 import           Conduit
+import           Control.Monad.Change.Modify (Modifiable)
 import           Control.Monad.State
 import qualified Data.ByteString             as B
 import qualified Data.ByteString.Lazy        as BL
@@ -70,7 +71,7 @@ vmEventToBytes = BL.toStrict . Binary.encode
 class HasVMEventsSink k where
   getVMEventsSink :: k ([VMEvent] -> k ())
 
-produceVMEventsM :: (HasKafkaState m, MonadIO m) => [VMEvent] -> m Offset
+produceVMEventsM :: (Modifiable KafkaState m, MonadIO m) => [VMEvent] -> m Offset
 produceVMEventsM vmEvents = do
     x <- withKafkaViolently . produceMessages $
         map (TopicAndMessage (lookupTopic "block") . makeMessage . vmEventToBytes) vmEvents

--- a/core-strato/blockapps-mpdbs/src/Blockchain/DB/ChainDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/DB/ChainDB.hs
@@ -1,7 +1,11 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 
-module Blockchain.DB.ChainDB (
-    HasChainDB(..)
+module Blockchain.DB.ChainDB
+  ( BlockHashRoot(..)
+  , GenesisRoot(..)
   , bootstrapChainDB
   , putBlockHeaderInChainDB
   , getChainRoot
@@ -13,17 +17,16 @@ module Blockchain.DB.ChainDB (
   , withBlockchain
   ) where
 
+import           Control.DeepSeq
 import           Control.Monad                        (join, when)
+import           Control.Monad.Change.Modify
 import           Control.Monad.IO.Class
 
 import           Data.Maybe                           (isNothing)
 import qualified Data.NibbleString                    as N
+import           Data.Proxy
 import           Data.Traversable                     (for)
-
 import qualified Database.LevelDB                     as DB
-
-
-
 
 import qualified Blockchain.Database.MerklePatricia   as MP
 import           Blockchain.Data.RLP
@@ -33,6 +36,7 @@ import           Blockchain.Strato.Model.Class
 import           Blockchain.Strato.Model.ExtendedWord (Word256, word256ToBytes)
 import           Blockchain.Strato.Model.SHA          (SHA(..))
 
+import           GHC.Generics
 import           Text.Format
 
 
@@ -92,13 +96,14 @@ import           Text.Format
 |-------------------------------------------------------------------------------|
 -}
 
-class Monad m => HasChainDB m where
-  getBlockHashRoot    :: m MP.StateRoot
-  putBlockHashRoot    :: MP.StateRoot -> m ()
-  getGenesisRoot      :: m MP.StateRoot
-  putGenesisRoot      :: MP.StateRoot -> m ()
-  getBestBlockRoot    :: m MP.StateRoot
-  putBestBlockRoot    :: MP.StateRoot -> m ()
+newtype BlockHashRoot = BlockHashRoot { unBlockHashRoot :: MP.StateRoot }
+  deriving (Eq, Ord, Show, Format, Generic, NFData)
+
+newtype GenesisRoot = GenesisRoot { unGenesisRoot :: MP.StateRoot }
+  deriving (Eq, Ord, Show, Format, Generic, NFData)
+
+newtype BestBlockRoot = BestBlockRoot { unBestBlockRoot :: MP.StateRoot }
+  deriving (Eq, Ord, Show, Format, Generic, NFData)
 
 getLDB :: HasStateDB m => m DB.DB
 getLDB = MP.ldb <$> getStateDB
@@ -112,10 +117,15 @@ getkv db = fmap (fmap rlpDecode) . MP.getKeyVal db
 putkv :: (RLPSerializable a, MonadIO m) => MP.MPDB -> N.NibbleString -> a -> m MP.StateRoot
 putkv db k = (fmap MP.stateRoot) . MP.putKeyVal db k . rlpEncode
 
-bootstrapChainDB :: (HasStateDB m, HasChainDB m) => SHA -> m ()
+bootstrapChainDB :: (HasStateDB m, Modifiable BlockHashRoot m) => SHA -> m ()
 bootstrapChainDB genesisHash = putChainBlockHashInfo genesisHash (SHA 0) MP.emptyTriePtr
 
-putBlockHeaderInChainDB :: (BlockHeaderLike h, Format h, HasStateDB m, HasChainDB m) => h -> m ()
+putBlockHeaderInChainDB :: ( BlockHeaderLike h
+                           , Format h
+                           , HasStateDB m
+                           , Modifiable BlockHashRoot m
+                           )
+                        => h -> m ()
 putBlockHeaderInChainDB b = do
   let p = blockHeaderParentHash b
       h = blockHeaderHash b
@@ -126,35 +136,39 @@ putBlockHeaderInChainDB b = do
       Nothing -> error $ "putBlockHeaderInChainDB: No parent block with hash " ++ format p ++ " found.\n" ++ format b
       Just chainRoot -> putChainBlockHashInfo h p chainRoot
 
-getChainRoot :: (HasStateDB m, HasChainDB m) => SHA -> m (Maybe MP.StateRoot)
+getChainRoot :: (HasStateDB m, Modifiable BlockHashRoot m) => SHA -> m (Maybe MP.StateRoot)
 getChainRoot = fmap (fmap snd) . getChainBlockHashInfo
 
-getChainBlockHashInfo :: (HasStateDB m, HasChainDB m) => SHA -> m (Maybe (SHA, MP.StateRoot))
+getChainBlockHashInfo :: (HasStateDB m, Modifiable BlockHashRoot m) => SHA -> m (Maybe (SHA, MP.StateRoot))
 getChainBlockHashInfo (SHA h) = do
-  bhdb <- MP.MPDB <$> getLDB <*> getBlockHashRoot
+  bhdb <- MP.MPDB <$> getLDB <*> (unBlockHashRoot <$> get Proxy)
   getkv bhdb (word256ToMPKey h)
 
-putChainBlockHashInfo :: (HasStateDB m, HasChainDB m) => SHA -> SHA -> MP.StateRoot -> m ()
+putChainBlockHashInfo :: (HasStateDB m, Modifiable BlockHashRoot m) => SHA -> SHA -> MP.StateRoot -> m ()
 putChainBlockHashInfo (SHA h) parentHash sr = do
-  bhdb <- MP.MPDB <$> getLDB <*> getBlockHashRoot
+  bhdb <- MP.MPDB <$> getLDB <*> (unBlockHashRoot <$> get Proxy)
   newBlockHashRoot <- putkv bhdb (word256ToMPKey h) (parentHash, sr)
-  putBlockHashRoot newBlockHashRoot
+  put Proxy $ BlockHashRoot newBlockHashRoot
 
-getGenesisStateRoot :: (HasStateDB m, HasChainDB m) => Word256 -> m (Maybe MP.StateRoot)
+getGenesisStateRoot :: (HasStateDB m, Modifiable GenesisRoot m) => Word256 -> m (Maybe MP.StateRoot)
 getGenesisStateRoot = fmap (fmap snd) . getChainGenesisInfo
 
-getChainGenesisInfo :: (HasStateDB m, HasChainDB m) => Word256 -> m (Maybe (SHA, MP.StateRoot))
+getChainGenesisInfo :: (HasStateDB m, Modifiable GenesisRoot m) => Word256 -> m (Maybe (SHA, MP.StateRoot))
 getChainGenesisInfo cid = do
-  gdb <- MP.MPDB <$> getLDB <*> getGenesisRoot
+  gdb <- MP.MPDB <$> getLDB <*> (unGenesisRoot <$> get Proxy)
   getkv gdb (word256ToMPKey cid)
 
-putChainGenesisInfo :: (HasStateDB m, HasChainDB m) => Word256 -> SHA -> MP.StateRoot -> m ()
+putChainGenesisInfo :: (HasStateDB m, Modifiable GenesisRoot m) => Word256 -> SHA -> MP.StateRoot -> m ()
 putChainGenesisInfo chainId creationBlock stateRoot = do
-  gdb <- MP.MPDB <$> getLDB <*> getGenesisRoot
+  gdb <- MP.MPDB <$> getLDB <*> (unGenesisRoot <$> get Proxy)
   newGenesisRoot <- putkv gdb (word256ToMPKey chainId) (creationBlock, stateRoot)
-  putGenesisRoot newGenesisRoot
+  put Proxy $ GenesisRoot newGenesisRoot
 
-getChainStateRoot :: (HasStateDB m, HasChainDB m) => Word256 -> SHA -> m (Maybe MP.StateRoot)
+getChainStateRoot :: ( HasStateDB m
+                     , Modifiable BlockHashRoot m
+                     , Modifiable GenesisRoot m
+                     )
+                  => Word256 -> SHA -> m (Maybe MP.StateRoot)
 getChainStateRoot chainId bHash = do
   mChainRoot <- getChainBlockHashInfo bHash
   fmap join . for mChainRoot $ \(parentHash, chainRoot) -> do
@@ -172,7 +186,7 @@ getChainStateRoot chainId bHash = do
             putChainStateRoot chainId bHash stateRoot
             return stateRoot
 
-putChainStateRoot :: (HasStateDB m, HasChainDB m) => Word256 -> SHA -> MP.StateRoot -> m ()
+putChainStateRoot :: (HasStateDB m, Modifiable BlockHashRoot m) => Word256 -> SHA -> MP.StateRoot -> m ()
 putChainStateRoot chainId bHash stateRoot = do
   mChainRoot <- getChainBlockHashInfo bHash
   case mChainRoot of
@@ -182,18 +196,22 @@ putChainStateRoot chainId bHash stateRoot = do
       newChainRoot <- putkv cdb (word256ToMPKey chainId) (chainId, stateRoot)
       putChainBlockHashInfo bHash parentHash newChainRoot
 
-getChainBestBlock :: (HasStateDB m, HasChainDB m) => Word256 -> m (Maybe (SHA, Integer))
+getChainBestBlock :: (HasStateDB m, Modifiable BestBlockRoot m) => Word256 -> m (Maybe (SHA, Integer))
 getChainBestBlock chainId = do
-  bbdb <- MP.MPDB <$> getLDB <*> getBestBlockRoot
+  bbdb <- MP.MPDB <$> getLDB <*> (unBestBlockRoot <$> get Proxy)
   getkv bbdb (word256ToMPKey chainId)
 
-putChainBestBlock :: (HasStateDB m, HasChainDB m) => Word256 -> SHA -> Integer -> m ()
+putChainBestBlock :: (HasStateDB m, Modifiable BestBlockRoot m) => Word256 -> SHA -> Integer -> m ()
 putChainBestBlock chainId bHash ordering = do
-  bbdb <- MP.MPDB <$> getLDB <*> getBestBlockRoot
+  bbdb <- MP.MPDB <$> getLDB <*> (unBestBlockRoot <$> get Proxy)
   newBestBlockRoot <- putkv bbdb (word256ToMPKey chainId) (bHash, ordering)
-  putBestBlockRoot newBestBlockRoot
+  put Proxy $ BestBlockRoot newBestBlockRoot
 
-withBlockchain :: (HasStateDB m, HasChainDB m) => SHA -> Maybe Word256 -> m a -> m a
+withBlockchain :: ( HasStateDB m
+                  , Modifiable BlockHashRoot m
+                  , Modifiable GenesisRoot m
+                  )
+               => SHA -> Maybe Word256 -> m a -> m a
 withBlockchain bh cid f = do
   case cid of
     Nothing -> f

--- a/core-strato/blockapps-mpdbs/src/Blockchain/DB/ChainDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/DB/ChainDB.hs
@@ -6,6 +6,7 @@
 module Blockchain.DB.ChainDB
   ( BlockHashRoot(..)
   , GenesisRoot(..)
+  , BestBlockRoot(..)
   , bootstrapChainDB
   , putBlockHeaderInChainDB
   , getChainRoot
@@ -24,7 +25,6 @@ import           Control.Monad.IO.Class
 
 import           Data.Maybe                           (isNothing)
 import qualified Data.NibbleString                    as N
-import           Data.Proxy
 import           Data.Traversable                     (for)
 import qualified Database.LevelDB                     as DB
 

--- a/core-strato/blockapps-util/package.yaml
+++ b/core-strato/blockapps-util/package.yaml
@@ -24,6 +24,7 @@ library:
     - hflags
     - lens
     - lifted-base
+    - monad-alter
     - monad-control
     - mtl
     - network

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -2,16 +2,17 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications  #-}
 
 module Blockchain.MilenaTools where
 
 
 import           Control.Concurrent     (threadDelay)
 import           Control.Lens
+import qualified Control.Monad.Change.Modify as Mod
 import           Control.Monad.IO.Class      (MonadIO, liftIO)
 import           Control.Monad.Except        (ExceptT (..), runExceptT, throwError)
 import           Control.Monad.Trans.State
-import qualified Control.Monad.Trans.State.Strict as Str
 import           Network.Kafka
 import           Network.Kafka.Protocol
 import           Prelude
@@ -61,40 +62,27 @@ getConsumerGroupCoordinator group = do
         NoError -> return broker
         other   -> throwError $ KafkaFailedToFetchGroupCoordinator other
 
-
-class HasKafkaState m where
-    getKafkaState :: m KafkaState
-    putKafkaState :: KafkaState -> m ()
-
-instance (Monad m) => HasKafkaState (StateT KafkaState m) where
-    getKafkaState = get
-    putKafkaState = put
-
-instance (Monad m) => HasKafkaState (Str.StateT KafkaState m) where
-    getKafkaState = Str.get
-    putKafkaState = Str.put
-
-withKafkaViolently :: (MonadIO m, HasKafkaState m) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
+withKafkaViolently :: (MonadIO m, Mod.Modifiable KafkaState m) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
 withKafkaViolently k = do
-    s <- getKafkaState
+    s <- Mod.get (Mod.Proxy @KafkaState)
     r <- liftIO . runExceptT $ runStateT k s
     case r of
         Left err -> error $ show err
         Right (a, newS) -> do
-            putKafkaState newS
+            Mod.put (Mod.Proxy @KafkaState) newS
             return a
 
-withKafkaRetry :: (MonadIO m, HasKafkaState m) => Int -> StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
+withKafkaRetry :: (MonadIO m, Mod.Modifiable KafkaState m) => Int -> StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
 withKafkaRetry t k = do
-  s <- getKafkaState
+  s <- Mod.get (Mod.Proxy @KafkaState)
   let go = do
         r <- liftIO . runExceptT $ runStateT k s
         case r of
           Right a -> return a
           Left _ -> (liftIO $ threadDelay (1000*t)) >> go
   (a, newS) <- go
-  putKafkaState newS
+  Mod.put (Mod.Proxy @KafkaState) newS
   return a
 
-withKafkaRetry1s :: (MonadIO m, HasKafkaState m) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
+withKafkaRetry1s :: (MonadIO m, Mod.Modifiable KafkaState m) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
 withKafkaRetry1s = withKafkaRetry 1000

--- a/core-strato/ethereum-vm/src/Blockchain/EVM/VMM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/EVM/VMM.hs
@@ -44,7 +44,6 @@ module Blockchain.EVM.VMM (
 
 import           Control.Monad
 import qualified Control.Monad.Change.Alter         as A
---import qualified Control.Monad.Change.Modify        as Mod
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Resource

--- a/core-strato/ethereum-vm/src/Blockchain/EVM/VMM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/EVM/VMM.hs
@@ -44,6 +44,7 @@ module Blockchain.EVM.VMM (
 
 import           Control.Monad
 import qualified Control.Monad.Change.Alter         as A
+import           Control.Monad.Change.Modify        hiding (get, put)
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Resource
@@ -106,19 +107,26 @@ instance HasStateDB VMM where
       vmState <- lift get
       lift $ put vmState{dbs=(dbs vmState){contextStateDB=(contextStateDB $ dbs vmState){MP.stateRoot=x}}}
 
-instance HasChainDB VMM where
-  getBlockHashRoot = lift $ fmap (contextBlockHashRoot . dbs) get
-  putBlockHashRoot sr = do
-    vmState <- lift get
-    lift $ put vmState{dbs=(dbs vmState){contextBlockHashRoot = sr}}
-  getGenesisRoot = lift $ fmap (contextGenesisRoot . dbs) get
-  putGenesisRoot sr = do
-    vmState <- lift get
-    lift $ put vmState{dbs=(dbs vmState){contextGenesisRoot = sr}}
-  getBestBlockRoot = lift $ contextBestBlockRoot . dbs <$> get
-  putBestBlockRoot sr = do
-    vmState <- lift get
-    lift $ put vmState{dbs=(dbs vmState){contextBestBlockRoot = sr}}
+instance Modifiable BlockHashRoot VMM where
+  modify _ f = do
+    cxt <- lift get
+    bhr' <- f $ contextBlockHashRoot $ dbs cxt
+    lift $ put cxt{dbs = (dbs cxt){contextBlockHashRoot = bhr'}}
+    return bhr'
+
+instance Modifiable GenesisRoot VMM where
+  modify _ f = do
+    cxt <- lift get
+    gr' <- f $ contextGenesisRoot $ dbs cxt
+    lift $ put cxt{dbs = (dbs cxt){contextGenesisRoot = gr'}}
+    return gr'
+
+instance Modifiable BestBlockRoot VMM where
+  modify _ f = do
+    cxt <- lift get
+    bbr' <- f $ contextBestBlockRoot $ dbs cxt
+    lift $ put cxt{dbs = (dbs cxt){contextBestBlockRoot = bbr'}}
+    return bbr'
 
 instance HasRawStorageDB VMM where
     getRawStorageTxDB = do

--- a/core-strato/ethereum-vm/src/Blockchain/EVM/VMM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/EVM/VMM.hs
@@ -44,7 +44,7 @@ module Blockchain.EVM.VMM (
 
 import           Control.Monad
 import qualified Control.Monad.Change.Alter         as A
-import           Control.Monad.Change.Modify        hiding (get, put)
+--import qualified Control.Monad.Change.Modify        as Mod
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Resource
@@ -60,7 +60,6 @@ import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.Log
 import qualified Blockchain.Database.MerklePatricia as MP
 import           Blockchain.DB.BlockSummaryDB
-import           Blockchain.DB.ChainDB
 import           Blockchain.DB.CodeDB
 import           Blockchain.DB.HashDB
 import           Blockchain.DB.MemAddressStateDB
@@ -107,27 +106,6 @@ instance HasStateDB VMM where
       vmState <- lift get
       lift $ put vmState{dbs=(dbs vmState){contextStateDB=(contextStateDB $ dbs vmState){MP.stateRoot=x}}}
 
-instance Modifiable BlockHashRoot VMM where
-  modify _ f = do
-    cxt <- lift get
-    bhr' <- f $ contextBlockHashRoot $ dbs cxt
-    lift $ put cxt{dbs = (dbs cxt){contextBlockHashRoot = bhr'}}
-    return bhr'
-
-instance Modifiable GenesisRoot VMM where
-  modify _ f = do
-    cxt <- lift get
-    gr' <- f $ contextGenesisRoot $ dbs cxt
-    lift $ put cxt{dbs = (dbs cxt){contextGenesisRoot = gr'}}
-    return gr'
-
-instance Modifiable BestBlockRoot VMM where
-  modify _ f = do
-    cxt <- lift get
-    bbr' <- f $ contextBestBlockRoot $ dbs cxt
-    lift $ put cxt{dbs = (dbs cxt){contextBestBlockRoot = bbr'}}
-    return bbr'
-
 instance HasRawStorageDB VMM where
     getRawStorageTxDB = do
       cxt <- lift get
@@ -143,7 +121,6 @@ instance HasRawStorageDB VMM where
     putRawStorageBlockMap theMap = do
       cxt <- lift get
       lift $ put cxt{dbs=(dbs cxt){contextStorageBlockMap=theMap}}
-
 
 instance HasCodeDB VMM where
     getCodeDB = lift $ fmap (contextCodeDB . dbs) get

--- a/core-strato/strato-adit/package.yaml
+++ b/core-strato/strato-adit/package.yaml
@@ -24,6 +24,7 @@ dependencies:
   - hflags
   - lens
   - lifted-base
+  - monad-alter
   - mtl
   - normaldistribution
   - random

--- a/core-strato/strato-adit/src/Executable/AditM.hs
+++ b/core-strato/strato-adit/src/Executable/AditM.hs
@@ -1,11 +1,15 @@
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
+{-# LANGUAGE TemplateHaskell       #-}
 module Executable.AditM where
 
 import           Blockchain.Output
+import           Control.Lens                 (lens)
+import           Control.Monad.Change.Modify  (Has(..))
 import           Control.Monad.State
 import           Control.Monad.Trans.Resource
 import           Control.Lens
@@ -14,7 +18,6 @@ import           Data.Time.Clock
 
 import           Blockchain.EthConf           (mkConfiguredKafkaState)
 import           Network.Kafka
-import           Blockchain.MilenaTools
 
 data AditState = AditState {
     aditKafkaState  :: KafkaState,
@@ -40,11 +43,8 @@ recordException = do
 
 type AditM = StateT AditState (ResourceT (LoggingT IO))
 
-instance HasKafkaState AditM where
-    getKafkaState = aditKafkaState <$> get
-    putKafkaState ns = do
-        ctx <- get
-        put $ ctx { aditKafkaState = ns }
+instance AditState `Has` KafkaState where
+  this _ = lens aditKafkaState (\c a -> c{aditKafkaState = a})
 
 runAditT :: AditM a -> LoggingT IO a
 runAditT m = do

--- a/core-strato/strato-index/package.yaml
+++ b/core-strato/strato-index/package.yaml
@@ -21,6 +21,8 @@ dependencies:
   - format
   - hedis
   - hflags
+  - lens
+  - monad-alter
   - persistent
   - persistent-postgresql
   - resourcet

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/IContext.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/IContext.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
 
 module Blockchain.Strato.Indexer.IContext
     ( IContext(..)
@@ -17,6 +19,8 @@ module Blockchain.Strato.Indexer.IContext
     , reIBBI
     ) where
 
+import           Control.Lens                    (lens)
+import           Control.Monad.Change.Modify     (Has(..))
 import           Control.Monad.IO.Class
 import           Blockchain.Output
 import           Control.Monad.Trans.Resource
@@ -33,7 +37,6 @@ import qualified Blockchain.Strato.RedisBlockDB  as RBDB
 import qualified Database.Redis                  as Redis
 
 import           Network.Kafka
-import           Blockchain.MilenaTools
 import           Network.Kafka.Protocol
 
 import           Blockchain.Strato.Indexer.Kafka
@@ -55,11 +58,8 @@ newtype IndexerBestBlockInfo = IndexerBestBlockInfo (SQL.Key BlockDataRef)
 instance HasSQLDB IConfigM where
   getSQLDB = asks contextSQLDB
 
-instance HasKafkaState IContextM where
-    getKafkaState = contextKafkaState <$> get
-    putKafkaState ks = do
-        st <- get
-        put st { contextKafkaState = ks }
+instance IContext `Has` KafkaState where
+  this _ = lens contextKafkaState (\c k -> c{contextKafkaState = k})
 
 instance RBDB.HasRedisBlockDB IContextM where
     getRedisBlockDB = contextRedisBlockDB <$> get

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/IContext.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/IContext.hs
@@ -20,7 +20,7 @@ module Blockchain.Strato.Indexer.IContext
     ) where
 
 import           Control.Lens                    (lens)
-import           Control.Monad.Change.Modify     (Has(..))
+import           Control.Monad.Change.Modify     (Has(..), Accessible(..))
 import           Control.Monad.IO.Class
 import           Blockchain.Output
 import           Control.Monad.Trans.Resource
@@ -45,7 +45,7 @@ newtype IConfig = IConfig { contextSQLDB :: SQLDB }
 
 data IContext = IContext {
     contextKafkaState   :: KafkaState,
-    contextRedisBlockDB :: Redis.Connection,
+    contextRedisBlockDB :: RBDB.RedisConnection,
     contextBestBlock    :: IndexerBestBlockInfo
 }
 
@@ -61,8 +61,8 @@ instance HasSQLDB IConfigM where
 instance IContext `Has` KafkaState where
   this _ = lens contextKafkaState (\c k -> c{contextKafkaState = k})
 
-instance RBDB.HasRedisBlockDB IContextM where
-    getRedisBlockDB = contextRedisBlockDB <$> get
+instance Accessible RBDB.RedisConnection IContextM where
+  access _ = contextRedisBlockDB <$> get
 
 getIndexerBestBlockInfo :: IContextM IndexerBestBlockInfo
 getIndexerBestBlockInfo = contextBestBlock <$> get
@@ -92,7 +92,9 @@ runIContextM cid f = do
     redis <- liftIO $ Redis.checkedConnect lookupRedisBlockDBConfig
     (ret, _) <- runResourceT
               . flip runReaderT (IConfig sqldb)
-              . flip runStateT (IContext (mkConfiguredKafkaState cid) redis (reIBBI 0))
+              . flip runStateT (IContext (mkConfiguredKafkaState cid)
+                                         (RBDB.RedisConnection redis)
+                                         (reIBBI 0))
               $ f
     $logInfoS "runIContextM" "runIContextM complete, returning"
     return ret

--- a/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/core-strato/strato-init/src/Blockchain/GenesisBlock.hs
@@ -15,6 +15,7 @@ module Blockchain.GenesisBlock (
 import           Control.Monad
 import           Blockchain.Output
 import           Control.Monad.Change.Alter                   (Alters)
+import           Control.Monad.Change.Modify                  (Accessible)
 import           Control.Monad.IO.Class
 import qualified Data.ByteString.Base16                       as B16
 import qualified Data.ByteString.Char8                        as C8
@@ -122,7 +123,7 @@ data BackupType = NoBackup | BlockBackup | MPBackup
 initializeGenesisBlock :: ( HasCodeDB m
                           , HasHashDB m
                           , Mem.HasMemAddressStateDB m
-                          , RBDB.HasRedisBlockDB m
+                          , Accessible RBDB.RedisConnection m
                           , HasSQLDB m
                           , HasStateDB m
                           , HasStorageDB m

--- a/core-strato/strato-init/src/Blockchain/Setup.hs
+++ b/core-strato/strato-init/src/Blockchain/Setup.hs
@@ -14,6 +14,7 @@ module Blockchain.Setup (
 import           Control.Concurrent
 import           Control.Monad
 import qualified Control.Monad.Change.Alter         as A
+import           Control.Monad.Change.Modify        (Accessible(..))
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Reader
 import           Control.Monad.Trans.Resource
@@ -92,7 +93,7 @@ data SetupDBs =
     hashDB  :: HashDB,
     codeDB  :: CodeDB,
     sqlDB   :: SQLDB,
-    redisDB :: Redis.Connection,
+    redisDB :: RBDB.RedisConnection,
     localStorageTx :: IORef (Map.Map (Address, B.ByteString) B.ByteString),
     localStorageBlock :: IORef (Map.Map (Address, B.ByteString) B.ByteString),
     localAddressStateTx :: IORef (Map.Map Address AddressStateModification),
@@ -148,8 +149,8 @@ instance HasCodeDB SetupDBM where
 instance HasSQLDB SetupDBM where
   getSQLDB = asks sqlDB
 
-instance RBDB.HasRedisBlockDB SetupDBM where
-  getRedisBlockDB = asks redisDB
+instance Accessible RBDB.RedisConnection SetupDBM where
+  access _ = asks redisDB
 
 {-
 connStr :: ConnectionString
@@ -474,7 +475,7 @@ oneTimeSetup genesisBlockName = do
 
          pool <- runNoLoggingT $ createPostgresqlPool connStr 20
 
-         redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
+         redisBDBPool <- RBDB.RedisConnection <$> liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
 
          void . runLoggingT $ flip runReaderT (SetupDBs smpdb hdb cdb pool redisBDBPool m1 m2 m3 m4) $ do
            void $ addCode EVM B.empty --blank code is the default for Accounts, but gets added nowhere else.

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -47,6 +47,7 @@ dependencies:
   - json-rpc-client
   - lens
   - lifted-base
+  - monad-alter
   - monad-control
   - monadIO
   - blockapps-milena

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -12,6 +12,7 @@ module Blockchain.CommunicationConduit
     ) where
 
 import           Blockchain.Output
+import           Control.Monad.Change.Modify           (Accessible)
 import           Control.Monad.IO.Unlift
 import           Control.Monad.State
 import           Control.Monad.Trans.Resource
@@ -120,7 +121,7 @@ debounceTxSends = do
 
 handleMsgClientConduit :: ( MonadIO (StateT Context m)
                           , MonadResource m
-                          , RBDB.HasRedisBlockDB (StateT Context m)
+                          , Accessible RBDB.RedisConnection (StateT Context m)
                           , WrapsSQLDB (StateT Context) m
                           , MonadLogger (StateT Context m)
                           )
@@ -169,7 +170,7 @@ handleMsgClientConduit myId peer = do
 
 handleMsgServerConduit :: (MonadIO (StateT Context m)
                          , MonadResource m
-                         , RBDB.HasRedisBlockDB (StateT Context m)
+                         , Accessible RBDB.RedisConnection (StateT Context m)
                          , WrapsSQLDB (StateT Context) m
                          , MonadLogger (StateT Context m)
                          )

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -64,7 +64,7 @@ newtype Config = Config { configSQLDB :: SQLDB }
 
 data Context =
     Context {
-        contextRedisBlockDB :: Redis.Connection,
+        contextRedisBlockDB :: RBDB.RedisConnection,
         contextKafkaState   :: K.KafkaState,
         vmTrace             :: [String],
         unseqSink           :: forall m . (MonadIO m, Modifiable K.KafkaState m) => [IngestEvent] -> m (),
@@ -84,8 +84,8 @@ type ContextM = StateT Context (ReaderT Config (ResourceT (LoggingT IO)))
 instance Context `Has` K.KafkaState where
   this _ = lens contextKafkaState (\c k -> c{contextKafkaState = k})
 
-instance (Monad m, MonadState Context m) => RBDB.HasRedisBlockDB m where
-    getRedisBlockDB = contextRedisBlockDB <$> get
+instance MonadState Context m => Accessible RBDB.RedisConnection m where
+  access _ = gets contextRedisBlockDB
 
 instance (MonadUnliftIO m, MonadReader Config m, MonadIO m) => HasSQLDB m where
   getSQLDB = asks configSQLDB
@@ -157,7 +157,7 @@ initContext maxHeaders = do
   redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
   return (Config (sqlDB' dbs),
          Context { actionTimestamp = Nothing
-                 , contextRedisBlockDB = redisBDBPool
+                 , contextRedisBlockDB = RBDB.RedisConnection redisBDBPool
                  , contextKafkaState = mkConfiguredKafkaState "strato-p2p"
                  , blockHeaders=[]
                  , remainingBlockHeaders=[]

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE Rank2Types           #-}
@@ -34,6 +35,7 @@ module Blockchain.Context
 import           Conduit
 import           Control.Applicative
 import           Control.Lens                          hiding (Context)
+import           Control.Monad.Change.Modify           hiding (get, put)
 import           Blockchain.Output
 import           Control.Monad.Reader
 import           Control.Monad.State
@@ -65,8 +67,8 @@ data Context =
         contextRedisBlockDB :: Redis.Connection,
         contextKafkaState   :: K.KafkaState,
         vmTrace             :: [String],
-        unseqSink           :: forall m . (MonadIO m, K.HasKafkaState m) => [IngestEvent] -> m (),
-        vmEventsSink        :: forall m . (MonadIO m, K.HasKafkaState m) => [VMEvent] -> m (),
+        unseqSink           :: forall m . (MonadIO m, Modifiable K.KafkaState m) => [IngestEvent] -> m (),
+        vmEventsSink        :: forall m . (MonadIO m, Modifiable K.KafkaState m) => [VMEvent] -> m (),
         blockHeaders        :: [BlockHeader],
         remainingBlockHeaders :: [BlockHeader],
         actionTimestamp     :: Maybe UTCTime,
@@ -79,11 +81,8 @@ makeLenses ''Context
 
 type ContextM = StateT Context (ReaderT Config (ResourceT (LoggingT IO)))
 
-instance {-# OVERLAPPING #-} (MonadState Context m) => K.HasKafkaState m where
-    getKafkaState = contextKafkaState <$> get
-    putKafkaState s = do
-      ctx <- get
-      put $ ctx { contextKafkaState = s }
+instance Context `Has` K.KafkaState where
+  this _ = lens contextKafkaState (\c k -> c{contextKafkaState = k})
 
 instance (Monad m, MonadState Context m) => RBDB.HasRedisBlockDB m where
     getRedisBlockDB = contextRedisBlockDB <$> get
@@ -94,10 +93,10 @@ instance (MonadUnliftIO m, MonadReader Config m, MonadIO m) => HasSQLDB m where
 instance HasSQLDB m => WrapsSQLDB (StateT Context) m where
   runWithSQL = lift
 
-instance (MonadState Context m, MonadIO m) => HasUnseqSink m where
+instance (MonadState Context m, MonadIO m, Modifiable K.KafkaState m) => HasUnseqSink m where
   getUnseqSink = gets unseqSink
 
-instance (MonadState Context m, MonadIO m) => HasVMEventsSink m where
+instance (MonadState Context m, MonadIO m, Modifiable K.KafkaState m) => HasVMEventsSink m where
   getVMEventsSink = gets vmEventsSink
 
 getDebugMsg :: MonadState Context m => m String

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -15,6 +15,7 @@ module Blockchain.Event (
 
 import           Control.Arrow                         ((&&&))
 import           Control.Monad
+import           Control.Monad.Change.Modify           hiding (get, put)
 import           Control.Monad.IO.Class
 import           Blockchain.Output
 import           Control.Monad.State
@@ -31,6 +32,7 @@ import qualified Data.Set                              as S
 import qualified Data.Text                             as T
 import           Data.Time.Clock
 import           MonadUtils
+import qualified Network.Kafka                         as K
 import           System.Random
 import           Text.Printf
 import           UnliftIO.Exception
@@ -114,6 +116,7 @@ handleEvents :: ( MonadIO m
                 , SK.HasUnseqSink m
                 , MonadState Context m
                 , MonadLogger m
+                , Modifiable K.KafkaState m
                 ) => PPeer -> ConduitM Event (Either P2PCNC Message) m ()
 handleEvents peer = awaitForever $ \case
     MsgEvt Hello{}  -> error "A hello message appeared after the handshake"
@@ -123,7 +126,7 @@ handleEvents peer = awaitForever $ \case
     MsgEvt (Transactions txs) -> do
         stampActionTimestamp
         let txo = Origin.PeerString (peerString peer)
-        SK.emitKafkaTransactions txo txs
+        lift $ SK.emitKafkaTransactions txo txs
 
     MsgEvt (NewBlock block' tdiff) -> do
         stampActionTimestamp
@@ -148,7 +151,7 @@ handleEvents peer = awaitForever $ \case
                     syncFetch Forward fetchNumber
                 Just _  -> do
                     lift . void $ setTitleAndProduceBlocks [block']
-                    void $ SK.emitKafkaBlock (Origin.PeerString $ peerString peer) block'
+                    void . lift $ SK.emitKafkaBlock (Origin.PeerString $ peerString peer) block'
 
     MsgEvt (NewBlockHashes _) -> do
         stampActionTimestamp
@@ -284,7 +287,7 @@ handleEvents peer = awaitForever $ \case
         $logInfoS "handleEvents/BlockBodies" $ T.pack $ "len headers is " ++ show (length headers) ++ ", len bodies is " ++ show (length bodies)
         let blocks' = zipWith createBlockFromHeaderAndBody headers bodies
         newCount <- lift $ setTitleAndProduceBlocks blocks'
-        forM_ blocks' $ lift . SK.emitKafkaBlock (Origin.PeerString $ peerString peer)
+        lift . forM_ blocks' $ SK.emitKafkaBlock (Origin.PeerString $ peerString peer)
         rHeaders <- lift getRemainingBHeaders
         let (neededHeaders, remainingHeaders) = splitNeededHeaders rHeaders
         lift $ putBlockHeaders neededHeaders
@@ -300,14 +303,14 @@ handleEvents peer = awaitForever $ \case
     MsgEvt (Blockstanbul wm) -> do
       stampActionTimestamp
       setPeerAddrIfUnset $ blockstanbulSender wm
-      SK.emitBlockstanbulMsg wm
+      lift $ SK.emitBlockstanbulMsg wm
 
     -- private chains
     MsgEvt (GetChainDetails cids') -> handleGetChainDetails peer cids'
 
     MsgEvt (ChainDetails chpairs) -> do
       stampActionTimestamp
-      mapM_ (uncurry (SK.emitKafkaChainDetails (Origin.PeerString $ peerString peer))) chpairs
+      lift $ mapM_ (uncurry (SK.emitKafkaChainDetails (Origin.PeerString $ peerString peer))) chpairs
 
     -- TODO: Optimize/do security checking (a peer can spam you with random hashes and keep you busy forever)
     MsgEvt (GetTransactions trHashes) -> do

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -112,7 +112,7 @@ yieldL = yield . Left
 
 handleEvents :: ( MonadIO m
                 , MonadResource m
-                , RBDB.HasRedisBlockDB m
+                , Accessible RBDB.RedisConnection m
                 , SK.HasUnseqSink m
                 , MonadState Context m
                 , MonadLogger m
@@ -259,7 +259,7 @@ handleEvents peer = awaitForever $ \case
           yieldR . BlockBodies . Prelude.reverse $ map toBody bodies
           ptxs <- fmap catMaybes . RBDB.withRedisBlockDB $ mapM RBDB.getPrivateTransactions pshas
           unless (null ptxs) . yieldR $ Transactions ptxs)
-        where getUntilMissing :: (RBDB.HasRedisBlockDB m, MonadIO m)
+        where getUntilMissing :: (Accessible RBDB.RedisConnection m, MonadIO m)
                               => [SHA] -> [Block] -> [SHA] -> m ([Block],[SHA])
               getUntilMissing []     bodies pshas = return (bodies, pshas)
               getUntilMissing (h:hs) bodies pshas = RBDB.withRedisBlockDB (RBDB.getBlock h) >>= \case
@@ -426,7 +426,7 @@ handleEvents peer = awaitForever $ \case
 
 handleGetChainDetails :: ( MonadIO m
                          , MonadResource m
-                         , RBDB.HasRedisBlockDB m
+                         , Accessible RBDB.RedisConnection m
                          , MonadState Context m
                          , MonadLogger m
                          )

--- a/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -9,7 +9,6 @@ module Blockchain.SeqEventNotify (
   ) where
 
 import           Conduit
-import           Control.Monad.Change.Modify (Modifiable)
 import           Control.Monad
 import           Blockchain.Output
 import qualified Data.Text                   as T
@@ -23,7 +22,6 @@ import           Blockchain.Sequencer.Kafka (readSeqP2pEvents, seqP2pEventsTopic
 seqEventNotificationSource :: ( MonadIO m
                               , MonadResource m
                               , MonadLogger m
-                              , Modifiable K.KafkaState m
                               )
                            => K.KafkaState -> ConduitM () OutputEvent m ()
 seqEventNotificationSource ks = evalStateC ks $ do

--- a/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -11,10 +11,10 @@ module Blockchain.SeqEventNotify (
 import           Conduit
 import           Control.Monad
 import           Blockchain.Output
-import qualified Data.Text                   as T
-import qualified Network.Kafka               as K
-import qualified Blockchain.MilenaTools      as K
-import qualified Network.Kafka.Protocol      as KP
+import qualified Data.Text                  as T
+import qualified Network.Kafka              as K
+import qualified Blockchain.MilenaTools     as K
+import qualified Network.Kafka.Protocol     as KP
 
 import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Kafka (readSeqP2pEvents, seqP2pEventsTopicName)

--- a/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -9,12 +9,13 @@ module Blockchain.SeqEventNotify (
   ) where
 
 import           Conduit
+import           Control.Monad.Change.Modify (Modifiable)
 import           Control.Monad
 import           Blockchain.Output
-import qualified Data.Text                  as T
-import qualified Network.Kafka              as K
-import qualified Blockchain.MilenaTools     as K
-import qualified Network.Kafka.Protocol     as KP
+import qualified Data.Text                   as T
+import qualified Network.Kafka               as K
+import qualified Blockchain.MilenaTools      as K
+import qualified Network.Kafka.Protocol      as KP
 
 import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Kafka (readSeqP2pEvents, seqP2pEventsTopicName)
@@ -22,6 +23,7 @@ import           Blockchain.Sequencer.Kafka (readSeqP2pEvents, seqP2pEventsTopic
 seqEventNotificationSource :: ( MonadIO m
                               , MonadResource m
                               , MonadLogger m
+                              , Modifiable K.KafkaState m
                               )
                            => K.KafkaState -> ConduitM () OutputEvent m ()
 seqEventNotificationSource ks = evalStateC ks $ do

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -50,7 +50,7 @@ testContext = do
   return ( ch
          , Config conn
          , Context { actionTimestamp = Nothing
-                   , contextRedisBlockDB = redisBDBPool
+                   , contextRedisBlockDB = RBDB.RedisConnection redisBDBPool
                    , contextKafkaState = error "no kafka state available"
                    , blockHeaders=[]
                    , remainingBlockHeaders=[]

--- a/core-strato/strato-redis-blockdb/package.yaml
+++ b/core-strato/strato-redis-blockdb/package.yaml
@@ -19,6 +19,7 @@ dependencies:
   - hedis
   - lens-family
   - lens-family-th
+  - monad-alter
   - mtl
   - random
   - strato-conf

--- a/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -5,10 +5,12 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeOperators         #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
 module Blockchain.Strato.RedisBlockDB
-    ( inNamespace, getSHAsByNumber
+    ( RedisConnection(..), inNamespace, getSHAsByNumber
     , getChainInfo, putChainInfo
     , getChainMembers, putChainMembers
     , addChainMember, removeChainMember
@@ -24,7 +26,7 @@ module Blockchain.Strato.RedisBlockDB
     , getGenesisHash
     , putHeader, putHeaders, putBlock, putBlocks
     , getBestBlockInfo, putBestBlockInfo, forceBestBlockInfo
-    , HasRedisBlockDB(..), withRedisBlockDB
+    , withRedisBlockDB
     , commonAncestorHelper
     , getWorldBestBlockInfo, updateWorldBestBlockInfo
     , acquireRedlock, releaseRedlock, defaultRedlockTTL
@@ -42,6 +44,7 @@ import           Blockchain.Util                       (partitionWith)
 
 import           Control.Arrow                         ((&&&), second)
 import           Control.Concurrent                    (threadDelay)
+import           Control.Monad.Change.Modify           hiding (get)
 import           Control.Monad
 import           Control.Monad.Trans
 import qualified Data.ByteString.Char8                 as S8
@@ -51,6 +54,8 @@ import qualified Data.Set                              as S
 import qualified Data.Text                             as T
 import           Database.Redis
 import           System.Random                         (randomIO)
+
+newtype RedisConnection = RedisConnection { unRedisConnection :: Connection }
 
 -- todo: move this somewhere?
 zipMapM :: (Traversable t, Monad m)
@@ -62,14 +67,11 @@ zipMapM f = mapM (\x -> (,) x <$> f x)
 liftLog :: LoggingT m a -> m a
 liftLog = runLoggingT
 
-class (Monad m) => HasRedisBlockDB m where
-    getRedisBlockDB :: m Connection
-
-withRedisBlockDB :: (MonadIO m, HasRedisBlockDB m)
+withRedisBlockDB :: (MonadIO m, Accessible RedisConnection m)
                  => Redis a
                  -> m a
 withRedisBlockDB m = do
-    db <- getRedisBlockDB
+    db <- unRedisConnection <$> access (Proxy @RedisConnection)
     liftIO $ runRedis db m
 
 inNamespace :: RedisDBKeyable k

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -9,7 +9,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 module Blockchain.Sequencer.Gregor
   (
@@ -24,6 +26,7 @@ module Blockchain.Sequencer.Gregor
 import           Control.Concurrent.Async.Lifted (race_)
 import           Control.Concurrent.STM (orElse, flushTQueue)
 import           Control.Lens               hiding (op)
+import           Control.Monad.Change.Modify (Has(..))
 import           Control.Monad.State
 import           Control.Monad.Trans.Resource
 import qualified Data.Text as T
@@ -77,9 +80,8 @@ runGregorM cfg = runLoggingT
                . runResourceT
                . flip evalStateT (convert cfg)
 
-instance K.HasKafkaState GregorM where
-  getKafkaState = use gregorKafkaState
-  putKafkaState = assign gregorKafkaState
+instance GregorContext `Has` K.KafkaState where
+  this _ = gregorKafkaState
 
 getKafkaConsumerGroup :: GregorM KP.ConsumerGroup
 getKafkaConsumerGroup = use gregorConsumerGroup

--- a/core-strato/strato-statediff/package.yaml
+++ b/core-strato/strato-statediff/package.yaml
@@ -26,6 +26,7 @@ library:
     - blockapps-util
     - ethereum-rlp
     - merkle-patricia-db
+    - monad-alter
     - monad-control
     - persistent
     - persistent-postgresql

--- a/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff.hs
+++ b/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff.hs
@@ -27,22 +27,20 @@ import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ExtendedWord
 
 import           Control.Applicative
+import           Control.Monad.Change.Modify
+import           Data.ByteString                             (ByteString)
 import qualified Data.ByteString                             as B
 import           Data.Function
 import           Data.Maybe
 import           Data.String
-import           Data.Text                                   (Text)
 import           Data.Traversable                            (forM)
-
-import           Data.ByteString                             (ByteString)
-
 import           Data.Map                                    (Map)
 import qualified Data.Map                                    as Map
-
+import           Data.Maybe
 import qualified Data.NibbleString                           as N
-
+import           Data.String
+import           Data.Text                                   (Text)
 import           GHC.Generics
-
 import           Text.Format
 
 -- | Describes all the changes that have occurred in the blockchain
@@ -160,7 +158,13 @@ instance Detailed StorageDiff where
   incrementalToEventual (EVMDiff m) = EVMDiff $ Map.map incrementalToEventual m
   incrementalToEventual (SolidVMDiff m) = SolidVMDiff $ Map.map incrementalToEventual m
 
-chainDiff :: (HasStateDB m, HasChainDB m, HasCodeDB m, HasHashDB m)
+chainDiff :: ( HasStateDB m
+             , HasCodeDB m
+             , HasHashDB m
+             , Modifiable BlockHashRoot m
+             , Modifiable GenesisRoot m
+             , Modifiable BestBlockRoot m
+             )
           => Integer -> SHA -> [Word256] -> m [StateDiff]
 chainDiff newBlockNum newBlockHash chains = fmap catMaybes . forM chains $ \chainId -> do
   newSR <- fromMaybe emptyTriePtr <$> getChainStateRoot chainId newBlockHash

--- a/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff.hs
+++ b/core-strato/strato-statediff/src/Blockchain/Strato/StateDiff.hs
@@ -36,9 +36,7 @@ import           Data.String
 import           Data.Traversable                            (forM)
 import           Data.Map                                    (Map)
 import qualified Data.Map                                    as Map
-import           Data.Maybe
 import qualified Data.NibbleString                           as N
-import           Data.String
 import           Data.Text                                   (Text)
 import           GHC.Generics
 import           Text.Format

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -249,7 +249,7 @@ setParentStateRoot b@OutputBlock{..} = do
 addBlock :: OutputBlock -> ContextM [Action]
 addBlock b@OutputBlock{obBlockData = bd, obBlockUncles = uncles, obReceiptTransactions = otxs} = do
     when flags_debug $ do
-      bhr <- Mod.get (Proxy :: Proxy BlockHashRoot)
+      bhr <- Mod.get (Proxy @BlockHashRoot)
       cr <- fmap (fromMaybe MP.emptyTriePtr) . getChainRoot $ blockHash b
       $logDebugS "addBlock" $ T.pack $ "Old blockhash root: " ++ format bhr
       $logDebugS "addBlock" $ T.pack $ "Old chain root: " ++ format cr
@@ -257,7 +257,7 @@ addBlock b@OutputBlock{obBlockData = bd, obBlockUncles = uncles, obReceiptTransa
     putBlockHeaderInChainDB bd
 
     when flags_debug $ do
-      bhr' <- Mod.get (Proxy :: Proxy BlockHashRoot)
+      bhr' <- Mod.get (Proxy @BlockHashRoot)
       cr' <- fmap (fromMaybe MP.emptyTriePtr) . getChainRoot $ blockHash b
       $logDebugS "addBlock" $ T.pack $ "New blockhash root after inserting header: " ++ format bhr'
       $logDebugS "addBlock" $ T.pack $ "New chain root after inserting header: " ++ format cr'
@@ -304,7 +304,7 @@ addBlock b@OutputBlock{obBlockData = bd, obBlockUncles = uncles, obReceiptTransa
           Left  _ -> P.incCounter vmBlocksInvalid -- error err -- todo: i dont think we ACTUALLY need to error here
 
     when flags_debug $ do
-      bhr'' <- Mod.get (Proxy :: Proxy BlockHashRoot)
+      bhr'' <- Mod.get (Proxy @BlockHashRoot)
       cr'' <- fmap (fromMaybe MP.emptyTriePtr) . getChainRoot $ blockHash b
       $logDebugS "addBlock" $ T.pack $ "New blockhash root after running block: " ++ format bhr''
       $logDebugS "addBlock" $ T.pack $ "New chain root after running block: " ++ format cr''

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -27,6 +27,7 @@ import           Control.Arrow                           ((&&&))
 import           Control.Lens.Operators
 import           Control.Monad
 import qualified Control.Monad.Change.Alter              as A
+import qualified Control.Monad.Change.Modify             as Mod
 import qualified Control.Monad.State                     as State
 import           Control.Monad.Trans.Except
 import qualified Data.ByteString                         as B
@@ -248,7 +249,7 @@ setParentStateRoot b@OutputBlock{..} = do
 addBlock :: OutputBlock -> ContextM [Action]
 addBlock b@OutputBlock{obBlockData = bd, obBlockUncles = uncles, obReceiptTransactions = otxs} = do
     when flags_debug $ do
-      bhr <- getBlockHashRoot
+      bhr <- Mod.get (Proxy :: Proxy BlockHashRoot)
       cr <- fmap (fromMaybe MP.emptyTriePtr) . getChainRoot $ blockHash b
       $logDebugS "addBlock" $ T.pack $ "Old blockhash root: " ++ format bhr
       $logDebugS "addBlock" $ T.pack $ "Old chain root: " ++ format cr
@@ -256,7 +257,7 @@ addBlock b@OutputBlock{obBlockData = bd, obBlockUncles = uncles, obReceiptTransa
     putBlockHeaderInChainDB bd
 
     when flags_debug $ do
-      bhr' <- getBlockHashRoot
+      bhr' <- Mod.get (Proxy :: Proxy BlockHashRoot)
       cr' <- fmap (fromMaybe MP.emptyTriePtr) . getChainRoot $ blockHash b
       $logDebugS "addBlock" $ T.pack $ "New blockhash root after inserting header: " ++ format bhr'
       $logDebugS "addBlock" $ T.pack $ "New chain root after inserting header: " ++ format cr'
@@ -303,7 +304,7 @@ addBlock b@OutputBlock{obBlockData = bd, obBlockUncles = uncles, obReceiptTransa
           Left  _ -> P.incCounter vmBlocksInvalid -- error err -- todo: i dont think we ACTUALLY need to error here
 
     when flags_debug $ do
-      bhr'' <- getBlockHashRoot
+      bhr'' <- Mod.get (Proxy :: Proxy BlockHashRoot)
       cr'' <- fmap (fromMaybe MP.emptyTriePtr) . getChainRoot $ blockHash b
       $logDebugS "addBlock" $ T.pack $ "New blockhash root after running block: " ++ format bhr''
       $logDebugS "addBlock" $ T.pack $ "New chain root after running block: " ++ format cr''
@@ -437,9 +438,6 @@ addTransaction isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=bt,otSign
                         lift $ purgeStorageMap address'
                         lift $ A.delete (Proxy @AddressState) address'
                     lift $ P.incCounter vmTxsSuccessful
-
-
-
             return execResults
         else do
             s1 <- lift $ addToBalance (blockDataCoinbase b) (fromIntegral intrinsicGas' * transactionGasPrice bt)

--- a/core-strato/vm-tools/src/Blockchain/VMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMContext.hs
@@ -48,7 +48,6 @@ import           Data.Foldable                      (toList)
 import           Data.List.Split                    (chunksOf)
 import qualified Data.Map                           as M
 import           Data.Maybe                         (fromMaybe)
-import           Data.Proxy
 import qualified Data.Sequence                      as Q
 import           Data.Word
 import qualified Data.Text                          as T
@@ -168,26 +167,14 @@ instance HasStateDB ContextM where
     cxt <- get
     put cxt{contextStateDB=(contextStateDB cxt){MP.stateRoot=sr}}
 
-instance Modifiable BlockHashRoot ContextM where
-  modify _ f = do
-    cxt <- get
-    bhr' <- f $ contextBlockHashRoot cxt
-    put cxt{contextBlockHashRoot = bhr'}
-    return bhr'
+instance Context `Has` BlockHashRoot where
+  this _ = lens contextBlockHashRoot (\c b -> c{contextBlockHashRoot = b})
 
-instance Modifiable GenesisRoot ContextM where
-  modify _ f = do
-    cxt <- get
-    gr' <- f $ contextGenesisRoot cxt
-    put cxt{contextGenesisRoot = gr'}
-    return gr'
+instance Context `Has` GenesisRoot where
+  this _ = lens contextGenesisRoot (\c b -> c{contextGenesisRoot = b})
 
-instance Modifiable BestBlockRoot ContextM where
-  modify _ f = do
-    cxt <- get
-    bbr' <- f $ contextBestBlockRoot cxt
-    put cxt{contextBestBlockRoot = bbr'}
-    return bbr'
+instance Context `Has` BestBlockRoot where
+  this _ = lens contextBestBlockRoot (\c b -> c{contextBestBlockRoot = b})
 
 instance K.HasKafkaState ContextM where
     getKafkaState = contextKafkaState <$> get

--- a/core-strato/vm-tools/src/Blockchain/VMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMContext.hs
@@ -36,6 +36,7 @@ import           Control.DeepSeq
 import           Control.Lens                       hiding (Context(..))
 import           Control.Monad.Catch
 import qualified Control.Monad.Change.Alter         as A
+import           Control.Monad.Change.Modify        hiding (get, put)
 import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
 import           Blockchain.Output
@@ -112,9 +113,9 @@ data Context = Context { contextStateDB                :: MP.MPDB
                        , contextAddressStateBlockDBMap :: M.Map Address AddressStateModification
                        , contextStorageTxMap           :: M.Map (Address, B.ByteString) B.ByteString
                        , contextStorageBlockMap        :: M.Map (Address, B.ByteString) B.ByteString
-                       , contextBlockHashRoot          :: MP.StateRoot
-                       , contextGenesisRoot            :: MP.StateRoot
-                       , contextBestBlockRoot          :: MP.StateRoot
+                       , contextBlockHashRoot          :: BlockHashRoot
+                       , contextGenesisRoot            :: GenesisRoot
+                       , contextBestBlockRoot          :: BestBlockRoot
                        , contextBaggerState            :: !BaggerState
                        , contextKafkaState             :: K.KafkaState
                        , contextBestBlockInfo          :: ContextBestBlockInfo
@@ -167,19 +168,26 @@ instance HasStateDB ContextM where
     cxt <- get
     put cxt{contextStateDB=(contextStateDB cxt){MP.stateRoot=sr}}
 
-instance HasChainDB ContextM where
-  getBlockHashRoot = contextBlockHashRoot <$> get
-  putBlockHashRoot sr = do
+instance Modifiable BlockHashRoot ContextM where
+  modify _ f = do
     cxt <- get
-    put cxt{contextBlockHashRoot = sr}
-  getGenesisRoot = contextGenesisRoot <$> get
-  putGenesisRoot sr = do
+    bhr' <- f $ contextBlockHashRoot cxt
+    put cxt{contextBlockHashRoot = bhr'}
+    return bhr'
+
+instance Modifiable GenesisRoot ContextM where
+  modify _ f = do
     cxt <- get
-    put cxt{contextGenesisRoot = sr}
-  getBestBlockRoot = contextBestBlockRoot <$> get
-  putBestBlockRoot sr = do
+    gr' <- f $ contextGenesisRoot cxt
+    put cxt{contextGenesisRoot = gr'}
+    return gr'
+
+instance Modifiable BestBlockRoot ContextM where
+  modify _ f = do
     cxt <- get
-    put cxt{contextBestBlockRoot = sr}
+    bbr' <- f $ contextBestBlockRoot cxt
+    put cxt{contextBestBlockRoot = bbr'}
+    return bbr'
 
 instance K.HasKafkaState ContextM where
     getKafkaState = contextKafkaState <$> get
@@ -273,9 +281,9 @@ runTestContextM f = withSystemTempDirectory "test_evm_context" $ \tmpdir ->
                      M.empty
                      M.empty
                      M.empty
-                     MP.emptyTriePtr
-                     MP.emptyTriePtr
-                     MP.emptyTriePtr
+                     (BlockHashRoot MP.emptyTriePtr)
+                     (GenesisRoot MP.emptyTriePtr)
+                     (BestBlockRoot MP.emptyTriePtr)
                      defaultBaggerState
                      initialKafkaState
                      Unspecified
@@ -315,9 +323,9 @@ runContextM f = do
                        M.empty
                        M.empty
                        M.empty
-                       MP.emptyTriePtr
-                       MP.emptyTriePtr
-                       MP.emptyTriePtr
+                       (BlockHashRoot MP.emptyTriePtr)
+                       (GenesisRoot MP.emptyTriePtr)
+                       (BestBlockRoot MP.emptyTriePtr)
                        defaultBaggerState
                        initialKafkaState
                        Unspecified

--- a/core-strato/vm-tools/src/Blockchain/VMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMContext.hs
@@ -93,8 +93,8 @@ import           Blockchain.VMOptions
 
 import           Executable.EVMFlags
 
-instance NFData Redis.Connection where
-  rnf c = c `seq` ()
+instance NFData RBDB.RedisConnection where
+  rnf (RBDB.RedisConnection c) = c `seq` ()
 
 data ContextBestBlockInfo = Unspecified | ContextBestBlockInfo (SHA, BlockData, Integer, Int, Int)
     deriving (Eq, Read, Show, Generic, NFData)
@@ -118,7 +118,7 @@ data Context = Context { contextStateDB                :: MP.MPDB
                        , contextBaggerState            :: !BaggerState
                        , contextKafkaState             :: K.KafkaState
                        , contextBestBlockInfo          :: ContextBestBlockInfo
-                       , contextRedisPool              :: Redis.Connection
+                       , contextRedisPool              :: RBDB.RedisConnection
                        , contextTxResultQueue          :: Q.Seq TransactionResult
                        , contextLogDBQueue             :: [LogDB]
                        , contextHasBlockstanbul        :: Bool
@@ -225,8 +225,8 @@ instance (MonadReader Config m, MonadIO m, MonadUnliftIO m) => HasSQLDB m where
 instance HasSQLDB m => WrapsSQLDB (StateT Context) m where
   runWithSQL = lift
 
-instance RBDB.HasRedisBlockDB ContextM where
-    getRedisBlockDB = contextRedisPool <$> get
+instance Accessible RBDB.RedisConnection ContextM where
+  access _ = contextRedisPool <$> get
 
 instance MonadMonitor (ResourceT (LoggingT IO)) where
     doIO = liftIO
@@ -271,7 +271,7 @@ runTestContextM f = withSystemTempDirectory "test_evm_context" $ \tmpdir ->
                      defaultBaggerState
                      initialKafkaState
                      Unspecified
-                     redisPool
+                     (RBDB.RedisConnection redisPool)
                      Q.empty []
                      False
                      False
@@ -313,7 +313,7 @@ runContextM f = do
                        defaultBaggerState
                        initialKafkaState
                        Unspecified
-                       redisPool
+                       (RBDB.RedisConnection redisPool)
                        Q.empty
                        []
                        flags_blockstanbul

--- a/core-strato/vm-tools/src/Blockchain/VMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMContext.hs
@@ -176,11 +176,8 @@ instance Context `Has` GenesisRoot where
 instance Context `Has` BestBlockRoot where
   this _ = lens contextBestBlockRoot (\c b -> c{contextBestBlockRoot = b})
 
-instance K.HasKafkaState ContextM where
-    getKafkaState = contextKafkaState <$> get
-    putKafkaState ks = do
-        ctx <- get
-        put $ ctx {contextKafkaState = ks}
+instance Context `Has` K.KafkaState where
+  this _ = lens contextKafkaState (\c b -> c{contextKafkaState = b})
 
 instance HasMemAddressStateDB ContextM where
   getAddressStateTxDBMap = contextAddressStateTxDBMap <$> get


### PR DESCRIPTION
Convert several classes into their monad-alter equivalents. `Modifiable a` generalizes state-like classes, i.e. {getX :: m X, putX :: X -> m ()}, whereas `Accessible a` generalizes reader-like classes, i.e. {getX :: m X}. I've changed `HasChainDB` to `(Modifiable BlockHashRoot, Modifiable GenesisRoot, Modifiable BestBlockRoot)`, `HasKafkaState` to `Modifiable KafkaState`, and `HasRedisBlockDB` to `Accessible RedisConnection`