### PR TITLE
Allow unit and property tests to be debugged

### DIFF
--- a/core-strato/debugger/src/Debugger/Rest/Server.hs
+++ b/core-strato/debugger/src/Debugger/Rest/Server.hs
@@ -98,11 +98,11 @@ combineProxies _ _ = Proxy
 
 restDebuggerAnd :: HasServer api '[]
                 => Proxy api
-                -> Server api
+                -> (DebugSettings -> Server api)
                 -> DebugSettings
                 -> Application
 restDebuggerAnd otherAPI otherServer dSettings =
-  serve (combineProxies restDebuggerAPI otherAPI) (restDebuggerServer dSettings :<|> otherServer)
+  serve (combineProxies restDebuggerAPI otherAPI) (restDebuggerServer dSettings :<|> otherServer dSettings)
 
 restDebugger :: DebugSettings
              -> Application

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Fuzzer.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Fuzzer.hs
@@ -28,6 +28,7 @@ import           Data.Source
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import           Data.Traversable (for)
+import           Debugger
 import           SolidVM.Solidity.Fuzzer.Types
 import           SolidVM.Solidity.Xabi
 import           SolidVM.Solidity.Xabi.Type   hiding (Account, Address, Contract)
@@ -58,12 +59,13 @@ trueVal :: BSS.ShortByteString
 trueVal = BSS.toShort . word256ToBytes . fromIntegral $ fromEnum True
 {-# NOINLINE trueVal #-}
 
-runFuzzer :: (SourceMap -> Either [SourceAnnotation T.Text] CodeCollection)
+runFuzzer :: Maybe DebugSettings
+          -> (SourceMap -> Either [SourceAnnotation T.Text] CodeCollection)
           -> SourceMap
           -> IO [FuzzerResult]
-runFuzzer compile src = flip (either $ pure . map (FuzzerFailure Nothing)) (compile src) $ \cc -> do
+runFuzzer dSettings compile src = flip (either $ pure . map (FuzzerFailure Nothing)) (compile src) $ \cc -> do
   let args = FuzzerArgs src "" "" "" "" Nothing
-  runLoggingT . evalMemContextM Nothing . flip runReaderT args $
+  runLoggingT . evalMemContextM dSettings . flip runReaderT args $
     fmap concat . for (M.toList $ cc ^. contracts) $ \(cName, c) ->
       if not (describePrefix `T.isPrefixOf` T.pack cName) then pure []
       else case funcArgs <$> c ^. constructor of

--- a/core-strato/solid-vm/src/SolidVM/Solidity/SourceTools.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/SourceTools.hs
@@ -56,8 +56,8 @@ sourceToolsServer tools =
   :<|> postAnalyze (analyzer tools)
   :<|> postFuzz (fuzzer tools)
 
-defaultSourceTools :: SourceTools
-defaultSourceTools =
+defaultSourceTools :: Maybe DebugSettings -> SourceTools
+defaultSourceTools dSettings =
   let parse = fmap concat
             . traverse (uncurry parseSourceWithAnnotations)
             . unSourceMap
@@ -65,12 +65,12 @@ defaultSourceTools =
               . M.fromList
               . unSourceMap
       analyze = runDetectors parse compile id
-      fuzz = runFuzzer compile
+      fuzz = runFuzzer dSettings compile
    in SourceTools compile analyze fuzz
 
-initializeSolidVMDebugger :: SourceTools -> IO (Maybe (DebugSettings, IO ()))
+initializeSolidVMDebugger :: (Maybe DebugSettings -> SourceTools) -> IO (Maybe (DebugSettings, IO ()))
 initializeSolidVMDebugger tools =
-  let restServer = restDebuggerAnd sourceToolsAPI (sourceToolsServer tools)
+  let restServer = restDebuggerAnd sourceToolsAPI (sourceToolsServer . tools . Just)
    in initializeDebugger restServer
 
 initializeSolidVMDebuggerSimple :: IO (Maybe (DebugSettings, IO ()))


### PR DESCRIPTION
Now you can have all the perks of the debugger while the code fuzzing tool runs unit and property tests, including setting breakpoints, stepping through code, viewing the state and stack trace, and evaluating watch expressions 