### PR TITLE
workaround the issue with nodesource repo certificate in buildbase

### DIFF
--- a/Dockerfile.buildbase
+++ b/Dockerfile.buildbase
@@ -2,10 +2,15 @@ ARG STACK_RESOLVER
 
 FROM fpco/stack-build:${STACK_RESOLVER}
 
-# apt-key adv line is the fix for `The repository 'https://packages.confluent.io/deb/5.2 stable InRelease' is not signed.` error (started happening 05/06/2021)
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8B1DA6120C2BF624 && \ 
+# 1. apt-key adv line is the fix for `The repository 'https://packages.confluent.io/deb/5.2 stable InRelease' is not signed.` error (started happening 05/06/2021)
+# 2. Moving nodesource.list, installing ca-certificates and node-js manually to resolve the problem with expired nodesource certificate on Sep 30th 2021 (see https://github.com/nodesource/distributions/issues/1266) - see the lines affected in this commit
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8B1DA6120C2BF624 && \
+    mv /etc/apt/sources.list.d/nodesource.list /etc/apt/sources.list.d/nodesource.list.disabled && \
     apt-get update && \
-    apt-get -y --allow-unauthenticated install autoconf libtool libblas-dev liblapack-dev libsodium-dev jq vim && \
+    apt-get -y --allow-unauthenticated install autoconf libtool libblas-dev liblapack-dev libsodium-dev jq vim ca-certificates && \
+    mv /etc/apt/sources.list.d/nodesource.list.disabled /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \ #nodesource_cert_fix
+    apt-get install -y nodejs && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean && \ 


### PR DESCRIPTION
nodesource package repo has their certificate expired on 30th Sept. 
(issue discussion: https://github.com/nodesource/distributions/issues/1266)

This breaks our STRATO build (the buildbase build using Dockerfile.buildbase) which caused the nightly build to start failing: 
https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_develop_nightly_build/detail/STRATO_develop_nightly_build/1265/pipeline

actual error:
```
~ apt-get update
<...>
Err:6 https://deb.nodesource.com/node_10.x bionic Release
  Certificate verification failed: The certificate is NOT trusted. The certificate chain uses expired certificate.  Could not handshake: Error in the certificate verification. [IP: 23.15.8.145 443]
<...>
E: The repository 'https://deb.nodesource.com/node_10.x bionic Release' does not have a Release file.
The command '/bin/sh -c apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8B1DA6120C2BF624 &&     apt-get update &&     apt-get -y --allow-unauthenticated install autoconf libtool libblas-dev liblapack-dev libsodium-dev jq vim &&     apt-get autoremove &&     rm -rf /var/lib/apt/lists/* &&     apt-get clean &&     git clone https://github.com/blockapps/secp256k1 &&     cd secp256k1/ &&     ./autogen.sh &&     ./configure --enable-module-recovery --enable-experimental --enable-module-ecdh &&     make &&     make install &&     cd .. &&     rm -rf secp256k1' returned a non-zero code: 100
Makefile:78: recipe for target 'build_buildbase' failed
make: *** [build_buildbase] Error 100
script returned exit code 2
```

This is to workaround the problem until they fix the cert packaged with ubuntu