### PR TITLE
Make blacklists more forgiving

### DIFF
--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -46,6 +46,8 @@ PPeer
     bondState Int
     activeState Int
     version T.Text
+    nextDisableWindowSeconds Int
+    disableExpiration UTCTime
     deriving Show Read Eq
 |]
 
@@ -75,7 +77,9 @@ buildPeer (pubKeyMaybe, ip, _) =
         pPeerLastBestBlockHash = SHA 0,
         pPeerBondState=0,
         pPeerActiveState = 0,
-        pPeerVersion = T.pack "61" -- fix
+        pPeerVersion = T.pack "61", -- fix
+        pPeerNextDisableWindowSeconds = 5,
+        pPeerDisableExpiration = jamshidBirth
         }
 
 parseEnode :: String -> Either String (Maybe String, String, Int)
@@ -167,17 +171,13 @@ defaultPeer = PPeer{
   pPeerLastBestBlockHash=SHA 0,
   pPeerBondState=0,
   pPeerActiveState=0,
-  pPeerVersion=""
+  pPeerVersion="",
+  pPeerNextDisableWindowSeconds=5,
+  pPeerDisableExpiration=posixSecondsToUTCTime 0
   }
 
-disablePeerForSeconds::PPeer->Int->IO (Either SomeException ())
-disablePeerForSeconds peer' seconds = try . withGlobalSQLPool $ \sqldb -> do
-  -- TODO(tim): Reenable port selection
-  let peer = peer'{pPeerTcpPort = 30303, pPeerUdpPort=30303}
-  currentTime <- getCurrentTime
-  flip SQL.runSqlPool sqldb $
-    SQL.updateWhere [PPeerIp SQL.==. pPeerIp peer, PPeerTcpPort SQL.==. pPeerTcpPort peer] [PPeerEnableTime SQL.=. fromIntegral seconds `addUTCTime` currentTime]
-  return ()
+thisPeer :: PPeer -> [SQL.Filter PPeer]
+thisPeer peer = [PPeerIp SQL.==. pPeerIp peer, PPeerTcpPort SQL.==. pPeerTcpPort peer]
 
 disableUDPPeerForSeconds::PPeer->Int->IO (Either SomeException ())
 disableUDPPeerForSeconds peer' seconds = try . withGlobalSQLPool $ \sqldb -> do
@@ -185,8 +185,34 @@ disableUDPPeerForSeconds peer' seconds = try . withGlobalSQLPool $ \sqldb -> do
   let peer = peer'{pPeerTcpPort=30303}
   currentTime <- getCurrentTime
   flip SQL.runSqlPool sqldb $
-    SQL.updateWhere [PPeerIp SQL.==. pPeerIp peer, PPeerTcpPort SQL.==. pPeerTcpPort peer] [PPeerUdpEnableTime SQL.=. fromIntegral seconds `addUTCTime` currentTime]
-  return ()
+    SQL.updateWhere (thisPeer peer) [PPeerUdpEnableTime SQL.=. fromIntegral seconds `addUTCTime` currentTime]
 
 resetPeers :: IO ()
 resetPeers = withGlobalSQLPool $ SQL.runSqlPool (SQL.updateWhere [] [PPeerActiveState SQL.=. 0])
+
+nonviolentDisable :: PPeer -> IO (Either SomeException ())
+nonviolentDisable peer' = try . withGlobalSQLPool $ \sqldb -> do
+  let peer = peer'{pPeerTcpPort=30303}
+  currentTime <- getCurrentTime
+  flip SQL.runSqlPool sqldb $
+    SQL.updateWhere (thisPeer peer) [PPeerEnableTime SQL.=. 10 `addUTCTime` currentTime]
+
+-- The first time a peer is disabled, the timeout is five seconds. Every subsequent failure that
+-- window is doubled, but those windows are reset every day. This prevents a mostly healthy node
+-- from building up longer and longer disables, e.g. if it caused an exception once a day
+-- by the end of the month it would be disabled for years.
+lengthenPeerDisable :: PPeer -> IO (Either SomeException ())
+lengthenPeerDisable peer' = try . withGlobalSQLPool $ \sqldb -> do
+  -- TODO(tim): Reenable port selection
+  let peer = peer'{pPeerTcpPort=30303}
+  currentTime <- getCurrentTime
+  let selector = thisPeer peer
+  flip SQL.runSqlPool sqldb $ do
+    if (currentTime < pPeerDisableExpiration peer)
+      then SQL.updateWhere selector [PPeerEnableTime SQL.=. fromIntegral (pPeerNextDisableWindowSeconds peer) `addUTCTime` currentTime
+                                    , PPeerNextDisableWindowSeconds SQL.*=. 2
+                                    ]
+      else SQL.updateWhere selector [ PPeerEnableTime SQL.=. 5 `addUTCTime` currentTime
+                                    , PPeerNextDisableWindowSeconds SQL.=. 5
+                                    , PPeerDisableExpiration SQL.=. (24 * 60 * 60) `addUTCTime` currentTime
+                                    ]

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
@@ -222,6 +222,8 @@ handleValidPacket prv sock addr _ packet otherPubKey = let portNum = 30303 :: In
                          , pPeerBondState = 0
                          , pPeerActiveState = 0
                          , pPeerVersion = T.pack "61" -- fix
+                         , pPeerNextDisableWindowSeconds=5
+                         , pPeerDisableExpiration=posixSecondsToUTCTime 0
                          }
         void $ addPeer peer
   where addPeer' = do
@@ -243,6 +245,8 @@ handleValidPacket prv sock addr _ packet otherPubKey = let portNum = 30303 :: In
                           ,  pPeerBondState = 0
                           ,  pPeerActiveState = 0
                           ,  pPeerVersion = T.pack "61" -- fix
+                          , pPeerNextDisableWindowSeconds=5
+                          , pPeerDisableExpiration=posixSecondsToUTCTime 0
                           }
           void $ addPeer peer
 

--- a/core-strato/strato-p2p/src/Blockchain/Metrics.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Metrics.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Blockchain.Metrics ( recordEvent
                           , recordMessage
@@ -7,14 +8,18 @@ module Blockchain.Metrics ( recordEvent
                           , recordGossipFinal
                           , addCanary
                           , killCanary
+                          , recordException
                           ) where
 
+import Control.Exception
 import Control.Monad.IO.Class
 import Data.Text
+import Data.Typeable
 import Prometheus
 
 import Blockchain.EventModel
 import Blockchain.Data.Wire
+import Blockchain.Strato.Discovery.Data.Peer (PPeer(..))
 import qualified Blockchain.Blockstanbul as PBFT
 
 -- TODO(tim): Add peer to labels
@@ -102,3 +107,16 @@ addCanary = liftIO $ incGauge canaryCount
 
 killCanary :: MonadIO m => m ()
 killCanary = liftIO $ decGauge canaryCount
+
+{-# NOINLINE exceptionCount #-}
+exceptionCount :: Vector (Text, Text, Text) Counter
+exceptionCount = unsafeRegister
+               . vector ("ip", "port", "type")
+               . counter
+               $ Info "p2p_peer_exceptions" "Counters for exceptions thrown by peer connections"
+
+recordException :: (Exception e, MonadIO m) => PPeer -> e -> m ()
+recordException PPeer{..} e =
+  let ty = pack . show $ typeOf e
+      port = pack $ show pPeerTcpPort
+  in liftIO $ withLabel exceptionCount (pPeerIp, port, ty) incCounter

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -38,6 +38,7 @@ import           Blockchain.ECIES
 import           Blockchain.EthConf                    hiding (genesisHash, port)
 import           Blockchain.EthEncryptionException
 import           Blockchain.EventException
+import           Blockchain.Metrics
 import           Blockchain.Options
 import           Blockchain.Output
 import           Blockchain.P2PRPC
@@ -115,7 +116,7 @@ runPeerInList :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
               -> CommPort
               -> m ()
 runPeerInList thePeer otherServiceHost otherServicePort = do
-  eErr <- liftIO $ disablePeerForSeconds thePeer 10 --don't connect to a peer more than once per minute, out of politeness
+  eErr <- liftIO $ nonviolentDisable thePeer --don't connect to a peer too frequently, out of politeness
   whenLeft eErr $ \err -> do
       $logErrorS "runPeerInList" . T.pack $ "Unable to disable peer:" ++ show err
       $logErrorS "runPeerInList" "Simulating disable..."
@@ -153,24 +154,20 @@ stratoP2PClient = do
               liftIO (SSem.signal sem)
               handleRunPeerResult p result
 
-      disablePeerForHours :: (MonadIO m, MonadLogger m) => PPeer -> Int -> m ()
-      disablePeerForHours thePeer s = do
-        eErr <- liftIO . disablePeerForSeconds thePeer . (60*60*) $ s
-        whenLeft eErr $ \err -> do
-            $logErrorS "stratoP2PClient/disablePeerForHours" . T.pack $
-                        "Unable to disable peer: " ++ show err
-            $logErrorS "stratoP2PClient/disablePeerForHours" "Will disable next time they misbehave"
-
       handleRunPeerResult :: (MonadLogger m, MonadIO m) => PPeer -> Either SomeException a -> m ()
       handleRunPeerResult thePeer = \case
         Left e | Just (ErrorCall x) <- fromException e -> error x
         Left e -> do
           $logInfoS "stratoP2PClient/handleRunPeerResult" $ T.pack $ "Connection ended: " ++ show (e :: SomeException)
-          case e of
-           e' | Just TimeoutException  <- fromException e' -> disablePeerForHours thePeer 4
-           e' | Just WrongGenesisBlock <- fromException e' -> disablePeerForHours thePeer (24*7)
-           e' | Just HeadMacIncorrect  <- fromException e' -> disablePeerForHours thePeer 24
-           _  -> return ()
+          recordException thePeer e
+          eErr <- liftIO $ case e of
+                   e' | Just TimeoutException  <- fromException e' -> lengthenPeerDisable thePeer
+                   e' | Just WrongGenesisBlock <- fromException e' -> lengthenPeerDisable thePeer
+                   e' | Just HeadMacIncorrect  <- fromException e' -> lengthenPeerDisable thePeer
+                   _  -> return $ Right ()
+          whenLeft eErr $ \err -> do
+            $logErrorLS "stratoP2PClient/handleRunPeerResult" err
+
         Right _ -> return ()
 
       osch = "localhost"


### PR DESCRIPTION
Currently if a peer times out (which can happen during a restart), the client will avoid connecting for 4 hours. This change creates an adaptive time out, so that the disconnected window ~ the downtime window for the server.

This change should make it unnecessary to reset the enable times on a whole network to allow a restarting node to connect