### PR TITLE
Added migrate-salt executable to reencrypt oauth user keys with global password salt

### DIFF
--- a/blockapps-haskell/vault-wrapper/api/src/Strato/Strato23/Crypto.hs
+++ b/blockapps-haskell/vault-wrapper/api/src/Strato/Strato23/Crypto.hs
@@ -32,9 +32,9 @@ textPassword = Password . Text.encodeUtf8
 
 instance Show SecretBox.Nonce where
   show = show . Saltine.encode
-
+ 
 data KeyStore = KeyStore
-  { keystoreSalt          :: ByteString
+  { keystoreSalt          :: ByteString     -- deprecated, since we use the password salt now
   , keystoreAcctNonce     :: SecretBox.Nonce
   , keystoreAcctEncSecKey :: ByteString
   , keystoreAcctAddress   :: Address
@@ -93,7 +93,7 @@ newKeyStore key = liftIO $ do
       acctAddr = fromPrivateKey acctSk
       acctPubKey = derivePublicKey acctSk
   return KeyStore
-    { keystoreSalt = salt
+    { keystoreSalt = salt -- Don't forget, this is unused now
     , keystoreAcctNonce = acctNonce
     , keystoreAcctEncSecKey = encAcctSk
     , keystoreAcctAddress = acctAddr

--- a/blockapps-haskell/vault-wrapper/server/app/MigrateSalt.hs
+++ b/blockapps-haskell/vault-wrapper/server/app/MigrateSalt.hs
@@ -5,15 +5,14 @@
 {-# LANGUAGE QuasiQuotes         #-}
 
 import           Control.Arrow
+import           Control.Lens.Combinators
 import qualified Crypto.Saltine.Core.SecretBox      as SB
 import qualified Data.ByteString                    as B
 import           Data.Int                           (Int32)
 import           Data.Maybe
 import qualified Data.Text                          as T
 import           Database.PostgreSQL.Simple         hiding (Query)
-import           Database.PostgreSQL.Simple.SqlQQ
-import           Opaleye
-
+import           Opaleye                            hiding (sum)
 
 import           Blockchain.Strato.Model.Secp256k1
 import qualified Strato.Strato23.Crypto             as VC
@@ -27,6 +26,12 @@ import           Options
 
 -- usage: migrate-salt --pw=<vault_password>
 
+-- the purpose of this script is to reencrypt keys from a STRATO version <6.0 that were
+--        encrypted with unique user salts, this time using the global password salt. If some of
+--        the keys in the vault were already encryped using the global password salt (i.e. keys 
+--        created after the upgrade), it will skip those (i.e. it will fail to decrypt them using 
+--        their user salts). 
+
 
 getUsersQuery :: Connection -> IO [(Int32, B.ByteString, SB.Nonce, B.ByteString)] 
 getUsersQuery conn = runQuery conn $ proc () -> do
@@ -38,12 +43,7 @@ main :: IO ()
 main = do
   _ <- $initHFlags "migrate-salt"
 
-  let usageMsg = "the purpose of this script is to reencrypt keys from a STRATO version <6.0 that were \
-                  \ encrypted with unique user salts, this time using the global password salt. If some of \
-                  \ the keys in the vault were already encryped using the global password salt (i.e. keys \
-                  \ created after the upgrade), it will skip those (i.e. it will fail to decrypt them using \ 
-                  \ their user salts). \
-                  \ Usage: migrate-salt --pw=<vault_password> "
+  let usageMsg = "Usage: migrate-salt --pw=<vault_password>"
   putStrLn usageMsg
   
   let dbConnectInfo = ConnectInfo { connectHost     = "postgres"
@@ -69,22 +69,27 @@ main = do
 
   -- query all users id, salt, nonce, and the encrypted key
   allUsers <- getUsersQuery conn
-  putStrLn $ "\nok, I'll update " ++ (show $ length allUsers) ++ " rows"
 
-  -- decrypt a user's privkey using the salt,nonce in the table.
+  -- decrypt the privkey using the salt,nonce in the table.
   -- then, reencrypt with the global password Secretbox.key and the original user nonce
-  let reencrypt :: Int32 -> B.ByteString -> SB.Nonce -> B.ByteString -> Maybe (B.ByteString, B.ByteString, Int32)
+  let reencrypt :: Int32 -> B.ByteString -> SB.Nonce -> B.ByteString -> Maybe (B.ByteString, Int32)
       reencrypt i salt nonce encKey = do
           let sbKey = VP.getKeyFromPasswordAndSalt pw salt
           decKey <- VC.decryptSecKey sbKey nonce encKey
           let newEncKey = VC.encrypt pwKey nonce (exportPrivateKey decKey)
-          pure (newEncKey, newEncKey, i)
+          pure (newEncKey, i)
  
-  -- update all the rows with the new encrypted keys
   let idsAndNewEncKeys = catMaybes $ map (\(i, s, n, k) -> reencrypt i s n k) allUsers
-  rowsChanged <- executeMany conn [sql|
-      UPDATE users SET enc_sec_key = ?, enc_sec_prv_key = ?, salt = '' 
-      WHERE id = ?
-  |] idsAndNewEncKeys
   
-  putStrLn $ "ok, done. I updated " ++ (show rowsChanged) ++ " rows"
+  putStrLn $ "\nFound " ++ (show $ length allUsers) ++ " keys"
+  putStrLn $ (show $ length idsAndNewEncKeys) ++ " of those keys can be reencrypted"
+
+  -- update all the rows with the new encrypted keys
+  rowsChanged <- return . sum =<< mapM (\(newKey, rowId) -> runUpdate_ conn $ Update
+                                   { uTable = usersTable
+                                   , uUpdateWith = updateEasy (set _6 (constant newKey))
+                                   , uWhere = views _1 (.== constant rowId)
+                                   , uReturning = rCount
+                                   }) idsAndNewEncKeys
+
+  putStrLn $ "ok, done. I updated " ++ (show rowsChanged) ++ " keys"

--- a/blockapps-haskell/vault-wrapper/server/app/MigrateSalt.hs
+++ b/blockapps-haskell/vault-wrapper/server/app/MigrateSalt.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE Arrows              #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE QuasiQuotes         #-}
+
+import           Control.Arrow
+import qualified Crypto.Saltine.Core.SecretBox      as SB
+import qualified Data.ByteString                    as B
+import           Data.Int                           (Int32)
+import           Data.Maybe
+import qualified Data.Text                          as T
+import           Database.PostgreSQL.Simple         hiding (Query)
+import           Database.PostgreSQL.Simple.SqlQQ
+import           Opaleye
+
+
+import           Blockchain.Strato.Model.Secp256k1
+import qualified Strato.Strato23.Crypto             as VC
+import           Strato.Strato23.Database.Queries   as VQ
+import           Strato.Strato23.Database.Tables
+import qualified Strato.Strato23.Server.Password    as VP
+import           HFlags
+import           Options
+
+
+
+-- usage: migrate-salt --pw=<vault_password>
+
+
+getUsersQuery :: Connection -> IO [(Int32, B.ByteString, SB.Nonce, B.ByteString)] 
+getUsersQuery conn = runQuery conn $ proc () -> do
+  (userId, _, salt, nonce, _, encKey, _, _) <- queryTable usersTable -< ()
+  returnA -< (userId, salt, nonce, encKey)
+
+
+main :: IO ()
+main = do
+  _ <- $initHFlags "migrate-salt"
+
+  let usageMsg = "the purpose of this script is to reencrypt keys from a STRATO version <6.0 that were \
+                  \ encrypted with unique user salts, this time using the global password salt. If some of \
+                  \ the keys in the vault were already encryped using the global password salt (i.e. keys \
+                  \ created after the upgrade), it will skip those (i.e. it will fail to decrypt them using \ 
+                  \ their user salts). \
+                  \ Usage: migrate-salt --pw=<vault_password> "
+  putStrLn usageMsg
+  
+  let dbConnectInfo = ConnectInfo { connectHost     = "postgres"
+                                  , connectPort     = 5432
+                                  , connectUser     = "postgres"
+                                  , connectPassword = "api"
+                                  , connectDatabase = "oauth"
+                                  }
+  conn <- connect dbConnectInfo
+  let pw = VC.textPassword $ T.pack flags_pw
+  
+  -- create the Secretbox.key from the pw and salt/nonce/ciphertext in messages table
+  (mMsgLst :: [(B.ByteString, SB.Nonce, B.ByteString)]) <- runQuery conn VQ.getMessageQuery
+  pwKey <- case mMsgLst of
+    [] -> error "message table is empty, so the password must not be set. Aborting..."
+    [(msgSalt, msgNonce, ciphertext)] -> do
+      let key = VP.getKeyFromPasswordAndSalt pw msgSalt
+      case VC.decrypt key msgNonce ciphertext of
+        Just msg | msg == VP.superSecretVaultWrapperMessage -> pure key
+        _ -> error "couldn't decrypt the secret message, probably you entered the wrong vault password"
+    _ -> error "multiple rows in message table, something is not right"
+ 
+
+  -- query all users id, salt, nonce, and the encrypted key
+  allUsers <- getUsersQuery conn
+  putStrLn $ "\nok, I'll update " ++ (show $ length allUsers) ++ " rows"
+
+  -- decrypt a user's privkey using the salt,nonce in the table.
+  -- then, reencrypt with the global password Secretbox.key and the original user nonce
+  let reencrypt :: Int32 -> B.ByteString -> SB.Nonce -> B.ByteString -> Maybe (B.ByteString, B.ByteString, Int32)
+      reencrypt i salt nonce encKey = do
+          let sbKey = VP.getKeyFromPasswordAndSalt pw salt
+          decKey <- VC.decryptSecKey sbKey nonce encKey
+          let newEncKey = VC.encrypt pwKey nonce (exportPrivateKey decKey)
+          pure (newEncKey, newEncKey, i)
+ 
+  -- update all the rows with the new encrypted keys
+  let idsAndNewEncKeys = catMaybes $ map (\(i, s, n, k) -> reencrypt i s n k) allUsers
+  rowsChanged <- executeMany conn [sql|
+      UPDATE users SET enc_sec_key = ?, enc_sec_prv_key = ?, salt = '' 
+      WHERE id = ?
+  |] idsAndNewEncKeys
+  
+  putStrLn $ "ok, done. I updated " ++ (show rowsChanged) ++ " rows"

--- a/blockapps-haskell/vault-wrapper/server/package.yaml
+++ b/blockapps-haskell/vault-wrapper/server/package.yaml
@@ -104,6 +104,19 @@ executables:
       - strato-model
       - text
 
+  migrate-salt:
+    source-dirs: app
+    main: MigrateSalt.hs
+    other-modules: [Options]
+    dependencies:
+      - blockapps-vault-wrapper-server
+      - bytestring
+      - hflags
+      - opaleye
+      - saltine
+      - strato-model
+      - text
+
 tests:
   vault-wrapper-spec:
     source-dirs: test/

--- a/blockapps-haskell/vault-wrapper/server/package.yaml
+++ b/blockapps-haskell/vault-wrapper/server/package.yaml
@@ -112,6 +112,7 @@ executables:
       - blockapps-vault-wrapper-server
       - bytestring
       - hflags
+      - lens
       - opaleye
       - saltine
       - strato-model


### PR DESCRIPTION
As part of the vault-wrapper performance improvements @jamshidh made, we now encrypt all user keys in the vault with the global encryption key (password + some global salt + some global nonce), as opposed to with unique encryption keys for each user (password + some _unique_ salt + some _unique_ nonce). 

This is fine for new keys.... but causes decryption to fail on upgraded nodes, because the user keys were originally encrypted with unique salts, but vault -wrapper tries to decrypt them with the global salt.

To fix this, we must reencrypt all user keys with the global encryption key when migrating nodes to 6.0. The executable `migrate-salt` does this. Specifically, it
- calculates the global encryption key by reading the global salt and nonce from the `messages` table and taking the vault password as a command line arg (`--pw`).
- reencrypts all user keys by
   - calculating their old (unique) encryption keys using the salt and nonce in their respective rows in the `users` table
   - reencrypting them using the global encryption key
- updates all of the rows in the table with their new reencrypted keys


usage: `migrate-salt --pw=<vault_password>`

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/3627/pipeline/30