### PR TITLE
Strato 2399 remove contract details slipstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build_common_profiled: get_solcs build_buildbase
 	mkdir -p ${FAKEROOT}/strato
 	mkdir -p ${FAKEROOT}/vault-wrapper
 	stack build \
-		--profile --ghc-options="-fno-prof-auto" --work-dir .stack-work-profile \
+		--profile --work-dir .stack-work-profile \
 		--copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin
 
 strato: build_common

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build_common_profiled: get_solcs build_buildbase
 	mkdir -p ${FAKEROOT}/strato
 	mkdir -p ${FAKEROOT}/vault-wrapper
 	stack build \
-		--profile --work-dir .stack-work-profile \
+		--profile --ghc-options="-fno-prof-auto" --work-dir .stack-work-profile \
 		--copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin
 
 strato: build_common
@@ -117,6 +117,10 @@ docker-compose:
 	@echo Creating the final docker-compose.yml...
 	awk '/build: ./{getline} 1' docker-compose.push.yml > docker-compose.yml
 
+docker-build:
+	cp -fr core-strato/licenses ${STRATODIR}
+	cp core-strato/doit.sh ${STRATODIR}
+	docker build --target strato --tag ${REPO_URL}strato:${VERSION} --file Dockerfile.multi ${FAKEROOT}
 
 test:
 	@echo ${VERSION}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,18 @@ In Docker for Mac "Preferences" -> "Advanced" allocate at least *2 CPU cores, 6 
     ```
     <CONFIG_VARS> make docker-compose
     ```
+### Debugging
+- GHC/Stack provides a tool called "profiling" which allows you to create a report of how much memory and cycles a process is using for each function, etc. 
+  [GHC Profiling](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/profiling.html)
+- Modify the `doit.sh` script so that the program you are profiling has the following args:
 
+```
+<progname> +RTS -p -RTS ...<args>
+```
+
+- Build strato with the `make build_common_profiled` command, then push the docker images using `make docker-build`
+- Run strato in docker using the `./strato` command
+- A `<progname>.prof` file will be created in the `var/lib/strato/` folder for you to analyze
 ### Plain `stack` usage for core-strato and bloc
 Stack commands (like `stack build`, `stack test` etc.) can only be used once the buildbase image is built.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In Docker for Mac "Preferences" -> "Advanced" allocate at least *2 CPU cores, 6 
 - Modify the `doit.sh` script so that the program you are profiling has the following args:
 
 ```
-<progname> +RTS -p -RTS ...<args>
+<progname> +RTS -p -h -RTS ...<args>
 ```
 
 - Build strato with the `make build_common_profiled` command, then push the docker images using `make docker-build`

--- a/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
@@ -4,7 +4,6 @@
 
 module Slipstream.Data.Globals (
   Globals(..),
-  SlipstreamInfo(..),
   TableColumns,
   TableName(..)
   ) where
@@ -30,15 +29,11 @@ instance NFData (LRU key val) where
 instance NFData (TableName) where
   rnf = (`seq` ())
 
-data SlipstreamInfo = SlipstreamInfo {
-  slipName :: Text,
-  slipHash :: CodePtr
-} deriving (Show, Generic, NFData)
 
 data Globals = Globals { createdTables :: M.Map TableName TableColumns
                        , historyList :: M.Map TableName Bool
                        , createdInstances :: S.Set CodePtr -- lets us avoid an extra bloc call
-                       , solidVMInfo :: HM.HashMap Keccak256 (M.Map Text SlipstreamInfo)
+                       , solidVMInfo :: HM.HashMap Keccak256 (M.Map Text CodePtr)
                        , contractStates :: LRU Account [(Text, Value)]
                        , csHandle :: Handle
                        } deriving (Generic, NFData)

--- a/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Data/Globals.hs
@@ -4,6 +4,7 @@
 
 module Slipstream.Data.Globals (
   Globals(..),
+  SlipstreamInfo(..),
   TableColumns,
   TableName(..)
   ) where
@@ -17,7 +18,6 @@ import           Data.Text
 import           GHC.Generics
 
 import           BlockApps.Solidity.Value
-import           BlockApps.Solidity.Xabi     (ContractDetails(..))
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.CodePtr
 import           Blockchain.Strato.Model.Keccak256
@@ -30,11 +30,15 @@ instance NFData (LRU key val) where
 instance NFData (TableName) where
   rnf = (`seq` ())
 
+data SlipstreamInfo = SlipstreamInfo {
+  slipName :: Text,
+  slipHash :: CodePtr
+} deriving (Show, Generic, NFData)
 
 data Globals = Globals { createdTables :: M.Map TableName TableColumns
                        , historyList :: M.Map TableName Bool
                        , createdInstances :: S.Set CodePtr -- lets us avoid an extra bloc call
-                       , contractABIs :: HM.HashMap Keccak256 (M.Map Text ContractDetails)
+                       , solidVMInfo :: HM.HashMap Keccak256 (M.Map Text SlipstreamInfo)
                        , contractStates :: LRU Account [(Text, Value)]
                        , csHandle :: Handle
                        } deriving (Generic, NFData)

--- a/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
@@ -61,7 +61,6 @@ updateGlobals :: MonadIO m => IORef Globals -> Globals -> m ()
 updateGlobals gref g = do
   recordGlobals g
   writeIORef gref g
-{-# SCC updateGlobals #-}
 
 
 xabiToText :: Xabi -> Text
@@ -69,33 +68,19 @@ xabiToText = T.replace "\'" "\'\'"
            . decodeUtf8 . BL.toStrict
            . JSON.encode
 
--- setContractABIs :: MonadIO m => IORef Globals -> CodePtr -> M.Map Text ContractDetails -> m ()
--- setContractABIs gref (SolidVMCode _ !codeHash) detailsMap = do 
---   globals@Globals{..} <- readIORef gref
---   updateGlobals gref globals{contractABIs=HM.insert codeHash detailsMap contractABIs}
--- setContractABIs _ (EVMCode _) _ = error "cannot use the contractABIs cache for EVM contracts"
--- setContractABIs _ (CodeAtAccount _ _) _ = error "cannot use the contractABIs cache for CodeAtAccount contracts"
-
--- getContractABIs :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (M.Map Text ContractDetails))
--- getContractABIs gref (SolidVMCode _ !codeHash) = do
---   abis <- contractABIs <$> readIORef gref
---   return $ HM.lookup codeHash abis
--- getContractABIs _ (EVMCode _) = error "cannot use the contractABIs cache for EVM contracts"
--- getContractABIs _ (CodeAtAccount _ _) = error "cannot use the contractABIs cache for CodeAtAccount contracts"
-
-setSolidVMInfo :: MonadIO m => IORef Globals -> CodePtr -> M.Map Text SlipstreamInfo -> m ()
+setSolidVMInfo :: MonadIO m => IORef Globals -> CodePtr -> M.Map Text CodePtr -> m ()
 setSolidVMInfo gref (SolidVMCode _ !codeHash) infoMap = do 
   globals@Globals{..} <- readIORef gref
   updateGlobals gref globals{solidVMInfo=HM.insert codeHash infoMap solidVMInfo}
-setSolidVMInfo _ (EVMCode _) _ = error "cannot use the SolidVMInfo cache for EVM contracts"
-setSolidVMInfo _ (CodeAtAccount _ _) _ = error "cannot use the SolidVMInfo cache for CodeAtAccount contracts"
+setSolidVMInfo _ (EVMCode _) _ = error "Cannot use the SolidVMInfo cache for EVM contracts"
+setSolidVMInfo _ (CodeAtAccount _ _) _ = error "Cannot use the SolidVMInfo cache for CodeAtAccount contracts"
 
-getSolidVMInfo :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (M.Map Text SlipstreamInfo))
+getSolidVMInfo :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (M.Map Text CodePtr))
 getSolidVMInfo gref (SolidVMCode _ !codeHash) = do
   info <- solidVMInfo <$> readIORef gref
   return $ HM.lookup codeHash info
-getSolidVMInfo _ (EVMCode _) = error "cannot use the SolidVMInfo cache for EVM contracts"
-getSolidVMInfo _ (CodeAtAccount _ _) = error "cannot use the SolidVMInfo cache for CodeAtAccount contracts"
+getSolidVMInfo _ (EVMCode _) = error "Cannot use the SolidVMInfo cache for EVM contracts"
+getSolidVMInfo _ (CodeAtAccount _ _) = error "Cannot use the SolidVMInfo cache for CodeAtAccount contracts"
 
 setTableCreated :: MonadIO m => IORef Globals -> TableName -> TableColumns -> m ()
 setTableCreated globalsIORef tableName tableColumns = do

--- a/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Globals.hs
@@ -19,8 +19,8 @@ module Slipstream.Globals
     enableHistoryTable,
     hasHistoryTable,
     disableHistoryTable,
-    getContractABIs,
-    setContractABIs,
+    setSolidVMInfo,
+    getSolidVMInfo,
     forceGlobalEval,
     newGlobals,
     module Slipstream.Data.Globals
@@ -46,7 +46,7 @@ import           UnliftIO.IORef
 
 import           BlockApps.Logging
 import           BlockApps.Solidity.Value
-import           BlockApps.Solidity.Xabi     (ContractDetails(..), Xabi(..))
+import           BlockApps.Solidity.Xabi     (Xabi(..))
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.CodePtr
 
@@ -61,6 +61,7 @@ updateGlobals :: MonadIO m => IORef Globals -> Globals -> m ()
 updateGlobals gref g = do
   recordGlobals g
   writeIORef gref g
+{-# SCC updateGlobals #-}
 
 
 xabiToText :: Xabi -> Text
@@ -68,20 +69,33 @@ xabiToText = T.replace "\'" "\'\'"
            . decodeUtf8 . BL.toStrict
            . JSON.encode
 
-setContractABIs :: MonadIO m => IORef Globals -> CodePtr -> M.Map Text ContractDetails -> m ()
-setContractABIs gref (SolidVMCode _ !codeHash) detailsMap = do 
+-- setContractABIs :: MonadIO m => IORef Globals -> CodePtr -> M.Map Text ContractDetails -> m ()
+-- setContractABIs gref (SolidVMCode _ !codeHash) detailsMap = do 
+--   globals@Globals{..} <- readIORef gref
+--   updateGlobals gref globals{contractABIs=HM.insert codeHash detailsMap contractABIs}
+-- setContractABIs _ (EVMCode _) _ = error "cannot use the contractABIs cache for EVM contracts"
+-- setContractABIs _ (CodeAtAccount _ _) _ = error "cannot use the contractABIs cache for CodeAtAccount contracts"
+
+-- getContractABIs :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (M.Map Text ContractDetails))
+-- getContractABIs gref (SolidVMCode _ !codeHash) = do
+--   abis <- contractABIs <$> readIORef gref
+--   return $ HM.lookup codeHash abis
+-- getContractABIs _ (EVMCode _) = error "cannot use the contractABIs cache for EVM contracts"
+-- getContractABIs _ (CodeAtAccount _ _) = error "cannot use the contractABIs cache for CodeAtAccount contracts"
+
+setSolidVMInfo :: MonadIO m => IORef Globals -> CodePtr -> M.Map Text SlipstreamInfo -> m ()
+setSolidVMInfo gref (SolidVMCode _ !codeHash) infoMap = do 
   globals@Globals{..} <- readIORef gref
-  updateGlobals gref globals{contractABIs=HM.insert codeHash detailsMap contractABIs}
-setContractABIs _ (EVMCode _) _ = error "cannot use the contractABIs cache for EVM contracts"
-setContractABIs _ (CodeAtAccount _ _) _ = error "cannot use the contractABIs cache for CodeAtAccount contracts"
+  updateGlobals gref globals{solidVMInfo=HM.insert codeHash infoMap solidVMInfo}
+setSolidVMInfo _ (EVMCode _) _ = error "cannot use the SolidVMInfo cache for EVM contracts"
+setSolidVMInfo _ (CodeAtAccount _ _) _ = error "cannot use the SolidVMInfo cache for CodeAtAccount contracts"
 
-
-getContractABIs :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (M.Map Text ContractDetails))
-getContractABIs gref (SolidVMCode _ !codeHash) = do
-  abis <- contractABIs <$> readIORef gref
-  return $ HM.lookup codeHash abis
-getContractABIs _ (EVMCode _) = error "cannot use the contractABIs cache for EVM contracts"
-getContractABIs _ (CodeAtAccount _ _) = error "cannot use the contractABIs cache for CodeAtAccount contracts"
+getSolidVMInfo :: MonadIO m => IORef Globals -> CodePtr -> m (Maybe (M.Map Text SlipstreamInfo))
+getSolidVMInfo gref (SolidVMCode _ !codeHash) = do
+  info <- solidVMInfo <$> readIORef gref
+  return $ HM.lookup codeHash info
+getSolidVMInfo _ (EVMCode _) = error "cannot use the SolidVMInfo cache for EVM contracts"
+getSolidVMInfo _ (CodeAtAccount _ _) = error "cannot use the SolidVMInfo cache for CodeAtAccount contracts"
 
 setTableCreated :: MonadIO m => IORef Globals -> TableName -> TableColumns -> m ()
 setTableCreated globalsIORef tableName tableColumns = do

--- a/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Metrics.hs
@@ -76,7 +76,7 @@ recordGlobals g = liftIO $ do
       rec lab acc = withLabel globalsSize lab (flip setGauge . fromIntegral . acc $ g)
   rec "created_tables" (M.size . createdTables)
   rec "history_list" (M.size . historyList)
-  rec "contract_abis" (HM.size . contractABIs)
+  rec "solidVM_info" (HM.size . solidVMInfo)
   rec "contract_states" (LRU.size . contractStates)
 
 recordKafkaMessages :: MonadIO m => [a] -> m ()

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -149,7 +149,6 @@ mergeDiffs lhs rhs = error $ "Invalid diff combination: " ++ show (lhs, rhs)
 data BatchedInserts = BatchedInserts
   { indexInsert     :: ProcessedContract
   , historyInserts  :: [ProcessedContract]
-  , eventCreations  :: [EventTable]
   } deriving (Show)
 
 enterBloc2 :: MonadIO m => r -> BlocSQLEnv -> CoreAPIM (ReaderT r (ReaderT BlocSQLEnv m)) a -> m a
@@ -202,42 +201,51 @@ processedContract ABIID{..} state AggregateAction{..} =
 lookupT :: (Monad m, Ord k) => k -> Map.Map k v -> MaybeT m v
 lookupT k = MaybeT . return . Map.lookup k
 
+contractDetailsToSlipstreamInfo :: OLD.ContractDetails -> SlipstreamInfo
+contractDetailsToSlipstreamInfo details = SlipstreamInfo {
+  slipName = OLD.contractdetailsName details,
+  slipHash = OLD.contractdetailsCodeHash details
+}
+
 -- Tries to get contract metadata ID and contract details for a given contract.
 --  If they're not in the cache but they are in bloc database or action metadata,
 --  it reparses the whole source blob, and caches the details for every contract
-getSolidVMDetailsForRow :: ( MonadIO m
+getSolidVMInfoForRow :: ( MonadIO m
                            , MonadLogger m
                            , Accessible BlocEnv m
                            , HasBlocSQL m
                            , Selectable Account AddressState m
                            , (Keccak256 `Alters` SourceMap) m
                            )
-                        => IORef Globals -> AggregateAction -> m (Maybe OLD.ContractDetails)
-getSolidVMDetailsForRow g row = runMaybeT  
+                        => IORef Globals -> AggregateAction -> m (Maybe (Map.Map Text SlipstreamInfo))
+getSolidVMInfoForRow g row = runMaybeT  
    $  checkCache 
-  <|> checkBloc 
   <|> checkMetadata
+  <|> checkBloc 
   
   where checkCache = do
           $logInfoS "getDetailsForRow" . T.pack $ "checking cache for contract details"
-          (MaybeT $ getContractABIs g codePtr) >>= (lookupT $ T.pack name)
-        
-        checkBloc = do
-          $logInfoS "getDetailsForRow" . T.pack $ "checking bloc database for contract details"
-          (MaybeT $ either (const Nothing) Just <$> getContractDetailsByCodeHash codePtr) >>= (parseAndSet . OLD.contractdetailsSrc)
+          MaybeT $ getSolidVMInfo g codePtr
         
         checkMetadata = do
           $logInfoS "getDetailsForRow" . T.pack $ "checking metadata for contract details"
-          (lookupT "src" $ actionMetadata row) >>= parseAndSet . deserializeSourceMap
+          src <- lookupT "src" $ actionMetadata row 
+          parseAndSet $ deserializeSourceMap src
         
+        checkBloc = do
+          $logInfoS "getDetailsForRow" . T.pack $ "checking bloc database for contract details"
+          details <- (MaybeT $ either (const Nothing) Just <$> getContractDetailsByCodeHash codePtr)
+          parseAndSet $ OLD.contractdetailsSrc details
 
         -- parse source code, add all of details to cache, return the one we need
         parseAndSet src = do
-          detailsMap <- lift $ sourceToContractDetails (Don't Compile) src
-          setContractABIs g codePtr detailsMap
-          lookupT (T.pack name) detailsMap
+          details <- lift $ sourceToContractDetails (Don't Compile) src -- :: Map Text ContractDetails
+          let infoMap = fmap contractDetailsToSlipstreamInfo details
+          setSolidVMInfo g codePtr infoMap
+          pure infoMap
           
-        codePtr@(SolidVMCode name _) = actionCodeHash row
+        codePtr = actionCodeHash row
+{-# SCC getSolidVMInfoForRow #-}
 
 
 
@@ -260,21 +268,25 @@ getEVMDetailsForRow row = liftM2 (<|>)
     lookupT name detailsMap)
 
 
-
--- we want adjustGlobals to use cache and not recompile where possible, so we need the cache to link all contracts that share a source, and at the moment, we can only do this with SolidVMCode pointers
+-- Now only used for EVM
 adjustGlobals :: ( MonadIO m
                  , MonadLogger m
                  , HasBlocSQL m
                  , (Keccak256 `Alters` SourceMap) m
                  )
               => IORef Globals
-              -> Should Compile
               -> AggregateAction
               -> OLD.ContractDetails
               -> m ()
-adjustGlobals gref shouldCompile row details = do
+adjustGlobals gref row details = do
   -- TODO: because this uses HistoryTableName directly - this won't work if we add other (non-history) globals
-  let go m (k,f) = runMaybeT $ do
+  detailsMap <- sourceToContractDetails (Do Compile) $ OLD.contractdetailsSrc details
+  mapM_ (go detailsMap) $ [("history", enableHistoryTable)
+                          ,("nohistory", disableHistoryTable)
+                          ]
+
+  where 
+    go m (k,f) = runMaybeT $ do
         v <- lookupT k $ actionMetadata row
         let contracts' = filter (not . T.null) $ T.splitOn "," v
         forM_ contracts' $ \c -> do
@@ -282,21 +294,43 @@ adjustGlobals gref shouldCompile row details = do
           let codePtr = OLD.contractdetailsCodeHash details'
           $logInfoS "adjustGlobals" . T.pack $ "Adding to globals for " ++ T.unpack k ++ ": " ++ show codePtr
           lift $ f gref $ HistoryTableName (actionOrganization row) (actionApplication row) (OLD.contractdetailsName details')
- 
-
   -- if we pass Don't Compile, we assume it's SolidVMCode, and use details from cache
-  detailsMap <- case shouldCompile of
-    Do Compile -> sourceToContractDetails shouldCompile $ OLD.contractdetailsSrc details
-    Don't Compile -> do 
-      mMap <- getContractABIs gref (actionCodeHash row)
-      case mMap of
-        Nothing -> error "solidVMABIs should be in the cache, but adjustGlobals didn't find them"
-        Just dMap -> return dMap
   
   -- TODO: ideally we check if these flags are in the metadata BEFORE we get the detailsMap
-  mapM_ (go detailsMap) $ [("history", enableHistoryTable)
+adjustSolidVMGlobals :: ( MonadIO m
+                 , MonadLogger m
+                 , HasBlocSQL m
+                 , Accessible BlocEnv m
+                 , Selectable Account AddressState m
+                 , (Keccak256 `Alters` SourceMap) m
+                 )
+              => IORef Globals
+              -> AggregateAction
+              -> m ()
+{- Make two functions - one for solidVM, one for EVM
+SolidVM only needs names of all contracts within its pointer -}
+adjustSolidVMGlobals gref row = do
+  -- TODO: because this uses HistoryTableName directly - this won't work if we add other (non-history) globals
+  let go m (k,f) = runMaybeT $ do
+        v <- lookupT k $ actionMetadata row
+        let contracts' = filter (not . T.null) $ T.splitOn "," v
+        forM_ contracts' $ \c -> do
+          info' <- lookupT c m
+          let codePtr = slipHash info'
+          $logInfoS "adjustGlobals" . T.pack $ "Adding to globals for " ++ T.unpack k ++ ": " ++ show codePtr
+          lift $ f gref $ HistoryTableName (actionOrganization row) (actionApplication row) (slipName info')
+
+  infoMap <- do 
+    mMap <- getSolidVMInfoForRow gref row
+    case mMap of
+      Nothing -> error "SolidVMABIs should be in the cache, but adjustGlobals didn't find them"
+      Just dMap -> return dMap
+  
+  -- TODO: ideally we check if these flags are in the metadata BEFORE we get the detailsMap
+  mapM_ (go infoMap) $ [("history", enableHistoryTable)
                           ,("nohistory", disableHistoryTable)
                           ]
+{-# SCC adjustSolidVMGlobals #-}
 
 readPreviousEVMState :: MonadIO m =>
                         IORef Globals -> Account -> OLD.Contract -> m [(Text, Value)]
@@ -307,7 +341,7 @@ readPreviousEVMState gref acct cont = do
 readPreviousSolidVMState :: MonadIO m =>
                             IORef Globals -> Account -> m [(Text, Value)]
 readPreviousSolidVMState gref acct = fromMaybe [] <$> getContractState gref acct
-
+{-# SCC readPreviousSolidVMState #-}
 
 rowToInsert :: MonadIO m =>
                IORef Globals -> ABIID -> AggregateAction -> OLD.Contract -> [(Text, Value)]
@@ -318,6 +352,7 @@ rowToInsert gref abiid row cont oldState = do
                     Action.SolidVMDiff mp -> SolidVM.decodeCacheValues mp oldState
   setContractState gref (actionAccount row) newState
   return $ processedContract abiid (Map.fromList $ newState) row
+{-# SCC rowToInsert #-}
 
 rowToHistories :: (MonadIO m, MonadLogger m) =>
                   IORef Globals -> ABIID -> AggregateAction -> [AggregateAction] -> OLD.Contract
@@ -333,35 +368,35 @@ rowToHistories gref abiid row actions cont oldState = do
                   Action.SolidVMDiff mp -> SolidVM.decodeCacheValues mp
       newMap <- gets Map.fromList
       return $ processedContract abiid newMap hRow
-
+{-# SCC  rowToHistories #-}
 
 -- Parses xabi event declarations to create a table,
 -- ignoring indexes and anonymous flag
-createEvents :: Monad m =>
-                OLD.ContractDetails -> Text -> Text -> m [EventTable]
-createEvents details org app = do
-  let events' = OLD.xabiEvents $ OLD.contractdetailsXabi details
-  return $ map makeEvent $ Map.toList events'
-  where
-    makeEvent :: (Text, OLD.Event) -> EventTable 
-    makeEvent (name, event) = 
-      EventTable
-      { eventOrganization = org
-      , eventApplication  = app
-      , eventContractName = OLD.contractdetailsName details
-      , eventName = name
-      , eventFields = map fst $ OLD.eventLogs event
-      }
+-- Only needs xabi events
+-- createEvents :: Monad m =>
+--                 (Map.Map Text OLD.Event) -> Text -> Text -> m [EventTable]
+-- createEvents events' org app = do
+--   return $ map makeEvent $ Map.toList events'
+--   where
+--     makeEvent :: (Text, OLD.Event) -> EventTable 
+--     makeEvent (name, event) = 
+--       EventTable
+--       { eventOrganization = org
+--       , eventApplication  = app
+--       , eventContractName = name
+--       , eventName = name
+--       , eventFields = map fst $ OLD.eventLogs event
+--       }
       
 
 contractToEventTables :: (Text, Text, Text) -> Contract -> [EventTable]
-contractToEventTables (o, a, n) c =
+contractToEventTables (org, app, name) c =
   flip map (Map.toList $ c^.events) $
       \(eName, fields) ->
         EventTable {
-          eventOrganization = o,
-          eventApplication  = a,
-          eventContractName = n,
+          eventOrganization = org,
+          eventApplication  = app,
+          eventContractName = name,
           eventName = eName,
           eventFields = map fst $ eventLogs fields
         }
@@ -393,7 +428,6 @@ getCodeCollection f cp ccString = do
           Nothing -> case Aeson.decodeStrict $ encodeUtf8 ccString of
             Just m -> Map.toList m
             Nothing -> [(T.empty, ccString)] -- for backwards compatibility
-
   --We shouldn't crash if the source can't be parsed (a bad validator could brind the network down)
   --For now I'm going to keep the crash in, since it will be a warning to us that we let a
   --bad contract into the blockchain (the API shouldn't allow this)
@@ -409,7 +443,8 @@ getCodeCollection f cp ccString = do
           --return $ CodeCollection Map.empty
           error $ "failed EVM parse: " ++ show e ++ "\n" ++ T.unpack ccString
         Right v -> return $ CodeCollection $ f $ snd v
-    CodeAtAccount _ _ -> error "no compilo codeataccount"
+    CodeAtAccount _ _ -> error "Cannot compile or parse code at account"
+{-# SCC getCodeCollection #-}
 
 getEVMInserts :: (
   MonadIO m, 
@@ -431,16 +466,19 @@ getEVMInserts g row actions acct = do
             , aiChain = maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
             }
           cont = either error id . xAbiToContract $ OLD.contractdetailsXabi details
-      adjustGlobals g (Do Compile) row details
+      adjustGlobals g row details
 
       oldState <- readPreviousEVMState g acct cont
       indexContract <- rowToInsert g abiid row cont oldState
       hs <- rowToHistories g abiid row actions cont oldState
-      pure . Right $ BatchedInserts indexContract hs []
+      pure . Right $ BatchedInserts indexContract hs
 
 getInsertsIgnoreEVM :: (Monad m) => IORef Globals -> AggregateAction -> [AggregateAction] -> Account -> m (Either Text BatchedInserts)
 getInsertsIgnoreEVM _ _ _ _ = pure $ Left "EVM code indexing ignored"
 
+-- TODO: use LRU cache for solidVM details
+-- Only call enable/disable history when the history flags are present (to prevent unnecessary querying to the cache/sql)
+-- Figure out about table expansion for history tables not working
 processTheMessages :: (MonadIO m, MonadUnliftIO m, MonadLogger m, HasSQL m) =>
                       BlocEnv -> BlocSQLEnv -> PGConnection -> IORef Globals -> [VMEvent] -> m ()
 processTheMessages env sqlEnv conn g messages = do
@@ -486,22 +524,21 @@ processTheMessages env sqlEnv conn g messages = do
       case actionStorage row of
         Action.EVMDiff{} -> evmInserts g row actions acct
         Action.SolidVMDiff{} -> do
-          mName <- getSolidVMDetailsForRow g row
-          case mName of
-            Nothing -> pure . Left $ "No SolidVM details for code hash "
-                            <> (T.pack . show $ actionCodeHash row)
-                            <> " and no 'src' field found in metadata"
-            Just details -> do
-              let name = T.filter (/= '"') $ OLD.contractdetailsName details
-                  abiid = ABIID name $ maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
-                  cont = error "internal error: contract should be unused for solidvm"
-
-              adjustGlobals g (Don't Compile) row details
-              oldState <- readPreviousSolidVMState g acct
-              indexContract <- rowToInsert g abiid row cont oldState
-              hs <- rowToHistories g abiid row actions cont oldState
-              eventTables <- createEvents details (actionOrganization row) (actionApplication row)
-              pure . Right $ BatchedInserts indexContract hs eventTables
+          -- mInfo <- getSolidVMInfoForRow g row
+          -- mName :: Maybe OLD.ContractDetails
+          let abiid = ABIID (T.pack name) $ maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
+              (SolidVMCode name _) = actionCodeHash row
+              cont = error "internal error: contract should be unused for Solidvm"
+          adjustSolidVMGlobals g row
+          oldState <- readPreviousSolidVMState g acct
+          indexContract <- rowToInsert g abiid row cont oldState
+          hs <- rowToHistories g abiid row actions cont oldState
+          pure . Right $ BatchedInserts indexContract hs
+          -- case mInfo of
+          --   Nothing -> pure . Left $ "No SolidVM details for code hash "
+          --                   <> (T.pack . show $ actionCodeHash row)
+          --                   <> " and no 'src' field found in metadata"
+          --   Just info -> do
 
 
   forM_ (lefts inserts) $ $logErrorS "processTheMessages"
@@ -525,4 +562,5 @@ processTheMessages env sqlEnv conn g messages = do
   forM_ transactionResults $ putTransactionResult
   
   flushPendingWrites g
+{-# SCC processTheMessages #-}
   

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -201,11 +201,6 @@ processedContract ABIID{..} state AggregateAction{..} =
 lookupT :: (Monad m, Ord k) => k -> Map.Map k v -> MaybeT m v
 lookupT k = MaybeT . return . Map.lookup k
 
-contractDetailsToSlipstreamInfo :: OLD.ContractDetails -> SlipstreamInfo
-contractDetailsToSlipstreamInfo details = SlipstreamInfo {
-  slipName = OLD.contractdetailsName details,
-  slipHash = OLD.contractdetailsCodeHash details
-}
 
 -- Tries to get contract metadata ID and contract details for a given contract.
 --  If they're not in the cache but they are in bloc database or action metadata,
@@ -217,7 +212,7 @@ getSolidVMInfoForRow :: ( MonadIO m
                            , Selectable Account AddressState m
                            , (Keccak256 `Alters` SourceMap) m
                            )
-                        => IORef Globals -> AggregateAction -> m (Maybe (Map.Map Text SlipstreamInfo))
+                        => IORef Globals -> AggregateAction -> m (Maybe (Map.Map Text CodePtr))
 getSolidVMInfoForRow g row = runMaybeT  
    $  checkCache 
   <|> checkMetadata
@@ -240,16 +235,15 @@ getSolidVMInfoForRow g row = runMaybeT
         -- parse source code, add all of details to cache, return the one we need
         parseAndSet src = do
           details <- lift $ sourceToContractDetails (Don't Compile) src -- :: Map Text ContractDetails
-          let infoMap = fmap contractDetailsToSlipstreamInfo details
+          let infoMap = fmap OLD.contractdetailsCodeHash details
           setSolidVMInfo g codePtr infoMap
           pure infoMap
           
         codePtr = actionCodeHash row
-{-# SCC getSolidVMInfoForRow #-}
 
 
 
--- For now, EVM details are not cached, because the cache links all the contracts in a source blob by source hash, and we only have source hashes for SolidVM code pointers. 
+-- EVM details are not cached, because the cache links all the contracts in a source blob by source hash, and we only have source hashes for SolidVM code pointers. 
 getEVMDetailsForRow :: ( MonadIO m
                        , MonadLogger m
                        , Accessible BlocEnv m
@@ -268,7 +262,7 @@ getEVMDetailsForRow row = liftM2 (<|>)
     lookupT name detailsMap)
 
 
--- Now only used for EVM
+-- only used for EVM
 adjustGlobals :: ( MonadIO m
                  , MonadLogger m
                  , HasBlocSQL m
@@ -294,9 +288,8 @@ adjustGlobals gref row details = do
           let codePtr = OLD.contractdetailsCodeHash details'
           $logInfoS "adjustGlobals" . T.pack $ "Adding to globals for " ++ T.unpack k ++ ": " ++ show codePtr
           lift $ f gref $ HistoryTableName (actionOrganization row) (actionApplication row) (OLD.contractdetailsName details')
-  -- if we pass Don't Compile, we assume it's SolidVMCode, and use details from cache
-  
   -- TODO: ideally we check if these flags are in the metadata BEFORE we get the detailsMap
+  
 adjustSolidVMGlobals :: ( MonadIO m
                  , MonadLogger m
                  , HasBlocSQL m
@@ -307,30 +300,28 @@ adjustSolidVMGlobals :: ( MonadIO m
               => IORef Globals
               -> AggregateAction
               -> m ()
-{- Make two functions - one for solidVM, one for EVM
-SolidVM only needs names of all contracts within its pointer -}
 adjustSolidVMGlobals gref row = do
   -- TODO: because this uses HistoryTableName directly - this won't work if we add other (non-history) globals
-  let go m (k,f) = runMaybeT $ do
+  let
+    go m (k,f) = runMaybeT $ do
+        -- if neither key (history/nohistory) is found, then this monad will contain the value of Nothing and nothing else will be computed
         v <- lookupT k $ actionMetadata row
         let contracts' = filter (not . T.null) $ T.splitOn "," v
         forM_ contracts' $ \c -> do
-          info' <- lookupT c m
-          let codePtr = slipHash info'
-          $logInfoS "adjustGlobals" . T.pack $ "Adding to globals for " ++ T.unpack k ++ ": " ++ show codePtr
-          lift $ f gref $ HistoryTableName (actionOrganization row) (actionApplication row) (slipName info')
+          -- infoMap (m) is only computed if this statement is evaluated 
+          codePtr@(SolidVMCode name _) <- lookupT c m
+          $logInfoS "adjustGlobals" . T.pack $ "Adding to globals for " ++ T.unpack k ++ ": " ++ (show codePtr)
+          lift $ f gref $ HistoryTableName (actionOrganization row) (actionApplication row) (T.pack name)
 
   infoMap <- do 
     mMap <- getSolidVMInfoForRow gref row
     case mMap of
-      Nothing -> error "SolidVMABIs should be in the cache, but adjustGlobals didn't find them"
+      Nothing -> error "SolidVMInfo should be in the cache, but adjustGlobals didn't find them"
       Just dMap -> return dMap
-  
-  -- TODO: ideally we check if these flags are in the metadata BEFORE we get the detailsMap
   mapM_ (go infoMap) $ [("history", enableHistoryTable)
                           ,("nohistory", disableHistoryTable)
                           ]
-{-# SCC adjustSolidVMGlobals #-}
+  -- Because of haskell lazy evaluation, the infoMap will only be computed if it is needed
 
 readPreviousEVMState :: MonadIO m =>
                         IORef Globals -> Account -> OLD.Contract -> m [(Text, Value)]
@@ -341,7 +332,6 @@ readPreviousEVMState gref acct cont = do
 readPreviousSolidVMState :: MonadIO m =>
                             IORef Globals -> Account -> m [(Text, Value)]
 readPreviousSolidVMState gref acct = fromMaybe [] <$> getContractState gref acct
-{-# SCC readPreviousSolidVMState #-}
 
 rowToInsert :: MonadIO m =>
                IORef Globals -> ABIID -> AggregateAction -> OLD.Contract -> [(Text, Value)]
@@ -352,7 +342,6 @@ rowToInsert gref abiid row cont oldState = do
                     Action.SolidVMDiff mp -> SolidVM.decodeCacheValues mp oldState
   setContractState gref (actionAccount row) newState
   return $ processedContract abiid (Map.fromList $ newState) row
-{-# SCC rowToInsert #-}
 
 rowToHistories :: (MonadIO m, MonadLogger m) =>
                   IORef Globals -> ABIID -> AggregateAction -> [AggregateAction] -> OLD.Contract
@@ -368,7 +357,6 @@ rowToHistories gref abiid row actions cont oldState = do
                   Action.SolidVMDiff mp -> SolidVM.decodeCacheValues mp
       newMap <- gets Map.fromList
       return $ processedContract abiid newMap hRow
-{-# SCC  rowToHistories #-}
 
 -- Parses xabi event declarations to create a table,
 -- ignoring indexes and anonymous flag
@@ -388,7 +376,6 @@ rowToHistories gref abiid row actions cont oldState = do
 --       , eventFields = map fst $ OLD.eventLogs event
 --       }
       
-
 contractToEventTables :: (Text, Text, Text) -> Contract -> [EventTable]
 contractToEventTables (org, app, name) c =
   flip map (Map.toList $ c^.events) $
@@ -444,7 +431,6 @@ getCodeCollection f cp ccString = do
           error $ "failed EVM parse: " ++ show e ++ "\n" ++ T.unpack ccString
         Right v -> return $ CodeCollection $ f $ snd v
     CodeAtAccount _ _ -> error "Cannot compile or parse code at account"
-{-# SCC getCodeCollection #-}
 
 getEVMInserts :: (
   MonadIO m, 
@@ -476,9 +462,6 @@ getEVMInserts g row actions acct = do
 getInsertsIgnoreEVM :: (Monad m) => IORef Globals -> AggregateAction -> [AggregateAction] -> Account -> m (Either Text BatchedInserts)
 getInsertsIgnoreEVM _ _ _ _ = pure $ Left "EVM code indexing ignored"
 
--- TODO: use LRU cache for solidVM details
--- Only call enable/disable history when the history flags are present (to prevent unnecessary querying to the cache/sql)
--- Figure out about table expansion for history tables not working
 processTheMessages :: (MonadIO m, MonadUnliftIO m, MonadLogger m, HasSQL m) =>
                       BlocEnv -> BlocSQLEnv -> PGConnection -> IORef Globals -> [VMEvent] -> m ()
 processTheMessages env sqlEnv conn g messages = do
@@ -490,7 +473,7 @@ processTheMessages env sqlEnv conn g messages = do
       transactionResults = [tr | NewTransactionResult tr <- messages]
       -- Use different functions based on flag value, this way it is only computed once, saving cpu cycles with if statements
       getCC = getCodeCollection' flags_indexEVM
-      evmInserts = if flags_indexEVM then getEVMInserts else getInsertsIgnoreEVM
+      evmInsertsF = if flags_indexEVM then getEVMInserts else getInsertsIgnoreEVM
 
   forM_ creates $ \(ccString, cp, o, a, hl) -> do
     cc <- getCC cp ccString
@@ -519,13 +502,11 @@ processTheMessages env sqlEnv conn g messages = do
       mapM_ recordAction actions
       recordCombinedAction row
       $logInfoS "processTheMessages" $ formatAction row
-      $logDebugLS "the diff is " $ actionStorage row
+      $logDebugLS "The diff is " $ actionStorage row
 
       case actionStorage row of
-        Action.EVMDiff{} -> evmInserts g row actions acct
+        Action.EVMDiff{} -> evmInsertsF g row actions acct
         Action.SolidVMDiff{} -> do
-          -- mInfo <- getSolidVMInfoForRow g row
-          -- mName :: Maybe OLD.ContractDetails
           let abiid = ABIID (T.pack name) $ maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
               (SolidVMCode name _) = actionCodeHash row
               cont = error "internal error: contract should be unused for Solidvm"
@@ -534,12 +515,6 @@ processTheMessages env sqlEnv conn g messages = do
           indexContract <- rowToInsert g abiid row cont oldState
           hs <- rowToHistories g abiid row actions cont oldState
           pure . Right $ BatchedInserts indexContract hs
-          -- case mInfo of
-          --   Nothing -> pure . Left $ "No SolidVM details for code hash "
-          --                   <> (T.pack . show $ actionCodeHash row)
-          --                   <> " and no 'src' field found in metadata"
-          --   Just info -> do
-
 
   forM_ (lefts inserts) $ $logErrorS "processTheMessages"
 
@@ -562,5 +537,3 @@ processTheMessages env sqlEnv conn g messages = do
   forM_ transactionResults $ putTransactionResult
   
   flushPendingWrites g
-{-# SCC processTheMessages #-}
-  

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -200,7 +200,7 @@ function newnode {
       runBackgroundProcess strato-api2 --gasOn=$gasOn +RTS -N1 >> logs/strato-api2 2>&1
   fi
 
-  SLIPSTREAM_CMD="slipstream +RTS -p -h -RTS --pghost=${postgres_host} --pgport=${postgres_port} \
+  SLIPSTREAM_CMD="slipstream --pghost=${postgres_host} --pgport=${postgres_port} \
     --pguser=${postgres_user} --password=${postgres_password} --database=${postgres_slipstream_db} \
     --stratourl=${stratoRoot} --vaultwrapperurl=${vaultWrapperRoot}  \
     --kafkahost=${kafkaHost} --kafkaport=${kafkaPort} --minLogLevel=${slipMinLogLevel} --indexEVM=${indexEVM}"

--- a/core-strato/doit.sh
+++ b/core-strato/doit.sh
@@ -200,7 +200,7 @@ function newnode {
       runBackgroundProcess strato-api2 --gasOn=$gasOn +RTS -N1 >> logs/strato-api2 2>&1
   fi
 
-  SLIPSTREAM_CMD="slipstream --pghost=${postgres_host} --pgport=${postgres_port} \
+  SLIPSTREAM_CMD="slipstream +RTS -p -h -RTS --pghost=${postgres_host} --pgport=${postgres_port} \
     --pguser=${postgres_user} --password=${postgres_password} --database=${postgres_slipstream_db} \
     --stratourl=${stratoRoot} --vaultwrapperurl=${vaultWrapperRoot}  \
     --kafkahost=${kafkaHost} --kafkaport=${kafkaPort} --minLogLevel=${slipMinLogLevel} --indexEVM=${indexEVM}"


### PR DESCRIPTION
This commit drastically reduces the size of the cache used by slipstream for SolidVm contracts.
It used to cache the source code, xabi info.
Almost all of this was redundant with what was already included in the Action provided to slipstream via the kafka topic it reads from.
Now all we need to cache is the `Map Keccak256 (Map Text CodePtr)` for when we need to enable/disable history. Ideally this would even go away and we only enable/disable history when creating a new contract type.
The reason this is currently needed is because we want to restrict history being toggled for contracts outside of the current codeptr's "jurisdiction".  Since a codeptr can be a group of contracts (ie its a dapp or a factory) that contains code for many contract types, we want to be able to toggle the history for the factory/dapp contract as well as the sub-contracts (widgets). However we also don't want to enable any insert to be able to toggle the history of ANY contract that exists. Therefore we have to parse the contract and figure out exactly what are the sub-contracts of this codeptr.
And because haskell is lazy, we only fetch this data when the history flag is actually given in the metadata, so the cache is only populated at that point.

After comparing memory usage between previous develop build, and a build from this branch, memory usage of the cache is now imperceptible, whereas before it was constantly growing. 

Further investigation is still needed as there is a pseudo-memory leak where slipstream will hold all of its memory used during the insertion of a batch of events, but not let go of the memory until it receives *the next* batch of events.