### PR TITLE
In usage stats get networkTxsTotal directly from db to avoid a cumulative error

### DIFF
--- a/apex/api/daemons/node-stats-utils.js
+++ b/apex/api/daemons/node-stats-utils.js
@@ -46,12 +46,14 @@ class StatsDaemon {
     const pgClientVault = new Sequelize(`${sequelizeConnUriPrefix}/oauth`, {logging: (dbconfig.logging ? dbconfig.logging : undefined)})
     const pgClientCirrus = new Sequelize(`${sequelizeConnUriPrefix}/cirrus`, {logging: (dbconfig.logging ? dbconfig.logging : undefined)})
     
-    const [[txsForPeriodResult], [usersCountResult], [cirrusTableListResult, cirrusTableListMetadata]] = await Promise.all([
+    const [[txsTotalResult], [txsForPeriodResult], [usersCountResult], [cirrusTableListResult, cirrusTableListMetadata]] = await Promise.all([
+      pgClientEth.query(`SELECT count(*) FROM raw_transaction AS rt LEFT JOIN transaction_result AS tr ON rt.tx_hash=tr.transaction_hash WHERE tr.status='Success' and rt.block_number >= 0`),
       pgClientEth.query(`SELECT count(*) FROM raw_transaction AS rt LEFT JOIN transaction_result AS tr ON rt.tx_hash=tr.transaction_hash WHERE rt.timestamp >= now() - INTERVAL '${secondsSinceLastStat} SECONDS' and tr.status='Success' and rt.block_number >= 0`),
       pgClientVault.query("SELECT count(*) FROM users WHERE x_user_unique_name != 'nodekey'"),
       pgClientCirrus.query("SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename != 'contract' AND tablename != 'cold_storage'"),
     ])
     
+    const txsTotal = +txsTotalResult[0]['count']
     const txsForPeriod = +txsForPeriodResult[0]['count']
     const usersCount = +usersCountResult[0]['count']
     const cirrusTableList = cirrusTableListResult.map((row) => row['tablename'])
@@ -99,7 +101,7 @@ class StatsDaemon {
     
     await models.UsageStat.create({
       networkTxs: txsForPeriod,
-      networkTxsTotal: lastUsageStat ? lastUsageStat.networkTxsTotal + txsForPeriod : txsForPeriod,
+      networkTxsTotal: txsTotal,
       contractTypesAdded: lastUsageStat ? cirrusTableCount - lastUsageStat.contractTypesTotal : cirrusTableCount,
       contractTypesTotal: cirrusTableCount,
       contractCountsByType: cirrusContractCountsByType,


### PR DESCRIPTION
Changed the way we calculate the total network txs on the nodes for usage statistics submitted to central BlockApps' statserver.
Tested and it works.