### PR TITLE
Better gossip

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -54,6 +54,9 @@ function newnode {
   if [ -n "${participationMode}" ]; then
     pmFlag="--participationMode=${participationMode}"
   fi
+  if [ -n "${wireMessageCacheSize}" ]; then
+    cacheFlag="--wireMessageCacheSize=${wireMessageCacheSize}"
+  fi
 
   echo "Starting strato-p2p"
   runBackgroundProcess strato-p2p \
@@ -67,6 +70,7 @@ function newnode {
      ${atbFlag} \
      ${pcamFlag} \
      ${pmFlag} \
+     ${cacheFlag} \
      &>> logs/strato-p2p
 
   evmMinLogLevel=LevelInfo

--- a/core-strato/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/core-strato/strato-p2p/exec_src/StratoP2PMain.hs
@@ -13,6 +13,8 @@ import           Executable.StratoP2PClient
 import           Executable.StratoP2PServer
 import           Executable.StratoP2PLoopback
 import           BlockApps.Init
+import           Data.IORef
+import           Data.Set.Ordered (empty)
 
 main :: IO ()
 main = do
@@ -20,9 +22,10 @@ main = do
   resetPeers
   _ <- $initHFlags "Strato P2P"
   setParticipationMode flags_participationMode
+  wireMessagesRef <- newIORef empty
   race_
     (run 10248 $ prometheus def p2pApp)
     (runLoggingT $
-      race_ stratoP2PLoopback
-        (race_ stratoP2PClient
-               stratoP2PServer))
+      race_ (stratoP2PLoopback wireMessagesRef)
+        (race_ (stratoP2PClient wireMessagesRef)
+               (stratoP2PServer wireMessagesRef)))

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -73,6 +73,7 @@ library:
     - monadIO
     - mtl
     - network
+    - ordered-containers
     - persistent
     - prometheus-client
     - random
@@ -120,6 +121,7 @@ tests:
       - lens
       - monad-alter
       - mtl
+      - ordered-containers
       - resourcet
       - seqevents
       - stm-chans

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -130,6 +130,7 @@ tests:
       - strato-model
       - strato-p2p
       - strato-sequencer
+      - text
       - transformers
       - unliftio
   

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -29,6 +29,7 @@ executables:
     dependencies:
       - blockapps-init
       - lifted-async
+      - ordered-containers
       - strato-p2p
       - wai-middleware-prometheus
       - warp

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -38,7 +38,7 @@ import           UnliftIO.Exception
 import           UnliftIO.STM
 
 import           Blockchain.Constants                  hiding (ethVersion)
-import           Blockchain.Context
+import           Blockchain.Context                    hiding (Inbound, Outbound)
 import           Blockchain.Data.Block
 import           Blockchain.Data.Control               (P2PCNC(..))
 import           Blockchain.Data.RLP

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -250,7 +250,7 @@ instance MonadIO m => (Keccak256 `A.Alters` (Proxy (Inbound WireMessage))) (Read
     pure $ if b then Just (Proxy @(Inbound WireMessage)) else Nothing
   insert _ k _ = asks configBlockstanbulWireMessages >>= flip atomicModifyIORef' (\wms ->
     let s = S.size wms
-        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+        wms' = if s >= flags_wireMessageCacheSize then S.delete (head $ toList wms) wms else wms
         wms'' = wms' S.>| k
      in (wms'', ()))
   delete _ k = asks configBlockstanbulWireMessages >>= flip atomicModifyIORef' (\wms ->
@@ -265,7 +265,7 @@ instance MonadIO m => ((T.Text, Keccak256) `A.Alters` (Proxy (Outbound WireMessa
   insert _ k _ = Mod.modifyStatefully_ (Mod.Proxy @Context) $ do
     wms <- use outboundWireMessages
     let s = S.size wms
-        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+        wms' = if s >= flags_wireMessageCacheSize then S.delete (head $ toList wms) wms else wms
         wms'' = wms' S.>| k
     assign outboundWireMessages wms''
   delete _ k = Mod.modifyStatefully_ (Mod.Proxy @Context) $

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -22,6 +22,8 @@ module Blockchain.Context
     , Stacks(..)
     , MonadP2P
     , TcpPortNumber(..)
+    , Inbound(..)
+    , Outbound(..)
     , Context(..)
     , Config(..)
     , ContextM
@@ -126,6 +128,9 @@ class Stacks a m where
 
 newtype TcpPortNumber = TcpPortNumber { unTcpPortNumber :: Int }
 
+newtype Inbound a = Inbound { unInbound :: a }
+newtype Outbound a = Outbound { unOutbound :: a }
+
 data Config = Config
   { configSQLDB              :: SQLDB
   , configRedisBlockDB       :: RBDB.RedisConnection
@@ -157,6 +162,7 @@ data Context = Context
   , remainingBlockHeaders :: RemainingBlockHeaders
   , actionTimestamp       :: ActionTimestamp
   , _blockstanbulPeerAddr :: PeerAddress
+  , _outboundWireMessages :: S.OSet (T.Text, Keccak256)
   }
 
 makeLenses ''Context
@@ -237,11 +243,11 @@ instance MonadIO m => (Keccak256 `A.Alters` OutputBlock) (ReaderT Config m) wher
   insertMany _ = void . RBDB.withRedisBlockDB . RBDB.insertBlocks
   deleteMany _ = void . RBDB.withRedisBlockDB . RBDB.deleteBlocks
 
-instance MonadIO m => (Keccak256 `A.Alters` (Proxy WireMessage)) (ReaderT Config m) where
+instance MonadIO m => (Keccak256 `A.Alters` (Proxy (Inbound WireMessage))) (ReaderT Config m) where
   lookup _  k = do
     wms <- readIORef =<< asks configBlockstanbulWireMessages
     let b = S.member k wms
-    pure $ if b then Just (Proxy @WireMessage) else Nothing
+    pure $ if b then Just (Proxy @(Inbound WireMessage)) else Nothing
   insert _ k _ = asks configBlockstanbulWireMessages >>= flip atomicModifyIORef' (\wms ->
     let s = S.size wms
         wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
@@ -250,6 +256,20 @@ instance MonadIO m => (Keccak256 `A.Alters` (Proxy WireMessage)) (ReaderT Config
   delete _ k = asks configBlockstanbulWireMessages >>= flip atomicModifyIORef' (\wms ->
     let wms' = S.delete k wms
      in (wms', ()))
+
+instance MonadIO m => ((T.Text, Keccak256) `A.Alters` (Proxy (Outbound WireMessage))) (ReaderT Config m) where
+  lookup _  k = do
+    wms <- _outboundWireMessages <$> Mod.get (Mod.Proxy @Context)
+    let b = S.member k wms
+    pure $ if b then Just (Proxy @(Outbound WireMessage)) else Nothing
+  insert _ k _ = Mod.modifyStatefully_ (Mod.Proxy @Context) $ do
+    wms <- use outboundWireMessages
+    let s = S.size wms
+        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+        wms'' = wms' S.>| k
+    assign outboundWireMessages wms''
+  delete _ k = Mod.modifyStatefully_ (Mod.Proxy @Context) $
+    outboundWireMessages %= S.delete k
 
 instance ( MonadIO m
          , MonadUnliftIO m
@@ -364,7 +384,8 @@ type MonadP2P m = ( MonadIO m
                   , All2 '[A.Alters]
                       '[ '(Keccak256, BlockData)
                        , '(Keccak256, OutputBlock)
-                       , '(Keccak256, Proxy WireMessage)
+                       , '(Keccak256, Proxy (Inbound WireMessage))
+                       , '((T.Text, Keccak256), Proxy (Outbound WireMessage))
                        ] m
                   )
 
@@ -424,6 +445,7 @@ initContext = Context
   , remainingBlockHeaders = RemainingBlockHeaders []
   , vmTrace=[]
   , _blockstanbulPeerAddr = PeerAddress Nothing
+  , _outboundWireMessages = S.empty
   }
 
 

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -37,6 +37,7 @@ module Blockchain.Context
     , initContext
     , runContextM
     , blockstanbulPeerAddr
+    , blockstanbulWireMessages
     , getBlockHeaders
     , putBlockHeaders
     , getRemainingBHeaders
@@ -59,13 +60,16 @@ import qualified Control.Monad.Change.Modify           as Mod
 import           Blockchain.Output
 import           Control.Monad.Reader
 import           Data.Default
+import           Data.Foldable                         (toList)
 import qualified Data.Map.Strict                       as M
 import           Data.Maybe
 import           Data.Proxy
+import qualified Data.Set.Ordered                      as S
 import qualified Data.Text                             as T
 import           Data.Time.Clock
 import           GHC.Exts                              (Constraint)
 
+import           Blockchain.Blockstanbul               (WireMessage)
 import           Blockchain.Data.Address
 import           Blockchain.Data.Block
 import           Blockchain.Data.ChainInfo
@@ -153,6 +157,7 @@ data Context = Context
   , remainingBlockHeaders :: RemainingBlockHeaders
   , actionTimestamp       :: ActionTimestamp
   , _blockstanbulPeerAddr :: PeerAddress
+  , _blockstanbulWireMessages :: S.OSet Keccak256
   }
 
 makeLenses ''Context
@@ -232,6 +237,21 @@ instance MonadIO m => (Keccak256 `A.Alters` OutputBlock) (ReaderT Config m) wher
                . RBDB.withRedisBlockDB . RBDB.getBlocks
   insertMany _ = void . RBDB.withRedisBlockDB . RBDB.insertBlocks
   deleteMany _ = void . RBDB.withRedisBlockDB . RBDB.deleteBlocks
+
+instance MonadIO m => (Keccak256 `A.Alters` (Proxy WireMessage)) (ReaderT Config m) where
+  lookup _  k = do
+    ctx <- readIORef =<< asks configContext
+    let b = S.member k $ _blockstanbulWireMessages ctx
+    pure $ if b then Just (Proxy @WireMessage) else Nothing
+  insert _ k _ = asks configContext >>= flip atomicModifyIORef' (\ctx ->
+    let wms = _blockstanbulWireMessages ctx
+        s = S.size wms
+        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+        wms'' = wms' S.>| k
+     in (ctx{_blockstanbulWireMessages = wms''}, ()))
+  delete _ k = asks configContext >>= flip atomicModifyIORef' (\ctx ->
+    let wms = S.delete k $ _blockstanbulWireMessages ctx
+     in (ctx{_blockstanbulWireMessages = wms}, ()))
 
 instance ( MonadIO m
          , MonadUnliftIO m
@@ -346,6 +366,7 @@ type MonadP2P m = ( MonadIO m
                   , All2 '[A.Alters]
                       '[ '(Keccak256, BlockData)
                        , '(Keccak256, OutputBlock)
+                       , '(Keccak256, Proxy WireMessage)
                        ] m
                   )
 
@@ -404,6 +425,7 @@ initContext = Context
   , remainingBlockHeaders = RemainingBlockHeaders []
   , vmTrace=[]
   , _blockstanbulPeerAddr = PeerAddress Nothing
+  , _blockstanbulWireMessages = S.empty
   }
 
 

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -37,7 +37,6 @@ module Blockchain.Context
     , initContext
     , runContextM
     , blockstanbulPeerAddr
-    , blockstanbulWireMessages
     , getBlockHeaders
     , putBlockHeaders
     , getRemainingBHeaders
@@ -135,6 +134,7 @@ data Config = Config
   , configConnectionTimeout  :: ConnectionTimeout
   , configMaxReturnedHeaders :: MaxReturnedHeaders
   , configContext            :: IORef Context
+  , configBlockstanbulWireMessages :: IORef (S.OSet Keccak256)
   }
 
 newtype ActionTimestamp = ActionTimestamp { unActionTimestamp :: Maybe UTCTime }
@@ -157,7 +157,6 @@ data Context = Context
   , remainingBlockHeaders :: RemainingBlockHeaders
   , actionTimestamp       :: ActionTimestamp
   , _blockstanbulPeerAddr :: PeerAddress
-  , _blockstanbulWireMessages :: S.OSet Keccak256
   }
 
 makeLenses ''Context
@@ -240,18 +239,17 @@ instance MonadIO m => (Keccak256 `A.Alters` OutputBlock) (ReaderT Config m) wher
 
 instance MonadIO m => (Keccak256 `A.Alters` (Proxy WireMessage)) (ReaderT Config m) where
   lookup _  k = do
-    ctx <- readIORef =<< asks configContext
-    let b = S.member k $ _blockstanbulWireMessages ctx
+    wms <- readIORef =<< asks configBlockstanbulWireMessages
+    let b = S.member k wms
     pure $ if b then Just (Proxy @WireMessage) else Nothing
-  insert _ k _ = asks configContext >>= flip atomicModifyIORef' (\ctx ->
-    let wms = _blockstanbulWireMessages ctx
-        s = S.size wms
+  insert _ k _ = asks configBlockstanbulWireMessages >>= flip atomicModifyIORef' (\wms ->
+    let s = S.size wms
         wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
         wms'' = wms' S.>| k
-     in (ctx{_blockstanbulWireMessages = wms''}, ()))
-  delete _ k = asks configContext >>= flip atomicModifyIORef' (\ctx ->
-    let wms = S.delete k $ _blockstanbulWireMessages ctx
-     in (ctx{_blockstanbulWireMessages = wms}, ()))
+     in (wms'', ()))
+  delete _ k = asks configBlockstanbulWireMessages >>= flip atomicModifyIORef' (\wms ->
+    let wms' = S.delete k wms
+     in (wms', ()))
 
 instance ( MonadIO m
          , MonadUnliftIO m
@@ -402,8 +400,8 @@ runContextM r = void . runResourceT . flip runReaderT r
 initConfig :: ( MonadLogger m
               , MonadUnliftIO m
               )
-           => Int -> m Config
-initConfig maxHeaders = do
+           => IORef (S.OSet Keccak256) -> Int -> m Config
+initConfig wireMessagesRef maxHeaders = do
   dbs <- openDBs
   redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
   initState <- newIORef initContext
@@ -415,6 +413,7 @@ initConfig maxHeaders = do
     , configConnectionTimeout = ConnectionTimeout flags_connectionTimeout
     , configMaxReturnedHeaders = MaxReturnedHeaders maxHeaders
     , configContext = initState
+    , configBlockstanbulWireMessages = wireMessagesRef
     }
 
 initContext :: Context
@@ -425,7 +424,6 @@ initContext = Context
   , remainingBlockHeaders = RemainingBlockHeaders []
   , vmTrace=[]
   , _blockstanbulPeerAddr = PeerAddress Nothing
-  , _blockstanbulWireMessages = S.empty
   }
 
 

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -325,7 +325,7 @@ handleEvents peer = awaitForever $ \case
       msgExists <- lift $ exists (Proxy @(Proxy (Inbound WireMessage))) msgHash
       if msgExists
         then $logInfoS "handleEvents/Blockstanbul" . T.pack $ concat
-               [ "Already seen wire message "
+               [ "Already seen inbound wire message "
                , format msgHash
                , ". Not forwarding to Sequencer."
                ]
@@ -411,15 +411,15 @@ handleEvents peer = awaitForever $ \case
         lift $ insert (Proxy @(Proxy (Inbound WireMessage))) msgHash Proxy
         msgExists <- lift $ exists (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash)
         if msgExists
-          then $logInfoS "handleEvents/Blockstanbul" $ T.concat
+          then $logInfoS "handleEvents/P2pBlockstanbul" $ T.concat
                  [ "Already seen outbound wire message "
                  , T.pack (format msgHash)
                  , ". Not forwarding to peer "
                  , pPeerIp peer
                  ]
           else do
-            $logInfoS "handleEvents/Blockstanbul" $ T.concat
-              [ "First time seeing wire message "
+            $logInfoS "handleEvents/P2pBlockstanbul" $ T.concat
+              [ "First time seeing outbound wire message "
               , T.pack (format msgHash)
               , ". Forwarding to peer "
               , pPeerIp peer

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -322,9 +322,12 @@ handleEvents peer = awaitForever $ \case
         $logInfoS "handleEvents/Blockstanbul" . T.pack $ "blockstanbulPeerAddr: " ++ show peerAddr
       let msgHash = rlpHash wm
       msgExists <- lift $ exists (Proxy @(Proxy WireMessage)) msgHash
-      unless msgExists $ do
-        lift $ insert (Proxy @(Proxy WireMessage)) msgHash (Proxy @WireMessage)
-        yieldL $ ToUnseq [IEBlockstanbul wm]
+      if msgExists
+        then $logInfoS "handleEvents/Blockstanbul" . T.pack $ "Already seen wire message " ++ format msgHash ++ ". Not forwarding to Sequencer."
+        else do
+          $logInfoS "handleEvents/Blockstanbul" . T.pack $ "First time seeing wire message " ++ format msgHash ++ ". Forwarding to Sequencer."
+          lift $ insert (Proxy @(Proxy WireMessage)) msgHash (Proxy @WireMessage)
+          yieldL $ ToUnseq [IEBlockstanbul wm]
 
     -- private chains
     MsgEvt (GetChainDetails cids') -> handleGetChainDetails peer $ S.fromList cids'

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -30,7 +30,7 @@ import           Data.Conduit
 import           Data.Default                          (def)
 import           Data.Foldable                         (for_)
 import qualified Data.DList                            as DL
-import           Data.List                             hiding (lookup)
+import           Data.List                             hiding (insert, lookup)
 import           Data.Map.Internal                     (WhenMissing(..), WhenMatched(..))
 import           Data.Map.Merge.Strict
 import qualified Data.Map.Strict                       as M
@@ -47,7 +47,7 @@ import           System.Random
 import           Text.Printf
 import           UnliftIO.Exception
 
-import           Blockchain.Blockstanbul               (blockstanbulSender)
+import           Blockchain.Blockstanbul               (blockstanbulSender, WireMessage)
 import           Blockchain.Context
 import           Blockchain.Data.Block
 import           Blockchain.Data.BlockDB
@@ -320,7 +320,11 @@ handleEvents peer = awaitForever $ \case
         setPeerAddrIfUnset $ blockstanbulSender wm
         peerAddr <- unPeerAddress <$> access (Proxy @PeerAddress)
         $logInfoS "handleEvents/Blockstanbul" . T.pack $ "blockstanbulPeerAddr: " ++ show peerAddr
-      yieldL $ ToUnseq [IEBlockstanbul wm]
+      let msgHash = rlpHash wm
+      msgExists <- lift $ exists (Proxy @(Proxy WireMessage)) msgHash
+      unless msgExists $ do
+        lift $ insert (Proxy @(Proxy WireMessage)) msgHash (Proxy @WireMessage)
+        yieldL $ ToUnseq [IEBlockstanbul wm]
 
     -- private chains
     MsgEvt (GetChainDetails cids') -> handleGetChainDetails peer $ S.fromList cids'

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -321,12 +321,21 @@ handleEvents peer = awaitForever $ \case
         peerAddr <- unPeerAddress <$> access (Proxy @PeerAddress)
         $logInfoS "handleEvents/Blockstanbul" . T.pack $ "blockstanbulPeerAddr: " ++ show peerAddr
       let msgHash = rlpHash wm
-      msgExists <- lift $ exists (Proxy @(Proxy WireMessage)) msgHash
+      lift $ insert (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash) Proxy
+      msgExists <- lift $ exists (Proxy @(Proxy (Inbound WireMessage))) msgHash
       if msgExists
-        then $logInfoS "handleEvents/Blockstanbul" . T.pack $ "Already seen wire message " ++ format msgHash ++ ". Not forwarding to Sequencer."
+        then $logInfoS "handleEvents/Blockstanbul" . T.pack $ concat
+               [ "Already seen wire message "
+               , format msgHash
+               , ". Not forwarding to Sequencer."
+               ]
         else do
-          $logInfoS "handleEvents/Blockstanbul" . T.pack $ "First time seeing wire message " ++ format msgHash ++ ". Forwarding to Sequencer."
-          lift $ insert (Proxy @(Proxy WireMessage)) msgHash (Proxy @WireMessage)
+          $logInfoS "handleEvents/Blockstanbul" . T.pack $ concat 
+            [ "First time seeing inbound wire message "
+            , format msgHash
+            , ". Forwarding to Sequencer."
+            ]
+          lift $ insert (Proxy @(Proxy (Inbound WireMessage))) msgHash Proxy
           yieldL $ ToUnseq [IEBlockstanbul wm]
 
     -- private chains
@@ -398,7 +407,25 @@ handleEvents peer = awaitForever $ \case
       P2pBlockstanbul msg -> do
         let outbound = Blockstanbul msg
         $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
-        yieldR outbound
+        let msgHash = rlpHash msg
+        lift $ insert (Proxy @(Proxy (Inbound WireMessage))) msgHash Proxy
+        msgExists <- lift $ exists (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash)
+        if msgExists
+          then $logInfoS "handleEvents/Blockstanbul" $ T.concat
+                 [ "Already seen outbound wire message "
+                 , T.pack (format msgHash)
+                 , ". Not forwarding to peer "
+                 , pPeerIp peer
+                 ]
+          else do
+            $logInfoS "handleEvents/Blockstanbul" $ T.concat
+              [ "First time seeing wire message "
+              , T.pack (format msgHash)
+              , ". Forwarding to peer "
+              , pPeerIp peer
+              ]
+            lift $ insert (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash) Proxy
+            yieldR outbound
       P2pAskForBlocks start _ p -> do
         ss <- lift $ shouldSendToPeer p
         when ss $ do

--- a/core-strato/strato-p2p/src/Blockchain/Options.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Options.hs
@@ -22,6 +22,7 @@ defineFlag "connectionTimeout" (300 :: Int) "Number of seconds to tolerate a use
 defineFlag "maxReturnedHeaders" (1000 :: Int) "Number of headers to return from a GetBlockHeaders request" -- todo: seriously???
 defineFlag "maxHeadersTxsLens" (2500 :: Int) "Number of txs size to return from a BlockHeader request"
 defineFlag "averageTxsPerBlock" (40 :: Int) "Average number of txs per block"
+defineFlag "wireMessageCacheSize" (2000 :: Int) "Number of wire messages to cache for network performance"
 defineFlag "txGossipFanout" (-1::Int) "Maxmimum number of peers to forward transactions to. Only\
                                       \ applicable for transactions received from peers, not\
                                       \ originating on this node."

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -31,6 +31,7 @@ import           Data.Conduit
 import           Data.Conduit.Network
 import           Data.Either.Combinators
 import           Data.Maybe
+import qualified Data.Set.Ordered                      as S
 import qualified Data.Text                             as T
 import           Data.Traversable                      (for)
 import qualified Network.Haskoin.Internals             as H
@@ -50,19 +51,21 @@ import           Blockchain.SeqEventNotify
 import           Blockchain.Sequencer.Event
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Strato.Discovery.UDP
+import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.TCPClientWithTimeout
 
 import qualified Text.Colors                           as C
 import           Text.Format
 
 runPeer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
-        => PPeer
+        => IORef (S.OSet Keccak256)
+        -> PPeer
         -> PrivateNumber
         -> BC.ByteString -- otherServiceCommHost
         -> CommPort      -- otherServiceCommPort
         -> m ()
-runPeer peer myPriv _ _ = do
-  cfg <- initConfig flags_maxReturnedHeaders
+runPeer wireMessagesRef peer myPriv _ _ = do
+  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   runContextM cfg $ do
     ender <- toIO . $logInfoS "runPeer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
     void $ register ender
@@ -112,11 +115,12 @@ runEthClientConduit myPriv peer peerSource peerSink seqSource unseqSink peerStr 
                   .| peerSink
 
 getPubKeyRunPeer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
-                 => PPeer
+                 => IORef (S.OSet Keccak256)
+                 -> PPeer
                  -> BC.ByteString
                  -> CommPort
                  -> m ()
-getPubKeyRunPeer peer otherServiceCommHost otherServiceCommPort = do
+getPubKeyRunPeer wireMessagesRef peer otherServiceCommHost otherServiceCommPort = do
   let PrivKey myPriv = privKey ethConf
 
   case (pPeerPubkey peer) of
@@ -126,26 +130,27 @@ getPubKeyRunPeer peer otherServiceCommHost otherServiceCommPort = do
       case eitherOtherPubKey of
             Right otherPubKey -> do
               $logInfoS "getPubKeyRunPeer" $ T.pack $ "#### Success, the pubkey has been obtained: " ++ format otherPubKey
-              runPeer peer{pPeerPubkey=Just otherPubKey} myPriv otherServiceCommHost otherServiceCommPort
+              runPeer wireMessagesRef peer{pPeerPubkey=Just otherPubKey} myPriv otherServiceCommHost otherServiceCommPort
             Left e -> $logInfoS "getPubKeyRunPeer" $ T.pack $ "Error, couldn't get public key for peer: " ++ show e
-    Just _ -> runPeer peer myPriv otherServiceCommHost otherServiceCommPort
+    Just _ -> runPeer wireMessagesRef peer myPriv otherServiceCommHost otherServiceCommPort
 
 
 runPeerInList :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
-              => PPeer
+              => IORef (S.OSet Keccak256)
+              -> PPeer
               -> BC.ByteString
               -> CommPort
               -> m ()
-runPeerInList thePeer otherServiceHost otherServicePort = do
+runPeerInList wireMessagesRef thePeer otherServiceHost otherServicePort = do
   eErr <- liftIO $ nonviolentDisable thePeer --don't connect to a peer too frequently, out of politeness
   whenLeft eErr $ \err -> do
       $logErrorS "runPeerInList" . T.pack $ "Unable to disable peer:" ++ show err
       $logErrorS "runPeerInList" "Simulating disable..."
       liftIO $ threadDelay $ 10 * 1000 * 1000
-  getPubKeyRunPeer thePeer otherServiceHost otherServicePort
+  getPubKeyRunPeer wireMessagesRef thePeer otherServiceHost otherServicePort
 
-stratoP2PClient :: LoggingT IO ()
-stratoP2PClient = do
+stratoP2PClient :: IORef (S.OSet Keccak256) -> LoggingT IO ()
+stratoP2PClient wireMessagesRef = do
   $logInfoS "stratoP2PClient" $ T.pack $ "maxConn: " ++ show flags_maxConn
 
   activePeersSem <- liftIO (SSem.new flags_maxConn)
@@ -171,7 +176,7 @@ stratoP2PClient = do
           (liftIO (SSem.tryWait sem)) >>= \case
             Nothing -> return ()
             Just _  -> void . forkIO . runLoggingT $ do
-              result <- try $ runPeerInList p osch oscp
+              result <- try $ runPeerInList wireMessagesRef p osch oscp
               liftIO (SSem.signal sem)
               handleRunPeerResult p result
 

--- a/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -46,10 +46,10 @@ stratoP2PLoopback wireMessagesRef = do
             msgExists <- A.exists (A.Proxy @(A.Proxy (Inbound WireMessage))) msgHash
             if msgExists
               then do
-                $logInfoS "handleEvents/Blockstanbul" . T.pack $ "Already seen wire message " ++ format msgHash ++ ". Not forwarding to Sequencer."
+                $logInfoS "stratoP2PLoopback/P2pBlockstanbul" . T.pack $ "Already seen inbound wire message " ++ format msgHash ++ ". Not forwarding to Sequencer."
                 pure Nothing
               else do
-                $logInfoS "handleEvents/Blockstanbul" . T.pack $ "First time seeing wire message " ++ format msgHash ++ ". Forwarding to Sequencer."
+                $logInfoS "stratoP2PLoopback/P2pBlockstanbul" . T.pack $ "First time seeing inbound wire message " ++ format msgHash ++ ". Forwarding to Sequencer."
                 A.insert (A.Proxy @(A.Proxy (Inbound WireMessage))) msgHash A.Proxy
                 pure $ Just wm
           _ -> pure Nothing

--- a/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -43,14 +43,14 @@ stratoP2PLoopback wireMessagesRef = do
     let toWireMessage = \case
           P2pBlockstanbul wm -> do
             let msgHash = rlpHash wm
-            msgExists <- A.exists (A.Proxy @(A.Proxy WireMessage)) msgHash
+            msgExists <- A.exists (A.Proxy @(A.Proxy (Inbound WireMessage))) msgHash
             if msgExists
               then do
                 $logInfoS "handleEvents/Blockstanbul" . T.pack $ "Already seen wire message " ++ format msgHash ++ ". Not forwarding to Sequencer."
                 pure Nothing
               else do
                 $logInfoS "handleEvents/Blockstanbul" . T.pack $ "First time seeing wire message " ++ format msgHash ++ ". Forwarding to Sequencer."
-                A.insert (A.Proxy @(A.Proxy WireMessage)) msgHash (A.Proxy @WireMessage)
+                A.insert (A.Proxy @(A.Proxy (Inbound WireMessage))) msgHash A.Proxy
                 pure $ Just wm
           _ -> pure Nothing
 

--- a/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -6,17 +6,23 @@ module Executable.StratoP2PLoopback (stratoP2PLoopback) where
 
 import Conduit
 import Control.Monad
+import qualified Control.Monad.Change.Alter            as A
 import qualified Control.Monad.Change.Modify           as Mod
+import Data.IORef
+import qualified Data.Set.Ordered as S
 import qualified Data.Text as T
 import qualified Network.Kafka                         as K
 import Prometheus
+import Text.Format
 
 import BlockApps.Logging
+import Blockchain.Blockstanbul (WireMessage)
 import Blockchain.Context
 import Blockchain.Options
 import Blockchain.SeqEventNotify
 import Blockchain.Sequencer.Event
 import Blockchain.Sequencer.Kafka
+import Blockchain.Strato.Model.Keccak256
 
 {-# NOINLINE loopbackEvents #-}
 loopbackEvents :: Vector T.Text Counter
@@ -28,19 +34,29 @@ loopbackEvents = unsafeRegister
 recordEvent :: MonadIO m => T.Text -> m ()
 recordEvent lab = liftIO $ withLabel loopbackEvents lab incCounter
 
-stratoP2PLoopback :: LoggingT IO ()
-stratoP2PLoopback = do
+stratoP2PLoopback :: IORef (S.OSet Keccak256) -> LoggingT IO ()
+stratoP2PLoopback wireMessagesRef = do
   $logInfoS "stratoP2PLoopback" "Reflecting PBFT back to unseq since 2019"
-  cfg <- initConfig flags_maxReturnedHeaders
+  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   void . runContextM cfg $ do
     ks <- Mod.get (Mod.Proxy @K.KafkaState)
     let toWireMessage = \case
-          P2pBlockstanbul wm -> Just wm
-          _ -> Nothing
+          P2pBlockstanbul wm -> do
+            let msgHash = rlpHash wm
+            msgExists <- A.exists (A.Proxy @(A.Proxy WireMessage)) msgHash
+            if msgExists
+              then do
+                $logInfoS "handleEvents/Blockstanbul" . T.pack $ "Already seen wire message " ++ format msgHash ++ ". Not forwarding to Sequencer."
+                pure Nothing
+              else do
+                $logInfoS "handleEvents/Blockstanbul" . T.pack $ "First time seeing wire message " ++ format msgHash ++ ". Forwarding to Sequencer."
+                A.insert (A.Proxy @(A.Proxy WireMessage)) msgHash (A.Proxy @WireMessage)
+                pure $ Just wm
+          _ -> pure Nothing
 
     runConduit $
          seqEventNotificationSource ks
       .| iterMC (const $ recordEvent "in")
-      .| concatMapC toWireMessage
+      .| concatMapMC toWireMessage
       .| iterMC (const $ recordEvent "out")
       .| mapM_C emitBlockstanbulMsg

--- a/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -24,6 +24,7 @@ import           Crypto.PubKey.ECC.DH
 import qualified Data.ByteString                       as B
 import           Data.Conduit.Network
 import           Data.Maybe                            (fromMaybe)
+import qualified Data.Set.Ordered                      as S
 import qualified Data.Text                             as T
 import           Network.Socket
 import           Network.Wai.Handler.Warp.Internal     (setSocketCloseOnExec)
@@ -37,14 +38,16 @@ import           Blockchain.P2PUtil
 import           Blockchain.SeqEventNotify
 import           Blockchain.Sequencer.Event
 import           Blockchain.Strato.Discovery.Data.Peer
+import           Blockchain.Strato.Model.Keccak256
 import qualified Text.Colors                           as C
 
 runEthServer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
-             => PrivateNumber
+             => IORef (S.OSet Keccak256)
+             -> PrivateNumber
              -> Int
              -> m ()
-runEthServer myPriv listenPort = do
-  cfg <- initConfig flags_maxReturnedHeaders
+runEthServer wireMessagesRef myPriv listenPort = do
+  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   void . runContextM cfg $ do
     uSink <- asks configUnseqSink
     ethServer myPriv listenPort uSink
@@ -117,11 +120,11 @@ runEthServerConduit myPriv p peerSource peerSink seqSource unseqSink peerStr = d
                   .| eventSink
                   .| peerSink
 
-stratoP2PServer :: LoggingT IO ()
-stratoP2PServer = do
+stratoP2PServer :: IORef (S.OSet Keccak256) -> LoggingT IO ()
+stratoP2PServer wireMessagesRef = do
   let PrivKey myPriv = privKey ethConf
 
   $logInfoS "stratoP2PServer" $ T.pack $ "connect address: " ++ flags_address
   $logInfoS "stratoP2PServer" $ T.pack $ "listen port:     " ++ show flags_listen
 
-  void $ runEthServer myPriv flags_listen
+  void $ runEthServer wireMessagesRef myPriv flags_listen

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -33,6 +33,7 @@ import qualified Data.Map.Strict                       as M
 import           Data.Maybe                            (fromJust)
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
+import           Data.Text (Text)
 import           Data.Word                             (Word8)
 import           Text.Printf
 
@@ -122,6 +123,7 @@ data TestContext = TestContext
   , _bestBlockNumber       :: BestBlockNumber
   , _stringPPeerMap        :: Map String DataPeer.PPeer
   , _pbftMessages          :: IORef (S.OSet Keccak256)
+  , _outboundPbftMessages  :: S.OSet (Text, Keccak256)
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
   }
@@ -315,16 +317,28 @@ instance MonadIO m => HasBlockstanbulContext (MonadTest m) where
   getBlockstanbulContext = use $ sequencerContext . blockstanbulContext
   putBlockstanbulContext = assign (sequencerContext . blockstanbulContext . _Just)
 
-instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy WireMessage)) (MonadTest m) where
+instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
   lookup _  k = do
     wms <- readIORef =<< use pbftMessages
-    pure $ if S.member k wms then Just (A.Proxy @WireMessage) else Nothing
+    pure $ if S.member k wms then Just (A.Proxy @(Inbound WireMessage)) else Nothing
   insert _ k _ = use pbftMessages >>= flip atomicModifyIORef' (\wms ->
     let s = S.size wms
         wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
         wms'' = wms' S.>| k
      in (wms'', ()))
   delete _ k = use pbftMessages >>= flip atomicModifyIORef' (\wms -> (S.delete k wms, ()))
+
+instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessage))) (MonadTest m) where
+  lookup _  k = do
+    wms <- use outboundPbftMessages
+    pure $ if S.member k wms then Just (A.Proxy @(Outbound WireMessage)) else Nothing
+  insert _ k _ = do
+    wms <- use outboundPbftMessages
+    let s = S.size wms
+        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+        wms'' = wms' S.>| k
+    assign outboundPbftMessages wms''
+  delete _ k = outboundPbftMessages %= S.delete k
 
 startingCheckpoint :: [Address] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
@@ -385,6 +399,7 @@ testContext wireMessagesRef ctx = TestContext
   , _bestBlockNumber       = BestBlockNumber 0
   , _stringPPeerMap        = M.empty
   , _pbftMessages          = wireMessagesRef
+  , _outboundPbftMessages  = S.empty
   , _unseqEvents           = []
   , _sequencerContext      = ctx
   }

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -121,7 +121,7 @@ data TestContext = TestContext
   , _genesisBlockHash      :: GenesisBlockHash
   , _bestBlockNumber       :: BestBlockNumber
   , _stringPPeerMap        :: Map String DataPeer.PPeer
-  , _pbftMessages          :: S.OSet Keccak256
+  , _pbftMessages          :: IORef (S.OSet Keccak256)
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
   }
@@ -317,15 +317,14 @@ instance MonadIO m => HasBlockstanbulContext (MonadTest m) where
 
 instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy WireMessage)) (MonadTest m) where
   lookup _  k = do
-    wms <- use pbftMessages
+    wms <- readIORef =<< use pbftMessages
     pure $ if S.member k wms then Just (A.Proxy @WireMessage) else Nothing
-  insert _ k _ = do
-    wms <- use pbftMessages
+  insert _ k _ = use pbftMessages >>= flip atomicModifyIORef' (\wms ->
     let s = S.size wms
         wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
         wms'' = wms' S.>| k
-    assign pbftMessages wms''
-  delete _ k = pbftMessages %= S.delete k
+     in (wms'', ()))
+  delete _ k = use pbftMessages >>= flip atomicModifyIORef' (\wms -> (S.delete k wms, ()))
 
 startingCheckpoint :: [Address] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
@@ -363,8 +362,8 @@ newSequencerContext bc = do
 
 -- testContext is useful for testing because it doesn't require
 -- Kafka, postgres, redis, or ethconf.
-testContext :: SequencerContext -> TestContext
-testContext ctx = TestContext
+testContext :: IORef (S.OSet Keccak256) -> SequencerContext -> TestContext
+testContext wireMessagesRef ctx = TestContext
   { _blocks                = []
   , _blockHeaders          = []
   , _remainingBlockHeaders = RemainingBlockHeaders []
@@ -385,7 +384,7 @@ testContext ctx = TestContext
   , _genesisBlockHash      = GenesisBlockHash (unsafeCreateKeccak256FromWord256 0)
   , _bestBlockNumber       = BestBlockNumber 0
   , _stringPPeerMap        = M.empty
-  , _pbftMessages          = S.empty
+  , _pbftMessages          = wireMessagesRef
   , _unseqEvents           = []
   , _sequencerContext      = ctx
   }
@@ -396,7 +395,8 @@ testPeer = DataPeer.buildPeer (Nothing, "0.0.0.0", 1212)
 runTestPeer :: TestContextM a -> IO ()
 runTestPeer f = do
   seqCtx <- newSequencerContext emptyBlockstanbulContext
-  ctx <- newIORef $ testContext seqCtx
+  wmr <- newIORef (S.empty)
+  ctx <- newIORef $ testContext wmr seqCtx
   void . runNoLoggingT . runResourceT $ runReaderT f ctx
 
 execTestPeer :: PrivateNumber
@@ -405,8 +405,9 @@ execTestPeer :: PrivateNumber
              -> IO (a, TestContext)
 execTestPeer pk as f = do
   seqCtx <- newSequencerContext $ newBlockstanbulContext pk as
-  ctx <- newIORef $ testContext seqCtx
-  a <- runNoLoggingT . runResourceT $ runReaderT f ctx
+  wmr <- newIORef (S.empty)
+  ctx <- newIORef $ testContext wmr seqCtx
+  a <- runLoggingT . runResourceT $ runReaderT f ctx
   ctx' <- readIORef ctx
   return (a, ctx')
 

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -27,10 +27,11 @@ import           Data.Coerce
 import           Data.Conduit.TMChan
 import           Data.Conduit.TQueue                   hiding (newTQueueIO)
 import           Data.Default                          (def)
-import           Data.Foldable                         (for_)
+import           Data.Foldable                         (for_, toList)
 import           Data.Map.Strict                       (Map)
 import qualified Data.Map.Strict                       as M
 import           Data.Maybe                            (fromJust)
+import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Word                             (Word8)
 import           Text.Printf
@@ -120,6 +121,7 @@ data TestContext = TestContext
   , _genesisBlockHash      :: GenesisBlockHash
   , _bestBlockNumber       :: BestBlockNumber
   , _stringPPeerMap        :: Map String DataPeer.PPeer
+  , _pbftMessages          :: S.OSet Keccak256
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
   }
@@ -313,6 +315,18 @@ instance MonadIO m => HasBlockstanbulContext (MonadTest m) where
   getBlockstanbulContext = use $ sequencerContext . blockstanbulContext
   putBlockstanbulContext = assign (sequencerContext . blockstanbulContext . _Just)
 
+instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy WireMessage)) (MonadTest m) where
+  lookup _  k = do
+    wms <- use pbftMessages
+    pure $ if S.member k wms then Just (A.Proxy @WireMessage) else Nothing
+  insert _ k _ = do
+    wms <- use pbftMessages
+    let s = S.size wms
+        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+        wms'' = wms' S.>| k
+    assign pbftMessages wms''
+  delete _ k = pbftMessages %= S.delete k
+
 startingCheckpoint :: [Address] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
 
@@ -371,6 +385,7 @@ testContext ctx = TestContext
   , _genesisBlockHash      = GenesisBlockHash (unsafeCreateKeccak256FromWord256 0)
   , _bestBlockNumber       = BestBlockNumber 0
   , _stringPPeerMap        = M.empty
+  , _pbftMessages          = S.empty
   , _unseqEvents           = []
   , _sequencerContext      = ctx
   }

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -235,6 +235,7 @@ services:
     - useSyncMode=${useSyncMode}
     - validators=${validators}
     - vmRunnerRTSOPTs=${vmRunnerRTSOPTs}
+    - wireMessageCacheSize=${wireMessageCacheSize}
     - zkHost=zookeeper
     build: .
     image: ${STRATO_IMAGE:-<REPO_URL>strato:<VERSION>}


### PR DESCRIPTION
This PR reduces the number of gossip messages traversing the network by caching inbound and outbound messages by their hash, then discarding duplicates. The outbound filtering seems to have the greatest effect on performance, improving the results of an 8-node load test by a factor of 2, and even beating version 5.4, which was previously the fastest version of STRATO tested. This indicates that performance is very sensitive to network effects.
https://jenkins.blockapps.net/job/STRATO_test/3493/