### PR TITLE
Remember more round changes

### DIFF
--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -62,7 +62,7 @@ data BlockstanbulContext = BlockstanbulContext {
   , _hasCommitted :: Bool
   , _pendingRound :: Maybe RoundNumber
   -- Which peers have we received a notice for a round-change
-  , _roundChanged :: M.Map Address RoundNumber
+  , _roundChanged :: M.Map RoundNumber (S.Set Address)
   , _voted :: M.Map Address (M.Map Address Bool)
   -- The nodekey for this validator
   , _prvkey :: HK.PrvKey
@@ -258,7 +258,7 @@ nextRound nt = do
         yield $ signMessage pk (Preprepare v lb)
   prepared .= M.empty
   committed .= M.empty
-  roundChanged .= M.empty
+  roundChanged %= M.dropWhileAntitone (<= thisR)
 
   hasPreprepared .= False
   hasCommitted .= False
@@ -401,10 +401,10 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
             yield . ToCommit . addCommitmentSeals seals $ blk
     IMsg auth (RoundChange vn) -> when (_round v < _round vn) $ do
       let rn = _round vn
-      rs <- roundChanged <%= M.insert (sender auth) rn
+      rs <- roundChanged <%= M.alter (Just . S.insert (sender auth) . fromMaybe S.empty) rn
       total <- poolSize
       sentRN <- use pendingRound
-      let sameRNCount = M.size . M.filter (== rn) $ rs
+      let sameRNCount = maybe 0 S.size . M.lookup rn $ rs
       when (3 * sameRNCount > total && Just rn > sentRN) $ do
         pendingRound .= Just rn
         pk <- use prvkey

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -363,13 +363,13 @@ spec = parallel $ do
         sendMessages [IMsg a1 $ RoundChange next] `shouldReturn` []
         -- 1 vote is not enough
         use pendingRound `shouldReturn` Nothing
-        use roundChanged `shouldReturn` M.singleton (sender a1) roundNext
+        use roundChanged `shouldReturn` M.singleton roundNext (S.singleton (sender a1))
         use view `shouldReturn` curView
         -- 2 votes will be broadcast, but not taken up.
         omsgs <- sendMessages [IMsg a2 $ RoundChange next]
         map oMessage omsgs `shouldBe` [RoundChange next]
         use pendingRound `shouldReturn` Just roundNext
-        use roundChanged `shouldReturn` M.fromList [(sender a1, roundNext), (sender a2, roundNext)]
+        use roundChanged `shouldReturn` M.singleton roundNext (S.fromList [sender a1, sender a2])
         use view `shouldReturn` curView
         -- 3 votes will do it
         sendMessages [IMsg a3 $ RoundChange next] `shouldReturn`
@@ -386,6 +386,20 @@ spec = parallel $ do
         use view `shouldReturn` next
         sendMessages [IMsg a $ RoundChange next] `shouldReturn` []
         use view `shouldReturn` next
+
+    it "Remembers round changes from the future" $ property $ \blk s1 s2 s3 ->
+      let [a1, a2, a3] = zipWith MsgAuth [1..] [s1, s2, s3]
+      in runTest $ do
+        _ <- setupRound blk [sender a1, sender a2, sender a3]
+        now <- use view
+        next <- uses view (over round (+1))
+        nextnext <- uses view (over round (+2))
+        _ <- sendMessages [IMsg a2 $ RoundChange nextnext, IMsg a2 $ RoundChange next]
+        use view `shouldReturn` now
+        _ <- sendMessages [IMsg a1 $ RoundChange next, IMsg a3 $ RoundChange next]
+        use view `shouldReturn` next
+        _ <- sendMessages [IMsg a1 $ RoundChange nextnext, IMsg a3 $ RoundChange nextnext]
+        use view `shouldReturn` nextnext
 
   describe "An UnannouncedBlock message" $ do
     let selfElected = do


### PR DESCRIPTION
Consider a 3 node network that is only partially connected, and then
gets reconnected when 1 node is ahead of the other two that are
on the same round.

In the current implementation, this network will be stuck forever.
However, its likely that the behind nodes have seen all the round
changes from the ahead node because it needed quorum to transition
ahead. When the behind nodes reconnect, they can use the lingering
round change from the ahead node to synchronize themselves and
step forward to the ahead node.