### PR TITLE
blockapps-rest production dependencies cleanup

### DIFF
--- a/blockapps-rest/Dockerfile.test
+++ b/blockapps-rest/Dockerfile.test
@@ -20,4 +20,4 @@ RUN sed -i 's|http://localhost|http://'"${host}"'|g' .oauth-test-config && \
 
 RUN yarn build
 
-RUN npm run test
+RUN yarn test

--- a/blockapps-rest/ReleaseNotes.md
+++ b/blockapps-rest/ReleaseNotes.md
@@ -5,6 +5,10 @@
 - Added the debugPostParse function to support compilation and static analysis tools
 - Added the debugPostAnalyze function to support static analysis tools
 
+### Version: 8.0.4
+
+- Production dependencies cleanup
+
 ### Version: 8.0.3
 
 - Updated non-dev dependencies to address security vulnerabilities in production installation

--- a/blockapps-rest/package.json
+++ b/blockapps-rest/package.json
@@ -23,22 +23,17 @@
     "node": ">= 10.1.0"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.8.3",
-    "@types/mocha": "^8.0.3",
     "@types/simple-oauth2": "^2.2.1",
     "@types/tcp-port-used": "^1.0.0",
     "axios": "^0.21.2",
     "bignumber.js": "^9.0.0",
     "bluebird": "^3.4.6",
-    "chai": "^4.2.0",
-    "chai-bignumber": "^3.0.0",
     "commander": "^5.1.0",
     "dotenv": "^6.2.0",
     "envfile": "^3.0.0",
     "express": "^4.16.4",
     "flatted": "^2.0.1",
     "fs": "0.0.1-security",
-    "gulp-typescript": "^6.0.0-alpha.1",
     "http-status-codes": "^1.3.0",
     "https": "1.0.0",
     "ip": "^1.1.5",
@@ -53,15 +48,18 @@
     "solidity-parser-antlr": "^0.4.1",
     "sync-request": "6.0.0",
     "tcp-port-used": "^1.0.1",
-    "typescript": "^4.0.5",
     "unix-time": "1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.8.4",
+    "@babel/polyfill": "^7.8.3",
     "@babel/preset-env": "^7.8.4",
     "@babel/register": "^7.8.4",
+    "@types/mocha": "^8.0.3",
     "babel-preset-minify": "^0.5.1",
+    "chai": "^4.2.0",
+    "chai-bignumber": "^3.0.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^17.0.0",
     "eslint-plugin-import": "^2.13.0",
@@ -72,8 +70,10 @@
     "gulp-clean": "^0.4.0",
     "gulp-cli": "^2.0.1",
     "gulp-sourcemaps": "^2.6.5",
+    "gulp-typescript": "^6.0.0-alpha.1",
     "jsdoc": "^3.6.4",
     "mocha": "^6.0.2",
-    "ts-node": "^10.0.0"
+    "ts-node": "^10.0.0",
+    "typescript": "^4.0.5"
   }
 }


### PR DESCRIPTION
another hotfix to address security vulnerabilities.
One of the dependencies (gulp-typescript) has sub-dependency with vulnerability.
Gulp-typescript should be a part of dev-dependencies list, not prod dependencies. The vulnerability in dev dependency is not critical for customers.
So I moved the gulp-typescript and some of the other dependencies to dev-deps. Which should lower the blockapps-rest installation size also.