### PR TITLE
Strato 2419 postgrest methods

### DIFF
--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -225,6 +225,9 @@ http {
       }
 
       location /cirrus/search/ {
+        limit_except GET { 
+          deny all;
+        }
         rewrite_by_lua_file lua/openid.lua;                                 #TEMPLATE_MARK_OAUTH  #TEMPLATE_MARK_OAUTH_STRATO_43_AND_ABOVE
         auth_request /_api_counter;                                         #TEMPLATE_MARK_STATS_ENABLED
         proxy_set_header Accept-Encoding "";

--- a/tests/e2e/cirrus.test.ts
+++ b/tests/e2e/cirrus.test.ts
@@ -1,0 +1,98 @@
+import axios from 'axios';
+import { fsUtil, 
+  rest, 
+  assert, 
+  Config, 
+  oauthUtil, 
+  AccessToken,
+  OAuthUser,
+  BlockChainUser } from 'blockapps-rest';
+
+let config:Config = fsUtil.getYaml("config.yaml");
+
+const options = { config };
+const contractName = 'CirrusAccessTest';
+const contractSrc = `
+pragma solidvm 3.0;
+contract ${contractName} {
+  int x;
+  constructor(int _x) {
+    x = _x;
+  }
+}`;
+
+describe('postgREST allowed methods', function () {
+  this.timeout(60000);
+  let admin:BlockChainUser
+  before(async () => {
+    const oauth:oauthUtil = oauthUtil.init(config.nodes[0].oauth);
+
+    let accessToken:AccessToken = await oauth.getAccessTokenByClientSecret();
+    const ouser:OAuthUser = {token: accessToken.token.access_token};
+
+    admin = await rest.createUser(ouser, options);
+    const res = await rest.createContract(admin, {
+      name: contractName,
+      source: contractSrc,
+      args: {
+        _x: 7,
+      },
+    }, options);
+  });
+  it('Cannot create a new row - POST 403 Forbidden', async () => {
+    try {
+      const axRes = await axios.post(`${config.nodes[0].url}/cirrus/search/${contractName}`, {
+        x: 15,
+        address: 'deadbeef',
+        chainId: 'abcdef',
+        block_hash: 'deadbeef',
+        block_timestamp: '9999-12-31 12:12:12 UTC',
+        block_number: 'deadbeef',
+        transaction_hash: 'deadbeef',
+        transaction_sender: 'deadbeef',
+      }, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${admin.token}`,
+          Accept: 'application/json',
+        },
+      });
+      assert.notEqual(axRes.status, 200, 'Successful POST request');
+    } catch (err) {
+      assert.equal(err.response.status, 403)
+    }
+  });
+  it('Cannot update an existing row - PATCH 403 Forbidden', async () => {
+    try {
+      const axRes = await axios.post(`${config.nodes[0].url}/cirrus/search/${contractName}?x=lt.10&limit=1`, {
+        x: 100,
+        address: '02345de',
+        chainId: 'deadbeef',
+        block_hash: 'deadbeef',
+        block_timestamp: '9999-12-31 12:12:12 UTC',
+        block_number: 'deadbeef',
+        transaction_hash: 'deadbeef',
+        transaction_sender: 'deadbeef',
+      }, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${admin.token}`,
+          Accept: 'application/json',
+        },
+      });
+      assert.notEqual(axRes.status, 200, 'Successful PATCH request');
+    } catch (err) {
+      assert.equal(err.response.status, 403)
+    }
+  });
+  it('Can GET rows from a table - GET 200 Success', async () => {
+    const axRes = await axios.post(`${config.nodes[0].url}/cirrus/search/${contractName}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${admin.token}`,
+        Accept: 'application/json',
+      },
+    });
+    assert.equal(axRes.status, 200);
+  });
+});

--- a/tests/e2e/cirrus.test.ts
+++ b/tests/e2e/cirrus.test.ts
@@ -51,7 +51,6 @@ describe('postgREST allowed methods', function () {
         transaction_hash: 'deadbeef',
         transaction_sender: 'deadbeef',
       }, {
-        method: 'POST',
         headers: {
           Authorization: `Bearer ${admin.token}`,
           Accept: 'application/json',
@@ -64,7 +63,7 @@ describe('postgREST allowed methods', function () {
   });
   it('Cannot update an existing row - PATCH 403 Forbidden', async () => {
     try {
-      const axRes = await axios.post(`${config.nodes[0].url}/cirrus/search/${contractName}?x=lt.10&limit=1`, {
+      const axRes = await axios.patch(`${config.nodes[0].url}/cirrus/search/${contractName}?x=lt.10&limit=1`, {
         x: 100,
         address: '02345de',
         chainId: 'deadbeef',
@@ -74,7 +73,6 @@ describe('postgREST allowed methods', function () {
         transaction_hash: 'deadbeef',
         transaction_sender: 'deadbeef',
       }, {
-        method: 'PATCH',
         headers: {
           Authorization: `Bearer ${admin.token}`,
           Accept: 'application/json',
@@ -86,13 +84,12 @@ describe('postgREST allowed methods', function () {
     }
   });
   it('Can GET rows from a table - GET 200 Success', async () => {
-    const axRes = await axios.post(`${config.nodes[0].url}/cirrus/search/${contractName}`, {
-      method: 'GET',
+    const axRes = await axios.get(`${config.nodes[0].url}/cirrus/search/${contractName}`, {
       headers: {
         Authorization: `Bearer ${admin.token}`,
         Accept: 'application/json',
       },
     });
-    assert.equal(axRes.status, 200);
+    assert.equal(axRes.status, 200, `Actually recieved status: ${axRes.status}`);
   });
 });

--- a/tests/package.json
+++ b/tests/package.json
@@ -35,6 +35,7 @@
     "request": "^2.88.0",
     "request-promise": "4.2.2",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.0.5",
+    "axios": "^0.19.2"
   }
 }


### PR DESCRIPTION
Use Nginx to prevent all methods except GET to be passed to the postgrest container, this fulfills the promise that cirrus really IS a reado-only database used to index contracts.