### PR TITLE
STRATO-1893 fix smd api urls when strato is running on custom port

### DIFF
--- a/smd-ui/src/components/Accounts/accounts.saga.js
+++ b/smd-ui/src/components/Accounts/accounts.saga.js
@@ -61,7 +61,7 @@ export function getAccountsApi() {
 
 export function getUserAddressesApi(username) {
   const options = { params: { user: username } };
-  const url = env.BLOC_URL + createUrl("/users/:user", options);
+  const url = env.BLOC_URL + createUrl("/users/::user", options);
 
   return fetch(
     url,
@@ -107,7 +107,7 @@ export function getAccountDetailApi(address, chainid) {
 
 export function postFaucet(username, address) {
   const options = { params: { user: username, address }, query: { resolve: true } };
-  const url = env.BLOC_URL + createUrl("/users/:user/:address/fill", options);
+  const url = env.BLOC_URL + createUrl("/users/::user/::address/fill", options);
 
   return fetch(
     url,

--- a/smd-ui/src/components/Accounts/components/OauthAccounts/oauthAccounts.saga.js
+++ b/smd-ui/src/components/Accounts/components/OauthAccounts/oauthAccounts.saga.js
@@ -21,7 +21,7 @@ const accountDataUrl = env.STRATO_URL + "/account";
 
 export function postFaucet(username, address) {
   const options = { params: { user: username, address }, query: { resolve: true } };
-  const url = env.BLOC_URL + createUrl("/users/:user/:address/fill", options);
+  const url = env.BLOC_URL + createUrl("/users/::user/::address/fill", options);
 
   return fetch(
     url,

--- a/smd-ui/src/components/Accounts/components/SendTokens/sendTokens.saga.js
+++ b/smd-ui/src/components/Accounts/components/SendTokens/sendTokens.saga.js
@@ -14,7 +14,7 @@ import { handleErrors } from '../../../../lib/handleErrors';
 import { isOauthEnabled } from '../../../../lib/checkMode';
 import { createUrl } from '../../../../lib/url';
 
-const blocSendUrl = env.BLOC_URL + "/users/:user/:address/send";
+const blocSendUrl = env.BLOC_URL + "/users/::user/::address/send";
 const transactionUrl = env.STRATO_URL_V23 + "/transaction";
 
 export function sendTokensAPICall(from, fromAddress, toAddress, value, password, chainid) {

--- a/smd-ui/src/components/ContractQuery/contractQuery.saga.js
+++ b/smd-ui/src/components/ContractQuery/contractQuery.saga.js
@@ -45,7 +45,7 @@ export function queryCirrusRequest(name, queryString, chainId) {
 
 export function queryCirrusVarsRequest(contractName) {
   const options = { params: { contractName } };
-  const url = env.BLOC_URL + createUrl('/contracts/:contractName/Latest', options);
+  const url = env.BLOC_URL + createUrl('/contracts/::contractName/Latest', options);
 
   return fetch(
     url,

--- a/smd-ui/src/components/Contracts/components/ContractCard/contractCard.saga.js
+++ b/smd-ui/src/components/Contracts/components/ContractCard/contractCard.saga.js
@@ -20,7 +20,7 @@ import { createUrl } from '../../../../lib/url';
 
 export function getState(contractName, contractAddress, chainid) {
   const options = { params: { contractName, contractAddress }, query: { chainid } };
-  const url = env.BLOC_URL + createUrl("/contracts/:contractName/:contractAddress/state", options);
+  const url = env.BLOC_URL + createUrl("/contracts/::contractName/::contractAddress/state", options);
 
   return fetch(
     url,
@@ -42,7 +42,7 @@ export function getState(contractName, contractAddress, chainid) {
 
 export function getCirrusInstances(contractName) {
   const options = { params: { contractName } };
-  const url = env.CIRRUS_URL + createUrl("/:contractName", options);
+  const url = env.CIRRUS_URL + createUrl("/::contractName", options);
 
   return fetch(
     url,

--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.saga.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.saga.js
@@ -19,7 +19,7 @@ import { isOauthEnabled } from '../../../../lib/checkMode';
 
 export function getArgs(contractName, contractAddress, symbol, chainid) {
   const options = { params: { contractName, contractAddress }, query: { chainid } };
-  const url = env.BLOC_URL + createUrl("/contracts/:contractName/:contractAddress", options);
+  const url = env.BLOC_URL + createUrl("/contracts/::contractName/::contractAddress", options);
 
   return fetch(
     url,
@@ -52,7 +52,7 @@ export function postMethodCall(payload) {
     };
 
   const prefix = isModeOauth ? env.STRATO_URL_V23 : env.BLOC_URL;
-  const url = prefix + createUrl(isModeOauth ? '/transaction' : '/users/:username/:userAddress/contract/:contractName/:contractAddress/call', options);
+  const url = prefix + createUrl(isModeOauth ? '/transaction' : '/users/::username/::userAddress/contract/::contractName/::contractAddress/call', options);
 
   const blocBody = {
     password: payload.password,

--- a/smd-ui/src/components/CreateBlocUser/createBlocUser.saga.js
+++ b/smd-ui/src/components/CreateBlocUser/createBlocUser.saga.js
@@ -19,7 +19,7 @@ import { createUrl } from '../../lib/url';
 
 export function createBlocUserApiCall(username, password) {
   const options = { params: { username } };
-  const url = env.BLOC_URL + createUrl("/users/:username", options);
+  const url = env.BLOC_URL + createUrl("/users/::username", options);
 
   return fetch(
     url,

--- a/smd-ui/src/components/CreateContract/createContract.saga.js
+++ b/smd-ui/src/components/CreateContract/createContract.saga.js
@@ -25,7 +25,7 @@ export function createContractApiCall(contract, src, username, address, password
   const isOauth = isOauthEnabled();
   const options = isOauth ? { query: { resolve: true, chainid } } : { params: { username, address }, query: { resolve: true, chainid } };
   const prefix = isOauth ? env.STRATO_URL_V23 : env.BLOC_URL;
-  const url = prefix + createUrl(isOauth ? "/transaction" : "/users/:username/:address/contract", options);
+  const url = prefix + createUrl(isOauth ? "/transaction" : "/users/::username/::address/contract", options);
 
   const blocBody = { contract, value: 0, password, src, args, metadata };
   const oauthBody = {

--- a/smd-ui/src/lib/url.js
+++ b/smd-ui/src/lib/url.js
@@ -6,7 +6,7 @@
 export function createUrl(url, options = {}) {
   const { params, query } = options;
 
-  const withParams = params ? url.replace(/:(\w+)/g, (_, key) => {
+  const withParams = params ? url.replace(/::(\w+)/g, (_, key) => {
     return params[key];
   }) : url;
 

--- a/smd-ui/src/tests/lib/url.spec.js
+++ b/smd-ui/src/tests/lib/url.spec.js
@@ -3,7 +3,7 @@ import { createUrl } from '../../lib/url';
 describe('Lib: url', () => {
 
   test('create url', () => {
-    const baseUrl = 'http://localhost/user/:username/:address';
+    const baseUrl = 'http://localhost/user/::username/::address';
     const options = { params: { username: 'clinicalops', address: '0X22255555' }, query: { chainid: '54216454215454', resolve: true } };
     expect(createUrl(baseUrl, options)).toMatchSnapshot();
   });
@@ -15,7 +15,7 @@ describe('Lib: url', () => {
   });
 
   test('create url (params only)', () => {
-    const baseUrl = 'http://localhost/user/:username/:address';
+    const baseUrl = 'http://localhost/user/::username/::address';
     const options = { params: { username: 'clinicalops', address: '0X22255555' } };
     expect(createUrl(baseUrl, options)).toMatchSnapshot();
   });
@@ -25,7 +25,7 @@ describe('Lib: url', () => {
      HERE: If chainid is null that will not be appended as a query
      Also: resolve: false will not be append as a query
     */
-    const baseUrl = 'http://localhost/user/:username/:address';
+    const baseUrl = 'http://localhost/user/::username/::address';
     const options = { params: { username: 'clinicalops', address: '0X22255555' }, query: { chainid: null, resolve: false } };
     expect(createUrl(baseUrl, options)).toMatchSnapshot();
   });


### PR DESCRIPTION
This fixes the Faucet button under Account tab in SMD when running STRATO on custom port.

There was a problem with placeholders using the single colon when using the custom port (localhost:8080) - the createUrl was replacing the port `:8080` with `undefined`.
I changed the placeholders to use `::`.