### PR TITLE
Run chainDiff using withCurrentBlockHash

### DIFF
--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -798,7 +798,7 @@ calculateAndEmitChainDiffs chainMap = do
       chainIds = format . unsafeCreateKeccak256FromWord256 . fst <$> chainList
   $logInfoS "calculateAndEmitChainDiffs" . T.pack $ "Calculating ChainDiffs for: " ++ show chainIds
   runConduit $ yieldMany chainList
-            .| mapMC (\(cId, (newNumber, newHash)) -> SD.chainDiff (Just cId) newNumber newHash)
+            .| mapMC (\(cId, (newNumber, newHash)) -> withCurrentBlockHash newHash $ SD.chainDiff (Just cId) newNumber newHash)
             .| mapM_C (traverse_ $ yield . OutStateDiff)
 
 diffMaxCost :: Int


### PR DESCRIPTION
https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/4554/

Fixes the crashing behavior Kelly saw in the Beanstalk load test.
With the introduction of using `CodeAtAccount`s for contract creations, `stateDiff` needs to be able to use the address state trie to resolve `CodePtr`s. This means it needs to know which block hash it's running from, so calls to `stateDiff` must be wrapped with `withCurrentBlockHash bHash` for some block hash `bHash`. We added this to the main chain call to `stateDiff`, but forgot to add it to the private chain call to `chainDiff`.