### PR TITLE
Fix bug with creating governance contracts with constructor arguments…

### DIFF
--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -616,7 +616,7 @@ getContractDetailsAndMetadataId (ContractName contractName) acct = do
 
 getContractDetailsByCodeHash :: CodePtr -> Bloc (Maybe (Int32, ContractDetails))
 getContractDetailsByCodeHash = \case
-  CodeAtAccount acct name -> fmap (fmap (\cd -> cd{contractdetailsName=Text.pack name})) <$> getContractDetailsAndMetadataIdByAccountOnly acct
+  CodeAtAccount acct name -> getContractDetailsAndMetadataId (ContractName $ Text.pack name) acct
   codeHash -> do
     mDetails <- fmap listToMaybe . blocQuery $ getContractsContractByCodeHashQuery codeHash
     for mDetails $ \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId,xabi') -> do


### PR DESCRIPTION
… using CodeAtAccount

This bug occurs when creating a private chain using CodeAtAccount with a different contract name than the one stored at the account, and the constructor arguments in the governance contract are different than the one stored at that account. Bloc loads the xabi for the other contract, then rejects the constructor arguments given for the governance contract. This PR fixes the problem by passing in the name of the governance contract while looking up the xabi, instead of swapping it in afterwards