### PR TITLE
Use correct chainId field from methodCall payload in SMD

### DIFF
--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.saga.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.saga.js
@@ -41,14 +41,14 @@ export function getArgs(contractName, contractAddress, symbol, chainid) {
 
 export function postMethodCall(payload) {
   const isModeOauth = isOauthEnabled();
-  const options = isModeOauth ? { query: { resolve: true, chainid: payload.chainid } } :
+  const options = isModeOauth ? { query: { resolve: true, chainid: payload.chainId } } :
     {
       params: {
         username: payload.username,
         userAddress: payload.userAddress,
         contractName: payload.contractName,
         contractAddress: payload.contractAddress
-      }, query: { resolve: true, chainid: payload.chainid }
+      }, query: { resolve: true, chainid: payload.chainId }
     };
 
   const prefix = isModeOauth ? env.STRATO_URL_V23 : env.BLOC_URL;


### PR DESCRIPTION
Apparently, SMD hasn't been able to send transactions on private chains since late 2019, but no one's noticed until now :sweat_smile: 
The problem is caused by an incorrect lowercase 'i' in `payload.chainid`, which should be `payload.chainId`. This is preventing Mark from being able to add Rejolut to a private chain for a demo.