### PR TITLE
Store redis data and kafka data in the volumes

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -159,11 +159,21 @@ function newnode {
           # Kill all the rest of monitored processes
           for pid_to_kill in "${!MONITORED_PIDS[@]}"; do
             if ps -p ${pid_to_kill} > /dev/null; then
-              echo "killing process ${MONITORED_PIDS[${pid_to_kill}]} (pid: ${pid_to_kill})"
-              kill -9 ${pid_to_kill} || true
+              echo "Sending SIGTERM to process ${MONITORED_PIDS[${pid_to_kill}]} (pid: ${pid_to_kill})"
+              kill -TERM ${pid_to_kill} || true
               echo "done"
             fi
           done
+          # Allow 10s for cleanup of processes
+          sleep 10
+          for pid_to_kill in "${!MONITORED_PIDS[@]}"; do
+            if ps -p ${pid_to_kill} > /dev/null; then
+              echo "Sending SIGKILL to process ${MONITORED_PID[${pid_to_kill}]} (pid: ${pid_to_kill})"
+              kill -KILL ${pid_to_kill} || true
+              echo "done"
+            fi
+          done
+
           FILE_NAME="/var/lib/strato/logs/$(echo ${DEAD_PROCESS} | cut -d ' ' -f 1)"
           echo "Tail of logs for crashed process:"
           echo "+tail -n 20 ${FILE_NAME}"

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -124,7 +124,7 @@ services:
       static:
         ipv4_address: 172.20.20.5
     volumes:
-      - redisdata:/redis
+      - redisdata:/data
   vault-wrapper:
     depends_on:
     - postgres
@@ -296,6 +296,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_LOG_CLEANER_ENABLE: "false"
+      KAFKA_LOG_DIR: '/kafka/kafka-logs'
       KAFKA_LOG_RETENTION_HOURS: 2147483647
       KAFKA_OFFSET_METADATA_MAX_BYTES: 1048576
       KAFKA_OFFSETS_RETENTION_MINUTES: 2147483647


### PR DESCRIPTION
The redis image uses /data as the mount point for its expected volume. Kafka uses /tmp/kafka,
so this changes it to point to inside of the /kafka mount.