### PR TITLE
[STRATO-2058] Fix cirrus fails to convert appropriate types

### DIFF
--- a/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
@@ -17,7 +17,7 @@ import qualified Data.ByteString.Char8           as BC
 import qualified Data.ByteString                 as B
 import qualified Data.ByteString.Lazy            as BL
 import qualified Data.Map                        as Map
-import           Data.Maybe                      (fromMaybe, catMaybes)
+import           Data.Maybe                      (fromMaybe, catMaybes, listToMaybe)
 import           Data.Text                       (Text)
 import qualified Data.Text                       as T
 import           Data.Text.Encoding              (decodeUtf8, encodeUtf8)
@@ -74,6 +74,9 @@ wrapAndEscape = wrapParens . csv . map wrapSingleQuotes
 wrapAndEscapeDouble :: [Text] -> Text
 wrapAndEscapeDouble = wrapParens . csv . map wrapDoubleQuotes
 
+unwrapDoubleQuotes :: Text -> Text
+unwrapDoubleQuotes = T.dropAround (== '"')
+
 solidityValueToText :: SolidityValue -> Text
 solidityValueToText (SolidityValueAsString x) = escapeQuotes x
 solidityValueToText (SolidityBool x)          = tshow x
@@ -95,6 +98,11 @@ tableColumns :: [(Text, SolidityValue)] -> TableColumns
 tableColumns = map go
   where go (x,y) = let z = wrapDoubleQuotes $ escapeQuotes x
                    in T.concat [z, " ", typeText y]
+
+-- Considered partial because I'm assuming the TableColumns will always be in this format:
+-- ["\"myCol1\" type1", "\"myCol2\" type2", "\"myCol3\" type3"]
+partialParseTableColumns :: TableColumns -> [Text]
+partialParseTableColumns = concat . mapM (fmap unwrapDoubleQuotes . listToMaybe . T.words)
 
 tableUpsert :: [Text] -> Text
 tableUpsert = csv . map go
@@ -283,8 +291,9 @@ expandContractTable globalsIORef (x:xs) tableName = do
           ]
       expandContractTable globalsIORef xs tableName
     Just cols -> do
-      let list = tableColumns $ Map.toList $ Map.map valueToSolidityValue $ Map.filter isFunction $ contractData x
-          extras = filter (not . flip elem cols) list
+      let list = Map.toList $ Map.map valueToSolidityValue $ Map.filter isFunction $ contractData x
+          difference new old = filter ((`notElem` old) . fst) new
+          extras = tableColumns $ difference list (partialParseTableColumns cols)
       unless (null extras) $ do
         $logInfoS "expandTable" . T.pack $ "We just got new fields for a contract that already has a table!"
         $logInfoS "expandTable" $ T.concat


### PR DESCRIPTION
[Jira](https://blockapps.atlassian.net/browse/STRATO-2058)

[Jenkins (test passed)](https://jenkins.blockapps.net/job/STRATO_test/4795/)

How it works _now with the PR_
1. Slipstream grabs the old columns, so `old = ["\"storedData\" text""]`. This from is a bit iffy to deal with since it is in a text format (it also should be a `bigint`). Also the data type always defaults to text if the value isn't initialized
2. Slipstream grabs the new columns, so `new = [("\"storedData\" bigint", <value1>), ("\"storedDataAlt\" bigint", <value2>)]`. This gets the proper data types
3. Now, we get rid of the old fields from the new one, so `extras = new - old = [("\"storedDataAlt\" bigint", <value2>)]`.
4. Then we go on to expand with the `extras`

So the main part to get working was the subtraction `-` between the new and old that ignores this data type inconsistency. This functionality is captured by the `difference` function.

The underlying issue that old uninitialized columns are defaulted to the `text` type. A fix to change this thought would require a larger refactoring.