### PR TITLE
peg blockapps-rest version in apex to v6.4.1

### DIFF
--- a/apex/api/package.json
+++ b/apex/api/package.json
@@ -23,7 +23,7 @@
     "aws-sdk": "2.254.1",
     "bcrypt": "1.0.3",
     "big-integer": "^1.6.26",
-    "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#develop",
+    "blockapps-rest": "git://github.com/blockapps/blockapps-rest.git#v6.4.1",
     "body-parser": "1.18.2",
     "chai": "4.1.2",
     "chai-http": "3.0.0",


### PR DESCRIPTION
a temporary solution to stick apex to the ba-rest v6.4.1.
The ticket to get rid of blockapps-rest dependency in Apex is also created and being prioritized.