### PR TITLE
[STRATO-2075] Move SQL commands in logs from INFO level to DEBUG level

### DIFF
--- a/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
+++ b/blockapps-haskell/vault-wrapper/server/src/Strato/Strato23/Monad.hs
@@ -188,7 +188,7 @@ vaultQuery
   => Query x
   -> VaultM [y]
 vaultQuery q = do
-  traverse_ (logInfoCS callStack . Text.pack) (showSql q)
+  traverse_ (logDebugCS callStack . Text.pack) (showSql q)
   pool <- asks dbPool
   withResource pool $ (\conn -> liftIO $ runQuery conn q)
 


### PR DESCRIPTION
The 1-hour old logs are wiped in vault-wrapper container because vw is way too verbose with messages like:

> 2021-07-29T17:45:45.219365819Z [2021-07-29 17:45:45.219127334 UTC]  INFO | ThreadId 282130 |                                     | SELECT
> 2021-07-29T17:45:45.219376610Z "salt2_1" as "result1_2",
> 2021-07-29T17:45:45.219380220Z "nonce3_1" as "result2_2",
> 2021-07-29T17:45:45.219383650Z "enc_sec_prv_key5_1" as "result3_2",
> 2021-07-29T17:45:45.219386951Z "address6_1" as "result4_2"
> 2021-07-29T17:45:45.219389412Z FROM (SELECT
> 2021-07-29T17:45:45.219656979Z       *
> 2021-07-29T17:45:45.219667219Z       FROM (SELECT
> 2021-07-29T17:45:45.219670740Z             "id" as "id0_1",
> 2021-07-29T17:45:45.219674170Z             "x_user_unique_name" as "x_user_unique_name1_1",
> 2021-07-29T17:45:45.219677940Z             "salt" as "salt2_1",
> 2021-07-29T17:45:45.219681200Z             "nonce" as "nonce3_1",
> 2021-07-29T17:45:45.219684420Z             "enc_sec_key" as "enc_sec_key4_1",
> 2021-07-29T17:45:45.219687871Z             "enc_sec_prv_key" as "enc_sec_prv_key5_1",
> 2021-07-29T17:45:45.219691281Z             "address" as "address6_1"
> 2021-07-29T17:45:45.219694561Z             FROM "users" as "T1") as "T1"
> 2021-07-29T17:45:45.219698001Z       WHERE (("x_user_unique_name1_1") = (CAST(E'nodekey' AS text)))) as "T1"
> 2021-07-29T17:45:45.219708402Z 172.20.20.7 - - [29/Jul/2021:17:45:45 +0000] "GET /strato/v2.3/key HTTP/1.1" 200 - "" ""
> 2021-07-29T17:45:45.219969799Z [2021-07-29 17:45:45.219759985 UTC]  INFO | ThreadId 282127 |                                     | SELECT
> 2021-07-29T17:45:45.219981159Z "salt2_1" as "result1_2",
> 2021-07-29T17:45:45.219984640Z "nonce3_1" as "result2_2",
> 2021-07-29T17:45:45.219987910Z "enc_sec_prv_key5_1" as "result3_2",
> 2021-07-29T17:45:45.219991170Z "address6_1" as "result4_2"
> 2021-07-29T17:45:45.220006751Z FROM (SELECT
> 2021-07-29T17:45:45.220072205Z       *
> 2021-07-29T17:45:45.220196844Z       FROM (SELECT
> 2021-07-29T17:45:45.220300200Z             "id" as "id0_1",
> 2021-07-29T17:45:45.220306690Z             "x_user_unique_name" as "x_user_unique_name1_1",
> 2021-07-29T17:45:45.220310321Z             "salt" as "salt2_1",
> 2021-07-29T17:45:45.220313591Z             "nonce" as "nonce3_1",
> 2021-07-29T17:45:45.220316791Z             "enc_sec_key" as "enc_sec_key4_1",
> 2021-07-29T17:45:45.220319982Z             "enc_sec_prv_key" as "enc_sec_prv_key5_1",
> 2021-07-29T17:45:45.220465611Z 172.20.20.7 - - [29/Jul/2021:17:45:45 +0000] "GET /strato/v2.3/key HTTP/1.1" 200 - "" ""
> 2021-07-29T17:45:45.220473121Z             "address" as "address6_1"
> 2021-07-29T17:45:45.220536845Z             FROM "users" as "T1") as "T1"
> 2021-07-29T17:45:45.220548776Z       WHERE (("x_user_unique_name1_1") = (CAST(E'nodekey' AS text)))) as "T1"
> 2021-07-29T17:45:45.221098482Z [2021-07-29 17:45:45.220848876 UTC]  INFO | ThreadId 282125 |                                     | SELECT
> 2021-07-29T17:45:45.221108693Z "salt2_1" as "result1_2",
> 2021-07-29T17:45:45.221112123Z "nonce3_1" as "result2_2",
> 2021-07-29T17:45:45.221115363Z "enc_sec_prv_key5_1" as "result3_2",
> 2021-07-29T17:45:45.221255663Z 172.20.20.7 - - [29/Jul/2021:17:45:45 +0000] "GET /strato/v2.3/key HTTP/1.1" 200 - "" ""
> 2021-07-29T17:45:45.221265574Z "address6_1" as "result4_2"

Move these SQL commands to "debug" level logs