### PR TITLE
When the enode is invalid, return a 400 error explaining the error, r…

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Data/Enode.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Data/Enode.hs
@@ -89,7 +89,7 @@ instance FromJSON Enode where
     case readEnodeOrFail $ T.unpack str of
       Left e -> fail e
       Right val -> return val
-  parseJSON x = error $ "could not parse JSON for Enode: " ++ show x
+  parseJSON x = fail $ "could not parse JSON for Enode: " ++ show x
 
 instance ToJSON Enode where
   toJSON enode = String (T.pack $ showEnode enode)
@@ -116,6 +116,26 @@ readIP input =
         (((LabeledError.read "Enode/readIP3" b3) .&. 0xff) `shiftL` 24))
   in (IPv4 addy)
 
+readEitherIP :: String -> Either String IPAddress
+readEitherIP input =
+  let (b3,temp) = break (=='.') input
+      s0 = dropWhile (=='.') temp
+      (b2, temp2) = break (=='.') s0
+      s1 = dropWhile (=='.') temp2
+      (b1, temp3) = break (=='.') s1
+      b0 = dropWhile (=='.') temp3
+      msg i = "Enode/readIP" ++ i ++ ": IP addresses must be in valid IPv4 form"
+      addy = do
+        b0' <- LabeledError.readEither (msg "0") b0
+        b1' <- LabeledError.readEither (msg "1") b1
+        b2' <- LabeledError.readEither (msg "2") b2
+        b3' <- LabeledError.readEither (msg "3") b3
+        pure $ b0'
+           + ((b1' .&. 0xff) `shiftL` 8)
+           + ((b2' .&. 0xff) `shiftL` 16)
+           + ((b3' .&. 0xff) `shiftL` 24)
+  in IPv4 <$> addy
+
 showEnode :: Enode -> String
 showEnode (Enode (OrgId pk) ip tp up) =
     "enode://" ++
@@ -139,11 +159,17 @@ readEnodeOrFail :: String -> Either String Enode
 readEnodeOrFail input =
   case matchRegex (mkRegex "^enode://([0-9a-f]{128})@([^:]+)\\:([0-9]+)(\\?discport=([0-9]+))?$") input of
     Nothing -> Left $ "enode is in the wrong format: " ++ input
-    Just [pubkey, ip, port, _, discport] ->
-      Right $ Enode (OrgId . fst $ B16.decode (C8.pack pubkey)) (readIP ip) (LabeledError.read "Enode/readEnodeOrFail" port) $
-                    case discport of
-                      "" -> Nothing
-                      _ -> Just $ LabeledError.read "Enode/readEnodeOrFail" discport
+    Just [pubkey, ip, port, _, discport] -> do
+      let ~(oId, rest) = B16.decode $ C8.pack pubkey
+      orgId <- if B.null rest
+        then pure $ OrgId oId
+        else fail $ "Failed on parsing OrdId: " ++ pubkey
+      ipAddr <- readEitherIP ip
+      tcp <- LabeledError.readEither "Enode/readEnodeOrFail" port
+      udp <- case discport of
+        "" -> pure Nothing
+        _ -> Just <$> LabeledError.readEither "Enode/readEnodeOrFail" discport
+      pure $ Enode orgId ipAddr tcp udp
     _ -> error "internal error in 'readEnodeOrFail': regex returned with wrong number of matches"
 
 instance PersistFieldSql Enode where

--- a/shared-util/labeled-error/src/LabeledError.hs
+++ b/shared-util/labeled-error/src/LabeledError.hs
@@ -1,6 +1,7 @@
 
 module LabeledError where
 
+import           Data.Bifunctor (first)
 import           Prelude hiding (head, tail)
 import qualified Prelude
 
@@ -9,6 +10,9 @@ import Text.Read
 
 read :: Read a => String -> String -> a
 read s x = fromMaybe (error $ "[" ++ s ++ "] read parse error: can't parse '" ++ x ++ "'") . readMaybe $ x
+
+readEither :: Read a => String -> String -> Either String a
+readEither s = first (const s) . Text.Read.readEither
 
 head :: String -> [a] -> a
 head label [] = error $ "[" ++ label ++ "]: 'head' was called on an empty list"


### PR DESCRIPTION
…ather than returning a 500

Before: (Note that the IP address is `1.2.3.f`)
```
root@20825c7c3660:/var/lib/strato# curl -i -X POST http://strato:3000/bloc/v2.2/chain -H 'Content-Type: application/json' -d '{"label":"asdf","src":"contract Governance {}",
> "args":{},"members":[{"address":"deadbeef","enode":"enode://abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd@1.2.3.f:30303"}],"balances":[{"address":"deadbeef","balance":100000000000000000}],"metadata":{"VM":"SolidVM"}}'
HTTP/1.1 500 Internal Server Error
Transfer-Encoding: chunked
Date: Thu, 25 Feb 2021 16:51:05 GMT
Server: Warp/3.3.5

"Runtime Error!\nSomething wrong has happened inside of bloc.\nPlease contact your network administrator to have this problem fixed.\n(More information can be found in the strato-api logs.)\n"
```

After:
```
curl -X POST http://strato:3000/bloc/v2.2/chain -H 'Content-Type: application/json' -d '{"label":"asdf","src":"contract Governance {}","args":{},"members":[{"address":"deadbeef","enode":"enode://abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd@a.2.3.f:30303"}],"balances":[{"address":"deadbeef","balance":100000000000000000}],"metadata":{"VM":"SolidVM"}}'
HTTP/1.1 400 Bad Request
Transfer-Encoding: chunked
Date: Thu, 25 Feb 2021 18:22:47 GMT
Server: Warp/3.3.5

Error in $.members[0].enode: Enode/readIP0: IP addresses must be in valid IPv4 form
```

The regex used is pretty strict on the rest of the enode, requiring the OrgId (public key) component to be exactly 128 ascii hex characters and the TCP and UDP ports to be all digits, meaning that when corrupting these parts of the enode address, the resulting error message comes from failure on the regex, which gives a vaguer error message: (note that the last `d` in the OrgId is removed, making it 127 characters long)
```
curl -X POST http://strato:3000/bloc/v2.2/chain -H 'Content-Type: application/json' -d '{"label":"asdf","src":"contract Governance {}","args":{},"members":[{"address":"deadbeef","enode":"enode://abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabc@1.2.3.4:30303"}],"balances":[{"address":"deadbeef","balance":100000000000000000}],"metadata":{"VM":"SolidVM"}}'
HTTP/1.1 400 Bad Request
Transfer-Encoding: chunked
Date: Thu, 25 Feb 2021 18:23:02GMT
Server: Warp/3.3.5

Error in $.members[0].enode: enode is in the wrong format: enode://abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabc@1.2.3.4:30303
```

I think changing the regex is out of scope for this bugfix, but maybe we should think about changing it in the future to get more precise error messages.