### PR TITLE
Add the `:creator` field to contract storage, supporting logic

### DIFF
--- a/core-strato/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
@@ -18,7 +18,8 @@ module Blockchain.Data.AddressStateDB (
   codePtrToSHA,
   resolvedCodePtrToSHA,
   codePtrToCodeKind,
-  unsafeCodePtrToCodeKind
+  unsafeCodePtrToCodeKind,
+  getAppAddress
 ) where
 
 import           Prelude hiding (lookup)
@@ -175,3 +176,20 @@ unsafeCodePtrToCodeKind :: (Account `Alters` AddressState) m => CodePtr -> m Cod
 unsafeCodePtrToCodeKind = unsafeResolveCodePtr >=> \case
   Just (SolidVMCode _ _) -> pure SolidVM
   _ -> pure EVM -- TODO: should this return (Maybe CodeKind)?
+
+
+getAppAddress :: ( Selectable (Maybe Word256) ParentChainId m
+                 , (Account `Alters` AddressState) m
+                 )
+              => Maybe Word256 -> Account -> m (Maybe Account)
+getAppAddress chainId acct = do
+  lookup Proxy acct >>= \case
+    Nothing -> pure Nothing
+    Just AddressState{..} -> do
+      let codeAccountChainId = (acct ^. accountChainId)
+      isAccessibleChain <- codeAccountChainId `isAncestorChainOf` chainId
+      if isAccessibleChain
+        then case addressStateCodeHash of
+          (CodeAtAccount pAcct _) -> getAppAddress codeAccountChainId pAcct
+          _-> pure $ Just acct
+        else pure Nothing

--- a/core-strato/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
@@ -19,7 +19,7 @@ module Blockchain.Data.AddressStateDB (
   resolvedCodePtrToSHA,
   codePtrToCodeKind,
   unsafeCodePtrToCodeKind,
-  getAppAddress
+  getAppAccount
 ) where
 
 import           Prelude hiding (lookup)
@@ -178,11 +178,11 @@ unsafeCodePtrToCodeKind = unsafeResolveCodePtr >=> \case
   _ -> pure EVM -- TODO: should this return (Maybe CodeKind)?
 
 
-getAppAddress :: ( Selectable (Maybe Word256) ParentChainId m
+getAppAccount :: ( Selectable (Maybe Word256) ParentChainId m
                  , (Account `Alters` AddressState) m
                  )
               => Maybe Word256 -> Account -> m (Maybe Account)
-getAppAddress chainId acct = do
+getAppAccount chainId acct = do
   lookup Proxy acct >>= \case
     Nothing -> pure Nothing
     Just AddressState{..} -> do
@@ -190,6 +190,6 @@ getAppAddress chainId acct = do
       isAccessibleChain <- codeAccountChainId `isAncestorChainOf` chainId
       if isAccessibleChain
         then case addressStateCodeHash of
-          (CodeAtAccount pAcct _) -> getAppAddress codeAccountChainId pAcct
+          (CodeAtAccount pAcct _) -> getAppAccount codeAccountChainId pAcct
           _-> pure $ Just acct
         else pure Nothing

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -68,7 +68,6 @@ import qualified Blockchain.Database.MerklePatricia   as MP
 import           Blockchain.DB.CodeDB
 import           Blockchain.DB.ModifyStateDB          (pay)
 import           Blockchain.DB.X509CertDB
-import           Blockchain.DB.AddressStateDB
 import           Blockchain.DB.SolidStorageDB
 import           Blockchain.ExtWord
 import qualified Blockchain.SolidVM.Builtins          as Builtins
@@ -225,7 +224,7 @@ create' creator newAccount ch cc contractName' argExps x509s = do
   Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ x509s
   parentName <- fromMaybeM (return "") $ runMaybeT 
      $   pure creator                                               -- Creator's address
-     >>= MaybeT . getAddressStateMaybe                              -- Address's state
+     >>= MaybeT . A.lookup (A.Proxy @AddressState)                  -- Address's state
      >>= pure  .  addressStateCodeHash                              -- state's codehash/CodePtr
      >>= MaybeT . resolveCodePtrParent (creator ^. accountChainId)  -- CodePtr's parent
      >>= (\case     
@@ -233,10 +232,6 @@ create' creator newAccount ch cc contractName' argExps x509s = do
             _                  -> pure "")
   
   
-  liftIO $ putStrLn $ "DAN -----------------CREATE ------------------"
-  liftIO $ putStrLn $ "DAN - we are creating " ++ contractName' ++ " with parent " ++ show parentName
- 
-
   initializeAction newAccount contractName' parentName ch
 
   A.adjustWithDefault_ (A.Proxy @AddressState) newAccount $ \newAddressState ->
@@ -249,14 +244,12 @@ create' creator newAccount ch cc contractName' argExps x509s = do
   let !contract' = fromMaybe (missingType "create'/contract" contractName') (cc ^. contracts . at contractName')
 
   -- Add Storage
-
   addCallInfo newAccount contract' (contractName' ++ " constructor") ch cc M.empty False
 
   popCallInfo
 
-  -- get org first, set creator
-  beforeOrg <- getOrg creator newAccount
-  liftIO $ putStrLn $ "DAN - org before constructor " ++ show beforeOrg
+
+  -- set creator
   flip setCreator newAccount =<< (Env.origin <$> getEnv)
 
 
@@ -266,16 +259,17 @@ create' creator newAccount ch cc contractName' argExps x509s = do
   onTraced $ liftIO $ putStrLn $ C.red $ "Done Creating Contract: " ++ show newAccount ++ " of type " ++ contractName'
 
 
-
-  -- get org and set creator again, in case something changed during constructor execution
-  afterOrg <- getOrg creator newAccount 
-  liftIO $ putStrLn $ "DAN - org after constructor " ++ show afterOrg
+  -- set creator again, in case the caller's cert changed during constructor execution
   flip setCreator newAccount =<< (Env.origin <$> getEnv)
-
-
+  
+  org <- getOrg creator
   Mod.modifyStatefully_ (Mod.Proxy @Action) $
-    actionData %= M.adjust (actionDataOrganization .~ (T.pack afterOrg)) newAccount
+    actionData %= M.adjust (actionDataOrganization .~ (T.pack org)) newAccount
 
+
+  -- I'm showing these strings because I like them to be in quotes in the logs :)
+  liftIO $ putStrLn $ "create'/versioning --->  we created " ++ (show contractName') ++ 
+      " in app " ++ (show parentName) ++ " of org " ++ show org
 
 
   finalEvs <- Mod.get (Mod.Proxy @(Q.Seq Event))
@@ -381,6 +375,8 @@ call _ _ _ _ blockData _ _ codeAddress sender' _ _ _ _ origin' txHash' chainId' 
 -- set the hidden ":creator" field, if the caller has a cert
 setCreator :: MonadSM m => Account -> Account -> m ()
 setCreator creator contract = do
+  liftIO $ putStrLn $ "setCreator/versioning ---> getting creator org of " ++ (format creator) ++ " for new contract " ++ format contract
+  
   x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
   maybeCertLevelDB <- x509CertDBGet $ _accountAddress creator
   let maybeCertBlockDB = M.lookup (_accountAddress creator) x509s'
@@ -388,44 +384,48 @@ setCreator creator contract = do
       org = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
   case org of
     "" -> do
-      liftIO $ putStrLn $ "DAN - we didn't get an org the creator...."
+      liftIO $ putStrLn $ "setCreator/versioning ---> no org found for this creator...."
       return ()
     str -> do 
     -- insert the org for this contract into storage, in the ":creator" field
-      liftIO $ putStrLn $ "DAN - we actually got an org for the creator, so we are setting it: " ++ show org
+      liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show str)
       putSolidStorageKeyVal' contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack str)
 
 
 
--- get the org and app for the Cirrus table name
-getOrg :: MonadSM m => Account -> Account -> m (String)
-getOrg creator thisContract = do 
-  creatorCodeHash <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) creator
---  thisCodeHash <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) thisContract
+-- get the org for the Cirrus table name
+getOrg :: MonadSM m => Account -> m (String)
+getOrg caller = do
+  liftIO $ putStrLn $ "getOrg/versioning ---> Getting org for the caller " ++ format caller
+  callerCodeHash <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) caller
 
-  case creatorCodeHash of
+  case callerCodeHash of
     EVMCode _ -> do 
-    -- creator is a user account, so they are creating the first instance of this app
+    -- caller is a user account, so they are creating the first instance of this app
     -- we will look up their cert in the DB and use it to get the org name for this app
       x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-      maybeCertLevelDB <- x509CertDBGet $ _accountAddress creator
-      let maybeCertBlockDB = M.lookup (_accountAddress creator) x509s'
+      maybeCertLevelDB <- x509CertDBGet $ _accountAddress caller
+      let maybeCertBlockDB = M.lookup (_accountAddress caller) x509s'
           maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
       let org' = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
-      liftIO $ putStrLn $ "DAN - OMG! A user created us. Their org is :" ++ show org'
+      liftIO $ putStrLn $ "getOrg/versioning ---> They are a user, of org " ++ (show org')
       return org'
     x -> do
-    -- creator is a contract account, so this app already exists
+    -- caller is a contract account, so this app already exists
     -- so we need to find the app contract and get its ":creator" and it's name
-      mAppAccount <- getAppAddress (thisContract ^. accountChainId) creator
+      mAppAccount <- getAppAddress (caller ^. accountChainId) caller
       case mAppAccount of 
-        Nothing -> internalError "somehow, the parent contract didn't have an AddressState?" x
+        Nothing -> internalError "getOrg/versioning --> the app contract didn't have an AddressState, or was on an inaccessible chain" x
         Just acct -> do
+          liftIO $ putStrLn $ "getOrg/versioning ---> They are part of app contract " ++ (format acct) 
           appCreator <- getSolidStorageKeyVal' acct $ MS.StoragePath [MS.Field ":creator"]
-          liftIO $ putStrLn $ "DAN - OMG! We got the parent's creator! It's " ++ show appCreator
           case appCreator of
-            MS.BString org' -> return $ BC.unpack org'
-            _ -> return "" 
+            MS.BString org' -> do 
+              liftIO $ putStrLn $ "getOrg/versioning ---> Its org is " ++ show org'
+              return $ BC.unpack org'
+            _ -> do
+              liftIO $ putStrLn "getOrg/versioning ---> It's org is unset? Returning empty string" 
+              return "" 
 
 
 getCodeAndCollection :: MonadSM m => Account -> m (Contract, Keccak256, CodeCollection)
@@ -530,9 +530,9 @@ callWrapper from to mContract functionName argExps = do
   (contract', hsh, cc) <- getCodeAndCollection to
   parentName <- fromMaybeM (return "") $ runMaybeT 
      $   pure to                                                -- Contract's address
-     >>= MaybeT . getAddressStateMaybe                          -- Address's state
+     >>= MaybeT . A.lookup (A.Proxy @AddressState)              -- Address's state
      >>= pure  .  addressStateCodeHash                          -- state's codehash/CodePtr
-     >>= MaybeT . resolveCodePtrParent (to ^. accountChainId)   -- CodePtr's parent
+     >>= MaybeT . resolveCodePtrParent toChain                  -- CodePtr's parent
      >>= (\case     
             SolidVMCode name _ -> pure name                     -- Name of the parent
             _                  -> pure "")
@@ -540,17 +540,15 @@ callWrapper from to mContract functionName argExps = do
   let contract = fromMaybe contract' $ mContract >>= \c -> M.lookup c $ _contracts cc
       parentName' = if parentName == (_contractName contract) then "" else parentName
   
-  
-  liftIO $ putStrLn $ "DAN -----------------CALL------------------"
-  liftIO $ putStrLn $ "DAN - we are calling " ++ (_contractName contract) ++ " with parent " ++ show parentName
- 
   initializeAction to (_contractName contract) parentName' hsh
 
   -- grab the org for this contract
-  org <- getOrg from to
-  liftIO $ putStrLn $ "DAN - org after call " ++ show org
+  org <- getOrg to
   Mod.modifyStatefully_ (Mod.Proxy @Action) $
     actionData %= M.adjust (actionDataOrganization .~ (T.pack org)) to
+
+  liftIO $ putStrLn $ "callWraper/versioning --->  we are calling " ++ (_contractName contract) ++ 
+        " in app " ++ (show parentName) ++ " of org " ++ show org
 
 
   let functionsIncludingConstructor =
@@ -854,11 +852,11 @@ runStatement st@(Xabi.EmitStatement eventName exptups pos) = do
         invalidArguments "arguments to statement are inconsistent with those declared" (unparseStatement st)
       else do
         let account = currentAccount curInfo
-        org <- flip getOrg account =<< (Env.sender <$> getEnv) -- the org of the app
+        org <- getOrg account -- the org of the app
          
         parentName <- fromMaybeM (return "") $ runMaybeT 
             $   pure account
-            >>= MaybeT . getAddressStateMaybe
+            >>= MaybeT . A.lookup (A.Proxy @AddressState) 
             >>= pure  .  addressStateCodeHash
             >>= MaybeT . resolveCodePtrParent (account ^. accountChainId)
             >>= (\case     
@@ -868,6 +866,10 @@ runStatement st@(Xabi.EmitStatement eventName exptups pos) = do
         -- pair up field names with values one-by-one (no type checking tho, lol)
         let pairs = zip (map (T.unpack . fst) $ Xabi.eventLogs ev) expStrs
         
+        liftIO $ putStrLn $ "Emit Event/versioning ---> we are emitting event " ++ eventName ++ 
+              " in contract " ++ (_contractName curCnct) ++ " in app " ++ (show parentName) ++ 
+              " of org " ++ show org
+
         addEvent $ Event org parentName (_contractName curCnct) account eventName pairs
         return Nothing
 
@@ -1685,7 +1687,6 @@ runTheConstructors from to hsh cc contractName' argExps = do
 
 
   addCallInfo to contract' (contractName' ++ " constructer") hsh cc (M.fromList zipped) False
-  
 
   forM_ [(n, e) | (n, Xabi.VariableDecl _ _ (Just e)) <- M.toList $ contract'^.storageDefs] $ \(n, e) -> do
     v <- expToVar e
@@ -1715,26 +1716,9 @@ runTheConstructors from to hsh cc contractName' argExps = do
 
       Nothing -> return ()
 
-
-
-------------------- MY TRASH! NO TOUCH! --------------------
-
-  -- TODO: lookup creator org, create and set it, then do same after body is run
-  parentCodeHash <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) from
-  myCodeHash <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) to
-
-
-  liftIO $ putStrLn $ "DAN - we got the codeHash of the from, address is " ++ (format from) ++ " with hash " ++ show parentCodeHash
-  liftIO $ putStrLn $ "DAN - we got the codeHash of the to, address is " ++ (format to) ++ " with hash " ++ show myCodeHash
-  
-
----------------------------------------------------------------
-
   popCallInfo
 
   return ()
-
-
 
 
 -- Note: this is intentionally nonstrict in `theType`

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -413,7 +413,7 @@ getOrg caller = do
     x -> do
     -- caller is a contract account, so this app already exists
     -- so we need to find the app contract and get its ":creator" and it's name
-      mAppAccount <- getAppAddress (caller ^. accountChainId) caller
+      mAppAccount <- getAppAccount (caller ^. accountChainId) caller
       case mAppAccount of 
         Nothing -> internalError "getOrg/versioning --> the app contract didn't have an AddressState, or was on an inaccessible chain" x
         Just acct -> do

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -69,6 +69,7 @@ import           Blockchain.DB.CodeDB
 import           Blockchain.DB.ModifyStateDB          (pay)
 import           Blockchain.DB.X509CertDB
 import           Blockchain.DB.AddressStateDB
+import           Blockchain.DB.SolidStorageDB
 import           Blockchain.ExtWord
 import qualified Blockchain.SolidVM.Builtins          as Builtins
 import           Blockchain.SolidVM.CodeCollectionDB
@@ -230,8 +231,13 @@ create' creator newAccount ch cc contractName' argExps x509s = do
      >>= (\case     
             SolidVMCode name _ -> pure name                         -- Name of the parent
             _                  -> pure "")
+  
+  
+  liftIO $ putStrLn $ "DAN -----------------CREATE ------------------"
+  liftIO $ putStrLn $ "DAN - we are creating " ++ contractName' ++ " with parent " ++ show parentName
+ 
 
-  initializeActionCreate creator newAccount contractName' parentName ch
+  initializeAction newAccount contractName' parentName ch
 
   A.adjustWithDefault_ (A.Proxy @AddressState) newAccount $ \newAddressState ->
     pure newAddressState{ addressStateContractRoot = MP.emptyTriePtr
@@ -248,30 +254,34 @@ create' creator newAccount ch cc contractName' argExps x509s = do
 
   popCallInfo
 
+  -- get org first, set creator
+  beforeOrg <- getOrg creator newAccount
+  liftIO $ putStrLn $ "DAN - org before constructor " ++ show beforeOrg
+  flip setCreator newAccount =<< (Env.origin <$> getEnv)
+
+
   -- Run the constructor
   runTheConstructors creator newAccount ch cc contractName' argExps
 
   onTraced $ liftIO $ putStrLn $ C.red $ "Done Creating Contract: " ++ show newAccount ++ " of type " ++ contractName'
 
-  finalEvs <- Mod.get (Mod.Proxy @(Q.Seq Event))
-  x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
 
 
-  -- make sure the org is updated
-  maybeCertLevelDB <- x509CertDBGet $ _accountAddress creator
-  let maybeCertBlockDB = M.lookup (_accountAddress creator) x509s'
-      maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-      org = T.pack . fromMaybe "" . fmap subOrg $ getCertSubject =<< maybeCert
+  -- get org and set creator again, in case something changed during constructor execution
+  afterOrg <- getOrg creator newAccount 
+  liftIO $ putStrLn $ "DAN - org after constructor " ++ show afterOrg
+  flip setCreator newAccount =<< (Env.origin <$> getEnv)
+
 
   Mod.modifyStatefully_ (Mod.Proxy @Action) $
-    actionData %= M.adjust (actionDataOrganization .~ org) newAccount
+    actionData %= M.adjust (actionDataOrganization .~ (T.pack afterOrg)) newAccount
 
-  case maybeCert of
-      Just c  -> Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert (_accountAddress newAccount) c x509s'
-      Nothing -> pure ()
 
-  x509s'' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+
+  finalEvs <- Mod.get (Mod.Proxy @(Q.Seq Event))
   finalAct <- Mod.get (Mod.Proxy @Action)
+  x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+
 
   return ExecResults {
     erRemainingTxGas = 0, --Just use up all the allocated gas for now....
@@ -285,7 +295,7 @@ create' creator newAccount ch cc contractName' argExps x509s = do
     erAction = Just finalAct,
     erException = Nothing,
     erKind = SolidVM,
-    erNewX509Certs = x509s''
+    erNewX509Certs = x509s'
     }
 
 {-
@@ -366,6 +376,56 @@ call _ _ _ _ blockData _ _ codeAddress sender' _ _ _ _ origin' txHash' chainId' 
       erKind = SolidVM,
       erNewX509Certs = x509s
       }
+
+
+-- set the hidden ":creator" field, if the caller has a cert
+setCreator :: MonadSM m => Account -> Account -> m ()
+setCreator creator contract = do
+  x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+  maybeCertLevelDB <- x509CertDBGet $ _accountAddress creator
+  let maybeCertBlockDB = M.lookup (_accountAddress creator) x509s'
+      maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
+      org = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
+  case org of
+    "" -> do
+      liftIO $ putStrLn $ "DAN - we didn't get an org the creator...."
+      return ()
+    str -> do 
+    -- insert the org for this contract into storage, in the ":creator" field
+      liftIO $ putStrLn $ "DAN - we actually got an org for the creator, so we are setting it: " ++ show org
+      putSolidStorageKeyVal' contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack str)
+
+
+
+-- get the org and app for the Cirrus table name
+getOrg :: MonadSM m => Account -> Account -> m (String)
+getOrg creator thisContract = do 
+  creatorCodeHash <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) creator
+--  thisCodeHash <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) thisContract
+
+  case creatorCodeHash of
+    EVMCode _ -> do 
+    -- creator is a user account, so they are creating the first instance of this app
+    -- we will look up their cert in the DB and use it to get the org name for this app
+      x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+      maybeCertLevelDB <- x509CertDBGet $ _accountAddress creator
+      let maybeCertBlockDB = M.lookup (_accountAddress creator) x509s'
+          maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
+      let org' = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
+      liftIO $ putStrLn $ "DAN - OMG! A user created us. Their org is :" ++ show org'
+      return org'
+    x -> do
+    -- creator is a contract account, so this app already exists
+    -- so we need to find the app contract and get its ":creator" and it's name
+      mAppAccount <- getAppAddress (thisContract ^. accountChainId) creator
+      case mAppAccount of 
+        Nothing -> internalError "somehow, the parent contract didn't have an AddressState?" x
+        Just acct -> do
+          appCreator <- getSolidStorageKeyVal' acct $ MS.StoragePath [MS.Field ":creator"]
+          liftIO $ putStrLn $ "DAN - OMG! We got the parent's creator! It's " ++ show appCreator
+          case appCreator of
+            MS.BString org' -> return $ BC.unpack org'
+            _ -> return "" 
 
 
 getCodeAndCollection :: MonadSM m => Account -> m (Contract, Keccak256, CodeCollection)
@@ -479,7 +539,19 @@ callWrapper from to mContract functionName argExps = do
 
   let contract = fromMaybe contract' $ mContract >>= \c -> M.lookup c $ _contracts cc
       parentName' = if parentName == (_contractName contract) then "" else parentName
-  initializeActionCall to (_contractName contract) parentName' hsh
+  
+  
+  liftIO $ putStrLn $ "DAN -----------------CALL------------------"
+  liftIO $ putStrLn $ "DAN - we are calling " ++ (_contractName contract) ++ " with parent " ++ show parentName
+ 
+  initializeAction to (_contractName contract) parentName' hsh
+
+  -- grab the org for this contract
+  org <- getOrg from to
+  liftIO $ putStrLn $ "DAN - org after call " ++ show org
+  Mod.modifyStatefully_ (Mod.Proxy @Action) $
+    actionData %= M.adjust (actionDataOrganization .~ (T.pack org)) to
+
 
   let functionsIncludingConstructor =
         case contract^.constructor of
@@ -503,7 +575,6 @@ callWrapper from to mContract functionName argExps = do
                 -- "public", right now I just ignore this and allow anything to be called as a getter
                 return (fmap Just $ getVar $ Constant $ SReference $ AccountPath to . MS.singleton $ BC.pack functionName, OrderedVals [])
               Nothing -> unknownFunction "logFunctionCall" (functionName, contract^.contractName)
-
 
 
   logFunctionCall args to contract functionName f
@@ -783,12 +854,7 @@ runStatement st@(Xabi.EmitStatement eventName exptups pos) = do
         invalidArguments "arguments to statement are inconsistent with those declared" (unparseStatement st)
       else do
         let account = currentAccount curInfo
-            address = _accountAddress account
-        x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-        maybeCertLevelDB <- x509CertDBGet address
-        let maybeCertBlockDB = M.lookup address x509s
-            maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-            organization = fromMaybe "" . fmap subOrg $ getCertSubject =<< maybeCert
+        org <- flip getOrg account =<< (Env.sender <$> getEnv) -- the org of the app
          
         parentName <- fromMaybeM (return "") $ runMaybeT 
             $   pure account
@@ -802,7 +868,7 @@ runStatement st@(Xabi.EmitStatement eventName exptups pos) = do
         -- pair up field names with values one-by-one (no type checking tho, lol)
         let pairs = zip (map (T.unpack . fst) $ Xabi.eventLogs ev) expStrs
         
-        addEvent $ Event organization parentName (_contractName curCnct) account eventName pairs
+        addEvent $ Event org parentName (_contractName curCnct) account eventName pairs
         return Nothing
 
 
@@ -1619,7 +1685,7 @@ runTheConstructors from to hsh cc contractName' argExps = do
 
 
   addCallInfo to contract' (contractName' ++ " constructer") hsh cc (M.fromList zipped) False
-
+  
 
   forM_ [(n, e) | (n, Xabi.VariableDecl _ _ (Just e)) <- M.toList $ contract'^.storageDefs] $ \(n, e) -> do
     v <- expToVar e
@@ -1643,14 +1709,33 @@ runTheConstructors from to hsh cc contractName' argExps = do
         commands <- case Xabi.funcContents theFunction of
           Nothing -> missingField "contract constructor has been declared but not defined" contractName'
           Just cms -> pure cms
+
         _ <- pushSender from $ runStatements commands
         return ()
 
       Nothing -> return ()
 
+
+
+------------------- MY TRASH! NO TOUCH! --------------------
+
+  -- TODO: lookup creator org, create and set it, then do same after body is run
+  parentCodeHash <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) from
+  myCodeHash <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) to
+
+
+  liftIO $ putStrLn $ "DAN - we got the codeHash of the from, address is " ++ (format from) ++ " with hash " ++ show parentCodeHash
+  liftIO $ putStrLn $ "DAN - we got the codeHash of the to, address is " ++ (format to) ++ " with hash " ++ show myCodeHash
+  
+
+---------------------------------------------------------------
+
   popCallInfo
 
   return ()
+
+
+
 
 -- Note: this is intentionally nonstrict in `theType`
 addLocalVariable :: MonadSM m => Xabi.Type -> String -> Value -> m ()

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -39,8 +39,7 @@ module Blockchain.SolidVM.SM (
   getXabiValueType,
   getValueType,
   pushSender,
-  initializeActionCreate,
-  initializeActionCall,
+  initializeAction,
   markDiffForAction,
   addEvent
   ) where
@@ -642,29 +641,14 @@ getXabiValueType (AccountPath loc path) = do
 getValueType :: MonadSM m => AccountPath -> m BasicType
 getValueType p = hintFromType =<< getXabiValueType p
 
-initializeActionCreate :: MonadSM m => Account -> Account -> String -> String -> Keccak256 -> m ()
-initializeActionCreate creator acct name prt hsh = do
-  let address = _accountAddress creator
-  x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-  maybeCertLevelDB <- x509CertDBGet address
-  let maybeCertBlockDB = M.lookup address x509s
-      maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-      organization = T.pack $ fromMaybe "" . fmap subOrg $ getCertSubject =<< maybeCert
-  let newData = ActionData (SolidVMCode name hsh) organization (T.pack prt) SolidVM (ActionSolidVMDiff M.empty) []
+
+initializeAction :: MonadSM m => Account -> String -> String -> Keccak256 -> m ()
+initializeAction acct name appName hsh = do
+  -- org name to be set later, b/c the lookup is complex
+  let newData = ActionData (SolidVMCode name hsh) "" (T.pack appName) SolidVM (ActionSolidVMDiff M.empty) []
   Mod.modifyStatefully_ (Mod.Proxy @Action) $
     actionData %= M.insertWith mergeActionData acct newData
 
-initializeActionCall :: MonadSM m => Account -> String -> String -> Keccak256 -> m ()
-initializeActionCall acct name prt hsh = do
-  let address = _accountAddress acct
-  x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-  maybeCertLevelDB <- x509CertDBGet address
-  let maybeCertBlockDB = M.lookup address x509s
-      maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-      organization = T.pack $ fromMaybe "" . fmap subOrg $ getCertSubject =<< maybeCert
-  let newData = ActionData (SolidVMCode name hsh) organization (T.pack prt) SolidVM (ActionSolidVMDiff M.empty) []
-  Mod.modifyStatefully_ (Mod.Proxy @Action) $
-    actionData %= M.insertWith mergeActionData acct newData
 
 markDiffForAction :: Mod.Modifiable Action m => Account -> MS.StoragePath -> MS.BasicValue -> m ()
 markDiffForAction owner key' val' = do


### PR DESCRIPTION
This PR:
- `:creator` is set as the org of the person creating _the contract instance_.
- introduce `setCreator :: MonadSM m => Account -> Account -> m ()` function:
   - called to set the `:creator` field for a contract being created
   - first arg is the account of the creator (the `Env.origin` - not the immediate upstream caller, since that might be a contract, and we actually want the `:creator` to be the person creating the contract instance, whether or not they are creating the first instance of an app or not). Thus, we can assume they are a user,  so we lookup their cert in the cache/DB (I've left those lookup calls as they are, since I know Luke is working on a refactor)
   - second arg is the contract account of which we will set the `:creator`
   - called before and after constructor execution, in case the creator's cert was (re)registered during constructor execution
- introduce `getOrg :: MonadSM m => Account -> m (String)` function:
   - called when creating a contract, calling a contract, or emitting event
   - if given an account that has an `EVMCode` hash, we can assume it's a user creating a contract, so we lookup their cert in the cert cache/DB
   - if given an account that has some other code hash, we assume it's a contract creating or calling a contract, so we traverse the tree of hashes up to the parent "app" contract, and access their `:creator` field (using `getAppAccount` - see below)
- introduce a function in `AddressStateDB` called `getAppAccount :: MonadSM m => Maybe Word256 -> Account -> m (Account)` to basically do a `resolveCodePtr`, but return the account of the top contract
- log statements, all with the word "versioning" in them, so that we can see every place where orgs and apps are retrieved and set, for debugging

https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/4557/pipeline