### PR TITLE
drop bloc22 database on resync to prevent broken db migrations from r…

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -233,7 +233,7 @@ function cleanupDB {
     SELECT pg_terminate_backend(pg_stat_activity.pid)
     FROM pg_stat_activity
     WHERE pg_stat_activity.datname like '%eth_%';"
-
+  PGPASSWORD=$pgPass dropdb ${db_conn_params} --if-exists "bloc22"
   PGPASSWORD=$pgPass psql ${db_conn_params} -c "copy (select datname from pg_database where datname like '%eth_%') to stdout" | while read line; do
     echo "dropping the old db: $line"
     PGPASSWORD=$pgPass dropdb ${db_conn_params} "$line"


### PR DESCRIPTION
…unning

This is required to prevent STRATO container from going into infinite restart loop when the messed up migration scripts fail in the node resync scenario in v6.0.3+