### PR TITLE
[STRATO-1691] Slowstream - source caching and optimization

### DIFF
--- a/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
@@ -1,18 +1,21 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Slipstream.Data.Globals where
 
-import Control.DeepSeq
-import Data.Cache.LRU
+import           Control.DeepSeq
+import           Data.Cache.LRU
 import qualified Data.HashMap.Strict as HM
-import qualified Data.Set as S
-import Data.Text
-import Data.Int (Int32)
-import GHC.Generics
+import qualified Data.Map.Strict     as M
+import qualified Data.Set            as S
+import           Data.Text
+import           Data.Int (Int32)
+import           GHC.Generics
 
-import BlockApps.Solidity.Value
-import BlockApps.Solidity.Xabi     (ContractDetails(..))
-import BlockApps.Ethereum
-import Slipstream.Data.GlobalsColdStorage (Handle)
+import           BlockApps.Solidity.Value
+import           BlockApps.Solidity.Xabi     (ContractDetails(..))
+import           BlockApps.Ethereum
+import           Slipstream.Data.GlobalsColdStorage (Handle)
+
+
 
 instance NFData (LRU key val) where
   rnf = (`seq` ()) -- LRU is already pretty strict
@@ -20,10 +23,11 @@ instance NFData (LRU key val) where
 
 data Globals = Globals { createdEvents :: S.Set (Text, Text) -- (contractName, eventName)
                        , createdContracts :: S.Set CodePtr -- list of contacts with a table
+                       , createdInstances :: S.Set CodePtr -- probably redundant, but for now :)
                        , historyList :: S.Set CodePtr
                        , noIndexList :: S.Set CodePtr
                        , functionHistoryList :: S.Set CodePtr
-                       , contractABIs :: HM.HashMap CodePtr (Int32, ContractDetails)
+                       , contractABIs :: HM.HashMap SHA (M.Map Text (Int32, ContractDetails))
                        , contractStates :: LRU (Address, Maybe ChainId) [(Text, Value)]
                        , csHandle :: Handle
                        } deriving (Generic, NFData)

--- a/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
@@ -22,6 +22,7 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.Cache.LRU              as LRU
 import           Data.Either.Extra
 import qualified Data.HashMap.Strict         as HM
+import qualified Data.Map.Strict              as M
 import           Data.Int                    (Int32)
 import           Data.Set                    (Set)
 import qualified Data.Set                    as Set
@@ -37,7 +38,7 @@ import           Slipstream.GlobalsColdStorage
 import           Slipstream.Metrics
 
 newGlobals :: MonadIO m => Handle -> m (IORef Globals)
-newGlobals = newIORef . Globals Set.empty Set.empty Set.empty Set.empty Set.empty HM.empty (LRU.newLRU (Just 1024))
+newGlobals = newIORef . Globals Set.empty Set.empty Set.empty Set.empty Set.empty Set.empty HM.empty (LRU.newLRU (Just 1024))
 
 updateGlobals :: MonadIO m => IORef Globals -> Globals -> m ()
 updateGlobals gref g = do
@@ -50,15 +51,18 @@ xabiToText = T.replace "\'" "\'\'"
            . decodeUtf8 . BL.toStrict
            . JSON.encode
 
-setContractABIs :: MonadIO m => IORef Globals -> CodePtr -> (Int32, ContractDetails) -> m ()
-setContractABIs gref codePtr detailsTup = do
+setContractABIs :: MonadIO m => IORef Globals -> CodePtr -> M.Map Text (Int32, ContractDetails) -> m ()
+setContractABIs gref (SolidVMCode _ !codeHash) detailsMap = do 
   globals@Globals{..} <- readIORef gref
-  updateGlobals gref globals{contractABIs=HM.insert codePtr detailsTup contractABIs}
+  updateGlobals gref globals{contractABIs=HM.insert codeHash detailsMap contractABIs}
+setContractABIs _ (EVMCode _) _ = error "cannot use the contractABIs cache for EVM contracts"
 
-getContractABIs :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (Int32, ContractDetails))
-getContractABIs gref codePtr = do
+
+getContractABIs :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (M.Map Text (Int32, ContractDetails)))
+getContractABIs gref (SolidVMCode _ !codeHash) = do
   abis <- contractABIs <$> readIORef gref
-  return $ HM.lookup codePtr abis 
+  return $ HM.lookup codeHash abis
+getContractABIs _ (EVMCode _) = error "cannot use the contractABIs cache for EVM contracts"
 
 setContractCreated :: MonadIO m => IORef Globals -> CodePtr -> m ()
 setContractCreated globalsIORef codeHash = do
@@ -69,6 +73,18 @@ isContractCreated :: MonadIO m => IORef Globals -> CodePtr -> m Bool
 isContractCreated globalsIORef codeHash = do
   Globals{..} <- readIORef globalsIORef
   return $ codeHash `Set.member` createdContracts
+
+-- Hopefully temporary, just to remove extra calls to bloc in ensureContractInstance
+setInstanceCreated :: MonadIO m => IORef Globals -> CodePtr -> m ()
+setInstanceCreated globalsIORef codeHash = do
+  globals@Globals{..} <- readIORef globalsIORef
+  updateGlobals globalsIORef globals{createdInstances=Set.insert codeHash createdInstances}
+
+isInstanceCreated :: MonadIO m => IORef Globals -> CodePtr -> m Bool
+isInstanceCreated globalsIORef codeHash = do
+  Globals{..} <- readIORef globalsIORef
+  return $ codeHash `Set.member` createdInstances
+
 
 setEventCreated :: MonadIO m => IORef Globals -> (Text, Text) -> m ()
 setEventCreated globalsIORef evTup = do

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -237,7 +237,7 @@ lookupT k = MaybeT . return . Map.lookup k
 
 -- Tries to get contract metadata ID and contract details for a given contract.
 --  If they're not in the cache but they are in bloc database or action metadata,
---  it reparses the whole source blob, and caches them for every contract
+--  it reparses the whole source blob, and caches the details for every contract
 getSolidVMDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
 getSolidVMDetailsForRow g row = runMaybeT  
    $  checkCache 
@@ -257,7 +257,7 @@ getSolidVMDetailsForRow g row = runMaybeT
           (lookupT "src" $ actionMetadata row) >>= parseAndSet
         
 
-        -- parse source code, add all of the contract's details to cache, return the one we need
+        -- parse source code, add all of details to cache, return the one we need
         parseAndSet :: Text -> MaybeT Bloc (Int32, ContractDetails)
         parseAndSet src = do
           detailsMap <- lift $ sourceToContractDetails (Don't Compile) src

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -235,45 +235,40 @@ lookupT k = MaybeT . return . Map.lookup k
 
 
 
--- Tries to get contract metadata ID and contract details for a given codehash.
+-- Tries to get contract metadata ID and contract details for a given contract.
 --  If they're not in the cache but they are in bloc database or action metadata,
---  it adds them to cache
--- TODO: (Dan)...this could be monadically prettier...when time allows, come back. 
+--  it reparses the whole source blob, and caches them for every contract
 getSolidVMDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
 getSolidVMDetailsForRow g row = runMaybeT  
-   $  MaybeT checkCache 
-  <|> MaybeT checkBloc 
-  <|> MaybeT checkMetadata
-  where checkCache :: Bloc (Maybe (Int32, ContractDetails))
-        checkCache = do
-          $logInfoS "getDetailsForRow" . T.pack $ "checking contractABIs cache for contract details"
-
-          mDetails <- runMaybeT $ getContractABIs g codePtr
-          case mDetails of 
-            Nothing -> return Nothing
-            Just detailsMap -> return $ Map.lookup (T.pack name) detailsMap
-        checkBloc :: Bloc (Maybe (Int32, ContractDetails)) 
+   $  checkCache 
+  <|> checkBloc 
+  <|> checkMetadata
+  
+  where checkCache = do
+          $logInfoS "getDetailsForRow" . T.pack $ "checking cache for contract details"
+          (MaybeT $ getContractABIs g codePtr) >>= (lookupT $ T.pack name)
+        
         checkBloc = do
           $logInfoS "getDetailsForRow" . T.pack $ "checking bloc database for contract details"
-          mDetails <- getContractDetailsByCodeHash codePtr
-          case mDetails of 
-            Nothing -> return Nothing
-            Just (_,details) -> do
-              detailsMap <- sourceToContractDetails (Don't Compile) (contractdetailsSrc details)
-              setContractABIs g codePtr detailsMap
-              return $ Map.lookup (T.pack name) detailsMap 
-        checkMetadata :: Bloc (Maybe (Int32, ContractDetails))
-        checkMetadata = runMaybeT $ do
+          (MaybeT $ getContractDetailsByCodeHash codePtr) >>= (parseAndSet . contractdetailsSrc . snd)
+        
+        checkMetadata = do
           $logInfoS "getDetailsForRow" . T.pack $ "checking metadata for contract details"
-          let md = actionMetadata row
-          src <- lookupT "src" md
+          (lookupT "src" $ actionMetadata row) >>= parseAndSet
+        
+
+        -- parse source code, add all of the contract's details to cache, return the one we need
+        parseAndSet :: Text -> MaybeT Bloc (Int32, ContractDetails)
+        parseAndSet src = do
           detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
           setContractABIs g codePtr detailsMap
           lookupT (T.pack name) detailsMap
+          
         codePtr@(SolidVMCode name _) = actionCodeHash row
 
 
--- Yes, I hate that we aren't caching for EVM...we briefly did, but because we want adjustGlobals to use cache and not recompile where possible, we need the cache to link all contracts that share a source, and at the moment, we can only do this with SolidVMCode pointers. Too bad. EVM is "softly deprecated", so we are optimizing for SolidVM 
+
+-- For now, EVM details are not cached, because the cache links all the contracts in a source blob by source hash, and we only have source hashes for SolidVM code pointers. 
 getEVMDetailsForRow :: AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
 getEVMDetailsForRow row = liftM2 (<|>)
   (getContractDetailsByCodeHash $ actionCodeHash row)
@@ -285,6 +280,8 @@ getEVMDetailsForRow row = liftM2 (<|>)
     lookupT name detailsMap)
 
 
+
+-- we want adjustGlobals to use cache and not recompile where possible, so we need the cache to link all contracts that share a source, and at the moment, we can only do this with SolidVMCode pointers
 adjustGlobals :: IORef Globals
               -> Should Compile
               -> AggregateAction

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -248,7 +248,7 @@ getSolidVMDetailsForRow g row = runMaybeT
         checkCache = do
           $logInfoS "getDetailsForRow" . T.pack $ "checking contractABIs cache for contract details"
 
-          mDetails <- getContractABIs g codePtr
+          mDetails <- runMaybeT $ getContractABIs g codePtr
           case mDetails of 
             Nothing -> return Nothing
             Just detailsMap -> return $ Map.lookup (T.pack name) detailsMap
@@ -303,11 +303,8 @@ adjustGlobals gref shouldCompile row details = do
   
   -- if we pass Don't Compile, we assume it's SolidVMCode, and use details from cache
   detailsMap <- case shouldCompile of
-    Do Compile -> do 
-      $logInfoS "adjustGlobals" . T.pack $ "compiling from source"
-      sourceToContractDetails shouldCompile $ contractdetailsSrc details
+    Do Compile -> sourceToContractDetails shouldCompile $ contractdetailsSrc details
     Don't Compile -> do 
-      $logInfoS "adjustGlobals" . T.pack $ "reading from svmABIs"
       mMap <- getContractABIs gref (actionCodeHash row)
       case mMap of
         Nothing -> error "solidVMABIs should be in the cache, but adjustGlobals didn't find them"

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -32,7 +32,8 @@ import qualified Data.ByteString.Short as SB
 -- import qualified Data.ByteString.Char8 as C8
 import Data.Either (lefts, rights)
 import Data.Function
-import Data.Foldable
+--import Data.Foldable
+--import Data.Traversable
 import Data.Int (Int32)
 import Data.IORef
 import Data.List (foldl', sortOn)
@@ -232,34 +233,57 @@ makeFunctionInserts xabi ABIID{..} state AggregateAction{..} =
 lookupT :: (Monad m, Ord k) => k -> Map.Map k v -> MaybeT m v
 lookupT k = MaybeT . return . Map.lookup k
 
+
+
 -- Tries to get contract metadata ID and contract details for a given codehash.
 --  If they're not in the cache but they are in bloc database or action metadata,
 --  it adds them to cache
-getDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
-getDetailsForRow g row = runMaybeT $ checkCache <|> checkBloc <|> checkMetadata
-  where checkCache = do
+-- TODO: (Dan)...this could be monadically prettier...when time allows, come back. 
+getSolidVMDetailsForRow :: IORef Globals -> AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
+getSolidVMDetailsForRow g row = runMaybeT  
+   $  MaybeT checkCache 
+  <|> MaybeT checkBloc 
+  <|> MaybeT checkMetadata
+  where checkCache :: Bloc (Maybe (Int32, ContractDetails))
+        checkCache = do
           $logInfoS "getDetailsForRow" . T.pack $ "checking contractABIs cache for contract details"
-          MaybeT $ getContractABIs g codePtr
-        checkBloc = MaybeT $ do
+
+          mDetails <- getContractABIs g codePtr
+          case mDetails of 
+            Nothing -> return Nothing
+            Just detailsMap -> return $ Map.lookup (T.pack name) detailsMap
+        checkBloc :: Bloc (Maybe (Int32, ContractDetails)) 
+        checkBloc = do
           $logInfoS "getDetailsForRow" . T.pack $ "checking bloc database for contract details"
           mDetails <- getContractDetailsByCodeHash codePtr
-          for_ mDetails $ setContractABIs g codePtr
-          return mDetails
-        checkMetadata = do
+          case mDetails of 
+            Nothing -> return Nothing
+            Just (_,details) -> do
+              detailsMap <- sourceToContractDetails (Don't Compile) (contractdetailsSrc details)
+              setContractABIs g codePtr detailsMap
+              return $ Map.lookup (T.pack name) detailsMap 
+        checkMetadata :: Bloc (Maybe (Int32, ContractDetails))
+        checkMetadata = runMaybeT $ do
           $logInfoS "getDetailsForRow" . T.pack $ "checking metadata for contract details"
           let md = actionMetadata row
           src <- lookupT "src" md
-          detailsTup <- case codePtr of
-            EVMCode _ -> do
-              detailsMap <- lift $ sourceToContractDetails (Do Compile) src
-              name <- lookupT "name" md
-              lookupT name detailsMap
-            SolidVMCode name _ -> do
-              detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
-              lookupT (T.pack name) detailsMap
-          setContractABIs g codePtr detailsTup
-          MaybeT $ return $ Just detailsTup
-        codePtr = actionCodeHash row 
+          detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
+          setContractABIs g codePtr detailsMap
+          lookupT (T.pack name) detailsMap
+        codePtr@(SolidVMCode name _) = actionCodeHash row
+
+
+-- Yes, I hate that we aren't caching for EVM...we briefly did, but because we want adjustGlobals to use cache and not recompile where possible, we need the cache to link all contracts that share a source, and at the moment, we can only do this with SolidVMCode pointers. Too bad. EVM is "softly deprecated", so we are optimizing for SolidVM 
+getEVMDetailsForRow :: AggregateAction -> Bloc (Maybe (Int32, ContractDetails))
+getEVMDetailsForRow row = liftM2 (<|>)
+  (getContractDetailsByCodeHash $ actionCodeHash row)
+  (runMaybeT $ do
+    let md = actionMetadata row
+    src <- lookupT "src" md
+    name <- lookupT "name" md
+    detailsMap <- lift $ sourceToContractDetails (Do Compile) src
+    lookupT name detailsMap)
+
 
 adjustGlobals :: IORef Globals
               -> Should Compile
@@ -276,8 +300,19 @@ adjustGlobals gref shouldCompile row details = do
           $logInfoS "adjustGlobals" . T.pack $ "Adding to globals for " ++ T.unpack k ++ ": " ++ show codePtr
           lift $ f gref codePtr
 
-  -- won't actually recompile the contract
-  detailsMap <- sourceToContractDetails shouldCompile $ contractdetailsSrc details
+  
+  -- if we pass Don't Compile, we assume it's SolidVMCode, and use details from cache
+  detailsMap <- case shouldCompile of
+    Do Compile -> do 
+      $logInfoS "adjustGlobals" . T.pack $ "compiling from source"
+      sourceToContractDetails shouldCompile $ contractdetailsSrc details
+    Don't Compile -> do 
+      $logInfoS "adjustGlobals" . T.pack $ "reading from svmABIs"
+      mMap <- getContractABIs gref (actionCodeHash row)
+      case mMap of
+        Nothing -> error "solidVMABIs should be in the cache, but adjustGlobals didn't find them"
+        Just dMap -> return dMap
+  
   mapM_ (go detailsMap) $ [("history", addToHistoryList)
                           ,("nohistory", removeFromHistoryList)
                           ,("noindex", addToNoIndexList)
@@ -286,14 +321,16 @@ adjustGlobals gref shouldCompile row details = do
                           ,("nofunctionhistory", removeFromFunctionHistoryList)
                           ]
 
-ensureContractInstance :: Int32 -> AggregateAction -> Bloc ()
-ensureContractInstance cmId row = do
+ensureContractInstance :: IORef Globals -> Int32 -> AggregateAction -> Bloc ()
+ensureContractInstance g cmId row = do
   let addr = actionAddress row
       chainId = actionTxChainId row
-  (mInstance :: Maybe Int32) <- fmap listToMaybe . blocQuery $
-    contractInstancesByCodeHash (actionCodeHash row) addr chainId
-  when (isNothing mInstance) . void $
-    insertContractInstance cmId addr chainId
+      codePtr = actionCodeHash row
+  instExists <- isInstanceCreated g codePtr
+  if instExists then
+    return ()
+  else
+    insertContractInstance cmId addr chainId >> setInstanceCreated g codePtr
 
 readPreviousEVMState :: IORef Globals -> Address -> Maybe ChainId -> Contract -> Bloc [(Text, Value)]
 readPreviousEVMState gref addr chainId cont = do
@@ -393,7 +430,7 @@ processTheMessages env conn g messages = do
 
       case actionStorage row of
         BS.ActionEVMDiff{} -> do
-          mDetails <- getDetailsForRow g row
+          mDetails <- getEVMDetailsForRow row
           case mDetails of
             Nothing -> pure . Left $ "No details found for code hash "
                             <> (T.pack . show $ actionCodeHash row)
@@ -407,14 +444,14 @@ processTheMessages env conn g messages = do
                   cont = either error id . xAbiToContract $ contractdetailsXabi details
               adjustGlobals g (Do Compile) row details
 
-              ensureContractInstance cmId row
+              ensureContractInstance g cmId row
 
               oldState <- readPreviousEVMState g addr chainId cont
               indexContract <- rowToInsert g abiid row cont oldState
               (hs, fhs) <- rowToHistories g abiid row actions cont details oldState
               pure . Right $ BatchedInserts indexContract hs fhs []
         BS.ActionSolidVMDiff{} -> do
-          mName <- getDetailsForRow g row
+          mName <- getSolidVMDetailsForRow g row
           case mName of
             Nothing -> pure . Left $ "No SolidVM details for code hash "
                             <> (T.pack . show $ actionCodeHash row)
@@ -425,7 +462,7 @@ processTheMessages env conn g messages = do
                   abiid = ABIID abi name $ maybe "" (T.pack . chainIdString) $ actionTxChainId row
                   cont = error "internal error: contract should be unused for solidvm"
 
-              ensureContractInstance cmId row
+              ensureContractInstance g cmId row
           
               adjustGlobals g (Don't Compile) row details
               oldState <- readPreviousSolidVMState g addr chainId

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -297,7 +297,8 @@ adjustGlobals gref shouldCompile row details = do
           $logInfoS "adjustGlobals" . T.pack $ "Adding to globals for " ++ T.unpack k ++ ": " ++ show codePtr
           lift $ f gref codePtr
 
-  
+ 
+
   -- if we pass Don't Compile, we assume it's SolidVMCode, and use details from cache
   detailsMap <- case shouldCompile of
     Do Compile -> sourceToContractDetails shouldCompile $ contractdetailsSrc details
@@ -307,6 +308,7 @@ adjustGlobals gref shouldCompile row details = do
         Nothing -> error "solidVMABIs should be in the cache, but adjustGlobals didn't find them"
         Just dMap -> return dMap
   
+  -- TODO: ideally we check if these flags are in the metadata BEFORE we get the detailsMap
   mapM_ (go detailsMap) $ [("history", addToHistoryList)
                           ,("nohistory", removeFromHistoryList)
                           ,("noindex", addToNoIndexList)


### PR DESCRIPTION
This PR does the following to optimize slipstream:

1. The `contractABIs` globals cache in slipstream now links the details of contracts that share a source blob. `contractABIs :: HM.HashMap SHA (M.Map Text (Int32, ContractDetails))`. When a contract is seen for the first time, the entire source blob is parsed, and all of the contracts' details in that blob are added to the cache (see the function `getSolidVMDetailsForRow`). Because code hashes for EVM are not source hashes like they are in SolidVM, this cache is only used by SolidVM contracts. EVM contract details are NOT cached and are grabbed from the bloc database each time they are needed. 

2. The function `adjustGlobals`, which creates/removes history tables for contracts, now reads from the `contractABIs` cache instead of recompiling/reparsing the source blob every time. The reason it did this is because we allow the creation of one contract to create history tables for other (possibly yet uncreated) contracts, if they share a source blob. THIS was the real source of slowness in slipstream: the recompiling/reparsing of an entire source blob with every event slipstream receives. Now it only has to do this once, when the cache is populated for a particular source blob. Again, this is only for SolidVM, because the cache is only for SolidVM. EVM contract updates still recompile the whole source blob every time.

3. The function `ensureContractInstance`, which checks if the bloc database has a contract instance for a particular contract and inserts one if it does not, used to query bloc every time to see if a contract instance had been created. Now, this information is held in a `IORefGlobals` variable, `instancesCreated`. No more redundant SQL queries. Should help performance a bit.