### PR TITLE
Private chain constructor arguments

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -71,15 +71,15 @@ createChainInfo :: ChainInput -> Bloc (Maybe Int32, ChainInfo)
 createChainInfo (ChainInput msrc mCodePtr cname lbl balances chaininputArgs members mmd _) = do
   when (null members) $ throwIO $ UserError "Private chains must include at least one member"
   when (sum (nmap2' balances) == 0) $ throwIO $ UserError "At least one account must have a non-zero balance"
-
-  let theVM = fromMaybe "EVM" $ Map.lookup "VM" =<< mmd
+  let md = fromMaybe Map.empty mmd
+      theVM = fromMaybe "EVM" $ Map.lookup "VM" md
   mContract <- case msrc of
     Just src -> fmap snd <$> getContractDetailsForContract theVM src cname
     Nothing -> case mCodePtr of
       Just codePtr -> getContractDetailsByCodeHash codePtr
       Nothing -> fmap snd <$> getContractDetailsForContract theVM "" cname
   (cAcctInfo, codeInfo, metaData) <- case mContract of
-      Nothing -> return ([],[], mmd)
+      Nothing -> return ([],[], md)
       Just (_, ContractDetails{..}) -> do
           contract <- either (throwIO . UserError . Text.pack) return $ xAbiToContract contractdetailsXabi
           let argValues = replaceMembers
@@ -106,13 +106,13 @@ createChainInfo (ChainInput msrc mCodePtr cname lbl balances chaininputArgs memb
           let contractAcctInfo = ContractWithStorage governanceAddress govBal contractHash storage
               b' = fst . B16.decode $ encodeUtf8 b
               codeInfo' = maybeToList $ (\s -> CodeInfo b' s contractdetailsName) <$> msrc
-          mmd' <- case theVM of
+          md' <- case theVM of
               "SolidVM" -> do
                 let xabiArgs = maybe Map.empty funcArgs $ xabiConstr contractdetailsXabi
                 (_, argsAsSource) <- constructArgValuesAndSource (Just argValues) xabiArgs
-                pure $ (id . at "args" ?~ argsAsSource) <$> mmd
-              _ -> pure mmd
-          return ([contractAcctInfo],codeInfo',mmd') -- Perhaps in the future, we can support multiple contracts
+                pure $ (at "args" ?~ argsAsSource) md
+              _ -> pure md
+          return ([contractAcctInfo],codeInfo',md') -- Perhaps in the future, we can support multiple contracts
   nonce <- byteStringToWord256 <$> liftIO (getEntropy 32)
   let maybeNonContract a b | a == governanceAddress = Nothing
                            | otherwise = Just $ NonContract a b
@@ -126,7 +126,7 @@ createChainInfo (ChainInput msrc mCodePtr cname lbl balances chaininputArgs memb
                            Nothing
                            creationBlockHash
                            nonce
-                           (fromMaybe Map.empty metaData)
+                           metaData
         )
         Nothing
   return (fst <$> mContract, chainInfo)

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Server/Chain.hs
@@ -11,6 +11,7 @@
 module BlockApps.Bloc22.Server.Chain where
 
 import           Control.Applicative               (liftA2)
+import           Control.Lens                      ((?~), at)
 import           Control.Monad                     (when, unless)
 import           Crypto.Random.Entropy
 import qualified Data.ByteString.Base16            as B16
@@ -34,6 +35,7 @@ import           BlockApps.Solidity.Struct
 import           BlockApps.Solidity.Type
 import           BlockApps.Solidity.Xabi
 import           BlockApps.Bloc22.Database.Queries
+import           BlockApps.Bloc22.Server.Users     (constructArgValuesAndSource)
 import           BlockApps.Bloc22.Server.Utils     (waitFor)
 import           BlockApps.XAbiConverter           (xAbiToContract)
 
@@ -76,19 +78,21 @@ createChainInfo (ChainInput msrc mCodePtr cname lbl balances chaininputArgs memb
     Nothing -> case mCodePtr of
       Just codePtr -> getContractDetailsByCodeHash codePtr
       Nothing -> fmap snd <$> getContractDetailsForContract theVM "" cname
-  (cAcctInfo, codeInfo) <- case mContract of
-      Nothing -> return ([],[])
+  (cAcctInfo, codeInfo, metaData) <- case mContract of
+      Nothing -> return ([],[], mmd)
       Just (_, ContractDetails{..}) -> do
           contract <- either (throwIO . UserError . Text.pack) return $ xAbiToContract contractdetailsXabi
           let argValues = replaceMembers
                             (mainStruct contract)
                             (nmap1' members)
                             chaininputArgs
-          storage <- fmap Map.toList . either (throwIO . UserError) return $ encodeValues
+          storage <- case theVM of
+            "EVM" -> fmap Map.toList . either (throwIO . UserError) return $ encodeValues
                        (typeDefs contract)
                        (mainStruct contract)
                        0
                        (Map.toList argValues)
+            _ -> pure []
           let balMap = Map.fromList $ map (unNamedTuple @"address" @"balance") balances
               govBal = fromMaybe 0 $ Map.lookup governanceAddress balMap
 
@@ -102,7 +106,13 @@ createChainInfo (ChainInput msrc mCodePtr cname lbl balances chaininputArgs memb
           let contractAcctInfo = ContractWithStorage governanceAddress govBal contractHash storage
               b' = fst . B16.decode $ encodeUtf8 b
               codeInfo' = maybeToList $ (\s -> CodeInfo b' s contractdetailsName) <$> msrc
-          return ([contractAcctInfo],codeInfo') -- Perhaps in the future, we can support multiple contracts
+          mmd' <- case theVM of
+              "SolidVM" -> do
+                let xabiArgs = maybe Map.empty funcArgs $ xabiConstr contractdetailsXabi
+                (_, argsAsSource) <- constructArgValuesAndSource (Just argValues) xabiArgs
+                pure $ (id . at "args" ?~ argsAsSource) <$> mmd
+              _ -> pure mmd
+          return ([contractAcctInfo],codeInfo',mmd') -- Perhaps in the future, we can support multiple contracts
   nonce <- byteStringToWord256 <$> liftIO (getEntropy 32)
   let maybeNonContract a b | a == governanceAddress = Nothing
                            | otherwise = Just $ NonContract a b
@@ -116,7 +126,7 @@ createChainInfo (ChainInput msrc mCodePtr cname lbl balances chaininputArgs memb
                            Nothing
                            creationBlockHash
                            nonce
-                           (fromMaybe Map.empty mmd)
+                           (fromMaybe Map.empty metaData)
         )
         Nothing
   return (fst <$> mContract, chainInfo)

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -329,7 +329,9 @@ runChainConstructors cId cInfo = do
          (unsafeCreateKeccak256FromWord256 0)
          (Just cId)
          (Just $ M.fromList $
-           [("args", "()"), ("funcName", "<constructor>")]
+           [ ("args", fromMaybe "()" (M.lookup "args" . chainMetadata $ chainInfo cInfo))
+           , ("funcName", "<constructor>")
+           ]
            ++ case ms of Nothing -> []; Just s -> [("src", s)])
 
   flushMemStorageDB


### PR DESCRIPTION
Allow the "args" field of the POST /bloc/v2.2/chain route to be used as constructor arguments for SolidVM governance contracts. This is needed for Beanstalk, now that the Governance source will be uploaded once when the application is deployed, leveraging the code collection project's functionality.