### PR TITLE
Single element chainids

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
@@ -7,6 +7,7 @@
 
 module BlockApps.Bloc22.Server.Transaction where
 
+import           Control.Applicative               ((<|>))
 import           Control.Monad
 import           Control.Monad.Except
 import qualified Data.Map.Strict                   as Map

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Transaction.hs
@@ -46,7 +46,7 @@ postBlocTransaction mUserName chainId resolve (PostBlocTransactionRequest mAddr 
                         (transferpayloadValue p)
                         txParams
                         (transferpayloadMetadata p)
-                        chainId
+                        (transferpayloadChainid p <|> chainId)
                         resolve
             fmap (:[]) $ postUsersSend' btp (callSignature userName)
           xs -> do
@@ -70,7 +70,7 @@ postBlocTransaction mUserName chainId resolve (PostBlocTransactionRequest mAddr 
                         (contractpayloadValue p)
                         txParams
                         (contractpayloadMetadata p)
-                        chainId
+                        (contractpayloadChainid p <|> chainId)
                         resolve
                 poster = case Map.lookup "VM" =<< md of
                             Nothing -> postUsersContractEVM'
@@ -108,7 +108,7 @@ postBlocTransaction mUserName chainId resolve (PostBlocTransactionRequest mAddr 
                         (functionpayloadValue p)
                         txParams
                         (functionpayloadMetadata p)
-                        chainId
+                        (functionpayloadChainid p <|> chainId)
                         resolve
             fmap (:[]) $ postUsersContractMethod' bfp (callSignature userName)
           xs -> do


### PR DESCRIPTION
Since we allow passing chainid as a parameter for each element in the list, it makes sense to use this value if the list is one element long, as well.
Found while testing Beanstalk, although there is a workaround