### PR TITLE
Don't automatically pass chain state roots to next block

### DIFF
--- a/core-strato/blockapps-mpdbs/src/Blockchain/DB/ChainDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/DB/ChainDB.hs
@@ -129,7 +129,6 @@ bootstrapChainDB :: ( Modifiable BlockHashRoot m
 bootstrapChainDB genesisHash = putChainBlockHashInfo genesisHash (SHA 0) MP.emptyTriePtr
 
 putBlockHeaderInChainDB :: ( BlockHeaderLike h
-                           , Format h
                            , Modifiable BlockHashRoot m
                            , (MP.StateRoot `Alters` MP.NodeData) m
                            )
@@ -139,10 +138,7 @@ putBlockHeaderInChainDB b = do
       h = blockHeaderHash b
   mExistingChainRoot <- getChainRoot h     -- if we've seen this block before,
   when (isNothing mExistingChainRoot) $ do -- its chain root will already exist
-    mChainRoot <- getChainRoot p
-    case mChainRoot of
-      Nothing -> error $ "putBlockHeaderInChainDB: No parent block with hash " ++ format p ++ " found.\n" ++ format b
-      Just chainRoot -> putChainBlockHashInfo h p chainRoot
+    putChainBlockHashInfo h p MP.emptyTriePtr
 
 getChainRoot :: ( Modifiable BlockHashRoot m
                 , (MP.StateRoot `Alters` MP.NodeData) m
@@ -195,21 +191,22 @@ getChainStateRoot :: ( Modifiable BlockHashRoot m
                      , (MP.StateRoot `Alters` MP.NodeData) m
                      )
                   => Word256 -> SHA -> m (Maybe MP.StateRoot)
-getChainStateRoot chainId bHash = do
-  mChainRoot <- getChainBlockHashInfo bHash
-  fmap join . for mChainRoot $ \(parentHash, chainRoot) -> do
-    mStateRoot <- getkv chainRoot (word256ToMPKey chainId)
-    case mStateRoot of
-      Just (_ :: Word256, stateRoot) -> return $ Just stateRoot
-      Nothing -> do
-        mGenStateRoot <- getChainGenesisInfo chainId
-        fmap join . for mGenStateRoot $ \(creationBlock, genStateRoot) -> do
-          mStateRoot' <- if parentHash == creationBlock
-            then return $ Just genStateRoot
-            else getChainStateRoot chainId parentHash
-          for mStateRoot' $ \stateRoot -> do
-            putChainStateRoot chainId bHash stateRoot
-            return stateRoot
+getChainStateRoot chainId bh = do
+  mGenStateRoot <- getChainGenesisInfo chainId
+  fmap join . for mGenStateRoot $ uncurry $ go bh
+  where go bHash creationBlock genStateRoot = do
+          mChainRoot <- getChainBlockHashInfo bHash
+          fmap join . for mChainRoot $ \(parentHash, chainRoot) -> do
+            mStateRoot <- getkv chainRoot (word256ToMPKey chainId)
+            case mStateRoot of
+              Just (_ :: Word256, stateRoot) -> return $ Just stateRoot
+              Nothing -> do
+                mStateRoot' <- if parentHash == creationBlock
+                  then return $ Just genStateRoot
+                  else go parentHash creationBlock genStateRoot
+                for mStateRoot' $ \stateRoot -> do
+                  putChainStateRoot chainId bHash stateRoot
+                  return stateRoot
 
 putChainStateRoot :: ( Modifiable BlockHashRoot m
                      , (MP.StateRoot `Alters` MP.NodeData) m


### PR DESCRIPTION
https://blockapps.atlassian.net/browse/STRATO-1559

select rt.chain_id, rt.from_address, rt.nonce, tr.message from raw_transaction as rt inner join transaction_result as tr on rt.tx_hash = tr.transaction_hash where rt.chain_id like 'd6%' order by rt.chain_id, rt.from_address, rt."timestamp", rt. nonce;

Develop:
chainid | from   | nonce | message
d6f2... | 545e... |     3 | Nonce mismatch: expecting 3, actual 0
d6f2... | 545e... |     4 | Nonce mismatch: expecting 4, actual 0
d6f2... | 545e... |     5 | Nonce mismatch: expecting 5, actual 0
d6f2... | 545e... |     6 | Nonce mismatch: expecting 6, actual 0
d6f2... | 545e... |     7 | Nonce mismatch: expecting 7, actual 0
d6f2... | 545e... |     0 | Success!
d6f2... | 545e... |     0 | Nonce mismatch: expecting 0, actual 1
d6f2... | 545e... |     1 | Nonce mismatch: expecting 1, actual 0

STRATO-1559-private-stateroot:
chainid | from   | nonce | message
d6f2... | 545e... |     3 | Nonce mismatch: expecting 3, actual 0
d6f2... | 545e... |     4 | Nonce mismatch: expecting 4, actual 0
d6f2... | 545e... |     5 | Nonce mismatch: expecting 5, actual 0
d6f2... | 545e... |     6 | Nonce mismatch: expecting 6, actual 0
d6f2... | 545e... |     7 | Nonce mismatch: expecting 7, actual 0
d6f2... | 545e... |     0 | Success!
d6f2... | 545e... |     0 | Nonce mismatch: expecting 0, actual 1
d6f2... | 545e... |     1 | Success!