### PR TITLE
STRATO-2397-evm-cirrus-flag

### DIFF
--- a/Jenkinsfile.autobuild
+++ b/Jenkinsfile.autobuild
@@ -185,7 +185,7 @@ pipeline {
                 rm -rf strato-api-tests
                 git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
                 cd strato-api-tests
-                git checkout strato-7.5.0  #TODO: api version tags in the future
+                git checkout deprecate-external-storage-tests  #TODO: api version tags in the future
                 docker build --tag strato-api-tests .
                 docker run \
                   -e OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration \

--- a/Jenkinsfile.autobuild
+++ b/Jenkinsfile.autobuild
@@ -185,7 +185,7 @@ pipeline {
                 rm -rf strato-api-tests
                 git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
                 cd strato-api-tests
-                git checkout deprecate-external-storage-tests  #TODO: api version tags in the future
+                git checkout strato-7.5.0  #TODO: api version tags in the future
                 docker build --tag strato-api-tests .
                 docker run \
                   -e OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration \

--- a/Jenkinsfile.autobuild
+++ b/Jenkinsfile.autobuild
@@ -185,7 +185,7 @@ pipeline {
                 rm -rf strato-api-tests
                 git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
                 cd strato-api-tests
-                git checkout strato-7.5.0  #TODO: api version tags in the future
+                git checkout tags/strato-7.5-no-ext-storage  #TODO: api version tags in the future
                 docker build --tag strato-api-tests .
                 docker run \
                   -e OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration \

--- a/Jenkinsfile.autobuild
+++ b/Jenkinsfile.autobuild
@@ -214,9 +214,6 @@ pipeline {
               sh 'npm install'
               sh 'npm run test'
             }
-            dir ('core-strato/strato-init') {
-              sh './check_genesis_ingestion.sh'
-            }
           },
         )
       }

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -189,7 +189,7 @@ pipeline {
                 rm -rf strato-api-tests
                 git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
                 cd strato-api-tests
-                git checkout tags/strato-7.5.0  #TODO: api version tags in the future
+                git checkout tags/strato-7.5-no-ext-storage #TODO: api version tags in the future
                 docker build --tag strato-api-tests .
                 docker run \
                   -e OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration \

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -219,9 +219,6 @@ pipeline {
               sh 'npm run test'
               //sh 'npm run test:long' // TODO: revise tests, determine the long test suite and uncomment line
             }
-            dir ('strato-worktree/core-strato/strato-init') {
-              sh './check_genesis_ingestion.sh'
-            }
           },
         )
       }

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -202,7 +202,7 @@ pipeline {
                 rm -rf strato-api-tests
                 git clone -b master https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
                 cd strato-api-tests
-                git checkout tags/strato-7.5.0  #TODO: api version tags in the future
+                git checkout tags/strato-7.5-no-ext-storage #TODO: api version tags in the future
                 docker build --tag strato-api-tests .
                 docker run \
                   -e OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration \

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -231,9 +231,6 @@ pipeline {
               sh 'npm install'
               sh 'npm run test'
             }
-            dir ('strato-worktree/core-strato/strato-init') {
-              sh './check_genesis_ingestion.sh'
-            }
           },
         )
       }

--- a/blockapps-haskell/slipstream/src/Slipstream/Options.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Options.hs
@@ -24,3 +24,4 @@ defineFlag "globalsStateCount" (1024 :: Int) "The maximum number of states to ke
 
 defineFlag "kafkaMaxBytes" (1024 * 1024 * 32 :: Int) "Number of bytes to read in each batch from kafka"
 defineFlag "sourceCacheTimeout" (60::Integer) "The number of seconds nonces are held in the global source code cache"
+defineFlag "indexEVM" (False :: Bool) "Whether or not to index EVM contracts in cirrus"

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -408,6 +408,57 @@ getCodeCollection cp ccString = do
         Right v -> return $ CodeCollection $ Map.fromList $ map (\(x, y) -> (T.unpack x, xabiToPartialContract y)) $ snd v
     CodeAtAccount _ _ -> error "no compilo codeataccount"
 
+getCodeCollectionIgnoreEVM :: MonadIO m => CodePtr -> Text -> m CodeCollection
+getCodeCollectionIgnoreEVM cp ccString = do
+  let initList =
+        case Aeson.decodeStrict $ encodeUtf8 ccString of
+          Just l -> l
+          Nothing -> case Aeson.decodeStrict $ encodeUtf8 ccString of
+            Just m -> Map.toList m
+            Nothing -> [(T.empty, ccString)] -- for backwards compatibility
+
+  --We shouldn't crash if the source can't be parsed (a bad validator could brind the network down)
+  --For now I'm going to keep the crash in, since it will be a warning to us that we let a
+  --bad contract into the blockchain (the API shouldn't allow this)
+
+  case cp of
+    SolidVMCode _ _ ->
+      case compileSource $ Map.fromList initList of
+        Left e -> error $ "failed parse: "  ++ show e --return $ CodeCollection Map.empty
+        Right v -> return v
+    EVMCode _ -> return $ CodeCollection Map.empty
+    CodeAtAccount _ _ -> error "no compilo codeataccount"
+
+getEVMInserts :: (
+  MonadIO m, 
+  MonadUnliftIO m, 
+  MonadLogger m,
+  Accessible BlocEnv m,
+  HasBlocSQL m,
+  Selectable Account AddressState m,
+  (Keccak256 `Alters` SourceMap) m) => IORef Globals -> AggregateAction -> [AggregateAction] -> Account -> m (Either Text BatchedInserts)
+getEVMInserts g row actions acct = do
+  mDetails <- getEVMDetailsForRow row
+  case mDetails of
+    Nothing -> pure . Left $ "No details found for code hash "
+                    <> (T.pack . show $ actionCodeHash row)
+                    <> " and no 'src' field found in actionMetadata"
+    Just details -> do
+      let abiid = ABIID
+            { aiName = T.filter (/= '"') $ OLD.contractdetailsName details
+            , aiChain = maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
+            }
+          cont = either error id . xAbiToContract $ OLD.contractdetailsXabi details
+      adjustGlobals g (Do Compile) row details
+
+      oldState <- readPreviousEVMState g acct cont
+      indexContract <- rowToInsert g abiid row cont oldState
+      hs <- rowToHistories g abiid row actions cont oldState
+      pure . Right $ BatchedInserts indexContract hs []
+
+getInsertsIgnoreEVM :: (Monad m) => IORef Globals -> AggregateAction -> [AggregateAction] -> Account -> m (Either Text BatchedInserts)
+getInsertsIgnoreEVM _ _ _ _ = pure $ Left "EVM code indexing ignored"
+
 processTheMessages :: (MonadIO m, MonadUnliftIO m, MonadLogger m, HasSQL m) =>
                       BlocEnv -> BlocSQLEnv -> PGConnection -> IORef Globals -> [VMEvent] -> m ()
 processTheMessages env sqlEnv conn g messages = do
@@ -417,11 +468,12 @@ processTheMessages env sqlEnv conn g messages = do
       -- TODO (Dan) : would be nice if we didn't just rip events out at the top level like this
       creates = [(c, cp, o, a, hl) | CodeCollectionAdded c cp o a hl <- messages]
       transactionResults = [tr | NewTransactionResult tr <- messages]
-
-
+      -- Use different functions based on flag value, this way it is only computed once, saving cpu cycles with if statements
+      getCC = if flags_indexEVM then getCodeCollection else getCodeCollectionIgnoreEVM
+      evmInserts = if flags_indexEVM then getEVMInserts else getInsertsIgnoreEVM
 
   forM_ creates $ \(ccString, cp, o, a, hl) -> do
-    cc <- getCodeCollection cp ccString
+    cc <- getCC cp ccString
     forM_ (Map.toList $ cc^.contracts) $ \(nameString, c) -> do
       let n = T.pack nameString
       $logInfoS "processTheMessages" $ "New Contract Added: org=" <> o <> ", app=" <> a <> ", name=" <> n
@@ -450,27 +502,7 @@ processTheMessages env sqlEnv conn g messages = do
       $logDebugLS "the diff is " $ actionStorage row
 
       case actionStorage row of
-        Action.EVMDiff{} -> do
-          if flags_indexEVM then do
-            mDetails <- getEVMDetailsForRow row
-            case mDetails of
-              Nothing -> pure . Left $ "No details found for code hash "
-                              <> (T.pack . show $ actionCodeHash row)
-                              <> " and no 'src' field found in actionMetadata"
-              Just details -> do
-                let abiid = ABIID
-                      { aiName = T.filter (/= '"') $ OLD.contractdetailsName details
-                      , aiChain = maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
-                      }
-                    cont = either error id . xAbiToContract $ OLD.contractdetailsXabi details
-                adjustGlobals g (Do Compile) row details
-
-                oldState <- readPreviousEVMState g acct cont
-                indexContract <- rowToInsert g abiid row cont oldState
-                hs <- rowToHistories g abiid row actions cont oldState
-                pure . Right $ BatchedInserts indexContract hs []
-            else 
-              pure . Left $ "Cirrus Indexing turned off by flag"
+        Action.EVMDiff{} -> evmInserts g row actions acct
         Action.SolidVMDiff{} -> do
           mName <- getSolidVMDetailsForRow g row
           case mName of

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -87,6 +87,7 @@ import Slipstream.Globals
 import Slipstream.Metrics
 import Slipstream.OutputData
 import Slipstream.XabiContract
+import Slipstream.Options
 
 instance ( (Keccak256 `Alters` SourceMap) m
          , MonadLogger m
@@ -450,23 +451,26 @@ processTheMessages env sqlEnv conn g messages = do
 
       case actionStorage row of
         Action.EVMDiff{} -> do
-          mDetails <- getEVMDetailsForRow row
-          case mDetails of
-            Nothing -> pure . Left $ "No details found for code hash "
-                            <> (T.pack . show $ actionCodeHash row)
-                            <> " and no 'src' field found in actionMetadata"
-            Just details -> do
-              let abiid = ABIID
-                    { aiName = T.filter (/= '"') $ OLD.contractdetailsName details
-                    , aiChain = maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
-                    }
-                  cont = either error id . xAbiToContract $ OLD.contractdetailsXabi details
-              adjustGlobals g (Do Compile) row details
+          if flags_indexEVM == True then do
+            mDetails <- getEVMDetailsForRow row
+            case mDetails of
+              Nothing -> pure . Left $ "No details found for code hash "
+                              <> (T.pack . show $ actionCodeHash row)
+                              <> " and no 'src' field found in actionMetadata"
+              Just details -> do
+                let abiid = ABIID
+                      { aiName = T.filter (/= '"') $ OLD.contractdetailsName details
+                      , aiChain = maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
+                      }
+                    cont = either error id . xAbiToContract $ OLD.contractdetailsXabi details
+                adjustGlobals g (Do Compile) row details
 
-              oldState <- readPreviousEVMState g acct cont
-              indexContract <- rowToInsert g abiid row cont oldState
-              hs <- rowToHistories g abiid row actions cont oldState
-              pure . Right $ BatchedInserts indexContract hs []
+                oldState <- readPreviousEVMState g acct cont
+                indexContract <- rowToInsert g abiid row cont oldState
+                hs <- rowToHistories g abiid row actions cont oldState
+                pure . Right $ BatchedInserts indexContract hs []
+            else 
+              pure . Left $ "Cirrus Indexing turned off by flag"
         Action.SolidVMDiff{} -> do
           mName <- getSolidVMDetailsForRow g row
           case mName of

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -451,7 +451,7 @@ processTheMessages env sqlEnv conn g messages = do
 
       case actionStorage row of
         Action.EVMDiff{} -> do
-          if flags_indexEVM == True then do
+          if flags_indexEVM then do
             mDetails <- getEVMDetailsForRow row
             case mDetails of
               Nothing -> pure . Left $ "No details found for code hash "

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -381,9 +381,12 @@ parseActions events' =
 parseEvents :: [VMEvent] -> [Action.Event]
 parseEvents events' = [a | EventEmitted a <- events']
 
+getCodeCollection' :: MonadIO m => Bool -> CodePtr -> Text -> m CodeCollection
+getCodeCollection' True = getCodeCollection (Map.fromList . map (\(x, y) -> (T.unpack x, xabiToPartialContract y)) )
+getCodeCollection' False = getCodeCollection (const Map.empty)
 
-getCodeCollection :: MonadIO m => CodePtr -> Text -> m CodeCollection
-getCodeCollection cp ccString = do
+getCodeCollection :: MonadIO m => ([(Text, OLD.Xabi)] -> Map.Map String Contract) -> CodePtr -> Text -> m CodeCollection
+getCodeCollection f cp ccString = do
   let initList =
         case Aeson.decodeStrict $ encodeUtf8 ccString of
           Just l -> l
@@ -405,28 +408,7 @@ getCodeCollection cp ccString = do
         Left e ->
           --return $ CodeCollection Map.empty
           error $ "failed EVM parse: " ++ show e ++ "\n" ++ T.unpack ccString
-        Right v -> return $ CodeCollection $ Map.fromList $ map (\(x, y) -> (T.unpack x, xabiToPartialContract y)) $ snd v
-    CodeAtAccount _ _ -> error "no compilo codeataccount"
-
-getCodeCollectionIgnoreEVM :: MonadIO m => CodePtr -> Text -> m CodeCollection
-getCodeCollectionIgnoreEVM cp ccString = do
-  let initList =
-        case Aeson.decodeStrict $ encodeUtf8 ccString of
-          Just l -> l
-          Nothing -> case Aeson.decodeStrict $ encodeUtf8 ccString of
-            Just m -> Map.toList m
-            Nothing -> [(T.empty, ccString)] -- for backwards compatibility
-
-  --We shouldn't crash if the source can't be parsed (a bad validator could brind the network down)
-  --For now I'm going to keep the crash in, since it will be a warning to us that we let a
-  --bad contract into the blockchain (the API shouldn't allow this)
-
-  case cp of
-    SolidVMCode _ _ ->
-      case compileSource $ Map.fromList initList of
-        Left e -> error $ "failed parse: "  ++ show e --return $ CodeCollection Map.empty
-        Right v -> return v
-    EVMCode _ -> return $ CodeCollection Map.empty
+        Right v -> return $ CodeCollection $ f $ snd v
     CodeAtAccount _ _ -> error "no compilo codeataccount"
 
 getEVMInserts :: (
@@ -469,7 +451,7 @@ processTheMessages env sqlEnv conn g messages = do
       creates = [(c, cp, o, a, hl) | CodeCollectionAdded c cp o a hl <- messages]
       transactionResults = [tr | NewTransactionResult tr <- messages]
       -- Use different functions based on flag value, this way it is only computed once, saving cpu cycles with if statements
-      getCC = if flags_indexEVM then getCodeCollection else getCodeCollectionIgnoreEVM
+      getCC = getCodeCollection' flags_indexEVM
       evmInserts = if flags_indexEVM then getEVMInserts else getInsertsIgnoreEVM
 
   forM_ creates $ \(ccString, cp, o, a, hl) -> do

--- a/blockapps-haskell/slipstream/tests/OutputDataSpec.hs
+++ b/blockapps-haskell/slipstream/tests/OutputDataSpec.hs
@@ -75,7 +75,7 @@ spec = do
       let testAdd = Address $ fst . head . readHex $ "ADDRESS"
       let input = [(ProcessedContract {
             address = testAdd,
-            codehash = EVMCode $ hash "<CODEHASH>",
+            codehash = SolidVMCode "Vehicle" $ hash "<CODEHASH>",
             organization = "",
             application = "",
             contractName = "Vehicle",
@@ -134,7 +134,7 @@ spec = do
   describe "Array serialization with history enabled" $ do
     it "should create JSON entries" $ do
       let testAdd = Address $ fst . head . readHex $ "ADDRESS"
-          cHash = EVMCode $ hash "<CODEHASH>"
+          cHash = SolidVMCode "Vehicle" $ hash "<CODEHASH>"
       let input = [(ProcessedContract {
              address = testAdd,
              codehash = cHash,
@@ -232,7 +232,7 @@ ALTER TABLE "history@Vehicle" ADD PRIMARY KEY USING INDEX "index_history@Vehicle
       let testAdd = Address $ fst . head . readHex $ "ADDRESS"
       let input = [(ProcessedContract {
             address = testAdd,
-            codehash = EVMCode $ hash "<CODEHASH>",
+            codehash = SolidVMCode "\"Vehicle''" $ hash "<CODEHASH>",
             organization = "",
             application = "",
             contractName = "\"Vehicle''",

--- a/blockapps-rest/.gitignore
+++ b/blockapps-rest/.gitignore
@@ -51,5 +51,6 @@ docs
 
 config.yaml
 
+yarn.lock
 # OS files
 **/.DS_Store

--- a/blockapps-rest/.oauth-test-config
+++ b/blockapps-rest/.oauth-test-config
@@ -1,7 +1,7 @@
 apiDebug: true
 password: "1234"
 timeout: 600000
-
+VM: SolidVM
 # WARNING - extra strict syntax
 # DO NOT change the nodes order
 # node 0 is the default url for all single node api calls

--- a/blockapps-rest/src/test/fixtures/TestHistory.sol
+++ b/blockapps-rest/src/test/fixtures/TestHistory.sol
@@ -1,0 +1,9 @@
+contract TestHistory {
+  uint x;
+  constructor(uint _x) {
+    x = _x;
+  }
+  function setX(uint _x) {
+    x = _x;
+  }
+}

--- a/blockapps-rest/src/test/fixtures/config.yaml
+++ b/blockapps-rest/src/test/fixtures/config.yaml
@@ -1,7 +1,7 @@
 apiDebug: true
 password: "1234"
 timeout: 600000
-
+VM: SolidVM
 # WARNING - extra strict syntax
 # DO NOT change the nodes order
 # node 0 is the default url for all single node api calls

--- a/blockapps-rest/src/test/index.test.ts
+++ b/blockapps-rest/src/test/index.test.ts
@@ -403,7 +403,7 @@ describe("history", function() {
       {
         ...options,
         query: {
-          someInt: `eq.${fst}`,
+          x: `eq.${fst}`,
           address: `eq.${contract.address}`
         }
       }

--- a/blockapps-rest/src/test/index.test.ts
+++ b/blockapps-rest/src/test/index.test.ts
@@ -360,17 +360,19 @@ describe("history", function() {
   });
 
   it("test history", async () => {
-    const filename = `${fixtures}/sampleDapp.sol`;
+    const filename = `${fixtures}/TestHistory.sol`;
+    const fst = Math.floor(Math.random() * 100)
+    const scd = Math.floor(Math.random() * 100)
     const contractArgs = {
-      name: "AdminInterface",
+      name: "TestHistory",
       source: fsUtil.get(filename),
       args: {
-        uid: Math.floor(Math.random() * 100)
+        _x: fst,
       }
     };
     const historyOptions:Options = {
       ...options,
-      history: ["Event", "Ticket", "Transaction"]
+      history: ["TestHistory"]
     };
 
     const contract = <Contract> await rest.createContract(
@@ -382,95 +384,31 @@ describe("history", function() {
     assert.equal(contract.name, contractArgs.name, "name");
     assert.isOk(util.isAddress(contract.address), "address");
 
-    // get state for Dapp
-    const state = await rest.getState(admin, contract, options);
+    // call a function
+    const methodArgs = { _x: scd };
+    const method = "setX";
 
-    assert.isOk(util.isAddress(state.eventManager), "address");
-    assert.isOk(util.isAddress(state.ticketManager), "address");
-    assert.isOk(util.isAddress(state.transactionManager), "address");
-
-    // create event
-    const eMethodArgs = { someInt: contractArgs.args.uid, someString: "hello" };
-    const eMethod = "createEvent";
-
-    const eCallArgs = factory.createCallArgs(
-      { name: "EventManager", address: state.eventManager },
-      eMethod,
-      eMethodArgs
+    const callArgs = factory.createCallArgs(
+      { name: "TestHistory", address: contract.address },
+      method,
+      methodArgs
     );
-    const eResult = await rest.call(admin, eCallArgs, options);
-    console.log(eResult);
+    const result = await rest.call(admin, callArgs, options);
+    console.log(result);
 
-    // create ticket
-
-    const tMethodArgs = {
-      pnr: `${contractArgs.args.uid}5678`,
-      ticketNumber: `${contractArgs.args.uid}1234`
-    };
-    const tMethod = "createTicket";
-
-    const tCallArgs = factory.createCallArgs(
-      { name: "TicketManager", address: state.ticketManager },
-      tMethod,
-      tMethodArgs
-    );
-    const tResult = await rest.call(admin, tCallArgs, options);
-
-    // create transaction
-
-    const txMethodArgs = {
-      transactionId: `${contractArgs.args.uid}0000`
-    };
-    const txMethod = "createTransaction";
-
-    const txCallArgs = factory.createCallArgs(
-      { name: "TransactionManager", address: state.transactionManager },
-      txMethod,
-      txMethodArgs
-    );
-    const txResult = await rest.call(admin, txCallArgs, options);
-
-    const eventHistory = await rest.searchUntil(
+    const contractHistory = await rest.searchUntil(
       admin,
-      { name: `history@Event` },
+      { name: `history@TestHistory` },
       (r) => r.length > 0,
       {
         ...options,
         query: {
-          someInt: `eq.${eMethodArgs.someInt}`
+          someInt: `eq.${fst}`,
+          address: `eq.${contract.address}`
         }
       }
     );
-    assert.isArray(eventHistory);
-    assert.equal(eventHistory.length, 1);
-
-    const ticketHistory = await rest.searchUntil(
-      admin,
-      { name: `history@Ticket` },
-      (r) => r.length > 0,
-      {
-        ...options,
-        query: {
-          pnr: `eq.${tMethodArgs.pnr}`,
-          ticketNumber: `eq.${tMethodArgs.ticketNumber}`
-        }
-      }
-    );
-    assert.isArray(ticketHistory);
-    assert.equal(ticketHistory.length, 1);
-
-    const txHistory = await rest.searchUntil(
-      admin,
-      { name: `history@Transaction` },
-      (r) => r.length > 0,
-      {
-        ...options,
-        query: {
-          transactionId: `eq.${txMethodArgs.transactionId}`
-        }
-      }
-    );
-    assert.isArray(txHistory);
-    assert.equal(txHistory.length, 1);
+    assert.isArray(contractHistory);
+    assert.equal(contractHistory.length, 1);
   });
 });

--- a/blockapps-rest/src/test/index.test.ts
+++ b/blockapps-rest/src/test/index.test.ts
@@ -385,7 +385,7 @@ describe("history", function() {
     assert.isOk(util.isAddress(contract.address), "address");
 
     // call a function
-    const methodArgs = { _x: scd };
+    const methodArgs = { x: scd };
     const method = "setX";
 
     const callArgs = factory.createCallArgs(

--- a/blockapps-rest/src/util/test/fixtures/config.yaml
+++ b/blockapps-rest/src/util/test/fixtures/config.yaml
@@ -1,7 +1,7 @@
 apiDebug: true
 password: "1234"
 timeout: 600000
-
+VM: "SolidVM"
 # WARNING - extra strict syntax
 # DO NOT change the nodes order
 # node 0 is the default url for all single node api calls

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -203,7 +203,7 @@ function newnode {
   SLIPSTREAM_CMD="slipstream --pghost=${postgres_host} --pgport=${postgres_port} \
     --pguser=${postgres_user} --password=${postgres_password} --database=${postgres_slipstream_db} \
     --stratourl=${stratoRoot} --vaultwrapperurl=${vaultWrapperRoot}  \
-    --kafkahost=${kafkaHost} --kafkaport=${kafkaPort} --minLogLevel=${slipMinLogLevel}"
+    --kafkahost=${kafkaHost} --kafkaport=${kafkaPort} --minLogLevel=${slipMinLogLevel} --indexEVM=${indexEVM}"
 
   if [ ${SLIPSTREAM_OPTIONAL} = true ]; then
       $SLIPSTREAM_CMD &>> logs/slipstream &
@@ -400,6 +400,7 @@ setEnv svmTrace ${svmTrace:-false}
 setEnv diffPublish true
 
 setEnv evmCompatible ${EVM_COMPATIBLE:-false}
+setEnv indexEVM ${indexEVM:-false}
 
 setEnv evmDebugMode false
 setEnv evmTraceMode false
@@ -408,6 +409,7 @@ setEnv vmDebug ${vmDebug:-false}
 setEnv wsDebug ${wsDebug:-false}
 setEnv debugPort ${debugPort:-8051}
 setEnv debugWSPort ${debugWSPort:-8052}
+
 
 stratoBootnode=${bootnode:+--stratoBootnode=$bootnode}
 [[ -n $bootnode ]] && addBootnodes=true

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -400,8 +400,12 @@ setEnv svmTrace ${svmTrace:-false}
 setEnv diffPublish true
 
 setEnv evmCompatible ${EVM_COMPATIBLE:-false}
-setEnv indexEVM ${indexEVM:-false}
-
+if [ "${evmCompatible}" = true ]
+then
+  setEnv indexEVM true
+else
+  setEnv indexEVM ${indexEVM:-false}
+fi
 setEnv evmDebugMode false
 setEnv evmTraceMode false
 

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -221,6 +221,7 @@ services:
     - wsDebug=${wsDebug}
     - zkHost=zookeeper
     - EVM_COMPATIBLE=${EVM_COMPATIBLE}
+    - indexEVM=${indexEVM:-false}
     build: .
     image: ${STRATO_IMAGE:-<REPO_URL>strato:<VERSION>}
     ports:

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -2,7 +2,7 @@ apiDebug: false
 password: "1234"
 timeout: 600000
 contractsPath: ./contracts/
-
+VM: SolidVM
 nodes:
   - id: 0
     url: 'http://localhost'

--- a/tests/config/192.config.yaml
+++ b/tests/config/192.config.yaml
@@ -5,6 +5,7 @@ libPath: ./server/lib
 dataFilename: ./server/dapp/dapp.presets.yaml
 deployFilename: ./server/config/192.deploy.yaml
 contractsPath: ./contracts/
+VM: SolidVM
 
 # WARNING - extra strict syntax
 # DO NOT change the nodes order

--- a/tests/config/2node.config.yaml
+++ b/tests/config/2node.config.yaml
@@ -5,6 +5,7 @@ libPath: ./server/lib
 contractsPath: ./contracts/
 dataFilename: ./server/dapp/dapp.presets.yaml
 deployFilename: ./server/config/2node.deploy.yaml
+VM: SolidVM
 
 # WARNING - extra strict syntax
 # DO NOT change the nodes order

--- a/tests/config/localhost-oauth.config.yaml
+++ b/tests/config/localhost-oauth.config.yaml
@@ -5,6 +5,7 @@ libPath: ./server/lib
 contractsPath: ./contracts/
 dataFilename: ./server/dapp/dapp.presets.yaml
 deployFilename: ./server/config/localhost-oauth.deploy.yaml
+VM: SolidVM
 
 # WARNING - extra strict syntax
 # DO NOT change the nodes order

--- a/tests/config/localhost.config.yaml
+++ b/tests/config/localhost.config.yaml
@@ -5,6 +5,7 @@ libPath: ./server/lib
 contractsPath: ./contracts/
 dataFilename: ./server/dapp/dapp.presets.yaml
 deployFilename: ./server/config/localhost.deploy.yaml
+VM: SolidVM
 
 # WARNING - extra strict syntax
 # DO NOT change the nodes order

--- a/tests/config/multinode.config.yaml
+++ b/tests/config/multinode.config.yaml
@@ -3,6 +3,7 @@ password: '1234'
 timeout: 1200000
 libPath: ./server/lib
 contractsPath: ./contracts/
+VM: SolidVM
 
 # WARNING - extra strict syntax
 # DO NOT change the nodes order

--- a/tests/config/throughput-multi.config.yml
+++ b/tests/config/throughput-multi.config.yml
@@ -5,6 +5,8 @@ libPath: ./server/lib
 contractsPath: ./contracts/
 batchSize: 100
 batchValue: 1
+VM: SolidVM
+
 # WARNING - extra strict syntax
 # DO NOT change the nodes order
 # node 0 is the default url for all single node api calls

--- a/tests/config/throughput.config.yaml
+++ b/tests/config/throughput.config.yaml
@@ -5,6 +5,8 @@ libPath: ./server/lib
 contractsPath: ./contracts/
 batchSize: 100
 batchValue: 2
+VM: SolidVM
+
 # WARNING - extra strict syntax
 # DO NOT change the nodes order
 # node 0 is the default url for all single node api calls

--- a/tests/e2e/blockhash.test.ts
+++ b/tests/e2e/blockhash.test.ts
@@ -25,7 +25,7 @@ contract Random {
 `;
 
 let config:Config = fsUtil.getYaml("config.yaml");
-let options:Options = {VM:"EVM", config};
+let options:Options = {config: {...config, VM: "EVM"}};
 
 describe('Using blockhash', function () {
   it('should upload a contract that uses blockhash', async () => {

--- a/tests/e2e/blockhash.test.ts
+++ b/tests/e2e/blockhash.test.ts
@@ -25,7 +25,7 @@ contract Random {
 `;
 
 let config:Config = fsUtil.getYaml("config.yaml");
-let options:Options = {config};
+let options:Options = {VM:"EVM", config};
 
 describe('Using blockhash', function () {
   it('should upload a contract that uses blockhash', async () => {

--- a/tests/e2e/governance.test.ts
+++ b/tests/e2e/governance.test.ts
@@ -23,7 +23,17 @@ let config:Config=fsUtil.getYaml("config.yaml");
 let options:Options={config}
 
 const label = 'My chain label';
-const src = 'contract Governance { enum Rule { NOTHING, AUTO_APPROVE, TWO_VOTES_IN, MAJORITY_RULES } event MemberAdded(address member, string enode); event MemberRemoved(address member); function voteToAdd(address m, string e) { MemberAdded(m,e); } function voteToRemove(address m) { MemberRemoved(m); } }';
+const src = `contract Governance {
+  enum Rule { NOTHING, AUTO_APPROVE, TWO_VOTES_IN, MAJORITY_RULES }
+  event MemberAdded(address member, string enode);
+  event MemberRemoved(address member);
+  function voteToAdd(address m, string e) { 
+    emit MemberAdded(m,e);
+  }
+  function voteToRemove(address m) {
+    emit MemberRemoved(m);
+  }
+}`;
 const args = {addRule: 'AUTO_APPROVE', removeRule: 'AUTO_APPROVE'};
 const members = [{
     address: "00000000000000000000000000000000deadbeef"


### PR DESCRIPTION
First off sorry for so many commits, I basically had to just run jenkins tests until they all passed...

The tests will fail for the last commit because its using the wrong api-test branch, but that because I had to revert it from my branch in that repo. The tests will pass on master once that PR is merged.

Basically this adds the flag `indexEVM` with the default of False. Note to slightly improve performance, I checked for the flag once outside of the loop and use a different function based on that value to determine what should be inserted (for evm only)

Never tested it inside the loop so this probably only a marginal perfomance gain.

Other changes are just changing the config files for everything to use SolidVM. Also simplified the ba-rest history test