### PR TITLE
Use postRaw function for debug POST endpoints, instead of the normal post function

### DIFF
--- a/blockapps-rest/src/api.ts
+++ b/blockapps-rest/src/api.ts
@@ -6,6 +6,7 @@ import {
   get,
   put,
   post,
+  postRaw,
   postue,
   httpDelete,
   getNodeUrl,
@@ -453,19 +454,19 @@ async function debugClearWatches(user:OAuthUser, options:Options) {
 async function debugPostEval(user:OAuthUser, args, options:Options) {
   const url = getNodeUrl(options);
   const endpoint = constructEndpoint(Endpoint.DEBUG_EVAL, options);
-  return post(url, endpoint, args, setAuthHeaders(user, options));
+  return postRaw(url, endpoint, args, setAuthHeaders(user, options));
 }
 
 async function debugPostParse(user:OAuthUser, args, options:Options) {
   const url = getNodeUrl(options);
   const endpoint = constructEndpoint(Endpoint.DEBUG_PARSE, options);
-  return post(url, endpoint, args, setAuthHeaders(user, options));
+  return postRaw(url, endpoint, args, setAuthHeaders(user, options));
 }
 
 async function debugPostAnalyze(user:OAuthUser, args, options:Options) {
   const url = getNodeUrl(options);
   const endpoint = constructEndpoint(Endpoint.DEBUG_ANALYZE, options);
-  return post(url, endpoint, args, setAuthHeaders(user, options));
+  return postRaw(url, endpoint, args, setAuthHeaders(user, options));
 }
 
 export default {

--- a/blockapps-rest/src/util/api.util.ts
+++ b/blockapps-rest/src/util/api.util.ts
@@ -207,6 +207,10 @@ async function post(url, endpoint, _body, options:Options) {
   return ax.post(url, endpoint, body, options);
 }
 
+async function postRaw(url, endpoint, body, options:Options) {
+  return ax.post(url, endpoint, body, options);
+}
+
 async function get(host, endpoint, options:Options) {
   return ax.get(host, endpoint, options);
 }
@@ -234,6 +238,7 @@ export {
   getNodeUrl,
   put,
   post,
+  postRaw,
   postue,
   httpDelete,
   setAuthHeaders


### PR DESCRIPTION
Because the normal `post` function assumes that we're creating a transaction, so it adds `txParams` to the request body. 