### PR TITLE
Update jobs that prometheus records for health_check

### DIFF
--- a/apex/api/daemons/node-health-check.js
+++ b/apex/api/daemons/node-health-check.js
@@ -12,7 +12,10 @@ const neededJobs = {
     "slipstream_main":"slipstream",
     "strato_p2p":"strato-p2p",
     "vm_main":"vm-runner",
-    "seq_main":"strato-sequencer"
+    "seq_main":"strato-sequencer",
+    "blockapps-vault-wrapper-server":"vault-wrapper",
+    "blockapps-bloc":"bloc",
+    "strato-api":"strato-api"
 }
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";


### PR DESCRIPTION
```GET /metrics 200 3.852 ms - -
warn: Jobs are updated? The following prometheus job is not in the check list required:  blockapps-bloc
warn: Jobs are updated? The following prometheus job is not in the check list required:  strato-api
warn: Jobs are updated? The following prometheus job is not in the check list required:  blockapps-vault-wrapper-server
info: Create entry for latest health status: bloc=true, slipstream=true, strato-api=true, strato-p2p=true, strato-sequencer=true, vault-wrapper=true, vm-runner=true
info: sysInfoCollected at checkSystemInfo:  mem_active=9589694464, mem_free=1135828992, mem_available=8023085056, disk_usage=47.527645432953456, currentLoad=27.677588688510713, fsSize=[name=/dev/nvme0n1p3, fsSize=464647585792, fsSize_use=52.47, fsSize_used=243811528704, fsSize_size=464647585792], fsStats_rx=69353136128, fsStats_wx=905274796032, networkStats=[iface=, networkStats_rx_bytes=0, networkStats_tx_bytes=0], Alerts=[]
info: Health Status queried at 2019-09-12T19:59:28+00:00
```
Apex can include these three more jobs^^ in its checklist, which prometheus are recording.
 
```GET /metrics 200 2.394 ms - -
info: Create entry for latest health status: bloc=true, slipstream=true, strato-api=true, strato-p2p=true, strato-sequencer=true, vault-wrapper=true, vm-runner=true
info: sysInfoCollected at checkSystemInfo:  mem_active=9276125184, mem_free=1515282432, mem_available=8068997120, disk_usage=47.52881257643291, currentLoad=12.019962781255286, fsSize=[name=/dev/nvme0n1p3, fsSize=464647585792, fsSize_use=52.47, fsSize_used=243806105600, fsSize_size=464647585792], fsStats_rx=68705247232, fsStats_wx=904897898496, networkStats=[iface=, networkStats_rx_bytes=0, networkStats_tx_bytes=0], Alerts=[]
info: Health Status queried at 2019-09-12T19:56:39+00:00
```