### PR TITLE
Added type families to better organize large type constraints

### DIFF
--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeApplications     #-}
@@ -141,34 +143,40 @@ debounceTxSends = do
       recordEmptyQueue
       yieldMany . map W.Transactions $ chunksOf 100 txs
 
-handleMsgClientConduit :: ( MonadIO m
+handleMsgClientConduit :: ( HasVMEventsSink m
+                          , MonadIO m
                           , MonadResource m
                           , MonadLogger m
-                          , Mod.Accessible (SK.UnseqSink m) m
-                          , Mod.Modifiable BestBlock m
-                          , Mod.Modifiable WorldBestBlock m
-                          , Mod.Modifiable ActionTimestamp m
-                          , Mod.Accessible ActionTimestamp m
-                          , Mod.Modifiable [BlockData] m
-                          , Mod.Accessible [BlockData] m
-                          , Mod.Modifiable RemainingBlockHeaders m
-                          , Mod.Accessible RemainingBlockHeaders m
-                          , Mod.Modifiable PeerAddress m
-                          , Mod.Accessible PeerAddress m
-                          , Mod.Accessible MaxReturnedHeaders m
-                          , Mod.Accessible ConnectionTimeout m
-                          , (Integer `A.Selectable` Canonical BlockData) m
-                          , (SHA `A.Alters` BlockData) m
-                          , (IPAddress `A.Selectable` IPChains) m
-                          , (OrgId `A.Selectable` OrgIdChains) m
-                          , (SHA `A.Selectable` ChainTxsInBlock) m
-                          , (Word256 `A.Selectable` ChainMembers) m
-                          , (Word256 `A.Selectable` ChainInfo) m
-                          , (SHA `A.Selectable` Private (Word256, OutputTx)) m
-                          , (SHA `A.Alters` OutputBlock) m
-                          , Mod.Accessible GenesisBlockHash m
-                          , Mod.Accessible BestBlockNumber m
-                          , HasVMEventsSink m
+                          , All '[Mod.Accessible, Mod.Modifiable]
+                              '[ ActionTimestamp
+                               , [BlockData]
+                               , RemainingBlockHeaders
+                               , PeerAddress
+                               ] m
+                          , All '[Mod.Accessible]
+                              '[ (SK.UnseqSink m)
+                               , MaxReturnedHeaders
+                               , ConnectionTimeout
+                               , GenesisBlockHash
+                               , BestBlockNumber
+                               ] m
+                          , All '[Mod.Modifiable]
+                              '[ BestBlock
+                               , WorldBestBlock
+                               ] m
+                          , All2 '[A.Selectable]
+                              '[ '(Integer, Canonical BlockData)
+                               , '(IPAddress, IPChains)
+                               , '(OrgId, OrgIdChains)
+                               , '(SHA, ChainTxsInBlock)
+                               , '(Word256, ChainMembers)
+                               , '(Word256, ChainInfo)
+                               , '(SHA, Private (Word256, OutputTx))
+                               ] m
+                          , All2 '[A.Alters]
+                              '[ '(SHA, BlockData)
+                               , '(SHA, OutputBlock)
+                               ] m
                           )
                        => Point
                        -> PPeer
@@ -212,33 +220,40 @@ handleMsgClientConduit myId peer = do
         other -> assertHandshake other
     handleEvents peer .| filterMC (either (const $ return True) checkOutbound)
 
-handleMsgServerConduit :: ( MonadIO m
+handleMsgServerConduit :: ( HasVMEventsSink m
+                          , MonadIO m
                           , MonadResource m
                           , MonadLogger m
-                          , Mod.Accessible (SK.UnseqSink m) m
-                          , Mod.Modifiable BestBlock m
-                          , Mod.Modifiable WorldBestBlock m
-                          , Mod.Modifiable ActionTimestamp m
-                          , Mod.Accessible ActionTimestamp m
-                          , Mod.Modifiable [BlockData] m
-                          , Mod.Accessible [BlockData] m
-                          , Mod.Modifiable RemainingBlockHeaders m
-                          , Mod.Accessible RemainingBlockHeaders m
-                          , Mod.Modifiable PeerAddress m
-                          , Mod.Accessible PeerAddress m
-                          , Mod.Accessible MaxReturnedHeaders m
-                          , Mod.Accessible ConnectionTimeout m
-                          , (Integer `A.Selectable` Canonical BlockData) m
-                          , (SHA `A.Alters` BlockData) m
-                          , (IPAddress `A.Selectable` IPChains) m
-                          , (OrgId `A.Selectable` OrgIdChains) m
-                          , (SHA `A.Selectable` ChainTxsInBlock) m
-                          , (Word256 `A.Selectable` ChainMembers) m
-                          , (Word256 `A.Selectable` ChainInfo) m
-                          , (SHA `A.Selectable` Private (Word256, OutputTx)) m
-                          , (SHA `A.Alters` OutputBlock) m
-                          , Mod.Accessible GenesisBlockHash m
-                          , HasVMEventsSink m
+                          , All '[Mod.Accessible, Mod.Modifiable]
+                              '[ ActionTimestamp
+                               , [BlockData]
+                               , RemainingBlockHeaders
+                               , PeerAddress
+                               ] m
+                          , All '[Mod.Accessible]
+                              '[ (SK.UnseqSink m)
+                               , MaxReturnedHeaders
+                               , ConnectionTimeout
+                               , GenesisBlockHash
+                               , BestBlockNumber
+                               ] m
+                          , All '[Mod.Modifiable]
+                              '[ BestBlock
+                               , WorldBestBlock
+                               ] m
+                          , All2 '[A.Selectable]
+                              '[ '(Integer, Canonical BlockData)
+                               , '(IPAddress, IPChains)
+                               , '(OrgId, OrgIdChains)
+                               , '(SHA, ChainTxsInBlock)
+                               , '(Word256, ChainMembers)
+                               , '(Word256, ChainInfo)
+                               , '(SHA, Private (Word256, OutputTx))
+                               ] m
+                          , All2 '[A.Alters]
+                              '[ '(SHA, BlockData)
+                               , '(SHA, OutputBlock)
+                               ] m
                           )
                  => Point
                  -> PPeer

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -1,13 +1,19 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 
 module Blockchain.Event (
   module Blockchain.EventModel,
+  All,
+  All2,
   handleEvents,
   handleGetChainDetails,
   getBestKafkaBlockNumber,
@@ -38,6 +44,7 @@ import qualified Data.Set                              as S
 import qualified Data.Text                             as T
 import           Data.These
 import           Data.Time.Clock
+import           GHC.Exts                              (Constraint)
 import           MonadUtils
 import           Prelude                               hiding (lookup)
 import           System.Random
@@ -79,6 +86,24 @@ import           Text.Tools
 
 import           Debug.Trace                           (trace)
 
+-- TODO: These type families should be exposed by monad-alter, not defined here
+--       but merging in the latest monad-alter will take some additional work
+type family All' (k :: * -> (* -> *) -> Constraint) (ts :: [*]) (m :: * -> *) :: Constraint where
+  All' k (t : '[]) m = k t m
+  All' k (t ': ts) m = (k t m, All' k ts m)
+
+type family All (ks :: [* -> (* -> *) -> Constraint]) (ts :: [*]) (m :: * -> *) :: Constraint where
+  All (k ': '[]) ts m = All' k ts m
+  All (k ': ks) ts m = (All' k ts m, All ks ts m)
+
+type family All2' (k :: * -> * -> (* -> *) -> Constraint) (ts :: [(*,*)]) (m :: * -> *) :: Constraint where
+  All2' k ('(t1, t2) : '[]) m = k t1 t2 m
+  All2' k ('(t1, t2) ': ts) m = (k t1 t2 m, All2' k ts m)
+
+type family All2 (ks :: [* -> * -> (* -> *) -> Constraint]) (ts :: [(*,*)]) (m :: * -> *) :: Constraint where
+  All2 (k ': '[]) ts m = All2' k ts m
+  All2 (k ': ks) ts m = (All2' k ts m, All2 ks ts m)
+
 setTitleAndProduceBlocks :: ( MonadLogger m
                             , MonadIO m
                             , HasVMEventsSink m
@@ -117,32 +142,38 @@ yieldR = yield . Right
 yieldL :: Monad m => e -> ConduitT i (Either e a) m ()
 yieldL = yield . Left
 
-handleEvents :: ( MonadIO m
+handleEvents :: ( HasVMEventsSink m
+                , MonadIO m
                 , MonadResource m
-                , Accessible (SK.UnseqSink m) m
                 , MonadLogger m
-                , HasVMEventsSink m
-                , Modifiable BestBlock m
-                , Modifiable WorldBestBlock m
-                , Modifiable ActionTimestamp m
-                , Accessible ActionTimestamp m
-                , Modifiable [BlockData] m
-                , Accessible [BlockData] m
-                , Modifiable RemainingBlockHeaders m
-                , Accessible RemainingBlockHeaders m
-                , Modifiable PeerAddress m
-                , Accessible PeerAddress m
-                , Accessible MaxReturnedHeaders m
-                , Accessible ConnectionTimeout m
-                , (Integer `Selectable` Canonical BlockData) m
-                , (SHA `Alters` BlockData) m
-                , (IPAddress `Selectable` IPChains) m
-                , (OrgId `Selectable` OrgIdChains) m
-                , (SHA `Selectable` ChainTxsInBlock) m
-                , (Word256 `Selectable` ChainMembers) m
-                , (Word256 `Selectable` ChainInfo) m
-                , (SHA `Selectable` Private (Word256, OutputTx)) m
-                , (SHA `Alters` OutputBlock) m
+                , All '[Accessible, Modifiable]
+                    '[ ActionTimestamp
+                     , [BlockData]
+                     , RemainingBlockHeaders
+                     , PeerAddress
+                     ] m
+                , All '[Accessible]
+                    '[ (SK.UnseqSink m)
+                     , MaxReturnedHeaders
+                     , ConnectionTimeout
+                     ] m
+                , All '[Modifiable]
+                    '[ BestBlock
+                     , WorldBestBlock
+                     ] m
+                , All2 '[Selectable]
+                    '[ '(Integer, Canonical BlockData)
+                     , '(IPAddress, IPChains)
+                     , '(OrgId, OrgIdChains)
+                     , '(SHA, ChainTxsInBlock)
+                     , '(Word256, ChainMembers)
+                     , '(Word256, ChainInfo)
+                     , '(SHA, Private (Word256, OutputTx))
+                     ] m
+                , All2 '[Alters]
+                    '[ '(SHA, BlockData)
+                     , '(SHA, OutputBlock)
+                     ] m
                 ) => PPeer -> ConduitM Event (Either P2PCNC Message) m ()
 handleEvents peer = awaitForever $ \case
     MsgEvt Hello{}  -> error "A hello message appeared after the handshake"


### PR DESCRIPTION
I meant to throw this into the last PR, but forgot. I think these type families help organize the large type constraints being used in strato-p2p now. They allow you to better see which capabilities the function has, as well, which is hopefully a good compromise for having so many in the first place. Rather than creating constraint type aliases to bundle multiple capabilities together, this approach keeps the list explicit, but tidy.