### PR TITLE
Fix the blockapps-rest release process

### DIFF
--- a/blockapps-rest/.releaseignore
+++ b/blockapps-rest/.releaseignore
@@ -1,1 +1,1 @@
-.releaseignore|node_modules|.editorconfig|.env|.eslint*|.oauth*|Jenkins*|dist|.vscode|package-lock.json|.dockerignore|Dockerfile.test
+.releaseignore|node_modules|.editorconfig|.env|.eslint*|.oauth*|Jenkins*|dist|.vscode|package-lock.json|.dockerignore|Dockerfile.test|lib


### PR DESCRIPTION
ignore generated lib dir when releasing blockapps-rest