### PR TITLE
Strato 2046 compile svm contract

### DIFF
--- a/smd-ui/src/components/CodeEditor/codeEditor.reducer.js
+++ b/smd-ui/src/components/CodeEditor/codeEditor.reducer.js
@@ -26,7 +26,8 @@ const initialState = {
   lastTabSelected: 0,
   currentTabSelected: 0,
   isRemoveTab: false,
-  localCompileException: ''
+  localCompileException: '',
+  codeType : "SolidVM"
 };
 
 const formatCompilationErrors = function (error) {
@@ -73,7 +74,8 @@ const reducer = function (state = loadState(), action) {
         ...state,
         response: "Uploading Contract...",
         createDisabled: true,
-        enableCreateAction: false
+        enableCreateAction: false,
+        codeType : action.codeType
       };
 
     case CODE_EDITOR_COMPILE_SUCCESS:

--- a/smd-ui/src/components/CodeEditor/codeEditor.saga.js
+++ b/smd-ui/src/components/CodeEditor/codeEditor.saga.js
@@ -74,14 +74,14 @@ export function compileSource(contractName, source, codeType) {
   });
 }
 
-export function* compileCodeFromEditor(codeAction) {
+export function* compileCodeFromEditor(action) {
   try {
     let response
-    response = yield call(tokenizeSource, codeAction.code);
+    response = yield call(tokenizeSource, action.code);
     if (response) {
       let contracts = response.src && Object.keys(response.src);
       const contractName = contracts && contracts[0]
-      yield call(compileSource, contractName, codeAction.code, codeAction.codeType);
+      yield call(compileSource, contractName, action.code, action.codeType);
     }
     yield put(compileCodeFromEditorSuccess(response));
   }

--- a/smd-ui/src/components/CreateContract/createContract.reducer.js
+++ b/smd-ui/src/components/CreateContract/createContract.reducer.js
@@ -24,9 +24,8 @@ const initialState = {
   contractName: undefined,
   createDisabled: true,
   filename: undefined,
-  solidvm: true,
-  toster: false,
-  tosterMessage: ''
+  isToasts: false,
+  toastsMessage: ''
 };
 
 const reducer = function (state = initialState, action) {

--- a/smd-ui/src/components/CreateContract/index.js
+++ b/smd-ui/src/components/CreateContract/index.js
@@ -113,7 +113,7 @@ class CreateContract extends Component {
     const fileText = this.props.textFromEditor ? this.props.textFromEditor : this.props.contract
 
     const contracts = this.props.sourceFromEditor ? Object.keys(this.props.sourceFromEditor) : this.props.abi && this.props.abi.src && Object.keys(this.props.abi.src);
-    const metadata = { VM: this.props.solidvm ? 'SolidVM' : 'EVM' };
+    const metadata = { VM: this.props.codeType ? this.props.codeType : 'SolidVM' };
     contracts.forEach(function (contract) {
       if (values[`history@${contract}`]) {
         if (metadata['history']) {
@@ -596,7 +596,7 @@ export const validate = (values) => {
 
 export const CREATE_CONTRACT_FORM = 'create-contract'
 
-const selector = formValueSelector(CREATE_CONTRACT_FORM);
+// const selector = formValueSelector(CREATE_CONTRACT_FORM);
 
 export function mapStateToProps(state) {
   return {
@@ -609,18 +609,18 @@ export function mapStateToProps(state) {
     username: state.createContract.username,
     isToasts: state.createContract.isToasts,
     toastsMessage: state.createContract.toastsMessage,
-    // TODO: update the testcase for selector
-    solidvm: selector(state, 'solidvm'),
+    codeType : state.codeEditor.codeType,
     initialValues: {
       username: state.user.oauthUser ? state.user.oauthUser.username : '',
-      address: state.user.oauthUser ? state.user.oauthUser.address : ''
+      address: state.user.oauthUser ? state.user.oauthUser.address : '',
+      solidvm : state.codeEditor.codeType === "SolidVM"
     },
     chainLabel: state.chains.listChain,
     chainLabelIds: state.chains.listLabelIds
   };
 }
 
-const formed = reduxForm({ form: CREATE_CONTRACT_FORM, validate })(CreateContract);
+const formed = reduxForm({ form: CREATE_CONTRACT_FORM, validate, enableReinitialize : true})(CreateContract);
 const connected = connect(mapStateToProps, {
   contractOpenModal,
   contractCloseModal,

--- a/smd-ui/src/components/CreateContract/index.js
+++ b/smd-ui/src/components/CreateContract/index.js
@@ -13,7 +13,7 @@ import { fetchAccounts, fetchUserAddresses } from '../Accounts/accounts.actions'
 import { fetchContracts } from '../Contracts/contracts.actions';
 import { Button, Dialog } from '@blueprintjs/core';
 import Dropzone from 'react-dropzone'
-import { Field, reduxForm, formValueSelector } from 'redux-form';
+import { Field, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import mixpanelWrapper from '../../lib/mixpanelWrapper';
@@ -26,6 +26,13 @@ import './createContract.css';
 // TODO: use solc instead of /contracts/xabi for compile
 
 class CreateContract extends Component {
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.isToasts) {
+      toasts.show({ message: nextProps.toastsMessage });
+      this.props.resetError();
+    }
+  }
 
   renderDropzoneInput = (field) => {
     const touchedAndHasErrors = field.meta.touched && field.meta.error
@@ -59,13 +66,6 @@ class CreateContract extends Component {
       : this.props.contractNameChange(
         e.target.value
       );
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.isToasts) {
-      toasts.show({ message: nextProps.toastsMessage });
-      this.props.resetError();
-    }
   }
 
   handleFileDrop = (files, dropZoneField) => {
@@ -454,22 +454,11 @@ class CreateContract extends Component {
               {contracts && <div className="row">
                 <div className="col-sm-3 text-right">
                   <label className="pt-label smd-pad-4">
-                    SolidVM
+                    VM
                   </label>
                 </div>
                 <div className="col-sm-9 smd-pad-4">
-                  <label className="pt-control pt-checkbox">
-                    <Field
-                      id="input-b"
-                      className="form-width"
-                      name="solidvm"
-                      type="checkbox"
-                      component="input"
-                      dir="auto"
-                      title="SolidVM"
-                    />
-                    <span className="pt-control-indicator"></span>
-                  </label>
+                  {this.props.codeType}
                 </div>
               </div>}
               {contracts && <div className="row">
@@ -596,7 +585,6 @@ export const validate = (values) => {
 
 export const CREATE_CONTRACT_FORM = 'create-contract'
 
-// const selector = formValueSelector(CREATE_CONTRACT_FORM);
 
 export function mapStateToProps(state) {
   return {
@@ -612,15 +600,14 @@ export function mapStateToProps(state) {
     codeType : state.codeEditor.codeType,
     initialValues: {
       username: state.user.oauthUser ? state.user.oauthUser.username : '',
-      address: state.user.oauthUser ? state.user.oauthUser.address : '',
-      solidvm : state.codeEditor.codeType === "SolidVM"
+      address: state.user.oauthUser ? state.user.oauthUser.address : ''
     },
     chainLabel: state.chains.listChain,
     chainLabelIds: state.chains.listLabelIds
   };
 }
 
-const formed = reduxForm({ form: CREATE_CONTRACT_FORM, validate, enableReinitialize : true})(CreateContract);
+const formed = reduxForm({ form: CREATE_CONTRACT_FORM, validate })(CreateContract);
 const connected = connect(mapStateToProps, {
   contractOpenModal,
   contractCloseModal,

--- a/smd-ui/src/tests/Accounts/index.spec.js
+++ b/smd-ui/src/tests/Accounts/index.spec.js
@@ -20,7 +20,8 @@ describe('Accounts: index', () => {
         changeAccountFilter: jest.fn(),
         faucetRequest: jest.fn(),
         resetUserAddress: jest.fn(),
-        fetchUserAddresses: jest.fn()
+        fetchUserAddresses: jest.fn(),
+        fetchOauthAccounts : jest.fn()
       }
       const wrapper = shallow(
         <Accounts.WrappedComponent {...props} />
@@ -38,7 +39,8 @@ describe('Accounts: index', () => {
         changeAccountFilter: jest.fn(),
         faucetRequest: jest.fn(),
         resetUserAddress: jest.fn(),
-        fetchUserAddresses: jest.fn()
+        fetchUserAddresses: jest.fn(),
+        fetchOauthAccounts : jest.fn()
       }
       const wrapper = shallow(
         <Accounts.WrappedComponent {...props} />
@@ -82,7 +84,8 @@ describe('Accounts: index', () => {
         changeAccountFilter: jest.fn(),
         faucetRequest: jest.fn(),
         resetUserAddress: jest.fn(),
-        fetchUserAddresses: jest.fn()
+        fetchUserAddresses: jest.fn(),
+        fetchOauthAccounts : jest.fn()
       }
       const wrapper = shallow(
         <Accounts.WrappedComponent {...props} />
@@ -103,7 +106,8 @@ describe('Accounts: index', () => {
       changeAccountFilter: jest.fn(),
       faucetRequest: jest.fn(),
       resetUserAddress: jest.fn(),
-      fetchUserAddresses: jest.fn()
+      fetchUserAddresses: jest.fn(),
+      fetchOauthAccounts : jest.fn()
     }
 
     shallow(

--- a/smd-ui/src/tests/App/index.spec.js
+++ b/smd-ui/src/tests/App/index.spec.js
@@ -6,7 +6,7 @@ describe('App: index', () => {
 
   test('render component', () => {
     const wrapper = shallow(
-      <App.WrappedComponent />
+      <App.WrappedComponent getOrCreateOauthUserRequest={jest.fn()}/>
     );
 
     expect(wrapper.debug()).toMatchSnapshot();

--- a/smd-ui/src/tests/CodeEditor/__snapshots__/codeEditor.reducer.spec.js.snap
+++ b/smd-ui/src/tests/CodeEditor/__snapshots__/codeEditor.reducer.spec.js.snap
@@ -97,6 +97,7 @@ exports[`CodeEditor: reducer compile code request 1`] = `
 Object {
   "abi": undefined,
   "codeCompileSuccess": undefined,
+  "codeType": undefined,
   "contractName": undefined,
   "createDisabled": true,
   "currentTabSelected": 0,
@@ -350,6 +351,7 @@ exports[`CodeEditor: reducer set initial state 1`] = `
 Object {
   "abi": undefined,
   "codeCompileSuccess": undefined,
+  "codeType": "SolidVM",
   "contractName": undefined,
   "createDisabled": true,
   "currentTabSelected": 0,

--- a/smd-ui/src/tests/CreateContract/__snapshots__/createContract.reducer.spec.js.snap
+++ b/smd-ui/src/tests/CreateContract/__snapshots__/createContract.reducer.spec.js.snap
@@ -254,10 +254,9 @@ Object {
   "createDisabled": true,
   "filename": undefined,
   "isOpen": false,
+  "isToasts": false,
   "response": "Status: Upload Contract",
-  "solidvm": true,
-  "toster": false,
-  "tosterMessage": "",
+  "toastsMessage": "",
   "username": "",
 }
 `;

--- a/smd-ui/src/tests/CreateContract/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/CreateContract/__snapshots__/index.spec.js.snap
@@ -214,6 +214,7 @@ Object {
     "936986d54af89e2fa3c4888563856940d8f80cd5c1d01c386bd98207d29ae1e9": Object {},
     "ab1696d5f6a36836f0bd23d96918cce4f78b3667518d70e721914f391142a5e1": Object {},
   },
+  "codeType": "SolidVM",
   "contract": "",
   "contractName": "Cloner",
   "createDisabled": false,
@@ -223,7 +224,6 @@ Object {
   },
   "isOpen": true,
   "isToasts": false,
-  "solidvm": undefined,
   "toastsMessage": "message",
   "username": "",
 }

--- a/smd-ui/src/tests/CreateContract/index.spec.js
+++ b/smd-ui/src/tests/CreateContract/index.spec.js
@@ -533,7 +533,6 @@ describe('CreateContract: index', () => {
         username: '',
         isToasts: false,
         toastsMessage: 'message',
-        solidvm: true,
       },
       accounts: {
         accounts: indexAccountsMock
@@ -548,6 +547,9 @@ describe('CreateContract: index', () => {
       chains: {
         listChain: chain,
         listLabelIds: chain["airline cartel 9"]
+      },
+      codeEditor : {
+        codeType : "SolidVM"
       }
     }
     expect(mapStateToProps(state)).toMatchSnapshot();


### PR DESCRIPTION
Successful Jenkins Build: https://jenkins.blockapps.net/job/STRATO_test/4573/
Jira issue: https://blockapps.atlassian.net/browse/STRATO-2046

Since contracts are compiled and posted as transactions in separate api calls, as well as a contract not necessarily needing to be compiled before being posted, the type of VM a piece of code is using needs to specified for each API call (compile and create).
Since adding the functionality of compiling both EVM and SolidVM, there was a possible discrepancy between the compilation VM and the creation VM.
Now the last VM that the user compiled their code with is **always** used as the VM in the contract creation transaction. Previously this could be checked with a checkbox.

There still stands the issue of API calls made to the chain outside of a controlled environment like SMD. Some of the data from a compilation call is maintained within the chain so that when there is a successful compilation in one VM, but a creation in another, it will not raise an error of the VM mismatch and result in a successful transaction. 