### PR TITLE
Strato 2036 add query by hash

### DIFF
--- a/smd-ui/src/components/QueryEngine/queryTypes.js
+++ b/smd-ui/src/components/QueryEngine/queryTypes.js
@@ -7,17 +7,25 @@ export const TRANSACTION_QUERY_TYPES = {
     key: 'blocknumber',
     displayName : 'Block Number'
   },
+  hash : {
+    key : 'hash',
+    displayName : 'Hash'
+  },
   to : {
     key: 'to',
     displayName : 'To'
   },
-  maxvalue: {
-    key: 'maxvalue',
-    displayName: 'Max Value'
+  from : {
+    key: 'from',
+    displayName : 'From'
   },
   minvalue: {
     key: 'minvalue',
     displayName: 'Min Value'
+  },
+  maxvalue: {
+    key: 'maxvalue',
+    displayName: 'Max Value'
   },
   mingasprice: {
     key: 'mingasprice',
@@ -34,10 +42,6 @@ export const TRANSACTION_QUERY_TYPES = {
   value : {
     key: 'value',
     displayName : 'Value'
-  },
-  from : {
-    key: 'from',
-    displayName : 'From'
   },
   last : {
     key: 'last',

--- a/smd-ui/src/tests/ContractQuery/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/ContractQuery/__snapshots__/index.spec.js.snap
@@ -304,7 +304,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?&chainId=undefined
             </code>
           </div>
         </div>,
@@ -1295,7 +1295,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -1308,7 +1308,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -1320,13 +1320,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?&chainId=undefined",
+                "http://localhost:8080/cirrus/search/Bid?&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/Bid?&chainId=undefined",
+              "http://localhost:8080/cirrus/search/Bid?&chainId=undefined",
             ],
             "type": "code",
           },
@@ -1764,7 +1764,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?&chainId=undefined
               </code>
             </div>
           </div>,
@@ -2755,7 +2755,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -2768,7 +2768,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -2780,13 +2780,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/Bid?&chainId=undefined",
+                  "http://localhost:8080/cirrus/search/Bid?&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?&chainId=undefined",
+                "http://localhost:8080/cirrus/search/Bid?&chainId=undefined",
               ],
               "type": "code",
             },
@@ -3492,7 +3492,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>
           </div>
         </div>,
@@ -4586,7 +4586,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -4599,7 +4599,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -4611,13 +4611,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+              "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
             ],
             "type": "code",
           },
@@ -5074,7 +5074,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>
             </div>
           </div>,
@@ -6168,7 +6168,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -6181,7 +6181,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -6193,13 +6193,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                  "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
               ],
               "type": "code",
             },
@@ -6815,7 +6815,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>
           </div>
         </div>,
@@ -7909,7 +7909,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -7922,7 +7922,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -7934,13 +7934,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+              "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
             ],
             "type": "code",
           },
@@ -8397,7 +8397,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>
             </div>
           </div>,
@@ -9491,7 +9491,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -9504,7 +9504,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -9516,13 +9516,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                  "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
               ],
               "type": "code",
             },
@@ -10091,7 +10091,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/null?&chainId=undefined
+              http://localhost:8080/cirrus/search/null?&chainId=undefined
             </code>
           </div>
         </div>,
@@ -10875,7 +10875,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/null?&chainId=undefined
+              http://localhost:8080/cirrus/search/null?&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -10888,7 +10888,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/null?&chainId=undefined
+              http://localhost:8080/cirrus/search/null?&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -10900,13 +10900,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/null?&chainId=undefined",
+                "http://localhost:8080/cirrus/search/null?&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/null?&chainId=undefined",
+              "http://localhost:8080/cirrus/search/null?&chainId=undefined",
             ],
             "type": "code",
           },
@@ -11198,7 +11198,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/null?&chainId=undefined
+                http://localhost:8080/cirrus/search/null?&chainId=undefined
               </code>
             </div>
           </div>,
@@ -11982,7 +11982,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/null?&chainId=undefined
+                http://localhost:8080/cirrus/search/null?&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -11995,7 +11995,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/null?&chainId=undefined
+                http://localhost:8080/cirrus/search/null?&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -12007,13 +12007,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/null?&chainId=undefined",
+                  "http://localhost:8080/cirrus/search/null?&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/null?&chainId=undefined",
+                "http://localhost:8080/cirrus/search/null?&chainId=undefined",
               ],
               "type": "code",
             },
@@ -12524,7 +12524,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
             </code>
           </div>
         </div>,
@@ -13668,7 +13668,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -13681,7 +13681,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -13693,13 +13693,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+              "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
             ],
             "type": "code",
           },
@@ -14165,7 +14165,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
               </code>
             </div>
           </div>,
@@ -15309,7 +15309,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -15322,7 +15322,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -15334,13 +15334,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+                  "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
               ],
               "type": "code",
             },

--- a/smd-ui/src/tests/ContractQuery/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/ContractQuery/__snapshots__/index.spec.js.snap
@@ -304,7 +304,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?&chainId=undefined
+              http://localhost/cirrus/search/Bid?&chainId=undefined
             </code>
           </div>
         </div>,
@@ -1295,7 +1295,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?&chainId=undefined
+              http://localhost/cirrus/search/Bid?&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -1308,7 +1308,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?&chainId=undefined
+              http://localhost/cirrus/search/Bid?&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -1320,13 +1320,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/Bid?&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost:8080/cirrus/search/Bid?&chainId=undefined",
+              "http://localhost/cirrus/search/Bid?&chainId=undefined",
             ],
             "type": "code",
           },
@@ -1764,7 +1764,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?&chainId=undefined
+                http://localhost/cirrus/search/Bid?&chainId=undefined
               </code>
             </div>
           </div>,
@@ -2755,7 +2755,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?&chainId=undefined
+                http://localhost/cirrus/search/Bid?&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -2768,7 +2768,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?&chainId=undefined
+                http://localhost/cirrus/search/Bid?&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -2780,13 +2780,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost:8080/cirrus/search/Bid?&chainId=undefined",
+                  "http://localhost/cirrus/search/Bid?&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/Bid?&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?&chainId=undefined",
               ],
               "type": "code",
             },
@@ -3492,7 +3492,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>
           </div>
         </div>,
@@ -4586,7 +4586,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -4599,7 +4599,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -4611,13 +4611,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
             ],
             "type": "code",
           },
@@ -5074,7 +5074,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>
             </div>
           </div>,
@@ -6168,7 +6168,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -6181,7 +6181,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -6193,13 +6193,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
               ],
               "type": "code",
             },
@@ -6815,7 +6815,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>
           </div>
         </div>,
@@ -7909,7 +7909,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -7922,7 +7922,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -7934,13 +7934,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
             ],
             "type": "code",
           },
@@ -8397,7 +8397,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>
             </div>
           </div>,
@@ -9491,7 +9491,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -9504,7 +9504,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -9516,13 +9516,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
               ],
               "type": "code",
             },
@@ -10091,7 +10091,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/null?&chainId=undefined
+              http://localhost/cirrus/search/null?&chainId=undefined
             </code>
           </div>
         </div>,
@@ -10875,7 +10875,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/null?&chainId=undefined
+              http://localhost/cirrus/search/null?&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -10888,7 +10888,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/null?&chainId=undefined
+              http://localhost/cirrus/search/null?&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -10900,13 +10900,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/null?&chainId=undefined",
+                "http://localhost/cirrus/search/null?&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost:8080/cirrus/search/null?&chainId=undefined",
+              "http://localhost/cirrus/search/null?&chainId=undefined",
             ],
             "type": "code",
           },
@@ -11198,7 +11198,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/null?&chainId=undefined
+                http://localhost/cirrus/search/null?&chainId=undefined
               </code>
             </div>
           </div>,
@@ -11982,7 +11982,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/null?&chainId=undefined
+                http://localhost/cirrus/search/null?&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -11995,7 +11995,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/null?&chainId=undefined
+                http://localhost/cirrus/search/null?&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -12007,13 +12007,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost:8080/cirrus/search/null?&chainId=undefined",
+                  "http://localhost/cirrus/search/null?&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/null?&chainId=undefined",
+                "http://localhost/cirrus/search/null?&chainId=undefined",
               ],
               "type": "code",
             },
@@ -12524,7 +12524,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
             </code>
           </div>
         </div>,
@@ -13668,7 +13668,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
             </code>
           </div>,
           "className": "row",
@@ -13681,7 +13681,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -13693,13 +13693,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
             ],
             "type": "code",
           },
@@ -14165,7 +14165,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
               </code>
             </div>
           </div>,
@@ -15309,7 +15309,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
               </code>
             </div>,
             "className": "row",
@@ -15322,7 +15322,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -15334,13 +15334,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost:8080/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
               ],
               "type": "code",
             },

--- a/smd-ui/src/tests/QueryEngine/__snapshots__/queryTypes.spec.js.snap
+++ b/smd-ui/src/tests/QueryEngine/__snapshots__/queryTypes.spec.js.snap
@@ -110,6 +110,10 @@ Object {
     "displayName": "Gas Limit",
     "key": "gaslimit",
   },
+  "hash": Object {
+    "displayName": "Hash",
+    "key": "hash",
+  },
   "last": Object {
     "displayName": "Last",
     "key": "last",


### PR DESCRIPTION
Successful Jenkins Build: https://jenkins.blockapps.net/job/STRATO_test/4553/
Jira Issue: https://blockapps.atlassian.net/browse/STRATO-2036

Allows transactions to be queried by their hash now.
Order of query parameters changed to be more logical.