### PR TITLE
Supply instantiated CablePackage to strato-sequencer benchmark

### DIFF
--- a/core-strato/strato-sequencer/bench/BlockstanbulSend.hs
+++ b/core-strato/strato-sequencer/bench/BlockstanbulSend.hs
@@ -13,6 +13,7 @@ import Blockchain.Data.Transaction
 import Blockchain.Blockstanbul
 import qualified Blockchain.Blockstanbul.BenchmarkLib as PBFT
 import Blockchain.Sequencer
+import Blockchain.Sequencer.CablePackage
 import Blockchain.Sequencer.Monad
 
 import Criterion.Main
@@ -30,9 +31,11 @@ runFakeSequencerM cfg ctx mv =
 benchConfig :: IO SequencerConfig
 benchConfig = do
   ch <- atomically newTMChan
+  cp <- atomically newCablePackage
   return SequencerConfig { blockstanbulBlockPeriod = 0
                          , blockstanbulRoundPeriod = 1000000
                          , blockstanbulTimeouts = ch
+                         , cablePackage = cp
                          }
 
 benchContext :: SequencerContext


### PR DESCRIPTION
The nightly test build was failing due to the strato-sequencer benchmark's `cablePackage` not being intialized correctly.
Before:
```strato-sequencer-0.1.0.0: benchmarks    
Running 1 benchmarks...                 
Benchmark send-to-blockstanbul: RUNNING...
benchmarking 0x0                        
send-to-blockstanbul: bench/BlockstanbulSend.hs:(33,10)-(36,26): Missing field in record construction cablePackage
                                        
Benchmark send-to-blockstanbul: ERROR   
Completed 12 action(s).                 

--  While building package strato-sequencer-0.1.0.0 using:
      /home/dustin/.stack/setup-exe-cache/x86_64-linux-dkf7b33dd99b569c2d0a323e8a6dc29e94/Cabal-simple_mPHDZzAJ_2.2.0.1_ghc-8.4.3 --builddir=.stack-work/dist/x86_64-linux-dkf7b33dd99b569c2d0a323e8a6dc29e94/Cabal-2.2.0.1 bench send-to-blockstanbul
    Process exited with code: ExitFailure 1
Received ExitFailure 1 when running
Raw command: /usr/bin/docker start -a -i 323dee6f046a0bc7e0b43fa179e6e3d17158335fadd078c667a8d86768d77b38```

After:
```strato-sequencer-0.1.0.0: benchmarks
Running 1 benchmarks...               
Benchmark send-to-blockstanbul: RUNNING...
benchmarking 0x0                      
time                 54.83 ms   (51.72 ms .. 56.86 ms)
                     0.995 R²   (0.989 R² .. 0.998 R²)
mean                 58.42 ms   (56.46 ms .. 61.77 ms)
std dev              4.631 ms   (2.937 ms .. 6.769 ms)
variance introduced by outliers: 24% (moderately inflated)
                                      
benchmarking 20x 4KB                  
time                 61.76 ms   (57.18 ms .. 65.35 ms)
                     0.988 R²   (0.970 R² .. 0.997 R²)
mean                 62.40 ms   (60.21 ms .. 66.08 ms)
std dev              4.966 ms   (2.547 ms .. 8.022 ms)
variance introduced by outliers: 24% (moderately inflated)
                                      
benchmarking 80x 4KB                  
time                 81.31 ms   (66.31 ms .. 94.74 ms)
                     0.958 R²   (0.914 R² .. 0.997 R²)
mean                 79.31 ms   (74.46 ms .. 86.63 ms)
std dev              10.02 ms   (5.602 ms .. 14.34 ms)
variance introduced by outliers: 38% (moderately inflated)
                                      
benchmarking 320x 4KB                 
time                 129.9 ms   (115.6 ms .. 139.0 ms)
                     0.984 R²   (0.929 R² .. 0.999 R²)
mean                 131.8 ms   (126.1 ms .. 141.8 ms)
std dev              10.81 ms   (4.965 ms .. 16.53 ms)
variance introduced by outliers: 23% (moderately inflated)
                                      
benchmarking 1280x 4KB                
time                 324.4 ms   (279.4 ms .. 390.0 ms)
                     0.994 R²   (0.992 R² .. 1.000 R²)
mean                 332.1 ms   (317.5 ms .. 349.2 ms)
std dev              19.72 ms   (7.543 ms .. 25.02 ms)
variance introduced by outliers: 19% (moderately inflated)
                                      
benchmarking 10x 4MB                  
time                 398.7 ms   (269.6 ms .. 666.7 ms)
                     0.949 R²   (0.917 R² .. 1.000 R²)
mean                 333.8 ms   (307.8 ms .. 375.8 ms)
std dev              40.28 ms   (7.640 ms .. 52.91 ms)
variance introduced by outliers: 23% (moderately inflated)
                                      
benchmarking 20x 4MB                  
time                 585.3 ms   (455.2 ms .. 659.5 ms)
                     0.993 R²   (NaN R² .. 1.000 R²)
mean                 618.2 ms   (579.7 ms .. 669.8 ms)
std dev              53.36 ms   (8.639 ms .. 69.36 ms)
variance introduced by outliers: 22% (moderately inflated)
                                      
benchmarking 40x 4MB                  
time                 1.119 s    (1.073 s .. 1.153 s)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.088 s    (1.073 s .. 1.101 s)
std dev              16.92 ms   (14.31 ms .. 18.25 ms)
variance introduced by outliers: 19% (moderately inflated)
                                      
benchmarking 40 whoSignedThisTransaction contracts at 4MB
time                 1.108 s    (1.090 s .. 1.132 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.047 s    (1.001 s .. 1.071 s)
std dev              44.02 ms   (2.573 ms .. 54.53 ms)
variance introduced by outliers: 19% (moderately inflated)
                                      
Benchmark send-to-blockstanbul: FINISH
Completed 2 action(s).  ```