### PR TITLE
Enable registering certs in constructor

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -572,6 +572,7 @@ argsToVals ctract fn args =
 
 callWrapper :: MonadSM m => Account -> Account -> Maybe String -> String -> Xabi.ArgList -> m (Maybe Value)
 callWrapper from to mContract functionName argExps = do
+  beforeX509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
   let fromChain = from ^. accountChainId
       toChain = to ^. accountChainId
   isAccessibleChain <- toChain `isAncestorChainOf` fromChain
@@ -624,9 +625,13 @@ callWrapper from to mContract functionName argExps = do
                 return (fmap Just $ getVar $ Constant $ SReference $ AccountPath to . MS.singleton $ BC.pack functionName, OrderedVals [])
               Nothing -> unknownFunction "logFunctionCall" (functionName, contract^.contractName)
 
+  funcResult <- logFunctionCall args to contract functionName f
+  case funcResult of
+    Just _ -> return funcResult
 
-  logFunctionCall args to contract functionName f
-
+    Nothing -> do
+      Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ beforeX509s --revert X509s to previous state on call failure
+      return funcResult
 
 runStatements :: MonadSM m => [Xabi.Statement] -> m (Maybe Value)
 runStatements [] = return Nothing

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -76,6 +76,7 @@ import           Blockchain.Data.ExecResults
 import           Blockchain.DB.CodeDB                  (getCode)
 import qualified Blockchain.DB.MemAddressStateDB       as Mem
 import           Blockchain.DB.StorageDB
+import           Blockchain.DB.X509CertDB
 import qualified Blockchain.SolidVM                    as SolidVM
 import           Blockchain.Strato.Indexer.Kafka       (writeIndexEvents)
 import           Blockchain.Strato.Indexer.Model       (IndexEvent (..))
@@ -88,7 +89,6 @@ import qualified Blockchain.Strato.Model.Keccak256     as Keccak256
 import           Blockchain.Strato.StateDiff.Database  (commitSqlDiffs)
 import           Blockchain.Timing
 import           Blockchain.Util
-
 import qualified Text.Colors                           as CL
 import           Text.Format                           (format)
 
@@ -365,9 +365,12 @@ runChainConstructors cId cInfo = do
            ]
            ++ case ms of Nothing -> []; Just s -> [("src", s)])
 
+  $logInfoS "runChainConstructor" "flushMemStorageDB"
   flushMemStorageDB
+  $logInfoS "runChainConstructor" "flushMemAddressStateDB"
   Mem.flushMemAddressStateDB
-
+  $logInfoS "runChainConstructor" "flushX509ToLevelDB"
+  flushX509ToLevelDB
   sr <- A.lookupWithDefault (Proxy @MP.StateRoot) (Just cId)
   return (sr, actions)
 


### PR DESCRIPTION
The x509 cache was never flushed to leveldb in private chain creations, so this adds that

To account for unsuccessful chain creations, I added the functionality in solidvm that now an unsuccessfull call will revert the x509 cache to its previous state. Inductively than a failed constructor will revert the cache to its initial state (empty).

