### PR TITLE
ba-rest production security vulnerabilities fixed; versions order fixed

### DIFF
--- a/blockapps-rest/Jenkinsfile.release
+++ b/blockapps-rest/Jenkinsfile.release
@@ -123,7 +123,7 @@ pipeline {
             sh "git clone https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/blockapps-rest"
           }
           dir ("blockapps-rest") {
-            sh "yarn install --frozen-lockfile"
+            sh "yarn install"
             sh "yarn build"
             sh "cp ~/.npmrc ~/.npmrc.BAK"
             withCredentials([string(credentialsId: 'npm-admin-token', variable: 'NPMTOKEN')]) {

--- a/blockapps-rest/README.md
+++ b/blockapps-rest/README.md
@@ -1,3 +1,8 @@
+## Mirror Repository Warning
+This repository is a mirror of the development repository maintained by BlockApps. This repository contains a 
+code of the versions released to [npm](https://www.npmjs.com/package/blockapps-rest). 
+We do not accept or merge any pull requests in this repository.
+
 ## Introduction
 
 The Blockapps-Rest library is Node.js server-side SDK for BlockApps STRATO. It provides all the necessary abstractions and utility functions that can be used to interact with the STRATO platforms and perform the following operations:

--- a/blockapps-rest/ReleaseNotes.md
+++ b/blockapps-rest/ReleaseNotes.md
@@ -1,9 +1,13 @@
 ## RELEASE NOTES
 
-### Version: 8.0.3
+### Version: 8.1.0
 
 - Added the debugPostParse function to support compilation and static analysis tools
 - Added the debugPostAnalyze function to support static analysis tools
+
+### Version: 8.0.3
+
+- Updated non-dev dependencies to address security vulnerabilities in production installation
 
 ### Version: 8.0.2
 

--- a/blockapps-rest/package.json
+++ b/blockapps-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockapps-rest",
-  "version": "8.0.3",
+  "version": "8.1.0",
   "description": "BlockApps Rest API SDK",
   "main": "dist/index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "@types/mocha": "^8.0.3",
     "@types/simple-oauth2": "^2.2.1",
     "@types/tcp-port-used": "^1.0.0",
-    "axios": "^0.19.0",
+    "axios": "^0.21.2",
     "bignumber.js": "^9.0.0",
     "bluebird": "^3.4.6",
     "chai": "^4.2.0",
@@ -51,7 +51,6 @@
     "sha3": "^2.1.3",
     "simple-oauth2": "2.2.1",
     "solidity-parser-antlr": "^0.4.1",
-    "soljitsu": "^1.0.0",
     "sync-request": "6.0.0",
     "tcp-port-used": "^1.0.1",
     "typescript": "^4.0.5",


### PR DESCRIPTION
Had to release a hotfix for ba-rest to address the high severity security vulnerabilities in dependencies (by customer's request). Released 8.0.3 without the current changes from develop. So I also cherry-picked the hotfix into develop here and adjusted the versioning for what is unreleased in develop