### PR TITLE
remove .docker-work dir in autobuild pipeline after the build step

### DIFF
--- a/Jenkinsfile.autobuild
+++ b/Jenkinsfile.autobuild
@@ -24,6 +24,7 @@ pipeline {
       steps {
         sh 'rm -rf .docker-work'
         sh 'REPO=private make all'
+        sh 'rm -rf .docker-work'
         dir ('blockapps-rest') {
           sh 'yarn install --pure-lockfile'
           sh 'yarn build'


### PR DESCRIPTION
Along with the adjustment of how long should the  jenkinsworkspace directories be kept after the branch or PR is removed, this should solve the no space issue on the test agent.