### PR TITLE
[STRATO-2300] Properly query contract details in bloc when creating a chain via CodeAtAccount

### DIFF
--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -117,6 +117,25 @@ contractDetailsJoinTable = joinF
     (queryTable contractsMetaDataTable)
     (queryTable contractsSourceTable)
 
+
+-- lets us query contract definitions in a code collection (via CodeAtAccount)
+contractInstanceMetadataJoinTable :: Query
+  ( Column PGBytea -- address
+  , Column PGBytea -- chainId
+  , Column PGBytea -- bin
+  , Column PGBytea -- bin runtime
+  , Column PGBytea -- codehash
+  , Column PGBytea -- source hash
+  , Column PGBytea -- xabi
+  )
+contractInstanceMetadataJoinTable = joinF
+  ( \ (_,_,addr,_,chId) (_,_,bin,binRuntime,codeHash,_,sh,xabi) -> (addr,chId,bin,binRuntime,codeHash,sh,xabi))
+  ( \ (_,cmId,_,_,_) (cmId2,_,_,_,_,_,_,_) -> cmId .== cmId2)
+  (queryTable contractsInstanceTable)
+  (queryTable contractsMetaDataTable)
+
+
+
 contractByAccount
   :: Account
   -> Query
@@ -138,29 +157,6 @@ contractByAccount (Account contractAddress chainId) = proc () -> do
   restrict -< cid .== constant (ChainId <$> chainId)
   returnA -< contract
 
-
-contractByCodeAtAccount
-  :: Account
-  -> Text
-  -> Query
-    ( Column PGInt4
-    , Column PGText
-    , Column PGText
-    , Column PGBytea
-    , Column PGTimestamptz
-    , Column PGBytea
-    , Column PGBytea
-    , Column PGBytea
-    , Column PGBytea
-    , Column PGBytea
-    , Column PGBytea
-    )
-contractByCodeAtAccount (Account contractAddress chainId) contractName = proc () -> do
-  contract@(_,name,_,addr,_,_,_,_,_,cid,_) <- contractsJoinTable -< ()
-  restrict -< name .== constant contractName
-  restrict -< addr .== constant contractAddress
-  restrict -< cid .== constant (ChainId <$> chainId)
-  returnA -< contract
 
 contractByCodeHash
   :: CodePtr
@@ -277,25 +273,6 @@ WHERE C.name=$1 AND CI.address=$2
 LIMIT 1;
 -}
 
-getContractsContractByCodeAtAccountQuery
-  :: Account
-  -> Text
-  -> Query
-    ( Column PGBytea
-    , Column PGBytea
-    , Column PGBytea
-    , Column PGBytea
-    , Column PGText
-    , Column PGText
-    , Column PGInt4
-    , Column PGBytea
-    )
-getContractsContractByCodeAtAccountQuery contractAcct contractName=
-  limit 1 $ proc () -> do
-    (cmId,name,src,_,_,bin,binRuntime,codeHash,xcodeHash,_,xabi) <-
-      contractByCodeAtAccount contractAcct contractName -< ()
-    returnA -< (bin,binRuntime,codeHash,xcodeHash,name,src,cmId,xabi)
-
 
 
 
@@ -381,6 +358,36 @@ decodeXabiJSON xabi' = case decode (fromStrict xabi') of
   Nothing -> throwIO $ DBError "Corrupted Xabi stored in database"
   Just x -> return x
 
+
+getContractDetailsByCodeCollection :: (MonadIO m, MonadLogger m, HasBlocSQL m)
+                                   => Account
+                                   -> Text
+                                   -> m (Maybe (Int32, ContractDetails))
+getContractDetailsByCodeCollection (Account parentAddress parentChainId) contractName = do
+  sourceHash <- blocQuery1 "sourceHashByAccount" $ proc () -> do
+    (addr,chId,_,_,_,sh,_) <- contractInstanceMetadataJoinTable-< ()
+    restrict -< addr .== constant parentAddress
+    restrict -< chId .== constant (ChainId <$> parentChainId)
+    returnA -< sh
+  row <- blocQuery1 "contractBySourceHashAndName" $ proc () -> do
+    contract@(_,_,_,_,_,name,_,_,_) <- contractBySourceHash sourceHash -< ()
+    restrict -< name .== constant contractName
+    returnA -< contract
+  detailsWith row
+  where
+    detailsWith (bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId,xabi') = do
+      xabi <- deserializeXabi xabi'
+      return $ Just (cmId, ContractDetails
+        { contractdetailsBin = Text.decodeUtf8 bin
+        , contractdetailsAccount = Nothing
+        , contractdetailsBinRuntime = Text.decodeUtf8 binr
+        , contractdetailsCodeHash = ch
+        , contractdetailsName = name
+        , contractdetailsSrc = deserializeSourceMap src
+        , contractdetailsXabi = xabi
+        })
+
+
 getContractDetailsByMetadataId :: (MonadIO m, MonadLogger m, HasBlocSQL m) =>
                                   Int32 -> Account -> m ContractDetails
 getContractDetailsByMetadataId cmId acct = do
@@ -416,41 +423,17 @@ getContractDetailsAndMetadataId acct = do
           , contractdetailsSrc = deserializeSourceMap src
           , contractdetailsXabi = xabi
           })
-    tuple <- fmap listToMaybe . blocQuery $ getContractsContractByAddressQuery acct
-    
+    tuple <- fmap listToMaybe . blocQuery $
+      getContractsContractByAddressQuery acct
     case tuple of
       Just t -> Just <$> detailsWith (Just acct) t
       Nothing -> throwIO $ UserError $ Text.pack $ "Contract " ++ show acct ++ " doesn't exist"
 
 
 
-getContractDetailsByCodeAtAccount :: (MonadIO m, MonadLogger m, HasBlocSQL m) =>
-                                      CodePtr -> m (Maybe (Int32, ContractDetails))
-getContractDetailsByCodeAtAccount (CodeAtAccount acct contractName) = do
-    let
-      detailsWith detailsAcct (bin,binRuntime,codeHash,_ :: ByteString,name,src,cmId,xabi') = do
-        xabi <- deserializeXabi xabi'
-        return (cmId, ContractDetails
-          { contractdetailsBin = Text.decodeUtf8 bin
-          , contractdetailsAccount = detailsAcct
-          , contractdetailsBinRuntime = Text.decodeUtf8 binRuntime
-          , contractdetailsCodeHash = codeHash
-          , contractdetailsName = name
-          , contractdetailsSrc = deserializeSourceMap src
-          , contractdetailsXabi = xabi
-          })
-    tuple <- fmap listToMaybe . blocQuery $ getContractsContractByCodeAtAccountQuery acct (Text.pack contractName) 
-
-    case tuple of
-      Just t -> Just <$> detailsWith (Just acct) t
-      Nothing -> throwIO $ UserError $ Text.pack $ "Can't find " ++ (show contractName) ++ " in code collection at " ++ (show acct)
-getContractDetailsByCodeAtAccount p = throwIO $ UserError $ Text.pack $ "CodePtr" ++ (show p) ++  " is not CodeAtAccount"
-
-
-
 getContractDetailsByCodeHash :: (MonadIO m, MonadLogger m, HasBlocSQL m, HasBlocEnv m) =>
                                 CodePtr -> m (Maybe (Int32, ContractDetails))
-getContractDetailsByCodeHash codePtr = do 
+getContractDetailsByCodeHash codePtr = do
   srcCache <- fmap globalCodePtrCache getBlocEnv
   now <- liftIO $ getTime Monotonic
   let later = (now +) <$> Cache.defaultExpiration srcCache
@@ -465,7 +448,7 @@ getContractDetailsByCodeHash codePtr = do
     Just cachedDetails -> pure $ Just cachedDetails
     Nothing -> do
       mIdAndDetails <- case codePtr of
-        caa@(CodeAtAccount _ _) -> getContractDetailsByCodeAtAccount caa 
+        (CodeAtAccount acct name) -> getContractDetailsByCodeCollection acct (Text.pack name)
         codeHash -> do
           mDetails <- fmap listToMaybe . blocQuery $ getContractsContractByCodeHashQuery codeHash
           for mDetails $ \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId,xabi') -> do

--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -443,7 +443,7 @@ getContractDetailsByCodeAtAccount (CodeAtAccount acct contractName) = do
 
     case tuple of
       Just t -> Just <$> detailsWith (Just acct) t
-      Nothing -> throwIO $ UserError $ Text.pack $ "Contract " ++ show acct ++ " doesn't exist"
+      Nothing -> throwIO $ UserError $ Text.pack $ "Can't find " ++ (show contractName) ++ " in code collection at " ++ (show acct)
 getContractDetailsByCodeAtAccount p = throwIO $ UserError $ Text.pack $ "CodePtr" ++ (show p) ++  " is not CodeAtAccount"
 
 

--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -138,6 +138,30 @@ contractByAccount (Account contractAddress chainId) = proc () -> do
   restrict -< cid .== constant (ChainId <$> chainId)
   returnA -< contract
 
+
+contractByCodeAtAccount
+  :: Account
+  -> Text
+  -> Query
+    ( Column PGInt4
+    , Column PGText
+    , Column PGText
+    , Column PGBytea
+    , Column PGTimestamptz
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    )
+contractByCodeAtAccount (Account contractAddress chainId) contractName = proc () -> do
+  contract@(_,name,_,addr,_,_,_,_,_,cid,_) <- contractsJoinTable -< ()
+  restrict -< name .== constant contractName
+  restrict -< addr .== constant contractAddress
+  restrict -< cid .== constant (ChainId <$> chainId)
+  returnA -< contract
+
 contractByCodeHash
   :: CodePtr
   -> Query
@@ -252,6 +276,29 @@ JOIN contracts_instance CI
 WHERE C.name=$1 AND CI.address=$2
 LIMIT 1;
 -}
+
+getContractsContractByCodeAtAccountQuery
+  :: Account
+  -> Text
+  -> Query
+    ( Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGBytea
+    , Column PGText
+    , Column PGText
+    , Column PGInt4
+    , Column PGBytea
+    )
+getContractsContractByCodeAtAccountQuery contractAcct contractName=
+  limit 1 $ proc () -> do
+    (cmId,name,src,_,_,bin,binRuntime,codeHash,xcodeHash,_,xabi) <-
+      contractByCodeAtAccount contractAcct contractName -< ()
+    returnA -< (bin,binRuntime,codeHash,xcodeHash,name,src,cmId,xabi)
+
+
+
+
 getContractsContractByAddressQuery
   :: Account
   -> Query
@@ -369,15 +416,41 @@ getContractDetailsAndMetadataId acct = do
           , contractdetailsSrc = deserializeSourceMap src
           , contractdetailsXabi = xabi
           })
-    tuple <- fmap listToMaybe . blocQuery $
-      getContractsContractByAddressQuery acct
+    tuple <- fmap listToMaybe . blocQuery $ getContractsContractByAddressQuery acct
+    
     case tuple of
       Just t -> Just <$> detailsWith (Just acct) t
       Nothing -> throwIO $ UserError $ Text.pack $ "Contract " ++ show acct ++ " doesn't exist"
 
+
+
+getContractDetailsByCodeAtAccount :: (MonadIO m, MonadLogger m, HasBlocSQL m) =>
+                                      CodePtr -> m (Maybe (Int32, ContractDetails))
+getContractDetailsByCodeAtAccount (CodeAtAccount acct contractName) = do
+    let
+      detailsWith detailsAcct (bin,binRuntime,codeHash,_ :: ByteString,name,src,cmId,xabi') = do
+        xabi <- deserializeXabi xabi'
+        return (cmId, ContractDetails
+          { contractdetailsBin = Text.decodeUtf8 bin
+          , contractdetailsAccount = detailsAcct
+          , contractdetailsBinRuntime = Text.decodeUtf8 binRuntime
+          , contractdetailsCodeHash = codeHash
+          , contractdetailsName = name
+          , contractdetailsSrc = deserializeSourceMap src
+          , contractdetailsXabi = xabi
+          })
+    tuple <- fmap listToMaybe . blocQuery $ getContractsContractByCodeAtAccountQuery acct (Text.pack contractName) 
+
+    case tuple of
+      Just t -> Just <$> detailsWith (Just acct) t
+      Nothing -> throwIO $ UserError $ Text.pack $ "Contract " ++ show acct ++ " doesn't exist"
+getContractDetailsByCodeAtAccount p = throwIO $ UserError $ Text.pack $ "CodePtr" ++ (show p) ++  " is not CodeAtAccount"
+
+
+
 getContractDetailsByCodeHash :: (MonadIO m, MonadLogger m, HasBlocSQL m, HasBlocEnv m) =>
                                 CodePtr -> m (Maybe (Int32, ContractDetails))
-getContractDetailsByCodeHash codePtr = do
+getContractDetailsByCodeHash codePtr = do 
   srcCache <- fmap globalCodePtrCache getBlocEnv
   now <- liftIO $ getTime Monotonic
   let later = (now +) <$> Cache.defaultExpiration srcCache
@@ -392,7 +465,7 @@ getContractDetailsByCodeHash codePtr = do
     Just cachedDetails -> pure $ Just cachedDetails
     Nothing -> do
       mIdAndDetails <- case codePtr of
-        CodeAtAccount acct _ -> getContractDetailsAndMetadataId acct
+        caa@(CodeAtAccount _ _) -> getContractDetailsByCodeAtAccount caa 
         codeHash -> do
           mDetails <- fmap listToMaybe . blocQuery $ getContractsContractByCodeHashQuery codeHash
           for mDetails $ \(bin,binr,ch,_ :: ByteString,_ :: ByteString,name,src,cmId,xabi') -> do

--- a/api/bloc2/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Server/Chain.hs
@@ -84,6 +84,7 @@ createChainInfo :: (MonadIO m, MonadLogger m, HasBlocSQL m, HasBlocEnv m) =>
 createChainInfo creationBlockHash (ChainInput src mCodePtr cname lbl balances chaininputArgs members pChain mmd _) = do
   when (null members) $ throwIO $ UserError "Private chains must include at least one member"
   when (sum (nmap2' balances) == 0) $ throwIO $ UserError "At least one account must have a non-zero balance"
+
   let md = fromMaybe Map.empty mmd
       theVM = fromMaybe "EVM" $ Map.lookup "VM" md
   mContract <-
@@ -123,13 +124,9 @@ createChainInfo creationBlockHash (ChainInput src mCodePtr cname lbl balances ch
               codeInfo' = [CodeInfo b' jsrc $ Just contractdetailsName]
           md' <- case theVM of
               "SolidVM" -> do
-                $logInfoS "DAN" . Text.pack $ "the xabi " ++ (show $ contractdetailsXabi)
-                $logInfoS "DAN" . Text.pack $ "the xabi funcArgs " ++ (show $ funcArgs <$> xabiConstr contractdetailsXabi)
                 let xabiArgs = maybe Map.empty funcArgs $ xabiConstr contractdetailsXabi
                 (_, argsAsSource) <- constructArgValuesAndSource (Just argValues) xabiArgs
-                let thing = (at "args" ?~ argsAsSource) md
-                $logInfoS "DAN" . Text.pack $ "the final metadata: " ++ show thing
-                pure thing
+                pure $ (at "args" ?~ argsAsSource) md
               _ -> pure md
           return ([contractAcctInfo],codeInfo',md') -- Perhaps in the future, we can support multiple contracts
   nonce <- byteStringToWord256 <$> liftIO (getEntropy 32)

--- a/api/bloc2/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Server/Chain.hs
@@ -84,7 +84,6 @@ createChainInfo :: (MonadIO m, MonadLogger m, HasBlocSQL m, HasBlocEnv m) =>
 createChainInfo creationBlockHash (ChainInput src mCodePtr cname lbl balances chaininputArgs members pChain mmd _) = do
   when (null members) $ throwIO $ UserError "Private chains must include at least one member"
   when (sum (nmap2' balances) == 0) $ throwIO $ UserError "At least one account must have a non-zero balance"
-
   let md = fromMaybe Map.empty mmd
       theVM = fromMaybe "EVM" $ Map.lookup "VM" md
   mContract <-
@@ -124,9 +123,13 @@ createChainInfo creationBlockHash (ChainInput src mCodePtr cname lbl balances ch
               codeInfo' = [CodeInfo b' jsrc $ Just contractdetailsName]
           md' <- case theVM of
               "SolidVM" -> do
+                $logInfoS "DAN" . Text.pack $ "the xabi " ++ (show $ contractdetailsXabi)
+                $logInfoS "DAN" . Text.pack $ "the xabi funcArgs " ++ (show $ funcArgs <$> xabiConstr contractdetailsXabi)
                 let xabiArgs = maybe Map.empty funcArgs $ xabiConstr contractdetailsXabi
                 (_, argsAsSource) <- constructArgValuesAndSource (Just argValues) xabiArgs
-                pure $ (at "args" ?~ argsAsSource) md
+                let thing = (at "args" ?~ argsAsSource) md
+                $logInfoS "DAN" . Text.pack $ "the final metadata: " ++ show thing
+                pure thing
               _ -> pure md
           return ([contractAcctInfo],codeInfo',md') -- Perhaps in the future, we can support multiple contracts
   nonce <- byteStringToWord256 <$> liftIO (getEntropy 32)

--- a/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/OutputData.hs
@@ -165,9 +165,18 @@ baseTableColumns :: TableColumns
 baseTableColumns = baseColumns
 
 
+-- discard app if org is null
+constructTableNameParameters :: Text -> Text -> Text -> (Text, Text, Text)
+constructTableNameParameters org app contract =
+  if T.null org
+    then ("", "", contract)
+    else (org, app, contract)
+
+
 -- sometimes we need the unwrapped tablename
 tableNameToDoubleQuoteText :: TableName -> Text
 tableNameToDoubleQuoteText = wrapDoubleQuotes . escapeQuotes . tableNameToText
+
 
 tableNameToText :: TableName -> Text
 tableNameToText (IndexTableName o a c) =
@@ -234,7 +243,11 @@ createIndexTable :: OutputM m
                  -> ProcessedContract
                  -> ConduitM () Text m ()
 createIndexTable globalsIORef contract = do
-  let tableName = IndexTableName (organization contract) (application contract) (contractName contract)
+  let (org, app, cname) = constructTableNameParameters
+          (organization contract)
+          (application contract)
+          (contractName contract)
+      tableName = IndexTableName org app cname
   contractAlreadyCreated <- isTableCreated globalsIORef tableName
 
   --When contract hasn't been written to "contract" table and indexing table doesn't exist
@@ -251,7 +264,11 @@ createHistoryTable :: OutputM m
                    -> ProcessedContract
                    -> ConduitM () Text m ()
 createHistoryTable globalsIORef contract = do
-  let tableName = HistoryTableName (organization contract) (application contract) (contractName contract)
+  let (org, app, cname) = constructTableNameParameters
+          (organization contract)
+          (application contract)
+          (contractName contract)
+      tableName = HistoryTableName org app cname
   history <- isHistoric globalsIORef tableName
   tableExists <- isTableCreated globalsIORef tableName
   when (history && not tableExists) $ do
@@ -270,7 +287,11 @@ expandIndexTable :: OutputM m
                  -> ConduitM () Text m ()
 expandIndexTable _ [] = return ()
 expandIndexTable globalsIORef lst@(x:_) = do
-  let tableName = IndexTableName (organization x) (application x) (contractName x)
+  let (org, app, cname) = constructTableNameParameters
+          (organization x)
+          (application x)
+          (contractName x)
+      tableName = IndexTableName org app cname
   expandContractTable globalsIORef lst tableName
 
 expandHistoryTable :: OutputM m
@@ -279,7 +300,11 @@ expandHistoryTable :: OutputM m
                  -> ConduitM () Text m ()
 expandHistoryTable _ [] = return ()
 expandHistoryTable globalsIORef lst@(x:_) = do
-  let tableName = HistoryTableName (organization x) (application x) (contractName x)
+  let (org, app, cname) = constructTableNameParameters
+          (organization x)
+          (application x)
+          (contractName x)
+      tableName = HistoryTableName org app cname
   expandContractTable globalsIORef lst tableName
 
 expandContractTable :: OutputM m
@@ -337,13 +362,18 @@ insertHistoryTable :: OutputM m
                    -> ConduitM () Text m ()
 insertHistoryTable _ [] = error "insertHistoryTable: unhandled empty list"
 insertHistoryTable globalsIORef contracts@(x:_) = do
-  let tableName = HistoryTableName (organization x) (application x) (contractName x)
+  let (org, app, cname) = constructTableNameParameters
+          (organization x)
+          (application x)
+          (contractName x)
+      tableName = HistoryTableName org app cname
   history <- isHistoric globalsIORef tableName
   when history . yield $ insertHistoryTableQuery contracts
 
 insertContractTableQuery :: ProcessedContract -> Text
 insertContractTableQuery ProcessedContract{..} =
-  let tableName = IndexTableName organization application contractName
+  let (org, app, cname) = constructTableNameParameters organization application contractName
+      tableName = IndexTableName org app cname
       conVals = wrapAndEscape . map escapeQuotes $
         [ T.pack $ keccak256ToHex $ resolvedCodePtrToSHA codehash
         , tableNameToText tableName
@@ -358,7 +388,11 @@ insertContractTableQuery ProcessedContract{..} =
 
 createIndexTableQuery :: ProcessedContract -> Text
 createIndexTableQuery contract =
-  let tableName = IndexTableName (organization contract) (application contract) (contractName contract)
+  let (org, app, cname) = constructTableNameParameters
+          (organization contract)
+          (application contract)
+          (contractName contract)
+      tableName = IndexTableName org app cname
       list = Map.toList $ Map.map valueToSolidityValue $ Map.filter isFunction $ contractData contract
    in T.concat
         [ "CREATE TABLE IF NOT EXISTS " , tableNameToDoubleQuoteText tableName , " ("
@@ -371,7 +405,11 @@ createIndexTableQuery contract =
 
 createHistoryTableQuery :: ProcessedContract -> Text
 createHistoryTableQuery contract =
-  let tableName = HistoryTableName (organization contract) (application contract) (contractName contract)
+  let (org, app, cname) = constructTableNameParameters
+          (organization contract)
+          (application contract)
+          (contractName contract)
+      tableName = HistoryTableName org app cname
       list = Map.toList $ Map.map valueToSolidityValue $ Map.filter isFunction $ contractData contract
    in T.concat
         [ "CREATE TABLE IF NOT EXISTS ", tableNameToDoubleQuoteText tableName, " ("
@@ -383,7 +421,11 @@ createHistoryTableQuery contract =
 
 addHistoryUnique :: ProcessedContract -> Text
 addHistoryUnique contract =
-  let historyName' = HistoryTableName (organization contract) (application contract) (contractName contract)
+  let (org, app, cname) = constructTableNameParameters
+          (organization contract)
+          (application contract)
+          (contractName contract)
+      historyName' = HistoryTableName org app cname
       historyName = tableNameToDoubleQuoteText historyName'
       indexName = "index_" <> (escapeQuotes $ tableNameToText historyName')
   in  "CREATE UNIQUE INDEX IF NOT EXISTS " <> wrapDoubleQuotes indexName <>
@@ -393,7 +435,11 @@ addHistoryUnique contract =
 insertIndexTableQuery :: [ProcessedContract] -> Text
 insertIndexTableQuery [] = error "insertIndexTableQuery: unhandled empty list"
 insertIndexTableQuery contracts@(x:_) =
-  let tableName = IndexTableName (organization x) (application x) (contractName x)
+  let (org, app, cname) = constructTableNameParameters
+          (organization x)
+          (application x)
+          (contractName x)
+      tableName = IndexTableName org app cname
       list = Map.toList $ Map.map valueToSolidityValue $ Map.filter isFunction $ contractData x
       keySt  = wrapAndEscapeDouble . map escapeQuotes $ baseTableColumns ++ map fst list
       baseVals = [ tshow . address
@@ -432,7 +478,11 @@ insertIndexTableQuery contracts@(x:_) =
 insertHistoryTableQuery :: [ProcessedContract] -> Text
 insertHistoryTableQuery [] = error "insertHistoryTableQuery: unhandled empty list"
 insertHistoryTableQuery contracts@(x:_) =
-  let tableName = HistoryTableName (organization x) (application x) (contractName x)
+  let (org, app, cname) = constructTableNameParameters
+          (organization x)
+          (application x)
+          (contractName x)
+      tableName = HistoryTableName org app cname
       list = Map.toList . Map.map valueToSolidityValue . Map.filter isFunction $ contractData x
       keySt  = wrapAndEscapeDouble . map escapeQuotes $ baseTableColumns ++ map fst list
       baseVals = [ tshow . address
@@ -473,7 +523,12 @@ createEventTable :: OutputM m
                  -> EventTable
                  -> m (Maybe Text)
 createEventTable globalsIORef ev = do
-  let eventTable = EventTableName (eventOrganization ev) (eventApplication ev) (eventContractName ev) (eventName ev)
+  let (org, app, cname) = constructTableNameParameters
+          (eventOrganization ev)
+          (eventApplication ev)
+          (eventContractName ev)
+      eventTable = EventTableName org app cname (eventName ev)
+  
   eventAlreadyCreated <- isTableCreated globalsIORef eventTable
   if eventAlreadyCreated then 
     return Nothing
@@ -483,7 +538,12 @@ createEventTable globalsIORef ev = do
 
 createEventTableQuery :: EventTable -> Text
 createEventTableQuery ev =
-  let tableName = EventTableName (eventOrganization ev) (eventApplication ev) (eventContractName ev) (eventName ev)
+  let (org, app, cname) = constructTableNameParameters
+          (eventOrganization ev)
+          (eventApplication ev)
+          (eventContractName ev)
+      tableName = EventTableName org app cname (eventName ev)
+
       cols = csv $ ["id SERIAL NOT NULL", "address text"] ++ 
                 (map (\t -> T.concat [wrapDoubleQuotes t, " text"]) $ eventFields ev) 
   in T.concat   
@@ -513,7 +573,12 @@ expandEventTables :: OutputM m
                   -> ConduitM () Text m ()
 expandEventTables _ [] = return ()
 expandEventTables globalsIORef (x:xs) = do
-  let tableName = EventTableName (T.pack $ Action.evContractOrganization x) (T.pack $ Action.evContractApplication x) (T.pack $ Action.evContractName x) (T.pack $ Action.evName x)
+  let (org, app, cname) = constructTableNameParameters
+          (T.pack $ Action.evContractOrganization x)
+          (T.pack $ Action.evContractApplication x)
+          (T.pack $ Action.evContractName x)
+      tableName = EventTableName org app cname (T.pack $ Action.evName x)
+
   columns <- getTableColumns globalsIORef tableName
   case columns of
     Nothing -> do
@@ -550,14 +615,24 @@ insertEventTable :: OutputM m
                  -> Action.Event
                  -> m (Maybe Text)
 insertEventTable globalsIORef ev = do
-  let eventTable = EventTableName (T.pack $ Action.evContractOrganization ev) (T.pack $ Action.evContractApplication ev) (T.pack $ Action.evContractName ev) (T.pack $ Action.evName ev)
+  let (org, app, cname) = constructTableNameParameters
+          (T.pack $ Action.evContractOrganization ev)
+          (T.pack $ Action.evContractApplication ev)
+          (T.pack $ Action.evContractName ev)
+      eventTable = EventTableName org app cname (T.pack $ Action.evName ev)
+
   eventExists <- isTableCreated globalsIORef eventTable
   if eventExists then return (Just $ insertEventTableQuery ev)
   else return Nothing
 
 insertEventTableQuery :: Action.Event -> Text
 insertEventTableQuery ev = 
- let tableName = EventTableName (T.pack $ Action.evContractOrganization ev) (T.pack $ Action.evContractApplication ev) (T.pack $ Action.evContractName ev) (T.pack $ Action.evName ev)
+ let (org, app, cname) = constructTableNameParameters
+          (T.pack $ Action.evContractOrganization ev)
+          (T.pack $ Action.evContractApplication ev)
+          (T.pack $ Action.evContractName ev)
+     tableName = EventTableName org app cname (T.pack $ Action.evName ev)
+
      cols = wrapAndEscapeDouble . map escapeQuotes $ ["id", "address"] ++ (map (T.pack . fst) $ Action.evArgs ev)
      vals = csv $ map (wrapSingleQuotes . T.pack . snd) $ Action.evArgs ev
  in T.concat

--- a/tests/e2e/createChain.test.ts
+++ b/tests/e2e/createChain.test.ts
@@ -244,7 +244,7 @@ describe("Create Chain", function() {
     vmOptions.config.VM = 'SolidVM'; 
     
     // upload main (and thus, the whole code collection)
-    const main = await rest.createContract(alice, {name: "Main", source: ccSrc, args: {}}, vmOptions);
+    const main = <Contract> await rest.createContract(alice, {name: "Main", source: ccSrc, args: {}}, vmOptions);
     
     assert.isDefined(main, "should exist");
     assert.isDefined(main.address, "should be defined");
@@ -260,7 +260,12 @@ describe("Create Chain", function() {
     
     const codePtr = { account: main.address, name: "Governance" };
 
+    // TODO: we need to add `codePtr` to the definition of `Chain` in blockapps-rest. Then, we can remove the ts-ignore below
+    // More details here: https://blockapps.atlassian.net/browse/STRATO-2313 
+
+    // @ts-ignore
     const chainId = await rest.createChain(alice, {label, members: mems, balances: bals, codePtr, args}, {name: "Governance"}, vmOptions);
+
     assert.isDefined(chainId, "chainId defined");
     assert.notEqual(chainId, "", "chainId is not zero");
 

--- a/tests/e2e/createChain.test.ts
+++ b/tests/e2e/createChain.test.ts
@@ -224,6 +224,54 @@ describe("Create Chain", function() {
     assert.isUndefined(chainId, "chainId not defined");
   });
 
+  it('should be able to create a private chain with a CodePtr to existing code', async() => {
+    // create users
+    const alice = await rest.createUser(ouser1, options);
+    const bob   = await rest.createUser(ouser2, options);
+    assert.isDefined(alice, "should exit");
+    assert.isDefined(alice.address, "should be defined");
+    assert.notEqual(alice.address, 0, "should be a nonzero address");
+    assert.isDefined(bob, "should exit");
+    assert.isDefined(bob.address, "should be defined");
+    assert.notEqual(bob.address, 0, "should be a nonzero address");
+
+
+    const ccSrc = "contract Main { uint x; constructor() { x = 0; } } contract Governance { uint y; constructor() { y = 1; } }";
+
+
+    // this is a SolidVM feature
+    let vmOptions = {config};
+    vmOptions.config.VM = 'SolidVM'; 
+    
+    // upload main (and thus, the whole code collection)
+    const main = await rest.createContract(alice, {name: "Main", source: ccSrc, args: {}}, vmOptions);
+    
+    assert.isDefined(main, "should exist");
+    assert.isDefined(main.address, "should be defined");
+    assert.notEqual(main.address, 0, "should be a nonzero address");
+
+    // create chain with codePtr
+    const mems = [{address: alice.address, enode: members[0].enode}
+                  ,{address: bob.address, enode: members[1].enode}
+		             ];
+    const bals = [{ address: alice.address, balance: 1000000}
+                 ,{ address: bob.address, balance: 10000000}
+                 ];
+    
+    const codePtr = { account: main.address, name: "Governance" };
+
+    const chainId = await rest.createChain(alice, {label, members: mems, balances: bals, codePtr, args}, {name: "Governance"}, vmOptions);
+    assert.isDefined(chainId, "chainId defined");
+    assert.notEqual(chainId, "", "chainId is not zero");
+
+    // query cirrus for the gov contract
+    const govList = await rest.search(alice, { name: "Governance" }, { query: { chainId: `eq.${chainId}` }, ...options });
+    assert.equal(govList.length, 1, "one instance of Governance on this chain");
+    const gov = govList[0];
+    assert.isDefined(gov, "Governance contract apperas in Cirrus");
+    assert.equal(gov.y, '1', "Governance contract storage matches what we expect");
+  });
+
 });
 
 function promiseTimeout(timeout) {

--- a/tests/e2e/slipstream.test.ts
+++ b/tests/e2e/slipstream.test.ts
@@ -77,7 +77,7 @@ contract Y {
   it("can index contracts recursively constructed", async () => {
     const [user, contract] = await upload("Y", newContract, options);
     await sleep(2000);
-    const indexY = await rest.search(user, {...contract, name: "Y"}, options);
+    const indexY = await rest.search(user, {...contract, name: "Y"}, {...options, query: {address: `eq.${contract.address}`}});
     assert.equal(indexY.length, 1, JSON.stringify(indexY, null, 2));
     const indexX = await rest.search(user, {...contract, name: "X"}, options);
     console.log(`indexX returned ${JSON.stringify(indexX, null, 2)}`);
@@ -96,7 +96,7 @@ contract Z {
   it("Will index updates to a contract", async () => {
     const [user, contract] = await upload("Z", Counter, options);
     await sleep(2000);
-    let indexZ = await rest.search(user, {...contract, name: "Z"}, options);
+    let indexZ = await rest.search(user, {...contract, name: "Z"}, {...options, query: {address: `eq.${contract.address}`}});
     assert.equal(indexZ.length, 1, JSON.stringify(indexZ, null, 2));
     console.log(`Initial index: ${JSON.stringify(indexZ, null, 2)}`);
     let res = await rest.call(user, {contract, method: "incr", args: {}}, options);
@@ -184,6 +184,24 @@ contract KeywordEventTest {
   });
 
 
+
+  it("Will expand Cirrus tables when contract versions with new fields are created", async () => {
+    const version1 = "contract ExpansionTest { uint x; constructor() { x = 0; } }";
+    const version2 = "contract ExpansionTest { uint x; uint y; constructor() { x = 2; y = 10; } }";
+
+    const [user, contract] = await upload("ExpansionTest", version1, options);
+    const v1SearchList = await rest.search(user, {...contract, name: "ExpansionTest"}, {...options, query: {address: `eq.${contract.address}`}});
+    assert.equal(v1SearchList.length, 1, "one result from Cirrus");
+    const v1 = v1SearchList[0];
+    assert.equal(v1.x, 0, "first version appears correctly in Cirrus");
+
+    const [user2, contract2] = await upload("ExpansionTest", version2, options);
+    const v2SearchList = await rest.search(user, {...contract, name: "ExpansionTest"}, {...options, query: {address: `eq.${contract2.address}`}});
+    assert.equal(v2SearchList.length, 1, "one result from Cirrus");
+    const v2 = v2SearchList[0];
+    assert.equal(v2.x, 2, "second version appears correctly in Cirrus");
+    assert.equal(v2.y, 10, "second version new field appears correctly in Cirrus");
+  });
 
 });
 


### PR DESCRIPTION
TL;DR; 
We used to be able to create new private chains by providing a `CodeAtAccount` to the API as our governance contract. But the feature mysteriously disappeared in the last month, when Jim went through and (rightfully) removed all of the queries by name we were doing in Bloc. In my quest to find the missing code and add it back, I decided to go back to STRATO 7.0.0 and figure out how the feature used to work..... it was then that I discovered that that this feature never _truly_ worked the way we wanted - it always relied on the `getContractByLatestQuery` to find your contract. As in, it just looked for the most recent contract that had the same name as the one you were trying to create the chain with. It never actually checked whether that contract definition was the one from the code collection you pointed to. Luckily, we never had multiple definitions for the same governance contract names, so this was never a problem. But in the world of mixed-networks and multiple contract versions, it could be. And besides - the `getContractByLatestQuery` is gone...... so, I had to make it work the correct way once and for all.


First, I added a join table to the bloc22 database that joins the `contracts_instance` table with the `contracts_metadata` table, using the `contract_metadata_id`. We already have some joins that do this, but they also join with other tables to get full contract details for _a particular contract instance_, discarding the thing I needed - the source hash (this is the one thing that links the different contract definitions in the code collection).

So, I wrote a new join that joins _just_ the two tables, and preserves the source hash. That way, you can retrieve the source hash for a particular instance (the `account` in `CodeAtAccount`).

With that join, I then wrote a query that finds the source hash for the `Account`, and then another query that looks at all the contracts with that source hash and finds the specific contract you want (using the `contractName` you put in the `CodeAtAccount)`. 

I wrapped these queries into a function, and replaced the broken call with a call to it (in `getContractDetailsByCodeHash`).

Everything works now. Local tests and seismic tests pass. E2E tests are written and pass.

This PR also addresses this slipstream bug: https://blockapps.atlassian.net/browse/STRATO-2312
I added another `e2e` test to test table expansions.