### PR TITLE
More detectors and improvements to existing ones

### DIFF
--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
@@ -15,6 +15,7 @@ import qualified SolidVM.Solidity.Detectors.Functions.Unimplemented.Continue    
 import qualified SolidVM.Solidity.Detectors.Statements.StateVariableShadowing      as StateVariableShadowing
 import qualified SolidVM.Solidity.Detectors.Statements.UninitializedLocalVariables as UninitializedLocalVariables
 import qualified SolidVM.Solidity.Detectors.Statements.WriteAfterWrite             as WriteAfterWrite
+import qualified SolidVM.Solidity.Detectors.Variables.StateVariables               as StateVariables
 
 parserDetectors :: [ParserDetector]
 parserDetectors = [ IncorrectSolidityVersion.detector
@@ -29,6 +30,7 @@ compilerDetectors = [ Trivial.detector
                     , UninitializedLocalVariables.detector
                     , WriteAfterWrite.detector
                     , ConstantFunctions.detector
+                    , StateVariables.detector
                     ]
 
 runDetectors :: Applicative f

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
@@ -12,6 +12,7 @@ import qualified SolidVM.Solidity.Detectors.Expressions.DivideBeforeMultiply    
 import qualified SolidVM.Solidity.Detectors.Pragmas.IncorrectSolidityVersion       as IncorrectSolidityVersion
 import qualified SolidVM.Solidity.Detectors.Functions.ConstantFunctions            as ConstantFunctions
 import qualified SolidVM.Solidity.Detectors.Functions.Unimplemented.Continue       as Continue
+import qualified SolidVM.Solidity.Detectors.Functions.Unimplemented.Modifiers      as Modifiers
 import qualified SolidVM.Solidity.Detectors.Statements.StateVariableShadowing      as StateVariableShadowing
 import qualified SolidVM.Solidity.Detectors.Statements.UninitializedLocalVariables as UninitializedLocalVariables
 import qualified SolidVM.Solidity.Detectors.Statements.WriteAfterWrite             as WriteAfterWrite
@@ -24,6 +25,7 @@ parserDetectors = [ IncorrectSolidityVersion.detector
 compilerDetectors :: [CompilerDetector]
 compilerDetectors = [ Trivial.detector
                     , Continue.detector
+                    , Modifiers.detector
                     , BooleanLiterals.detector
                     , DivideBeforeMultiply.detector
                     , StateVariableShadowing.detector

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
@@ -7,6 +7,7 @@ import           Data.Source
 import           Data.Text                                                         (Text)
 import           SolidVM.Solidity.Parse.Declarations                               (SourceUnit)
 import qualified SolidVM.Solidity.Detectors.Trivial                                as Trivial
+import qualified SolidVM.Solidity.Detectors.Expressions.BooleanLiterals            as BooleanLiterals
 import qualified SolidVM.Solidity.Detectors.Expressions.DivideBeforeMultiply       as DivideBeforeMultiply
 import qualified SolidVM.Solidity.Detectors.Pragmas.IncorrectSolidityVersion       as IncorrectSolidityVersion
 import qualified SolidVM.Solidity.Detectors.Functions.ConstantFunctions            as ConstantFunctions
@@ -22,6 +23,7 @@ parserDetectors = [ IncorrectSolidityVersion.detector
 compilerDetectors :: [CompilerDetector]
 compilerDetectors = [ Trivial.detector
                     , Continue.detector
+                    , BooleanLiterals.detector
                     , DivideBeforeMultiply.detector
                     , StateVariableShadowing.detector
                     , UninitializedLocalVariables.detector

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Expressions/BooleanLiterals.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Expressions/BooleanLiterals.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module SolidVM.Solidity.Detectors.Expressions.BooleanLiterals
+  ( detector
+  ) where
+
+import           CodeCollection
+import qualified Data.Map.Strict as M
+import           Data.Source
+import           Data.Text       (Text)
+import           SolidVM.Solidity.Xabi
+import           SolidVM.Solidity.Xabi.Statement
+
+-- type CompilerDetector = CodeCollection -> [SourceAnnotation T.Text]
+detector :: CompilerDetector
+detector CodeCollection{..} = concat $ contractHelper <$> M.elems _contracts
+
+contractHelper :: Contract -> [SourceAnnotation Text]
+contractHelper Contract{..} = concat $ functionHelper <$> M.elems _functions
+
+functionHelper :: Func -> [SourceAnnotation Text]
+functionHelper Func{..} = case funcContents of
+  Nothing -> []
+  Just stmts -> concat $ statementHelper <$> stmts
+
+statementHelper :: Statement -> [SourceAnnotation Text]
+statementHelper (IfStatement cond thens mElse _) =
+  let cs = expressionHelper cond
+      ts = concat $ statementHelper <$> thens
+      es = concat $ maybe [] (map statementHelper) mElse
+   in concat [cs, ts, es]
+statementHelper (WhileStatement cond body _) =
+  let cs = expressionHelper cond
+      bs = concat $ statementHelper <$> body
+   in concat [cs, bs]
+statementHelper (ForStatement mInit mCond mPost body _) =
+  let is = maybe [] simpleStatementHelper mInit
+      cs = maybe [] expressionHelper mCond
+      ps = maybe [] expressionHelper mPost
+      bs = concat $ statementHelper <$> body
+   in concat [is, cs, ps, bs]
+statementHelper (Block _) = []
+statementHelper (DoWhileStatement body cond _) =
+  let cs = expressionHelper cond
+      bs = concat $ statementHelper <$> body
+   in concat [bs, cs]
+statementHelper (Continue _) = []
+statementHelper (Break _) = []
+statementHelper (Return mExpr _) =
+  maybe [] expressionHelper mExpr
+statementHelper (Throw _) = []
+statementHelper (EmitStatement _ vals _) =
+  concatMap (expressionHelper . snd) vals
+statementHelper (AssemblyStatement _ _) = []
+statementHelper (SimpleStatement stmt _) = simpleStatementHelper stmt
+
+simpleStatementHelper :: SimpleStatement -> [SourceAnnotation Text]
+simpleStatementHelper (VariableDefinition _ mExpr) =
+  maybe [] expressionHelper mExpr
+simpleStatementHelper (ExpressionStatement expr) =
+  expressionHelper expr
+
+expressionHelper :: Expression -> [SourceAnnotation Text]
+expressionHelper (Binary _ "=" _ (BoolLiteral _ _)) = []
+expressionHelper (Binary y "==" (BoolLiteral x _) _) =
+  ["Use of boolean literal in equality condition." <$ (x <> y)]
+expressionHelper (Binary y "==" _ (BoolLiteral x _)) =
+  ["Use of boolean literal in equality condition." <$ (y <> x)]
+expressionHelper (Binary _ _ a b) = concat [expressionHelper a, expressionHelper b]
+expressionHelper (PlusPlus _ e) = expressionHelper e
+expressionHelper (MinusMinus _ e) = expressionHelper e
+expressionHelper (NewExpression _ _) = []
+expressionHelper (IndexAccess _ a b) =
+  let as = expressionHelper a
+      bs = maybe [] expressionHelper b
+   in concat [as, bs]
+expressionHelper (MemberAccess _ e _) = expressionHelper e
+expressionHelper (FunctionCall _ e args) =
+  let as = expressionHelper e
+      bs = case args of
+             OrderedArgs es -> concat $ expressionHelper <$> es
+             NamedArgs nes -> concat $ expressionHelper . snd <$> nes
+   in concat [as, bs]
+expressionHelper (Unitary _ _ a) = expressionHelper a
+expressionHelper (Ternary _ a b c) =
+  concat [expressionHelper a, expressionHelper b, expressionHelper c]
+expressionHelper (BoolLiteral a _) =
+  ["Misuse of boolean literal. Consider removing." <$ a]
+expressionHelper (NumberLiteral _ _ _) = []
+expressionHelper (StringLiteral _ _) = []
+expressionHelper (TupleExpression _ es) =
+  concat $ maybe [] expressionHelper <$> es
+expressionHelper (ArrayExpression _ es) = concat $ expressionHelper <$> es
+expressionHelper (Variable _ _) = []

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
@@ -6,36 +6,38 @@ module SolidVM.Solidity.Detectors.Functions.ConstantFunctions
   ) where
 
 import           CodeCollection
+import           Control.Applicative ((<|>))
 import           Control.Monad.Reader
 import           Control.Monad.Trans.State
 import           Data.Foldable (traverse_)
 import qualified Data.Map.Strict as M
-import           Data.Maybe      (isJust)
+import           Data.Maybe      (isJust, maybeToList)
 import           Data.Source
 import           Data.Text       (Text)
 import qualified Data.Text       as T
 import           SolidVM.Solidity.Xabi
 import           SolidVM.Solidity.Xabi.Statement
 
-type R = (StateMutability, M.Map String VariableDecl)
+data R = R
+  { mutability :: Maybe StateMutability
+  , stateVars  :: M.Map String VariableDecl
+  , codeCollection :: CodeCollection
+  }
 type SSS = StateT [M.Map String (SourceAnnotation ())] (Reader R)
 
 -- type CompilerDetector = CodeCollection -> [SourceAnnotation T.Text]
 detector :: CompilerDetector
-detector CodeCollection{..} = concat $ contractHelper <$> M.elems _contracts
+detector cc@CodeCollection{..} = concat $ contractHelper cc <$> M.elems _contracts
 
-contractHelper :: Contract -> [SourceAnnotation Text]
-contractHelper Contract{..} = concat $ functionHelper _storageDefs <$> M.elems _functions
+contractHelper :: CodeCollection -> Contract -> [SourceAnnotation Text]
+contractHelper cc Contract{..} = concat $ functionHelper cc _storageDefs <$> M.elems _functions
 
-functionHelper :: M.Map String VariableDecl -> Func -> [SourceAnnotation Text]
-functionHelper stateVariables Func{..} =
-  let f mut = case funcContents of
-        Nothing -> []
-        Just stmts -> runReader (statementsHelper stmts) (mut, stateVariables)
-   in case funcStateMutability of
-        Nothing -> []
-        Just Payable -> []
-        Just m -> f m
+functionHelper :: CodeCollection -> M.Map String VariableDecl -> Func -> [SourceAnnotation Text]
+functionHelper cc stateVariables Func{..} = case funcContents of
+  Nothing -> []
+  Just stmts ->
+    let r = R funcStateMutability stateVariables cc
+     in runReader (statementsHelper stmts) r
 
 statementsHelper :: [Statement] -> Reader R [SourceAnnotation Text]
 statementsHelper ss = concat <$> evalStateT (traverse statementHelper ss) [M.empty]
@@ -90,8 +92,9 @@ statementHelper (Return mExpr _) =
 statementHelper (Throw _) = pure []
 statementHelper (EmitStatement _ vals _) =
   concat <$> traverse (expressionHelper . snd) vals
-statementHelper (AssemblyStatement _ x) = asks fst >>= \case
-  Payable -> pure []
+statementHelper (AssemblyStatement _ x) = asks mutability >>= \case
+  Nothing -> pure []
+  Just Payable -> pure []
   mut -> let msg = T.pack $ concat
                [ show mut
                , " function using assembly code."
@@ -106,22 +109,69 @@ simpleStatementHelper (VariableDefinition vdefs mExpr) = do
 simpleStatementHelper (ExpressionStatement expr) =
   expressionHelper expr
 
+ccVarHelper :: CodeCollection
+            -> String
+            -> SourceAnnotation ()
+            -> [SourceAnnotation Text]
+ccVarHelper CodeCollection{..} varName x = generateAnn $ M.foldMapWithKey findVars _contracts
+  where findVars cName Contract{..} =
+          maybeToList $ (cName <$ M.lookup varName _storageDefs)
+                    <|> (cName <$ M.lookup varName _enums)
+                    <|> (cName <$ M.lookup varName _structs)
+                    <|> (cName <$ M.lookup varName _constants)
+        generateAnn = \case
+          [] ->
+            let msg = T.pack $ concat
+                  [ "Undefined variable: "
+                  , varName
+                  ]
+             in [msg <$ x]
+          (c:[]) ->
+            let msg = T.pack $ concat
+                  [ "Variable "
+                  , varName
+                  , " undefined, but found in other contracts. "
+                  , "Check if this contract is missing inheritance from "
+                  , c
+                  , "."
+                  ]
+             in [msg <$ x]
+          (c:d:[]) ->
+            let msg = T.pack $ concat
+                  [ "Variable "
+                  , varName
+                  , " undefined, but found in other contracts. "
+                  , "Check if this contract is missing inheritance from "
+                  , c
+                  , " or "
+                  , d
+                  , "."
+                  ]
+             in [msg <$ x]
+          cs ->
+            let build (c:[]) = ["or " ++ c ++ "."]
+                build (c:rest) = (c ++ ", ") : build rest
+                build [] = ["."] -- playing Pascal's wager with the type system
+                msg = T.pack $ concat
+                  [ "Variable "
+                  , varName
+                  , " undefined, but found in other contracts. "
+                  , "Check if this contract is missing inheritance from "
+                  , concat $ build cs
+                  ]
+             in [msg <$ x]
+
 localVarReadHelper :: String -> SourceAnnotation () -> SSS [SourceAnnotation Text]
 localVarReadHelper name x = do
   isLocal <- isLocalVariable name
   if isLocal
     then pure []
     else do
-      ~(mut, stateVars) <- ask
+      ~R{..} <- ask
       case M.lookup name stateVars of
-        Nothing ->
-          let msg = T.pack $ concat
-                [ "Undefined variable: "
-                , name
-                ]
-           in pure [msg <$ x]
-        Just _ -> case mut of
-          Pure ->
+        Nothing -> pure $ ccVarHelper codeCollection name x
+        Just _ -> case mutability of
+          Just Pure ->
             let msg = T.pack $ concat
                   [ "Pure function reading state variable "
                   , name
@@ -135,22 +185,19 @@ localVarWriteHelper name x = do
   if isLocal
     then pure []
     else do
-      ~(mut, stateVars) <- ask
+      ~R{..} <- ask
       case M.lookup name stateVars of
-        Nothing ->
-          let msg = T.pack $ concat
-                [ "Undefined variable: "
-                , name
-                ]
-           in pure [msg <$ x]
-        Just _ -> case mut of
-          Payable -> pure []
-          _ -> let msg = T.pack $ concat
-                     [ show mut
-                     , " function mutating state variable "
-                     , name
-                     ]
-                in pure [msg <$ x]
+        Nothing -> pure $ ccVarHelper codeCollection name x
+        Just _ -> case mutability of
+          Nothing -> pure []
+          Just Payable -> pure []
+          Just mut ->
+            let msg = T.pack $ concat
+                  [ show mut
+                  , " function mutating state variable "
+                  , name
+                  ]
+             in pure [msg <$ x]
 
 expressionHelper :: Expression -> SSS [SourceAnnotation Text]
 expressionHelper (Binary y "=" (Variable x name) b) = do

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
@@ -9,7 +9,7 @@ import           CodeCollection
 import           Control.Applicative ((<|>))
 import           Control.Monad.Reader
 import           Control.Monad.Trans.State
-import           Data.Foldable (traverse_)
+import           Data.Foldable (find, traverse_)
 import qualified Data.Map.Strict as M
 import           Data.Maybe      (isJust, maybeToList)
 import           Data.Source
@@ -22,6 +22,7 @@ data R = R
   { mutability :: Maybe StateMutability
   , stateVars  :: M.Map String VariableDecl
   , codeCollection :: CodeCollection
+  , contract :: Contract
   }
 type SSS = StateT [M.Map String (SourceAnnotation ())] (Reader R)
 
@@ -30,13 +31,16 @@ detector :: CompilerDetector
 detector cc@CodeCollection{..} = concat $ contractHelper cc <$> M.elems _contracts
 
 contractHelper :: CodeCollection -> Contract -> [SourceAnnotation Text]
-contractHelper cc Contract{..} = concat $ functionHelper cc _storageDefs <$> M.elems _functions
+contractHelper cc c@Contract{..} = 
+  let constr = maybe M.empty (M.singleton "constructor") _constructor
+      funcsAndConstr = constr <> _functions
+   in concat $ functionHelper cc c _storageDefs <$> M.elems funcsAndConstr
 
-functionHelper :: CodeCollection -> M.Map String VariableDecl -> Func -> [SourceAnnotation Text]
-functionHelper cc stateVariables Func{..} = case funcContents of
+functionHelper :: CodeCollection -> Contract -> M.Map String VariableDecl -> Func -> [SourceAnnotation Text]
+functionHelper cc c stateVariables Func{..} = case funcContents of
   Nothing -> []
   Just stmts ->
-    let r = R funcStateMutability stateVariables cc
+    let r = R funcStateMutability stateVariables cc c
      in runReader (statementsHelper stmts) r
 
 statementsHelper :: [Statement] -> Reader R [SourceAnnotation Text]
@@ -109,57 +113,74 @@ simpleStatementHelper (VariableDefinition vdefs mExpr) = do
 simpleStatementHelper (ExpressionStatement expr) =
   expressionHelper expr
 
+generateAnn :: String -> SourceAnnotation () -> [String] -> [SourceAnnotation Text]
+generateAnn varName x = \case
+  [] ->
+    let msg = T.pack $ concat
+          [ "Undefined variable: "
+          , varName
+          ]
+     in [msg <$ x]
+  (c:[]) ->
+    let msg = T.pack $ concat
+          [ "Variable "
+          , varName
+          , " undefined, but found in other contracts. "
+          , "Check if this contract is missing inheritance from "
+          , c
+          , "."
+          ]
+     in [msg <$ x]
+  (c:d:[]) ->
+    let msg = T.pack $ concat
+          [ "Variable "
+          , varName
+          , " undefined, but found in other contracts. "
+          , "Check if this contract is missing inheritance from "
+          , c
+          , " or "
+          , d
+          , "."
+          ]
+     in [msg <$ x]
+  cs ->
+    let build (c:[]) = ["or " ++ c ++ "."]
+        build (c:rest) = (c ++ ", ") : build rest
+        build [] = ["."] -- playing Pascal's wager with the type system
+        msg = T.pack $ concat
+          [ "Variable "
+          , varName
+          , " undefined, but found in other contracts. "
+          , "Check if this contract is missing inheritance from "
+          , concat $ build cs
+          ]
+     in [msg <$ x]
+
 ccVarHelper :: CodeCollection
             -> String
             -> SourceAnnotation ()
             -> [SourceAnnotation Text]
-ccVarHelper CodeCollection{..} varName x = generateAnn $ M.foldMapWithKey findVars _contracts
+ccVarHelper CodeCollection{..} varName x = generateAnn varName x $ M.foldMapWithKey findVars _contracts
   where findVars cName Contract{..} =
           maybeToList $ (cName <$ M.lookup varName _storageDefs)
-                    <|> (cName <$ M.lookup varName _enums)
-                    <|> (cName <$ M.lookup varName _structs)
                     <|> (cName <$ M.lookup varName _constants)
-        generateAnn = \case
-          [] ->
-            let msg = T.pack $ concat
-                  [ "Undefined variable: "
-                  , varName
-                  ]
-             in [msg <$ x]
-          (c:[]) ->
-            let msg = T.pack $ concat
-                  [ "Variable "
-                  , varName
-                  , " undefined, but found in other contracts. "
-                  , "Check if this contract is missing inheritance from "
-                  , c
-                  , "."
-                  ]
-             in [msg <$ x]
-          (c:d:[]) ->
-            let msg = T.pack $ concat
-                  [ "Variable "
-                  , varName
-                  , " undefined, but found in other contracts. "
-                  , "Check if this contract is missing inheritance from "
-                  , c
-                  , " or "
-                  , d
-                  , "."
-                  ]
-             in [msg <$ x]
-          cs ->
-            let build (c:[]) = ["or " ++ c ++ "."]
-                build (c:rest) = (c ++ ", ") : build rest
-                build [] = ["."] -- playing Pascal's wager with the type system
-                msg = T.pack $ concat
-                  [ "Variable "
-                  , varName
-                  , " undefined, but found in other contracts. "
-                  , "Check if this contract is missing inheritance from "
-                  , concat $ build cs
-                  ]
-             in [msg <$ x]
+
+ccMemberAccessHelper :: CodeCollection
+                     -> Contract
+                     -> String
+                     -> String
+                     -> SourceAnnotation ()
+                     -> [SourceAnnotation Text]
+ccMemberAccessHelper CodeCollection{..} c varName fieldName x =
+  if isJust $ findDefs >>= find (==fieldName)
+    then []
+    else generateAnn fullName x $ M.foldMapWithKey findVars _contracts
+  where findVars cName Contract{..} =
+          maybeToList $ (cName <$ M.lookup varName _enums)
+                    <|> (cName <$ M.lookup varName _structs)
+        findDefs = (fst <$> M.lookup varName (_enums c))
+               <|> (map (\(a,_,_) -> T.unpack a) <$> M.lookup varName (_structs c))
+        fullName = varName ++ "." ++ fieldName
 
 localVarReadHelper :: String -> SourceAnnotation () -> SSS [SourceAnnotation Text]
 localVarReadHelper name x = do
@@ -249,6 +270,10 @@ expressionHelper (IndexAccess _ a b) = do
   as <- expressionHelper a
   bs <- maybe (pure []) expressionHelper b
   pure $ concat [as, bs]
+expressionHelper (MemberAccess x (Variable _ varName) fieldName) = do
+  cc <- asks codeCollection
+  c <- asks contract
+  pure $ ccMemberAccessHelper cc c varName fieldName x
 expressionHelper (MemberAccess _ e _) = expressionHelper e
 expressionHelper (FunctionCall _ e args) = do
   as <- case e of

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
@@ -204,7 +204,9 @@ expressionHelper (IndexAccess _ a b) = do
   pure $ concat [as, bs]
 expressionHelper (MemberAccess _ e _) = expressionHelper e
 expressionHelper (FunctionCall _ e args) = do
-  as <- expressionHelper e
+  as <- case e of
+          Variable _ _ -> pure []
+          _ -> expressionHelper e
   bs <- case args of
           OrderedArgs es -> concat <$> traverse expressionHelper es
           NamedArgs nes -> concat <$> traverse expressionHelper (snd <$> nes)

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
@@ -11,7 +11,7 @@ import           Control.Monad.Reader
 import           Control.Monad.Trans.State
 import           Data.Foldable (find, traverse_)
 import qualified Data.Map.Strict as M
-import           Data.Maybe      (isJust, maybeToList)
+import           Data.Maybe      (catMaybes, isJust, maybeToList)
 import           Data.Source
 import           Data.Text       (Text)
 import qualified Data.Text       as T
@@ -41,10 +41,15 @@ functionHelper cc c stateVariables Func{..} = case funcContents of
   Nothing -> []
   Just stmts ->
     let r = R funcStateMutability stateVariables cc c
-     in runReader (statementsHelper stmts) r
+        argNames = T.unpack <$> (catMaybes $ fst <$> funcArgs)
+        valNames = T.unpack <$> (catMaybes $ fst <$> funcVals)
+        args = M.fromList $ zip (argNames ++ valNames) (repeat funcContext)
+     in runReader (statementsHelper args stmts) r
 
-statementsHelper :: [Statement] -> Reader R [SourceAnnotation Text]
-statementsHelper ss = concat <$> evalStateT (traverse statementHelper ss) [M.empty]
+statementsHelper :: (M.Map String (SourceAnnotation ()))
+                 -> [Statement]
+                 -> Reader R [SourceAnnotation Text]
+statementsHelper args ss = concat <$> evalStateT (traverse statementHelper ss) [args]
 
 statementsHelper' :: [Statement] -> SSS [SourceAnnotation Text]
 statementsHelper' ss = do

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/Unimplemented/Modifiers.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/Unimplemented/Modifiers.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module SolidVM.Solidity.Detectors.Functions.Unimplemented.Modifiers
+  ( detector
+  ) where
+
+import           CodeCollection
+import qualified Data.Map.Strict as M
+import           Data.Source
+import           Data.Text       (Text)
+import           SolidVM.Solidity.Xabi
+
+-- type CompilerDetector = CodeCollection -> [SourceAnnotation T.Text]
+detector :: CompilerDetector
+detector CodeCollection{..} = concat $ contractHelper <$> M.elems _contracts
+
+contractHelper :: Contract -> [SourceAnnotation Text]
+contractHelper Contract{..} = concat $ functionHelper <$> M.elems _functions
+
+functionHelper :: Func -> [SourceAnnotation Text]
+functionHelper Func{..} = case funcModifiers of
+  Just (_:_) -> ["Custom modifiers are unsupported in SolidVM." <$ funcContext]
+  _ -> []

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Statements/WriteAfterWrite.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Statements/WriteAfterWrite.hs
@@ -37,21 +37,25 @@ statementHelper (IfStatement cond thens mElse _) = do
   cs <- expressionHelper cond
   let ts = statementsHelper thens
       es = maybe [] statementsHelper mElse
+  put M.empty
   pure $ concat [cs, ts, es]
 statementHelper (WhileStatement cond body _) = do
   cs <- expressionHelper cond
   let bs = statementsHelper body
+  put M.empty
   pure $ concat [cs, bs]
 statementHelper (ForStatement mInit mCond mPost body _) = do
   is <- maybe (pure []) simpleStatementHelper mInit
   cs <- maybe (pure []) expressionHelper mCond
   ps <- maybe (pure []) expressionHelper mPost
   let bs = statementsHelper body
+  put M.empty
   pure $ concat [is, cs, ps, bs]
 statementHelper (Block _) = pure []
 statementHelper (DoWhileStatement body cond _) = do
   cs <- expressionHelper cond
   bs <- statementsHelper' body
+  put M.empty
   pure $ concat [bs, cs]
 statementHelper (Continue _) = pure []
 statementHelper (Break _) = pure []
@@ -78,6 +82,30 @@ expressionHelper (Binary y "=" (Variable x name) b) = do
   modify $ M.insert name (x <> y)
   bs <- expressionHelper b
   pure $ concat [ann, bs]
+expressionHelper (Binary y "+=" (Variable x name) b) = do
+  modify $ M.insert name (x <> y)
+  expressionHelper b
+expressionHelper (Binary y "-=" (Variable x name) b) = do
+  modify $ M.insert name (x <> y)
+  expressionHelper b
+expressionHelper (Binary y "*=" (Variable x name) b) = do
+  modify $ M.insert name (x <> y)
+  expressionHelper b
+expressionHelper (Binary y "/=" (Variable x name) b) = do
+  modify $ M.insert name (x <> y)
+  expressionHelper b
+expressionHelper (Binary y "%=" (Variable x name) b) = do
+  modify $ M.insert name (x <> y)
+  expressionHelper b
+expressionHelper (Binary y "|=" (Variable x name) b) = do
+  modify $ M.insert name (x <> y)
+  expressionHelper b
+expressionHelper (Binary y "&=" (Variable x name) b) = do
+  modify $ M.insert name (x <> y)
+  expressionHelper b
+expressionHelper (Binary y "^=" (Variable x name) b) = do
+  modify $ M.insert name (x <> y)
+  expressionHelper b
 expressionHelper (Binary _ _ a b) =
   concat <$> traverse expressionHelper [a, b]
 expressionHelper (PlusPlus _ (Variable x name)) = do
@@ -99,6 +127,7 @@ expressionHelper (FunctionCall _ e args) = do
   bs <- case args of
           OrderedArgs es -> concat <$> traverse expressionHelper es
           NamedArgs nes -> concat <$> traverse expressionHelper (snd <$> nes)
+  put M.empty
   pure $ concat [as, bs]
 expressionHelper (Unitary _ _ a) = expressionHelper a
 expressionHelper (Ternary _ a b c) = concat <$> traverse expressionHelper [a, b, c]

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Variables/StateVariables.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Variables/StateVariables.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module SolidVM.Solidity.Detectors.Variables.StateVariables
+  ( detector
+  ) where
+
+import           CodeCollection
+import           Control.Lens
+import           Control.Monad.State
+import           Data.Foldable       (traverse_)
+import qualified Data.Map.Strict     as M
+import           Data.Maybe          (isJust)
+import           Data.Source
+import           Data.Text           (Text)
+import qualified Data.Text           as T
+import           SolidVM.Solidity.Xabi
+import           SolidVM.Solidity.Xabi.Statement
+
+type StateVars = M.Map String (Bool, Bool, SourceAnnotation ())
+type LocalVars = [M.Map String (SourceAnnotation ())]
+type SSS = State (StateVars, LocalVars)
+
+-- type CompilerDetector = CodeCollection -> [SourceAnnotation T.Text]
+detector :: CompilerDetector
+detector CodeCollection{..} = concat $ contractHelper <$> M.elems _contracts
+
+contractHelper :: Contract -> [SourceAnnotation Text]
+contractHelper Contract{..} =
+  let stateVariables = M.map (\v -> (False, False, varContext v)) _storageDefs
+      emptyState = (stateVariables, [])
+      action = traverse functionHelper $ M.elems _functions
+      stateVariables' = fst $ execState action emptyState
+      findStateAnns name (False, False, a) = [(T.pack $ "Unused state variable " ++ name ++ ".") <$ a]
+      findStateAnns name (True, False, a) = [(T.pack $ "State variable " ++ name ++ " is never written to. Consider making it a constant.") <$ a]
+      findStateAnns _ _ = []
+   in M.foldMapWithKey findStateAnns stateVariables'
+
+functionHelper :: Func -> SSS [SourceAnnotation Text]
+functionHelper Func{..} = maybe (pure []) statementsHelper funcContents
+
+statementsHelper :: [Statement] -> SSS [SourceAnnotation Text]
+statementsHelper ss = do
+  modify $ fmap (M.empty:)
+  anns <- concat <$> traverse statementHelper ss
+  modify $ fmap tail
+  pure anns
+
+isLocalVariable :: String -> SSS Bool
+isLocalVariable name = foldr lookupVar False <$> gets snd
+  where lookupVar _ True = True
+        lookupVar m _    = isJust $ M.lookup name m
+
+pushLocalVariable :: String -> SourceAnnotation () -> SSS ()
+pushLocalVariable name decl = modify . fmap $ \case
+  [] -> error "This can't happen by the laws of physics"
+  (x:xs) -> (M.insert name decl x):xs
+
+pushLocalVariables :: [VarDefEntry] -> SSS ()
+pushLocalVariables = traverse_ pushEntry
+  where pushEntry BlankEntry = pure () 
+        pushEntry VarDefEntry{..} = pushLocalVariable vardefName vardefContext
+
+statementHelper :: Statement -> SSS [SourceAnnotation Text]
+statementHelper (IfStatement cond thens mElse _) = do
+  cs <- expressionHelper cond
+  ts <- statementsHelper thens
+  es <- maybe (pure []) statementsHelper mElse
+  pure $ concat [cs, ts, es]
+statementHelper (WhileStatement cond body _) = do
+  cs <- expressionHelper cond
+  bs <- statementsHelper body
+  pure $ concat [cs, bs]
+statementHelper (ForStatement mInit mCond mPost body _) = do
+  is <- maybe (pure []) simpleStatementHelper mInit
+  cs <- maybe (pure []) expressionHelper mCond
+  ps <- maybe (pure []) expressionHelper mPost
+  bs <- statementsHelper body
+  pure $ concat [is, cs, ps, bs]
+statementHelper (Block _) = pure []
+statementHelper (DoWhileStatement body cond _) = do
+  cs <- expressionHelper cond
+  bs <- statementsHelper body
+  pure $ concat [bs, cs]
+statementHelper (Continue _) = pure []
+statementHelper (Break _) = pure []
+statementHelper (Return mExpr _) =
+  maybe (pure []) expressionHelper mExpr
+statementHelper (Throw _) = pure []
+statementHelper (EmitStatement _ vals _) =
+  concat <$> traverse (expressionHelper . snd) vals
+statementHelper (AssemblyStatement _ _) = pure []
+statementHelper (SimpleStatement stmt _) = simpleStatementHelper stmt
+
+simpleStatementHelper :: SimpleStatement -> SSS [SourceAnnotation Text]
+simpleStatementHelper (VariableDefinition vdefs mExpr) = do
+  pushLocalVariables vdefs
+  maybe (pure []) expressionHelper mExpr
+simpleStatementHelper (ExpressionStatement expr) =
+  expressionHelper expr
+
+stateVarReadHelper :: String -> SourceAnnotation () -> SSS [SourceAnnotation Text]
+stateVarReadHelper name _ = do
+  isLocal <- isLocalVariable name
+  unless isLocal $
+    id . _1 . at name . _Just . _1 .= True
+  pure [] -- don't @ me
+
+stateVarWriteHelper :: String -> SourceAnnotation () -> SSS [SourceAnnotation Text]
+stateVarWriteHelper name _ = do
+  isLocal <- isLocalVariable name
+  unless isLocal $
+    id . _1 . at name . _Just . _2 .= True
+  pure [] -- don't @ me
+
+expressionHelper :: Expression -> SSS [SourceAnnotation Text]
+expressionHelper (Binary y "=" (Variable x name) b) = do
+  ann <- stateVarWriteHelper name (x <> y)
+  bs <- expressionHelper b
+  pure $ concat [ann, bs]
+expressionHelper (Binary y "+=" (Variable x name) b) = do
+  ann <- stateVarWriteHelper name (x <> y)
+  bs <- expressionHelper b
+  pure $ concat [ann, bs]
+expressionHelper (Binary y "-=" (Variable x name) b) = do
+  ann <- stateVarWriteHelper name (x <> y)
+  bs <- expressionHelper b
+  pure $ concat [ann, bs]
+expressionHelper (Binary y "*=" (Variable x name) b) = do
+  ann <- stateVarWriteHelper name (x <> y)
+  bs <- expressionHelper b
+  pure $ concat [ann, bs]
+expressionHelper (Binary y "/=" (Variable x name) b) = do
+  ann <- stateVarWriteHelper name (x <> y)
+  bs <- expressionHelper b
+  pure $ concat [ann, bs]
+expressionHelper (Binary y "%=" (Variable x name) b) = do
+  ann <- stateVarWriteHelper name (x <> y)
+  bs <- expressionHelper b
+  pure $ concat [ann, bs]
+expressionHelper (Binary y "|=" (Variable x name) b) = do
+  ann <- stateVarWriteHelper name (x <> y)
+  bs <- expressionHelper b
+  pure $ concat [ann, bs]
+expressionHelper (Binary y "&=" (Variable x name) b) = do
+  ann <- stateVarWriteHelper name (x <> y)
+  bs <- expressionHelper b
+  pure $ concat [ann, bs]
+expressionHelper (Binary y "^=" (Variable x name) b) = do
+  ann <- stateVarWriteHelper name (x <> y)
+  bs <- expressionHelper b
+  pure $ concat [ann, bs]
+expressionHelper (Binary _ _ a b) =
+  concat <$> traverse expressionHelper [a, b]
+expressionHelper (PlusPlus y (Variable x name)) =
+  stateVarWriteHelper name (x <> y)
+expressionHelper (PlusPlus _ e) = expressionHelper e
+expressionHelper (MinusMinus y (Variable x name)) =
+  stateVarWriteHelper name (x <> y)
+expressionHelper (MinusMinus _ e) = expressionHelper e
+expressionHelper (NewExpression _ _) = pure []
+expressionHelper (IndexAccess _ a b) = do
+  as <- expressionHelper a
+  bs <- maybe (pure []) expressionHelper b
+  pure $ concat [as, bs]
+expressionHelper (MemberAccess _ e _) = expressionHelper e
+expressionHelper (FunctionCall _ e args) = do
+  as <- case e of
+          Variable _ _ -> pure []
+          _ -> expressionHelper e
+  bs <- case args of
+          OrderedArgs es -> concat <$> traverse expressionHelper es
+          NamedArgs nes -> concat <$> traverse expressionHelper (snd <$> nes)
+  pure $ concat [as, bs]
+expressionHelper (Unitary _ _ a) = expressionHelper a
+expressionHelper (Ternary _ a b c) = concat <$> traverse expressionHelper [a, b, c]
+expressionHelper (BoolLiteral _ _) = pure []
+expressionHelper (NumberLiteral _ _ _) = pure []
+expressionHelper (StringLiteral _ _) = pure []
+expressionHelper (TupleExpression _ es) =
+  concat <$> traverse (maybe (pure []) expressionHelper) es
+expressionHelper (ArrayExpression _ es) = concat <$> traverse expressionHelper es
+expressionHelper (Variable x name) =
+  [] <$ stateVarReadHelper name x

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Variables/StateVariables.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Variables/StateVariables.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 module SolidVM.Solidity.Detectors.Variables.StateVariables
   ( detector
   ) where
@@ -17,7 +18,7 @@ import qualified Data.Text           as T
 import           SolidVM.Solidity.Xabi
 import           SolidVM.Solidity.Xabi.Statement
 
-type StateVars = M.Map String (Bool, Bool, SourceAnnotation ())
+type StateVars = M.Map String (Bool, Bool, VariableDecl)
 type LocalVars = [M.Map String (SourceAnnotation ())]
 type SSS = State (StateVars, LocalVars)
 
@@ -27,12 +28,16 @@ detector CodeCollection{..} = concat $ contractHelper <$> M.elems _contracts
 
 contractHelper :: Contract -> [SourceAnnotation Text]
 contractHelper Contract{..} =
-  let stateVariables = M.map (\v -> (False, False, varContext v)) _storageDefs
+  let stateVariables = M.map (False, False,) _storageDefs
       emptyState = (stateVariables, [])
       action = traverse functionHelper $ M.elems _functions
       stateVariables' = fst $ execState action emptyState
-      findStateAnns name (False, False, a) = [(T.pack $ "Unused state variable " ++ name ++ ".") <$ a]
-      findStateAnns name (True, False, a) = [(T.pack $ "State variable " ++ name ++ " is never written to. Consider making it a constant.") <$ a]
+      findStateAnns name (False, False, a) =
+        [(T.pack $ "Unused state variable " ++ name ++ ".") <$ varContext a]
+      findStateAnns name (True, False, VariableDecl{..}) | varInitialVal == Nothing =
+        [(T.pack $ "Uninitialized state variable " ++ name ++ ". Consider initializing it to prevent incorrect behavior.") <$ varContext]
+      findStateAnns name (True, False, a) =
+        [(T.pack $ "State variable " ++ name ++ " is never written to. Consider making it a constant.") <$ varContext a]
       findStateAnns _ _ = []
    in M.foldMapWithKey findStateAnns stateVariables'
 

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Statement.hs
@@ -27,25 +27,26 @@ statement = do
   <|> (do
           ~(a, e) <- withPosition $ do
             void $ reserved "return"
-            optionMaybe expression <* semi
+            optionMaybe expression
+          _ <- semi
           pure $ Return e a)
   <|> (do
           ~(a, (i, e)) <- withPosition $ do
             reserved "emit"
             ident <- identifier
             exps <- parens $ commaSep expression
-            _ <- semi
             pure (ident, exps)
+          _ <- semi
           pure $ EmitStatement i (map ((,) Nothing) e) a
       )
   <|> try (do
-              ~(a, e) <- withPosition $ variableDefinitionStatement <* semi
+              ~(a, e) <- (withPosition variableDefinitionStatement) <* semi
               pure $ SimpleStatement e a 
           )
-  <|> (Continue <$> position (reserved "continue" >> semi))
-  <|> (Break <$> position (reserved "break" >> semi))
+  <|> (Continue <$> (position (reserved "continue") <* semi))
+  <|> (Break <$> (position (reserved "break") <* semi))
   <|> (reserved "assembly" >> inlineAssembly)
-  <|> (uncurry (flip SimpleStatement) <$> withPosition (ExpressionStatement <$> expression <* semi))
+  <|> ((\(a,e) -> SimpleStatement (ExpressionStatement e) a) <$> ((withPosition expression) <* semi))
 
 
 

--- a/core-strato/vm-runner/exec_src/Main.hs
+++ b/core-strato/vm-runner/exec_src/Main.hs
@@ -15,7 +15,7 @@ import           HFlags
 
 import           BlockApps.Init
 import           Blockchain.Output
-import           Blockchain.SolidVM.CodeCollectionDB  (parseSource, compileSourceNoInheritance)
+import           Blockchain.SolidVM.CodeCollectionDB  (parseSource, compileSource)
 import           Blockchain.VMOptions() -- HFlags
 import           Executable.EthereumVM
 import           Executable.EVMFlags() -- HFlags
@@ -28,7 +28,7 @@ main = do
   let parse = fmap concat
             . traverse (uncurry parseSource)
             . unSourceMap
-      compile = compileSourceNoInheritance
+      compile = compileSource
               . M.fromList
               . unSourceMap
       analyze = runDetectors parse compile

--- a/strato-vscode/src/diagnostics.ts
+++ b/strato-vscode/src/diagnostics.ts
@@ -3,7 +3,7 @@ import { rest, importer } from 'blockapps-rest';
 import getConfig from './load.config';
 import { getApplicationUser } from './auth';
 
-let validatingDocument = false;
+let validationCounter: number = 0;
 
 /**
  * Analyzes the text document for problems. 
@@ -13,29 +13,30 @@ let validatingDocument = false;
  */
 export async function refreshDiagnostics(doc: vscode.TextDocument, solidityDiagnostics: vscode.DiagnosticCollection): Promise<void> {
   if (doc.uri.path.slice(-4) === '.sol') {
-    if (!validatingDocument) {
-      validatingDocument = true; // control the flag at a higher level
-      // slow down, give enough time to type (1.5 seconds?)
-      setTimeout(async () => await validate(doc, solidityDiagnostics), 1500);
-    }
+    validationCounter = (validationCounter + 1) % 10000;
+    const thisCounter = validationCounter;
+    setTimeout(async () => await validate(thisCounter, doc, solidityDiagnostics), 1500);
   }
 }
 
-async function validate(doc: vscode.TextDocument, solidityDiagnostics: vscode.DiagnosticCollection): Promise<void> {
-  try {
-    const diagnostics: vscode.Diagnostic[] = [];
-    const user = await getApplicationUser();
-    const config = getConfig() || {};
-    const options = { config };
-    const annotations = await rest.debugPostAnalyze(user, [[doc.uri.path, doc.getText()]], options);
+async function validate(counter: number, doc: vscode.TextDocument, solidityDiagnostics: vscode.DiagnosticCollection): Promise<void> {
+  if (validationCounter === counter) {
+    try {
+      const diagnostics: vscode.Diagnostic[] = [];
 
-    for (let ann in annotations) {
-      diagnostics.push(createDiagnostic(doc, annotations[ann]));
+      const user = await getApplicationUser();
+      const config = getConfig() || {};
+      const options = { config };
+      const annotations = await rest.debugPostAnalyze(user, [[doc.uri.path, doc.getText()]], options);
+
+      for (let ann in annotations) {
+        diagnostics.push(createDiagnostic(doc, annotations[ann]));
+      }
+
+      solidityDiagnostics.set(doc.uri, diagnostics);
+    } catch (e) {
+      console.log(`validate exception: ${JSON.stringify(e)}`);
     }
-
-    solidityDiagnostics.set(doc.uri, diagnostics);
-  } finally {
-    validatingDocument = false;
   }
 }
 


### PR DESCRIPTION
New detectors:
- Redundant boolean literals
- Using custom modifiers (not yet supported in SolidVM)
- Uninitialized and unused state variables, and state variables that could be constant
- Missing inheritance

Improved:
- Write after write detector
- Don't include semicolons and the trailing whitespace in the source range for statements (gives better UX when underlining warnings)
- Better debouncing of calls to the API from the IDE, for smoother typing UX