### PR TITLE
[WIP] Strato 1958 pipelines remove nonoauth

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -41,12 +41,6 @@ pipeline {
           sh '''#!/bin/bash -le
             set -x
             cd strato-getting-started
-            rm -rf strato_logs*
-            ./fetchlogs --as-dir
-            rm -rf strato_pipeline_logs
-            mkdir strato_pipeline_logs
-            mv strato_logs strato_logs_nonoauth
-            mv strato_logs_nonoauth strato_pipeline_logs/
 
             docker rm -f $(docker ps -aq) || true; docker system prune -f --volumes
 
@@ -268,9 +262,7 @@ pipeline {
       dir ('strato-getting-started') {
         sh 'rm -rf strato_logs*'
         sh './fetchlogs --as-dir'
-        sh 'mv strato_logs strato_logs_oauth'
-        sh 'mv strato_logs_oauth strato_pipeline_logs/'
-        archiveArtifacts artifacts: 'strato_pipeline_logs/**', fingerprint: true
+        archiveArtifacts artifacts: 'strato_logs', fingerprint: true
       }
     }
 

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -33,156 +33,6 @@ pipeline {
     }
 
     stage('Deploy') {
-      steps {
-        withCredentials([
-            usernamePassword(credentialsId: 'aws-s3-test-bucket-access-user', passwordVariable: 'AWS_SECRET_ACCESS_KEY', usernameVariable: 'AWS_ACCESS_KEY_ID')
-        ]) {
-          sh '''#!/bin/bash -le
-            set -x
-            rm -rf strato-getting-started
-            git clone https://github.com/blockapps/strato-getting-started
-            cp strato-worktree/docker-compose.yml strato-getting-started/
-            cd strato-getting-started
-            export NODE_HOST=$(</host)
-            export genesis=smokeTest
-            export BLOC_DEBUG=true
-            export SLIPSTREAM_OPTIONAL=false
-            export PASSWORD=123
-            export EXT_STORAGE_S3_BUCKET=strato-external-storage-test
-            export EXT_STORAGE_S3_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-            export EXT_STORAGE_S3_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-            ./strato -m 1 --single
-            docker ps
-            # Few quick tests
-            check_availability() {
-              counter=0
-              until curl --silent --fail --location ${NODE_HOST}/health | jq .healthInfo.isHealthy | grep true
-              do
-                if [[ "$counter" -gt 120 ]]; then
-                  echo "STRATO node took longer than 2 minutes to initialize! aborting."
-                  exit 73
-                fi
-                echo "waiting for STRATO health endpoint to be available through nginx"
-                counter=$((counter+1))
-                sleep 1
-              done
-              echo "STRATO health endpoint is available through nginx - node is running"
-            }
-            check_availability
-            echo "Restarting docker containers to simulate computer restart..."
-            docker-compose -p strato --log-level ERROR stop
-            docker-compose -p strato --log-level ERROR start
-            PASSWORD=${PASSWORD} ./strato --set-password
-            check_availability
-          '''
-        }
-      }
-    }
-
-    stage('Test & Push images') {
-      steps {
-        parallel (
-          'Push images': {
-            withCredentials([
-                usernamePassword(credentialsId: 'docker-aws-registry-login', passwordVariable: 'DOCKER_PASSWD', usernameVariable: 'DOCKER_USER')
-            ]) {
-              archiveArtifacts artifacts: "strato-worktree/docker-compose.yml"
-              sh '''#!/bin/bash -le
-                set -x
-                docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
-                cd strato-worktree
-                docker-compose --log-level ERROR -f docker-compose.push.yml push 2>&1
-              '''
-            }
-          },
-
-          'Apex tests': {
-            sh '''#!/bin/bash -le
-              set -x
-              echo "Running apex unit tests"
-              APEX_CONTAINER=$(docker ps --format '{{.Names}}' | grep apex_1)
-              docker exec -t -e NODE_ENV=test "$APEX_CONTAINER" ./run-tests.sh
-            '''
-          },
-
-          'Core Strato tests': {
-            sh '''#!/bin/bash -le
-              set -x
-              echo "Running core-strato unit tests"
-              cd strato-worktree/core-strato
-              ./run_unit_tests.sh
-            '''
-          },
-
-          'Bloch tests': {
-            sh '''#!/bin/bash -le
-              set -x
-              echo 'Running BlockApps Haskell tests'
-              cd strato-worktree/blockapps-haskell
-              ./run_unit_tests.sh
-            '''
-          },
-
-          'Shared tests': {
-            dir('strato-worktree/') {
-              sh 'stack test ./shared-util/'
-            }
-          },
-
-          'SMD tests': {
-            sh '''#!/bin/bash -le
-              set -x
-              echo 'Running SMD tests'
-              cd strato-worktree/smd-ui
-              docker build -f Dockerfile.test .
-            '''
-          },
-
-          'Integration tests' : {
-            dir ('strato-worktree/tests') {
-              sh 'rm -rf node_modules'
-              sh 'npm install'
-              sh 'npm run test:blockhash'
-              sh 'npm run test:truchainz'
-              sh 'npm run test:multicontract'
-              sh 'npm run test:slipstream'
-              sh 'npm run test:solidvm'
-              sh 'npm run test:uploadOrder'
-              // -- additional tests:
-              //sh 'npm run test:e2e'
-              //sh 'npm run test:dataTypes'
-              //sh 'npm run test:load'
-              //sh 'npm run test:load10k'
-              //sh 'npm run test:loadecho'
-              //sh 'npm run test:upload'
-              //sh 'npm run test:upload10k'
-              //sh 'npm run test:loadFF' // SolidVM only
-              //sh 'npm run test:uploadOrder'
-            }
-            dir ('strato-worktree/core-strato/strato-init') {
-              sh './check_genesis_ingestion.sh'
-            }
-          },
-
-          'STRATO API Tests': {
-            withCredentials([
-               usernamePassword(credentialsId: 'blockapps-cd-github', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')
-            ]) {
-                sh '''#!/bin/bash -le
-                  set -x
-                  rm -rf strato-api-tests
-                  git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
-                  cd strato-api-tests
-                  docker build --tag strato-api-tests .
-                  docker run -e STRATO_NODE_URL=http://172.17.0.1:80 -e OAUTH_ENABLED=false -e DEBUG_LOG=false strato-api-tests
-                '''
-              }
-          },
-        )
-      }
-    }
-
-    stage('Redeploy with OAuth') {
 
       steps {
         withCredentials([
@@ -240,9 +90,23 @@ pipeline {
       }
     }
 
-    stage('Test with OAuth Node') {
+    stage('Test and Push Images') {
       steps {
         parallel (
+          'Push images': {
+            withCredentials([
+                usernamePassword(credentialsId: 'docker-aws-registry-login', passwordVariable: 'DOCKER_PASSWD', usernameVariable: 'DOCKER_USER')
+            ]) {
+              archiveArtifacts artifacts: "strato-worktree/docker-compose.yml"
+              sh '''#!/bin/bash -le
+              set -x
+              docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
+              cd strato-worktree
+              docker-compose --log-level ERROR -f docker-compose.push.yml push 2>&1
+            '''
+            }
+          },
+            
           'Apex tests': {
             sh '''#!/bin/bash -le
               set -x
@@ -252,6 +116,24 @@ pipeline {
             '''
           },
 
+          'Core Strato tests': {
+            sh '''#!/bin/bash -le
+            set -x
+            echo "Running core-strato unit tests"
+            cd strato-worktree/core-strato
+            ./run_unit_tests.sh
+          '''
+          },
+
+          'Bloch tests': {
+            sh '''#!/bin/bash -le
+            set -x
+            echo 'Running BlockApps Haskell tests'
+            cd strato-worktree/blockapps-haskell
+            ./run_unit_tests.sh
+          '''
+          },
+            
           'Track And Trace': {
             withEnv([
                 "ADMIN_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI1ZWE2NTBkNi1lMTM2LTQ5YjEtYTEzYi01MzY5MDM5MDdiNDEiLCJleHAiOjIwMjM5NzQxNDAsIm5iZiI6MCwiaWF0IjoxNTkxOTc0MTQwLCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6IjBjYWFlM2RmLWQ2ZWUtNDkxZC04ODYyLTJlY2ZmM2Y2YTI0MyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDE0MCwic2Vzc2lvbl9zdGF0ZSI6IjI3MjEyNjBhLWU1ODItNGJiOS04N2I5LTc0YWQ3YWI5MmMzNyIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW5pc3RyYXRvckB0dC5hcHAiLCJlbWFpbCI6ImFkbWluaXN0cmF0b3JAdHQuYXBwIn0.s-0MRMAEsG532YLM1k6GaXr3RKFUFpB13vR0WuYP8R1je2cP83hvE7Ll-N8hHbyAy8lumfEgSS6NXVIBCRrm0DEqX-XICOIEEkE6d6H-BPXqKZhfFV_HItfVWbWPDRHsCwvTI2ZAR8rgt19Dd8tWNOUVT_demsi20XYj8H2HuMo9vNMT7AN2wl1qRQPHffEppBrtPAx-PSauQpHm51xPgJSJMJPVhaVMWoM1tL91Ef6TOldZS8y89hReRaxeSZJP9kQWtIMLYe41AWcIKzrteOMBhPwa5e8PFfcDFJjvT6N_ASDtPldsxlNGrceMb0JVMwqmbcoetoE5_lMNKzGTkw",
@@ -318,6 +200,32 @@ pipeline {
             '''
           },
 
+          'Integration tests' : {
+            dir ('strato-worktree/tests') {
+              sh 'rm -rf node_modules'
+              sh 'npm install'
+              sh 'npm run test:blockhash'
+              sh 'npm run test:truchainz'
+              sh 'npm run test:multicontract'
+              sh 'npm run test:slipstream'
+              sh 'npm run test:solidvm'
+              sh 'npm run test:uploadOrder'
+              // -- additional tests:
+              //sh 'npm run test:e2e'
+              //sh 'npm run test:dataTypes'
+              //sh 'npm run test:load'
+              //sh 'npm run test:load10k'
+              //sh 'npm run test:loadecho'
+              //sh 'npm run test:upload'
+              //sh 'npm run test:upload10k'
+              //sh 'npm run test:loadFF' // SolidVM only
+              //sh 'npm run test:uploadOrder'
+            }
+            dir ('strato-worktree/core-strato/strato-init') {
+              sh './check_genesis_ingestion.sh'
+            }
+          },
+            
           'STRATO API Tests': {
             withCredentials([
               usernamePassword(credentialsId: 'blockapps-cd-github', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -64,12 +64,6 @@ pipeline {
           sh '''#!/bin/bash -le
             set -x
             cd strato-getting-started
-            rm -rf strato_logs*
-            ./fetchlogs --as-dir
-            rm -rf strato_pipeline_logs
-            mkdir strato_pipeline_logs
-            mv strato_logs strato_logs_nonoauth
-            mv strato_logs_nonoauth strato_pipeline_logs/
 
             docker rm -f $(docker ps -aq) || true; docker system prune -f --volumes
 
@@ -261,9 +255,7 @@ pipeline {
       dir ('strato-getting-started') {
         sh 'rm -rf strato_logs*'
         sh './fetchlogs --as-dir'
-        sh 'mv strato_logs strato_logs_oauth'
-        sh 'mv strato_logs_oauth strato_pipeline_logs/'
-        archiveArtifacts artifacts: 'strato_pipeline_logs/**', fingerprint: true
+        archiveArtifacts artifacts: 'strato_logs', fingerprint: true
       }
     }
 

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -54,82 +54,8 @@ pipeline {
       }
     }
 
+
     stage('Deploy') {
-      steps {
-        withCredentials([
-            usernamePassword(credentialsId: 'aws-s3-test-bucket-access-user', passwordVariable: 'AWS_SECRET_ACCESS_KEY', usernameVariable: 'AWS_ACCESS_KEY_ID')
-        ]) {
-          sh '''#!/bin/bash -le
-            set -x
-            rm -rf strato-getting-started
-            git clone https://github.com/blockapps/strato-getting-started
-            cp strato-worktree/docker-compose.yml strato-getting-started/
-            cd strato-getting-started
-            export genesis=smokeTest
-            export NODE_HOST=$(</host)
-            export EXT_STORAGE_S3_BUCKET=strato-external-storage-test
-            export EXT_STORAGE_S3_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-            export EXT_STORAGE_S3_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-            export PASSWORD=123
-            ./strato -m 1 --single
-            docker ps
-            # Few quick tests
-            check_availability() {
-              counter=0
-              until curl --silent --fail --location ${NODE_HOST}/health | jq .healthInfo.isHealthy | grep true
-              do
-                if [[ "$counter" -gt 120 ]]; then
-                  echo "STRATO node took longer than 2 minutes to initialize! aborting."
-                  exit 73
-                fi
-                echo "waiting for STRATO health endpoint to be available through nginx"
-                counter=$((counter+1))
-                sleep 1
-              done
-              echo "STRATO health endpoint is available through nginx - node is running"
-            }
-            check_availability
-            echo "Restarting docker containers to simulate computer restart..."
-            docker-compose -p strato --log-level ERROR stop
-            docker-compose -p strato --log-level ERROR start
-            PASSWORD=${PASSWORD} ./strato --set-password
-            check_availability
-          '''
-        }
-      }
-    }
-
-    stage('Some quick tests without OAuth') {
-      steps {
-        parallel(
-          'Apex tests': {
-            sh '''#!/bin/bash -le
-              set -x
-              echo "Running apex unit tests"
-              APEX_CONTAINER=$(docker ps --format '{{.Names}}' | grep apex_1)
-              docker exec -t -e NODE_ENV=test "$APEX_CONTAINER" ./run-tests.sh
-            '''
-          },
-
-          'STRATO API Tests': {
-            withCredentials([
-               usernamePassword(credentialsId: 'blockapps-cd-github', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')
-            ]) {
-                sh '''#!/bin/bash -le
-                  set -x
-                  rm -rf strato-api-tests
-                  git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
-                  cd strato-api-tests
-                  docker build --tag strato-api-tests .
-                  docker run -e STRATO_NODE_URL=http://172.17.0.1:80 -e OAUTH_ENABLED=false -e DEBUG_LOG=false strato-api-tests
-                '''
-              }
-          },
-        )
-      }
-    }
-
-    stage('Deploy with OAuth') {
 
       steps {
         withCredentials([
@@ -187,7 +113,7 @@ pipeline {
       }
     }
 
-    stage('Some quick tests w/OAuth') {
+    stage('Some quick tests') {
       steps {
         parallel(
           'Apex tests': {

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -53,19 +53,29 @@ pipeline {
         ]) {
           sh '''#!/bin/bash -le
             set -x
-            rm -rf strato-getting-started
-            git clone https://github.com/blockapps/strato-getting-started
-            cp strato-worktree/docker-compose.yml strato-getting-started/
             cd strato-getting-started
+            rm -rf strato_logs*
+            ./fetchlogs --as-dir
+            rm -rf strato_pipeline_logs
+            mkdir strato_pipeline_logs
+            mv strato_logs strato_logs_nonoauth
+            mv strato_logs_nonoauth strato_pipeline_logs/
+
+            docker rm -f $(docker ps -aq) || true; docker system prune -f --volumes
+
             export NODE_HOST=$(</host)
             export genesis=smokeTest
             export BLOC_DEBUG=true
             export SLIPSTREAM_OPTIONAL=false
+            export OAUTH_ENABLED=true
+            export OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration
+            export OAUTH_CLIENT_ID=dev
+            export OAUTH_CLIENT_SECRET=d5e67b8c-4fbf-42c6-a8d9-29a4dd13575f
             export PASSWORD=123
             export EXT_STORAGE_S3_BUCKET=strato-external-storage-test
             export EXT_STORAGE_S3_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
             export EXT_STORAGE_S3_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-            ./strato -m 1 --single
+            ./strato.sh -m 1 --single
             docker ps
             # Few quick tests
             check_availability() {
@@ -93,24 +103,23 @@ pipeline {
       }
     }
 
-    stage('Test & Push images') {
+    stage('Test and Push Images') {
       steps {
         parallel (
-
           'Push images': {
             withCredentials([
-              usernamePassword(credentialsId: 'docker-aws-registry-login', passwordVariable: 'DOCKER_PASSWD', usernameVariable: 'DOCKER_USER')
+                usernamePassword(credentialsId: 'docker-aws-registry-login', passwordVariable: 'DOCKER_PASSWD', usernameVariable: 'DOCKER_USER')
             ]) {
               archiveArtifacts artifacts: "strato-worktree/docker-compose.yml"
               sh '''#!/bin/bash -le
-                set -x
-                docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
-                cd strato-worktree
-                docker-compose --log-level ERROR -f docker-compose.push.yml push 2>&1
-              '''
+              set -x
+              docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
+              cd strato-worktree
+              docker-compose --log-level ERROR -f docker-compose.push.yml push 2>&1
+            '''
             }
           },
-
+            
           'Apex tests': {
             sh '''#!/bin/bash -le
               set -x
@@ -122,20 +131,20 @@ pipeline {
 
           'Core Strato tests': {
             sh '''#!/bin/bash -le
-              set -x
-              echo "Running core-strato unit tests"
-              cd strato-worktree/core-strato
-              ./run_unit_tests.sh
-            '''
+            set -x
+            echo "Running core-strato unit tests"
+            cd strato-worktree/core-strato
+            ./run_unit_tests.sh
+          '''
           },
 
           'Bloch tests': {
             sh '''#!/bin/bash -le
-              set -x
-              echo 'Running BlockApps Haskell tests'
-              cd strato-worktree/blockapps-haskell
-              ./run_unit_tests.sh
-            '''
+            set -x
+            echo 'Running BlockApps Haskell tests'
+            cd strato-worktree/blockapps-haskell
+            ./run_unit_tests.sh
+          '''
           },
 
           'Shared tests': {
@@ -152,6 +161,8 @@ pipeline {
               docker build -f Dockerfile.test .
             '''
           },
+	  
+	  /*
           '(quick) Integration tests' : {
             sh '''#!/bin/bash -le
               set -x
@@ -170,8 +181,7 @@ pipeline {
               ./check_genesis_ingestion.sh
               popd
             '''
-          },
-
+          },	  
           'STRATO API Tests': {
             withCredentials([
                usernamePassword(credentialsId: 'blockapps-cd-github', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')
@@ -186,6 +196,8 @@ pipeline {
                 '''
               }
           },
+	  */
+
         )
       }
     }
@@ -270,44 +282,44 @@ pipeline {
                   "RETAILER_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI4OWVlNDc1Ny1kNzc4LTQ1ZTgtYmI4Zi0yODNmYWIxZjEyNmQiLCJleHAiOjIwMjM5NzQyODUsIm5iZiI6MCwiaWF0IjoxNTkxOTc0Mjg1LCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImIzMGI2MjI0LWM0ZDktNDlhZC04Njc0LWYyY2NmNTNmMjYyOSIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDI4NSwic2Vzc2lvbl9zdGF0ZSI6IjczOTBlYzM2LWJiOGYtNGRmZi1hYTU2LWM2ZjZlOGYwNTBlNSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoicmV0YWlsZXJAdHQuYXBwIiwiZW1haWwiOiJyZXRhaWxlckB0dC5hcHAifQ.w-tQl7k_G_9gr2xUQt5GurI3q6sQN3upk8QIT4cnpWgO-4fYkCslg4sF7K6StC-yJlp7Ye7B9y1L5jg9EDhClM_fMukycdsN32Fr3-Ac2PaqshJmtwdJb32VXi47Vdokl3nB1S37a7sL6BIdT7yZESC9EYdPSPPvhmlR8hbKJiqVbqPHJZXmkpwXTQKaeGIB0h56AlVxtfTL4av4bn1gj7WbQ1q0CvtnTg390QyuS18n_NHxzrKu6a51X5kAPGo9gt7CjvPKLOuqIMY1kaPqzXgPMcrP4Qxc0zDC2XWCTJJgeDPp_mz4ndKxgUKN9jr3DSJARQt6tpJ7xM7VjOqchg"
               ]) {
 
-                sh 'rm -rf track-and-trace'
-                sh 'git clone -b master https://github.com/blockapps/track-and-trace.git'
-                dir ('track-and-trace/server') {
-                  writeFile file: "config/jenkinstest.config.yaml", text: """
-                  apiDebug: false
-                  restVersion: 6
-                  timeout: 120000
-                  dappPath: ./dapp
-                  libPath: blockapps-sol/dist
-                  apiUrl: /api/v1
-                  deployFilename: ./config/jenkinstest.deploy.yaml
-                  
-                  nodes:
-                    - id: 0
-                      url: "http://localhost"
-                      publicKey: "6d8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0"
-                      port: 30303
-                      oauth:
-                        appTokenCookieName: "tt_session"
-                        scope: "email openid"
-                        appTokenCookieMaxAge: 7776000000 # 90 days: 90 * 24 * 60 * 60 * 1000
-                        openIdDiscoveryUrl: "https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration"
-                        clientId: "dev-infinite"
-                        clientSecret: "091a22ec-3c81-4be4-83fb-d9f82084c3e8"
-                        redirectUri: "http://UNUSED/api/v1/authentication/callback"
-                        logoutRedirectUri: "http://UNUSED"
+              sh 'rm -rf track-and-trace'
+              sh 'git clone -b master https://github.com/blockapps/track-and-trace.git'
+              dir ('track-and-trace/server') {
+                writeFile file: "config/jenkinstest.config.yaml", text: """
+                apiDebug: false
+                restVersion: 6
+                timeout: 120000
+                dappPath: ./dapp
+                libPath: blockapps-sol/dist
+                apiUrl: /api/v1
+                deployFilename: ./config/jenkinstest.deploy.yaml
+                
+                nodes:
+                  - id: 0
+                    url: "http://localhost"
+                    publicKey: "6d8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0"
+                    port: 30303
+                    oauth:
+                      appTokenCookieName: "tt_session"
+                      scope: "email openid"
+                      appTokenCookieMaxAge: 7776000000 # 90 days: 90 * 24 * 60 * 60 * 1000
+                      openIdDiscoveryUrl: "https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration"
+                      clientId: "dev-infinite"
+                      clientSecret: "091a22ec-3c81-4be4-83fb-d9f82084c3e8"
+                      redirectUri: "http://UNUSED/api/v1/authentication/callback"
+                      logoutRedirectUri: "http://UNUSED"
 
-                  """
-                  // symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
-                  sh 'cp -r ../../strato-worktree/blockapps-rest blockapps-rest'
-                  sh '''sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json'''
-                  sh 'touch .env'
-                  sh 'yarn build'
-                  sh 'yarn install'
-                  sh 'SERVER=jenkinstest yarn test'
-                }
+                """
+                // symlink or npm link or yarn link don't work here without sudo - don't wanna mess the file permissions
+                sh 'cp -r ../../strato-worktree/blockapps-rest blockapps-rest'
+                sh '''sed -i 's|.*blockapps-rest.*|"blockapps-rest": "file:./blockapps-rest",|' package.json'''
+                sh 'touch .env'
+                sh 'yarn build'
+                sh 'yarn install'
+                sh 'SERVER=jenkinstest yarn test'
               }
-            },
+            }
+          },
 
           'Shared tests': {
             sh '''#!/bin/bash -le
@@ -357,6 +369,32 @@ pipeline {
               DOCKER_HOST=172.17.0.1 # on "Docker for Mac" use "docker.for.mac.localhost" special reserved ip instead
               docker build -f Dockerfile.test --build-arg host=${DOCKER_HOST} --no-cache .
             '''
+          },
+
+          'Integration tests' : {
+            dir ('strato-worktree/tests') {
+              sh 'rm -rf node_modules'
+              sh 'npm install'
+              sh 'npm run test:blockhash'
+              sh 'npm run test:truchainz'
+              sh 'npm run test:multicontract'
+              sh 'npm run test:slipstream'
+              sh 'npm run test:solidvm'
+              sh 'npm run test:uploadOrder'
+              // -- additional tests:
+              //sh 'npm run test:e2e'
+              //sh 'npm run test:dataTypes'
+              //sh 'npm run test:load'
+              //sh 'npm run test:load10k'
+              //sh 'npm run test:loadecho'
+              //sh 'npm run test:upload'
+              //sh 'npm run test:upload10k'
+              //sh 'npm run test:loadFF' // SolidVM only
+              //sh 'npm run test:uploadOrder'
+            }
+            dir ('strato-worktree/core-strato/strato-init') {
+              sh './check_genesis_ingestion.sh'
+            }
           },
         )
       }

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -140,141 +140,16 @@ pipeline {
             ./run_unit_tests.sh
           '''
           },
-
-          'Shared tests': {
-            dir('strato-worktree/') {
-              sh 'stack test ./shared-util/'
-            }
-          },
-
-          'SMD tests': {
-            sh '''#!/bin/bash -le
-              set -x
-              echo 'Running SMD tests'
-              cd strato-worktree/smd-ui
-              docker build -f Dockerfile.test .
-            '''
-          },
-	  
-	  /*
-          '(quick) Integration tests' : {
-            sh '''#!/bin/bash -le
-              set -x
-              echo 'Running local integration tests'
-              pushd strato-worktree/tests
-              rm -rf node_modules
-              npm install
-              npm run test:blockhash
-              npm run test:truchainz
-              npm run test:multicontract
-              npm run test:slipstream
-              npm run test:solidvm
-              npm run test:uploadOrder
-              popd
-              pushd strato-worktree/core-strato/strato-init
-              ./check_genesis_ingestion.sh
-              popd
-            '''
-          },	  
-          'STRATO API Tests': {
-            withCredentials([
-               usernamePassword(credentialsId: 'blockapps-cd-github', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')
+            
+          'Track And Trace': {
+            withEnv([
+                "ADMIN_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI1ZWE2NTBkNi1lMTM2LTQ5YjEtYTEzYi01MzY5MDM5MDdiNDEiLCJleHAiOjIwMjM5NzQxNDAsIm5iZiI6MCwiaWF0IjoxNTkxOTc0MTQwLCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6IjBjYWFlM2RmLWQ2ZWUtNDkxZC04ODYyLTJlY2ZmM2Y2YTI0MyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDE0MCwic2Vzc2lvbl9zdGF0ZSI6IjI3MjEyNjBhLWU1ODItNGJiOS04N2I5LTc0YWQ3YWI5MmMzNyIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW5pc3RyYXRvckB0dC5hcHAiLCJlbWFpbCI6ImFkbWluaXN0cmF0b3JAdHQuYXBwIn0.s-0MRMAEsG532YLM1k6GaXr3RKFUFpB13vR0WuYP8R1je2cP83hvE7Ll-N8hHbyAy8lumfEgSS6NXVIBCRrm0DEqX-XICOIEEkE6d6H-BPXqKZhfFV_HItfVWbWPDRHsCwvTI2ZAR8rgt19Dd8tWNOUVT_demsi20XYj8H2HuMo9vNMT7AN2wl1qRQPHffEppBrtPAx-PSauQpHm51xPgJSJMJPVhaVMWoM1tL91Ef6TOldZS8y89hReRaxeSZJP9kQWtIMLYe41AWcIKzrteOMBhPwa5e8PFfcDFJjvT6N_ASDtPldsxlNGrceMb0JVMwqmbcoetoE5_lMNKzGTkw",
+                "MASTER_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiJlYmMzNzJkMy04NzlkLTRjMDQtOWEwMi1iZjcyMGYyNWM5OGQiLCJleHAiOjIwMjM5NzQyMzgsIm5iZiI6MCwiaWF0IjoxNTkxOTc0MjM4LCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImM5M2NjMzQxLWYzZGEtNGY0Yy1hZTczLTVkMDIzN2ZmZDVlZCIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDIzOCwic2Vzc2lvbl9zdGF0ZSI6ImVkNTY2OTQ0LWRlZTgtNDE5YS04M2Y1LTRiYTJjYzlhNjE3NCIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoibWFzdGVyQHR0LmFwcCIsImVtYWlsIjoibWFzdGVyQHR0LmFwcCJ9.wS7tU80jGm3akaaB_iSYw3a2aCJQ44-RfbYsYtAN1wYd6wk1gtaf9leCD0Cks98ItMtf8E7ZHb5yNLTZ6vsxrjhPNkmN0dVbn7Ol9UxJ_qOC4oVXyowESAGVSVZSeZ79PSKz16Mm9KQYacqEEfECnzVE4CN2143lBmWqQT6wjPbzn3-0xz6W7xZfQpuJX6EIYNOPjyheSTpKUpZxCNoFzTy0GRyHrVhnlucTkBTy3Dj-BLM3aDVwHyuSASXnq_qL3TZIG7ksJ4mF1L6XAQGu5p8pFs22XMlz0iXKtYJNfCzmRLoeto85oBcsw4gkh2e0xkOC9FJrDkkIDo8tTUTilQ",
+                "DISTRIBUTOR_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI2MjljMGMzOC1kMzg1LTQxMjktYmVlNy1lMTkzZjFhYzFhMzgiLCJleHAiOjIwMjM5NzQyNTIsIm5iZiI6MCwiaWF0IjoxNTkxOTc0MjUyLCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImZmODIxNzY1LWI0YjUtNDE2Zi1hMTY3LWM2ZmRhMTJkZjA2YSIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDI1Miwic2Vzc2lvbl9zdGF0ZSI6Ijc4MWNlZTE3LWFhZTgtNDNjMC1hNjVjLTk0MmI2Y2UwYTMyYSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlzdHJpYnV0b3JAdHQuYXBwIiwiZW1haWwiOiJkaXN0cmlidXRvckB0dC5hcHAifQ.nHdFsWfUSuech6fFOlQ9QWpxCxQ4W5IIpO6sICyo6KTm030F91LCyS55R419sA40rOhcUbMml-SGb_ZY1m6avwb4A89jBf0JgLx_iVfwKI4LQC_eQoyLety9e-VVJrRvovJsRrE__D8GTpvGBKOfXdkpmNF4iNSyL3jggFTpT05gv5LEvCQ4yB5kD6f3XoYIN9F1t8IfUMT9MaF8-zGJ1UHXfFnlWPz_ICPn8FJdl-bIObfMlk6YqEXv0SB_Gg9LtcoEUMEmt-vfwL01BXYr__G7LkJmqOXamomZi00Oi824EYCIyeJwSVU7EmqBpUA_EOzMWSR774Vr0sZjpG2vIQ",
+                "MANUFACTURER_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiJhMGQ1MzkxYS1iNmQ0LTQzNDQtYjJhOS0wNTNhYjNmM2M2YzMiLCJleHAiOjIwMjM5NzQyNjQsIm5iZiI6MCwiaWF0IjoxNTkxOTc0MjY0LCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImVjNjVmNDNlLWM4MGUtNDY1My1hODFiLTNmZGE4MmJlOTk1NCIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDI2NCwic2Vzc2lvbl9zdGF0ZSI6IjliMmUxMzljLTMyOTUtNGYwMy04Nzk4LWVjY2JmNmQ0MzBiZSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoibWFudWZhY3R1cmVyQHR0LmFwcCIsImVtYWlsIjoibWFudWZhY3R1cmVyQHR0LmFwcCJ9.rakA66et-VRzE6lQis5c71-hG49o3ev0NfXQNuvBHkB8AG1UY5nEi8OxH0V66aMwKwMKWxefBU9BeLr8Kci8c8fDKNq8uM4mO6RN7PrmfJ1AAcgIuC7MNermTegIgb7IApxXo1zhxYUAyVyVCIRjOAy-QdlH36SDIRS3F-pJMDEUd-VKdqYDNFmcWr16-Lf8xvQH2xZVJQ_fsX9mz19RRQnBjYDEK1LHgtcGu7o5Sk5SUEAfBwMfQa6WuMkr9mZAtclGhqKflthafkrWww66BEDsOapwt-1IdWD0n4EM6-7aDCsFiVquRtWElT_O4PEKZN-pkiCoyGSyKR9g0GiU3Q",
+                "REGULATOR_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI3MGE4ZjJkYS1jY2RlLTRlNWQtYjEyNi1kOWI3NzBkODIxZGIiLCJleHAiOjIwMjM5NzQyNzQsIm5iZiI6MCwiaWF0IjoxNTkxOTc0Mjc1LCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6IjJjNTE3MjAzLWNhNTEtNDQyNi04M2RlLTNmODdiY2VjZjg4YSIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDI3NCwic2Vzc2lvbl9zdGF0ZSI6IjZiZTI0OWYwLTMzYWQtNDkwMS1hOGYyLTEzNjRjNWFiYzIyYSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoicmVndWxhdG9yQHR0LmFwcCIsImVtYWlsIjoicmVndWxhdG9yQHR0LmFwcCJ9.eRpCW0cXzmUERDfYZ6PAvJCnssyZuqTW7vLH-CI4NYxVK9xu8CkWlCw-QlaI2ieBwn0u6nXUR7mEcKbYZQkk8sMATXxpCA_POVaoF7waf3gtyeJyU9dfoCwor5hytAa_LYuFd9FPVA9in9imkaXzUAVD9lqFIuCBv0AW2IOXUF1ELn6snMFej_V84_jGoppN-XSZsaCY2IZxvJFgeKgjsNholp_2n1mu64tzoFyM-SmEcxY6gNZC3f_aLMmYtJY-K4-WBusgSxj8TRoKQe98xPTgr1KmFGHc_1GCUGJFAhEKCHwMOHFf_bT80ai8UC77vF_0zvmgy-I-mJLRh05IDQ",
+                "RETAILER_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI4OWVlNDc1Ny1kNzc4LTQ1ZTgtYmI4Zi0yODNmYWIxZjEyNmQiLCJleHAiOjIwMjM5NzQyODUsIm5iZiI6MCwiaWF0IjoxNTkxOTc0Mjg1LCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImIzMGI2MjI0LWM0ZDktNDlhZC04Njc0LWYyY2NmNTNmMjYyOSIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDI4NSwic2Vzc2lvbl9zdGF0ZSI6IjczOTBlYzM2LWJiOGYtNGRmZi1hYTU2LWM2ZjZlOGYwNTBlNSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoicmV0YWlsZXJAdHQuYXBwIiwiZW1haWwiOiJyZXRhaWxlckB0dC5hcHAifQ.w-tQl7k_G_9gr2xUQt5GurI3q6sQN3upk8QIT4cnpWgO-4fYkCslg4sF7K6StC-yJlp7Ye7B9y1L5jg9EDhClM_fMukycdsN32Fr3-Ac2PaqshJmtwdJb32VXi47Vdokl3nB1S37a7sL6BIdT7yZESC9EYdPSPPvhmlR8hbKJiqVbqPHJZXmkpwXTQKaeGIB0h56AlVxtfTL4av4bn1gj7WbQ1q0CvtnTg390QyuS18n_NHxzrKu6a51X5kAPGo9gt7CjvPKLOuqIMY1kaPqzXgPMcrP4Qxc0zDC2XWCTJJgeDPp_mz4ndKxgUKN9jr3DSJARQt6tpJ7xM7VjOqchg"
             ]) {
-                sh '''#!/bin/bash -le
-                  set -x
-                  rm -rf strato-api-tests
-                  git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
-                  cd strato-api-tests
-                  docker build --tag strato-api-tests .
-                  docker run -e STRATO_NODE_URL=http://172.17.0.1:80 -e OAUTH_ENABLED=false -e DEBUG_LOG=false strato-api-tests
-                '''
-              }
-          },
-	  */
-
-        )
-      }
-    }
-
-    stage('Redeploy with OAuth') {
-
-      steps {
-        withCredentials([
-            usernamePassword(credentialsId: 'aws-s3-test-bucket-access-user', passwordVariable: 'AWS_SECRET_ACCESS_KEY', usernameVariable: 'AWS_ACCESS_KEY_ID')
-        ]) {
-          sh '''#!/bin/bash -le
-            set -x
-            cd strato-getting-started
-            rm -rf strato_logs*
-            ./fetchlogs --as-dir
-            rm -rf strato_pipeline_logs
-            mkdir strato_pipeline_logs
-            mv strato_logs strato_logs_nonoauth
-            mv strato_logs_nonoauth strato_pipeline_logs/
-
-            docker rm -f $(docker ps -aq) || true; docker system prune -f --volumes
-
-            export NODE_HOST=$(</host)
-            export genesis=smokeTest
-            export BLOC_DEBUG=true
-            export SLIPSTREAM_OPTIONAL=false
-            export OAUTH_ENABLED=true
-            export OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration
-            export OAUTH_CLIENT_ID=dev
-            export OAUTH_CLIENT_SECRET=d5e67b8c-4fbf-42c6-a8d9-29a4dd13575f
-            export PASSWORD=123
-            export EXT_STORAGE_S3_BUCKET=strato-external-storage-test
-            export EXT_STORAGE_S3_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-            export EXT_STORAGE_S3_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-            ./strato.sh -m 1 --single
-            docker ps
-            # Few quick tests
-            check_availability() {
-              counter=0
-              until curl --silent --fail --location ${NODE_HOST}/health | jq .healthInfo.isHealthy | grep true
-              do
-                if [[ "$counter" -gt 120 ]]; then
-                  echo "STRATO node took longer than 2 minutes to initialize! aborting."
-                  exit 73
-                fi
-                echo "waiting for STRATO health endpoint to be available through nginx"
-                counter=$((counter+1))
-                sleep 1
-              done
-              echo "STRATO health endpoint is available through nginx - node is running"
-            }
-            check_availability
-            echo "Restarting docker containers to simulate computer restart..."
-            docker-compose -p strato --log-level ERROR stop
-            docker-compose -p strato --log-level ERROR start
-            PASSWORD=${PASSWORD} ./strato --set-password
-            check_availability
-          '''
-        }
-      }
-    }
-
-    stage('Test with OAuth Node') {
-      steps {
-        parallel (
-          'Apex tests': {
-            sh '''#!/bin/bash -le
-              set -x
-              echo "Running apex unit tests"
-              APEX_CONTAINER=$(docker ps --format '{{.Names}}' | grep apex_1)
-              docker exec -t -e NODE_ENV=test "$APEX_CONTAINER" ./run-tests.sh
-            '''
-          },
-
-            'Track And Trace': {
-              withEnv([
-                  "ADMIN_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI1ZWE2NTBkNi1lMTM2LTQ5YjEtYTEzYi01MzY5MDM5MDdiNDEiLCJleHAiOjIwMjM5NzQxNDAsIm5iZiI6MCwiaWF0IjoxNTkxOTc0MTQwLCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6IjBjYWFlM2RmLWQ2ZWUtNDkxZC04ODYyLTJlY2ZmM2Y2YTI0MyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDE0MCwic2Vzc2lvbl9zdGF0ZSI6IjI3MjEyNjBhLWU1ODItNGJiOS04N2I5LTc0YWQ3YWI5MmMzNyIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW5pc3RyYXRvckB0dC5hcHAiLCJlbWFpbCI6ImFkbWluaXN0cmF0b3JAdHQuYXBwIn0.s-0MRMAEsG532YLM1k6GaXr3RKFUFpB13vR0WuYP8R1je2cP83hvE7Ll-N8hHbyAy8lumfEgSS6NXVIBCRrm0DEqX-XICOIEEkE6d6H-BPXqKZhfFV_HItfVWbWPDRHsCwvTI2ZAR8rgt19Dd8tWNOUVT_demsi20XYj8H2HuMo9vNMT7AN2wl1qRQPHffEppBrtPAx-PSauQpHm51xPgJSJMJPVhaVMWoM1tL91Ef6TOldZS8y89hReRaxeSZJP9kQWtIMLYe41AWcIKzrteOMBhPwa5e8PFfcDFJjvT6N_ASDtPldsxlNGrceMb0JVMwqmbcoetoE5_lMNKzGTkw",
-                  "MASTER_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiJlYmMzNzJkMy04NzlkLTRjMDQtOWEwMi1iZjcyMGYyNWM5OGQiLCJleHAiOjIwMjM5NzQyMzgsIm5iZiI6MCwiaWF0IjoxNTkxOTc0MjM4LCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImM5M2NjMzQxLWYzZGEtNGY0Yy1hZTczLTVkMDIzN2ZmZDVlZCIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDIzOCwic2Vzc2lvbl9zdGF0ZSI6ImVkNTY2OTQ0LWRlZTgtNDE5YS04M2Y1LTRiYTJjYzlhNjE3NCIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoibWFzdGVyQHR0LmFwcCIsImVtYWlsIjoibWFzdGVyQHR0LmFwcCJ9.wS7tU80jGm3akaaB_iSYw3a2aCJQ44-RfbYsYtAN1wYd6wk1gtaf9leCD0Cks98ItMtf8E7ZHb5yNLTZ6vsxrjhPNkmN0dVbn7Ol9UxJ_qOC4oVXyowESAGVSVZSeZ79PSKz16Mm9KQYacqEEfECnzVE4CN2143lBmWqQT6wjPbzn3-0xz6W7xZfQpuJX6EIYNOPjyheSTpKUpZxCNoFzTy0GRyHrVhnlucTkBTy3Dj-BLM3aDVwHyuSASXnq_qL3TZIG7ksJ4mF1L6XAQGu5p8pFs22XMlz0iXKtYJNfCzmRLoeto85oBcsw4gkh2e0xkOC9FJrDkkIDo8tTUTilQ",
-                  "DISTRIBUTOR_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI2MjljMGMzOC1kMzg1LTQxMjktYmVlNy1lMTkzZjFhYzFhMzgiLCJleHAiOjIwMjM5NzQyNTIsIm5iZiI6MCwiaWF0IjoxNTkxOTc0MjUyLCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImZmODIxNzY1LWI0YjUtNDE2Zi1hMTY3LWM2ZmRhMTJkZjA2YSIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDI1Miwic2Vzc2lvbl9zdGF0ZSI6Ijc4MWNlZTE3LWFhZTgtNDNjMC1hNjVjLTk0MmI2Y2UwYTMyYSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlzdHJpYnV0b3JAdHQuYXBwIiwiZW1haWwiOiJkaXN0cmlidXRvckB0dC5hcHAifQ.nHdFsWfUSuech6fFOlQ9QWpxCxQ4W5IIpO6sICyo6KTm030F91LCyS55R419sA40rOhcUbMml-SGb_ZY1m6avwb4A89jBf0JgLx_iVfwKI4LQC_eQoyLety9e-VVJrRvovJsRrE__D8GTpvGBKOfXdkpmNF4iNSyL3jggFTpT05gv5LEvCQ4yB5kD6f3XoYIN9F1t8IfUMT9MaF8-zGJ1UHXfFnlWPz_ICPn8FJdl-bIObfMlk6YqEXv0SB_Gg9LtcoEUMEmt-vfwL01BXYr__G7LkJmqOXamomZi00Oi824EYCIyeJwSVU7EmqBpUA_EOzMWSR774Vr0sZjpG2vIQ",
-                  "MANUFACTURER_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiJhMGQ1MzkxYS1iNmQ0LTQzNDQtYjJhOS0wNTNhYjNmM2M2YzMiLCJleHAiOjIwMjM5NzQyNjQsIm5iZiI6MCwiaWF0IjoxNTkxOTc0MjY0LCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImVjNjVmNDNlLWM4MGUtNDY1My1hODFiLTNmZGE4MmJlOTk1NCIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDI2NCwic2Vzc2lvbl9zdGF0ZSI6IjliMmUxMzljLTMyOTUtNGYwMy04Nzk4LWVjY2JmNmQ0MzBiZSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoibWFudWZhY3R1cmVyQHR0LmFwcCIsImVtYWlsIjoibWFudWZhY3R1cmVyQHR0LmFwcCJ9.rakA66et-VRzE6lQis5c71-hG49o3ev0NfXQNuvBHkB8AG1UY5nEi8OxH0V66aMwKwMKWxefBU9BeLr8Kci8c8fDKNq8uM4mO6RN7PrmfJ1AAcgIuC7MNermTegIgb7IApxXo1zhxYUAyVyVCIRjOAy-QdlH36SDIRS3F-pJMDEUd-VKdqYDNFmcWr16-Lf8xvQH2xZVJQ_fsX9mz19RRQnBjYDEK1LHgtcGu7o5Sk5SUEAfBwMfQa6WuMkr9mZAtclGhqKflthafkrWww66BEDsOapwt-1IdWD0n4EM6-7aDCsFiVquRtWElT_O4PEKZN-pkiCoyGSyKR9g0GiU3Q",
-                  "REGULATOR_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI3MGE4ZjJkYS1jY2RlLTRlNWQtYjEyNi1kOWI3NzBkODIxZGIiLCJleHAiOjIwMjM5NzQyNzQsIm5iZiI6MCwiaWF0IjoxNTkxOTc0Mjc1LCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6IjJjNTE3MjAzLWNhNTEtNDQyNi04M2RlLTNmODdiY2VjZjg4YSIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDI3NCwic2Vzc2lvbl9zdGF0ZSI6IjZiZTI0OWYwLTMzYWQtNDkwMS1hOGYyLTEzNjRjNWFiYzIyYSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoicmVndWxhdG9yQHR0LmFwcCIsImVtYWlsIjoicmVndWxhdG9yQHR0LmFwcCJ9.eRpCW0cXzmUERDfYZ6PAvJCnssyZuqTW7vLH-CI4NYxVK9xu8CkWlCw-QlaI2ieBwn0u6nXUR7mEcKbYZQkk8sMATXxpCA_POVaoF7waf3gtyeJyU9dfoCwor5hytAa_LYuFd9FPVA9in9imkaXzUAVD9lqFIuCBv0AW2IOXUF1ELn6snMFej_V84_jGoppN-XSZsaCY2IZxvJFgeKgjsNholp_2n1mu64tzoFyM-SmEcxY6gNZC3f_aLMmYtJY-K4-WBusgSxj8TRoKQe98xPTgr1KmFGHc_1GCUGJFAhEKCHwMOHFf_bT80ai8UC77vF_0zvmgy-I-mJLRh05IDQ",
-                  "RETAILER_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJWY0N4SEpnUjFOdnJ4UWR5QXhQcEI5VEowM205SVRDdWt0b1JfTENVSE1VIn0.eyJqdGkiOiI4OWVlNDc1Ny1kNzc4LTQ1ZTgtYmI4Zi0yODNmYWIxZjEyNmQiLCJleHAiOjIwMjM5NzQyODUsIm5iZiI6MCwiaWF0IjoxNTkxOTc0Mjg1LCJpc3MiOiJodHRwczovL2tleWNsb2FrLmJsb2NrYXBwcy5uZXQvYXV0aC9yZWFsbXMvc3RyYXRvLWRldmVsIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImIzMGI2MjI0LWM0ZDktNDlhZC04Njc0LWYyY2NmNTNmMjYyOSIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRldi1pbmZpbml0ZSIsImF1dGhfdGltZSI6MTU5MTk3NDI4NSwic2Vzc2lvbl9zdGF0ZSI6IjczOTBlYzM2LWJiOGYtNGRmZi1hYTU2LWM2ZjZlOGYwNTBlNSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwicHJlZmVycmVkX3VzZXJuYW1lIjoicmV0YWlsZXJAdHQuYXBwIiwiZW1haWwiOiJyZXRhaWxlckB0dC5hcHAifQ.w-tQl7k_G_9gr2xUQt5GurI3q6sQN3upk8QIT4cnpWgO-4fYkCslg4sF7K6StC-yJlp7Ye7B9y1L5jg9EDhClM_fMukycdsN32Fr3-Ac2PaqshJmtwdJb32VXi47Vdokl3nB1S37a7sL6BIdT7yZESC9EYdPSPPvhmlR8hbKJiqVbqPHJZXmkpwXTQKaeGIB0h56AlVxtfTL4av4bn1gj7WbQ1q0CvtnTg390QyuS18n_NHxzrKu6a51X5kAPGo9gt7CjvPKLOuqIMY1kaPqzXgPMcrP4Qxc0zDC2XWCTJJgeDPp_mz4ndKxgUKN9jr3DSJARQt6tpJ7xM7VjOqchg"
-              ]) {
 
               sh 'rm -rf track-and-trace'
               sh 'git clone -b master https://github.com/blockapps/track-and-trace.git'

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -244,7 +244,7 @@ pipeline {
             dir ('strato-worktree/tests') {
               sh 'rm -rf node_modules'
               sh 'npm install'
-              sh 'npm run test:blockhash'
+              sh 'echo "TODO (nikita): this will fail on oauth, need a fix in test" && npm run test:blockhash' 
               sh 'npm run test:truchainz'
               sh 'npm run test:multicontract'
               sh 'npm run test:slipstream'

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -54,12 +54,6 @@ pipeline {
           sh '''#!/bin/bash -le
             set -x
             cd strato-getting-started
-            rm -rf strato_logs*
-            ./fetchlogs --as-dir
-            rm -rf strato_pipeline_logs
-            mkdir strato_pipeline_logs
-            mv strato_logs strato_logs_nonoauth
-            mv strato_logs_nonoauth strato_pipeline_logs/
 
             docker rm -f $(docker ps -aq) || true; docker system prune -f --volumes
 
@@ -405,11 +399,9 @@ pipeline {
   post {
     always {
       dir ('strato-getting-started') {
-          sh 'rm -rf strato_logs*'
-          sh './fetchlogs --as-dir'
-          sh 'mv strato_logs strato_logs_oauth'
-          sh 'mv strato_logs_oauth strato_pipeline_logs/'
-          archiveArtifacts artifacts: 'strato_pipeline_logs/**', fingerprint: true
+        sh 'rm -rf strato_logs*'
+        sh './fetchlogs --as-dir'
+        archiveArtifacts artifacts: 'strato_logs', fingerprint: true
       }
     }
 


### PR DESCRIPTION
Some tests that used to work on non-oauth are now failing on oauth. (e.g. Integration tests -> npm run test:blockhash; may be some others too). Need to fix the test to work on oauth or remove if test is obsolete for oauth)