### PR TITLE
Strict foldl

### DIFF
--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Statement.hs
@@ -2,7 +2,7 @@
 module SolidVM.Solidity.Parse.Statement where
 
 import           Control.Monad
-import           Data.Foldable (asum)
+import           Data.Foldable (asum, foldl')
 import           Data.Functor.Identity
 import qualified Data.Text as T
 import           Text.Parsec
@@ -146,7 +146,7 @@ memberAccess = do
 arrayIndex :: SolidityParser (Expression -> Expression)
 arrayIndex = do
   idxs <- many1 . brackets $ optionMaybe expression
-  return $ \x -> foldl IndexAccess x idxs
+  return $ \x -> foldl' IndexAccess x idxs
 
 binary :: String -> Operator String u Identity Expression
 binary x = Infix (do { reservedOp x; return (Binary x)}) AssocLeft

--- a/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -585,7 +585,7 @@ commonAncestorHelper oldNum newNum oldSha' newSha' = helper [oldSha'] [newSha'] 
                 let oldSha = head oldShaChain
                     newSha = head newShaChain
                 ps@[newParent, oldParent] <- forM [newSha, oldSha] (\x -> fromMaybe x <$> getParent x)
-                let seen' = foldl (flip S.insert) seen (filter (/= (SHA 0)) ps) -- todo double S.insert is probably more optimal
+                let seen' = foldl' (flip S.insert) seen (filter (/= (SHA 0)) ps) -- todo double S.insert is probably more optimal
                 if newParent `S.member` seen
                 then complete newParent (mkParentChain newParent newShaChain)
                 else if oldParent `S.member` seen

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -64,7 +64,7 @@ import qualified Data.ByteString                           as B
 import qualified Data.ByteString.Lazy                      as BL
 import           Data.Conduit.TMChan
 import           Data.Conduit.TQueue
-import           Data.Foldable                             (toList)
+import           Data.Foldable                             (foldl',toList)
 import           Data.IORef
 import           Data.Map                                  (Map)
 import qualified Data.Map                                  as M
@@ -409,7 +409,7 @@ clearLdbBatchOps = modify (\st -> st{_ldbBatchOps = Q.empty})
 addLdbBatchOps :: [LDB.BatchOp] -> SequencerM ()
 addLdbBatchOps ops = do
   existingOps <- use ldbBatchOps
-  let newOps = foldl (Q.|>) existingOps ops
+  let newOps = foldl' (Q.|>) existingOps ops
   ldbBatchOps .= newOps
 
 fuseChannels ::SequencerM (ConduitM () SeqLoopEvent SequencerM ())

--- a/core-strato/vm-tools/src/Blockchain/Bagger/TransactionList.hs
+++ b/core-strato/vm-tools/src/Blockchain/Bagger/TransactionList.hs
@@ -11,6 +11,7 @@ module Blockchain.Bagger.TransactionList
 
 import           Blockchain.Data.TransactionDef
 import           Blockchain.Sequencer.Event     (OutputTx (..))
+import           Data.Foldable                  (foldl')
 import qualified Data.Map.Strict                as M
 
 type TransactionList = M.Map Integer OutputTx
@@ -48,7 +49,7 @@ trimAboveCost maxCost calcCost tl =
 
 popSequential :: Integer -> TransactionList -> ([OutputTx], TransactionList)
 popSequential nonce' tl = (popped, M.fromList kept)
-    where (_, popped, kept) = foldl theFold initialFoldState (M.toAscList tl)
+    where (_, popped, kept) = foldl' theFold initialFoldState (M.toAscList tl)
           initialFoldState  = (nonce' - 1, [], [])
           theFold (lastNonce, popped', kept') e@(elemNonce, elemTx) =
             if elemNonce == lastNonce + 1


### PR DESCRIPTION
`foldl'` has much better performance than `foldl`, and does not run the risk of causing stack overflows. An excerpt from https://wiki.haskell.org/Stack_overflow:
> When should foldl be used? The pragmatic answer is: by and far, it shouldn't be used.
