### PR TITLE
[STRATO-2085] remove/replace error calls in x509-certs with graceful failure

### DIFF
--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -271,4 +271,4 @@ getCertIssuer (X509Certificate cert) = do
                   , issCountry    = extractDn DnCountry
                   }
   where extractDn :: DnElement -> Maybe String
-        extractDn dn = fmap fromASN1CS . getDnElement dn . certSubjectDN $ getCertificate cert    
+        extractDn dn = fmap fromASN1CS . getDnElement dn . certIssuerDN $ getCertificate cert

--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -113,7 +113,9 @@ instance ToJSON X509Certificate where
   toJSON = String . T.pack . C8.unpack . certToBytes
 
 instance FromJSON X509Certificate where
-  parseJSON (String str) = either (error "failed to JSON parse cert") pure $ bsToCert $ C8.pack $ T.unpack str
+  parseJSON (String str) = 
+    let errDump err = fail $ "failed to JSON parse cert " ++ (show str) ++ " because " ++ err 
+    in either (errDump) pure $ bsToCert $ C8.pack $ T.unpack str
   parseJSON x = fail $ "parseJSON for SignedCertificate expects a String, but was given " ++ show x
 
 
@@ -208,7 +210,7 @@ toASN1CS = asn1CharacterString UTF8
 fromASN1CS :: ASN1CharacterString -> String
 fromASN1CS cs = 
   let errstr = "failed to decode ASN1CharacterString: " ++ show cs
-  in fromMaybe (error errstr) (asn1CharacterToString cs)
+  in fromMaybe errstr (asn1CharacterToString cs)
 
 
 getIssuerDN :: Issuer -> DistinguishedName

--- a/x509-certs/src/BlockApps/X509/Keys.hs
+++ b/x509-certs/src/BlockApps/X509/Keys.hs
@@ -13,7 +13,6 @@ import           Data.ASN1.Encoding
 import           Data.ASN1.BinaryEncoding
 import           Data.ASN1.Types                
 import qualified Data.ByteString                    as B
-import           Data.Maybe
 import           Data.PEM
 import           Data.X509
 
@@ -69,7 +68,9 @@ bsToPub bs =
         Left err -> Left (show err)
         Right asn -> case fromASN1 asn of
           Left str -> Left str
-          Right (pub, _) -> Right $ fromMaybe (error "could not unserialize key") $ unserializeAndUnwrap pub
+          Right (pub', _) -> case unserializeAndUnwrap pub' of
+            Just pub -> Right pub
+            Nothing -> Left $ "failed to unserialize and unwrap this key " ++ (show pub')
 
 
 -- from the actual secp256k1 type to the X509 wrapper type
@@ -81,4 +82,4 @@ serializeAndWrap pub =
 -- from the X509 wrapper type to the actual secp256k1 type
 unserializeAndUnwrap :: PubKey -> Maybe PublicKey
 unserializeAndUnwrap (PubKeyEC (PubKeyEC_Named SEC_p256k1 (SerializedPoint sp))) = importPublicKey sp
-unserializeAndUnwrap x = error $ "unserializeAndUnwrap called with unsupported pubkey type: " ++ show x
+unserializeAndUnwrap _ = Nothing 


### PR DESCRIPTION
The offending `error` was the one in `unserializeAndUnwrap`, but I also replaced some other `error` calls. We do lose the information about why the cert failed to parse.....but at a later point we can come back and add our own class of `Exception` s and turn all the `Maybe` s into `Either` s so we can throw proper exceptions. 