### PR TITLE
remove the compiled binaries from filesystem BEFORE docker build in the pipelines

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -23,8 +23,8 @@ pipeline {
     stage('Build') {
       steps {
         dir ('strato-worktree') {
-          sh 'REPO=private make all'
           sh 'rm -rf .docker-work'
+          sh 'REPO=private make all'
           dir ('blockapps-rest') {
             sh 'yarn install --pure-lockfile'
             sh 'yarn build'

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -24,6 +24,7 @@ pipeline {
       steps {
         dir ('strato-worktree') {
           sh 'REPO=private make all'
+          sh 'rm -rf .docker-work'
           dir ('blockapps-rest') {
             sh 'yarn install --pure-lockfile'
             sh 'yarn build'

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -45,6 +45,7 @@ pipeline {
           dir ('strato-worktree') {
             sh 'echo ${RELEASE_VERSION} > VERSION'
             sh 'REPO=public make all'
+            sh 'rm -rf .docker-work'
             dir ('blockapps-rest') {
               sh 'yarn install --pure-lockfile'
               sh 'yarn build'

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -44,8 +44,8 @@ pipeline {
         withEnv(["RELEASE_VERSION=${env.RELEASE_VERSION}"]) {
           dir ('strato-worktree') {
             sh 'echo ${RELEASE_VERSION} > VERSION'
-            sh 'REPO=public make all'
             sh 'rm -rf .docker-work'
+            sh 'REPO=public make all'
             dir ('blockapps-rest') {
               sh 'yarn install --pure-lockfile'
               sh 'yarn build'

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -38,6 +38,7 @@ pipeline {
       steps {
         dir ('strato-worktree') {
           sh 'REPO=private make all'
+          sh 'rm -rf .docker-work'
           dir ('blockapps-rest') {
             sh 'yarn install --pure-lockfile'
             sh 'yarn build'

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -37,8 +37,8 @@ pipeline {
     stage('Build') {
       steps {
         dir ('strato-worktree') {
-          sh 'REPO=private make all'
           sh 'rm -rf .docker-work'
+          sh 'REPO=private make all'
           dir ('blockapps-rest') {
             sh 'yarn install --pure-lockfile'
             sh 'yarn build'


### PR DESCRIPTION
Remove .docker-work after the docker images are built (to avoid the side-affects in future builds)

Jira ticket: https://blockapps.atlassian.net/browse/STRATO-2122
Jenkins builds: 4957-4962 https://jenkins.blockapps.net/job/STRATO_test/ (failing due to the other issue but the builds went fine and the REbuilds are still fast.