### PR TITLE
Revert "Alter the TX insertion to distinguish EVM from SolidVM"

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
@@ -109,13 +109,7 @@ postBlocTransaction mUserName chainId resolve (PostBlocTransactionRequest mAddr 
                         (functionpayloadMetadata p)
                         chainId
                         resolve
-            let poster = case Map.lookup "VM" =<< (functionpayloadMetadata p) of
-                  Nothing -> postUsersContractMethodEVM'
-                  Just "EVM" -> postUsersContractMethodEVM'
-                  Just "SolidVM" -> postUsersContractMethodSolidVM'
-                  Just vm -> \_ _ -> throwError $ UserError $ Text.pack
-                                   $ "Invalid value for VM choice: " ++ show vm
-            fmap (:[]) $ poster bfp (callSignature userName)
+            fmap (:[]) $ postUsersContractMethod' bfp (callSignature userName)
           xs -> do
             p <- mapM fromFunction xs
             let bflp = FunctionListParameters
@@ -123,14 +117,7 @@ postBlocTransaction mUserName chainId resolve (PostBlocTransactionRequest mAddr 
                         (map (\(FunctionPayload (ContractName n) a m r v md) -> MethodCall n a m r (fromMaybe (Strung 0) v) txParams md) p)
                         chainId
                         resolve
-            let md = functionpayloadMetadata (head p)
-            let poster = case Map.lookup "VM" =<< md of
-                  Nothing -> postUsersContractMethodListEVM'
-                  Just "EVM" -> postUsersContractMethodListEVM'
-                  Just "SolidVM" -> postUsersContractMethodListSolidVM'
-                  Just vm -> \_ _ -> throwError $ UserError $ Text.pack
-                    $ "Invalid value for VM choice: " ++ show vm
-            poster bflp (callSignature userName)
+            postUsersContractMethodList' bflp (callSignature userName)
   where fromTransfer = \case
           BlocTransfer t -> return t
           _ -> throwError $ UserError "Could not decode transfer arguments from body"

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -497,12 +497,7 @@ postUsersContractMethodList userName userAddr chainId resolve PostMethodListRequ
                postmethodlistrequestTxs
                chainId
                (resolve || postmethodlistrequestResolve)
-  case join $ fmap (Map.lookup "VM") $ methodcallMetadata (head postmethodlistrequestTxs) of
-    Just "EVM" -> postUsersContractMethodListEVM' bflp (return . signTransaction sk)
-    Just "SolidVM" -> postUsersContractMethodListSolidVM' bflp (return . signTransaction sk)
-    Nothing -> postUsersContractMethodListEVM' bflp (return . signTransaction sk) -- The EVM is the default VM
-    Just vmName -> throwError $ UserError $ Text.pack $ "Invalid value for VM choice: " ++ show vmName ++ ", valid options are 'EVM' or 'SolidVM'"
-
+  postUsersContractMethodList' bflp (return . signTransaction sk)
 
 genNonces :: (Show a, Monad m) => m Nonce -> Lens' a (Maybe TxParams) -> [a] -> m [a]
 genNonces n l as = do
@@ -522,8 +517,8 @@ genNonces n l as = do
         id <<+= 1
     return $ (l .~ Just params'{txparamsNonce = Just newNonce }) a
 
-postUsersContractMethodListEVM' :: FunctionListParameters -> Signer -> Bloc [BlocTransactionResult]
-postUsersContractMethodListEVM' FunctionListParameters{..} sign = do
+postUsersContractMethodList' :: FunctionListParameters -> Signer -> Bloc [BlocTransactionResult]
+postUsersContractMethodList' FunctionListParameters{..} sign = do
   if null txs
     then return []
     else do
@@ -549,63 +544,7 @@ postUsersContractMethodListEVM' FunctionListParameters{..} sign = do
              Just (_, TypeFunction selector _ _) -> return selector
              _ -> lift $ throwError . UserError $ "Contract doesn't have a method named '" <> methodcallMethodName <> "'"
           let xabiArgs = maybe Map.empty funcArgs . Map.lookup methodcallMethodName $ xabiFuncs xabi
-          argsBin <- lift $ constructArgValues (Just (fmap argValueToText methodcallArgs)) xabiArgs
-          let methodcallMetadataWithCallInfo = Just $
-                Map.insert "funcName" methodcallMethodName
-                $ Map.insert "src" ""
-                $ fromMaybe Map.empty methodcallMetadata
-          tx <- lift . signAndPrepare sign fromAddr methodcallMetadataWithCallInfo $
-            TransactionHeader
-              (Just methodcallContractAddress)
-              fromAddr
-              (fromMaybe emptyTxParams _methodcallTxParams)
-              (Wei (fromIntegral $ unStrung methodcallValue))
-              (sel <> argsBin)
-              chainId
-          -- resultXabiTypes <- getXabiFunctionsReturnValuesQuery functionId
-          return (tx,mapKey,methodcallMethodName)
-      let txs' = [tx | (tx,_,_) <- txsCmIdsFuncNames]
-      mapM_ ($logInfoLS "postUsersContractMethodList'/txs") txs'
-      hashes <- blocStrato $ postTxList txs'
-      void . blocModify $ \conn -> runInsertMany conn hashNameTable
-        [( Nothing
-        , constant hash
-        , constant cmId
-        , constant (2 :: Int32)
-        , constant funcName
-        )
-        | (hash,(_,cmId, funcName)) <- zip hashes txsCmIdsFuncNames
-        ]
-      getBatchBlocTransactionResult' chainId hashes resolve
-
-postUsersContractMethodListSolidVM' :: FunctionListParameters -> Signer -> Bloc [BlocTransactionResult]
-postUsersContractMethodListSolidVM' FunctionListParameters{..} sign = do
-  if null txs
-    then return []
-    else do
-      txsWithParams <- genNonces (getAccountNonce fromAddr chainId) methodcallTxParams txs
-      txsCmIdsFuncNames <- fmap fst . forStateT Map.empty txsWithParams $
-        \(MethodCall{..}) -> do
-          mtuple <- use $ at methodcallContractName
-          (mapKey, xabi) <- case mtuple of
-            Just (cmId, x) -> return (cmId, x)
-            Nothing -> do
-              (mapKey' :: Int32,x') <- lift $ blocQuery1 "postUsersContractMethodList'" $ proc () -> do
-                (_,_,_,_,_,_,cmId,x'') <- getContractsContractLatestQuery methodcallContractName -< ()
-                returnA -< (cmId,x'')
-              x <- lift $ deserializeXabi x'
-              at methodcallContractName <?= (mapKey', x)
-          contract' <- case xAbiToContract xabi of
-            Left err -> throwError . AnError $ Text.pack err
-            Right c -> return c
-          let maybeFunc = OMap.lookup methodcallMethodName (fields $ C.mainStruct contract')
-
-          sel <-
-            case maybeFunc of
-             Just (_, TypeFunction selector _ _) -> return selector
-             _ -> lift $ throwError . UserError $ "Contract doesn't have a method named '" <> methodcallMethodName <> "'"
-          let xabiArgs = maybe Map.empty funcArgs . Map.lookup methodcallMethodName $ xabiFuncs xabi
-          (_, argsAsSource) <-
+          (argsBin, argsAsSource) <-
             lift $ constructArgValuesAndSource (Just (fmap argValueToText methodcallArgs)) xabiArgs
           let methodcallMetadataWithCallInfo = Just $
                 Map.insert "funcName" methodcallMethodName
@@ -617,7 +556,7 @@ postUsersContractMethodListSolidVM' FunctionListParameters{..} sign = do
               fromAddr
               (fromMaybe emptyTxParams _methodcallTxParams)
               (Wei (fromIntegral $ unStrung methodcallValue))
-              (sel <> Text.encodeUtf8 argsAsSource)
+              (sel <> argsBin)
               chainId
           -- resultXabiTypes <- getXabiFunctionsReturnValuesQuery functionId
           return (tx,mapKey,methodcallMethodName)
@@ -664,14 +603,10 @@ postUsersContractMethod
                 md
                 chainId
                 resolve
-    case join $ fmap (Map.lookup "VM") $ md of
-      Just "EVM" -> postUsersContractMethodEVM' bfp (return . signTransaction sk)
-      Just "SolidVM" -> postUsersContractMethodSolidVM' bfp (return . signTransaction sk)
-      Nothing -> postUsersContractMethodEVM' bfp (return . signTransaction sk) -- The EVM is the default VM
-      Just vmName -> throwError $ UserError $ Text.pack $ "Invalid value for VM choice: " ++ show vmName ++ ", valid options are 'EVM' or 'SolidVM'"
+    postUsersContractMethod' bfp (return . signTransaction sk)
 
-postUsersContractMethodEVM' :: FunctionParameters -> Signer -> Bloc BlocTransactionResult
-postUsersContractMethodEVM' FunctionParameters{..} sign = do
+postUsersContractMethod' :: FunctionParameters -> Signer -> Bloc BlocTransactionResult
+postUsersContractMethod' FunctionParameters{..} sign = do
     params <- getAccountTxParams fromAddr chainId txParams
 
     let err = UserError $ Text.concat
@@ -697,59 +632,7 @@ postUsersContractMethodEVM' FunctionParameters{..} sign = do
        Just (_, TypeFunction selector _ _) -> return selector
        _ -> throwError . UserError $ "Contract doesn't have a method named '" <> funcName <> "'"
 
-    argsBin <- constructArgValues (Just (fmap argValueToText args)) xabiArgs
-    let metadataWithCallInfo =
-          Map.insert "funcName" funcName
-          $ Map.insert "src" ""
-          $ fromMaybe Map.empty metadata
-
-    tx <- signAndPrepare sign fromAddr (Just metadataWithCallInfo) $
-      TransactionHeader
-        (Just contractAddr)
-        fromAddr
-        params
-        (Wei (maybe 0 (fromIntegral . unStrung) value))
-        ((sel::ByteString) <> (argsBin::ByteString))
-        chainId
-    $logInfoLS "postUsersContractMethod'" tx
-    hash <- blocStrato $ postTx tx
-    void . blocModify $ \conn -> runInsertMany conn hashNameTable [
-      ( Nothing
-      , constant hash
-      , constant cmId
-      , constant (2 :: Int32)
-      , constant funcName
-      )]
-    getBlocTransactionResult' chainId [hash] resolve
-
-postUsersContractMethodSolidVM' :: FunctionParameters -> Signer -> Bloc BlocTransactionResult
-postUsersContractMethodSolidVM' FunctionParameters{..} sign = do
-    params <- getAccountTxParams fromAddr chainId txParams
-
-    let err = UserError $ Text.concat
-                [ "postUsersContractMethod': Couldn't find contract details for "
-                , contractName
-                , " at address "
-                , Text.pack $ addressString contractAddr
-                ]
-    (cmId,xabi) <- maybe (throwError err) (return . fmap contractdetailsXabi) =<<
-      getContractDetailsAndMetadataId
-        (ContractName contractName)
-        (Unnamed contractAddr)
-        chainId
-    contract' <- case xAbiToContract xabi of
-      Left e -> throwError . AnError $ Text.pack e
-      Right c -> return c
-
-    let maybeFunc = OMap.lookup funcName (fields $ C.mainStruct contract')
-        xabiArgs = maybe Map.empty funcArgs . Map.lookup funcName $ xabiFuncs xabi
-
-    sel <-
-      case maybeFunc of
-       Just (_, TypeFunction selector _ _) -> return selector
-       _ -> throwError . UserError $ "Contract doesn't have a method named '" <> funcName <> "'"
-
-    (_, argsAsSource) <- constructArgValuesAndSource (Just (fmap argValueToText args)) xabiArgs
+    (argsBin, argsAsSource) <- constructArgValuesAndSource (Just (fmap argValueToText args)) xabiArgs
     let metadataWithCallInfo =
           Map.insert "funcName" funcName
           $ Map.insert "args" argsAsSource
@@ -761,7 +644,7 @@ postUsersContractMethodSolidVM' FunctionParameters{..} sign = do
         fromAddr
         params
         (Wei (maybe 0 (fromIntegral . unStrung) value))
-        (sel <> Text.encodeUtf8 argsAsSource)
+        ((sel::ByteString) <> (argsBin::ByteString))
         chainId
     $logInfoLS "postUsersContractMethod'" tx
     hash <- blocStrato $ postTx tx
@@ -1003,7 +886,7 @@ constructArgValuesAndSource args argNamesTypes = do
         let valsAsText = map valueToText vals
         return $
           (
-            "",
+            toStorage (ValueArrayFixed (fromIntegral (length vals)) vals),
             "(" <> Text.intercalate "," valsAsText <> ")"
           )
 

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -113,12 +113,8 @@ function newnode {
     "${baFlag}" "${scFlag}" --minLogLevel=$seqMinLogLevel \
     +RTS "${seqRTSOPTs:-}" -N1 &>> logs/strato-sequencer
 
-  if [ "${apiIndexOff}" = true ]; then
-    ioFlag="--api_index_off=${apiIndexOff}"
-  fi
-
   echo "Starting strato-api-indexer"
-  runBackgroundProcess strato-api-indexer "${ioFlag}" +RTS -N1 >> logs/strato-api-indexer 2>&1
+  runBackgroundProcess strato-api-indexer +RTS -N1 >> logs/strato-api-indexer 2>&1
 
   echo "Starting strato-p2p-indexer"
   runBackgroundProcess strato-p2p-indexer +RTS -N1 >> logs/strato-p2p-indexer 2>&1
@@ -147,7 +143,7 @@ function newnode {
                          --diffPublish=$diffPublish --sqlDiff=$sqlDiff --svmTrace=$svmTrace --createTransactionResults=true \
                          --miningVerification=$verifyBlocks --difficultyBomb=$difficultyBomb \
                          --trace=$evmTraceMode --debug=$evmDebugMode --minLogLevel=$evmMinLogLevel \
-                         "${tbFlag}" "${breFlag}" "${sebFlag}" "${sechFlag}" "${svdFlag}" "${ctrFlag}" "${ioFlag}"\
+                         "${tbFlag}" "${breFlag}" "${sebFlag}" "${sechFlag}" "${svdFlag}" "${ctrFlag}" \
                          +RTS "${vmRunnerRTSOPTs:-}" -N1 &>> logs/vm-runner
 
   echo "Starting strato-api"

--- a/core-strato/strato-index/exec_src/ApiIndexerMain.hs
+++ b/core-strato/strato-index/exec_src/ApiIndexerMain.hs
@@ -6,8 +6,6 @@ import           Blockchain.Output
 import           Blockchain.Strato.Indexer.ApiIndexer
 import           HFlags
 
-import           Executable.IndexerFlags()  -- HFlags
-
 main :: IO ()
 main = do
   blockappsInit "strato-api-indexer"

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/ApiIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/ApiIndexer.hs
@@ -31,7 +31,6 @@ import           Blockchain.EthConf                 (lookupConsumerGroup)
 import           Blockchain.Strato.Indexer.IContext
 import           Blockchain.Strato.Indexer.Kafka
 import           Blockchain.Strato.Indexer.Model
-import           Executable.IndexerFlags
 
 import           Blockchain.Sequencer.Event
 
@@ -48,16 +47,11 @@ apiIndexer =  runIContextM "strato-api-indexer" $ do
         putIndexerBestBlockInfo bbi
         putIndexerBestBlockInfoTime <- liftIO $ getTime Realtime
         $logInfoS "apiIndexer" . T.pack $ "Fetched " ++ show (length idxEvents) ++ " events starting from " ++ show offset
-
-        unless flags_api_index_off $ do
-          let txs = [tx | IndexTransaction _ tx <- idxEvents]
-          lift $ forM_ txs $ \OutputTx{..} -> insertTX Log otOrigin Nothing [otBaseTx]
-
+        let txs = [tx | IndexTransaction _ tx <- idxEvents]
+        lift $ forM_ txs $ \OutputTx{..} -> insertTX Log otOrigin Nothing [otBaseTx]
         let chainInfos = [(cId, cInfo) | NewChainInfo cId cInfo <- idxEvents]
         lift $ forM_ chainInfos . uncurry $ putChainInfo
-        let blocks = case flags_api_index_off of
-                       True -> []
-                       False -> [b | RanBlock b <- idxEvents]
+        let blocks = [b | RanBlock b <- idxEvents]
         blocksTime <- liftIO $ getTime Realtime
         let nums = map (blockDataNumber . obBlockData) blocks
             nextOffset' = offset + fromIntegral (length idxEvents)

--- a/core-strato/strato-index/src/Executable/IndexerFlags.hs
+++ b/core-strato/strato-index/src/Executable/IndexerFlags.hs
@@ -1,6 +1,0 @@
-{-# LANGUAGE TemplateHaskell #-}
-module Executable.IndexerFlags where
-
-import           HFlags
-
-defineFlag "api_index_off" (False :: Bool) "Whether to run with api indexer off for better TPS"

--- a/core-strato/vm-runner/exec_src/Main.hs
+++ b/core-strato/vm-runner/exec_src/Main.hs
@@ -13,7 +13,6 @@ import           Blockchain.Output
 import           Blockchain.VMOptions() -- HFlags
 import           Executable.EthereumVM
 import           Executable.EVMFlags() -- HFlags
-import           Executable.IndexerFlags()
 
 main :: IO ()
 main = do

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -53,7 +53,6 @@ import           Blockchain.VMOptions
 
 import           Executable.EVMCheckpoint
 import           Executable.EVMFlags
-import           Executable.IndexerFlags
 
 import qualified Blockchain.Bagger                     as Bagger
 import qualified Blockchain.Bagger.BaggerState         as B
@@ -111,10 +110,11 @@ ethereumVM = void . execContextM $ do
         let txPairs = [(ts,t) | VmTx ts t <- seqEvents]
             allTxs = map (uncurry VmTx) txPairs
             blocks = [b | VmBlock b <- seqEvents]
-        when (not $ null txPairs || flags_api_index_off) . void
+        when (not $ null txPairs) . void
                                   . K.withKafkaViolently
                                   . writeIndexEvents
                                   $ map (uncurry IndexTransaction) txPairs
+
         let ptxs = [IndexPrivateTx t | VmPrivateTx t <- seqEvents]
         when (not $ null ptxs) . void
                                . K.withKafkaViolently

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -151,7 +151,6 @@ services:
     environment:
     - addBootnodes=${addBootnodes}
     - averageTxsPerBlock=${averageTxsPerBlock}
-    - apiIndexOff=${apiIndexOff:-false}
     - blockstanbul=${blockstanbul}
     - blockstanbulAdmins=${blockstanbulAdmins}
     - blockstanbulBlockPeriodMs=${blockstanbulBlockPeriodMs}

--- a/tests/load/stratoLoadFiscalFactory.test.js
+++ b/tests/load/stratoLoadFiscalFactory.test.js
@@ -85,7 +85,7 @@ describe('Strato Load Test', function() {
 
 function * waitResult(address, batchSize, batchCount) {
   let nonce = 0;
-  while(nonce < batchSize*batchCount + 1) {
+  while(nonce < batchSize*batchCount + 2) {
     yield promiseTimeout(500);
     try {
       console.log(`Current Nonce is: ${nonce}`)
@@ -142,7 +142,7 @@ function factory_createCallList(contractAddress, batchSize, batchIndex, batchCop
         txParams: {
           gasLimit: 10000000,
           gasPrice: 1,
-          nonce: (batchSize * batchIndex) + i + 1
+          nonce: (batchSize * batchIndex) + i + 2
         },
         value: 0,
 		metadata: {"VM": "SolidVM"},
@@ -177,7 +177,7 @@ function factory_createCallList(contractAddress, batchSize, batchIndex, batchCop
         txParams: {
           gasLimit: 10000000*batchCopies,
           gasPrice: 1,
-          nonce: (batchSize * batchIndex) + i + 1
+          nonce: (batchSize * batchIndex) + i + 2
         },
 		metadata: {"VM": "SolidVM"},
         value: 0,


### PR DESCRIPTION
Temporarily reverting this PR because now SolidVM contract function calls fail in SMD (actually the whole strato container crashes). SMD doesn't know about the VM metadata parameter for transactions, which is now required if you want to make a function call to a SolidVM contract. Ideally, Bloc should store contract VM type, and do a lookup when someone makes a contract function call, so it knows which VM to pass the call to. This will make the metadata parameter obsolete. Also, perhaps all function call data should be in the transaction data field, regardless of VM type, and not split between the data and metadata fields with both variants for both VM types. 