### PR TITLE
Use rest.searchUntil for chain codePtr test

### DIFF
--- a/tests/e2e/createChain.test.ts
+++ b/tests/e2e/createChain.test.ts
@@ -270,7 +270,7 @@ describe("Create Chain", function() {
     assert.notEqual(chainId, "", "chainId is not zero");
 
     // query cirrus for the gov contract
-    const govList = await rest.search(alice, { name: "Governance" }, { query: { chainId: `eq.${chainId}` }, ...options });
+    const govList = await rest.searchUntil(alice, { name: "Governance" }, (r) => r.length > 0, { query: { chainId: `eq.${chainId}` }, ...options });
     assert.equal(govList.length, 1, "one instance of Governance on this chain");
     const gov = govList[0];
     assert.isDefined(gov, "Governance contract apperas in Cirrus");


### PR DESCRIPTION
I noticed this stochastic failure in a develop build, so I decided to fix it and see how many times I could run the build without getting a failure. I got 18 consecutive successful builds, then 2 failures, and now another success. The failures were different stochastic ones, one in the e2e test suite, which was probably caused by a nonce mismatch, and the other was in the track-and-trace test suite. I wonder if some of these failures are caused by there being a race condition between slipstream inserting the tx result and vm-runner writing the statediff to the eth db, because the failures I've seen now have to do with stale values being read from the eth db after a transaction