### PR TITLE
Break ChainDetails messages up, and remove bloated logging of chain infos

### DIFF
--- a/core-strato/strato-p2p/src/Blockchain/Display.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Display.hs
@@ -42,5 +42,9 @@ displayMessage dir peerName (BlockBodies bodies) = do
     ++ "(" ++ show (length bodies)
     ++ " bodies, includes " ++ show transactionCount
     ++ " transaction" ++ (if transactionCount == 1 then "" else "s") ++ ")"
+displayMessage dir peerName (ChainDetails cInfos) = do
+  let chainIds = fst <$> cInfos
+  $logInfoS "displayMessage" $ T.pack $ prefix dir peerName ++ CL.blue "ChainDetails: "
+    ++ concat (map (\cId -> "\n  " ++ format cId) chainIds)
 displayMessage dir peerName msg =
   $logInfoS "displayMessage" $ T.pack $ (prefix dir peerName) ++ format msg

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -460,7 +460,7 @@ handleGetChainDetails peer cids' = do
 
   unless (null filteredPairs) $ do
     cInfos <- fmap M.toList . lift $ selectMany (Proxy @ChainInfo) cids
-    yieldR $ ChainDetails cInfos
+    for_ cInfos $ yieldR . ChainDetails . (:[])
     lift stampActionTimestamp
     $logInfoS "handleGetChainDetails" $ T.pack $ "the following ChainIds were returned " ++
       (intercalate "\n" $ formatChainId . Just . fst <$> cInfos)


### PR DESCRIPTION
This limits each `ChainDetails` message to one chain info, so the TCP limit should never be reached (unless there is a very, very big chain info). Also, the `displayMessage` function was logging the entire chain info, so I changed it to only log the chain ID.