### PR TITLE
STRATO-2033 fix for vault db migrations to prevent the pubkey removal migration skip

### DIFF
--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Database/Migrations.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Database/Migrations.hs
@@ -34,6 +34,7 @@ migrations = [ (Throw, createTables)
              , (Throw, insertAddress)
              , (Throw, messageTable)
              , (Throw, insertSecPrvKey)
+             , (Throw, insertPublicKey)
              , (Throw, removePublicKey)
              ]
 
@@ -51,6 +52,9 @@ insertAddress = [sql| ALTER TABLE users ADD COLUMN IF NOT EXISTS address bytea; 
 
 insertSecPrvKey :: Query
 insertSecPrvKey = [sql| ALTER TABLE users ADD COLUMN IF NOT EXISTS enc_sec_prv_key bytea NOT NULL; |]
+
+insertPublicKey :: Query
+insertPublicKey = [sql| ALTER TABLE users ADD COLUMN IF NOT EXISTS pub_key bytea; |]
 
 removePublicKey :: Query
 removePublicKey = [sql| ALTER TABLE users DROP COLUMN IF EXISTS pub_key; |]


### PR DESCRIPTION
re-added the old migration to add pubkey. Because just replacing it (and keeping the total number of migrations in list the same) makes the migration script skip the new one (that removes the pubkey).
That being said, we should only add migrations going forward, don't alter them.

STRATO_test build: https://jenkins.blockapps.net/job/STRATO_test/4513/