### PR TITLE
STRATO-2047 Add solidvm pragma

### DIFF
--- a/core-strato/blockapps-mpdbs/src/Blockchain/DB/SolidStorageDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/DB/SolidStorageDB.hs
@@ -42,19 +42,20 @@ type FullSolidStorage m = ( HasMemAddressStateDB m
 toKey :: Account -> StoragePath -> RawStorageKey
 toKey =  curry $ fmap unparsePath
 
-toVal :: BasicValue -> RawStorageValue
-toVal bv =
-  let v = if isDefault bv
-            then BDefault
-            else bv
-   in rlpSerialize $ rlpEncode v
+toVal :: Bool -> BasicValue -> RawStorageValue
+toVal svm3_0 bv
+    | svm3_0 == True =  let v = if isDefault bv
+                                    then BDefault
+                                    else bv
+                        in rlpSerialize $ rlpEncode v
+    | otherwise = rlpSerialize $ rlpEncode bv
 
 fromVal :: RawStorageValue -> BasicValue
 fromVal = rlpDecode . rlpDeserialize
 
-putSolidStorageKeyVal' :: HasSolidStorageDB m => Account -> StoragePath -> BasicValue -> m ()
-putSolidStorageKeyVal' acct key val = do
-  putRawStorageKeyVal' (toKey acct key) (toVal val)
+putSolidStorageKeyVal' :: HasSolidStorageDB m => Bool -> Account -> StoragePath -> BasicValue -> m ()
+putSolidStorageKeyVal' svm3_0 acct key val = do
+  putRawStorageKeyVal' (toKey acct key) (toVal svm3_0 val)
 
 getSolidStorageKeyVal' :: HasSolidStorageDB m => Account -> StoragePath -> m BasicValue
 getSolidStorageKeyVal' acct key = do

--- a/core-strato/blockapps-mpdbs/test/StorageSpec.hs
+++ b/core-strato/blockapps-mpdbs/test/StorageSpec.hs
@@ -205,20 +205,20 @@ storageSpec = do
       putRawStorageKeyVal' ((Account 0x888 Nothing), "aKey") "aValue"
       getRawStorageKeyVal' ((Account 0x888 Nothing), "aKey") `shouldReturn` "aValue"
 
-  describe "SolidStorageDB" $ do
+  describe "SolidStorageDB SolidVM=3.0" $ do
     it "should get its puts" . runStorM $ do
-      putSolidStorageKeyVal' undefined (Account 0x99 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) (MS.BString "txt")
+      putSolidStorageKeyVal' True (Account 0x99 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) (MS.BString "txt")
       getSolidStorageKeyVal' (Account 0x99 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99])
           `shouldReturn` MS.BString "txt"
 
     it "should be able to flush" . runStorM $ do
-      putSolidStorageKeyVal' undefined (Account 0x342 Nothing) (MS.singleton "x") (MS.BBool True)
+      putSolidStorageKeyVal' True (Account 0x342 Nothing) (MS.singleton "x") (MS.BBool True)
       flushMemSolidStorageDB
 
     let solidIdTest msg bv = it ("put " <> msg <> " in SolidStorage should not change the state root") . runStorM $ do
           want <- addressStateContractRoot <$> lookupWithDefault Proxy (Account 0x1234 Nothing)
           want `shouldBe` "V\232\US\ETB\ESC\204U\166\255\131E\230\146\192\248n[H\224\ESC\153l\173\192\SOHb/\181\227c\180!"
-          putSolidStorageKeyVal' undefined (Account 0x1234 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) bv
+          putSolidStorageKeyVal' True (Account 0x1234 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) bv
           flushMemStorageDB
           got <- addressStateContractRoot <$> lookupWithDefault Proxy (Account 0x1234 Nothing)
           want `shouldBe` got
@@ -233,7 +233,7 @@ storageSpec = do
 
     it "put 1 in SolidStorage should change the state root" . runStorM $ do
       want <- addressStateContractRoot <$> lookupWithDefault Proxy (Account 0x1234 Nothing)
-      putSolidStorageKeyVal' undefined (Account 0x1234 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) (MS.BInteger 1)
+      putSolidStorageKeyVal' True (Account 0x1234 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) (MS.BInteger 1)
       flushMemStorageDB
       got <- addressStateContractRoot <$> lookupWithDefault Proxy (Account 0x1234 Nothing)
       want `shouldNotBe` got

--- a/core-strato/blockapps-mpdbs/test/StorageSpec.hs
+++ b/core-strato/blockapps-mpdbs/test/StorageSpec.hs
@@ -207,18 +207,18 @@ storageSpec = do
 
   describe "SolidStorageDB" $ do
     it "should get its puts" . runStorM $ do
-      putSolidStorageKeyVal' (Account 0x99 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) (MS.BString "txt")
+      putSolidStorageKeyVal' undefined (Account 0x99 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) (MS.BString "txt")
       getSolidStorageKeyVal' (Account 0x99 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99])
           `shouldReturn` MS.BString "txt"
 
     it "should be able to flush" . runStorM $ do
-      putSolidStorageKeyVal' (Account 0x342 Nothing) (MS.singleton "x") (MS.BBool True)
+      putSolidStorageKeyVal' undefined (Account 0x342 Nothing) (MS.singleton "x") (MS.BBool True)
       flushMemSolidStorageDB
 
     let solidIdTest msg bv = it ("put " <> msg <> " in SolidStorage should not change the state root") . runStorM $ do
           want <- addressStateContractRoot <$> lookupWithDefault Proxy (Account 0x1234 Nothing)
           want `shouldBe` "V\232\US\ETB\ESC\204U\166\255\131E\230\146\192\248n[H\224\ESC\153l\173\192\SOHb/\181\227c\180!"
-          putSolidStorageKeyVal' (Account 0x1234 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) bv
+          putSolidStorageKeyVal' undefined (Account 0x1234 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) bv
           flushMemStorageDB
           got <- addressStateContractRoot <$> lookupWithDefault Proxy (Account 0x1234 Nothing)
           want `shouldBe` got
@@ -233,7 +233,7 @@ storageSpec = do
 
     it "put 1 in SolidStorage should change the state root" . runStorM $ do
       want <- addressStateContractRoot <$> lookupWithDefault Proxy (Account 0x1234 Nothing)
-      putSolidStorageKeyVal' (Account 0x1234 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) (MS.BInteger 1)
+      putSolidStorageKeyVal' undefined (Account 0x1234 Nothing) (MS.fromList [MS.Field "x", MS.ArrayIndex 99]) (MS.BInteger 1)
       flushMemStorageDB
       got <- addressStateContractRoot <$> lookupWithDefault Proxy (Account 0x1234 Nothing)
       want `shouldNotBe` got

--- a/core-strato/solid-vm/bench/CodeBench.hs
+++ b/core-strato/solid-vm/bench/CodeBench.hs
@@ -30,7 +30,7 @@ wingsContract = BC.unpack $(embedFile "bench/wings.sol")
 wingsCC :: CodeCollection
 wingsCC =
   let file = either (error . show) id $ runParser solidityFile "" ""  wingsContract
-      namedContracts = [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') undefined xabi)
+      namedContracts = [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') "" xabi)
                         | NamedXabi name (xabi, parents') <- unsourceUnits file]
   in applyInheritance . CodeCollection $ M.fromList namedContracts
 

--- a/core-strato/solid-vm/bench/CodeBench.hs
+++ b/core-strato/solid-vm/bench/CodeBench.hs
@@ -30,7 +30,7 @@ wingsContract = BC.unpack $(embedFile "bench/wings.sol")
 wingsCC :: CodeCollection
 wingsCC =
   let file = either (error . show) id $ runParser solidityFile "" ""  wingsContract
-      namedContracts = [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') xabi)
+      namedContracts = [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') undefined xabi)
                         | NamedXabi name (xabi, parents') <- unsourceUnits file]
   in applyInheritance . CodeCollection $ M.fromList namedContracts
 

--- a/core-strato/solid-vm/exec_src/ExprsNeeded.hs
+++ b/core-strato/solid-vm/exec_src/ExprsNeeded.hs
@@ -19,7 +19,8 @@ main = do
   contents <- readFile filename
   File parsedFile <- either (die . show) return
               $ runParser solidityFile "" "" contents
-  let namedContracts = [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') xabi)
+  let vmVersion' = if (Pragma "solidvm" "3.0") `elem` parsedFile then "svm3.0" else ""
+      namedContracts = [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') vmVersion' xabi)
                        | NamedXabi name (xabi, parents') <- parsedFile]
       cc = CodeCollection $ M.fromList namedContracts
       nodes = codeCollectionCrawler cc

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -109,6 +109,20 @@ type SolidVMBase m = VMBase m
 onTraced :: Monad m => m () -> m ()
 onTraced = when flags_svmTrace
 
+-- TL;DR Use onTracedSM whenever you have a showSM in a trace over onTraced
+-- Full: In some onTraced logging statements we called showSM. Through a series
+-- of function calls (showSM -> getVar -> getSolidStorageKeyVal'
+-- -> getRawStorageKeyVal' -> getRawStorageKeyValMC -> lookupWithDefault 
+-- -> genericLookupRawStorageDB) we end up calling genericLookupRawStorageDB.
+-- This adds default values to the MP Trie whenever we lookup a nonexistant 
+-- value in our DB. THIS IS PROBLOMATIC, we are adding somthing to the MP Trie
+-- (and therefore changing the stateroot) for just having a logging statement!
+-- TODO: Do not add default values to RawStorageDBs for SolidVM > 3.
+onTracedSM :: MonadSM m => Contract -> m () -> m ()
+onTracedSM cntrct m = do
+      let svm3_0 = _vmVersion cntrct == "svm3.0"
+      when (flags_svmTrace && not svm3_0) m
+
 withSrcPos :: MonadIO m => Xabi.SourcePos -> String -> m ()
 withSrcPos pos str = liftIO . putStrLn $ concat 
   [ show pos
@@ -464,7 +478,7 @@ getCodeAndCollection address' = do
 
 logFunctionCall :: MonadSM m => ValList -> Account -> Contract -> String -> m (Maybe Value) -> m (Maybe Value)
 logFunctionCall args address contract functionName f = do
-  onTraced $ do
+  onTracedSM contract $ do
     argStrings <-
       case args of
         OrderedVals argList -> fmap (intercalate ", ") $ forM argList showSM
@@ -480,7 +494,7 @@ logFunctionCall args address contract functionName f = do
 
   result <- f
 
-  onTraced $ do
+  onTracedSM contract $ do
     resultString <- maybe (return "()") showSM result
     liftIO $ putStrLn $ box ["returning from " ++ functionName ++ ":", resultString]
 
@@ -621,7 +635,8 @@ runStatement st@(Xabi.SimpleStatement (Xabi.ExpressionStatement (Xabi.Binary "="
   srcVar <- expToVar src
   srcVal <- getVar srcVar
 
-  onTraced $ do
+  cntrct <- getCurrentContract
+  onTracedSM cntrct $ do
     valString <- showSM srcVal
     withSrcPos pos $ "    Setting: " ++ unparseExpression dst ++ " = " ++ valString
 
@@ -658,7 +673,8 @@ runStatement (Xabi.SimpleStatement (Xabi.ExpressionStatement (Xabi.Binary "=" ds
 
   setVar dstVar srcVal
   
-  onTraced $ do
+  cntrct <- getCurrentContract
+  onTracedSM cntrct $ do
     valString <- showSM srcVal
     withSrcPos pos $ "    Setting: " ++ unparseExpression dst ++ " = " ++ valString
               
@@ -729,7 +745,8 @@ runStatement s@(Xabi.SimpleStatement (Xabi.VariableDefinition entries maybeExpre
           (_, SReference{}) -> getVar $ Constant rhs
           (_, c) -> return c
 
-  onTraced $ do
+  cntrct <- getCurrentContract
+  onTracedSM cntrct $ do
     valueString <- showSM value
     let toName :: Xabi.VarDefEntry -> String
         toName Xabi.BlankEntry = ""
@@ -1822,7 +1839,8 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro = do
 logAssigningVariable :: MonadSM m => Value -> m ()
 logAssigningVariable v = do
   valueString <- showSM v
-  onTraced $ liftIO $ putStrLn $ "            %%%% assigning variable: " ++ valueString
+  cntrct <- getCurrentContract
+  onTracedSM cntrct $ liftIO $ putStrLn $ "            %%%% assigning variable: " ++ valueString
 
 logVals :: (Show a, Show b, MonadIO m) => a -> b -> m ()
 logVals val1 val2 = onTraced . liftIO $ printf

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -122,6 +122,9 @@ onTracedSM :: MonadSM m => Contract -> m () -> m ()
 onTracedSM cntrct m = do
       let svm3_0 = _vmVersion cntrct == "svm3.0"
       when (flags_svmTrace && not svm3_0) m
+      when (flags_svmTrace && svm3_0) $
+        liftIO $ putStrLn $ "svmTrace statement(s) is absent because contract " 
+                    ++ _contractName cntrct ++ " uses SolidVM=3.0"
 
 withSrcPos :: MonadIO m => Xabi.SourcePos -> String -> m ()
 withSrcPos pos str = liftIO . putStrLn $ concat 

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -250,7 +250,7 @@ create' creator newAccount ch cc contractName' argExps x509s = do
 
 
   -- set creator
-  flip setCreator newAccount =<< (Env.origin <$> getEnv)
+  (\crtr -> setCreator crtr newAccount contract') =<< (Env.origin <$> getEnv)
 
 
   -- Run the constructor
@@ -260,7 +260,7 @@ create' creator newAccount ch cc contractName' argExps x509s = do
 
 
   -- set creator again, in case the caller's cert changed during constructor execution
-  flip setCreator newAccount =<< (Env.origin <$> getEnv)
+  (\crtr -> setCreator crtr newAccount contract') =<< (Env.origin <$> getEnv)
   
   org <- getOrg creator
   Mod.modifyStatefully_ (Mod.Proxy @Action) $
@@ -373,8 +373,8 @@ call _ _ _ _ blockData _ _ codeAddress sender' _ _ _ _ origin' txHash' chainId' 
 
 
 -- set the hidden ":creator" field, if the caller has a cert
-setCreator :: MonadSM m => Account -> Account -> m ()
-setCreator creator contract = do
+setCreator :: MonadSM m => Account -> Account -> Contract -> m ()
+setCreator creator contract cntrct = do
   liftIO $ putStrLn $ "setCreator/versioning ---> getting creator org of " ++ (format creator) ++ " for new contract " ++ format contract
   
   x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
@@ -389,8 +389,8 @@ setCreator creator contract = do
     str -> do 
     -- insert the org for this contract into storage, in the ":creator" field
       liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show str)
-      contract' <- getCurrentContract
-      let svm3_0 = _vmVersion contract' == "svm3.0"
+      onTraced $ liftIO $ putStrLn $ "setCreator/versioning ---> the vm version is " ++ _vmVersion cntrct
+      let svm3_0 = _vmVersion cntrct == "svm3.0"
       putSolidStorageKeyVal' svm3_0 contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack str)
 
 

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -389,7 +389,9 @@ setCreator creator contract = do
     str -> do 
     -- insert the org for this contract into storage, in the ":creator" field
       liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show str)
-      putSolidStorageKeyVal' contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack str)
+      contract' <- getCurrentContract
+      let svm3_0 = _vmVersion contract' == "svm3.0"
+      putSolidStorageKeyVal' svm3_0 contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack str)
 
 
 

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -33,8 +33,8 @@ compileSource initCodeMap =
   let getNamedContracts fileName src =
         let maybeFile = runParser solidityFile "" (T.unpack fileName) $ T.unpack src
             file = either (parseError "compileSource") id maybeFile
-
-         in [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') xabi)
+            vmVersion' = if (Pragma "solidvm" "3.0") `elem` (unsourceUnits file) then "svm3.0" else ""
+         in [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') vmVersion' xabi)
             | NamedXabi name (xabi, parents') <- unsourceUnits file]
       allContracts = concat . map (uncurry getNamedContracts) $ M.toList initCodeMap
    in applyInheritance

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -39,6 +39,7 @@ import qualified Data.Text as T
 import qualified Data.Vector as V
 import           Text.Printf
 
+import           CodeCollection
 import           Blockchain.DB.SolidStorageDB
 import           Blockchain.SolidVM.Exception
 import           Blockchain.SolidVM.SM
@@ -158,7 +159,9 @@ setVal dst@(SReference addressedPath@(AccountPath addr path)) src = do
                                 _             -> toBasic src
                         _         -> toBasic src
   markDiffForAction addr path basicSrc
-  putSolidStorageKeyVal' addr path basicSrc
+  contract <- getCurrentContract
+  let svm3_0 = _vmVersion contract == "svm3.0"
+  putSolidStorageKeyVal' svm3_0 addr path basicSrc
 
 
 setVal dst src = typeError "unknown case called in setVal:" ("src = " ++ show src ++ ", dst = " ++ show dst)
@@ -254,7 +257,9 @@ deleteVar (Constant (SReference a@(AccountPath addr path))) = do
       ro <- readOnly <$> getCurrentCallInfo
       when ro $ invalidWrite "Invalid delete during read-only access" $ "addr: " ++ show addr ++ ", path: " ++ show path
       markDiffForAction addr path $ MS.BDefault
-      putSolidStorageKeyVal' addr path $ MS.BDefault
+      contract <- getCurrentContract
+      let svm3_0 = _vmVersion contract == "svm3.0"
+      putSolidStorageKeyVal' svm3_0 addr path $ MS.BDefault
 
 deleteVar v = todo "deleteVar not yet supported for local variables" $ show v
 

--- a/core-strato/solid-vm/src/CodeCollection.hs
+++ b/core-strato/solid-vm/src/CodeCollection.hs
@@ -33,7 +33,8 @@ data Contract =
     _structs :: Map String [(T.Text, Xabi.FieldType)],
     _events :: Map T.Text Xabi.Event,
     _functions :: Map String Func,
-    _constructor :: Maybe Func
+    _constructor :: Maybe Func,
+    _vmVersion :: String
   } deriving (Show, Generic)
 
 makeLenses ''Contract
@@ -52,8 +53,8 @@ emptyCodeCollection =
 
 
 
-xabiToContract :: String -> [String] -> Xabi -> Contract
-xabiToContract contractName' parents' xabi = validateXabi xabi `seq`
+xabiToContract :: String -> [String] -> String -> Xabi -> Contract
+xabiToContract contractName' parents' vmVersion' xabi = validateXabi xabi `seq`
   Contract {
   _contractName = contractName',
   _parents = parents',
@@ -67,7 +68,8 @@ xabiToContract contractName' parents' xabi = validateXabi xabi `seq`
       case M.toList $ Xabi.xabiConstr xabi of
         [] -> Nothing
         [(_, x)] -> Just x
-        _ -> duplicateDefinition "multiple constructors in contract" contractName' --TODO- figure out if this is allowed in Solidity
+        _ -> duplicateDefinition "multiple constructors in contract" contractName', --TODO- figure out if this is allowed in Solidity
+  _vmVersion = vmVersion'
   }
 
 validateXabi :: Xabi -> ()

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -627,6 +627,7 @@ contract qq {
 
     it "can index into maps with bool" . runTest $ do
       runBS [r|
+pragma solidvm 3.0;
 contract qq {
   mapping(bool => uint) bs;
   constructor() public {
@@ -710,6 +711,7 @@ contract qq {
 
   it "can array index with uninitialized numbers" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract qq {
   uint[] xs;
   uint y;
@@ -722,6 +724,7 @@ contract qq {
 
   it "can map index with uninitialized numbers" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract qq {
   mapping(uint => uint) xs;
   uint y;
@@ -734,6 +737,7 @@ contract qq {
 
   it "can map index with uninitialized strings" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract qq {
   mapping(string => uint) xs;
   uint y;
@@ -833,6 +837,7 @@ contract qq {
 
   it "can detect nulls" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract qq {
   mapping(uint => uint) ns;
   bool found;
@@ -1225,6 +1230,7 @@ contract qq {
 
   it "can accept nested arrays" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract qq {
   bool[2][] pairs;
 
@@ -1319,6 +1325,7 @@ contract qq {
 
   it "can call a remote function" . runTest $ do
     let qq = [r|
+pragma solidvm 3.0;
 contract qq {
   qq x;
   uint num;
@@ -1464,6 +1471,7 @@ contract qq {
 
   it "can pass local arrays as arguments" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract Validator {
   function isEmptyArray(bytes32[] memory _arr) pure internal returns (bool) {
     return _arr.length == 0;
@@ -1722,6 +1730,7 @@ contract qq {
 
   it "can compare contracts to int literals" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract qq {
   bool eq;
   bool neq;
@@ -1792,6 +1801,7 @@ contract qq {
 
   it "can compare ints to enums" . runTest $ do
     runCall "f" "(1)" [r|
+pragma solidvm 3.0;
 contract qq {
   enum E {A, B, C, D}
   bool is_a;
@@ -1895,6 +1905,7 @@ contract qq {
 
   it "can call boolean arguments" . runTest $ do
     runCall "set" "(true,false)" [r|
+pragma solidvm 3.0;
 contract qq {
   bool a;
   bool b;
@@ -2313,6 +2324,7 @@ contract qq {
 
   it "can cast empty bytes32 to int" . runTest $ do
     void $ runBS [r|
+pragma solidvm 3.0;
 contract qq {
   uint public x;
   constructor() public {
@@ -2532,6 +2544,7 @@ contract qq {
 
   it "RHS expr in an AND clause is not evaluated if the LHS expr evaluates to False" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract qq {
   uint x = 0;
   uint magic = 42;
@@ -2573,6 +2586,7 @@ contract qq {
 
   it "RHS expr in an OR clause is not evaluated if the LHS expr evaluates to True" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract qq {
   uint x = 0;
   uint magic = 42;
@@ -2757,6 +2771,7 @@ contract qq {
 
   it "can cast strings to bool" . runTest $ do
     runBS [r|
+pragma solidvm 3.0;
 contract qq {
   bool control;
   bool t;


### PR DESCRIPTION
https://blockapps.atlassian.net/browse/STRATO-2047

https://jenkins.blockapps.net/job/STRATO_test/4577/

Addition to support a `solidvm` pragma. For example, at the top of a contract file put the following to run the contract with SolidVM 3.0.
```
pragma solidvm 3.0;
<rest of contract>
```

For this PR, the key part that needs to be versioned is this change: https://blockapps.atlassian.net/browse/STRATO-2047 The `toVal` function of that change creates stateroot mismatch issues when running pre7.0 blocks with that change. Now, with the new pragma, we can isolate the change to only new code that has `pragma solidvm 3.0;`.

This change also ensures that svmTrace=true with SolidVM=3.0 doesn't cause stateroot mismatches.

There are some ways we should extend this pragma for the future:
- Use the versions library for SemVar (https://hackage.haskell.org/package/versions)

Additional bug that should be fixed for future version of SolidVM: `genericLookupWithDefaultRawStorageDB` should not modify the stateroot by putting default values into the MP Trie.
