### PR TITLE
Set the hostname for the kafka container

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -16,6 +16,8 @@ function newnode {
   then initialize=true
        cleanupDB
        doInit
+  else
+       sleep 10
   fi
 
   echo "Starting Strato processes. All output is logged to $PWD/logs."

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -308,6 +308,7 @@ services:
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
     - kafkadata:/kafka
+    hostname: fixed-hostname-so-kafka-reads-the-logs
     networks:
       static:
         ipv4_address: 172.20.20.13


### PR DESCRIPTION
It actually writes to <KAFKA_LOG_DIR>-<hostname>, and since docker was generating
a random hostname each time it was not reusing the logs already in the volume