### PR TITLE
Use bytestring directly for better small RLP performance

### DIFF
--- a/core-strato/ethereum-rlp/bench/RLPShootout.hs
+++ b/core-strato/ethereum-rlp/bench/RLPShootout.hs
@@ -1,6 +1,12 @@
+{-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+{-# OPTIONS_GHC -fno-warn-unused-local-binds #-}
+{-# OPTIONS_GHC -fno-warn-unused-matches #-}
+
+import Control.Monad
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Random as BR
+import Text.Printf
 
 import Control.Monad (replicateM)
 
@@ -8,38 +14,46 @@ import Blockchain.Data.RLP
 
 import Criterion.Main
 
-benchSerialize_slow :: BS.ByteString -> Benchmark
-benchSerialize_slow str = bench ("List based string serialization; size=" ++ show (BS.length str))
-                      . nf rlpSerialize_slow
-                      . RLPString
-                      $ str
+benchString :: (String, (RLPObject -> BS.ByteString)) -> BS.ByteString -> Benchmark
+benchString (name, f) str = bench (printf "%s based string serialization; size=%d" name (BS.length str))
+                          . nf f
+                          $ RLPString str
 
-benchSerialize :: BS.ByteString-> Benchmark
-benchSerialize str = bench ("Put based string serialization; size=" ++ show (BS.length str))
-                   . nf rlpSerialize
-                   . RLPString
-                   $ str
-
-benchObjSerialize_slow :: [BS.ByteString] -> Benchmark
-benchObjSerialize_slow arr = bench ("List based array serialization; size=1024x" ++ show (BS.length (head arr)))
-                         . nf rlpSerialize_slow
+benchOneLevel :: (String, (RLPObject -> BS.ByteString)) -> [BS.ByteString] -> Benchmark
+benchOneLevel (name, f) arr = bench (printf "%s based one-level array serialization; size=1024x%d" name (BS.length (head arr)))
+                         . nf f
                          . RLPArray
                          . map RLPString
                          $ arr
 
-benchObjSerialize :: [BS.ByteString] -> Benchmark
-benchObjSerialize arr = bench ("Put based array serialization; size=1024x" ++ show (BS.length (head arr)))
-                    . nf rlpSerialize
-                    . RLPArray
-                    . map RLPString
-                    $ arr
+benchMP :: (String, RLPObject -> BS.ByteString) -> (Int, RLPObject) -> Benchmark
+benchMP (name, f) (sz, obj) = bench (printf "%s based MP node simulation; value size=%d" name sz)
+                            $ nf f obj
+
+benchStacks :: (String, RLPObject -> BS.ByteString) -> (Int, Int, RLPObject) -> Benchmark
+benchStacks (name, f) (ht, wid, obj) = bench (printf "%s based stack; height=%d, width=%d" name ht wid)
+                                     $ nf f obj
+
+
+mpnode :: Int -> RLPObject
+mpnode n = RLPArray . map RLPString $ (replicate 16 (BS.replicate 32 0xcc)) ++ [BS.replicate n 0x77]
+
+stack :: Int -> Int -> RLPObject
+stack k 0 = RLPString $ BS.replicate k 0x72
+stack k n = RLPArray [stack k $ n-1]
 
 main :: IO ()
 main = do
-  strings <- mapM BR.random [1024, 1024 * 1024, 10 * 1024 * 1024]
+  strings <- mapM BR.random [16, 1024, 1024 * 1024, 10 * 1024 * 1024]
   arrays <- mapM (replicateM 1024 . BR.random) [1, 1024, 10 * 1024]
-  let tests = map benchSerialize strings
-           ++ map benchSerialize_slow strings
-           ++ map benchObjSerialize arrays
-           ++ map benchObjSerialize_slow arrays
-  defaultMain tests
+  let fullNodes = map (\x -> (x, mpnode x)) [0, 16, 256, 1024]
+  let nstacks = map (\x -> (x, 4, stack 4 x)) [0, 4, 16, 64, 256, 1024]
+  let wstacks = map (\x -> (x, 1024, stack 1024 x)) [0, 4, 16, 64, 256, 1024]
+
+  let funcs = [("Bytestring", rlpSerialize)]
+  defaultMain $ concat [ liftM2 benchString funcs strings
+                       , liftM2 benchOneLevel funcs arrays
+                       , liftM2 benchMP funcs fullNodes
+                       , liftM2 benchStacks funcs nstacks
+                       , liftM2 benchStacks funcs wstacks
+                       ]

--- a/core-strato/ethereum-rlp/library/Blockchain/Data/RLP.hs
+++ b/core-strato/ethereum-rlp/library/Blockchain/Data/RLP.hs
@@ -11,15 +11,13 @@ module Blockchain.Data.RLP (
   RLPSerializable(..),
   rlpSplit,
   rlpSerialize,
-  rlpSerialize_slow,
-  rlpDeserialize
+  rlpDeserialize,
+  int2Bytes
   ) where
 
 import           Control.DeepSeq
-import           Data.Binary.Put
 import           Data.Bits
 import qualified Data.ByteString                    as B
-import qualified Data.ByteString.Lazy               as BL
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Char8              as BC
 import           Data.ByteString.Internal
@@ -110,22 +108,6 @@ int2Bytes val | val < 0x100000000 = map (fromIntegral . (val `shiftR`)) [24, 16.
 int2Bytes val | val < 0x10000000000 = map (fromIntegral . (val `shiftR`)) [32, 24..0]
 int2Bytes _ = error "int2Bytes not defined for val >= 0x10000000000."
 
-rlp2Bytes::RLPObject->[Word8]
-rlp2Bytes (RLPScalar val) = [fromIntegral val]
-rlp2Bytes (RLPString s) | B.length s <= 55 = 0x80 + fromIntegral (B.length s):B.unpack s
-rlp2Bytes (RLPString s) =
-  [0xB7 + fromIntegral (length lengthAsBytes)] ++ lengthAsBytes ++ B.unpack s
-  where
-    lengthAsBytes = int2Bytes $ B.length s
-rlp2Bytes (RLPArray innerObjects) =
-  if length innerBytes <= 55
-  then 0xC0 + fromIntegral (length innerBytes):innerBytes
-  else let lenBytes = int2Bytes $ length innerBytes
-       in [0xF7 + fromIntegral (length lenBytes)] ++ lenBytes ++ innerBytes
-  where
-    innerBytes = concat $ rlp2Bytes <$> innerObjects
-
---TODO- Probably should just use Data.Binary's 'Binary' class for this
 
 -- | Converts bytes to 'RLPObject's.
 --
@@ -140,37 +122,26 @@ rlpDeserialize s =
 -- | Converts 'RLPObject's to bytes.
 --
 -- Full serialization of an object can be obtained using @rlpSerialize . rlpEncode@.
-rlpSerialize_slow::RLPObject->B.ByteString
-rlpSerialize_slow = B.pack . rlp2Bytes
 
 rlpSerialize :: RLPObject -> B.ByteString
-rlpSerialize = BL.toStrict . rlpSerialize'
-
-rlpSerialize':: RLPObject -> BL.ByteString
-rlpSerialize' = runPut . rlpToPut
-
-rlpToPut :: RLPObject -> Put
-rlpToPut = \case
-  (RLPScalar val) -> putWord8 val
-  (RLPString s) -> do
+rlpSerialize = \case
+  RLPScalar val -> B.singleton val
+  RLPString s ->
     let l = B.length s
+    in if l <= 55
+         then B.cons (0x80 + fromIntegral l) s
+         else let ibs = int2Bytes l
+                  ll = length ibs
+              in (B.pack $ 0xb7 + fromIntegral ll:ibs) <> s
+  RLPArray innerObjects -> do
+    let innerBytes = B.concat . map rlpSerialize $ innerObjects
+        l = B.length innerBytes
     if l <= 55
-      then putWord8 $ 0x80 + fromIntegral l
-      else
-        let ibs = int2Bytes l
-            ll = length ibs
-        in putWord8 (0xb7 + fromIntegral ll) >> mapM_ putWord8 ibs
-    putByteString s
-  (RLPArray innerObjects) -> do
-    let innerBytes = BL.concat . map rlpSerialize' $ innerObjects
-        l = BL.length innerBytes
-    if l <= 55
-      then putWord8 (0xc0 + fromIntegral l)
+      then B.cons (0xc0 + fromIntegral l) innerBytes
       else
         let ibs = int2Bytes . fromIntegral $ l
             ll = length ibs
-        in putWord8 (0xf7 + fromIntegral ll) >> mapM_ putWord8 ibs
-    putLazyByteString innerBytes
+        in (B.pack $ 0xf7 + fromIntegral ll:ibs) <> innerBytes
 
 
 instance RLPSerializable Integer where

--- a/core-strato/ethereum-rlp/test/Main.hs
+++ b/core-strato/ethereum-rlp/test/Main.hs
@@ -7,9 +7,28 @@ import Test.Framework.Providers.HUnit
 import Test.Hspec
 import Test.HUnit
 
-import qualified Data.ByteString as BS
+import qualified Data.ByteString as B
+import Data.Word
 
 import Blockchain.Data.RLP
+
+rlpSerialize_list::RLPObject->B.ByteString
+rlpSerialize_list = B.pack . rlp2Bytes
+
+rlp2Bytes::RLPObject->[Word8]
+rlp2Bytes (RLPScalar val) = [fromIntegral val]
+rlp2Bytes (RLPString s) | B.length s <= 55 = 0x80 + fromIntegral (B.length s):B.unpack s
+rlp2Bytes (RLPString s) =
+  [0xB7 + fromIntegral (length lengthAsBytes)] ++ lengthAsBytes ++ B.unpack s
+  where
+    lengthAsBytes = int2Bytes $ B.length s
+rlp2Bytes (RLPArray innerObjects) =
+  if length innerBytes <= 55
+  then 0xC0 + fromIntegral (length innerBytes):innerBytes
+  else let lenBytes = int2Bytes $ length innerBytes
+       in [0xF7 + fromIntegral (length lenBytes)] ++ lenBytes ++ innerBytes
+  where
+    innerBytes = concat $ rlp2Bytes <$> innerObjects
 
 testNumber::Assertion
 testNumber = do
@@ -18,7 +37,7 @@ testNumber = do
 
 testConsistent :: RLPObject -> Expectation
 testConsistent obj =
-  let oldEnc = rlpSerialize_slow obj
+  let oldEnc = rlpSerialize_list obj
       newEnc = rlpSerialize obj
   in newEnc `shouldBe` oldEnc
 
@@ -28,6 +47,6 @@ main =
   defaultMainWithOpts
   [ testCase "test RLP number encoding" testNumber
   , testCase "test numbers" . mapM_ (testConsistent . RLPScalar) $ [0..255]
-  , testCase "test strings" . mapM_ (testConsistent . RLPString . flip BS.replicate 0xfa) $
+  , testCase "test strings" . mapM_ (testConsistent . RLPString . flip B.replicate 0xfa) $
         [0, 10, 55, 56, 1024, 1024 * 1024]
   ] mempty


### PR DESCRIPTION
```Benchmark rlpserial: RUNNING...
benchmarking Bytestring based string serialization; size=16
time                 17.87 ns   (17.62 ns .. 18.22 ns)
                     0.994 R²   (0.987 R² .. 0.998 R²)
mean                 18.83 ns   (18.32 ns .. 19.58 ns)
std dev              2.154 ns   (1.510 ns .. 3.575 ns)
variance introduced by outliers: 93% (severely inflated)

benchmarking Bytestring based string serialization; size=1024
time                 105.1 ns   (103.8 ns .. 106.9 ns)
                     0.996 R²   (0.990 R² .. 0.999 R²)
mean                 107.9 ns   (105.3 ns .. 112.4 ns)
std dev              10.88 ns   (6.081 ns .. 17.29 ns)
variance introduced by outliers: 91% (severely inflated)

benchmarking Bytestring based string serialization; size=1048576
time                 69.95 μs   (67.89 μs .. 71.68 μs)
                     0.995 R²   (0.994 R² .. 0.997 R²)
mean                 69.19 μs   (67.78 μs .. 70.57 μs)
std dev              4.564 μs   (3.979 μs .. 5.200 μs)
variance introduced by outliers: 67% (severely inflated)

benchmarking Bytestring based string serialization; size=10485760
time                 923.8 μs   (918.3 μs .. 930.6 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 933.4 μs   (926.6 μs .. 942.5 μs)
std dev              26.19 μs   (20.33 μs .. 32.80 μs)
variance introduced by outliers: 17% (moderately inflated)

benchmarking Bytestring based one-level array serialization; size=1024x1
time                 37.02 μs   (36.34 μs .. 38.20 μs)
                     0.985 R²   (0.972 R² .. 0.995 R²)
mean                 39.70 μs   (38.47 μs .. 41.79 μs)
std dev              5.420 μs   (4.000 μs .. 7.227 μs)
variance introduced by outliers: 91% (severely inflated)

benchmarking Bytestring based one-level array serialization; size=1024x1024
time                 766.8 μs   (760.4 μs .. 778.5 μs)
                     0.994 R²   (0.985 R² .. 0.999 R²)
mean                 790.0 μs   (774.8 μs .. 826.2 μs)
std dev              72.38 μs   (40.09 μs .. 135.3 μs)
variance introduced by outliers: 71% (severely inflated)

benchmarking Bytestring based one-level array serialization; size=1024x10240
time                 6.836 ms   (6.273 ms .. 7.281 ms)
                     0.974 R²   (0.963 R² .. 0.985 R²)
mean                 6.064 ms   (5.898 ms .. 6.266 ms)
std dev              558.9 μs   (432.1 μs .. 695.5 μs)
variance introduced by outliers: 55% (severely inflated)

benchmarking Bytestring based MP node simulation; value size=0
time                 747.0 ns   (735.5 ns .. 766.6 ns)
                     0.988 R²   (0.978 R² .. 0.995 R²)
mean                 825.8 ns   (791.9 ns .. 872.6 ns)
std dev              135.2 ns   (99.92 ns .. 175.3 ns)
variance introduced by outliers: 96% (severely inflated)

benchmarking Bytestring based MP node simulation; value size=16
time                 737.6 ns   (723.3 ns .. 762.5 ns)
                     0.989 R²   (0.980 R² .. 0.995 R²)
mean                 776.0 ns   (749.0 ns .. 812.4 ns)
std dev              103.0 ns   (78.10 ns .. 135.3 ns)
variance introduced by outliers: 94% (severely inflated)

benchmarking Bytestring based MP node simulation; value size=256
time                 784.3 ns   (773.5 ns .. 803.0 ns)
                     0.990 R²   (0.978 R² .. 0.998 R²)
mean                 819.1 ns   (791.7 ns .. 872.8 ns)
std dev              121.1 ns   (74.51 ns .. 183.5 ns)
variance introduced by outliers: 95% (severely inflated)

benchmarking Bytestring based MP node simulation; value size=1024
time                 945.4 ns   (868.6 ns .. 1.034 μs)
                     0.971 R²   (0.960 R² .. 0.997 R²)
mean                 916.2 ns   (892.3 ns .. 961.0 ns)
std dev              109.2 ns   (81.67 ns .. 152.0 ns)
variance introduced by outliers: 92% (severely inflated)

benchmarking Bytestring based stack; height=0, width=4
time                 19.15 ns   (18.60 ns .. 20.12 ns)
                     0.976 R²   (0.966 R² .. 0.987 R²)
mean                 21.80 ns   (20.79 ns .. 22.90 ns)
std dev              3.702 ns   (3.216 ns .. 4.443 ns)
variance introduced by outliers: 97% (severely inflated)

benchmarking Bytestring based stack; height=4, width=4
time                 171.1 ns   (168.9 ns .. 174.3 ns)
                     0.995 R²   (0.988 R² .. 0.998 R²)
mean                 178.3 ns   (173.0 ns .. 190.3 ns)
std dev              25.22 ns   (12.68 ns .. 47.03 ns)
variance introduced by outliers: 95% (severely inflated)

benchmarking Bytestring based stack; height=16, width=4
time                 629.2 ns   (625.1 ns .. 636.6 ns)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 645.4 ns   (634.6 ns .. 659.0 ns)
std dev              39.48 ns   (28.78 ns .. 52.17 ns)
variance introduced by outliers: 76% (severely inflated)

benchmarking Bytestring based stack; height=64, width=4
time                 3.083 μs   (3.053 μs .. 3.140 μs)
                     0.994 R²   (0.988 R² .. 0.999 R²)
mean                 3.185 μs   (3.102 μs .. 3.298 μs)
std dev              324.7 ns   (206.0 ns .. 427.8 ns)
variance introduced by outliers: 88% (severely inflated)

benchmarking Bytestring based stack; height=256, width=4
time                 27.67 μs   (25.73 μs .. 30.01 μs)
                     0.959 R²   (0.944 R² .. 0.976 R²)
mean                 28.12 μs   (26.52 μs .. 30.18 μs)
std dev              5.925 μs   (5.209 μs .. 7.191 μs)
variance introduced by outliers: 96% (severely inflated)

benchmarking Bytestring based stack; height=1024, width=4
time                 444.2 μs   (437.9 μs .. 452.6 μs)
                     0.995 R²   (0.991 R² .. 0.998 R²)
mean                 449.7 μs   (440.2 μs .. 466.3 μs)
std dev              40.41 μs   (28.84 μs .. 66.54 μs)
variance introduced by outliers: 72% (severely inflated)

benchmarking Bytestring based stack; height=0, width=1024
time                 104.9 ns   (103.1 ns .. 108.3 ns)
                     0.992 R²   (0.987 R² .. 0.996 R²)
mean                 111.8 ns   (109.0 ns .. 116.0 ns)
std dev              11.25 ns   (9.295 ns .. 14.68 ns)
variance introduced by outliers: 91% (severely inflated)

benchmarking Bytestring based stack; height=4, width=1024
time                 619.4 ns   (614.3 ns .. 628.1 ns)
                     0.996 R²   (0.991 R² .. 0.999 R²)
mean                 640.2 ns   (626.1 ns .. 667.8 ns)
std dev              62.53 ns   (39.98 ns .. 97.44 ns)
variance introduced by outliers: 89% (severely inflated)

benchmarking Bytestring based stack; height=16, width=1024
time                 2.640 μs   (2.502 μs .. 2.756 μs)
                     0.984 R²   (0.973 R² .. 0.991 R²)
mean                 2.420 μs   (2.341 μs .. 2.537 μs)
std dev              308.0 ns   (237.0 ns .. 451.7 ns)
variance introduced by outliers: 92% (severely inflated)

benchmarking Bytestring based stack; height=64, width=1024
time                 9.123 μs   (9.012 μs .. 9.281 μs)
                     0.990 R²   (0.982 R² .. 0.995 R²)
mean                 10.17 μs   (9.701 μs .. 10.84 μs)
std dev              1.824 μs   (1.423 μs .. 2.208 μs)
variance introduced by outliers: 95% (severely inflated)

benchmarking Bytestring based stack; height=256, width=1024
time                 41.95 μs   (41.37 μs .. 42.77 μs)
                     0.995 R²   (0.991 R² .. 0.998 R²)
mean                 44.20 μs   (43.11 μs .. 45.62 μs)
std dev              4.137 μs   (3.030 μs .. 5.328 μs)
variance introduced by outliers: 82% (severely inflated)

benchmarking Bytestring based stack; height=1024, width=1024
time                 661.8 μs   (655.1 μs .. 670.7 μs)
                     0.996 R²   (0.993 R² .. 0.998 R²)
mean                 676.2 μs   (664.3 μs .. 692.9 μs)
std dev              48.19 μs   (33.53 μs .. 61.62 μs)
variance introduced by outliers: 61% (severely inflated)

Benchmark rlpserial: FINISH
Completed 2 action(s).
```