### PR TITLE
disk usage check hotfix

### DIFF
--- a/apex/api/daemons/node-health-check.js
+++ b/apex/api/daemons/node-health-check.js
@@ -207,10 +207,12 @@ async function checkSystemInfo() {
     sysInfoCollected.mem_free = memdata.free;
     sysInfoCollected.mem_available = memdata.available;
 
-    if (memdata.available / memdata.total * 100 < config.healthCheck.diskUsageBound) {
+    if (memdata.available / memdata.total * 100 < config.healthCheck.memoryUsageBound) {
       isHealthy = false;
       additional_info.push("Low Memory")
     }
+    // FIXME: the callback function is async and the response may come late and be unprocessed!
+    // Why checking the disk space with both - `diskspace` and `si` ?? Can we fully remove this faulty `diskspace` code block?
     disk.check('/', function(err, info) {
       if (err) {
         winston.warn("Error when checking for disk usage", err);
@@ -219,7 +221,7 @@ async function checkSystemInfo() {
       } else {
         const diskUsageRatio = info.free / info.total *100;
         sysInfoCollected.disk_usage = diskUsageRatio;
-        if (diskUsageRatio < config.healthCheck.memoryUsageBound) {
+        if (diskUsageRatio < config.healthCheck.diskUsageBound) {
           isHealthy = false;
           additional_info.push("Low Disk Space")
         }
@@ -238,7 +240,7 @@ async function checkSystemInfo() {
       fsDetails.fsSize_used = fs.used;
       fsDetails.fsSize_size = fs.size;
       fss.push(fsDetails)
-      if (fsDetails.fsSize_use < config.healthCheck.diskUsageBound) {
+      if ((100 - fsDetails.fsSize_use) <= config.healthCheck.diskUsageBound) {
         isHealthy = false;
         additional_info.push(`Low Disk Space on ${fsDetails.name}`)
       }


### PR DESCRIPTION
diskspace check behaves wrong in 4.5
See testnet101.ci.blockapps.net:8080 (user1/1234)
or tech.beanstalk-staging.blockapps.net:8080
for erroneous warning in SMD
With only, say 3% of diskspace **used** the warning appears saying the disk space is low.

Hotfix for the logic and also figured we need to refactor code a bit but that's not urgent

Jenkins build: https://jenkins.blockapps.net/job/STRATO_test/2145/
