### PR TITLE
[STRATO-1944] gasOn flag - allows unfauceted accounts to post TXs

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Monad.hs
@@ -90,6 +90,7 @@ data BlocEnv = BlocEnv
   , dbPool             :: Pool Connection
   , deployMode         :: DeployMode
   , stateFetchLimit    :: Integer
+  , gasOn              :: Bool
   , globalNonceCounter :: Cache (Address, Maybe ChainId) Nonce
   , globalSourceCache  :: Cache (Text, Text) (Map Text (Int32, ContractDetails))
   , txTBQueue          :: TBQueue (Maybe Text, Maybe ChainId, Bool, PostBlocTransactionRequest)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -985,7 +985,10 @@ getAccountNonce addr chainIds = do
   $logInfoLS "getAccountNonce/req" params
   $logInfoLS "getAccountNonce/resp" mAccts
   case mAccts of
-    [] -> return $ Map.fromList [(Nothing, Nonce $ fromInteger 0)]
+    [] -> do
+      requireBalance <- asks gasOn
+      if requireBalance then throwIO . UserError $ "User does not have a balance"
+      else return $ Map.fromList [(Nothing, Nonce $ fromInteger 0)]
     accts -> do
       let mkCid AddressStateRef{..} = ChainId <$> toMaybe 0 addressStateRefChainId
           mkNonce AddressStateRef{..} = Nonce $ fromInteger addressStateRefNonce

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Users.hs
@@ -47,6 +47,7 @@ import qualified Data.Text.Encoding                as Text
 import           Data.Traversable
 import           Database.PostgreSQL.Simple        (SqlError(..))
 import           Opaleye                           hiding (not, null, index, max)
+import           Text.Format
 import           System.Clock
 import           UnliftIO
 
@@ -772,7 +773,7 @@ recurseTRDs resolve hashes = go 0 (toPending hashes)
           if num >= 600
             then return pending'
             else do
-              $logDebugLS "recurseTRDs/pending'" $ map trdHash pending'
+              $logDebugLS "recurseTRDs/pending'" $ map (format . trdHash) pending'
               void . liftIO $ threadDelay 100000
               go (num + 1) pending'
       return $ merge pending done (\(TRD _ _ i _) (TRD _ _ j _) -> i < j)
@@ -984,7 +985,7 @@ getAccountNonce addr chainIds = do
   $logInfoLS "getAccountNonce/req" params
   $logInfoLS "getAccountNonce/resp" mAccts
   case mAccts of
-    [] -> throwIO . UserError $ "User does not have a balance"
+    [] -> return $ Map.fromList [(Nothing, Nonce $ fromInteger 0)]
     accts -> do
       let mkCid AddressStateRef{..} = ChainId <$> toMaybe 0 addressStateRefChainId
           mkNonce AddressStateRef{..} = Nonce $ fromInteger addressStateRefNonce

--- a/blockapps-haskell/bloc/exe/app/Main.hs
+++ b/blockapps-haskell/bloc/exe/app/Main.hs
@@ -85,6 +85,7 @@ main = do
                                pool22
                                mode
                                flags_stateFetchLimit
+                               flags_gasOn
                                nonceCache
                                sourceCache
                                tbqueue

--- a/blockapps-haskell/bloc/exe/app/Options.hs
+++ b/blockapps-haskell/bloc/exe/app/Options.hs
@@ -17,3 +17,4 @@ defineFlag "stateFetchLimit" (100::Integer) "The maximum number of array entries
 defineFlag "nonceCounterTimeout" (10::Integer) "The number of seconds nonces are held in the global nonce counter cache"
 defineFlag "sourceCacheTimeout" (60::Integer) "The number of seconds nonces are held in the global source code cache"
 defineFlag "txQueueSize" (4096::Integer) "The maximum number of requests to queue"
+defineFlag "gasOn" (True :: Bool) "Whether or not to throw an error if an account sending a TX has no balance - used in conjunction with the VM gasOn flag"

--- a/blockapps-haskell/doit.sh
+++ b/blockapps-haskell/doit.sh
@@ -54,6 +54,7 @@ vaultWrapperHost="${vaultWrapperHost}"
 --nonceCounterTimeout=\$nonceCounterTimeout="${nonceCounterTimeout}"
 --sourceCacheTimeout=\$sourceCacheTimeout="${sourceCacheTimeout}"
 --txQueueSize=\$txQueueSize="${txQueueSize}"
+--gasOn="${gasOn}"
 "
 
 locale-gen "en_US.UTF-8"
@@ -125,7 +126,7 @@ runBackgroundProcess blockapps-strato-server >> /logs/strato-server 2>&1
 
 runBackgroundProcess blockapps-bloc --pghost="$postgres_host" --pgport="$postgres_port" --pguser="$postgres_user" --password="$postgres_password" \
            --stratourl="$stratoRoot" --vaultwrapperurl="$vaultWrapperRoot" --minLogLevel="${blocMinLogLevel}" \
-           --nonceCounterTimeout="$nonceCounterTimeout" --sourceCacheTimeout="$sourceCacheTimeout" --txQueueSize="$txQueueSize" \
+           --nonceCounterTimeout="$nonceCounterTimeout" --sourceCacheTimeout="$sourceCacheTimeout" --txQueueSize="$txQueueSize" --gasOn="$gasOn" \
            +RTS -N1 &>> /logs/bloc
 
 until curl localhost:8000 &> /dev/null; do

--- a/blockapps-haskell/slipstream/exec_src/Main.hs
+++ b/blockapps-haskell/slipstream/exec_src/Main.hs
@@ -62,6 +62,7 @@ createBlocEnv = liftIO $ do
                  , dbPool = pool
                  , deployMode = Public
                  , stateFetchLimit = 0
+                 , gasOn = error "gasOn being accessed in Slipstream"
                  , globalNonceCounter = error "globalNonceCounter being accessed in Slipstream"
                  , globalSourceCache = error "globalSourceCache being accessed in Slipstream"
                  , txTBQueue = error "txTBQueue being accessed by in Slipstream"

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -147,7 +147,7 @@ function newnode {
                          --miningVerification=$verifyBlocks --difficultyBomb=$difficultyBomb \
                          --trace=$evmTraceMode --debug=$evmDebugMode --minLogLevel=$evmMinLogLevel \
                          "${tbFlag}" "${breFlag}" "${sebFlag}" "${sechFlag}" "${svdFlag}" "${ctrFlag}" \
-                         +RTS "${vmRunnerRTSOPTs:-}" -N1 &>> logs/vm-runner
+                         --gasOn=$gasOn +RTS "${vmRunnerRTSOPTs:-}" -N1 &>> logs/vm-runner
 
   if [ "${USE_STRATO_API}" = true ]; then
       tbFlag="--blockstanbul=${blockstanbul}"

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -477,12 +477,7 @@ addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=b
         $logDebugS "addTx" . T.pack $ "transaction cost: " ++ show gTX
         $logDebugS "addTx" . T.pack $ "intrinsicGas: " ++ show intrinsicGas'
 
-    (acctBalance, acctNonce) <- lift $
-      (addressStateBalance &&& addressStateNonce) <$>
-        A.lookupWithDefault (Proxy @AddressState) tAddr
-    
-
-    let txCost      = transactionGasLimit bt * transactionGasPrice bt + transactionValue bt
+    let txCost = transactionGasLimit bt * transactionGasPrice bt + transactionValue bt
         realIG = fromIntegral intrinsicGas'
         maxGas = fromIntegral (maxBound :: Int)
     
@@ -491,6 +486,10 @@ addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=b
         faucetSuccess <- lift $ addToBalance tAddr txCost
         unless faucetSuccess $ error "failed to give balance to a gasOff account"
     
+    (acctBalance, acctNonce) <- lift $
+      (addressStateBalance &&& addressStateNonce) <$>
+        A.lookupWithDefault (Proxy @AddressState) tAddr
+   
     when (chainId /= txChainId bt) $ throwE $ TFChainIdMismatch chainId (txChainId bt) t
     when (txCost > acctBalance) $ throwE $ TFInsufficientFunds txCost acctBalance t
     when (realIG > transactionGasLimit bt) $ throwE $ TFIntrinsicGasExceedsTxLimit realIG (transactionGasLimit bt) t

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -480,10 +480,17 @@ addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=b
     (acctBalance, acctNonce) <- lift $
       (addressStateBalance &&& addressStateNonce) <$>
         A.lookupWithDefault (Proxy @AddressState) tAddr
+    
 
     let txCost      = transactionGasLimit bt * transactionGasPrice bt + transactionValue bt
         realIG = fromIntegral intrinsicGas'
         maxGas = fromIntegral (maxBound :: Int)
+    
+    unless flags_gasOn $ do
+        $logInfoS "addTx" . T.pack $ "gas is off, so I'm giving the account enough balance for this TX"
+        faucetSuccess <- lift $ addToBalance tAddr txCost
+        unless faucetSuccess $ error "failed to give balance to a gasOff account"
+    
     when (chainId /= txChainId bt) $ throwE $ TFChainIdMismatch chainId (txChainId bt) t
     when (txCost > acctBalance) $ throwE $ TFInsufficientFunds txCost acctBalance t
     when (realIG > transactionGasLimit bt) $ throwE $ TFIntrinsicGasExceedsTxLimit realIG (transactionGasLimit bt) t
@@ -493,7 +500,8 @@ addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=b
     let availableGas = transactionGasLimit bt - fromIntegral intrinsicGas'
 
     lift $ incrementNonce tAddr
-
+    
+     
     success <- lift $ addToBalance tAddr (-transactionGasLimit bt * transactionGasPrice bt)
     when flags_debug $ $logDebugS "addTx" "running code"
     let txTypeCounter = if isContractCreationTX bt then vmTxsCreation else vmTxsCall

--- a/core-strato/vm-tools/src/Blockchain/Bagger.hs
+++ b/core-strato/vm-tools/src/Blockchain/Bagger.hs
@@ -372,7 +372,7 @@ isValidForPool t@OutputTx{otSigner=address, otBaseTx=bt} = runExceptT $ do
     (addressNonce, addressBalance) <- lift $ getAddressNonceAndBalance address
     when (addressNonce > txn) .
        throwE $ NonceTooLow Validation Incoming addressNonce t
-    when (addressBalance < txFee && flags_gasOn) .
+    when (addressBalance < txFee) .
        throwE $ BalanceTooLow Validation Incoming txFee addressBalance t
     return ()
 
@@ -383,8 +383,13 @@ removeFromSeen :: MonadBagger m => OutputTx -> m ()
 removeFromSeen t = updateBaggerState (B.removeFromSeen t)
 
 getAddressNonceAndBalance :: MonadBagger m => Address -> m (Integer, Integer)
-getAddressNonceAndBalance addr = (DD.addressStateNonce &&& DD.addressStateBalance) <$>
-  A.lookupWithDefault (A.Proxy @DD.AddressState) addr
+getAddressNonceAndBalance addr = do 
+  (nonce, balance) <- (DD.addressStateNonce &&& DD.addressStateBalance) <$>
+      A.lookupWithDefault (A.Proxy @DD.AddressState) addr
+  if flags_gasOn then 
+    return (nonce, balance) 
+  else 
+    return (nonce, 9999999999999999999999999999) -- fake a high balance, so all TXs are accepted
 
 addToPromotionCache :: MonadBagger m => OutputTx -> m ()
 addToPromotionCache tx = updateBaggerState (B.addToPromotionCache tx)

--- a/core-strato/vm-tools/src/Blockchain/Bagger.hs
+++ b/core-strato/vm-tools/src/Blockchain/Bagger.hs
@@ -47,6 +47,7 @@ import           Blockchain.Sequencer.Event         (OutputBlock (..), OutputTx 
 import           Blockchain.Strato.Model.Class
 import           Blockchain.Strato.Model.Keccak256        hiding (hash)
 import qualified Blockchain.Verification            as V
+import           Blockchain.VMOptions               (flags_gasOn)
 
 import           Executable.EVMFlags                (flags_maxTxsPerBlock)
 
@@ -371,7 +372,7 @@ isValidForPool t@OutputTx{otSigner=address, otBaseTx=bt} = runExceptT $ do
     (addressNonce, addressBalance) <- lift $ getAddressNonceAndBalance address
     when (addressNonce > txn) .
        throwE $ NonceTooLow Validation Incoming addressNonce t
-    when (addressBalance < txFee) .
+    when (addressBalance < txFee && flags_gasOn) .
        throwE $ BalanceTooLow Validation Incoming txFee addressBalance t
     return ()
 

--- a/core-strato/vm-tools/src/Blockchain/VMOptions.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMOptions.hs
@@ -18,6 +18,7 @@ module Blockchain.VMOptions (
   flags_transactionRootVerification,
   flags_startingBlock,
   flags_miner,
+  flags_gasOn
   ) where
 
 import           Blockchain.Mining
@@ -46,3 +47,4 @@ defineFlag "svmDev" (False::Bool) "Whether to crash on SolidVM exceptions"
 defineFlag "svmTrace" (False::Bool) "Whether to have verbose logging in SolidVM"
 defineFlag "cacheTransactionResults" True "Keep transaction results in an LRU cache to avoid reruns"
 defineEQFlag "miner" [| Instant :: MinerType |] "MINER" "What mining algorithm"
+defineFlag "gasOn" (True::Bool) "Whether to charge for transactions or not"

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -113,16 +113,17 @@ services:
     - vault-wrapper
     environment:
     - BLOC_DEBUG=${BLOC_DEBUG}
+    - gasOn=${gasOn:-true}
     - kafkaHost=kafka
     - kafkaPort=9092
     - nonceCounterTimeout=${nonceCounterTimeout:-10}
-    - sourceCacheTimeout=${sourceCacheTimeout:-60}
     - postgres_host=postgres
     - postgres_password=${postgres_password:-api}
     - postgres_port=5432
     - postgres_slipstream_db=cirrus
     - postgres_user=postgres
     - PROCESS_MONITORING=${PROCESS_MONITORING}
+    - sourceCacheTimeout=${sourceCacheTimeout:-60}
     - SLIPSTREAM_OPTIONAL=${SLIPSTREAM_OPTIONAL}
     - SLIPSTREAM_DEBUG=${SLIPSTREAM_DEBUG}
     - SMD_MODE=${SMD_MODE}

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -200,6 +200,7 @@ services:
     - evmDebugMode=${evmDebugMode}
     - evmTraceMode=${evmTraceMode}
     - faucetEnabled=${faucetEnabled}
+    - gasOn=${gasOn:-true}
     - genesis=${genesis}
     - genesisBlock=${genesisBlock}
     - kafkaHost=kafka


### PR DESCRIPTION
This PR implements the gas removal needed for beanstalk phase 4.

The main change is the addition of the `gasOn:{true/false}` flag to Bloc and to the VM. The default value is `true`.
-  If set to `true`, there is no behaviour change. Accounts must have enough balance to post a TX, and the VM and Bloc will otherwise throw errors.
-  If set to `false`, Bloc allows accounts with no balance to post a TX, and the VM will give the account exactly as much balance is required for the TX, before running it.