### PR TITLE
[STRATO-1714] limit contracts

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -335,7 +335,7 @@ getContractsAddressesQuery :: Maybe ChainId -> Query
   , Column PGBytea
   )
 getContractsAddressesQuery chainId = proc () -> do
-  (_,name,_,addr,timestamp,_,_,_,_,cid,_) <- contractsJoinTable -< ()
+  (_,name,_,addr,timestamp,_,_,_,_,cid,_) <- limit 100 $ contractsJoinTable -< ()
   restrict -< cid .== constant chainId
   returnA -< (name,addr,timestamp,cid)
 
@@ -363,7 +363,7 @@ getContractsNamesAsAddressesQuery :: Maybe ChainId -> Query
   , Column PGBytea
   )
 getContractsNamesAsAddressesQuery chainId = proc () -> do
-  (n1,n2,ts,cid) <- joinF
+  (n1,n2,ts,cid) <- limit 100 $ joinF
     (\ (_,_,_,timestamp,cid) (_,_,_,_,name,name2,_,_,_) -> (name,name2,timestamp,cid))
     (\ (_,contractmetadataId,_,_,_) (_,_,_,_,_,_,_,cm2Id,_) -> contractmetadataId .== cm2Id)
     (queryTable contractsInstanceTable)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -56,12 +56,12 @@ getContracts chainId = blocTransaction $ do
     namesToMap = foldr'
       (\ (key,name,utc,cid) -> Map.insertWith (++) key [nameToVal name utc cid])
       Map.empty
-  contractsAddresses <- blocQuery $ getContractsAddressesQuery chainId
-  contractsNamesAsAddresses <- blocQuery $ getContractsNamesAsAddressesQuery chainId
   -- Take only 100 entries as a short-term solution to prevent from crashing.
   -- See also: https://blockapps.atlassian.net/browse/STRATO-1714
-  let reducedResponseMap = (addressesToMap $ take 100 contractsAddresses) `Map.union`
-                           (namesToMap $ take 100 contractsNamesAsAddresses)
+  contractsAddresses <- blocQuery $ getContractsAddressesQuery chainId
+  contractsNamesAsAddresses <- blocQuery $ getContractsNamesAsAddressesQuery chainId
+  let reducedResponseMap = (addressesToMap $ contractsAddresses) `Map.union`
+                           (namesToMap $ contractsNamesAsAddresses)
   return . GetContractsResponse $ reducedResponseMap
 
 getContractsData :: ContractName -> Bloc [MaybeNamed Address]

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -58,10 +58,11 @@ getContracts chainId = blocTransaction $ do
       Map.empty
   contractsAddresses <- blocQuery $ getContractsAddressesQuery chainId
   contractsNamesAsAddresses <- blocQuery $ getContractsNamesAsAddressesQuery chainId
-  return . GetContractsResponse $ Map.take 50 $
-    addressesToMap contractsAddresses
-    `Map.union`
-    namesToMap contractsNamesAsAddresses
+  -- Take only 100 entries as a short-term solution to prevent from crashing.
+  -- See also: https://blockapps.atlassian.net/browse/STRATO-1714
+  let reducedResponseMap = (addressesToMap $ take 100 contractsAddresses) `Map.union`
+                           (namesToMap $ take 100 contractsNamesAsAddresses)
+  return . GetContractsResponse $ reducedResponseMap
 
 getContractsData :: ContractName -> Bloc [MaybeNamed Address]
 getContractsData (ContractName contractName) = blocTransaction $ do

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -58,7 +58,7 @@ getContracts chainId = blocTransaction $ do
       Map.empty
   contractsAddresses <- blocQuery $ getContractsAddressesQuery chainId
   contractsNamesAsAddresses <- blocQuery $ getContractsNamesAsAddressesQuery chainId
-  return . GetContractsResponse $
+  return . GetContractsResponse $ Map.take 50 $
     addressesToMap contractsAddresses
     `Map.union`
     namesToMap contractsNamesAsAddresses


### PR DESCRIPTION
This fix limits the number of returned contracts of '/contracts' to 100 per contract type. Before the fix, the response from calling `curl -X GET "http://localhost/bloc/v2.2/contracts" -H "accept: application/json;charset=utf-8"` has 1,102,360 bytes. After the fix, the size reduced to 12,772 bytes for the same test. Problems and suggested solutions can be found in this ticket: https://blockapps.atlassian.net/browse/STRATO-1714