### PR TITLE
Solidvm event fixes

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -35,6 +35,7 @@ import           Blockchain.DB.SolidStorageDB
 import           Blockchain.SolidVM.Exception
 import           Blockchain.SolidVM.SM
 import           Blockchain.SolidVM.Value
+import           Blockchain.Strato.Model.Address (formatAddress)
 import qualified SolidVM.Model.Storable as MS
 import qualified SolidVM.Solidity.Xabi.Type as Xabi
 import           Text.Format
@@ -254,11 +255,11 @@ getStorageItem mTypeHint apt@(AddressedPath loc key) = do
 showSM :: Value -> SM String
 showSM SNULL = return "NULL"
 showSM (SInteger v) = return $ show v
-showSM (SString v) = return $ show v
+showSM (SString v) = return v
 showSM (SBool v) = return $ show v
 showSM (SEnumVal enumName valName num) = return
     $ printf "%s.%s (= %x)" enumName valName num
-showSM (SAddress a) = return $ format a
+showSM (SAddress a) = return $ formatAddress a
 showSM (STuple v) = do
   vals <- mapM getVar (V.toList v)
   strings <- forM vals showSM

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -30,6 +30,7 @@ import qualified Blockchain.Data.EventDB            as EventDB
 import           Blockchain.Data.TransactionDef     (formatChainId)
 import qualified Blockchain.Data.TransactionResult  as TxrDB
 import           Blockchain.EthConf                 (lookupConsumerGroup)
+import           Blockchain.ExtWord
 
 import           Blockchain.Output
 import           Blockchain.Sequencer.Event
@@ -57,6 +58,27 @@ terminateTopic = hash $ C8.pack "ChainTerminated()"
 logF :: MonadLogger m => [String] -> m ()
 logF = $logInfoS "txrIndexer" . T.pack . concat
 
+doAddMember :: Word256 -> Address -> Enode -> IContextM ()
+doAddMember chainId address enode = do
+  logF [ "Adding member "
+       , format address
+       , " on chain "
+       , formatChainId $ Just chainId
+       ]
+  lift $ addMember chainId address (showEnode enode) -- We only need the Text version for Postgres
+  void . RBDB.withRedisBlockDB $ RBDB.addChainMember chainId address enode
+  void . withKafkaRetry1s $ writeUnseqEvents [IENewChainMember chainId address enode]
+
+doRemoveMember :: Word256 -> Address -> IContextM ()
+doRemoveMember chainId address = do
+  logF [ "Removing member "
+       , format address
+       , " on chain "
+       , formatChainId $ Just chainId
+       ]
+  lift $ removeMember chainId address
+  void . RBDB.withRedisBlockDB $ RBDB.removeChainMember chainId address
+
 txrIndexer :: LoggingT IO ()
 txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
     $logInfoS "txrIndexer" "About to fetch IndexEvents"
@@ -81,24 +103,10 @@ txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
                     eEnode :: Either SomeException Enode <- liftIO . try . evaluate . force $ readEnode enode' --TODO: we don't need this powerful of an evaluation, we just need to improve `readEnode`
                     case eEnode of
                       Left err -> $logErrorS "txrIndexer" . T.pack $ "failed to parse enode: " ++ show err
-                      Right enode -> do
-                        logF [ "Adding member "
-                             , format address
-                             , " on chain "
-                             , formatChainId $ Just chainId
-                             ]
-                        lift $ addMember chainId address enode' -- We only need the Text version for Postgres
-                        void . RBDB.withRedisBlockDB $ RBDB.addChainMember chainId address enode
-                        void . withKafkaRetry1s $ writeUnseqEvents [IENewChainMember chainId address enode]
+                      Right enode -> doAddMember chainId address enode
                   Just x | SHA x == removeTopic -> do
                     let address = decode . BL.fromStrict . BS.take 20 . BS.drop 12 $ logDBTheData l
-                    logF [ "Removing member "
-                         , format address
-                         , " on chain "
-                         , formatChainId $ Just chainId
-                         ]
-                    lift $ removeMember chainId address
-                    void . RBDB.withRedisBlockDB $ RBDB.removeChainMember chainId address
+                    doRemoveMember chainId address
                   Just x | SHA x == terminateTopic -> do
                     logF ["Terminating chain ", formatChainId $ Just chainId]
                     lift $ terminateChain chainId
@@ -121,25 +129,10 @@ txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
                       eNode :: Either SomeException Enode <- liftIO . try . evaluate . force $ readEnode enodeStr --TODO: we don't need this powerful of an evaluation, we just need to improve `readEnode`
                       case eNode of
                         Left err -> $logErrorS "txrIndexer" . T.pack $ "failed to parse enode" ++ show err
-                        Right enode -> do
-                          logF [ "Adding member "
-                               , format address
-                               , " on chain "
-                               , formatChainId $ Just chainId
-                               ]
-                          lift $ addMember chainId address enodeStr
-                          void . RBDB.withRedisBlockDB $ RBDB.addChainMember chainId address enode
-                          void . withKafkaRetry1s $ writeUnseqEvents [IENewChainMember chainId address enode]
+                        Right enode -> doAddMember chainId address enode
                   ("MemberRemoved", [addressStr]) -> case stringAddress addressStr of
                     Nothing -> $logErrorS "txrIndexer" . T.pack $ "failed to parse address for MemberRemoved event: " ++ addressStr
-                    Just address -> do
-                      logF [ "Removing member "
-                           , format address
-                           , " on chain "
-                           , formatChainId $ Just chainId
-                           ]
-                      lift $ removeMember chainId address
-                      void . RBDB.withRedisBlockDB $ RBDB.removeChainMember chainId address
+                    Just address -> doRemoveMember chainId address
                   _ -> return ()
                 void . lift $ EventDB.putEventDB ev
             TxResult r -> do

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -14,7 +14,7 @@ import           Data.Binary
 import qualified Data.ByteString                    as BS
 import qualified Data.ByteString.Char8              as C8
 import qualified Data.ByteString.Lazy               as BL
-import           Data.Maybe                         (isJust)
+import           Data.Foldable                      (for_)
 import qualified Data.List                          as List
 import qualified Data.Text                          as T
 import           Data.Text.Encoding                 (decodeUtf8)
@@ -27,6 +27,7 @@ import           Blockchain.Data.DataDefs           (LogDB (..), EventDB (..), T
 import           Blockchain.Data.Enode
 import qualified Blockchain.Data.LogDB              as LogDB
 import qualified Blockchain.Data.EventDB            as EventDB
+import           Blockchain.Data.TransactionDef     (formatChainId)
 import qualified Blockchain.Data.TransactionResult  as TxrDB
 import           Blockchain.EthConf                 (lookupConsumerGroup)
 
@@ -42,8 +43,6 @@ import           Blockchain.Strato.Model.SHA
 import qualified Blockchain.Strato.RedisBlockDB     as RBDB
 import           Blockchain.Util                    (byteString2Integer)
 
-import           Numeric
-
 import           Text.Format
 
 addTopic :: SHA
@@ -55,6 +54,9 @@ removeTopic = hash $ C8.pack "MemberRemoved(address)"
 terminateTopic :: SHA
 terminateTopic = hash $ C8.pack "ChainTerminated()"
 
+logF :: MonadLogger m => [String] -> m ()
+logF = $logInfoS "txrIndexer" . T.pack . concat
+
 txrIndexer :: LoggingT IO ()
 txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
     $logInfoS "txrIndexer" "About to fetch IndexEvents"
@@ -63,73 +65,89 @@ txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
     let zipIdxEvents = zip [offset+1..] idxEvents
     forM_ zipIdxEvents $ \(nextIdx, e) -> do -- todo: don't insert one-by-one?
         case e of
-            LogDBEntry l -> do
-                let mChainId = logDBChainId l
-                    topic1 = logDBTopic1 l
-                $logInfoS "txrIndexer" . T.pack $ "Inserting LogDB entry for tx: " ++ format (logDBTransactionHash l) ++ " on chain " ++ show (flip showHex "" <$> mChainId) ++ " at block " ++ format (logDBBlockHash l)
-                when (isJust mChainId) $ do
-                  let Just chainId = mChainId
-                  case topic1 of
-                    Just x | SHA x == addTopic -> do
-                      let address = decode . BL.fromStrict . BS.take 20 . BS.drop 12 $ logDBTheData l --TODO: unhack
-                          enodelen = fromInteger . byteString2Integer . BS.take 32 . BS.drop 64 $ logDBTheData l
-                          enode' = T.unpack . decodeUtf8 . BS.take enodelen . BS.drop 96 $ logDBTheData l
-                      eEnode :: Either SomeException Enode <- liftIO . try . evaluate . force $ readEnode enode'
-                      case eEnode of
-                        Left err -> $logErrorS "txrIndexer" . T.pack $ "failed to parse enode: " ++ show err
+            LogDBEntry l -> for_ (logDBChainId l) $ \chainId -> do
+                logF [ "Inserting LogDB entry for tx: "
+                     , format $ logDBTransactionHash l
+                     , " on chain "
+                     , formatChainId $ Just chainId
+                     , " at block "
+                     , format $ logDBBlockHash l
+                     ]
+                case logDBTopic1 l of
+                  Just x | SHA x == addTopic -> do
+                    let address = decode . BL.fromStrict . BS.take 20 . BS.drop 12 $ logDBTheData l --TODO: unhack
+                        enodelen = fromInteger . byteString2Integer . BS.take 32 . BS.drop 64 $ logDBTheData l
+                        enode' = T.unpack . decodeUtf8 . BS.take enodelen . BS.drop 96 $ logDBTheData l
+                    eEnode :: Either SomeException Enode <- liftIO . try . evaluate . force $ readEnode enode' --TODO: we don't need this powerful of an evaluation, we just need to improve `readEnode`
+                    case eEnode of
+                      Left err -> $logErrorS "txrIndexer" . T.pack $ "failed to parse enode: " ++ show err
+                      Right enode -> do
+                        logF [ "Adding member "
+                             , format address
+                             , " on chain "
+                             , formatChainId $ Just chainId
+                             ]
+                        lift $ addMember chainId address enode' -- We only need the Text version for Postgres
+                        void . RBDB.withRedisBlockDB $ RBDB.addChainMember chainId address enode
+                        void . withKafkaRetry1s $ writeUnseqEvents [IENewChainMember chainId address enode]
+                  Just x | SHA x == removeTopic -> do
+                    let address = decode . BL.fromStrict . BS.take 20 . BS.drop 12 $ logDBTheData l
+                    logF [ "Removing member "
+                         , format address
+                         , " on chain "
+                         , formatChainId $ Just chainId
+                         ]
+                    lift $ removeMember chainId address
+                    void . RBDB.withRedisBlockDB $ RBDB.removeChainMember chainId address
+                  Just x | SHA x == terminateTopic -> do
+                    logF ["Terminating chain ", formatChainId $ Just chainId]
+                    lift $ terminateChain chainId
+                  _ -> return ()
+                void . lift $ LogDB.putLogDB l
+            EventDBEntry ev -> for_ (eventDBChainId ev) $ \chainId -> do
+                let evName = eventDBName ev
+                    evArgs = eventDBArgs ev
+                logF [ "Inserting EventDB entry for Event: "
+                     , evName
+                     , " with args: "
+                     , List.intercalate "," evArgs
+                     , " for chainID: "
+                     , formatChainId $ Just chainId
+                     ]
+                case (evName, evArgs) of
+                  ("MemberAdded", [addressStr, enodeStr]) -> case stringAddress addressStr of
+                    Nothing -> $logErrorS "txrIndexer" . T.pack $ "failed to parse address for MemberAdded event: " ++ addressStr
+                    Just address -> do
+                      eNode :: Either SomeException Enode <- liftIO . try . evaluate . force $ readEnode enodeStr --TODO: we don't need this powerful of an evaluation, we just need to improve `readEnode`
+                      case eNode of
+                        Left err -> $logErrorS "txrIndexer" . T.pack $ "failed to parse enode" ++ show err
                         Right enode -> do
-                          $logInfoS "txrIndexer" . T.pack $ "Adding member " ++ (showHex address "") ++ " on chain " ++ showHex chainId ""
-                          lift $ addMember chainId address enode' -- We only need the Text version for Postgres
+                          logF [ "Adding member "
+                               , format address
+                               , " on chain "
+                               , formatChainId $ Just chainId
+                               ]
+                          lift $ addMember chainId address enodeStr
                           void . RBDB.withRedisBlockDB $ RBDB.addChainMember chainId address enode
                           void . withKafkaRetry1s $ writeUnseqEvents [IENewChainMember chainId address enode]
-                    Just x | SHA x == removeTopic -> do
-                      let address = decode . BL.fromStrict . BS.take 20 . BS.drop 12 $ logDBTheData l
-                      $logInfoS "txrIndexer" . T.pack $ "Removing member " ++ (showHex address "") ++ " on chain " ++ showHex chainId ""
+                  ("MemberRemoved", [addressStr]) -> case stringAddress addressStr of
+                    Nothing -> $logErrorS "txrIndexer" . T.pack $ "failed to parse address for MemberRemoved event: " ++ addressStr
+                    Just address -> do
+                      logF [ "Removing member "
+                           , format address
+                           , " on chain "
+                           , formatChainId $ Just chainId
+                           ]
                       lift $ removeMember chainId address
                       void . RBDB.withRedisBlockDB $ RBDB.removeChainMember chainId address
-                    Just x | SHA x == terminateTopic -> do
-                      $logInfoS "txrIndexer" . T.pack $ "Terminating chain " ++ showHex chainId ""
-                      lift $ terminateChain chainId
-                    _ -> return ()
-                void . lift $ LogDB.putLogDB l
-            EventDBEntry ev -> do
-                let mChainId = eventDBChainId ev
-                    evName = eventDBName ev
-                    evArgs = eventDBArgs ev
-                $logInfoS "txrIndexer" . T.pack $ "Inserting EventDB entry for Event: " ++ evName ++ " with args: " ++ (List.intercalate "," evArgs) ++ " for chainID: " ++ show mChainId
-                when (isJust mChainId) $ do
-                  let Just chainId = mChainId
-                  case evName of 
-                    "MemberAdded" -> do
-                        if (length evArgs) == 2
-                        then do 
-                          let Just address = stringAddress $ head evArgs
-                              enodeStr = last evArgs 
-                          eNode :: Either SomeException Enode <- liftIO . try . evaluate . force $ readEnode enodeStr
-                          case eNode of
-                            Left err -> $logErrorS "txrIndexer" . T.pack $ "failed to parse enode" ++ show err
-                            Right enode -> do
-                              $logInfoS "txrIndexer" . T.pack $ "Adding member " ++ (showHex address "") ++ " on chain " ++ showHex chainId ""
-                              lift $ addMember chainId address enodeStr
-                              void . RBDB.withRedisBlockDB $ RBDB.addChainMember chainId address enode
-                              void . withKafkaRetry1s $ writeUnseqEvents [IENewChainMember chainId address enode]
-                        else
-                          $logInfoS "txrIndexer" . T.pack $ "MemberAdded called with invalid args - logging and moving on"
-                          -- TODO: should this throw error instead of adding to postgres?
-                    "MemberRemoved" -> do
-                        if (length evArgs == 1)
-                        then do
-                          let Just address = stringAddress $ head evArgs
-                          $logInfoS "txrIndexer" . T.pack $ "Removing member " ++ (showHex address "") ++ " on chain " ++ showHex chainId ""
-                          lift $ removeMember chainId address
-                          void . RBDB.withRedisBlockDB $ RBDB.removeChainMember chainId address
-                        else
-                          $logInfoS "txrIndexer" . T.pack $ "MemberRemoved called with invalid args - logging and moving on"
-                    _ -> return () 
+                  _ -> return ()
                 void . lift $ EventDB.putEventDB ev
             TxResult r -> do
-                $logInfoS "txrIndexer" . T.pack $
-                    "Inserting TXResult for tx " ++ format (transactionResultTransactionHash r) ++ " at block " ++ format (transactionResultBlockHash r)
+                logF [ "Inserting TXResult for tx "
+                     , format $ transactionResultTransactionHash r
+                     , " at block "
+                     , format $ transactionResultBlockHash r
+                     ]
                 void . lift $ TxrDB.putTransactionResult r
             _ -> return ()
         setKafkaCheckpoint nextIdx


### PR DESCRIPTION
Fixes https://blockapps.atlassian.net/browse/STRATO-1659

`showSM` was preventing the address and enode fields of private chain events from parsing correctly. Moreover, the use of irrefutable patterns caused the node to crash when a `RemoveMember` event was triggered.

Ideally, the `EventDB` type would use SolidVM `Value`s instead of `String`s, but this would require some shuffling of types between packages. Actually, the `EventDB` type could be polymorphic in its `Value` type, which would allow it to be VM-agnostic, should we ever add another VM to the mix. Then, `strato-index` could monomorphize on the SolidVM `Value`s for the `IndexEvent` type. This would still require making an `EventDB` type outside of `DataDefs.txt`, but wouldn't require moving types out of their packages.  
