### PR TITLE
Use difference lists to accumulate lists in State

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -94,12 +94,11 @@ data BatchState = BatchState
   }
 makeLenses ''BatchState
 
-forStateT :: Monad m => s -> [a] -> (a -> StateT s m b) -> m ([b],s)
-forStateT s [] _ = return ([],s)
-forStateT s (a:as) run = do
-  (b,s') <- runStateT (run a) s
-  (bs,s'') <- forStateT s' as run
-  return (b:bs,s'')
+forStateT :: Monad m => s -> [a] -> (a -> StateT s m b) -> m [b]
+forStateT s as f = flip evalStateT s $ mapM f as
+
+forState :: s -> [a] -> (a -> State s b) -> [b]
+forState s as = runIdentity . forStateT s as
 
 getUsers :: Bloc [UserName]
 getUsers = do
@@ -334,7 +333,7 @@ postUsersUploadList userName addr chainId resolve (UploadListRequest pw contract
 postUsersUploadListSolidVM' :: ContractListParameters -> Signer -> Bloc [BlocTransactionResult]
 postUsersUploadListSolidVM' ContractListParameters{..} sign = do
   txsWithParams <- genNonces (getAccountNonce fromAddr chainId) uploadlistcontractTxParams contracts
-  namesCmIdsTxs <- fmap fst . forStateT Map.empty txsWithParams $
+  namesCmIdsTxs <- forStateT Map.empty txsWithParams $
     \(UploadListContract name args params value md) -> do
       mtuple <- use $ at name
       (_, src, cmId, xabi) <- case mtuple of
@@ -387,7 +386,7 @@ postUsersUploadListSolidVM' ContractListParameters{..} sign = do
 postUsersUploadListEVM' :: ContractListParameters -> Signer -> Bloc [BlocTransactionResult]
 postUsersUploadListEVM' ContractListParameters{..} sign = do
   txsWithParams <- genNonces (getAccountNonce fromAddr chainId) uploadlistcontractTxParams contracts
-  namesCmIdsTxs <- fmap fst . forStateT Map.empty txsWithParams $
+  namesCmIdsTxs <- forStateT Map.empty txsWithParams $
     \(UploadListContract name args params value md) -> do
       mtuple <- use $ at name
       (bin, src, cmId, xabi) <- case mtuple of
@@ -505,7 +504,7 @@ genNonces n l as = do
   nonce <- if S.size noncesInUse == length as
             then return . Nonce . error $ "internal error: unused nonce when already specified " ++ show as
             else n
-  return . fst . runIdentity . forStateT nonce as $ \a -> do
+  return . forState nonce as $ \a -> do
     let params' = fromMaybe emptyTxParams (a ^. l)
     newNonce <- case txparamsNonce params' of
       Just v -> return v
@@ -523,7 +522,7 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
     then return []
     else do
       txsWithParams <- genNonces (getAccountNonce fromAddr chainId) methodcallTxParams txs
-      txsCmIdsFuncNames <- fmap fst . forStateT Map.empty txsWithParams $
+      txsCmIdsFuncNames <- forStateT Map.empty txsWithParams $
         \(MethodCall{..}) -> do
           mtuple <- use $ at methodcallContractName
           (mapKey, xabi) <- case mtuple of
@@ -728,7 +727,7 @@ recurseTRDs chainId resolve hashes = go 0 (toPending hashes)
         else (p : merge (d:ds) ps c)
 
 evalAndReturn :: [TRD] -> Bloc [BlocTransactionResult]
-evalAndReturn list = fmap fst . forStateT emptyBatchState list $
+evalAndReturn list = forStateT emptyBatchState list $
     \(TRD status hash _ mtxr) -> case status of
         Pending -> return $ BlocTransactionResult Pending hash Nothing Nothing
         Failure -> return $ BlocTransactionResult Failure hash mtxr Nothing

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE RecordWildCards   #-}
 module BlockApps.Bloc22.Server.Utils
   ( getBatchBlocTxStatus
-  , accumStateT
   , partitionWith
   , binRuntimeToCodeHash
   , emptyTxParams
@@ -17,7 +16,6 @@ import           Control.Concurrent               (threadDelay)
 import           Control.Monad                    (forM, unless, when)
 import           Control.Monad.Except             (throwError)
 import           Control.Monad.IO.Class           (liftIO)
-import           Control.Monad.Trans.State.Strict
 import qualified Data.ByteString.Base16           as BS16
 import qualified Data.Map.Strict                  as M
 import           Data.Maybe
@@ -56,9 +54,6 @@ emptyTxParams = TxParams Nothing Nothing Nothing
 
 binRuntimeToCodeHash :: Text.Text -> Keccak256
 binRuntimeToCodeHash = keccak256 . fst . BS16.decode . Text.encodeUtf8
-
-accumStateT :: Monad m => s -> [a] -> (a -> StateT s m b) -> m [b]
-accumStateT s as f = evalStateT (mapM f as) s
 
 partitionWith :: Ord k => (a -> k) -> [a] -> [(k,[a])]
 partitionWith f = M.toList . foldr g M.empty

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
@@ -19,8 +19,7 @@ import           Control.Monad.Except             (throwError)
 import           Control.Monad.IO.Class           (liftIO)
 import           Control.Monad.Trans.State.Strict
 import qualified Data.ByteString.Base16           as BS16
-import           Data.Functor.Identity
-import qualified Data.Map.Strict                  as Map
+import qualified Data.Map.Strict                  as M
 import           Data.Maybe
 import qualified Data.Text                        as Text
 import qualified Data.Text.Encoding               as Text
@@ -35,7 +34,7 @@ import           BlockApps.Strato.Types
 maybeTxBatchResult :: Maybe ChainId -> [Keccak256] -> Bloc [Maybe TransactionResult]
 maybeTxBatchResult chainId hashes = maybeHeads <$> (blocStrato (postTxResultBatch chainId hashes))
   where maybeHeads btxr =
-          let list = map (flip Map.lookup $ unBatchTransactionResult btxr) hashes
+          let list = map (flip M.lookup $ unBatchTransactionResult btxr) hashes
           in flip map list $ \mtrs -> case mtrs of
             Nothing -> Nothing
             Just trs -> listToMaybe trs

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Utils.hs
@@ -61,12 +61,9 @@ binRuntimeToCodeHash = keccak256 . fst . BS16.decode . Text.encodeUtf8
 accumStateT :: Monad m => s -> [a] -> (a -> StateT s m b) -> m [b]
 accumStateT s as f = evalStateT (mapM f as) s
 
-buildStateT :: Monad m => s -> [a] -> (a -> StateT s m ()) -> m s
-buildStateT s as f = execStateT (mapM_ f as) s
-
-partitionWith :: Ord k => (a -> k) -> [a] -> [(k, [a])]
-partitionWith f as = Map.toList . fmap reverse . runIdentity . buildStateT Map.empty as $ \a ->
-  modify $ Map.alter (Just . (a:) . fromMaybe []) (f a)
+partitionWith :: Ord k => (a -> k) -> [a] -> [(k,[a])]
+partitionWith f = M.toList . foldr g M.empty
+  where g a = M.alter (Just . (a:) . fromMaybe []) (f a)
 
 waitFor :: Text.Text -> Bloc Bool -> Bloc ()
 waitFor msg action = go 20

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -334,7 +334,7 @@ rowToHistories gref abiid row actions cont details oldState = do
   hist <- isHistoric gref $ actionCodeHash row
   second join . unzip <$> if not hist
     then pure []
-    else accumStateT oldState actions $ \hRow -> do
+    else flip evalStateT oldState . forM actions $ \hRow -> do
       modify $ case actionStorage hRow of
                   BS.ActionEVMDiff mp -> SVR.decodeCacheValues cont (flip Map.lookup mp)
                   BS.ActionSolidVMDiff mp -> SolidVM.decodeCacheValues mp

--- a/core-strato/blockapps-util/src/Blockchain/Util.hs
+++ b/core-strato/blockapps-util/src/Blockchain/Util.hs
@@ -7,13 +7,14 @@ module Blockchain.Util
   , module Blockchain.Strato.Model.Util
   ) where
 
-import           Control.Monad.State.Lazy (State, execState, get, put)
+import           Control.Monad.State.Lazy (State, execState)
 import           Data.Bits
 import qualified Data.ByteString          as B
 import           Data.ByteString.Internal
 import           Data.Char
 import           Data.Data
 import qualified Data.Map.Strict          as M
+import           Data.Maybe               (fromMaybe)
 import           Data.Word
 import           Numeric
 
@@ -34,12 +35,8 @@ buildState s (a:as) run =
    in buildState s' as run
 
 partitionWith :: Ord k => (a -> k) -> [a] -> [(k,[a])]
-partitionWith f as = M.toList . buildState M.empty as $ \a -> do
-  s <- get
-  let k = f a
-  case M.lookup k s of
-    Nothing -> put (M.insert k [a] s)
-    Just _  -> put (M.update (Just . (++ [a])) k s)
+partitionWith f = M.toList . foldr g M.empty
+  where g a = M.alter (Just . (a:) . fromMaybe []) (f a)
 
 showHex4 :: Word256 -> String
 showHex4 i = replicate (4 - length rawOutput) '0' ++ rawOutput

--- a/core-strato/blockapps-util/src/Blockchain/Util.hs
+++ b/core-strato/blockapps-util/src/Blockchain/Util.hs
@@ -7,7 +7,6 @@ module Blockchain.Util
   , module Blockchain.Strato.Model.Util
   ) where
 
-import           Control.Monad.State.Lazy (State, execState)
 import           Data.Bits
 import qualified Data.ByteString          as B
 import           Data.ByteString.Internal
@@ -27,12 +26,6 @@ import qualified Data.Binary              as Binary
 
 toMaybe :: Eq a => a -> a -> Maybe a
 toMaybe a b = if a == b then Nothing else Just b
-
-buildState :: s -> [a] -> (a -> State s ()) -> s
-buildState s [] _ = s
-buildState s (a:as) run =
-  let s' = execState (run a) s
-   in buildState s' as run
 
 partitionWith :: Ord k => (a -> k) -> [a] -> [(k,[a])]
 partitionWith f = M.toList . foldr g M.empty

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -34,6 +34,7 @@ dependencies:
   - cryptohash
   - crypto-pubkey
   - crypto-pubkey-types
+  - dlist
   - dns
   - either
   - esqueleto

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -22,6 +22,7 @@ import           Control.Monad.State
 import           Control.Monad.Trans.Resource
 import           Data.Conduit
 import           Data.Foldable                         (for_)
+import qualified Data.DList                            as DL
 import           Data.List
 import           Data.Map.Strict                       (Map)
 import qualified Data.Map.Strict                       as M
@@ -259,15 +260,15 @@ handleEvents peer = awaitForever $ \case
       stampActionTimestamp
       mrh <- gets maxReturnedHeaders
       let shas = take mrh shas'
-      getUntilMissing shas [] [] >>= \(bodies, pshas) -> do
-          yieldR . BlockBodies . Prelude.reverse $ map toBody bodies
+      getUntilMissing shas DL.empty DL.empty >>= \(bodies, pshas) -> do
+          yieldR . BlockBodies $ map toBody bodies
           ptxs <- fmap (map snd . catMaybes) . RBDB.withRedisBlockDB $ mapM RBDB.getPrivateTransactions pshas
           unless (null ptxs) . yieldR . Transactions $ morphTx <$> ptxs
         where getUntilMissing :: (Accessible RBDB.RedisConnection m, MonadIO m)
-                              => [SHA] -> [OutputBlock] -> [SHA] -> m ([OutputBlock],[SHA])
-              getUntilMissing []     bodies pshas = return (bodies, pshas)
+                              => [SHA] -> DL.DList OutputBlock -> DL.DList SHA -> m ([OutputBlock],[SHA])
+              getUntilMissing []     bodies pshas = return (DL.toList bodies, DL.toList pshas)
               getUntilMissing (h:hs) bodies pshas = RBDB.withRedisBlockDB (RBDB.getBlock h) >>= \case
-                  Nothing   -> return (bodies, pshas)
+                  Nothing   -> return (DL.toList bodies, DL.toList pshas)
                   Just body -> do
                     cIdTxsMap <- RBDB.withRedisBlockDB $ RBDB.getChainTxsInBlock h
                     let kvs = M.assocs cIdTxsMap
@@ -275,7 +276,7 @@ handleEvents peer = awaitForever $ \case
                     let trMems = zip kvs mems
                         pshas' = concat . map (snd . fst) $
                                   filter ((checkPeerIsMember peer) . snd) trMems
-                    getUntilMissing hs (body:bodies) (pshas ++ pshas')
+                    getUntilMissing hs (bodies `DL.snoc` body) (pshas `DL.append` DL.fromList pshas')
 
               toBody :: OutputBlock -> ([Transaction], [BlockHeader])
               toBody = ((map otBaseTx . obReceiptTransactions) &&& fmap morphBlockHeader . obBlockUncles)

--- a/core-strato/vm-runner/package.yaml
+++ b/core-strato/vm-runner/package.yaml
@@ -22,6 +22,7 @@ dependencies:
   - conduit
   - containers
   - cross-monitoring
+  - dlist
   - ethereum-rlp
   - ethereum-vm
   - extra

--- a/core-strato/vm-runner/package.yaml
+++ b/core-strato/vm-runner/package.yaml
@@ -32,7 +32,6 @@ dependencies:
   - merkle-patricia-db
   - monad-alter
   - mtl
-  - ordered-containers
   - prometheus-client
   - resourcet
   - solid-vm

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -125,7 +125,7 @@ instance Bagger.MonadBagger ContextM where
         setStateDBStateRoot sr
         (TxMiningResult res ranTxs unranTxs newGas) <-
           timeit "mineTransactions bagger" (Just vmBlockInsertionMined)
-          $ mineTransactions' theBlockHeader remainingGas [] txs
+          $ mineTransactions' theBlockHeader remainingGas DL.empty txs
         timeit "flushMemStorageDB bagger" (Just vmBlockInsertionMined) flushMemStorageDB
         timeit "flushMemAddressStateDB bagger" (Just vmBlockInsertionMined) flushMemAddressStateDB
         newStateRoot <- Mod.get (Proxy @MP.StateRoot)
@@ -389,7 +389,7 @@ addTransactions chainId canCache blockData blockGas0 txs =
             then Bagger.getCachedRunResults blockData
             else return Nothing
   trrs <- case mtrrs of
-    Nothing -> go blockGas0 txs []
+    Nothing -> go blockGas0 txs DL.empty
     Just (cachedSR, _, cachedTRRs) -> do
       let cachedTXs = map trrTransaction cachedTRRs
       when (flags_debug && txs /= cachedTXs) $ do
@@ -404,7 +404,7 @@ addTransactions chainId canCache blockData blockGas0 txs =
   return (catMaybes otrs, asms)
 
   where
-    go _ [] trrs = return $ reverse trrs
+    go _ [] trrs = return $ DL.toList trrs
     go blockGas (t@OutputTx{otBaseTx=bt}:rest) trrs = do
       flushMemAddressStateTxToBlockDB
       flushMemStorageTxDBToBlockDB
@@ -422,7 +422,7 @@ addTransactions chainId canCache blockData blockGas0 txs =
             Left _           -> blockGas
             Right execResult -> blockGas - (transactionGasLimit bt - calculateReturned bt execResult)
 
-      go remainingBlockGas rest (trr : trrs)
+      go remainingBlockGas rest (trrs `DL.snoc` trr)
 
 data TxMiningResult = TxMiningResult { tmrFailure  :: Maybe TransactionFailureCause
                                      , tmrRanTxs   :: [TxRunResult]
@@ -430,8 +430,8 @@ data TxMiningResult = TxMiningResult { tmrFailure  :: Maybe TransactionFailureCa
                                      , tmrRemGas   :: Integer
                                      } deriving (Show)
 
-mineTransactions' :: BlockData -> Integer -> [TxRunResult] -> [OutputTx] -> ContextM TxMiningResult
-mineTransactions' _ remGas ran [] = return $ TxMiningResult Nothing (reverse ran) [] remGas
+mineTransactions' :: BlockData -> Integer -> DL.DList TxRunResult -> [OutputTx] -> ContextM TxMiningResult
+mineTransactions' _ remGas ran [] = return $ TxMiningResult Nothing (DL.toList ran) [] remGas
 mineTransactions' header remGas ran unran@(tx@OutputTx{otBaseTx=bt}:txs) = do
     flushMemAddressStateTxToBlockDB
     flushMemStorageTxDBToBlockDB
@@ -444,8 +444,8 @@ mineTransactions' header remGas ran unran@(tx@OutputTx{otBaseTx=bt}:txs) = do
     case result of
         Right execResult -> do
           let nextRemGas = remGas - (transactionGasLimit bt-calculateReturned bt execResult)
-          mineTransactions' header nextRemGas (trr:ran) txs
-        Left  failure    -> return $ TxMiningResult (Just failure) (reverse ran) unran remGas
+          mineTransactions' header nextRemGas (ran `DL.snoc` trr) txs
+        Left  failure    -> return $ TxMiningResult (Just failure) (DL.toList ran) unran remGas
 
 
 blockIsHomestead :: Integer -> Bool

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -33,6 +33,7 @@ import           Control.Monad.Trans.Except
 import           Data.Bifunctor                          (bimap)
 import qualified Data.ByteString                         as B
 import qualified Data.ByteString.Short                   as BSS
+import qualified Data.DList                              as DL
 import           Data.Either.Extra
 import           Data.List
 import qualified Data.Map                                as M
@@ -244,7 +245,7 @@ addBlocks unfiltered = do
       didReplaceBest   <- liftIO (newIORef False)
       ranPrivateTxs    <- liftIO (newIORef M.empty)
       replacedBest     <- liftIO (newIORef (error "addBlocks.replacedBest: evaluating uninitialized BestBlockInfo!"))
-      (actions, srLog') <- flip State.runStateT [] $ forM filtered $ \block ->
+      (actions, srLog') <- flip State.runStateT DL.empty $ forM filtered $ \block ->
           let blockNo = blockDataNumber $! obBlockData block
               txCount = length $! obReceiptTransactions block
           in timeit (printf "Block #%d (%d TXs insertion)" blockNo txCount) timerToUse $ do
@@ -257,12 +258,12 @@ addBlocks unfiltered = do
           -- and the intermediate ones increase the granularity at which we can compute a sequence
           -- of diffs. The number of blocks to skip between stateroots is determined by the cost of
           -- the diff between them, which is estimated by the number of transactions.
-          id %= ((blockDataStateRoot $ obBlockData block, hsh, num, txCount):)
+          id %= (`DL.snoc` (blockDataStateRoot $ obBlockData block, hsh, num, txCount))
         unless (M.null ranPriv) . liftIO $
           modifyIORef' ranPrivateTxs $ flip M.unionWith ranPriv $
             \(n1,s1) (n2,s2) -> if n1 > n2 then (n1,s1) else (n2,s2)
         return actions
-      let srLog = reverse srLog'
+      let srLog = DL.toList srLog'
       $logDebugLS "addBlocks/srLog" srLog
       didReplaceBest' <- liftIO (readIORef didReplaceBest)
       ranPrivateTxs' <- liftIO (readIORef ranPrivateTxs)

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -16,10 +16,10 @@ import qualified Blockchain.Database.MerklePatricia      as MP
 import           Blockchain.Output
 import           Control.Monad.Trans.State.Lazy        (gets)
 import qualified Data.ByteString                       as BS
+import qualified Data.DList                            as DL
 import           Data.List
 import           Data.Proxy
 import qualified Data.Text                             as T
-import qualified Data.Map.Ordered                      as O
 import qualified Data.Map                              as M
 import           Data.Maybe                            (isNothing, fromMaybe)
 import qualified Data.Set                              as S
@@ -149,8 +149,8 @@ ethereumVM = void . execContextM $ do
         pbft <- gets contextHasBlockstanbul
         reqd <- use contextBlockRequested
         let pending = B.pending state
-            priv = B.privateHashes $ B.miningCache state
-            hasTxs = not (null poolableNewTxs) || not (M.null pending) || not (O.null priv)
+            priv = DL.toList . B.privateHashes $ B.miningCache state
+            hasTxs = not (null poolableNewTxs) || not (M.null pending) || not (null priv)
             shouldOutputBlocks = isCaughtUp && (
               if pbft
                 then reqd && hasTxs

--- a/core-strato/vm-tools/package.yaml
+++ b/core-strato/vm-tools/package.yaml
@@ -22,6 +22,7 @@ dependencies:
   - data-default
   - deepseq
   - directory
+  - dlist
   - ethereum-rlp
   - exceptions
   - extra
@@ -35,7 +36,6 @@ dependencies:
   - monad-alter
   - mtl
   - nibblestring
-  - ordered-containers
   - persistent-postgresql
   - persistent-sqlite
   - prometheus-client

--- a/core-strato/vm-tools/src/Blockchain/Bagger.hs
+++ b/core-strato/vm-tools/src/Blockchain/Bagger.hs
@@ -17,9 +17,8 @@ import           Control.Monad.IO.Class
 import           Blockchain.Output
 import           Control.Monad.Trans.Class          (lift)
 import           Control.Monad.Trans.Except
-import           Data.Foldable                      (foldl')
+import qualified Data.DList                         as DL
 import qualified Data.Map                           as M
-import qualified Data.Map.Ordered                   as OMap
 import           Data.Proxy
 import qualified Data.Text                          as T
 import           Data.Time.Clock
@@ -97,9 +96,7 @@ class ( Monad m
         sequence_ (addToQueued Insertion <$> publicTxs)
         state <- getBaggerState
         let cache = B.miningCache state
-            hashes' = B.privateHashes cache
-            f hashMap tx = hashMap OMap.|> (txHash (otBaseTx tx), tx)
-            hashes = foldl' f hashes' privateTxs
+            hashes = B.privateHashes cache `DL.append` DL.fromList privateTxs
         putBaggerState state{ B.miningCache = cache{ B.privateHashes = hashes } }
         promoteExecutables
         setStateDBStateRoot existingStateDbStateRoot
@@ -114,7 +111,9 @@ class ( Monad m
         -- Really, it should just be Int and then we wouldn't need to worry about leap seconds.
         time  <- posixSecondsToUTCTime . fromInteger . round . utcTimeToPOSIXSeconds <$> liftIO getCurrentTime
         let pHashes = B.privateHashes $ B.miningCache state
-            hashMap = OMap.fromList $ map (\a -> (a,a)) txShas -- why is this not a standard function?
+            shaSet = S.fromList txShas
+            f = not . (`S.member` shaSet) . txHash . otBaseTx
+            hashMap = DL.fromList . filter f $ DL.toList pHashes
         let newMiningCache = B.MiningCache { B.bestBlockSHA          = bh
                                            , B.bestBlockHeader       = bd
                                            , B.bestBlockTxHashes     = txShas
@@ -122,7 +121,7 @@ class ( Monad m
                                            , B.remainingGas          = nextGasLimit $ DD.blockDataGasLimit bd
                                            , B.lastExecutedTxs       = []
                                            , B.promotedTransactions  = []
-                                           , B.privateHashes         = pHashes OMap.\\ hashMap
+                                           , B.privateHashes         = hashMap
                                            , B.startTimestamp        = time
                                            }
         putBaggerState $ state { B.seen = S.empty, B.miningCache = newMiningCache }
@@ -410,7 +409,7 @@ buildFromMiningCache = do
     let parentHash   = B.bestBlockSHA cache
     let parentHeader = B.bestBlockHeader cache
     let stateRoot    = B.lastExecutedStateRoot cache
-    let txs          = (trrTransaction <$> B.lastExecutedTxs cache) ++ (snd <$> OMap.assocs (B.privateHashes cache))
+    let txs          = (trrTransaction <$> B.lastExecutedTxs cache) ++ (DL.toList $ B.privateHashes cache)
     let parentNum    = DD.blockDataNumber parentHeader
     let parentDiff   = DD.blockDataDifficulty parentHeader
     let parentTS     = DD.blockDataTimestamp parentHeader

--- a/core-strato/vm-tools/src/Blockchain/Bagger.hs
+++ b/core-strato/vm-tools/src/Blockchain/Bagger.hs
@@ -15,10 +15,10 @@ import qualified Control.Monad.Change.Modify        as Mod
 import           Control.Monad.Extra
 import           Control.Monad.IO.Class
 import           Blockchain.Output
-import           Control.Monad.State.Lazy           (get, put, lift)
+import           Control.Monad.Trans.Class          (lift)
 import           Control.Monad.Trans.Except
+import           Data.Foldable                      (foldl')
 import qualified Data.Map                           as M
-import           Data.Map.Ordered                   (OMap)
 import qualified Data.Map.Ordered                   as OMap
 import           Data.Proxy
 import qualified Data.Text                          as T
@@ -47,7 +47,6 @@ import qualified Blockchain.EthConf                 as Conf
 import           Blockchain.Sequencer.Event         (OutputBlock (..), OutputTx (..))
 import           Blockchain.SHA                     hiding (hash)
 import           Blockchain.Strato.Model.Class
-import           Blockchain.Util
 import qualified Blockchain.Verification            as V
 
 import           Executable.EVMFlags                (flags_maxTxsPerBlock)
@@ -99,10 +98,8 @@ class ( Monad m
         state <- getBaggerState
         let cache = B.miningCache state
             hashes' = B.privateHashes cache
-            hashes = buildState hashes' privateTxs $ \tx -> do
-              (st :: OMap SHA OutputTx) <- get
-              let st' = st OMap.|> (txHash (otBaseTx tx), tx)
-              put st'
+            f hashMap tx = hashMap OMap.|> (txHash (otBaseTx tx), tx)
+            hashes = foldl' f hashes' privateTxs
         putBaggerState state{ B.miningCache = cache{ B.privateHashes = hashes } }
         promoteExecutables
         setStateDBStateRoot existingStateDbStateRoot

--- a/core-strato/vm-tools/src/Blockchain/Bagger/BaggerState.hs
+++ b/core-strato/vm-tools/src/Blockchain/Bagger/BaggerState.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Blockchain.Bagger.BaggerState where
 
 import           Control.Applicative                (Alternative, empty)
 import           Control.DeepSeq
 
-import           Data.Map.Ordered                   (OMap)
-import qualified Data.Map.Ordered                   as OMap
+import qualified Data.DList                         as DL
 import qualified Data.Map.Strict                    as M
 import           Data.Time.Clock
 import           Data.Time.Clock.POSIX
@@ -30,9 +28,6 @@ import           Blockchain.SHA
 
 type ATL = M.Map Address TransactionList
 
-instance (NFData a, NFData b) => NFData (OMap a b) where
-  rnf m = OMap.assocs m `deepseq` ()
-
 data MiningCache = MiningCache { bestBlockSHA          :: SHA
                                , bestBlockHeader       :: DD.BlockData
                                , bestBlockTxHashes     :: [SHA]
@@ -40,7 +35,7 @@ data MiningCache = MiningCache { bestBlockSHA          :: SHA
                                , remainingGas          :: Integer
                                , lastExecutedTxs       :: [TxRunResult]
                                , promotedTransactions  :: [OutputTx]
-                               , privateHashes         :: OMap SHA OutputTx
+                               , privateHashes         :: DL.DList OutputTx
                                , startTimestamp        :: UTCTime
                                } deriving (Show, Generic)
 
@@ -87,7 +82,7 @@ defaultMiningCache  = MiningCache { bestBlockSHA          = SHA 0
                                   , remainingGas          = 0
                                   , lastExecutedTxs       = []
                                   , promotedTransactions  = []
-                                  , privateHashes         = OMap.empty
+                                  , privateHashes         = DL.empty
                                   , startTimestamp        = posixSecondsToUTCTime 0
                                   }
 


### PR DESCRIPTION
There's a common misconception that, for lists, although `cons` is O(1), `snoc` is necessarily O(n): the entire list must be traversed to append an element to the end. This misconception applies to `append` as well. However, there is a technique called `difference lists`, which admits `snoc` and `append` in O(1) time. More information can be found at https://wiki.haskell.org/Difference_list.
In this PR, I've transformed several instances of lists held in a State monad into difference lists, which, in some cases, saves a `reverse` when flushing the list, and in other cases converts repeated O(n) appends to O(1) appends. In one case, I did away with the use of `OMap` in favor of difference lists, and in several places, cleaned up recursive functions run in the State monad with appropriate folds. 