### PR TITLE
[STRATO-2073] STRATO API client thread crashes with 502 error

### DIFF
--- a/blockapps-haskell/solidity/src/BlockApps/SolidVMStorageDecoder.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/SolidVMStorageDecoder.hs
@@ -173,10 +173,13 @@ constructFromNothing' (ArrayIndex n:sp) =
 
 synthesize :: [(StoragePath, BasicValue)] -> Either ReplayFailure TotalStorage
 synthesize spbvs = do
-  byFields <- mapM fieldsOnly spbvs
+  byFields <- mapM fieldsOnly $ filter correctFields spbvs
   let basicLists = foldr (\(t, p) m -> HM.alter (Just . maybe [p] (p:)) t m) HM.empty byFields
   sequence $ HM.map synthesize' basicLists
- where fieldsOnly (StoragePath (Field t:sp), bv) = return (t, (StoragePath sp, bv))
+ where correctFields (StoragePath (Field _:_), _) = True  -- Motivation: we are filting out the
+       correctFields (StoragePath [], _) = False  -- the :creator field. Without doing this registerCert
+       correctFields _ = True -- causes issues. See commit's diff & parseField.
+       fieldsOnly (StoragePath (Field t:sp), bv) = return (t, (StoragePath sp, bv))
        fieldsOnly _ = Left FieldRequiredAtTopLevel
 
 synthesize' :: [(StoragePath, BasicValue)] -> Either ReplayFailure V.Value

--- a/shared-util/solid-vm-model/src/SolidVM/Model/Storable.hs
+++ b/shared-util/solid-vm-model/src/SolidVM/Model/Storable.hs
@@ -186,8 +186,10 @@ parseMapIndex = do
 parseField :: Parser [StoragePathPiece]
 parseField = do
   skip (== c2w8 '.')
-  n <- Atto.takeWhile1 (inClass "_a-zA-Z0-9")
-  (Field n:) <$> pathParser
+  (do n <- Atto.takeWhile1 (inClass "_a-zA-Z0-9")
+      (Field n:) <$> pathParser)
+    <|>
+      ((string ":creator") *> pathParser)
 
 parsePath :: B.ByteString-> Either String StoragePath
 parsePath = fmap StoragePath . parseOnly pathParser


### PR DESCRIPTION
[Jira](https://blockapps.atlassian.net/browse/STRATO-2073)

[Jenkins (test passed)](https://jenkins.blockapps.net/job/STRATO_test/4792/)

Change to `parseField`: Now when SolidVM parses the `:creator` field in storage it will silently ignore the field.
Change to `synthesize`: Now blank storage paths (which occur since the `:creator` field is silently dropped) are filtered from the list of storage paths and their respective values.