### PR TITLE
Use a reverse post order traversal to limit copies

### DIFF
--- a/core-strato/ethereum-rlp/bench/RLPShootout.hs
+++ b/core-strato/ethereum-rlp/bench/RLPShootout.hs
@@ -50,7 +50,7 @@ main = do
   let nstacks = map (\x -> (x, 4, stack 4 x)) [0, 4, 16, 64, 256, 1024]
   let wstacks = map (\x -> (x, 1024, stack 1024 x)) [0, 4, 16, 64, 256, 1024]
 
-  let funcs = [("Bytestring", rlpSerialize)]
+  let funcs = [("Bytestring", rlpSerialize_safe), ("Reverse post order", rlpSerialize)]
   defaultMain $ concat [ liftM2 benchString funcs strings
                        , liftM2 benchOneLevel funcs arrays
                        , liftM2 benchMP funcs fullNodes

--- a/core-strato/ethereum-rlp/bench/ZipBench.hs
+++ b/core-strato/ethereum-rlp/bench/ZipBench.hs
@@ -15,7 +15,8 @@ main = do
   let rlps = map (rlpDeserialize . fst . B16.decode)
            . filter (not . C8.null)
            $ C8.split '\n' input
-  defaultMain [ bench "bytestring based rlp" $ nf (map rlpSerialize) rlps
-              , bench "length " $ nf length rlps
+  defaultMain [ bench "bytestring based rlp" $ nf (map rlpSerialize_safe) rlps
+              , bench "reverse post order traversal rlp" $ nf (map rlpSerialize) rlps
+              , bench "getting buffer length" $ nf (map finalLength) rlps
+              , bench "input list length" $ nf length rlps
               ]
-

--- a/core-strato/ethereum-rlp/library/Blockchain/Data/RLP.hs
+++ b/core-strato/ethereum-rlp/library/Blockchain/Data/RLP.hs
@@ -11,22 +11,30 @@ module Blockchain.Data.RLP (
   RLPSerializable(..),
   rlpSplit,
   rlpSerialize,
+  rlpSerialize_safe, -- For testing
   rlpDeserialize,
-  int2Bytes
+  finalLength -- For testing
   ) where
 
 import           Control.DeepSeq
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.State
 import           Data.Bits
 import qualified Data.ByteString                    as B
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Char8              as BC
+import qualified Data.ByteString.Internal as BI
 import           Data.ByteString.Internal
 import qualified Data.Map                           as M
 import qualified Data.Text                          as T
 import           Data.Word
+import           Foreign.ForeignPtr
+import           Foreign.Ptr
+import           Foreign.Storable
 import           GHC.Generics
 import           Text.PrettyPrint.ANSI.Leijen       hiding ((<$>))
 import           Numeric
+import           System.IO.Unsafe
 
 import           Blockchain.Data.Util
 
@@ -123,8 +131,83 @@ rlpDeserialize s =
 --
 -- Full serialization of an object can be obtained using @rlpSerialize . rlpEncode@.
 
+log256 :: Int -> Int
+log256 val | val < 0x100 = 1
+log256 val | val < 0x10000 = 2
+log256 val | val < 0x1000000 = 3
+log256 val | val < 0x100000000 = 4
+log256 val | val < 0x10000000000 = 5
+log256 val = error $ "log256 not defined for val=" ++ show val
+
+finalLength :: RLPObject -> Int
+finalLength (RLPScalar{}) = 1
+finalLength (RLPString s) = let sub = B.length s in 1 + log256 sub + sub
+finalLength (RLPArray cs) = let sub = sum . map finalLength $ cs
+                            in 1 + log256 sub + sub
+
+{-
+ - This algorithm does two passes over the RLP. The first calculates the
+ - length, which a buffer is allocated for.  The second does a reverse post
+ - order tree traversal (children first, from right to left) and writes to the buffer
+ - from right to left. The change in pointer position is then used to calculate
+ - the total payload length of a node and written into the RLP header.
+ -}
 rlpSerialize :: RLPObject -> B.ByteString
-rlpSerialize = \case
+rlpSerialize (s@RLPScalar{}) = rlpSerialize_safe s
+rlpSerialize (s@RLPString{}) = rlpSerialize_safe s
+rlpSerialize rlp = let maxLen = finalLength rlp
+                   in fst . unsafePerformIO $ BI.createAndTrim' maxLen $ \p0 -> do
+  let pEnd = p0 `plusPtr` maxLen
+  pStart <- execStateT (loop rlp) pEnd
+  return (pStart `minusPtr` p0, pEnd `minusPtr` pStart, ())
+
+  where loop :: RLPObject -> StateT (Ptr Word8) IO ()
+        loop (RLPScalar x) = do
+          p <- gets (`plusPtr` (-1))
+          liftIO $ poke p x
+          put p
+        loop (RLPString (BI.PS fsrc off len)) = do
+          pPayloadStart <- gets (`plusPtr` (-len))
+          liftIO $ withForeignPtr fsrc $ \src -> BI.memcpy pPayloadStart (src `plusPtr` off) (fromIntegral len)
+          if len <= 55
+            then do
+              let pHeaderStart = pPayloadStart `plusPtr` (-1)
+              liftIO . poke pHeaderStart $ 0x80 + fromIntegral len
+              put pHeaderStart
+            else do
+              put pPayloadStart
+              intLoop len
+              pLenStart <- get
+              let pHeaderStart = pLenStart `plusPtr` (-1)
+              liftIO . poke pHeaderStart $ 0xb7 + (fromIntegral $ pPayloadStart `minusPtr` pLenStart)
+              put pHeaderStart
+        loop (RLPArray xs) = do
+          pPayloadEnd <- get
+          mapM_ loop $ reverse xs
+          pPayloadStart <- get
+          let len = pPayloadEnd `minusPtr` pPayloadStart
+          if len <= 55
+            then do
+              let pHeaderStart = pPayloadStart `plusPtr` (-1)
+              liftIO . poke pHeaderStart $ 0xc0 + fromIntegral len
+              put pHeaderStart
+            else do
+              intLoop len
+              pLenStart <- get
+              let pHeaderStart = pLenStart `plusPtr` (-1)
+              liftIO . poke pHeaderStart $ 0xf7 + (fromIntegral $ pPayloadStart `minusPtr` pLenStart)
+              put pHeaderStart
+
+        intLoop :: Int -> StateT (Ptr Word8) IO ()
+        intLoop 0 = return ()
+        intLoop n = do
+          p <- gets (`plusPtr` (-1))
+          liftIO $ poke p $ fromIntegral n
+          put p
+          intLoop (n `shiftR` 8)
+
+rlpSerialize_safe :: RLPObject -> B.ByteString
+rlpSerialize_safe = \case
   RLPScalar val -> B.singleton val
   RLPString s ->
     let l = B.length s
@@ -134,7 +217,7 @@ rlpSerialize = \case
                   ll = length ibs
               in (B.pack $ 0xb7 + fromIntegral ll:ibs) <> s
   RLPArray innerObjects -> do
-    let innerBytes = B.concat . map rlpSerialize $ innerObjects
+    let innerBytes = B.concat . map rlpSerialize_safe $ innerObjects
         l = B.length innerBytes
     if l <= 55
       then B.cons (0xc0 + fromIntegral l) innerBytes
@@ -142,7 +225,6 @@ rlpSerialize = \case
         let ibs = int2Bytes . fromIntegral $ l
             ll = length ibs
         in (B.pack $ 0xf7 + fromIntegral ll:ibs) <> innerBytes
-
 
 instance RLPSerializable Integer where
   rlpEncode 0             = RLPString B.empty

--- a/core-strato/ethereum-rlp/package.yaml
+++ b/core-strato/ethereum-rlp/package.yaml
@@ -58,6 +58,7 @@ dependencies:
   - deepseq
   - binary
   - text
+  - transformers
 
 library:
   source-dirs: library/
@@ -83,6 +84,7 @@ benchmarks:
       - ethereum-rlp
       - criterion
       - random-bytestring
+
   zipbench:
     source-dirs: bench/
     main: ZipBench.hs

--- a/core-strato/ethereum-rlp/test/Main.hs
+++ b/core-strato/ethereum-rlp/test/Main.hs
@@ -8,27 +8,8 @@ import Test.Hspec
 import Test.HUnit
 
 import qualified Data.ByteString as B
-import Data.Word
 
 import Blockchain.Data.RLP
-
-rlpSerialize_list::RLPObject->B.ByteString
-rlpSerialize_list = B.pack . rlp2Bytes
-
-rlp2Bytes::RLPObject->[Word8]
-rlp2Bytes (RLPScalar val) = [fromIntegral val]
-rlp2Bytes (RLPString s) | B.length s <= 55 = 0x80 + fromIntegral (B.length s):B.unpack s
-rlp2Bytes (RLPString s) =
-  [0xB7 + fromIntegral (length lengthAsBytes)] ++ lengthAsBytes ++ B.unpack s
-  where
-    lengthAsBytes = int2Bytes $ B.length s
-rlp2Bytes (RLPArray innerObjects) =
-  if length innerBytes <= 55
-  then 0xC0 + fromIntegral (length innerBytes):innerBytes
-  else let lenBytes = int2Bytes $ length innerBytes
-       in [0xF7 + fromIntegral (length lenBytes)] ++ lenBytes ++ innerBytes
-  where
-    innerBytes = concat $ rlp2Bytes <$> innerObjects
 
 testNumber::Assertion
 testNumber = do
@@ -37,7 +18,7 @@ testNumber = do
 
 testConsistent :: RLPObject -> Expectation
 testConsistent obj =
-  let oldEnc = rlpSerialize_list obj
+  let oldEnc = rlpSerialize_safe obj
       newEnc = rlpSerialize obj
   in newEnc `shouldBe` oldEnc
 
@@ -49,4 +30,6 @@ main =
   , testCase "test numbers" . mapM_ (testConsistent . RLPScalar) $ [0..255]
   , testCase "test strings" . mapM_ (testConsistent . RLPString . flip B.replicate 0xfa) $
         [0, 10, 55, 56, 1024, 1024 * 1024]
+  , testCase "test array of strings" . testConsistent $ RLPArray [RLPString "hello", RLPString "world", RLPString "!"]
+  , testCase "test array of a long string" . testConsistent $ RLPArray [RLPString $ B.replicate 55 0xcc]
   ] mempty


### PR DESCRIPTION
This algorithm does two passes over the RLP. The first calculates the
length, which a buffer is allocated for.  The second does a reverse post
order tree traversal (children first, from right to left) and writes to the buffer
from right to left. The change in pointer position is then used to calculate
the total payload length of a node and written into the RLP header.

The end result is a 40% reduction in time spent on RLP serialization for the wings corpus
```
Benchmark zipbench: RUNNING...
benchmarking bytestring based rlp
time                 163.0 ms   (145.4 ms .. 171.3 ms)
                     0.991 R²   (0.963 R² .. 1.000 R²)
mean                 162.6 ms   (155.8 ms .. 175.0 ms)
std dev              12.51 ms   (3.924 ms .. 19.48 ms)
variance introduced by outliers: 14% (moderately inflated)

benchmarking reverse post order traversal rlp
time                 96.07 ms   (95.68 ms .. 96.31 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 97.62 ms   (97.03 ms .. 98.69 ms)
std dev              1.253 ms   (407.3 μs .. 1.567 ms)

benchmarking getting buffer length
time                 40.32 ms   (40.10 ms .. 40.57 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 40.99 ms   (40.78 ms .. 41.23 ms)
std dev              465.4 μs   (334.1 μs .. 641.4 μs)

benchmarking input list length
time                 14.68 ms   (14.30 ms .. 15.06 ms)
                     0.998 R²   (0.998 R² .. 1.000 R²)
mean                 16.95 ms   (16.42 ms .. 17.81 ms)
std dev              1.627 ms   (1.207 ms .. 2.181 ms)
variance introduced by outliers: 48% (moderately inflated)

Benchmark zipbench: FINISH
```

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/1886/pipeline