### PR TITLE
Add a persistent loopback for pbft

### DIFF
--- a/core-strato/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/core-strato/strato-p2p/exec_src/StratoP2PMain.hs
@@ -10,6 +10,7 @@ import           Blockchain.Output
 import           Blockchain.Strato.Discovery.Data.Peer (resetPeers)
 import           Executable.StratoP2PClient
 import           Executable.StratoP2PServer
+import           Executable.StratoP2PLoopback
 import           BlockApps.Init
 
 main :: IO ()
@@ -20,5 +21,6 @@ main = do
   race_
     (run 10248 metricsApp)
     (runLoggingT $
-      race_ stratoP2PClient
-            stratoP2PServer)
+      race_ stratoP2PLoopback
+        (race_ stratoP2PClient
+               stratoP2PServer))

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -25,6 +25,7 @@ dependencies:
   - blockapps-util
   - bytestring
   - classy-prelude
+  - common-log
   - conduit
   - conduit-combinators
   - conduit-extra

--- a/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Executable.StratoP2PLoopback (stratoP2PLoopback) where
+
+import Conduit
+import Control.Monad
+import Control.Monad.Trans.State
+import qualified Data.Text as T
+import Prometheus
+
+import BlockApps.Logging
+import Blockchain.Context
+import Blockchain.Options
+import Blockchain.SeqEventNotify
+import Blockchain.Sequencer.Event
+import Blockchain.Sequencer.Kafka
+
+{-# NOINLINE loopbackEvents #-}
+loopbackEvents :: Vector T.Text Counter
+loopbackEvents = unsafeRegister
+               . vector "direction"
+               . counter
+               $ Info "p2p_loopback_events" "Counts of events reflected back to the sequencer"
+
+recordEvent :: MonadIO m => T.Text -> m ()
+recordEvent lab = liftIO $ withLabel loopbackEvents lab incCounter
+
+stratoP2PLoopback :: LoggingT IO ()
+stratoP2PLoopback = do
+  $logInfoS "stratoP2PLoopback" "Reflecting PBFT back to unseq since 2019"
+  ctx <- initContext flags_maxReturnedHeaders
+  void . runContextM ctx $ do
+    ks <- gets contextKafkaState
+    let toWireMessage = \case
+          OEBlockstanbul wm -> Just wm
+          _ -> Nothing
+
+    runConduit $
+         seqEventNotificationSource ks
+      .| iterMC (const $ recordEvent "in")
+      .| concatMapC toWireMessage
+      .| iterMC (const $ recordEvent "out")
+      .| mapM_C emitBlockstanbulMsg


### PR DESCRIPTION
This is functionally redundant with https://github.com/blockapps/strato-platform/blob/13b3e9057150bc0ec0ede0eebaa93c9d7f5c4aae/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs#L448, but in a reset node this allows the node to remember its own consensus decisions.

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/2163/pipeline