### PR TITLE
Deduplicate roundchanges in kafkafiles

### DIFF
--- a/core-strato/blockapps-tools/exec_src/Main.hs
+++ b/core-strato/blockapps-tools/exec_src/Main.hs
@@ -83,6 +83,7 @@ data Options = State{root::String, db::String}
              | SetParticipationMode { mode :: ParticipationMode }
              | ChainHash
              | DeriveEnode { privatekey :: String, ip :: String }
+             | CompressRoundChanges { infilename :: String, outfilename :: String }
              deriving (Show, Data, Typeable)
 
 stateOptions::Annotate Ann
@@ -323,6 +324,12 @@ deriveEnodeOptions = record DeriveEnode { privatekey = error "unused privatekey"
                    , ip := error "--ip required" += typ "IP address" += explicit += name "ip"
                    ]
 
+compressRoundChangesOptions :: Annotate Ann
+compressRoundChangesOptions = record CompressRoundChanges { infilename = error "unused infilename", outfilename = error "unused outfilename"}
+                            [ infilename := error "compressroundchanges --infilename=<file>" += typ "PATH" += explicit += name "infilename"
+                            , outfilename := error "compressroundchanges --outfilename=<file>" += typ "PATH" += explicit += name "outfilename"
+                            ]
+
 options::Annotate Ann
 options = modes_ [blockGoOptions
                 , blockOptions
@@ -363,6 +370,7 @@ options = modes_ [blockGoOptions
                 , setParticipationModeOptions
                 , chainHashOptions
                 , deriveEnodeOptions
+                , compressRoundChangesOptions
                 ]
 
 --      += summary "Apply shims, reorganize, and generate to the input"
@@ -420,3 +428,4 @@ run VerifyKafkaFile{..}        = verifyKafkaFile filename
 run SetParticipationMode{..}   = remoteSetParticipationMode mode
 run ChainHash                  = chainHash
 run DeriveEnode{..}            = deriveEnode privatekey ip
+run CompressRoundChanges{..}   = compressRoundChanges infilename outfilename

--- a/core-strato/blockapps-tools/package.yaml
+++ b/core-strato/blockapps-tools/package.yaml
@@ -23,6 +23,7 @@ dependencies:
   - blockapps-mpdbs
   - blockapps-privacy
   - blockapps-util
+  - blockstanbul
   - bytestring
   - cmdargs
   - common-log
@@ -56,6 +57,7 @@ dependencies:
   - strato-statediff
   - transformers
   - hedis
+  - unliftio
 
 library:
   source-dirs: src/

--- a/core-strato/blockapps-tools/src/Kafka.hs
+++ b/core-strato/blockapps-tools/src/Kafka.hs
@@ -2,26 +2,30 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-module Kafka (saveKafka, loadKafka, verifyKafkaFile, readMsg, writeMsg) where
+module Kafka (saveKafka, loadKafka, verifyKafkaFile, compressRoundChanges, readMsg, writeMsg) where
 
 import Control.Lens.Combinators (_1, _2, use, uses)
 import Control.Lens.Operators ((.=), (+=), (%=))
 import Control.Monad
 import Control.Monad.Trans.State
 import Control.Monad.IO.Class
+import Data.Binary
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
 import Conduit
 import qualified Data.Conduit.List as CL
 import Data.Memory.Endian (fromBE, toBE)
 import Data.String
-import Data.Word
 import Foreign.Marshal.Alloc
 import Foreign.Storable
 import System.Exit
 import System.IO
 import Text.Printf
+import UnliftIO.IORef
 
+import Blockchain.Blockstanbul.Messages
 import Blockchain.EthConf
+import Blockchain.Sequencer.Event
 import Blockchain.Stream.Raw
 import Blockchain.Strato.StateDiff.Kafka
 import Network.Kafka
@@ -134,3 +138,40 @@ verifyKafkaFile file = do
       .| iterMC (\msg -> _2 += B.length msg)
       .| mapM_C (\msg -> use _1 >>= \idx -> liftIO (printf "Read message #%d: %d bytes\n" idx (B.length msg)))
     printf "%d messages read, %d bytes read\n" msgsRead bytesRead
+
+
+compressRoundChanges :: FilePath -> FilePath -> IO ()
+compressRoundChanges src' dst' =
+  withBinaryFile dst' WriteMode $ \dst ->
+  withBinaryFile src' ReadMode $ \src -> do
+    hSetBuffering dst . BlockBuffering . Just $ 1024 * 1024
+    hSetBuffering src . BlockBuffering . Just $ 1024 * 1024
+    runConduit $
+         streamFile src
+      .| mapC BL.fromStrict
+      .| mapC decode
+      .| dedupRoundChanges
+      .| mapC encode
+      .| mapC BL.toStrict
+      .| mapM_C (writeMsg dst)
+
+-- On a long running network, there can be millions of round changes but only
+-- thousands of actual events. These round changes take hours to process, but
+-- can mostly be dropped from the file as a long run of round changes has the
+-- same effect as the highest round number from each peer.  Here we assume that
+-- the order is mostly increasing, and just need to keep 64 to
+-- have a very good chance of not losing an important round change.
+dedupRoundChanges :: MonadIO m => ConduitT IngestEvent IngestEvent m ()
+dedupRoundChanges = do
+  queue <- newIORef []
+  let flush = do
+        yieldMany . reverse . take 16 =<< readIORef queue
+        writeIORef queue []
+      add iev = modifyIORef queue (iev:)
+  let loop = do
+        mIev <- await
+        case mIev of
+          Nothing -> flush
+          Just iev@(IEBlockstanbul (WireMessage{_message=RoundChange{}})) -> add iev >> loop
+          Just iev -> flush >> yield iev >> loop
+  loop


### PR DESCRIPTION
This is the savings at various intervals of roundchanges kept: 
```
tim@ip-172-31-11-233 /t/trash ❯❯❯ queryStrato verifykafkafile --filename=monsanto-prod3-unseqevents | tail -n 1
4995399 messages read, 1735946088 bytes read
tim@ip-172-31-11-233 /t/trash ❯❯❯ queryStrato verifykafkafile --filename=downsampled | tail -n 1
383626 messages read, 1009619742 bytes read
tim@ip-172-31-11-233 /t/trash ❯❯❯ queryStrato verifykafkafile --filename=downsampled2 | tail -n 1
145646 messages read, 972140223 bytes read
tim@ip-172-31-11-233 /t/trash ❯❯❯ queryStrato verifykafkafile --filename=downsampled3 | tail -n 1
122268 messages read, 968458507 bytes read
```
`downsampled` kept the last 1024 RCs, `downsampled2` kept the last 64, and `downsampled3` kept the last 16. There's not enough of a benefit for the extra risk of keeping 16 vs 64, but still a ~3x improvement for 64 vs 1024. Note also that bytewise, round changes occupy only about half of the input file yet are around 98% of the messages. This change reduced a 6 hour job to around 15 minutes, so at ~96% of the original time the width was not as much of a factor as quantity