### PR TITLE
Added paging to GET /contracts endpoint, and applied filters in correct place

### DIFF
--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -334,14 +334,14 @@ JOIN contracts_metadata CM
 JOIN contracts_instance CI
   ON CI.contract_metadata_id = CM.id;
 -}
-getContractsAddressesQuery :: Maybe ChainId -> Query
+getContractsAddressesQuery :: Int -> Int -> Maybe ChainId -> Query
   ( Column PGText
   , Column PGBytea
   , Column PGTimestamptz
   , Column PGBytea
   )
-getContractsAddressesQuery chainId = proc () -> do
-  (_,name,_,addr,timestamp,_,_,_,_,cid,_) <- limit 100 $ contractsJoinTable -< ()
+getContractsAddressesQuery o l chainId = limit l . offset o $ proc () -> do
+  (_,name,_,addr,timestamp,_,_,_,_,cid,_) <- contractsJoinTable -< ()
   restrict -< cid .== constant chainId
   returnA -< (name,addr,timestamp,cid)
 

--- a/api/bloc2/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -51,8 +51,8 @@ hexStorageToWord256 :: HexStorage -> Word256
 hexStorageToWord256 (HexStorage bs) = bytesToWord256 bs
 
 getContracts :: (MonadIO m, MonadLogger m, HasBlocSQL m) =>
-                Maybe ChainId -> m GetContractsResponse
-getContracts chainId = blocTransaction $ do
+                Maybe Integer -> Maybe Integer -> Maybe ChainId -> m GetContractsResponse
+getContracts mOffset mLimit chainId = blocTransaction $ do
   let
     -- current bloc returns milliseconds
     -- TODO: get those extra 3 significant figures of accuracy
@@ -61,9 +61,9 @@ getContracts chainId = blocTransaction $ do
     addressesToMap = foldr'
       (\ (key,addr,utc,cid) -> Map.insertWith (++) key [addressToVal addr utc cid])
       Map.empty
-  -- Take only 100 entries as a short-term solution to prevent from crashing.
-  -- See also: https://blockapps.atlassian.net/browse/STRATO-1714
-  contractsAddresses <- blocQuery $ getContractsAddressesQuery chainId
+    offset = fromInteger $ fromMaybe 0 mOffset
+    limit = fromInteger $ fromMaybe 100 mLimit -- TODO: Make the 100 configurable?
+  contractsAddresses <- blocQuery $ getContractsAddressesQuery offset limit chainId
   let reducedResponseMap = addressesToMap contractsAddresses
   return . GetContractsResponse $ reducedResponseMap
 

--- a/api/bloc2api/src/BlockApps/Bloc22/API/Contracts.hs
+++ b/api/bloc2api/src/BlockApps/Bloc22/API/Contracts.hs
@@ -41,8 +41,13 @@ import           Blockchain.Strato.Model.SourceMap
 -- | Routes and types
 --------------------------------------------------------------------------------
 type GetContracts = "contracts"
+                 :> QueryParam "offset" Integer
+                 :> QueryParam "limit" Integer
                  :> QueryParam "chainid" ChainId
                  :> Get '[JSON] GetContractsResponse
+
+instance ToParam (QueryParam "limit" Integer) where
+  toParam _ = DocQueryParam "limit" [] "Maximum number of entries to return" Normal
 
 data AddressCreatedAt = AddressCreatedAt
   { createdAt  :: Int64

--- a/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/blockapps-haskell/bloc/bloc22/server/src/BlockApps/Bloc22/Database/Queries.hs
@@ -338,8 +338,8 @@ getContractsAddressesQuery :: Maybe ChainId -> Query
   , Column PGTimestamptz
   , Column PGBytea
   )
-getContractsAddressesQuery chainId = proc () -> do
-  (_,name,_,addr,timestamp,_,_,_,_,cid,_) <- limit 100 $ contractsJoinTable -< ()
+getContractsAddressesQuery chainId = limit 100 $ proc () -> do
+  (_,name,_,addr,timestamp,_,_,_,_,cid,_) <- contractsJoinTable -< ()
   restrict -< cid .== constant chainId
   returnA -< (name,addr,timestamp,cid)
 


### PR DESCRIPTION
There is a filter limiting the number of results returned by the GET /contracts endpoint, but the filter was being applied in the wrong place, before filtering on chainId. This causes weird results in SMD, where if the first 100 results from the database are on different chains than the one you're querying, the endpoint returns an empty list (which is obviously not what the user is expecting).
While I was at it, I went ahead and added proper `limit` and `offset` query parameters to the GET /contracts endpoint, so that the full list can be retrieved in the future. However, for the purpose of the demo, I don't think it's necessary to add the pagination to SMD yet.