### PR TITLE
Strato api tests version specified

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -205,6 +205,7 @@ pipeline {
                 rm -rf strato-api-tests
                 git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
                 cd strato-api-tests
+                git checkout tags/strato-7.0.0  #TODO: api version tags in the future
                 docker build --tag strato-api-tests .
                 docker run \
                   -e OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration \

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -179,6 +179,7 @@ pipeline {
                   rm -rf strato-api-tests
                   git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
                   cd strato-api-tests
+                  git checkout tags/strato-7.0.0  #TODO: api version tags in the future
                   docker build --tag strato-api-tests .
                   docker run \
                     -e OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration \

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -218,6 +218,7 @@ pipeline {
                 rm -rf strato-api-tests
                 git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
                 cd strato-api-tests
+                git checkout tags/strato-7.0.0  #TODO: api version tags in the future
                 docker build --tag strato-api-tests .
                 docker run \
                   -e OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration \


### PR DESCRIPTION
we can augment it later but for now I want to start using the specific version of strato-api-tests for each platform branch.

Jenkins Build: [SUCCESSFUL] https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/4617/pipeline