### PR TITLE
Added /parse endpoint to debugger API

### DIFF
--- a/blockapps-rest/ReleaseNotes.md
+++ b/blockapps-rest/ReleaseNotes.md
@@ -1,5 +1,9 @@
 ## RELEASE NOTES
 
+### Version: 8.0.3
+
+- Added the debugPostParse function to support compilation and static analysis tools
+
 ### Version: 8.0.2
 
 - Hotfix for access token lifetime reserve setting introduced in 8.0.1

--- a/blockapps-rest/package.json
+++ b/blockapps-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockapps-rest",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "BlockApps Rest API SDK",
   "main": "dist/index.js",
   "scripts": {

--- a/blockapps-rest/src/api.ts
+++ b/blockapps-rest/src/api.ts
@@ -456,6 +456,12 @@ async function debugPostEval(user:OAuthUser, args, options:Options) {
   return post(url, endpoint, args, setAuthHeaders(user, options));
 }
 
+async function debugPostParse(user:OAuthUser, args, options:Options) {
+  const url = getNodeUrl(options);
+  const endpoint = constructEndpoint(Endpoint.DEBUG_PARSE, options);
+  return post(url, endpoint, args, setAuthHeaders(user, options));
+}
+
 export default {
   getAccounts,
   getHealth,
@@ -506,5 +512,6 @@ export default {
   debugPutWatches,
   debugDeleteWatches,
   debugClearWatches,
-  debugPostEval
+  debugPostEval,
+  debugPostParse,
 };

--- a/blockapps-rest/src/rest.ts
+++ b/blockapps-rest/src/rest.ts
@@ -1598,6 +1598,11 @@ async function debugPostEval(user:OAuthUser, args, options:Options) {
   return response;
 }
 
+async function debugPostParse(user:OAuthUser, args, options:Options) {
+  const response = await api.debugPostParse(user, args, options);
+  return response;
+}
+
 // =====================================================================
 //   Common patterns used in applications
 // =====================================================================
@@ -1717,6 +1722,7 @@ export default {
   debugDeleteWatches,
   debugClearWatches,
   debugPostEval,
+  debugPostParse,
   //
   RestError,
   response,

--- a/blockapps-rest/src/util/api.util.ts
+++ b/blockapps-rest/src/util/api.util.ts
@@ -44,7 +44,8 @@ const Endpoint = {
   DEBUG_STACK_TRACE: `${debugUrl}/stack-trace`,
   DEBUG_VARIABLES: `${debugUrl}/variables`,
   DEBUG_WATCHES: `${debugUrl}/watches`,
-  DEBUG_EVAL: `${debugUrl}/eval`
+  DEBUG_EVAL: `${debugUrl}/eval`,
+  DEBUG_PARSE: `${debugUrl}/parse`,
 };
 
 function constructEndpoint(endpointTemplate, options:Options, params = {}) {

--- a/core-strato/debugger/src/Debugger/Init.hs
+++ b/core-strato/debugger/src/Debugger/Init.hs
@@ -13,6 +13,9 @@ module Debugger.Init
   ) where
 
 import           Control.Concurrent.Async
+import qualified Data.Aeson               as A
+import qualified Data.Map.Strict          as M
+import qualified Data.Text                as T
 import           Debugger.Options
 import           Debugger.Rest
 import           Debugger.Types
@@ -20,13 +23,13 @@ import           Debugger.WebSocket
 import           Network.Wai.Handler.Warp
 import           UnliftIO.STM
 
-initializeDebugger :: IO (Maybe (DebugSettings, IO ()))
-initializeDebugger = if not flags_debugEnabled
+initializeDebugger :: A.ToJSON a => (M.Map T.Text T.Text -> a) -> IO (Maybe (DebugSettings, IO ()))
+initializeDebugger parse = if not flags_debugEnabled
   then pure Nothing
   else do
     dSettings <- atomically newDebugSettings
     let debuggerRunner =
-          let rest = run flags_debugPort (restDebugger dSettings)
+          let rest = run flags_debugPort (restDebugger dSettings parse)
            in if flags_wsDebug
                 then race_ rest $ wsDebugger flags_debugWSPort dSettings
                 else rest

--- a/core-strato/debugger/src/Debugger/Rest/Api.hs
+++ b/core-strato/debugger/src/Debugger/Rest/Api.hs
@@ -13,6 +13,7 @@ module Debugger.Rest.Api
   , restDebuggerAPI
   ) where
 
+import           Data.Aeson      as A
 import qualified Data.Map.Strict as M
 import qualified Data.Text       as T
 import           Debugger.Types
@@ -34,6 +35,7 @@ type RestDebuggerAPI = GetStatus
                   :<|> PutWatches
                   :<|> DeleteWatches
                   :<|> PostEvals
+                  :<|> PostParse
 
 type GetStatus = "status" :> Get '[JSON] DebuggerStatus
 type PutPause = "pause" :> Put '[JSON] DebuggerStatus
@@ -51,6 +53,7 @@ type GetWatches = "watches" :> Get '[JSON] (M.Map EvaluationRequest EvaluationRe
 type PutWatches = "watches" :> ReqBody '[JSON] [EvaluationRequest] :> Put '[JSON] DebuggerStatus
 type DeleteWatches = "watches" :> ReqBody '[JSON] [EvaluationRequest] :> Delete '[JSON] DebuggerStatus
 type PostEvals = "eval" :> ReqBody '[JSON] [EvaluationRequest] :> Post '[JSON] [EvaluationResponse]
+type PostParse = "parse" :> ReqBody '[JSON] (M.Map T.Text T.Text) :> Post '[JSON] A.Value
 
 restDebuggerAPI :: Proxy RestDebuggerAPI
 restDebuggerAPI = Proxy

--- a/core-strato/debugger/src/Debugger/Rest/Server.hs
+++ b/core-strato/debugger/src/Debugger/Rest/Server.hs
@@ -12,6 +12,7 @@ module Debugger.Rest.Server where
 
 import           Control.Monad
 import           Control.Monad.IO.Class
+import           Data.Aeson             as A
 import qualified Data.Map.Strict        as M
 import           Data.Maybe             (fromMaybe)
 import qualified Data.Text              as T
@@ -74,8 +75,17 @@ deleteWatches = flip removeWatches
 postEvals :: DebugSettings -> [EvaluationRequest] -> Handler [EvaluationResponse]
 postEvals d ts = fmap (fromMaybe $ Left "") <$> liftIO (evaluateExpressions ts d)
 
-restDebuggerServer :: DebugSettings -> Server RestDebuggerAPI
-restDebuggerServer dSettings =
+postParse :: ToJSON a
+          => (M.Map T.Text T.Text -> a)
+          -> M.Map T.Text T.Text
+          -> Handler A.Value
+postParse parse = pure . toJSON . parse
+
+restDebuggerServer :: ToJSON a
+                   => DebugSettings
+                   -> (M.Map T.Text T.Text -> a)
+                   -> Server RestDebuggerAPI
+restDebuggerServer dSettings parse =
        getStatus dSettings
   :<|> putPause dSettings
   :<|> putResume dSettings
@@ -92,6 +102,10 @@ restDebuggerServer dSettings =
   :<|> putWatches dSettings
   :<|> deleteWatches dSettings
   :<|> postEvals dSettings
+  :<|> postParse parse
 
-restDebugger :: DebugSettings -> Application
-restDebugger dSettings = serve restDebuggerAPI (restDebuggerServer dSettings)
+restDebugger :: ToJSON a
+             => DebugSettings
+             -> (M.Map T.Text T.Text -> a)
+             -> Application
+restDebugger dSettings parse = serve restDebuggerAPI (restDebuggerServer dSettings parse)

--- a/core-strato/solid-vm/package.yaml
+++ b/core-strato/solid-vm/package.yaml
@@ -16,6 +16,7 @@ library:
   exposed-modules:
     - Blockchain.SolidVM
     - Blockchain.SolidVM.SM
+    - Blockchain.SolidVM.CodeCollectionDB
     - Blockchain.SolidVM.Exception
     - SolidVM.Solidity.Parse.File
     - SolidVM.Solidity.Parse.Lexer

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE FlexibleContexts #-}
-module Blockchain.SolidVM.CodeCollectionDB (codeCollectionFromSource, codeCollectionFromHash) where
+module Blockchain.SolidVM.CodeCollectionDB
+  ( compileSource
+  , codeCollectionFromSource
+  , codeCollectionFromHash
+  ) where
 
 import           Control.Exception
 import           Control.Monad.IO.Class

--- a/core-strato/solid-vm/src/CodeCollection.hs
+++ b/core-strato/solid-vm/src/CodeCollection.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -8,6 +9,7 @@
 module CodeCollection where
 
 import Control.Lens
+import Data.Aeson as A
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe
@@ -23,7 +25,7 @@ import qualified SolidVM.Solidity.Xabi.Def as Xabi
 import qualified SolidVM.Solidity.Xabi.Statement as Xabi
 import qualified SolidVM.Solidity.Xabi.VarDef as Xabi
 
-data Contract =
+data ContractF a =
   Contract {
     _contractName :: String,
     _parents :: [String],
@@ -32,20 +34,29 @@ data Contract =
     _enums :: Map String [String],
     _structs :: Map String [(T.Text, Xabi.FieldType)],
     _events :: Map T.Text Xabi.Event,
-    _functions :: Map String Func,
-    _constructor :: Maybe Func,
+    _functions :: Map String (FuncF a),
+    _constructor :: Maybe (FuncF a),
     _vmVersion :: String
-  } deriving (Show, Generic)
+  } deriving (Show, Generic, Functor)
 
-makeLenses ''Contract
+instance ToJSON a => ToJSON (ContractF a)
+instance FromJSON a => FromJSON (ContractF a)
 
-data CodeCollection =
+type Contract = ContractF Xabi.SourcePos
+
+makeLenses ''ContractF
+
+data CodeCollectionF a =
   CodeCollection {
-    _contracts :: Map String Contract
-  } deriving (Show, Generic)
+    _contracts :: Map String (ContractF a)
+  } deriving (Show, Generic, Functor)
 
-makeLenses ''CodeCollection
+instance ToJSON a => ToJSON (CodeCollectionF a)
+instance FromJSON a => FromJSON (CodeCollectionF a)
 
+type CodeCollection = CodeCollectionF Xabi.SourcePos
+
+makeLenses ''CodeCollectionF
 
 emptyCodeCollection :: CodeCollection
 emptyCodeCollection =

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Xabi.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Xabi.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -127,7 +128,7 @@ instance ToSchema StateMutability where
     & mapped.schema.description ?~ "Reserved keywords for function state mutability"
     & mapped.schema.example ?~ toJSON View
 
-data Func = Func
+data FuncF a = Func
   { funcArgs :: [(Maybe Text, Xabi.IndexedType)]
   , funcVals :: [(Maybe Text, Xabi.IndexedType)]
   , funcStateMutability :: Maybe StateMutability
@@ -135,11 +136,16 @@ data Func = Func
   -- These Values are only used for parsing and unparsing solidity.
   -- This data will not be stored in the db and will have no
   -- relevance when constructing from the db.
-  , funcContents :: Maybe [Statement]
+  , funcContents :: Maybe [StatementF a]
   , funcVisibility :: Maybe Visibility
   , funcConstructorCalls :: Map String [Expression]
   , funcModifiers :: Maybe [String]
-  } deriving (Eq,Show,Generic)
+  } deriving (Eq,Show,Generic, Functor)
+
+instance ToJSON a => ToJSON (FuncF a)
+instance FromJSON a => FromJSON (FuncF a)
+
+type Func = FuncF SourcePos
 
 data VariableDecl =
   VariableDecl {
@@ -148,12 +154,18 @@ data VariableDecl =
   varInitialVal :: Maybe Expression
   } deriving (Show, Eq,Generic)
 
+instance ToJSON VariableDecl
+instance FromJSON VariableDecl
+
 data ConstantDecl =
   ConstantDecl {
   constType :: Xabi.Type,
   constIsPublic :: Bool,
   constInitialVal :: Expression
   } deriving (Show, Eq, Generic)
+
+instance ToJSON ConstantDecl
+instance FromJSON ConstantDecl
 
 funcPayable :: Func -> Bool
 funcPayable Func{funcStateMutability = Just Payable} = True

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Xabi/Statement.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Xabi/Statement.hs
@@ -1,7 +1,12 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 module SolidVM.Solidity.Xabi.Statement
-  ( StatementF(..)
+  ( SourcePosition(..)
+  , toSourcePosition
+  , fromSourcePosition
+  , StatementF(..)
   , Statement
   , Location(..)
   , VarDefEntry(..)
@@ -14,10 +19,28 @@ module SolidVM.Solidity.Xabi.Statement
   , module Text.Parsec.Pos
   ) where
 
+import Data.Aeson
 import qualified Data.Text as T
 import GHC.Generics
 import SolidVM.Solidity.Xabi.Type
 import Text.Parsec.Pos
+
+data SourcePosition = SourcePosition
+  { _sourcePositionName   :: String
+  , _sourcePositionLine   :: !Int
+  , _sourcePositionColumn :: !Int
+  } deriving (Show, Eq, Generic)
+
+instance ToJSON SourcePosition
+instance FromJSON SourcePosition
+
+toSourcePosition :: SourcePos -> SourcePosition
+toSourcePosition pos = SourcePosition (sourceName pos)
+                                      (sourceLine pos)
+                                      (sourceColumn pos)
+
+fromSourcePosition :: SourcePosition -> SourcePos
+fromSourcePosition (SourcePosition n l c) = newPos n l c
 
 data StatementF a =
   IfStatement Expression [StatementF a] (Maybe [StatementF a]) a -- if then else
@@ -32,17 +55,23 @@ data StatementF a =
   | EmitStatement String [(Maybe String, Expression)] a
   | AssemblyStatement InlineAssembly a
   | SimpleStatement SimpleStatement a
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Generic, Functor, ToJSON, FromJSON)
 
 type Statement = StatementF SourcePos
 
 data Location = Memory | Storage deriving (Show, Eq, Generic)
+
+instance ToJSON Location
+instance FromJSON Location
 
 data VarDefEntry = BlankEntry
                  | VarDefEntry { vardefType :: Maybe Type
                                , _vardefLocation :: Maybe Location
                                , vardefName :: String
                                } deriving (Show, Eq, Generic)
+
+instance ToJSON VarDefEntry
+instance FromJSON VarDefEntry
 
 vardefLocation :: VarDefEntry -> Maybe Location
 vardefLocation BlankEntry = Nothing
@@ -52,6 +81,9 @@ data SimpleStatement =
   VariableDefinition [VarDefEntry] (Maybe Expression) -- Nothing type indicates "var" keyword
   | ExpressionStatement Expression deriving (Show, Eq, Generic)
 
+instance ToJSON SimpleStatement
+instance FromJSON SimpleStatement
+
 -- Currently, the only supported inline assembly is:
 -- assembly {
 --  result := mload(add(source, 32))
@@ -59,6 +91,8 @@ data SimpleStatement =
 -- Anything else is a parse error.
 data InlineAssembly = MloadAdd32 T.Text T.Text deriving (Show, Eq, Generic)
 
+instance ToJSON InlineAssembly
+instance FromJSON InlineAssembly
 
 
 data Expression =
@@ -78,6 +112,15 @@ data Expression =
   | ArrayExpression [Expression]
   | Variable String deriving (Show, Eq, Generic)
 
+instance ToJSON Expression
+instance FromJSON Expression
+
 data ArgList = OrderedArgs [Expression] | NamedArgs [(String, Expression)] deriving (Show, Eq, Generic)
 
+instance ToJSON ArgList
+instance FromJSON ArgList
+
 data NumberUnit = Wei | Szabo | Finney | Ether deriving (Show, Eq, Generic)
+
+instance ToJSON NumberUnit
+instance FromJSON NumberUnit

--- a/core-strato/vm-runner/exec_src/Main.hs
+++ b/core-strato/vm-runner/exec_src/Main.hs
@@ -14,15 +14,17 @@ import           HFlags
 
 import           BlockApps.Init
 import           Blockchain.Output
+import           Blockchain.SolidVM.CodeCollectionDB  (compileSource)
 import           Blockchain.VMOptions() -- HFlags
 import           Executable.EthereumVM
 import           Executable.EVMFlags() -- HFlags
+import           SolidVM.Solidity.Xabi.Statement      (toSourcePosition)
 
 main :: IO ()
 main = do
   blockappsInit "vm_main"
   void $ $initHFlags "Ethereum VM"
-  mDebugger <- initializeDebugger
+  mDebugger <- initializeDebugger (fmap toSourcePosition . compileSource)
   let metricsRunner = run 8000 metricsApp
       debugSettings = fst <$> mDebugger
       helpers = case snd <$> mDebugger of


### PR DESCRIPTION
The existing /compile route uses the Bloc Solidity parser for SolidVM contracts, which doesn't inspect function contents. To write almost all of the static analysis tools, we need to use the parser found in the `solid-vm` package, which does inspect function contents.

After this, I would like to handle parse errors better, and extend the source position tracking to `Expression`s, so that our static analysis tools can provide precise feedback within the source document.

Successful build: https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_test/detail/STRATO_test/5024/pipeline