### PR TITLE
Ugh, prevent xabiToContract and applyInheritance from throwing exceptions

### DIFF
--- a/core-strato/debugger/src/Debugger/Rest/Server.hs
+++ b/core-strato/debugger/src/Debugger/Rest/Server.hs
@@ -13,6 +13,7 @@ module Debugger.Rest.Server where
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Aeson             as A
+import           Data.Functor.Identity
 import qualified Data.Map.Strict        as M
 import           Data.Maybe             (fromMaybe)
 import           Data.Source
@@ -21,7 +22,6 @@ import           Debugger.Rest.Api
 import           Debugger.Server
 import           Debugger.Types
 import           Servant
-import           Text.Parsec.Error
 
 getStatus :: DebugSettings -> Handler DebuggerStatus
 getStatus = status
@@ -77,29 +77,16 @@ deleteWatches = flip removeWatches
 postEvals :: DebugSettings -> [EvaluationRequest] -> Handler [EvaluationResponse]
 postEvals d ts = fmap (fromMaybe $ Left "") <$> liftIO (evaluateExpressions ts d)
 
-parseErrorToAnnotation :: ParseError -> SourceAnnotation T.Text
-parseErrorToAnnotation pe =
-  let msgs = errorMessages pe
-      sp = toSourcePosition $ errorPos pe
-      ann = showErrorMessages
-        "or"
-        "unknown parse error"
-        "expecting"
-        "unexpected"
-        "end of input"
-        msgs
-   in SourceAnnotation sp sp $ T.pack ann
-
 postParse :: ToJSON a
-          => (SourceMap -> Either ParseError a)
+          => (SourceMap -> Either [SourceAnnotation T.Text] a)
           -> SourceMap
           -> Handler A.Value
-postParse parse = pure . either (toJSON . parseErrorToAnnotation) toJSON . parse
+postParse parse = pure . either toJSON toJSON . parse
 
-postAnalyze :: (SourceMap -> Either ParseError [SourceAnnotation T.Text])
+postAnalyze :: (SourceMap -> Identity [SourceAnnotation T.Text])
             -> SourceMap
             -> Handler [SourceAnnotation T.Text]
-postAnalyze analyze = pure . either ((:[]) . parseErrorToAnnotation) id . analyze
+postAnalyze analyze = pure . runIdentity . analyze
 
 restDebuggerServer :: ToJSON a
                    => DebugSettings

--- a/core-strato/solid-vm/exec_src/ExprsNeeded.hs
+++ b/core-strato/solid-vm/exec_src/ExprsNeeded.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+import Control.Exception (throw)
 import qualified Data.Map as M
 import qualified Data.Text as T
 import System.Environment
@@ -24,7 +25,7 @@ main = do
         Pragma _ n v -> Just (n, v)
         _ -> Nothing
   let vmVersion' = if (Just ("solidvm","3.0")) `elem` (pragmas <$> parsedFile) then "svm3.0" else ""
-      namedContracts = [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') vmVersion' xabi)
+      namedContracts = [(T.unpack name, either (throw . fst) id $ xabiToContract (T.unpack name) (map T.unpack parents') vmVersion' xabi)
                        | NamedXabi name (xabi, parents') <- parsedFile]
       cc = CodeCollection $ M.fromList namedContracts
       nodes = codeCollectionCrawler cc

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -22,6 +22,7 @@ module Blockchain.SolidVM
   ) where
 
 import           Control.DeepSeq                      (force)
+import           Control.Exception                    (throw)
 import           Control.Lens hiding (assign, from, to, Context)
 import           Control.Applicative
 import           Control.Monad
@@ -1130,7 +1131,7 @@ expToVar' x@(Xabi.MemberAccess _ expr name) = do
       (SBuiltinVariable "super", method) -> do
         ctract <- getCurrentContract
         (_, cc) <- getCurrentCodeCollection
-        let parents' = getParents cc ctract
+        let parents' = either (throw . fst) id $ getParents cc ctract
         case filter (elem method . M.keys .  _functions) parents' of
           [] -> typeError "cannot use super without a parent contract" (method, ctract)
           ps -> do

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -1,25 +1,34 @@
+{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
 module Blockchain.SolidVM.CodeCollectionDB
-  ( parseSource
+  ( ParseOrSolidVMError(..)
+  , parseSource
+  , parseSourceWithAnnotations
   , compileSourceNoInheritance
   , compileSource
+  , compileSourceWithAnnotations
   , codeCollectionFromSource
   , codeCollectionFromHash
   ) where
 
 import           Control.Exception
+import           Control.Monad                        ((<=<))
 import           Control.Monad.IO.Class
 import qualified Data.Aeson                           as Aeson
+import           Data.Bifunctor                       (bimap, first)
 import qualified Data.ByteString                      as B
 import qualified Data.ByteString.Lazy                 as BL
 import           Data.Foldable                        (foldrM)
 import           Data.IORef
 import           Data.Map                             (Map)
 import qualified Data.Map                             as M
+import           Data.Maybe                           (catMaybes)
 import           Data.Source
 import qualified Data.Text                            as T
 import           Data.Text.Encoding                   (decodeUtf8, encodeUtf8)
+import           Data.Traversable                     (for)
 import           System.IO.Unsafe
 import           Text.Parsec                          (runParser)
 import           Text.Parsec.Error
@@ -34,14 +43,25 @@ import           SolidVM.Solidity.Parse.File
 
 import           CodeCollection
 
+data ParseOrSolidVMError = PEx ParseError
+                         | SVMEx (Positioned ((,) SolidException))
+
 {-# NOINLINE unsafeCodeMapIORef #-}
 unsafeCodeMapIORef :: IORef (Map Keccak256 CodeCollection)
 unsafeCodeMapIORef = unsafePerformIO $ newIORef M.empty
 
-parseSource :: T.Text -> T.Text -> Either ParseError [SourceUnit]
-parseSource fileName src = unsourceUnits <$> runParser solidityFile "" (T.unpack fileName) (T.unpack src)
+withAnnotations :: (a -> Either ParseOrSolidVMError b) -> a -> Either [SourceAnnotation T.Text] b
+withAnnotations f = first unwind . f
+  where unwind (PEx pe) = [parseErrorToAnnotation pe]
+        unwind (SVMEx (e,x)) = [T.pack (show e) <$ x]
 
-compileSourceNoInheritance :: Map T.Text T.Text -> Either ParseError CodeCollection
+parseSource :: T.Text -> T.Text -> Either ParseOrSolidVMError [SourceUnit]
+parseSource fileName src = bimap PEx unsourceUnits $ runParser solidityFile "" (T.unpack fileName) (T.unpack src)
+
+parseSourceWithAnnotations :: T.Text -> T.Text -> Either [SourceAnnotation T.Text] [SourceUnit]
+parseSourceWithAnnotations = withAnnotations . parseSource
+
+compileSourceNoInheritance :: Map T.Text T.Text -> Either ParseOrSolidVMError CodeCollection
 compileSourceNoInheritance initCodeMap = do
   let getNamedContracts fileName src = do
         sourceUnits <- parseSource fileName src
@@ -49,20 +69,29 @@ compileSourceNoInheritance initCodeMap = do
               Pragma _ n v -> Just (n, v)
               _ -> Nothing
             vmVersion' = if Just ("solidvm", "3.0") `elem` (pragmas <$> sourceUnits) then "svm3.0" else ""
-        pure [(T.unpack name, xabiToContract (T.unpack name) (map T.unpack parents') vmVersion' xabi)
-             | NamedXabi name (xabi, parents') <- sourceUnits]
+        fmap catMaybes . for sourceUnits $ \case
+          NamedXabi name (xabi, parents') -> do
+            ctrct <- first SVMEx
+                   $ xabiToContract (T.unpack name) (map T.unpack parents') vmVersion' xabi
+            pure $ Just (T.unpack name, ctrct)
+          _ -> pure Nothing
       throwDuplicate (cName, contract) m = case M.lookup cName m of
         Nothing -> pure $ M.insert cName contract m
-        Just _ ->  Left $ newErrorMessage (Message $ "Duplicate contract found: " ++ cName)
-                                          (fromSourcePosition $ _sourceAnnotationStart $ _contractContext contract)
+        Just _ ->  Left . PEx
+                 $ newErrorMessage (Message $ "Duplicate contract found: " ++ cName)
+                                   (fromSourcePosition $ _sourceAnnotationStart $ _contractContext contract)
   allContracts <- fmap concat . traverse (uncurry getNamedContracts) $ M.toList initCodeMap
   deduplicatedContracts <- foldrM throwDuplicate M.empty allContracts
   pure $ CodeCollection {
     _contracts = deduplicatedContracts
   }
 
-compileSource :: Map T.Text T.Text -> Either ParseError CodeCollection
-compileSource = fmap applyInheritance . compileSourceNoInheritance
+compileSource :: Map T.Text T.Text -> Either ParseOrSolidVMError CodeCollection
+compileSource = applyInheritanceE <=< compileSourceNoInheritance
+  where applyInheritanceE = first SVMEx . applyInheritance
+
+compileSourceWithAnnotations :: Map T.Text T.Text -> Either [SourceAnnotation T.Text] CodeCollection
+compileSourceWithAnnotations = withAnnotations compileSource
 
 codeCollectionFromSource :: (MonadIO m, HasCodeDB m) => B.ByteString -> m (Keccak256, CodeCollection)
 codeCollectionFromSource initCode = do
@@ -85,7 +114,10 @@ codeCollectionFromSource initCode = do
       recordCacheEvent StorageWrite
       hsh' <- addCode SolidVM canonicalInitCode
       let ecc = compileSource initMap
-          cc = either (parseError "codeCollectionFromSource") id ecc
+          cc = case ecc of
+                 Right a -> a
+                 Left (PEx p) -> parseError "codeCollectionFromSource" p
+                 Left (SVMEx (s, _)) -> throw s
       let codeMap' = M.insert hsh cc codeMap
       recordCacheSize $ M.size codeMap'
       liftIO $ writeIORef unsafeCodeMapIORef codeMap'
@@ -107,7 +139,10 @@ codeCollectionFromHash hsh = do
                   Just l -> M.fromList l
                   Nothing -> M.singleton T.empty (decodeUtf8 initCode)
           let ecc = compileSource initMap
-              cc = either (parseError "codeCollectionFromHash") id ecc
+              cc = case ecc of
+                     Right a -> a
+                     Left (PEx p) -> parseError "codeCollectionFromHash" p
+                     Left (SVMEx (s, _)) -> throw s
               codeMap' = M.insert hsh cc codeMap
           recordCacheSize $ M.size codeMap'
           liftIO $ writeIORef unsafeCodeMapIORef codeMap'

--- a/core-strato/solid-vm/src/CodeCollection.hs
+++ b/core-strato/solid-vm/src/CodeCollection.hs
@@ -15,6 +15,7 @@ import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Set as S
 import Data.Source
+import Data.Traversable (for)
 import qualified Data.Text as T
 import GHC.Generics
 
@@ -67,11 +68,18 @@ emptyCodeCollection :: CodeCollection
 emptyCodeCollection =
   CodeCollection M.empty
 
+type SolidEither = Either (Positioned ((,) SolidException))
 
-
-xabiToContract :: String -> [String] -> String -> Xabi -> Contract
-xabiToContract contractName' parents' vmVersion' xabi = validateXabi xabi `seq`
-  Contract {
+xabiToContract :: String -> [String] -> String -> Xabi -> SolidEither Contract
+xabiToContract contractName' parents' vmVersion' xabi = do
+  validateXabi xabi
+  constr <- case M.toList $ Xabi.xabiConstr xabi of
+    [] -> Right Nothing
+    [(_, x)] -> Right $ Just x
+    _ -> Left $ ( DuplicateDefinition "multiple constructors in contract" (show contractName') --TODO- figure out if this is allowed in Solidity
+                , Xabi.xabiContext xabi
+                )
+  pure Contract {
   _contractName = contractName',
   _parents = parents',
   _storageDefs = M.fromList $ map (\(k,v) -> (T.unpack k, v)) $ M.toList $ Xabi.xabiVars xabi,
@@ -80,49 +88,58 @@ xabiToContract contractName' parents' vmVersion' xabi = validateXabi xabi `seq`
   _structs = M.fromList [(T.unpack name, (\(k,v) -> (k,v,a)) <$> vals) | (name, Xabi.Struct vals _ a) <- M.toList $ Xabi.xabiTypes xabi],
   _events = Xabi.xabiEvents xabi,
   _functions = M.fromList $ map (\(k,v) -> (T.unpack k, v)) $ M.toList $ Xabi.xabiFuncs xabi,
-  _constructor =
-      case M.toList $ Xabi.xabiConstr xabi of
-        [] -> Nothing
-        [(_, x)] -> Just x
-        _ -> duplicateDefinition "multiple constructors in contract" contractName', --TODO- figure out if this is allowed in Solidity
+  _constructor = constr,
   _vmVersion = vmVersion',
   _contractContext = Xabi.xabiContext xabi
   }
 
-validateXabi :: Xabi -> ()
-validateXabi Xabi{xabiModifiers=mx} =
+validateXabi :: Xabi -> SolidEither ()
+validateXabi Xabi{xabiModifiers=mx, xabiContext=ctx} =
   case M.size mx of
-      0 -> ()
-      _ -> todo "modifiers not supported by solidvm" mx
+      0 -> Right ()
+      _ -> Left $ ( TODO "modifiers not supported by solidvm" (show mx)
+                  , ctx
+                  )
 
 
-applyInheritance :: CodeCollection -> CodeCollection
-applyInheritance cc =
-  cc{
-    _contracts = M.map (addInheritedObjects cc) $ cc^.contracts
+applyInheritance :: CodeCollection -> SolidEither CodeCollection
+applyInheritance cc = do
+  ccs <- traverse (addInheritedObjects cc) $ cc^.contracts
+  pure $ cc{
+    _contracts = ccs
   }
 
-addInheritedObjects :: CodeCollection -> Contract -> Contract
-addInheritedObjects cc c =
-  c{
-  _functions=toUnionMaker _functions cc c,
-  _storageDefs=toUnionMaker _storageDefs cc c,
-  _enums=toUnionMaker _enums cc c,
-  _structs=toUnionMaker _structs cc c,
-  _events = toUnionMaker _events cc c,
-  _constants=toUnionMaker _constants cc c
+addInheritedObjects :: CodeCollection -> Contract -> SolidEither Contract
+addInheritedObjects cc c = do
+  fu <- toUnionMaker _functions cc c
+  sd <- toUnionMaker _storageDefs cc c
+  en <- toUnionMaker _enums cc c
+  st <- toUnionMaker _structs cc c
+  ev <- toUnionMaker _events cc c
+  co <- toUnionMaker _constants cc c
+  pure $ c{
+  _functions=fu,
+  _storageDefs=sd,
+  _enums=en,
+  _structs=st,
+  _events = ev,
+  _constants=co
   }
 
-getParents :: CodeCollection -> Contract -> [Contract]
+getParents :: CodeCollection -> Contract -> SolidEither [Contract]
 getParents cc c =
-  let toErr p = fromMaybe (internalError "contract parent does not exist" p)
-  in map (\p -> toErr p . M.lookup p $ cc ^. contracts) $ c ^. parents
+  let toErr x p = maybe (Left ( InternalError "contract parent does not exist" p
+                              , x
+                              ))
+                        Right
+  in for (c ^. parents) $ \p ->
+       toErr (c ^. contractContext) p . M.lookup p $ cc ^. contracts
 
-toUnionMaker :: (Ord a) => (Contract -> M.Map a b) -> CodeCollection -> Contract -> M.Map a b
-toUnionMaker f cc c =
-  let parents' = getParents cc c
-      parentMaps = map (toUnionMaker f cc) parents'
-  in M.unions $ f c : parentMaps
+toUnionMaker :: (Ord a) => (Contract -> M.Map a b) -> CodeCollection -> Contract -> SolidEither (M.Map a b)
+toUnionMaker f cc c = do
+  parents' <- getParents cc c
+  parentMaps <- traverse (toUnionMaker f cc) parents'
+  pure . M.unions $ f c : parentMaps
 
 statementCrawler :: Xabi.StatementF a -> [T.Text]
 statementCrawler = \case

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
@@ -3,6 +3,7 @@ module SolidVM.Solidity.Detectors
   ) where
 
 import           CodeCollection
+import           Data.Bifoldable
 import           Data.Source
 import           Data.Text                                                         (Text)
 import           SolidVM.Solidity.Parse.Declarations                               (SourceUnit)
@@ -39,12 +40,13 @@ compilerDetectors = [ Trivial.detector
                     , StateVariables.detector
                     ]
 
-runDetectors :: Applicative f
-             => (SourceMap -> f [SourceUnit])
-             -> (SourceMap -> f CodeCollection)
+runDetectors :: (Applicative (f a), Bifoldable f)
+             => (SourceMap -> f a [SourceUnit])
+             -> (SourceMap -> f a CodeCollection)
+             -> (a -> [SourceAnnotation Text])
              -> SourceMap
-             -> f [SourceAnnotation Text]
-runDetectors parse compile source =
+             -> [SourceAnnotation Text]
+runDetectors parse compile handleErrors source =
   let parserAnnotations = concat . (parserDetectors <*>) . (:[]) <$> parse source
       compilerAnnotations = concat . (compilerDetectors <*>) . (:[]) <$> compile source
-   in (++) <$> parserAnnotations <*> compilerAnnotations
+   in bifoldMap handleErrors id $ (++) <$> parserAnnotations <*> compilerAnnotations

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Expressions/BooleanLiterals.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Expressions/BooleanLiterals.hs
@@ -46,6 +46,7 @@ statementHelper (DoWhileStatement body cond _) =
    in concat [bs, cs]
 statementHelper (Continue _) = []
 statementHelper (Break _) = []
+statementHelper (Return (Just (BoolLiteral _ _)) _) = []
 statementHelper (Return mExpr _) =
   maybe [] expressionHelper mExpr
 statementHelper (Throw _) = []

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Functions/ConstantFunctions.hs
@@ -140,12 +140,7 @@ simpleStatementHelper (ExpressionStatement expr) =
 
 generateAnn :: String -> SourceAnnotation () -> [String] -> [SourceAnnotation Text]
 generateAnn varName x = \case
-  [] ->
-    let msg = T.pack $ concat
-          [ "Undefined variable: "
-          , varName
-          ]
-     in [msg <$ x]
+  [] -> []
   (c:[]) ->
     let msg = T.pack $ concat
           [ "Variable "

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -900,4 +900,5 @@ tcExpr (StringLiteral x _) = pure $ stringType' x
 tcExpr (TupleExpression x es) =
   productType' x <$> traverse (maybe (pure $ topType' x) tcExpr) es
 tcExpr (ArrayExpression x es) = foldr (<~>) (pure $ topType' x) $ tcExpr <$> es
+tcExpr (Variable x "this") = pure $ Static Account x
 tcExpr (Variable x name) = getVarType' name x

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -521,11 +521,10 @@ getConstructorType' x l = do
   case M.lookup (T.unpack l) _contracts of
     Nothing -> pure . bottom $ ("Unknown contract: " <> l) <$ x
     Just c -> case _constructor c of
-      Nothing -> pure $ Function (Product [] x) (Sum (Static Account x :| [Product [] x])) x
+      Nothing -> pure $ Function (Product [] x) (Static (Xabi.Contract l) x) x
       Just Func{..} ->
         let fArgs = flip Product x $ flip Static x . indexedTypeType . snd <$> funcArgs
-            fRets = flip Product x $ flip Static x . indexedTypeType . snd <$> funcVals
-         in pure $ Function fArgs (Sum (Static Account x :| [Product [] x, fRets])) x
+         in pure $ Function fArgs (Static (Xabi.Contract l) x) x
 
 getTypeErrors :: Type' -> [SourceAnnotation Text]
 getTypeErrors (Bottom ts) = NE.toList ts
@@ -581,9 +580,10 @@ statementsHelper args ss = do
   let x = funcContext f
   ~(ts', s) <- flip runStateT ((Nothing, args) :| []) $ do
     cCalls <- for (M.assocs $ funcConstructorCalls f) $ \(cName, exprs) -> do
-      let constructorArgs = getConstructorType' x $ T.pack cName
+      let cName' = T.pack cName
+          constructorArgs = getConstructorType' x cName'
           givenArgs = flip Product x <$> traverse tcExpr exprs
-          givenFunc = (\t-> Function t (Product [] x) x) <$> givenArgs
+          givenFunc = (\t-> Function t (Static (Xabi.Contract cName') x) x) <$> givenArgs
       constructorArgs <~> givenFunc
     stmts' <- traverse statementHelper ss
     pure $ concat [stmts', cCalls]
@@ -692,6 +692,7 @@ parseCertArgs :: SourceAnnotation Text -> Type'
 parseCertArgs x = stringType' x
 
 getVarType' :: String -> SourceAnnotation Text -> SSS Type'
+getVarType' "this" ctx = pure $ Static Account ctx
 getVarType' "uint" ctx = pure $ Function (intArgs ctx) (Static (Int (Just False) Nothing) ctx) ctx
 getVarType' "int" ctx =  pure $ Function (intArgs ctx) (Static (Int (Just True) Nothing) ctx) ctx
 getVarType' "address" ctx =  pure $ Function (addressArgs ctx) (Static Account ctx) ctx
@@ -707,6 +708,12 @@ getVarType' "assert" ctx =  pure $ Function (assertArgs ctx) (Product [] ctx) ct
 getVarType' "registerCert" ctx =  pure $ Function (registerCertArgs ctx) (Product [] ctx) ctx
 getVarType' "getUserCert" ctx =  pure $ Function (getUserCertArgs ctx) (certType' ctx) ctx
 getVarType' "parseCert" ctx =  pure $ Function (parseCertArgs ctx) (certType' ctx) ctx
+getVarType' "Util" ctx = pure $ Static (Label "Util") ctx
+getVarType' "msg" ctx = pure $ Static (Label "msg") ctx
+getVarType' "tx" ctx = pure $ Static (Label "tx") ctx
+getVarType' "block" ctx = pure $ Static (Label "block") ctx
+getVarType' "super" ctx = pure $ Static (Label "super") ctx
+
 getVarType' name ctx = do
   mVar <- foldr (lookupVar . snd) Nothing <$> get
   case mVar of
@@ -732,7 +739,8 @@ getVarType' name ctx = do
             pure $ case M.lookup name $ _contracts cc of
               Just _->
                 let ctrct = Static (Xabi.Contract $ T.pack name) ctx
-                 in Function (Sum (Static Account ctx :| [ctrct]))
+                    lbl = Static (Label name) ctx
+                 in Function (Sum (Static Account ctx :| [ctrct, lbl]))
                              ctrct
                              ctx
               Nothing -> bottom $ ("Unknown variable: " <> T.pack name) <$ ctx
@@ -900,5 +908,4 @@ tcExpr (StringLiteral x _) = pure $ stringType' x
 tcExpr (TupleExpression x es) =
   productType' x <$> traverse (maybe (pure $ topType' x) tcExpr) es
 tcExpr (ArrayExpression x es) = foldr (<~>) (pure $ topType' x) $ tcExpr <$> es
-tcExpr (Variable x "this") = pure $ Static Account x
 tcExpr (Variable x name) = getVarType' name x

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -276,6 +276,8 @@ typecheck' f r1 r2 = case (r1, r2) of
   (Top n1 _, Top n2 x) -> pure $ Top (n1 <> n2) x
   (Top names _, m@(Static t x)) -> reduceType' x . (m:) <$> traverse (\n -> f x n t) (S.toList names)
   (m@(Static t x), Top names _) -> m <$ reduceType' x . (m:) <$> traverse (\n -> f x n t) (S.toList names)
+  (Top _ _, m) -> pure m
+  (m, Top _ _) -> pure m
   (t1, Sum t2) -> pickType' (context' t1) <$> traverse (typecheck' f t1) (NE.toList t2)
   (Sum t1, t2) -> pickType' (context' t2) <$> traverse (flip (typecheck' f) t2) (NE.toList t1)
   (Static t1 _, Static t2 x) -> pure $ case typecheckStatic t1 t2 of
@@ -511,7 +513,7 @@ typecheckMember (Static (Label c') x) n = do
             t -> pure t
         t -> pure t
     t -> pure t
-typecheckMember x n = pure . bottom $ ("Unknown member: " <> T.pack (show x) <> "\n  " <> n) <$ context' x
+typecheckMember x n = pure . bottom $ ("Unknown member: " <> showType' x <> "\n  " <> n) <$ context' x
 
 getConstructorType' :: MonadReader R m => SourceAnnotation Text -> Text -> m Type'
 getConstructorType' x l = do
@@ -728,9 +730,11 @@ getVarType' name ctx = do
           Nothing -> do
             cc <- asks codeCollection
             pure $ case M.lookup name $ _contracts cc of
-              Just _-> Function (Static Account ctx)
-                                (Static (Xabi.Contract $ T.pack name) ctx)
-                                ctx
+              Just _->
+                let ctrct = Static (Xabi.Contract $ T.pack name) ctx
+                 in Function (Sum (Static Account ctx :| [ctrct]))
+                             ctrct
+                             ctx
               Nothing -> bottom $ ("Unknown variable: " <> T.pack name) <$ ctx
             
   where lookupVar m Nothing = M.lookup name m

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -439,7 +439,31 @@ typecheckIndex x y = bottom $ "Mismatched index type" <$ (context' x <> context'
 
 typecheckMember :: Type' -> Text -> SSS Type'
 typecheckMember (Static (Array _ _) x) "length" = pure $ Static (Int Nothing Nothing) x
+typecheckMember (Static (Array t _) x) "push" = pure $ Function (Static t x) (Product [] x) x
 typecheckMember (Static (Array _ _) x) n = pure . bottom $ ("Unknown member of Array: " <> n) <$ x
+typecheckMember (Static (Label "Util") x) "bytes32ToString" = pure $ Function (Static (Bytes Nothing (Just 32)) x) (Static (String Nothing) x) x
+typecheckMember (Static (Label "Util") x) "b32" = pure $ Function (Static (Bytes Nothing (Just 32)) x) (Static (Bytes Nothing (Just 32)) x) x
+typecheckMember (Static (Label "msg") x) "sender" = pure $ Static Account x
+typecheckMember (Static (Label "tx") x) "origin" = pure $ Static Account x
+typecheckMember (Static (Label "tx") x) "username" = pure $ Static (String Nothing) x
+typecheckMember (Static (Label "tx") x) "organization" = pure $ Static (String Nothing) x
+typecheckMember (Static (Label "tx") x) "group" = pure $ Static (String Nothing) x
+typecheckMember (Static (Label "block") x) "timestamp" = pure $ Static (Int Nothing Nothing) x
+typecheckMember (Static (Label "block") x) "number" = pure $ Static (Int Nothing Nothing) x
+typecheckMember (Static (Label "super") x) method = do
+  ctract <- asks contract
+  cc <- asks codeCollection
+  let method' = T.unpack method
+  case getParents ((fmap $ const ()) <$> cc) ((fmap $ const ()) <$> ctract) of
+    Left _ -> pure . bottom $ "Contract has missing parents" <$ x
+    Right parents' -> case filter (elem method' . M.keys .  _functions) parents' of
+      [] -> pure . bottom $ "cannot use super without a parent contract" <$ x
+      ps -> case M.lookup method' . _functions $ last ps of
+        Nothing -> pure . bottom $ ("super does not have a function called " <> method) <$ x
+        Just Func{..} ->
+          let fArgs = flip Product x $ flip Static x . indexedTypeType . snd <$> funcArgs
+              fRets = flip Product x $ flip Static x . indexedTypeType . snd <$> funcVals
+           in pure $ Function fArgs fRets x
 typecheckMember (Static e@(Enum _ enum mNames) x) n = do
   names <- case mNames of
     Just names -> pure names

--- a/core-strato/vm-runner/exec_src/Main.hs
+++ b/core-strato/vm-runner/exec_src/Main.hs
@@ -6,6 +6,7 @@
 
 import           Control.Monad
 import           Control.Concurrent.Async             as Async
+import           Data.Functor.Identity                (Identity(..))
 import qualified Data.Map.Strict                      as M
 import           Debugger
 import           Debugger.Options() -- HFlags
@@ -15,7 +16,7 @@ import           HFlags
 
 import           BlockApps.Init
 import           Blockchain.Output
-import           Blockchain.SolidVM.CodeCollectionDB  (parseSource, compileSource)
+import           Blockchain.SolidVM.CodeCollectionDB
 import           Blockchain.VMOptions() -- HFlags
 import           Executable.EthereumVM
 import           Executable.EVMFlags() -- HFlags
@@ -26,12 +27,12 @@ main = do
   blockappsInit "vm_main"
   void $ $initHFlags "Ethereum VM"
   let parse = fmap concat
-            . traverse (uncurry parseSource)
+            . traverse (uncurry parseSourceWithAnnotations)
             . unSourceMap
-      compile = compileSource
+      compile = compileSourceWithAnnotations
               . M.fromList
               . unSourceMap
-      analyze = runDetectors parse compile
+      analyze = Identity . runDetectors parse compile id
       tools = SourceTools compile analyze
   mDebugger <- initializeDebugger tools
   let metricsRunner = run 8000 metricsApp

--- a/shared-util/source-tools/src/Data/Source/Annotation.hs
+++ b/shared-util/source-tools/src/Data/Source/Annotation.hs
@@ -8,6 +8,7 @@ module Data.Source.Annotation
   ( SourceAnnotation(..)
   , Positioned
   , Annotated
+  , parseErrorToAnnotation
   , withAnnotation
   , withPosition
   , position
@@ -18,11 +19,12 @@ import           Data.Aeson                as Aeson
 import           Data.Data
 import           Data.Source.Position
 import           Data.Swagger
-import           Data.Text                 (Text)
+import           Data.Text                 (Text, pack)
 import           GHC.Generics
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
-import           Text.Parsec
+import           Text.Parsec               (ParsecT)
+import           Text.Parsec.Error
 
 data SourceAnnotation a = SourceAnnotation
   { _sourceAnnotationStart      :: SourcePosition
@@ -62,6 +64,19 @@ instance Semigroup a => Semigroup (SourceAnnotation a) where
 
 type Positioned f = f (SourceAnnotation ())
 type Annotated f = f (SourceAnnotation Text)
+
+parseErrorToAnnotation :: ParseError -> SourceAnnotation Text
+parseErrorToAnnotation pe =
+  let msgs = errorMessages pe
+      sp = toSourcePosition $ errorPos pe
+      ann = showErrorMessages
+        "or"
+        "unknown parse error"
+        "expecting"
+        "unexpected"
+        "end of input"
+        msgs
+   in SourceAnnotation sp sp $ pack ann
 
 withAnnotation :: Monad m
                => a

--- a/shared-util/source-tools/src/Data/Source/Tools.hs
+++ b/shared-util/source-tools/src/Data/Source/Tools.hs
@@ -5,15 +5,15 @@ module Data.Source.Tools
   , SourceTools
   ) where
 
+import Data.Functor.Identity  (Identity)
 import Data.Source.Annotation
 import Data.Source.Map
 import Data.Text              (Text)
 import GHC.Generics
-import Text.Parsec            (ParseError)
 
 data SourceToolsF parse analyze a = SourceTools
   { parser   :: SourceMap -> parse a
   , analyzer :: SourceMap -> analyze [SourceAnnotation Text]
   } deriving (Generic)
 
-type SourceTools = SourceToolsF (Either ParseError) (Either ParseError)
+type SourceTools = SourceToolsF (Either [SourceAnnotation Text]) Identity


### PR DESCRIPTION
The functions `xabiToContract` and `applyInheritance` throw `SolidException`s internally, causing the /parse and /analyze endpoints to return 502 errors when there are missing parent contracts in a source blob. Instead of wrapping everything in a `try`, I've floated calls to `throw` out to functions not used by these endpoints.

Additionally, I've merged in some fixes to a few detectors which depend on the first fixes to work to be used in the IDE.