### PR TITLE
Verbose x509 logs

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -226,6 +226,7 @@ create :: SolidVMBase m
 --       value gasPrice availableGas newAddress initCode txHash chainId metadata =
 create _ _ _ blockData _ sender' origin' _ _ _ newAddress code txHash' chainId' metadata = do
   x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+  liftIO $ putStrLn $ "create/contract " ++ "Got X509s from memory - There are" ++ (show $ M.size x509s) ++ " certs in memory" 
   recordCreate
   let env' = Env.Environment {
         Env.blockHeader = blockData,
@@ -257,6 +258,7 @@ create _ _ _ blockData _ sender' origin' _ _ _ newAddress code txHash' chainId' 
 create' :: MonadSM m => Account -> Account -> Keccak256 -> CodeCollection -> String -> Xabi.ArgList -> M.Map Address X509Certificate -> m ExecResults
 create' creator newAccount ch cc contractName' argExps x509s = do
   Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ x509s
+  liftIO $ putStrLn $ "create'/contract " ++ "Putting X509s from argument into memory"
   parentName <- fromMaybeM (return "") $ runMaybeT 
      $   pure creator                                               -- Creator's address
      >>= MaybeT . A.lookup (A.Proxy @AddressState)                  -- Address's state
@@ -312,7 +314,7 @@ create' creator newAccount ch cc contractName' argExps x509s = do
   finalEvs <- Mod.get (Mod.Proxy @(Q.Seq Event))
   finalAct <- Mod.get (Mod.Proxy @Action)
   x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-
+  liftIO $ putStrLn $ "create'/contract " ++ "Getting and returning X509s from memory - There are " ++ (show $ M.size x509s') ++ " certs in memory"
 
   return ExecResults {
     erRemainingTxGas = 0, --Just use up all the allocated gas for now....
@@ -414,25 +416,31 @@ setCreator :: MonadSM m => Account -> Account -> Contract -> m ()
 setCreator creator contract cntrct = do
   
   x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+  liftIO $ putStrLn $ "setCreator " ++ "There are" ++ (show $ M.size x509s') ++ " certs in memory"
   maybeCertLevelDB <- x509CertDBGet $ _accountAddress creator
   let maybeCertBlockDB = M.lookup (_accountAddress creator) x509s'
       maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
       _org = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
+  case maybeCertBlockDB of
+    (Just _) -> liftIO $ putStrLn $ C.green "setCreator/versioning ---> Cache hit for x509 cert"
+
+    Nothing -> liftIO $ putStrLn $ C.red "setCreator/versioning ---> Cache miss for x509 cert - now looking in levelDB"
+
   case maybeCert of
-    (Just cert) -> liftIO $ putStrLn $ "setCreator/versioning ---> Found cert for " ++ (format creator) ++ ":\n\t\t" ++ (format $ getCertSubject cert)
+    (Just cert) -> liftIO $ putStrLn $ C.green $ "setCreator/versioning ---> Found cert for " ++ (format creator) ++ ":\n\t" ++ (format $ getCertSubject cert)
     
-    Nothing -> liftIO $ putStrLn $ "setCreator/versioning ---> No cert found for " ++ (format creator)
+    Nothing -> liftIO $ putStrLn $ C.red $ "setCreator/versioning ---> No cert found for " ++ (format creator)
   
   let hasSvm3_0 = _vmVersion cntrct == "svm3.0"
   case _org of
     "" -> do
-      liftIO $ putStrLn $ C.red $ "Ignoring creator field for empty org field"
+      liftIO $ putStrLn $ C.yellow "Ignoring creator field for empty org field"
       return ()
     org -> do
       -- liftIO $ putStrLn $ "setCreator/versioning ---> getting org of " ++ (format creator) ++ " for new contract " ++ format contract
       liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show org)
-      putSolidStorageKeyVal' hasSvm3_0 contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
   --   -- insert the org for this contract into storage, in the ":creator" field
+      putSolidStorageKeyVal' hasSvm3_0 contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
       
   -- case org of
   --   "" -> do
@@ -1612,6 +1620,7 @@ callBuiltin "registerCert" [SAccount a, SString cert] _ = do
     case ex509Cert of
         Left _         -> return SNULL
         Right x509Cert -> do x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+                             liftIO $ putStrLn $ "Getting X509s from memory - there are " ++ (show $ M.size x509s) ++ " certs in memory" 
                              let theAddress = _accountAddress $ namedAccountToAccount Nothing a
                              Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert theAddress x509Cert x509s
                              onTraced $ liftIO $ putStrLn $ "    registering cert to address: " ++ format theAddress ++ " as " ++ show (fmap subCommonName $ getCertSubject x509Cert)

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -259,6 +259,7 @@ addTransactions :: (VMBase m, Bagger.MonadBagger m, MonadMonitor m)
                 -> ConduitT a VmOutEvent m ()
 addTransactions blockData txs =
  timeit ("addTransactions, " ++ show (length txs) ++ " TXs") (Just vmBlockInsertionMined) $ do
+  lift $ $logInfoS "addTransactions" "Adding transactions, starting with blank x509 map"
   trrs <- lift $ go (blockDataGasLimit blockData) txs DL.empty M.empty
   mapM_ (outputTransactionResult blockData blockHeaderHash) trrs
   yield . OutASM $ foldr (flip M.union) M.empty $ map trrAfterMap trrs
@@ -271,11 +272,18 @@ addTransactions blockData txs =
       beforeMap <- getAddressStateTxDBMap
       let chainId = fromAnchorChain $ otAnchorChain t
       Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) x509s
+      $logInfoS "addTransactions/go" "setting argument x509s into memory"
       beforeX509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+      $logInfoS "addTransactions/go" $ T.pack $ "Getting beforeX509s from memory - there are" ++ (show $ M.size beforeX509s) ++ "certs in memory"
       (!deltaT, !result) <- timeIt $ runExceptT $ addTransaction chainId False blockData blockGas t
       case result of
-          Left _  -> Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) beforeX509s
-          Right execResult -> Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.union (erNewX509Certs execResult) beforeX509s
+          Left _  -> do
+            Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) beforeX509s
+            $logInfoS "addTransactions/go" "putting beforex509s into memory"
+
+          Right execResult -> do
+            Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.union (erNewX509Certs execResult) beforeX509s
+            $logInfoS "addTransactions/go" "putting union of beforex509s and tx x509s into memory"
 
       afterMap <- getAddressStateTxDBMap
 
@@ -290,7 +298,7 @@ addTransactions blockData txs =
             Right execResult -> blockGas - (transactionGasLimit bt - calculateReturned bt execResult)
 
       x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-
+      $logInfoS "addTransactions/go" $ T.pack $ "getting x509s' from memory and calling go with these x509s - there are " ++ (show $ M.size x509s') ++ " certs in memory"
       go remainingBlockGas rest (trrs `DL.snoc` trr) x509s'
 
 mineTransactions :: (VMBase m, MonadMonitor m) => Bagger.MineTransactions m
@@ -373,8 +381,12 @@ addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=b
     if success
         then do
             x509s <- lift $ Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+            $logInfoS "addTx" $ T.pack $ "Getting X509s from memory - there are " ++ (show $ M.size x509s) ++ "in memory"
             execResults <- runCodeForTransaction isRunningTests' isHomestead b (fromInteger (transactionGasLimit bt) - intrinsicGas') tAcct t
             lift $ Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.union (erNewX509Certs execResults) x509s
+            $logInfoS "addTx" "Putting the union of old X509s and existing X509s into memory"
+            x509s_ <- lift $ Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+            $logInfoS "addTx" $ T.pack $ "There are now " ++ (show $ M.size x509s_) ++ " certs in memory"
             s1 <- lift $ addToBalance coinbaseAcct (transactionGasLimit bt * transactionGasPrice bt)
             unless s1 $ error "addToBalance failed even after a check in addBlock"
             lift $ P.incCounter vmTxsProcessed


### PR DESCRIPTION
Added very verbose log messages revolving around the x509 cert cache in order to better track the stateroot issue when the VM cannot find an x509 for some reason.

These should be removed once we figure out the issue.