### PR TITLE
Remove the pub_key column from user table query in migrate-salt

### DIFF
--- a/blockapps-haskell/vault-wrapper/server/app/MigrateSalt.hs
+++ b/blockapps-haskell/vault-wrapper/server/app/MigrateSalt.hs
@@ -35,7 +35,7 @@ import           Options
 
 getUsersQuery :: Connection -> IO [(Int32, B.ByteString, SB.Nonce, B.ByteString)] 
 getUsersQuery conn = runQuery conn $ proc () -> do
-  (userId, _, salt, nonce, _, encKey, _, _) <- queryTable usersTable -< ()
+  (userId, _, salt, nonce, _, encKey, _) <- queryTable usersTable -< ()
   returnA -< (userId, salt, nonce, encKey)
 
 


### PR DESCRIPTION
The `pub_key` column is removed in `develop`. The `migrate-salt` executable reflects this in its userTable query.

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/3639/pipeline/30