### PR TITLE
Fixed bugs with debugging API introduced with cleanup from last PR

### DIFF
--- a/blockapps-rest/src/util/api.util.ts
+++ b/blockapps-rest/src/util/api.util.ts
@@ -9,7 +9,7 @@ const strato12Url = "/strato-api/eth/v1.2";
 const strato23Url = "/strato/v2.3";
 const cirrusUrl = "/cirrus/search";
 const externalStorageUrl = "/apex-api/bloc/file";
-const debugUrl = "/debug";
+const debugUrl = "/vm-debug";
 
 const Endpoint = {
   ACCOUNT: `${strato12Url}/account`,

--- a/nginx-packager/docker-run.sh
+++ b/nginx-packager/docker-run.sh
@@ -72,6 +72,8 @@ if [ ! -f /usr/local/openresty/nginx/conf/nginx.conf ]; then
   if [ "$VM_DEBUG" != true ]; then
     sed -i '/#TEMPLATE_MARK_DEBUG/d' /tmp/nginx.conf
   fi
+  sed -i 's/<DEBUG_PORT_PLACEHOLDER>/'"$debugPort"'/g' /tmp/nginx.conf
+  sed -i 's/<WS_DEBUG_PORT_PLACEHOLDER>/'"$debugWSPort"'/g' /tmp/nginx.conf
 
   # Remove SSL lines if deployment is not SSL-enabled
   # Set SSL cert file type if SSL-enabled

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -375,14 +375,14 @@ http {
         proxy_pass http://strato:8050/;                                     #TEMPLATE_MARK_BLOCKSTANBUL
       }                                                                     #TEMPLATE_MARK_BLOCKSTANBUL
 
-      location /debug/ {                                                    #TEMPLATE_MARK_DEBUG
+      location /vm-debug/ {                                                 #TEMPLATE_MARK_DEBUG
         rewrite_by_lua_file lua/openid.lua;                                 #TEMPLATE_MARK_DEBUG #TEMPLATE_MARK_OAUTH
-        proxy_pass http://strato:$debugPort/;                               #TEMPLATE_MARK_DEBUG
+        proxy_pass http://strato:<DEBUG_PORT_PLACEHOLDER>/;                 #TEMPLATE_MARK_DEBUG
       }                                                                     #TEMPLATE_MARK_DEBUG
 
-      location /ws-debug/ {                                                 #TEMPLATE_MARK_DEBUG
+      location /vm-debug-ws/ {                                              #TEMPLATE_MARK_DEBUG
         rewrite_by_lua_file lua/openid.lua;                                 #TEMPLATE_MARK_DEBUG #TEMPLATE_MARK_OAUTH
-        proxy_pass http://strato:$debugWSPort/;                             #TEMPLATE_MARK_DEBUG
+        proxy_pass http://strato:<WS_DEBUG_PORT_PLACEHOLDER>/;              #TEMPLATE_MARK_DEBUG
         proxy_http_version 1.1;                                             #TEMPLATE_MARK_DEBUG
         proxy_set_header Upgrade $http_upgrade;                             #TEMPLATE_MARK_DEBUG
         proxy_set_header Connection "Upgrade";                              #TEMPLATE_MARK_DEBUG

--- a/strato-vscode/src/stratoDebug.ts
+++ b/strato-vscode/src/stratoDebug.ts
@@ -59,7 +59,8 @@ export class StratoDebugSession extends LoggingDebugSession {
 	private _showHex = false;
 	private _useInvalidatedEvent = false;
 
-    private _ws = new WebSocket("ws://localhost:8080/ws-debug/")
+	private _initialized = false;
+    private _ws;
 	private _status = undefined;
 	private _user;
     private _options;
@@ -71,6 +72,22 @@ export class StratoDebugSession extends LoggingDebugSession {
 	 */
 	public constructor() {
 		super("strato-debug.txt");
+		this.setDebuggerLinesStartAt1(true);
+		this.setDebuggerColumnsStartAt1(true);
+	}
+
+	public async initialize() {
+		this._initialized = true;
+		const { user, options } = await this.getUserAndOptionsInternal()
+		const { config } = options
+		const { nodes } = config
+		var token = user.token;
+        var wsOptions = {
+            headers: {
+                "Authorization" : "Bearer " + token
+            }
+        };
+        this._ws = new WebSocket(`${nodes[0].url}/vm-debug-ws/`, wsOptions);
         this._ws.on('message', (bytes) => {
            const message = JSON.parse(bytes.toString('utf-8'));
 		   if(message.tag === 'WSOStatus') {
@@ -93,8 +110,6 @@ export class StratoDebugSession extends LoggingDebugSession {
 		   }
            console.log(`From websocket: ${message}`)
         });
-		this.setDebuggerLinesStartAt1(true);
-		this.setDebuggerColumnsStartAt1(true);
 	}
 
 	/**
@@ -163,7 +178,7 @@ export class StratoDebugSession extends LoggingDebugSession {
 		this.sendEvent(new InitializedEvent());
 	}
 
-	protected async getUserAndOptions(): Promise<any> {
+	private async getUserAndOptionsInternal(): Promise<any> {
 		if (!this._user) {
 		    this._user = await getApplicationUser()
 		}
@@ -172,6 +187,13 @@ export class StratoDebugSession extends LoggingDebugSession {
             this._options = { config };
 		}
 		return { user: this._user, options: this._options }
+	}
+
+	protected async getUserAndOptions(): Promise<any> {
+		if (!this._initialized) {
+			await this.initialize();
+		}
+        return this.getUserAndOptionsInternal();
 	}
 
 	/**
@@ -222,9 +244,9 @@ export class StratoDebugSession extends LoggingDebugSession {
 		const bps = clientLines.map((l) => ({
 			tag: "UnconditionalBP",
 			contents: {
-				breakpointFile: file,
-				breakpointLine: l,
-				breakpointColumn: 1
+				name: file,
+				line: l,
+				column: 1
 			}
 		}))
 
@@ -341,9 +363,9 @@ export class StratoDebugSession extends LoggingDebugSession {
 		const stackFrames: StackFrame[] = []
 		for (let i = 0; i < stk.length; i++) {
 			const f = stk[i];
-			const source = await this.createSourceFromFilename(f.breakpointFile)
-			const sf = new StackFrame(i, f.breakpointFile, source, this.convertDebuggerLineToClient(f.breakpointLine));
-			sf.column = this.convertDebuggerColumnToClient(f.breakpointColumn);
+			const source = await this.createSourceFromFilename(f.name)
+			const sf = new StackFrame(i, f.name, source, this.convertDebuggerLineToClient(f.line));
+			sf.column = this.convertDebuggerColumnToClient(f.column);
 			stackFrames.push(sf);
 		}
 		response.body = {

--- a/strato-vscode/yarn.lock
+++ b/strato-vscode/yarn.lock
@@ -471,7 +471,7 @@ binary@~0.3.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
-blockapps-rest@../../strato/blockapps-rest:
+blockapps-rest@../blockapps-rest:
   version "8.0.0"
   dependencies:
     "@babel/polyfill" "^7.8.3"


### PR DESCRIPTION
https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/4421/

I realized this morning that the nginx changes didn't actually work with VSCode, so I went back and fixed it. Now the VSCode extension also connects to the websocket using the JWT token, too.