### PR TITLE
Add a primary key to the history tables

### DIFF
--- a/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
@@ -221,6 +221,7 @@ createHistoryTable globalsIORef contract = do
   when history $ do
     incNumHistoryTables
     yield $ createHistoryTableQuery contract
+    yield $ addHistoryUnique contract
 
 insertIndexTable :: OutputM m
                  => IORef Globals
@@ -278,11 +279,20 @@ createHistoryTableQuery contract =
       list = Map.toList $ Map.map valueToSolidityValue $ Map.filter isFunction $ contractData contract
    in T.concat
         [ "CREATE TABLE IF NOT EXISTS ", wrapDoubleQuotes historyName, " ("
-        , csv $ ["address text", "\"chainId\" text", "block_hash text", "block_timestamp text",
-                 "block_number text", "transaction_hash text", "transaction_sender text",
-                 "transaction_function_name text"] ++ tableColumns list
+        , csv $ ["address text NOT NULL", "\"chainId\" text NOT NULL", "block_hash text NOT NULL", "block_timestamp text",
+                 "block_number text", "transaction_hash text NOT NULL", "transaction_sender text",
+                 "transaction_function_name text"]
+                 ++ tableColumns list
         , ");"
         ]
+
+addHistoryUnique :: ProcessedContract -> Text
+addHistoryUnique contract =
+  let historyName = ("history@" <>) . escapeQuotes $ contractName contract
+      indexName = "index_" <> historyName
+  in  "CREATE UNIQUE INDEX IF NOT EXISTS " <> wrapDoubleQuotes indexName <>
+      "\n  ON " <> wrapDoubleQuotes historyName <> " (address, \"chainId\", block_hash, transaction_hash);\n" <>
+      "ALTER TABLE " <> wrapDoubleQuotes historyName <> " ADD PRIMARY KEY USING INDEX " <> wrapDoubleQuotes indexName <> ";"
 
 insertIndexTableQuery :: [ProcessedContract] -> Text
 insertIndexTableQuery [] = error "insertIndexTableQuery: unhandled empty list"
@@ -355,5 +365,5 @@ insertHistoryTableQuery contracts@(x:_) =
         , keySt
         , "\n  VALUES "
         , inserts
-        , ";"
+        , "\n  ON CONFLICT DO NOTHING;"
         ]

--- a/blockapps-haskell/slipstream/tests/OutputDataSpec.hs
+++ b/blockapps-haskell/slipstream/tests/OutputDataSpec.hs
@@ -142,7 +142,7 @@ spec = do
             }]
       g <- newGlobals fakeHandle
       addToHistoryList g cHash
-      [contractInsert, vehicleCreate, historyCreate, vehicleInsert, historyInsert]
+      [contractInsert, vehicleCreate, historyCreate, historyIndex, vehicleInsert, historyInsert]
         <- runLoggingT . runConduit $ createInserts g input .| sinkList
 
       contractInsert `shouldBe`
@@ -167,15 +167,20 @@ spec = do
   PRIMARY KEY (address, "chainId") );|]
 
       historyCreate `shouldBe`
-          [r|CREATE TABLE IF NOT EXISTS "history@Vehicle" (address text,
-    "chainId" text,
-    block_hash text,
+          [r|CREATE TABLE IF NOT EXISTS "history@Vehicle" (address text NOT NULL,
+    "chainId" text NOT NULL,
+    block_hash text NOT NULL,
     block_timestamp text,
     block_number text,
-    transaction_hash text,
+    transaction_hash text NOT NULL,
     transaction_sender text,
     transaction_function_name text,
     "owners" jsonb);|]
+
+      historyIndex `shouldBe`
+          [r|CREATE UNIQUE INDEX IF NOT EXISTS "index_history@Vehicle"
+  ON "history@Vehicle" (address, "chainId", block_hash, transaction_hash);
+ALTER TABLE "history@Vehicle" ADD PRIMARY KEY USING INDEX "index_history@Vehicle";|]
 
       vehicleInsert `shouldBe`
           [r|INSERT INTO "Vehicle" ("address",
@@ -225,7 +230,8 @@ spec = do
     '242d201a68fa4440fcb3c77610785eb207b5a8b9f88208a3525efe6a7677ed59',
     '0000000000000000000000000000000000000add',
     '',
-    '[{"hash":"Owner_hash_181999847806006","number":"18199984780605"}]');|]
+    '[{"hash":"Owner_hash_181999847806006","number":"18199984780605"}]')
+  ON CONFLICT DO NOTHING;|]
 
   describe "String escaping" $ do
     it "should create JSON entries with quotes escaped" $ do


### PR DESCRIPTION
address, chainId, block_hash, transaction_hash are chosen to identify
unique results. The goal is to remove duplicate entries, and give
priority to the first entry in the table to prevent cross contamination
from later state.


When the table already has duplicates, it will not be able to create the index but keep processing. This is the correct behavior, as we saw yesterday that it is not easy to determine the best version of the row: 
```
[2019-06-12 20:29:33.517540715 UTC] ERROR | ThreadId 1     | handlePGError                       | PGERROR [23505]: could not create unique index "index_history@User"
Key (address, "chainId", block_hash, transaction_hash)=(8f7b0a04d132381cb337c893ad48b1350e5380a9, , 07e9dd1719118e208e118eeacaeba63bff872e45149b1a37268e18d766df3930, 0859c17d4baf655bddd4da5c625e2f0de69820e0217b17b08aee08187b910ac8) is duplicated.
[2019-06-12 20:29:33.544613943 UTC]  INFO | ThreadId 1     | pglog                               | PGNOTICE [42P07]: relation "history@Stewardship" already exists, skipping
[2019-06-12 20:29:33.546578522 UTC] ERROR | ThreadId 1     | handlePGError                       | PGERROR [23505]: could not create unique index "index_history@Stewardship"
Key (address, "chainId", block_hash, transaction_hash)=(8054bafe20f1c3adf53039ba76a9074d9cfd97e0, , 4126f939a8b1b8a66b71b230f716684899b26eb417569856d3c38dedccfe835b, 382b309c2432c20afb0d1cc82613887093195c625ce2690b0ecef2b9b67593bf) is duplicated.
[2019-06-12 20:29:33.794723395 UTC]  INFO | ThreadId 1     | pglog                               | PGNOTICE [42P07]: relation "history@StewardshipTSD" already exists, skipping
[2019-06-12 20:29:33.795637544 UTC] ERROR | ThreadId 1     | handlePGError                       | PGERROR [23505]: could not create unique index "index_history@StewardshipTSD"
Key (address, "chainId", block_hash, transaction_hash)=(0000000000000000000000000000000000000100, 6aaa0325c9b15ecf57dc0daab3845c2c1847748f75f5191c4a26195b75030641, dd6e6ba432ac074e3ad43877b0a2ab981e80e7afb36fa897de08818522ab88b8, 61638380ce24b617e3d477a434ece090d3541e777830c993cd43aa642c33409e) is duplicated.
```

When there is at most one of each key, they are converted to primary keys:
```cirrus=# \d+ "history@User";
                              Table "public.history@User"
          Column           |  Type  | Modifiers | Storage  | Stats target | Description
---------------------------+--------+-----------+----------+--------------+-------------
 address                   | text   | not null  | extended |              |
 chainId                   | text   | not null  | extended |              |
 block_hash                | text   | not null  | extended |              |
 block_timestamp           | text   |           | extended |              |
 block_number              | text   |           | extended |              |
 transaction_hash          | text   | not null  | extended |              |
 transaction_sender        | text   |           | extended |              |
 transaction_function_name | text   |           | extended |              |
 ACCEPTED                  | bigint |           | plain    |              |
 BAD_GATEWAY               | bigint |           | plain    |              |
 BAD_REQUEST               | bigint |           | plain    |              |
 CLIENT_ERROR              | bigint |           | plain    |              |
 CONFLICT                  | bigint |           | plain    |              |
 CREATED                   | bigint |           | plain    |              |
 FORBIDDEN                 | bigint |           | plain    |              |
 GATEWAY_TIMEOUT           | bigint |           | plain    |              |
 INTERNAL_SERVER_ERROR     | bigint |           | plain    |              |
 NOT_FOUND                 | bigint |           | plain    |              |
 OK                        | bigint |           | plain    |              |
 SERVER_ERROR              | bigint |           | plain    |              |
 UNAUTHORIZED              | bigint |           | plain    |              |
 account                   | text   |           | extended |              |
 creator                   | text   |           | extended |              |
 id                        | bigint |           | plain    |              |
 orgId                     | text   |           | extended |              |
 pwHash                    | text   |           | extended |              |
 role                      | text   |           | extended |              |
 username                  | text   |           | extended |              |
 version                   | bigint |           | plain    |              |
Indexes:
    "index_history@User" PRIMARY KEY, btree (address, "chainId", block_hash, transaction_hash)
```

There are unfortunately errors from the later attempts to attach the index, but the alternatives don't seem great:
```[2019-06-12 20:51:55.571516299 UTC]  INFO | ThreadId 1     | pglog                               | PGERROR [55000]: index "index_history@User" is already associated with a constraint
[2019-06-12 20:51:55.751209134 UTC]  INFO | ThreadId 1     | pglog                               | PGERROR [55000]: index "index_history@Stewardship" is already associated with a constraint
[2019-06-12 20:51:55.825293738 UTC]  INFO | ThreadId 1     | pglog                               | PGERROR [55000]: index "index_history@StewardshipTSD" is already associated with a constraint
```
https://stackoverflow.com/questions/6801919/postgres-add-constraint-if-it-doesnt-already-exist