### PR TITLE
STRATO-1770 remove unnecessary "error" calls in solidvm

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -621,7 +621,7 @@ expToPath (Xabi.Variable x) = do
       val <- weakGetVar var
       case val of
         SReference apt -> return apt
-        _ -> error "expToPath should never be called for a local variable"
+        _ -> typeError "expToPath should never be called for a local variable" ((show x) ++ " = " ++ show val)
     Nothing -> return $ AddressedPath (currentAddress callInfo) path
 expToPath x@(Xabi.IndexAccess parent mIndex) = do
   parPath  <- do
@@ -792,7 +792,7 @@ expToVar' (Xabi.MemberAccess expr name) = do
           _ -> return . Constant . SReference . apSnoc apt $ MS.Field "length"
 
       (SReference p, itemName) -> return . Constant . SReference $ apSnoc p $ MS.Field $ BC.pack itemName
-      _ -> typeError "unhandled case in expToVar' for MemberAccess: " (show val)
+      _ -> typeError "SolidVM: Illegal member access" ((show val) ++ "." ++ name)
 {-
     Variable vref -> do
       val' <- liftIO $ readIORef vref
@@ -840,7 +840,7 @@ expToVar' x@(Xabi.IndexAccess parent (Just mIndex)) = do
         (SArray _ theVector, SInteger i) -> do
           return $ theVector V.! fromIntegral i
         (SReference _, _) -> Constant . SReference <$> expToPath x
-        _ -> error $ "expToVar' called for IndexAccess with unsupported types:\nval = " ++ show val ++ "\ntheIndex = " ++ show theIndex
+        _ -> typeError "expToVar' called for IndexAccess with unsupported types: " ("\nval = " ++ show val ++ "\ntheIndex = " ++ show theIndex)
 --    _ -> error $ "unknown case in expToVar' for IndexAccess: " ++ show var
 
 

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -604,7 +604,7 @@ getIndexType (AddressedPath addr p) = do
          Xabi.Mapping{Xabi.key=Xabi.Address{}} -> MapAddressIndex
          Xabi.Mapping{Xabi.key=Xabi.Bool{}} -> MapBoolIndex
          Xabi.Array{} -> ArrayIndex
-         _ -> todo "unanticipated index type" t
+         _ -> typeError "unanticipated index type" t
        loop n t = case t of
          Xabi.Mapping{Xabi.value=t'} -> loop (n - 1) t'
          Xabi.Array{Xabi.entry=t'} -> loop (n - 1) t'

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -574,7 +574,7 @@ runStatement st@(Xabi.EmitStatement eventName exptups) = do
         return Nothing
 
 
-runStatement x = error $ "unknown statement in call to runStatement: " ++ show x
+runStatement x = unknownStatement "unknown statement in call to runStatement: " (show x)
 
 while :: MonadSM m => m Bool -> m (Maybe Value) -> m (Maybe Value)
 while condition code = do
@@ -792,7 +792,7 @@ expToVar' (Xabi.MemberAccess expr name) = do
           _ -> return . Constant . SReference . apSnoc apt $ MS.Field "length"
 
       (SReference p, itemName) -> return . Constant . SReference $ apSnoc p $ MS.Field $ BC.pack itemName
-      _ -> error $ "unhandled case in expToVar' for MemberAccess: " ++ show val
+      _ -> typeError "unhandled case in expToVar' for MemberAccess: " (show val)
 {-
     Variable vref -> do
       val' <- liftIO $ readIORef vref

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -65,6 +65,10 @@ anyUnknownFunc :: Selector HandledException
 anyUnknownFunc (HE UnknownFunction{}) = True
 anyUnknownFunc _ = False
 
+anyTypeError :: Selector HandledException
+anyTypeError (HE Blockchain.SolidVM.Exception.TypeError{}) = True
+anyTypeError _ = False
+
 sender :: Address
 sender = 0xdeadbeef
 
@@ -2185,3 +2189,15 @@ contract qq {
   }
 }|]
     getFields ["x"] `shouldReturn` [BInteger 833]
+
+  it "rejects member access on primitives" $ (runTest (runBS [r|
+contract qq {
+  uint x = 0;
+  uint y = x.mem;
+}|])) `shouldThrow` anyTypeError
+
+  it "rejects index access on primitives" $ (runTest (runBS [r|
+contract qq {
+  uint x = 0;
+  uint y = x[1];
+}|])) `shouldThrow` anyTODO

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -2200,4 +2200,4 @@ contract qq {
 contract qq {
   uint x = 0;
   uint y = x[1];
-}|])) `shouldThrow` anyTODO
+}|])) `shouldThrow` anyTypeError

--- a/core-strato/vm-tools/src/Blockchain/VM/SolidException.hs
+++ b/core-strato/vm-tools/src/Blockchain/VM/SolidException.hs
@@ -13,6 +13,7 @@ module Blockchain.VM.SolidException
   , unknownFunction
   , unknownConstant
   , unknownVariable
+  , unknownStatement
   ) where
 
 import Control.DeepSeq
@@ -34,6 +35,7 @@ data SolidException = TypeError String String
                     | UnknownFunction String String
                     | UnknownConstant String String
                     | UnknownVariable String String
+                    | UnknownStatement String String
                     deriving (Eq, Exception, Generic, NFData)
 
 instance Show SolidException where
@@ -50,6 +52,7 @@ instance Show SolidException where
   show (UnknownConstant a b) = printf "unknown constant: %s: %s" a b
   show (UnknownFunction a b) = printf "unknown function: %s: %s" a b
   show (UnknownVariable a b) = printf "unknown variable: %s: %s" a b
+  show (UnknownStatement a b) = printf "unknown statement: %s: %s" a b
 
 toThrower :: (Show v) => (String -> String -> SolidException) -> String -> v -> a
 toThrower cont msg = throw . cont msg . show
@@ -92,3 +95,6 @@ unknownConstant = toThrower UnknownConstant
 
 unknownVariable :: (Show v) => String -> v -> a
 unknownVariable = toThrower UnknownVariable
+
+unknownStatement :: (Show v) => String -> v -> a
+unknownStatement = toThrower UnknownVariable

--- a/core-strato/vm-tools/src/Blockchain/VM/SolidException.hs
+++ b/core-strato/vm-tools/src/Blockchain/VM/SolidException.hs
@@ -97,4 +97,4 @@ unknownVariable :: (Show v) => String -> v -> a
 unknownVariable = toThrower UnknownVariable
 
 unknownStatement :: (Show v) => String -> v -> a
-unknownStatement = toThrower UnknownVariable
+unknownStatement = toThrower UnknownStatement


### PR DESCRIPTION
Some user errors in SolidVM were being handled with "error" (notably, illegal member accesses, as discovered by a crash in the partner network). I removed all calls to "error" for user errors and replaced them with appropriate SolidVMExceptions. Some calls to "error" remain, for the theoretically impossible errors 