### PR TITLE
Vault Wrapper error codes

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
@@ -180,7 +180,9 @@ enterBloc env x
                      "Please contact your network administrator to have this problem fixed.",
                      "(More information can be found in the Bloc logs.)"
                    ]}
-          VaultWrapperError (FailureResponse Response{..}) | statusIsClientError responseStatusCode ->
+          VaultWrapperError (FailureResponse Response{..}) | responseStatusCode == status503 ->
+            err503{errBody= JSON.encode $ compensateForTheOddStratoApiFormattingAndPullOutTheMessage responseBody}
+                                                           | statusIsClientError responseStatusCode ->
             err400{errBody= JSON.encode $ compensateForTheOddStratoApiFormattingAndPullOutTheMessage responseBody}
           VaultWrapperError (ConnectionError _) ->
             err500{errBody = JSON.encode $ unlines

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
@@ -181,7 +181,7 @@ enterBloc env x
                      "(More information can be found in the Bloc logs.)"
                    ]}
           VaultWrapperError (FailureResponse Response{..}) | responseStatusCode == status503 ->
-            err503{errBody= JSON.encode $ compensateForTheOddStratoApiFormattingAndPullOutTheMessage responseBody}
+            err503{errBody = responseBody}
                                                            | statusIsClientError responseStatusCode ->
             err400{errBody= JSON.encode $ compensateForTheOddStratoApiFormattingAndPullOutTheMessage responseBody}
           VaultWrapperError (ConnectionError _) ->

--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
@@ -11,6 +11,8 @@
 module Strato.Strato23.Monad where
 
 import           Control.Exception.Lifted        hiding (Handler, handle)
+import           Data.IORef                      (readIORef)
+import           Data.Maybe                      (fromMaybe)
 import           Data.Pool                       (Pool, withResource)
 import           Control.Monad.Base
 import           Control.Monad.Except
@@ -49,6 +51,18 @@ newtype VaultM x = VaultM
 
 
 instance MonadError VaultWrapperError VaultM where
+  throwError NoPasswordError = do
+    $logErrorS "throwError/NoPasswordError"
+               "Password has not been set. Please set password by calling POST /strato/v2.3/password for node to function properly"
+    VaultM $ throwError NoPasswordError
+  throwError IncorrectPasswordError = do
+    pw <- liftIO . readIORef =<< asks superSecretPassword
+    $logErrorS "throwError/IncorrectPasswordError" $
+      Text.concat [ "The password has been set incorrectly to "
+                  , fromMaybe "Nothing" pw
+                  , ". Please restart the node and supply the correct password."
+                  ]
+    VaultM $ throwError IncorrectPasswordError
   throwError err@(RuntimeError _) = do
     $logErrorS "throwError/RuntimeError" . Text.pack
         $ show err ++ "\n  callstack missing for runtime errors"

--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
@@ -95,6 +95,8 @@ data VaultWrapperEnv = VaultWrapperEnv
 data VaultWrapperError
   = DBError Text
   | UserError Text
+  | NoPasswordError
+  | IncorrectPasswordError
   | CouldNotFind Text
   | AnError Text
   | Unimplemented Text
@@ -125,34 +127,45 @@ enterVaultWrapper env x
             err500{errBody = fromString $ unlines
                    [
                      "Internal Error!",
-                     "Something is broken in the Vault Wrapper Server database.",
-                     "Please contact your network administrator to have this problem fixed.",
-                     "(More information can be found in the Vault Wrapper logs.)"
+                     "Something is broken in the STRATO database.",
+                     "Please contact your network administrator to have this problem fixed."
                    ]}
           UserError err -> err400{errBody = fromString $ show err}
+          NoPasswordError ->
+            err503{errBody = fromString $ unlines
+                   [
+                     "Internal Error!",
+                     "STRATO has not been initialized properly.",
+                     "Please contact your network administrator to have this problem fixed."
+                   ]}
+          IncorrectPasswordError ->
+            err503{errBody = fromString $ unlines
+                   [
+                     "Internal Error!",
+                     "STRATO has not been initialized properly.",
+                     "Please contact your network administrator to have this problem fixed."
+                   ]}
           AlreadyExists err -> err409{errBody = fromString $ show err}
           CouldNotFind err -> err404{errBody = fromString $ show err}
           AnError _ ->
             err500{errBody = fromString $ unlines
                    [
                      "Internal Error!",
-                     "Something is broken in the Vault Wrapper Server.",
-                     "Please contact your network administrator to have this problem fixed.",
-                     "(More information can be found in the Vault Wrapper logs.)"
+                     "Something is broken in STRATO.",
+                     "Please contact your network administrator to have this problem fixed."
                    ]}
           Unimplemented err ->
             err501{errBody = fromString $ unlines
                    [
                      "Internal Error!",
-                     "You are using a feature of the Vault Wrapper Server that has not yet been implemented.",
+                     "You are using a feature that has not yet been implemented.",
                      Text.unpack err
                    ]}
           RuntimeError _ -> err500{errBody = fromString $ unlines
                    [
                      "Internal Error!",
-                     "Something wrong has happened inside of Vault Wrapper.",
-                     "Please contact your network administrator to have this problem fixed.",
-                     "(More information can be found in the Vault Wrapper logs.)"
+                     "Something wrong has happened inside of STRATO.",
+                     "Please contact your network administrator to have this problem fixed."
                    ]}
 
 withPassword :: (Password -> VaultM a) -> VaultM a
@@ -160,7 +173,7 @@ withPassword f = do
   pwioref <- asks superSecretPassword
   password <- liftIO $ readIORef pwioref
   case password of
-    Nothing -> vaultWrapperError $ AnError "Server misconfigured"
+    Nothing -> vaultWrapperError NoPasswordError
     Just pw -> f (textPassword pw)
 
 formatTopLocation::[(String, SrcLoc)]->String

--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
@@ -11,8 +11,6 @@
 module Strato.Strato23.Monad where
 
 import           Control.Exception.Lifted        hiding (Handler, handle)
-import           Data.IORef                      (readIORef)
-import           Data.Maybe                      (fromMaybe)
 import           Data.Pool                       (Pool, withResource)
 import           Control.Monad.Base
 import           Control.Monad.Except
@@ -56,12 +54,8 @@ instance MonadError VaultWrapperError VaultM where
                "Password has not been set. Please set password by calling POST /strato/v2.3/password for node to function properly"
     VaultM $ throwError NoPasswordError
   throwError IncorrectPasswordError = do
-    pw <- liftIO . readIORef =<< asks superSecretPassword
-    $logErrorS "throwError/IncorrectPasswordError" $
-      Text.concat [ "The password has been set incorrectly to "
-                  , fromMaybe "Nothing" pw
-                  , ". Please restart the node and supply the correct password."
-                  ]
+    $logErrorS "throwError/IncorrectPasswordError"
+      "The password has been set incorrectly. Please restart the node and supply the correct password."
     VaultM $ throwError IncorrectPasswordError
   throwError err@(RuntimeError _) = do
     $logErrorS "throwError/RuntimeError" . Text.pack

--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Server/Key.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Server/Key.hs
@@ -12,14 +12,14 @@ import           Strato.Strato23.Monad
 import           Strato.Strato23.Database.Queries
 
 getKey :: Text -> Maybe Text -> VaultM StatusAndAddress
-getKey headerUserName queryParamUserName = do
+getKey headerUserName queryParamUserName = withPassword $ \pw -> do
   let userName = fromMaybe headerUserName queryParamUserName
   (salt, nonce, encKey, addr) <- toUserError ("User " <> userName <> " doesn't exist")
                                . vaultQuery1 $ getUserKeyQuery userName
   if isJust queryParamUserName          -- decrypt and derive the address if query param
     then return $ StatusAndAddress addr -- not specified, to guarantee correctness
-    else withPassword $ \pw -> case decryptSecKey pw salt nonce encKey of
-      Nothing -> vaultWrapperError $ UserError "Server misconfigured"
+    else case decryptSecKey pw salt nonce encKey of
+      Nothing -> vaultWrapperError IncorrectPasswordError
       Just pKey -> return . StatusAndAddress $ deriveAddress pKey
 
 postKey :: Text -> VaultM StatusAndAddress
@@ -29,5 +29,5 @@ postKey userName = withPassword $ \pw -> do
   if not created
     then vaultWrapperError $ UserError ("User " <> userName <> " already exists")
     else case decryptSecKey pw keystoreSalt keystoreAcctNonce keystoreAcctEncSecKey of
-      Nothing -> vaultWrapperError $ AnError "Error occurred while creating keystore"
+      Nothing -> vaultWrapperError IncorrectPasswordError
       Just pKey -> return . StatusAndAddress $ deriveAddress pKey

--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Server/Signature.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Server/Signature.hs
@@ -28,7 +28,7 @@ postSignature userName (UserData (Hex msgHash)) = do
         . vaultQuery1
         $ getUserKeyQuery userName
   withPassword $ \pw -> case decryptSecKey pw salt nonce pKey of
-    Nothing -> vaultWrapperError $ UserError "Incorrect password"
+    Nothing -> vaultWrapperError IncorrectPasswordError
     Just prvKey -> case msg (word256ToByteString msgHash) of
       Nothing -> vaultWrapperError $ AnError "Message was not 32 bytes long"
       Just msg' -> do


### PR DESCRIPTION
Return a 503 error code from Vault Wrapper if the password has not been set, and have Bloc forward this error to the user instead of returning the generic message