### PR TITLE
Statediffs first

### DIFF
--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -463,6 +463,17 @@ sendOutEvents OutBatch{..} = do
 --    filterOutMetadata :: Action -> Action
 --    filterOutMetadata x = x{Action._metadata=Nothing}
   
+  for_ outToStateDiffs $ \(cId, cInfo, bHash) ->
+    withCurrentBlockHash bHash $ initializeChainDBs (Just cId) cInfo
+  traverse_ commitSqlDiffs outStateDiffs
+  when (not flags_sqlDiff) $
+    timeit "updateSQLBalanceAndNonce" (Just vmBlockInsertionMined) $
+      forM_ outASMs $ \asm -> do
+        updateSQLBalanceAndNonce $
+          [ (theAccount,
+             (addressStateBalance asMod, addressStateNonce asMod))
+          | (theAccount, Mem.ASModification asMod) <- M.toList asm
+          ]
   loopTimeit "productVMEvents" $ do
       _ <- produceVMEvents $ 
              concat (map (map (CodeCollectionAdded . T.unpack) . maybeToList . M.lookup "src" . fromMaybe M.empty . Action._metadata) (toList outActions))
@@ -483,9 +494,6 @@ sendOutEvents OutBatch{..} = do
     void . K.withKafkaRetry1s . produceUnminedBlocksM $
       outputBlockToBlock <$> toList outBlocks
   void . K.withKafkaRetry1s . writeIndexEvents $ toList outIndexEvents
-  for_ outToStateDiffs $ \(cId, cInfo, bHash) ->
-    withCurrentBlockHash bHash $ initializeChainDBs (Just cId) cInfo
-  traverse_ commitSqlDiffs outStateDiffs
   loopTimeit "flushLogEntries" $ do
     void . K.withKafkaRetry1s $ writeIndexEvents (LogDBEntry <$> toList outLogs)
   loopTimeit "flushEventEntries" $ do
@@ -497,14 +505,6 @@ sendOutEvents OutBatch{..} = do
 --        toWrite = chunksOf 2000 $ TxResult <$> q
 --    recordTxrFlush $ length q
 --    mapM_ (K.withKafkaRetry1s . writeIndexEvents) toWrite
-  when (not flags_sqlDiff) $
-    timeit "updateSQLBalanceAndNonce" (Just vmBlockInsertionMined) $
-      forM_ outASMs $ \asm -> do
-        updateSQLBalanceAndNonce $
-          [ (theAccount,
-             (addressStateBalance asMod, addressStateNonce asMod))
-          | (theAccount, Mem.ASModification asMod) <- M.toList asm
-          ]
 
 consumerGroup :: KP.ConsumerGroup
 consumerGroup = lookupConsumerGroup "ethereum-vm"

--- a/tests/e2e/uploadOrder.test.ts
+++ b/tests/e2e/uploadOrder.test.ts
@@ -179,9 +179,12 @@ describe('Nonce upload orders', async () => {
     console.log(`Setting 300, then 4`);
     const user2 = await createNewUser("user2");
     const balance1 = await getBalance(user, user2.address);
-    await send(user, user2.address, [4, 300]);
+    const v1 = 40000000; // These numbers should be higher than any value other tests use
+    const v2 = 3000000000;
+    await send(user, user2.address, [v1, v2]);
     const balance2 = await getBalance(user, user2.address);
-    assert.deepEqual(new BigNumber(balance2).minus(balance1), new BigNumber(304));
+    const actualDiff = new BigNumber(balance2).minus(balance1).toNumber();
+    assert.isAtLeast(actualDiff, v1+v2, `Difference in balance should be at least ${v1+v2}`);
   }).timeout(config.timeout);
   
   it ("won't collide nonces when none are provided for send txs", async () => {
@@ -189,9 +192,12 @@ describe('Nonce upload orders', async () => {
     console.log(`Setting 4, then 300`);
     const user2 = await createNewUser("user2");
     const balance1 = await getBalance(user, user2.address);
-    await sendNoNonces(user, user2.address, [4, 300]);
+    const v1 = 40000000; // These numbers should be higher than any value other tests use
+    const v2 = 3000000000;
+    await sendNoNonces(user, user2.address, [v1, v2]);
     const balance2 = await getBalance(user, user2.address);
-    assert.deepEqual(new BigNumber(balance2).minus(balance1), new BigNumber(304));
+    const actualDiff = new BigNumber(balance2).minus(balance1).toNumber();
+    assert.isAtLeast(actualDiff, v1+v2, `Difference in balance should be at least ${v1+v2}`);
   }).timeout(config.timeout);
 
   it ('will respect the nonce provided on each method tx', async () => {


### PR DESCRIPTION
The primary change in this PR is to move the state diff part of the vm-runner loop before the emission of any index events, which should eliminate the race condition between slipstream inserting tx results and the eth db being updated.
The secondary change is a fix to the nonce e2e tests, which intermittently failed due to a race condition with another test. I’ve tested this branch almost 50 times, with the only failures being the aforementioned nonce test, and no failures since fixing that test