### PR TITLE
slipstream not optional by default

### DIFF
--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -205,7 +205,7 @@ function newnode {
     --stratourl=${stratoRoot} --vaultwrapperurl=${vaultWrapperRoot}  \
     --kafkahost=${kafkaHost} --kafkaport=${kafkaPort} --minLogLevel=${slipMinLogLevel}"
 
-  if [ ${SLIPSTREAM_OPTIONAL:-true} = true ]; then
+  if [ ${SLIPSTREAM_OPTIONAL} = true ]; then
       $SLIPSTREAM_CMD &>> logs/slipstream &
   else
       runBackgroundProcess $SLIPSTREAM_CMD &>> logs/slipstream

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -204,6 +204,7 @@ services:
     - seqMaxEventsPerIter=${seqMaxEventsPerIter}
     - seqMaxUsPerIter=${seqMaxUsPerIter}
     - seqRTSOPTs=${seqRTSOPTs}
+    - SLIPSTREAM_OPTIONAL=${SLIPSTREAM_OPTIONAL}
     - splitinit=true
     - START_EXPERIMENTAL_STRATO_API=${START_EXPERIMENTAL_STRATO_API}
     - stratoHost=strato:3000


### PR DESCRIPTION
Same code change as in https://github.com/blockapps/strato-platform/pull/1345
But targeting the release/7.3.0 branch