### PR TITLE
Support building on NixOS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -114,3 +114,6 @@ docker:
   image: "strato-buildbase:lts-14.27"
   set-user: true
   run-args: ["--ulimit=nofile=60000"]
+
+nix:
+  enable: false


### PR DESCRIPTION
By default, on NixOS, stack tries to use Nix. However, Nix and Docker
do not work together, so we need to explicitly disable Nix.

On all other OSs, stack does not use Nix by default.