### PR TITLE
fix spelling mistake of "constructor" within solidvm logs

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1717,7 +1717,7 @@ runTheConstructors from to hsh cc contractName' argExps = do
           return (n, (t, var))
 
 
-  addCallInfo to contract' (contractName' ++ " constructer") hsh cc (M.fromList zipped) False
+  addCallInfo to contract' (contractName' ++ " constructor") hsh cc (M.fromList zipped) False
 
   forM_ [(n, e) | (n, Xabi.VariableDecl _ _ (Just e) _) <- M.toList $ contract'^.storageDefs] $ \(n, e) -> do
     v <- expToVar e


### PR DESCRIPTION
Noticed a super small spelling mistake in the VM logs whilst writing some documentation... "Constructor" was spelled with an "er" not "or".