### PR TITLE
Local ba rest for tests

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -22,11 +22,13 @@ pipeline {
 
     stage('Build') {
       steps {
-        sh '''#!/bin/bash -le
-          set -x
-          cd strato-worktree
-          REPO=private make all
-        '''
+        dir ('strato-worktree') {
+          sh 'REPO=private make all'
+          dir ('blockapps-rest') {
+            sh 'yarn'
+            sh 'yarn build'
+          }
+        }
       }
     }
 
@@ -125,8 +127,11 @@ pipeline {
                 cd track-and-trace
                 git checkout oauth42style
                 git submodule update --init --recursive
-                sed -i "s/localhost:8080/localhost/g" server/config/localhost.config.yaml
                 cd server
+                sed -i "s/localhost:8080/localhost/g" config/localhost.config.yaml
+                # symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
+                cp -r ../../strato-worktree/blockapps-rest blockapps-rest
+                sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json
                 touch .env
                 yarn build
                 yarn install
@@ -283,8 +288,11 @@ pipeline {
                 git clone https://github.com/blockapps/track-and-trace.git
                 cd track-and-trace
                 git submodule update --init --recursive
-                sed -i "s/localhost:8080/localhost/g" server/config/localhost.config.yaml
                 cd server
+                sed -i "s/localhost:8080/localhost/g" config/localhost.config.yaml
+                # symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
+                cp -r ../../strato-worktree/blockapps-rest blockapps-rest
+                sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json
                 touch .env
                 yarn build
                 yarn install

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -129,9 +129,7 @@ pipeline {
                 git submodule update --init --recursive
                 cd server
                 sed -i "s/localhost:8080/localhost/g" config/localhost.config.yaml
-                # symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
-                cp -r ../../strato-worktree/blockapps-rest blockapps-rest
-                sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json
+                # oauth42style uses the old hardcoded ba-rest version
                 touch .env
                 yarn build
                 yarn install

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -42,12 +42,14 @@ pipeline {
     stage('Build') {
       steps {
         withEnv(["RELEASE_VERSION=${env.RELEASE_VERSION}"]) {
-          sh '''#!/bin/bash -le
-            set -x
-            cd strato-worktree
-            echo ${RELEASE_VERSION} > VERSION
-            REPO=public make all
-            '''
+          dir ('strato-worktree') {
+            sh 'echo ${RELEASE_VERSION} > VERSION'
+            sh 'REPO=private make all'
+            dir ('blockapps-rest') {
+              sh 'yarn'
+              sh 'yarn build'
+            }
+          }
         }
       }
     }
@@ -123,8 +125,11 @@ pipeline {
                 cd track-and-trace
                 git checkout oauth42style
                 git submodule update --init --recursive
-                sed -i "s/localhost:8080/localhost/g" server/config/localhost.config.yaml
                 cd server
+                sed -i "s/localhost:8080/localhost/g" config/localhost.config.yaml
+                # symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
+                cp -r ../../strato-worktree/blockapps-rest blockapps-rest
+                sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json
                 touch .env
                 yarn build
                 yarn install
@@ -222,8 +227,11 @@ pipeline {
               git clone https://github.com/blockapps/track-and-trace.git
               cd track-and-trace
               git submodule update --init --recursive
-              sed -i "s/localhost:8080/localhost/g" server/config/localhost.config.yaml
               cd server
+              sed -i "s/localhost:8080/localhost/g" config/localhost.config.yaml
+              # symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
+              cp -r ../../strato-worktree/blockapps-rest blockapps-rest
+              sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json
               touch .env
               yarn build
               yarn install

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -127,9 +127,7 @@ pipeline {
                 git submodule update --init --recursive
                 cd server
                 sed -i "s/localhost:8080/localhost/g" config/localhost.config.yaml
-                # symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
-                cp -r ../../strato-worktree/blockapps-rest blockapps-rest
-                sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json
+                # oauth42style uses the old hardcoded ba-rest version
                 touch .env
                 yarn build
                 yarn install

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -36,11 +36,13 @@ pipeline {
 
     stage('Build') {
       steps {
-        sh '''#!/bin/bash -le
-          set -x
-          cd strato-worktree
-          REPO=private make all
-        '''
+        dir ('strato-worktree') {
+          sh 'REPO=private make all'
+          dir ('blockapps-rest') {
+            sh 'yarn'
+            sh 'yarn build'
+          }
+        }
       }
     }
 
@@ -140,8 +142,11 @@ pipeline {
                 cd track-and-trace
                 git checkout oauth42style
                 git submodule update --init --recursive
-                sed -i "s/localhost:8080/localhost/g" server/config/localhost.config.yaml
                 cd server
+                sed -i "s/localhost:8080/localhost/g" config/localhost.config.yaml
+                # symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
+                cp -r ../../strato-worktree/blockapps-rest blockapps-rest
+                sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json
                 touch .env
                 yarn build
                 yarn install
@@ -292,8 +297,11 @@ pipeline {
                 git clone https://github.com/blockapps/track-and-trace.git
                 cd track-and-trace
                 git submodule update --init --recursive
-                sed -i "s/localhost:8080/localhost/g" server/config/localhost.config.yaml
                 cd server
+                sed -i "s/localhost:8080/localhost/g" config/localhost.config.yaml
+                # symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
+                cp -r ../../strato-worktree/blockapps-rest blockapps-rest
+                sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json
                 touch .env
                 yarn build
                 yarn install

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -144,9 +144,7 @@ pipeline {
                 git submodule update --init --recursive
                 cd server
                 sed -i "s/localhost:8080/localhost/g" config/localhost.config.yaml
-                # symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
-                cp -r ../../strato-worktree/blockapps-rest blockapps-rest
-                sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json
+                # oauth42style uses the old hardcoded ba-rest version
                 touch .env
                 yarn build
                 yarn install


### PR DESCRIPTION
In pipelines use the blockapps-rest bundled in the strato-patform branch for track-and-trace oauth test in the pipelines.
Successful build: https://jenkins.blockapps.net/job/STRATO_test/2904/

Next step would be to:
- use the bundled blockapps-rest in strato-platform/tests/package.json (needs to be updated with oauth first)
- apex should not use blockapps-rest at all (platform should not rely on blockapps-rest!)