### PR TITLE
With severity

### DIFF
--- a/blockapps-rest/src/util/importer.ts
+++ b/blockapps-rest/src/util/importer.ts
@@ -257,4 +257,5 @@ function combine(filename, toObject, relativePath):Promise<any> {
 
 export default {
   combine,
+  getShortName,
 }

--- a/core-strato/debugger/src/Debugger/Rest/Api.hs
+++ b/core-strato/debugger/src/Debugger/Rest/Api.hs
@@ -56,7 +56,7 @@ type PutWatches = "watches" :> ReqBody '[JSON] [EvaluationRequest] :> Put '[JSON
 type DeleteWatches = "watches" :> ReqBody '[JSON] [EvaluationRequest] :> Delete '[JSON] DebuggerStatus
 type PostEvals = "eval" :> ReqBody '[JSON] [EvaluationRequest] :> Post '[JSON] [EvaluationResponse]
 type PostParse = "parse" :> ReqBody '[JSON] SourceMap :> Post '[JSON] A.Value
-type PostAnalyze = "analyze" :> ReqBody '[JSON] SourceMap :> Post '[JSON] [SourceAnnotation T.Text]
+type PostAnalyze = "analyze" :> ReqBody '[JSON] SourceMap :> Post '[JSON] [SourceAnnotation (WithSeverity T.Text)]
 
 restDebuggerAPI :: Proxy RestDebuggerAPI
 restDebuggerAPI = Proxy

--- a/core-strato/debugger/src/Debugger/Rest/Server.hs
+++ b/core-strato/debugger/src/Debugger/Rest/Server.hs
@@ -83,9 +83,9 @@ postParse :: ToJSON a
           -> Handler A.Value
 postParse parse = pure . either toJSON toJSON . parse
 
-postAnalyze :: (SourceMap -> Identity [SourceAnnotation T.Text])
+postAnalyze :: (SourceMap -> Identity [SourceAnnotation (WithSeverity T.Text)])
             -> SourceMap
-            -> Handler [SourceAnnotation T.Text]
+            -> Handler [SourceAnnotation (WithSeverity T.Text)]
 postAnalyze analyze = pure . runIdentity . analyze
 
 restDebuggerServer :: ToJSON a

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors.hs
@@ -25,28 +25,47 @@ parserDetectors :: [ParserDetector]
 parserDetectors = [ IncorrectSolidityVersion.detector
                   ]
 
-compilerDetectors :: [CompilerDetector]
-compilerDetectors = [ Trivial.detector
-                    , Typechecker.detector
-                    , Continue.detector
-                    , Modifiers.detector
-                    , ParentConstructors.detector
-                    , BooleanLiterals.detector
-                    , DivideBeforeMultiply.detector
-                    , StateVariableShadowing.detector
-                    , UninitializedLocalVariables.detector
-                    , WriteAfterWrite.detector
-                    , ConstantFunctions.detector
-                    , StateVariables.detector
-                    ]
+compilerWarningDetectors :: [CompilerDetector]
+compilerWarningDetectors = [ Trivial.detector
+                           , Continue.detector
+                           , Modifiers.detector
+                           , ParentConstructors.detector
+                           , BooleanLiterals.detector
+                           , DivideBeforeMultiply.detector
+                           , StateVariableShadowing.detector
+                           , UninitializedLocalVariables.detector
+                           , WriteAfterWrite.detector
+                           , ConstantFunctions.detector
+                           , StateVariables.detector
+                           ]
+compilerErrorDetectors :: [CompilerDetector]
+compilerErrorDetectors = [ Typechecker.detector
+                         ]
 
 runDetectors :: (Applicative (f a), Bifoldable f)
              => (SourceMap -> f a [SourceUnit])
              -> (SourceMap -> f a CodeCollection)
              -> (a -> [SourceAnnotation Text])
              -> SourceMap
-             -> [SourceAnnotation Text]
+             -> [SourceAnnotation (WithSeverity Text)]
 runDetectors parse compile handleErrors source =
-  let parserAnnotations = concat . (parserDetectors <*>) . (:[]) <$> parse source
-      compilerAnnotations = concat . (compilerDetectors <*>) . (:[]) <$> compile source
-   in bifoldMap handleErrors id $ (++) <$> parserAnnotations <*> compilerAnnotations
+  let parserAnnotations = map (withSeverity Warning)
+                        . concat
+                        . (parserDetectors <*>)
+                        . (:[])
+                        <$> parse source
+      compilerErrors = map (withSeverity Error) 
+                     . concat
+                     . (compilerErrorDetectors <*>)
+                     . (:[])
+                     <$> compile source
+      compilerWarnings = map (withSeverity Warning)
+                       . concat
+                       . (compilerWarningDetectors <*>)
+                       . (:[])
+                       <$> compile source
+   in bifoldMap (map (withSeverity Error) . handleErrors) id $
+        (\p e w -> concat [p,e,w])
+        <$> parserAnnotations
+        <*> compilerErrors
+        <*> compilerWarnings

--- a/shared-util/source-tools/src/Data/Source/Severity.hs
+++ b/shared-util/source-tools/src/Data/Source/Severity.hs
@@ -1,11 +1,19 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Data.Source.Severity
   ( Severity(..)
+  , WithSeverity(..)
+  , severity
+  , context
+  , withSeverityContext
+  , withSeverity
   ) where
 
 import           Control.DeepSeq
+import           Control.Lens
 import           Data.Aeson                as Aeson hiding (Error)
 import           Data.Data
 import           GHC.Generics
@@ -16,3 +24,16 @@ data Severity = Debug | Info | Warning | Error
 
 instance Arbitrary Severity where
   arbitrary = oneof [pure Debug, pure Info, pure Warning, pure Error]
+
+data WithSeverity a = WithSeverity
+  { _severity :: Severity
+  , _context :: a
+  } deriving (Eq, Show, Ord, Generic, Functor, Data, NFData, ToJSON, FromJSON)
+
+makeLenses ''WithSeverity
+
+withSeverityContext :: WithSeverity a -> a
+withSeverityContext = _context
+
+withSeverity :: Functor f => Severity -> f a -> f (WithSeverity a)
+withSeverity = fmap . WithSeverity

--- a/shared-util/source-tools/src/Data/Source/Tools.hs
+++ b/shared-util/source-tools/src/Data/Source/Tools.hs
@@ -8,12 +8,13 @@ module Data.Source.Tools
 import Data.Functor.Identity  (Identity)
 import Data.Source.Annotation
 import Data.Source.Map
+import Data.Source.Severity
 import Data.Text              (Text)
 import GHC.Generics
 
 data SourceToolsF parse analyze a = SourceTools
   { parser   :: SourceMap -> parse a
-  , analyzer :: SourceMap -> analyze [SourceAnnotation Text]
+  , analyzer :: SourceMap -> analyze [SourceAnnotation (WithSeverity Text)]
   } deriving (Generic)
 
 type SourceTools = SourceToolsF (Either [SourceAnnotation Text]) Identity

--- a/strato-vscode/src/diagnostics.ts
+++ b/strato-vscode/src/diagnostics.ts
@@ -82,7 +82,10 @@ async function findDeadCode(srcArr: Array<Array<string>>): Promise<Array<Object>
       for(let i = 0; i < privFuncs.length; ++i) {
         if (privFuncs.length != 0) {
           deadFuncs.push({
-            'annotation': `The function '${privFuncs[i].funcName}' in contract '${contractName}' is never used and should be removed`,
+            'annotation': {
+              '_context': `The function '${privFuncs[i].funcName}' in contract '${contractName}' is never used and should be removed`,
+              '_severity': 'Warning'
+            },
             'start': {
               'line': privFuncs[i].start.line,
               'column': privFuncs[i].start.column,
@@ -121,7 +124,8 @@ async function validate(counter: number, doc: vscode.TextDocument, solidityDiagn
 		    const folder = currentFolder.uri.path;
         // eslint-disable-next-line import/no-mutable-exports
         const dirPath = `${folder}/${serverPath}`
-        srcArr = await importer.combine(doc.uri.path, false, dirPath);
+        srcArr = await importer.combine(doc.uri.path, true, dirPath);
+        srcArr[importer.getShortName(doc.uri.path)] = doc.getText();
       }
       // Run dead code detector
       const deadCodeArr = await findDeadCode(srcArr);
@@ -172,8 +176,16 @@ function createDiagnostic(doc: vscode.TextDocument, ann: any): vscode.Diagnostic
     // create range that represents, where in the document the word is
     const range = new vscode.Range(sLine, sCol, eLine, eCol);
 
-    const diagnostic = new vscode.Diagnostic(range, ann.annotation,
-      vscode.DiagnosticSeverity.Warning);
+    let severity = vscode.DiagnosticSeverity.Information;
+    switch (ann.annotation._severity) {
+      case 'Error': severity = vscode.DiagnosticSeverity.Error; break;
+      case 'Warning': severity = vscode.DiagnosticSeverity.Warning; break;
+      case 'Info': severity = vscode.DiagnosticSeverity.Information; break;
+      case 'Debug': severity = vscode.DiagnosticSeverity.Hint; break;
+    }
+
+    const diagnostic = new vscode.Diagnostic(range, ann.annotation._context,
+      severity);
     diagnostic.code = '';
     return diagnostic;
   }


### PR DESCRIPTION
Added severity level to the response from the /analyze endpoint, which allows VSCode to underline the diagnostics with different colors (red for errors, yellow for warnings, etc.)