### PR TITLE
Generic lookup/caching of contract details in Slipstream

### DIFF
--- a/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
@@ -4,7 +4,6 @@ module Slipstream.Data.Globals where
 import Control.DeepSeq
 import Data.Cache.LRU
 import qualified Data.HashMap.Strict as HM
-import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text
 import Data.Int (Int32)
@@ -24,7 +23,7 @@ data Globals = Globals { createdEvents :: S.Set (Text, Text) -- (contractName, e
                        , historyList :: S.Set CodePtr
                        , noIndexList :: S.Set CodePtr
                        , functionHistoryList :: S.Set CodePtr
-                       , solidVMABIs :: HM.HashMap SHA (M.Map Text (Int32, ContractDetails))
+                       , contractABIs :: HM.HashMap CodePtr (Int32, ContractDetails)
                        , contractStates :: LRU (Address, Maybe ChainId) [(Text, Value)]
                        , csHandle :: Handle
                        } deriving (Generic, NFData)

--- a/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
@@ -23,7 +23,6 @@ import qualified Data.Cache.LRU              as LRU
 import           Data.Either.Extra
 import qualified Data.HashMap.Strict         as HM
 import           Data.Int                    (Int32)
-import qualified Data.Map                    as M
 import           Data.Set                    (Set)
 import qualified Data.Set                    as Set
 import           Data.Text                   (Text)
@@ -51,23 +50,15 @@ xabiToText = T.replace "\'" "\'\'"
            . decodeUtf8 . BL.toStrict
            . JSON.encode
 
-setSolidVMABIs :: MonadIO m => IORef Globals -> CodePtr -> M.Map Text (Int32, ContractDetails) -> m ()
-setSolidVMABIs gref (SolidVMCode _ !codeHash) detailsMap = do
+setContractABIs :: MonadIO m => IORef Globals -> CodePtr -> (Int32, ContractDetails) -> m ()
+setContractABIs gref codePtr detailsTup = do
   globals@Globals{..} <- readIORef gref
-  updateGlobals gref globals{solidVMABIs=HM.insert codeHash detailsMap solidVMABIs}
-setSolidVMABIs _ EVMCode{} _ = error "internal error: setSolidVMDetails for EVMCode"
+  updateGlobals gref globals{contractABIs=HM.insert codePtr detailsTup contractABIs}
 
-getSolidVMABIs :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (Text, Int32, ContractDetails))
-getSolidVMABIs gref (SolidVMCode name' codeHash) = do
-  abis <- solidVMABIs <$> readIORef gref
-  case HM.lookup codeHash abis of
-    Nothing -> return Nothing
-    Just details -> do
-      let name = T.pack name'
-      case M.lookup name details of
-        Nothing -> return Nothing
-        Just (cmId, deets) -> return $ Just (name, cmId, deets)
-getSolidVMABIs _ EVMCode{} = error "internal error: getSolidVMDetails for EVMCode"
+getContractABIs :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (Int32, ContractDetails))
+getContractABIs gref codePtr = do
+  abis <- contractABIs <$> readIORef gref
+  return $ HM.lookup codePtr abis 
 
 setContractCreated :: MonadIO m => IORef Globals -> CodePtr -> m ()
 setContractCreated globalsIORef codeHash = do

--- a/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
@@ -20,7 +20,6 @@ import Control.Monad
 import Control.Monad.IO.Class
 import qualified Data.Cache.LRU as LRU
 import qualified Data.HashMap.Strict as HM
-import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Network.Kafka.Protocol (Offset)
@@ -78,8 +77,7 @@ recordGlobals g = liftIO $ do
   rec "history_list" (S.size . historyList)
   rec "function_history_list" (S.size . functionHistoryList)
   rec "no_index_list" (S.size . noIndexList)
-  rec "solidvm_details_codehashes" (HM.size . solidVMABIs)
-  rec "solidvm_details_contracts" (sum . map M.size . HM.elems . solidVMABIs)
+  rec "contract_abis" (HM.size . contractABIs)
   rec "contract_states" (LRU.size . contractStates)
 
 recordKafkaMessages :: MonadIO m => [a] -> m ()

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -32,6 +32,7 @@ import qualified Data.ByteString.Short as SB
 -- import qualified Data.ByteString.Char8 as C8
 import Data.Either (lefts, rights)
 import Data.Function
+import Data.Foldable
 import Data.Int (Int32)
 import Data.IORef
 import Data.List (foldl', sortOn)
@@ -236,11 +237,16 @@ lookupT k = MaybeT . return . Map.lookup k
 --  it adds them to cache
 getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
 getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata
-  where checkCache = MaybeT $ getContractABIs g codePtr
+  where checkCache = do
+          $logInfoS "DEETS" . T.pack $ "checking cache"
+          MaybeT $ getContractABIs g codePtr
         checkBloc = MaybeT $ do
-          _ <- (getContractDetailsByCodeHash codePtr) >>= (traverse (setContractABIs g codePtr))
-          getContractABIs g codePtr
+          $logInfoS "DEETS" . T.pack $ "checking bloc"
+          mDetails <- getContractDetailsByCodeHash codePtr
+          for_ mDetails $ setContractABIs g codePtr
+          return mDetails
         checkMetadata = do
+          $logInfoS "DEETS" . T.pack $ "checking metadata"
           let md = actionMetadata row
           src <- lookupT "src" md
           detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
@@ -249,7 +255,7 @@ getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata
             SolidVMCode cname _ -> return $ T.pack cname
           detailsTup <- lookupT name detailsMap
           setContractABIs g codePtr detailsTup
-          MaybeT $ getContractABIs g codePtr 
+          MaybeT $ return $ Just detailsTup
         codePtr = actionCodeHash row 
 
 adjustGlobals :: IORef Globals

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -231,24 +231,19 @@ makeFunctionInserts xabi ABIID{..} state AggregateAction{..} =
 lookupT :: (Monad m, Ord k) => k -> Map.Map k v -> MaybeT m v
 lookupT k = MaybeT . return . Map.lookup k
 
--- TODO: this generic caching/lookup routine...
---    abi setter/getter needs to know that maps are not a thing anymore...
---     and, need to map calls to it for the metadata lookups, since they 
---     return the maps
+-- Tries to get contract metadata ID and contract details for a given codehash.
+--  If they're not in the cache but they are in blocDB or action metadata,
+--  it adds them to cache
 getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
 getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata
-  where checkCache = do
-          $logInfoS "DEETS" . T.pack $ "checking cache for details for " ++ (show codePtr)
-          MaybeT $ getContractABIs g codePtr
+  where checkCache = MaybeT $ getContractABIs g codePtr
         checkBloc = MaybeT $ do
           _ <- (getContractDetailsByCodeHash codePtr) >>= (traverse (setContractABIs g codePtr))
           getContractABIs g codePtr
         checkMetadata = do
-          $logInfoS "DEETS" . T.pack $ "checking metadata for details for " ++ (show codePtr)
           let md = actionMetadata row
           src <- lookupT "src" md
           detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
-          $logInfoS "DEETS" . T.pack $ "got metadata details for " ++ (show detailsMap)
           name <- case codePtr of
             EVMCode _ -> lookupT "name" md
             SolidVMCode cname _ -> return $ T.pack cname
@@ -257,53 +252,6 @@ getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata
           MaybeT $ getContractABIs g codePtr 
         codePtr = actionCodeHash row 
 
--- Will also check BlocDB for details, if they are not in the cache
---   i.e. on node restart
-
-{- 
-getSolidVMDetails :: IORef Globals -> AggregateAction -> Bloc (Maybe (Text, Int32, ContractDetails))
-getSolidVMDetails g row = do
-  mDetails <- getCachedSolidVMDetails g row
-  case mDetails of
-    Just _ -> return mDetails
-    Nothing -> do 
-      blocDetails <- getContractDetailsByCodeHash $ actionCodeHash row
-      case blocDetails of
-        Nothing -> return Nothing
-        Just (_, deets) -> do
-          detailsMap <- sourceToContractDetails (Don't Compile) (contractdetailsSrc deets)
-          setSolidVMABIs g (actionCodeHash row) detailsMap
-          getSolidVMABIs g (actionCodeHash row)
-
-
--- Note: This could be reshaped to remove the bloch dependency, as
--- we only care about the ABI from `sourceToContractDetails` and
--- not the metadata id. 
-getCachedSolidVMDetails :: IORef Globals -> AggregateAction -> Bloc (Maybe (Text, Int32, ContractDetails))
-getCachedSolidVMDetails g row = liftM2 (<|>)
-  (getSolidVMABIs g codePtr)
-  (runMaybeT $ do
-    let md = actionMetadata row
-    src <- lookupT "src" md
-    detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
-    setSolidVMABIs g codePtr detailsMap
-    MaybeT $ getSolidVMABIs g codePtr
-  )
- where codePtr = actionCodeHash row
-
-
--- TODO: This should now work for both EVM and SolidVM, so we should have
---   a generic caching/bloc-lookup routine
-detailsForRow :: AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
-detailsForRow row = liftM2 (<|>)
-  (getContractDetailsByCodeHash $ actionCodeHash row)
-  (runMaybeT $ do
-    let md = actionMetadata row
-    src <- lookupT "src" md
-    name <- lookupT "name" md
-    detailsMap <- lift $ sourceToContractDetails (Do Compile) src
-    lookupT name detailsMap)
--}
 adjustGlobals :: IORef Globals
               -> Should Compile
               -> AggregateAction

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -233,7 +233,7 @@ lookupT :: (Monad m, Ord k) => k -> Map.Map k v -> MaybeT m v
 lookupT k = MaybeT . return . Map.lookup k
 
 -- Tries to get contract metadata ID and contract details for a given codehash.
---  If they're not in the cache but they are in the action metadata or bloc database,
+--  If they're not in the cache but they are in bloc database or action metadata,
 --  it adds them to cache
 getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
 getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -231,6 +231,31 @@ makeFunctionInserts xabi ABIID{..} state AggregateAction{..} =
 lookupT :: (Monad m, Ord k) => k -> Map.Map k v -> MaybeT m v
 lookupT k = MaybeT . return . Map.lookup k
 
+-- TODO: this generic caching/lookup routine...
+--    abi setter/getter needs to know that maps are not a thing anymore...
+--     and, need to map calls to it for the metadata lookups, since they 
+--     return the maps
+getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Text, Int32, ContractDetails))
+getDetailsForRow g row = checkCache <|> checkBloc <|> checkMetadata
+  where checkCache = MaybeT $ getCachedDetails g codePtr
+        checkBloc = runMaybeT $ do
+          detailsFromBloc <- getContractDetailsByCodeHash codePtr
+          setContractABIs g codePtr detailsFromBloc
+          getContractABIs g codePtr
+        checkMetadata = case codePtr of
+          EVMCode hsh -> runMaybeT $ do
+            let md = actionMetadata row
+            src <- lookupT "src" md
+            name <- lookupT "name" md
+            detailsMap <- lift $ sourceToContractDetails (Do Compile) src
+            lookupT name detailsMap
+          SolidVMCode _ hsh -> runMaybeT $ do
+            let md = actionMetadata row
+            src <- lookupT "src" md
+            detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
+            setSolidVMABIs g codePtr detailsMap
+            MaybeT $ getSolidVMABIs g codePtr
+        codePtr = actionCodeHash row 
 
 -- Will also check BlocDB for details, if they are not in the cache
 --   i.e. on node restart

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -236,10 +236,15 @@ lookupT k = MaybeT . return . Map.lookup k
 --  If they're not in the cache but they are in the action metadata or bloc database,
 --  it adds them to cache
 getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
-getDetailsForRow g row = runMaybeT $ checkCache <|> checkMetadata <|> checkBloc
+getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata
   where checkCache = do
           $logInfoS "getDetailsForRow" . T.pack $ "checking contractABIs cache for contract details"
           MaybeT $ getContractABIs g codePtr
+        checkBloc = MaybeT $ do
+          $logInfoS "getDetailsForRow" . T.pack $ "checking bloc database for contract details"
+          mDetails <- getContractDetailsByCodeHash codePtr
+          for_ mDetails $ setContractABIs g codePtr
+          return mDetails
         checkMetadata = do
           $logInfoS "getDetailsForRow" . T.pack $ "checking metadata for contract details"
           let md = actionMetadata row
@@ -254,11 +259,6 @@ getDetailsForRow g row = runMaybeT $ checkCache <|> checkMetadata <|> checkBloc
               lookupT (T.pack name) detailsMap
           setContractABIs g codePtr detailsTup
           MaybeT $ return $ Just detailsTup
-        checkBloc = MaybeT $ do
-          $logInfoS "getDetailsForRow" . T.pack $ "checking bloc database for contract details"
-          mDetails <- getContractDetailsByCodeHash codePtr
-          for_ mDetails $ setContractABIs g codePtr
-          return mDetails
         codePtr = actionCodeHash row 
 
 adjustGlobals :: IORef Globals

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -235,30 +235,33 @@ lookupT k = MaybeT . return . Map.lookup k
 --    abi setter/getter needs to know that maps are not a thing anymore...
 --     and, need to map calls to it for the metadata lookups, since they 
 --     return the maps
-getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Text, Int32, ContractDetails))
-getDetailsForRow g row = checkCache <|> checkBloc <|> checkMetadata
-  where checkCache = MaybeT $ getCachedDetails g codePtr
-        checkBloc = runMaybeT $ do
-          detailsFromBloc <- getContractDetailsByCodeHash codePtr
-          setContractABIs g codePtr detailsFromBloc
+getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
+getDetailsForRow g row = liftM3 (\a b c -> a <|> b <|> c) checkCache checkBloc checkMetadata
+  where checkCache = do
+          $logInfoS "DEETS" . T.pack $ "checking cache for details"
           getContractABIs g codePtr
-        checkMetadata = case codePtr of
-          EVMCode hsh -> runMaybeT $ do
-            let md = actionMetadata row
-            src <- lookupT "src" md
-            name <- lookupT "name" md
-            detailsMap <- lift $ sourceToContractDetails (Do Compile) src
-            lookupT name detailsMap
-          SolidVMCode _ hsh -> runMaybeT $ do
-            let md = actionMetadata row
-            src <- lookupT "src" md
-            detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
-            setSolidVMABIs g codePtr detailsMap
-            MaybeT $ getSolidVMABIs g codePtr
+        checkBloc = runMaybeT $ do
+          $logInfoS "DEETS" . T.pack $ "checking bloc for details"
+          detailsFromBloc <- lift $ getContractDetailsByCodeHash codePtr
+          setContractABIs g codePtr $ fromJust detailsFromBloc
+          MaybeT $ getContractABIs g codePtr
+        checkMetadata = runMaybeT $ do
+          $logInfoS "DEETS" . T.pack $ "checking metadata for details"
+          let md = actionMetadata row
+          src <- lookupT "src" md
+          detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
+          name <- case codePtr of
+            EVMCode _ -> lookupT "name" md
+            SolidVMCode cname _ -> return $ T.pack cname
+          detailsTup <- lookupT name detailsMap
+          setContractABIs g codePtr detailsTup
+          MaybeT $ getContractABIs g codePtr 
         codePtr = actionCodeHash row 
 
 -- Will also check BlocDB for details, if they are not in the cache
 --   i.e. on node restart
+
+{- 
 getSolidVMDetails :: IORef Globals -> AggregateAction -> Bloc (Maybe (Text, Int32, ContractDetails))
 getSolidVMDetails g row = do
   mDetails <- getCachedSolidVMDetails g row
@@ -301,7 +304,7 @@ detailsForRow row = liftM2 (<|>)
     name <- lookupT "name" md
     detailsMap <- lift $ sourceToContractDetails (Do Compile) src
     lookupT name detailsMap)
-
+-}
 adjustGlobals :: IORef Globals
               -> Should Compile
               -> AggregateAction
@@ -434,7 +437,7 @@ processTheMessages env conn g messages = do
 
       case actionStorage row of
         BS.ActionEVMDiff{} -> do
-          mDetails <- detailsForRow row
+          mDetails <- getDetailsForRow g row
           case mDetails of
             Nothing -> pure . Left $ "No details found for code hash "
                             <> (T.pack . show $ actionCodeHash row)
@@ -455,13 +458,14 @@ processTheMessages env conn g messages = do
               (hs, fhs) <- rowToHistories g abiid row actions cont details oldState
               pure . Right $ BatchedInserts indexContract hs fhs []
         BS.ActionSolidVMDiff{} -> do
-          mName <- getSolidVMDetails g row
+          mName <- getDetailsForRow g row
           case mName of
             Nothing -> pure . Left $ "No SolidVM details for code hash "
                             <> (T.pack . show $ actionCodeHash row)
                             <> " and no 'src' field found in metadata"
-            Just (name, cmId, details) -> do
+            Just (cmId, details) -> do
               let abi = xabiToText $ contractdetailsXabi details
+                  name = T.filter (/= '"') $ contractdetailsName details
                   abiid = ABIID abi name $ maybe "" (T.pack . chainIdString) $ actionTxChainId row
                   cont = error "internal error: contract should be unused for solidvm"
 

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -236,16 +236,16 @@ lookupT k = MaybeT . return . Map.lookup k
 --     and, need to map calls to it for the metadata lookups, since they 
 --     return the maps
 getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
-getDetailsForRow g row = liftM3 (\a b c -> a <|> b <|> c) checkCache checkBloc checkMetadata
+getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata
   where checkCache = do
           $logInfoS "DEETS" . T.pack $ "checking cache for details"
-          getContractABIs g codePtr
-        checkBloc = runMaybeT $ do
+          MaybeT $ getContractABIs g codePtr
+        checkBloc = do
           $logInfoS "DEETS" . T.pack $ "checking bloc for details"
           detailsFromBloc <- lift $ getContractDetailsByCodeHash codePtr
           setContractABIs g codePtr $ fromJust detailsFromBloc
           MaybeT $ getContractABIs g codePtr
-        checkMetadata = runMaybeT $ do
+        checkMetadata = do
           $logInfoS "DEETS" . T.pack $ "checking metadata for details"
           let md = actionMetadata row
           src <- lookupT "src" md

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -238,18 +238,17 @@ lookupT k = MaybeT . return . Map.lookup k
 getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
 getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata
   where checkCache = do
-          $logInfoS "DEETS" . T.pack $ "checking cache for details"
+          $logInfoS "DEETS" . T.pack $ "checking cache for details for " ++ (show codePtr)
           MaybeT $ getContractABIs g codePtr
-        checkBloc = do
-          $logInfoS "DEETS" . T.pack $ "checking bloc for details"
-          detailsFromBloc <- lift $ getContractDetailsByCodeHash codePtr
-          setContractABIs g codePtr $ fromJust detailsFromBloc
-          MaybeT $ getContractABIs g codePtr
+        checkBloc = MaybeT $ do
+          _ <- (getContractDetailsByCodeHash codePtr) >>= (traverse (setContractABIs g codePtr))
+          getContractABIs g codePtr
         checkMetadata = do
-          $logInfoS "DEETS" . T.pack $ "checking metadata for details"
+          $logInfoS "DEETS" . T.pack $ "checking metadata for details for " ++ (show codePtr)
           let md = actionMetadata row
           src <- lookupT "src" md
           detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
+          $logInfoS "DEETS" . T.pack $ "got metadata details for " ++ (show detailsMap)
           name <- case codePtr of
             EVMCode _ -> lookupT "name" md
             SolidVMCode cname _ -> return $ T.pack cname

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -233,29 +233,32 @@ lookupT :: (Monad m, Ord k) => k -> Map.Map k v -> MaybeT m v
 lookupT k = MaybeT . return . Map.lookup k
 
 -- Tries to get contract metadata ID and contract details for a given codehash.
---  If they're not in the cache but they are in blocDB or action metadata,
+--  If they're not in the cache but they are in the action metadata or bloc database,
 --  it adds them to cache
 getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
-getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata
+getDetailsForRow g row = runMaybeT $ checkCache <|> checkMetadata <|> checkBloc
   where checkCache = do
-          $logInfoS "DEETS" . T.pack $ "checking cache"
+          $logInfoS "getDetailsForRow" . T.pack $ "checking contractABIs cache for contract details"
           MaybeT $ getContractABIs g codePtr
+        checkMetadata = do
+          $logInfoS "getDetailsForRow" . T.pack $ "checking metadata for contract details"
+          let md = actionMetadata row
+          src <- lookupT "src" md
+          detailsTup <- case codePtr of
+            EVMCode _ -> do
+              detailsMap <- lift $ sourceToContractDetails (Do Compile) src
+              name <- lookupT "name" md
+              lookupT name detailsMap
+            SolidVMCode name _ -> do
+              detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
+              lookupT (T.pack name) detailsMap
+          setContractABIs g codePtr detailsTup
+          MaybeT $ return $ Just detailsTup
         checkBloc = MaybeT $ do
-          $logInfoS "DEETS" . T.pack $ "checking bloc"
+          $logInfoS "getDetailsForRow" . T.pack $ "checking bloc database for contract details"
           mDetails <- getContractDetailsByCodeHash codePtr
           for_ mDetails $ setContractABIs g codePtr
           return mDetails
-        checkMetadata = do
-          $logInfoS "DEETS" . T.pack $ "checking metadata"
-          let md = actionMetadata row
-          src <- lookupT "src" md
-          detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
-          name <- case codePtr of
-            EVMCode _ -> lookupT "name" md
-            SolidVMCode cname _ -> return $ T.pack cname
-          detailsTup <- lookupT name detailsMap
-          setContractABIs g codePtr detailsTup
-          MaybeT $ return $ Just detailsTup
         codePtr = actionCodeHash row 
 
 adjustGlobals :: IORef Globals


### PR DESCRIPTION
Before this PR, getting the details for a contract in slipstream was done using different functions for SolidVM contracts and EVM contracts. The biggest difference between these functions was that SolidVM contract details were cached once they were seen, whereas EVM contract details were always pulled from the bloc database every time slipstream received an action on an EVM contract. Now, the process is (almost) VM-agnostic. Contract details (regardless of VM type) are first looked for in the cache (a hashmap where the key is the `CodePtr`), if they are not found, they are looked for in the bloc database, and if not there, they are derived from the source code in the TX metadata (this is the one non-vm-agnostic part, since `src` is represented slightly differently in the metadata for the two VMs). If the details are found in the latter two places, they are cached for next time. There should be a slight performance improvement for EVM contracts (since slipstream doesn't have to query bloc DB for them every time), but mostly the code is cleaner, as there is now one generic, vm-agnostic lookup/caching function for contract details.


https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/2748/pipeline