### PR TITLE
Update `stack.yaml`

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,3 @@
-Skip to content
- blockapps / strato-platform
-Code  Issues 0  Pull requests 8  Projects 0  Wiki  Security  Pulse
-strato-platform/stack.yaml
-@VictorHWong VictorHWong commit
-879df23 4 hours ago
-@th0114nd @jamshidh @dustinnorwood @yunfjiang @VictorHWong
-116 lines (109 sloc)  3.11 KB
-  
 flags: {}
 packages:
 - blockapps-haskell/bloc/bloc22/api
@@ -60,6 +51,7 @@ packages:
 - core-strato/privacy/
 - core-strato/fastMP/
 - monad-alter/
+- shared-util/blockapps-init/
 - shared-util/common-log/
 - shared-util/cross-monitoring/
 - shared-util/format
@@ -122,15 +114,3 @@ docker:
   image: "strato-buildbase:lts-12.4"
   set-user: true
   run-args: ["--ulimit=nofile=60000"]
-© 2019 GitHub, Inc.
-Terms
-Privacy
-Security
-Status
-Help
-Contact GitHub
-Pricing
-API
-Training
-Blog
-About

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,12 @@
+Skip to content
+ blockapps / strato-platform
+Code  Issues 0  Pull requests 8  Projects 0  Wiki  Security  Pulse
+strato-platform/stack.yaml
+@VictorHWong VictorHWong commit
+879df23 4 hours ago
+@th0114nd @jamshidh @dustinnorwood @yunfjiang @VictorHWong
+116 lines (109 sloc)  3.11 KB
+  
 flags: {}
 packages:
 - blockapps-haskell/bloc/bloc22/api
@@ -51,30 +60,13 @@ packages:
 - core-strato/privacy/
 - core-strato/fastMP/
 - monad-alter/
-- shared-util/blockapps-init/
 - shared-util/common-log/
 - shared-util/cross-monitoring/
 - shared-util/format
 - shared-util/solid-vm-model/
 - clockwork
 - logserver
-- location:
-    git: https://github.com/echatav/secp256k1-haskell/
-    commit: c27236f93ba2af4da0865558e2dedf2d8643cd8c
-  extra-dep: true
-- location:
-    git: https://github.com/iostat/relapse
-    commit: 2b25839d1b75508301adde293b8c6ef8591ef00a
-  extra-dep: true
-- location:
-    git: https://github.com/bitemyapp/esqueleto.git
-    commit: b81e0d951e510ebffca03c5a58658ad884cc6fbd
-  extra-dep: true
 
-- location:
-    git: https://github.com/ababkin/semver-range
-    commit: fc56a310eaac1d2dbbd7a7ef2ee94cf05f4464f5
-  extra-dep: true
 
 extra-deps:
 - Crypto-4.2.5.1
@@ -101,6 +93,14 @@ extra-deps:
 - bloomfilter-2.0.1.0
 - servant-aeson-specs-0.6.2.0
 - strings-1.1
+- git: https://github.com/echatav/secp256k1-haskell/
+  commit: c27236f93ba2af4da0865558e2dedf2d8643cd8c
+- git: https://github.com/iostat/relapse
+  commit: 2b25839d1b75508301adde293b8c6ef8591ef00a
+- git: https://github.com/bitemyapp/esqueleto.git
+  commit: b81e0d951e510ebffca03c5a58658ad884cc6fbd
+- git: https://github.com/ababkin/semver-range
+  commit: fc56a310eaac1d2dbbd7a7ef2ee94cf05f4464f5
 
 resolver: lts-12.4 #also duplicated in docker section below
 compiler-check: newer-minor
@@ -122,3 +122,15 @@ docker:
   image: "strato-buildbase:lts-12.4"
   set-user: true
   run-args: ["--ulimit=nofile=60000"]
+© 2019 GitHub, Inc.
+Terms
+Privacy
+Security
+Status
+Help
+Contact GitHub
+Pricing
+API
+Training
+Blog
+About


### PR DESCRIPTION
The current `stack.yaml` has outdated syntax and needs to be updated.

From Dustin, "Legacy syntax Prior to Stack 1.11, it was possible to specify dependencies in your packages configuration value as well. This support has been removed to simplify the file format. Instead, these values should be moved to extra-deps. As a concrete example, you would convert:

```
packages:
- .
- location:
    git: https://github.com/bitemyapp/esqueleto.git
    commit: 08c9b4cdf977d5bcd1baba046a007940c1940758
  extra-dep: true
- location:
    git: https://github.com/yesodweb/wai.git
    commit: 6bf765e000c6fd14e09ebdea6c4c5b1510ff5376
    subdirs:
      - wai-extra
  extra-dep: true

extra-deps:
  - streaming-commons-0.2.0.0
  - time-1.9.1
  - yesod-colonnade-1.3.0.1
  - yesod-elements-1.1
```


into 

```
packages:
- .

extra-deps:
  - streaming-commons-0.2.0.0
  - time-1.9.1
  - yesod-colonnade-1.3.0.1
  - yesod-elements-1.1
  - git: https://github.com/bitemyapp/esqueleto.git
    commit: 08c9b4cdf977d5bcd1baba046a007940c1940758
  - git: https://github.com/yesodweb/wai.git
    commit: 6bf765e000c6fd14e09ebdea6c4c5b1510ff5376
    subdirs:
      - wai-extra
```

So in your stack.yaml file, for the packages imported from git, just change the imports from the old style to the new style