### PR TITLE
Always create a timer

### DIFF
--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -11,7 +11,6 @@ module Blockchain.CommunicationConduit
     , mkEthP2PEventConduit
     ) where
 
-import           Blockchain.Output
 import           Control.Monad.Change.Modify           (Accessible)
 import           Control.Monad.IO.Unlift
 import           Control.Monad.State
@@ -50,11 +49,13 @@ import           Blockchain.ExtMergeSources
 import           Blockchain.Frame
 import           Blockchain.Metrics
 import           Blockchain.Options
+import           Blockchain.Output
 import           Blockchain.SeqEventNotify
 import           Blockchain.Strato.Discovery.Data.Peer
 import qualified Blockchain.Strato.RedisBlockDB        as RBDB
 import           Blockchain.Strato.RedisBlockDB.Models
 import           Blockchain.Stream.VMEvent
+import           Blockchain.TimerSource
 import           Blockchain.Util
 
 ethVersion :: Int
@@ -72,9 +73,8 @@ mkEthP2PEventSource :: ( Monad m
                     => AppData
                     -> EthCryptState
                     -> K.KafkaState
-                    -> [ConduitM () Event m ()]
                     -> m (ConduitM () Event m ())
-mkEthP2PEventSource app inCtx ks extra = do
+mkEthP2PEventSource app inCtx ks = do
   canarySource <- mkCanarySource
   (.| CL.iterM recordEvent) <$> mergeSourcesByForce (
     [ appSource app
@@ -85,7 +85,8 @@ mkEthP2PEventSource app inCtx ks extra = do
     , seqEventNotificationSource ks
         .| CL.map NewSeqEvent
     , canarySource .| CL.map absurd
-    ] ++ extra) 4096 -- 🙏
+    , timerSource
+    ]) 4096 -- 🙏
 
 mkCanarySource :: (MonadLogger m, MonadUnliftIO m, MonadResource m) => m (ConduitM () Void m ())
 mkCanarySource = do
@@ -114,9 +115,11 @@ debounceTxSends = do
   awaitForever $ \case
     Right (W.Transactions txs) -> do
       atomically $ mapM_ (writeTQueue txq) txs
+      recordQueuedTxs txs
     Right other -> yield other
     Left TXQueueTimeout -> do
       txs <- atomically $ flushTQueue txq
+      recordEmptyQueue
       yieldMany . map W.Transactions $ chunksOf 100 txs
 
 handleMsgClientConduit :: ( MonadIO (StateT Context m)

--- a/core-strato/strato-p2p/src/Blockchain/Metrics.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Metrics.hs
@@ -9,6 +9,8 @@ module Blockchain.Metrics ( recordEvent
                           , addCanary
                           , killCanary
                           , recordException
+                          , recordQueuedTxs
+                          , recordEmptyQueue
                           ) where
 
 import Control.Exception
@@ -120,3 +122,15 @@ recordException PPeer{..} e =
   let ty = pack . show $ typeOf e
       port = pack $ show pPeerTcpPort
   in liftIO $ withLabel exceptionCount (pPeerIp, port, ty) incCounter
+
+{-# NOINLINE txQueueDepth #-}
+txQueueDepth :: Gauge
+txQueueDepth = unsafeRegister
+             . gauge
+             $ Info "p2p_queue_depth" "Number of queued transactions to send"
+
+recordQueuedTxs :: MonadIO m => [a] -> m ()
+recordQueuedTxs = liftIO . addGauge txQueueDepth . fromIntegral . Prelude.length
+
+recordEmptyQueue :: MonadIO m => m ()
+recordEmptyQueue = liftIO $ setGauge txQueueDepth 0

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -45,7 +45,6 @@ import           Blockchain.P2PRPC
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Strato.Discovery.UDP
 import           Blockchain.TCPClientWithTimeout
-import           Blockchain.TimerSource
 
 import qualified Text.Colors                           as C
 import           Text.Format
@@ -77,7 +76,7 @@ runPeer peer myPriv _ _ = runResourceT $ do
 
         (_, (outCtx, inCtx)) <- liftIO $ appSource app $$+ ethCryptConnect myPriv otherPubKey `fuseUpstream` appSink app
 
-        !eventSource <- mkEthP2PEventSource app inCtx (contextKafkaState initState) [timerSource]
+        !eventSource <- mkEthP2PEventSource app inCtx (contextKafkaState initState)
         let !eventSink = mkEthP2PEventConduit (show $ appSockAddr app) outCtx
         attempt :: Either SomeException () <- try . runConduit . evalStateLC initState $
                   transPipe lift eventSource

--- a/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -59,7 +59,7 @@ runEthServer myPriv listenPort = do
             Just otherPubKey -> do
               void . liftIO $ setPeerActiveState (pPeerIp p) (pPeerTcpPort p) Active
               (_, (outCtx, inCtx)) <- liftIO $ appSource app $$+ ethCryptAccept myPriv otherPubKey `fuseUpstream` appSink app
-              !eventSource <- mkEthP2PEventSource app inCtx (contextKafkaState initState) []
+              !eventSource <- mkEthP2PEventSource app inCtx (contextKafkaState initState)
               let !eventSink = mkEthP2PEventConduit (show $ appSockAddr app) outCtx
               (attempt :: Either SomeException ()) <- try . runConduit . evalStateLC initState $
                      transPipe lift eventSource


### PR DESCRIPTION
There's not really a good reason for server and client threads to be treated differently:
both can have a useless peer. Additionally, measure the length of the queue so it
is more clear if a backlog is forming

https://blockapps.atlassian.net/browse/STRATO-1235
https://jenkins.blockapps.net/job/STRATO_test/2006/