### PR TITLE
[Identity] ethereum-encryption and strato-p2p use the vault-wrapper NODEKEY

### DIFF
--- a/core-strato/ethereum-encryption/package.yaml
+++ b/core-strato/ethereum-encryption/package.yaml
@@ -27,7 +27,6 @@ library:
   - conduit-extra
   - crypto-pubkey
   - crypto-pubkey-types
-  - crypto-random
   - cryptohash
   - cryptonite
   - entropy
@@ -35,6 +34,7 @@ library:
   - lifted-base
   - memory
   - mtl
+  - strato-model
 
 
 tests:
@@ -42,6 +42,10 @@ tests:
     source-dirs: test/
     main: Spec.hs
     dependencies:
-      - QuickCheck
+      - base16-bytestring
+      - bytestring
+      - crypto-pubkey-types
       - ethereum-encryption
       - hspec
+      - strato-model
+      - QuickCheck

--- a/core-strato/ethereum-encryption/src/Blockchain/Data/PubKey.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/Data/PubKey.hs
@@ -6,7 +6,8 @@ module Blockchain.Data.PubKey (
   pointToString,
   pointToBytes,
   bytesToPoint,
-  pubKeyToBytes
+  secPubKeyToPoint,
+  pointToSecPubKey
   ) where
 
 import           Crypto.Types.PubKey.ECC
@@ -16,10 +17,10 @@ import qualified Data.ByteString.Base16    as B16
 import qualified Data.ByteString.Char8     as BC
 import           Data.Maybe
 import           Data.Word
-import qualified Network.Haskoin.Internals as H
 
 import           Blockchain.Data.RLP
 import           Blockchain.ExtWord
+import qualified Blockchain.Strato.Model.Secp256k1          as Secp256k1
 import qualified Text.Colors               as CL
 import           Text.Format
 
@@ -55,15 +56,6 @@ pointToBytes::Point->B.ByteString
 pointToBytes (Point x y) = B.pack $ intToBytes x ++ intToBytes y
 pointToBytes PointO      = error "pointToBytes got value PointO, I don't know what to do here"
 
-hPointToBytes::H.Point->B.ByteString
-hPointToBytes point = word256ToBytes (fromIntegral x) <> word256ToBytes (fromIntegral y)
-  where
-    x = fromMaybe (error "getX failed in prvKey2Address") $ H.getX point
-    y = fromMaybe (error "getY failed in prvKey2Address") $ H.getY point
-
-pubKeyToBytes::H.PubKey->B.ByteString
-pubKeyToBytes pubKey = hPointToBytes $ H.pubKeyPoint pubKey
-
 bytesToPoint::B.ByteString->Point
 bytesToPoint bs | B.length bs == 64 =
   let (xs, ys)= B.splitAt 32 bs
@@ -73,3 +65,15 @@ bytesToPoint _ = error "bytesToPoint called with the wrong number of bytes"
 intToBytes::Integer->[Word8]
 intToBytes x = map (fromIntegral . (x `shiftR`)) [256-8, 256-16..0]
 
+
+-- TODO: eventually, secp256k1 is the ONLY library we should use (no Point conversions)
+secPubKeyToPoint :: Secp256k1.PublicKey -> Point
+secPubKeyToPoint pub = 
+  let pkbs = B.drop 1 $ Secp256k1.exportPublicKey False pub
+  in bytesToPoint pkbs
+
+pointToSecPubKey :: Point -> Secp256k1.PublicKey
+pointToSecPubKey pt = 
+  let pkbs = B.singleton 0x04 `B.append` pointToBytes pt -- 0x04 indicates this is a SEC serialized pubkey
+      err = "could not convert point to secp256k1 public key: " ++ show pt
+  in fromMaybe (error err) (Secp256k1.importPublicKey pkbs)

--- a/core-strato/ethereum-encryption/src/Blockchain/ECIES.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/ECIES.hs
@@ -9,59 +9,60 @@ module Blockchain.ECIES (
 
 import                 Codec.Utils
 import                 Control.Monad
+import                 Control.Monad.IO.Class
 import "cipher-aes"    Crypto.Cipher.AES
 import                 Crypto.Hash.SHA256
-import "crypto-pubkey" Crypto.PubKey.ECC.DH
 import                 Crypto.Types.PubKey.ECC
 import                 Data.Binary
 import                 Data.Binary.Get
 import                 Data.Binary.Put
-import                 Data.Bits
 import qualified       Data.ByteString         as B
 import qualified       Data.ByteString.Lazy    as BL
 import                 Data.HMAC
 import                 System.Entropy
 
+import                 Blockchain.Data.PubKey
 import                 Blockchain.ExtWord
+import                 Blockchain.Strato.Model.Secp256k1
 
 theCurve :: Curve
 theCurve = getCurveByName SEC_p256k1
 
-encrypt  ::  PrivateNumber->Point->B.ByteString->B.ByteString->IO BL.ByteString
-encrypt myPrvKey otherPubKey bytes prefix = do
-  cipherIV <- getEntropy 16
-  return $ encode $ encryptECIES myPrvKey otherPubKey cipherIV bytes prefix
+encrypt  ::  MonadIO m => SharedKey->Point->B.ByteString->B.ByteString-> m BL.ByteString
+encrypt sharedKey myPubKey bytes prefix = do
+  cipherIV <- liftIO $ getEntropy 16
+  return $ encode $ encryptECIES sharedKey myPubKey cipherIV bytes prefix
 
-decrypt  ::  PrivateNumber->BL.ByteString->B.ByteString->Either String B.ByteString
-decrypt prvKey bytes prefix = do
+decrypt :: HasVault m => BL.ByteString -> B.ByteString -> m (Either String B.ByteString)
+decrypt bytes prefix = do
   let eciesMsg = decode bytes
 
   --Special case of the next check, indicates that a different key encoding was used
   when (eciesForm eciesMsg `elem` [2,3]) $ error "peer connected with unsupported handshake packet"
 
-  unless (eciesForm eciesMsg == 4) $
-       Left $ "first byte of buffer must be 4: " ++ show (BL.unpack bytes)
+  if (eciesForm eciesMsg /= 4) then
+       return $ Left $ "first byte of buffer must be 4: " ++ show (BL.unpack bytes)
+  else do
+    sharedKey <- getShared $ pointToSecPubKey $ eciesPubKey eciesMsg 
+    
+    let msg = decryptECIES sharedKey eciesMsg
+        (expectedMac, _) = getMacAndCipher sharedKey (eciesCipherIV eciesMsg) msg prefix
 
-  let msg = decryptECIES prvKey eciesMsg
-
-  let (expectedMac, _) = getMacAndCipher prvKey (eciesPubKey eciesMsg) (eciesCipherIV eciesMsg) msg prefix
-
-  unless (eciesMac eciesMsg == expectedMac) $
-       Left $ "mac doesn't match: expected " ++ show expectedMac
+    if (eciesMac eciesMsg /= expectedMac) then
+       return $ Left $ "mac doesn't match: expected " ++ show expectedMac
               ++ ", got " ++ show (eciesMac eciesMsg)
-
-  return msg
+    else return $ Right msg
 
 -----------------
 
-intToBytes  ::  Integer->[Word8]
-intToBytes x = map (fromIntegral . (x `shiftR`)) [256-8, 256-16..0]
+--intToBytes  ::  Integer->[Word8]
+--intToBytes x = map (fromIntegral . (x `shiftR`)) [256-8, 256-16..0]
 
 ctr  ::  [Word8]
 ctr=[0,0,0,1]
 
-s1  ::  [Word8]
-s1 = []
+--s1  ::  [Word8]
+--s1 = []
 
 
 data ECIESMessage =
@@ -110,38 +111,35 @@ errorHead msg _   = error msg
 encrypt'  ::  B.ByteString->B.ByteString->B.ByteString->B.ByteString
 encrypt' key cipherIV input = encryptCTR (initAES key) cipherIV input
 
-getMacAndCipher  ::  PrivateNumber->PublicPoint->B.ByteString->B.ByteString->B.ByteString->([Octet], B.ByteString)
-getMacAndCipher myPrvKey otherPubKey cipherIV msg prefix =
+getMacAndCipher  ::  SharedKey->B.ByteString->B.ByteString->B.ByteString->([Octet], B.ByteString)
+getMacAndCipher (SharedKey sharedKey) cipherIV msg prefix =
   (
     hmac (HashMethod (B.unpack . hash . B.pack) 512) (B.unpack mKey) (B.unpack cipherWithIV ++ B.unpack prefix),
     cipher
   )
   where
     cipherWithIV = cipherIV `B.append` cipher
-    SharedKey sharedKey = getShared theCurve myPrvKey otherPubKey
-    key = hash $ B.pack (ctr ++ intToBytes sharedKey ++ s1)
+    key = hash $ B.pack ctr `B.append` sharedKey
     mKeyMaterial = B.take 16 $ B.drop 16 key
     mKey = hash mKeyMaterial
     eKey = B.take 16 key
     cipher = encrypt' eKey cipherIV msg
 
-encryptECIES  ::  PrivateNumber->PublicPoint->B.ByteString->B.ByteString->B.ByteString->ECIESMessage
-encryptECIES myPrvKey otherPubKey cipherIV msg prefix =
+encryptECIES  ::  SharedKey->PublicPoint->B.ByteString->B.ByteString->B.ByteString->ECIESMessage
+encryptECIES sharedKey myPubKey cipherIV msg prefix =
   ECIESMessage {
     eciesForm = 4, --form=4 indicates pubkey is not compressed
-    eciesPubKey=calculatePublic theCurve myPrvKey,
+    eciesPubKey=myPubKey, 
     eciesCipherIV=cipherIV,
     eciesCipher=cipher,
     eciesMac=mac
     }
   where
-    (mac, cipher) = getMacAndCipher myPrvKey otherPubKey cipherIV msg prefix
+    (mac, cipher) = getMacAndCipher sharedKey cipherIV msg prefix
 
 
-decryptECIES  ::  PrivateNumber->ECIESMessage->B.ByteString
-decryptECIES myPrvKey msg =
-  decryptCTR (initAES eKey) (eciesCipherIV msg) (eciesCipher msg)
-  where
-    SharedKey sharedKey = getShared theCurve myPrvKey (eciesPubKey msg)
-    key = hash $ B.pack (ctr ++ intToBytes sharedKey ++ s1)
-    eKey = B.take 16 key
+decryptECIES  :: SharedKey -> ECIESMessage -> B.ByteString
+decryptECIES (SharedKey sharedKey) msg =
+  let key = hash $ B.pack ctr `B.append` sharedKey
+      eKey = B.take 16 key
+  in encryptCTR (initAES eKey) (eciesCipherIV msg) (eciesCipher msg)

--- a/core-strato/ethereum-encryption/src/Blockchain/Handshake.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/Handshake.hs
@@ -7,7 +7,7 @@ module Blockchain.Handshake (
   bytesToAckMsg
   ) where
 
-import "crypto-pubkey" Crypto.PubKey.ECC.DH
+import                 Control.Monad.IO.Class
 import                 Crypto.Types.PubKey.ECC
 import                 Data.Binary
 import                 Data.Binary.Get
@@ -16,19 +16,12 @@ import                 Data.Bits
 import qualified       Data.ByteString             as B
 import qualified       Data.ByteString.Lazy        as BL
 import                 Data.Maybe
-import qualified       Network.Haskoin.Internals   as H
 
 import                 Blockchain.Data.PubKey
 import qualified       Blockchain.ECIES            as ECIES
-import                 Blockchain.ExtendedECDSA
 import                 Blockchain.ExtWord
 import                 Blockchain.Strato.Model.Keccak256 (hash, keccak256ToByteString)
-
-sigToBytes::ExtendedSignature->B.ByteString
-sigToBytes (ExtendedSignature signature yIsOdd) =
-  word256ToBytes (fromIntegral $ H.sigR signature) <>
-  word256ToBytes (fromIntegral $ H.sigS signature) <>
-  B.singleton (if yIsOdd then 1 else 0)
+import                 Blockchain.Strato.Model.Secp256k1
 
 
 data AckMessage = AckMessage {
@@ -78,41 +71,31 @@ bytesToAckMsg bytes | B.length bytes == 97 =
     }
 bytesToAckMsg _ = error "wrong number of bytes in call to bytesToECIESMsg"
 
-getHandshakeBytes::PrivateNumber->PublicPoint->B.ByteString->IO B.ByteString
-getHandshakeBytes myPriv otherPubKey myNonce = do
-  let
-    myPublic = calculatePublic ECIES.theCurve myPriv
-    SharedKey sharedKey = getShared ECIES.theCurve myPriv otherPubKey
 
-    msg = fromIntegral sharedKey `xor` bytesToWord256 myNonce
+getHandshakeBytes :: (MonadIO m, HasVault m) => PublicPoint -> B.ByteString -> m B.ByteString
+getHandshakeBytes otherPubKey myNonce = do
+  myPublic' <- getPub
+  SharedKey sharedKey <- getShared $ pointToSecPubKey otherPubKey
 
-
- --  putStrLn $ "sharedKey: " ++ show sharedKey
-  -- putStrLn $ "msg:       " ++ show msg
-  sig <- H.withSource H.devURandom $ extSignMsg msg (fromMaybe (error "invalid private number in call to getHandshakeBytes") $ H.makePrvKey $ fromIntegral myPriv)
+  let myPublic = secPubKeyToPoint myPublic'
+      msg = word256ToBytes $ bytesToWord256 sharedKey `xor` bytesToWord256 myNonce
+  
+  sig <- sign msg 
+  
+  -- this signature recovery is pointless - the "ephermal" key is actually just myPublic
   let
     ephemeral =
       fromMaybe (error "malformed signature given to call getHandshakeBytes") $
-      getPubKeyFromSignature sig msg
-    hepubk = keccak256ToByteString $ hash $ pubKeyToBytes ephemeral
+      recoverPub sig msg
+    hepubk = keccak256ToByteString $ hash $ pointToBytes $ secPubKeyToPoint ephemeral
     pubk = pointToBytes myPublic
-    theData = sigToBytes sig `B.append`
+    theData = (BL.toStrict $ encode sig) `B.append`
                 hepubk `B.append`
                 pubk `B.append`
                 myNonce `B.append`
-                B.singleton 0
-  -- putStrLn $ "ephemeral: " ++ show ephemeral
-  -- putStrLn $ "hepubk: " ++ show hepubk
-  -- putStrLn $ "pubk: " ++ show pubk
-  -- putStrLn $ "theData: " ++ show theData
-
-  eciesMsgBytes <- fmap BL.toStrict $ ECIES.encrypt myPriv otherPubKey theData B.empty
-
-  -- putStrLn $ "eciesMsg: "
-  -- putStrLn $ show eciesMsg
-
-  -- putStrLn $ "length ciphertext: " ++ (show . B.length $ eciesCipher eciesMsg)
-  -- putStrLn $ "length of wire message: " ++ (show . B.length $ eciesMsgBytes)
+                B.singleton 0  -- TODO: would be nice to have binary instances here, not just raw BS stuff
+  
+  eciesMsgBytes <- fmap BL.toStrict $ ECIES.encrypt (SharedKey sharedKey) myPublic theData B.empty
 
   return $ eciesMsgBytes
 

--- a/core-strato/ethereum-encryption/src/Blockchain/Handshake.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/Handshake.hs
@@ -89,7 +89,7 @@ getHandshakeBytes otherPubKey myNonce = do
       recoverPub sig msg
     hepubk = keccak256ToByteString $ hash $ pointToBytes $ secPubKeyToPoint ephemeral
     pubk = pointToBytes myPublic
-    theData = (BL.toStrict $ encode sig) `B.append`
+    theData = (exportSignature sig) `B.append`
                 hepubk `B.append`
                 pubk `B.append`
                 myNonce `B.append`

--- a/core-strato/ethereum-encryption/src/Blockchain/RLPx.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/RLPx.hs
@@ -12,8 +12,6 @@ import                 Control.Monad.IO.Class
 import "cipher-aes"    Crypto.Cipher.AES
 import "cryptonite"    Crypto.Hash                       (hashInitWith, hashUpdate)
 import                 Crypto.Hash.Algorithms            (Keccak_256(..))
-import "crypto-pubkey" Crypto.PubKey.ECC.DH
-import "crypto-random" Crypto.Random
 import                 Crypto.Types.PubKey.ECC
 import                 Data.Binary
 import                 Data.Bits
@@ -22,7 +20,6 @@ import qualified       Data.ByteString.Lazy              as BL
 import                 Data.Conduit
 import qualified       Data.Conduit.Binary               as CB
 import                 Data.Maybe
-import qualified       Network.Haskoin.Internals         as H
 
 import qualified       Blockchain.AESCTR                 as AES
 import                 Blockchain.Data.PubKey
@@ -30,14 +27,12 @@ import                 Blockchain.Data.RLP
 import qualified       Blockchain.ECIES                  as ECIES
 import                 Blockchain.Error
 import                 Blockchain.EthEncryptionException
-import                 Blockchain.ExtendedECDSA
 import                 Blockchain.ExtWord
 import                 Blockchain.Frame
 import                 Blockchain.Handshake
 import                 Blockchain.Strato.Model.Keccak256 (hash, keccak256ToByteString)
+import                 Blockchain.Strato.Model.Secp256k1
 
-intToBytes :: Integer -> [Word8]
-intToBytes x = map (fromIntegral . (x `shiftR`)) [256-8, 256-16..0]
 
 bXor :: B.ByteString
      -> B.ByteString
@@ -45,27 +40,29 @@ bXor :: B.ByteString
 bXor x y | B.length x == B.length y = B.pack $ B.zipWith xor x y
 bXor _ _ = error' "bXor called with two ByteStrings of different length"
 
-ethCryptConnect :: MonadIO m
-                => PrivateNumber
-                -> PublicPoint
+ethCryptConnect :: (MonadIO m, HasVault m)
+                => PublicPoint
                 -> ConduitM B.ByteString B.ByteString m (EthCryptState, EthCryptState)
-ethCryptConnect myPriv otherPubKey = do
+ethCryptConnect otherPubKey = do
 
   let myNonce = word256ToBytes 20 --TODO- Important!  Don't hardcode this
 
-  handshakeInitBytes <- liftIO $ getHandshakeBytes myPriv otherPubKey myNonce
-
+  handshakeInitBytes <- getHandshakeBytes otherPubKey myNonce
   yield handshakeInitBytes
 
   handshakeReplyBytes <- CB.take 210
 
   when (BL.length handshakeReplyBytes /= 210) $ liftIO $ throwIO $ HandshakeException "handshake reply didn't contain enough bytes"
 
-  let ackMsg            = bytesToAckMsg $ either (error . ("error in ethCryptConnect"++)) id $ ECIES.decrypt myPriv handshakeReplyBytes B.empty
-      m_originated      = False -- hardcoded for now, I can only connect as client
+  eAckBS <- ECIES.decrypt handshakeReplyBytes B.empty
+
+  let ackMsg = bytesToAckMsg $ either (error . ("error in ethCryptConnect"++)) id eAckBS 
+  
+  SharedKey shared <- getShared $ pointToSecPubKey $ ackEphemeralPubKey ackMsg
+
+
+  let m_originated      = False -- hardcoded for now, I can only connect as client
       otherNonce        = word256ToBytes $ ackNonce ackMsg
-      SharedKey shared' = getShared ECIES.theCurve myPriv (ackEphemeralPubKey ackMsg)
-      shared            = B.pack $ intToBytes shared'
       frameDecKey       = myNonce `add` otherNonce `add` shared `add` shared
       macEncKey         = frameDecKey `add` shared
       ingressCipher     = if m_originated then handshakeInitBytes else BL.toStrict handshakeReplyBytes
@@ -90,46 +87,40 @@ add :: B.ByteString
 add acc val | B.length acc ==32 && B.length val == 32 = keccak256ToByteString $ hash $ val `B.append` acc
 add _ _     = error "add called with ByteString of length not 32"
 
-hPubKeyToPubKey :: H.PubKey -> Point
-hPubKeyToPubKey pubKey =
-  Point (fromIntegral x) (fromIntegral y)
-  where
-    x = fromMaybe (error "getX failed in prvKey2Address") $ H.getX hPoint
-    y = fromMaybe (error "getY failed in prvKey2Address") $ H.getY hPoint
-    hPoint = H.pubKeyPoint pubKey
 
-ethCryptAccept :: MonadIO m
-               => PrivateNumber
-               -> Point
+ethCryptAccept :: (MonadIO m, HasVault m)
+               => Point
                -> ConduitM B.ByteString B.ByteString m (EthCryptState, EthCryptState)
-ethCryptAccept myPriv otherPoint = do
-  hsBytes <- CB.take 307
-
+ethCryptAccept otherPoint = do
+  
+  hsBytes <- CB.take 323 -- was 307... new binary encoded sigV is 16 bytes (not 1) for some reason
+  
+  hs <- ECIES.decrypt hsBytes B.empty
   maybeResult <-
-    case ECIES.decrypt myPriv hsBytes B.empty of
+    case hs of
      Left _  -> return Nothing
-     Right x -> ethCryptAcceptOld myPriv otherPoint hsBytes x
+     Right x -> ethCryptAcceptOld otherPoint hsBytes x
+  
 
   case maybeResult of
    Just x -> return x
    Nothing -> do
      let (first:second:_) = BL.unpack hsBytes
          fullSize = fromIntegral first*256 + fromIntegral second
-         remainingSize = fullSize - 307 + 2
+         remainingSize = fullSize - 323 + 2 -- was 307
      remainingBytes <- CB.take remainingSize
      let fullBuffer = BL.drop 2 $ hsBytes `BL.append` remainingBytes
-         maybeEciesMsgIBytes = ECIES.decrypt myPriv fullBuffer $ BL.toStrict $ BL.take 2 $ hsBytes `BL.append` remainingBytes
-         eciesMsgIBytes = either (error . (++ ": " ++ show (BL.unpack fullBuffer)) . ("Malformed packed sent from peer: " ++)) id maybeEciesMsgIBytes
-     ethCryptAcceptEIP8 myPriv otherPoint (hsBytes `BL.append` remainingBytes) eciesMsgIBytes
+     maybeEciesMsgIBytes <- ECIES.decrypt fullBuffer $ BL.toStrict $ BL.take 2 $ hsBytes `BL.append` remainingBytes
+     let eciesMsgIBytes = either (error . (++ ": " ++ show (BL.unpack fullBuffer)) . ("Malformed packed sent from peer: " ++)) id maybeEciesMsgIBytes
+     ethCryptAcceptEIP8 otherPoint (hsBytes `BL.append` remainingBytes) eciesMsgIBytes
 
 
-ethCryptAcceptEIP8 :: MonadIO m
-                   => PrivateNumber
-                   -> Point
+ethCryptAcceptEIP8 :: (MonadIO m, HasVault m)
+                   => Point
                    -> BL.ByteString
                    -> B.ByteString
                    -> ConduitM B.ByteString B.ByteString m (EthCryptState, EthCryptState)
-ethCryptAcceptEIP8 myPriv _ hsBytes eciesMsgIBytes = do
+ethCryptAcceptEIP8 _ hsBytes eciesMsgIBytes = do
 
   let (RLPArray [signatureRLP, pubKeyRLP, otherNonceRLP, versionRLP], _) = rlpSplit eciesMsgIBytes
       otherNonce = rlpDecode otherNonceRLP
@@ -141,32 +132,29 @@ ethCryptAcceptEIP8 myPriv _ hsBytes eciesMsgIBytes = do
 
   when (version /= 4) $ error "wrong version in packet sent to ethCryptAcceptEIP8"
 
-  let SharedKey sharedKey = getShared ECIES.theCurve myPriv otherPoint
-      msg = fromIntegral sharedKey `xor` bytesToWord256 otherNonce
-      otherEphemeral = hPubKeyToPubKey $
+  SharedKey sharedKey <- getShared $ pointToSecPubKey otherPoint
+  let msg = word256ToBytes $ bytesToWord256 sharedKey `xor` bytesToWord256 otherNonce
+      otherEphemeral = secPubKeyToPoint $
                             fromMaybe (error "malformed signature in tcpHandshakeServer") $
-                            getPubKeyFromSignature extSig msg
+                            recoverPub extSig msg
 
-  entropyPool <- liftIO createEntropyPool
-  let g = cprgCreate entropyPool :: SystemRNG
-      (myPriv', _) = generatePrivate g $ getCurveByName SEC_p256k1
-      myEphemeral = calculatePublic ECIES.theCurve myPriv'
+  ephemeralPriv <- liftIO $ newPrivateKey
+  let myEphemeral = secPubKeyToPoint $ derivePublicKey ephemeralPriv
       myNonce = 25 :: Word256
       ackMsg = AckMessage { ackEphemeralPubKey=myEphemeral, ackNonce=myNonce, ackKnownPeer=False }
+      cryptSecret = deriveSharedKey ephemeralPriv (pointToSecPubKey otherPoint)
 
-  eciesMsgOBytes <- liftIO $ fmap BL.toStrict $ ECIES.encrypt myPriv' otherPoint (BL.toStrict $ encode $ ackMsg) B.empty
+  eciesMsgOBytes <- fmap BL.toStrict $ ECIES.encrypt cryptSecret myEphemeral (BL.toStrict $ encode $ ackMsg) B.empty
 
   yield $ eciesMsgOBytes
 
-  let SharedKey ephemeralSharedSecret = getShared ECIES.theCurve myPriv' otherEphemeral
-      ephemeralSharedSecretBytes = intToBytes ephemeralSharedSecret
-
+  let SharedKey ephemeralSharedSecret = deriveSharedKey ephemeralPriv $ pointToSecPubKey otherEphemeral
       myNonceBS = word256ToBytes myNonce
       frameDecKey = otherNonce `add`
                         myNonceBS `add`
-                        (B.pack ephemeralSharedSecretBytes) `add`
-                        (B.pack ephemeralSharedSecretBytes)
-      macEncKey = frameDecKey `add` (B.pack ephemeralSharedSecretBytes)
+                        ephemeralSharedSecret `add`
+                        ephemeralSharedSecret
+      macEncKey = frameDecKey `add` ephemeralSharedSecret
 
   return (
       EthCryptState { --encrypt
@@ -181,42 +169,37 @@ ethCryptAcceptEIP8 myPriv _ hsBytes eciesMsgIBytes = do
         }
       )
 
-ethCryptAcceptOld :: MonadIO m
-                  => PrivateNumber
-                  -> Point
+ethCryptAcceptOld :: (MonadIO m, HasVault m)
+                  => Point
                   -> BL.ByteString
                   -> B.ByteString
                   -> ConduitM B.ByteString B.ByteString m (Maybe (EthCryptState, EthCryptState))
-ethCryptAcceptOld myPriv otherPoint hsBytes eciesMsgIBytes = do
+ethCryptAcceptOld otherPoint hsBytes eciesMsgIBytes = do
 
-    let SharedKey sharedKey = getShared ECIES.theCurve myPriv otherPoint
-        otherNonce = B.take 32 $ B.drop 161 $ eciesMsgIBytes
-        msg = fromIntegral sharedKey `xor` bytesToWord256 otherNonce
-        extSig = rlpDecode . RLPString $ eciesMsgIBytes
-        otherEphemeral = hPubKeyToPubKey $
+    SharedKey sharedKey <- getShared $ pointToSecPubKey otherPoint
+    let otherNonce = B.take 32 $ B.drop 177 $ eciesMsgIBytes -- was B.drop 161
+        msg = word256ToBytes $ bytesToWord256 sharedKey `xor` bytesToWord256 otherNonce
+        extSig = decode $ BL.fromStrict eciesMsgIBytes
+        otherEphemeral = secPubKeyToPoint $
                             fromMaybe (error "malformed signature in tcpHandshakeServer") $
-                            getPubKeyFromSignature extSig msg
-
-    entropyPool <- liftIO createEntropyPool
-    let g = cprgCreate entropyPool :: SystemRNG
-        (myPriv', _) = generatePrivate g $ getCurveByName SEC_p256k1
-        myEphemeral = calculatePublic ECIES.theCurve myPriv'
+                            recoverPub extSig msg
+    
+    ephemeralPriv <- liftIO $ newPrivateKey
+    let myEphemeral = secPubKeyToPoint $ derivePublicKey ephemeralPriv
         myNonce = 25 :: Word256
         ackMsg = AckMessage { ackEphemeralPubKey=myEphemeral, ackNonce=myNonce, ackKnownPeer=False }
-
-    eciesMsgOBytes <- liftIO $ fmap BL.toStrict $ ECIES.encrypt myPriv' otherPoint (BL.toStrict $ encode $ ackMsg) B.empty
+        cryptSecret = deriveSharedKey ephemeralPriv (pointToSecPubKey otherPoint)
+    eciesMsgOBytes <- fmap BL.toStrict $ ECIES.encrypt cryptSecret myEphemeral (BL.toStrict $ encode $ ackMsg) B.empty
 
     yield $ eciesMsgOBytes
 
-    let SharedKey ephemeralSharedSecret = getShared ECIES.theCurve myPriv' otherEphemeral
-        ephemeralSharedSecretBytes = intToBytes ephemeralSharedSecret
-
+    let SharedKey ephemeralSharedSecret = deriveSharedKey ephemeralPriv $ pointToSecPubKey otherEphemeral
         myNonceBS = word256ToBytes myNonce
         frameDecKey = otherNonce `add`
                         myNonceBS `add`
-                        (B.pack ephemeralSharedSecretBytes) `add`
-                        (B.pack ephemeralSharedSecretBytes)
-        macEncKey = frameDecKey `add` (B.pack ephemeralSharedSecretBytes)
+                        ephemeralSharedSecret `add`
+                        ephemeralSharedSecret
+        macEncKey = frameDecKey `add` ephemeralSharedSecret
 
     return $ Just (
       EthCryptState { --encrypt

--- a/core-strato/ethereum-encryption/src/Blockchain/RLPx.hs
+++ b/core-strato/ethereum-encryption/src/Blockchain/RLPx.hs
@@ -93,8 +93,7 @@ ethCryptAccept :: (MonadIO m, HasVault m)
                -> ConduitM B.ByteString B.ByteString m (EthCryptState, EthCryptState)
 ethCryptAccept otherPoint = do
   
-  hsBytes <- CB.take 323 -- was 307... new binary encoded sigV is 16 bytes (not 1) for some reason
-  
+  hsBytes <- CB.take 307   
   hs <- ECIES.decrypt hsBytes B.empty
   maybeResult <-
     case hs of
@@ -107,7 +106,7 @@ ethCryptAccept otherPoint = do
    Nothing -> do
      let (first:second:_) = BL.unpack hsBytes
          fullSize = fromIntegral first*256 + fromIntegral second
-         remainingSize = fullSize - 323 + 2 -- was 307
+         remainingSize = fullSize - 307 + 2 
      remainingBytes <- CB.take remainingSize
      let fullBuffer = BL.drop 2 $ hsBytes `BL.append` remainingBytes
      maybeEciesMsgIBytes <- ECIES.decrypt fullBuffer $ BL.toStrict $ BL.take 2 $ hsBytes `BL.append` remainingBytes
@@ -177,9 +176,9 @@ ethCryptAcceptOld :: (MonadIO m, HasVault m)
 ethCryptAcceptOld otherPoint hsBytes eciesMsgIBytes = do
 
     SharedKey sharedKey <- getShared $ pointToSecPubKey otherPoint
-    let otherNonce = B.take 32 $ B.drop 177 $ eciesMsgIBytes -- was B.drop 161
+    let otherNonce = B.take 32 $ B.drop 161 $ eciesMsgIBytes
         msg = word256ToBytes $ bytesToWord256 sharedKey `xor` bytesToWord256 otherNonce
-        extSig = decode $ BL.fromStrict eciesMsgIBytes
+        extSig = importSignature $ B.take 65 eciesMsgIBytes
         otherEphemeral = secPubKeyToPoint $
                             fromMaybe (error "malformed signature in tcpHandshakeServer") $
                             recoverPub extSig msg

--- a/core-strato/ethereum-encryption/test/Spec.hs
+++ b/core-strato/ethereum-encryption/test/Spec.hs
@@ -1,13 +1,34 @@
-import Test.Hspec
-import Test.QuickCheck
+import           Test.Hspec
+import           Test.QuickCheck
 
-import Blockchain.Data.RLP
-import Blockchain.ExtendedECDSA
+
+import qualified Data.ByteString          as B
+import qualified Data.ByteString.Base16   as B16
+import qualified Data.ByteString.Char8    as C8
+import           Data.Maybe
+
+import           Blockchain.Data.RLP
+import           Blockchain.Data.PubKey
+import           Blockchain.ExtendedECDSA
+
+import qualified Blockchain.Strato.Model.Secp256k1         as NEW
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
-spec = describe "basic test" $ do
+spec = do
+  describe "basic test" $ do
     it "encode and decode signatures" $ property $ \extsig ->
         rlpDecode (rlpEncode extsig) `shouldBe` (extsig :: ExtendedSignature)
+  describe "secp256k1-haskell/cryptonite regressions" $ do
+    it "can cross-convert public keys" $ do
+      let pubBS = fst $ B16.decode $ C8.pack "0cf05b89208bfc93eae8d96a3cd243a96241980fed21aeb393421e48f92f5dc9d119598593433d6eb5a2d37289e0456d52001a43be84360bcb120acceb246b3c"
+          oldPub = bytesToPoint pubBS
+          -- proper SEC serialized public keys have a headerbyte 0x04 to indicidate ECDSA point
+          -- libsecp256k1 checks for this when importing
+          headerByte = B.singleton 0x04
+          newPub = fromMaybe (error "could not import public key") (NEW.importPublicKey (headerByte `B.append` pubBS))
+      pointToBytes oldPub `shouldBe` (B.drop 1 $ NEW.exportPublicKey False newPub)
+      oldPub `shouldBe` secPubKeyToPoint newPub
+      pointToSecPubKey oldPub `shouldBe` newPub

--- a/core-strato/run_unit_tests.sh
+++ b/core-strato/run_unit_tests.sh
@@ -10,6 +10,7 @@ TESTS=(
   blockapps-tools
   blockstanbul
   ethereum-discovery
+  ethereum-encryption
   ethereum-rlp
   ethereum-vm
   fast-keccak256

--- a/core-strato/run_unit_tests_long.sh
+++ b/core-strato/run_unit_tests_long.sh
@@ -6,6 +6,7 @@ set -x
 declare -i RESULT=0
 TESTS=(
   blockapps-data
+  ethereum-encryption
   ethereum-discovery
   ethereum-vm
   merkle-patricia-db

--- a/core-strato/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/core-strato/strato-p2p/exec_src/StratoP2PMain.hs
@@ -5,7 +5,7 @@ import           HFlags
 import           Network.Wai.Handler.Warp
 import           Network.Wai.Middleware.Prometheus
 
-import           Blockchain.Options (flags_participationMode)
+import           Blockchain.Options
 import           Blockchain.Output
 import           Blockchain.Participation (p2pApp, setParticipationMode)
 import           Blockchain.Strato.Discovery.Data.Peer (resetPeers)

--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -46,6 +46,8 @@ library:
     - blockapps-data
     - blockapps-datadefs
     - blockapps-haskoin
+    - blockapps-vault-wrapper-api
+    - blockapps-vault-wrapper-client
     - blockstanbul
     - bytestring
     - conduit
@@ -101,7 +103,7 @@ library:
 tests:
   strato-p2p-client-test:
     source-dirs: test
-    ghc-options: -Wall -Werror
+    ghc-options: -Wall -Werror -dynamic
     main: Main.hs
     dependencies:
       - QuickCheck

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -461,7 +461,7 @@ initConfig wireMessagesRef maxHeaders = do
   redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
   vaultClient <- do
     mgr <- liftIO $ newManager defaultManagerSettings
-    url <- liftIO $ parseBaseUrl "http://vault-wrapper:8000/strato/v2.3"
+    url <- liftIO $ parseBaseUrl flags_vaultWrapperUrl
     return $ ClientEnv mgr url Nothing
 
   initState <- newIORef initContext

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -55,6 +55,7 @@ module Blockchain.Context
 
 import           Conduit
 import           Control.Applicative
+import           Control.Concurrent
 import           Control.Lens                          hiding (Context)
 import qualified Control.Monad.Change.Alter            as A
 import qualified Control.Monad.Change.Modify           as Mod
@@ -87,6 +88,7 @@ import qualified Blockchain.Sequencer.Kafka            as SK
 
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Strato.Model.Keccak256
+import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Stream.VMEvent             ( HasVMEventsSink(..)
                                                        , VMEvent(..)
                                                        , fetchLastVMEvents
@@ -101,6 +103,10 @@ import qualified Database.Redis                        as Redis
 import qualified Network.Kafka                         as K
 import qualified Blockchain.MilenaTools                as K
 import           Blockchain.Util                       (toMaybe)
+import           Network.HTTP.Client                    (newManager, defaultManagerSettings)
+import           Servant.Client
+import qualified Strato.Strato23.API                   as VC
+import qualified Strato.Strato23.Client                as VC
 
 import           UnliftIO
 
@@ -138,6 +144,7 @@ data Config = Config
   , configVmEventsSink       :: forall m . (MonadIO m, MonadLogger m, Mod.Modifiable K.KafkaState m) => [VMEvent] -> m ()
   , configConnectionTimeout  :: ConnectionTimeout
   , configMaxReturnedHeaders :: MaxReturnedHeaders
+  , configVaultClient        :: ClientEnv
   , configContext            :: IORef Context
   , configBlockstanbulWireMessages :: IORef (S.OSet Keccak256)
   }
@@ -351,11 +358,38 @@ instance MonadUnliftIO m => A.Selectable String PPeer (ReaderT Config m) where
 
     where actions = SQL.selectList [ PPeerIp SQL.==. T.pack ip ] []
 
+
+instance (MonadIO m, Monad m) => HasVault (ReaderT Config m) where
+  sign bs = do
+    vc <- asks configVaultClient 
+    liftIO $ waitOnVault $ runClientM (VC.postSignature (T.pack "nodekey") (VC.MsgHash bs)) vc
+  
+  getPub = do
+    vc <- asks configVaultClient 
+    fmap VC.unPubKey $ liftIO $ waitOnVault $ runClientM (VC.getKey (T.pack "nodekey") Nothing) vc
+  
+  getShared pub = do
+    vc <- asks configVaultClient 
+    liftIO $ waitOnVault $ runClientM (VC.getSharedKey "nodekey" pub) vc
+
+
+waitOnVault :: (Show a) => IO (Either a b) -> IO b
+waitOnVault action = do
+  putStrLn "calling vault-wrapper..."
+  res <- action
+  case res of
+    Left err -> do
+      putStrLn $ "got an error from vault-wrapper: " ++ show err
+      threadDelay 2000000
+      waitOnVault action
+    Right val -> return val
+
 type MonadP2P m = ( MonadIO m
                   , MonadLogger m
                   , MonadResource m
                   , MonadUnliftIO m
                   , Stacks Block m
+                  , HasVault m
                   , All '[Mod.Accessible, Mod.Modifiable]
                       '[ ActionTimestamp
                        , [BlockData]
@@ -425,6 +459,11 @@ initConfig :: ( MonadLogger m
 initConfig wireMessagesRef maxHeaders = do
   dbs <- openDBs
   redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
+  vaultClient <- do
+    mgr <- liftIO $ newManager defaultManagerSettings
+    url <- liftIO $ parseBaseUrl "http://vault-wrapper:8000/strato/v2.3"
+    return $ ClientEnv mgr url Nothing
+
   initState <- newIORef initContext
   return $ Config
     { configSQLDB = sqlDB' dbs
@@ -433,6 +472,7 @@ initConfig wireMessagesRef maxHeaders = do
     , configVmEventsSink = void . produceVMEventsM
     , configConnectionTimeout = ConnectionTimeout flags_connectionTimeout
     , configMaxReturnedHeaders = MaxReturnedHeaders maxHeaders
+    , configVaultClient = vaultClient
     , configContext = initState
     , configBlockstanbulWireMessages = wireMessagesRef
     }

--- a/core-strato/strato-p2p/src/Blockchain/EventException.hs
+++ b/core-strato/strato-p2p/src/Blockchain/EventException.hs
@@ -7,6 +7,10 @@ import           Control.Exception.Lifted
 
 import           Blockchain.Data.Wire
 
-data EventException = PeerDisconnected | EventBeforeHandshake Message | WrongGenesisBlock deriving (Show)
+data EventException =
+    PeerDisconnected
+  | EventBeforeHandshake Message
+  | WrongGenesisBlock
+  | NoPeerPubKey deriving (Show)
 
 instance Exception EventException where

--- a/core-strato/strato-p2p/src/Blockchain/Options.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Options.hs
@@ -23,6 +23,7 @@ defineFlag "maxReturnedHeaders" (1000 :: Int) "Number of headers to return from 
 defineFlag "maxHeadersTxsLens" (2500 :: Int) "Number of txs size to return from a BlockHeader request"
 defineFlag "averageTxsPerBlock" (40 :: Int) "Average number of txs per block"
 defineFlag "wireMessageCacheSize" (2000 :: Int) "Number of wire messages to cache for network performance"
+defineFlag "vaultWrapperUrl" ("http://vault-wrapper:8000/strato/v2.3" :: String) "The Vault-Wrapper URL"
 defineFlag "txGossipFanout" (-1::Int) "Maxmimum number of peers to forward transactions to. Only\
                                       \ applicable for transactions received from peers, not\
                                       \ originating on this node."

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -24,7 +24,6 @@ import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
 import           Control.Monad.Reader
 import           Control.Monad.Trans.Resource
-import           Crypto.PubKey.ECC.DH
 import qualified Data.ByteString                       as B
 import qualified Data.ByteString.Char8                 as BC
 import           Data.Conduit
@@ -34,13 +33,11 @@ import           Data.Maybe
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Text                             as T
 import           Data.Traversable                      (for)
-import qualified Network.Haskoin.Internals             as H
 import           UnliftIO
 
 import           Blockchain.CommunicationConduit
 import           Blockchain.Context
-import           Blockchain.ECIES
-import           Blockchain.EthConf                    hiding (genesisHash, port)
+import           Blockchain.Data.PubKey                (secPubKeyToPoint)
 import           Blockchain.EthEncryptionException
 import           Blockchain.EventException
 import           Blockchain.Metrics
@@ -49,6 +46,7 @@ import           Blockchain.Output
 import           Blockchain.P2PRPC
 import           Blockchain.SeqEventNotify
 import           Blockchain.Sequencer.Event
+import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Strato.Discovery.UDP
 import           Blockchain.Strato.Model.Keccak256
@@ -60,17 +58,29 @@ import           Text.Format
 runPeer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
         => IORef (S.OSet Keccak256)
         -> PPeer
-        -> PrivateNumber
         -> BC.ByteString -- otherServiceCommHost
         -> CommPort      -- otherServiceCommPort
         -> m ()
-runPeer wireMessagesRef peer myPriv _ _ = do
+runPeer wireMessagesRef peer _ _ = do
   cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   runContextM cfg $ do
     ender <- toIO . $logInfoS "runPeer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
     void $ register ender
-    let otherPubKey = fromMaybe (error "programmer error: runPeer was called without a pubkey") $ pPeerPubkey peer
-        myPublic    = calculatePublic theCurve myPriv
+
+    myPublic <- getPub
+    
+    otherPubKey <- case (pPeerPubkey peer) of
+      Nothing -> do
+        $logInfoS "getPubKeyRunPeer" $ T.pack $ "Attempting to connect to " ++ pPeerString peer ++ ", but I don't have the pubkey.  I will try to use a UDP ping to get the pubkey."
+        eitherOtherPubKey <- getServerPubKey (T.unpack $ pPeerIp peer) (fromIntegral $ pPeerTcpPort peer)
+        case eitherOtherPubKey of
+          Right pub -> do
+            $logInfoS "getPubKeyRunPeer" $ T.pack $ "#### Success, the pubkey has been obtained: " ++ format pub
+            return pub
+          Left e -> do 
+            $logErrorS "getPubKeyRunPeer" $ T.pack $ "Error, couldn't get public key for peer: " ++ show e
+            throwIO NoPeerPubKey
+      Just pub -> return pub
 
     $logInfoS "runPeer" . T.pack . C.blue  $ "Welcome to strato-p2p-client"
     $logInfoS "runPeer" . T.pack . C.blue  $ "============================"
@@ -88,24 +98,25 @@ runPeer wireMessagesRef peer myPriv _ _ = do
       attempt :: Maybe SomeException <- withActivePeer peer $ do
         initState <- newIORef initContext
         local (\c -> c{configContext = initState}) $
-          runEthClientConduit myPriv peer pSource pSink sSource uSink pStr
+          runEthClientConduit peer{pPeerPubkey=Just otherPubKey} pSource pSink sSource uSink pStr
       case attempt of
         Nothing -> $logDebugS "runPeer" "Peer ran successfully!"
         Just err -> $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err
 
 runEthClientConduit :: MonadP2P m
-                    => PrivateNumber
-                    -> PPeer
+                    => PPeer
                     -> ConduitM () B.ByteString m ()
                     -> ConduitM B.ByteString Void m ()
                     -> ConduitM () P2pEvent m ()
                     -> ([IngestEvent] -> m ())
                     -> String
                     -> m (Maybe SomeException)
-runEthClientConduit myPriv peer peerSource peerSink seqSource unseqSink peerStr = do
-  let myPublic    = calculatePublic theCurve myPriv
+runEthClientConduit peer peerSource peerSink seqSource unseqSink peerStr = do
+  myPublic' <- getPub
+
+  let myPublic = secPubKeyToPoint myPublic'
       otherPubKey = fromMaybe (error "programmer error: runEthClientConduit was called without a pubkey") $ pPeerPubkey peer
-  (_, (outCtx, inCtx)) <- peerSource $$+ ethCryptConnect myPriv otherPubKey `fuseUpstream` peerSink
+  (_, (outCtx, inCtx)) <- peerSource $$+ ethCryptConnect otherPubKey `fuseUpstream` peerSink
 
   !eventSource <- mkEthP2PEventSource peerSource seqSource peerStr inCtx
   !eventSink <- mkEthP2PEventConduit peerStr outCtx unseqSink
@@ -113,26 +124,6 @@ runEthClientConduit myPriv peer peerSource peerSink seqSource unseqSink peerStr 
                   .| handleMsgClientConduit myPublic peer
                   .| eventSink
                   .| peerSink
-
-getPubKeyRunPeer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
-                 => IORef (S.OSet Keccak256)
-                 -> PPeer
-                 -> BC.ByteString
-                 -> CommPort
-                 -> m ()
-getPubKeyRunPeer wireMessagesRef peer otherServiceCommHost otherServiceCommPort = do
-  let PrivKey myPriv = privKey ethConf
-
-  case (pPeerPubkey peer) of
-    Nothing -> do
-      $logInfoS "getPubKeyRunPeer" $ T.pack $ "Attempting to connect to " ++ pPeerString peer ++ ", but I don't have the pubkey.  I will try to use a UDP ping to get the pubkey."
-      eitherOtherPubKey <- liftIO $ getServerPubKey (fromMaybe (error "invalid private number in main") $ H.makePrvKey $ fromIntegral myPriv) (T.unpack $ pPeerIp peer) (fromIntegral $ pPeerTcpPort peer)
-      case eitherOtherPubKey of
-            Right otherPubKey -> do
-              $logInfoS "getPubKeyRunPeer" $ T.pack $ "#### Success, the pubkey has been obtained: " ++ format otherPubKey
-              runPeer wireMessagesRef peer{pPeerPubkey=Just otherPubKey} myPriv otherServiceCommHost otherServiceCommPort
-            Left e -> $logInfoS "getPubKeyRunPeer" $ T.pack $ "Error, couldn't get public key for peer: " ++ show e
-    Just _ -> runPeer wireMessagesRef peer myPriv otherServiceCommHost otherServiceCommPort
 
 
 runPeerInList :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
@@ -147,7 +138,7 @@ runPeerInList wireMessagesRef thePeer otherServiceHost otherServicePort = do
       $logErrorS "runPeerInList" . T.pack $ "Unable to disable peer:" ++ show err
       $logErrorS "runPeerInList" "Simulating disable..."
       liftIO $ threadDelay $ 10 * 1000 * 1000
-  getPubKeyRunPeer wireMessagesRef thePeer otherServiceHost otherServicePort
+  runPeer wireMessagesRef thePeer otherServiceHost otherServicePort
 
 stratoP2PClient :: IORef (S.OSet Keccak256) -> LoggingT IO ()
 stratoP2PClient wireMessagesRef = do

--- a/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -20,7 +20,6 @@ import           Control.Monad
 import qualified Control.Monad.Change.Alter            as A
 import           Control.Monad.Reader
 import           Control.Monad.Trans.Resource
-import           Crypto.PubKey.ECC.DH
 import qualified Data.ByteString                       as B
 import           Data.Conduit.Network
 import           Data.Maybe                            (fromMaybe)
@@ -30,8 +29,8 @@ import           Network.Socket
 import           Network.Wai.Handler.Warp.Internal     (setSocketCloseOnExec)
 import           UnliftIO
 
-import           Blockchain.ECIES
-import           Blockchain.EthConf
+import           Blockchain.Data.PubKey                (secPubKeyToPoint)
+import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Options
 import           Blockchain.Output
 import           Blockchain.P2PUtil
@@ -43,43 +42,41 @@ import qualified Text.Colors                           as C
 
 runEthServer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
              => IORef (S.OSet Keccak256)
-             -> PrivateNumber
              -> Int
              -> m ()
-runEthServer wireMessagesRef myPriv listenPort = do
+runEthServer wireMessagesRef listenPort = do
   cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   void . runContextM cfg $ do
     uSink <- asks configUnseqSink
-    ethServer myPriv listenPort uSink
+    ethServer listenPort uSink
 
 ethServer :: ( MonadP2P m
              , MonadReader Config m
              , A.Selectable String PPeer m
              , ((T.Text, Int) `A.Alters` ActivityState) m
              )
-          => PrivateNumber -> Int -> ([IngestEvent] -> m ()) -> m ()
-ethServer myPriv listenPort uSink = do
+          => Int -> ([IngestEvent] -> m ()) -> m ()
+ethServer listenPort uSink = do
   let settings = setAfterBind setSocketCloseOnExec $ serverSettings listenPort "*"
   runGeneralTCPServer settings $ \app ->
     let pSource = appSource app
         pSink = appSink app
         sSource = seqEventNotificationSource $ contextKafkaState initContext
         sAddr = appSockAddr app
-     in ethServerHandler myPriv pSource pSink sSource uSink sAddr
+     in ethServerHandler pSource pSink sSource uSink sAddr
 
 ethServerHandler :: ( MonadP2P m
                     , MonadReader Config m
                     , A.Selectable String PPeer m
                     , ((T.Text, Int) `A.Alters` ActivityState) m
                     )
-                 => PrivateNumber
-                 -> ConduitM () B.ByteString m ()
+                 => ConduitM () B.ByteString m ()
                  -> ConduitM B.ByteString Void m ()
                  -> ConduitM () P2pEvent m ()
                  -> ([IngestEvent] -> m ())
                  -> SockAddr
                  -> m ()
-ethServerHandler myPriv peerSource peerSink seqSource unseqSink sockAddr = do
+ethServerHandler peerSource peerSink seqSource unseqSink sockAddr = do
   let theSockAddr = sockAddrToIP sockAddr
       peerStr = show theSockAddr
   ender <- toIO . $logInfoS "runEthServer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow theSockAddr
@@ -95,24 +92,26 @@ ethServerHandler myPriv peerSource peerSink seqSource unseqSink sockAddr = do
           (attempt :: Maybe SomeException) <- withActivePeer p $ do
             initState <- newIORef initContext
             local (\c -> c{configContext = initState}) $
-              runEthServerConduit myPriv p peerSource peerSink seqSource unseqSink peerStr
+              runEthServerConduit p peerSource peerSink seqSource unseqSink peerStr
           case attempt of
             Nothing -> $logDebugS "runEthServer" "Peer ran successfully!"
             Just err -> $logErrorS "runEthServer" . T.pack $ "Peer did not run successfully: " ++ show err
 
 runEthServerConduit :: MonadP2P m
-                    => PrivateNumber
-                    -> PPeer
+                    => PPeer
                     -> ConduitM () B.ByteString m ()
                     -> ConduitM B.ByteString Void m ()
                     -> ConduitM () P2pEvent m ()
                     -> ([IngestEvent] -> m ())
                     -> String
                     -> m (Maybe SomeException)
-runEthServerConduit myPriv p peerSource peerSink seqSource unseqSink peerStr = do
-  let myPubkey = calculatePublic theCurve myPriv
+runEthServerConduit p peerSource peerSink seqSource unseqSink peerStr = do
+  myPubKey' <- getPub
+  
+  let myPubkey = secPubKeyToPoint myPubKey'
       otherPubKey = fromMaybe (error "programmer error: runEthServerConduit was called without a pubkey") $ pPeerPubkey p
-  (_, (outCtx, inCtx)) <- peerSource $$+ ethCryptAccept myPriv otherPubKey `fuseUpstream` peerSink
+  (_, (outCtx, inCtx)) <- peerSource $$+ ethCryptAccept otherPubKey `fuseUpstream` peerSink
+  
   !eventSource <- mkEthP2PEventSource peerSource seqSource peerStr inCtx
   !eventSink <- mkEthP2PEventConduit peerStr outCtx unseqSink
   fmap (either Just (const Nothing)) . try . runConduit $ eventSource
@@ -122,9 +121,8 @@ runEthServerConduit myPriv p peerSource peerSink seqSource unseqSink peerStr = d
 
 stratoP2PServer :: IORef (S.OSet Keccak256) -> LoggingT IO ()
 stratoP2PServer wireMessagesRef = do
-  let PrivKey myPriv = privKey ethConf
 
   $logInfoS "stratoP2PServer" $ T.pack $ "connect address: " ++ flags_address
   $logInfoS "stratoP2PServer" $ T.pack $ "listen port:     " ++ show flags_listen
 
-  void $ runEthServer wireMessagesRef myPriv flags_listen
+  void $ runEthServer wireMessagesRef flags_listen

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -17,29 +17,23 @@ import qualified Control.Monad.Change.Alter            as A
 import qualified Control.Monad.Change.Modify           as Mod
 import           Control.Monad.Reader
 import           Control.Monad.State
-import           Crypto.PubKey.ECC.DH
-import           Crypto.PubKey.ECC.Types
-import           Data.Bits                             (shiftR)
 import qualified Data.ByteString                       as B
 import qualified Data.ByteString.Base16                as B16
 import qualified Data.ByteString.Char8                 as BC
-import           Data.Coerce
 import           Data.Conduit.TMChan
 import           Data.Conduit.TQueue                   hiding (newTQueueIO)
 import           Data.Default                          (def)
 import           Data.Foldable                         (for_, toList)
 import           Data.Map.Strict                       (Map)
 import qualified Data.Map.Strict                       as M
-import           Data.Maybe                            (fromJust)
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Text (Text)
-import           Data.Word                             (Word8)
 import           Text.Printf
 
 import           Blockchain.Blockstanbul
-import           Blockchain.Blockstanbul.EventLoop
 import           Blockchain.Blockstanbul.HTTPAdmin
+import           Blockchain.Blockstanbul.StateMachine
 import           Blockchain.Context                    hiding (actionTimestamp, blockHeaders, remainingBlockHeaders)
 import           Blockchain.Data.ArbitraryInstances()
 import           Blockchain.Data.Block                 hiding (bestBlockNumber)
@@ -56,7 +50,7 @@ import           Blockchain.Options                    (AuthorizationMode(..))
 import           Blockchain.Output
 import           Blockchain.Privacy
 import qualified Blockchain.Sequencer                  as Seq
-import qualified  Blockchain.Sequencer.DB.DependentBlockDB as DBDB
+import qualified Blockchain.Sequencer.DB.DependentBlockDB as DBDB
 import           Blockchain.Sequencer.DB.GetChainsDB
 import           Blockchain.Sequencer.DB.GetTransactionsDB
 import           Blockchain.Sequencer.DB.SeenTransactionDB
@@ -66,11 +60,11 @@ import           Blockchain.Sequencer.Monad
 import qualified Blockchain.Strato.Discovery.Data.Peer as DataPeer
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.Keccak256           (Keccak256, unsafeCreateKeccak256FromWord256)
+import           Blockchain.Strato.Model.Secp256k1
 
 import           Executable.StratoP2PClient
 import           Executable.StratoP2PServer
 
-import qualified Network.Haskoin.Crypto                as HK
 
 import           Test.Hspec
 import qualified Test.Hspec.Expectations.Lifted        as L
@@ -79,27 +73,6 @@ import           Test.QuickCheck
 import           UnliftIO
 import           UnliftIO.Concurrent                   (threadDelay)
 
--- TODO: these were imported from ethereum-encryption, which is still using
---       crypto-pubkey and crypto-random. Remove these once ethereum-encryption
---       switches over to cryptonite
-theCurve :: Curve
-theCurve = getCurveByName SEC_p256k1
-
-pointToString :: Point -> String
-pointToString = BC.unpack . B16.encode . pointToBytes
-
-pointToBytes :: Point -> B.ByteString
-pointToBytes (Point x y) = B.pack $ intToBytes x ++ intToBytes y
-pointToBytes PointO      = error "pointToBytes got value PointO, I don't know what to do here"
-
-intToBytes :: Integer -> [Word8]
-intToBytes x = map (fromIntegral . (x `shiftR`)) [256-8, 256-16..0]
-
-makeHKPrvKey :: PrivateNumber -> Maybe HK.PrvKey
-makeHKPrvKey = HK.makePrvKey . coerce
-
-getAddress :: PrivateNumber -> Address
-getAddress = prvKey2Address . fromJust . makeHKPrvKey
 
 data TestContext = TestContext
   { _blocks                :: [Block]
@@ -109,6 +82,7 @@ data TestContext = TestContext
   , _connectionTimeout     :: ConnectionTimeout
   , _maxReturnedHeaders    :: MaxReturnedHeaders
   , _peerAddr              :: PeerAddress
+  , _prvKey                :: PrivateKey
   , _shaBlockDataMap       :: Map Keccak256 DataDefs.BlockData
   , _worldBestBlock        :: WorldBestBlock
   , _bestBlock             :: BestBlock
@@ -234,6 +208,7 @@ instance MonadIO m => HasPrivateHashDB (MonadTest m) where
   requestChain = insertGetChainsDB
   requestTransaction = insertGetTransactionsDB
 
+
 genericTestLookup :: (MonadState s m, Ord k)
                   => Lens' s (Map k (Modification a))
                   -> Mod.Proxy a
@@ -317,6 +292,19 @@ instance MonadIO m => HasBlockstanbulContext (MonadTest m) where
   getBlockstanbulContext = use $ sequencerContext . blockstanbulContext
   putBlockstanbulContext = assign (sequencerContext . blockstanbulContext . _Just)
 
+instance MonadIO m => HasVault (MonadTest m) where
+  sign bs = do
+    pk <- use prvKey
+    return $ signMsg pk bs
+  
+  getPub = do
+    pk <- use prvKey
+    return $ derivePublicKey pk
+  
+  getShared pub = do
+    pk <- use prvKey
+    return $ deriveSharedKey pk pub
+
 instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
   lookup _  k = do
     wms <- readIORef =<< use pbftMessages
@@ -343,17 +331,14 @@ instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessa
 startingCheckpoint :: [Address] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
 
-newBlockstanbulContext :: PrivateNumber -> [Address] -> BlockstanbulContext
-newBlockstanbulContext pk as =
+newBlockstanbulContext :: Address -> [Address] -> BlockstanbulContext
+newBlockstanbulContext paddr as =
   let ckpt = startingCheckpoint as
-      hkpk = fromJust $ makeHKPrvKey pk
-   in newContext ckpt hkpk
+  in newContext ckpt paddr
 
 emptyBlockstanbulContext :: BlockstanbulContext
-emptyBlockstanbulContext = newBlockstanbulContext
-  (error "emptyBlockstanbulContext: Evaluating private key")
-  []
-
+emptyBlockstanbulContext = newBlockstanbulContext undefined []
+  
 newSequencerContext :: MonadIO m => BlockstanbulContext -> m SequencerContext
 newSequencerContext bc = do
   -- loopCh <- atomically newTMChan
@@ -376,8 +361,8 @@ newSequencerContext bc = do
 
 -- testContext is useful for testing because it doesn't require
 -- Kafka, postgres, redis, or ethconf.
-testContext :: IORef (S.OSet Keccak256) -> SequencerContext -> TestContext
-testContext wireMessagesRef ctx = TestContext
+testContext :: IORef (S.OSet Keccak256) -> PrivateKey -> SequencerContext -> TestContext
+testContext wireMessagesRef prv ctx = TestContext
   { _blocks                = []
   , _blockHeaders          = []
   , _remainingBlockHeaders = RemainingBlockHeaders []
@@ -385,6 +370,7 @@ testContext wireMessagesRef ctx = TestContext
   , _connectionTimeout     = ConnectionTimeout 60
   , _maxReturnedHeaders    = MaxReturnedHeaders 1000
   , _peerAddr              = PeerAddress Nothing
+  , _prvKey                = prv
   , _shaBlockDataMap       = M.empty
   , _worldBestBlock        = WorldBestBlock (BestBlock (unsafeCreateKeccak256FromWord256 0) (-1) 0)
   , _bestBlock             = BestBlock (unsafeCreateKeccak256FromWord256 0) (-1) 0
@@ -411,23 +397,23 @@ runTestPeer :: TestContextM a -> IO ()
 runTestPeer f = do
   seqCtx <- newSequencerContext emptyBlockstanbulContext
   wmr <- newIORef (S.empty)
-  ctx <- newIORef $ testContext wmr seqCtx
+  ctx <- newIORef $ testContext wmr undefined seqCtx
   void . runNoLoggingT . runResourceT $ runReaderT f ctx
 
-execTestPeer :: PrivateNumber
+execTestPeer :: PrivateKey
              -> [Address]
              -> TestContextM a
              -> IO (a, TestContext)
 execTestPeer pk as f = do
-  seqCtx <- newSequencerContext $ newBlockstanbulContext pk as
+  seqCtx <- newSequencerContext $ newBlockstanbulContext (fromPrivateKey pk) as
   wmr <- newIORef (S.empty)
-  ctx <- newIORef $ testContext wmr seqCtx
+  ctx <- newIORef $ testContext wmr pk seqCtx
   a <- runLoggingT . runResourceT $ runReaderT f ctx
   ctx' <- readIORef ctx
   return (a, ctx')
 
 data P2PPeer m = P2PPeer
-  { _p2pPeerPrivKey     :: PrivateNumber
+  { _p2pPeerPrivKey     :: PrivateKey
   , _p2pPeerPPeer       :: DataPeer.PPeer
   , _p2pPeerUnseqSource :: TQueue SeqLoopEvent
   , _p2pPeerSeqSource   :: TMChan P2pEvent
@@ -442,15 +428,15 @@ createPeer :: Seq.MonadSequencer m
            -> String
            -> IO (P2PPeer m)
 createPeer unseqSink name ipAddr = do
-  privKey <- generatePrivate theCurve
+  privKey <- newPrivateKey
   unseqSource <- newTQueueIO
   seqSource <- newBroadcastTMChanIO
   let sequencer = runConduit $ sourceTQueue unseqSource
                             .| mapMC (Seq.runSequencerBatch . (:[]))
                             .| (awaitForever $ yieldMany . Seq._toP2p)
                             .| sinkTMChan seqSource
-      pubkey = calculatePublic theCurve privKey
-      ppeer = DataPeer.buildPeer ( Just $ pointToString pubkey
+      pubkeystr = BC.unpack $ B16.encode $ B.drop 1 $ exportPublicKey False $ derivePublicKey privKey
+      ppeer = DataPeer.buildPeer ( Just pubkeystr
                                  , ipAddr
                                  , 30303
                                  )
@@ -484,15 +470,13 @@ createConnection server client = do
   clientToServer <- newTQueueIO
   serverSeqSource <- atomically . dupTMChan $ _p2pPeerSeqSource server
   clientSeqSource <- atomically . dupTMChan $ _p2pPeerSeqSource client
-  let runServer = runEthServerConduit (_p2pPeerPrivKey server)
-                                      (_p2pPeerPPeer client)
+  let runServer = runEthServerConduit (_p2pPeerPPeer client)
                                       (sourceTQueue clientToServer)
                                       (sinkTQueue serverToClient)
                                       (sourceTMChan serverSeqSource)
                                       (_p2pPeerUnseqSink server)
                                       (_p2pPeerName server ++ " -> " ++ _p2pPeerName client)
-      runClient = runEthClientConduit (_p2pPeerPrivKey client)
-                                      (_p2pPeerPPeer server)
+      runClient = runEthClientConduit (_p2pPeerPPeer server)
                                       (sourceTQueue serverToClient)
                                       (sinkTQueue clientToServer)
                                       (sourceTMChan clientSeqSource)
@@ -506,7 +490,7 @@ createConnection server client = do
     runServer
     runClient
 
-runConnectionWith :: (PrivateNumber -> m (Maybe SomeException) -> IO b) 
+runConnectionWith :: (PrivateKey -> m (Maybe SomeException) -> IO b) 
                   -> P2PConnection m 
                   -> IO (b, b)
 runConnectionWith f connection =
@@ -515,7 +499,7 @@ runConnectionWith f connection =
    in concurrently runServer runClient
 
 makeValidators :: [P2PPeer m] -> [Address]
-makeValidators = map (getAddress . _p2pPeerPrivKey)
+makeValidators = map (fromPrivateKey . _p2pPeerPrivKey)
 
 -- endlessStreamOfIPAddresses :: [String]
 -- endlessStreamOfIPAddresses = generateThem
@@ -571,7 +555,7 @@ spec = do
         ]
       let validators' = take 2 peers
           validatorAddresses = makeValidators validators'
-          runForTwoSeconds :: PrivateNumber -> TestContextM a -> IO TestContext
+          runForTwoSeconds :: PrivateKey -> TestContextM a -> IO TestContext
           runForTwoSeconds pk = fmap snd . execTestPeer pk validatorAddresses . timeout 2000000
           runSequencers = mapConcurrently (\p -> runForTwoSeconds (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) peers
           runConnections = mapConcurrently (runConnectionWith runForTwoSeconds) connections

--- a/core-strato/strato-p2p/test/Main.hs
+++ b/core-strato/strato-p2p/test/Main.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-overlapping-patterns #-}
 module Main where
 
+import HFlags
 import Test.Hspec.Runner
 
 import qualified Spec
@@ -12,4 +13,5 @@ predicate _ = False
 
 main :: IO ()
 main = do
+  _ <- $initHFlags "P2P unit tests"
   hspecWith (configAddFilter predicate defaultConfig) Spec.spec

--- a/core-strato/strato-p2p/test/Main.hs
+++ b/core-strato/strato-p2p/test/Main.hs
@@ -2,7 +2,6 @@
 {-# OPTIONS_GHC -fno-warn-overlapping-patterns #-}
 module Main where
 
-import HFlags
 import Test.Hspec.Runner
 
 import qualified Spec
@@ -13,5 +12,4 @@ predicate _ = False
 
 main :: IO ()
 main = do
-  _ <- $initHFlags "P2P unit tests"
   hspecWith (configAddFilter predicate defaultConfig) Spec.spec


### PR DESCRIPTION
This is a subPR for the identity project's nodekey migration. See the full PR description here: #1096

The changes in this PR upgrade `ethereum-encryption` and `strato-p2p` to use the `vault-wrapper` for ECDSA/ECDH operations on the nodekey, via the `HasVault` typeclass defined in `Blockchain.Strato.Model.Secp256k1`. The specifics:

`ethereum-encryption`:
- Replace `cryptonite`'s `getShared` function and integer-based ECDH shared key type with `Secp256k1`'s `getSharedKey` function and bytestring-based key. 
- Add the `HasVault` constraint to all the functions that will need to get an ECDSA signature, the public key, or an ECDH shared secret using the nodekey.
- Use the new `Signature` type from `Secp256k1` and use its binary instance for encoding messages to yield
- Update the lengths of the bytestrings that are awaited/yielded in the `ConduitT`, to accommodate the slightly-larger encoded length of the `Signature` type (versus Haskoin) - again, this may have to change back to the original, but we'll see.
- Added code to convert from `Secp256k1` `PublicKey` type to `cryptonite` `Point`, again only temporarily until I can remove `cryptonite` altogether.
- Added tests to `ethereum-encryption` to verify correctness of the above conversion code.

`strato-p2p`:
- Add a `HasVault` instance for the p2p `ReaderT` monad, using a `ClientEnv` stored in the Config. This instance does everything (signatures, pubkey derivation, and ECDH shared secrets, since `ethereum-encryption` is called by p2p).
- Update `StratoP2PClient` and `StratoP2PServer` to get the server public key using the `HasVault` instance. I had to move the code in the `getPubKeyRunPeer` function into the `runPeer` function, because I needed to be inside the `runReaderT` so I could access the vaultClient in the `Config`.
- Update the p2p `EventSpec` tests to use the new `ethereum-encryption`, `sequencer`, and `blockstanbul` contexts and configs. Using a "dummy" `HasVault` instance that signs using the test peer's hardcoded private key.

Don't merge this yet!