### PR TITLE
Parse imports

### DIFF
--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/File.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/File.hs
@@ -13,6 +13,7 @@ import           Text.Parsec
 import           Prelude                               hiding (lookup)
 
 import           BlockApps.Solidity.Parse.Declarations
+import           BlockApps.Solidity.Parse.Imports
 import           BlockApps.Solidity.Parse.Lexer
 import           BlockApps.Solidity.Parse.ParserTypes
 import           BlockApps.Solidity.Parse.Pragmas
@@ -20,6 +21,6 @@ import           BlockApps.Solidity.Parse.Pragmas
 solidityFile :: SolidityParser File
 solidityFile = do
   whiteSpace
-  units <- many (solidityPragma <|> solidityContract)
+  units <- many (solidityPragma <|> solidityImport <|> solidityContract)
   eof
   return . File $ units

--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/Imports.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/Imports.hs
@@ -1,0 +1,19 @@
+-- |
+-- Module: Imports
+-- Description: Parsers for Solidity imports
+-- Maintainer: Dustin Norwood <dustin@blockapps.net>
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
+module BlockApps.Solidity.Parse.Imports (solidityImport) where
+
+import qualified Data.Text as T
+import           BlockApps.Solidity.Parse.Lexer
+import           BlockApps.Solidity.Parse.ParserTypes
+
+solidityImport :: SolidityParser SourceUnit
+solidityImport = do
+  reserved "import"
+  path <- T.pack <$> stringLiteral
+  semi
+  return $ Import path
+

--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/ParserTypes.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/ParserTypes.hs
@@ -15,6 +15,7 @@ import           Text.Parsec
 import           BlockApps.Solidity.Xabi
 
 data SourceUnit = Pragma Identifier String
+                | Import T.Text
                 | NamedXabi T.Text (Xabi, [T.Text])
                 deriving (Eq, Show)
 
@@ -53,7 +54,6 @@ data SolcVersion = ZeroPointFour | ZeroPointFive deriving (Eq, Show, Ord, Enum)
 decideVersion :: File -> SolcVersion
 decideVersion = maximum . (ZeroPointFour:) . mapMaybe go . unsourceUnits
   where go :: SourceUnit -> Maybe SolcVersion
-        go NamedXabi{} = Nothing
         go (Pragma pragmaName rest) = do
           guard $ pragmaName == "solidity"
           rng <- eitherToMaybe . parseSemVerRange . T.strip . T.pack $ rest
@@ -62,3 +62,4 @@ decideVersion = maximum . (ZeroPointFour:) . mapMaybe go . unsourceUnits
           let possibilities = [semver 0 5 n | n <- [0..99]]
           guard $ any (matchesSimple rng) possibilities
           return ZeroPointFive
+        go _ = Nothing

--- a/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/UnParser.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/Solidity/Parse/UnParser.hs
@@ -28,6 +28,7 @@ unparse (File units) = List.concat $ List.map unparseSourceUnit units
 
 unparseSourceUnit :: SourceUnit -> String
 unparseSourceUnit (Pragma ident contents) = "pragma " ++ ident ++ " " ++ contents ++ ";\n"
+unparseSourceUnit (Import path) = "import \"" ++ Text.unpack path ++ "\";\n"
 unparseSourceUnit (NamedXabi name (contract,inherited)) =
      (case xabiKind contract of
         ContractKind -> "contract "

--- a/blockapps-haskell/solidity/test/BlockApps/Solidity/Parse/DeclarationsSpec.hs
+++ b/blockapps-haskell/solidity/test/BlockApps/Solidity/Parse/DeclarationsSpec.hs
@@ -202,7 +202,7 @@ spec = do
     let xempty = xabiEmpty
     let parseContract = runParser solidityContract "" ""
     let nameOf (NamedXabi n _) = n
-        nameOf _ = error "unexpected pragma"
+        nameOf _ = error "unexpected pragma or import"
     it "should parse an empty contract" $ do
       let contractString = "contract a {}"
           eRes = parseContract contractString

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -37,6 +37,7 @@ import qualified SolidVM.Solidity.Xabi.VarDef       as Xabitype
 import           Blockchain.VM.SolidException
 
 data SourceUnitF a = Pragma a Identifier String
+                   | Import a Text.Text
                    | NamedXabi Text.Text (XabiF a, [Text.Text])
                    deriving (Eq, Show, Generic, Functor)
 

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/File.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/File.hs
@@ -22,6 +22,7 @@ import           Text.Parsec
 
 
 import           SolidVM.Solidity.Parse.Declarations
+import           SolidVM.Solidity.Parse.Imports
 import           SolidVM.Solidity.Parse.Lexer
 import           SolidVM.Solidity.Parse.ParserTypes
 import           SolidVM.Solidity.Parse.Pragmas
@@ -34,7 +35,7 @@ newtype File = File {
 solidityFile :: SolidityParser File
 solidityFile = do
   whiteSpace
-  units <- many (solidityPragma <|> solidityContract)
+  units <- many (solidityPragma <|> solidityImport <|> solidityContract)
   eof
   return . File $ units
 
@@ -42,7 +43,6 @@ solidityFile = do
 decideVersion :: File -> SolcVersion
 decideVersion = maximum . (ZeroPointFour:) . mapMaybe go . unsourceUnits
   where go :: SourceUnit -> Maybe SolcVersion
-        go NamedXabi{} = Nothing
         go (Pragma _ pragmaName rest) = do
           guard $ pragmaName == "solidity"
           rng <- eitherToMaybe . parseSemVerRange . T.strip . T.pack $ rest
@@ -51,3 +51,4 @@ decideVersion = maximum . (ZeroPointFour:) . mapMaybe go . unsourceUnits
           let possibilities = [semver 0 5 n | n <- [0..99]]
           guard $ any (matchesSimple rng) possibilities
           return ZeroPointFive
+        go _ = Nothing

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Imports.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Imports.hs
@@ -1,0 +1,22 @@
+-- |
+-- Module: Imports
+-- Description: Parsers for Solidity imports
+-- Maintainer: Dustin Norwood <dustin@blockapps.net>
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
+module SolidVM.Solidity.Parse.Imports (solidityImport) where
+
+import           Data.Source
+import qualified Data.Text   as T
+
+import           SolidVM.Solidity.Parse.Declarations
+import           SolidVM.Solidity.Parse.Lexer
+import           SolidVM.Solidity.Parse.ParserTypes
+
+solidityImport :: SolidityParser SourceUnit
+solidityImport = do
+  ~(a, path) <- withPosition $ do
+    reserved "import"
+    T.pack <$> stringLiteral
+  semi
+  return $ Import a path

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -34,6 +34,7 @@ unparse (File units) = List.concat $ List.map unparseSourceUnit units
 
 unparseSourceUnit :: SourceUnit -> String
 unparseSourceUnit (Pragma _ ident contents) = "pragma " ++ ident ++ " " ++ contents ++ ";\n"
+unparseSourceUnit (Import _ path) = "import \"" ++ Text.unpack path ++ "\";\n"
 unparseSourceUnit (NamedXabi name (contract,inherited)) =
      (case xabiKind contract of
         ContractKind -> "contract "


### PR DESCRIPTION
Allow Bloc's and SolidVM's parsers to parse import statements, but don't do anything with them.