### PR TITLE
use better error throwing for kafka errors

### DIFF
--- a/core-strato/blockapps-data/src/Blockchain/Stream/UnminedBlock.hs
+++ b/core-strato/blockapps-data/src/Blockchain/Stream/UnminedBlock.hs
@@ -26,10 +26,10 @@ import           Blockchain.MilenaTools
 produceUnminedBlocks :: MonadIO m => [Block] -> m ()
 produceUnminedBlocks = void . liftIO . runKafkaConfigured "blockapps-data" . produceUnminedBlocksM
 
-produceUnminedBlocksM :: (Kafka k) => [Block] -> k ()
+produceUnminedBlocksM :: (Kafka m) => [Block] -> m ()
 produceUnminedBlocksM blks = do
   results <- fmap concat $ forM blks $ \b -> produceMessages [TopicAndMessage (lookupTopic "unminedblock") . makeMessage . rlpSerialize . rlpEncode $ b]
-  mapM_ parseKafkaResponse results -- type [Either [KafkaError] ProduceResponse]
+  liftIO $ mapM_ parseKafkaResponse $ results -- type [Either [KafkaError] ProduceResponse]
 
 fetchUnminedBlocks :: Kafka k => Offset -> k [Block]
 fetchUnminedBlocks = fmap (map (rlpDecode . rlpDeserialize)) . fetchBytes (lookupTopic "unminedblock")

--- a/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
+++ b/core-strato/blockapps-util/src/Blockchain/MilenaTools.hs
@@ -14,6 +14,8 @@ import qualified Control.Monad.Change.Modify as Mod
 import           Control.Monad.IO.Class      (MonadIO, liftIO)
 import           Control.Monad.Except        (ExceptT (..), runExceptT, throwError)
 import           Control.Monad.Trans.State
+import           Control.Exception
+import           Data.List                    (find)
 -- import           Control.Monad               (when, void)
 import qualified Data.Text                   as T
 import           Network.Kafka
@@ -57,15 +59,21 @@ commitSingleOffset groupName topic partition offset ofsMetadata = do
     _ -> error "unexpected response from commitOffset in call to commitSingleOffset"
 
 -- Functions that parse kafka responses for errors that are hidden within the list of responses
-parseKafkaResponse :: Monad m => ProduceResponse -> m ()
+parseKafkaResponse :: ProduceResponse -> IO ()
 parseKafkaResponse pr =
-  let scd = concatMap snd $ _produceResponseFields pr -- type [(Partition, KafkaError, Offset)]
-      e = map (\(_, ke, _) -> ke) scd -- type [KafkaError]
-  in
-  if (any (/= NoError) e) then 
-    error $ "Kafka write error: " ++ show e
-  else
-    return ()
+  case maybeError of
+    (Just e) -> throwIO e
+
+    Nothing -> return ()
+
+  where scd = concatMap snd $ _produceResponseFields pr -- type [(Partition, KafkaError, Offset)]
+        es = map (\(_, ke, _) -> ke) scd -- type [KafkaError]
+        maybeError = find (/= NoError) es
+
+  -- if (any (/= NoError) e) then 
+  --   throwIO $ e !! 0
+  -- else
+  --   return ()
 
 
 withKafkaRetry :: (MonadIO m, MonadLogger m, Mod.Modifiable KafkaState m, Show a) => Int -> StateT KafkaState (ExceptT KafkaClientError IO) a -> m a

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/Kafka.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/Kafka.hs
@@ -7,7 +7,7 @@ module Blockchain.Strato.Indexer.Kafka
     , writeIndexEvents
     ) where
 
-
+import           Control.Monad.IO.Class
 import           Data.Binary
 
 import qualified Data.ByteString.Lazy            as L
@@ -36,5 +36,5 @@ writeIndexEvents :: K.Kafka k => [IndexEvent] -> k [KP.ProduceResponse]
 writeIndexEvents events = do
   results <- KW.produceMessagesAsSingletonSets $
     (K.TopicAndMessage indexEventsTopicName . KW.makeMessage . L.toStrict . encode) <$> events
-  mapM_ parseKafkaResponse results
+  liftIO $ mapM_ parseKafkaResponse results
   return results

--- a/core-strato/vm-tools/src/Blockchain/Stream/VMEvent.hs
+++ b/core-strato/vm-tools/src/Blockchain/Stream/VMEvent.hs
@@ -26,6 +26,7 @@ module Blockchain.Stream.VMEvent (
 import           Conduit
 import           Control.Monad.Change.Modify (Modifiable)
 import           Control.Monad.State
+import           Control.Exception
 import qualified Data.Aeson                  as JSON
 import qualified Data.ByteString             as B
 import qualified Data.ByteString.Lazy        as BL
@@ -100,9 +101,9 @@ produceVMEvents vmEvents = do
     liftIO $ runKafkaConfigured "blockapps-data" $ fmap concat $
       forM vmEvents $ \e -> produceMessagesAsSingletonSets [TopicAndMessage (lookupTopic "vmevents") . makeMessage . BL.toStrict . JSON.encode $ e]
   case result of 
-    Left kce -> error $ "Error: Kafka Connection error: " ++ show kce
+    Left kce -> liftIO $ throwIO kce
     Right res -> do -- [ProduceResponse]
-      mapM_ parseKafkaResponse res
+      liftIO $ mapM_ parseKafkaResponse res
       return offset
       where [offset] = concatMap (map (\(_, _, x') -> x') . concatMap snd . _produceResponseFields) res
             -- parsedResults = map parseKafkaResponse res


### PR DESCRIPTION
Change instances of `error` to `throwIO` in the parsing and handling of kafka errors (per Dustin's request)