### PR TITLE
Script the migration for global password oauth

### DIFF
--- a/blockapps-haskell/vault-wrapper/api/src/Strato/Strato23/Crypto.hs
+++ b/blockapps-haskell/vault-wrapper/api/src/Strato/Strato23/Crypto.hs
@@ -20,6 +20,7 @@ import qualified Data.ByteString                   as BS
 import           Data.Maybe
 import           Data.Text                         (Text)
 import qualified Data.Text.Encoding                as Text
+import           Text.Printf
 
 newtype Password = Password ByteString
   deriving (Eq,Show)
@@ -63,8 +64,7 @@ decryptSecKey
   -> SecretBox.Nonce
   -> ByteString -- encrypted secret key
   -> Maybe SecKey
-decryptSecKey pw salt nonce = secKey <=< d
-  where d = decrypt pw salt nonce
+decryptSecKey pw salt nonce = secKey <=< decrypt pw salt nonce
 
 encrypt
   :: Password
@@ -83,6 +83,17 @@ encrypt (Password pw) salt nonce plaintext =
       encKey = fromMaybe err . Saltine.decode $
         Scrypt.generate scryptParams pw salt
    in SecretBox.secretbox encKey nonce plaintext
+
+reencryptKey :: Password -> Password -> ByteString -> SecretBox.Nonce -> ByteString -> Address -> Either String ByteString
+reencryptKey oldPass newPass salt nonce oldKey givenAddress=
+  case decryptSecKey oldPass salt nonce oldKey of
+    Nothing -> Left "could not decrypt account"
+    Just plainKey -> let foundAddress = deriveAddress plainKey
+                     in if foundAddress /= givenAddress
+                          then Left $ printf "address mismatch (wrong password?): got %s, want %s"
+                                             (show foundAddress)
+                                             (show givenAddress)
+                          else Right $ encrypt newPass salt nonce (getSecKey plainKey)
 
 deriveAddress :: SecKey -> Address
 deriveAddress = keccak256Address . BS.drop 1 . exportPubKey False . derivePubKey

--- a/blockapps-haskell/vault-wrapper/server/app/MigrateKeys.hs
+++ b/blockapps-haskell/vault-wrapper/server/app/MigrateKeys.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE Arrows #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import Control.Arrow
+import Control.Lens.Combinators
+import Control.Monad
+import qualified Data.ByteString.Char8 as C8
+import qualified Data.Text as T
+import HFlags
+import Database.PostgreSQL.Simple hiding (Query)
+import Database.PostgreSQL.Simple.SqlQQ
+import Database.PostgreSQL.Simple.Transaction
+import Opaleye
+import System.Environment
+import System.Exit
+import Text.CSV
+import Text.Printf
+
+import Options
+import Strato.Strato23.Crypto
+import Strato.Strato23.Database.Create as C
+import Strato.Strato23.Database.Tables as TS
+import Strato.Strato23.Server.Password
+
+getUserOldKeyQuery :: T.Text -> Query (Column PGBytea, Column PGBytea, Column PGBytea, Column PGBytea)
+getUserOldKeyQuery username = proc () -> do
+  (_, name, salt, nonce, encSecKey, _, address) <- queryTable TS.usersTable -< ()
+  restrict -< name .== constant username
+  returnA -< (salt, nonce, encSecKey, address)
+
+q1 :: IO [a] -> IO a
+q1 mv = do
+  xs <- mv
+  case xs of
+    [] -> die "no result; expected one"
+    _:_:_ -> die "multiple results; expected exactly one"
+    [x] -> return x
+
+main :: IO ()
+main = do
+  _ <- $initHFlags "migrate-keys"
+  let dbConnectInfo = ConnectInfo { connectHost = flags_pghost
+                                  , connectPort = read flags_pgport
+                                  , connectUser = flags_pguser
+                                  , connectPassword = flags_password
+                                  , connectDatabase = flags_database
+                                  }
+  conn <- connect dbConnectInfo
+  withTransactionSerializable conn $ do
+    void $ execute_ conn [sql| ALTER TABLE users ADD COLUMN IF NOT EXISTS enc_sec_prv_key bytea; |]
+    newPassword <- Password . C8.pack <$> getEnv "SECRET_VAULT_WRAPPER_PASSWORD"
+    eCSV <- parseCSVFromFile "/dev/stdin"
+    case eCSV of
+      Left err -> die $ show err
+      Right cs -> forM_ cs $ \case
+          [] -> return ()
+          [""] -> return ()
+          [user, subject] -> do
+            let oldPassword = Password $ C8.pack subject
+            (salt, nonce, oldkey, addr) <- q1 . runQuery conn . getUserOldKeyQuery $ T.pack user
+            newKey <- either die return $ reencryptKey oldPassword newPassword salt nonce oldkey addr
+            void . runUpdate_ conn $ Update
+                                   { uTable = TS.usersTable
+                                   -- Note: These lenses are 1-indexed. Its not a huge problem to set enc_key again,
+                                   -- but it might be confusing why enc_sec_key is not being set.
+                                   , uUpdateWith = updateEasy (set _6 (constant newKey))
+                                   , uWhere = views _2 (.== constant (T.pack user))
+                                   , uReturning = rCount
+                                   }
+          other -> die $ printf "reverting: unanticipated input row: %s" (show other)
+    -- Will fail if any of the users were left out of the input
+    void $ execute_ conn [sql| ALTER TABLE users ALTER COLUMN enc_sec_prv_key SET NOT NULL; |]
+    void $ execute_ conn C.messageTable
+    wasSet <- setPassword newPassword conn
+    unless wasSet $ die "unable to set password (password already set?)"
+
+  putStrLn "Keys migrated successfully"

--- a/blockapps-haskell/vault-wrapper/server/app/Options.hs
+++ b/blockapps-haskell/vault-wrapper/server/app/Options.hs
@@ -6,9 +6,9 @@ module Options where
 import           HFlags
 
 defineFlag "u:pguser" ("postgres" :: String) "Postgres user"
-defineFlag "P:pghost" ("localhost" :: String) "Postgres hostname"
+defineFlag "P:pghost" ("postgres" :: String) "Postgres hostname"
 defineFlag "pgport" ("5432" :: String) "Postgres port"
-defineFlag "p:password" ("" :: String) "Postgres password"
+defineFlag "p:password" ("api" :: String) "Postgres password"
 defineFlag "d:database" ("oauth" :: String) "Postgres database name"
 defineFlag "port" (8000::Int) "The port which the server runs on"
 defineFlag "loglevel" (4::Int) "The log level for output messages"

--- a/blockapps-haskell/vault-wrapper/server/package.yaml
+++ b/blockapps-haskell/vault-wrapper/server/package.yaml
@@ -79,9 +79,21 @@ dependencies:
 library:
   source-dirs: src
 
-executable:
-  source-dirs: [src/, app/]
-  main: Main.hs
+executables:
+  blockapps-vault-wrapper-server:
+    source-dirs: app
+    main: Main.hs
+    other-modules: [Options]
+    dependencies:
+      - blockapps-vault-wrapper-server
+
+  migrate-keys:
+    source-dirs: app
+    main: MigrateKeys.hs
+    other-modules: [Options]
+    dependencies:
+      - csv
+      - blockapps-vault-wrapper-server
 
 tests:
   server-test:

--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Database/Migrations.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Database/Migrations.hs
@@ -33,6 +33,7 @@ migrations = [ (Throw, createTables)
              , (Throw, insertSchemaVersion)
              , (Throw, insertAddress)
              , (Throw, messageTable)
+             , (Throw, insertSecPrvKey)
              ]
 
 getSchemaVersion :: Query
@@ -48,4 +49,4 @@ insertAddress :: Query
 insertAddress = [sql| ALTER TABLE users ADD COLUMN IF NOT EXISTS address bytea; |]
 
 insertSecPrvKey :: Query
-insertSecPrvKey = [sql| ALTER TABLE users ADD COLUMN IF NOT EXISTS enc_sec_prv_key bytea; |]
+insertSecPrvKey = [sql| ALTER TABLE users ADD COLUMN IF NOT EXISTS enc_sec_prv_key bytea NOT NULL; |]

--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Server/Password.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Server/Password.hs
@@ -11,6 +11,8 @@ import           Data.Maybe                       (listToMaybe)
 import           Data.IORef
 import           Data.Text                        (Text)
 import           Data.Text.Encoding               (encodeUtf8)
+import           Database.PostgreSQL.Simple       (Connection)
+
 import           Strato.Strato23.Crypto
 import           Strato.Strato23.Database.Queries
 import           Strato.Strato23.Monad
@@ -18,6 +20,15 @@ import           Strato.Strato23.Monad
 superSecretVaultWrapperMessage :: ByteString
 superSecretVaultWrapperMessage =
   "A monad is just a monoid in the category of endofunctors, what's the problem?"
+
+setPassword :: Password -> Connection -> IO Bool
+setPassword pw conn = do
+  (salt, nonce) <- newSaltAndNonce
+  let ciphertext = encrypt pw
+                           salt
+                           nonce
+                           superSecretVaultWrapperMessage
+  postMessageQuery salt nonce ciphertext conn
 
 postPassword :: Text -> VaultM ()
 postPassword password = do
@@ -30,12 +41,7 @@ postPassword password = do
       mMsg <- listToMaybe <$> vaultQuery getMessageQuery
       case mMsg of
         Nothing -> do
-          (salt, nonce) <- newSaltAndNonce
-          let ciphertext = encrypt (Password pw)
-                                   salt
-                                   nonce
-                                   superSecretVaultWrapperMessage
-          success <- vaultModify $ postMessageQuery salt nonce ciphertext
+          success <- vaultModify . setPassword $ Password pw
           if success
             then liftIO . atomicWriteIORef existingPassword $ Just password
             else vaultWrapperError $ AnError "Failed to insert encrypted message into database"


### PR DESCRIPTION
With global password oauth, the subject encrypted keys are no longer
used. To make them useful, collecting a csv of (user, subject) pairs
allows them to be converted to the current encryption scheme:

```
$ stack install .
ublockapps-vault-wrapper-server-0.1.0.0: unregistering (local file changes: src/Strato/Strato23/Database/Migrations.hs)
blockapps-vault-wrapper-server-0.1.0.0: build (lib + exe)
blockapps-vault-wrapper-server-0.1.0.0: copy/register
Log files have been written to: /home/tim/strato-platform/starscream/.stack-work/logs/
Copying from /home/tim/strato-platform/starscream/.stack-work/install/x86_64-linux-dkf7b33dd99b569c2d0a323e8a6dc29e94/lts-12.4/8.4.3/bin/blockapps-vault-wrapper-server to /home/tim/strato-platform/starscream/.stack-work/docker/_home/.local/bin/blockapps-vault-wrapper-server
Copying from /home/tim/strato-platform/starscream/.stack-work/install/x86_64-linux-dkf7b33dd99b569c2d0a323e8a6dc29e94/lts-12.4/8.4.3/bin/migrate-keys to /home/tim/strato-platform/starscream/.stack-work/docker/_home/.local/bin/migrate-keys

Copied executables to /home/tim/strato-platform/starscream/.stack-work/docker/_home/.local/bin:
- blockapps-vault-wrapper-server
- migrate-keys
$ docker cp $(stack exec which migrate-keys) strato_vault-wrapper_1:/usr/local/bin
$ docker exec strato_postgres_1 psql -U postgres -x -d oauth -c "select * from users;"
-[ RECORD 1 ]------+---------------------------------------------------------------------------------------------------
id                 | 1
x_user_unique_name | admin@ht3.test
salt               | \x07243670f51f394c94afb7b46138ba88
nonce              | \x944f93a34a1706a2adac740d1c88dda9f778c196f44b2a14
enc_sec_key        | \x4fd7dcf246812d90bc8a55f65760718cd4b65071e1eb7eeb6b536ff01fc83d78f9c77eb1935fbfcabd76ebc1181940b2
address            | \x64646566633530316665343965653037366432383339393666633932623432323164633464386233
-[ RECORD 2 ]------+---------------------------------------------------------------------------------------------------
id                 | 2
x_user_unique_name | master@ht3.test
salt               | \xbab82655e9cdca84c921d9efe1b671cc
nonce              | \x9432d2b208f4b4005393f23583544e8c04ab2b68a8d97bb8
enc_sec_key        | \x96016ec80835a3f543b6adf42099b30629af4cae3de826d00fcc08ca6fd11af7152d99eb09c89cccaa9c8192d3265322
address            | \x30396432636234656230646563663235613134333765613134386538386235626136626332663333

$ cat ~/migrate.csv
admin@ht3.test,c5de9b86-ec6a-41e3-afd7-358548af6a13
master@ht3.test,d234238f-ccbe-479e-83e6-cf10cfa9875b
$ cat ~/migrate.csv | docker exec -i -e SECRET_VAULT_WRAPPER_PASSWORD="****" strato_vault-wrapper_1 migrate-keys
Keys migrated successfully
$ docker exec strato_postgres_1 psql -U postgres -x -d oauth -c "select * from users;"
-[ RECORD 1 ]------+---------------------------------------------------------------------------------------------------
id                 | 1
x_user_unique_name | admin@ht3.test
salt               | \x07243670f51f394c94afb7b46138ba88
nonce              | \x944f93a34a1706a2adac740d1c88dda9f778c196f44b2a14
enc_sec_key        | \x4fd7dcf246812d90bc8a55f65760718cd4b65071e1eb7eeb6b536ff01fc83d78f9c77eb1935fbfcabd76ebc1181940b2
address            | \x64646566633530316665343965653037366432383339393666633932623432323164633464386233
enc_sec_prv_key    | \x8a147163eed69df2f03c24054906a8ddd0c5ec48d212c2e3abca25465625b59454db0df45acd687e1dcc6cea87ddfd6c
-[ RECORD 2 ]------+---------------------------------------------------------------------------------------------------
id                 | 2
x_user_unique_name | master@ht3.test
salt               | \xbab82655e9cdca84c921d9efe1b671cc
nonce              | \x9432d2b208f4b4005393f23583544e8c04ab2b68a8d97bb8
enc_sec_key        | \x96016ec80835a3f543b6adf42099b30629af4cae3de826d00fcc08ca6fd11af7152d99eb09c89cccaa9c8192d3265322
address            | \x30396432636234656230646563663235613134333765613134386538386235626136626332663333
enc_sec_prv_key    | \x81e1f96474b3c44fc18bbce9300c3e41f4dd9bf90cf5e869b451afb6ad47ba06cf4cb663867df83c56d3848af5f8b31e

$ docker exec strato_postgres_1 psql -U postgres -x -d oauth -c "select * from message;"
-[ RECORD 1 ]-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
id      | 1
salt    | \x7c202decc55287bca175858fc37c7baf
nonce   | \x34057a04e6aa3af9aa5e5d4226884ce6ae0b7e23cb8f2b81
enc_msg | \x9876c1174ad77dfbe16e8bf81a58c63da9014e7409c61c436546f39db4afd44182b41920cb6ca36b15e15c033628f69c607dfd98d2dadcd463142c55a3001bebaab53382181bf16618ff45dbe03659cd4445ac744db4927dd64501a464

```
