### PR TITLE
Default to blocking reads from kafka

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Stream/VMEvent.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Stream/VMEvent.hs
@@ -97,9 +97,7 @@ fetchVMEvents = fetchVMEventsFromTopic defaultVMEventsTopicName
 
 -- | Same as `fetchVMEvents`, except sets our commonly-used Milena state configurations
 fetchVMEvents' :: Kafka k => Offset -> k [VMEvent]
-fetchVMEvents' ofs = do
-    setDefaultKafkaState
-    fetchVMEventsFromTopic defaultVMEventsTopicName ofs
+fetchVMEvents' ofs = fetchVMEventsFromTopic defaultVMEventsTopicName ofs
 
 fetchVMEventsFromTopic :: Kafka k => TopicName -> Offset -> k [VMEvent]
 fetchVMEventsFromTopic topic offset = map bytesToVMEvent <$> fetchBytes topic offset
@@ -131,7 +129,6 @@ fetchLastVMEvents::Offset->IO [VMEvent]
 fetchLastVMEvents n = do
   ret <-
     runKafkaConfigured "strato-p2p-client" $ do
-      setDefaultKafkaState
       lastOffset <- getLastOffset LatestTime 0 (lookupTopic "block")
       when (lastOffset == 0) $ error "Block stream is empty, you need to run strato-setup to insert the genesis block."
       let offset = max (lastOffset - n) 0
@@ -146,9 +143,7 @@ lookback = 1000
 
 getBestKafkaBlockNumber:: IO Integer
 getBestKafkaBlockNumber = do
-  lastOffset <-
-    runKafkaConfigured "strato-p2p-client" $
-      setDefaultKafkaState >> getLastOffset LatestTime 0 (lookupTopic "block")
+  lastOffset <- runKafkaConfigured "strato-p2p-client" $ getLastOffset LatestTime 0 (lookupTopic "block")
 
   case lastOffset of
     Left e       -> error $ show e
@@ -165,9 +160,7 @@ getBestKafkaBlockNumber = do
 getBestKafkaBlockHelper::Offset->Offset->IO (Maybe Integer)
 getBestKafkaBlockHelper lower upper = do
   vmEventsErr <-
-    runKafkaConfigured "strato-p2p-client" $ do
-      setDefaultKafkaState
-      fetchVMEventsRange lower upper
+    runKafkaConfigured "strato-p2p-client" $ fetchVMEventsRange lower upper
 
   case vmEventsErr of
     Left e -> error $ show e

--- a/core-strato/blockapps-tools/src/DumpKafkaBlocks.hs
+++ b/core-strato/blockapps-tools/src/DumpKafkaBlocks.hs
@@ -6,7 +6,6 @@ import           Control.Monad.IO.Class
 import           Network.Kafka.Protocol
 
 import           Blockchain.EthConf
-import           Blockchain.Stream.Raw     (setDefaultKafkaState)
 import           Blockchain.Stream.VMEvent
 
 import           Text.Format
@@ -19,7 +18,6 @@ dumpKafkaBlocks startingBlock = do
     Right _ -> return ()
   where
     doConsume' offset = do
-      setDefaultKafkaState
       vmEvents <- fetchVMEvents offset
       liftIO $ putStrLn $ unlines $ map format vmEvents
       doConsume' (offset + fromIntegral (length vmEvents))

--- a/core-strato/blockapps-tools/src/DumpKafkaSequencer.hs
+++ b/core-strato/blockapps-tools/src/DumpKafkaSequencer.hs
@@ -8,7 +8,6 @@ import           Network.Kafka.Protocol
 
 import           Blockchain.EthConf
 import           Blockchain.Sequencer.Kafka
-import           Blockchain.Stream.Raw      (setDefaultKafkaState)
 
 dumpKafkaSequencer :: Offset -> IO ()
 dumpKafkaSequencer ofs = do
@@ -28,7 +27,6 @@ dumpKafkaSequencerVM startingBlock = do
     Right _ -> return ()
   where
     doConsume' offset = do
-      setDefaultKafkaState
       seqEvents <- readSeqVmEvents offset
       liftIO . putStrLn . unlines $ show <$> seqEvents
       doConsume' (offset + fromIntegral (length seqEvents))
@@ -41,7 +39,6 @@ dumpKafkaSequencerP2P startingBlock = do
     Right _ -> return ()
   where
     doConsume' offset = do
-      setDefaultKafkaState
       seqEvents <- readSeqP2pEvents offset
       liftIO . putStrLn . unlines $ show <$> seqEvents
       doConsume' (offset + fromIntegral (length seqEvents))

--- a/core-strato/blockapps-tools/src/DumpKafkaUnSequencer.hs
+++ b/core-strato/blockapps-tools/src/DumpKafkaUnSequencer.hs
@@ -8,7 +8,6 @@ import           Network.Kafka.Protocol
 
 import           Blockchain.EthConf
 import           Blockchain.Sequencer.Kafka
-import           Blockchain.Stream.Raw
 
 import           Text.Format
 
@@ -20,7 +19,6 @@ dumpKafkaUnSequencer startingBlock = do
     Right _ -> return ()
   where
     doConsume' offset = do
-      setDefaultKafkaState
       unseqEvents <- readUnseqEvents offset
       liftIO . putStrLn . unlines $ format <$> unseqEvents
       doConsume' (offset + fromIntegral (length unseqEvents))

--- a/core-strato/blockapps-tools/src/DumpKafkaUnminedBlocks.hs
+++ b/core-strato/blockapps-tools/src/DumpKafkaUnminedBlocks.hs
@@ -6,7 +6,6 @@ import           Control.Monad.IO.Class
 import           Network.Kafka.Protocol
 
 import           Blockchain.EthConf
-import           Blockchain.Stream.Raw          (setDefaultKafkaState)
 import           Blockchain.Stream.UnminedBlock
 
 import           Text.Format
@@ -19,7 +18,6 @@ dumpKafkaUnminedBlocks startingBlock = do
     Right _ -> return ()
   where
     doConsume' offset = do
-      setDefaultKafkaState
       blocks <- fetchUnminedBlocks offset
       liftIO . putStrLn . unlines $ format <$> blocks
       doConsume' (offset + fromIntegral (length blocks))

--- a/core-strato/strato-conf/src/Blockchain/EthConf.hs
+++ b/core-strato/strato-conf/src/Blockchain/EthConf.hs
@@ -162,7 +162,7 @@ runKafkaConfigured :: KafkaClientId -> StateT KafkaState (ExceptT KafkaClientErr
 runKafkaConfigured name = runKafka (mkConfiguredKafkaState name)
 
 mkConfiguredKafkaState :: KafkaClientId -> KafkaState
-mkConfiguredKafkaState cid = mkKafkaState cid (kh, kp)
+mkConfiguredKafkaState cid = (mkKafkaState cid (kh, kp)) { _stateRequiredAcks = -1, _stateWaitSize = 1, _stateWaitTime = 100000}
     where k = kafkaConfig ethConf
           kh = fromString $ kafkaHost k
           kp = fromIntegral $ kafkaPort k


### PR DESCRIPTION
This was the issue with the dumpkafkastatediff option, because it forget to
setDefaultKafkaState. Instead, any runKafkaConfigured instance will automatically
use long blocking reads

https://jenkins.blockapps.net/job/STRATO_test/2012/