### PR TITLE
Strato 2388 Handle Kafka Errors

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Stream/UnminedBlock.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Stream/UnminedBlock.hs
@@ -7,6 +7,7 @@ module Blockchain.Stream.UnminedBlock (
   fetchUnminedBlocks,
   fetchUnminedBlocksIO
 ) where
+import           Control.Monad
 
 import           Network.Kafka
 import           Network.Kafka.Producer
@@ -22,23 +23,21 @@ import           Control.Monad.State
 import           Blockchain.MilenaTools
 
 
-
-
 produceUnminedBlocks :: MonadIO m => [Block] -> m ()
 produceUnminedBlocks = void . liftIO . runKafkaConfigured "blockapps-data" . produceUnminedBlocksM
 
-produceUnminedBlocksM :: Kafka k => [Block] -> k ()
+produceUnminedBlocksM :: (Kafka k) => [Block] -> k ()
 produceUnminedBlocksM blks = do
   results <- fmap concat $ forM blks $ \b -> produceMessages [TopicAndMessage (lookupTopic "unminedblock") . makeMessage . rlpSerialize . rlpEncode $ b]
-  let parsedResults = map parseResult results -- type [Either [KafkaError] ProduceResponse]
-  when (any (/= NoError) $ mapResults parsedResults) $ void $ error $ "Error: Kafka write failed: " ++ show parsedResults
+  mapM_ parseKafkaResponse results -- type [Either [KafkaError] ProduceResponse]
+  -- when (any (/= NoError) $ mapResults parsedResults) $ void $ error $ "Error: Kafka write failed: " ++ show parsedResults
   -- return ()
   -- void . produceMessages . fmap makeMessage'
   --   where makeMessage' = TopicAndMessage (lookupTopic "unminedblock") . makeMessage . rlpSerialize . rlpEncode
-  where mapResults :: [Either [KafkaError] ProduceResponse] -> [KafkaError]
-        mapResults [] = [NoError]
-        mapResults (Left es : xs)= es ++ mapResults xs
-        mapResults (Right _ : xs) = [NoError] ++ mapResults xs
+  -- where mapResults :: [Either [KafkaError] ProduceResponse] -> [KafkaError]
+  --       mapResults [] = [NoError]
+  --       mapResults (Left es : xs)= es ++ mapResults xs
+  --       mapResults (Right _ : xs) = [NoError] ++ mapResults xs
 fetchUnminedBlocks :: Kafka k => Offset -> k [Block]
 fetchUnminedBlocks = fmap (map (rlpDecode . rlpDeserialize)) . fetchBytes (lookupTopic "unminedblock")
 

--- a/core-strato/blockapps-data/src/Blockchain/Stream/UnminedBlock.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Stream/UnminedBlock.hs
@@ -19,14 +19,26 @@ import           Blockchain.Stream.Raw
 import           Blockchain.EthConf
 import           Blockchain.KafkaTopics
 import           Control.Monad.State
+import           Blockchain.MilenaTools
+
+
+
 
 produceUnminedBlocks :: MonadIO m => [Block] -> m ()
 produceUnminedBlocks = void . liftIO . runKafkaConfigured "blockapps-data" . produceUnminedBlocksM
 
 produceUnminedBlocksM :: Kafka k => [Block] -> k ()
-produceUnminedBlocksM = void . produceMessages . fmap makeMessage'
-    where makeMessage' = TopicAndMessage (lookupTopic "unminedblock") . makeMessage . rlpSerialize . rlpEncode
-
+produceUnminedBlocksM blks = do
+  results <- fmap concat $ forM blks $ \b -> produceMessages [TopicAndMessage (lookupTopic "unminedblock") . makeMessage . rlpSerialize . rlpEncode $ b]
+  let parsedResults = map parseResult results -- type [Either [KafkaError] ProduceResponse]
+  when (any (/= NoError) $ mapResults parsedResults) $ void $ error $ "Error: Kafka write failed: " ++ show parsedResults
+  -- return ()
+  -- void . produceMessages . fmap makeMessage'
+  --   where makeMessage' = TopicAndMessage (lookupTopic "unminedblock") . makeMessage . rlpSerialize . rlpEncode
+  where mapResults :: [Either [KafkaError] ProduceResponse] -> [KafkaError]
+        mapResults [] = [NoError]
+        mapResults (Left es : xs)= es ++ mapResults xs
+        mapResults (Right _ : xs) = [NoError] ++ mapResults xs
 fetchUnminedBlocks :: Kafka k => Offset -> k [Block]
 fetchUnminedBlocks = fmap (map (rlpDecode . rlpDeserialize)) . fetchBytes (lookupTopic "unminedblock")
 

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -56,13 +56,15 @@ commitSingleOffset groupName topic partition offset ofsMetadata = do
 
 
 
-withKafkaRetry :: (MonadIO m, MonadLogger m, Mod.Modifiable KafkaState m) => Int -> StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
+withKafkaRetry :: (MonadIO m, MonadLogger m, Mod.Modifiable KafkaState m, Show a) => Int -> StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
 withKafkaRetry t k = do
   s <- Mod.get (Mod.Proxy @KafkaState)
   let go = do
         r <- liftIO . runExceptT $ runStateT k s
         case r of
-          Right a -> return a
+          Right a -> do
+            $logDebugLS "withKafkaRetry allegedly succeded with: " . T.pack $ show a
+            return a
           Left e -> do
             $logErrorS "withKafkaRetry" . T.pack $ show e
             (liftIO $ threadDelay (1000*t)) >> go
@@ -70,5 +72,5 @@ withKafkaRetry t k = do
   Mod.put (Mod.Proxy @KafkaState) newS
   return a
 
-withKafkaRetry1s :: (MonadIO m, MonadLogger m, Mod.Modifiable KafkaState m) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
+withKafkaRetry1s :: (MonadIO m, MonadLogger m, Mod.Modifiable KafkaState m, Show a) => StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
 withKafkaRetry1s = withKafkaRetry 1000

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -14,6 +14,7 @@ import qualified Control.Monad.Change.Modify as Mod
 import           Control.Monad.IO.Class      (MonadIO, liftIO)
 import           Control.Monad.Except        (ExceptT (..), runExceptT, throwError)
 import           Control.Monad.Trans.State
+-- import           Control.Monad               (when, void)
 import qualified Data.Text                   as T
 import           Network.Kafka
 import           Network.Kafka.Protocol
@@ -54,6 +55,31 @@ commitSingleOffset groupName topic partition offset ofsMetadata = do
       
     _ -> error "unexpected response from commitOffset in call to commitSingleOffset"
 
+-- Functions that parse kafka responses for errors that are hidden within the list of responses
+parseResult :: ProduceResponse -> Either [KafkaError] ProduceResponse
+parseResult x =
+  let scd = concatMap snd $ _produceResponseFields x -- type [(Partition, KafkaError, Offset)]
+      e = map (\(_, ke, _) -> ke) scd -- type [KafkaError]
+  in
+  if (any (/= NoError) e) then 
+    Left e
+  else 
+    Right x
+  -- let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x
+
+-- parseResult (Right (MetadataResponse x)) = do 
+--   let e = concatMap (map (\(_, x', _) -> x') . concatMap snd . _produceResponseFields) x
+--   when (any (/= NoError) e) $ void $ error $ "Error: Kafka write failed: " ++ show e
+--   let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x
+--   return offset
+-- parseResult (Right (FetchResponse x))
+-- parseResult (Right (OffsetResponse x))
+-- parseResult (Right (OffsetCommitResponse x))
+-- parseResult (Right (OffsetFetchResponse x))
+-- parseResult (Right (HeartbeatResponse x))
+-- parseResult (Right (GroupCoordinatorResponse x))
+-- parseResult (Right (CreateTopicsResponse x))
+-- parseResult (Right (DeleteTopicsResponse x))
 
 
 withKafkaRetry :: (MonadIO m, MonadLogger m, Mod.Modifiable KafkaState m, Show a) => Int -> StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
@@ -67,7 +93,7 @@ withKafkaRetry t k = do
             return a
           Left e -> do
             $logErrorS "withKafkaRetry" . T.pack $ show e
-            (liftIO $ threadDelay (1000*t)) >> go
+            (liftIO $ threadDelay (1000 * t)) >> go
   (a, newS) <- go
   Mod.put (Mod.Proxy @KafkaState) newS
   return a

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -19,6 +19,7 @@ import qualified Data.Text                   as T
 import           Network.Kafka
 import           Network.Kafka.Protocol
 import           Prelude
+-- import Control.Monad.Reader (Monad)
 
 _kMetadata::Metadata->KafkaString
 _kMetadata (Metadata x) = x
@@ -56,30 +57,15 @@ commitSingleOffset groupName topic partition offset ofsMetadata = do
     _ -> error "unexpected response from commitOffset in call to commitSingleOffset"
 
 -- Functions that parse kafka responses for errors that are hidden within the list of responses
-parseResult :: ProduceResponse -> Either [KafkaError] ProduceResponse
-parseResult x =
-  let scd = concatMap snd $ _produceResponseFields x -- type [(Partition, KafkaError, Offset)]
+parseKafkaResponse :: Monad m => ProduceResponse -> m ()
+parseKafkaResponse pr =
+  let scd = concatMap snd $ _produceResponseFields pr -- type [(Partition, KafkaError, Offset)]
       e = map (\(_, ke, _) -> ke) scd -- type [KafkaError]
   in
   if (any (/= NoError) e) then 
-    Left e
-  else 
-    Right x
-  -- let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x
-
--- parseResult (Right (MetadataResponse x)) = do 
---   let e = concatMap (map (\(_, x', _) -> x') . concatMap snd . _produceResponseFields) x
---   when (any (/= NoError) e) $ void $ error $ "Error: Kafka write failed: " ++ show e
---   let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x
---   return offset
--- parseResult (Right (FetchResponse x))
--- parseResult (Right (OffsetResponse x))
--- parseResult (Right (OffsetCommitResponse x))
--- parseResult (Right (OffsetFetchResponse x))
--- parseResult (Right (HeartbeatResponse x))
--- parseResult (Right (GroupCoordinatorResponse x))
--- parseResult (Right (CreateTopicsResponse x))
--- parseResult (Right (DeleteTopicsResponse x))
+    error $ "Kafka write error: " ++ show e
+  else
+    return ()
 
 
 withKafkaRetry :: (MonadIO m, MonadLogger m, Mod.Modifiable KafkaState m, Show a) => Int -> StateT KafkaState (ExceptT KafkaClientError IO) a -> m a
@@ -89,7 +75,6 @@ withKafkaRetry t k = do
         r <- liftIO . runExceptT $ runStateT k s
         case r of
           Right a -> do
-            $logDebugLS "withKafkaRetry allegedly succeded with: " . T.pack $ show a
             return a
           Left e -> do
             $logErrorS "withKafkaRetry" . T.pack $ show e

--- a/core-strato/milena/Network/Kafka/Producer.hs
+++ b/core-strato/milena/Network/Kafka/Producer.hs
@@ -5,6 +5,7 @@ import Data.ByteString.Char8 (ByteString)
 import qualified Data.Digest.Murmur32 as Murmur32
 import Control.Applicative
 import Control.Lens
+import Control.Monad (join)
 import Control.Monad.Trans (liftIO)
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -32,6 +33,10 @@ produceRequest ra ti ts =
 -- | Send messages to partition calculated by 'partitionAndCollate'.
 produceMessages :: Kafka m => [TopicAndMessage] -> m [ProduceResponse]
 produceMessages = prod (groupMessagesToSet NoCompression)
+
+-- | Send messages to partition calculated by 'partitionAndCollate'.
+produceMessagesAsSingletonSets :: Kafka m => [TopicAndMessage] -> m [ProduceResponse]
+produceMessagesAsSingletonSets = fmap join . traverse (prod (groupMessagesToSet NoCompression) . pure)
 
 -- | Send compressed messages to partition calculated by 'partitionAndCollate'.
 produceCompressedMessages :: Kafka m => CompressionCodec -> [TopicAndMessage] -> m [ProduceResponse]

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Kafka.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Kafka.hs
@@ -89,19 +89,19 @@ readSeqP2pEventsFromTopic = readFromTopic'
 writeUnseqEvents :: K.Kafka k => [IngestEvent] -> k [KP.ProduceResponse]
 writeUnseqEvents events = do
   recordEvents unseqWrites events
-  KW.produceMessages $
+  KW.produceMessagesAsSingletonSets $
       (K.TopicAndMessage unseqEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 
 writeSeqVmEvents :: K.Kafka k => [VmEvent] -> k [KP.ProduceResponse]
 writeSeqVmEvents events = do
   recordEvents seqVMWrites events
-  KW.produceMessages $
+  KW.produceMessagesAsSingletonSets $
       (K.TopicAndMessage seqVmEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 
 writeSeqP2pEvents :: K.Kafka k => [P2pEvent] -> k [KP.ProduceResponse]
 writeSeqP2pEvents events = do
   recordEvents seqP2PWrites events
-  KW.produceMessages $
+  KW.produceMessagesAsSingletonSets $
       (K.TopicAndMessage seqP2pEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 
 readFromTopic' :: (Binary b, K.Kafka k) => KP.TopicName -> KP.Offset -> k [b]

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -278,6 +278,7 @@ create' creator newAccount ch cc contractName' argExps x509s = do
                         }
 
   onTraced $ liftIO $ putStrLn $ C.red $ "Creating Contract: " ++ show newAccount ++ " of type " ++ contractName'
+  onTraced $ liftIO $ putStrLn $ "Contract uses SolidVM version: " ++ show vmVersion'
 
   -- Add Storage
   addCallInfo newAccount contract' (contractName' ++ " constructor") ch cc M.empty False
@@ -292,7 +293,7 @@ create' creator newAccount ch cc contractName' argExps x509s = do
   -- Run the constructor
   runTheConstructors creator newAccount ch cc contractName' argExps
 
-  onTraced $ liftIO $ putStrLn $ C.red $ "Done Creating Contract: " ++ show newAccount ++ " of type " ++ contractName'
+  onTraced $ liftIO $ putStrLn $ C.green $ "Done Creating Contract: " ++ show newAccount ++ " of type " ++ contractName'
 
 
   -- set creator again, in case the caller's cert changed during constructor execution
@@ -408,28 +409,37 @@ call _ _ _ _ blockData _ _ codeAddress sender' _ _ _ _ origin' txHash' chainId' 
       }
 
 
--- set the hidden ":creator" field, if the caller has a cert
+-- set the hidden ":creator" field, for solidvm 3.0 only
 setCreator :: MonadSM m => Account -> Account -> Contract -> m ()
 setCreator creator contract cntrct = do
-  liftIO $ putStrLn $ "setCreator/versioning ---> getting creator org of " ++ (format creator) ++ " for new contract " ++ format contract
   
   x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
   maybeCertLevelDB <- x509CertDBGet $ _accountAddress creator
   let maybeCertBlockDB = M.lookup (_accountAddress creator) x509s'
       maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-      org = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
-  case org of
-    "" -> do
-      liftIO $ putStrLn $ "setCreator/versioning ---> no org found for this creator...."
+  case maybeCert of
+    (Just cert) -> onTraced $ liftIO $ putStrLn $ "setCreator/versioning ---> Found cert for " ++ (format creator) ++ ": " ++ (format $ getCertSubject cert)
+    
+    Nothing -> onTraced $ liftIO $ putStrLn $ "setCreator/versioning ---> No cert found for " ++ (format creator)
+  
+  let org = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
+  
+  let hasSvm3_0 = _vmVersion cntrct == "svm3.0"
+  if hasSvm3_0 
+    then do
+      liftIO $ putStrLn $ "setCreator/versioning ---> getting org of " ++ (format creator) ++ " for new contract " ++ format contract
+      liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show org)
+      putSolidStorageKeyVal' hasSvm3_0 contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
+  --   -- insert the org for this contract into storage, in the ":creator" field
+    else do
+      onTraced $ liftIO $ putStrLn $ C.red $ "Ignoring creator field for non-svm3.0 contract"
       return ()
-    str -> do 
-    -- insert the org for this contract into storage, in the ":creator" field
-      liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show str)
-      onTraced $ liftIO $ putStrLn $ "setCreator/versioning ---> the vm version is " ++ _vmVersion cntrct
-      let svm3_0 = _vmVersion cntrct == "svm3.0"
-      putSolidStorageKeyVal' svm3_0 contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack str)
-
-
+      
+  -- case org of
+  --   "" -> do
+  --     liftIO $ putStrLn $ "setCreator/versioning ---> no org found for this creator...."
+  --     return ()
+  --   (Just org) -> do 
 
 -- get the org for the Cirrus table name
 getOrg :: MonadSM m => Account -> String -> m (String)

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -409,7 +409,7 @@ call _ _ _ _ blockData _ _ codeAddress sender' _ _ _ _ origin' txHash' chainId' 
       }
 
 
--- set the hidden ":creator" field, for solidvm 3.0 only
+-- set the hidden ":creator" field
 setCreator :: MonadSM m => Account -> Account -> Contract -> m ()
 setCreator creator contract cntrct = do
   
@@ -417,23 +417,22 @@ setCreator creator contract cntrct = do
   maybeCertLevelDB <- x509CertDBGet $ _accountAddress creator
   let maybeCertBlockDB = M.lookup (_accountAddress creator) x509s'
       maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
+      _org = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
   case maybeCert of
     (Just cert) -> onTraced $ liftIO $ putStrLn $ "setCreator/versioning ---> Found cert for " ++ (format creator) ++ ": " ++ (format $ getCertSubject cert)
     
     Nothing -> onTraced $ liftIO $ putStrLn $ "setCreator/versioning ---> No cert found for " ++ (format creator)
   
-  let org = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
-  
   let hasSvm3_0 = _vmVersion cntrct == "svm3.0"
-  if hasSvm3_0 
-    then do
-      liftIO $ putStrLn $ "setCreator/versioning ---> getting org of " ++ (format creator) ++ " for new contract " ++ format contract
+  case _org of
+    "" -> do
+      onTraced $ liftIO $ putStrLn $ C.red $ "Ignoring creator field for emtpy org field"
+      return ()
+    org -> do
+      -- liftIO $ putStrLn $ "setCreator/versioning ---> getting org of " ++ (format creator) ++ " for new contract " ++ format contract
       liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show org)
       putSolidStorageKeyVal' hasSvm3_0 contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
   --   -- insert the org for this contract into storage, in the ":creator" field
-    else do
-      onTraced $ liftIO $ putStrLn $ C.red $ "Ignoring creator field for non-svm3.0 contract"
-      return ()
       
   -- case org of
   --   "" -> do

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -426,7 +426,7 @@ setCreator creator contract cntrct = do
   let hasSvm3_0 = _vmVersion cntrct == "svm3.0"
   case _org of
     "" -> do
-      onTraced $ liftIO $ putStrLn $ C.red $ "Ignoring creator field for emtpy org field"
+      onTraced $ liftIO $ putStrLn $ C.red $ "Ignoring creator field for empty org field"
       return ()
     org -> do
       -- liftIO $ putStrLn $ "setCreator/versioning ---> getting org of " ++ (format creator) ++ " for new contract " ++ format contract
@@ -474,7 +474,7 @@ getOrg caller vers = do
                 liftIO $ putStrLn $ "getOrg/versioning ---> Its org is " ++ show org'
                 return $ BC.unpack org'
               _ -> do
-                liftIO $ putStrLn "getOrg/versioning ---> It's org is unset? Returning empty string" 
+                liftIO $ putStrLn "getOrg/versioning ---> It's org is unset. Returning empty string" 
                 return "" 
 
 

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/Kafka.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/Kafka.hs
@@ -34,7 +34,7 @@ readIndexEventsFromTopic topic offset = setDefaultKafkaState >> map (decode . L.
 
 writeIndexEvents :: K.Kafka k => [IndexEvent] -> k [KP.ProduceResponse]
 writeIndexEvents events = do
-  results <- KW.produceMessages $
+  results <- KW.produceMessagesAsSingletonSets $
     (K.TopicAndMessage indexEventsTopicName . KW.makeMessage . L.toStrict . encode) <$> events
   mapM_ parseKafkaResponse results
   return results

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/Kafka.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/Kafka.hs
@@ -18,6 +18,7 @@ import qualified Network.Kafka.Protocol          as KP
 import           Blockchain.KafkaTopics          (lookupTopic)
 import           Blockchain.Strato.Indexer.Model
 import           Blockchain.Stream.Raw           (fetchBytes, setDefaultKafkaState)
+import           Blockchain.MilenaTools
 
 indexEventsTopicName :: KP.TopicName
 indexEventsTopicName = lookupTopic "indexevents"
@@ -32,5 +33,8 @@ readIndexEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [IndexEv
 readIndexEventsFromTopic topic offset = setDefaultKafkaState >> map (decode . L.fromStrict) <$> fetchBytes topic offset
 
 writeIndexEvents :: K.Kafka k => [IndexEvent] -> k [KP.ProduceResponse]
-writeIndexEvents events = KW.produceMessages $
+writeIndexEvents events = do
+  results <- KW.produceMessages $
     (K.TopicAndMessage indexEventsTopicName . KW.makeMessage . L.toStrict . encode) <$> events
+  mapM_ parseKafkaResponse results
+  return results

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -171,7 +171,6 @@ handleVmEvents = awaitForever $ \InBatch{..} -> do
       then do
         $logInfoS "evm/loop/newBlock" "calling Bagger.makeNewBlock"
         newBlock <- Bagger.makeNewBlock mineTransactions
-        $logInfoS "evm/loop/newBlock" "calling produceUnminedBlocksM"
         pure $ Just newBlock
       else pure Nothing
   traverse_ (yield . OutBlock) mNewBlock

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -504,8 +504,8 @@ sendOutEvents OutBatch{..} = do
       --actionEvents =  map (NewAction . filterOutMetadata . filterOutEvents) (toList outActions)
       trEvents = map NewTransactionResult $ toList outTXRs
           
-  loopTimeit "productVMEvents" $ do
-    $logInfoS "sendOutEvnets" $ "outputting VMEvents"
+  loopTimeit "produceVMEvents" $ do
+    $logInfoS "sendOutEvents" $ "outputting VMEvents"
     _ <- produceVMEvents $ ccEvents ++ eventEvents ++ actionEvents ++ trEvents
     return ()
          

--- a/core-strato/vm-tools/src/Blockchain/Stream/VMEvent.hs
+++ b/core-strato/vm-tools/src/Blockchain/Stream/VMEvent.hs
@@ -87,7 +87,7 @@ class HasVMEventsSink k where
 
 produceVMEventsM :: (Modifiable KafkaState m, MonadLogger m, MonadIO m) => [VMEvent] -> m Offset
 produceVMEventsM vmEvents = do
-    x <- withKafkaRetry1s . produceMessages $
+    x <- withKafkaRetry1s . produceMessagesAsSingletonSets $
         map (TopicAndMessage (lookupTopic "vmevents") . makeMessage . BL.toStrict . JSON.encode) vmEvents
 
     let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x
@@ -98,7 +98,7 @@ produceVMEvents:: (MonadIO m) => [VMEvent] -> m Offset
 produceVMEvents vmEvents = do
   result <- -- type Either KafkaClientError [ProduceResponse]
     liftIO $ runKafkaConfigured "blockapps-data" $ fmap concat $
-      forM vmEvents $ \e -> produceMessages [TopicAndMessage (lookupTopic "vmevents") . makeMessage . BL.toStrict . JSON.encode $ e]
+      forM vmEvents $ \e -> produceMessagesAsSingletonSets [TopicAndMessage (lookupTopic "vmevents") . makeMessage . BL.toStrict . JSON.encode $ e]
   case result of 
     Left kce -> error $ "Error: Kafka Connection error: " ++ show kce
     Right res -> do -- [ProduceResponse]

--- a/core-strato/vm-tools/src/Blockchain/Stream/VMEvent.hs
+++ b/core-strato/vm-tools/src/Blockchain/Stream/VMEvent.hs
@@ -51,7 +51,6 @@ import           Text.Format
 import           Text.Tools
 
 
-
 data VMEvent =
   NewAction Action |
   EventEmitted Event |
@@ -95,19 +94,25 @@ produceVMEventsM vmEvents = do
     return offset
 
 -- todo: refactor this to consume produceVMEventsM
-produceVMEvents::(MonadIO m)=>[VMEvent]->m Offset
+produceVMEvents:: (MonadIO m) => [VMEvent] -> m Offset
 produceVMEvents vmEvents = do
-  result <-
+  result <- -- type Either KafkaClientError [ProduceResponse]
     liftIO $ runKafkaConfigured "blockapps-data" $ fmap concat $
       forM vmEvents $ \e -> produceMessages [TopicAndMessage (lookupTopic "vmevents") . makeMessage . BL.toStrict . JSON.encode $ e]
+  case result of 
+    Left kce -> error $ "Error: Kafka write failed: " ++ show kce
+    Right res -> -- [ProduceResponse]
+      if (any (/= NoError) $ mapResults parsedResults) then
+          error $ "Kafka Write Error:" ++ show parsedResults
+        else
+          return offset
+      where parsedResults = map parseResult res --type [Either [KafkaError] ProduceResponse]
+            mapResults :: [Either [KafkaError] ProduceResponse] -> [KafkaError]
+            mapResults [] = [NoError]
+            mapResults (Left es : xs)= es ++ mapResults xs
+            mapResults (Right _ : xs) = [NoError] ++ mapResults xs
+            [offset] = concatMap (map (\(_, _, x') -> x') . concatMap snd . _produceResponseFields) res
 
-  case result of
-   Left e -> error $ show e
-   Right x -> do
-     let e = concatMap (map (\(_, x', _) ->x') . concatMap snd . _produceResponseFields) x
-     when (any (/= NoError) e) $ void $ error $ "error: kafka write failed: " ++ show e
-     let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x
-     return offset
 
 -- | Reads VMEvents from `defaultVMEventsTopicName`
 fetchVMEvents :: Kafka k => Offset -> k [VMEvent]

--- a/core-strato/vm-tools/src/Blockchain/Stream/VMEvent.hs
+++ b/core-strato/vm-tools/src/Blockchain/Stream/VMEvent.hs
@@ -100,18 +100,12 @@ produceVMEvents vmEvents = do
     liftIO $ runKafkaConfigured "blockapps-data" $ fmap concat $
       forM vmEvents $ \e -> produceMessages [TopicAndMessage (lookupTopic "vmevents") . makeMessage . BL.toStrict . JSON.encode $ e]
   case result of 
-    Left kce -> error $ "Error: Kafka write failed: " ++ show kce
-    Right res -> -- [ProduceResponse]
-      if (any (/= NoError) $ mapResults parsedResults) then
-          error $ "Kafka Write Error:" ++ show parsedResults
-        else
-          return offset
-      where parsedResults = map parseResult res --type [Either [KafkaError] ProduceResponse]
-            mapResults :: [Either [KafkaError] ProduceResponse] -> [KafkaError]
-            mapResults [] = [NoError]
-            mapResults (Left es : xs)= es ++ mapResults xs
-            mapResults (Right _ : xs) = [NoError] ++ mapResults xs
-            [offset] = concatMap (map (\(_, _, x') -> x') . concatMap snd . _produceResponseFields) res
+    Left kce -> error $ "Error: Kafka Connection error: " ++ show kce
+    Right res -> do -- [ProduceResponse]
+      mapM_ parseKafkaResponse res
+      return offset
+      where [offset] = concatMap (map (\(_, _, x') -> x') . concatMap snd . _produceResponseFields) res
+            -- parsedResults = map parseKafkaResponse res
 
 
 -- | Reads VMEvents from `defaultVMEventsTopicName`

--- a/core-strato/vm-tools/src/Blockchain/Stream/VMOutput.hs
+++ b/core-strato/vm-tools/src/Blockchain/Stream/VMOutput.hs
@@ -75,7 +75,7 @@ class HasVMOutputsSink k where
 
 produceVMOutputsM :: (Modifiable KafkaState m, MonadLogger m, MonadIO m) => [VMOutput] -> m Offset
 produceVMOutputsM vmOutputs = do
-    x <- withKafkaRetry1s . produceMessages $
+    x <- withKafkaRetry1s . produceMessagesAsSingletonSets $
         map (TopicAndMessage (lookupTopic "block") . makeMessage . vmOutputToBytes) vmOutputs
 
     let [offset] = concatMap (map (\(_, _, x') ->x') . concatMap snd . _produceResponseFields) x
@@ -85,7 +85,7 @@ produceVMOutputsM vmOutputs = do
 produceVMOutputs::(MonadIO m)=>[VMOutput]->m Offset
 produceVMOutputs vmOutputs = do
   result <- liftIO $ runKafkaConfigured "blockapps-data" $
-            produceMessages $ map (TopicAndMessage (lookupTopic "block") . makeMessage . vmOutputToBytes) vmOutputs
+            produceMessagesAsSingletonSets $ map (TopicAndMessage (lookupTopic "block") . makeMessage . vmOutputToBytes) vmOutputs
 
   case result of
    Left e -> error $ show e

--- a/x509-certs/package.yaml
+++ b/x509-certs/package.yaml
@@ -34,6 +34,7 @@ library:
   - pem
   - random
   - text
+  - format
   - time
   - transformers
   - secp256k1-haskell

--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -46,8 +46,8 @@ import           Data.X509
 
 import           Time.Types
 import           Time.System
-
-
+import qualified Text.Colors       as CL
+import           Text.Format
 
 
 
@@ -61,6 +61,7 @@ newtype X509Certificate = X509Certificate SignedCertificate deriving (Show, Eq)
 
 instance NFData X509Certificate where
     rnf (X509Certificate cert) = cert `seq` ()
+
 
 data Issuer = Issuer
   {
@@ -80,6 +81,8 @@ data Subject = Subject
   , subPub        :: PublicKey
   } deriving (Show, Eq)
 
+instance Format Subject where
+  format = CL.blue . show
 
 
 instance ToJSON Subject where


### PR DESCRIPTION
Added extra logs for x509 searches
Catch errors from kafka that were previously uncaught because they were nested in an array