### PR TITLE
enable string getters from external contracts

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -621,9 +621,13 @@ callWrapper from to mContract functionName isRCC argExps  = do
           _ -> do --Maybe the function is actually a getter
             case M.lookup (T.pack functionName) $ contract^.storageDefs of
               Just _ -> do
-                --TODO- this should only exist if the storage variable is declared
-                -- "public", right now I just ignore this and allow anything to be called as a getter
-                return (fmap Just $ getVar $ Constant $ SReference $ AccountPath to . MS.singleton $ BC.pack functionName, OrderedVals [])
+                liftIO $ putStrLn ("callWrapper/getter " ++ functionName) 
+                addCallInfo to contract functionName hsh cc M.empty True
+                --TODO- this should only exist if the storage variable is declared "public", 
+                -- right now I just ignore this and allow anything to be called as a getter
+                val <- fmap Just $ getVar $ Constant $ SReference $ AccountPath to . MS.singleton $ BC.pack functionName
+                popCallInfo
+                return (pure val, OrderedVals [])
               Nothing -> unknownFunction "logFunctionCall" (functionName, contract^.contractName)
 
   when isRCC (

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -1112,6 +1112,24 @@ contract qq {
 }|] `shouldReturn` Nothing
     getFields ["x"] `shouldReturn` [BInteger 100]
 
+  it "can call external getters by variable name" . runTest $ do
+    runBS [r|
+contract S {
+  string s;
+  constructor() {
+    s = "Blockapps";
+  }
+}
+contract qq {
+  string local_s;
+  S myS;
+  constructor() {
+    myS = new S();
+    local_s = myS.s();
+  }
+}|] 
+    getFields ["local_s"] `shouldReturn` [BString "Blockapps"]
+
   it "can cast address to contract" . runTest $ do
     runBS [r|
 contract X {}


### PR DESCRIPTION
The call info is only added to the stack by `runTheCall`, which is not what is used for simple getter functions by a variable name. To correctly parse the value by type, `getXabiValueType` needed the call info for the external contract, however it was not being pushed to it. This adds that call info (and of course pops it off afterward). This wasn't causing errors for non-string values becuase it didn't need the contract info to parse the value. 