### PR TITLE
Store slipstream's offset in kafka

### DIFF
--- a/blockapps-haskell/slipstream/exec_src/Main.hs
+++ b/blockapps-haskell/slipstream/exec_src/Main.hs
@@ -97,8 +97,7 @@ main = do
       let state = mkConfiguredKafkaState ("slipstream" :: KafkaClientId) . fromIntegral $ flags_kafkaMaxBytes
 
       gref <- newGlobals handle
-
-      lift . runKafka state $ getAndProcessMessages env conn gref 0 0
+      lift . runKafka state $ getAndProcessMessages env conn gref
     case msg of
       Left e -> liftIO . die $ show e
       Right () -> $logInfoS "main" "completing successfully"

--- a/blockapps-haskell/slipstream/package.yaml
+++ b/blockapps-haskell/slipstream/package.yaml
@@ -27,9 +27,11 @@ dependencies:
   - blockapps-bloc22-api
   - blockapps-bloc22-server
   - blockapps-ethereum
+  - blockapps-milena
   - blockapps-solidity
   - blockapps-strato-client
   - blockapps-strato-api
+  - blockapps-util
   - bloomfilter
   - bytestring
   - classy-prelude
@@ -46,7 +48,6 @@ dependencies:
   - http-client
   - lens
   - lrucache
-  - milena
   - MissingH
   - monad-control
   - mtl
@@ -85,7 +86,6 @@ executables:
     dependencies:
       - base
       - hflags
-      - milena
       - monad-control
       - mtl
       - persistent-postgresql

--- a/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
@@ -153,3 +153,8 @@ setContractState gref address chainId values = do
 
 forceGlobalEval :: (MonadIO m) => IORef Globals -> m ()
 forceGlobalEval gref = liftIO $ modifyIORef' gref force
+
+flushPendingWrites :: MonadIO m => IORef Globals -> m ()
+flushPendingWrites gref = do
+  Globals{..} <- readIORef gref
+  syncStorage csHandle

--- a/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
@@ -81,6 +81,22 @@ mkConfiguredKafkaState cid = makeKafkaState cid (kh, kp)
 lookupTopic :: K.TopicName
 lookupTopic = fromString "statediff"
 
+lookupPartition :: K.Partition
+lookupPartition = K.Partition 0
+
+getStatediffOffset :: SlipKafka K.Offset
+getStatediffOffset = getLastOffset LatestTime lookupPartition lookupTopic
+
+putStatediffOffset :: K.Offset -> SlipKafka ()
+putStatediffOffset off = do
+    clientid <- use stateName
+    corid <- stateCorrelationId <<+= 1
+    let offReq = K.OffsetCommitRequest $ K.OffsetCommitReq ("sliptream", [(lookupTopic, [(lookupPartition, off, protocolTime (LatestTime), K.Metadata "")])])
+        req = K.Request (corid, K.ClientId clientid, offReq)
+    resp <- withAnyHandle $ \h -> K.doRequest' corid h req :: SlipKafka (Either String K.OffsetCommitResponse)
+    $logInfoLS "putStatediffOffset" resp
+
+
 getTheMessages :: K.Offset -> SlipKafka [B.ByteString]
 getTheMessages offset = do
   let extract :: K.FetchResponse -> Either String [B.ByteString]
@@ -102,8 +118,14 @@ getTheMessages offset = do
               Left e -> error $ "getTheMessages: " ++ e
               Right bs -> bs
 
-getAndProcessMessages :: BlocEnv -> PGConnection -> IORef Globals -> K.Offset -> Int -> SlipKafka ()
-getAndProcessMessages env conn cache offset errorCounter = do
+getAndProcessMessages :: BlocEnv -> PGConnection -> IORef Globals -> SlipKafka ()
+getAndProcessMessages env conn cache = do
+  let errorCount = 0
+  offset <- getLastOffset LatestTime lookupPartition lookupTopic
+  getAndProcessMessages' env conn cache offset errorCount
+
+getAndProcessMessages' :: BlocEnv -> PGConnection -> IORef Globals -> K.Offset -> Int -> SlipKafka ()
+getAndProcessMessages' env conn cache offset errorCounter = do
   eMessages <- try $ getTheMessages offset
   case eMessages of
     Left e -> do
@@ -111,11 +133,14 @@ getAndProcessMessages env conn cache offset errorCounter = do
       $logErrorLS "getTheMessages" (e :: KafkaClientError)
       if (errorCounter > exceptionMaxCount )
            then error $ "Slipstream reached exceptionMaxCount."
-           else getAndProcessMessages env conn cache offset (errorCounter + 1)
+           else getAndProcessMessages' env conn cache offset (errorCounter + 1)
     Right messages -> do
       recordKafkaMessages messages
       forceGlobalEval cache
       lift . lift $ processTheMessages env conn cache messages
       when (null messages) $
         liftIO $ threadDelay 1000000
-      getAndProcessMessages env conn cache (offset + fromIntegral (length messages)) errorCounter
+      let newOffset = offset + fromIntegral (length messages)
+      putStatediffOffset newOffset
+      getAndProcessMessages' env conn cache (offset + fromIntegral (length messages)) errorCounter
+

--- a/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
@@ -60,17 +60,19 @@ runKafka s k = runExceptT $ evalStateT k s
 
 makeKafkaState :: KafkaClientId -> KafkaAddress -> K.MaxBytes -> KafkaState
 makeKafkaState cid addy maxBytes =
-    KafkaState cid
-               defaultRequiredAcks
-               defaultRequestTimeout
-               defaultMinBytes
-               maxBytes
-               defaultMaxWaitTime
-               defaultCorrelationId
-               M.empty
-               M.empty
-               M.empty
-               (addy NE.:| [])
+  let waitTime = 100000 -- 100s
+      minBytes = 1      -- Awaken from sleep only if there is at least one message
+  in KafkaState cid
+                defaultRequiredAcks
+                defaultRequestTimeout
+                minBytes
+                maxBytes
+                waitTime
+                defaultCorrelationId
+                M.empty
+                M.empty
+                M.empty
+                (addy NE.:| [])
 
 mkConfiguredKafkaState :: KafkaClientId -> K.MaxBytes -> KafkaState
 mkConfiguredKafkaState cid = makeKafkaState cid (kh, kp)
@@ -84,17 +86,25 @@ lookupTopic = fromString "statediff"
 lookupPartition :: K.Partition
 lookupPartition = K.Partition 0
 
+lookupGroup :: K.ConsumerGroup
+lookupGroup = "slipstream"
+
+generateRequestId :: SlipKafka (K.CorrelationId, K.ClientId)
+generateRequestId = liftM2 (,) (stateCorrelationId <<+= 1) (uses stateName K.ClientId)
+
+-- TODO: Use blockapps-milena to get topic stored offsets instead of zookeeper ones.
 getStatediffOffset :: SlipKafka K.Offset
 getStatediffOffset = getLastOffset LatestTime lookupPartition lookupTopic
 
 putStatediffOffset :: K.Offset -> SlipKafka ()
 putStatediffOffset off = do
-    clientid <- use stateName
-    corid <- stateCorrelationId <<+= 1
-    let offReq = K.OffsetCommitRequest $ K.OffsetCommitReq ("slipstream", [(lookupTopic, [(lookupPartition, off, protocolTime (LatestTime), K.Metadata "")])])
-        req = K.Request (corid, K.ClientId clientid, offReq)
-    resp <- withAnyHandle $ \h -> K.doRequest' corid h req :: SlipKafka (Either String K.OffsetCommitResponse)
-    $logInfoLS "putStatediffOffset" resp
+    (corrId, clientId) <- generateRequestId
+    let commitRequest = K.OffsetCommitRequest
+               $ K.OffsetCommitReq (lookupGroup, [(lookupTopic, [(lookupPartition, off, protocolTime LatestTime, K.Metadata "")])])
+        req = K.Request (corrId, clientId, commitRequest)
+    resp <- withAnyHandle $ \h -> K.doRequest' corrId h req :: SlipKafka (Either String K.OffsetCommitResponse)
+    $logInfoLS "putStatediffOffset/req" req
+    $logInfoLS "putStatediffOffset/resp" resp
 
 
 getTheMessages :: K.Offset -> SlipKafka [B.ByteString]
@@ -126,28 +136,29 @@ getAndProcessMessages env conn cache = do
 
 getAndProcessMessages' :: BlocEnv -> PGConnection -> IORef Globals -> K.Offset -> Int -> SlipKafka ()
 getAndProcessMessages' env conn cache offset errorCounter = do
+  recordOffset offset
   eMessages <- try $ getTheMessages offset
   case eMessages of
     Left e -> do
-      liftIO $ threadDelay 1000000
       $logErrorLS "getTheMessages" (e :: KafkaClientError)
+      liftIO $ threadDelay 1000000
       if (errorCounter > exceptionMaxCount )
            then error $ "Slipstream reached exceptionMaxCount."
            else getAndProcessMessages' env conn cache offset (errorCounter + 1)
     Right messages -> do
+      $logDebugLS "getAndProcessMessages'" messages
       recordKafkaMessages messages
       forceGlobalEval cache
       lift . lift $ processTheMessages env conn cache messages
-      when (null messages) $
-        liftIO $ threadDelay 1000000
       let newOffset = offset + fromIntegral (length messages)
       currentOffset <- getStatediffOffset
-      -- If the offset has been changed since our last read, assume that we should
-      -- begin to read from there instead.
       offset' <- if currentOffset /= offset
-                    then return currentOffset
+                    then do
+                      $logInfoLS "getAndProcessMessages'/manual_offset" currentOffset
+                      recordOffsetOverride
+                      return currentOffset
                     else do
-                        putStatediffOffset newOffset
-                        return newOffset
-      getAndProcessMessages' env conn cache offset' errorCounter
+                      putStatediffOffset newOffset
+                      return newOffset
 
+      getAndProcessMessages' env conn cache offset' errorCounter

--- a/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
@@ -30,6 +30,7 @@ import qualified Network.Kafka.Protocol as K hiding (Message)
 
 import BlockApps.Bloc22.Monad (BlocEnv)
 import BlockApps.Logging
+import Blockchain.MilenaTools
 import Slipstream.Globals
 import Slipstream.Metrics
 import Slipstream.Options
@@ -89,22 +90,29 @@ lookupPartition = K.Partition 0
 lookupGroup :: K.ConsumerGroup
 lookupGroup = "slipstream"
 
-generateRequestId :: SlipKafka (K.CorrelationId, K.ClientId)
-generateRequestId = liftM2 (,) (stateCorrelationId <<+= 1) (uses stateName K.ClientId)
-
--- TODO: Use blockapps-milena to get topic stored offsets instead of zookeeper ones.
 getStatediffOffset :: SlipKafka K.Offset
-getStatediffOffset = getLastOffset LatestTime lookupPartition lookupTopic
+getStatediffOffset = do
+  resp <- fetchSingleOffset lookupGroup lookupTopic lookupPartition
+  $logDebugLS "getStateDiffOffset/resp" resp
+  case resp of
+    Left K.UnknownTopicOrPartition -> do
+      $logInfoS "getStatediffOffset" "No offset found, creating one from 0"
+      putStatediffOffset 0 >> getStatediffOffset
+    Left err -> do
+      $logErrorLS "getStatediffOffset" err
+      error $ show err
+    Right (off, _) -> return off
 
 putStatediffOffset :: K.Offset -> SlipKafka ()
 putStatediffOffset off = do
-    (corrId, clientId) <- generateRequestId
-    let commitRequest = K.OffsetCommitRequest
-               $ K.OffsetCommitReq (lookupGroup, [(lookupTopic, [(lookupPartition, off, protocolTime LatestTime, K.Metadata "")])])
-        req = K.Request (corrId, clientId, commitRequest)
-    resp <- withAnyHandle $ \h -> K.doRequest' corrId h req :: SlipKafka (Either String K.OffsetCommitResponse)
-    $logInfoLS "putStatediffOffset/req" req
-    $logInfoLS "putStatediffOffset/resp" resp
+    $logInfoLS "putStateDiffOffset/req" off
+    resp <- commitSingleOffset lookupGroup lookupTopic lookupPartition off ""
+    $logDebugLS "putStateDiffOffset/resp" resp
+    case resp of
+      Left err -> do
+        $logErrorLS "putStatediffOffset" err
+        error $ show err
+      Right () -> return ()
 
 
 getTheMessages :: K.Offset -> SlipKafka [B.ByteString]

--- a/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/MessageConsumer.hs
@@ -91,7 +91,7 @@ putStatediffOffset :: K.Offset -> SlipKafka ()
 putStatediffOffset off = do
     clientid <- use stateName
     corid <- stateCorrelationId <<+= 1
-    let offReq = K.OffsetCommitRequest $ K.OffsetCommitReq ("sliptream", [(lookupTopic, [(lookupPartition, off, protocolTime (LatestTime), K.Metadata "")])])
+    let offReq = K.OffsetCommitRequest $ K.OffsetCommitReq ("slipstream", [(lookupTopic, [(lookupPartition, off, protocolTime (LatestTime), K.Metadata "")])])
         req = K.Request (corid, K.ClientId clientid, offReq)
     resp <- withAnyHandle $ \h -> K.doRequest' corid h req :: SlipKafka (Either String K.OffsetCommitResponse)
     $logInfoLS "putStatediffOffset" resp
@@ -121,7 +121,7 @@ getTheMessages offset = do
 getAndProcessMessages :: BlocEnv -> PGConnection -> IORef Globals -> SlipKafka ()
 getAndProcessMessages env conn cache = do
   let errorCount = 0
-  offset <- getLastOffset LatestTime lookupPartition lookupTopic
+  offset <- getStatediffOffset
   getAndProcessMessages' env conn cache offset errorCount
 
 getAndProcessMessages' :: BlocEnv -> PGConnection -> IORef Globals -> K.Offset -> Int -> SlipKafka ()
@@ -141,6 +141,13 @@ getAndProcessMessages' env conn cache offset errorCounter = do
       when (null messages) $
         liftIO $ threadDelay 1000000
       let newOffset = offset + fromIntegral (length messages)
-      putStatediffOffset newOffset
-      getAndProcessMessages' env conn cache (offset + fromIntegral (length messages)) errorCounter
+      currentOffset <- getStatediffOffset
+      -- If the offset has been changed since our last read, assume that we should
+      -- begin to read from there instead.
+      offset' <- if currentOffset /= offset
+                    then return currentOffset
+                    else do
+                        putStatediffOffset newOffset
+                        return newOffset
+      getAndProcessMessages' env conn cache offset' errorCounter
 

--- a/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
@@ -13,6 +13,7 @@ module Slipstream.Metrics
   , recordStorageHit
   , recordStorageMiss
   , recordOffset
+  , recordOffsetOverride
   ) where
 
 import Control.Monad

--- a/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
@@ -12,6 +12,7 @@ module Slipstream.Metrics
   , recordCacheMiss
   , recordStorageHit
   , recordStorageMiss
+  , recordOffset
   ) where
 
 import Control.Monad
@@ -21,6 +22,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
+import Network.Kafka.Protocol (Offset)
 import Prometheus
 
 import Blockapps.Crossmon
@@ -131,3 +133,29 @@ recordStorageHit = recCache ("storage_hit", "")
 
 recordStorageMiss :: MonadIO m => T.Text -> m ()
 recordStorageMiss reason = recCache ("storage_miss", reason)
+
+{-# NOINLINE offsetChanges #-}
+offsetChanges :: Counter
+offsetChanges = unsafeRegister
+              . counter
+              $ Info "slipstream_offset_changes" "Number of times the kafka offset has changed"
+
+{-# NOINLINE currentOffset #-}
+currentOffset :: Gauge
+currentOffset = unsafeRegister
+              . gauge
+              $ Info "slipstream_statediff_offset" "Offset into the statediff topic"
+
+recordOffset :: MonadIO m => Offset -> m ()
+recordOffset off = liftIO $ do
+  incCounter offsetChanges
+  setGauge currentOffset $ fromIntegral off
+
+{-# NOINLINE offsetOverrides #-}
+offsetOverrides :: Counter
+offsetOverrides = unsafeRegister
+                . counter
+                $ Info "slipstream_offset_overrides" "Number of manual changes to the offset"
+
+recordOffsetOverride :: MonadIO m => m ()
+recordOffsetOverride = liftIO $ incCounter offsetOverrides

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -405,3 +405,4 @@ processTheMessages env conn g messages = do
     outputData conn . createInsertIndexTable g $ map indexInsert ins
     outputData conn . createInsertHistoryTable g $ concatMap historyInserts ins
     outputData conn . createInsertFunctionHistoryTable g $ concatMap functionInserts ins
+  flushPendingWrites g

--- a/core-strato/blockapps-milena/Network/Kafka/Protocol.hs
+++ b/core-strato/blockapps-milena/Network/Kafka/Protocol.hs
@@ -271,9 +271,6 @@ requestBytes x = runPut $ do
     where mr = runPut $ serialize x
 
 apiVersion :: RequestMessage -> ApiVersion
--- TODO(tim): slipstream currently uses the milena abandonware, which only has support for version 0
-apiVersion (OffsetFetchRequest (OffsetFetchReq ("slipstream", _))) = 0
-apiVersion (OffsetCommitRequest (OffsetCommitReq ("slipstream", _, _, _, _))) = 0
 apiVersion OffsetFetchRequest{}  = 1 -- have to be V1 to use kafka storage to allow metadata
 apiVersion OffsetCommitRequest{} = 2 -- use V2 commit to not deal with Timestamps, and get stored in Kafka
 apiVersion _                     = ApiVersion 0 -- everything else is at version 0 right now

--- a/core-strato/blockapps-milena/Network/Kafka/Protocol.hs
+++ b/core-strato/blockapps-milena/Network/Kafka/Protocol.hs
@@ -271,6 +271,9 @@ requestBytes x = runPut $ do
     where mr = runPut $ serialize x
 
 apiVersion :: RequestMessage -> ApiVersion
+-- TODO(tim): slipstream currently uses the milena abandonware, which only has support for version 0
+apiVersion (OffsetFetchRequest (OffsetFetchReq ("slipstream", _))) = 0
+apiVersion (OffsetCommitRequest (OffsetCommitReq ("slipstream", _, _, _, _))) = 0
 apiVersion OffsetFetchRequest{}  = 1 -- have to be V1 to use kafka storage to allow metadata
 apiVersion OffsetCommitRequest{} = 2 -- use V2 commit to not deal with Timestamps, and get stored in Kafka
 apiVersion _                     = ApiVersion 0 -- everything else is at version 0 right now

--- a/core-strato/blockapps-tools/package.yaml
+++ b/core-strato/blockapps-tools/package.yaml
@@ -40,6 +40,7 @@ dependencies:
   - strato-index
   - strato-redis-blockdb
   - strato-model
+  - strato-statediff
   - transformers
   - hedis
 

--- a/core-strato/blockapps-tools/src/Checkpoints.hs
+++ b/core-strato/blockapps-tools/src/Checkpoints.hs
@@ -19,12 +19,12 @@ import qualified Network.Kafka                   as K
 import qualified Blockchain.MilenaTools          as K
 import qualified Network.Kafka.Protocol          as KP
 
-import qualified Blockchain.Sequencer.Constants  as SeqConst
-import qualified Blockchain.Sequencer.Kafka      as SeqKafka
+import qualified Blockchain.Sequencer.Constants         as SeqConst
+import qualified Blockchain.Sequencer.Kafka             as SeqKafka
+import qualified Blockchain.Strato.Indexer.Kafka        as IdxKafka
+import qualified Blockchain.Strato.StateDiff.Kafka      as DiffKafka
 
-import qualified Blockchain.Strato.Indexer.Kafka as IdxKafka
-
-data CheckpointService   = Sequencer | EVM | ApiIndexer | P2PIndexer | NullService deriving (Eq, Ord, Enum, Data)
+data CheckpointService   = Sequencer | EVM | ApiIndexer | P2PIndexer | Slipstream | NullService deriving (Eq, Ord, Enum, Data)
 data CheckpointOperation = Get | Put | NullOperation deriving (Eq, Ord, Enum, Data)
 
 -- have to manually do these cause theres no way to lowercase them for glorious lowercase cli
@@ -49,6 +49,7 @@ instance Read CheckpointService where
             "evm"         -> return EVM
             "apiindexer"  -> return ApiIndexer
             "p2pindexer"  -> return P2PIndexer
+            "slipstream"  -> return Slipstream
             "NullService" -> return NullService
             _             -> P.pfail
 
@@ -57,6 +58,7 @@ instance Show CheckpointService where
     show EVM         = "evm"
     show ApiIndexer  = "apiindexer"
     show P2PIndexer  = "p2pindexer"
+    show Slipstream  = "slipstream"
     show NullService = "NullService"
 
 type KafkaBits = (K.KafkaClientId, KP.ConsumerGroup, KP.TopicName)
@@ -73,6 +75,8 @@ kafkaBitsForService = \case
         (clientId, lookupConsumerGroup clientId, IdxKafka.indexEventsTopicName)
     P2PIndexer -> let clientId = "strato-p2p-indexer" in
             (clientId, lookupConsumerGroup clientId, IdxKafka.indexEventsTopicName)
+    Slipstream -> let clientId = "slipstream" in
+            (clientId, lookupConsumerGroup clientId, DiffKafka.stateDiffTopicName)
 
 hasCheckpointData :: CheckpointService -> Bool
 hasCheckpointData EVM        = True
@@ -156,7 +160,7 @@ checkpointUsage =
     , "   * " ++ errPutFlagRequirement
     , ""
     , "Flags:"
-    , "  -s --service=SERVICE  The service whose metadata to operate against. One of: sequencer evm apiidx p2pidx"
+    , "  -s --service=SERVICE  The service whose metadata to operate against. One of: sequencer evm apiindexer p2pindexer slipstream"
     , "  -o --op=OP            The operation to perform. One of: get put"
     , "  -i --offset=INT       If -o PUT is specified, set the service's checkpointed Kafka offset"
     , "  -m --metadata=DATA    If -o PUT is specified, set the service-specific metadata in the checkpoint to DATA"

--- a/core-strato/blockapps-tools/src/Checkpoints.hs
+++ b/core-strato/blockapps-tools/src/Checkpoints.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 module Checkpoints where
 
+import           Control.Concurrent              (threadDelay)
 import           Control.Monad                   (forM_, unless, void, when)
 
 import qualified Data.ByteString.Char8           as S8
@@ -10,6 +11,7 @@ import           Data.Data
 import           Data.Maybe
 
 import           GHC.Read
+import           System.IO
 import qualified Text.ParserCombinators.ReadPrec as P
 import qualified Text.Read.Lex                   as L
 
@@ -91,7 +93,10 @@ lookupByBits :: KafkaBits -> IO CPTuple
 lookupByBits bits@(clientId, consumerId, topicName) =
     runKafkaConfigured clientId (K.fetchSingleOffset consumerId topicName 0) >>= \case
         Left err -> error $ "Failed to fetch checkpoint: " ++ show err
-        Right (Left KP.UnknownTopicOrPartition) -> lookupByBits bits
+        Right (Left KP.UnknownTopicOrPartition) -> do
+          hPutStrLn stderr "UnknownTopicOrPartition, retrying..."
+          threadDelay 1000000
+          lookupByBits bits
         Right (Left err) -> error $ "Unexpected response when fetching checkpoint: " ++ show err
         Right (Right ret) -> return ret
 

--- a/core-strato/strato-conf/src/Blockchain/EthConf.hs
+++ b/core-strato/strato-conf/src/Blockchain/EthConf.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Blockchain.EthConf (
       EthConf(..),
@@ -167,6 +168,7 @@ mkConfiguredKafkaState cid = mkKafkaState cid (kh, kp)
           kp = fromIntegral $ kafkaPort k
 
 lookupConsumerGroup :: KafkaClientId -> KP.ConsumerGroup
+lookupConsumerGroup "slipstream" = KP.ConsumerGroup "slipstream"
 lookupConsumerGroup kcid = KP.ConsumerGroup . KP.KString $ kStr `B8.append` nodeId
     where kStr   = KP._kString kcid
           nodeId = B8.pack $ "_" ++ peerId (ethUniqueId ethConf)


### PR DESCRIPTION
Slipstream should arrive at the same results with duplicate messages, but for efficiency there is no need to replay them

The offset can be read from the strato container with
`queryStrato --service slipstream --op get`
and set with 
`queryStrato --service slipstream --op put --offset 0`. Note that it may take 100s for slipstream to read the new offset, as changing the offset will not wake the reader when no new messages exist. If there is active traffic towards slipstream, it will pick up the change after the current processing iteration