### PR TITLE
In-memory P2P

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Data/ArbitraryInstances.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ArbitraryInstances.hs
@@ -136,7 +136,7 @@ instance Arbitrary IPAddress where
 
 instance Arbitrary Enode where
   arbitrary = Enode
-          <$> (B.pack <$> vectorOf 64 arbitrary)
+          <$> (OrgId . B.pack <$> vectorOf 64 arbitrary)
           <*> arbitrary
           <*> arbitrary `suchThat` (>=0)
           <*> (arbitrary `suchThat` maybe True (>=0))

--- a/core-strato/blockapps-data/src/Blockchain/Data/Block.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/Block.hs
@@ -1,9 +1,15 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-module Blockchain.Data.Block (
-  Block(..),
-  blockDataLens,
-  extraLens,
-  setBlockNo
+{-# LANGUAGE DeriveFunctor      #-}
+
+module Blockchain.Data.Block
+  ( Block(..)
+  , BestBlock(..)
+  , WorldBestBlock(..)
+  , Canonical(..)
+  , Private(..)
+  , blockDataLens
+  , extraLens
+  , setBlockNo
   ) where
 
 
@@ -17,6 +23,7 @@ import GHC.Generics
 
 import Blockchain.Data.DataDefs
 import Blockchain.Data.Transaction
+import Blockchain.Strato.Model.SHA
 
 data Block =
   Block{
@@ -32,3 +39,13 @@ extraLens = blockDataLens . extraDataLens
 
 setBlockNo :: Integer -> Block -> Block
 setBlockNo n blk = blk{blockBlockData = (blockBlockData blk){blockDataNumber = n}}
+
+data BestBlock = BestBlock
+  { bestBlockHash            :: SHA
+  , bestBlockNumber          :: Integer
+  , bestBlockTotalDifficulty :: Integer
+  } deriving (Eq, Show)
+
+newtype WorldBestBlock = WorldBestBlock { unWorldBestBlock :: BestBlock } deriving (Eq, Show)
+newtype Canonical a = Canonical { unCanonical :: a } deriving (Functor)
+newtype Private a = Private { unPrivate :: a } deriving (Functor)

--- a/core-strato/blockapps-data/src/Blockchain/Data/Enode.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/Enode.hs
@@ -4,45 +4,72 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
-module Blockchain.Data.Enode (
-  Enode(..),
-  IPAddress(..),
-  showEnode,
-  readEnode,
-  showIP,
-  readIP
+module Blockchain.Data.Enode
+  ( Enode(..)
+  , IPAddress(..)
+  , OrgId(..)
+  , ChainMembers(..)
+  , ChainTxsInBlock(..)
+  , IPChains(..)
+  , OrgIdChains(..)
+  , showEnode
+  , readEnode
+  , showIP
+  , readIP
   ) where
 
 
-import                  Control.DeepSeq
-import                  Data.Bits
-import                  Data.Binary
-import qualified        Data.ByteString             as B
-import qualified        Data.ByteString.Char8       as C8
-import qualified        Data.ByteString.Base16      as B16
-import                  Data.Data
-import                  Data.List
-import                  Database.Persist.Sql
-import qualified        Data.Text                   as T
-import                  Data.Aeson
-import qualified        GHC.Generics                as GHCG
-import                  Network.Socket.Internal
+import           Control.DeepSeq
+import           Data.Aeson
+import           Data.Bits
+import           Data.Binary
+import qualified Data.ByteString             as B
+import qualified Data.ByteString.Char8       as C8
+import qualified Data.ByteString.Base16      as B16
+import           Data.Data
+import           Data.Default
+import           Data.List
+import           Database.Persist.Sql
+import qualified Data.Map.Strict             as M
+import qualified Data.Set                    as S
+import qualified Data.Text                   as T
+import qualified GHC.Generics                as GHCG
+import           Network.Socket.Internal
 
-import                  Blockchain.Data.RLP
+import           Blockchain.Data.Address
+import           Blockchain.Data.RLP
+import           Blockchain.ExtWord
+import           Blockchain.Strato.Model.SHA
 
 
-data IPAddress = IPv4 HostAddress deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary, Data)
+newtype IPAddress = IPv4 HostAddress deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary, Data)
 
 instance RLPSerializable IPAddress where
   rlpEncode (IPv4 addy) = rlpEncode $ toInteger addy
   rlpDecode x = IPv4 (fromInteger $ rlpDecode x)
 
+newtype OrgId = OrgId { unOrgId :: B.ByteString } deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary, Data)
+
+instance RLPSerializable OrgId where
+  rlpEncode (OrgId bs) = rlpEncode bs
+  rlpDecode = OrgId . rlpDecode
+
 data Enode = Enode
-  { pubKey     :: B.ByteString
+  { pubKey     :: OrgId
   , ipAddress  :: IPAddress
   , tcpPort    :: Int
   , udpPort    :: Maybe Int
   } deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary, Data)
+
+newtype ChainMembers = ChainMembers { unChainMembers :: M.Map Address Enode } deriving (Eq)
+newtype ChainTxsInBlock = ChainTxsInBlock { unChainTxsInBlock :: M.Map Word256 [SHA] } deriving (Eq)
+newtype IPChains = IPChains { unIPChains :: S.Set Word256 } deriving (Eq)
+newtype OrgIdChains = OrgIdChains { unOrgIdChains :: S.Set Word256 } deriving (Eq)
+
+instance Default ChainMembers    where def = ChainMembers M.empty
+instance Default ChainTxsInBlock where def = ChainTxsInBlock M.empty
+instance Default IPChains        where def = IPChains S.empty
+instance Default OrgIdChains     where def = OrgIdChains S.empty
 
 instance RLPSerializable Enode where
   rlpEncode (Enode pk ip tp up) =
@@ -84,7 +111,7 @@ readIP input =
   in (IPv4 addy)
 
 showEnode :: Enode -> String
-showEnode (Enode pk ip tp up) =
+showEnode (Enode (OrgId pk) ip tp up) =
     "enode://" ++
     (C8.unpack $ B16.encode pk) ++
     "@" ++
@@ -111,7 +138,7 @@ readEnode input =
           case udp of
             [] -> Nothing
             _ -> Just (read udp)
-     in (Enode (fst $ B16.decode (C8.pack pk)) (readIP ip) (read tcp) up)
+     in (Enode (OrgId . fst $ B16.decode (C8.pack pk)) (readIP ip) (read tcp) up)
 
 
 instance PersistFieldSql Enode where

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -204,7 +204,7 @@ lengthenPeerDisable peer' = try . withGlobalSQLPool $ \sqldb -> do
 
 -- TODO: Allow an empty public key in the Enode type
 peerToEnode :: PPeer -> Maybe Enode
-peerToEnode peer = (\pk -> Enode (pointToBytes pk)
+peerToEnode peer = (\pk -> Enode (OrgId $ pointToBytes pk)
                                  (readIP . T.unpack $ pPeerIp peer)
                                  (pPeerTcpPort peer)
                                  (Just $ pPeerUdpPort peer)) <$> pPeerPubkey peer

--- a/core-strato/run_unit_tests.sh
+++ b/core-strato/run_unit_tests.sh
@@ -30,6 +30,10 @@ TESTS=(
 BENCHES=(
   vm-runner
 )
+# There's a good chance that strato-getting-started is also running, so	
+# we change redis's port to avoid a conflict.	
+REDIS=$(docker run -d -p 2023:6379 redis:3.2 redis-server --appendonly yes)	
+trap "docker rm -f ${REDIS}" EXIT
 
 for tst in ${TESTS[@]}; do
   time stack test $tst

--- a/core-strato/run_unit_tests.sh
+++ b/core-strato/run_unit_tests.sh
@@ -32,10 +32,8 @@ BENCHES=(
 )
 # There's a good chance that strato-getting-started is also running, so
 # we change redis's port to avoid a conflict.
-POSTGRES=$(docker run -d -p 2345:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:9.6)
-trap "docker rm -f ${POSTGRES}" EXIT
 REDIS=$(docker run -d -p 2023:6379 redis:3.2 redis-server --appendonly yes)
-trap "docker rm -f ${POSTGRES} ${REDIS}" EXIT
+trap "docker rm -f ${REDIS}" EXIT
 
 for tst in ${TESTS[@]}; do
   time stack test $tst

--- a/core-strato/run_unit_tests.sh
+++ b/core-strato/run_unit_tests.sh
@@ -30,10 +30,6 @@ TESTS=(
 BENCHES=(
   vm-runner
 )
-# There's a good chance that strato-getting-started is also running, so
-# we change redis's port to avoid a conflict.
-REDIS=$(docker run -d -p 2023:6379 redis:3.2 redis-server --appendonly yes)
-trap "docker rm -f ${REDIS}" EXIT
 
 for tst in ${TESTS[@]}; do
   time stack test $tst

--- a/core-strato/run_unit_tests_long.sh
+++ b/core-strato/run_unit_tests_long.sh
@@ -23,6 +23,10 @@ TEST_AND_BENCH=(
   ethereum-rlp
   strato-sequencer
 )
+# There's a good chance that strato-getting-started is also running, so	
+# we change redis's port to avoid a conflict.	
+REDIS=$(docker run -d -p 2023:6379 redis:3.2 redis-server --appendonly yes)	
+trap "docker rm -f ${REDIS}" EXIT
 
 for tst in ${TESTS[@]}; do
   time stack test $tst

--- a/core-strato/run_unit_tests_long.sh
+++ b/core-strato/run_unit_tests_long.sh
@@ -24,13 +24,6 @@ TEST_AND_BENCH=(
   strato-sequencer
 )
 
-# There's a good chance that strato-getting-started is also running, so
-# we change redis's port to avoid a conflict.
-POSTGRES=$(docker run -d -p 2345:5432 postgres:9.6)
-trap "docker rm -f ${POSTGRES}" EXIT
-REDIS=$(docker run -d -p 2023:6379 redis:3.2 redis-server --appendonly yes)
-trap "docker rm -f ${POSTGRES} ${REDIS}" EXIT
-
 for tst in ${TESTS[@]}; do
   time stack test $tst
 done

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - crypto-pubkey
   - crypto-pubkey-types
   - dlist
+  - data-default
   - dns
   - either
   - esqueleto
@@ -72,6 +73,7 @@ dependencies:
   - strato-conf
   - text
   - time
+  - these
   - transformers
   - transformers-base
   - wai-middleware-prometheus

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeOperators        #-}
 
 module Blockchain.CommunicationConduit
     ( handleMsgServerConduit
@@ -10,7 +12,8 @@ module Blockchain.CommunicationConduit
     , mkEthP2PEventConduit
     ) where
 
-import           Control.Monad.Change.Modify           (Accessible)
+import qualified Control.Monad.Change.Alter            as A
+import qualified Control.Monad.Change.Modify           as Mod
 import           Control.Monad.IO.Unlift
 import           Control.Monad.State
 import           Control.Monad.Trans.Resource
@@ -26,6 +29,7 @@ import           Data.Conduit.Network
 import           Data.Conduit.TQueue
 import           Data.List.Split
 import           Data.Maybe
+import qualified Data.Set                              as S
 import qualified Data.Text                             as T
 import           Data.Void
 import           Text.Printf
@@ -38,25 +42,27 @@ import           Network.Kafka                         as K
 import           Blockchain.Constants                  hiding (ethVersion)
 import           Blockchain.Context
 import           Blockchain.Data.Block
+import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.Control               (P2PCNC(..))
 import           Blockchain.Data.DataDefs
+import           Blockchain.Data.Enode
 import           Blockchain.Data.RLP
 import           Blockchain.Data.Wire                  as W
-import           Blockchain.DB.DetailsDB               hiding (getBestBlockHash)
-import           Blockchain.DB.SQLDB
 import           Blockchain.Display
 import           Blockchain.Event
 import           Blockchain.EventException
 import           Blockchain.ExtMergeSources
+import           Blockchain.ExtWord
 import           Blockchain.Frame
 import           Blockchain.Metrics
 import           Blockchain.Options
 import           Blockchain.Output
 import           Blockchain.Participation
 import           Blockchain.SeqEventNotify
+import           Blockchain.Sequencer.Event
+import qualified Blockchain.Sequencer.Kafka            as SK
 import           Blockchain.Strato.Discovery.Data.Peer
-import qualified Blockchain.Strato.RedisBlockDB        as RBDB
-import           Blockchain.Strato.RedisBlockDB.Models
+import           Blockchain.Strato.Model.SHA
 import           Blockchain.Stream.VMEvent
 import           Blockchain.TimerSource
 import           Blockchain.Util
@@ -135,15 +141,29 @@ debounceTxSends = do
       recordEmptyQueue
       yieldMany . map W.Transactions $ chunksOf 100 txs
 
-handleMsgClientConduit :: ( MonadIO (StateT Context m)
+handleMsgClientConduit :: ( MonadIO m
                           , MonadResource m
-                          , Accessible RBDB.RedisConnection (StateT Context m)
-                          , WrapsSQLDB (StateT Context) m
-                          , MonadLogger (StateT Context m)
+                          , MonadLogger m
+                          , Mod.Accessible (SK.UnseqSink m) m
+                          , MonadState Context m
+                          , Mod.Modifiable K.KafkaState m
+                          , Mod.Modifiable BestBlock m
+                          , Mod.Modifiable WorldBestBlock m
+                          , (Integer `A.Selectable` Canonical BlockData) m
+                          , (SHA `A.Alters` BlockData) m
+                          , (IPAddress `A.Selectable` IPChains) m
+                          , (OrgId `A.Selectable` OrgIdChains) m
+                          , (SHA `A.Selectable` ChainTxsInBlock) m
+                          , (Word256 `A.Selectable` ChainMembers) m
+                          , (Word256 `A.Selectable` ChainInfo) m
+                          , (SHA `A.Selectable` Private (Word256, OutputTx)) m
+                          , (SHA `A.Alters` OutputBlock) m
+                          , Mod.Accessible GenesisBlockHash m
+                          , Mod.Accessible BestBlockNumber m
                           )
                        => Point
                        -> PPeer
-                       -> ConduitM Event (Either P2PCNC Message) (StateT Context m) ()
+                       -> ConduitM Event (Either P2PCNC Message) m ()
 handleMsgClientConduit myId peer = do
     $logDebugS "handleMsgClientConduit" $ T.pack $ "<waving hand emoji>"
     yield $ Right Hello { version = 4
@@ -157,42 +177,54 @@ handleMsgClientConduit myId peer = do
     $logDebugS "handleMsgClientConduit" $ T.pack $ "about to parse message"
     awaitMsg >>= \case
         Just Hello{} ->
-            RBDB.withRedisBlockDB RBDB.getBestBlockInfo >>= \case
-                Nothing -> error "we don't have a local BestBlock"
-                Just (RedisBestBlock hash _ tdiff) -> do
-                    genHash <- lift . runWithSQL $ getGenesisBlockHash
-                    yield $ Right Status {
-                        protocolVersion = fromIntegral ethVersion,
-                        networkID       = computeNetworkID,
-                        totalDifficulty = fromIntegral tdiff,
-                        latestHash      = hash,
-                        genesisHash     = genHash
-                    }
+            yield =<< lift (Mod.get (Mod.Proxy @BestBlock) >>= \(BestBlock bHash _ tdiff) -> do
+              (GenesisBlockHash genHash) <- Mod.access (Mod.Proxy @GenesisBlockHash)
+              return $ Right Status {
+                protocolVersion = fromIntegral ethVersion,
+                networkID       = computeNetworkID,
+                totalDifficulty = fromIntegral tdiff,
+                latestHash      = bHash,
+                genesisHash     = genHash
+              })
         other -> assertHandshake other
     awaitMsg >>= \case
         Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash} -> do
-                genHash <- lift . runWithSQL $ getGenesisBlockHash
+                (GenesisBlockHash genHash) <- lift $ Mod.access (Mod.Proxy @GenesisBlockHash)
                 when (peerGH /= genHash) $ throwIO WrongGenesisBlock
-                void $ RBDB.withRedisBlockDB (RBDB.updateWorldBestBlockInfo peerBestHash 0 peerTD) -- we set to 0 cause we dont necessarily know the number yet
-                lastBlockNumber <- liftIO getBestKafkaBlockNumber
+                -- we set to 0 cause we dont necessarily know the number yet
+                lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
+                (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
                 Just (ChainBlock firstBlock:_) <- liftIO $ fetchVMEventsIO 0
                 mrh <- gets maxReturnedHeaders
                 yield . Right $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) (blockDataNumber $ blockBlockData firstBlock))) mrh 0 Forward
                 yield . Right $ GetChainDetails []
-                handleGetChainDetails peer []
+                handleGetChainDetails peer S.empty
                 stampActionTimestamp
         other -> assertHandshake other
     handleEvents peer .| filterMC (either (const $ return True) checkOutbound)
 
-handleMsgServerConduit :: (MonadIO (StateT Context m)
-                         , MonadResource m
-                         , Accessible RBDB.RedisConnection (StateT Context m)
-                         , WrapsSQLDB (StateT Context) m
-                         , MonadLogger (StateT Context m)
-                         )
+handleMsgServerConduit :: ( MonadIO m
+                          , MonadResource m
+                          , MonadLogger m
+                          , Mod.Accessible (SK.UnseqSink m) m
+                          , MonadState Context m
+                          , Mod.Modifiable K.KafkaState m
+                          , Mod.Modifiable BestBlock m
+                          , Mod.Modifiable WorldBestBlock m
+                          , (Integer `A.Selectable` Canonical BlockData) m
+                          , (SHA `A.Alters` BlockData) m
+                          , (IPAddress `A.Selectable` IPChains) m
+                          , (OrgId `A.Selectable` OrgIdChains) m
+                          , (SHA `A.Selectable` ChainTxsInBlock) m
+                          , (Word256 `A.Selectable` ChainMembers) m
+                          , (Word256 `A.Selectable` ChainInfo) m
+                          , (SHA `A.Selectable` Private (Word256, OutputTx)) m
+                          , (SHA `A.Alters` OutputBlock) m
+                          , Mod.Accessible GenesisBlockHash m
+                          )
                  => Point
                  -> PPeer
-                 -> ConduitM Event (Either P2PCNC Message) (StateT Context m) ()
+                 -> ConduitM Event (Either P2PCNC Message) m ()
 handleMsgServerConduit myPubkey peer = do
     $logDebugS "handleMsgServerConduit" $ T.pack $ "about to parse message"
     awaitMsg >>= \case
@@ -210,19 +242,18 @@ handleMsgServerConduit myPubkey peer = do
     awaitMsg >>= \case
         Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash} -> do
             $logInfoS "serverHandshake/Status{}" "received status"
-            RBDB.withRedisBlockDB RBDB.getBestBlockInfo >>= \case
-                Nothing -> error "we don't have a local BestBlock!"
-                Just (RedisBestBlock hash _ tdiff) -> do
-                    genHash <- lift . runWithSQL $ getGenesisBlockHash
-                    when (genHash /= peerGH) $ error "peer has a different genesis block than we do!"
-                    void $ RBDB.withRedisBlockDB (RBDB.updateWorldBestBlockInfo peerBestHash 0 peerTD) -- we set to 0 cause we dont necessarily know the number yet
-                    yield $ Right Status {
-                        protocolVersion=fromIntegral ethVersion,
-                        networkID=computeNetworkID,
-                        totalDifficulty= fromIntegral tdiff,
-                        latestHash=hash,
-                        genesisHash=genHash
-                    }
+            yield =<< lift (Mod.get (Mod.Proxy @BestBlock) >>= \(BestBlock bHash _ tdiff) -> do
+              (GenesisBlockHash genHash) <- Mod.access (Mod.Proxy @GenesisBlockHash)
+              when (genHash /= peerGH) $ error "peer has a different genesis block than we do!"
+              -- we set to 0 cause we dont necessarily know the number yet
+              Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
+              return $ Right Status {
+                  protocolVersion = fromIntegral ethVersion,
+                  networkID = computeNetworkID,
+                  totalDifficulty = fromIntegral tdiff,
+                  latestHash = bHash,
+                  genesisHash = genHash
+              })
         other -> assertHandshake other
     handleEvents peer .| filterMC (either (const $ return True) checkOutbound)
 

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -145,8 +145,6 @@ handleMsgClientConduit :: ( MonadIO m
                           , MonadResource m
                           , MonadLogger m
                           , Mod.Accessible (SK.UnseqSink m) m
-                          , MonadState Context m
-                          , Mod.Modifiable K.KafkaState m
                           , Mod.Modifiable BestBlock m
                           , Mod.Modifiable WorldBestBlock m
                           , Mod.Modifiable ActionTimestamp m
@@ -170,6 +168,7 @@ handleMsgClientConduit :: ( MonadIO m
                           , (SHA `A.Alters` OutputBlock) m
                           , Mod.Accessible GenesisBlockHash m
                           , Mod.Accessible BestBlockNumber m
+                          , HasVMEventsSink m
                           )
                        => Point
                        -> PPeer
@@ -217,8 +216,6 @@ handleMsgServerConduit :: ( MonadIO m
                           , MonadResource m
                           , MonadLogger m
                           , Mod.Accessible (SK.UnseqSink m) m
-                          , MonadState Context m
-                          , Mod.Modifiable K.KafkaState m
                           , Mod.Modifiable BestBlock m
                           , Mod.Modifiable WorldBestBlock m
                           , Mod.Modifiable ActionTimestamp m
@@ -241,6 +238,7 @@ handleMsgServerConduit :: ( MonadIO m
                           , (SHA `A.Selectable` Private (Word256, OutputTx)) m
                           , (SHA `A.Alters` OutputBlock) m
                           , Mod.Accessible GenesisBlockHash m
+                          , HasVMEventsSink m
                           )
                  => Point
                  -> PPeer

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -149,6 +149,16 @@ handleMsgClientConduit :: ( MonadIO m
                           , Mod.Modifiable K.KafkaState m
                           , Mod.Modifiable BestBlock m
                           , Mod.Modifiable WorldBestBlock m
+                          , Mod.Modifiable ActionTimestamp m
+                          , Mod.Accessible ActionTimestamp m
+                          , Mod.Modifiable [BlockData] m
+                          , Mod.Accessible [BlockData] m
+                          , Mod.Modifiable RemainingBlockHeaders m
+                          , Mod.Accessible RemainingBlockHeaders m
+                          , Mod.Modifiable PeerAddress m
+                          , Mod.Accessible PeerAddress m
+                          , Mod.Accessible MaxReturnedHeaders m
+                          , Mod.Accessible ConnectionTimeout m
                           , (Integer `A.Selectable` Canonical BlockData) m
                           , (SHA `A.Alters` BlockData) m
                           , (IPAddress `A.Selectable` IPChains) m
@@ -195,11 +205,11 @@ handleMsgClientConduit myId peer = do
                 lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
                 (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
                 Just (ChainBlock firstBlock:_) <- liftIO $ fetchVMEventsIO 0
-                mrh <- gets maxReturnedHeaders
+                mrh <- lift $ unMaxReturnedHeaders <$> Mod.access (Mod.Proxy @MaxReturnedHeaders)
                 yield . Right $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) (blockDataNumber $ blockBlockData firstBlock))) mrh 0 Forward
                 yield . Right $ GetChainDetails []
                 handleGetChainDetails peer S.empty
-                stampActionTimestamp
+                lift stampActionTimestamp
         other -> assertHandshake other
     handleEvents peer .| filterMC (either (const $ return True) checkOutbound)
 
@@ -211,6 +221,16 @@ handleMsgServerConduit :: ( MonadIO m
                           , Mod.Modifiable K.KafkaState m
                           , Mod.Modifiable BestBlock m
                           , Mod.Modifiable WorldBestBlock m
+                          , Mod.Modifiable ActionTimestamp m
+                          , Mod.Accessible ActionTimestamp m
+                          , Mod.Modifiable [BlockData] m
+                          , Mod.Accessible [BlockData] m
+                          , Mod.Modifiable RemainingBlockHeaders m
+                          , Mod.Accessible RemainingBlockHeaders m
+                          , Mod.Modifiable PeerAddress m
+                          , Mod.Accessible PeerAddress m
+                          , Mod.Accessible MaxReturnedHeaders m
+                          , Mod.Accessible ConnectionTimeout m
                           , (Integer `A.Selectable` Canonical BlockData) m
                           , (SHA `A.Alters` BlockData) m
                           , (IPAddress `A.Selectable` IPChains) m

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -248,10 +248,10 @@ instance MonadReader Config m => Mod.Accessible SQLDB m where
 instance HasSQLDB m => WrapsSQLDB (StateT Context) m where
   runWithSQL = lift
 
-instance (MonadIO m, MonadState Context m, Mod.Modifiable K.KafkaState m) => Mod.Accessible (UnseqSink m) m where
+instance MonadIO m => Mod.Accessible (UnseqSink (StateT Context m)) (StateT Context m) where
   access _ = gets unseqSink
 
-instance (MonadState Context m, MonadIO m, Mod.Modifiable K.KafkaState m) => HasVMEventsSink m where
+instance MonadIO m => HasVMEventsSink (StateT Context m) where
   getVMEventsSink = gets vmEventsSink
 
 -- dummy newtype wrapper to avoid overlapping instance

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,12 +11,14 @@
 {-# LANGUAGE TypeSynonymInstances  #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS -fno-warn-orphans      #-}
+{-# OPTIONS -fno-warn-missing-methods #-}
 module Blockchain.Context
     ( Context(..)
     , Config(..)
     , ContextM
     , GenesisBlockHash(..)
     , BestBlockNumber(..)
+    , WithPPeerByIP(..)
     , initContext
     , runContextM
     , blockstanbulPeerAddr
@@ -201,6 +204,19 @@ instance (MonadIO m, MonadState Context m, Mod.Modifiable K.KafkaState m) => Mod
 instance (MonadState Context m, MonadIO m, Mod.Modifiable K.KafkaState m) => HasVMEventsSink m where
   getVMEventsSink = gets vmEventsSink
 
+-- dummy newtype wrapper to avoid overlapping instance
+newtype WithPPeerByIP m a = WithPPeerByIP { unPPeerByIp :: m a }
+  deriving (Functor, Applicative, Monad)
+
+instance HasSQLDB m => A.Selectable String PPeer (WithPPeerByIP m) where
+  select _ ip = WithPPeerByIP $ do
+    db <- Mod.access (Mod.Proxy @SQLDB)
+    SQL.runSqlPool actions db >>= \case
+        [] -> return Nothing
+        lst -> return . Just . SQL.entityVal $ head lst
+
+    where actions = SQL.selectList [ PPeerIp SQL.==. T.pack ip ] []
+
 getDebugMsg :: MonadState Context m => m String
 getDebugMsg = concat . reverse . vmTrace <$> get
 
@@ -245,10 +261,10 @@ clearActionTimestamp = do
     put cxt{actionTimestamp=Nothing}
 
 runContextM :: MonadUnliftIO m
-            => (r, s)
-            -> StateT s (ReaderT r (ResourceT m)) a
+            => r
+            -> ReaderT r (ResourceT m) a
             -> m ()
-runContextM (r, s) = void . runResourceT . flip runReaderT r . flip runStateT s
+runContextM r = void . runResourceT . flip runReaderT r
 
 initContext :: ( MonadLogger m
                , MonadUnliftIO m
@@ -272,16 +288,10 @@ initContext maxHeaders = do
                  })
 
 
-getPeerByIP :: WrapsSQLDB t m
+getPeerByIP :: A.Selectable String PPeer m
             => String
-            -> (t m) (Maybe (SQL.Entity PPeer))
-getPeerByIP ip = runWithSQL $ do
-    db <- Mod.access (Mod.Proxy @SQLDB)
-    SQL.runSqlPool actions db >>= \case
-        [] -> return Nothing
-        lst -> return . Just $ head lst
-
-    where actions = SQL.selectList [ PPeerIp SQL.==. T.pack ip ] []
+            -> m (Maybe PPeer)
+getPeerByIP = A.select (A.Proxy @PPeer)
 
 setPeerAddrIfUnset :: MonadState Context m => Address -> m ()
 setPeerAddrIfUnset addr = blockstanbulPeerAddr %= (<|> Just addr)

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -16,19 +16,22 @@ module Blockchain.Context
     ( Context(..)
     , Config(..)
     , ContextM
+    , ActionTimestamp(..)
+    , emptyActionTimestamp
+    , RemainingBlockHeaders(..)
+    , MaxReturnedHeaders(..)
+    , ConnectionTimeout(..)
+    , PeerAddress(..)
     , GenesisBlockHash(..)
     , BestBlockNumber(..)
     , WithPPeerByIP(..)
     , initContext
     , runContextM
     , blockstanbulPeerAddr
-    , getDebugMsg
-    , addDebugMsg
     , getBlockHeaders
     , putBlockHeaders
     , getRemainingBHeaders
     , putRemainingBHeaders
-    , clearDebugMsg
     , stampActionTimestamp
     , getActionTimestamp
     , clearActionTimestamp
@@ -84,6 +87,19 @@ import           Blockchain.Util                       (toMaybe)
 
 newtype Config = Config { configSQLDB :: SQLDB }
 
+newtype ActionTimestamp = ActionTimestamp { unActionTimestamp :: Maybe UTCTime }
+
+emptyActionTimestamp :: ActionTimestamp
+emptyActionTimestamp = ActionTimestamp Nothing
+
+newtype RemainingBlockHeaders = RemainingBlockHeaders { unRemainingBlockHeaders :: [BlockData] }
+newtype MaxReturnedHeaders = MaxReturnedHeaders { unMaxReturnedHeaders :: Int }
+newtype ConnectionTimeout = ConnectionTimeout { unConnectionTimeout :: Int }
+newtype PeerAddress = PeerAddress { unPeerAddress :: Maybe Address }
+
+withPeerAddress :: (Maybe Address -> Maybe Address) -> PeerAddress -> PeerAddress
+withPeerAddress f = PeerAddress . f . unPeerAddress
+
 data Context = Context
   { contextRedisBlockDB   :: RBDB.RedisConnection
   , contextKafkaState     :: K.KafkaState
@@ -91,11 +107,11 @@ data Context = Context
   , unseqSink             :: forall m . (MonadIO m, Mod.Modifiable K.KafkaState m) => [IngestEvent] -> m ()
   , vmEventsSink          :: forall m . (MonadIO m, Mod.Modifiable K.KafkaState m) => [VMEvent] -> m ()
   , blockHeaders          :: [BlockData]
-  , remainingBlockHeaders :: [BlockData]
-  , actionTimestamp       :: Maybe UTCTime
-  , connectionTimeout     :: Int
-  , maxReturnedHeaders    :: Int
-  , _blockstanbulPeerAddr :: Maybe Address
+  , remainingBlockHeaders :: RemainingBlockHeaders
+  , actionTimestamp       :: ActionTimestamp
+  , connectionTimeout     :: ConnectionTimeout
+  , maxReturnedHeaders    :: MaxReturnedHeaders
+  , _blockstanbulPeerAddr :: PeerAddress
   }
 
 makeLenses ''Context
@@ -189,6 +205,40 @@ instance Monad m => Mod.Modifiable K.KafkaState (StateT Context m) where
   get _   = gets contextKafkaState
   put _ k = modify $ \c -> c{contextKafkaState = k}
 
+instance Monad m => Mod.Modifiable ActionTimestamp (StateT Context m) where
+  get _   = gets actionTimestamp
+  put _ k = modify $ \c -> c{actionTimestamp = k}
+
+instance Monad m => Mod.Accessible ActionTimestamp (StateT Context m) where
+  access _ = Mod.get (Mod.Proxy @ActionTimestamp)
+
+instance Monad m => Mod.Modifiable [BlockData] (StateT Context m) where
+  get _   = gets blockHeaders
+  put _ k = modify $ \c -> c{blockHeaders = k}
+
+instance Monad m => Mod.Accessible [BlockData] (StateT Context m) where
+  access _ = Mod.get (Mod.Proxy @[BlockData])
+
+instance Monad m => Mod.Modifiable RemainingBlockHeaders (StateT Context m) where
+  get _   = gets remainingBlockHeaders
+  put _ k = modify $ \c -> c{remainingBlockHeaders = k}
+
+instance Monad m => Mod.Accessible RemainingBlockHeaders (StateT Context m) where
+  access _ = Mod.get (Mod.Proxy @RemainingBlockHeaders)
+
+instance Monad m => Mod.Accessible MaxReturnedHeaders (StateT Context m) where
+  access _ = gets maxReturnedHeaders
+
+instance Monad m => Mod.Modifiable PeerAddress (StateT Context m) where
+  get _   = use blockstanbulPeerAddr
+  put _ k = blockstanbulPeerAddr .= k
+
+instance Monad m => Mod.Accessible PeerAddress (StateT Context m) where
+  access _ = Mod.get (Mod.Proxy @PeerAddress)
+
+instance Monad m => Mod.Accessible ConnectionTimeout (StateT Context m) where
+  access _ = gets connectionTimeout
+
 instance MonadIO m => Mod.Accessible RBDB.RedisConnection (StateT Context m) where
   access _ = gets contextRedisBlockDB
 
@@ -217,48 +267,28 @@ instance HasSQLDB m => A.Selectable String PPeer (WithPPeerByIP m) where
 
     where actions = SQL.selectList [ PPeerIp SQL.==. T.pack ip ] []
 
-getDebugMsg :: MonadState Context m => m String
-getDebugMsg = concat . reverse . vmTrace <$> get
+getBlockHeaders :: Mod.Accessible [BlockData] m => m [BlockData]
+getBlockHeaders = Mod.access (Mod.Proxy @[BlockData])
 
-getBlockHeaders :: MonadState Context m => m [BlockData]
-getBlockHeaders = blockHeaders <$> get
+putBlockHeaders :: Mod.Modifiable [BlockData] m => [BlockData]-> m ()
+putBlockHeaders = Mod.put (Mod.Proxy @[BlockData])
 
-putBlockHeaders :: MonadState Context m => [BlockData]->m ()
-putBlockHeaders headers = do
-    cxt <- get
-    put cxt{blockHeaders=headers}
+getRemainingBHeaders :: (Functor m, Mod.Accessible RemainingBlockHeaders m) => m [BlockData]
+getRemainingBHeaders = unRemainingBlockHeaders <$> Mod.access (Mod.Proxy @RemainingBlockHeaders)
 
-getRemainingBHeaders :: MonadState Context m => m [BlockData]
-getRemainingBHeaders = remainingBlockHeaders <$> get
+putRemainingBHeaders :: Mod.Modifiable RemainingBlockHeaders m => [BlockData]-> m ()
+putRemainingBHeaders = Mod.put (Mod.Proxy @RemainingBlockHeaders) . RemainingBlockHeaders
 
-putRemainingBHeaders :: MonadState Context m => [BlockData]->m ()
-putRemainingBHeaders headers = do
-    cxt <- get
-    put cxt{remainingBlockHeaders=headers}
-
-addDebugMsg :: MonadState Context m => String->m ()
-addDebugMsg msg = do
-    cxt <- get
-    put cxt{vmTrace=msg:vmTrace cxt}
-
-clearDebugMsg :: MonadState Context m => m ()
-clearDebugMsg = do
-    cxt <- get
-    put cxt{vmTrace=[]}
-
-stampActionTimestamp :: (MonadIO m, MonadState Context m) => m ()
+stampActionTimestamp :: (MonadIO m, Mod.Modifiable ActionTimestamp m) => m ()
 stampActionTimestamp = do
-    cxt <- get
-    ts <- liftIO getCurrentTime
-    put cxt{actionTimestamp=Just ts}
+  ts <- liftIO getCurrentTime
+  Mod.put (Mod.Proxy @ActionTimestamp) . ActionTimestamp $ Just ts
 
-getActionTimestamp :: MonadState Context m => m (Maybe UTCTime)
-getActionTimestamp = actionTimestamp <$> get
+getActionTimestamp :: Mod.Accessible ActionTimestamp m => m ActionTimestamp
+getActionTimestamp = Mod.access (Mod.Proxy @ActionTimestamp)
 
-clearActionTimestamp :: MonadState Context m => m ()
-clearActionTimestamp = do
-    cxt <- get
-    put cxt{actionTimestamp=Nothing}
+clearActionTimestamp :: Mod.Modifiable ActionTimestamp m => m ()
+clearActionTimestamp = Mod.put (Mod.Proxy @ActionTimestamp) emptyActionTimestamp
 
 runContextM :: MonadUnliftIO m
             => r
@@ -274,17 +304,17 @@ initContext maxHeaders = do
   dbs <- openDBs
   redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
   return (Config (sqlDB' dbs),
-         Context { actionTimestamp = Nothing
+         Context { actionTimestamp = emptyActionTimestamp
                  , contextRedisBlockDB = RBDB.RedisConnection redisBDBPool
                  , contextKafkaState = mkConfiguredKafkaState "strato-p2p"
-                 , blockHeaders=[]
-                 , remainingBlockHeaders=[]
+                 , blockHeaders = []
+                 , remainingBlockHeaders = RemainingBlockHeaders []
                  , unseqSink=void . K.withKafkaViolently . writeUnseqEvents
                  , vmEventsSink=void . produceVMEventsM
                  , vmTrace=[]
-                 , connectionTimeout=flags_connectionTimeout
-                 , maxReturnedHeaders = maxHeaders
-                 , _blockstanbulPeerAddr = Nothing
+                 , connectionTimeout = ConnectionTimeout flags_connectionTimeout
+                 , maxReturnedHeaders = MaxReturnedHeaders maxHeaders
+                 , _blockstanbulPeerAddr = PeerAddress Nothing
                  })
 
 
@@ -293,10 +323,10 @@ getPeerByIP :: A.Selectable String PPeer m
             -> m (Maybe PPeer)
 getPeerByIP = A.select (A.Proxy @PPeer)
 
-setPeerAddrIfUnset :: MonadState Context m => Address -> m ()
-setPeerAddrIfUnset addr = blockstanbulPeerAddr %= (<|> Just addr)
+setPeerAddrIfUnset :: Mod.Modifiable PeerAddress m => Address -> m ()
+setPeerAddrIfUnset addr = Mod.modify_ (Mod.Proxy @PeerAddress) $ pure . withPeerAddress (<|> Just addr)
 
-shouldSendToPeer :: MonadState Context m => Address -> m Bool
-shouldSendToPeer addr = maybe True zeroOrArg <$> use blockstanbulPeerAddr
+shouldSendToPeer :: (Functor m, Mod.Accessible PeerAddress m) => Address -> m Bool
+shouldSendToPeer addr = maybe True zeroOrArg . unPeerAddress <$> Mod.access (Mod.Proxy @PeerAddress)
         -- 0x0 is for a broadcast sync message.
   where zeroOrArg addr' = addr' == 0x0 || addr' == addr

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -14,6 +14,8 @@ module Blockchain.Context
     ( Context(..)
     , Config(..)
     , ContextM
+    , GenesisBlockHash(..)
+    , BestBlockNumber(..)
     , initContext
     , runContextM
     , blockstanbulPeerAddr
@@ -36,30 +38,46 @@ module Blockchain.Context
 import           Conduit
 import           Control.Applicative
 import           Control.Lens                          hiding (Context)
+import qualified Control.Monad.Change.Alter            as A
 import qualified Control.Monad.Change.Modify           as Mod
 import           Blockchain.Output
 import           Control.Monad.Reader
 import           Control.Monad.State
+import           Data.Default
+import qualified Data.Map.Strict                       as M
+import           Data.Maybe
 import qualified Data.Text                             as T
 import           Data.Time.Clock
 
 import           Blockchain.Data.Address
-import           Blockchain.Data.BlockHeader
+import           Blockchain.Data.Block
+import           Blockchain.Data.ChainInfo
+import           Blockchain.Data.DataDefs
+import           Blockchain.Data.Enode
+import           Blockchain.DB.DetailsDB
 import           Blockchain.DB.SQLDB
 import           Blockchain.DBM
 import           Blockchain.EthConf
+import           Blockchain.ExtWord
 import           Blockchain.Options
-import           Blockchain.Sequencer.Event            (IngestEvent (..))
+import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Kafka            (writeUnseqEvents, UnseqSink)
 
 import           Blockchain.Strato.Discovery.Data.Peer
-import           Blockchain.Stream.VMEvent             (HasVMEventsSink(..), VMEvent, produceVMEventsM)
+import           Blockchain.Strato.Model.SHA
+import           Blockchain.Stream.VMEvent             ( HasVMEventsSink(..)
+                                                       , VMEvent
+                                                       , getBestKafkaBlockNumber
+                                                       , produceVMEventsM
+                                                       )
 
 import qualified Blockchain.Strato.RedisBlockDB        as RBDB
+import           Blockchain.Strato.RedisBlockDB.Models (RedisBestBlock(..))
 import qualified Database.Persist.Sql                  as SQL
 import qualified Database.Redis                        as Redis
 import qualified Network.Kafka                         as K
 import qualified Blockchain.MilenaTools                as K
+import           Blockchain.Util                       (toMaybe)
 
 newtype Config = Config { configSQLDB :: SQLDB }
 
@@ -69,8 +87,8 @@ data Context = Context
   , vmTrace               :: [String]
   , unseqSink             :: forall m . (MonadIO m, Mod.Modifiable K.KafkaState m) => [IngestEvent] -> m ()
   , vmEventsSink          :: forall m . (MonadIO m, Mod.Modifiable K.KafkaState m) => [VMEvent] -> m ()
-  , blockHeaders          :: [BlockHeader]
-  , remainingBlockHeaders :: [BlockHeader]
+  , blockHeaders          :: [BlockData]
+  , remainingBlockHeaders :: [BlockData]
   , actionTimestamp       :: Maybe UTCTime
   , connectionTimeout     :: Int
   , maxReturnedHeaders    :: Int
@@ -79,13 +97,96 @@ data Context = Context
 
 makeLenses ''Context
 
+newtype GenesisBlockHash = GenesisBlockHash { unGenesisBlockHash :: SHA }
+newtype BestBlockNumber = BestBlockNumber { unBestBlockNumber :: Integer }
+
 type ContextM = StateT Context (ReaderT Config (ResourceT (LoggingT IO)))
+
+instance MonadIO m => (SHA `A.Alters` BlockData) (StateT Context m) where
+  lookup _     = RBDB.withRedisBlockDB . RBDB.getHeader
+  insert _ k v = void . RBDB.withRedisBlockDB $ RBDB.insertHeader k v
+  delete _     = void . RBDB.withRedisBlockDB . RBDB.deleteHeader
+  lookupMany _ = fmap (M.fromList . catMaybes . map sequenceA)
+               . RBDB.withRedisBlockDB . RBDB.getHeaders
+  insertMany _ = void . RBDB.withRedisBlockDB . RBDB.insertHeaders
+  deleteMany _ = void . RBDB.withRedisBlockDB . RBDB.deleteHeaders
+
+instance (MonadIO m, MonadLogger m) => Mod.Modifiable WorldBestBlock (StateT Context m) where
+  get _ = RBDB.withRedisBlockDB RBDB.getWorldBestBlockInfo <&> \case
+    Nothing -> WorldBestBlock $ BestBlock (SHA 0) (-1) 0
+    Just (RedisBestBlock s n d) -> WorldBestBlock $ BestBlock s n d
+  put _ (WorldBestBlock (BestBlock s n d)) =
+    RBDB.withRedisBlockDB (RBDB.updateWorldBestBlockInfo s n d) >>= \case
+      Left  _ -> $logInfoS "ContextM.put WorldBestBlock" $ T.pack "Failed to update WorldBestBlockInfo"
+      Right False -> $logInfoS "ContextM.put WorldBestBlock" $ T.pack "NewBlock is not better than existing WorldBestBlock"
+      Right True  -> return ()
+
+instance (MonadIO m, MonadLogger m) => Mod.Modifiable BestBlock (StateT Context m) where
+  get _ = RBDB.withRedisBlockDB RBDB.getBestBlockInfo <&> \case
+    Nothing -> BestBlock (SHA 0) (-1) 0
+    Just (RedisBestBlock s n d) -> BestBlock s n d
+  put _ (BestBlock s n d) =
+    RBDB.withRedisBlockDB (RBDB.putBestBlockInfo s n d) >>= \case
+      Left  _ -> $logInfoS "ContextM.put BestBlock" $ T.pack "Failed to update BestBlock"
+      Right _ -> return ()
+
+instance MonadIO m => A.Selectable Integer (Canonical BlockData) (StateT Context m) where
+  select _ i = fmap (fmap Canonical) . RBDB.withRedisBlockDB $ RBDB.getCanonicalHeader i
+
+instance MonadIO m => A.Selectable IPAddress IPChains (StateT Context m) where
+  select p ip = A.selectWithDefault p ip <&> toMaybe def
+  selectWithDefault _ = fmap IPChains
+                      . RBDB.withRedisBlockDB
+                      . RBDB.getIPChains
+
+instance MonadIO m => A.Selectable OrgId OrgIdChains (StateT Context m) where
+  select p ip = A.selectWithDefault p ip <&> toMaybe def
+  selectWithDefault _ = fmap OrgIdChains
+                      . RBDB.withRedisBlockDB
+                      . RBDB.getOrgIdChains
+                      . unOrgId
+
+instance MonadIO m => A.Selectable SHA ChainTxsInBlock (StateT Context m) where
+  select p sha = A.selectWithDefault p sha <&> toMaybe def
+  selectWithDefault _ = fmap ChainTxsInBlock
+                      . RBDB.withRedisBlockDB
+                      . RBDB.getChainTxsInBlock
+
+instance MonadIO m => A.Selectable Word256 ChainMembers (StateT Context m) where
+  select p cid = A.selectWithDefault p cid <&> toMaybe def
+  selectWithDefault _ = fmap ChainMembers
+                      . RBDB.withRedisBlockDB
+                      . RBDB.getChainMembers
+
+instance MonadIO m => A.Selectable Word256 ChainInfo (StateT Context m) where
+  select _ = RBDB.withRedisBlockDB . RBDB.getChainInfo
+
+instance MonadIO m => A.Selectable SHA (Private (Word256, OutputTx)) (StateT Context m) where
+  select _ = fmap (fmap Private) . RBDB.withRedisBlockDB . RBDB.getPrivateTransactions
+
+instance MonadIO m => (SHA `A.Alters` OutputBlock) (StateT Context m) where
+  lookup _     = RBDB.withRedisBlockDB . RBDB.getBlock
+  insert _ k v = void . RBDB.withRedisBlockDB $ RBDB.insertBlock k v
+  delete _     = void . RBDB.withRedisBlockDB . RBDB.deleteBlock
+  lookupMany _ = fmap (M.fromList . catMaybes . map sequenceA)
+               . RBDB.withRedisBlockDB . RBDB.getBlocks
+  insertMany _ = void . RBDB.withRedisBlockDB . RBDB.insertBlocks
+  deleteMany _ = void . RBDB.withRedisBlockDB . RBDB.deleteBlocks
+
+instance ( MonadIO m
+         , MonadUnliftIO m
+         , MonadReader Config m
+         ) => Mod.Accessible GenesisBlockHash (StateT Context m) where
+  access _ = GenesisBlockHash <$> runWithSQL getGenesisBlockHash
+
+instance MonadIO m => Mod.Accessible BestBlockNumber (StateT Context m) where
+  access _ = BestBlockNumber <$> liftIO getBestKafkaBlockNumber
 
 instance Monad m => Mod.Modifiable K.KafkaState (StateT Context m) where
   get _   = gets contextKafkaState
-  put _ k = get >>= \c -> put c{contextKafkaState = k}
+  put _ k = modify $ \c -> c{contextKafkaState = k}
 
-instance MonadState Context m => Mod.Accessible RBDB.RedisConnection m where
+instance MonadIO m => Mod.Accessible RBDB.RedisConnection (StateT Context m) where
   access _ = gets contextRedisBlockDB
 
 instance MonadReader Config m => Mod.Accessible SQLDB m where
@@ -103,18 +204,18 @@ instance (MonadState Context m, MonadIO m, Mod.Modifiable K.KafkaState m) => Has
 getDebugMsg :: MonadState Context m => m String
 getDebugMsg = concat . reverse . vmTrace <$> get
 
-getBlockHeaders :: MonadState Context m => m [BlockHeader]
+getBlockHeaders :: MonadState Context m => m [BlockData]
 getBlockHeaders = blockHeaders <$> get
 
-putBlockHeaders :: MonadState Context m => [BlockHeader]->m ()
+putBlockHeaders :: MonadState Context m => [BlockData]->m ()
 putBlockHeaders headers = do
     cxt <- get
     put cxt{blockHeaders=headers}
 
-getRemainingBHeaders :: MonadState Context m => m [BlockHeader]
+getRemainingBHeaders :: MonadState Context m => m [BlockData]
 getRemainingBHeaders = remainingBlockHeaders <$> get
 
-putRemainingBHeaders :: MonadState Context m => [BlockHeader]->m ()
+putRemainingBHeaders :: MonadState Context m => [BlockData]->m ()
 putRemainingBHeaders headers = do
     cxt <- get
     put cxt{remainingBlockHeaders=headers}

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -15,7 +15,6 @@ module Blockchain.Event (
   ) where
 
 import           Control.Arrow                         ((&&&), second)
-import           Control.Lens                          (use)
 import           Control.Monad
 import           Control.Monad.Change.Alter
 import           Control.Monad.Change.Modify           hiding (get, put, yield, awaitForever)
@@ -40,7 +39,6 @@ import qualified Data.Text                             as T
 import           Data.These
 import           Data.Time.Clock
 import           MonadUtils
-import qualified Network.Kafka                         as K
 import           Prelude                               hiding (lookup)
 import           System.Random
 import           Text.Printf
@@ -122,11 +120,20 @@ yieldL = yield . Left
 handleEvents :: ( MonadIO m
                 , MonadResource m
                 , Accessible (SK.UnseqSink m) m
-                , MonadState Context m
                 , MonadLogger m
-                , Modifiable K.KafkaState m
+                , HasVMEventsSink m
                 , Modifiable BestBlock m
                 , Modifiable WorldBestBlock m
+                , Modifiable ActionTimestamp m
+                , Accessible ActionTimestamp m
+                , Modifiable [BlockData] m
+                , Accessible [BlockData] m
+                , Modifiable RemainingBlockHeaders m
+                , Accessible RemainingBlockHeaders m
+                , Modifiable PeerAddress m
+                , Accessible PeerAddress m
+                , Accessible MaxReturnedHeaders m
+                , Accessible ConnectionTimeout m
                 , (Integer `Selectable` Canonical BlockData) m
                 , (SHA `Alters` BlockData) m
                 , (IPAddress `Selectable` IPChains) m
@@ -143,12 +150,12 @@ handleEvents peer = awaitForever $ \case
     MsgEvt Ping     -> yieldR Pong
 
     MsgEvt (Transactions txs) -> do
-        stampActionTimestamp
+        lift stampActionTimestamp
         let txo = Origin.PeerString (peerString peer)
         lift $ SK.emitKafkaTransactions txo txs
 
     MsgEvt (NewBlock block' tdiff) -> do
-        stampActionTimestamp
+        lift stampActionTimestamp
         $logInfoS "handleEvents/NewBlock" $ T.pack $ "newBlock with tdiff " ++ show tdiff
         let sha         = blockHash block'
         let header      = blockHeader block'
@@ -170,7 +177,7 @@ handleEvents peer = awaitForever $ \case
             void . lift $ SK.emitKafkaBlock (Origin.PeerString $ peerString peer) block'
 
     MsgEvt (NewBlockHashes _) -> do
-        stampActionTimestamp
+        lift stampActionTimestamp
         bestBlock <- lift $ Mod.get (Proxy @BestBlock)
         let bestBlockNum = numberFromBestBlock bestBlock
         let fetchNumber = if bestBlockNum < 2 then 1 else bestBlockNum - 1
@@ -178,11 +185,11 @@ handleEvents peer = awaitForever $ \case
         syncFetch Forward fetchNumber
 
     MsgEvt (GetBlockHeaders (BlockNumber start) max' skip' dir) -> do
-      stampActionTimestamp
+      lift stampActionTimestamp
       start' <- case dir of
         Reverse -> return $ if start > fromIntegral max' then start - (fromIntegral max') else 1
         Forward -> return start
-      mrh <- gets maxReturnedHeaders
+      mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
       -- When the skip is 0, none of the blocks are skipped but when the skip is 3,
       -- 3/4s of the blocks will be dropped when creating the blockheaders
       -- so we overcompensate here.
@@ -198,7 +205,7 @@ handleEvents peer = awaitForever $ \case
       yieldR . BlockHeaders . skipEntries skip' $ morphBlockHeader . unCanonical . snd <$> chain
 
     MsgEvt (GetBlockHeaders (BlockHash start) max' skip' dir) -> do
-      stampActionTimestamp
+      lift stampActionTimestamp
       maybeHeader <- lift $ lookup (Proxy @BlockData) start
       case maybeHeader of
         Nothing    -> yieldR (BlockBodies [])
@@ -209,14 +216,14 @@ handleEvents peer = awaitForever $ \case
                 Reverse -> if num > fromIntegral max'
                              then num - fromIntegral max'
                              else 1
-          mrh <- gets maxReturnedHeaders
+          mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
           let count = (1 + skip') * min mrh (fromIntegral num)
           chain <- fmap M.toList . lift . selectMany (Proxy @(Canonical BlockData)) $ take count [start'..]
           yieldR . BlockHeaders . skipEntries skip' $ morphBlockHeader . unCanonical . snd <$> chain
 
     MsgEvt (BlockHeaders bHeaders) -> do
         let headers = morphBlockHeader <$> bHeaders
-        stampActionTimestamp
+        lift stampActionTimestamp
         alreadyRequestedHeaders <- lift getBlockHeaders -- get already requested headers
         when (null alreadyRequestedHeaders) $ do        -- proceed if we are not already requesting headers
             -- let headerHashes = S.fromList $ map headerHash headers
@@ -255,7 +262,7 @@ handleEvents peer = awaitForever $ \case
             lift $ putRemainingBHeaders remainingHeaders
             $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "putBlockHeaders called with length " ++ show (length neededHeaders')
             yieldR . GetBlockBodies $ blockHeaderHash <$> neededHeaders'
-            stampActionTimestamp
+            lift stampActionTimestamp
 
     -- todo: seems like geth and parity will send bodies on a best-effort, skipping shas they doesnt have
     -- todo: e.g. if they have bodies for SHAs [1, 2, 4, 7, 8, 9] and you request [1..10] you'll get
@@ -268,11 +275,11 @@ handleEvents peer = awaitForever $ \case
     -- todo: instead, we'd just return [1, 2] in this case, and hope the peer re-requests the missing blocks from
     -- todo: someone else or us at a later time
     MsgEvt (GetBlockBodies [])   -> do
-      stampActionTimestamp
+      lift stampActionTimestamp
       yieldR (BlockBodies []) -- todo parity bans peers when they do this. should we?
     MsgEvt (GetBlockBodies shas') -> do
-      stampActionTimestamp
-      mrh <- gets maxReturnedHeaders
+      lift stampActionTimestamp
+      mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
       let shas = take mrh shas'
       lift (getUntilMissing shas DL.empty DL.empty) >>= \(bodies, pshas) -> do
           yieldR . BlockBodies $ map (second (map morphBlockHeader) . toBody) bodies
@@ -307,7 +314,7 @@ handleEvents peer = awaitForever $ \case
     -- todo:
     MsgEvt (BlockBodies []) -> return () --clearActionTimestamp
     MsgEvt (BlockBodies bodies) -> do
-        stampActionTimestamp
+        lift stampActionTimestamp
         headers <- lift getBlockHeaders
         let verified = and $ zipWith (\h b -> blockDataTransactionsRoot h == transactionsVerificationValue (fst b)) headers bodies
         unless verified $ error "headers don't match bodies"
@@ -322,29 +329,29 @@ handleEvents peer = awaitForever $ \case
         lift $ putRemainingBHeaders remainingHeaders
         if null neededHeaders
             then when (newCount > 0) $ do
-                mrh <- gets maxReturnedHeaders
+                mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
                 yieldR $ GetBlockHeaders (BlockHash $ blockHeaderHash $ last headers) mrh 0 Forward
-                stampActionTimestamp
+                lift stampActionTimestamp
             else do
                 yieldR $ GetBlockBodies (map blockHeaderHash neededHeaders)
-                stampActionTimestamp
-    MsgEvt (Blockstanbul wm) -> do
+                lift stampActionTimestamp
+    MsgEvt (Blockstanbul wm) -> lift $ do
       stampActionTimestamp
       setPeerAddrIfUnset $ blockstanbulSender wm
-      peerAddr <- use blockstanbulPeerAddr
+      peerAddr <- unPeerAddress <$> access (Proxy @PeerAddress)
       $logInfoS "handleEvents/Blockstanbul" . T.pack $ "blockstanbulPeerAddr: " ++ show peerAddr
-      lift $ SK.emitBlockstanbulMsg wm
+      SK.emitBlockstanbulMsg wm
 
     -- private chains
     MsgEvt (GetChainDetails cids') -> handleGetChainDetails peer $ S.fromList cids'
 
     MsgEvt (ChainDetails chpairs) -> do
-      stampActionTimestamp
+      lift stampActionTimestamp
       lift $ mapM_ (uncurry (SK.emitKafkaChainDetails (Origin.PeerString $ peerString peer))) chpairs
 
     -- TODO: Optimize/do security checking (a peer can spam you with random hashes and keep you busy forever)
     MsgEvt (GetTransactions trHashes) -> do
-      stampActionTimestamp
+      lift stampActionTimestamp
       $logInfoS "handleEvents/GetTransactions" $ T.pack $ "requesting info for txHashes: "
         ++ (intercalate "\n" (format <$> trHashes))
       ptrs <- fmap (map unPrivate . M.elems) . lift $ selectMany (Proxy @(Private (Word256, OutputTx))) trHashes
@@ -406,14 +413,14 @@ handleEvents peer = awaitForever $ \case
         $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
         yieldR outbound
       P2pAskForBlocks start _ p -> do
-        ss <- shouldSendToPeer p
+        ss <- lift $ shouldSendToPeer p
         when ss $ do
           $logDebugS "handleEvents/P2pAskForBlocks" . T.pack $ "syncFetch: " ++ show start
           syncFetch Forward start
       P2pPushBlocks start end p -> do
-        ss <- shouldSendToPeer p
+        ss <- lift $ shouldSendToPeer p
         when ss $ do
-          mrh <- gets maxReturnedHeaders
+          mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
           let count = min mrh . fromIntegral $ end - start + 1
           chain <- fmap M.toList . lift . selectMany (Proxy @(Canonical BlockData)) $ take count [start..]
           when (null chain) $
@@ -424,12 +431,12 @@ handleEvents peer = awaitForever $ \case
           yieldR outbound
 
     TimerEvt -> do
-        maybeOldTS <- getActionTimestamp
+        maybeOldTS <- unActionTimestamp <$> lift getActionTimestamp
         case maybeOldTS of
             Just oldTS -> do
                 ts <- liftIO getCurrentTime
                 let diffTime = ts `diffUTCTime` oldTS
-                maxTime <- gets (fromIntegral . connectionTimeout)
+                maxTime <- fromIntegral . unConnectionTimeout <$> lift (access (Proxy @ConnectionTimeout))
                 liftIO $ setTitle $ "timer: " ++ show (maxTime - diffTime)
                 when (diffTime > maxTime) $ do
                     yieldR $ Disconnect UselessPeer
@@ -447,12 +454,12 @@ handleEvents peer = awaitForever $ \case
 
 handleGetChainDetails :: ( MonadIO m
                          , MonadResource m
-                         , MonadState Context m
                          , MonadLogger m
                          , (IPAddress `Selectable` IPChains) m
                          , (OrgId `Selectable` OrgIdChains) m
                          , (Word256 `Selectable` ChainMembers) m
                          , (Word256 `Selectable` ChainInfo) m
+                         , Modifiable ActionTimestamp m
                          )
                       => PPeer
                       -> S.Set Word256
@@ -466,7 +473,7 @@ handleGetChainDetails peer cids' = do
                            $ pPeerPubkey peer
               return $ S.union (unIPChains ipChains) (unOrgIdChains orgIdChains)
             else return cids'
-  stampActionTimestamp
+  lift stampActionTimestamp
   $logInfoS "handleGetChainDetails" $ T.pack $ "details requested for chainIDs " ++ (intercalate "\n" $ formatChainId . Just <$> cids)
   mems <- lift $ selectMany (Proxy @ChainMembers) cids
   let filteredPairs = M.keys $ M.filter (checkPeerIsMember peer) mems
@@ -474,7 +481,7 @@ handleGetChainDetails peer cids' = do
   unless (null filteredPairs) $ do
     cInfos <- fmap M.toList . lift $ selectMany (Proxy @ChainInfo) cids
     yieldR $ ChainDetails cInfos
-    stampActionTimestamp
+    lift stampActionTimestamp
     $logInfoS "handleGetChainDetails" $ T.pack $ "the following ChainIds were returned " ++
       (intercalate "\n" $ formatChainId . Just . fst <$> cInfos)
 
@@ -483,14 +490,18 @@ numberFromBestBlock (BestBlock _ n _) = n
 
 -- todo: we should take blockNumber as argument here instead of just looking for
 -- bestBlock to prevent us from getting stuck
-syncFetch :: (MonadIO m, MonadState Context m)
+syncFetch :: ( MonadIO m
+             , Modifiable ActionTimestamp m
+             , Accessible [BlockData] m
+             , Accessible MaxReturnedHeaders m
+             )
           => Direction -> Integer -> ConduitM Event (Either P2PCNC Message) m ()
 syncFetch d num = do
     blockHeaders' <- lift getBlockHeaders -- get blockHeaders from Context
     when (null blockHeaders') $ do
-        mrh <- gets maxReturnedHeaders
+        mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
         yieldR $ GetBlockHeaders (BlockNumber num) mrh 0 d
-        stampActionTimestamp
+        lift stampActionTimestamp
 
 shouldSend :: PPeer -> Origin.TXOrigin -> Bool
 shouldSend peer txo = case txo of

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -1,9 +1,10 @@
-
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
 
 module Blockchain.Event (
   module Blockchain.EventModel,
@@ -13,34 +14,41 @@ module Blockchain.Event (
   checkPeerIsMember' -- For testing
   ) where
 
-import           Control.Arrow                         ((&&&), first)
+import           Control.Arrow                         ((&&&), second)
 import           Control.Lens                          (use)
 import           Control.Monad
+import           Control.Monad.Change.Alter
 import           Control.Monad.Change.Modify           hiding (get, put, yield, awaitForever)
+import qualified Control.Monad.Change.Modify           as Mod (get, put)
 import           Control.Monad.IO.Class
 import           Blockchain.Output
 import           Control.Monad.State
 import           Control.Monad.Trans.Resource
 import           Data.Conduit
+import           Data.Default                          (def)
 import           Data.Foldable                         (for_)
 import qualified Data.DList                            as DL
-import           Data.List
-import           Data.Map.Strict                       (Map)
+import           Data.List                             hiding (lookup)
+import           Data.Map.Internal                     (WhenMissing(..), WhenMatched(..))
+import           Data.Map.Merge.Strict
 import qualified Data.Map.Strict                       as M
 import           Data.Maybe
 import qualified Data.ByteString.Base16                as BC16
 import qualified Data.ByteString.Char8                 as BS8
 import qualified Data.Set                              as S
 import qualified Data.Text                             as T
+import           Data.These
 import           Data.Time.Clock
 import           MonadUtils
 import qualified Network.Kafka                         as K
+import           Prelude                               hiding (lookup)
 import           System.Random
 import           Text.Printf
 import           UnliftIO.Exception
 
 import           Blockchain.Blockstanbul               (blockstanbulSender)
 import           Blockchain.Context
+import           Blockchain.Data.Block
 import           Blockchain.Data.BlockDB
 import           Blockchain.Data.BlockHeader
 import           Blockchain.Data.ChainInfo
@@ -63,10 +71,7 @@ import           Blockchain.Verification
 import           Blockchain.Sequencer.Event
 import qualified Blockchain.Sequencer.Kafka            as SK
 
-import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.Class
-import qualified Blockchain.Strato.RedisBlockDB        as RBDB
-import           Blockchain.Strato.RedisBlockDB.Models hiding (Transactions)
 
 import           Blockapps.Crossmon                    (recordMaxBlockNumber)
 import           Blockchain.Metrics
@@ -116,11 +121,21 @@ yieldL = yield . Left
 
 handleEvents :: ( MonadIO m
                 , MonadResource m
-                , Accessible RBDB.RedisConnection m
                 , Accessible (SK.UnseqSink m) m
                 , MonadState Context m
                 , MonadLogger m
                 , Modifiable K.KafkaState m
+                , Modifiable BestBlock m
+                , Modifiable WorldBestBlock m
+                , (Integer `Selectable` Canonical BlockData) m
+                , (SHA `Alters` BlockData) m
+                , (IPAddress `Selectable` IPChains) m
+                , (OrgId `Selectable` OrgIdChains) m
+                , (SHA `Selectable` ChainTxsInBlock) m
+                , (Word256 `Selectable` ChainMembers) m
+                , (Word256 `Selectable` ChainInfo) m
+                , (SHA `Selectable` Private (Word256, OutputTx)) m
+                , (SHA `Alters` OutputBlock) m
                 ) => PPeer -> ConduitM Event (Either P2PCNC Message) m ()
 handleEvents peer = awaitForever $ \case
     MsgEvt Hello{}  -> error "A hello message appeared after the handshake"
@@ -139,28 +154,25 @@ handleEvents peer = awaitForever $ \case
         let header      = blockHeader block'
         let num         = blockHeaderBlockNumber header
         let parentHash' = blockHeaderParentHash header
-        eResult <- RBDB.withRedisBlockDB (RBDB.updateWorldBestBlockInfo sha num tdiff)
-        case eResult of
-          Left  _     -> $logInfoS "handleEvents/NewBlock" $ T.pack "Failed to update WorldBestBlockInfo"
-          Right False -> $logInfoS "handleEvents/NewBlock" $ T.pack "NewBlock is not better than existing WorldBestBlock"
-          Right True  -> do
-            (redisParentHeader :: Maybe BlockData) <- RBDB.withRedisBlockDB (RBDB.getHeader parentHash')
-            case redisParentHeader of
-                Nothing -> do
-                    bestBlock <- RBDB.withRedisBlockDB RBDB.getBestBlockInfo
-                    let bestBlockNum = numFromRedis bestBlock
-                    let fetchNumber = if bestBlockNum < 2 then 1 else bestBlockNum - 1
-                    $logInfoS "handleEvents/NewBlock" $ T.pack $ "newBlock :: fetchNumber is " ++ show fetchNumber
-                    $logInfoS "handleEvents/NewBlock" $ T.pack $ "#### New block is missing its parent, I am resyncing"
-                    syncFetch Forward fetchNumber
-                Just _  -> do
-                    lift . void $ setTitleAndProduceBlocks [block']
-                    void . lift $ SK.emitKafkaBlock (Origin.PeerString $ peerString peer) block'
+        lift . Mod.put (Proxy @WorldBestBlock) . WorldBestBlock $
+          BestBlock sha num tdiff
+        parentHeader <- lift $ lookup (Proxy @BlockData) parentHash'
+        case parentHeader of
+          Nothing -> do
+            bestBlock <- lift $ Mod.get (Proxy @BestBlock)
+            let bestBlockNum = numberFromBestBlock bestBlock
+                fetchNumber = if bestBlockNum < 2 then 1 else bestBlockNum - 1
+            $logInfoS "handleEvents/NewBlock" $ T.pack $ "newBlock :: fetchNumber is " ++ show fetchNumber
+            $logInfoS "handleEvents/NewBlock" $ T.pack $ "#### New block is missing its parent, I am resyncing"
+            syncFetch Forward fetchNumber
+          Just _ -> do
+            lift . void $ setTitleAndProduceBlocks [block']
+            void . lift $ SK.emitKafkaBlock (Origin.PeerString $ peerString peer) block'
 
     MsgEvt (NewBlockHashes _) -> do
         stampActionTimestamp
-        bestBlock <- RBDB.withRedisBlockDB RBDB.getBestBlockInfo
-        let bestBlockNum = numFromRedis bestBlock
+        bestBlock <- lift $ Mod.get (Proxy @BestBlock)
+        let bestBlockNum = numberFromBestBlock bestBlock
         let fetchNumber = if bestBlockNum < 2 then 1 else bestBlockNum - 1
         $logInfoS "handleEvents/NewBlockHashes" $ T.pack $ "newBlockHashes :: fetchNumber is " ++ show fetchNumber
         syncFetch Forward fetchNumber
@@ -175,7 +187,7 @@ handleEvents peer = awaitForever $ \case
       -- 3/4s of the blocks will be dropped when creating the blockheaders
       -- so we overcompensate here.
       let count = (1 + skip') * max mrh max'
-      chain <- RBDB.withRedisBlockDB $ RBDB.getCanonicalHeaderChain start' count
+      chain <- fmap M.toList . lift . selectMany (Proxy @(Canonical BlockData)) $ take count [start'..]
       when (null chain) $
         $logInfoS "handleEvents/GetBlockHeaders" $ T.concat $
             ["Warning: A peer requested blocks starting at #"
@@ -183,11 +195,11 @@ handleEvents peer = awaitForever $ \case
             , ", but we don't have these in our canonical chain...."
             , " I don't know what to do, so I am returning a blank response."
             , " This may indicate something unhealthy in the network."]
-      yieldR . BlockHeaders . skipEntries skip' $ morphBlockHeader . snd <$> chain
+      yieldR . BlockHeaders . skipEntries skip' $ morphBlockHeader . unCanonical . snd <$> chain
 
     MsgEvt (GetBlockHeaders (BlockHash start) max' skip' dir) -> do
       stampActionTimestamp
-      maybeHeader <- RBDB.withRedisBlockDB $ RBDB.getHeader start
+      maybeHeader <- lift $ lookup (Proxy @BlockData) start
       case maybeHeader of
         Nothing    -> yieldR (BlockBodies [])
         Just head' -> do
@@ -199,10 +211,11 @@ handleEvents peer = awaitForever $ \case
                              else 1
           mrh <- gets maxReturnedHeaders
           let count = (1 + skip') * min mrh (fromIntegral num)
-          chain <- RBDB.withRedisBlockDB $ RBDB.getCanonicalHeaderChain start' count
-          yieldR . BlockHeaders . skipEntries skip' $ morphBlockHeader . snd <$> chain
+          chain <- fmap M.toList . lift . selectMany (Proxy @(Canonical BlockData)) $ take count [start'..]
+          yieldR . BlockHeaders . skipEntries skip' $ morphBlockHeader . unCanonical . snd <$> chain
 
-    MsgEvt (BlockHeaders headers) -> do
+    MsgEvt (BlockHeaders bHeaders) -> do
+        let headers = morphBlockHeader <$> bHeaders
         stampActionTimestamp
         alreadyRequestedHeaders <- lift getBlockHeaders -- get already requested headers
         when (null alreadyRequestedHeaders) $ do        -- proceed if we are not already requesting headers
@@ -211,23 +224,23 @@ handleEvents peer = awaitForever $ \case
             --     allNeeded = headerHashes `S.union` parentHashes
 
             -- check if blockheaders we recieved have parents.
-            parentsInDB <- RBDB.withRedisBlockDB . RBDB.getHeaders $ parentHash <$> headers
-            let existingParents = [(sha, x) | (sha, Just x) <- parentsInDB]
-            let missingParents  = [sha | (sha, Nothing) <- parentsInDB, sha /= SHA 0]
-            unless (null missingParents) $ do
-                 bestBlock <- RBDB.withRedisBlockDB RBDB.getBestBlockInfo
-                 let fetchNumber = numFromRedis bestBlock + 1
+            let parents = map blockDataParentHash headers
+            existingParents <- lift $ lookupMany (Proxy @BlockData) parents
+            let missingParents  = S.fromList parents S.\\ M.keysSet existingParents
+            unless (S.null missingParents) $ do
+                 bestBlock <- lift $ Mod.get (Proxy @BestBlock)
+                 let fetchNumber = numberFromBestBlock bestBlock + 1
                  $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "blockHeaders :: fetchNumber is " ++ show fetchNumber
-                 let lastParent = case length existingParents of
-                                      0 -> fetchNumber
-                                      _ -> head . sort $ blockHeaderBlockNumber . snd <$> existingParents
-                 $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "missing blocks: " ++ (unlines $ format <$> missingParents)
+                 let lastParent = if M.null existingParents
+                                    then fetchNumber
+                                    else head . sort $ blockHeaderBlockNumber <$> M.elems existingParents
+                 $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "missing blocks: " ++ (unlines $ format <$> S.toList missingParents)
                  syncFetch Reverse lastParent
 
-            -- todo: try with (&&&)
-            headersInDB <- RBDB.withRedisBlockDB . RBDB.getHeaders $ headerHash <$> headers
-            let neededHeaders = filter (\x -> (headerHash x) `elem` [sha | (sha, Nothing) <- headersInDB]) headers
-            let (neededHeaders', remainingHeaders) = splitNeededHeaders neededHeaders
+            let headerHashes = M.fromList $ map (blockHeaderHash &&& id) headers
+            headersInDB <- lift . lookupMany (Proxy @BlockData) $ M.keys headerHashes
+            let neededHeaders = M.elems $ headerHashes M.\\ headersInDB
+                (neededHeaders', remainingHeaders) = splitNeededHeaders neededHeaders
             -- blockOffsets <- lift $ fmap (map blockOffsetHash) $ getBlockOffsetsForHashes $ S.toList allNeeded
             -- let neededHeaders = filter (not . (`elem` blockOffsets) . headerHash) headers
             --     neededHashes = map headerHash neededHeaders
@@ -241,7 +254,7 @@ handleEvents peer = awaitForever $ \case
             lift $ putBlockHeaders neededHeaders'
             lift $ putRemainingBHeaders remainingHeaders
             $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "putBlockHeaders called with length " ++ show (length neededHeaders')
-            yieldR . GetBlockBodies $ headerHash <$> neededHeaders'
+            yieldR . GetBlockBodies $ blockHeaderHash <$> neededHeaders'
             stampActionTimestamp
 
     -- todo: seems like geth and parity will send bodies on a best-effort, skipping shas they doesnt have
@@ -261,26 +274,34 @@ handleEvents peer = awaitForever $ \case
       stampActionTimestamp
       mrh <- gets maxReturnedHeaders
       let shas = take mrh shas'
-      getUntilMissing shas DL.empty DL.empty >>= \(bodies, pshas) -> do
-          yieldR . BlockBodies $ map toBody bodies
-          ptxs <- fmap (map snd . catMaybes) . RBDB.withRedisBlockDB $ mapM RBDB.getPrivateTransactions pshas
-          unless (null ptxs) . yieldR . Transactions $ morphTx <$> ptxs
-        where getUntilMissing :: (Accessible RBDB.RedisConnection m, MonadIO m)
+      lift (getUntilMissing shas DL.empty DL.empty) >>= \(bodies, pshas) -> do
+          yieldR . BlockBodies $ map (second (map morphBlockHeader) . toBody) bodies
+          ptxs <- fmap M.elems . lift $ selectMany (Proxy @(Private (Word256, OutputTx))) pshas
+          unless (null ptxs) . yieldR . Transactions $ morphTx  . snd . unPrivate <$> ptxs
+        where getUntilMissing :: ( (SHA `Selectable` ChainTxsInBlock) m
+                                 , (Word256 `Selectable` ChainMembers) m
+                                 , (SHA `Alters` OutputBlock) m
+                                 )
                               => [SHA] -> DL.DList OutputBlock -> DL.DList SHA -> m ([OutputBlock],[SHA])
               getUntilMissing []     bodies pshas = return (DL.toList bodies, DL.toList pshas)
-              getUntilMissing (h:hs) bodies pshas = RBDB.withRedisBlockDB (RBDB.getBlock h) >>= \case
+              getUntilMissing (h:hs) bodies pshas = lookup (Proxy @OutputBlock) h >>= \case
                   Nothing   -> return (DL.toList bodies, DL.toList pshas)
                   Just body -> do
-                    cIdTxsMap <- RBDB.withRedisBlockDB $ RBDB.getChainTxsInBlock h
-                    let kvs = M.assocs cIdTxsMap
-                    mems <- RBDB.withRedisBlockDB . mapM (RBDB.getChainMembers . fst) $ kvs
-                    let trMems = zip kvs mems
-                        pshas' = concat . map (snd . fst) $
-                                  filter ((checkPeerIsMember peer) . snd) trMems
-                    getUntilMissing hs (bodies `DL.snoc` body) (pshas `DL.append` DL.fromList pshas')
+                    ChainTxsInBlock cIdTxsMap <- selectWithDefault (Proxy @ChainTxsInBlock) h
+                    mems <- selectMany (Proxy @ChainMembers) $ M.keys cIdTxsMap
+                    let whenMissing f = WhenMissing (pure . M.map f) (\_ x -> (pure . Just $ f x))
+                        trMems = merge (whenMissing This)
+                                       (whenMissing That)
+                                       (WhenMatched $ \_ x y -> pure . Just $ These x y)
+                                       cIdTxsMap
+                                       mems
+                        filtered = flip M.filter trMems $
+                          mergeTheseWith (const False) (checkPeerIsMember peer) (||)
+                        pshas' = M.foldr (DL.append . DL.fromList . these id (const []) const) DL.empty filtered
+                    getUntilMissing hs (bodies `DL.snoc` body) (pshas `DL.append` pshas')
 
-              toBody :: OutputBlock -> ([Transaction], [BlockHeader])
-              toBody = ((map otBaseTx . obReceiptTransactions) &&& fmap morphBlockHeader . obBlockUncles)
+              toBody :: OutputBlock -> ([Transaction], [BlockData])
+              toBody = ((map otBaseTx . obReceiptTransactions) &&& obBlockUncles)
 
     -- todo: support the "best effort" behavior that everyone uses for bodies they dont have (mentioned above
     -- todo:
@@ -288,11 +309,11 @@ handleEvents peer = awaitForever $ \case
     MsgEvt (BlockBodies bodies) -> do
         stampActionTimestamp
         headers <- lift getBlockHeaders
-        let verified = and $ zipWith (\h b -> transactionsRoot h == transactionsVerificationValue (fst b)) headers bodies
+        let verified = and $ zipWith (\h b -> blockDataTransactionsRoot h == transactionsVerificationValue (fst b)) headers bodies
         unless verified $ error "headers don't match bodies"
         $logInfoS "handleEvents/BlockBodies" $ T.pack $ "len headers is " ++ show (length headers) ++ ", len bodies is " ++ show (length bodies)
-        recordMaxBlockNumber "p2p_block_bodies" . maximum $ map number headers
-        let blocks' = zipWith createBlockFromHeaderAndBody headers bodies
+        recordMaxBlockNumber "p2p_block_bodies" . maximum $ map blockDataNumber headers
+        let blocks' = zipWith createBlockFromHeaderAndBody (morphBlockHeader <$> headers) bodies
         newCount <- lift $ setTitleAndProduceBlocks blocks'
         lift . forM_ blocks' $ SK.emitKafkaBlock (Origin.PeerString $ peerString peer)
         rHeaders <- lift getRemainingBHeaders
@@ -302,10 +323,10 @@ handleEvents peer = awaitForever $ \case
         if null neededHeaders
             then when (newCount > 0) $ do
                 mrh <- gets maxReturnedHeaders
-                yieldR $ GetBlockHeaders (BlockHash $ headerHash $ last headers) mrh 0 Forward
+                yieldR $ GetBlockHeaders (BlockHash $ blockHeaderHash $ last headers) mrh 0 Forward
                 stampActionTimestamp
             else do
-                yieldR $ GetBlockBodies (map headerHash neededHeaders)
+                yieldR $ GetBlockBodies (map blockHeaderHash neededHeaders)
                 stampActionTimestamp
     MsgEvt (Blockstanbul wm) -> do
       stampActionTimestamp
@@ -315,7 +336,7 @@ handleEvents peer = awaitForever $ \case
       lift $ SK.emitBlockstanbulMsg wm
 
     -- private chains
-    MsgEvt (GetChainDetails cids') -> handleGetChainDetails peer cids'
+    MsgEvt (GetChainDetails cids') -> handleGetChainDetails peer $ S.fromList cids'
 
     MsgEvt (ChainDetails chpairs) -> do
       stampActionTimestamp
@@ -326,10 +347,11 @@ handleEvents peer = awaitForever $ \case
       stampActionTimestamp
       $logInfoS "handleEvents/GetTransactions" $ T.pack $ "requesting info for txHashes: "
         ++ (intercalate "\n" (format <$> trHashes))
-      ptrs <- fmap catMaybes . lift . RBDB.withRedisBlockDB $ mapM RBDB.getPrivateTransactions trHashes
-      mems <- lift . RBDB.withRedisBlockDB $ mapM (RBDB.getChainMembers . fst) ptrs
-      let trMems = zip ptrs mems
-      yieldR . Transactions . map (morphTx . snd . fst) $ filter ((checkPeerIsMember peer) . snd) trMems
+      ptrs <- fmap (map unPrivate . M.elems) . lift $ selectMany (Proxy @(Private (Word256, OutputTx))) trHashes
+      mems <- lift . selectMany (Proxy @ChainMembers) $ map fst ptrs
+      let isMember cId = maybe False (checkPeerIsMember peer)
+                       $ M.lookup cId mems
+      yieldR . Transactions . map (morphTx . snd) $ filter (isMember . fst) ptrs
 
     MsgEvt (Disconnect _) -> do
             $logInfoS "handleEvents/Disconnect" $ T.pack $ "Disconnect event received in Event handler"
@@ -338,20 +360,18 @@ handleEvents peer = awaitForever $ \case
     NewSeqEvent oe -> case oe of
       P2pBlock b  -> do
         when (shouldSend peer $ obOrigin b) $ do
-          worldBestBlock <- RBDB.withRedisBlockDB RBDB.getWorldBestBlockInfo
-          case worldBestBlock of
-            Nothing -> return ()
-            Just (RedisBestBlock _ _ worldTDiff) -> do
-              $logInfoS "handleEvents/P2pBlock" . T.pack $ "World TDiff: " ++ show worldTDiff
-              when (obTotalDifficulty b >= worldTDiff) $ do
-                $logInfoS "handleEvents/P2pBlock" . T.pack $ "yielding new block: " ++ show (blockDataNumber . blockBlockData . outputBlockToBlock $ b)
-                yieldR $ NewBlock (outputBlockToBlock b) (obTotalDifficulty b)
+          WorldBestBlock (BestBlock _ _ worldTDiff) <- lift $ Mod.get (Proxy @WorldBestBlock)
+          $logInfoS "handleEvents/P2pBlock" . T.pack $ "World TDiff: " ++ show worldTDiff
+          when (obTotalDifficulty b >= worldTDiff) $ do
+            $logInfoS "handleEvents/P2pBlock" . T.pack $ "yielding new block: " ++ show (blockDataNumber . blockBlockData . outputBlockToBlock $ b)
+            yieldR $ NewBlock (outputBlockToBlock b) (obTotalDifficulty b)
       P2pTx tx -> do
         whenM (shouldSendGossip peer $ otOrigin tx) $ do
           let cId = txChainId tx
           match <- case cId of
             Nothing -> return True
-            Just cid' -> checkPeerIsMember peer <$> RBDB.withRedisBlockDB (RBDB.getChainMembers cid')
+            Just cid' -> fmap (maybe False (checkPeerIsMember peer)) . lift $
+              select (Proxy @ChainMembers) cid'
 
           if not match
             then $logInfoS "handleEvents/P2pTx" $ T.pack $
@@ -363,7 +383,7 @@ handleEvents peer = awaitForever $ \case
       P2pGenesis (OutputGenesis og (cId, cInfo@(ChainInfo uci _))) -> do
         when (shouldSend peer og) $ do
           $logInfoS "handleEvents/P2pGenesis" . T.pack $ "received new chain: " ++ formatChainId (Just cId) ++ " with " ++ show uci
-          if checkPeerIsMember peer $ members uci
+          if checkPeerIsMember peer . ChainMembers $ members uci
             then do
               $logInfoS "handleEvents/P2pGenesis" $ T.pack $ "sending ChainDetails for chainID " ++ (formatChainId $ Just cId)
               yieldR $ ChainDetails [(cId, cInfo)]
@@ -376,11 +396,11 @@ handleEvents peer = awaitForever $ \case
       P2pNewChainMember cId _ _ -> do
         let formatted = format $ SHA cId
         $logInfoS "handleEvents/P2pNewChainMember" $ T.pack $ "New member added to chain " ++ formatted
-        mems <- lift . RBDB.withRedisBlockDB $ RBDB.getChainMembers cId
+        mems <- lift $ selectWithDefault (Proxy @ChainMembers) cId
         when (checkPeerIsMember peer mems) $ do
           $logInfoS "handleEvents/P2pNewChainMember" $ T.pack $ "Emitting chain details for chain " ++ formatted
-          mcInfo <- lift . RBDB.withRedisBlockDB $ RBDB.getChainInfo cId
-          for_ ((cId,) <$> mcInfo) $ yieldR . ChainDetails . (:[])
+          mcInfo <- fmap (fmap ((,) cId)) . lift $ select (Proxy @ChainInfo) cId
+          for_ mcInfo $ yieldR . ChainDetails . (:[])
       P2pBlockstanbul msg -> do
         let outbound = Blockstanbul msg
         $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
@@ -395,11 +415,11 @@ handleEvents peer = awaitForever $ \case
         when ss $ do
           mrh <- gets maxReturnedHeaders
           let count = min mrh . fromIntegral $ end - start + 1
-          chain <- RBDB.withRedisBlockDB $ RBDB.getCanonicalHeaderChain start count
+          chain <- fmap M.toList . lift . selectMany (Proxy @(Canonical BlockData)) $ take count [start..]
           when (null chain) $
             $logErrorS "handleEvents/P2pPushBlocks" . T.pack $ printf
               "Blockstanbul believes we have blocks for [%d..%d], they are not found in redis" start end
-          let outbound = BlockHeaders $ morphBlockHeader . snd <$> chain
+          let outbound = BlockHeaders $ morphBlockHeader . unCanonical . snd <$> chain
           $logDebugS "handleEvents/P2pPushBlocks" . T.pack $ "Outgoing message: " ++ show outbound
           yieldR outbound
 
@@ -427,40 +447,39 @@ handleEvents peer = awaitForever $ \case
 
 handleGetChainDetails :: ( MonadIO m
                          , MonadResource m
-                         , Accessible RBDB.RedisConnection m
                          , MonadState Context m
                          , MonadLogger m
+                         , (IPAddress `Selectable` IPChains) m
+                         , (OrgId `Selectable` OrgIdChains) m
+                         , (Word256 `Selectable` ChainMembers) m
+                         , (Word256 `Selectable` ChainInfo) m
                          )
                       => PPeer
-                      -> [Word256]
+                      -> S.Set Word256
                       -> ConduitM Event (Either P2PCNC Message) m ()
 handleGetChainDetails peer cids' = do
-  cids <- S.toList <$> case cids' of
-            [] -> RBDB.withRedisBlockDB $ do
-                    ipChains <- RBDB.getIPChains (peerIPAddress peer)
-                    orgIdChains <- fmap (fromMaybe S.empty)
-                                 . traverse (RBDB.getOrgIdChains . pointToBytes)
-                                 $ pPeerPubkey peer
-                    return $ S.union ipChains orgIdChains
-            xs -> return $ S.fromList xs
+  cids <- S.toList <$> if S.null cids'
+            then lift $ do
+              ipChains <- selectWithDefault (Proxy @IPChains) (peerIPAddress peer)
+              orgIdChains <- fmap (fromMaybe def)
+                           . traverse (selectWithDefault (Proxy @OrgIdChains) . OrgId . pointToBytes)
+                           $ pPeerPubkey peer
+              return $ S.union (unIPChains ipChains) (unOrgIdChains orgIdChains)
+            else return cids'
   stampActionTimestamp
   $logInfoS "handleGetChainDetails" $ T.pack $ "details requested for chainIDs " ++ (intercalate "\n" $ formatChainId . Just <$> cids)
-  mems <- lift . RBDB.withRedisBlockDB $ mapM RBDB.getChainMembers cids
-  let pairs = zip cids mems
-      filteredPairs = map fst $ filter ((checkPeerIsMember peer) . snd) pairs
+  mems <- lift $ selectMany (Proxy @ChainMembers) cids
+  let filteredPairs = M.keys $ M.filter (checkPeerIsMember peer) mems
 
   unless (null filteredPairs) $ do
-    cInfos <- lift . RBDB.withRedisBlockDB $ mapM RBDB.getChainInfo cids
-    let finalPairs = map (fmap fromJust) . filter (isJust . snd) $ zip cids cInfos
-    yieldR $ ChainDetails finalPairs
+    cInfos <- fmap M.toList . lift $ selectMany (Proxy @ChainInfo) cids
+    yieldR $ ChainDetails cInfos
     stampActionTimestamp
-    $logInfoS "handleGetChainDetails" $ T.pack $ "the following (ChainId, ChainInfo) pairs were returned " ++
-      (intercalate "\n" $ (show . first (formatChainId . Just)) <$> finalPairs)
+    $logInfoS "handleGetChainDetails" $ T.pack $ "the following ChainIds were returned " ++
+      (intercalate "\n" $ formatChainId . Just . fst <$> cInfos)
 
-numFromRedis :: Maybe RedisBestBlock -> Integer
-numFromRedis = \case
-    Nothing                     -> 0
-    Just (RedisBestBlock _ n _) -> n
+numberFromBestBlock :: BestBlock -> Integer
+numberFromBestBlock (BestBlock _ n _) = n
 
 -- todo: we should take blockNumber as argument here instead of just looking for
 -- bestBlock to prevent us from getting stuck
@@ -496,17 +515,17 @@ shouldSendGossip peer txo = recordGossipFinal
     _ -> return True
 
 
-checkPeerIsMember :: PPeer -> Map Address Enode -> Bool
+checkPeerIsMember :: PPeer -> ChainMembers -> Bool
 checkPeerIsMember = checkPeerIsMember' flags_privateChainAuthorizationMode
 
-checkPeerIsMember' :: AuthorizationMode -> PPeer -> Map Address Enode -> Bool
+checkPeerIsMember' :: AuthorizationMode -> PPeer -> ChainMembers -> Bool
 checkPeerIsMember' mode peer mems =
-  let elems = M.elems mems
+  let elems = M.elems $ unChainMembers mems
       ips = map ipAddress elems
       keys = map (Just . pubKey) elems
       ipkeys = map (ipAddress &&& (Just . pubKey)) elems
       thisIP = peerIPAddress peer
-      thisKey = pointToBytes <$> pPeerPubkey peer
+      thisKey = OrgId . pointToBytes <$> pPeerPubkey peer
   in case mode of
         IPOnly -> thisIP `elem` ips
         PubkeyOnly -> thisKey `elem` keys
@@ -529,9 +548,9 @@ splitNeededHeaders x =
       indexToSplit _ li [] [] = li
   in splitAt -}
 
-splitNeededHeaders :: [BlockHeader] -> ([BlockHeader], [BlockHeader])
+splitNeededHeaders :: [BlockData] -> ([BlockData], [BlockData])
 splitNeededHeaders neededHeaders =
-  let txsLens = extraData2TxsLen <$> extraData <$> neededHeaders
+  let txsLens = extraData2TxsLen <$> blockDataExtraData <$> neededHeaders
       txsLensInSums =  scanl (+) (0) $ fromMaybe flags_averageTxsPerBlock <$> txsLens
       txsLensInLimit = takeWhile (< flags_maxHeadersTxsLens) $ tail txsLensInSums
   in splitAt (length txsLensInLimit) neededHeaders

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -56,8 +56,8 @@ runPeer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
 runPeer peer myPriv _ _ = runResourceT $ do
   ender <- toIO . $logInfoS "runPeer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
   void $ register ender
-  ctx <- initContext flags_maxReturnedHeaders
-  runContextM ctx $ do
+  (cfg, initState) <- initContext flags_maxReturnedHeaders
+  runContextM cfg $ do
     let otherPubKey = fromMaybe (error "programmer error: runPeer was called without a pubkey") $ pPeerPubkey peer
         myPublic    = calculatePublic theCurve myPriv
 
@@ -68,8 +68,7 @@ runPeer peer myPriv _ _ = runResourceT $ do
     $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "server pubkey is: " ++ format otherPubKey
     let peerPort    = pPeerTcpPort peer
         peerAddress = BC.pack . T.unpack $ pPeerIp peer
-    initState <- get
-    lift $ runTCPClientWithConnectTimeout (clientSettings peerPort peerAddress) 5 $ \app -> do
+    runTCPClientWithConnectTimeout (clientSettings peerPort peerAddress) 5 $ \app -> do
         void . liftIO $ setPeerActiveState (pPeerIp peer) peerPort Active
 
         (_, (outCtx, inCtx)) <- liftIO $ appSource app $$+ ethCryptConnect myPriv otherPubKey `fuseUpstream` appSink app

--- a/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -5,7 +5,6 @@ module Executable.StratoP2PLoopback (stratoP2PLoopback) where
 
 import Conduit
 import Control.Monad
-import Control.Monad.Trans.State
 import qualified Data.Text as T
 import Prometheus
 
@@ -29,14 +28,14 @@ recordEvent lab = liftIO $ withLabel loopbackEvents lab incCounter
 stratoP2PLoopback :: LoggingT IO ()
 stratoP2PLoopback = do
   $logInfoS "stratoP2PLoopback" "Reflecting PBFT back to unseq since 2019"
-  ctx <- initContext flags_maxReturnedHeaders
-  void . runContextM ctx $ do
-    ks <- gets contextKafkaState
-    let toWireMessage = \case
+  (cfg, initState) <- initContext flags_maxReturnedHeaders
+  void . runContextM cfg $ do
+    let ks = contextKafkaState initState
+        toWireMessage = \case
           P2pBlockstanbul wm -> Just wm
           _ -> Nothing
 
-    runConduit $
+    runConduit . evalStateLC initState $
          seqEventNotificationSource ks
       .| iterMC (const $ recordEvent "in")
       .| concatMapC toWireMessage

--- a/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -14,14 +14,11 @@ import           Blockchain.Context
 import           Blockchain.RLPx
 import           Conduit
 import           Control.Monad
-import           Control.Monad.Trans.Identity
 import           Control.Monad.Trans.Resource
-import           Control.Monad.Trans.State
 import           Crypto.PubKey.ECC.DH
 import           Data.Conduit.Network
 import           Data.Streaming.Network                (appCloseConnection)
 import qualified Data.Text                             as T
-import qualified Database.Persist.Types                as SQL
 import           Network.Wai.Handler.Warp.Internal     (setSocketCloseOnExec)
 import           UnliftIO
 
@@ -38,21 +35,19 @@ runEthServer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
              -> Int
              -> m ()
 runEthServer myPriv listenPort = do
-  ctx <- initContext flags_maxReturnedHeaders
+  (cfg, initState) <- initContext flags_maxReturnedHeaders
   let myPubkey = calculatePublic theCurve myPriv
-  void . runContextM ctx $ do
-    initState <- get
+  void . runContextM cfg $ do
     let settings = setAfterBind setSocketCloseOnExec $ serverSettings listenPort "*"
-    lift . runGeneralTCPServer settings $ \app -> runResourceT $ do
+    runGeneralTCPServer settings $ \app -> do
       let theSockAddr = sockAddrToIP (appSockAddr app)
       ender <- toIO . $logInfoS "runEthServer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow theSockAddr
       void $ register ender
-      runIdentityT (getPeerByIP theSockAddr) >>= \case
+      unPPeerByIp (getPeerByIP theSockAddr) >>= \case
         Nothing -> do
           $logErrorS "runEthServer" . T.pack $ "Didn't see peer in discovery at IP " ++ show theSockAddr ++ ". rejecting violently."
           liftIO (appCloseConnection app)
-        Just peer -> do
-          let p  = SQL.entityVal peer
+        Just p -> do
           case pPeerPubkey p of
             Nothing -> do
               $logErrorS "runEthServer" . T.pack $ "Didn't get pubkey during discovery for peer " ++ show theSockAddr  ++ ". rejecting violently."

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -154,11 +154,11 @@ spec = do
 
         shouldAccept :: AuthorizationMode -> (String, String) -> IO ()
         shouldAccept mode (key, ip) =
-          DataPeer.buildPeer (Just key, ip, 30303) `shouldSatisfy` (\p -> checkPeerIsMember' mode p chainMembers)
+          DataPeer.buildPeer (Just key, ip, 30303) `shouldSatisfy` (\p -> checkPeerIsMember' mode p $ ChainMembers chainMembers)
 
         shouldReject :: AuthorizationMode -> (String, String) -> IO ()
         shouldReject mode (key, ip) =
-          DataPeer.buildPeer (Just key, ip, 30303) `shouldNotSatisfy` (\p -> checkPeerIsMember' mode p chainMembers)
+          DataPeer.buildPeer (Just key, ip, 30303) `shouldNotSatisfy` (\p -> checkPeerIsMember' mode p $ ChainMembers chainMembers)
 
     describe "IPOnly" $ do
       it "should reject the wrong ip" $ IPOnly `shouldReject` (key1, ip4)

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -5,10 +5,10 @@ module EventSpec where
 
 import ClassyPrelude (atomically)
 import Conduit
+import Control.Monad.State
 import Control.Monad.Trans.Reader
 import Data.Conduit.TMChan
 import Database.Persist.Sql
-import Database.Persist.Postgresql
 import qualified Data.Map                              as M
 import qualified Database.Redis                        as Redis
 import Text.Printf
@@ -38,8 +38,8 @@ import Test.QuickCheck
 -- Kafka, postgres, or ethconf. It does need redis, but targets
 -- a test instance.
 testContext :: (MonadIO m, MonadUnliftIO m)
-            => ConnectionPool -> m (TMChan [IngestEvent], Config, Context)
-testContext pool = do
+            => m (TMChan [IngestEvent], Context)
+testContext = do
   redisBDBPool <- liftIO . Redis.checkedConnect $ Redis.defaultConnectInfo {
         Redis.connectHost           = "localhost",
         Redis.connectPort           = Redis.PortNumber 2023,
@@ -47,7 +47,6 @@ testContext pool = do
     }
   ch <- atomically newTMChan
   return ( ch
-         , Config pool
          , Context { actionTimestamp = Nothing
                    , contextRedisBlockDB = RBDB.RedisConnection redisBDBPool
                    , contextKafkaState = error "no kafka state available"
@@ -76,18 +75,13 @@ migrateAll = do
 
 runTestPeer :: (TMChan [IngestEvent] -> ContextM a) -> IO ()
 runTestPeer mv = do
-  runNoLoggingT $ withPostgresqlPool "host=localhost port=2345 user=postgres" 4 $ \pool -> do
-    (ch, cfg, ctx) <- testContext pool
-    liftSqlPersistMPool migrateAll pool
-    runContextM (cfg, ctx) (mv ch)
+  runNoLoggingT $ do
+    (ch, ctx) <- testContext
+    runContextM (error "runTestPeer: no SQL database setup") . flip runStateT ctx $ mv ch
 
 spec :: Spec
 spec = do
   describe "environment sanity checks" $ do
-    it "has a PPeer table" $ do
-      runTestPeer . const $ do
-        pool <- lift $ asks configSQLDB
-        liftSqlPersistMPool (count ([] :: [Filter DataPeer.PPeer])) pool `L.shouldReturn` 0
     it "can pretend to write to kafka" $ do
       quickCheck . once $ \ori txs -> runTestPeer . const $ emitKafkaTransactions ori txs
       quickCheck . once $ \ori blk -> runTestPeer . const $ emitKafkaBlock ori blk

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -1,105 +1,215 @@
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE Rank2Types            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeOperators         #-}
 module EventSpec where
 
-import ClassyPrelude (atomically)
-import Conduit
-import Control.Monad.State
-import Control.Monad.Trans.Reader
-import Data.Conduit.TMChan
-import Database.Persist.Sql
-import qualified Data.Map                              as M
-import qualified Database.Redis                        as Redis
-import Text.Printf
+import           Conduit
+import           Control.Lens                          hiding (Context)
+import qualified Control.Monad.Change.Alter            as A
+import qualified Control.Monad.Change.Modify           as Mod
+import           Control.Monad.State
+import           Data.Map.Strict                       (Map)
+import qualified Data.Map.Strict                       as M
+import           Text.Printf
 
-import Blockchain.Blockstanbul               (blockstanbulSender)
-import Blockchain.Context
-import Blockchain.Data.ArbitraryInstances()
-import qualified Blockchain.Data.Blockchain as DataBlock
-import qualified Blockchain.Data.DataDefs as DataDefs
-import Blockchain.Data.Control
-import Blockchain.Data.Enode
-import Blockchain.Data.Wire
-import Blockchain.Event
-import Blockchain.Options (AuthorizationMode(..))
-import Blockchain.Output
-import Blockchain.Sequencer.Event
-import Blockchain.Sequencer.Kafka
+import           Blockchain.Blockstanbul               (blockstanbulSender)
+import           Blockchain.Context                    hiding (actionTimestamp, blockHeaders, remainingBlockHeaders, maxReturnedHeaders, connectionTimeout, unseqSink, vmEventsSink)
+import           Blockchain.Data.ArbitraryInstances()
+import           Blockchain.Data.Block                 hiding (bestBlockNumber)
+import           Blockchain.Data.ChainInfo
+import           Blockchain.Data.Control
+import qualified Blockchain.Data.DataDefs              as DataDefs
+import           Blockchain.Data.Enode
+import           Blockchain.Data.Wire
+import           Blockchain.Event
+import           Blockchain.ExtWord
+import           Blockchain.Options                    (AuthorizationMode(..))
+import           Blockchain.Output
+import           Blockchain.Sequencer.Event
+import           Blockchain.Sequencer.Kafka
+import           Blockchain.Stream.VMEvent
 import qualified Blockchain.Strato.Discovery.Data.Peer as DataPeer
-import qualified Blockchain.Strato.RedisBlockDB as RBDB
-import Blockchain.Strato.RedisBlockDB.Models
+import           Blockchain.Strato.Model.SHA           (SHA(..))
 
-import Test.Hspec
-import qualified Test.Hspec.Expectations.Lifted as L
-import Test.QuickCheck
+import           Test.Hspec
+import qualified Test.Hspec.Expectations.Lifted        as L
+import           Test.QuickCheck
+
+data TestContext = TestContext
+  { _unseqSink             :: [[IngestEvent]]
+  , _vmEventsSink          :: [[VMEvent]]
+  , _blockHeaders          :: [DataDefs.BlockData]
+  , _remainingBlockHeaders :: RemainingBlockHeaders
+  , _actionTimestamp       :: ActionTimestamp
+  , _connectionTimeout     :: ConnectionTimeout
+  , _maxReturnedHeaders    :: MaxReturnedHeaders
+  , _peerAddr              :: PeerAddress
+  , _shaBlockDataMap       :: Map SHA DataDefs.BlockData
+  , _worldBestBlock        :: WorldBestBlock
+  , _bestBlock             :: BestBlock
+  , _canonicalBlockDataMap :: Map Integer (Canonical DataDefs.BlockData)
+  , _ipAddressIpChainsMap  :: Map IPAddress IPChains
+  , _orgIdChainsMap        :: Map OrgId OrgIdChains
+  , _shaChainTxsInBlockMap :: Map SHA ChainTxsInBlock
+  , _chainMembersMap       :: Map Word256 ChainMembers
+  , _chainInfoMap          :: Map Word256 ChainInfo
+  , _privateTxMap          :: Map SHA (Private (Word256, OutputTx))
+  , _shaOutputBlockMap     :: Map SHA OutputBlock
+  , _genesisBlockHash      :: GenesisBlockHash
+  , _bestBlockNumber       :: BestBlockNumber
+  , _stringPPeerMap        :: Map String DataPeer.PPeer
+  }
+
+makeLenses ''TestContext
+
+type TestContextM = StateT TestContext (ResourceT (LoggingT IO))
+
+instance Monad m => (SHA `A.Alters` DataDefs.BlockData) (StateT TestContext m) where
+  lookup _ k   = M.lookup k <$> use shaBlockDataMap
+  insert _ k v = shaBlockDataMap %= M.insert k v
+  delete _ k   = shaBlockDataMap %= M.delete k
+
+instance Monad m => Mod.Modifiable WorldBestBlock (StateT TestContext m) where
+  get _ = use worldBestBlock
+  put _ = assign worldBestBlock
+
+instance Monad m => Mod.Modifiable BestBlock (StateT TestContext m) where
+  get _ = use bestBlock
+  put _ = assign bestBlock
+
+instance Monad m => A.Selectable Integer (Canonical DataDefs.BlockData) (StateT TestContext m) where
+  select _ i = M.lookup i <$> use canonicalBlockDataMap
+
+instance Monad m => A.Selectable IPAddress IPChains (StateT TestContext m) where
+  select _ ip = M.lookup ip <$> use ipAddressIpChainsMap
+
+instance Monad m => A.Selectable OrgId OrgIdChains (StateT TestContext m) where
+  select _ ip = M.lookup ip <$> use orgIdChainsMap
+
+instance Monad m => A.Selectable SHA ChainTxsInBlock (StateT TestContext m) where
+  select _ sha = M.lookup sha <$> use shaChainTxsInBlockMap
+
+instance Monad m => A.Selectable Word256 ChainMembers (StateT TestContext m) where
+  select _ cid = M.lookup cid <$> use chainMembersMap
+
+instance Monad m => A.Selectable Word256 ChainInfo (StateT TestContext m) where
+  select _ cid = M.lookup cid <$> use chainInfoMap
+
+instance Monad m => A.Selectable SHA (Private (Word256, OutputTx)) (StateT TestContext m) where
+  select _ tx = M.lookup tx <$> use privateTxMap
+
+instance Monad m => (SHA `A.Alters` OutputBlock) (StateT TestContext m) where
+  lookup _ k   = M.lookup k <$> use shaOutputBlockMap
+  insert _ k v = shaOutputBlockMap %= M.insert k v
+  delete _ k   = shaOutputBlockMap %= M.delete k
+
+instance Monad m => Mod.Accessible GenesisBlockHash (StateT TestContext m) where
+  access _ = use genesisBlockHash
+
+instance Monad m => Mod.Accessible BestBlockNumber (StateT TestContext m) where
+  access _ = use bestBlockNumber
+
+instance Monad m => Mod.Modifiable ActionTimestamp (StateT TestContext m) where
+  get _ = use actionTimestamp
+  put _ = assign actionTimestamp
+
+instance Monad m => Mod.Accessible ActionTimestamp (StateT TestContext m) where
+  access _ = Mod.get (Mod.Proxy @ActionTimestamp)
+
+instance Monad m => Mod.Modifiable [DataDefs.BlockData] (StateT TestContext m) where
+  get _ = use blockHeaders
+  put _ = assign blockHeaders
+
+instance Monad m => Mod.Accessible [DataDefs.BlockData] (StateT TestContext m) where
+  access _ = Mod.get (Mod.Proxy @[DataDefs.BlockData])
+
+instance Monad m => Mod.Modifiable RemainingBlockHeaders (StateT TestContext m) where
+  get _ = use remainingBlockHeaders
+  put _ = assign remainingBlockHeaders
+
+instance Monad m => Mod.Accessible RemainingBlockHeaders (StateT TestContext m) where
+  access _ = Mod.get (Mod.Proxy @RemainingBlockHeaders)
+
+instance Monad m => Mod.Accessible MaxReturnedHeaders (StateT TestContext m) where
+  access _ = use maxReturnedHeaders
+
+instance Monad m => Mod.Modifiable PeerAddress (StateT TestContext m) where
+  get _ = use peerAddr
+  put _ = assign peerAddr
+
+instance Monad m => Mod.Accessible PeerAddress (StateT TestContext m) where
+  access _ = Mod.get (Mod.Proxy @PeerAddress)
+
+instance Monad m => Mod.Accessible ConnectionTimeout (StateT TestContext m) where
+  access _ = use connectionTimeout
+
+instance Monad m => Mod.Accessible (UnseqSink (StateT TestContext m)) (StateT TestContext m) where
+  access _ = return $ \e -> unseqSink %= (e:)
+
+instance Monad m => HasVMEventsSink (StateT TestContext m) where
+  getVMEventsSink = return $ \v -> vmEventsSink %= (v:)
+
+instance Monad m => A.Selectable String DataPeer.PPeer (StateT TestContext m) where
+  select _ tx = M.lookup tx <$> use stringPPeerMap
 
 -- testContext is useful for testing because it doesn't require
--- Kafka, postgres, or ethconf. It does need redis, but targets
--- a test instance.
-testContext :: (MonadIO m, MonadUnliftIO m)
-            => m (TMChan [IngestEvent], Context)
-testContext = do
-  redisBDBPool <- liftIO . Redis.checkedConnect $ Redis.defaultConnectInfo {
-        Redis.connectHost           = "localhost",
-        Redis.connectPort           = Redis.PortNumber 2023,
-        Redis.connectDatabase       = 0
-    }
-  ch <- atomically newTMChan
-  return ( ch
-         , Context { actionTimestamp = emptyActionTimestamp
-                   , contextRedisBlockDB = RBDB.RedisConnection redisBDBPool
-                   , contextKafkaState = error "no kafka state available"
-                   , blockHeaders=[]
-                   , remainingBlockHeaders = RemainingBlockHeaders []
-                   , unseqSink=atomically . writeTMChan ch
-                   , vmEventsSink=const (return ())
-                   , vmTrace=[]
-                   , connectionTimeout = ConnectionTimeout 60
-                   , maxReturnedHeaders = MaxReturnedHeaders 1000
-                   , _blockstanbulPeerAddr = PeerAddress Nothing
-                   })
+-- Kafka, postgres, redis, or ethconf.
+testContext :: TestContext
+testContext = TestContext
+  { _unseqSink             = []
+  , _vmEventsSink          = []
+  , _blockHeaders          = []
+  , _remainingBlockHeaders = RemainingBlockHeaders []
+  , _actionTimestamp       = emptyActionTimestamp
+  , _connectionTimeout     = ConnectionTimeout 60
+  , _maxReturnedHeaders    = MaxReturnedHeaders 1000
+  , _peerAddr              = PeerAddress Nothing
+  , _shaBlockDataMap       = M.empty
+  , _worldBestBlock        = WorldBestBlock (BestBlock (SHA 0) (-1) 0)
+  , _bestBlock             = BestBlock (SHA 0) (-1) 0
+  , _canonicalBlockDataMap = M.empty
+  , _ipAddressIpChainsMap  = M.empty
+  , _orgIdChainsMap        = M.empty
+  , _shaChainTxsInBlockMap = M.empty
+  , _chainMembersMap       = M.empty
+  , _chainInfoMap          = M.empty
+  , _privateTxMap          = M.empty
+  , _shaOutputBlockMap     = M.empty
+  , _genesisBlockHash      = GenesisBlockHash (SHA 0)
+  , _bestBlockNumber       = BestBlockNumber 0
+  , _stringPPeerMap        = M.empty
+  }
 
 testPeer :: DataPeer.PPeer
 testPeer = DataPeer.buildPeer (Nothing, "0.0.0.0", 1212)
 
-migrateAll :: ReaderT SqlBackend (NoLoggingT (ResourceT IO)) ()
-migrateAll = do
-  -- TODO(tim): bracket and TRUNCATE the tables in a DBMS agnostic way
-  _ <- runMigrationSilent DataBlock.migrateAll
-  -- SQLite doesn't have support for dropping columns, and since this is
-  -- a brand new file there's no need for the manual migration steps
-  _ <- runMigrationSilent DataDefs.migrateAuto
-  _ <- runMigrationSilent DataPeer.migrateAll
-  return ()
-
-runTestPeer :: (TMChan [IngestEvent] -> ContextM a) -> IO ()
-runTestPeer mv = do
-  runNoLoggingT $ do
-    (ch, ctx) <- testContext
-    runContextM (error "runTestPeer: no SQL database setup") . flip runStateT ctx $ mv ch
+runTestPeer :: TestContextM a -> IO ()
+runTestPeer = void . runNoLoggingT . runResourceT . flip runStateT testContext
 
 spec :: Spec
 spec = do
   describe "environment sanity checks" $ do
     it "can pretend to write to kafka" $ do
-      quickCheck . once $ \ori txs -> runTestPeer . const $ emitKafkaTransactions ori txs
-      quickCheck . once $ \ori blk -> runTestPeer . const $ emitKafkaBlock ori blk
-    it "has a redis instance" $ do
-      runTestPeer . const $ do
-        RBDB.withRedisBlockDB RBDB.getBestBlockInfo `L.shouldReturn` (Nothing :: Maybe RedisBestBlock)
+      quickCheck . once $ \ori txs -> runTestPeer $ emitKafkaTransactions ori txs
+      quickCheck . once $ \ori blk -> runTestPeer $ emitKafkaBlock ori blk
 
   describe "handleEvents" $ do
     it "should pong a ping" $
-      runTestPeer . const $ do
+      runTestPeer $ do
         runConduit $ yield (MsgEvt Ping) .| handleEvents testPeer .| sinkList `L.shouldReturn` [Right Pong]
     it "should return empty BlockBodies to empty BlockHeaders" $
-      runTestPeer . const $ do
+      runTestPeer $ do
         runConduit $ yield (MsgEvt (BlockHeaders [])) .| handleEvents testPeer .| sinkList
           `L.shouldReturn` [Right $ GetBlockBodies []]
     it "should forward blockstanbul messages" $ property $ withMaxSuccess 10 $ \wm ->
       let addr = blockstanbulSender wm
-      in addr /= 0 && addr /= 0xa ==> runTestPeer $ \ch -> do
+      in addr /= 0 && addr /= 0xa ==> runTestPeer $ do
         -- Without "proof" of which peer this is, assume it could be addr
         shouldSendToPeer addr `L.shouldReturn` True
         shouldSendToPeer 0xa `L.shouldReturn` True
@@ -107,14 +217,14 @@ spec = do
                            .| handleEvents testPeer
                            .| sinkList
            `L.shouldReturn` []
-        atomically (closeTMChan ch >> readTMChan ch) `L.shouldReturn` Just ([IEBlockstanbul wm])
-        atomically (readTMChan ch) `L.shouldReturn` Nothing
+        unseqEvents <- use unseqSink
+        unseqEvents `L.shouldBe` [[IEBlockstanbul wm]]
         -- Now that the peer is known to be addr, we should only send if they are designated
         shouldSendToPeer addr `L.shouldReturn` True
         shouldSendToPeer 0xa `L.shouldReturn` False
 
     it "should broadcast blockstanbul messages" $ property $ withMaxSuccess 10 $ \wm ->
-      runTestPeer . const $ do
+      runTestPeer $ do
         runConduit $ yield (NewSeqEvent (P2pBlockstanbul wm))
                       .| handleEvents testPeer
                       .| sinkList
@@ -123,7 +233,7 @@ spec = do
         shouldSendToPeer 0xa `L.shouldReturn` True
 
     it "should forward a timer to a TXQueue timeout" $ do
-      runTestPeer . const $ do
+      runTestPeer $ do
         runConduit $ yield TimerEvt
                       .| handleEvents testPeer
                       .| sinkList

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -47,17 +47,17 @@ testContext = do
     }
   ch <- atomically newTMChan
   return ( ch
-         , Context { actionTimestamp = Nothing
+         , Context { actionTimestamp = emptyActionTimestamp
                    , contextRedisBlockDB = RBDB.RedisConnection redisBDBPool
                    , contextKafkaState = error "no kafka state available"
                    , blockHeaders=[]
-                   , remainingBlockHeaders=[]
+                   , remainingBlockHeaders = RemainingBlockHeaders []
                    , unseqSink=atomically . writeTMChan ch
                    , vmEventsSink=const (return ())
                    , vmTrace=[]
-                   , connectionTimeout=60
-                   , maxReturnedHeaders=1000
-                   , _blockstanbulPeerAddr=Nothing
+                   , connectionTimeout = ConnectionTimeout 60
+                   , maxReturnedHeaders = MaxReturnedHeaders 1000
+                   , _blockstanbulPeerAddr = PeerAddress Nothing
                    })
 
 testPeer :: DataPeer.PPeer

--- a/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -25,7 +25,8 @@ module Blockchain.Strato.RedisBlockDB
     , getCanonical, getCanonicalHeader, getCanonicalChain, getCanonicalHeaderChain
     , getChildren
     , getGenesisHash
-    , putHeader, putHeaders, putBlock, putBlocks
+    , putHeader, putHeaders, insertHeader, insertHeaders, deleteHeader, deleteHeaders
+    , putBlock, putBlocks, insertBlock, insertBlocks, deleteBlock, deleteBlocks
     , getBestBlockInfo, putBestBlockInfo, forceBestBlockInfo
     , withRedisBlockDB
     , commonAncestorHelper
@@ -155,7 +156,7 @@ putChainMembers cId mems = do
     case res of
         TxSuccess _ -> fmap (foldl' (>>) (Right Ok)) . forM (M.elems mems) $ \e -> getCompose $
           Compose (addIPChain (ipAddress e) cId) *>
-          Compose (addOrgIdChain (pubKey e) cId)
+          Compose (addOrgIdChain (unOrgId $ pubKey e) cId)
         TxAborted   -> pure . Left $ SingleLine (S8.pack $ "putChainMembers - Aborted")
         TxError e   -> pure . Left $ SingleLine (S8.pack $ "putChainMembers - Error" ++ e)
 
@@ -170,7 +171,7 @@ addChainMember cId address enode = do
     case res of
         TxSuccess _ -> getCompose $
           Compose (addIPChain (ipAddress enode) cId) *>
-          Compose (addOrgIdChain (pubKey enode) cId)
+          Compose (addOrgIdChain (unOrgId $ pubKey enode) cId)
         TxAborted   -> pure . Left $ SingleLine (S8.pack $ "addChainMember - Aborted")
         TxError e   -> pure . Left $ SingleLine (S8.pack $ "addChainMember - Error" ++ e)
 
@@ -187,7 +188,7 @@ removeChainMember cId address = do
           Nothing -> pure $ Right Ok -- TODO: Maybe this should return a Left?
           Just enode -> getCompose $
             Compose (removeIPChain (ipAddress enode) cId) *>
-            Compose (removeOrgIdChain (pubKey enode) cId)
+            Compose (removeOrgIdChain (unOrgId $ pubKey enode) cId)
         TxAborted   -> pure . Left $ SingleLine (S8.pack $ "removeChainMember - Aborted")
         TxError e   -> pure . Left $ SingleLine (S8.pack $ "removeChainMember - Error" ++ e)
 
@@ -489,9 +490,18 @@ getBlocksByNumbers = zipMapM getBlocksByNumber
 
 putHeader :: BlockData
           -> Redis (Either Reply Status)
-putHeader h = do
-    let sha       = blockHeaderHash h
-        parent    = blockHeaderParentHash h
+putHeader = uncurry insertHeader . (blockHeaderHash &&& id)
+
+putHeaders :: Traversable t
+           => t BlockData
+           -> Redis (t (Either Reply Status))
+putHeaders = mapM putHeader
+
+insertHeader :: SHA
+             -> BlockData
+             -> Redis (Either Reply Status)
+insertHeader sha h = do
+    let parent    = blockHeaderParentHash h
         number'    = blockHeaderBlockNumber h
         storeHead = morphBlockHeader h :: RedisHeader
         inNS'     = flip inNamespace sha
@@ -503,19 +513,38 @@ putHeader h = do
         sadd (inNamespace Numbers number') [toValue sha]
     case res of
         TxSuccess _ -> pure $ Right Ok
-        TxAborted   -> pure . Left $ SingleLine (S8.pack $ "putHeader - Aborted")
-        TxError e   -> pure . Left $ SingleLine (S8.pack $ "putHeader - Error" ++ e)
+        TxAborted   -> pure . Left $ SingleLine (S8.pack $ "insertHeader - Aborted")
+        TxError e   -> pure . Left $ SingleLine (S8.pack $ "insertHeader - Error" ++ e)
 
-putHeaders :: Traversable t
-           => t BlockData
-           -> Redis (t (Either Reply Status))
-putHeaders = mapM putHeader
+insertHeaders :: M.Map SHA BlockData
+              -> Redis (M.Map SHA (Either Reply Status))
+insertHeaders = sequenceA . M.mapWithKey insertHeader
+
+deleteHeader :: SHA
+             -> Redis (Either Reply Status)
+deleteHeader _ = pure . Left $ SingleLine (S8.pack $ "deleteHeader - Not Implemented")
+
+deleteHeaders :: Traversable t
+              => t SHA
+              -> Redis (t (Either Reply Status))
+deleteHeaders = mapM deleteHeader
 
 putBlock :: OutputBlock
          -> Redis (Either Reply Status)
-putBlock b = do
-    let sha     = blockHash b
-        header  = blockHeader b
+putBlock b =
+  let sha = blockHash b
+   in insertBlock sha b
+
+putBlocks :: Traversable t
+          => t OutputBlock
+          -> Redis (t (Either Reply Status))
+putBlocks = mapM putBlock
+
+insertBlock :: SHA
+            -> OutputBlock
+            -> Redis (Either Reply Status)
+insertBlock sha b = do
+    let header  = blockHeader b
         number' = blockHeaderBlockNumber header
         parent  = blockHeaderParentHash header
         header' = morphBlockHeader header :: RedisHeader
@@ -544,10 +573,18 @@ putBlock b = do
         TxAborted   -> pure . Left $ SingleLine (S8.pack "Aborted")
         TxError e   -> pure . Left $ SingleLine (S8.pack e)
 
-putBlocks :: Traversable t
-          => t OutputBlock
-          -> Redis (t (Either Reply Status))
-putBlocks = mapM putBlock
+insertBlocks :: M.Map SHA OutputBlock
+             -> Redis (M.Map SHA (Either Reply Status))
+insertBlocks = sequenceA . M.mapWithKey insertBlock
+
+deleteBlock :: SHA
+            -> Redis (Either Reply Status)
+deleteBlock _ = pure . Left $ SingleLine (S8.pack $ "deleteBlock - Not Implemented")
+
+deleteBlocks :: Traversable t
+             => t SHA
+             -> Redis (t (Either Reply Status))
+deleteBlocks = mapM deleteBlock
 
 putBestBlockInfo :: SHA
                  -> Integer

--- a/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
+++ b/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -30,10 +30,11 @@ import           Util                                  hiding (intercalate)
 
 import           Blockapps.Crossmon
 import           Blockchain.BlockChain
-import           Blockchain.Data.DataDefs              (blockDataExtraData, blockDataNumber, BlockData(..))
+import           Blockchain.Data.Block                 (BestBlock(..), WorldBestBlock(..))
 import           Blockchain.Data.BlockHeader           (extraData2TxsLen)
 import           Blockchain.Data.BlockSummary
 import           Blockchain.Data.ChainInfo
+import           Blockchain.Data.DataDefs              (blockDataExtraData, blockDataNumber, BlockData(..))
 import           Blockchain.Data.GenesisBlock
 import           Blockchain.Data.LogDB
 import           Blockchain.Data.EventDB
@@ -65,8 +66,6 @@ import           Blockchain.Strato.Indexer.Model       (IndexEvent (..))
 import           Blockchain.Strato.Model.Class
 import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Strato.Model.SHA
-import qualified Blockchain.Strato.RedisBlockDB        as RBDB
-import           Blockchain.Strato.RedisBlockDB.Models
 import           Blockchain.Strato.StateDiff.Kafka     (writeActionJSONToKafka)
 import           Blockchain.Timing
 import           Blockchain.Util                       (getCurrentMicrotime, secondsToMicrotime)
@@ -375,12 +374,12 @@ getUnprocessedKafkaEvents offset = do
 shouldProcessNewTransactions :: ContextM Bool -- todo: probably shouldn't do it by number, but tdiff.
 shouldProcessNewTransactions =
     if flags_useSyncMode then do
-        worldBestBlock <- RBDB.withRedisBlockDB RBDB.getWorldBestBlockInfo
+        worldBestBlock <- fmap unWorldBestBlock <$> Mod.access (Mod.Proxy @(Maybe WorldBestBlock))
         case worldBestBlock of
             Nothing -> do
                 $logInfoS "shouldProcessNewTransactions" "got Nothing from worldBestBlockInfo, playing it safe and not mining Txs"
                 return False -- we either had no peers or some other error, lets play it safe
-            Just (RedisBestBlock worldBestSha _ _) -> do
+            Just (BestBlock worldBestSha _ _) -> do
                 didRunBest <- hasBSum worldBestSha
                 let msg =
                       if didRunBest

--- a/core-strato/vm-tools/src/Blockchain/VMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMContext.hs
@@ -54,6 +54,7 @@ import qualified Data.NibbleString                  as N
 import qualified Data.Sequence                      as Q
 import           Data.Word
 import qualified Data.Text                          as T
+import           Data.Traversable                   (for)
 import qualified Database.LevelDB                   as DB
 import qualified Database.Persist.Postgresql        as PSQL
 import qualified Database.Persist.Sqlite            as Lite
@@ -72,6 +73,7 @@ import           Blockchain.Blockstanbul.Authentication as Auth
 import           Blockchain.Constants
 import           Blockchain.Data.Address
 import           Blockchain.Data.AddressStateDB
+import           Blockchain.Data.Block
 import           Blockchain.Data.BlockDB
 import           Blockchain.Data.BlockSummary
 import           Blockchain.Data.DataDefs           (LogDB, EventDB, TransactionResult)
@@ -93,6 +95,7 @@ import qualified Blockchain.Strato.Indexer.Kafka    as IK
 import qualified Blockchain.Strato.Indexer.Model    as IM
 import           Blockchain.Strato.Model.SHA
 import qualified Blockchain.Strato.RedisBlockDB     as RBDB
+import           Blockchain.Strato.RedisBlockDB.Models
 import qualified Blockchain.TxRunResultCache        as TRC
 import           Blockchain.VMMetrics
 import           Blockchain.VMOptions
@@ -269,6 +272,12 @@ instance HasSQLDB m => WrapsSQLDB (StateT Context) m where
 
 instance Mod.Accessible RBDB.RedisConnection ContextM where
   access _ = gets contextRedisPool
+
+instance Mod.Accessible (Maybe WorldBestBlock) ContextM where
+  access _ = do
+    mRBB <- RBDB.withRedisBlockDB RBDB.getWorldBestBlockInfo
+    for mRBB $ \(RedisBestBlock sha num diff) ->
+      return . WorldBestBlock $ BestBlock sha num diff
 
 instance MonadMonitor (ResourceT (LoggingT IO)) where
     doIO = liftIO


### PR DESCRIPTION
There's a lot going on here. The P2P module is deeply coupled with Redis, and since there are so many different datatypes being stored in Redis, this leads to many different classes needed to abstract away its dependency. One way we could cut down on this would be to split up `handleEvents` into separate functions for each event type, and introduce a typeclass `HandlesP2PEvents`, with type signatures for each wire message. Then, the type signature for `handleEvents` would be `HandlesP2PEvents m => ...`, and each wire message-specific function would be constrained only on the specific types it requires.