### PR TITLE
Only witness privateWitnessHash for PrivateHashTXs

### DIFF
--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -220,23 +220,23 @@ blockstanbulSend' msg = do
   $logDebugS "seq/pbft/send_vm" . T.pack $ format vmevs
   return vmevs
 
+privateWitnessableHash :: Word256 -> Word256 -> SHA
+privateWitnessableHash tHash cHash =
+  superProprietaryStratoSHAHash
+  . RL.rlpSerialize
+  $ RL.RLPArray [RL.rlpEncode tHash, RL.rlpEncode cHash]
+
 transformPrivateHashTXs :: [(Timestamp, IngestTx)] -> SequencerM ()
 transformPrivateHashTXs pairs = forM_ pairs $ \(ts, t@(IngestTx _ (TD.PrivateHashTX th' ch'))) -> do
   motx <- wrapTransaction lookupChainIdFromChainHash t
   for_ motx $ \otx -> do
-    let witnessHash = witnessableHash otx
-    witnessed <- wasTransactionHashWitnessed witnessHash
-    unless witnessed $ do
-      let privateWitnessHash =
-            superProprietaryStratoSHAHash
-            . RL.rlpSerialize
-            $ RL.RLPArray [RL.rlpEncode th', RL.rlpEncode ch']
-      pwitnessed <- wasTransactionHashWitnessed privateWitnessHash
-      unless pwitnessed $ do
-        witnessTransactionHash privateWitnessHash
-        runPrivateHashTX (SHA th') (SHA ch')
-        markForP2P $ P2pTx otx
-        markForVM  $ VmTx ts otx
+    let privateWitnessHash = privateWitnessableHash th' ch'
+    pwitnessed <- wasTransactionHashWitnessed privateWitnessHash
+    unless pwitnessed $ do
+      witnessTransactionHash privateWitnessHash
+      runPrivateHashTX (SHA th') (SHA ch')
+      markForP2P $ P2pTx otx
+      markForVM  $ VmTx ts otx
 
 transformFullTransactions :: [(Timestamp, IngestTx)] -> SequencerM ()
 transformFullTransactions pairs = do
@@ -310,6 +310,8 @@ transformFullTransactions pairs = do
                     SHA th' = txHash ptx
                     SHA ch' = cHash
                     phtx = ptx{otBaseTx = TD.PrivateHashTX th' ch'}
+                    privateWitnessHash = privateWitnessableHash th' ch'
+                witnessTransactionHash privateWitnessHash
                 logF . concat $
                   [ "Created chain hash "
                   , format cHash


### PR DESCRIPTION
The problem was that `transformPrivateHashTXs` was filtering out transaction hashes that had already been witnessed, which means that if a remote node saw the full private transaction body first, it would subsequently discard the `PrivateHashTX`, even though it was its first time seeing it. The reason this was done was because we didn't want the node creating the transaction to emit the same `PrivateHashTX` to the VM multiple times. However, now we only use the "privateWitnessHash", which is just the hash of the RLP encoded array of the two elements in the `PrivateHashTX`. Instead of witnessing this hash only in `transformPrivateHashTXs`, we also witness it in `transformFullTransactions` when the transaction comes from the API. This allows the `PrivateHashTX` to not be emitted twice, but also doesn't cause other nodes to ignore `PrivateHashTX`s when they appear after the full transaction body.