### PR TITLE
Fix load test performance bug in sequencer

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/ChainInfo.hs
@@ -240,7 +240,7 @@ data UnsignedChainInfo = UnsignedChainInfo
   , creationBlock  :: Keccak256
   , chainNonce     :: Word256
   , chainMetadata  :: (M.Map T.Text T.Text)
-  } deriving (Eq, Show, GHCG.Generic, Data)
+  } deriving (Eq, GHCG.Generic, Data)
 
 
 
@@ -264,19 +264,22 @@ instance ToSchema ChainInfo where
 --    NamedSchema (Just "ChainInfo")
 --      ( mempty )
 
-instance Format UnsignedChainInfo where
-  format UnsignedChainInfo{..} = unlines
+instance Show UnsignedChainInfo where
+  show UnsignedChainInfo{..} = unlines
     [ "UnsignedChainInfo"
     , "-----------------"
     , tab $ "Label:          " ++ show chainLabel
     , tab $ "Account info:   " ++ format accountInfo
-    , tab $ "Code info:      " ++ format codeInfo
+    , tab $ "Code info:      " ++ show (codeInfoName <$> codeInfo)
     , tab $ "Members:        " ++ show members
     , tab $ "Parent chain:   " ++ CL.yellow (format parentChain)
     , tab $ "Creation block: " ++ format creationBlock
     , tab $ "Nonce:          " ++ CL.yellow (format chainNonce)
-    , tab $ "Metadata:       " ++ show chainMetadata
+    , tab $ "Metadata:       " ++ show (M.keys chainMetadata)
     ]
+
+instance Format UnsignedChainInfo where
+  format = show
 
 data ChainInfo = ChainInfo
   { chainInfo      :: UnsignedChainInfo

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -561,7 +561,8 @@ transformGenesis chains = forM_ chains $ \ig -> do
       logF $ "Checking emission status of block " ++ format (creationBlock $ chainInfo cInfo)
       ready <- fmap _emitted . lift . A.repsert (A.Proxy @EmittedBlock) (creationBlock $ chainInfo cInfo) $ \case
         Nothing -> pure $ EmittedBlock False (M.singleton chainId cInfo)
-        Just (EmittedBlock emitted' depChains) -> pure $ EmittedBlock emitted' (M.insert chainId cInfo depChains)
+        Just (EmittedBlock emitted' depChains) | emitted' -> pure $ EmittedBlock emitted' M.empty
+                                               | otherwise -> pure $ EmittedBlock emitted' (M.insert chainId cInfo depChains)
       logF $ "Emission status of block " ++ format (creationBlock $ chainInfo cInfo) ++ ": " ++ show ready
       when ready $ do
         yield . ToVm $ VmGenesis og

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -423,6 +423,7 @@ prunePrivacyDBs = do
   prune txHashRegistry
   prune chainHashRegistry
   prune chainIdRegistry
+  prune emittedBlockRegistry
   where prune r = modify' $ r .~ M.empty
 
 runSequencerM :: SequencerConfig -> Maybe BlockstanbulContext -> SequencerM a -> (LoggingT IO) a


### PR DESCRIPTION
Also abbreviated the Show instance for ChainInfo, in case there are log messages printing the entire chain info object.