### PR TITLE
Allow queryStrato options to trigger a sync

### DIFF
--- a/core-strato/blockapps-haskoin/Network/Haskoin/Crypto/BigWord.hs
+++ b/core-strato/blockapps-haskoin/Network/Haskoin/Crypto/BigWord.hs
@@ -103,14 +103,14 @@ type FieldP  = BigWord ModP
 -- | Data type representing an Integer modulo curve order N.
 type FieldN  = BigWord ModN
 
-data Mod512
-data Mod256 deriving (Data, Typeable)
-data Mod256Tx
-data Mod256Block
-data Mod160
-data Mod128
-data ModP
-data ModN
+data Mod512      deriving (Data, Typeable)
+data Mod256      deriving (Data, Typeable)
+data Mod256Tx    deriving (Data, Typeable)
+data Mod256Block deriving (Data, Typeable)
+data Mod160      deriving (Data, Typeable)
+data Mod128      deriving (Data, Typeable)
+data ModP        deriving (Data, Typeable)
+data ModN        deriving (Data, Typeable)
 
 newtype BigWord n = BigWord { getBigWordInteger :: Integer }
     deriving (Eq, Ord, Data, Typeable, Generic, Hashable)

--- a/core-strato/blockapps-tools/exec_src/Main.hs
+++ b/core-strato/blockapps-tools/exec_src/Main.hs
@@ -19,6 +19,7 @@ import           DumpKafkaUnSequencer
 import           DumpRedis
 import           FRawMP
 import           Hash
+import           InsertP2P
 import           InsertTX
 import           Psql
 import           Raw
@@ -27,6 +28,8 @@ import           RLP
 import           State
 
 import qualified Blockchain.Database.MerklePatricia as MP
+import           Blockchain.Sequencer.Event
+import           Blockchain.Strato.Model.Address
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Char8              as BC
 import           Data.Int
@@ -53,6 +56,8 @@ data Options = State{root::String, db::String}
              | CanonRedis{ipAddress::String, start::Int, range::Int}
              | Psql{}
              | InsertTX{}
+             | AskForBlocks{startBlock::Integer, endBlock::Integer, peer::Address}
+             | PushBlocks{startBlock::Integer, endBlock::Integer, peer::Address}
              deriving (Show, Data, Typeable)
 
 stateOptions::Annotate Ann
@@ -69,7 +74,7 @@ canonRedisOptions =
     start := def += typ "STARTINGBLOCK" += argPos 1,
     range := def += typ "RANGE" += argPos 2
   ]
-  
+
 redisOptions :: Annotate Ann
 redisOptions =
   record DumpRedis{databaseNumber=undefined} [
@@ -197,6 +202,22 @@ checkpointOptions =
         ]
     where nil = undefined
 
+askOptions :: Annotate Ann
+askOptions =
+  record AskForBlocks{startBlock=error "unused start block", endBlock=error "unused end block", peer = 0x0}
+         [ startBlock := error "--start-block required" += typ "NUMBER" += explicit += name "start-block"
+         , endBlock := error "--end-block required" += typ "NUMBER" += explicit += name "end-block"
+         , peer := 0x0 += typ "ETHEREUM_ADDRESS" += explicit += name "peer"
+         ]
+
+pushOptions :: Annotate Ann
+pushOptions =
+  record PushBlocks{startBlock=error "unused start block", endBlock=error "unused end block", peer = 0x0}
+         [ startBlock := error "--start-block required" += typ "NUMBER" += explicit += name "start-block"
+         , endBlock := error "--end-block required" += typ "NUMBER" += explicit += name "end-block"
+         , peer := 0x0 += typ "ETHEREUM_ADDRESS" += explicit += name "peer"
+         ]
+
 options::Annotate Ann
 options = modes_ [blockGoOptions
                 , blockOptions
@@ -219,7 +240,10 @@ options = modes_ [blockGoOptions
                 , rawOptions
                 , redisOptions
                 , rlpOptions
-                , stateOptions]
+                , stateOptions
+                , askOptions
+                , pushOptions
+                ]
 
 --      += summary "Apply shims, reorganize, and generate to the input"
 
@@ -253,6 +277,8 @@ run DumpKafkaStateDiff{..}     = dumpKafkaStateDiff $ fromIntegral startingBlock
 run Psql{}                     = psql
 run InsertTX{}                 = insertTX
 run Checkpoints{..}            = case operation of
-    Get           -> doCheckpointGet service
-    Put           -> doCheckpointPut service (fromIntegral <$> offset) cp
-    NullOperation -> doCheckpointUsage
+      Get           -> doCheckpointGet service
+      Put           -> doCheckpointPut service (fromIntegral <$> offset) cp
+      NullOperation -> doCheckpointUsage
+run AskForBlocks{..}           = insertP2P (OEAskForBlocks startBlock endBlock peer)
+run PushBlocks{..}             = insertP2P (OEPushBlocks startBlock endBlock peer)

--- a/core-strato/blockapps-tools/src/InsertP2P.hs
+++ b/core-strato/blockapps-tools/src/InsertP2P.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+module InsertP2P where
+
+import Text.Printf
+
+import Blockchain.EthConf
+import Blockchain.Sequencer.Event
+import Blockchain.Sequencer.Kafka
+
+insertP2P :: OutputEvent -> IO ()
+insertP2P oev = do
+  printf "Inserting %s into seq_p2p_events...\n" $ show oev
+  resps <- runKafkaConfigured "queryStrato" $ do
+    assertTopicCreation
+    writeSeqP2pEvents [oev]
+  mapM_ print resps

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
@@ -14,6 +15,7 @@ module Blockchain.Strato.Model.Address
 
 import           Control.DeepSeq
 import           Control.Monad
+import           Data.Data
 import           Data.Maybe                           (fromMaybe)
 import           Numeric
 import           Test.QuickCheck                      (Arbitrary(..))
@@ -55,7 +57,7 @@ instance RLPSerializable Address where
   rlpDecode (RLPString s) = Address $ decode $ BL.fromStrict s
   rlpDecode x             = error ("Malformed rlp object sent to rlp2Address: " ++ show x)
 
-newtype Address = Address Word160 deriving (Eq, Read, Enum, Real, Bounded, Num, Ord, Generic, Integral, Hashable)
+newtype Address = Address Word160 deriving (Eq, Read, Enum, Real, Bounded, Num, Ord, Generic, Integral, Hashable, Data)
 
 instance Show Address where
   show (Address a) = printf "%040x" a

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -186,6 +186,5 @@ setPeerAddrIfUnset addr = blockstanbulPeerAddr %= (<|> Just addr)
 
 shouldSendToPeer :: MonadState Context m => Address -> m Bool
 shouldSendToPeer addr = maybe True zeroOrArg <$> use blockstanbulPeerAddr
-        -- TODO(tim): 0x0 may come from a Legacy kafka message, remove
-        -- in a future release
+        -- 0x0 is for a broadcast sync message.
   where zeroOrArg addr' = addr' == 0x0 || addr' == addr


### PR DESCRIPTION
```
tim@ip-172-31-11-233 ~/s/i/core-strato ❯❯❯ docker exec -it -w /var/lib/strato strato_strato_1 queryStrato askforblocks --start-block 0 --end-block 20 --peer 0xdeadbeef
Inserting OEAskForBlocks {askStart = 0, askEnd = 20, askPeer = 00000000000000000000000000000000deadbeef} into seq_p2p_events...
[ProduceResp {_produceResponseFields = [(TopicName "seq_p2p_events",[(Partition 0,NoError,Offset 3561)])]}]
tim@ip-172-31-11-233 ~/s/i/core-strato ❯❯❯ docker exec -it -w /var/lib/strato strato_strato_1 queryStrato pushblocks --start-block 0 --end-block 20 --peer 0xdeadbeef
Inserting OEPushBlocks {pushStart = 0, pushEnd = 20, pushPeer = 00000000000000000000000000000000deadbeef} into seq_p2p_events...
[ProduceResp {_produceResponseFields = [(TopicName "seq_p2p_events",[(Partition 0,NoError,Offset 3563)])]}]
```