### PR TITLE
Override chain memberships on indexevents

### DIFF
--- a/core-strato/blockapps-tools/exec_src/Main.hs
+++ b/core-strato/blockapps-tools/exec_src/Main.hs
@@ -25,11 +25,13 @@ import           Psql
 import           Raw
 import           RawMP
 import           RLP
+import           RSVP
 import           State
 
 import qualified Blockchain.Database.MerklePatricia as MP
 import           Blockchain.Sequencer.Event
 import           Blockchain.Strato.Model.Address
+import           Blockchain.Strato.Model.ExtendedWord
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Char8              as BC
 import           Data.Int
@@ -58,6 +60,7 @@ data Options = State{root::String, db::String}
              | InsertTX{}
              | AskForBlocks{startBlock::Integer, endBlock::Integer, peer::Address}
              | PushBlocks{startBlock::Integer, endBlock::Integer, peer::Address}
+             | RSVP {chainId :: Word256, memberId :: String, address::Address}
              deriving (Show, Data, Typeable)
 
 stateOptions::Annotate Ann
@@ -218,6 +221,14 @@ pushOptions =
          , peer := 0x0 += typ "ETHEREUM_ADDRESS" += explicit += name "peer"
          ]
 
+
+rsvpOptions :: Annotate Ann
+rsvpOptions = record RSVP { chainId = error "unused chain id", memberId = error "unused member", address = error "unused address"}
+            [ chainId := error "--chain-id required" += typ "NUMBER" += explicit += name "chain-id"
+            , memberId := error "--member required" += typ "MEMBER ID" += explicit += name "member"
+            , address := error "--address required" += typ "ADDRESS" += explicit += name "address"
+            ]
+
 options::Annotate Ann
 options = modes_ [blockGoOptions
                 , blockOptions
@@ -243,6 +254,7 @@ options = modes_ [blockGoOptions
                 , stateOptions
                 , askOptions
                 , pushOptions
+                , rsvpOptions
                 ]
 
 --      += summary "Apply shims, reorganize, and generate to the input"
@@ -282,3 +294,4 @@ run Checkpoints{..}            = case operation of
       NullOperation -> doCheckpointUsage
 run AskForBlocks{..}           = insertP2P (OEAskForBlocks startBlock endBlock peer)
 run PushBlocks{..}             = insertP2P (OEPushBlocks startBlock endBlock peer)
+run RSVP{..}                   = rsvp chainId memberId address

--- a/core-strato/blockapps-tools/src/RSVP.hs
+++ b/core-strato/blockapps-tools/src/RSVP.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module RSVP (rsvp) where
 
-import Control.Exception
 import Control.Monad.IO.Class
 import qualified Data.ByteString.Char8 as C8
 import System.Exit
@@ -22,10 +21,8 @@ rsvp chainId member addr = do
       blkHash = SHA 0x7065
       govAddr = 0x100
       bloom = 0x0
-      -- TODO: For now, member has to be an enode address and > 31 bytes. In the
-      -- future, I think this would be the wrong encoding if it was e.g. a VM address as a string.
       memberLen = fromIntegral $ length member
-      payload = assert (memberLen > 31) $ word256ToBytes (fromIntegral addr) <> word256ToBytes 0x0 <> word256ToBytes memberLen <> C8.pack member
+      payload = word256ToBytes (fromIntegral addr) <> word256ToBytes 0x0 <> word256ToBytes memberLen <> C8.pack member
       entry = LogDB blkHash txHash (Just $ chainId) govAddr (Just $ unSHA addTopic) Nothing Nothing Nothing payload bloom
   result <- runKafkaConfigured "queryStrato" $ do
     let req = [LogDBEntry entry]

--- a/core-strato/blockapps-tools/src/RSVP.hs
+++ b/core-strato/blockapps-tools/src/RSVP.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+module RSVP (rsvp) where
+
+import Control.Exception
+import Control.Monad.IO.Class
+import qualified Data.ByteString.Char8 as C8
+import System.Exit
+import Text.Printf
+
+import Blockchain.EthConf
+import Blockchain.Data.DataDefs
+import Blockchain.Strato.Indexer.Model
+import Blockchain.Strato.Indexer.TxrIndexer (addTopic)
+import Blockchain.Strato.Indexer.Kafka
+import Blockchain.Strato.Model.Address
+import Blockchain.Strato.Model.SHA
+import Blockchain.Strato.Model.ExtendedWord
+
+rsvp :: Word256 -> String -> Address -> IO ()
+rsvp chainId member addr = do
+  let txHash = SHA 0x7065
+      blkHash = SHA 0x7065
+      govAddr = 0x100
+      bloom = 0x0
+      -- TODO: For now, member has to be an enode address and > 31 bytes. In the
+      -- future, I think this would be the wrong encoding if it was e.g. a VM address as a string.
+      memberLen = fromIntegral $ length member
+      payload = assert (memberLen > 31) $ word256ToBytes (fromIntegral addr) <> word256ToBytes 0x0 <> word256ToBytes memberLen <> C8.pack member
+      entry = LogDB blkHash txHash (Just $ chainId) govAddr (Just $ unSHA addTopic) Nothing Nothing Nothing payload bloom
+  result <- runKafkaConfigured "queryStrato" $ do
+    let req = [LogDBEntry entry]
+    liftIO $ printf "request: %s\n" (show req)
+    resp <- writeIndexEvents [LogDBEntry entry]
+    liftIO $ printf "response: %s\n" (show resp)
+  case result of
+    Left err -> die $ show err
+    Right () -> exitSuccess
+


### PR DESCRIPTION
```
tim@ip-172-31-11-233 ~ ❯❯❯ qs rsvp --member "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303?discport=30301" --address 0xdeadbeef --chain-id 0x231874
request: [LogDBEntry (LogDB {logDBBlockHash = SHA 28773, logDBTransactionHash = SHA 28773, logDBChainId = Just 2300020, logDBAddress = 0000000000000000000000000000000000000100, logDBTopic1 = Just 39070067797853737669970129961535393849807626736811793806712152402107872446364, logDBTopic2 = Nothing, logDBTopic3 = Nothing, logDBTopic4 = Nothing, logDBTheData = "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\222\173\190\239\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\167enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303?discport=30301", logDBBloom = 0})]
response: [ProduceResp {_produceResponseFields = [(TopicName "indexevents",[(Partition 0,NoError,Offset 2848)])]}]
````


```
[2019-06-17 19:02:43.832043051 UTC]  INFO | ThreadId 4     | txrIndexer                          | Inserting LogDB entry for tx: 0000000000000000000000000000000000000000000000000000000000007065 on chain Just "231874" at block 0000000000000000000000000000000000000000000000000000000000007065
[2019-06-17 19:02:43.832188244 UTC]  INFO | ThreadId 4     | txrIndexer                          | Adding member deadbeef on chain 231874
```

redis-cli:
```
127.0.0.1:6379> get pic:10.3.58.6
"\xc4\x83#\x18t"

127.0.0.1:6379> get "m:\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00#\x18t"
"\xf8g\xf8e\x94\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xad\xbe\xef\xf8N\xb8@o\x8a\x80\xd1C\x11\xc3\x9f5\xf5\x16\xfafM\xea\xaa\xa1>\x85\xb2\xf7I?7\xf6\x14M\x86\x99\x1e\xc0\x12\x93s\ad{\xd3\xb9\xa8*\xbe)t\xe1@rA\xd5IG\xbb\xb3\x97c\xa4\xca\xc9\xf7qf\xad\x92\xa0\x84\n\x03:\x06\x82v_\xc3\x82v]"


```

dumpkafkaunsequencer
```
Block #20 (via Quarry) ac8c474b3a3a1034bcfe1397576d538491c721ef01b95e1b2e13d83389776421
    parentHash: 236882601195376c8182a9ecd478027bb72bf7c9149cfe29acf64aa72846e8a3
    unclesHash: 1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347 (the empty array)
    coinbase: 0000000000000000000000000000000000000000
    stateRoot: 292d29774488745d4b0b86dacd37b2eacf6ad7558271db112c104b115c2238cc
    transactionsRoot: bd11f6b313b8547ccdc5b2a594b66f174215204ba69b82fcc477e77adad21dab
    receiptsRoot: <empty>
    difficulty: 131776
    gasLimit: 50985675712407904097
    gasUsed: 0
    timestamp: 2019-06-13 21:22:35 UTC
    extraData: 005d000000000000000000000000000000000000000000000000000000000000
    nonce: 0
    93        (no uncles)
Block #21 (via Quarry) 1a8cc9f791192eed5dffe44909e19d962e86904a028fd79562e37b68f26593ec
    parentHash: ec07c384f81be0d4b86150aa18c0bf57142db410ba275197afb818bfb08e5b8f
    unclesHash: 1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347 (the empty array)
    coinbase: 0000000000000000000000000000000000000000
    stateRoot: 5a0342bd71f1d8d5442df2f254db58f7e0ccc893a5cc4e8f5806ca243d0ffc62
    transactionsRoot: 07887ccd390e91bda33778403c6cf53ba93f3ee3e91be70ba082db9f24bc3d71
    receiptsRoot: <empty>
    difficulty: 131840
    gasLimit: 51035466411345802440
    gasUsed: 0
    timestamp: 2019-06-13 21:22:36 UTC
    extraData: 0061000000000000000000000000000000000000000000000000000000000000
    nonce: 0
    97        (no uncles)
0000000000000000000000000000000000000000000000000000000000231874, 00000000000000000000000000000000deadbeef, Enode {pubKey = "o\138\128\209C\DC1\195\159\&5\245\SYN\250fM\234\170\161>\133\178\247I?7\246\DC4M\134\153\RS\192\DC2\147s\ad{\211\185\168*\190)t\225@rA\213IG\187\179\151c\164\202\201\247qf\173\146\160", ipAddress = IPv4 167983622, tcpPort = 30303, udpPort = Just 30301}
```

However, the write to postgres fails on a singlenode because the chain_info does not exist:
```eth_8d88939a6303b108407ad7d58d2f7f72cb36ecc5=# select count(*) from chain_info_ref;
 count
-------
     0
(1 row)
```
. When the node issuing the RSVP has the chaininfo, the member is added: 

```
eth_3c38499d79c650304f0d8db274e24ec88138453b=# select * from chain_member_ref where chain_info_id = 3;
-[ RECORD 1 ]-+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
id            | 4
chain_info_id | 3
name          | enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@34.237.166.201:30303?discport=30301
address       | 77777777
-[ RECORD 2 ]-+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
id            | 5
chain_info_id | 3
name          | enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@3.209.126.162:30303?discport=30301
address       | deadbeef
```