### PR TITLE
Strato 2392 round number bug: Move the Message Filter to the Sequener (Option 1 of 2)

### DIFF
--- a/core-strato/blockstanbul/package.yaml
+++ b/core-strato/blockstanbul/package.yaml
@@ -29,6 +29,7 @@ library:
   - generic-arbitrary
   - http-client
   - lens
+  - monad-alter
   - mtl
   - prometheus-client
   - servant-client

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -81,11 +81,12 @@ authorize = \case
     msgExists <- lift $ A.exists (A.Proxy @(A.Proxy WireMessage)) msgHash
     if msgExists
       then do
-        $logInfoS "handleEvents/Blockstanbul" . T.pack $ concat
-          [ "Already seen inbound wire message "
-          , format msgHash
-          , ". Not forwarding to Sequencer."
-          ]
+        let reason = concat
+              [ "Rejecting message; already seen inbound wire message "
+              , format msgHash
+              ]
+        $logWarnS "blockstanbul/auth" . T.pack $ reason
+        throwE reason
       else do
         $logInfoS "handleEvents/Blockstanbul" . T.pack $ concat 
           [ "First time seeing inbound wire message "

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -1,16 +1,23 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Blockchain.Blockstanbul.EventLoop where
 
 import Conduit
 import Control.Lens hiding (view)
 import Control.Monad hiding (sequence)
+import qualified Control.Monad.Change.Alter as A
 import Control.Monad.Extra (whenM)
 import Control.Monad.Trans.Except
 import Blockchain.Output
+import Control.Monad.Trans.State.Strict (StateT)
 import Control.Monad.State.Class
 import qualified Data.Map.Strict as M
 import Data.Maybe
@@ -39,6 +46,19 @@ import Text.Format
 
 import Blockchain.Blockstanbul.StateMachine
 
+instance (k `A.Alters` v) m => (k `A.Alters` v) (ConduitT i o m) where
+  lookup p   = lift . A.lookup p
+  insert p k = lift . A.insert p k
+  delete p   = lift . A.delete p
+
+instance (Keccak256 `A.Alters` (A.Proxy WireMessage)) m => (Keccak256 `A.Alters` (A.Proxy WireMessage)) (StateT s m) where
+  lookup p   = lift . A.lookup p
+  insert p k = lift . A.insert p k
+  delete p   = lift . A.delete p
+
+instance (Monad m, A.Selectable k v m) => A.Selectable k v (ConduitT i o m) where
+  select p = lift . A.select p
+
 yieldL :: Monad m => b -> ConduitM a (Either b c) m ()
 yieldL = yield . Left
 
@@ -51,12 +71,28 @@ yieldManyR = yieldMany . map Right
 
 authorize :: (StateMachineM m) => InEvent -> ExceptT String m ()
 authorize = \case
-  IMsg (MsgAuth addr _) _ -> do
+  IMsg a@(MsgAuth addr _) m -> do
     ret <- uses validators (addr `S.member`)
     unless ret $ do
       let reason = "Rejecting message; sender not a validator: " ++ show addr
       $logWarnS "blockstanbul/auth" . T.pack $ reason
       throwE reason
+    let msgHash = rlpHash $ WireMessage a m
+    msgExists <- lift $ A.exists (A.Proxy @(A.Proxy WireMessage)) msgHash
+    if msgExists
+      then do
+        $logInfoS "handleEvents/Blockstanbul" . T.pack $ concat
+          [ "Already seen inbound wire message "
+          , format msgHash
+          , ". Not forwarding to Sequencer."
+          ]
+      else do
+        $logInfoS "handleEvents/Blockstanbul" . T.pack $ concat 
+          [ "First time seeing inbound wire message "
+          , format msgHash
+          , ". Forwarding to Sequencer."
+          ]
+        lift $ A.insert (A.Proxy @(A.Proxy WireMessage)) msgHash A.Proxy
   _ -> return ()
 
 
@@ -180,7 +216,11 @@ nextRound nt = do
                                               (uses validators S.toList)
                                               (uses authSenders M.keys)
 
-eventLoop :: (MonadIO m, MonadLogger m, HasVault m) => BlockstanbulContext -> ConduitM InEvent EOutEvent m BlockstanbulContext
+eventLoop :: ( MonadIO m
+             , MonadLogger m
+             , HasVault m
+             , (Keccak256 `A.Alters` (A.Proxy WireMessage)) m
+             ) => BlockstanbulContext -> ConduitM InEvent EOutEvent m BlockstanbulContext
 eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
   debugShowCtx
   authz <- lift $ isAuthorized ev
@@ -367,7 +407,13 @@ loopback :: EOutEvent -> Maybe InEvent
 loopback (Right (OMsg a m)) = Just $ IMsg a m
 loopback _ = Nothing
 
-sendMessages' :: (MonadIO m, MonadLogger m, HasBlockstanbulContext m, HasVault m) => [InEvent] -> m [EOutEvent]
+sendMessages' :: ( MonadIO m
+                 , MonadLogger m
+                 , HasBlockstanbulContext m
+                 , HasVault m
+                 , (Keccak256 `A.Alters` (A.Proxy WireMessage)) m
+                 )
+              => [InEvent] -> m [EOutEvent]
 sendMessages' wms = do
   -- It may be somewhat confusing, but there are actually 2 StateTs with BlockstanbulContext
   -- Every run of the conduit has one, but the outer monad preserves the context between runs.
@@ -389,10 +435,22 @@ sendMessages' wms = do
       putBlockstanbulContext ctx'
       return evs
 
-sendMessages :: (MonadIO m, MonadLogger m, HasBlockstanbulContext m, HasVault m) => [InEvent] -> m [OutEvent]
+sendMessages :: ( MonadIO m
+                , MonadLogger m
+                , HasBlockstanbulContext m
+                , HasVault m
+                , (Keccak256 `A.Alters` (A.Proxy WireMessage)) m
+                )
+             => [InEvent] -> m [OutEvent]
 sendMessages = fmap (map fromE) . sendMessages'
 
-sendAllMessages :: (MonadIO m, MonadLogger m, HasBlockstanbulContext m, HasVault m) => [InEvent] -> m [OutEvent]
+sendAllMessages :: ( MonadIO m
+                   , MonadLogger m
+                   , HasBlockstanbulContext m
+                   , HasVault m
+                   , (Keccak256 `A.Alters` (A.Proxy WireMessage)) m
+                   )
+                => [InEvent] -> m [OutEvent]
 sendAllMessages wms = do
   eout <- sendMessages' wms
   let out = fromE <$> eout 

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/StateMachine.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/StateMachine.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Blockchain.Blockstanbul.StateMachine where 
 
@@ -10,6 +11,7 @@ module Blockchain.Blockstanbul.StateMachine where
 import           Conduit
 import           Control.Lens                     hiding (view)
 import           Control.Monad     
+import qualified Control.Monad.Change.Alter       as A
 import           Control.Monad.State.Class
 
 import qualified Data.Map.Strict                  as M
@@ -39,6 +41,7 @@ type StateMachineM m = ( MonadState BlockstanbulContext m
                        , MonadIO m
                        , MonadLogger m
                        , HasVault m
+                       , (Keccak256 `A.Alters` (A.Proxy WireMessage)) m
                        )
 
 

--- a/core-strato/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/core-strato/strato-p2p/exec_src/StratoP2PMain.hs
@@ -13,8 +13,6 @@ import           Executable.StratoP2PClient
 import           Executable.StratoP2PServer
 import           Executable.StratoP2PLoopback
 import           BlockApps.Init
-import           Data.IORef
-import           Data.Set.Ordered (empty)
 
 main :: IO ()
 main = do
@@ -22,10 +20,8 @@ main = do
   resetPeers
   _ <- $initHFlags "Strato P2P"
   setParticipationMode flags_participationMode
-  wireMessagesRef <- newIORef empty
   race_
     (run 10248 $ prometheus def p2pApp)
     (runLoggingT $
-      race_ (stratoP2PLoopback wireMessagesRef)
-        (race_ (stratoP2PClient wireMessagesRef)
-               (stratoP2PServer wireMessagesRef)))
+      race_ stratoP2PLoopback
+        (race_ stratoP2PClient stratoP2PServer))

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -42,7 +42,7 @@ import           UnliftIO.Exception
 import           UnliftIO.STM
 
 import           Blockchain.Constants                  hiding (ethVersion)
-import           Blockchain.Context                    hiding (Inbound, Outbound)
+import           Blockchain.Context
 import           Blockchain.Data.Block
 import           Blockchain.Data.Control               (P2PCNC(..))
 import           Blockchain.Data.RLP

--- a/core-strato/strato-p2p/src/Blockchain/Context.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Context.hs
@@ -23,8 +23,6 @@ module Blockchain.Context
     , Stacks(..)
     , MonadP2P
     , TcpPortNumber(..)
-    , Inbound(..)
-    , Outbound(..)
     , Context(..)
     , Config(..)
     , ContextM
@@ -63,16 +61,13 @@ import qualified Control.Monad.Change.Modify           as Mod
 import           Blockchain.Output
 import           Control.Monad.Reader
 import           Data.Default
-import           Data.Foldable                         (toList)
 import qualified Data.Map.Strict                       as M
 import           Data.Maybe
 import           Data.Proxy
-import qualified Data.Set.Ordered                      as S
 import qualified Data.Text                             as T
 import           Data.Time.Clock
 import           GHC.Exts                              (Constraint)
 
-import           Blockchain.Blockstanbul               (WireMessage)
 import           Blockchain.Data.Address
 import           Blockchain.Data.Block
 import           Blockchain.Data.ChainInfo
@@ -135,9 +130,6 @@ class Stacks a m where
 
 newtype TcpPortNumber = TcpPortNumber { unTcpPortNumber :: Int }
 
-newtype Inbound a = Inbound { unInbound :: a }
-newtype Outbound a = Outbound { unOutbound :: a }
-
 data Config = Config
   { configSQLDB              :: SQLDB
   , configRedisBlockDB       :: RBDB.RedisConnection
@@ -147,7 +139,6 @@ data Config = Config
   , configMaxReturnedHeaders :: MaxReturnedHeaders
   , configVaultClient        :: ClientEnv
   , configContext            :: IORef Context
-  , configBlockstanbulWireMessages :: IORef (S.OSet Keccak256)
   }
 
 newtype ActionTimestamp = ActionTimestamp { unActionTimestamp :: Maybe UTCTime }
@@ -170,7 +161,6 @@ data Context = Context
   , remainingBlockHeaders :: RemainingBlockHeaders
   , actionTimestamp       :: ActionTimestamp
   , _blockstanbulPeerAddr :: PeerAddress
-  , _outboundWireMessages :: S.OSet (T.Text, Keccak256)
   }
 
 makeLenses ''Context
@@ -260,34 +250,6 @@ instance MonadIO m => (Keccak256 `A.Alters` OutputBlock) (ReaderT Config m) wher
                . RBDB.withRedisBlockDB . RBDB.getBlocks
   insertMany _ = void . RBDB.withRedisBlockDB . RBDB.insertBlocks
   deleteMany _ = void . RBDB.withRedisBlockDB . RBDB.deleteBlocks
-
-instance MonadIO m => (Keccak256 `A.Alters` (Proxy (Inbound WireMessage))) (ReaderT Config m) where
-  lookup _  k = do
-    wms <- readIORef =<< asks configBlockstanbulWireMessages
-    let b = S.member k wms
-    pure $ if b then Just (Proxy @(Inbound WireMessage)) else Nothing
-  insert _ k _ = asks configBlockstanbulWireMessages >>= flip atomicModifyIORef' (\wms ->
-    let s = S.size wms
-        wms' = if s >= flags_wireMessageCacheSize then S.delete (head $ toList wms) wms else wms
-        wms'' = wms' S.>| k
-     in (wms'', ()))
-  delete _ k = asks configBlockstanbulWireMessages >>= flip atomicModifyIORef' (\wms ->
-    let wms' = S.delete k wms
-     in (wms', ()))
-
-instance MonadIO m => ((T.Text, Keccak256) `A.Alters` (Proxy (Outbound WireMessage))) (ReaderT Config m) where
-  lookup _  k = do
-    wms <- _outboundWireMessages <$> Mod.get (Mod.Proxy @Context)
-    let b = S.member k wms
-    pure $ if b then Just (Proxy @(Outbound WireMessage)) else Nothing
-  insert _ k _ = Mod.modifyStatefully_ (Mod.Proxy @Context) $ do
-    wms <- use outboundWireMessages
-    let s = S.size wms
-        wms' = if s >= flags_wireMessageCacheSize then S.delete (head $ toList wms) wms else wms
-        wms'' = wms' S.>| k
-    assign outboundWireMessages wms''
-  delete _ k = Mod.modifyStatefully_ (Mod.Proxy @Context) $
-    outboundWireMessages %= S.delete k
 
 instance ( MonadIO m
          , MonadUnliftIO m
@@ -431,8 +393,6 @@ type MonadP2P m = ( MonadIO m
                   , All2 '[A.Alters]
                       '[ '(Keccak256, BlockData)
                        , '(Keccak256, OutputBlock)
-                       , '(Keccak256, Proxy (Inbound WireMessage))
-                       , '((T.Text, Keccak256), Proxy (Outbound WireMessage))
                        ] m
                   )
 
@@ -468,8 +428,8 @@ runContextM r = void . runResourceT . flip runReaderT r
 initConfig :: ( MonadLogger m
               , MonadUnliftIO m
               )
-           => IORef (S.OSet Keccak256) -> Int -> m Config
-initConfig wireMessagesRef maxHeaders = do
+           => Int -> m Config
+initConfig maxHeaders = do
   dbs <- openDBs
   redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
   vaultClient <- do
@@ -487,7 +447,6 @@ initConfig wireMessagesRef maxHeaders = do
     , configMaxReturnedHeaders = MaxReturnedHeaders maxHeaders
     , configVaultClient = vaultClient
     , configContext = initState
-    , configBlockstanbulWireMessages = wireMessagesRef
     }
 
 initContext :: Context
@@ -498,7 +457,6 @@ initContext = Context
   , remainingBlockHeaders = RemainingBlockHeaders []
   , vmTrace=[]
   , _blockstanbulPeerAddr = PeerAddress Nothing
-  , _outboundWireMessages = S.empty
   }
 
 

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -325,21 +325,7 @@ handleEvents peer = awaitForever $ \case
         $logInfoS "handleEvents/Blockstanbul" . T.pack $ "blockstanbulPeerAddr: " ++ show peerAddr
       let msgHash = rlpHash wm
       lift $ insert (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash) Proxy
-      msgExists <- lift $ exists (Proxy @(Proxy (Inbound WireMessage))) msgHash
-      if msgExists
-        then $logInfoS "handleEvents/Blockstanbul" . T.pack $ concat
-               [ "Already seen inbound wire message "
-               , format msgHash
-               , ". Not forwarding to Sequencer."
-               ]
-        else do
-          $logInfoS "handleEvents/Blockstanbul" . T.pack $ concat 
-            [ "First time seeing inbound wire message "
-            , format msgHash
-            , ". Forwarding to Sequencer."
-            ]
-          lift $ insert (Proxy @(Proxy (Inbound WireMessage))) msgHash Proxy
-          yieldL $ ToUnseq [IEBlockstanbul wm]
+      yieldL $ ToUnseq [IEBlockstanbul wm]
 
     -- private chains
     MsgEvt (GetChainDetails cids') -> handleGetChainDetails peer $ S.fromList cids'
@@ -410,25 +396,25 @@ handleEvents peer = awaitForever $ \case
       P2pBlockstanbul msg -> do
         let outbound = Blockstanbul msg
         $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
-        let msgHash = rlpHash msg
-        lift $ insert (Proxy @(Proxy (Inbound WireMessage))) msgHash Proxy
-        msgExists <- lift $ exists (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash)
-        if msgExists
-          then $logInfoS "handleEvents/P2pBlockstanbul" $ T.concat
-                 [ "Already seen outbound wire message "
-                 , T.pack (format msgHash)
-                 , ". Not forwarding to peer "
-                 , pPeerIp peer
-                 ]
-          else do
-            $logInfoS "handleEvents/P2pBlockstanbul" $ T.concat
-              [ "First time seeing outbound wire message "
-              , T.pack (format msgHash)
-              , ". Forwarding to peer "
-              , pPeerIp peer
-              ]
-            lift $ insert (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash) Proxy
-            yieldR outbound
+        -- let msgHash = rlpHash msg
+        -- msgExists <- lift $ exists (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash)
+        -- if msgExists
+        --   then $logInfoS "handleEvents/P2pBlockstanbul" $ T.concat
+        --          [ "Already seen outbound wire message "
+        --          , T.pack (format msgHash)
+        --          , ". Not forwarding to peer "
+        --          , pPeerIp peer
+        --          ]
+        --   else do
+        --     $logInfoS "handleEvents/P2pBlockstanbul" $ T.concat
+        --       [ "First time seeing outbound wire message "
+        --       , T.pack (format msgHash)
+        --       , ". Forwarding to peer "
+        --       , pPeerIp peer
+        --       ]
+        --     lift $ insert (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash) Proxy
+        --     yieldR outbound
+        yieldR outbound
       P2pAskForBlocks start _ p -> do
         ss <- lift $ shouldSendToPeer p
         when ss $ do

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -48,7 +48,7 @@ import           System.Random
 import           Text.Printf
 import           UnliftIO.Exception
 
-import           Blockchain.Blockstanbul               (blockstanbulSender, WireMessage)
+import           Blockchain.Blockstanbul               (blockstanbulSender)
 import           Blockchain.Context
 import           Blockchain.Data.Block
 import           Blockchain.Data.BlockHeader
@@ -323,8 +323,6 @@ handleEvents peer = awaitForever $ \case
         setPeerAddrIfUnset $ blockstanbulSender wm
         peerAddr <- unPeerAddress <$> access (Proxy @PeerAddress)
         $logInfoS "handleEvents/Blockstanbul" . T.pack $ "blockstanbulPeerAddr: " ++ show peerAddr
-      let msgHash = rlpHash wm
-      lift $ insert (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash) Proxy
       yieldL $ ToUnseq [IEBlockstanbul wm]
 
     -- private chains
@@ -396,24 +394,6 @@ handleEvents peer = awaitForever $ \case
       P2pBlockstanbul msg -> do
         let outbound = Blockstanbul msg
         $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
-        -- let msgHash = rlpHash msg
-        -- msgExists <- lift $ exists (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash)
-        -- if msgExists
-        --   then $logInfoS "handleEvents/P2pBlockstanbul" $ T.concat
-        --          [ "Already seen outbound wire message "
-        --          , T.pack (format msgHash)
-        --          , ". Not forwarding to peer "
-        --          , pPeerIp peer
-        --          ]
-        --   else do
-        --     $logInfoS "handleEvents/P2pBlockstanbul" $ T.concat
-        --       [ "First time seeing outbound wire message "
-        --       , T.pack (format msgHash)
-        --       , ". Forwarding to peer "
-        --       , pPeerIp peer
-        --       ]
-        --     lift $ insert (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash) Proxy
-        --     yieldR outbound
         yieldR outbound
       P2pAskForBlocks start _ p -> do
         ss <- lift $ shouldSendToPeer p

--- a/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -31,7 +31,6 @@ import           Data.Conduit
 import           Data.Conduit.Network
 import           Data.Either.Combinators
 import           Data.Maybe
-import qualified Data.Set.Ordered                      as S
 import qualified Data.Text                             as T
 import           Data.Traversable                      (for)
 import           UnliftIO
@@ -50,20 +49,18 @@ import           Blockchain.Sequencer.Event
 import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Strato.Discovery.UDP
-import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.TCPClientWithTimeout
 
 import qualified Text.Colors                           as C
 import           Text.Format
 
 runPeer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
-        => IORef (S.OSet Keccak256)
-        -> PPeer
+        => PPeer
         -> BC.ByteString -- otherServiceCommHost
         -> CommPort      -- otherServiceCommPort
         -> m ()
-runPeer wireMessagesRef peer _ _ = do
-  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+runPeer peer _ _ = do
+  cfg <- initConfig flags_maxReturnedHeaders
   runContextM cfg $ do
     ender <- toIO . $logInfoS "runPeer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
     void $ register ender
@@ -129,21 +126,20 @@ runEthClientConduit peer peerSource peerSink seqSource unseqSink peerStr = do
 
 
 runPeerInList :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
-              => IORef (S.OSet Keccak256)
-              -> PPeer
+              => PPeer
               -> BC.ByteString
               -> CommPort
               -> m ()
-runPeerInList wireMessagesRef thePeer otherServiceHost otherServicePort = do
+runPeerInList thePeer otherServiceHost otherServicePort = do
   eErr <- liftIO $ nonviolentDisable thePeer --don't connect to a peer too frequently, out of politeness
   whenLeft eErr $ \err -> do
       $logErrorS "runPeerInList" . T.pack $ "Unable to disable peer:" ++ show err
       $logErrorS "runPeerInList" "Simulating disable..."
       liftIO $ threadDelay $ 10 * 1000 * 1000
-  runPeer wireMessagesRef thePeer otherServiceHost otherServicePort
+  runPeer thePeer otherServiceHost otherServicePort
 
-stratoP2PClient :: IORef (S.OSet Keccak256) -> LoggingT IO ()
-stratoP2PClient wireMessagesRef = do
+stratoP2PClient :: LoggingT IO ()
+stratoP2PClient = do
   $logInfoS "stratoP2PClient" $ T.pack $ "maxConn: " ++ show flags_maxConn
 
   activePeersSem <- liftIO (SSem.new flags_maxConn)
@@ -169,7 +165,7 @@ stratoP2PClient wireMessagesRef = do
           (liftIO (SSem.tryWait sem)) >>= \case
             Nothing -> return ()
             Just _  -> void . forkIO . runLoggingT $ do
-              result <- try $ runPeerInList wireMessagesRef p osch oscp
+              result <- try $ runPeerInList p osch oscp
               liftIO (SSem.signal sem)
               handleRunPeerResult p result
 

--- a/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -7,8 +7,6 @@ module Executable.StratoP2PLoopback (stratoP2PLoopback) where
 import Conduit
 import Control.Monad
 import qualified Control.Monad.Change.Modify           as Mod
-import Data.IORef
-import qualified Data.Set.Ordered as S
 import qualified Data.Text as T
 import qualified Network.Kafka                         as K
 import Prometheus
@@ -19,7 +17,6 @@ import Blockchain.Options
 import Blockchain.SeqEventNotify
 import Blockchain.Sequencer.Event
 import Blockchain.Sequencer.Kafka
-import Blockchain.Strato.Model.Keccak256
 
 {-# NOINLINE loopbackEvents #-}
 loopbackEvents :: Vector T.Text Counter
@@ -31,10 +28,10 @@ loopbackEvents = unsafeRegister
 recordEvent :: MonadIO m => T.Text -> m ()
 recordEvent lab = liftIO $ withLabel loopbackEvents lab incCounter
 
-stratoP2PLoopback :: IORef (S.OSet Keccak256) -> LoggingT IO ()
-stratoP2PLoopback wireMessagesRef = do
+stratoP2PLoopback :: LoggingT IO ()
+stratoP2PLoopback = do
   $logInfoS "stratoP2PLoopback" "Reflecting PBFT back to unseq since 2019"
-  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+  cfg <- initConfig flags_maxReturnedHeaders
   void . runContextM cfg $ do
     ks <- Mod.get (Mod.Proxy @K.KafkaState)
     let toWireMessage = \case

--- a/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -6,17 +6,14 @@ module Executable.StratoP2PLoopback (stratoP2PLoopback) where
 
 import Conduit
 import Control.Monad
-import qualified Control.Monad.Change.Alter            as A
 import qualified Control.Monad.Change.Modify           as Mod
 import Data.IORef
 import qualified Data.Set.Ordered as S
 import qualified Data.Text as T
 import qualified Network.Kafka                         as K
 import Prometheus
-import Text.Format
 
 import BlockApps.Logging
-import Blockchain.Blockstanbul (WireMessage)
 import Blockchain.Context
 import Blockchain.Options
 import Blockchain.SeqEventNotify
@@ -41,17 +38,7 @@ stratoP2PLoopback wireMessagesRef = do
   void . runContextM cfg $ do
     ks <- Mod.get (Mod.Proxy @K.KafkaState)
     let toWireMessage = \case
-          P2pBlockstanbul wm -> do
-            let msgHash = rlpHash wm
-            msgExists <- A.exists (A.Proxy @(A.Proxy (Inbound WireMessage))) msgHash
-            if msgExists
-              then do
-                $logInfoS "stratoP2PLoopback/P2pBlockstanbul" . T.pack $ "Already seen inbound wire message " ++ format msgHash ++ ". Not forwarding to Sequencer."
-                pure Nothing
-              else do
-                $logInfoS "stratoP2PLoopback/P2pBlockstanbul" . T.pack $ "First time seeing inbound wire message " ++ format msgHash ++ ". Forwarding to Sequencer."
-                A.insert (A.Proxy @(A.Proxy (Inbound WireMessage))) msgHash A.Proxy
-                pure $ Just wm
+          P2pBlockstanbul wm -> pure $ Just wm
           _ -> pure Nothing
 
     runConduit $

--- a/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/core-strato/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -24,7 +24,6 @@ import           Control.Monad.Trans.Resource
 import qualified Data.ByteString                       as B
 import           Data.Conduit.Network
 import           Data.Maybe                            (fromMaybe)
-import qualified Data.Set.Ordered                      as S
 import qualified Data.Text                             as T
 import           Network.Socket
 import           Network.Wai.Handler.Warp.Internal     (setSocketCloseOnExec)
@@ -38,16 +37,14 @@ import           Blockchain.P2PUtil
 import           Blockchain.SeqEventNotify
 import           Blockchain.Sequencer.Event
 import           Blockchain.Strato.Discovery.Data.Peer
-import           Blockchain.Strato.Model.Keccak256
 import qualified Text.Colors                           as C
 
 runEthServer :: (MonadIO m, MonadLogger m, MonadUnliftIO m)
-             => IORef (S.OSet Keccak256)
-             -> Int
+             => Int
              -> m ()
-runEthServer wireMessagesRef listenPort = do
+runEthServer listenPort = do
   let settings = setAfterBind setSocketCloseOnExec $ serverSettings listenPort "*"
-  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+  cfg <- initConfig flags_maxReturnedHeaders
   runGeneralTCPServer settings $ \app ->
       runContextM cfg $ do    -- Note- the monad has to run here, inside the server connection, because ResourceT should be cleaned up per connection
         let sSource = seqEventNotificationSource $ contextKafkaState initContext
@@ -108,10 +105,10 @@ runEthServerConduit p peerSource peerSink seqSource unseqSink peerStr = do
                   .| eventSink
                   .| peerSink
 
-stratoP2PServer :: IORef (S.OSet Keccak256) -> LoggingT IO ()
-stratoP2PServer wireMessagesRef = do
+stratoP2PServer :: LoggingT IO ()
+stratoP2PServer = do
 
   $logInfoS "stratoP2PServer" $ T.pack $ "connect address: " ++ flags_address
   $logInfoS "stratoP2PServer" $ T.pack $ "listen port:     " ++ show flags_listen
 
-  void $ runEthServer wireMessagesRef flags_listen
+  void $ runEthServer flags_listen

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -332,29 +332,6 @@ instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy WireMessage)) (MonadTest m)
      in wms' S.>| k)
   delete _ k = sequencerContext . blockstanbulEvents %= S.delete k
 
-instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
-  lookup _  k = do
-    wms <- readIORef =<< use pbftMessages
-    pure $ if S.member k wms then Just (A.Proxy @(Inbound WireMessage)) else Nothing
-  insert _ k _ = use pbftMessages >>= flip atomicModifyIORef' (\wms ->
-      let s = S.size wms
-          wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
-          wms'' = wms' S.>| k
-       in (wms'', ()))
-  delete _ k = use pbftMessages >>= flip atomicModifyIORef' (\wms -> (S.delete k wms, ()))
-
-instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessage))) (MonadTest m) where
-  lookup _  k = do
-    wms <- use outboundPbftMessages
-    pure $ if S.member k wms then Just (A.Proxy @(Outbound WireMessage)) else Nothing
-  insert _ k _ = do
-    wms <- use outboundPbftMessages
-    let s = S.size wms
-        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
-        wms'' = wms' S.>| k
-    assign outboundPbftMessages wms''
-  delete _ k = outboundPbftMessages %= S.delete k
-
 startingCheckpoint :: [Address] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
 

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -322,6 +322,17 @@ instance MonadIO m => HasVault (MonadTest m) where
     pk <- use prvKey
     return $ deriveSharedKey pk pub
 
+instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy WireMessage)) (MonadTest m) where
+  lookup _  k = do
+    wms <- use $ sequencerContext . blockstanbulEvents
+    let b = S.member k wms
+    pure $ if b then Just (A.Proxy @WireMessage) else Nothing
+  insert _ k _ = sequencerContext . blockstanbulEvents %= (\wms ->
+    let s = S.size wms
+        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+     in wms' S.>| k)
+  delete _ k = sequencerContext . blockstanbulEvents %= S.delete k
+
 instance (MonadLogger m, MonadIO m) => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
   lookup _  k = do
     wms <- readIORef =<< use pbftMessages
@@ -382,6 +393,7 @@ newSequencerContext bc = do
       , _blockstanbulContext = Just bc
       , _loopTimeout         = error "MonadTest: Evaluating loopTimeout" -- loopCh
       , _latestRoundNumber   = latestRound
+      , _blockstanbulEvents  = S.empty
       }
 
 -- testContext is useful for testing because it doesn't require

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -32,7 +32,6 @@ import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Text (Text)
-import qualified Data.Text                             as T
 import           Text.Printf
 
 import           Blockchain.Blockstanbul
@@ -333,22 +332,15 @@ instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy WireMessage)) (MonadTest m)
      in wms' S.>| k)
   delete _ k = sequencerContext . blockstanbulEvents %= S.delete k
 
-instance (MonadLogger m, MonadIO m) => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
+instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
   lookup _  k = do
     wms <- readIORef =<< use pbftMessages
-    $logErrorS "WIRE_MESSAGES_REF_LOOKUP" $ T.pack $ show wms
     pure $ if S.member k wms then Just (A.Proxy @(Inbound WireMessage)) else Nothing
-  insert _ k _ = do
-    r <- use pbftMessages
-    ms <- readIORef r
-    $logErrorS "WIRE_MESSAGES_REF_PRE_INSERT" $ T.pack $ show ms
-    atomicModifyIORef' r (\wms ->
+  insert _ k _ = use pbftMessages >>= flip atomicModifyIORef' (\wms ->
       let s = S.size wms
           wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
           wms'' = wms' S.>| k
        in (wms'', ()))
-    ms' <- readIORef r
-    $logErrorS "WIRE_MESSAGES_REF_POST_INSERT" $ T.pack $ show ms'
   delete _ k = use pbftMessages >>= flip atomicModifyIORef' (\wms -> (S.delete k wms, ()))
 
 instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessage))) (MonadTest m) where
@@ -624,7 +616,7 @@ spec = do
       ifor_ ctxs $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1 :: Maybe Word256)
   
 
-    fit "should update the round number after failing on a divided network first" $ do
+    it "should update the round number after failing on a divided network first" $ do
       let unseqSink = (unseqEvents %=) . (++)
       peers <- traverse (uncurry $ createPeer unseqSink)
         [ ("node1", "1.2.3.4")

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -32,6 +32,7 @@ import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Text (Text)
+import qualified Data.Text                             as T
 import           Text.Printf
 
 import           Blockchain.Blockstanbul
@@ -78,6 +79,7 @@ import           Test.QuickCheck
 import           UnliftIO
 import           UnliftIO.Concurrent                   (threadDelay)
 
+type WMRef = IORef (S.OSet Keccak256)
 
 data TestContext = TestContext
   { _blocks                :: [Block]
@@ -101,7 +103,7 @@ data TestContext = TestContext
   , _genesisBlockHash      :: GenesisBlockHash
   , _bestBlockNumber       :: BestBlockNumber
   , _stringPPeerMap        :: Map String DataPeer.PPeer
-  , _pbftMessages          :: IORef (S.OSet Keccak256)
+  , _pbftMessages          :: WMRef
   , _outboundPbftMessages  :: S.OSet (Text, Keccak256)
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
@@ -320,15 +322,22 @@ instance MonadIO m => HasVault (MonadTest m) where
     pk <- use prvKey
     return $ deriveSharedKey pk pub
 
-instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
+instance (MonadLogger m, MonadIO m) => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
   lookup _  k = do
     wms <- readIORef =<< use pbftMessages
+    $logErrorS "WIRE_MESSAGES_REF_LOOKUP" $ T.pack $ show wms
     pure $ if S.member k wms then Just (A.Proxy @(Inbound WireMessage)) else Nothing
-  insert _ k _ = use pbftMessages >>= flip atomicModifyIORef' (\wms ->
-    let s = S.size wms
-        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
-        wms'' = wms' S.>| k
-     in (wms'', ()))
+  insert _ k _ = do
+    r <- use pbftMessages
+    ms <- readIORef r
+    $logErrorS "WIRE_MESSAGES_REF_PRE_INSERT" $ T.pack $ show ms
+    atomicModifyIORef' r (\wms ->
+      let s = S.size wms
+          wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+          wms'' = wms' S.>| k
+       in (wms'', ()))
+    ms' <- readIORef r
+    $logErrorS "WIRE_MESSAGES_REF_POST_INSERT" $ T.pack $ show ms'
   delete _ k = use pbftMessages >>= flip atomicModifyIORef' (\wms -> (S.delete k wms, ()))
 
 instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessage))) (MonadTest m) where
@@ -377,7 +386,7 @@ newSequencerContext bc = do
 
 -- testContext is useful for testing because it doesn't require
 -- Kafka, postgres, redis, or ethconf.
-testContext :: IORef (S.OSet Keccak256) -> PrivateKey -> SequencerContext -> TestContext
+testContext :: WMRef -> PrivateKey -> SequencerContext -> TestContext
 testContext wireMessagesRef prv ctx = TestContext
   { _blocks                = []
   , _blockHeaders          = []
@@ -417,6 +426,7 @@ runTestPeer f = do
   void . runNoLoggingT . runResourceT $ runReaderT f ctx
 
 execTestPeer :: PrivateKey
+             -> WMRef
              -> [Address]
              -> TestContextM a
              -> IO (a, TestContext)
@@ -424,12 +434,12 @@ execTestPeer = execTestPeerOnRound 0
 
 execTestPeerOnRound :: Word256
                     -> PrivateKey
+                    -> WMRef
                     -> [Address]
                     -> TestContextM a
                     -> IO (a, TestContext)
-execTestPeerOnRound n pk as f = do
+execTestPeerOnRound n pk wmr as f = do
   seqCtx <- newSequencerContext $ (view . round .~ n) (newBlockstanbulContext (fromPrivateKey pk) as)
-  wmr <- newIORef (S.empty)
   ctx <- newIORef $ testContext wmr pk seqCtx
   a <- runLoggingT . runResourceT $ runReaderT f ctx
   ctx' <- readIORef ctx
@@ -445,6 +455,7 @@ execTestPeerWithContext f ctx = do
 data P2PPeer m = P2PPeer
   { _p2pPeerPrivKey     :: PrivateKey
   , _p2pPeerPPeer       :: DataPeer.PPeer
+  , _p2pPeerWireMessageRef :: WMRef
   , _p2pPeerUnseqSource :: TQueue SeqLoopEvent
   , _p2pPeerSeqSource   :: TMChan P2pEvent
   , _p2pPeerUnseqSink   :: [IngestEvent] -> m ()
@@ -459,6 +470,7 @@ createPeer :: Seq.MonadSequencer m
            -> IO (P2PPeer m)
 createPeer unseqSink name ipAddr = do
   privKey <- newPrivateKey
+  wmr <- newIORef (S.empty)
   unseqSource <- newTQueueIO
   seqSource <- newBroadcastTMChanIO
   let sequencer = runConduit $ sourceTQueue unseqSource
@@ -476,6 +488,7 @@ createPeer unseqSink name ipAddr = do
   pure $ P2PPeer
     privKey
     ppeer
+    wmr
     unseqSource
     seqSource
     unseq
@@ -520,12 +533,14 @@ createConnection server client = do
     runServer
     runClient
 
-runConnectionWith :: (PrivateKey -> m (Maybe SomeException) -> IO b) 
+runConnectionWith :: (PrivateKey -> WMRef -> m (Maybe SomeException) -> IO b) 
                   -> P2PConnection m 
                   -> IO (b, b)
 runConnectionWith f connection =
-  let runServer = f (_p2pPeerPrivKey (_serverP2PPeer connection)) $ _runServer connection
-      runClient = f (_p2pPeerPrivKey (_clientP2PPeer connection)) $ _runClient connection
+  let server = _serverP2PPeer connection
+      client = _clientP2PPeer connection
+      runServer = f (_p2pPeerPrivKey server) (_p2pPeerWireMessageRef server) $ _runServer connection
+      runClient = f (_p2pPeerPrivKey client) (_p2pPeerWireMessageRef client) $ _runClient connection
    in concurrently runServer runClient
 
 makeValidators :: [P2PPeer m] -> [Address]
@@ -553,7 +568,7 @@ spec = do
             ContractCreationTX{} -> tx{transactionChainId = Nothing}
             PrivateHashTX{} -> tx
       otx <- (\o -> o{otBaseTx = clearChainId (otBaseTx o), otOrigin = Origin.API}) <$> liftIO (generate arbitrary)
-      let runForTwoSeconds pk = execTestPeer pk validatorAddresses . timeout 2000000
+      let runForTwoSeconds pk wmr = execTestPeer pk wmr validatorAddresses . timeout 2000000
           run = runConnectionWith runForTwoSeconds connection
           postTx = threadDelay 500000 >> (atomically $ writeTMChan (_p2pPeerSeqSource server) (P2pTx otx))
       ((_, serverCtx), (_, clientCtx)) <- fst <$> concurrently run postTx
@@ -586,9 +601,9 @@ spec = do
         ]
       let validators' = take 2 peers
           validatorAddresses = makeValidators validators'
-          runForTwoSeconds :: PrivateKey -> TestContextM a -> IO TestContext
-          runForTwoSeconds pk = fmap snd . execTestPeer pk validatorAddresses . timeout 2000000
-          runSequencers = mapConcurrently (\p -> runForTwoSeconds (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) peers
+          runForTwoSeconds :: PrivateKey -> WMRef -> TestContextM a -> IO TestContext
+          runForTwoSeconds pk wmr = fmap snd . execTestPeer pk wmr validatorAddresses . timeout 2000000
+          runSequencers = mapConcurrently (\p -> runForTwoSeconds (_p2pPeerPrivKey p) (_p2pPeerWireMessageRef p) (_p2pPeerSequencer p)) peers
           runConnections = mapConcurrently (runConnectionWith runForTwoSeconds) connections
           postTimeout = do
             threadDelay 1000000
@@ -603,29 +618,25 @@ spec = do
         [ ("node1", "1.2.3.4")
         , ("node2", "5.6.7.8")
         , ("node3", "9.10.11.12")
-        , ("node4", "13.14.15.16")
         ]
       connections <- traverse (uncurry createConnection)
         [ (peers !! 0, peers !! 1)
         , (peers !! 0, peers !! 2)
-        , (peers !! 0, peers !! 3)
         , (peers !! 1, peers !! 2)
-        , (peers !! 1, peers !! 3)
-        , (peers !! 2, peers !! 3)
         ]
       let validators' = peers
           primaryValidators = [head validators']
           secondaryValidators = tail validators'
           primaryValidatorAddresses = makeValidators primaryValidators
           validatorAddresses = makeValidators validators'
-          runForTwoSecondsPrimary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
-          runForTwoSecondsPrimary n pk = fmap snd . execTestPeerOnRound n pk primaryValidatorAddresses . timeout 2000000
-          runForTwoSecondsSecondary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
-          runForTwoSecondsSecondary n pk = fmap snd . execTestPeerOnRound n pk validatorAddresses . timeout 2000000
+          runForTwoSecondsPrimary :: Word256 -> PrivateKey -> WMRef -> TestContextM a -> IO TestContext
+          runForTwoSecondsPrimary n pk wmr = fmap snd . execTestPeerOnRound n pk wmr primaryValidatorAddresses . timeout 2000000
+          runForTwoSecondsSecondary :: Word256 -> PrivateKey -> WMRef -> TestContextM a -> IO TestContext
+          runForTwoSecondsSecondary n pk wmr = fmap snd . execTestPeerOnRound n pk wmr validatorAddresses . timeout 2000000
           runForTwoSecondsWithContext :: TestContext -> TestContextM a -> IO TestContext
           runForTwoSecondsWithContext ctx = fmap snd . flip execTestPeerWithContext ctx . timeout 2000000
-          runSequencersPrimary1 = mapConcurrently (\p -> runForTwoSecondsPrimary 0 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) primaryValidators
-          runSequencersSecondary = mapConcurrently (\p -> runForTwoSecondsSecondary 1000 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) secondaryValidators
+          runSequencersPrimary1 = mapConcurrently (\p -> runForTwoSecondsPrimary 0 (_p2pPeerPrivKey p) (_p2pPeerWireMessageRef p) (_p2pPeerSequencer p)) primaryValidators
+          runSequencersSecondary = mapConcurrently (\p -> runForTwoSecondsSecondary 1000 (_p2pPeerPrivKey p) (_p2pPeerWireMessageRef p) (_p2pPeerSequencer p)) secondaryValidators
           runSequencers1 = concurrently runSequencersPrimary1 runSequencersSecondary
           runSequencers2 ctxs = mapConcurrently (\(ctx, p) -> runForTwoSecondsWithContext ((sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses) ctx) (_p2pPeerSequencer p)) $ zip ctxs peers
           runConnections = mapConcurrently (runConnectionWith $ runForTwoSecondsSecondary 0) connections
@@ -639,9 +650,9 @@ spec = do
             threadDelay 1000000
             for_ secondaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 1000))
       ctxs1 <- uncurry (++) . fst <$> concurrently runSequencers1 (concurrently runConnections $ concurrently postTimeoutPrimary1 postTimeoutSecondary)
-      ifor_ ctxs1 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just (1 :: Word256) else Just 1001)
+      ifor_ ctxs1 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just (1 :: Word256) else Just 1000)
       ctxs2 <- fst <$> concurrently (runSequencers2 ctxs1) (concurrently runConnections $ concurrently postTimeoutPrimary2 postTimeoutSecondary)
-      ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just 1 else Just 1001 :: Maybe Word256)
+      ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1001 :: Maybe Word256)
   
   describe "handleEvents" $ do
     it "should pong a ping" $

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -11,9 +11,10 @@
 {-# LANGUAGE TypeOperators         #-}
 module EventSpec where
 
+import           Prelude hiding (round)
 import           Conduit
 import           Control.Concurrent.STM.TMChan
-import           Control.Lens                          hiding (Context)
+import           Control.Lens                          hiding (Context, view)
 import qualified Control.Monad.Change.Alter            as A
 import qualified Control.Monad.Change.Modify           as Mod
 import           Control.Monad.Reader
@@ -27,6 +28,7 @@ import           Data.Default                          (def)
 import           Data.Foldable                         (for_, toList)
 import           Data.Map.Strict                       (Map)
 import qualified Data.Map.Strict                       as M
+import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Text (Text)
@@ -34,6 +36,7 @@ import           Text.Printf
 
 import           Blockchain.Blockstanbul
 import           Blockchain.Blockstanbul.HTTPAdmin
+import           Blockchain.Blockstanbul.Messages      (round)
 import           Blockchain.Blockstanbul.StateMachine
 import           Blockchain.Context                    hiding (actionTimestamp, blockHeaders, remainingBlockHeaders)
 import           Blockchain.Data.ArbitraryInstances()
@@ -417,12 +420,26 @@ execTestPeer :: PrivateKey
              -> [Address]
              -> TestContextM a
              -> IO (a, TestContext)
-execTestPeer pk as f = do
-  seqCtx <- newSequencerContext $ newBlockstanbulContext (fromPrivateKey pk) as
+execTestPeer = execTestPeerOnRound 0
+
+execTestPeerOnRound :: Word256
+                    -> PrivateKey
+                    -> [Address]
+                    -> TestContextM a
+                    -> IO (a, TestContext)
+execTestPeerOnRound n pk as f = do
+  seqCtx <- newSequencerContext $ (view . round .~ n) (newBlockstanbulContext (fromPrivateKey pk) as)
   wmr <- newIORef (S.empty)
   ctx <- newIORef $ testContext wmr pk seqCtx
   a <- runLoggingT . runResourceT $ runReaderT f ctx
   ctx' <- readIORef ctx
+  return (a, ctx')
+
+execTestPeerWithContext :: TestContextM a -> TestContext -> IO (a, TestContext)
+execTestPeerWithContext f ctx = do
+  ref <- newIORef ctx
+  a <- runLoggingT . runResourceT $ runReaderT f ref
+  ctx' <- readIORef ref
   return (a, ctx')
 
 data P2PPeer m = P2PPeer
@@ -543,6 +560,7 @@ spec = do
       _unseqEvents serverCtx `shouldBe` []
       let clientTxs = [t | IETx _ (IngestTx _ t) <- _unseqEvents clientCtx]
       clientTxs `shouldBe` [otBaseTx otx]
+
     it "should update the round number on every node in the network" $ do
       let unseqSink = (unseqEvents %=) . (++)
       peers <- traverse (uncurry $ createPeer unseqSink)
@@ -577,6 +595,54 @@ spec = do
             for_ validators' (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
       ctxs <- fst <$> concurrently runSequencers (concurrently runConnections postTimeout)
       ifor_ ctxs $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1 :: Maybe Word256)
+  
+
+    fit "should update the round number after failing on a divided network first" $ do
+      let unseqSink = (unseqEvents %=) . (++)
+      peers <- traverse (uncurry $ createPeer unseqSink)
+        [ ("node1", "1.2.3.4")
+        , ("node2", "5.6.7.8")
+        , ("node3", "9.10.11.12")
+        , ("node4", "13.14.15.16")
+        ]
+      connections <- traverse (uncurry createConnection)
+        [ (peers !! 0, peers !! 1)
+        , (peers !! 0, peers !! 2)
+        , (peers !! 0, peers !! 3)
+        , (peers !! 1, peers !! 2)
+        , (peers !! 1, peers !! 3)
+        , (peers !! 2, peers !! 3)
+        ]
+      let validators' = peers
+          primaryValidators = [head validators']
+          secondaryValidators = tail validators'
+          primaryValidatorAddresses = makeValidators primaryValidators
+          validatorAddresses = makeValidators validators'
+          runForTwoSecondsPrimary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
+          runForTwoSecondsPrimary n pk = fmap snd . execTestPeerOnRound n pk primaryValidatorAddresses . timeout 2000000
+          runForTwoSecondsSecondary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
+          runForTwoSecondsSecondary n pk = fmap snd . execTestPeerOnRound n pk validatorAddresses . timeout 2000000
+          runForTwoSecondsWithContext :: TestContext -> TestContextM a -> IO TestContext
+          runForTwoSecondsWithContext ctx = fmap snd . flip execTestPeerWithContext ctx . timeout 2000000
+          runSequencersPrimary1 = mapConcurrently (\p -> runForTwoSecondsPrimary 0 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) primaryValidators
+          runSequencersSecondary = mapConcurrently (\p -> runForTwoSecondsSecondary 1000 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) secondaryValidators
+          runSequencers1 = concurrently runSequencersPrimary1 runSequencersSecondary
+          runSequencers2 ctxs = mapConcurrently (\(ctx, p) -> runForTwoSecondsWithContext ((sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses) ctx) (_p2pPeerSequencer p)) $ zip ctxs peers
+          runConnections = mapConcurrently (runConnectionWith $ runForTwoSecondsSecondary 0) connections
+          postTimeoutPrimary1 = do
+            threadDelay 1000000
+            for_ primaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
+          postTimeoutPrimary2 = do
+            threadDelay 1000000
+            for_ primaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 1))
+          postTimeoutSecondary = do
+            threadDelay 1000000
+            for_ secondaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 1000))
+      ctxs1 <- uncurry (++) . fst <$> concurrently runSequencers1 (concurrently runConnections $ concurrently postTimeoutPrimary1 postTimeoutSecondary)
+      ifor_ ctxs1 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just (1 :: Word256) else Just 1001)
+      ctxs2 <- fst <$> concurrently (runSequencers2 ctxs1) (concurrently runConnections $ concurrently postTimeoutPrimary2 postTimeoutSecondary)
+      ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just 1 else Just 1001 :: Maybe Word256)
+  
   describe "handleEvents" $ do
     it "should pong a ping" $
       runTestPeer $ do

--- a/core-strato/strato-sequencer/package.yaml
+++ b/core-strato/strato-sequencer/package.yaml
@@ -33,12 +33,14 @@ library:
     - ethereum-rlp
     - extra
     - format
+    - hflags
     - http-client
     - lens
     - leveldb-haskell
     - lifted-async
     - milena
     - monad-alter
+    - ordered-containers
     - prometheus-client
     - seqevents
     - stm

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -76,14 +76,6 @@ instance Mod.Modifiable r m => Mod.Modifiable r (ConduitT i o m) where
 instance (Monad m, Mod.Accessible r m) => Mod.Accessible r (ConduitT i o m) where
   access = lift . Mod.access
 
-instance (k `A.Alters` v) m => (k `A.Alters` v) (ConduitT i o m) where
-  lookup p   = lift . A.lookup p
-  insert p k = lift . A.insert p k
-  delete p   = lift . A.delete p
-
-instance (Monad m, A.Selectable k v m) => A.Selectable k v (ConduitT i o m) where
-  select p = lift . A.select p
-
 instance HasBlockstanbulContext m => HasBlockstanbulContext (ConduitT i o m) where
   getBlockstanbulContext = lift getBlockstanbulContext
   putBlockstanbulContext = lift . putBlockstanbulContext
@@ -129,6 +121,7 @@ type MonadSequencer m =
   , HasFullPrivacy m
   , (Keccak256 `A.Alters` DependentBlockEntry) m
   , (Keccak256 `A.Alters` ()) m
+  , (Keccak256 `A.Alters` (Proxy WireMessage)) m
   , HasVault m
   )
 
@@ -213,6 +206,7 @@ checkForVotes :: ( MonadLogger m
                  , MonadBlockstanbul m
                  , HasFullPrivacy m
                  , (Keccak256 `A.Alters` DependentBlockEntry) m
+                 , (Keccak256 `A.Alters` (Proxy WireMessage)) m
                  )
               => [CandidateReceived]
               -> ConduitT a SeqEvent m ()
@@ -235,6 +229,7 @@ checkForTimeouts :: ( MonadLogger m
                     , MonadBlockstanbul m
                     , HasFullPrivacy m
                     , (Keccak256 `A.Alters` DependentBlockEntry) m
+                    , (Keccak256 `A.Alters` (Proxy WireMessage)) m
                     )
                  => [RoundNumber]
                  -> ConduitT a SeqEvent m ()
@@ -260,6 +255,7 @@ blockstanbulSend :: ( MonadLogger m
                     , MonadBlockstanbul m
                     , HasFullPrivacy m
                     , (Keccak256 `A.Alters` DependentBlockEntry) m
+                    , (Keccak256 `A.Alters` (Proxy WireMessage)) m
                     )
                  => [InEvent]
                  -> ConduitT a SeqEvent m ()
@@ -273,6 +269,7 @@ blockstanbulSend' :: ( MonadLogger m
                      , MonadBlockstanbul m
                      , (Keccak256 `A.Alters` ChainHashEntry) m
                      , (Keccak256 `A.Alters` DependentBlockEntry) m
+                     , (Keccak256 `A.Alters` (Proxy WireMessage)) m
                      )
                   => InEvent
                   -> ConduitT a SeqEvent m ()
@@ -449,6 +446,7 @@ runBlockWithConsensus :: ( MonadLogger m
                          , MonadBlockstanbul m
                          , HasFullPrivacy m
                          , (Keccak256 `A.Alters` DependentBlockEntry) m
+                         , (Keccak256 `A.Alters` (Proxy WireMessage)) m
                          )
                       => SequencedBlock
                       -> ConduitT a SeqEvent m ()
@@ -490,6 +488,7 @@ runConsensus :: ( MonadLogger m
                 , MonadBlockstanbul m
                 , (Keccak256 `A.Alters` ChainHashEntry) m
                 , (Keccak256 `A.Alters` DependentBlockEntry) m
+                , (Keccak256 `A.Alters` (Proxy WireMessage)) m
                 )
              => ConduitT SequencedBlock SeqEvent m ()
 runConsensus = awaitForever $ \sb -> do
@@ -538,6 +537,7 @@ transformBlocks :: ( MonadLogger m
                    , MonadBlockstanbul m
                    , HasFullPrivacy m
                    , (Keccak256 `A.Alters` DependentBlockEntry) m
+                   , (Keccak256 `A.Alters` (Proxy WireMessage)) m
                    )
                 => [IngestBlock]
                 -> ConduitT a SeqEvent m ()
@@ -601,6 +601,7 @@ splitEvents :: ( MonadLogger m
                , HasFullPrivacy m
                , (Keccak256 `A.Alters` DependentBlockEntry) m
                , (Keccak256 `A.Alters` ()) m
+               , (Keccak256 `A.Alters` (Proxy WireMessage)) m
                )
             => [IngestEvent]
             -> ConduitT a SeqEvent m ()

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -60,6 +60,7 @@ module Blockchain.Sequencer.Monad
   , blockstanbulContext
   , loopTimeout
   , latestRoundNumber
+  , blockstanbulEvents
 ) where
 
 import           Prelude                                   hiding (round)
@@ -87,6 +88,7 @@ import           Data.Map                                  (Map)
 import qualified Data.Map                                  as M
 import           Data.Maybe
 import qualified Data.Sequence                             as Q
+import qualified Data.Set.Ordered                          as S
 import qualified Data.Text                                 as T
 import           Data.Time.Clock
 import qualified Database.LevelDB                          as LDB
@@ -105,6 +107,7 @@ import           Blockchain.Sequencer.DB.GetTransactionsDB
 import           Blockchain.Sequencer.DB.SeenTransactionDB
 import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Metrics
+import           Blockchain.Sequencer.Options
 import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.Strato.Model.Secp256k1
 import           Prometheus
@@ -135,6 +138,7 @@ data SequencerContext = SequencerContext
   , _blockstanbulContext :: Maybe BlockstanbulContext
   , _loopTimeout         :: TMChan ()
   , _latestRoundNumber   :: IORef RoundNumber
+  , _blockstanbulEvents  :: S.OSet Keccak256
   }
 makeLenses ''SequencerContext
 
@@ -392,6 +396,16 @@ instance HasBlockstanbulContext SequencerM where
   getBlockstanbulContext = use blockstanbulContext
   putBlockstanbulContext = modify' . (.~) (blockstanbulContext . _Just)
 
+instance (Keccak256 `A.Alters` (A.Proxy WireMessage)) SequencerM where
+  lookup _  k = do
+    wms <- use blockstanbulEvents
+    let b = S.member k wms
+    pure $ if b then Just (A.Proxy @WireMessage) else Nothing
+  insert _ k _ = blockstanbulEvents %= (\wms ->
+    let s = S.size wms
+        wms' = if s >= flags_blockstanbulEventCacheSize then S.delete (head $ toList wms) wms else wms
+     in wms' S.>| k)
+  delete _ k = blockstanbulEvents %= S.delete k
 
 -- If there is no vault client (i.e. in hspec tests), the HasVault instance will use this key, 
 -- I know, it's ugly...the SequencerSpec test uses SequencerM itself, so this was a lot 
@@ -460,6 +474,7 @@ runSequencerM c mbc m = do
             , _blockstanbulContext = mbc
             , _loopTimeout         = loopCh
             , _latestRoundNumber   = latestRound
+            , _blockstanbulEvents  = S.empty
             }
     return $ fst a
 

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Options.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Options.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Blockchain.Sequencer.Options where
+
+import           HFlags
+
+defineFlag "blockstanbulEventCacheSize" (2000 :: Int) "Number of Blockstanbul events to cache for network performance"


### PR DESCRIPTION
This is one approach to fixing the round number bug found seen on the devnet: Move the PBFT message filter into the sequencer, after the check to see if the sender is a validator. This fixes the bug because the original round change messages being sent to the root node don't make it into the filter the first time, so they are able to be reprocessed when they are sent a second time. This method was a little more invasive, and may have negative performance impacts, due to more messages being written to Kafka and subsequently being read by the sequencer.