### PR TITLE
fix buildbase image build

### DIFF
--- a/Dockerfile.buildbase
+++ b/Dockerfile.buildbase
@@ -2,7 +2,9 @@ ARG STACK_RESOLVER
 
 FROM fpco/stack-build:${STACK_RESOLVER}
 
-RUN apt-get update && \
+# apt-key adv line is the fix for `The repository 'https://packages.confluent.io/deb/5.2 stable InRelease' is not signed.` error (started happening 05/06/2021)
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8B1DA6120C2BF624 && \ 
+    apt-get update && \
     apt-get -y --allow-unauthenticated install autoconf libtool libblas-dev liblapack-dev libsodium-dev jq vim && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
the fix for the failing nightly builds failing to build the `buildbase` docker image (e.g. here: https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_develop_nightly_build/detail/STRATO_develop_nightly_build/1104/pipeline/)