### PR TITLE
Revert "Vault-Wrapper throws 404 (not 400) when user key not found"

### DIFF
--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
@@ -76,10 +76,6 @@ dbErrorToUserError = flip catchError $ \case
 toUserError :: MonadError VaultWrapperError m => Text -> m a -> m a
 toUserError msg = flip catchError (\_ -> throwError $ UserError msg)
 
-toCouldNotFind :: MonadError VaultWrapperError m => Text -> m a -> m a
-toCouldNotFind msg = flip catchError (\_ -> throwError $ CouldNotFind msg)
- 
-
 --prettyCallStack' is the same idea as prettyCallStack, but with formatting more suitable for out project.  In particular, package names a very mangled by stack, making prettyCallStack unreadable.
 prettyCallStack'::CallStack->String
 prettyCallStack' cs =

--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Server/Key.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Server/Key.hs
@@ -14,7 +14,7 @@ import           Strato.Strato23.Database.Queries
 getKey :: Text -> Maybe Text -> VaultM StatusAndAddress
 getKey headerUserName queryParamUserName = withPassword $ \pw -> do
   let userName = fromMaybe headerUserName queryParamUserName
-  (salt, nonce, encKey, addr) <- toCouldNotFind ("User " <> userName <> " doesn't exist")
+  (salt, nonce, encKey, addr) <- toUserError ("User " <> userName <> " doesn't exist")
                                . vaultQuery1 $ getUserKeyQuery userName
   if isJust queryParamUserName          -- decrypt and derive the address if query param
     then return $ StatusAndAddress addr -- not specified, to guarantee correctness


### PR DESCRIPTION
causes problems with client applications that expect a 400