### PR TITLE
Fix the p2p tests by using postgres instead of sqlite

### DIFF
--- a/core-strato/run_unit_tests.sh
+++ b/core-strato/run_unit_tests.sh
@@ -5,25 +5,25 @@ set -x
 
 declare -i RESULT=0
 TESTS=(
-  # blockapps-data
-  # blockapps-ecrecover
-  # blockapps-mpdbs
-  # blockstanbul
-  # ethereum-discovery
-  # ethereum-rlp
-  # ethereum-vm
-  # fast-keccak256
-  # merkle-patricia-db
-  # solid-vm
-  # strato-api:unittests
-  # strato-genesis
-  # strato-init
-  # strato-model
+  blockapps-data
+  blockapps-ecrecover
+  blockapps-mpdbs
+  blockstanbul
+  ethereum-discovery
+  ethereum-rlp
+  ethereum-vm
+  fast-keccak256
+  merkle-patricia-db
+  solid-vm
+  strato-api:unittests
+  strato-genesis
+  strato-init
+  strato-model
   strato-p2p
-  # strato-redis-blockdb
-  # strato-sequencer
-  # vm-runner
-  # vm-tools
+  strato-redis-blockdb
+  strato-sequencer
+  vm-runner
+  vm-tools
 )
 
 BENCHES=(

--- a/core-strato/run_unit_tests.sh
+++ b/core-strato/run_unit_tests.sh
@@ -5,25 +5,25 @@ set -x
 
 declare -i RESULT=0
 TESTS=(
-  blockapps-data
-  blockapps-ecrecover
-  blockapps-mpdbs
-  blockstanbul
-  ethereum-discovery
-  ethereum-rlp
-  ethereum-vm
-  fast-keccak256
-  merkle-patricia-db
-  solid-vm
-  strato-api:unittests
-  strato-genesis
-  strato-init
-  strato-model
+  # blockapps-data
+  # blockapps-ecrecover
+  # blockapps-mpdbs
+  # blockstanbul
+  # ethereum-discovery
+  # ethereum-rlp
+  # ethereum-vm
+  # fast-keccak256
+  # merkle-patricia-db
+  # solid-vm
+  # strato-api:unittests
+  # strato-genesis
+  # strato-init
+  # strato-model
   strato-p2p
-  strato-redis-blockdb
-  strato-sequencer
-  vm-runner
-  vm-tools
+  # strato-redis-blockdb
+  # strato-sequencer
+  # vm-runner
+  # vm-tools
 )
 
 BENCHES=(
@@ -31,8 +31,10 @@ BENCHES=(
 )
 # There's a good chance that strato-getting-started is also running, so
 # we change redis's port to avoid a conflict.
+POSTGRES=$(docker run -d -p 2345:5432 postgres:9.6)
+trap "docker rm -f ${POSTGRES}" EXIT
 REDIS=$(docker run -d -p 2023:6379 redis:3.2 redis-server --appendonly yes)
-trap "docker rm -f ${REDIS}" EXIT
+trap "docker rm -f ${POSTGRES} ${REDIS}" EXIT
 
 for tst in ${TESTS[@]}; do
   time stack test $tst

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -104,7 +104,7 @@ tests:
       - QuickCheck
       - hspec
       - hspec-expectations-lifted
-      - persistent-sqlite
+      - persistent-postgresql
       - stm-chans
       - stm-conduit
       - strato-p2p

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -8,11 +8,9 @@ import Conduit
 import Control.Monad.Trans.Reader
 import Data.Conduit.TMChan
 import Database.Persist.Sql
+import Database.Persist.Postgresql
 import qualified Data.Map                              as M
-import qualified Data.Text                             as T
-import qualified Database.Persist.Sqlite               as Lite
 import qualified Database.Redis                        as Redis
-import System.IO.Temp                        (emptySystemTempFile)
 import Text.Printf
 
 import Blockchain.Blockstanbul               (blockstanbulSender)
@@ -40,19 +38,16 @@ import Test.QuickCheck
 -- Kafka, postgres, or ethconf. It does need redis, but targets
 -- a test instance.
 testContext :: (MonadIO m, MonadUnliftIO m)
-            => m (TMChan [IngestEvent], Config, Context)
-testContext = do
+            => ConnectionPool -> m (TMChan [IngestEvent], Config, Context)
+testContext pool = do
   redisBDBPool <- liftIO . Redis.checkedConnect $ Redis.defaultConnectInfo {
         Redis.connectHost           = "localhost",
         Redis.connectPort           = Redis.PortNumber 2023,
         Redis.connectDatabase       = 0
     }
-  -- TODO(tim): cleanup the sqlite_db files, or use :memory: and withSqlitePool
-  file <- liftIO $ emptySystemTempFile "p2p.sqlite_db"
-  conn <- runNoLoggingT $ Lite.createSqlitePool (T.pack file) 20
   ch <- atomically newTMChan
   return ( ch
-         , Config conn
+         , Config pool
          , Context { actionTimestamp = Nothing
                    , contextRedisBlockDB = RBDB.RedisConnection redisBDBPool
                    , contextKafkaState = error "no kafka state available"
@@ -81,10 +76,10 @@ migrateAll = do
 
 runTestPeer :: (TMChan [IngestEvent] -> ContextM a) -> IO ()
 runTestPeer mv = do
-  (ch, cfg, ctx) <- testContext
-  let pool = configSQLDB cfg
-  liftSqlPersistMPool migrateAll pool
-  runNoLoggingT (runContextM (cfg, ctx) (mv ch))
+  runNoLoggingT $ withPostgresqlPool "host=localhost port=2345 user=postgres" 4 $ \pool -> do
+    (ch, cfg, ctx) <- testContext pool
+    liftSqlPersistMPool migrateAll pool
+    runContextM (cfg, ctx) (mv ch)
 
 spec :: Spec
 spec = do

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -103,7 +103,7 @@ spec = do
       runTestPeer . const $ do
         runConduit $ yield (MsgEvt (BlockHeaders [])) .| handleEvents testPeer .| sinkList
           `L.shouldReturn` [Right $ GetBlockBodies []]
-    it "should forward blockstanbul messages" $ property $ \wm ->
+    it "should forward blockstanbul messages" $ property $ withMaxSuccess 10 $ \wm ->
       let addr = blockstanbulSender wm
       in addr /= 0 && addr /= 0xa ==> runTestPeer $ \ch -> do
         -- Without "proof" of which peer this is, assume it could be addr
@@ -119,7 +119,7 @@ spec = do
         shouldSendToPeer addr `L.shouldReturn` True
         shouldSendToPeer 0xa `L.shouldReturn` False
 
-    it "should broadcast blockstanbul messages" $ property $ \wm ->
+    it "should broadcast blockstanbul messages" $ property $ withMaxSuccess 10 $ \wm ->
       runTestPeer . const $ do
         runConduit $ yield (NewSeqEvent (OEBlockstanbul wm))
                       .| handleEvents testPeer


### PR DESCRIPTION
```strato-p2p-0.0.4: copy/register
Installing library in /home/tim/strato-platform/ironhide/.stack-work/install/x86_64-linux-dkf7b33dd99b569c2d0a323e8a6dc29e94/lts-12.4/8.4.3/lib/x86_64-linux-ghc-8.4.3/strato-p2p-0.0.4-6krcVlQq9Jl85NU9pinFIi
Installing executable strato-p2p in /home/tim/strato-platform/ironhide/.stack-work/install/x86_64-linux-dkf7b33dd99b569c2d0a323e8a6dc29e94/lts-12.4/8.4.3/bin
Registering library for strato-p2p-0.0.4..
strato-p2p-0.0.4: test (suite: strato-p2p-client-test)

Progress 1/2: strato-p2p-0.0.4
Event
  environment sanity checks
    has a PPeer table
+++ OK, passed 1 tests.
+++ OK, passed 1 tests.
    can pretend to write to kafka
    has a redis instance
  handleEvents
    should pong a ping
    should return empty BlockBodies to empty BlockHeaders
    should forward blockstanbul messages
      +++ OK, passed 100 tests.
    should broadcast blockstanbul messages
      +++ OK, passed 100 tests.
    should forward a timer to a TXQueue timeout
  Private Chain Authorization
    IPOnly
      should reject the wrong ip
      should accept the right ip with the wrong key
    PubkeyOnly
      should reject the wrong key
      should accept the right key with the wrong ip
    StrongAuth
      should reject a mismatched ip, key pair
      should accept a matching ip, key pair
    FlexibleAuth
      should reject a wrong ip and wrong key
      should accept a matching ip
      should accept a matching key

Finished in 48.2985 seconds
17 examples, 0 failures

strato-p2p-0.0.4: Test suite strato-p2p-client-test passed
Completed 2 action(s).
```

The tests are a lot slower than using sqlite because of the network round trips, but that can be fixed by lowering the withMaxSuccess for the quickcheck tests