### PR TITLE
Split output events

### DIFF
--- a/core-strato/blockapps-mpdbs/src/Blockchain/DB/ChainDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/DB/ChainDB.hs
@@ -82,7 +82,7 @@ import           Text.Format
 |  (chain id, (creation block hash, genesis state root))                        |
 | It's important to note that each block hash may have a unique chain root,     |
 | but the genesis root only gets updated when the VM receives a new             |
-| OEGenesis message.                                                            |
+| VmGenesis message.                                                            |
 |                                                                               |
 | When the VM receives a new block, it will insert it into the block hash       |
 | trie, with the same chain root as its parent.                                 |

--- a/core-strato/blockapps-tools/exec_src/Main.hs
+++ b/core-strato/blockapps-tools/exec_src/Main.hs
@@ -426,9 +426,9 @@ run Checkpoints{..}            = case operation of
       Get           -> doCheckpointGet service
       Put           -> doCheckpointPut service (fromIntegral <$> offset) cp
       NullOperation -> doCheckpointUsage
-run AskForBlocks{..}           = insertP2P (OEAskForBlocks startBlock endBlock peer)
-run PushBlocks{..}             = insertP2P (OEPushBlocks startBlock endBlock peer)
-run AskForTxs                  = insertP2P . OEGetTx
+run AskForBlocks{..}           = insertP2P (OSPEAskForBlocks startBlock endBlock peer)
+run PushBlocks{..}             = insertP2P (OSPEPushBlocks startBlock endBlock peer)
+run AskForTxs                  = insertP2P . OSPEGetTx
                                            . map (SHA . bytesToWord256 . fst . B16.decode)
                                            . filter (not . B.null)
                                            . BC.split '\n' =<< B.getContents

--- a/core-strato/blockapps-tools/exec_src/Main.hs
+++ b/core-strato/blockapps-tools/exec_src/Main.hs
@@ -426,9 +426,9 @@ run Checkpoints{..}            = case operation of
       Get           -> doCheckpointGet service
       Put           -> doCheckpointPut service (fromIntegral <$> offset) cp
       NullOperation -> doCheckpointUsage
-run AskForBlocks{..}           = insertP2P (OSPEAskForBlocks startBlock endBlock peer)
-run PushBlocks{..}             = insertP2P (OSPEPushBlocks startBlock endBlock peer)
-run AskForTxs                  = insertP2P . OSPEGetTx
+run AskForBlocks{..}           = insertP2P (P2pAskForBlocks startBlock endBlock peer)
+run PushBlocks{..}             = insertP2P (P2pPushBlocks startBlock endBlock peer)
+run AskForTxs                  = insertP2P . P2pGetTx
                                            . map (SHA . bytesToWord256 . fst . B16.decode)
                                            . filter (not . B.null)
                                            . BC.split '\n' =<< B.getContents

--- a/core-strato/blockapps-tools/src/InsertP2P.hs
+++ b/core-strato/blockapps-tools/src/InsertP2P.hs
@@ -7,7 +7,7 @@ import Blockchain.EthConf
 import Blockchain.Sequencer.Event
 import Blockchain.Sequencer.Kafka
 
-insertP2P :: OutputEvent -> IO ()
+insertP2P :: OutputSeqP2pEvent -> IO ()
 insertP2P oev = do
   printf "Inserting %s into seq_p2p_events...\n" $ show oev
   resps <- runKafkaConfigured "queryStrato" $ do

--- a/core-strato/blockapps-tools/src/InsertP2P.hs
+++ b/core-strato/blockapps-tools/src/InsertP2P.hs
@@ -7,7 +7,7 @@ import Blockchain.EthConf
 import Blockchain.Sequencer.Event
 import Blockchain.Sequencer.Kafka
 
-insertP2P :: OutputSeqP2pEvent -> IO ()
+insertP2P :: P2pEvent -> IO ()
 insertP2P oev = do
   printf "Inserting %s into seq_p2p_events...\n" $ show oev
   resps <- runKafkaConfigured "queryStrato" $ do

--- a/core-strato/ethereum-jsonrpc/src/Commands.hs
+++ b/core-strato/ethereum-jsonrpc/src/Commands.hs
@@ -223,7 +223,7 @@ emitKafkaJsonRlpCommand::JsonRpcCommand->IO ()
 emitKafkaJsonRlpCommand c = do
     rets <-
       liftIO $ runKafkaConfigured "strato-api" $
-      writeSeqVmEvents [OSVEJsonRpcCommand c]
+      writeSeqVmEvents [VmJsonRpcCommand c]
     case rets of
         Left e      -> error $ "Could not write txs to Kafka: " ++ show e
         Right _ -> return ()

--- a/core-strato/ethereum-jsonrpc/src/Commands.hs
+++ b/core-strato/ethereum-jsonrpc/src/Commands.hs
@@ -223,7 +223,7 @@ emitKafkaJsonRlpCommand::JsonRpcCommand->IO ()
 emitKafkaJsonRlpCommand c = do
     rets <-
       liftIO $ runKafkaConfigured "strato-api" $
-      writeSeqVmEvents [OEJsonRpcCommand c]
+      writeSeqVmEvents [OSVEJsonRpcCommand c]
     case rets of
         Left e      -> error $ "Could not write txs to Kafka: " ++ show e
         Right _ -> return ()

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -177,9 +177,9 @@ data OutputEvent = OETx Timestamp OutputTx
                  | OEBlockstanbul PBFT.WireMessage
                  | OECreateBlockCommand
                  -- Ask and push for inclusive ranges of blocks
-                 | OEAskForBlocks {askStart :: Integer, askEnd :: Integer, askPeer :: A.Address}
-                 | OEPushBlocks {pushStart :: Integer, pushEnd :: Integer, pushPeer :: A.Address}
-                 | OEVoteToMake { voteRecipient :: A.Address, voteVotingDir :: Bool, voteSender :: A.Address }
+                 | OEAskForBlocks {oeAskStart :: Integer, oeAskEnd :: Integer, oeAskPeer :: A.Address}
+                 | OEPushBlocks {oePushStart :: Integer, oePushEnd :: Integer, oePushPeer :: A.Address}
+                 | OEVoteToMake { oeVoteRecipient :: A.Address, oeVoteVotingDir :: Bool, oeVoteSender :: A.Address }
                  | OENewCheckpoint PBFT.Checkpoint -- A pseudo out event that shouldn't leave the sequencer
                  | OEPrivateTx OutputTx
                  deriving (Eq, Show, GHCG.Generic, Data)
@@ -194,6 +194,45 @@ instance Format OutputEvent where
   format (OEBlockstanbul o)       = format o
   format (OEPrivateTx o)          = format o
   format x                        = show x
+
+data OutputSeqP2pEvent =
+    OSPETx OutputTx
+  | OSPEBlock OutputBlock
+  | OSPEGenesis OutputGenesis
+  | OSPEGetChain [Word256]
+  | OSPEGetTx [SHA]
+  | OSPENewChainMember Word256 A.Address Enode
+  | OSPEBlockstanbul PBFT.WireMessage
+  -- Ask and push for inclusive ranges of blocks
+  | OSPEAskForBlocks {ospeAskStart :: Integer, ospeAskEnd :: Integer, ospeAskPeer :: A.Address}
+  | OSPEPushBlocks {ospePushStart :: Integer, ospePushEnd :: Integer, ospePushPeer :: A.Address}
+  deriving (Eq, Show, GHCG.Generic, Data)
+
+instance Format OutputSeqP2pEvent where
+  format (OSPETx o)                 = format o
+  format (OSPEBlock o)              = format o
+  format (OSPEGenesis o)            = show o
+  format (OSPEGetChain cids)        = "[" ++ (intercalate "," $ map (format . SHA) cids) ++ "]"
+  format (OSPEGetTx shas)           = "[" ++ (intercalate "," $ map format shas) ++ "]"
+  format (OSPENewChainMember c a e) = intercalate ", " [format (SHA c), format a, show e]
+  format (OSPEBlockstanbul o)       = format o
+  format x                          = show x
+
+data OutputSeqVmEvent =
+    OSVETx Timestamp OutputTx
+  | OSVEBlock OutputBlock
+  | OSVEGenesis OutputGenesis
+  | OSVEJsonRpcCommand JsonRpcCommand
+  | OSVECreateBlockCommand
+  | OSVEVoteToMake { osveVoteRecipient :: A.Address, osveVoteVotingDir :: Bool, osveVoteSender :: A.Address }
+  | OSVEPrivateTx OutputTx
+  deriving (Eq, Show, GHCG.Generic, Data)
+
+instance Format OutputSeqVmEvent where
+  format (OSVETx ts o)              = show ts ++ " " ++ format o
+  format (OSVEBlock o)              = format o
+  format (OSVEGenesis o)            = show o
+  format x                          = show x
 
 data OutputTx = OutputTx { otOrigin      :: TO.TXOrigin
                          , otHash        :: SHA
@@ -415,84 +454,10 @@ instance Binary SequencedBlock where
 instance Binary OutputTx where
 instance Binary OutputBlock where
 instance Binary OutputGenesis where
-
 instance Binary IngestEvent where
-    -- put (IETx t)    = putWord8 0 >> put t -- legacy IETx
-    put (IETx ts t) = putWord8 2 >> put ts >> put t
-    put (IEBlock b) = putWord8 1 >> put b
-    put (IEGenesis g) = putWord8 3 >> put g
-    put (IEBlockstanbul m) = putWord8 4 >> put m
-    put (IENewChainMember c a e) = putWord8 5 >> put c >> put a >> put e
-    put (IEForcedConfigChange cc) = putWord8 6 >> put cc
-    get = do
-        tag <- getWord8
-        case tag of
-            0 -> IETx 0 <$> get -- legacy IETx
-            1 -> IEBlock  <$> get
-            2 -> IETx <$> get <*> get
-            3 -> IEGenesis <$> get
-            4 -> IEBlockstanbul <$> get
-            5 -> IENewChainMember <$> get <*> get <*> get
-            6 -> IEForcedConfigChange <$> get
-            x -> error $ "unknown InputEvent tag " ++ show x
-
 instance Binary JsonRpcCommand where
-  put JRCGetBalance{jrcAddress=a, jrcId=i, jrcBlockString=b} =
-    putWord8 0 >> put a >> put i >> put b
-  put JRCGetCode{jrcAddress=a, jrcId=i, jrcBlockString=b} =
-    putWord8 1 >> put a >> put i >> put b
-  put JRCGetTransactionCount {jrcAddress=a, jrcId=i, jrcBlockString=b} =
-    putWord8 2 >> put a >> put i >> put b
-  put JRCGetStorageAt {jrcAddress=a, jrcKey=k, jrcId=i, jrcBlockString=b} =
-    putWord8 3 >> put a >> put k >> put i >> put b
-  put JRCCall{jrcCode=c,jrcId=i,jrcBlockString=b} =
-    putWord8 4 >> put c >> put i >> put b
-  get = do
-        tag <- getWord8
-        case tag of
-            0 -> JRCGetBalance <$> get <*> get <*> get
-            1 -> JRCGetCode <$> get <*> get <*> get
-            2 -> JRCGetTransactionCount <$> get <*> get <*> get
-            3 -> JRCGetStorageAt <$> get <*> get <*> get <*> get
-            4 -> JRCCall <$> get <*> get <*> get
-            x -> error $ "unknown JsonRpcCommand tag " ++ show x
-
-instance Binary OutputEvent where
-    -- Reserved tags: 0, 9, 10
-    put (OETx ts t)          = putWord8 3 >> put ts >> put t
-    put (OEBlock b)          = putWord8 1 >> put b
-    put (OEJsonRpcCommand c) = putWord8 2 >> put c
-    put (OEGenesis g)        = putWord8 4 >> put g
-    put (OEGetChain cid)     = putWord8 5 >> put cid
-    put (OEGetTx tx)         = putWord8 6 >> put tx
-    put (OEBlockstanbul m)   = putWord8 7 >> put m
-    put (OECreateBlockCommand) = putWord8 8
-    put (OEAskForBlocks s e p) = putWord8 11 >> put s >> put e >> put p
-    put (OEPushBlocks s e p) = putWord8 12 >> put s >> put e >> put p
-    put (OENewChainMember c a e) = putWord8 13 >> put c >> put a >> put e
-    put (OEVoteToMake r d s) = putWord8 14 >> put r >> put d >> put s
-    put (OENewCheckpoint{}) = error "pbft checkpoints should not be sent to p2p/vm"
-    put (OEPrivateTx t)     = putWord8 15 >> put t
-    get = do
-        tag <- getWord8
-        case tag of
-            0 -> OETx 0 <$> get -- legacy OETx
-            1 -> OEBlock <$> get
-            2 -> OEJsonRpcCommand <$> get
-            3 -> OETx <$> get <*> get
-            4 -> OEGenesis <$> get
-            5 -> OEGetChain <$> get
-            6 -> OEGetTx <$> get
-            7 -> OEBlockstanbul <$> get
-            8 -> pure OECreateBlockCommand
-            9 -> OEAskForBlocks <$> get <*> get <*> pure 0x0 -- legacy OEAFB
-            10 -> OEPushBlocks <$> get <*> get <*> pure 0x0 -- legacy OEPB
-            11 -> OEAskForBlocks <$> get <*> get <*> get
-            12 -> OEPushBlocks <$> get <*> get <*> get
-            13 -> OENewChainMember <$> get <*> get <*> get
-            14 -> OEVoteToMake <$> get <*> get <*> get
-            15 -> OEPrivateTx <$> get
-            x -> error $ "unknown OutputEvent tag " ++ show x
+instance Binary OutputSeqP2pEvent where
+instance Binary OutputSeqVmEvent where
 
 instance Format IngestBlock where
     format b@IngestBlock { ibOrigin              = origin
@@ -592,6 +557,8 @@ derive makeArbitrary ''IngestBlock
 derive makeArbitrary ''IngestGenesis
 derive makeArbitrary ''SequencedBlock
 derive makeArbitrary ''OutputEvent
+derive makeArbitrary ''OutputSeqP2pEvent
+derive makeArbitrary ''OutputSeqVmEvent
 derive makeArbitrary ''OutputTx
 derive makeArbitrary ''OutputBlock
 derive makeArbitrary ''OutputGenesis

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -167,34 +167,6 @@ data JsonRpcCommand
     | JRCCall { jrcCode :: BS.ByteString, jrcId :: String, jrcBlockString :: String}
     deriving (Eq, Read, Show, GHCG.Generic, Data)
 
-data OutputEvent = OETx Timestamp OutputTx
-                 | OEBlock OutputBlock
-                 | OEGenesis OutputGenesis
-                 | OEJsonRpcCommand JsonRpcCommand
-                 | OEGetChain [Word256]
-                 | OEGetTx [SHA]
-                 | OENewChainMember Word256 A.Address Enode
-                 | OEBlockstanbul PBFT.WireMessage
-                 | OECreateBlockCommand
-                 -- Ask and push for inclusive ranges of blocks
-                 | OEAskForBlocks {oeAskStart :: Integer, oeAskEnd :: Integer, oeAskPeer :: A.Address}
-                 | OEPushBlocks {oePushStart :: Integer, oePushEnd :: Integer, oePushPeer :: A.Address}
-                 | OEVoteToMake { oeVoteRecipient :: A.Address, oeVoteVotingDir :: Bool, oeVoteSender :: A.Address }
-                 | OENewCheckpoint PBFT.Checkpoint -- A pseudo out event that shouldn't leave the sequencer
-                 | OEPrivateTx OutputTx
-                 deriving (Eq, Show, GHCG.Generic, Data)
-
-instance Format OutputEvent where
-  format (OETx ts o)              = show ts ++ " " ++ format o
-  format (OEBlock o)              = format o
-  format (OEGenesis o)            = show o
-  format (OEGetChain cids)        = "[" ++ (intercalate "," $ map (format . SHA) cids) ++ "]"
-  format (OEGetTx shas)           = "[" ++ (intercalate "," $ map format shas) ++ "]"
-  format (OENewChainMember c a e) = intercalate ", " [format (SHA c), format a, show e]
-  format (OEBlockstanbul o)       = format o
-  format (OEPrivateTx o)          = format o
-  format x                        = show x
-
 data P2pEvent =
     P2pTx OutputTx
   | P2pBlock OutputBlock
@@ -556,7 +528,6 @@ derive makeArbitrary ''IngestTx
 derive makeArbitrary ''IngestBlock
 derive makeArbitrary ''IngestGenesis
 derive makeArbitrary ''SequencedBlock
-derive makeArbitrary ''OutputEvent
 derive makeArbitrary ''P2pEvent
 derive makeArbitrary ''VmEvent
 derive makeArbitrary ''OutputTx

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -195,43 +195,43 @@ instance Format OutputEvent where
   format (OEPrivateTx o)          = format o
   format x                        = show x
 
-data OutputSeqP2pEvent =
-    OSPETx OutputTx
-  | OSPEBlock OutputBlock
-  | OSPEGenesis OutputGenesis
-  | OSPEGetChain [Word256]
-  | OSPEGetTx [SHA]
-  | OSPENewChainMember Word256 A.Address Enode
-  | OSPEBlockstanbul PBFT.WireMessage
+data P2pEvent =
+    P2pTx OutputTx
+  | P2pBlock OutputBlock
+  | P2pGenesis OutputGenesis
+  | P2pGetChain [Word256]
+  | P2pGetTx [SHA]
+  | P2pNewChainMember Word256 A.Address Enode
+  | P2pBlockstanbul PBFT.WireMessage
   -- Ask and push for inclusive ranges of blocks
-  | OSPEAskForBlocks {ospeAskStart :: Integer, ospeAskEnd :: Integer, ospeAskPeer :: A.Address}
-  | OSPEPushBlocks {ospePushStart :: Integer, ospePushEnd :: Integer, ospePushPeer :: A.Address}
+  | P2pAskForBlocks {askStart :: Integer, askEnd :: Integer, askPeer :: A.Address}
+  | P2pPushBlocks {pushStart :: Integer, pushEnd :: Integer, pushPeer :: A.Address}
   deriving (Eq, Show, GHCG.Generic, Data)
 
-instance Format OutputSeqP2pEvent where
-  format (OSPETx o)                 = format o
-  format (OSPEBlock o)              = format o
-  format (OSPEGenesis o)            = show o
-  format (OSPEGetChain cids)        = "[" ++ (intercalate "," $ map (format . SHA) cids) ++ "]"
-  format (OSPEGetTx shas)           = "[" ++ (intercalate "," $ map format shas) ++ "]"
-  format (OSPENewChainMember c a e) = intercalate ", " [format (SHA c), format a, show e]
-  format (OSPEBlockstanbul o)       = format o
+instance Format P2pEvent where
+  format (P2pTx o)                 = format o
+  format (P2pBlock o)              = format o
+  format (P2pGenesis o)            = show o
+  format (P2pGetChain cids)        = "[" ++ (intercalate "," $ map (format . SHA) cids) ++ "]"
+  format (P2pGetTx shas)           = "[" ++ (intercalate "," $ map format shas) ++ "]"
+  format (P2pNewChainMember c a e) = intercalate ", " [format (SHA c), format a, show e]
+  format (P2pBlockstanbul o)       = format o
   format x                          = show x
 
-data OutputSeqVmEvent =
-    OSVETx Timestamp OutputTx
-  | OSVEBlock OutputBlock
-  | OSVEGenesis OutputGenesis
-  | OSVEJsonRpcCommand JsonRpcCommand
-  | OSVECreateBlockCommand
-  | OSVEVoteToMake { osveVoteRecipient :: A.Address, osveVoteVotingDir :: Bool, osveVoteSender :: A.Address }
-  | OSVEPrivateTx OutputTx
+data VmEvent =
+    VmTx Timestamp OutputTx
+  | VmBlock OutputBlock
+  | VmGenesis OutputGenesis
+  | VmJsonRpcCommand JsonRpcCommand
+  | VmCreateBlockCommand
+  | VmVoteToMake { voteRecipient :: A.Address, voteVotingDir :: Bool, voteSender :: A.Address }
+  | VmPrivateTx OutputTx
   deriving (Eq, Show, GHCG.Generic, Data)
 
-instance Format OutputSeqVmEvent where
-  format (OSVETx ts o)              = show ts ++ " " ++ format o
-  format (OSVEBlock o)              = format o
-  format (OSVEGenesis o)            = show o
+instance Format VmEvent where
+  format (VmTx ts o)              = show ts ++ " " ++ format o
+  format (VmBlock o)              = format o
+  format (VmGenesis o)            = show o
   format x                          = show x
 
 data OutputTx = OutputTx { otOrigin      :: TO.TXOrigin
@@ -456,8 +456,8 @@ instance Binary OutputBlock where
 instance Binary OutputGenesis where
 instance Binary IngestEvent where
 instance Binary JsonRpcCommand where
-instance Binary OutputSeqP2pEvent where
-instance Binary OutputSeqVmEvent where
+instance Binary P2pEvent where
+instance Binary VmEvent where
 
 instance Format IngestBlock where
     format b@IngestBlock { ibOrigin              = origin
@@ -557,8 +557,8 @@ derive makeArbitrary ''IngestBlock
 derive makeArbitrary ''IngestGenesis
 derive makeArbitrary ''SequencedBlock
 derive makeArbitrary ''OutputEvent
-derive makeArbitrary ''OutputSeqP2pEvent
-derive makeArbitrary ''OutputSeqVmEvent
+derive makeArbitrary ''P2pEvent
+derive makeArbitrary ''VmEvent
 derive makeArbitrary ''OutputTx
 derive makeArbitrary ''OutputBlock
 derive makeArbitrary ''OutputGenesis

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Kafka.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Kafka.hs
@@ -66,23 +66,23 @@ readUnseqEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [IngestE
 readUnseqEventsFromTopic = readFromTopic'
 {-# INLINE readUnseqEventsFromTopic #-}
 
-readSeqVmEvents :: K.Kafka k => KP.Offset -> k [OutputSeqVmEvent]
+readSeqVmEvents :: K.Kafka k => KP.Offset -> k [VmEvent]
 readSeqVmEvents off = do
   events <- readSeqVmEventsFromTopic seqVmEventsTopicName off
   recordEvents seqVMReads events
   return events
 
-readSeqVmEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [OutputSeqVmEvent]
+readSeqVmEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [VmEvent]
 readSeqVmEventsFromTopic = readFromTopic'
 {-# INLINE readSeqVmEventsFromTopic #-}
 
-readSeqP2pEvents :: K.Kafka k => KP.Offset -> k [OutputSeqP2pEvent]
+readSeqP2pEvents :: K.Kafka k => KP.Offset -> k [P2pEvent]
 readSeqP2pEvents off = do
   events <- readSeqP2pEventsFromTopic seqP2pEventsTopicName off
   recordEvents seqP2PReads events
   return events
 
-readSeqP2pEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [OutputSeqP2pEvent]
+readSeqP2pEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [P2pEvent]
 readSeqP2pEventsFromTopic = readFromTopic'
 {-# INLINE readSeqP2pEventsFromTopic #-}
 
@@ -92,13 +92,13 @@ writeUnseqEvents events = do
   KW.produceMessages $
       (K.TopicAndMessage unseqEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 
-writeSeqVmEvents :: K.Kafka k => [OutputSeqVmEvent] -> k [KP.ProduceResponse]
+writeSeqVmEvents :: K.Kafka k => [VmEvent] -> k [KP.ProduceResponse]
 writeSeqVmEvents events = do
   recordEvents seqVMWrites events
   KW.produceMessages $
       (K.TopicAndMessage seqVmEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 
-writeSeqP2pEvents :: K.Kafka k => [OutputSeqP2pEvent] -> k [KP.ProduceResponse]
+writeSeqP2pEvents :: K.Kafka k => [P2pEvent] -> k [KP.ProduceResponse]
 writeSeqP2pEvents events = do
   recordEvents seqP2PWrites events
   KW.produceMessages $

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Kafka.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Kafka.hs
@@ -66,23 +66,23 @@ readUnseqEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [IngestE
 readUnseqEventsFromTopic = readFromTopic'
 {-# INLINE readUnseqEventsFromTopic #-}
 
-readSeqVmEvents :: K.Kafka k => KP.Offset -> k [OutputEvent]
+readSeqVmEvents :: K.Kafka k => KP.Offset -> k [OutputSeqVmEvent]
 readSeqVmEvents off = do
   events <- readSeqVmEventsFromTopic seqVmEventsTopicName off
   recordEvents seqVMReads events
   return events
 
-readSeqVmEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [OutputEvent]
+readSeqVmEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [OutputSeqVmEvent]
 readSeqVmEventsFromTopic = readFromTopic'
 {-# INLINE readSeqVmEventsFromTopic #-}
 
-readSeqP2pEvents :: K.Kafka k => KP.Offset -> k [OutputEvent]
+readSeqP2pEvents :: K.Kafka k => KP.Offset -> k [OutputSeqP2pEvent]
 readSeqP2pEvents off = do
   events <- readSeqP2pEventsFromTopic seqP2pEventsTopicName off
   recordEvents seqP2PReads events
   return events
 
-readSeqP2pEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [OutputEvent]
+readSeqP2pEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [OutputSeqP2pEvent]
 readSeqP2pEventsFromTopic = readFromTopic'
 {-# INLINE readSeqP2pEventsFromTopic #-}
 
@@ -92,13 +92,13 @@ writeUnseqEvents events = do
   KW.produceMessages $
       (K.TopicAndMessage unseqEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 
-writeSeqVmEvents :: K.Kafka k => [OutputEvent] -> k [KP.ProduceResponse]
+writeSeqVmEvents :: K.Kafka k => [OutputSeqVmEvent] -> k [KP.ProduceResponse]
 writeSeqVmEvents events = do
   recordEvents seqVMWrites events
   KW.produceMessages $
       (K.TopicAndMessage seqVmEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 
-writeSeqP2pEvents :: K.Kafka k => [OutputEvent] -> k [KP.ProduceResponse]
+writeSeqP2pEvents :: K.Kafka k => [OutputSeqP2pEvent] -> k [KP.ProduceResponse]
 writeSeqP2pEvents events = do
   recordEvents seqP2PWrites events
   KW.produceMessages $

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -332,7 +332,7 @@ handleEvents peer = awaitForever $ \case
             throwIO PeerDisconnected
 
     NewSeqEvent oe -> case oe of
-      OSPEBlock b  -> do
+      P2pBlock b  -> do
         when (shouldSend peer $ obOrigin b) $ do
           worldBestBlock <- RBDB.withRedisBlockDB RBDB.getWorldBestBlockInfo
           case worldBestBlock of
@@ -342,7 +342,7 @@ handleEvents peer = awaitForever $ \case
               when (obTotalDifficulty b >= worldTDiff) $ do
                 $logInfoS "handleEvents/OEBlock" . T.pack $ "yielding new block: " ++ show (blockDataNumber . blockBlockData . outputBlockToBlock $ b)
                 yieldR $ NewBlock (outputBlockToBlock b) (obTotalDifficulty b)
-      OSPETx tx -> do
+      P2pTx tx -> do
         whenM (shouldSendGossip peer $ otOrigin tx) $ do
           let cId = txChainId tx
           match <- case cId of
@@ -356,7 +356,7 @@ handleEvents peer = awaitForever $ \case
               $logInfoS "handleEvents/OETx" $ T.pack $ "sending Transaction " ++ format (otHash tx) ++ " for chainID " ++ formatChainId cId
               $logDebugS "handleEvents/OETx" . T.pack $ "the transaction was: " ++ format tx
               yieldR $ Transactions [otBaseTx tx]
-      OSPEGenesis (OutputGenesis og (cId, cInfo@(ChainInfo uci _))) -> do
+      P2pGenesis (OutputGenesis og (cId, cInfo@(ChainInfo uci _))) -> do
         when (shouldSend peer og) $ do
           $logInfoS "handleEvents/OEGenesis" . T.pack $ "received new chain: " ++ formatChainId (Just cId) ++ " with " ++ show uci
           if checkPeerIsMember peer $ members uci
@@ -367,9 +367,9 @@ handleEvents peer = awaitForever $ \case
               $logInfoS "handleEvents/OEGenesis" $ T.pack $
                 printf "peer %s is not authorized for received chainID %s" (maybe "<nokey>" showEnode $ pPeerEnode peer) (formatChainId $ Just cId)
               $logDebugLS "handleEvents/OEGenesis/members" $ members uci
-      OSPEGetChain chainIds -> yieldR $ GetChainDetails chainIds
-      OSPEGetTx shas -> yieldR $ GetTransactions shas
-      OSPENewChainMember cId _ _ -> do
+      P2pGetChain chainIds -> yieldR $ GetChainDetails chainIds
+      P2pGetTx shas -> yieldR $ GetTransactions shas
+      P2pNewChainMember cId _ _ -> do
         let formatted = format $ SHA cId
         $logInfoS "handleEvents/OENewChainMember" $ T.pack $ "New member added to chain " ++ formatted
         mems <- lift . RBDB.withRedisBlockDB $ RBDB.getChainMembers cId
@@ -377,16 +377,16 @@ handleEvents peer = awaitForever $ \case
           $logInfoS "handleEvents/OENewChainMember" $ T.pack $ "Emitting chain details for chain " ++ formatted
           mcInfo <- lift . RBDB.withRedisBlockDB $ RBDB.getChainInfo cId
           for_ ((cId,) <$> mcInfo) $ yieldR . ChainDetails . (:[])
-      OSPEBlockstanbul msg -> do
+      P2pBlockstanbul msg -> do
         let outbound = Blockstanbul msg
         $logDebugS "handleEvents/OEBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
         yieldR outbound
-      OSPEAskForBlocks start _ p -> do
+      P2pAskForBlocks start _ p -> do
         ss <- shouldSendToPeer p
         when ss $ do
           $logDebugS "handleEvents/OEAskForBlocks" . T.pack $ "syncFetch: " ++ show start
           syncFetch Forward start
-      OSPEPushBlocks start end p -> do
+      P2pPushBlocks start end p -> do
         ss <- shouldSendToPeer p
         when ss $ do
           mrh <- gets maxReturnedHeaders

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -332,7 +332,7 @@ handleEvents peer = awaitForever $ \case
             throwIO PeerDisconnected
 
     NewSeqEvent oe -> case oe of
-      OEBlock b  -> do
+      OSPEBlock b  -> do
         when (shouldSend peer $ obOrigin b) $ do
           worldBestBlock <- RBDB.withRedisBlockDB RBDB.getWorldBestBlockInfo
           case worldBestBlock of
@@ -342,7 +342,7 @@ handleEvents peer = awaitForever $ \case
               when (obTotalDifficulty b >= worldTDiff) $ do
                 $logInfoS "handleEvents/OEBlock" . T.pack $ "yielding new block: " ++ show (blockDataNumber . blockBlockData . outputBlockToBlock $ b)
                 yieldR $ NewBlock (outputBlockToBlock b) (obTotalDifficulty b)
-      OETx _ tx -> do
+      OSPETx tx -> do
         whenM (shouldSendGossip peer $ otOrigin tx) $ do
           let cId = txChainId tx
           match <- case cId of
@@ -356,7 +356,7 @@ handleEvents peer = awaitForever $ \case
               $logInfoS "handleEvents/OETx" $ T.pack $ "sending Transaction " ++ format (otHash tx) ++ " for chainID " ++ formatChainId cId
               $logDebugS "handleEvents/OETx" . T.pack $ "the transaction was: " ++ format tx
               yieldR $ Transactions [otBaseTx tx]
-      OEGenesis (OutputGenesis og (cId, cInfo@(ChainInfo uci _))) -> do
+      OSPEGenesis (OutputGenesis og (cId, cInfo@(ChainInfo uci _))) -> do
         when (shouldSend peer og) $ do
           $logInfoS "handleEvents/OEGenesis" . T.pack $ "received new chain: " ++ formatChainId (Just cId) ++ " with " ++ show uci
           if checkPeerIsMember peer $ members uci
@@ -367,9 +367,9 @@ handleEvents peer = awaitForever $ \case
               $logInfoS "handleEvents/OEGenesis" $ T.pack $
                 printf "peer %s is not authorized for received chainID %s" (maybe "<nokey>" showEnode $ pPeerEnode peer) (formatChainId $ Just cId)
               $logDebugLS "handleEvents/OEGenesis/members" $ members uci
-      OEGetChain chainIds -> yieldR $ GetChainDetails chainIds
-      OEGetTx shas -> yieldR $ GetTransactions shas
-      OENewChainMember cId _ _ -> do
+      OSPEGetChain chainIds -> yieldR $ GetChainDetails chainIds
+      OSPEGetTx shas -> yieldR $ GetTransactions shas
+      OSPENewChainMember cId _ _ -> do
         let formatted = format $ SHA cId
         $logInfoS "handleEvents/OENewChainMember" $ T.pack $ "New member added to chain " ++ formatted
         mems <- lift . RBDB.withRedisBlockDB $ RBDB.getChainMembers cId
@@ -377,16 +377,16 @@ handleEvents peer = awaitForever $ \case
           $logInfoS "handleEvents/OENewChainMember" $ T.pack $ "Emitting chain details for chain " ++ formatted
           mcInfo <- lift . RBDB.withRedisBlockDB $ RBDB.getChainInfo cId
           for_ ((cId,) <$> mcInfo) $ yieldR . ChainDetails . (:[])
-      OEBlockstanbul msg -> do
+      OSPEBlockstanbul msg -> do
         let outbound = Blockstanbul msg
         $logDebugS "handleEvents/OEBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
         yieldR outbound
-      OEAskForBlocks start _ p -> do
+      OSPEAskForBlocks start _ p -> do
         ss <- shouldSendToPeer p
         when ss $ do
           $logDebugS "handleEvents/OEAskForBlocks" . T.pack $ "syncFetch: " ++ show start
           syncFetch Forward start
-      OEPushBlocks start end p -> do
+      OSPEPushBlocks start end p -> do
         ss <- shouldSendToPeer p
         when ss $ do
           mrh <- gets maxReturnedHeaders
@@ -398,11 +398,6 @@ handleEvents peer = awaitForever $ \case
           let outbound = BlockHeaders $ morphBlockHeader . snd <$> chain
           $logDebugS "handleEvents/OEPushBlocks" . T.pack $ "Outgoing message: " ++ show outbound
           yieldR outbound
-      OEJsonRpcCommand _ -> $logErrorS "handleEvents/OEJsonRpcCommand" "The impossible happened"
-      OECreateBlockCommand -> $logErrorS "handleEvents/OECreateBlockCommand" "何"
-      OEVoteToMake{} -> $logErrorS "handleEvents/OEVoteToMake" "absurd"
-      OENewCheckpoint{} -> $logErrorS "handleEvents/OENewCheckpoint" "Maybe they should be disjoint types?"
-      OEPrivateTx{} -> $logErrorS "handleEvents/OEPrivateTx" "This type is reserved for the VM"
 
     TimerEvt -> do
         maybeOldTS <- getActionTimestamp

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -338,9 +338,9 @@ handleEvents peer = awaitForever $ \case
           case worldBestBlock of
             Nothing -> return ()
             Just (RedisBestBlock _ _ worldTDiff) -> do
-              $logInfoS "handleEvents/OEBlock" . T.pack $ "World TDiff: " ++ show worldTDiff
+              $logInfoS "handleEvents/P2pBlock" . T.pack $ "World TDiff: " ++ show worldTDiff
               when (obTotalDifficulty b >= worldTDiff) $ do
-                $logInfoS "handleEvents/OEBlock" . T.pack $ "yielding new block: " ++ show (blockDataNumber . blockBlockData . outputBlockToBlock $ b)
+                $logInfoS "handleEvents/P2pBlock" . T.pack $ "yielding new block: " ++ show (blockDataNumber . blockBlockData . outputBlockToBlock $ b)
                 yieldR $ NewBlock (outputBlockToBlock b) (obTotalDifficulty b)
       P2pTx tx -> do
         whenM (shouldSendGossip peer $ otOrigin tx) $ do
@@ -350,41 +350,41 @@ handleEvents peer = awaitForever $ \case
             Just cid' -> checkPeerIsMember peer <$> RBDB.withRedisBlockDB (RBDB.getChainMembers cid')
 
           if not match
-            then $logInfoS "handleEvents/OETx" $ T.pack $
+            then $logInfoS "handleEvents/P2pTx" $ T.pack $
                     printf "peer %s is not authorized for chainID %s" (maybe "<nokey>" showEnode $ pPeerEnode peer) (formatChainId cId)
             else do
-              $logInfoS "handleEvents/OETx" $ T.pack $ "sending Transaction " ++ format (otHash tx) ++ " for chainID " ++ formatChainId cId
-              $logDebugS "handleEvents/OETx" . T.pack $ "the transaction was: " ++ format tx
+              $logInfoS "handleEvents/P2pTx" $ T.pack $ "sending Transaction " ++ format (otHash tx) ++ " for chainID " ++ formatChainId cId
+              $logDebugS "handleEvents/P2pTx" . T.pack $ "the transaction was: " ++ format tx
               yieldR $ Transactions [otBaseTx tx]
       P2pGenesis (OutputGenesis og (cId, cInfo@(ChainInfo uci _))) -> do
         when (shouldSend peer og) $ do
-          $logInfoS "handleEvents/OEGenesis" . T.pack $ "received new chain: " ++ formatChainId (Just cId) ++ " with " ++ show uci
+          $logInfoS "handleEvents/P2pGenesis" . T.pack $ "received new chain: " ++ formatChainId (Just cId) ++ " with " ++ show uci
           if checkPeerIsMember peer $ members uci
             then do
-              $logInfoS "handleEvents/OEGenesis" $ T.pack $ "sending ChainDetails for chainID " ++ (formatChainId $ Just cId)
+              $logInfoS "handleEvents/P2pGenesis" $ T.pack $ "sending ChainDetails for chainID " ++ (formatChainId $ Just cId)
               yieldR $ ChainDetails [(cId, cInfo)]
             else do
-              $logInfoS "handleEvents/OEGenesis" $ T.pack $
+              $logInfoS "handleEvents/P2pGenesis" $ T.pack $
                 printf "peer %s is not authorized for received chainID %s" (maybe "<nokey>" showEnode $ pPeerEnode peer) (formatChainId $ Just cId)
-              $logDebugLS "handleEvents/OEGenesis/members" $ members uci
+              $logDebugLS "handleEvents/P2pGenesis/members" $ members uci
       P2pGetChain chainIds -> yieldR $ GetChainDetails chainIds
       P2pGetTx shas -> yieldR $ GetTransactions shas
       P2pNewChainMember cId _ _ -> do
         let formatted = format $ SHA cId
-        $logInfoS "handleEvents/OENewChainMember" $ T.pack $ "New member added to chain " ++ formatted
+        $logInfoS "handleEvents/P2pNewChainMember" $ T.pack $ "New member added to chain " ++ formatted
         mems <- lift . RBDB.withRedisBlockDB $ RBDB.getChainMembers cId
         when (checkPeerIsMember peer mems) $ do
-          $logInfoS "handleEvents/OENewChainMember" $ T.pack $ "Emitting chain details for chain " ++ formatted
+          $logInfoS "handleEvents/P2pNewChainMember" $ T.pack $ "Emitting chain details for chain " ++ formatted
           mcInfo <- lift . RBDB.withRedisBlockDB $ RBDB.getChainInfo cId
           for_ ((cId,) <$> mcInfo) $ yieldR . ChainDetails . (:[])
       P2pBlockstanbul msg -> do
         let outbound = Blockstanbul msg
-        $logDebugS "handleEvents/OEBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
+        $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
         yieldR outbound
       P2pAskForBlocks start _ p -> do
         ss <- shouldSendToPeer p
         when ss $ do
-          $logDebugS "handleEvents/OEAskForBlocks" . T.pack $ "syncFetch: " ++ show start
+          $logDebugS "handleEvents/P2pAskForBlocks" . T.pack $ "syncFetch: " ++ show start
           syncFetch Forward start
       P2pPushBlocks start end p -> do
         ss <- shouldSendToPeer p
@@ -393,10 +393,10 @@ handleEvents peer = awaitForever $ \case
           let count = min mrh . fromIntegral $ end - start + 1
           chain <- RBDB.withRedisBlockDB $ RBDB.getCanonicalHeaderChain start count
           when (null chain) $
-            $logErrorS "handleEvents/OEPushBlocks" . T.pack $ printf
+            $logErrorS "handleEvents/P2pPushBlocks" . T.pack $ printf
               "Blockstanbul believes we have blocks for [%d..%d], they are not found in redis" start end
           let outbound = BlockHeaders $ morphBlockHeader . snd <$> chain
-          $logDebugS "handleEvents/OEPushBlocks" . T.pack $ "Outgoing message: " ++ show outbound
+          $logDebugS "handleEvents/P2pPushBlocks" . T.pack $ "Outgoing message: " ++ show outbound
           yieldR outbound
 
     TimerEvt -> do

--- a/core-strato/strato-p2p/src/Blockchain/EventModel.hs
+++ b/core-strato/strato-p2p/src/Blockchain/EventModel.hs
@@ -3,4 +3,4 @@ module Blockchain.EventModel (Event(..)) where
 import Blockchain.Data.Wire
 import Blockchain.Sequencer.Event
 
-data Event = MsgEvt Message | NewSeqEvent OutputEvent | TimerEvt | AbortEvt String deriving (Show)
+data Event = MsgEvt Message | NewSeqEvent OutputSeqP2pEvent | TimerEvt | AbortEvt String deriving (Show)

--- a/core-strato/strato-p2p/src/Blockchain/EventModel.hs
+++ b/core-strato/strato-p2p/src/Blockchain/EventModel.hs
@@ -3,4 +3,4 @@ module Blockchain.EventModel (Event(..)) where
 import Blockchain.Data.Wire
 import Blockchain.Sequencer.Event
 
-data Event = MsgEvt Message | NewSeqEvent OutputSeqP2pEvent | TimerEvt | AbortEvt String deriving (Show)
+data Event = MsgEvt Message | NewSeqEvent P2pEvent | TimerEvt | AbortEvt String deriving (Show)

--- a/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -31,7 +31,7 @@ seqEventNotificationSource :: ( MonadIO m
                               , MonadResource m
                               , MonadLogger m
                               )
-                           => K.KafkaState -> ConduitM () OutputSeqP2pEvent m ()
+                           => K.KafkaState -> ConduitM () P2pEvent m ()
 seqEventNotificationSource ks = evalStateC ks $ do
     ofs' <- lift $ K.withKafkaViolently $ K.getLastOffset K.LatestTime 0 seqP2pEventsTopicName
     loop ofs'

--- a/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/core-strato/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -31,7 +31,7 @@ seqEventNotificationSource :: ( MonadIO m
                               , MonadResource m
                               , MonadLogger m
                               )
-                           => K.KafkaState -> ConduitM () OutputEvent m ()
+                           => K.KafkaState -> ConduitM () OutputSeqP2pEvent m ()
 seqEventNotificationSource ks = evalStateC ks $ do
     ofs' <- lift $ K.withKafkaViolently $ K.getLastOffset K.LatestTime 0 seqP2pEventsTopicName
     loop ofs'

--- a/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -33,7 +33,7 @@ stratoP2PLoopback = do
   void . runContextM ctx $ do
     ks <- gets contextKafkaState
     let toWireMessage = \case
-          OSPEBlockstanbul wm -> Just wm
+          P2pBlockstanbul wm -> Just wm
           _ -> Nothing
 
     runConduit $

--- a/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -33,7 +33,7 @@ stratoP2PLoopback = do
   void . runContextM ctx $ do
     ks <- gets contextKafkaState
     let toWireMessage = \case
-          OEBlockstanbul wm -> Just wm
+          OSPEBlockstanbul wm -> Just wm
           _ -> Nothing
 
     runConduit $

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -121,7 +121,7 @@ spec = do
 
     it "should broadcast blockstanbul messages" $ property $ withMaxSuccess 10 $ \wm ->
       runTestPeer . const $ do
-        runConduit $ yield (NewSeqEvent (OSPEBlockstanbul wm))
+        runConduit $ yield (NewSeqEvent (P2pBlockstanbul wm))
                       .| handleEvents testPeer
                       .| sinkList
             `L.shouldReturn` [Right $ Blockstanbul wm]

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -121,7 +121,7 @@ spec = do
 
     it "should broadcast blockstanbul messages" $ property $ withMaxSuccess 10 $ \wm ->
       runTestPeer . const $ do
-        runConduit $ yield (NewSeqEvent (OEBlockstanbul wm))
+        runConduit $ yield (NewSeqEvent (OSPEBlockstanbul wm))
                       .| handleEvents testPeer
                       .| sinkList
             `L.shouldReturn` [Right $ Blockstanbul wm]

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -155,14 +155,14 @@ checkForUnseq inEvents = do
     logF "Applied pending LDB writes"
     chainIds <- unGetChainsDB <$> use getChainsDB
     unless (S.null chainIds) $
-      markForP2P . OEGetChain $ toList chainIds
+      markForP2P . OSPEGetChain $ toList chainIds
     txHashes <- unGetTransactionsDB <$> use getTransactionsDB
     unless (S.null txHashes) $
-      markForP2P . OEGetTx $ toList txHashes
+      markForP2P . OSPEGetTx $ toList txHashes
 
 bootstrapBlockstanbul :: SequencerM ()
 bootstrapBlockstanbul = do
-  writeSeqVmEvents [OECreateBlockCommand]
+  writeSeqVmEvents [OSVECreateBlockCommand]
   createFirstTimer
 
 blockstanbulSend :: [InEvent] -> SequencerM ()
@@ -174,7 +174,7 @@ blockstanbulSend = mapM_ $ \ie -> do
    .| sinkList
     )
 
-blockstanbulSend' :: InEvent -> SequencerM [OutputEvent]
+blockstanbulSend' :: InEvent -> SequencerM [OutputSeqVmEvent]
 blockstanbulSend' msg = do
   resp' <- sendAllMessages [msg]
   let blocks = [b | ToCommit b <- resp']
@@ -194,16 +194,16 @@ blockstanbulSend' msg = do
       rewriteBlock b = do
         msb <- getSequencedBlock b
         for msb $ \sb -> do
-          return . OEBlock $ sequencedBlockToOutputBlock sb 1
-      creates = [OECreateBlockCommand | MakeBlockCommand <- resp]
+          return . OSVEBlock $ sequencedBlockToOutputBlock sb 1
+      creates = [OSVECreateBlockCommand | MakeBlockCommand <- resp]
   rBlocks <- fmap catMaybes $ mapM rewriteBlock blocks
   let vmevs = creates
            ++ rBlocks
-           ++ [OEVoteToMake r d s| PendingVote r d s <- resp]
-           ++ [OENewCheckpoint ck | NewCheckpoint ck <- resp]
-      p2pevs = [OEBlockstanbul (WireMessage a m) | OMsg a m <- resp]
-            ++ [OEAskForBlocks (h+1) l p | GapFound h l p <- resp]
-            ++ [OEPushBlocks (l+1) h p | LeadFound h l p <- resp]
+           ++ [OSVEVoteToMake r d s| PendingVote r d s <- resp]
+           -- ++ [OSVENewCheckpoint ck | NewCheckpoint ck <- resp] -- todo: create separate queue for checkpoints
+      p2pevs = [OSPEBlockstanbul (WireMessage a m) | OMsg a m <- resp]
+            ++ [OSPEAskForBlocks (h+1) l p | GapFound h l p <- resp]
+            ++ [OSPEPushBlocks (l+1) h p | LeadFound h l p <- resp]
 
   unless (null blocks) $ do
     let tLast = blockHeaderTimestamp . BDB.blockBlockData . head $ blocks
@@ -232,8 +232,8 @@ transformPrivateHashTXs pairs = forM_ pairs $ \(ts, t@(IngestTx _ (TD.PrivateHas
       unless pwitnessed $ do
         witnessTransactionHash privateWitnessHash
         runPrivateHashTX (SHA th') (SHA ch')
-        markForP2P $ OETx ts otx
-        markForVM  $ OETx ts otx
+        markForP2P $ OSPETx otx
+        markForVM  $ OSVETx ts otx
 
 transformFullTransactions :: [(Timestamp, IngestTx)] -> SequencerM ()
 transformFullTransactions pairs = do
@@ -258,8 +258,8 @@ transformFullTransactions pairs = do
     if not isPrivateChain
       then do
         logF $ "Sending " ++ show (length txs) ++ " public transactions to P2P and the VM"
-        mapM_ (markForVM . pairToOETx) txs
-        mapM_ (markForP2P . pairToOETx) txs
+        mapM_ (markForVM . pairToOSVETx) txs
+        mapM_ (markForP2P . OSPETx . snd) txs
       else forM_ (partitionWith (TD.transactionChainId . otBaseTx . snd) txs) $ \(Just chainId, ptxs) -> do
         logF . concat $
           [ "Transforming "
@@ -268,7 +268,7 @@ transformFullTransactions pairs = do
           , format (SHA chainId)
           ]
         mapM_ (insertTransaction . snd) ptxs
-        mapM_ (markForVM . OEPrivateTx . snd) ptxs -- we want to get these transactions into the
+        mapM_ (markForVM . OSVEPrivateTx . snd) ptxs -- we want to get these transactions into the
                                                    -- P2P indexer ASAP so we can return them to
                                                    -- peers requesting them
         mcInfo <- fmap _chainIdInfo <$> A.lookup (Proxy :: Proxy ChainIdEntry) chainId
@@ -287,7 +287,7 @@ transformFullTransactions pairs = do
                 , format (SHA chainId)
                 , ". Sending to P2P."
                 ]
-              markForP2P $ pairToOETx (ts, ptx)
+              markForP2P $ OSPETx ptx
               --liftIO $ withLabel txMetrics "private_hash" incCounter
               when (otOrigin ptx == TO.API) $ do
                 cHash <- getNewChainHash chainId >>= \case
@@ -313,9 +313,9 @@ transformFullTransactions pairs = do
                   , " for transaction "
                   , format tHash
                   ]
-                markForVM $ pairToOETx (ts, phtx)
-                markForP2P $ pairToOETx (ts, phtx)
-            mapM_ (markForVM . OEBlock) =<< runBlocks chainId
+                markForVM $ pairToOSVETx (ts, phtx)
+                markForP2P $ OSPETx phtx
+            mapM_ (markForVM . OSVEBlock) =<< runBlocks chainId
 
 transformTransactions :: [(Timestamp, IngestTx)] -> SequencerM ()
 transformTransactions events = forM_ (partitionWith (isPrivateHashTX . itTransaction . snd) events) $ \(isPrivateHash, pairs) ->
@@ -352,16 +352,15 @@ expandBlock = awaitForever $ \sb -> do
           $logInfoS "expandBlock" . T.pack $ prettyBlock sb ++ " is ready to emit, but its emission chain is empty. It was likely already emitted."
           yield $ Left sb
 
-runConsensus :: ConduitM (Either SequencedBlock OutputBlock) OutputEvent SequencerM ()
+runConsensus :: ConduitM (Either SequencedBlock OutputBlock) OutputSeqVmEvent SequencerM ()
 runConsensus = awaitForever $ \eob -> do
   hasPBFT <- lift $ blockstanbulRunning
   if not hasPBFT
     then case eob of
       Left _ -> return ()
       Right ob -> do
-        let oeBlock = OEBlock ob
-        lift $ markForP2P oeBlock
-        yield oeBlock
+        lift . markForP2P $ OSPEBlock ob
+        yield $ OSVEBlock ob
     else do
       let convert :: BDB.Block -> InEvent
           convert blk = if isHistoricBlock blk
@@ -374,12 +373,12 @@ runConsensus = awaitForever $ \eob -> do
       oes <- lift . blockstanbulSend' . convert $ route eob
       yieldMany oes
 
-hydrateAndEmit :: Maybe Word256 -> ConduitM OutputEvent OutputEvent SequencerM ()
+hydrateAndEmit :: Maybe Word256 -> ConduitM OutputSeqVmEvent OutputSeqVmEvent SequencerM ()
 hydrateAndEmit chainId = awaitForever $ \case
-  OEBlock ob -> do
-    when (isNothing chainId) . yield $ OEBlock ob
+  OSVEBlock ob -> do
+    when (isNothing chainId) . yield $ OSVEBlock ob
     ob' <- lift $ hydratePrivateHashes chainId ob
-    for_ ob' $ yield . OEBlock
+    for_ ob' $ yield . OSVEBlock
   oe -> yield oe
 
 transformBlocks :: [IngestBlock] -> SequencerM ()
@@ -401,9 +400,9 @@ transformGenesis chains = forM_ chains $ \ig -> do
     True -> logF "We've seen this chain before. Not emitting to VM"
     False -> do
       logF "We haven't seen this chain before. Inserting into SeenChainDB and emitting to VM, P2P"
-      markForVM $ OEGenesis og
-      markForP2P (OEGenesis og)
-      mapM_ (markForVM . OEBlock) =<< insertNewChainInfo chainId cInfo
+      markForVM $ OSVEGenesis og
+      markForP2P (OSPEGenesis og)
+      mapM_ (markForVM . OSVEBlock) =<< insertNewChainInfo chainId cInfo
 
 splitEvents :: [IngestEvent] -> SequencerM ()
 splitEvents es = forM_ (partitionWith iEventType es) $ \(eventType, events) ->
@@ -424,7 +423,7 @@ splitEvents es = forM_ (partitionWith iEventType es) $ \(eventType, events) ->
       transformGenesis $ map (\(IEGenesis og) -> og) events
     IETNewChainMember -> do
       record "inevent_type_new_chain_member" "IngestNewChainMembers"
-      mapM_ (\(IENewChainMember c a e) -> markForP2P $ OENewChainMember c a e) events
+      mapM_ (\(IENewChainMember c a e) -> markForP2P $ OSPENewChainMember c a e) events
     IETBlockstanbul -> do
       record "inevent_type_blockstanbul" "IngestBlockstanbuls"
       blockstanbulSend $ map (\(IEBlockstanbul (WireMessage a m)) -> IMsg a m) events
@@ -465,12 +464,12 @@ prettyOTx OutputTx{otOrigin=o, otBaseTx=t} = prefix t ++ " via " ++ shortOrigin 
             shortOrigin (TO.PeerString peer) = "Peer " ++ take 8 peer
             shortOrigin x                    = format x
 
-writeSeqVmEvents :: [OutputEvent] -> SequencerM ()
+writeSeqVmEvents :: [OutputSeqVmEvent] -> SequencerM ()
 writeSeqVmEvents events = do
     ch <- asks (seqVMEvents . cablePackage)
     atomically . mapM_ (writeTQueue ch) $ events
 
-writeSeqP2pEvents :: [OutputEvent] -> SequencerM ()
+writeSeqP2pEvents :: [OutputSeqP2pEvent] -> SequencerM ()
 writeSeqP2pEvents events = do
     ch <- asks (seqP2PEvents . cablePackage)
     atomically . mapM_ (writeTQueue ch) $ events

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -155,14 +155,14 @@ checkForUnseq inEvents = do
     logF "Applied pending LDB writes"
     chainIds <- unGetChainsDB <$> use getChainsDB
     unless (S.null chainIds) $
-      markForP2P . OSPEGetChain $ toList chainIds
+      markForP2P . P2pGetChain $ toList chainIds
     txHashes <- unGetTransactionsDB <$> use getTransactionsDB
     unless (S.null txHashes) $
-      markForP2P . OSPEGetTx $ toList txHashes
+      markForP2P . P2pGetTx $ toList txHashes
 
 bootstrapBlockstanbul :: SequencerM ()
 bootstrapBlockstanbul = do
-  writeSeqVmEvents [OSVECreateBlockCommand]
+  writeSeqVmEvents [VmCreateBlockCommand]
   createFirstTimer
 
 blockstanbulSend :: [InEvent] -> SequencerM ()
@@ -174,7 +174,7 @@ blockstanbulSend = mapM_ $ \ie -> do
    .| sinkList
     )
 
-blockstanbulSend' :: InEvent -> SequencerM [OutputSeqVmEvent]
+blockstanbulSend' :: InEvent -> SequencerM [VmEvent]
 blockstanbulSend' msg = do
   resp' <- sendAllMessages [msg]
   let blocks = [b | ToCommit b <- resp']
@@ -194,16 +194,16 @@ blockstanbulSend' msg = do
       rewriteBlock b = do
         msb <- getSequencedBlock b
         for msb $ \sb -> do
-          return . OSVEBlock $ sequencedBlockToOutputBlock sb 1
-      creates = [OSVECreateBlockCommand | MakeBlockCommand <- resp]
+          return . VmBlock $ sequencedBlockToOutputBlock sb 1
+      creates = [VmCreateBlockCommand | MakeBlockCommand <- resp]
   rBlocks <- fmap catMaybes $ mapM rewriteBlock blocks
   let vmevs = creates
            ++ rBlocks
-           ++ [OSVEVoteToMake r d s| PendingVote r d s <- resp]
-           -- ++ [OSVENewCheckpoint ck | NewCheckpoint ck <- resp] -- todo: create separate queue for checkpoints
-      p2pevs = [OSPEBlockstanbul (WireMessage a m) | OMsg a m <- resp]
-            ++ [OSPEAskForBlocks (h+1) l p | GapFound h l p <- resp]
-            ++ [OSPEPushBlocks (l+1) h p | LeadFound h l p <- resp]
+           ++ [VmVoteToMake r d s| PendingVote r d s <- resp]
+           -- ++ [VmNewCheckpoint ck | NewCheckpoint ck <- resp] -- todo: create separate queue for checkpoints
+      p2pevs = [P2pBlockstanbul (WireMessage a m) | OMsg a m <- resp]
+            ++ [P2pAskForBlocks (h+1) l p | GapFound h l p <- resp]
+            ++ [P2pPushBlocks (l+1) h p | LeadFound h l p <- resp]
 
   unless (null blocks) $ do
     let tLast = blockHeaderTimestamp . BDB.blockBlockData . head $ blocks
@@ -232,8 +232,8 @@ transformPrivateHashTXs pairs = forM_ pairs $ \(ts, t@(IngestTx _ (TD.PrivateHas
       unless pwitnessed $ do
         witnessTransactionHash privateWitnessHash
         runPrivateHashTX (SHA th') (SHA ch')
-        markForP2P $ OSPETx otx
-        markForVM  $ OSVETx ts otx
+        markForP2P $ P2pTx otx
+        markForVM  $ VmTx ts otx
 
 transformFullTransactions :: [(Timestamp, IngestTx)] -> SequencerM ()
 transformFullTransactions pairs = do
@@ -258,8 +258,8 @@ transformFullTransactions pairs = do
     if not isPrivateChain
       then do
         logF $ "Sending " ++ show (length txs) ++ " public transactions to P2P and the VM"
-        mapM_ (markForVM . pairToOSVETx) txs
-        mapM_ (markForP2P . OSPETx . snd) txs
+        mapM_ (markForVM . pairToVmTx) txs
+        mapM_ (markForP2P . P2pTx . snd) txs
       else forM_ (partitionWith (TD.transactionChainId . otBaseTx . snd) txs) $ \(Just chainId, ptxs) -> do
         logF . concat $
           [ "Transforming "
@@ -268,7 +268,7 @@ transformFullTransactions pairs = do
           , format (SHA chainId)
           ]
         mapM_ (insertTransaction . snd) ptxs
-        mapM_ (markForVM . OSVEPrivateTx . snd) ptxs -- we want to get these transactions into the
+        mapM_ (markForVM . VmPrivateTx . snd) ptxs -- we want to get these transactions into the
                                                    -- P2P indexer ASAP so we can return them to
                                                    -- peers requesting them
         mcInfo <- fmap _chainIdInfo <$> A.lookup (Proxy :: Proxy ChainIdEntry) chainId
@@ -287,7 +287,7 @@ transformFullTransactions pairs = do
                 , format (SHA chainId)
                 , ". Sending to P2P."
                 ]
-              markForP2P $ OSPETx ptx
+              markForP2P $ P2pTx ptx
               --liftIO $ withLabel txMetrics "private_hash" incCounter
               when (otOrigin ptx == TO.API) $ do
                 cHash <- getNewChainHash chainId >>= \case
@@ -313,9 +313,9 @@ transformFullTransactions pairs = do
                   , " for transaction "
                   , format tHash
                   ]
-                markForVM $ pairToOSVETx (ts, phtx)
-                markForP2P $ OSPETx phtx
-            mapM_ (markForVM . OSVEBlock) =<< runBlocks chainId
+                markForVM $ pairToVmTx (ts, phtx)
+                markForP2P $ P2pTx phtx
+            mapM_ (markForVM . VmBlock) =<< runBlocks chainId
 
 transformTransactions :: [(Timestamp, IngestTx)] -> SequencerM ()
 transformTransactions events = forM_ (partitionWith (isPrivateHashTX . itTransaction . snd) events) $ \(isPrivateHash, pairs) ->
@@ -352,15 +352,15 @@ expandBlock = awaitForever $ \sb -> do
           $logInfoS "expandBlock" . T.pack $ prettyBlock sb ++ " is ready to emit, but its emission chain is empty. It was likely already emitted."
           yield $ Left sb
 
-runConsensus :: ConduitM (Either SequencedBlock OutputBlock) OutputSeqVmEvent SequencerM ()
+runConsensus :: ConduitM (Either SequencedBlock OutputBlock) VmEvent SequencerM ()
 runConsensus = awaitForever $ \eob -> do
   hasPBFT <- lift $ blockstanbulRunning
   if not hasPBFT
     then case eob of
       Left _ -> return ()
       Right ob -> do
-        lift . markForP2P $ OSPEBlock ob
-        yield $ OSVEBlock ob
+        lift . markForP2P $ P2pBlock ob
+        yield $ VmBlock ob
     else do
       let convert :: BDB.Block -> InEvent
           convert blk = if isHistoricBlock blk
@@ -373,12 +373,12 @@ runConsensus = awaitForever $ \eob -> do
       oes <- lift . blockstanbulSend' . convert $ route eob
       yieldMany oes
 
-hydrateAndEmit :: Maybe Word256 -> ConduitM OutputSeqVmEvent OutputSeqVmEvent SequencerM ()
+hydrateAndEmit :: Maybe Word256 -> ConduitM VmEvent VmEvent SequencerM ()
 hydrateAndEmit chainId = awaitForever $ \case
-  OSVEBlock ob -> do
-    when (isNothing chainId) . yield $ OSVEBlock ob
+  VmBlock ob -> do
+    when (isNothing chainId) . yield $ VmBlock ob
     ob' <- lift $ hydratePrivateHashes chainId ob
-    for_ ob' $ yield . OSVEBlock
+    for_ ob' $ yield . VmBlock
   oe -> yield oe
 
 transformBlocks :: [IngestBlock] -> SequencerM ()
@@ -400,9 +400,9 @@ transformGenesis chains = forM_ chains $ \ig -> do
     True -> logF "We've seen this chain before. Not emitting to VM"
     False -> do
       logF "We haven't seen this chain before. Inserting into SeenChainDB and emitting to VM, P2P"
-      markForVM $ OSVEGenesis og
-      markForP2P (OSPEGenesis og)
-      mapM_ (markForVM . OSVEBlock) =<< insertNewChainInfo chainId cInfo
+      markForVM $ VmGenesis og
+      markForP2P (P2pGenesis og)
+      mapM_ (markForVM . VmBlock) =<< insertNewChainInfo chainId cInfo
 
 splitEvents :: [IngestEvent] -> SequencerM ()
 splitEvents es = forM_ (partitionWith iEventType es) $ \(eventType, events) ->
@@ -423,7 +423,7 @@ splitEvents es = forM_ (partitionWith iEventType es) $ \(eventType, events) ->
       transformGenesis $ map (\(IEGenesis og) -> og) events
     IETNewChainMember -> do
       record "inevent_type_new_chain_member" "IngestNewChainMembers"
-      mapM_ (\(IENewChainMember c a e) -> markForP2P $ OSPENewChainMember c a e) events
+      mapM_ (\(IENewChainMember c a e) -> markForP2P $ P2pNewChainMember c a e) events
     IETBlockstanbul -> do
       record "inevent_type_blockstanbul" "IngestBlockstanbuls"
       blockstanbulSend $ map (\(IEBlockstanbul (WireMessage a m)) -> IMsg a m) events
@@ -464,12 +464,12 @@ prettyOTx OutputTx{otOrigin=o, otBaseTx=t} = prefix t ++ " via " ++ shortOrigin 
             shortOrigin (TO.PeerString peer) = "Peer " ++ take 8 peer
             shortOrigin x                    = format x
 
-writeSeqVmEvents :: [OutputSeqVmEvent] -> SequencerM ()
+writeSeqVmEvents :: [VmEvent] -> SequencerM ()
 writeSeqVmEvents events = do
     ch <- asks (seqVMEvents . cablePackage)
     atomically . mapM_ (writeTQueue ch) $ events
 
-writeSeqP2pEvents :: [OutputSeqP2pEvent] -> SequencerM ()
+writeSeqP2pEvents :: [P2pEvent] -> SequencerM ()
 writeSeqP2pEvents events = do
     ch <- asks (seqP2PEvents . cablePackage)
     atomically . mapM_ (writeTQueue ch) $ events

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -200,10 +200,10 @@ blockstanbulSend' msg = do
   let vmevs = creates
            ++ rBlocks
            ++ [VmVoteToMake r d s| PendingVote r d s <- resp]
-           -- ++ [VmNewCheckpoint ck | NewCheckpoint ck <- resp] -- todo: create separate queue for checkpoints
       p2pevs = [P2pBlockstanbul (WireMessage a m) | OMsg a m <- resp]
             ++ [P2pAskForBlocks (h+1) l p | GapFound h l p <- resp]
             ++ [P2pPushBlocks (l+1) h p | LeadFound h l p <- resp]
+      ckpts = [ck | NewCheckpoint ck <- resp]
 
   unless (null blocks) $ do
     let tLast = blockHeaderTimestamp . BDB.blockBlockData . head $ blocks
@@ -212,6 +212,9 @@ blockstanbulSend' msg = do
     now <- liftIO getCurrentTime
     when (now < tNext) $
       liftIO . threadDelay . round $ 1e6 * diffUTCTime tNext now
+
+  $logDebugS "seq/pbft/send_checkpoints" . T.pack $ show ckpts
+  writeUnseqCheckpoints ckpts
   $logDebugS "seq/pbft/send_p2p" . T.pack $ format p2pevs
   mapM_ markForP2P p2pevs
   $logDebugS "seq/pbft/send_vm" . T.pack $ format vmevs
@@ -463,6 +466,11 @@ prettyOTx OutputTx{otOrigin=o, otBaseTx=t} = prefix t ++ " via " ++ shortOrigin 
 
             shortOrigin (TO.PeerString peer) = "Peer " ++ take 8 peer
             shortOrigin x                    = format x
+
+writeUnseqCheckpoints :: [Checkpoint] -> SequencerM ()
+writeUnseqCheckpoints events = do
+    ch <- asks (unseqCheckpoints . cablePackage)
+    atomically . mapM_ (writeTQueue ch) $ events
 
 writeSeqVmEvents :: [VmEvent] -> SequencerM ()
 writeSeqVmEvents events = do

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Bootstrap.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Bootstrap.hs
@@ -80,5 +80,5 @@ bootstrapSequencer Block{blockBlockData = bd,
             }
       runGregorM dummyGregorCfg $ do
         assertTopicCreation
-        writeSeqVmEvents [OEBlock shortCircuit]  -- todo handle the error :)
-        writeSeqP2pEvents [OEBlock shortCircuit]  -- todo handle the error :)
+        writeSeqVmEvents [OSVEBlock shortCircuit]  -- todo handle the error :)
+        writeSeqP2pEvents [OSPEBlock shortCircuit]  -- todo handle the error :)

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Bootstrap.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Bootstrap.hs
@@ -80,5 +80,5 @@ bootstrapSequencer Block{blockBlockData = bd,
             }
       runGregorM dummyGregorCfg $ do
         assertTopicCreation
-        writeSeqVmEvents [OSVEBlock shortCircuit]  -- todo handle the error :)
-        writeSeqP2pEvents [OSPEBlock shortCircuit]  -- todo handle the error :)
+        writeSeqVmEvents [VmBlock shortCircuit]  -- todo handle the error :)
+        writeSeqP2pEvents [P2pBlock shortCircuit]  -- todo handle the error :)

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/CablePackage.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/CablePackage.hs
@@ -7,8 +7,8 @@ import Blockchain.Sequencer.Event
 data CablePackage = CablePackage
                   { unseqEvents :: TBQueue IngestEvent
                   , unseqCheckpoints :: TQueue OutputEvent --todo: Replace with Checkpoint type
-                  , seqP2PEvents :: TQueue OutputSeqP2pEvent
-                  , seqVMEvents :: TQueue OutputSeqVmEvent
+                  , seqP2PEvents :: TQueue P2pEvent
+                  , seqVMEvents :: TQueue VmEvent
                   }
 
 queueDepth :: Int

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/CablePackage.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/CablePackage.hs
@@ -1,12 +1,13 @@
 module Blockchain.Sequencer.CablePackage where
 
 import ClassyPrelude
+import Blockchain.Blockstanbul (Checkpoint)
 import Blockchain.Sequencer.Event
 
 
 data CablePackage = CablePackage
                   { unseqEvents :: TBQueue IngestEvent
-                  , unseqCheckpoints :: TQueue OutputEvent --todo: Replace with Checkpoint type
+                  , unseqCheckpoints :: TQueue Checkpoint
                   , seqP2PEvents :: TQueue P2pEvent
                   , seqVMEvents :: TQueue VmEvent
                   }

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/CablePackage.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/CablePackage.hs
@@ -6,8 +6,9 @@ import Blockchain.Sequencer.Event
 
 data CablePackage = CablePackage
                   { unseqEvents :: TBQueue IngestEvent
-                  , seqP2PEvents :: TQueue OutputEvent
-                  , seqVMEvents :: TQueue OutputEvent
+                  , unseqCheckpoints :: TQueue OutputEvent --todo: Replace with Checkpoint type
+                  , seqP2PEvents :: TQueue OutputSeqP2pEvent
+                  , seqVMEvents :: TQueue OutputSeqVmEvent
                   }
 
 queueDepth :: Int
@@ -18,4 +19,5 @@ newCablePackage = do
   a <- newTBQueue queueDepth
   b <- newTQueue
   c <- newTQueue
-  return $ CablePackage a b c
+  d <- newTQueue
+  return $ CablePackage a b c d

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -4,6 +4,7 @@
 -- the sequencer becomes more testable as it does not require a kafka setup to run,
 -- and the sequencer does not have to worry about long blocking reads from kafka
 -- preventing other events from being processed.
+{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -28,11 +29,11 @@ import           Control.Concurrent.Extra (Lock, withLock, newLock)
 import           Control.Concurrent.STM (orElse, flushTQueue)
 import           Control.Lens               hiding (op)
 import qualified Control.Monad.Change.Modify as Mod
-import           Control.Monad.Extra (whenJust)
 import           Control.Monad.State
 import           Control.Monad.Trans.Resource
 import           Data.Default
-import           Data.List (partition)
+import           Data.Foldable (for_)
+import           Data.List (foldl')
 import           Data.List.Extra (chunksOf)
 import qualified Data.Text as T
 import qualified Prometheus as P
@@ -64,8 +65,9 @@ data GregorContext = GregorContext
                      { _gregorKafkaState :: K.KafkaState
                      , _gregorConsumerGroup :: KP.ConsumerGroup
                      , _gregorUnseq :: TBQueue IngestEvent
-                     , _gregorSeqP2P :: TQueue OutputEvent
-                     , _gregorSeqVM :: TQueue OutputEvent
+                     , _gregorUnseqCheckpoints :: TQueue OutputEvent --todo: Replace with only Checkpoint type
+                     , _gregorSeqP2P :: TQueue OutputSeqP2pEvent
+                     , _gregorSeqVM :: TQueue OutputSeqVmEvent
                      }
 makeLenses ''GregorContext
 
@@ -79,6 +81,7 @@ convert GregorConfig{..} =
   in GregorContext { _gregorKafkaState = kState
                    , _gregorConsumerGroup = kafkaConsumerGroup
                    , _gregorUnseq = unseqEvents cablePackage
+                   , _gregorUnseqCheckpoints = unseqCheckpoints cablePackage
                    , _gregorSeqP2P = seqP2PEvents cablePackage
                    , _gregorSeqVM = seqVMEvents cablePackage
                    }
@@ -107,12 +110,12 @@ readUnseqEvents' = do
     P.unsafeAddCounter gregorUnseqRead $ fromIntegral count
     return (offset + fromIntegral count, ret)
 
-writeSeqVmEvents :: [OutputEvent] -> GregorM ()
+writeSeqVmEvents :: [OutputSeqVmEvent] -> GregorM ()
 writeSeqVmEvents events = do
     void $ K.withKafkaRetry1s (SK.writeSeqVmEvents events)
     P.unsafeAddCounter gregorVMWrite (fromIntegral(length events))
 
-writeSeqP2pEvents :: [OutputEvent] -> GregorM ()
+writeSeqP2pEvents :: [OutputSeqP2pEvent] -> GregorM ()
 writeSeqP2pEvents events = do
     void $ K.withKafkaRetry1s (SK.writeSeqP2pEvents events)
     P.unsafeAddCounter gregorP2PWrite (fromIntegral(length events))
@@ -193,35 +196,40 @@ unseqReader = forever . timeAction gregorUnseqTiming $ do
   -- with the events that `seqWriters` processes.
   updateOffset_locked nextOff
 
+data ImOnlyUsedInSeqWriters a b c = VM a | P2P b | KafkaCheckpoint c
+  deriving (Foldable)
+
 seqWriters :: GregorM ()
 seqWriters = forever . timeAction gregorSeqTiming $ do
   vmq <- use gregorSeqVM
   p2pq <- use gregorSeqP2P
+  ckptq <- use gregorUnseqCheckpoints
   events <- atomically $
-    fmap Left (blockFlushTQueue vmq) `orElse` fmap Right (blockFlushTQueue p2pq)
+    fmap VM (blockFlushTQueue vmq)
+    `orElse` (fmap P2P (blockFlushTQueue p2pq)
+    `orElse` fmap KafkaCheckpoint (blockFlushTQueue ckptq))
   $logDebugS "gregor/seqWriter" . T.pack . show $ length events
   case events of
-    Left vmevs -> do
+    VM vmevs -> do
       P.withLabel gregorLoop "seq_vm_events" P.incCounter
       P.unsafeAddCounter gregorVMRead (fromIntegral $ length vmevs)
+      writeSeqVmEvents vmevs
+
+    P2P p2pevs -> do
+      P.withLabel gregorLoop "seq_p2p_events" P.incCounter
+      P.unsafeAddCounter gregorP2PRead (fromIntegral $ length p2pevs)
+      writeSeqP2pEvents p2pevs
+
+    KafkaCheckpoint ckpts -> do
       let isCheckpoint OENewCheckpoint{} = True
           isCheckpoint _ = False
-          safeLast [] = Nothing
-          safeLast [x] = Just x
-          safeLast (_:xs) = safeLast xs
-          (ckpts, vmevs') = partition isCheckpoint vmevs
-      writeSeqVmEvents vmevs'
-      whenJust (safeLast ckpts) $ \case
+          lastCheckpoint = foldl' (\b a -> if isCheckpoint a then Just a else b) Nothing ckpts
+      for_ lastCheckpoint $ \case
         OENewCheckpoint ckpt -> do
           $logDebugLS "gregor/seqWriter/checkpoint" ckpt
           P.incCounter gregorCheckpointsSent
           updateMetadata_locked $ encodeMeta ckpt
         oe -> error $ "non-checkpoint partitioned with checkpoints: " ++ show oe -- we untyped now
-
-    Right p2pevs -> do
-      P.withLabel gregorLoop "seq_p2p_events" P.incCounter
-      P.unsafeAddCounter gregorP2PRead (fromIntegral $ length p2pevs)
-      writeSeqP2pEvents p2pevs
 
 -- Will only read if at least one element is in the queue.
 blockFlushTQueue :: TQueue a -> STM [a]

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -33,7 +33,6 @@ import           Control.Monad.State
 import           Control.Monad.Trans.Resource
 import           Data.Default
 import           Data.Foldable (for_)
-import           Data.List (foldl')
 import           Data.List.Extra (chunksOf)
 import qualified Data.Text as T
 import qualified Prometheus as P
@@ -65,7 +64,7 @@ data GregorContext = GregorContext
                      { _gregorKafkaState :: K.KafkaState
                      , _gregorConsumerGroup :: KP.ConsumerGroup
                      , _gregorUnseq :: TBQueue IngestEvent
-                     , _gregorUnseqCheckpoints :: TQueue OutputEvent --todo: Replace with only Checkpoint type
+                     , _gregorUnseqCheckpoints :: TQueue Checkpoint
                      , _gregorSeqP2P :: TQueue P2pEvent
                      , _gregorSeqVM :: TQueue VmEvent
                      }
@@ -221,15 +220,12 @@ seqWriters = forever . timeAction gregorSeqTiming $ do
       writeSeqP2pEvents p2pevs
 
     KafkaCheckpoint ckpts -> do
-      let isCheckpoint OENewCheckpoint{} = True
-          isCheckpoint _ = False
-          lastCheckpoint = foldl' (\b a -> if isCheckpoint a then Just a else b) Nothing ckpts
-      for_ lastCheckpoint $ \case
-        OENewCheckpoint ckpt -> do
-          $logDebugLS "gregor/seqWriter/checkpoint" ckpt
-          P.incCounter gregorCheckpointsSent
-          updateMetadata_locked $ encodeMeta ckpt
-        oe -> error $ "non-checkpoint partitioned with checkpoints: " ++ show oe -- we untyped now
+      let safeLast [] = Nothing
+          safeLast xs = Just $ last xs
+      for_ (safeLast ckpts) $ \ckpt -> do
+        $logDebugLS "gregor/seqWriter/checkpoint" ckpt
+        P.incCounter gregorCheckpointsSent
+        updateMetadata_locked $ encodeMeta ckpt
 
 -- Will only read if at least one element is in the queue.
 blockFlushTQueue :: TQueue a -> STM [a]

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Gregor.hs
@@ -66,8 +66,8 @@ data GregorContext = GregorContext
                      , _gregorConsumerGroup :: KP.ConsumerGroup
                      , _gregorUnseq :: TBQueue IngestEvent
                      , _gregorUnseqCheckpoints :: TQueue OutputEvent --todo: Replace with only Checkpoint type
-                     , _gregorSeqP2P :: TQueue OutputSeqP2pEvent
-                     , _gregorSeqVM :: TQueue OutputSeqVmEvent
+                     , _gregorSeqP2P :: TQueue P2pEvent
+                     , _gregorSeqVM :: TQueue VmEvent
                      }
 makeLenses ''GregorContext
 
@@ -110,12 +110,12 @@ readUnseqEvents' = do
     P.unsafeAddCounter gregorUnseqRead $ fromIntegral count
     return (offset + fromIntegral count, ret)
 
-writeSeqVmEvents :: [OutputSeqVmEvent] -> GregorM ()
+writeSeqVmEvents :: [VmEvent] -> GregorM ()
 writeSeqVmEvents events = do
     void $ K.withKafkaRetry1s (SK.writeSeqVmEvents events)
     P.unsafeAddCounter gregorVMWrite (fromIntegral(length events))
 
-writeSeqP2pEvents :: [OutputSeqP2pEvent] -> GregorM ()
+writeSeqP2pEvents :: [P2pEvent] -> GregorM ()
 writeSeqP2pEvents events = do
     void $ K.withKafkaRetry1s (SK.writeSeqP2pEvents events)
     P.unsafeAddCounter gregorP2PWrite (fromIntegral(length events))

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -29,7 +29,7 @@ module Blockchain.Sequencer.Monad (
   , getTransactionsDB
   , prunePrivacyDBs
   , runSequencerM
-  , pairToOSVETx
+  , pairToVmTx
   , markForVM
   , markForP2P
   , clearLdbBatchOps
@@ -105,8 +105,8 @@ data SequencerContext = SequencerContext
   , _getChainsDB         :: GetChainsDB
   , _getTransactionsDB   :: GetTransactionsDB
   , _ldbBatchOps         :: Q.Seq LDB.BatchOp
-  , _vmEvents            :: Q.Seq OutputSeqVmEvent
-  , _p2pEvents           :: Q.Seq OutputSeqP2pEvent
+  , _vmEvents            :: Q.Seq VmEvent
+  , _p2pEvents           :: Q.Seq P2pEvent
   , _blockstanbulContext :: Maybe BlockstanbulContext
   , _loopTimeout         :: TMChan ()
   , _latestRoundNumber   :: IORef RoundNumber
@@ -347,19 +347,19 @@ runSequencerM c mbc m = do
             }
     return $ fst a
 
-pairToOSVETx :: (Timestamp, OutputTx) -> OutputSeqVmEvent
-pairToOSVETx = uncurry OSVETx
+pairToVmTx :: (Timestamp, OutputTx) -> VmEvent
+pairToVmTx = uncurry VmTx
 
-markForVM :: OutputSeqVmEvent -> SequencerM ()
+markForVM :: VmEvent -> SequencerM ()
 markForVM oe = vmEvents %= (Q.|> oe)
 
-markForP2P :: OutputSeqP2pEvent -> SequencerM ()
+markForP2P :: P2pEvent -> SequencerM ()
 markForP2P oe = p2pEvents %= (Q.|> oe)
 
-drainP2P :: SequencerM [OutputSeqP2pEvent]
+drainP2P :: SequencerM [P2pEvent]
 drainP2P = fmap toList $ p2pEvents <<.= Q.empty
 
-drainVM :: SequencerM [OutputSeqVmEvent]
+drainVM :: SequencerM [VmEvent]
 drainVM = fmap toList $ vmEvents <<.= Q.empty
 
 clearDBERegistry :: SequencerM ()

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -29,7 +29,7 @@ module Blockchain.Sequencer.Monad (
   , getTransactionsDB
   , prunePrivacyDBs
   , runSequencerM
-  , pairToOETx
+  , pairToOSVETx
   , markForVM
   , markForP2P
   , clearLdbBatchOps
@@ -105,8 +105,8 @@ data SequencerContext = SequencerContext
   , _getChainsDB         :: GetChainsDB
   , _getTransactionsDB   :: GetTransactionsDB
   , _ldbBatchOps         :: Q.Seq LDB.BatchOp
-  , _vmEvents            :: Q.Seq OutputEvent
-  , _p2pEvents           :: Q.Seq OutputEvent
+  , _vmEvents            :: Q.Seq OutputSeqVmEvent
+  , _p2pEvents           :: Q.Seq OutputSeqP2pEvent
   , _blockstanbulContext :: Maybe BlockstanbulContext
   , _loopTimeout         :: TMChan ()
   , _latestRoundNumber   :: IORef RoundNumber
@@ -347,19 +347,19 @@ runSequencerM c mbc m = do
             }
     return $ fst a
 
-pairToOETx :: (Timestamp, OutputTx) -> OutputEvent
-pairToOETx = uncurry OETx
+pairToOSVETx :: (Timestamp, OutputTx) -> OutputSeqVmEvent
+pairToOSVETx = uncurry OSVETx
 
-markForVM :: OutputEvent -> SequencerM ()
+markForVM :: OutputSeqVmEvent -> SequencerM ()
 markForVM oe = vmEvents %= (Q.|> oe)
 
-markForP2P :: OutputEvent -> SequencerM ()
+markForP2P :: OutputSeqP2pEvent -> SequencerM ()
 markForP2P oe = p2pEvents %= (Q.|> oe)
 
-drainP2P :: SequencerM [OutputEvent]
+drainP2P :: SequencerM [OutputSeqP2pEvent]
 drainP2P = fmap toList $ p2pEvents <<.= Q.empty
 
-drainVM :: SequencerM [OutputEvent]
+drainVM :: SequencerM [OutputSeqVmEvent]
 drainVM = fmap toList $ vmEvents <<.= Q.empty
 
 clearDBERegistry :: SequencerM ()

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/ChainHelpers.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/ChainHelpers.hs
@@ -61,15 +61,3 @@ setIngestBlockGasUsed amount = mapIngestHeader $ \h -> h { blockDataGasUsed = am
 
 setIngestBlockNonce :: Integer -> IngestBlock -> IngestBlock
 setIngestBlockNonce val = mapIngestHeader $ \h -> h { blockDataNonce = fromIntegral val }
-
-extractBlocksFromOutputEvents :: [OutputEvent] -> [OutputBlock]
-extractBlocksFromOutputEvents = join . (map convert)
-    where convert (OETx _ _)  = []
-          convert (OEBlock b) = [b]
-          convert _           = error "partial function inf extractBlocksFromOutputEvents"
-
-extractTxsFromOutputEvents :: [OutputEvent] -> [OutputTx]
-extractTxsFromOutputEvents = join . (map convert)
-    where convert (OETx _ t)  = [t]
-          convert (OEBlock _) = []
-          convert _           = error "partial function in extractTxsFromOutputEvents"

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -171,7 +171,7 @@ spec = do
             outBlocks <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IEBlock <$> inChain)
               oes <- drainVM
-              return [block | OEBlock block <- oes ]
+              return [block | OSVEBlock block <- oes ]
             ret <- validateOrder gb outBlocks
             ret `shouldSatisfy` isValid
 
@@ -182,7 +182,7 @@ spec = do
             outBlocks <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IEBlock <$> shuffled)
               oes <- drainVM
-              return [block | OEBlock block <- oes ]
+              return [block | OSVEBlock block <- oes ]
             ret <- validateOrder gb outBlocks
             ret `shouldSatisfy` isValid
 
@@ -194,7 +194,7 @@ spec = do
             outTxs <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IETx ts <$> inTxs)
               oes <- drainVM
-              return [o | o@(OETx _ _) <- oes]
+              return [OETx s t | OSVETx s t <- oes]
             -- ^^ in case any arbitrary Txs weren't unique
             let dedupedIn = feedBackOutputsToInput outTxs
             dedupedOut <- withTemporaryDepBlockDB False gb $ do
@@ -210,7 +210,7 @@ spec = do
             outTxs <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IETx ts <$> inTxs)
               oes <- drainVM
-              return [o | o@(OETx _ _) <- oes]
+              return [OETx s t | OSVETx s t <- oes]
             -- ^^ in case any arbitrary Txs weren't unique
             let dedupedIn          = feedBackOutputsToInput outTxs
                 replicationsNeeded = (dedupWindow `quot` length dedupedIn) + 1
@@ -218,7 +218,7 @@ spec = do
             dedupedOut <- withTemporaryDepBlockDB False gb $ do
               splitEvents replicatedIn
               oes <- drainVM
-              return [o | o@(OETx _ _) <- oes]
+              return [o | o@(OSVETx _ _) <- oes]
             length dedupedOut `shouldBe` length dedupedOut
 
     describe "SequencerM" $ do
@@ -273,7 +273,7 @@ spec = do
             voteList `shouldMatchList` [vote]
             checkForVotes voteList
             vmevs <- drainVM
-            vmevs `shouldContain` [OEVoteToMake { voteRecipient = testAddr, voteVotingDir = True, voteSender = addr}]
+            vmevs `shouldContain` [OSVEVoteToMake { osveVoteRecipient = testAddr, osveVoteVotingDir = True, osveVoteSender = addr}]
             let esign' = signBenfInfo pvk (testAddr, False, 1)
                 esignStr' = (C8.unpack . B16.encode) $ rlpSerialize (rlpEncode esign')
                 vote' = API.CandidateReceived{API.sender=addr
@@ -286,7 +286,7 @@ spec = do
             voteList' `shouldMatchList` [vote']
             checkForVotes voteList'
             vmevs' <- drainVM
-            vmevs' `shouldNotContain` [OEVoteToMake { voteRecipient = testAddr, voteVotingDir = False, voteSender = addr}]
+            vmevs' `shouldNotContain` [OSVEVoteToMake { osveVoteRecipient = testAddr, osveVoteVotingDir = False, osveVoteSender = addr}]
             bctn <- getBlockstanbulContext
             let unwrapbct' = fromMaybe bct bctn
             _authSenders unwrapbct' `shouldBe` M.singleton addr 1
@@ -339,10 +339,10 @@ spec = do
             iev = IEBlock . blockToIngestBlock TO.Morphism $ b
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let pbftEvs = [m | OEBlockstanbul (WireMessage _ m) <- p2pevs]
+        let pbftEvs = [m | OSPEBlockstanbul (WireMessage _ m) <- p2pevs]
         map categorize pbftEvs `shouldMatchList` [PreprepareK, PrepareK, CommitK]
         vmevs <- drainVM
-        vmevs `shouldContain` [OECreateBlockCommand]
+        vmevs `shouldContain` [OSVECreateBlockCommand]
 
       it "should replay old blocks in blockstanbul" . runPBFTTestMWithGenesis $ \h -> do
         ctx <- fromMaybe (error "context required for PBFT") <$> getBlockstanbulContext
@@ -359,8 +359,8 @@ spec = do
         checkForUnseq [iev]
         drainP2P `shouldReturn` []
         vmevs <- drainVM
-        vmevs `shouldContain` [OECreateBlockCommand]
-        map outputBlockToBlock [oblk | OEBlock oblk <- vmevs] `shouldMatchList` [blk4]
+        vmevs `shouldContain` [OSVECreateBlockCommand]
+        map outputBlockToBlock [oblk | OSVEBlock oblk <- vmevs] `shouldMatchList` [blk4]
         ctx' <- fromMaybe (error "context required for pbft") <$> getBlockstanbulContext
         _view ctx' `shouldBe` View 0 1
 
@@ -420,10 +420,10 @@ spec = do
         let hashTx = PrivateHashTX th ch
         checkForUnseq [IETx 0 (IngestTx TO.Morphism hashTx)]
         vmevs <- drainVM
-        let txs = [tx | OETx _ tx <- vmevs]
+        let txs = [tx | OSVETx _ tx <- vmevs]
         map txType txs `shouldBe` [PrivateHash]
         p2pevs <- drainP2P
-        let txs' = [tx | OETx _ tx <- p2pevs]
+        let txs' = [tx | OSPETx tx <- p2pevs]
         map txType txs' `shouldBe` [PrivateHash]
 
       it "should forward a private transaction hash only once" . runTestM $ do
@@ -433,20 +433,20 @@ spec = do
             ietx = IETx 0 (IngestTx TO.Morphism hashTx)
         checkForUnseq [ietx,ietx]
         vmevs <- drainVM
-        let txs = [tx | OETx _ tx <- vmevs]
+        let txs = [tx | OSVETx _ tx <- vmevs]
         map txType txs `shouldBe` [PrivateHash]
         p2pevs <- drainP2P
-        let txs' = [tx | OETx _ tx <- p2pevs]
+        let txs' = [tx | OSPETx tx <- p2pevs]
         map txType txs' `shouldBe` [PrivateHash]
 
       it "should create a PrivateHashTX for a private transaction" . runTestM $ do
         checkForUnseq [chainDetails1]
         checkForUnseq [IETx 0 (IngestTx TO.API tx1)]
         vmevs <- drainVM
-        let txs = [tx | OETx _ tx <- vmevs]
+        let txs = [tx | OSVETx _ tx <- vmevs]
         map txType txs `shouldBe` [PrivateHash]
         p2pevs <- drainP2P
-        let txs' = [tx | OETx _ tx <- p2pevs]
+        let txs' = [tx | OSPETx tx <- p2pevs]
         map txType txs' `shouldBe` [Message, PrivateHash]
 
       it "should run Blockstanbul with private transactions" . runPBFTTestMWithGenesis $ \h -> do
@@ -455,10 +455,10 @@ spec = do
         checkForUnseq [IETx 0 (IngestTx TO.Morphism tx1)]
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let bs = [b | OEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OEBlock b <- vmevs]
+        let obs = [b | OSVEBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash],[Message]]
 
       it "should run Blockstanbul with delayed private transactions" . runPBFTTestMWithGenesis $ \h -> do
@@ -466,14 +466,14 @@ spec = do
         checkForUnseq [chainDetails1]
         checkForUnseq [iev]
         vmevs <- drainVM
-        let obs = [b | OEBlock b <- vmevs]
+        let obs = [b | OSVEBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash]]
         p2pevs <- drainP2P
-        let bs = [b | OEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash]]
         checkForUnseq [IETx 0 (IngestTx TO.Morphism tx1)]
         vmevs' <- drainVM
-        let obs' = [b | OEBlock b <- vmevs']
+        let obs' = [b | OSVEBlock b <- vmevs']
         map (map txType . obReceiptTransactions) obs' `shouldBe` [[Message]]
 
       it "should not split up block when all chains are known" . runPBFTTestMWithGenesis $ \h -> do
@@ -483,10 +483,10 @@ spec = do
         checkForUnseq [ietx tx1, ietx tx2]
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let bs = [b | OEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash, PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OEBlock b <- vmevs]
+        let obs = [b | OSVEBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe`
           [[PrivateHash,PrivateHash],[Message,Message]]
 
@@ -496,14 +496,14 @@ spec = do
         checkForUnseq [ietx tx1, ietx tx2]
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let bs = [b | OEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash,PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OEBlock b <- vmevs]
+        let obs = [b | OSVEBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash,PrivateHash]]
         checkForUnseq [chainDetails1, chainDetails2]
         vmevs' <- drainVM
-        let obs' = [b | OEBlock b <- vmevs']
+        let obs' = [b | OSVEBlock b <- vmevs']
         map (map txType . obReceiptTransactions) obs' `shouldBe` [[Message],[Message]]
 
       it "should split up block when chain infos are staggered" . runPBFTTestMWithGenesis $ \h -> do
@@ -511,18 +511,18 @@ spec = do
             ietx = IETx 0 . IngestTx TO.Morphism
         checkForUnseq [ietx tx1, ietx tx2, iev]
         p2pevs <- drainP2P
-        let bs = [b | OEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash,PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OEBlock b <- vmevs]
+        let obs = [b | OSVEBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash,PrivateHash]]
         checkForUnseq [chainDetails1]
         vmevs' <- drainVM
-        let obs' = [b | OEBlock b <- vmevs']
+        let obs' = [b | OSVEBlock b <- vmevs']
         map (map txType . obReceiptTransactions) obs' `shouldBe` [[Message]]
         checkForUnseq [chainDetails2]
         vmevs'' <- drainVM
-        let obs'' = [b | OEBlock b <- vmevs'']
+        let obs'' = [b | OSVEBlock b <- vmevs'']
         map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message]]
 
       it "should re-run blocks when chain info is delayed" . runPBFTTestMWithGenesis $ \h -> do
@@ -530,19 +530,19 @@ spec = do
             ietx = IETx 0 . IngestTx TO.Morphism
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let bs = [b | OEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OEBlock b <- vmevs]
+        let obs = [b | OSVEBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash]]
         checkForUnseq [chainDetails1]
         vmevs' <- drainVM
-        let obs' = [b | OEBlock b <- vmevs']
+        let obs' = [b | OSVEBlock b <- vmevs']
         obs' `shouldBe` []
         p2pevs' <- drainP2P
-        let gtxs' = [th | OEGetTx th <- p2pevs']
+        let gtxs' = [th | OSPEGetTx th <- p2pevs']
         gtxs' `shouldBe` [[txHash tx1]]
         checkForUnseq [ietx tx1]
         vmevs'' <- drainVM
-        let obs'' = [b | OEBlock b <- vmevs'']
+        let obs'' = [b | OSVEBlock b <- vmevs'']
         map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message]]

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -141,10 +141,10 @@ withTemporaryDepBlockDB pbft genesisBlock m = do
         `finally`
         (removeDirectoryRecursive fullPath >> setCurrentDirectory cwd)-- always clean up
 
-feedBackOutputsToInput :: [OutputEvent] -> [IngestEvent]
+feedBackOutputsToInput :: [VmEvent] -> [IngestEvent]
 feedBackOutputsToInput = map rebox
-    where rebox (OETx ts t) = IETx ts $ unboxTx t
-          rebox (OEBlock (OutputBlock origin _ header txs uncles)) = IEBlock $ IngestBlock origin header (unboxBlockTx <$> txs) uncles
+    where rebox (VmTx ts t) = IETx ts $ unboxTx t
+          rebox (VmBlock (OutputBlock origin _ header txs uncles)) = IEBlock $ IngestBlock origin header (unboxBlockTx <$> txs) uncles
           rebox x = error $ "why are we testing against " ++ show x
           unboxTx (OutputTx origin _ _ _ base) = IngestTx origin base
           unboxBlockTx (OutputTx _ _ _ _ base) = base
@@ -194,7 +194,7 @@ spec = do
             outTxs <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IETx ts <$> inTxs)
               oes <- drainVM
-              return [OETx s t | VmTx s t <- oes]
+              return [t | t@VmTx{} <- oes]
             -- ^^ in case any arbitrary Txs weren't unique
             let dedupedIn = feedBackOutputsToInput outTxs
             dedupedOut <- withTemporaryDepBlockDB False gb $ do
@@ -210,7 +210,7 @@ spec = do
             outTxs <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IETx ts <$> inTxs)
               oes <- drainVM
-              return [OETx s t | VmTx s t <- oes]
+              return [t | t@VmTx{} <- oes]
             -- ^^ in case any arbitrary Txs weren't unique
             let dedupedIn          = feedBackOutputsToInput outTxs
                 replicationsNeeded = (dedupWindow `quot` length dedupedIn) + 1

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -171,7 +171,7 @@ spec = do
             outBlocks <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IEBlock <$> inChain)
               oes <- drainVM
-              return [block | OSVEBlock block <- oes ]
+              return [block | VmBlock block <- oes ]
             ret <- validateOrder gb outBlocks
             ret `shouldSatisfy` isValid
 
@@ -182,7 +182,7 @@ spec = do
             outBlocks <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IEBlock <$> shuffled)
               oes <- drainVM
-              return [block | OSVEBlock block <- oes ]
+              return [block | VmBlock block <- oes ]
             ret <- validateOrder gb outBlocks
             ret `shouldSatisfy` isValid
 
@@ -194,7 +194,7 @@ spec = do
             outTxs <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IETx ts <$> inTxs)
               oes <- drainVM
-              return [OETx s t | OSVETx s t <- oes]
+              return [OETx s t | VmTx s t <- oes]
             -- ^^ in case any arbitrary Txs weren't unique
             let dedupedIn = feedBackOutputsToInput outTxs
             dedupedOut <- withTemporaryDepBlockDB False gb $ do
@@ -210,7 +210,7 @@ spec = do
             outTxs <- withTemporaryDepBlockDB False gb $ do
               splitEvents (IETx ts <$> inTxs)
               oes <- drainVM
-              return [OETx s t | OSVETx s t <- oes]
+              return [OETx s t | VmTx s t <- oes]
             -- ^^ in case any arbitrary Txs weren't unique
             let dedupedIn          = feedBackOutputsToInput outTxs
                 replicationsNeeded = (dedupWindow `quot` length dedupedIn) + 1
@@ -218,7 +218,7 @@ spec = do
             dedupedOut <- withTemporaryDepBlockDB False gb $ do
               splitEvents replicatedIn
               oes <- drainVM
-              return [o | o@(OSVETx _ _) <- oes]
+              return [o | o@(VmTx _ _) <- oes]
             length dedupedOut `shouldBe` length dedupedOut
 
     describe "SequencerM" $ do
@@ -273,7 +273,7 @@ spec = do
             voteList `shouldMatchList` [vote]
             checkForVotes voteList
             vmevs <- drainVM
-            vmevs `shouldContain` [OSVEVoteToMake { osveVoteRecipient = testAddr, osveVoteVotingDir = True, osveVoteSender = addr}]
+            vmevs `shouldContain` [VmVoteToMake { voteRecipient = testAddr, voteVotingDir = True, voteSender = addr}]
             let esign' = signBenfInfo pvk (testAddr, False, 1)
                 esignStr' = (C8.unpack . B16.encode) $ rlpSerialize (rlpEncode esign')
                 vote' = API.CandidateReceived{API.sender=addr
@@ -286,7 +286,7 @@ spec = do
             voteList' `shouldMatchList` [vote']
             checkForVotes voteList'
             vmevs' <- drainVM
-            vmevs' `shouldNotContain` [OSVEVoteToMake { osveVoteRecipient = testAddr, osveVoteVotingDir = False, osveVoteSender = addr}]
+            vmevs' `shouldNotContain` [VmVoteToMake { voteRecipient = testAddr, voteVotingDir = False, voteSender = addr}]
             bctn <- getBlockstanbulContext
             let unwrapbct' = fromMaybe bct bctn
             _authSenders unwrapbct' `shouldBe` M.singleton addr 1
@@ -339,10 +339,10 @@ spec = do
             iev = IEBlock . blockToIngestBlock TO.Morphism $ b
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let pbftEvs = [m | OSPEBlockstanbul (WireMessage _ m) <- p2pevs]
+        let pbftEvs = [m | P2pBlockstanbul (WireMessage _ m) <- p2pevs]
         map categorize pbftEvs `shouldMatchList` [PreprepareK, PrepareK, CommitK]
         vmevs <- drainVM
-        vmevs `shouldContain` [OSVECreateBlockCommand]
+        vmevs `shouldContain` [VmCreateBlockCommand]
 
       it "should replay old blocks in blockstanbul" . runPBFTTestMWithGenesis $ \h -> do
         ctx <- fromMaybe (error "context required for PBFT") <$> getBlockstanbulContext
@@ -359,8 +359,8 @@ spec = do
         checkForUnseq [iev]
         drainP2P `shouldReturn` []
         vmevs <- drainVM
-        vmevs `shouldContain` [OSVECreateBlockCommand]
-        map outputBlockToBlock [oblk | OSVEBlock oblk <- vmevs] `shouldMatchList` [blk4]
+        vmevs `shouldContain` [VmCreateBlockCommand]
+        map outputBlockToBlock [oblk | VmBlock oblk <- vmevs] `shouldMatchList` [blk4]
         ctx' <- fromMaybe (error "context required for pbft") <$> getBlockstanbulContext
         _view ctx' `shouldBe` View 0 1
 
@@ -420,10 +420,10 @@ spec = do
         let hashTx = PrivateHashTX th ch
         checkForUnseq [IETx 0 (IngestTx TO.Morphism hashTx)]
         vmevs <- drainVM
-        let txs = [tx | OSVETx _ tx <- vmevs]
+        let txs = [tx | VmTx _ tx <- vmevs]
         map txType txs `shouldBe` [PrivateHash]
         p2pevs <- drainP2P
-        let txs' = [tx | OSPETx tx <- p2pevs]
+        let txs' = [tx | P2pTx tx <- p2pevs]
         map txType txs' `shouldBe` [PrivateHash]
 
       it "should forward a private transaction hash only once" . runTestM $ do
@@ -433,20 +433,20 @@ spec = do
             ietx = IETx 0 (IngestTx TO.Morphism hashTx)
         checkForUnseq [ietx,ietx]
         vmevs <- drainVM
-        let txs = [tx | OSVETx _ tx <- vmevs]
+        let txs = [tx | VmTx _ tx <- vmevs]
         map txType txs `shouldBe` [PrivateHash]
         p2pevs <- drainP2P
-        let txs' = [tx | OSPETx tx <- p2pevs]
+        let txs' = [tx | P2pTx tx <- p2pevs]
         map txType txs' `shouldBe` [PrivateHash]
 
       it "should create a PrivateHashTX for a private transaction" . runTestM $ do
         checkForUnseq [chainDetails1]
         checkForUnseq [IETx 0 (IngestTx TO.API tx1)]
         vmevs <- drainVM
-        let txs = [tx | OSVETx _ tx <- vmevs]
+        let txs = [tx | VmTx _ tx <- vmevs]
         map txType txs `shouldBe` [PrivateHash]
         p2pevs <- drainP2P
-        let txs' = [tx | OSPETx tx <- p2pevs]
+        let txs' = [tx | P2pTx tx <- p2pevs]
         map txType txs' `shouldBe` [Message, PrivateHash]
 
       it "should run Blockstanbul with private transactions" . runPBFTTestMWithGenesis $ \h -> do
@@ -455,10 +455,10 @@ spec = do
         checkForUnseq [IETx 0 (IngestTx TO.Morphism tx1)]
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | P2pBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OSVEBlock b <- vmevs]
+        let obs = [b | VmBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash],[Message]]
 
       it "should run Blockstanbul with delayed private transactions" . runPBFTTestMWithGenesis $ \h -> do
@@ -466,14 +466,14 @@ spec = do
         checkForUnseq [chainDetails1]
         checkForUnseq [iev]
         vmevs <- drainVM
-        let obs = [b | OSVEBlock b <- vmevs]
+        let obs = [b | VmBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash]]
         p2pevs <- drainP2P
-        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | P2pBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash]]
         checkForUnseq [IETx 0 (IngestTx TO.Morphism tx1)]
         vmevs' <- drainVM
-        let obs' = [b | OSVEBlock b <- vmevs']
+        let obs' = [b | VmBlock b <- vmevs']
         map (map txType . obReceiptTransactions) obs' `shouldBe` [[Message]]
 
       it "should not split up block when all chains are known" . runPBFTTestMWithGenesis $ \h -> do
@@ -483,10 +483,10 @@ spec = do
         checkForUnseq [ietx tx1, ietx tx2]
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | P2pBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash, PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OSVEBlock b <- vmevs]
+        let obs = [b | VmBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe`
           [[PrivateHash,PrivateHash],[Message,Message]]
 
@@ -496,14 +496,14 @@ spec = do
         checkForUnseq [ietx tx1, ietx tx2]
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | P2pBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash,PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OSVEBlock b <- vmevs]
+        let obs = [b | VmBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash,PrivateHash]]
         checkForUnseq [chainDetails1, chainDetails2]
         vmevs' <- drainVM
-        let obs' = [b | OSVEBlock b <- vmevs']
+        let obs' = [b | VmBlock b <- vmevs']
         map (map txType . obReceiptTransactions) obs' `shouldBe` [[Message],[Message]]
 
       it "should split up block when chain infos are staggered" . runPBFTTestMWithGenesis $ \h -> do
@@ -511,18 +511,18 @@ spec = do
             ietx = IETx 0 . IngestTx TO.Morphism
         checkForUnseq [ietx tx1, ietx tx2, iev]
         p2pevs <- drainP2P
-        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | P2pBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash,PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OSVEBlock b <- vmevs]
+        let obs = [b | VmBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash,PrivateHash]]
         checkForUnseq [chainDetails1]
         vmevs' <- drainVM
-        let obs' = [b | OSVEBlock b <- vmevs']
+        let obs' = [b | VmBlock b <- vmevs']
         map (map txType . obReceiptTransactions) obs' `shouldBe` [[Message]]
         checkForUnseq [chainDetails2]
         vmevs'' <- drainVM
-        let obs'' = [b | OSVEBlock b <- vmevs'']
+        let obs'' = [b | VmBlock b <- vmevs'']
         map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message]]
 
       it "should re-run blocks when chain info is delayed" . runPBFTTestMWithGenesis $ \h -> do
@@ -530,19 +530,19 @@ spec = do
             ietx = IETx 0 . IngestTx TO.Morphism
         checkForUnseq [iev]
         p2pevs <- drainP2P
-        let bs = [b | OSPEBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
+        let bs = [b | P2pBlockstanbul (WireMessage _ (Preprepare _ b)) <- p2pevs]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash]]
         vmevs <- drainVM
-        let obs = [b | OSVEBlock b <- vmevs]
+        let obs = [b | VmBlock b <- vmevs]
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash]]
         checkForUnseq [chainDetails1]
         vmevs' <- drainVM
-        let obs' = [b | OSVEBlock b <- vmevs']
+        let obs' = [b | VmBlock b <- vmevs']
         obs' `shouldBe` []
         p2pevs' <- drainP2P
-        let gtxs' = [th | OSPEGetTx th <- p2pevs']
+        let gtxs' = [th | P2pGetTx th <- p2pevs']
         gtxs' `shouldBe` [[txHash tx1]]
         checkForUnseq [ietx tx1]
         vmevs'' <- drainVM
-        let obs'' = [b | OSVEBlock b <- vmevs'']
+        let obs'' = [b | VmBlock b <- vmevs'']
         map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message]]

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -103,19 +103,19 @@ ethereumVM = void . execContextM $ do
 
         insertNewChains seqEvents
 
-        mapM_ (uncurry3 queuePendingVote) [(r, d, s) | OEVoteToMake r d s <- seqEvents]
-        let newCommands = [c | OEJsonRpcCommand c <- seqEvents]
+        mapM_ (uncurry3 queuePendingVote) [(r, d, s) | OSVEVoteToMake r d s <- seqEvents]
+        let newCommands = [c | OSVEJsonRpcCommand c <- seqEvents]
         forM_ newCommands runJsonRpcCommand
 
-        let txPairs = [(ts,t) | OETx ts t <- seqEvents]
-            allTxs = map (uncurry OETx) txPairs
-            blocks = [b | OEBlock b <- seqEvents]
+        let txPairs = [(ts,t) | OSVETx ts t <- seqEvents]
+            allTxs = map (uncurry OSVETx) txPairs
+            blocks = [b | OSVEBlock b <- seqEvents]
         when (not $ null txPairs) . void
                                   . K.withKafkaViolently
                                   . writeIndexEvents
                                   $ map (uncurry IndexTransaction) txPairs
 
-        let ptxs = [IndexPrivateTx t | OEPrivateTx t <- seqEvents]
+        let ptxs = [IndexPrivateTx t | OSVEPrivateTx t <- seqEvents]
         when (not $ null ptxs) . void
                                . K.withKafkaViolently
                                $ writeIndexEvents ptxs
@@ -124,7 +124,7 @@ ethereumVM = void . execContextM $ do
         recordSeqEventCount bLen tLen
 
         $logDebugS "evm/loop" $ T.pack $ "allTxs :: " ++ show allTxs
-        let allNewTxs = [(ts, t) | OETx ts t <- allTxs, isNothing (txChainId $ otBaseTx t)] -- PrivateHashTXs have chainId = Nothing
+        let allNewTxs = [(ts, t) | OSVETx ts t <- allTxs, isNothing (txChainId $ otBaseTx t)] -- PrivateHashTXs have chainId = Nothing
         forM_ allNewTxs $ \(ts, _) ->
             $logInfoS "evm/loop/allNewTxs" $ T.pack $ "math :: " ++ show currentMicrotime ++ " - " ++ show ts ++ " = " ++ show (currentMicrotime - ts) ++ "; <= " ++ show microtimeCutoff ++ "? " ++ show ((currentMicrotime - ts) <= microtimeCutoff)
         let poolableNewTxs = [t | (ts, t) <- allNewTxs, abs (currentMicrotime - ts) <= microtimeCutoff]
@@ -141,7 +141,7 @@ ethereumVM = void . execContextM $ do
             writeBlockSummary b
         actions <- addBlocks blocks
 
-        contextBlockRequested ||= (OECreateBlockCommand `elem` seqEvents)
+        contextBlockRequested ||= (OSVECreateBlockCommand `elem` seqEvents)
         -- todo: perhaps we shouldnt even add TXs to the mempool, it might make for a VERY large checkpoint
         -- todo: which may fail
         isCaughtUp <- shouldProcessNewTransactions
@@ -184,9 +184,9 @@ ethereumVM = void . execContextM $ do
         withChainroot <- checkpointData . Just . unBlockHashRoot <$> Mod.get Proxy
         setCheckpoint newOffset withChainroot
 
-insertNewChains :: [OutputEvent] -> ContextM ()
+insertNewChains :: [OutputSeqVmEvent] -> ContextM ()
 insertNewChains events = do
-  let newChainInfos = [c | OEGenesis (OutputGenesis _ c) <- events]
+  let newChainInfos = [c | OSVEGenesis (OutputGenesis _ c) <- events]
 
   newChains <- forM newChainInfos $ \(cId, cInfo) -> do
     $logInfoS "insertNewChains" $ T.pack $ "Inserting Chain ID: " ++ format (SHA cId)
@@ -216,7 +216,7 @@ insertNewChains events = do
 
 
 runChainConstructor :: Word256 -> Maybe T.Text -> ContextM MP.StateRoot
-runChainConstructor cId maybeSource = do  
+runChainConstructor cId maybeSource = do
   -- We are inventing the rules of how the constructor should run when a chain is created.
   -- Since all VM runs need some environment variables passed in, we need to define what all of
   -- those variables should be.  The truth is, most of these variables are rarely used, but we
@@ -276,7 +276,7 @@ consumerGroup = lookupConsumerGroup "ethereum-vm"
 
 getFirstBlockFromSequencer :: ContextM OutputBlock
 getFirstBlockFromSequencer = do
-    (OEBlock block) <- head <$> getUnprocessedKafkaEvents (KP.Offset 0)
+    (OSVEBlock block) <- head <$> getUnprocessedKafkaEvents (KP.Offset 0)
     return block
 
 -- this one starts at 1, 0 is reserved for genesis block and is used to
@@ -347,7 +347,7 @@ setCheckpointNoMetadata ofs = do
     ret  <- K.withKafkaViolently $ K.commitSingleOffset consumerGroup seqVmEventsTopicName 0 ofs emptyMetadata
     either (error . show) return ret
 
-getUnprocessedKafkaEvents :: KP.Offset -> ContextM [OutputEvent]
+getUnprocessedKafkaEvents :: KP.Offset -> ContextM [OutputSeqVmEvent]
 getUnprocessedKafkaEvents offset = do
     $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Fetching sequenced blockchain events with offset " ++ show offset
     ret <- K.withKafkaViolently (readSeqVmEvents offset)
@@ -362,11 +362,11 @@ getUnprocessedKafkaEvents offset = do
             . scanl (+) 0
             . map approxCost
             $ ret
-        approxCost :: OutputEvent -> Int
+        approxCost :: OutputSeqVmEvent -> Int
         approxCost = \case
-          OEBlock OutputBlock{..} -> fromMaybe (length obReceiptTransactions)
-                                   . extraData2TxsLen
-                                   $ blockDataExtraData obBlockData
+          OSVEBlock OutputBlock{..} -> fromMaybe (length obReceiptTransactions)
+                                     . extraData2TxsLen
+                                     $ blockDataExtraData obBlockData
           _ -> 1
 
         ret' = eventLimit . countLimit $ ret
@@ -396,7 +396,7 @@ shouldProcessNewTransactions =
 
 
 
-logEventSummaries :: [OutputEvent] -> ContextM ()
+logEventSummaries :: [OutputSeqVmEvent] -> ContextM ()
 logEventSummaries events = do
   let names = map getNames events
       numberedNames = map (\x -> numberIt (length x) (head x)) $ group $ sort names
@@ -405,22 +405,15 @@ logEventSummaries events = do
     "#### Got: " ++ intercalate ", " numberedNames -- show numTXs ++ "TXs, " ++ show numBlocks ++ " blocks"
 
   where
-    getNames :: OutputEvent -> String
-    getNames (OETx _ _) = "TX"
-    getNames (OEBlock _) = "Block"
-    getNames (OEGenesis _) = "GenesisBlock"
-    getNames (OEJsonRpcCommand _) = "JsonRpcCommand"
+    getNames :: OutputSeqVmEvent -> String
+    getNames (OSVETx _ _) = "TX"
+    getNames (OSVEBlock _) = "Block"
+    getNames (OSVEGenesis _) = "GenesisBlock"
+    getNames (OSVEJsonRpcCommand _) = "JsonRpcCommand"
 
-    getNames (OEGetChain _) = "GetChain"
-    getNames (OEGetTx _) = "GetTx"
-    getNames (OEBlockstanbul _) = "Blockstanbul"
-    getNames OECreateBlockCommand = "CreateBlockCommand"
-    getNames (OEAskForBlocks _ _ _) = "AskForBlocks"
-    getNames (OEPushBlocks _ _ _) = "PushBlocks"
-    getNames (OENewChainMember _ _ _) = "OENewChainMember"
-    getNames (OEVoteToMake _ _ _) = "OEVoteToMake"
-    getNames OENewCheckpoint{} = "OENewCheckpoint"
-    getNames (OEPrivateTx _) = "OEPrivateTx"
+    getNames OSVECreateBlockCommand = "CreateBlockCommand"
+    getNames (OSVEVoteToMake _ _ _) = "VoteToMake"
+    getNames (OSVEPrivateTx _) = "PrivateTx"
 
     numberIt :: Int -> String -> String
     numberIt 1 x = "1 " ++ x

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -103,19 +103,19 @@ ethereumVM = void . execContextM $ do
 
         insertNewChains seqEvents
 
-        mapM_ (uncurry3 queuePendingVote) [(r, d, s) | OSVEVoteToMake r d s <- seqEvents]
-        let newCommands = [c | OSVEJsonRpcCommand c <- seqEvents]
+        mapM_ (uncurry3 queuePendingVote) [(r, d, s) | VmVoteToMake r d s <- seqEvents]
+        let newCommands = [c | VmJsonRpcCommand c <- seqEvents]
         forM_ newCommands runJsonRpcCommand
 
-        let txPairs = [(ts,t) | OSVETx ts t <- seqEvents]
-            allTxs = map (uncurry OSVETx) txPairs
-            blocks = [b | OSVEBlock b <- seqEvents]
+        let txPairs = [(ts,t) | VmTx ts t <- seqEvents]
+            allTxs = map (uncurry VmTx) txPairs
+            blocks = [b | VmBlock b <- seqEvents]
         when (not $ null txPairs) . void
                                   . K.withKafkaViolently
                                   . writeIndexEvents
                                   $ map (uncurry IndexTransaction) txPairs
 
-        let ptxs = [IndexPrivateTx t | OSVEPrivateTx t <- seqEvents]
+        let ptxs = [IndexPrivateTx t | VmPrivateTx t <- seqEvents]
         when (not $ null ptxs) . void
                                . K.withKafkaViolently
                                $ writeIndexEvents ptxs
@@ -124,7 +124,7 @@ ethereumVM = void . execContextM $ do
         recordSeqEventCount bLen tLen
 
         $logDebugS "evm/loop" $ T.pack $ "allTxs :: " ++ show allTxs
-        let allNewTxs = [(ts, t) | OSVETx ts t <- allTxs, isNothing (txChainId $ otBaseTx t)] -- PrivateHashTXs have chainId = Nothing
+        let allNewTxs = [(ts, t) | VmTx ts t <- allTxs, isNothing (txChainId $ otBaseTx t)] -- PrivateHashTXs have chainId = Nothing
         forM_ allNewTxs $ \(ts, _) ->
             $logInfoS "evm/loop/allNewTxs" $ T.pack $ "math :: " ++ show currentMicrotime ++ " - " ++ show ts ++ " = " ++ show (currentMicrotime - ts) ++ "; <= " ++ show microtimeCutoff ++ "? " ++ show ((currentMicrotime - ts) <= microtimeCutoff)
         let poolableNewTxs = [t | (ts, t) <- allNewTxs, abs (currentMicrotime - ts) <= microtimeCutoff]
@@ -141,7 +141,7 @@ ethereumVM = void . execContextM $ do
             writeBlockSummary b
         actions <- addBlocks blocks
 
-        contextBlockRequested ||= (OSVECreateBlockCommand `elem` seqEvents)
+        contextBlockRequested ||= (VmCreateBlockCommand `elem` seqEvents)
         -- todo: perhaps we shouldnt even add TXs to the mempool, it might make for a VERY large checkpoint
         -- todo: which may fail
         isCaughtUp <- shouldProcessNewTransactions
@@ -184,9 +184,9 @@ ethereumVM = void . execContextM $ do
         withChainroot <- checkpointData . Just . unBlockHashRoot <$> Mod.get Proxy
         setCheckpoint newOffset withChainroot
 
-insertNewChains :: [OutputSeqVmEvent] -> ContextM ()
+insertNewChains :: [VmEvent] -> ContextM ()
 insertNewChains events = do
-  let newChainInfos = [c | OSVEGenesis (OutputGenesis _ c) <- events]
+  let newChainInfos = [c | VmGenesis (OutputGenesis _ c) <- events]
 
   newChains <- forM newChainInfos $ \(cId, cInfo) -> do
     $logInfoS "insertNewChains" $ T.pack $ "Inserting Chain ID: " ++ format (SHA cId)
@@ -276,7 +276,7 @@ consumerGroup = lookupConsumerGroup "ethereum-vm"
 
 getFirstBlockFromSequencer :: ContextM OutputBlock
 getFirstBlockFromSequencer = do
-    (OSVEBlock block) <- head <$> getUnprocessedKafkaEvents (KP.Offset 0)
+    (VmBlock block) <- head <$> getUnprocessedKafkaEvents (KP.Offset 0)
     return block
 
 -- this one starts at 1, 0 is reserved for genesis block and is used to
@@ -347,7 +347,7 @@ setCheckpointNoMetadata ofs = do
     ret  <- K.withKafkaViolently $ K.commitSingleOffset consumerGroup seqVmEventsTopicName 0 ofs emptyMetadata
     either (error . show) return ret
 
-getUnprocessedKafkaEvents :: KP.Offset -> ContextM [OutputSeqVmEvent]
+getUnprocessedKafkaEvents :: KP.Offset -> ContextM [VmEvent]
 getUnprocessedKafkaEvents offset = do
     $logInfoS "getUnprocessedKafkaEvents" . T.pack $ "Fetching sequenced blockchain events with offset " ++ show offset
     ret <- K.withKafkaViolently (readSeqVmEvents offset)
@@ -362,9 +362,9 @@ getUnprocessedKafkaEvents offset = do
             . scanl (+) 0
             . map approxCost
             $ ret
-        approxCost :: OutputSeqVmEvent -> Int
+        approxCost :: VmEvent -> Int
         approxCost = \case
-          OSVEBlock OutputBlock{..} -> fromMaybe (length obReceiptTransactions)
+          VmBlock OutputBlock{..} -> fromMaybe (length obReceiptTransactions)
                                      . extraData2TxsLen
                                      $ blockDataExtraData obBlockData
           _ -> 1
@@ -396,7 +396,7 @@ shouldProcessNewTransactions =
 
 
 
-logEventSummaries :: [OutputSeqVmEvent] -> ContextM ()
+logEventSummaries :: [VmEvent] -> ContextM ()
 logEventSummaries events = do
   let names = map getNames events
       numberedNames = map (\x -> numberIt (length x) (head x)) $ group $ sort names
@@ -405,15 +405,15 @@ logEventSummaries events = do
     "#### Got: " ++ intercalate ", " numberedNames -- show numTXs ++ "TXs, " ++ show numBlocks ++ " blocks"
 
   where
-    getNames :: OutputSeqVmEvent -> String
-    getNames (OSVETx _ _) = "TX"
-    getNames (OSVEBlock _) = "Block"
-    getNames (OSVEGenesis _) = "GenesisBlock"
-    getNames (OSVEJsonRpcCommand _) = "JsonRpcCommand"
+    getNames :: VmEvent -> String
+    getNames (VmTx _ _) = "TX"
+    getNames (VmBlock _) = "Block"
+    getNames (VmGenesis _) = "GenesisBlock"
+    getNames (VmJsonRpcCommand _) = "JsonRpcCommand"
 
-    getNames OSVECreateBlockCommand = "CreateBlockCommand"
-    getNames (OSVEVoteToMake _ _ _) = "VoteToMake"
-    getNames (OSVEPrivateTx _) = "PrivateTx"
+    getNames VmCreateBlockCommand = "CreateBlockCommand"
+    getNames (VmVoteToMake _ _ _) = "VoteToMake"
+    getNames (VmPrivateTx _) = "PrivateTx"
 
     numberIt :: Int -> String -> String
     numberIt 1 x = "1 " ++ x


### PR DESCRIPTION
We used to have one Kafka topic coming out of the sequencer, `seqevents`, which contained messages of type `OutputEvent`. Both the VM and P2P read from this topic, and there was no way to discriminate which module should read which message. However, with the advent of PBFT and private chains, we eventually needed to direct these messages more accurately, so we split into two Kafka topics, `seq_vm_events` and `seq_p2p_events`, but both still contain messages of type `OutputEvent`. Since splitting the Kafka topics, we've introduced a number of branches to the `OutputEvent` type that are only meant to be sent to one module, e.g. `OECreateBlockCommand`, `OEVoteToMake`, and `OEPrivateTx` for the VM; `OEAskForBlocks`, `OEPushBlocks`, and `OENewChainMember` for P2P; and even one, `OENewCheckpoint`, which is never meant to leave the Sequencer, but instead be used to update the Sequencer's Kafka metadata for the `unseqevents` topic. This lead to `error` cases in P2P, and silent bypassing of these events in the VM. While nothing catastrophic ever came of this, it does mean that every time a new branch is added to `OutputEvent`, more boilerplate must be written in unneeded places, as well as the potential for run-time bugs that could easily be caught at compile-time. This PR breaks apart the `OutputEvent` type into three: `VmEvent` for messages written to `seq_vm_events`, `P2pEvent` for messages written to `seq_p2p_events`, and using the Blockstanbul `Checkpoint` type in its own `TQueue` to update the Kafka metadata for `unseqevents`. Also, I took the liberty of using generic `Binary` instances for these new types, as we should not need backwards compatibility for these instances anymore (since we'll be using sync instead of in-place restarts), and using generic instances eliminates another potential source of run-time bugs.

JIRA story is https://blockapps.atlassian.net/browse/STRATO-1634