### PR TITLE
Blockstanbul-vote has HTTPS support

### DIFF
--- a/core-strato/blockstanbul/exec-src/Main.hs
+++ b/core-strato/blockstanbul/exec-src/Main.hs
@@ -2,22 +2,20 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS -fno-warn-orphans    #-}
 
 module Main where
 
 import           Control.Exception
 import           Control.Monad
-import qualified Data.Aeson                 as Ae
 import qualified Data.ByteString.Char8      as C8
 import           Data.ByteString.Base16     as B16
-import qualified Data.ByteString.Lazy       as BL
 import           Data.Foldable (foldlM)
 import           Data.List.Split            (splitOn)
 import qualified Data.Text                  as T
-import           Network.HTTP
 import           Network.HTTP.Client        (newManager, defaultManagerSettings)
-import           Network.HTTP.Auth
+import           Network.HTTP.Simple
 import           System.Console.GetOpt
 import           System.Environment
 import           System.Exit
@@ -48,6 +46,7 @@ instance HasVault IO where
 
 data Options = Options
   { optRemove    :: Bool
+  , optHTTPS     :: Bool
   , optRecipient :: Address
   , optNodes     :: [String]
   , optNonce     :: Int
@@ -56,6 +55,7 @@ data Options = Options
 defaultOptions :: Options
 defaultOptions  = Options
   { optRemove    = False
+  , optHTTPS     = False
   , optRecipient = throw $ userError "Give me a recipient address."
   , optNodes     = throw $ userError "Give me the node(s) to whom I'll send the vote."
   , optNonce     = throw $ userError "Give me a non-negative int for your nonce."
@@ -90,7 +90,11 @@ options =
       (NoArg
        (\ opts -> return opts { optRemove = True}))
       "The voting direction"
-  ]
+  , Option ['h'] ["https"]
+      (NoArg
+       (\ opts -> return opts { optHTTPS = True}))
+      "Whether to use HTTPS"
+ ]
 
 helpMessage :: String
 helpMessage = usageInfo header options
@@ -127,32 +131,27 @@ main = do
                      . B16.encode
                      . rlpSerialize
                      . rlpEncode $ esign
-        let payload = CandidateReceived
+            payload = CandidateReceived
                     { sender = optSender
                     , signature = esignStr
                     , recipient = optRecipient
                     , votingdir = not optRemove
                     , nonce = non
                     }
-            body = C8.unpack $ BL.toStrict $ Ae.encode payload
-        let url = printf "http://%s/blockstanbul/vote" nodeURL
-        putStrLn $ "Sending to url: " ++ url
-        putStrLn $ "\n\nRequest body: " ++ body
-        let req' = postRequestWithBody url "application/json" body
-            auth = AuthBasic (error "realm unused")
-                             "admin" -- I hope we can just hardcode this
-                             "admin"
-                             (error "uri unused")
-            authStr = withAuthority auth req'
-            req = insertHeaders [mkHeader HdrAuthorization authStr] req'
-
-        eResp <- simpleHTTP req
-        case eResp of
-          Left err -> die $ "connection error: " ++ show err
-          Right resp -> do
-            print resp
-            putStrLn $ "response: " ++ rspBody resp
-    
+            url = printf "http://%s/blockstanbul/vote" nodeURL
+        
+        putStrLn $ "\n\n\nsending the following request to " ++ nodeURL
+        putStrLn $ show payload
+        
+        plainReq <- parseRequest url
+        let postReq = setRequestMethod (C8.pack "POST") plainReq
+            authReq = setRequestBasicAuth (C8.pack "admin") (C8.pack "admin") postReq
+            bodyReq = setRequestBodyJSON payload authReq
+            finalReq = if optHTTPS then setRequestSecure True bodyReq else bodyReq
+        
+        resp <- httpBS finalReq
+        putStrLn $ "\nresponse:\n" ++ show resp
+     
         go xs $ non + 1
     
   go optNodes optNonce   

--- a/core-strato/blockstanbul/exec-src/Main.hs
+++ b/core-strato/blockstanbul/exec-src/Main.hs
@@ -140,7 +140,7 @@ main = do
                     }
             url = printf "http://%s/blockstanbul/vote" nodeURL
         
-        putStrLn $ "\n\n\nsending the following request to " ++ nodeURL
+        putStrLn $ "\n\n\nsending the following request to " ++ nodeURL ++ ", HTTPS = " ++ show optHTTPS
         putStrLn $ show payload
         
         plainReq <- parseRequest url
@@ -150,7 +150,8 @@ main = do
             finalReq = if optHTTPS then setRequestSecure True bodyReq else bodyReq
         
         resp <- httpBS finalReq
-        putStrLn $ "\nresponse:\n" ++ show resp
+        putStrLn $ "\nresponse status: " ++ (show $ getResponseStatus resp)
+        putStrLn $ "response body: " ++ (show $ getResponseBody resp)
      
         go xs $ non + 1
     

--- a/core-strato/blockstanbul/package.yaml
+++ b/core-strato/blockstanbul/package.yaml
@@ -55,6 +55,7 @@ executables:
       - bytestring
       - HTTP
       - http-client
+      - http-conduit
       - ethereum-rlp
       - extra
       - servant-client

--- a/core-strato/blockstanbul/package.yaml
+++ b/core-strato/blockstanbul/package.yaml
@@ -46,14 +46,12 @@ executables:
     main: Main.hs
     other-modules: []
     dependencies:
-      - aeson
       - blockapps-vault-wrapper-api
       - blockapps-vault-wrapper-client
       - blockstanbul
       - base16-bytestring
       - base64-bytestring
       - bytestring
-      - HTTP
       - http-client
       - http-conduit
       - ethereum-rlp


### PR DESCRIPTION
Changed HTTP libraries in `blockstanbul-vote` to support sending votes to HTTPS nodes. Add the `--https` flag to send the votes using HTTPS.

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/3605/pipeline