### PR TITLE
Fix some suspicious-looking lines in the Bagger

### DIFF
--- a/core-strato/vm-tools/src/Blockchain/Bagger.hs
+++ b/core-strato/vm-tools/src/Blockchain/Bagger.hs
@@ -329,12 +329,12 @@ demoteUnexecutables = do
         forM_ pDiscardedByCost $ logDiscard "demoteUnexecutables Pending Balance" address addressBalance
 
         state'''' <- getBaggerState
-        let !(qDiscardedByNonce, state''''') = B.trimBelowNonceFromPending address addressNonce state''''
+        let !(qDiscardedByNonce, state''''') = B.trimBelowNonceFromQueued address addressNonce state''''
         putBaggerState state'''''
         forM_ qDiscardedByNonce removeFromSeen
         forM_ qDiscardedByNonce $ logDiscard "demoteUnexecutables Queued Nonce" address addressNonce
 
-        let !(qDiscardedByCost, state'''''') = B.trimAboveCostFromPending address addressBalance state'''''
+        let !(qDiscardedByCost, state'''''') = B.trimAboveCostFromQueued address addressBalance state'''''
         putBaggerState state''''''
         forM_ qDiscardedByCost removeFromSeen
         forM_ qDiscardedByCost $ logDiscard "demoteUnexecutables Queued Balance" address addressBalance

--- a/core-strato/vm-tools/src/Blockchain/Bagger/BaggerState.hs
+++ b/core-strato/vm-tools/src/Blockchain/Bagger/BaggerState.hs
@@ -176,7 +176,7 @@ addToPromotionCache tx s@BaggerState{ miningCache = mc@MiningCache{ promotedTran
 
 upsertPT :: OutputTx -> [OutputTx] -> [OutputTx]
 upsertPT tx@OutputTx{otSigner=addr, otBaseTx=bt} pt = ret
-    where filtered = filter (not . (\t -> otSigner t == addr && nonce (otBaseTx t) == nonce bt)) pt
+    where filtered = filter (not . (\t -> otSigner t == addr && nonce (otBaseTx t) <= nonce bt)) pt
           nonce = TD.transactionNonce
           !ret = tx : filtered
 


### PR DESCRIPTION
The first two changes (B.trimBelow{Nonce,Cost}FromQueued) are included because the first value in the pair is named `q`DiscardedBy{Nonce,Cost}. If you expand to see code from above those changes, you see that `p`DiscardedBy{Nonce,Cost} is already created by calling B.trimBelow{Nonce,Cost}FromPending. I think this was a copy/paste error, where the author forgot to changed `Pending` to `Queued`. It's not obvious in what ways this would manifest itself as a bug, as the `Queued` cache is the lower tier, i.e. transactions must be promoted to `Pending` before being included in a block. Even without this change, expired transactions would be culled from `Pending`, if promoted. The only impact I can see with these changes is that it will prevent the `Queued` cache from holding onto expired transactions forever, reducing the possibility of a space leak.

The last change (`nonce (otBaseTx t) <= nonce bt`) could be more important. The error @nikitamendelbaum saw on one of the test nodes was due to transactions with too low of nonce being put in a block by the Bagger. In the function `upsertPT`, a transaction is prepended to a list of transactions, and any transactions from the same sender, but with equal nonce, are filtered out. This is the Bagger's mechanism for creating the final list of transactions to put in a new block. This function guarantees that there are no nonce collisions, but, without this change, does not guarantee that no transactions with _lower_ nonce are filtered out of the block. Although I cannot find any offending code that would cause lower-nonced transactions to be inserted in this list out of order, this change should be a final fail-safe if such code exists. This will effectively eliminate the possibility of the `we messed up` error seen on the test nodes.

The Bagger is a complex and esoteric component of STRATO, complicated by instances of explicit state passing and unhelpful types. A future improvement would be to create newtype wrappers for transactions in the `Queued` and `Pending` caches, as well as wrap promoted transactions in some sort of poset datatype that does ordered cons in O(1) time (using simple lists is O(1) for unordered cons, O(n) for ordered cons).