### PR TITLE
[Identity] ethereum-discovery uses vault-wrapper NODEKEY

### DIFF
--- a/core-strato/ethereum-discovery/exec_src/Main.hs
+++ b/core-strato/ethereum-discovery/exec_src/Main.hs
@@ -5,6 +5,7 @@ import qualified Network.Socket               as S
 import           BlockApps.Init
 import           Blockchain.Output
 import           Executable.EthereumDiscovery
+import           Executable.Options()
 import           HFlags
 
 main :: IO ()

--- a/core-strato/ethereum-discovery/package.yaml
+++ b/core-strato/ethereum-discovery/package.yaml
@@ -19,6 +19,7 @@ library:
     - Blockchain.Strato.Discovery.P2PUtil
     - Executable.EthereumDiscovery
     - Executable.EthDiscoverySetup
+    - Executable.Options
   dependencies:
     - base16-bytestring
     - binary
@@ -39,6 +40,7 @@ library:
     - ethereum-rlp
     - exceptions
     - format
+    - hflags
     - http-client
     - monad-alter
     - mtl

--- a/core-strato/ethereum-discovery/package.yaml
+++ b/core-strato/ethereum-discovery/package.yaml
@@ -26,6 +26,8 @@ library:
     - blockapps-datadefs
     - blockapps-haskoin
     - blockapps-util
+    - blockapps-vault-wrapper-api
+    - blockapps-vault-wrapper-client
     - bytestring
     - classy-prelude
     - cpu
@@ -37,6 +39,7 @@ library:
     - ethereum-rlp
     - exceptions
     - format
+    - http-client
     - monad-alter
     - mtl
     - network-uri
@@ -45,6 +48,7 @@ library:
     - prometheus-client
     - random
     - resourcet
+    - servant-client
     - split
     - strato-conf
     - strato-model

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
@@ -6,7 +6,10 @@
 {-# LANGUAGE TypeOperators                  #-}
 {-# LANGUAGE TypeSynonymInstances           #-}
 {-# LANGUAGE UndecidableInstances           #-}
+{-# LANGUAGE TemplateHaskell                #-}
+{-# LANGUAGE OverloadedStrings              #-}
 {-# OPTIONS -fno-warn-redundant-constraints #-}
+
 module Blockchain.Strato.Discovery.ContextLite
   ( ContextLite -- (..)
   , initContextLite
@@ -16,6 +19,7 @@ module Blockchain.Strato.Discovery.ContextLite
 
 import           Blockchain.DB.SQLDB
 import           Blockchain.DBM
+import           Blockchain.Output
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Strato.Model.Secp256k1
 import           Control.Concurrent                    (threadDelay)
@@ -39,29 +43,30 @@ data ContextLite =
 instance Monad m => Accessible SQLDB (ReaderT ContextLite m) where
   access _ = asks liteSQLDB
 
-instance (Monad m, MonadIO m) => HasVault (ReaderT ContextLite m) where
+instance (Monad m, MonadIO m, MonadLogger m) => HasVault (ReaderT ContextLite m) where
   sign msg = do
     vc <- asks vaultClient
-    liftIO $ waitOnVault $ runClientM (VC.postSignature (T.pack "nodekey") (VC.MsgHash msg)) vc
+    $logInfoS "HasVault" "asking vault-wrapper for a message signature"
+    waitOnVault $ liftIO $ runClientM (VC.postSignature (T.pack "nodekey") (VC.MsgHash msg)) vc
 
   getPub = error "called HasVault's getPub in ethereum-discovery, but this should never happen"
   getShared _ = error "called HasVault's getShared in ethereum-discovery, but this should never happen"
 
--- TODO: this should be in a vc util module since we use it in multiple places now
-waitOnVault :: IO (Either a b) -> IO b
+waitOnVault :: (MonadIO m, MonadLogger m, Show a) => m (Either a b) -> m b
 waitOnVault action = do
   res <- action
   case res of 
-    Left _ -> do
-      threadDelay $ 2000000 -- 2 seconds
+    Left err -> do
+      $logErrorS "HasVault" . T.pack $ "vault-wrapper returned an error: " ++ show err 
+      liftIO $ threadDelay $ 2000000 -- 2 seconds
       waitOnVault action
     Right val -> return val
 
-initContextLite :: MonadUnliftIO m => m ContextLite
-initContextLite = do
+initContextLite :: MonadUnliftIO m => String -> m ContextLite
+initContextLite vaultUrl = do
   dbs <- openDBs
   mgr <- liftIO $ newManager defaultManagerSettings
-  url <- liftIO $ parseBaseUrl "http://vault-wrapper:8000/strato/v2.3" -- someday this may need to be a cl arg
+  url <- liftIO $ parseBaseUrl vaultUrl
   return ContextLite { liteSQLDB = sqlDB' dbs
                      , vaultClient = ClientEnv mgr url Nothing
                      }

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
@@ -17,22 +17,54 @@ module Blockchain.Strato.Discovery.ContextLite
 import           Blockchain.DB.SQLDB
 import           Blockchain.DBM
 import           Blockchain.Strato.Discovery.Data.Peer
+import           Blockchain.Strato.Model.Secp256k1
+import           Control.Concurrent                    (threadDelay)
 import           Control.Monad.Change.Modify           (Accessible(..))
+import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import           Control.Monad.IO.Unlift
 import qualified Data.Text                             as T
 import qualified Database.Persist.Postgresql           as SQL
 
-newtype ContextLite =
-  ContextLite { liteSQLDB::SQLDB }
+import           Network.HTTP.Client                   (newManager, defaultManagerSettings)
+import           Servant.Client
+import qualified Strato.Strato23.API                   as VC
+import qualified Strato.Strato23.Client                as VC
+
+data ContextLite =
+  ContextLite { liteSQLDB :: SQLDB
+              , vaultClient :: ClientEnv
+              }
 
 instance Monad m => Accessible SQLDB (ReaderT ContextLite m) where
   access _ = asks liteSQLDB
 
+instance (Monad m, MonadIO m) => HasVault (ReaderT ContextLite m) where
+  sign msg = do
+    vc <- asks vaultClient
+    liftIO $ waitOnVault $ runClientM (VC.postSignature (T.pack "nodekey") (VC.MsgHash msg)) vc
+
+  getPub = error "called HasVault's getPub in ethereum-discovery, but this should never happen"
+  getShared _ = error "called HasVault's getShared in ethereum-discovery, but this should never happen"
+
+-- TODO: this should be in a vc util module since we use it in multiple places now
+waitOnVault :: IO (Either a b) -> IO b
+waitOnVault action = do
+  res <- action
+  case res of 
+    Left _ -> do
+      threadDelay $ 2000000 -- 2 seconds
+      waitOnVault action
+    Right val -> return val
+
 initContextLite :: MonadUnliftIO m => m ContextLite
 initContextLite = do
   dbs <- openDBs
-  return ContextLite { liteSQLDB = sqlDB' dbs }
+  mgr <- liftIO $ newManager defaultManagerSettings
+  url <- liftIO $ parseBaseUrl "http://vault-wrapper:8000/strato/v2.3" -- someday this may need to be a cl arg
+  return ContextLite { liteSQLDB = sqlDB' dbs
+                     , vaultClient = ClientEnv mgr url Nothing
+                     }
 
 addPeer :: HasSQLDB m =>PPeer->m (SQL.Key PPeer)
 addPeer peer = do

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
@@ -300,34 +300,3 @@ getServerPubKey domain _ = do
         Left x         -> return $ Left x
         Right (Just x) -> return $ Right $ secPubKeyToPoint x
 
-
--- TODO: do we need this? If so, we need to use HasVault
-{- findNeighbors::H.PrvKey -> String -> PortNumber -> IO ()
-findNeighbors myPriv domain _ =
-    withSocketsDo $ bracket (getSocket domain port) close (talk myPriv)
-  where
-    -- TODO(tim): Reenable port selection
-    port = 30303
-    talk :: H.PrvKey -> Socket -> IO ()
-    talk prvKey' socket' = do
-      let (theType, theRLP) =
-            ndPacketToRLP $
-            FindNeighbors (NodeID $ fst $ B16.decode "eab4e595d178422cb8b31eddde2d6dda74ad16609693614a29a214d2b2f457a7c97a442e74e58afd1b16657c5c5908255a450d8a202e8d3b2b31c9b17e7221f3") 100000000000000000
-          theData = rlpSerialize theRLP
-          theMsgHash = hash $ B.singleton theType <> theData
-
-      ExtendedSignature signature yIsOdd <-
-        H.withSource H.devURandom $ encrypt prvKey' $ keccak256ToWord256 theMsgHash
-
-      let v = if yIsOdd then 1 else 0 -- 0x1c else 0x1b
-          r = H.sigR signature
-          s = H.sigS signature
-          theSignature =
-            word256ToBytes (fromIntegral r) <> word256ToBytes (fromIntegral s) <> B.singleton v
-          theHash = keccak256ToByteString $ hash $ theSignature <> B.singleton theType <> theData
-
-      _ <- NB.send socket' $ theHash <> theSignature <> B.singleton theType <> theData
-
-      _ <- NB.recv socket' 10 >>= print -- processDataStream' . B.unpack
-      return ()
--}

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
@@ -5,7 +5,7 @@ module Blockchain.Strato.Discovery.UDP (
   dataToPacket,
   sendPacket,
   getServerPubKey,
-  findNeighbors,
+--  findNeighbors,
   ndPacketToRLP,
   NodeDiscoveryPacket(..),
   Endpoint(..),
@@ -22,7 +22,7 @@ module Blockchain.Strato.Discovery.UDP (
 import           Network.Socket
 import qualified Network.Socket.ByteString             as NB
 
-import           Control.Error                         (fmapL, note)
+import           Control.Error                         (note)
 import           Control.Exception
 import           Control.Monad.IO.Class
 import           Blockchain.Output
@@ -32,29 +32,29 @@ import           Data.Bits
 import qualified Data.ByteString                       as B
 import qualified Data.ByteString.Base16                as B16
 import qualified Data.ByteString.Char8                 as BC
+import qualified Data.ByteString.Lazy                  as BL
 import           Data.List.Split
 import           Data.Maybe
 import qualified Data.Text                             as T
 import           Data.Time.Clock.POSIX
-import qualified Network.Haskoin.Internals             as H
 import qualified Network.URI                           as URI
 import           Numeric
 import           System.Endian
 import           System.Timeout
 
+import           Blockchain.Data.PubKey
 import           Blockchain.Data.RLP
-import           Blockchain.ExtendedECDSA
+import           Blockchain.ExtendedECDSA -- say it with me: DEPRECATED!
 import           Blockchain.ExtWord
-import           Blockchain.Strato.Discovery.P2PUtil   (DiscoverException (..), hPubKeyToPubKey)
+import           Blockchain.Strato.Discovery.P2PUtil   (DiscoverException (..))
 import           Blockchain.Strato.Model.Keccak256           
+import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Util
 
 import           Blockchain.Strato.Discovery.Data.Peer
 import qualified Text.Colors                           as CL
 import           Text.Format
 
-encrypt :: H.PrvKey -> Word256 -> H.SecretT IO ExtendedSignature
-encrypt = flip extSignMsg
 
 data RawNodeDiscoveryPacket =
   RawNDPacket Keccak256 ExtendedSignature Integer RLPObject deriving (Show)
@@ -178,19 +178,15 @@ ndPacketToRLP (FindNeighbors target expiration) = (3, RLPArray [rlpEncode target
 ndPacketToRLP (Neighbors neighbors expiration) = (4, RLPArray [RLPArray $ map rlpEncode neighbors, rlpEncode expiration])
 
 
-dataToPacket :: B.ByteString -> Either DiscoverException (NodeDiscoveryPacket, H.PubKey)
+dataToPacket :: B.ByteString -> Either DiscoverException (NodeDiscoveryPacket, PublicKey)
 dataToPacket msg = do
-    let r = bytesToWord256 $ B.take 32 $ B.drop 32 msg
-        s = bytesToWord256 $ B.take 32 $ B.drop 64 msg
-    v <- note (ByteStringLengthException $ show msg) $ listToMaybe . B.unpack $ B.take 1 $ B.drop 96 msg
-    let yIsOdd = v == 1
-        signature = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) yIsOdd
-        theRest = B.unpack $ B.drop 98 msg
+    let signature = decode $ BL.fromStrict $ B.take 81 $ B.drop 32 msg
+        theRest = B.unpack $ B.drop 114 msg
         (rlp, _) = rlpSplit $ B.pack theRest
-    theType <- note (ByteStringLengthException $ show msg) $ listToMaybe . B.unpack $ B.take 1 $ B.drop 97 msg
+    theType <- note (ByteStringLengthException $ show msg) $ listToMaybe . B.unpack $ B.take 1 $ B.drop 113 msg
     let messageHash = hash $ B.pack $ theType : B.unpack (rlpSerialize rlp)
     otherPubkey <- note (MalformedUDPException $ "malformed signature in udpHandshakeServer: " ++ show (signature, messageHash))
-                        (getPubKeyFromSignature signature $ keccak256ToWord256 messageHash)
+                        (recoverPub signature $ keccak256ToByteString messageHash)
     packet <- typeToPacket theType rlp
     return (packet, otherPubkey)
   where
@@ -201,50 +197,38 @@ dataToPacket msg = do
     typeToPacket 4 (RLPArray [RLPArray neighbors, timestamp]) = Right $ Neighbors (map rlpDecode neighbors) (rlpDecode timestamp)
     typeToPacket x y = Left $ MalformedUDPException $ "Unsupported case called in typeToPacket: " ++ show x ++ ", " ++ show y
 
-sendPacket :: (MonadIO m, MonadLogger m)
+sendPacket :: (HasVault m, MonadIO m, MonadLogger m)
            => Socket
-           -> H.PrvKey
            -> SockAddr
            -> NodeDiscoveryPacket
            -> m ()
-sendPacket sock prv addr packet = do
+sendPacket sock addr packet = do
   $logInfoS "sendPacket" $ T.pack $ CL.green "sending to" ++ " (" ++ show addr ++ ") " ++ format packet
   let (theType', theRLP) = ndPacketToRLP packet
       theData = rlpSerialize theRLP
-      theMsgHash = hash $ B.singleton theType' <> theData
+      theMsgHash = keccak256ToByteString $ hash $ B.singleton theType' <> theData
+  
+  sig <- sign theMsgHash 
+  let sigBS = BL.toStrict $ encode sig 
+      theHash = keccak256ToByteString $ hash $ sigBS <> B.singleton theType' <> theData
 
-  ExtendedSignature signature' yIsOdd' <- liftIO $ H.withSource H.devURandom $ extSignMsg (keccak256ToWord256 theMsgHash) prv
-
-  let v' = if yIsOdd' then 1 else 0
-      r' = H.sigR signature'
-      s' = H.sigS signature'
-      theSignature = word256ToBytes (fromIntegral r') <> word256ToBytes (fromIntegral s') <> B.singleton v'
-      theHash = keccak256ToByteString $ hash $ theSignature <> B.singleton theType' <> theData
-
-  _ <- liftIO $ NB.sendTo sock ( theHash <> theSignature <> B.singleton theType' <> theData) addr
+  _ <- liftIO $ NB.sendTo sock ( theHash <> sigBS <> B.singleton theType' <> theData) addr
   return ()
 
-processDataStream'::B.ByteString-> H.PubKey
-processDataStream' bs | B.length bs < 98 = error "processDataStream' called with too few bytes"
+processDataStream'::B.ByteString-> PublicKey
+processDataStream' bs | B.length bs < 114 = error "processDataStream' called with too few bytes"
 processDataStream' bs =
   let (hs, bs') = B.splitAt 32 bs
-      (rs, bs'') = B.splitAt 32 bs'
-      (ss, bs''') = B.splitAt 32 bs''
-      (vtype, rest) = B.splitAt 2 bs'''
-      v = B.index vtype 0
-      theType = B.index vtype 1
+      (sigBS, bs'') = B.splitAt 81 bs'
+      (vtype, rest) = B.splitAt 1 bs''
+      theType = B.index vtype 0
       theHash = bytesToWord256 hs
-      r = bytesToWord256 rs
-      s = bytesToWord256 ss
-      yIsOdd = v == 1 -- 0x1c
-      signature = ExtendedSignature (H.Signature (fromIntegral r) (fromIntegral s)) yIsOdd
-
+      signature = decode $ BL.fromStrict sigBS 
       (rlp, _) = rlpSplit rest
 
       messageHash = hash $ B.singleton theType <> rlpSerialize rlp
-      publicKey = getPubKeyFromSignature signature $ keccak256ToWord256 messageHash
-      theHash' = hash $ word256ToBytes (fromIntegral r) <> word256ToBytes (fromIntegral s)
-                         <> B.singleton v <> B.singleton theType <> rlpSerialize rlp
+      publicKey = recoverPub signature $ keccak256ToByteString messageHash
+      theHash' = hash $ BL.toStrict (encode signature) <> B.singleton theType <> rlpSerialize rlp
   in if theHash /= keccak256ToWord256 theHash'
     then error "bad UDP data sent from peer, the hash isn't correct"
     else fromMaybe (error "malformed signature in call to processDataStream") publicKey
@@ -285,42 +269,40 @@ getSocket domain _ = do
   _ <- connect s (addrAddress serveraddr)
   return s
 
-getServerPubKey :: H.PrvKey -> String -> PortNumber -> IO (Either SomeException Point)
-getServerPubKey myPriv domain _ =
-    withSocketsDo $ bracket (getSocket domain port) close (talk myPriv)
-  where
+getServerPubKey :: (HasVault m, MonadIO m) => String -> PortNumber -> m (Either SomeException Point)
+getServerPubKey domain _ = do
     -- TODO(tim): Reenable port selection
-    port = 30303
-    talk :: H.PrvKey -> Socket -> IO (Either SomeException Point)
-    talk prvKey' socket' = do
-      timestamp <- fmap round getPOSIXTime
-      let (theType, theRLP) =
+    timestamp <- liftIO $ fmap round getPOSIXTime
+    let (theType, theRLP) =
             ndPacketToRLP $
             Ping 4 (Endpoint (stringToIAddr "127.0.0.1") (fromIntegral port) 30303) (Endpoint (stringToIAddr "127.0.0.1") (fromIntegral port) 30303) (timestamp + 50)
-          theData = rlpSerialize theRLP
-          theMsgHash = hash $ B.singleton theType <> theData
+        theData = rlpSerialize theRLP
+        theMsgHash = keccak256ToByteString $ hash $ B.singleton theType <> theData
+    
+    sig <- sign theMsgHash
+    let sigBS = BL.toStrict $ encode sig 
+        theHash = keccak256ToByteString $ hash $ sigBS <> B.singleton theType <> theData
+        theMsg = theHash <> sigBS <> B.singleton theType <> theData
 
-      ExtendedSignature signature yIsOdd <- H.withSource H.devURandom $ encrypt prvKey' $ keccak256ToWord256 theMsgHash
-
-      let v = if yIsOdd then 1 else 0 -- 0x1c else 0x1b
-          r = H.sigR signature
-          s = H.sigS signature
-          theSignature =
-            word256ToBytes (fromIntegral r) <> word256ToBytes (fromIntegral s) <> B.singleton v
-          theHash = keccak256ToByteString $ hash $ theSignature <> B.singleton theType <> theData
-
-      _ <- NB.send socket' $ theHash <> theSignature <> B.singleton theType <> theData
+    liftIO $ withSocketsDo $ bracket (getSocket domain port) close (talk theMsg)
+  where
+    port = 30303
+    talk :: B.ByteString -> Socket -> IO (Either SomeException Point)
+    talk msg socket' = do
+      _ <- NB.send socket' msg 
 
       --According to https://groups.google.com/forum/#!topic/haskell-cafe/aqaoEDt7auY, it looks like the only way we can time out UDP recv is to
       --use the Haskell timeout....  I did try setting socket options also, but that didn't work.
-      pubKey <- try (timeout 5000000 . fmap processDataStream' $ NB.recv socket' 2000) :: IO (Either SomeException (Maybe H.PubKey))
+      pubKey <- try (timeout 5000000 . fmap processDataStream' $ NB.recv socket' 2000) :: IO (Either SomeException (Maybe PublicKey))
 
       case pubKey of
         Right Nothing  -> return $ Left $ SomeException UDPTimeout
         Left x         -> return $ Left x
-        Right (Just x) -> return $ fmapL SomeException $ hPubKeyToPubKey x
+        Right (Just x) -> return $ Right $ secPubKeyToPoint x
 
-findNeighbors::H.PrvKey -> String -> PortNumber -> IO ()
+
+-- TODO: do we need this? If so, we need to use HasVault
+{- findNeighbors::H.PrvKey -> String -> PortNumber -> IO ()
 findNeighbors myPriv domain _ =
     withSocketsDo $ bracket (getSocket domain port) close (talk myPriv)
   where
@@ -348,3 +330,4 @@ findNeighbors myPriv domain _ =
 
       _ <- NB.recv socket' 10 >>= print -- processDataStream' . B.unpack
       return ()
+-}

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
@@ -32,7 +32,6 @@ import           Data.Bits
 import qualified Data.ByteString                       as B
 import qualified Data.ByteString.Base16                as B16
 import qualified Data.ByteString.Char8                 as BC
-import qualified Data.ByteString.Lazy                  as BL
 import           Data.List.Split
 import           Data.Maybe
 import qualified Data.Text                             as T
@@ -180,10 +179,10 @@ ndPacketToRLP (Neighbors neighbors expiration) = (4, RLPArray [RLPArray $ map rl
 
 dataToPacket :: B.ByteString -> Either DiscoverException (NodeDiscoveryPacket, PublicKey)
 dataToPacket msg = do
-    let signature = decode $ BL.fromStrict $ B.take 81 $ B.drop 32 msg
-        theRest = B.unpack $ B.drop 114 msg
+    let signature = importSignature $ B.take 65 $ B.drop 32 msg
+        theRest = B.unpack $ B.drop 98 msg
         (rlp, _) = rlpSplit $ B.pack theRest
-    theType <- note (ByteStringLengthException $ show msg) $ listToMaybe . B.unpack $ B.take 1 $ B.drop 113 msg
+    theType <- note (ByteStringLengthException $ show msg) $ listToMaybe . B.unpack $ B.take 1 $ B.drop 97 msg
     let messageHash = hash $ B.pack $ theType : B.unpack (rlpSerialize rlp)
     otherPubkey <- note (MalformedUDPException $ "malformed signature in udpHandshakeServer: " ++ show (signature, messageHash))
                         (recoverPub signature $ keccak256ToByteString messageHash)
@@ -209,26 +208,26 @@ sendPacket sock addr packet = do
       theMsgHash = keccak256ToByteString $ hash $ B.singleton theType' <> theData
   
   sig <- sign theMsgHash 
-  let sigBS = BL.toStrict $ encode sig 
+  let sigBS = exportSignature sig
       theHash = keccak256ToByteString $ hash $ sigBS <> B.singleton theType' <> theData
 
   _ <- liftIO $ NB.sendTo sock ( theHash <> sigBS <> B.singleton theType' <> theData) addr
   return ()
 
 processDataStream'::B.ByteString-> PublicKey
-processDataStream' bs | B.length bs < 114 = error "processDataStream' called with too few bytes"
+processDataStream' bs | B.length bs < 98 = error "processDataStream' called with too few bytes"
 processDataStream' bs =
   let (hs, bs') = B.splitAt 32 bs
-      (sigBS, bs'') = B.splitAt 81 bs'
+      (sigBS, bs'') = B.splitAt 65 bs'
       (vtype, rest) = B.splitAt 1 bs''
       theType = B.index vtype 0
       theHash = bytesToWord256 hs
-      signature = decode $ BL.fromStrict sigBS 
+      signature = importSignature sigBS 
       (rlp, _) = rlpSplit rest
 
       messageHash = hash $ B.singleton theType <> rlpSerialize rlp
       publicKey = recoverPub signature $ keccak256ToByteString messageHash
-      theHash' = hash $ BL.toStrict (encode signature) <> B.singleton theType <> rlpSerialize rlp
+      theHash' = hash $ sigBS <> B.singleton theType <> rlpSerialize rlp
   in if theHash /= keccak256ToWord256 theHash'
     then error "bad UDP data sent from peer, the hash isn't correct"
     else fromMaybe (error "malformed signature in call to processDataStream") publicKey
@@ -280,7 +279,7 @@ getServerPubKey domain _ = do
         theMsgHash = keccak256ToByteString $ hash $ B.singleton theType <> theData
     
     sig <- sign theMsgHash
-    let sigBS = BL.toStrict $ encode sig 
+    let sigBS = exportSignature sig 
         theHash = keccak256ToByteString $ hash $ sigBS <> B.singleton theType <> theData
         theMsg = theHash <> sigBS <> B.singleton theType <> theData
 

--- a/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
+++ b/core-strato/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
@@ -36,6 +36,7 @@ import           Blockchain.Data.PubKey
 import           Blockchain.DB.SQLDB
 import           Blockchain.EthConf
 import           Blockchain.Strato.Model.Keccak256
+import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Strato.Discovery.ContextLite
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Strato.Discovery.P2PUtil
@@ -44,7 +45,6 @@ import           Blockchain.Strato.Discovery.UDP
 import qualified Text.Colors                             as CL
 import           Text.Format
 
-import qualified Network.Haskoin.Internals               as H
 
 runEthUDPServer :: ( MonadIO m
                    , MonadFail m
@@ -54,12 +54,11 @@ runEthUDPServer :: ( MonadIO m
                    , MonadUnliftIO m
                    )
                 => ContextLite
-                -> H.PrvKey
                 -> Int
                 -> Socket
                 -> m ()
-runEthUDPServer ctx myPriv _ sock =
-  void . runResourceT $ runReaderT (udpHandshakeServer myPriv sock portNum) ctx
+runEthUDPServer ctx _ sock =
+  void . runResourceT $ runReaderT (udpHandshakeServer sock portNum) ctx
      where portNum = 30303 -- TODO(tim): Reenable port selection
 
 connectMe :: (MonadIO m, MonadFail m, MonadLogger m)
@@ -75,11 +74,10 @@ connectMe _ = do
 
   return sock
 
-addPeersIfNeeded :: (MonadIO m, MonadFail m, MonadLogger m)
-                 => H.PrvKey
-                 -> Socket
+addPeersIfNeeded :: (HasVault m, MonadIO m, MonadFail m, MonadLogger m)
+                 => Socket
                  -> m ()
-addPeersIfNeeded prv sock= do
+addPeersIfNeeded sock= do
   numAvailablePeers <- liftIO getNumAvailablePeers
   let minPeers = minAvailablePeers (discoveryConfig ethConf)
   $logInfoS "addPeersIfNeeded" . T.pack $ "Number of available peers: " ++ show numAvailablePeers ++ " / " ++ show minPeers
@@ -94,16 +92,15 @@ addPeersIfNeeded prv sock= do
         (peeraddr:_) <- liftIO $ getAddrInfo Nothing (Just $ T.unpack $ pPeerIp thePeer) (Just $ show $ pPeerUdpPort thePeer)
         time <- liftIO $ round `fmap` getPOSIXTime
         randomBytes <- liftIO $ getEntropy 64
-        sendPacket sock prv (addrAddress peeraddr) $ FindNeighbors (NodeID randomBytes) (time + 50)
+        sendPacket sock (addrAddress peeraddr) $ FindNeighbors (NodeID randomBytes) (time + 50)
         eErr <- liftIO $ disableUDPPeerForSeconds thePeer 10
         whenLeft eErr $ \err -> $logErrorS "addPeersIfNeeded" . T.pack $ "Unable to disable peer: " ++ show err
 
-attemptBond :: (MonadIO m, MonadFail m, MonadLogger m)
-            => H.PrvKey
-            -> Socket
+attemptBond :: (HasVault m, MonadIO m, MonadFail m, MonadLogger m)
+            => Socket
             -> Int
             -> m ()
-attemptBond prv sock _ = do
+attemptBond sock _ = do
   let portNum = 30303 :: Int
   unbondedPeers <- liftIO getUnbondedPeers
   when (length unbondedPeers /= 0) $
@@ -122,7 +119,7 @@ attemptBond prv sock _ = do
       case ehostAddress of
         Left err -> $logInfoS "attemptBond" $ T.pack . show $ err
         Right hostAddress -> do
-          sendPacket sock prv (addrAddress peeraddr) $
+          sendPacket sock (addrAddress peeraddr) $
                 Ping 4
                    (Endpoint hostAddress 30303 30303)
                    (Endpoint (stringToIAddr $ T.unpack $ pPeerIp p)
@@ -131,20 +128,20 @@ attemptBond prv sock _ = do
                    (time+50)
 
 udpHandshakeServer :: ( HasSQLDB m
+                      , HasVault m
                       , MonadFail m
                       , MonadCatch m
                       , MonadThrow m
                       , MonadLogger m
                       , MonadUnliftIO m
                       )
-                   => H.PrvKey
-                   -> Socket
+                   => Socket
                    -> Int
                    -> m ()
-udpHandshakeServer prv sock _ = do
+udpHandshakeServer sock _ = do
     let portNum = 30303 -- TODO(tim): Reenable port selection
-    _ <- addPeersIfNeeded prv sock
-    _ <- attemptBond prv sock portNum
+    _ <- addPeersIfNeeded sock
+    _ <- attemptBond sock portNum
     -- TODO(tim): make a --strict-ethereum-compliance and reset this to 1280
     maybePacketData <- liftIO $ timeout 10000000 $ NB.recvFrom sock 80000
     _ <- case maybePacketData of
@@ -152,41 +149,41 @@ udpHandshakeServer prv sock _ = do
       Just (msg, addr) -> do
         _ <- $logInfoS "udpHandshakeServer" $ T.pack $ "received bytes: len=" ++ (show $ B.length msg)
         catch (handler msg addr) $ \(e :: SomeException) -> $logInfoS "udpHandshakeServer" $ "malformed UDP packet: " <> (T.pack $ show e)
-    udpHandshakeServer prv sock portNum
+    udpHandshakeServer sock portNum
   where
     handler msg addr = case argValidator msg addr of
       Left msgErr -> $logInfoS "udpHandshakeServer/handler" $ T.pack $ "Invalid message: " ++ show msgErr ++ " -- " ++ show msg
       Right (packet, otherPubKey, otherPort) -> do
         _ <- $logInfoS "udpHandshakeServer/handler" $ T.pack $ CL.cyan "receiving " ++ " (" ++ show addr ++ " " ++ BC.unpack (B.take 10 $ B16.encode $ pointToBytes otherPubKey) ++ "....) " ++ format packet
-        handleValidPacket prv sock addr otherPort packet otherPubKey
+        handleValidPacket sock addr otherPort packet otherPubKey
     argValidator :: B.ByteString -> SockAddr -> Either DiscoverException (NodeDiscoveryPacket, ECC.Point, PortNumber)
     argValidator msg _ = do
       (packet, otherPubkey) <- dataToPacket msg
-      validOtherPubKey <- hPubKeyToPubKey otherPubkey
+      let validOtherPubKey = secPubKeyToPoint otherPubkey
       -- otherPort <- getAddrPort addr
-      let otherPort = 30303 -- TODO(tim): Reenable port selection
+          otherPort = 30303 -- TODO(tim): Reenable port selection
       return (packet, validOtherPubKey, otherPort)
 
 handleValidPacket :: ( HasSQLDB m
+                     , HasVault m
                      , MonadCatch m
                      , MonadThrow m
                      , MonadLogger m
                      , MonadUnliftIO m -- TODO(tim): Remove when redundant with HasSQLDB
                      )
-                  => H.PrvKey
-                  -> Socket
+                  => Socket
                   -> SockAddr
                   -> PortNumber
                   -> NodeDiscoveryPacket
                   -> ECC.Point
                   -> m ()
                                                        -- TODO(tim): Reenable port selection
-handleValidPacket prv sock addr _ packet otherPubKey = let portNum = 30303 :: Int in case packet of
+handleValidPacket sock addr _ packet otherPubKey = let portNum = 30303 :: Int in case packet of
     Ping{} -> do
         addPeer'
         time <- liftIO $ round `fmap` getPOSIXTime
         peerAddr <- fmap IPV4Addr $ liftIO $ inet_addr "127.0.0.1" -- todo: WHAT THE FUCK?!???!?!
-        sendPacket sock prv addr $ Pong (Endpoint peerAddr 30303 30303) 4 (time+50)
+        sendPacket sock addr $ Pong (Endpoint peerAddr 30303 30303) 4 (time+50)
 
     Pong{} -> do
         addPeer'
@@ -201,7 +198,7 @@ handleValidPacket prv sock addr _ packet otherPubKey = let portNum = 30303 :: In
             ip = sockAddrToIP addr
         peers <- getPeersClosestTo targetPubkey (T.pack ip) otherPubKey
         let theNeighbors = (\p -> Neighbor (mkEndpoint p) (mkNodeId p)) <$> peers
-        sendPacket sock prv addr $ Neighbors theNeighbors nextTime
+        sendPacket sock addr $ Neighbors theNeighbors nextTime
                 -- TODO(tim): Reenable port selection
           where mkEndpoint PPeer{..} = Endpoint (stringToIAddr $ T.unpack pPeerIp) 30303 30303
                 mkNodeId             = pointToNodeID . fromJust . pPeerPubkey

--- a/core-strato/ethereum-discovery/src/Executable/EthereumDiscovery.hs
+++ b/core-strato/ethereum-discovery/src/Executable/EthereumDiscovery.hs
@@ -5,31 +5,27 @@ module Executable.EthereumDiscovery (
   ethereumDiscovery
   ) where
 
-import           UnliftIO.Exception
 import           Control.Monad.IO.Class
 import           Blockchain.Output
 import           Control.Monad.Trans.Resource
--- import qualified Data.ByteString.Base16                  as B16
--- import           Data.Maybe
 import qualified Data.Text                               as T
 import qualified Network.Socket                          as S
+import           UnliftIO.Exception
 
---import           Blockchain.Data.PubKey
 import           Blockchain.EthConf
-
 import           Blockchain.Strato.Discovery.ContextLite
---import           Blockchain.Strato.Discovery.P2PUtil
 import           Blockchain.Strato.Discovery.UDPServer
+import           Executable.Options
+
 import qualified Text.Colors                             as CL
 
 ethereumDiscovery :: LoggingT IO ()
 ethereumDiscovery = do
   _ <- $logInfoS "ethereumDiscovery" $ T.pack $ CL.blue "Welcome to ethereum-discovery"
   _ <- $logInfoS "ethereumDiscovery" $ T.pack $ CL.blue "============================="
-  -- TODO: a lil getPub here so that we can print the NodeID like we used to
---  _ <- $logInfoS "ethereumDiscovery" $ T.pack $ CL.green " * My NodeID is " ++ show (B16.encode $ pointToBytes pubKey)
+  _ <- $logInfoS "ethereumDiscovery" $ T.pack $ CL.green $ "Talking to vault-wrapper at " ++ flags_vaultWrapperUrl
   _ <- runResourceT $ do
-    cxt <- initContextLite
+    cxt <- initContextLite flags_vaultWrapperUrl
 
     bracket
       (connectMe $ discoveryPort $ discoveryConfig ethConf)

--- a/core-strato/ethereum-discovery/src/Executable/EthereumDiscovery.hs
+++ b/core-strato/ethereum-discovery/src/Executable/EthereumDiscovery.hs
@@ -9,35 +9,31 @@ import           UnliftIO.Exception
 import           Control.Monad.IO.Class
 import           Blockchain.Output
 import           Control.Monad.Trans.Resource
-import qualified Data.ByteString.Base16                  as B16
-import           Data.Maybe
+-- import qualified Data.ByteString.Base16                  as B16
+-- import           Data.Maybe
 import qualified Data.Text                               as T
-import qualified Network.Haskoin.Internals               as H
 import qualified Network.Socket                          as S
 
-import           Blockchain.Data.PubKey
+--import           Blockchain.Data.PubKey
 import           Blockchain.EthConf
 
 import           Blockchain.Strato.Discovery.ContextLite
-import           Blockchain.Strato.Discovery.P2PUtil
+--import           Blockchain.Strato.Discovery.P2PUtil
 import           Blockchain.Strato.Discovery.UDPServer
 import qualified Text.Colors                             as CL
 
-privateKey :: H.PrvKey
-privateKey = fromMaybe (error "Bad value for hardcoded private key in ethconf.yaml") $ H.makePrvKey $ unPrivKey $ privKey ethConf
-
 ethereumDiscovery :: LoggingT IO ()
 ethereumDiscovery = do
-  let Right pubKey = hPubKeyToPubKey $ H.derivePubKey privateKey
   _ <- $logInfoS "ethereumDiscovery" $ T.pack $ CL.blue "Welcome to ethereum-discovery"
   _ <- $logInfoS "ethereumDiscovery" $ T.pack $ CL.blue "============================="
-  _ <- $logInfoS "ethereumDiscovery" $ T.pack $ CL.green " * My NodeID is " ++ show (B16.encode $ pointToBytes pubKey)
+  -- TODO: a lil getPub here so that we can print the NodeID like we used to
+--  _ <- $logInfoS "ethereumDiscovery" $ T.pack $ CL.green " * My NodeID is " ++ show (B16.encode $ pointToBytes pubKey)
   _ <- runResourceT $ do
     cxt <- initContextLite
 
     bracket
       (connectMe $ discoveryPort $ discoveryConfig ethConf)
       (liftIO . S.close)
-      (runEthUDPServer cxt privateKey (discoveryPort $ discoveryConfig ethConf))
+      (runEthUDPServer cxt (discoveryPort $ discoveryConfig ethConf))
 
   return ()

--- a/core-strato/ethereum-discovery/src/Executable/Options.hs
+++ b/core-strato/ethereum-discovery/src/Executable/Options.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Executable.Options where
+
+import           HFlags
+
+
+defineFlag "vaultWrapperUrl" ("http://vault-wrapper:8000/strato/v2.3" :: String) "Vault-Wrapper URL"
+
+$(return [])


### PR DESCRIPTION
This is a subPR for the identity project's nodekey migration. See the full PR description here: #1096

The changes in this PR upgrade `ethereum-discovery` to use the `vault-wrapper` for ECDSA signatures with the nodekey, via the `HasVault` typeclass defined in `Blockchain.Strato.Model.Secp256k1`. The specifics:
- `ethereum-discovery`'s `ReaderT ContextLite` monad stores a servant `ClientEnv`.
- the `HasVault` instance on `ReaderT ContextLite` uses the `ClientEnv` to ask the vault-wrapper for ECDSA signatures
- the functions that need signatures (and their calling functions) have the `HasVault` class constraint
- public key signature recovery uses the `Blockchain.Strato.Model.Secp256k1` version (instead of Haskoin)
- signature encoding uses the `Secp256k1` `Binary` instance on the `Signature` type
- various tweaks of the number of bytes to send/recv given new signature encoding lengths (maybe this is a problem for upgrades, and I'll have to mimic the old signature encoding to get the same length, but we'll see)
- For now, convert to/from the `Secp256k1` public key type and the `cryptonite` `Point` type where necessary (mostly to create the `PPeer`) - eventually, I'd like to remove `cryptonite` altogether.


Don't merge this yet!