### PR TITLE
Compiling vault with "-threaded", because it keeps crashing with an e…

### DIFF
--- a/blockapps-haskell/vault-wrapper/server/package.yaml
+++ b/blockapps-haskell/vault-wrapper/server/package.yaml
@@ -75,6 +75,7 @@ executables:
       - wai-extra
       - wai-middleware-prometheus
       - warp
+    ghc-options: -threaded
       
   migrate-keys:
     source-dirs: app


### PR DESCRIPTION
…rror message that indicates that it needs to run with "-threaded".

I'm not sure this will fix the problem, but it at lease will get me more information.

Here is the error message:
++++++++++++++++++++++++++
blockapps-vault-wrapper-server: file descriptor 38233576 out of range for select (0--1024).
Recompile with -threaded to work around this.