### PR TITLE
Benchmark realistic RLP

### DIFF
--- a/core-strato/ethereum-rlp/bench/ZipBench.hs
+++ b/core-strato/ethereum-rlp/bench/ZipBench.hs
@@ -1,0 +1,21 @@
+-- Realistic RLP inputs collected from 100 Wings tickets on SolidVM
+-- The input file consists of lines of hex encoded RLP separated
+-- by newlines, gzipped.
+import Codec.Compression.GZip
+import Criterion.Main
+import qualified Data.ByteString.Char8 as C8
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Base16 as B16
+
+import Blockchain.Data.RLP
+
+main :: IO ()
+main = do
+  input <- BL.toStrict . decompress <$> BL.readFile "./bench/vm_100_txs.gz"
+  let rlps = map (rlpDeserialize . fst . B16.decode)
+           . filter (not . C8.null)
+           $ C8.split '\n' input
+  defaultMain [ bench "bytestring based rlp" $ nf (map rlpSerialize) rlps
+              , bench "length " $ nf length rlps
+              ]
+

--- a/core-strato/ethereum-rlp/package.yaml
+++ b/core-strato/ethereum-rlp/package.yaml
@@ -78,7 +78,16 @@ benchmarks:
   rlpserial:
     source-dirs: bench/
     main: RLPShootout.hs
+    other-modules: []
     dependencies:
       - ethereum-rlp
       - criterion
       - random-bytestring
+  zipbench:
+    source-dirs: bench/
+    main: ZipBench.hs
+    other-modules: []
+    dependencies:
+      - ethereum-rlp
+      - criterion
+      - zlib


### PR DESCRIPTION
```
Benchmark zipbench: RUNNING...
benchmarking bytestring based rlp
time                 164.6 ms   (145.0 ms .. 176.3 ms)
                     0.989 R²   (0.960 R² .. 0.999 R²)
mean                 167.7 ms   (158.8 ms .. 178.0 ms)
std dev              13.97 ms   (8.804 ms .. 22.29 ms)
variance introduced by outliers: 26% (moderately inflated)

benchmarking length
time                 15.58 ms   (14.84 ms .. 16.18 ms)
                     0.993 R²   (0.989 R² .. 0.997 R²)
mean                 18.17 ms   (17.29 ms .. 19.37 ms)
std dev              2.472 ms   (1.798 ms .. 3.055 ms)
variance introduced by outliers: 64% (severely inflated)

Benchmark zipbench: FINISH
```