### PR TITLE
Convert ArgValues directly to Values

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/package.yaml
+++ b/blockapps-haskell/bloc/bloc22/server/package.yaml
@@ -81,6 +81,7 @@ dependencies:
   - transformers
   - transformers-base
   - unordered-containers
+  - vector
   - wai-cors
   - wai-extra
   - warp

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -20,6 +20,7 @@ import qualified Data.Map.Strict                   as Map
 import           Data.Maybe                        (catMaybes, fromMaybe)
 import           Data.Text                         (Text)
 import qualified Data.Text                         as Text
+import qualified Data.Vector                       as V
 
 import           BlockApps.Bloc22.API.Chain
 import           BlockApps.Bloc22.Monad
@@ -30,7 +31,6 @@ import           BlockApps.Solidity.ArgValue
 import           BlockApps.Solidity.Contract
 import           BlockApps.Solidity.Struct
 import           BlockApps.Solidity.Type
-import           BlockApps.Solidity.Value
 import           BlockApps.Solidity.Xabi
 import           BlockApps.Strato.Client           as Strato
 import           BlockApps.Strato.TypeLits
@@ -42,13 +42,14 @@ import           BlockApps.XAbiConverter           (xAbiToContract)
 governanceAddress :: Address
 governanceAddress = Address 0x100
 
+-- TODO: use Value instead of ArgValue here
 replaceMembers :: Struct
                -> [Address]
-               -> Map.Map Text Text
-               -> Map.Map Text Text
+               -> Map.Map Text ArgValue
+               -> Map.Map Text ArgValue
 replaceMembers Struct{..} addrs m =
   let tag = "__members__"
-      members = valueToText $ ValueArrayDynamic . tosparse $ map (SimpleValue . ValueAddress) addrs
+      members = ArgArray . V.fromList $ map (ArgString . Text.pack . addressString) addrs
       m' = Map.alter (const $ Just members) tag m
    in case OMap.lookup tag fields of
         Nothing -> m'
@@ -78,17 +79,16 @@ createChainInfo (ChainInput src cname lbl balances chaininputArgs members mmd) =
       Nothing -> return ([],[])
       Just (_, ContractDetails{..}) -> do
           contract <- either (throwError . UserError . Text.pack) return $ xAbiToContract contractdetailsXabi
-          let argsText = map (fmap argValueToText) $ Map.toList chaininputArgs
-              argsText' = replaceMembers
+          let argValues = replaceMembers
                             (mainStruct contract)
                             (nmap1' members)
-                            (Map.fromList argsText)
-              storage = encodeValues
-                          (typeDefs contract)
-                          (mainStruct contract)
-                          0
-                          (Map.toList argsText')
-              balMap = Map.fromList $ map toTuple balances
+                            chaininputArgs
+          storage <- either (throwError . UserError) return $ encodeValues
+                       (typeDefs contract)
+                       (mainStruct contract)
+                       0
+                       (Map.toList argValues)
+          let balMap = Map.fromList $ map toTuple balances
               govBal = fromMaybe 0 $ Map.lookup governanceAddress balMap
 
           (contractHash, b, s) <-

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -258,7 +258,7 @@ postUsersContractEVM' ContractParameters{..} sign = blocTransaction $ do
     metadata' = Just $ fromMaybe Map.empty metadata `Map.union` Map.fromList [("src", src),("name", cName)]
   unless (ByteString.null leftOver) $ throwError $ AnError "Couldn't decode binary"
   let xabiArgs = maybe Map.empty funcArgs $ xabiConstr contractdetailsXabi
-  argsBin <- constructArgValues (fmap (fmap argValueToText) args) xabiArgs
+  argsBin <- constructArgValues args xabiArgs
   tx <- signAndPrepare sign fromAddr metadata' $
     TransactionHeader
       Nothing
@@ -295,7 +295,7 @@ postUsersContractSolidVM' ContractParameters{..} sign = blocTransaction $ do
   $logInfoLS "postUsersContractSolidVM'/args" args
 
   let xabiArgs = maybe Map.empty funcArgs $ xabiConstr contractdetailsXabi
-  (_, argsAsSource) <- constructArgValuesAndSource (fmap (fmap argValueToText) args) xabiArgs
+  (_, argsAsSource) <- constructArgValuesAndSource args xabiArgs
 
   let metadata' = Just $ fromMaybe Map.empty metadata `Map.union` Map.fromList [("name", cName), ("args", argsAsSource)]
 
@@ -360,7 +360,7 @@ postUsersUploadListSolidVM' ContractListParameters{..} sign = do
               x <- lift $ deserializeXabi x'
               at name <?= (b, src, cmId', x)
       let xabiArgs = maybe Map.empty funcArgs $ xabiConstr xabi
-      (_, argsAsSource) <- lift $ constructArgValuesAndSource (Just (fmap argValueToText args)) xabiArgs
+      (_, argsAsSource) <- lift $ constructArgValuesAndSource (Just args) xabiArgs
 
       let metadata' = Just $ fromMaybe Map.empty md `Map.union` Map.fromList [("name", name), ("args", argsAsSource)]
       tx <- lift . signAndPrepare sign fromAddr metadata' $
@@ -414,7 +414,7 @@ postUsersUploadListEVM' ContractListParameters{..} sign = do
               x <- lift $ deserializeXabi x'
               at name <?= (b, src, cmId', x)
       let xabiArgs = maybe Map.empty funcArgs $ xabiConstr xabi
-      argsBin <- lift $ constructArgValues (Just (fmap argValueToText args)) xabiArgs
+      argsBin <- lift $ constructArgValues (Just args) xabiArgs
       let metadata' = Just $ fromMaybe Map.empty md `Map.union` Map.fromList [("src",src),("name",name)]
       tx <- lift . signAndPrepare sign fromAddr metadata' $
           TransactionHeader
@@ -561,7 +561,7 @@ postUsersContractMethodList' FunctionListParameters{..} sign = do
              _ -> lift $ throwError . UserError $ "Contract doesn't have a method named '" <> methodcallMethodName <> "'"
           let xabiArgs = maybe Map.empty funcArgs . Map.lookup methodcallMethodName $ xabiFuncs xabi
           (argsBin, argsAsSource) <-
-            lift $ constructArgValuesAndSource (Just (fmap argValueToText methodcallArgs)) xabiArgs
+            lift $ constructArgValuesAndSource (Just methodcallArgs) xabiArgs
           let methodcallMetadataWithCallInfo = Just $
                 Map.insert "funcName" methodcallMethodName
                 $ Map.insert "args" argsAsSource
@@ -649,7 +649,7 @@ postUsersContractMethod' FunctionParameters{..} sign = do
        Just (_, TypeFunction selector _ _) -> return selector
        _ -> throwError . UserError $ "Contract doesn't have a method named '" <> funcName <> "'"
 
-    (argsBin, argsAsSource) <- constructArgValuesAndSource (Just (fmap argValueToText args)) xabiArgs
+    (argsBin, argsAsSource) <- constructArgValuesAndSource (Just args) xabiArgs
     let metadataWithCallInfo =
           Map.insert "funcName" funcName
           $ Map.insert "args" argsAsSource
@@ -830,11 +830,11 @@ convertResultResToVals txResp responseTypes =
   let byteResp = fst (Base16.decode (Text.encodeUtf8 txResp))
   in map valueToSolidityValue <$> bytestringToValues byteResp responseTypes
 
-getArgValues :: Map Text Text -> Map Text Xabi.IndexedType -> Bloc [Value]
+getArgValues :: Map Text ArgValue -> Map Text Xabi.IndexedType -> Bloc [Value]
 getArgValues argsMap argNamesTypes = do
     let
-      determineValue :: Text -> Xabi.IndexedType -> Bloc (Int32, Value)
-      determineValue valStr (Xabi.IndexedType ix xabiType) =
+      determineValue :: ArgValue -> Xabi.IndexedType -> Bloc (Int32, Value)
+      determineValue argVal (Xabi.IndexedType ix xabiType) =
         let
           typeM = case xabiType of
             Xabi.Int (Just True) b -> Right . SimpleType . TypeInt True $ fmap toInteger b
@@ -868,7 +868,7 @@ getArgValues argsMap argNamesTypes = do
             Xabi.Label _                 -> Right $ SimpleType typeUInt -- since Enums are converted to Ints
         in do
           ty <- either (blocError . UserError) return typeM
-          either (blocError . UserError) (return . (ix,)) (textToValue Nothing valStr ty)
+          either (blocError . UserError) (return . (ix,)) (argValueToValue Nothing ty argVal)
     argsVals <-
       if not (Map.keysSet argNamesTypes `isSubsetOf` Map.keysSet argsMap)
       then do
@@ -879,7 +879,7 @@ getArgValues argsMap argNamesTypes = do
       else sequence $ Map.intersectionWith determineValue argsMap argNamesTypes
     return $ map snd (sortOn fst (toList argsVals))
 
-constructArgValues :: Maybe (Map Text Text) -> Map Text Xabi.IndexedType -> Bloc ByteString
+constructArgValues :: Maybe (Map Text ArgValue) -> Map Text Xabi.IndexedType -> Bloc ByteString
 constructArgValues args argNamesTypes = do
     case args of
       Nothing ->
@@ -890,7 +890,7 @@ constructArgValues args argNamesTypes = do
         vals <- getArgValues argsMap argNamesTypes
         return $ toStorage (ValueArrayFixed (fromIntegral (length vals)) vals)
 
-constructArgValuesAndSource :: Maybe (Map Text Text) -> Map Text Xabi.IndexedType -> Bloc (ByteString, Text)
+constructArgValuesAndSource :: Maybe (Map Text ArgValue) -> Map Text Xabi.IndexedType -> Bloc (ByteString, Text)
 constructArgValuesAndSource args argNamesTypes = do
     case args of
       Nothing ->

--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/ArgValue.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/ArgValue.hs
@@ -2,52 +2,126 @@
 
 module BlockApps.Solidity.ArgValue where
 
+import           BlockApps.Ethereum
+import           BlockApps.Solidity.Type
+import           BlockApps.Solidity.TypeDefs
+import           BlockApps.Solidity.Value
 import           ClassyPrelude                ((<>))
 import           Control.Lens                 ((&), (?~))
-import           Data.Aeson
+import qualified Data.Aeson                   as A
+import qualified Data.Bimap                   as Bimap
+import           Data.ByteString              (ByteString)
+import qualified Data.ByteString              as ByteString
+import qualified Data.ByteString.Base16       as Base16
+import qualified Data.Map.Strict              as Map
 import           Data.Swagger
-import           Data.Text
-import qualified Data.Text as Text
-import           Data.Vector
+import           Data.Text                    (Text)
+import qualified Data.Text                    as Text
+import qualified Data.Text.Encoding           as Text
+import qualified Data.Vector                  as V
 import           Test.QuickCheck
 
 data ArgValue
   = ArgInt Integer
   | ArgBool Bool
   | ArgString Text
-  | ArgArray (Vector ArgValue)
+  | ArgArray (V.Vector ArgValue)
   deriving (Eq,Show)
 
 instance Arbitrary ArgValue where
   arbitrary = elements [ArgInt 5,ArgBool True,ArgBool False,ArgString "arggg"]
 
-instance FromJSON ArgValue where
+instance A.FromJSON ArgValue where
   parseJSON = \case
-    Bool x -> return $ ArgBool x
-    Number x -> return $ ArgInt (round x)
-    String x -> return $ ArgString x
-    Array xs -> ArgArray <$> traverse parseJSON xs
-    Null -> fail "parsing JSON for ArgValue: encountered Null"
-    Object _ -> fail "parsing JSON for ArgValue: encountered Object"
+    A.Bool x -> return $ ArgBool x
+    A.Number x -> return $ ArgInt (round x)
+    A.String x -> return $ ArgString x
+    A.Array xs -> ArgArray <$> traverse A.parseJSON xs
+    A.Null -> fail "parsing JSON for ArgValue: encountered Null"
+    A.Object _ -> fail "parsing JSON for ArgValue: encountered Object"
 
-instance ToJSON ArgValue where
+instance A.ToJSON ArgValue where
   toJSON = \case
-    ArgInt x -> Number (fromIntegral x)
-    ArgBool x -> Bool x
-    ArgString x -> String x
-    ArgArray xs -> Array (fmap toJSON xs)
+    ArgInt x -> A.Number (fromIntegral x)
+    ArgBool x -> A.Bool x
+    ArgString x -> A.String x
+    ArgArray xs -> A.Array (fmap A.toJSON xs)
 
 instance ToSchema ArgValue where
   declareNamedSchema = pure . pure $
     NamedSchema (Just "Solidity Argument Value") $ mempty
       & description ?~ "A Solidity argument value"
-      & example ?~ toJSON (ArgInt 5)
+      & example ?~ A.toJSON (ArgInt 5)
 
-argValueToText :: ArgValue -> Text
-argValueToText = \case
-  ArgInt x -> Text.pack (show x)
-  ArgBool x -> if x then "true" else "false"
-  ArgString x -> x
-  ArgArray xs -> "["
-    <> Text.intercalate "," (toList (fmap argValueToText xs))
-    <> "]"
+-- TODO: create valueToArgValue
+argValueToValue :: Maybe TypeDefs -> Type -> ArgValue -> Either Text Value
+argValueToValue defs theType argVal = case theType of
+  SimpleType ty -> SimpleValue <$> argValueToSimpleValue ty argVal
+  TypeArrayDynamic ty -> case argVal of
+    ArgArray xs -> ValueArrayDynamic . tosparse . V.toList <$>
+      traverse (argValueToValue defs ty) xs
+    o -> Left . Text.pack $ "argValueToValue: Expected TypeArrayDynamic to be an array, but got: " ++ show o
+  TypeArrayFixed len ty -> case argVal of
+    ArgArray xs -> if toInteger (V.length xs) == toInteger len
+      then ValueArrayFixed len . V.toList <$> traverse (argValueToValue defs ty) xs
+      else Left . Text.pack $ "argValueToValue: Expected length of TypeArrayFixed to match length of the array. Expected " ++ show len ++ ", but got " ++ show (length xs)
+    o -> Left . Text.pack $ "argValueToValue: Expected TypeArrayFixed to be an array, but got: " ++ show o
+  TypeMapping{}  -> Left "argValueToValue TODO: TypeMapping not yet implemented"
+  TypeFunction{} -> Left "argValueToValue TODO: TypeFunction not yet implemented"
+  TypeContract{} -> case argVal of
+    ArgString str -> ValueContract <$> case stringAddress (Text.unpack str) of
+      Nothing -> Left $ "argValueToValue: could not decode as contract address: " <> str
+      Just x -> return x
+    o -> Left . Text.pack $ "argValueToValue: Expected TypeContract to be a string, but got: " ++ show o
+  TypeEnum enumName -> case defs of
+    Nothing -> Left $ "argValueToValue: Enum values cannot be parsed without type definitions" -- TODO(dustin): Pass in TypeDefs
+    Just tds -> case Map.lookup enumName (enumDefs tds) of
+      Nothing -> Left $ "argValueToValue: Missing enum name in type definitions: " <> enumName
+      Just eSet -> case argVal of
+        ArgString str ->
+          let str' = last $ Text.split (== '.') str
+           in case Bimap.lookupR str' eSet of
+                Nothing -> Left $ "argValueToValue: Missing value '" <> str <> "' in enum definition for " <> enumName
+                Just i -> Right $ ValueEnum enumName str' $ fromIntegral i
+        o -> Left . Text.pack $ "argValueToValue: Expected TypeEnum to be a string, but got: " ++ show o
+  TypeStruct{}   -> Left "argValueToValue TODO: TypeStruct not yet implemented"
+
+argValueToSimpleValue :: SimpleType -> ArgValue -> Either Text SimpleValue
+argValueToSimpleValue theType argVal = case theType of
+  TypeBool -> case argVal of
+    ArgBool x -> return $ ValueBool x
+    o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeBool to be a boolean, but got " ++ show o
+  TypeAddress -> case argVal of
+    ArgString str -> ValueAddress <$> case stringAddress (Text.unpack str) of
+      Nothing -> Left $ "argValueToSimpleValue: could not decode as address: " <> str
+      Just x -> return x
+    o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeAddress to be a string, but got " ++ show o
+  TypeString -> case argVal of
+    ArgString str -> return $ ValueString str
+    o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeString to be a string, but got " ++ show o
+  TypeInt s b -> case argVal of
+    ArgInt i -> Right $ ValueInt s b i
+    o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeInt to be an integer, but got " ++ show o
+  TypeBytes (Just n) -> case argVal of
+    ArgString str -> ValueBytes (Just n) <$> readBytes n str
+    o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeBytes to be a string, but got " ++ show o
+  TypeBytes Nothing -> case argVal of
+    ArgString str -> ValueBytes Nothing <$> readBytesDyn str
+    o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeBytes to be a string, but got " ++ show o
+  where
+    readBytes :: Integer -> Text -> Either Text ByteString
+    readBytes n str =
+      let
+        (bytes', leftover) = Base16.decode (Text.encodeUtf8 str)
+      in
+        if leftover /= ByteString.empty || ByteString.length bytes' /= fromInteger n
+          then Left $ "argValueToSimpleValue: could not decode as statically sized bytes: " <> str <> ", expected a Base16 encoded string of length " <> Text.pack (show $ 2 * n) <> ", which represents a bytestring of length " <> Text.pack (show n)
+          else return bytes'
+    readBytesDyn :: Text -> Either Text ByteString
+    readBytesDyn str =
+      let
+        (bytes', leftover) = Base16.decode (Text.encodeUtf8 str)
+      in
+        if leftover /= ByteString.empty
+          then Left $ "argValueToSimpleValue: could not decode as dynamically sized bytes: " <> str
+          else return bytes'

--- a/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/SolidityVarReader.hs
@@ -44,6 +44,7 @@ import           Text.Printf
 import           Text.Read
 
 import           BlockApps.Ethereum
+import           BlockApps.Solidity.ArgValue
 import           BlockApps.Solidity.Contract
 import           BlockApps.Solidity.SolidityValue
 import           BlockApps.Solidity.Struct
@@ -491,15 +492,16 @@ encodeValues
   :: TypeDefs
   -> Struct
   -> Word256
-  -> [(Text,Text)]
-  -> Map Word256 Word256
+  -> [(Text,ArgValue)]
+  -> Either Text (Map Word256 Word256)
 encodeValues typeDefs' struct'@Struct{..} offset vars =
   zipMapMaybe (uncurry $ encodeValue typeDefs' offset struct') vars Map.empty
   where
-    zipMapMaybe _ [] m = m
+    zipMapMaybe _ [] m = Right m
     zipMapMaybe f (a:as) m = case (f a) of
-      Nothing -> zipMapMaybe f as m
-      Just b -> zipMapMaybe f as $ foldl' (apply (.|.)) m b
+      Left t -> Left t
+      Right Nothing -> zipMapMaybe f as m
+      Right (Just b) -> zipMapMaybe f as $ foldl' (apply (.|.)) m b
     apply f m (a,b) = case Map.lookup a m of
       Nothing -> Map.insert a b m
       Just c -> Map.insert a (f c b) m
@@ -509,14 +511,15 @@ encodeValue
   -> Word256
   -> Struct
   -> Text
-  -> Text
-  -> Maybe [(Word256,Word256)]
-encodeValue typeDefs' offset Struct{..} varName val = case OMap.lookup varName fields of
-   Nothing -> Nothing
-   Just (Right position, theType) -> case (textToValue (Just typeDefs') val theType) of
-     Left err -> error $ "encodeValue: textToValue failed to parse with: " ++ show err -- Solidity is a "strongly typed" "language"
-     Right v -> Just $ encodeValue' typeDefs' (position `Storage.addOffset` fromIntegral offset) theType v
-   Just (Left _, _) -> error "decodeValue: cannot convert constant variable to storage"
+  -> ArgValue
+  -> Either Text (Maybe [(Word256,Word256)])
+encodeValue typeDefs' offset Struct{..} varName argVal = case OMap.lookup varName fields of
+   Nothing -> Right Nothing
+   Just (Right position, theType) -> do
+     val <- argValueToValue (Just typeDefs') theType argVal
+     return . Just $
+       encodeValue' typeDefs' (position `Storage.addOffset` fromIntegral offset) theType val
+   Just (Left _, _) -> Left "encodeValue: cannot convert constant variable to storage"
 
 encodeValue'
   :: TypeDefs


### PR DESCRIPTION
This bypasses the error-prone Text conversion in parsing ArgValues, so instead of going from ArgValue to Text to Value, the conversion is now just ArgValue to Value. The main bug this fixes is parsing arrays of strings if any of the strings contain a comma. Before, passing in ["1","2","3,4"] would be converted to ["1","2","3","4"] due to a bug in argValueToText. Simply escaping commas or wrapping the entries in extra quotations could've led to other bugs, so I instead cut out the entire intermediate conversion to Text. Now the argument is correctly parsed as ["1","2","3,4"].

TODO: argValueToValue could be made more efficient by pattern matching on both the Type and the ArgValue at the same time.