### PR TITLE
Logging chainid

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Data/TransactionDef.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/TransactionDef.hs
@@ -6,7 +6,8 @@ module Blockchain.Data.TransactionDef (
   Transaction(..),
   isMessageTX,
   partialRLPEncode,
-  partialRLPDecode
+  partialRLPDecode,
+  formatChainId
   ) where
 
 import           Control.Arrow                ((***))

--- a/core-strato/vm-runner/package.yaml
+++ b/core-strato/vm-runner/package.yaml
@@ -13,6 +13,7 @@ dependencies:
   - binary
   - blockapps-data
   - blockapps-datadefs
+  - blockapps-ethereum
   - blockapps-init
   - blockapps-milena
   - blockapps-mpdbs

--- a/core-strato/vm-runner/package.yaml
+++ b/core-strato/vm-runner/package.yaml
@@ -13,7 +13,6 @@ dependencies:
   - binary
   - blockapps-data
   - blockapps-datadefs
-  - blockapps-ethereum
   - blockapps-init
   - blockapps-milena
   - blockapps-mpdbs

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -692,7 +692,7 @@ printTransactionMessage OutputTx{otBaseTx=t, otSigner=tAddr, otHash=theHash} (Ri
       [ "Adding transaction signed by: " ++ format tAddr
       , "Tx hash:  " ++ format theHash
       , "Tx nonce: " ++ show tNonce
-      , "Chain Id: " ++ maybe "Main Chain." show cid
+      , "Chain Id: " ++ formatChainId cid
       , shortDescription t ++ " " ++ extra
       , "t = " ++ printf "%.5f" (realToFrac deltaT::Double) ++ "s"
       ]

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -393,7 +393,7 @@ addTransactions canCache blockData blockGas0 txs = timeit ("addTransactions, " +
       (!deltaT, !result) <- timeIt $ runExceptT $ addTransaction False blockData blockGas t
       afterMap <- getAddressStateTxDBMap
 
-      printTransactionMessage t result deltaT
+      printTransactionMessage t result deltaT (blockdataChainId blockData)
       P.setGauge vmTxMined (realToFrac deltaT)
 
       trr <- setNewAddresses $ TxRunResult t result deltaT beforeMap afterMap []
@@ -412,7 +412,7 @@ data TxMiningResult = TxMiningResult { tmrFailure  :: Maybe TransactionFailureCa
                                      } deriving (Show)
 
 mineTransactions' :: BlockData -> Integer -> [TxRunResult] -> [OutputTx] -> ContextM TxMiningResult
-mineTransactions' _ remGas ran [] = return $ TxMiningResult Nothing (reverse ran) [] remGas
+mineTransactions' bd remGas ran [] = return $ TxMiningResult Nothing (reverse ran) [] remGas
 mineTransactions' header remGas ran unran@(tx@OutputTx{otBaseTx=bt}:txs) = do
     flushMemAddressStateTxToBlockDB
     flushMemStorageTxDBToBlockDB
@@ -420,7 +420,7 @@ mineTransactions' header remGas ran unran@(tx@OutputTx{otBaseTx=bt}:txs) = do
     (!time', !result) <- timeIt . runExceptT $ addTransaction False header remGas tx
     afterMap <- getAddressStateTxDBMap
     P.setGauge vmTxMining (realToFrac time')
-    printTransactionMessage tx result time'
+    printTransactionMessage tx result time'(blockdataChainId blockData)
     trr <- setNewAddresses $ TxRunResult tx result time' beforeMap afterMap []
     case result of
         Right execResult -> do
@@ -668,18 +668,19 @@ multilineLog source theLines = do
     $logInfoS source $ T.pack theLine
 
 printTransactionMessage::MonadLogger m=>
-                         OutputTx->Either TransactionFailureCause ExecResults->NominalDiffTime->m ()
-printTransactionMessage OutputTx{otSigner=tAddr, otBaseTx=baseTx, otHash=theHash} (Left errMsg) deltaT = do
+                         OutputTx->Either TransactionFailureCause ExecResults->NominalDiffTime->Maybe ChainId ->  m ()
+printTransactionMessage OutputTx{otSigner=tAddr, otBaseTx=baseTx, otHash=theHash} (Left errMsg) deltaT cid = do
   let tNonce = transactionNonce baseTx
   multilineLog "printTx/err" $ boringBox
     [ "Adding transaction signed by: " ++ format tAddr
     , "Tx hash:  " ++ format theHash
     , "Tx nonce: " ++ show tNonce
+    , "Chain Id: " ++ maybe "Main Chain." show cid
     , CL.red "Transaction failure: " ++ CL.red (format errMsg)
     , "t = " ++ printf "%.5f" (realToFrac deltaT::Double) ++ "s"
     ]
 
-printTransactionMessage OutputTx{otBaseTx=t, otSigner=tAddr, otHash=theHash} (Right results) deltaT = do
+printTransactionMessage OutputTx{otBaseTx=t, otSigner=tAddr, otHash=theHash} (Right results) deltaT cid = do
     let tNonce = transactionNonce t
         extra =
           if isMessageTX t
@@ -690,6 +691,7 @@ printTransactionMessage OutputTx{otBaseTx=t, otSigner=tAddr, otHash=theHash} (Ri
       [ "Adding transaction signed by: " ++ format tAddr
       , "Tx hash:  " ++ format theHash
       , "Tx nonce: " ++ show tNonce
+      , "Chain Id: " ++ maybe "Main Chain." show cid
       , shortDescription t ++ " " ++ extra
       , "t = " ++ printf "%.5f" (realToFrac deltaT::Double) ++ "s"
       ]

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -60,6 +60,7 @@ import           Blockchain.Data.ExecResults
 import           Blockchain.Data.Log
 import           Blockchain.Data.LogDB
 import           Blockchain.Data.Transaction
+import           Blockchain.Data.TransactionDef          (formatChainId)
 import           Blockchain.Data.TransactionResult
 import           Blockchain.Data.TransactionResultStatus
 import qualified Blockchain.Database.MerklePatricia      as MP
@@ -344,12 +345,12 @@ addBlockTransactions runPublicTxs b@OutputBlock{obBlockData = bd, obReceiptTrans
   let chains' = partitionWith (txChainId . otBaseTx) . filter ((/= PrivateHash) . txType . otBaseTx) $ transactions
       chains  = if runPublicTxs then chains' else filter (isJust . fst) chains'
   fmap concat . forM chains $ \(chainId, txs) -> do
-    $logDebugS "addBlockTransactions" . T.pack $ "Running chain: " ++ show chainId ++ " with " ++ show txs
+    $logDebugS "addBlockTransactions" . T.pack $ "Running chain: " ++ formatChainId chainId ++ " with " ++ show txs
     withBlockchain (blockHeaderHash bd) chainId $ do
       when flags_debug $ do
         sr <- Mod.get (Proxy @MP.StateRoot)
         $logDebugS "addBlockTransactions/withBlockchain" $ T.pack $ "Old chain state root: " ++ format sr
-      $logDebugS "evm/loop" $ T.pack $ "Running block for chain " ++ show chainId
+      $logDebugS "evm/loop" $ T.pack $ "Running block for chain " ++ formatChainId chainId
       let canUseCache = chainId == Nothing
       -- TODO: Run the checks Bagger does reject invalid transactions for private chains
       (actions, asm) <- addTransactions canUseCache bd (blockDataGasLimit $ obBlockData b) txs
@@ -393,7 +394,7 @@ addTransactions canCache blockData blockGas0 txs = timeit ("addTransactions, " +
       (!deltaT, !result) <- timeIt $ runExceptT $ addTransaction False blockData blockGas t
       afterMap <- getAddressStateTxDBMap
 
-      printTransactionMessage t result deltaT (blockdataChainId blockData)
+      printTransactionMessage t result deltaT (txChainId bt)
       P.setGauge vmTxMined (realToFrac deltaT)
 
       trr <- setNewAddresses $ TxRunResult t result deltaT beforeMap afterMap []
@@ -412,7 +413,7 @@ data TxMiningResult = TxMiningResult { tmrFailure  :: Maybe TransactionFailureCa
                                      } deriving (Show)
 
 mineTransactions' :: BlockData -> Integer -> [TxRunResult] -> [OutputTx] -> ContextM TxMiningResult
-mineTransactions' bd remGas ran [] = return $ TxMiningResult Nothing (reverse ran) [] remGas
+mineTransactions' _ remGas ran [] = return $ TxMiningResult Nothing (reverse ran) [] remGas
 mineTransactions' header remGas ran unran@(tx@OutputTx{otBaseTx=bt}:txs) = do
     flushMemAddressStateTxToBlockDB
     flushMemStorageTxDBToBlockDB
@@ -420,7 +421,7 @@ mineTransactions' header remGas ran unran@(tx@OutputTx{otBaseTx=bt}:txs) = do
     (!time', !result) <- timeIt . runExceptT $ addTransaction False header remGas tx
     afterMap <- getAddressStateTxDBMap
     P.setGauge vmTxMining (realToFrac time')
-    printTransactionMessage tx result time'(blockdataChainId blockData)
+    printTransactionMessage tx result time' (txChainId bt)
     trr <- setNewAddresses $ TxRunResult tx result time' beforeMap afterMap []
     case result of
         Right execResult -> do
@@ -668,14 +669,14 @@ multilineLog source theLines = do
     $logInfoS source $ T.pack theLine
 
 printTransactionMessage::MonadLogger m=>
-                         OutputTx->Either TransactionFailureCause ExecResults->NominalDiffTime->Maybe ChainId ->  m ()
+                         OutputTx->Either TransactionFailureCause ExecResults->NominalDiffTime->Maybe Word256 ->  m ()
 printTransactionMessage OutputTx{otSigner=tAddr, otBaseTx=baseTx, otHash=theHash} (Left errMsg) deltaT cid = do
   let tNonce = transactionNonce baseTx
   multilineLog "printTx/err" $ boringBox
     [ "Adding transaction signed by: " ++ format tAddr
     , "Tx hash:  " ++ format theHash
     , "Tx nonce: " ++ show tNonce
-    , "Chain Id: " ++ maybe "Main Chain." show cid
+    , "Chain Id: " ++ formatChainId cid
     , CL.red "Transaction failure: " ++ CL.red (format errMsg)
     , "t = " ++ printf "%.5f" (realToFrac deltaT::Double) ++ "s"
     ]


### PR DESCRIPTION
```[2019-08-09 19:39:00.791601351 UTC]  INFO | ThreadId 5     | Bagger.demoteUnexecutables          | pulling from mempool
[2019-08-09 19:39:00.79187147 UTC]  INFO | ThreadId 5     | Bagger.promoteExecutables           | pulling from mempool
[2019-08-09 19:39:00.817522463 UTC]  INFO | ThreadId 5     | timeit                              | #### Block #40 (1 TXs insertion) time = 0.0505s
[2019-08-09 19:39:00.842927585 UTC]  INFO | ThreadId 5     | addBlocks                           | Inserting Block #40 (c48cc52ce4459248432bf66e58c15e3b5eeb391f4b66208fdbb6c13bc57e8044, 1TXs).
[2019-08-09 19:39:00.861595262 UTC]  INFO | ThreadId 5     | printTx/ok                          | ==============================================================================
[2019-08-09 19:39:00.861982011 UTC]  INFO | ThreadId 5     | printTx/ok                          | | Adding transaction signed by: 9362ba25ee582d637163f1d6b94acd6142d32601     |
[2019-08-09 19:39:00.862107834 UTC]  INFO | ThreadId 5     | printTx/ok                          | | Tx hash:  1e75c95f9bcd0252d80150761b0a31d9d6abf5236bd24fc2817cb0592e0a81a2 |
[2019-08-09 19:39:00.872267355 UTC]  INFO | ThreadId 5     | printTx/ok                          | | Tx nonce: 3                                                                |
[2019-08-09 19:39:00.875160439 UTC]  INFO | ThreadId 5     | printTx/ok                          | | Chain Id: 780ad3048812c3960684a76f8f09d3ea2eed4dfba1df9c2114eb2c0a59196180 |
[2019-08-09 19:39:00.875314239 UTC]  INFO | ThreadId 5     | printTx/ok                          | | Value transfer of 123456 to dbc74c0d5731...                                |
[2019-08-09 19:39:00.8804134 UTC]  INFO | ThreadId 5     | printTx/ok                          | | t = 0.01532s                                                               |
[2019-08-09 19:39:00.903599121 UTC]  INFO | ThreadId 5     | printTx/ok                          | ==============================================================================
[2019-08-09 19:39:00.910548764 UTC]  INFO | ThreadId 5     | timeit                              | #### addTransactions, 1 TXs time = 0.0643s
[2019-08-09 19:39:00.917304375 UTC]  INFO | ThreadId 5     | timeit                              | #### flushMemStorageDB time = 0.0000s
[2019-08-09 19:39:00.917978918 UTC]  INFO | ThreadId 5     | timeit                              | #### flushMemAddressStateDB time = 0.0005s
[2019-08-09 19:39:00.978620986 UTC]  INFO | ThreadId 5     | addBlock                            | Inserted block became #40 (c48cc52ce4459248432bf66e58c15e3b5eeb391f4b66208fdbb6c13bc57e8044).
[2019-08-09 19:39:00.978791666 UTC]  INFO | ThreadId 5     | replaceBestIfBetter                 | shouldReplace = False, newNumber = 40, oldBestNumber = 40
```