### PR TITLE
State variables in the governance contract that aren't initialized now get sent to slipstream

### DIFF
--- a/core-strato/ethereum-vm/src/Blockchain/EVM.hs
+++ b/core-strato/ethereum-vm/src/Blockchain/EVM.hs
@@ -1199,6 +1199,7 @@ call :: EVMBase m
      => Bool
      -> Bool
      -> Bool
+     -> Bool
      -> S.Set Account
      -> BlockData
      -> Int
@@ -1214,7 +1215,7 @@ call :: EVMBase m
      -> Maybe Word256
      -> Maybe (M.Map T.Text T.Text)
      -> m ExecResults
-call isRunningTests' isHomestead noValueTransfer preExistingSuicideList b callDepth receiveAddress
+call isRunningTests' isHomestead noValueTransfer _ preExistingSuicideList b callDepth receiveAddress
      codeAddress sender value gasPrice theData availableGas origin txHash chainId metadata = do
   let env code =
         Environment{
@@ -1374,6 +1375,7 @@ nestedRun_debugWrapper noValueTransfer gas receiveAddress owner sender value inp
     ers <- call (isRunningTests currentVMState)
                 (vmIsHomestead currentVMState)
                 noValueTransfer
+                False
                 (suicideList currentVMState)
                 (envBlockHeader env)
                 (currentCallDepth+1)

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -19,6 +19,7 @@ module Blockchain.SolidVM
   ( SolidVMBase
   , call
   , create
+  , getCodeAndCollection
   ) where
 
 import           Control.DeepSeq                      (force)
@@ -348,6 +349,7 @@ call :: SolidVMBase m
      => Bool
      -> Bool
      -> Bool
+     -> Bool
      -> S.Set Account
      -> BlockData
      -> Int
@@ -366,7 +368,7 @@ call :: SolidVMBase m
 --call isRunningTests' isHomestead noValueTransfer preExistingSuicideList b callDepth receiveAddress
 --     (Address codeAddress) sender value gasPrice theData availableGas origin txHash chainId metadata =
 
-call _ _ _ _ blockData _ _ codeAddress sender' _ _ _ _ origin' txHash' chainId' metadata = do
+call _ _ _ isRCC _ blockData _ _ codeAddress sender' _ _ _ _ origin' txHash' chainId' metadata = do
   recordCall
 
   let env' = Env.Environment {
@@ -386,7 +388,7 @@ call _ _ _ _ blockData _ _ codeAddress sender' _ _ _ _ origin' txHash' chainId' 
         maybeArgs = runParser parseArgs "" "" argString
         !args = either (parseError "call arguments") Xabi.OrderedArgs maybeArgs
 
-    returnVal <- mapM encodeForReturn =<< callWrapper sender' codeAddress Nothing funcName args
+    returnVal <- mapM encodeForReturn =<< callWrapper sender' codeAddress Nothing funcName isRCC args 
 
     finalAct <- Mod.get (Mod.Proxy @Action)
     finalEvs <- Mod.get (Mod.Proxy @(Q.Seq Event))
@@ -571,8 +573,8 @@ argsToVals ctract fn args =
            _ -> getVar =<< expToVar x
 
 
-callWrapper :: MonadSM m => Account -> Account -> Maybe String -> String -> Xabi.ArgList -> m (Maybe Value)
-callWrapper from to mContract functionName argExps = do
+callWrapper :: MonadSM m => Account -> Account -> Maybe String -> String -> Bool -> Xabi.ArgList -> m (Maybe Value)
+callWrapper from to mContract functionName isRCC argExps  = do
   let fromChain = from ^. accountChainId
       toChain = to ^. accountChainId
   isAccessibleChain <- toChain `isAncestorChainOf` fromChain
@@ -625,7 +627,12 @@ callWrapper from to mContract functionName argExps = do
                 return (fmap Just $ getVar $ Constant $ SReference $ AccountPath to . MS.singleton $ BC.pack functionName, OrderedVals [])
               Nothing -> unknownFunction "logFunctionCall" (functionName, contract^.contractName)
 
-
+  when isRCC (
+    forM_ [(n, theType) | (n, Xabi.VariableDecl theType _ Nothing _) <- M.toList $ contract'^.storageDefs] $ \(n, theType) -> do
+      case theType of
+        Xabi.Mapping _ _ _-> return ()
+        Xabi.Array _ _-> return ()
+        _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ T.unpack n]) MS.BDefault)
   logFunctionCall args to contract functionName f
 
 
@@ -1393,7 +1400,7 @@ expToVar' (Xabi.FunctionCall _ e args) = do
         (SContract _ toAddress', MS.Field funcName) -> do
           fromAddress <- getCurrentAccount
           let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) toAddress'
-          res <- callWrapper fromAddress toAddress Nothing (BC.unpack funcName) args
+          res <- callWrapper fromAddress toAddress Nothing (BC.unpack funcName) False args 
           case res of
             Just v -> return $ Constant $ v
             Nothing -> return $ Constant SNULL
@@ -1401,7 +1408,7 @@ expToVar' (Xabi.FunctionCall _ e args) = do
         (SAccount toAddress', MS.Field funcName) -> do
           fromAddress <- getCurrentAccount
           let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) toAddress'
-          res <- callWrapper fromAddress toAddress Nothing (BC.unpack funcName) args
+          res <- callWrapper fromAddress toAddress Nothing (BC.unpack funcName) False args 
           case res of
             Just v -> return $ Constant $ v
             Nothing -> return $ Constant SNULL
@@ -1453,14 +1460,14 @@ expToVar' (Xabi.FunctionCall _ e args) = do
 
       from <- getCurrentAccount
       let address = namedAccountToAccount (from ^. accountChainId) address'
-      result <- callWrapper from address Nothing itemName args
+      result <- callWrapper from address Nothing itemName False args 
       return . Constant . fromMaybe SNULL $ result
 
     Constant (SContractFunction name address' functionName) -> do
       
       from <- getCurrentAccount
       let address = namedAccountToAccount (from ^. accountChainId) address'
-      result <- callWrapper from address name functionName args
+      result <- callWrapper from address name functionName False args 
       return . Constant . fromMaybe SNULL $ result
 
     Constant (SEnum enumName) -> do
@@ -1760,6 +1767,7 @@ runTheConstructors from to hsh cc contractName' argExps = do
       Xabi.Mapping _ _ _-> return ()
       Xabi.Array _ _-> return ()
       _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ T.unpack n]) MS.BDefault
+
 
   forM_ (reverse $ contract'^.parents) $ \parent -> do
     let args = Xabi.OrderedArgs

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -19,7 +19,6 @@ module Blockchain.SolidVM
   ( SolidVMBase
   , call
   , create
-  , getCodeAndCollection
   ) where
 
 import           Control.DeepSeq                      (force)
@@ -1767,7 +1766,6 @@ runTheConstructors from to hsh cc contractName' argExps = do
       Xabi.Mapping _ _ _-> return ()
       Xabi.Array _ _-> return ()
       _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ T.unpack n]) MS.BDefault
-
 
   forM_ (reverse $ contract'^.parents) $ \parent -> do
     let args = Xabi.OrderedArgs

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/Simple.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/Simple.hs
@@ -158,6 +158,7 @@ call s = SolidVM.call
   (callErr "isRunningTests'")
   (callErr "isHomestead")
   (callErr "noValueTransfer")
+  False
   (callErr "preExistingSuicideList")
   (s ^. callArgs . argsBlockData)
   (callErr "callDepth")

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -239,6 +239,7 @@ call2 :: T.Text -> T.Text -> Account -> ContextM (Maybe SB.ShortByteString)
 call2 funcName callArgs contractAddress = do
   let isTest = error "TODO: isTest"
       isHomestead = error "TODO: isHomestead"
+      isRCC = False
       suicides = error "TODO: suicides"
       blockData = BlockData { blockDataParentHash = unsafeCreateKeccak256FromWord256 0x0
                             , blockDataUnclesHash = unsafeCreateKeccak256FromWord256 0x0
@@ -265,7 +266,7 @@ call2 funcName callArgs contractAddress = do
       receiveAddress = error "TODO: receiveAddress"
       theData = error "TODO: theData"
       callMetadata = Just $ M.fromList [("funcName", funcName), ("args", callArgs)]
-  er <- SVM.call isTest isHomestead noValueTransfer suicides blockData callDepth receiveAddress
+  er <- SVM.call isTest isHomestead noValueTransfer isRCC suicides blockData callDepth receiveAddress
     contractAddress sender value gasPrice theData availableGas origin txHash chainId callMetadata
   rethrowEx er
   return $ erReturnVal er

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -194,6 +194,7 @@ runCall funcName callArgs bs = do
   let code = Code $ UTF8.fromString bs
       isTest = error "TODO: isTest"
       isHomestead = error "TODO: isHomestead"
+      isRCC = False
       suicides = error "TODO: suicides"
       blockData = BlockData { blockDataParentHash = unsafeCreateKeccak256FromWord256 0x0
                             , blockDataUnclesHash = unsafeCreateKeccak256FromWord256 0x0
@@ -228,7 +229,7 @@ runCall funcName callArgs bs = do
   $logErrorS "runCall" "Returned from create"
   rethrowEx er1
   $logErrorS "runCall" "Beginning call"
-  er2 <- SVM.call isTest isHomestead noValueTransfer suicides blockData callDepth receiveAddress
+  er2 <- SVM.call isTest isHomestead noValueTransfer isRCC suicides blockData callDepth receiveAddress
     newAddress sender value gasPrice theData availableGas origin txHash chainId callMetadata
   $logErrorS "runCall" "Returned from call"
   rethrowEx er2

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -472,6 +472,7 @@ runCodeForTransaction isRunningTests' isHomestead b availableGas tAcct o@OutputT
       call isRunningTests'
         isHomestead
         False
+        False
         S.empty
         b
         0

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -331,7 +331,7 @@ runChainConstructors cId cInfo = do
          False --isRunningTests
          True --isHomestead
          False --noValueTransfer
-         False -- isRunChainConstructors
+         True -- isRunChainConstructors
          S.empty --pre-existing suicide list
          (BlockData
             (Keccak256.unsafeCreateKeccak256FromWord256 0)

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -331,7 +331,7 @@ runChainConstructors cId cInfo = do
          False --isRunningTests
          True --isHomestead
          False --noValueTransfer
-         True -- isRunChainConstructors
+         False -- isRunChainConstructors
          S.empty --pre-existing suicide list
          (BlockData
             (Keccak256.unsafeCreateKeccak256FromWord256 0)

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -40,7 +40,13 @@ import qualified Network.Kafka.Protocol                as KP
 import           Prometheus
 import           Text.Printf
 import           Util                                  hiding (intercalate)
-
+--import qualified SolidVM.Model.Storable as MS
+--import qualified SolidVM.Solidity.Xabi as Xabi
+--import qualified SolidVM.Solidity.Xabi.Statement as Xabi
+--import qualified SolidVM.Solidity.Xabi.Type as Xabi
+--import qualified SolidVM.Solidity.Xabi.VarDef as Xabi
+--import qualified CodeCollection as CC
+--import           Blockchain.SolidVM.SM
 import           Blockapps.Crossmon
 import           Blockchain.BlockChain
 import           Blockchain.Data.Block                 (BestBlock(..), WorldBestBlock(..))
@@ -67,7 +73,7 @@ import           Blockchain.VMOptions
 
 import           Executable.EVMCheckpoint
 import           Executable.EVMFlags
-
+   
 import qualified Blockchain.Bagger                     as Bagger
 import qualified Blockchain.Bagger.BaggerState         as B
 import           Blockchain.Data.AddressStateDB
@@ -297,12 +303,13 @@ getNumPoolable txPairs = do
 outputTransactions :: [(Timestamp, OutputTx)] -> [VmOutEvent]
 outputTransactions = map $ OutIndexEvent . uncurry IndexTransaction
 
+
 -- TODO: maybe move this into solid-vm?
 runChainConstructors :: SolidVM.SolidVMBase m => Word256 -> ChainInfo -> m (MP.StateRoot, [Action])
 runChainConstructors cId cInfo = do
   -- We are inventing the rules of how the constructor should run when a chain is created.
   -- Since all VM runs need some environment variables passed in, we need to define what all of
-  -- those variables should be.  The truth is, most of these variables are rarely used, but we
+  -- those variables should be.  The truth is, most of these variables are rarely used, but wehe truth is, most of these variables are rarely used, but we
   -- still need to pre-decide what they should be else the VM would crash whenever they are used.
   -- I've set most of these variables to default dummy values below...  We might decide to refine
   -- some of these variables in the future.
@@ -321,16 +328,22 @@ runChainConstructors cId cInfo = do
           (MaybeT $ pure $ M.lookup hsh codeHashMap) <|>
             MaybeT (fmap (T.pack . BC.unpack . snd) <$> getCode hsh)
         pure $ Just (a,msrc)
-
+{-      !contract' =
+        fromMaybe (missingType "contract inherits from nonexistent parent" contractName')
+        $ cc^.contracts . at contractName'
+-}
   actions <- fmap catMaybes . for (accountInfo $ chainInfo cInfo) $ \aInfo -> do
     addrSrc <- case aInfo of
       NonContract{} -> pure Nothing
       ContractNoStorage a _ ch -> resolveSrc a ch
       ContractWithStorage a _ ch _ -> resolveSrc a ch
+    
+--    map markDiffForAction addrSrc
     fmap (join . fmap erAction) . for addrSrc $ \(addr,ms) -> SolidVM.call
          False --isRunningTests
          True --isHomestead
          False --noValueTransfer
+         True -- isRunChainConstructors
          S.empty --pre-existing suicide list
          (BlockData
             (Keccak256.unsafeCreateKeccak256FromWord256 0)
@@ -364,12 +377,49 @@ runChainConstructors cId cInfo = do
            , ("funcName", "<constructor>")
            ]
            ++ case ms of Nothing -> []; Just s -> [("src", s)])
+  
 
+ {-forM_ [(n, theType) | (n, Xabi.VariableDecl theType _ Nothing _) <- M.toList $ contract'^.storageDefs] $ \(n, theType) -> do
+    case theType of
+      Xabi.Mapping _ _ _-> return ()
+      Xabi.Array _ _-> return ()
+      _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ T.unpack n]) MS.BDefault
+  -}
+  --markDiffForAction (0x100) 
+  
+  {-forM_ [n | (n, Xabi.VariableDecl _ _ Nothing _) <- M.toList $ actions^.actionData] $ \n -> do
+   markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack n]) MS.BDefault
+  -}
+
+  --(contract', _, _) <- SolidVM.getCodeAndCollection (Account 0x100 (Just cId))
+
+  {-
+  forM_ [(n, theType) | (n, Xabi.VariableDecl theType _ Nothing _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, theType) -> do
+    case theType of
+      Xabi.Mapping _ _ _-> return ()
+      Xabi.Array _ _-> return ()
+      _ -> markDiffForAction (Account 0x100 (Just cId)) (MS.StoragePath [MS.Field $ BC.pack $ T.unpack n]) MS.BDefault
+  -}
   flushMemStorageDB
   Mem.flushMemAddressStateDB
 
   sr <- A.lookupWithDefault (Proxy @MP.StateRoot) (Just cId)
   return (sr, actions)
+
+{-
+Mod.Modifiable Action m => Account -> MS.StoragePath -> MS.BasicValue -> m ()
+myfunc :: Mod.Modifiable Action m => [Actions] -> m ()
+
+markDiffForAction :: Mod.Modifiable Action m => Account -> MS.StoragePath -> MS.BasicValue -> m ()
+markDiffForAction owner key' val' = do
+  let key = MS.unparsePath key'
+      val = rlpSerialize $ rlpEncode val'
+      ins = \case
+              Action.SolidVMDiff m -> Action.SolidVMDiff $ M.insert key val m
+              e -> internalError "SolidVM Diff executing in EVM" $ show e
+  Mod.modifyStatefully_ (Mod.Proxy @Action) $
+    Action.actionData . at owner . mapped . Action.actionDataStorageDiffs %= ins
+-}
 
 initializeCheckpointAndBlockSummary :: ( HasBlockSummaryDB m
                                        , Mod.Modifiable BlockHashRoot m

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -40,13 +40,6 @@ import qualified Network.Kafka.Protocol                as KP
 import           Prometheus
 import           Text.Printf
 import           Util                                  hiding (intercalate)
---import qualified SolidVM.Model.Storable as MS
---import qualified SolidVM.Solidity.Xabi as Xabi
---import qualified SolidVM.Solidity.Xabi.Statement as Xabi
---import qualified SolidVM.Solidity.Xabi.Type as Xabi
---import qualified SolidVM.Solidity.Xabi.VarDef as Xabi
---import qualified CodeCollection as CC
---import           Blockchain.SolidVM.SM
 import           Blockapps.Crossmon
 import           Blockchain.BlockChain
 import           Blockchain.Data.Block                 (BestBlock(..), WorldBestBlock(..))
@@ -70,10 +63,8 @@ import           Blockchain.Stream.VMEvent
 import           Blockchain.VMContext
 import           Blockchain.VMMetrics
 import           Blockchain.VMOptions
-
 import           Executable.EVMCheckpoint
 import           Executable.EVMFlags
-   
 import qualified Blockchain.Bagger                     as Bagger
 import qualified Blockchain.Bagger.BaggerState         as B
 import           Blockchain.Data.AddressStateDB
@@ -309,7 +300,7 @@ runChainConstructors :: SolidVM.SolidVMBase m => Word256 -> ChainInfo -> m (MP.S
 runChainConstructors cId cInfo = do
   -- We are inventing the rules of how the constructor should run when a chain is created.
   -- Since all VM runs need some environment variables passed in, we need to define what all of
-  -- those variables should be.  The truth is, most of these variables are rarely used, but wehe truth is, most of these variables are rarely used, but we
+  -- those variables should be.  The truth is, most of these variables are rarely used, but we
   -- still need to pre-decide what they should be else the VM would crash whenever they are used.
   -- I've set most of these variables to default dummy values below...  We might decide to refine
   -- some of these variables in the future.
@@ -328,17 +319,12 @@ runChainConstructors cId cInfo = do
           (MaybeT $ pure $ M.lookup hsh codeHashMap) <|>
             MaybeT (fmap (T.pack . BC.unpack . snd) <$> getCode hsh)
         pure $ Just (a,msrc)
-{-      !contract' =
-        fromMaybe (missingType "contract inherits from nonexistent parent" contractName')
-        $ cc^.contracts . at contractName'
--}
+
   actions <- fmap catMaybes . for (accountInfo $ chainInfo cInfo) $ \aInfo -> do
     addrSrc <- case aInfo of
       NonContract{} -> pure Nothing
       ContractNoStorage a _ ch -> resolveSrc a ch
       ContractWithStorage a _ ch _ -> resolveSrc a ch
-    
---    map markDiffForAction addrSrc
     fmap (join . fmap erAction) . for addrSrc $ \(addr,ms) -> SolidVM.call
          False --isRunningTests
          True --isHomestead
@@ -377,49 +363,12 @@ runChainConstructors cId cInfo = do
            , ("funcName", "<constructor>")
            ]
            ++ case ms of Nothing -> []; Just s -> [("src", s)])
-  
 
- {-forM_ [(n, theType) | (n, Xabi.VariableDecl theType _ Nothing _) <- M.toList $ contract'^.storageDefs] $ \(n, theType) -> do
-    case theType of
-      Xabi.Mapping _ _ _-> return ()
-      Xabi.Array _ _-> return ()
-      _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ T.unpack n]) MS.BDefault
-  -}
-  --markDiffForAction (0x100) 
-  
-  {-forM_ [n | (n, Xabi.VariableDecl _ _ Nothing _) <- M.toList $ actions^.actionData] $ \n -> do
-   markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack n]) MS.BDefault
-  -}
-
-  --(contract', _, _) <- SolidVM.getCodeAndCollection (Account 0x100 (Just cId))
-
-  {-
-  forM_ [(n, theType) | (n, Xabi.VariableDecl theType _ Nothing _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, theType) -> do
-    case theType of
-      Xabi.Mapping _ _ _-> return ()
-      Xabi.Array _ _-> return ()
-      _ -> markDiffForAction (Account 0x100 (Just cId)) (MS.StoragePath [MS.Field $ BC.pack $ T.unpack n]) MS.BDefault
-  -}
   flushMemStorageDB
   Mem.flushMemAddressStateDB
 
   sr <- A.lookupWithDefault (Proxy @MP.StateRoot) (Just cId)
   return (sr, actions)
-
-{-
-Mod.Modifiable Action m => Account -> MS.StoragePath -> MS.BasicValue -> m ()
-myfunc :: Mod.Modifiable Action m => [Actions] -> m ()
-
-markDiffForAction :: Mod.Modifiable Action m => Account -> MS.StoragePath -> MS.BasicValue -> m ()
-markDiffForAction owner key' val' = do
-  let key = MS.unparsePath key'
-      val = rlpSerialize $ rlpEncode val'
-      ins = \case
-              Action.SolidVMDiff m -> Action.SolidVMDiff $ M.insert key val m
-              e -> internalError "SolidVM Diff executing in EVM" $ show e
-  Mod.modifyStatefully_ (Mod.Proxy @Action) $
-    Action.actionData . at owner . mapped . Action.actionDataStorageDiffs %= ins
--}
 
 initializeCheckpointAndBlockSummary :: ( HasBlockSummaryDB m
                                        , Mod.Modifiable BlockHashRoot m

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -40,6 +40,7 @@ import qualified Network.Kafka.Protocol                as KP
 import           Prometheus
 import           Text.Printf
 import           Util                                  hiding (intercalate)
+
 import           Blockapps.Crossmon
 import           Blockchain.BlockChain
 import           Blockchain.Data.Block                 (BestBlock(..), WorldBestBlock(..))
@@ -63,8 +64,10 @@ import           Blockchain.Stream.VMEvent
 import           Blockchain.VMContext
 import           Blockchain.VMMetrics
 import           Blockchain.VMOptions
+
 import           Executable.EVMCheckpoint
 import           Executable.EVMFlags
+
 import qualified Blockchain.Bagger                     as Bagger
 import qualified Blockchain.Bagger.BaggerState         as B
 import           Blockchain.Data.AddressStateDB
@@ -293,7 +296,6 @@ getNumPoolable txPairs = do
 
 outputTransactions :: [(Timestamp, OutputTx)] -> [VmOutEvent]
 outputTransactions = map $ OutIndexEvent . uncurry IndexTransaction
-
 
 -- TODO: maybe move this into solid-vm?
 runChainConstructors :: SolidVM.SolidVMBase m => Word256 -> ChainInfo -> m (MP.StateRoot, [Action])

--- a/core-strato/vm-runner/test/Spec.hs
+++ b/core-strato/vm-runner/test/Spec.hs
@@ -99,6 +99,7 @@ spec = do
         call isRunningTests
              isHomestead
              True
+             False
              S.empty
              blockData
              0


### PR DESCRIPTION
This PR fixes the problem that state variables in the governance contract that aren't initialized upon chain creation were not being sent to slipstream