### PR TITLE
Allow booleans and integers to be passed as strings to Bloc

### DIFF
--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/ArgValue.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/ArgValue.hs
@@ -20,6 +20,7 @@ import qualified Data.Text                    as Text
 import qualified Data.Text.Encoding           as Text
 import qualified Data.Vector                  as V
 import           Test.QuickCheck
+import           Text.Read                    (readMaybe)
 
 data ArgValue
   = ArgInt Integer
@@ -90,6 +91,10 @@ argValueToSimpleValue :: SimpleType -> ArgValue -> Either Text SimpleValue
 argValueToSimpleValue theType argVal = case theType of
   TypeBool -> case argVal of
     ArgBool x -> return $ ValueBool x
+    ArgString str -> case Text.toLower str of
+      "true" -> return $ ValueBool True
+      "false" -> return $ ValueBool False
+      _ -> Left $ "argValueToSimpleValue: Could not parse boolean value from string \"" <> str <> "\""
     o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeBool to be a boolean, but got " ++ show o
   TypeAddress -> case argVal of
     ArgString str -> ValueAddress <$> case stringAddress (Text.unpack str) of
@@ -101,6 +106,9 @@ argValueToSimpleValue theType argVal = case theType of
     o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeString to be a string, but got " ++ show o
   TypeInt s b -> case argVal of
     ArgInt i -> Right $ ValueInt s b i
+    ArgString str -> case readMaybe (Text.unpack str) of
+      Just i -> Right $ ValueInt s b i
+      Nothing -> Left $ "argValueToSimpleValue: Could not parse integer value from string \"" <> str <> "\""
     o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeInt to be an integer, but got " ++ show o
   TypeBytes (Just n) -> case argVal of
     ArgString str -> ValueBytes (Just n) <$> readBytes n str


### PR DESCRIPTION
This is a safe change because we are already pattern matching on the Solidity type the argument _should_ be, so it's ok if it comes wrapped in quotes.