### PR TITLE
Derive enode address

### DIFF
--- a/core-strato/blockapps-tools/exec_src/Main.hs
+++ b/core-strato/blockapps-tools/exec_src/Main.hs
@@ -13,9 +13,10 @@ import           Block
 import           BlockGO
 import           Checkpoints
 import           Code
-import           DumpKafkaBlocks
 import           CanonRedis
 import           ChainHash
+import           DeriveEnode
+import           DumpKafkaBlocks
 import           DumpKafkaRaw
 import           DumpKafkaSequencer
 import           DumpKafkaStateDiff
@@ -81,6 +82,7 @@ data Options = State{root::String, db::String}
              | VerifyKafkaFile { filename :: String }
              | SetParticipationMode { mode :: ParticipationMode }
              | ChainHash
+             | DeriveEnode { privatekey :: String, ip :: String }
              deriving (Show, Data, Typeable)
 
 stateOptions::Annotate Ann
@@ -315,6 +317,12 @@ setParticipationModeOptions = record SetParticipationMode {mode = error "unused 
 chainHashOptions :: Annotate Ann
 chainHashOptions = record ChainHash []
 
+deriveEnodeOptions :: Annotate Ann
+deriveEnodeOptions = record DeriveEnode { privatekey = error "unused privatekey", ip = error "unused ip"}
+                   [ privatekey := error "--private-key required" += typ "BASE64 Private Key" += explicit += name "private-key"
+                   , ip := error "--ip required" += typ "IP address" += explicit += name "ip"
+                   ]
+
 options::Annotate Ann
 options = modes_ [blockGoOptions
                 , blockOptions
@@ -354,6 +362,7 @@ options = modes_ [blockGoOptions
                 , verifyKafkaFileOptions
                 , setParticipationModeOptions
                 , chainHashOptions
+                , deriveEnodeOptions
                 ]
 
 --      += summary "Apply shims, reorganize, and generate to the input"
@@ -410,3 +419,4 @@ run LoadKafka{..}              = loadKafka topic filename
 run VerifyKafkaFile{..}        = verifyKafkaFile filename
 run SetParticipationMode{..}   = remoteSetParticipationMode mode
 run ChainHash                  = chainHash
+run DeriveEnode{..}            = deriveEnode privatekey ip

--- a/core-strato/blockapps-tools/package.yaml
+++ b/core-strato/blockapps-tools/package.yaml
@@ -15,6 +15,7 @@ dependencies:
   - aeson
   - ansi-wl-pprint
   - base16-bytestring
+  - base64-bytestring
   - binary
   - blockapps-data
   - blockapps-datadefs
@@ -28,6 +29,7 @@ dependencies:
   - conduit
   - data-default
   - ethereum-discovery
+  - ethereum-encryption
   - ethereum-rlp
   - filepath
   - format

--- a/core-strato/blockapps-tools/src/DeriveEnode.hs
+++ b/core-strato/blockapps-tools/src/DeriveEnode.hs
@@ -1,0 +1,30 @@
+module DeriveEnode where
+
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.ByteString.Char8 as C8
+import Data.Maybe
+import System.Exit
+import Text.Printf
+
+import qualified Network.Haskoin.Crypto     as HK
+import Blockchain.Data.PubKey (pointToBytes)
+import Blockchain.Strato.Discovery.P2PUtil (hPubKeyToPubKey)
+import Blockchain.Strato.Model.Address
+import Text.Format
+
+deriveEnode :: String -> String -> IO ()
+deriveEnode iPrvKey ip = do
+  let !bytes = either (error . ("Invalid Base64 private key: " ++). show) id . B64.decode . C8.pack $ iPrvKey
+      !hPrvKey = fromMaybe (error "Invalid private key") . HK.decodePrvKey HK.makePrvKey $ bytes
+      !hPubKey = HK.derivePubKey hPrvKey
+      !address = prvKey2Address hPrvKey
+      !ePoint = hPubKeyToPubKey hPubKey
+  case ePoint of
+    Left err -> die $ show err
+    Right point -> do
+      printf "address: %s\n" (format address)
+      printf "point: %s\n" (show point)
+      let nodeid = C8.unpack $ B16.encode $ pointToBytes point
+      printf "nodeid: %s\n" nodeid
+      printf "enode://%s:%s:30303\n" nodeid ip

--- a/core-strato/ethereum-discovery/package.yaml
+++ b/core-strato/ethereum-discovery/package.yaml
@@ -52,6 +52,7 @@ library:
   exposed-modules:
     - Blockchain.Strato.Discovery.Data.Peer
     - Blockchain.Strato.Discovery.UDP
+    - Blockchain.Strato.Discovery.P2PUtil
     - Executable.EthereumDiscovery
     - Executable.EthDiscoverySetup
 


### PR DESCRIPTION
This can be used to derive the IDs of chain members without having to launch a node to determine their new public key.
```
tim@ip-172-31-11-233 ~/s/r/core-strato ❯❯❯ qs deriveenode --private-key="dQj/B4CVGWkZPv1xPgr1qe2O53HCnvKoIWcNaR8Tz6w=" --ip=3.213.89.121
address: 05cee1528b6d6e0dc542704c961b431b4a5fc9d9
point: Point 111964620724490035169385224097845442167881661517614324928939888033535872668530 100572470771613976272559039297908659990507271861188525075226038546762322842608
nodeid: f789bac681b25a270238ce6b743e85432e9edca23f5cb1598c931553321f1372de5a004fc24eca2572b3965df1ae179ccc265ff1d7ab151c2f0b15d247a693f0
enode://f789bac681b25a270238ce6b743e85432e9edca23f5cb1598c931553321f1372de5a004fc24eca2572b3965df1ae179ccc265ff1d7ab151c2f0b15d247a693f0:3.213.89.121:30303
tim@ip-172-31-11-233 ~/s/r/core-strato ❯❯❯ qs deriveenode --private-key='sdg0oa3LxCRijsq3sVagktab4yTl7AkbnptW6tZk1yc=' --ip=3.213.89.121
address: 1c1370261231e48f3c409989e0f45febbcbfb24b
point: Point 75077850183763562900415395598739917898369379139420197429082806481174340642507 3068947800819884360424235015813232446967310034269932843105848854277517158934
nodeid: a5fc8eacd1ee81bc7247e5ea805d06b03b3a29054e47dc6b8e924054dfc526cb06c8f68096e2c13eaf5327a10a78ea800ec363a59228a85d071cd781fa5f2a16
enode://a5fc8eacd1ee81bc7247e5ea805d06b03b3a29054e47dc6b8e924054dfc526cb06c8f68096e2c13eaf5327a10a78ea800ec363a59228a85d071cd781fa5f2a16:3.213.89.121:30303
```