### PR TITLE
Strato api ghc threaded

### DIFF
--- a/api/strato-api/package.yaml
+++ b/api/strato-api/package.yaml
@@ -44,6 +44,7 @@ executables:
     - wai-extra
     - wai-middleware-prometheus
     - warp
+    ghc-options: -threaded
 
   strato-api-init:
     main:                StratoAPIInit.hs

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -171,12 +171,12 @@ function newnode {
       runBackgroundProcess core-api --appFetchLimit=${appFetchLimit:-100} +RTS -N1 >> logs/core-api 2>&1
   else
       echo "Starting strato-api"
-      runBackgroundProcess strato-api --gasOn=$gasOn --evmCompatible=$evmCompatible >> logs/strato-api 2>&1
+      runBackgroundProcess strato-api --gasOn=$gasOn --evmCompatible=$evmCompatible +RTS -N1 >> logs/strato-api 2>&1
   fi
 
   if [ "${START_EXPERIMENTAL_STRATO_API}" = true ]; then
       echo "Starting strato-api2"
-      runBackgroundProcess strato-api2 --gasOn=$gasOn >> logs/strato-api2 2>&1
+      runBackgroundProcess strato-api2 --gasOn=$gasOn +RTS -N1 >> logs/strato-api2 2>&1
   fi
 
   echo "Configuring log rotation..."


### PR DESCRIPTION
I added the `-threaded` ghc flag to strato-api to avoid the errors with file descriptors crashing the strato-api executable inside strato_strato_1 container.

Kelly encountered this error during 7.1.0 pre-release testing. We also had this issue once or twice on genesis for beef environment.

I followed the solution from here: https://stackoverflow.com/questions/61534034/file-descriptor-out-of-range-for-select-recompile-with-threaded-to-work-aroun


**Jenkins build (SUCCESS): https://jenkins.blockapps.net/job/STRATO_test/4891/**


Error message in the crashed strato container: 
```
Tail of logs for crashed process:
+tail -n 20 /var/lib/strato/logs/strato-api
  (SolidVM,HexStorage ".agreementManager",HexStorage "\233\EOT\146SimpleAssetManager\148\140?\168\203\146\172\GST\243\141F\136\173\165\225\213%\204\STX\240")
  (SolidVM,HexStorage ".eventDefManager",HexStorage "\233\EOT\146SimpleAssetManager\148Bw\166\156\SI&\\w\186\133\199\235\176Y\160C\202\161\&8\\")
  (SolidVM,HexStorage ".exceptionDefManager",HexStorage "\235\EOT\148CompoundAssetManager\148\235j\237l\141\242\238s\141\212S\203\189\176\ACK\131\236\DEL\SO\217")
  (SolidVM,HexStorage ".membershipManager",HexStorage "\235\EOT\148CompoundAssetManager\148\EM\191\139\184\234\216\US\b\236\193$\138\&8\190>\152\253V\SUB[")
  (SolidVM,HexStorage ".nodeManager",HexStorage "\233\EOT\146SimpleAssetManager\148\173\157Fy\186m\SOH*\220v\163'\194v\209D\218\246\167'")
  (SolidVM,HexStorage ".owner",HexStorage "\214\ETX\148\245f\130\CANO\189B\255\182\181\249\199l\223\179\252\196\138\v\192")
  (SolidVM,HexStorage ".permissionManager",HexStorage "\241\EOT\154BeanstalkPermissionManager\148l\190?\198IKaea\193hO\203\161\222\192Z\161\215\189")
  (SolidVM,HexStorage ".privacyGroupManager",HexStorage "\233\EOT\146SimpleAssetManager\148n\183\169\194N\176\243\147\191c\t\243\&9\186{+wq\tB")
  (SolidVM,HexStorage ".programManager",HexStorage "\233\EOT\146SimpleAssetManager\148`\245\129\NAK\163I\135\237\155\206c\177A\179E\153\ETX\141!\193")
  (SolidVM,HexStorage ".roleManager",HexStorage "\233\EOT\146SimpleAssetManager\148\170\DC1P{\RSG\129>.\145\162D\142\252^\206U\253\134\149")
  (SolidVM,HexStorage ".userManager",HexStorage "\233\EOT\146SimpleAssetManager\148\234\136\145\244\193\b\231\212@\186\184\129\255%}I\191C\242\137")

End of storage

GET /bloc/v2.2/contracts/BeanstalkDapp/2ec13c880525e5f0d19c53099f5623fe5918ee4b/state
  Params: [("resolve","true")]
  Accept: application/json, text/plain, */*
  Status: 200 OK 0.019549865s
strato-api: file descriptor 64201816 out of range for select (0--1024).
Recompile with -threaded to work around this.
End of logs.
STRATO IS DOWN: Process with pid 87 crashed so all background processes were killed. Check /var/lib/strato/logs/ in th
```
