### PR TITLE
Strato 2392 round number bug: Add nonces to RoundChange messages (Option 2 of 2)

### DIFF
--- a/core-strato/blockstanbul/package.yaml
+++ b/core-strato/blockstanbul/package.yaml
@@ -20,6 +20,7 @@ library:
   - conduit
   - containers
   - cross-monitoring
+  - cryptonite
   - data-default
   - deepseq
   - ethereum-encryption

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -333,10 +333,10 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
           total <- poolSize
           sentRN <- use pendingRound
           let sameRNCount = maybe 0 S.size . M.lookup rn $ rs
+          rawMsg <- createRoundChangeMessage vn
           when (3 * sameRNCount > total && Just rn > sentRN) $ do
             pendingRound .= Just rn
             $logInfoS "blockstanbul/roundchange" "agreed change"
-            rawMsg <- createRoundChangeMessage vn
             msg <- signMessage rawMsg
             yieldR msg
           when (3 * sameRNCount > 2 * total) $ do
@@ -344,7 +344,6 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
             case next of
               Nothing -> error "TODO(tim): a round was voted on without existing"
               Just r -> nextRound (Round r)
-          rawMsg <- createRoundChangeMessage vn
           yieldL $ OMsg auth rawMsg
           return ()
     Timeout r' -> do

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -12,6 +12,7 @@ import Control.Monad.Extra (whenM)
 import Control.Monad.Trans.Except
 import Blockchain.Output
 import Control.Monad.State.Class
+import Crypto.Random.Entropy (getEntropy)
 import qualified Data.Map.Strict as M
 import Data.Maybe
 import qualified Data.Set as S
@@ -122,11 +123,17 @@ assertChainConsistency seqNo wantParent blk = do
 hasSameHash :: (StateMachineM m) => Keccak256 -> m Bool
 hasSameHash di = uses proposal $ maybe False ((==di) . blockHash)
 
+createRoundChangeMessage :: MonadIO m => View -> m TrustedMessage
+createRoundChangeMessage vw = do
+  nonce <- bytesToWord256 <$> liftIO (getEntropy 32)
+  pure $ RoundChange vw nonce
+
 roundChange :: (StateMachineM m) => ConduitM InEvent EOutEvent m ()
 roundChange = do
   nextView <- uses view (over round (+1))
   pendingRound .= Just (_round nextView)
-  msg <- signMessage (RoundChange nextView)
+  rawMsg <- createRoundChangeMessage nextView
+  msg <- signMessage rawMsg
   yieldR msg
 
 nextRound :: (StateMachineM m) => NextType -> ConduitM InEvent EOutEvent m ()
@@ -316,7 +323,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
             let blockNo = blockDataNumber . blockBlockData $ blk
             recordMaxBlockNumber "pbft_commit" blockNo
             yieldR . ToCommit . addCommitmentSeals seals $ blk
-    IMsg auth (RoundChange vn) -> when (_round v < _round vn) $ do
+    IMsg auth (RoundChange vn _) -> when (_round v < _round vn) $ do
       let rn = _round vn
       mSigners <- use $ roundChanged . at rn
       case S.member (sender auth) <$> mSigners of
@@ -329,14 +336,16 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
           when (3 * sameRNCount > total && Just rn > sentRN) $ do
             pendingRound .= Just rn
             $logInfoS "blockstanbul/roundchange" "agreed change"
-            msg <- signMessage (RoundChange vn)
+            rawMsg <- createRoundChangeMessage vn
+            msg <- signMessage rawMsg
             yieldR msg
           when (3 * sameRNCount > 2 * total) $ do
             next <- use pendingRound
             case next of
               Nothing -> error "TODO(tim): a round was voted on without existing"
               Just r -> nextRound (Round r)
-          yieldL $ OMsg auth (RoundChange vn)
+          rawMsg <- createRoundChangeMessage vn
+          yieldL $ OMsg auth rawMsg
           return ()
     Timeout r' -> do
       case r' `compare` _round v of

--- a/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
+++ b/core-strato/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
@@ -65,7 +65,7 @@ data MsgAuth = MsgAuth {
 data TrustedMessage = Preprepare View Block
                     | Prepare View Keccak256
                     | Commit View Keccak256 Signature
-                    | RoundChange {roundchangeView :: View }
+                    | RoundChange {roundchangeView :: View, roundchangeNonce :: Word256 }
                     deriving (Eq, Show, Generic, Binary, NFData, Data)
 
 
@@ -73,7 +73,7 @@ instance Format TrustedMessage where
   format (Preprepare v theBlock) = CL.blue "PRE_PREPARE " ++ format v ++ " " ++ format (blockHash theBlock)
   format (Prepare v theSHA) = CL.blue "PREPARE " ++ format v ++ " " ++ format theSHA
   format (Commit v theSHA _) = CL.blue "COMMIT " ++ format v ++ " " ++ format theSHA
-  format (RoundChange v) = CL.blue "ROUNDCHANGE " ++ format v
+  format (RoundChange v n) = CL.blue "ROUNDCHANGE " ++ format v ++ " " ++ show n
 
 data MessageKind = PreprepareK | PrepareK | CommitK | RoundChangeK deriving (Eq, Show, Enum, Generic)
 
@@ -223,7 +223,7 @@ getHash = \case
               (Preprepare _ blk) -> keccak256ToByteString . blockHash $ blk
               (Prepare _ di) -> keccak256ToByteString di
               (Commit _ di _) -> keccak256ToByteString di
-              (RoundChange _) -> keccak256ToByteString $ hash "TODO(tim): this signature is predictable"
+              (RoundChange _ _) -> keccak256ToByteString $ hash "TODO(tim): this signature is predictable"
 
 instance RLPSerializable View where
   rlpEncode (View r s) = RLPArray [rlpEncode r, rlpEncode s]
@@ -255,11 +255,11 @@ instance RLPSerializable WireMessage where
       , rlpEncode addr
       , rlpEncode sig
       , rlpEncode seal ]
-  rlpEncode (WireMessage (MsgAuth addr sig) (RoundChange vw)) = RLPArray
+  rlpEncode (WireMessage (MsgAuth addr sig) (RoundChange vw n)) = RLPArray
       [ rlpEncode roundchangeCode
       , RLPString . rlpSerialize . RLPArray $
         [ rlpEncode vw,
-          rlpEncode $ unsafeCreateKeccak256FromWord256 0]
+          rlpEncode n]
       , rlpEncode addr
       , rlpEncode sig
       , RLPString ""]
@@ -282,7 +282,7 @@ instance RLPSerializable WireMessage where
                   _ -> error $ "invalid rlp payload for commit: " ++ show body
             3 ->
               case body of
-                  RLPArray [vw, _] -> RoundChange (rlpDecode vw)
+                  RLPArray [vw, n] -> RoundChange (rlpDecode vw) (rlpDecode n)
                   _ -> error $ "invalid rlp payload for roundchange: " ++ show body
 
             _ -> error $ "invalid code for blockstanbul message: " ++ show code

--- a/core-strato/blockstanbul/test/MessageSpec.hs
+++ b/core-strato/blockstanbul/test/MessageSpec.hs
@@ -70,7 +70,7 @@ spec = parallel $ do
       rlpSerialize (rlpEncode msg) `shouldBe` rlp
 
     it "matches on serializing RoundChanges" $ do
-      let msg = WireMessage (MsgAuth addr sig) (RoundChange vw)
+      let msg = WireMessage (MsgAuth addr sig) (RoundChange vw 0xdeadbeef)
           (rlp, extra) = B16.decode "f88c03b1f0ce850ccccccccc87a0a0a0a0a0aa0aa00000000000000000000000000000000000000000000000000000000000000000940000000000000000787878787878787878787878b841750650a73723d1e37dcd40dde70fdf4cc3a38694d37c5de66bbbfb3284dbf3e3557cd60f05df24b251ea2d49677bfef397c664374e35bda99bcd603b8be0f11c0180" 
       extra `shouldBe` ""
       msg `shouldBe` rlpDecode (rlpDeserialize rlp)

--- a/core-strato/blockstanbul/test/MessageSpec.hs
+++ b/core-strato/blockstanbul/test/MessageSpec.hs
@@ -70,8 +70,8 @@ spec = parallel $ do
       rlpSerialize (rlpEncode msg) `shouldBe` rlp
 
     it "matches on serializing RoundChanges" $ do
-      let msg = WireMessage (MsgAuth addr sig) (RoundChange vw 0xdeadbeef)
-          (rlp, extra) = B16.decode "f88c03b1f0ce850ccccccccc87a0a0a0a0a0aa0aa00000000000000000000000000000000000000000000000000000000000000000940000000000000000787878787878787878787878b841750650a73723d1e37dcd40dde70fdf4cc3a38694d37c5de66bbbfb3284dbf3e3557cd60f05df24b251ea2d49677bfef397c664374e35bda99bcd603b8be0f11c0180" 
+      let msg = WireMessage (MsgAuth addr sig) (RoundChange vw 0x0)
+          (rlp, extra) = B16.decode "f86c0391d0ce850ccccccccc87a0a0a0a0a0aa0a80940000000000000000787878787878787878787878b841750650a73723d1e37dcd40dde70fdf4cc3a38694d37c5de66bbbfb3284dbf3e3557cd60f05df24b251ea2d49677bfef397c664374e35bda99bcd603b8be0f11c0180" 
       extra `shouldBe` ""
       msg `shouldBe` rlpDecode (rlpDeserialize rlp)
       rlpEncode msg `shouldBe` rlpDeserialize rlp

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -89,6 +89,9 @@ io :: InEvent -> OutEvent
 io (IMsg a msg) = OMsg a msg
 io x = error $ "io: " ++ show x
 
+mkRoundChange :: View -> TrustedMessage
+mkRoundChange vn = RoundChange vn 0xdeadbeef
+
 spec :: Spec
 spec = parallel $ do
   describe "The blockstanbul event loop" $ do
@@ -173,11 +176,11 @@ spec = parallel $ do
         use view `shouldReturn` v2
         -- Lets abort this round
         next <- uses view (over round (+1))
-        let aborts = map (\a -> IMsg a $ RoundChange next) as
+        let aborts = map (\a -> IMsg a $ mkRoundChange next) as
         omsgs5' <- sendMessages aborts
         let omsgs5 = [o | o@(OMsg _ _) <- omsgs5']
             rest5 = omsgs5' \\ omsgs5
-        oMessage (head omsgs5) `shouldBe` RoundChange next
+        oMessage (head omsgs5) `shouldBe` mkRoundChange next
         rest5 `shouldBe` [ResetTimer 21, NewCheckpoint $ Checkpoint next M.empty (map sender as) []]
         use view `shouldReturn` over round (+1) v2
         use proposer `shouldReturn` sender nextPpr
@@ -389,22 +392,22 @@ spec = parallel $ do
         (curView, _) <- setupRound blk . map sender $ [a1, a2, a3]
         next <- uses view (over round (+4))
         let roundNext = _round next
-        sendMessages [IMsg a1 $ RoundChange next] `shouldReturn` [OMsg a1 $ RoundChange next]
+        sendMessages [IMsg a1 $ mkRoundChange next] `shouldReturn` [OMsg a1 $ mkRoundChange next]
         -- 1 vote is not enough
         use pendingRound `shouldReturn` Nothing
         use roundChanged `shouldReturn` M.singleton roundNext (S.singleton (sender a1))
         use view `shouldReturn` curView
         -- 2 votes will be broadcast, but not taken up.
-        omsgs <- sendMessages [IMsg a2 $ RoundChange next]
-        map oMessage omsgs `shouldBe` [RoundChange next, RoundChange next]
+        omsgs <- sendMessages [IMsg a2 $ mkRoundChange next]
+        map oMessage omsgs `shouldBe` [mkRoundChange next, mkRoundChange next]
         use pendingRound `shouldReturn` Just roundNext
         use roundChanged `shouldReturn` M.singleton roundNext (S.fromList [sender a1, sender a2])
         use view `shouldReturn` curView
         -- 3 votes will do it
-        sendMessages [IMsg a3 $ RoundChange next] `shouldReturn`
+        sendMessages [IMsg a3 $ mkRoundChange next] `shouldReturn`
           [ ResetTimer 24
           , NewCheckpoint (Checkpoint next M.empty (sort $ map sender [a1, a2, a3]) [])
-          , OMsg a3 $ RoundChange next
+          , OMsg a3 $ mkRoundChange next
           ]
         use pendingRound `shouldReturn` Nothing
         use roundChanged `shouldReturn` M.empty
@@ -413,9 +416,9 @@ spec = parallel $ do
       runTest $ do
         _ <- setupRound blk [sender a]
         next <- uses view (over round (+1))
-        _ <- sendMessages [IMsg a $ RoundChange next]
+        _ <- sendMessages [IMsg a $ mkRoundChange next]
         use view `shouldReturn` next
-        sendMessages [IMsg a $ RoundChange next] `shouldReturn` []
+        sendMessages [IMsg a $ mkRoundChange next] `shouldReturn` []
         use view `shouldReturn` next
 
     it "Remembers round changes from the future" $ property $ \blk s1 s2 s3 ->
@@ -425,11 +428,11 @@ spec = parallel $ do
         now <- use view
         next <- uses view (over round (+1))
         nextnext <- uses view (over round (+2))
-        _ <- sendMessages [IMsg a2 $ RoundChange nextnext, IMsg a2 $ RoundChange next]
+        _ <- sendMessages [IMsg a2 $ mkRoundChange nextnext, IMsg a2 $ mkRoundChange next]
         use view `shouldReturn` now
-        _ <- sendMessages [IMsg a1 $ RoundChange next, IMsg a3 $ RoundChange next]
+        _ <- sendMessages [IMsg a1 $ mkRoundChange next, IMsg a3 $ mkRoundChange next]
         use view `shouldReturn` next
-        _ <- sendMessages [IMsg a1 $ RoundChange nextnext, IMsg a3 $ RoundChange nextnext]
+        _ <- sendMessages [IMsg a1 $ mkRoundChange nextnext, IMsg a3 $ mkRoundChange nextnext]
         use view `shouldReturn` nextnext
 
   describe "An UnannouncedBlock message" $ do
@@ -503,7 +506,7 @@ spec = parallel $ do
         v <- use view
         omsgs <- sendMessages [IMsg a $ Preprepare v blk]
         next <- uses view (over round (+1))
-        map oMessage omsgs `shouldBe` [RoundChange next]
+        map oMessage omsgs `shouldBe` [mkRoundChange next]
 
     it "Resets the lock after a commit result -- positive or negative" $ property $ \blk as ->
       runTest $ do
@@ -544,12 +547,12 @@ spec = parallel $ do
         me <- use selfAddr
         roundPlus1 <- uses view (over round (+1))
         let roundAndSequencePlus1 = over sequence (+1) roundPlus1
-        resp <- sendMessages [IMsg (MsgAuth me sig) $ RoundChange roundAndSequencePlus1]
+        resp <- sendMessages [IMsg (MsgAuth me sig) $ mkRoundChange roundAndSequencePlus1]
         let omsgs = [o | o@(OMsg _ _) <- resp]
             other = resp \\ omsgs
-        map oMessage omsgs `shouldBe` [ RoundChange roundAndSequencePlus1
+        map oMessage omsgs `shouldBe` [ mkRoundChange roundAndSequencePlus1
                                       , Preprepare roundPlus1 blk
-                                      , RoundChange roundAndSequencePlus1
+                                      , mkRoundChange roundAndSequencePlus1
                                       ]
         other `shouldBe`
           [ResetTimer $ _round roundPlus1

--- a/core-strato/blockstanbul/test/StateMachineSpec.hs
+++ b/core-strato/blockstanbul/test/StateMachineSpec.hs
@@ -180,7 +180,7 @@ spec = parallel $ do
         omsgs5' <- sendMessages aborts
         let omsgs5 = [o | o@(OMsg _ _) <- omsgs5']
             rest5 = omsgs5' \\ omsgs5
-        oMessage (head omsgs5) `shouldBe` mkRoundChange next
+        roundchangeView (oMessage (head omsgs5)) `shouldBe` next
         rest5 `shouldBe` [ResetTimer 21, NewCheckpoint $ Checkpoint next M.empty (map sender as) []]
         use view `shouldReturn` over round (+1) v2
         use proposer `shouldReturn` sender nextPpr
@@ -392,23 +392,26 @@ spec = parallel $ do
         (curView, _) <- setupRound blk . map sender $ [a1, a2, a3]
         next <- uses view (over round (+4))
         let roundNext = _round next
-        sendMessages [IMsg a1 $ mkRoundChange next] `shouldReturn` [OMsg a1 $ mkRoundChange next]
+        [OMsg a1' rc] <- sendMessages [IMsg a1 $ mkRoundChange next]
+        a1' `shouldBe` a1
+        roundchangeView rc `shouldBe` next
         -- 1 vote is not enough
         use pendingRound `shouldReturn` Nothing
         use roundChanged `shouldReturn` M.singleton roundNext (S.singleton (sender a1))
         use view `shouldReturn` curView
         -- 2 votes will be broadcast, but not taken up.
         omsgs <- sendMessages [IMsg a2 $ mkRoundChange next]
-        map oMessage omsgs `shouldBe` [mkRoundChange next, mkRoundChange next]
+        map (roundchangeView . oMessage) omsgs `shouldBe` [next, next]
         use pendingRound `shouldReturn` Just roundNext
         use roundChanged `shouldReturn` M.singleton roundNext (S.fromList [sender a1, sender a2])
         use view `shouldReturn` curView
         -- 3 votes will do it
-        sendMessages [IMsg a3 $ mkRoundChange next] `shouldReturn`
-          [ ResetTimer 24
-          , NewCheckpoint (Checkpoint next M.empty (sort $ map sender [a1, a2, a3]) [])
-          , OMsg a3 $ mkRoundChange next
-          ]
+        omsgs' <- sendMessages [IMsg a3 $ mkRoundChange next]
+        omsgs' !! 0 `shouldBe` ResetTimer 24
+        omsgs' !! 1 `shouldBe` NewCheckpoint (Checkpoint next M.empty (sort $ map sender [a1, a2, a3]) [])
+        let OMsg a3' rc' = omsgs' !! 2
+        a3' `shouldBe` a3
+        roundchangeView rc' `shouldBe` next
         use pendingRound `shouldReturn` Nothing
         use roundChanged `shouldReturn` M.empty
         use view `shouldReturn` next
@@ -506,7 +509,7 @@ spec = parallel $ do
         v <- use view
         omsgs <- sendMessages [IMsg a $ Preprepare v blk]
         next <- uses view (over round (+1))
-        map oMessage omsgs `shouldBe` [mkRoundChange next]
+        map (roundchangeView . oMessage) omsgs `shouldBe` [next]
 
     it "Resets the lock after a commit result -- positive or negative" $ property $ \blk as ->
       runTest $ do
@@ -550,10 +553,9 @@ spec = parallel $ do
         resp <- sendMessages [IMsg (MsgAuth me sig) $ mkRoundChange roundAndSequencePlus1]
         let omsgs = [o | o@(OMsg _ _) <- resp]
             other = resp \\ omsgs
-        map oMessage omsgs `shouldBe` [ mkRoundChange roundAndSequencePlus1
-                                      , Preprepare roundPlus1 blk
-                                      , mkRoundChange roundAndSequencePlus1
-                                      ]
+        roundchangeView (oMessage (omsgs !! 0)) `shouldBe` roundAndSequencePlus1
+        oMessage (omsgs !! 1) `shouldBe` Preprepare roundPlus1 blk
+        roundchangeView (oMessage (omsgs !! 2)) `shouldBe` roundAndSequencePlus1
         other `shouldBe`
           [ResetTimer $ _round roundPlus1
           , NewCheckpoint (Checkpoint roundPlus1 M.empty [me] [])]

--- a/core-strato/strato-p2p/src/Blockchain/Data/Wire.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Data/Wire.hs
@@ -330,7 +330,7 @@ wireMessage2Obj (Blockstanbul wm@PBFT.WireMessage{PBFT._message=msg}) =
      PBFT.Preprepare _ _ -> (0x18, rlpEncode wm)
      PBFT.Prepare _ _ -> (0x19, rlpEncode wm)
      PBFT.Commit _ _ _ -> (0x1a, rlpEncode wm)
-     PBFT.RoundChange _ -> (0x1b, rlpEncode wm)
+     PBFT.RoundChange _ _ -> (0x1b, rlpEncode wm)
 
 -- private chains
 wireMessage2Obj (GetChainDetails cIds) =

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -32,6 +32,7 @@ import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Text (Text)
+import qualified Data.Text                             as T
 import           Text.Printf
 
 import           Blockchain.Blockstanbul
@@ -78,6 +79,7 @@ import           Test.QuickCheck
 import           UnliftIO
 import           UnliftIO.Concurrent                   (threadDelay)
 
+type WMRef = IORef (S.OSet Keccak256)
 
 data TestContext = TestContext
   { _blocks                :: [Block]
@@ -101,7 +103,7 @@ data TestContext = TestContext
   , _genesisBlockHash      :: GenesisBlockHash
   , _bestBlockNumber       :: BestBlockNumber
   , _stringPPeerMap        :: Map String DataPeer.PPeer
-  , _pbftMessages          :: IORef (S.OSet Keccak256)
+  , _pbftMessages          :: WMRef
   , _outboundPbftMessages  :: S.OSet (Text, Keccak256)
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
@@ -320,15 +322,22 @@ instance MonadIO m => HasVault (MonadTest m) where
     pk <- use prvKey
     return $ deriveSharedKey pk pub
 
-instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
+instance (MonadLogger m, MonadIO m) => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
   lookup _  k = do
     wms <- readIORef =<< use pbftMessages
+    $logErrorS "WIRE_MESSAGES_REF_LOOKUP" $ T.pack $ show wms
     pure $ if S.member k wms then Just (A.Proxy @(Inbound WireMessage)) else Nothing
-  insert _ k _ = use pbftMessages >>= flip atomicModifyIORef' (\wms ->
-    let s = S.size wms
-        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
-        wms'' = wms' S.>| k
-     in (wms'', ()))
+  insert _ k _ = do
+    r <- use pbftMessages
+    ms <- readIORef r
+    $logErrorS "WIRE_MESSAGES_REF_PRE_INSERT" $ T.pack $ show ms
+    atomicModifyIORef' r (\wms ->
+      let s = S.size wms
+          wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+          wms'' = wms' S.>| k
+       in (wms'', ()))
+    ms' <- readIORef r
+    $logErrorS "WIRE_MESSAGES_REF_POST_INSERT" $ T.pack $ show ms'
   delete _ k = use pbftMessages >>= flip atomicModifyIORef' (\wms -> (S.delete k wms, ()))
 
 instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessage))) (MonadTest m) where
@@ -377,7 +386,7 @@ newSequencerContext bc = do
 
 -- testContext is useful for testing because it doesn't require
 -- Kafka, postgres, redis, or ethconf.
-testContext :: IORef (S.OSet Keccak256) -> PrivateKey -> SequencerContext -> TestContext
+testContext :: WMRef -> PrivateKey -> SequencerContext -> TestContext
 testContext wireMessagesRef prv ctx = TestContext
   { _blocks                = []
   , _blockHeaders          = []
@@ -417,6 +426,7 @@ runTestPeer f = do
   void . runNoLoggingT . runResourceT $ runReaderT f ctx
 
 execTestPeer :: PrivateKey
+             -> WMRef
              -> [Address]
              -> TestContextM a
              -> IO (a, TestContext)
@@ -424,12 +434,12 @@ execTestPeer = execTestPeerOnRound 0
 
 execTestPeerOnRound :: Word256
                     -> PrivateKey
+                    -> WMRef
                     -> [Address]
                     -> TestContextM a
                     -> IO (a, TestContext)
-execTestPeerOnRound n pk as f = do
+execTestPeerOnRound n pk wmr as f = do
   seqCtx <- newSequencerContext $ (view . round .~ n) (newBlockstanbulContext (fromPrivateKey pk) as)
-  wmr <- newIORef (S.empty)
   ctx <- newIORef $ testContext wmr pk seqCtx
   a <- runLoggingT . runResourceT $ runReaderT f ctx
   ctx' <- readIORef ctx
@@ -445,6 +455,7 @@ execTestPeerWithContext f ctx = do
 data P2PPeer m = P2PPeer
   { _p2pPeerPrivKey     :: PrivateKey
   , _p2pPeerPPeer       :: DataPeer.PPeer
+  , _p2pPeerWireMessageRef :: WMRef
   , _p2pPeerUnseqSource :: TQueue SeqLoopEvent
   , _p2pPeerSeqSource   :: TMChan P2pEvent
   , _p2pPeerUnseqSink   :: [IngestEvent] -> m ()
@@ -459,6 +470,7 @@ createPeer :: Seq.MonadSequencer m
            -> IO (P2PPeer m)
 createPeer unseqSink name ipAddr = do
   privKey <- newPrivateKey
+  wmr <- newIORef (S.empty)
   unseqSource <- newTQueueIO
   seqSource <- newBroadcastTMChanIO
   let sequencer = runConduit $ sourceTQueue unseqSource
@@ -476,6 +488,7 @@ createPeer unseqSink name ipAddr = do
   pure $ P2PPeer
     privKey
     ppeer
+    wmr
     unseqSource
     seqSource
     unseq
@@ -520,12 +533,14 @@ createConnection server client = do
     runServer
     runClient
 
-runConnectionWith :: (PrivateKey -> m (Maybe SomeException) -> IO b) 
+runConnectionWith :: (PrivateKey -> WMRef -> m (Maybe SomeException) -> IO b) 
                   -> P2PConnection m 
                   -> IO (b, b)
 runConnectionWith f connection =
-  let runServer = f (_p2pPeerPrivKey (_serverP2PPeer connection)) $ _runServer connection
-      runClient = f (_p2pPeerPrivKey (_clientP2PPeer connection)) $ _runClient connection
+  let server = _serverP2PPeer connection
+      client = _clientP2PPeer connection
+      runServer = f (_p2pPeerPrivKey server) (_p2pPeerWireMessageRef server) $ _runServer connection
+      runClient = f (_p2pPeerPrivKey client) (_p2pPeerWireMessageRef client) $ _runClient connection
    in concurrently runServer runClient
 
 makeValidators :: [P2PPeer m] -> [Address]
@@ -553,7 +568,7 @@ spec = do
             ContractCreationTX{} -> tx{transactionChainId = Nothing}
             PrivateHashTX{} -> tx
       otx <- (\o -> o{otBaseTx = clearChainId (otBaseTx o), otOrigin = Origin.API}) <$> liftIO (generate arbitrary)
-      let runForTwoSeconds pk = execTestPeer pk validatorAddresses . timeout 2000000
+      let runForTwoSeconds pk wmr = execTestPeer pk wmr validatorAddresses . timeout 2000000
           run = runConnectionWith runForTwoSeconds connection
           postTx = threadDelay 500000 >> (atomically $ writeTMChan (_p2pPeerSeqSource server) (P2pTx otx))
       ((_, serverCtx), (_, clientCtx)) <- fst <$> concurrently run postTx
@@ -586,9 +601,9 @@ spec = do
         ]
       let validators' = take 2 peers
           validatorAddresses = makeValidators validators'
-          runForTwoSeconds :: PrivateKey -> TestContextM a -> IO TestContext
-          runForTwoSeconds pk = fmap snd . execTestPeer pk validatorAddresses . timeout 2000000
-          runSequencers = mapConcurrently (\p -> runForTwoSeconds (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) peers
+          runForTwoSeconds :: PrivateKey -> WMRef -> TestContextM a -> IO TestContext
+          runForTwoSeconds pk wmr = fmap snd . execTestPeer pk wmr validatorAddresses . timeout 2000000
+          runSequencers = mapConcurrently (\p -> runForTwoSeconds (_p2pPeerPrivKey p) (_p2pPeerWireMessageRef p) (_p2pPeerSequencer p)) peers
           runConnections = mapConcurrently (runConnectionWith runForTwoSeconds) connections
           postTimeout = do
             threadDelay 1000000
@@ -603,29 +618,25 @@ spec = do
         [ ("node1", "1.2.3.4")
         , ("node2", "5.6.7.8")
         , ("node3", "9.10.11.12")
-        , ("node4", "13.14.15.16")
         ]
       connections <- traverse (uncurry createConnection)
         [ (peers !! 0, peers !! 1)
         , (peers !! 0, peers !! 2)
-        , (peers !! 0, peers !! 3)
         , (peers !! 1, peers !! 2)
-        , (peers !! 1, peers !! 3)
-        , (peers !! 2, peers !! 3)
         ]
       let validators' = peers
           primaryValidators = [head validators']
           secondaryValidators = tail validators'
           primaryValidatorAddresses = makeValidators primaryValidators
           validatorAddresses = makeValidators validators'
-          runForTwoSecondsPrimary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
-          runForTwoSecondsPrimary n pk = fmap snd . execTestPeerOnRound n pk primaryValidatorAddresses . timeout 2000000
-          runForTwoSecondsSecondary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
-          runForTwoSecondsSecondary n pk = fmap snd . execTestPeerOnRound n pk validatorAddresses . timeout 2000000
+          runForTwoSecondsPrimary :: Word256 -> PrivateKey -> WMRef -> TestContextM a -> IO TestContext
+          runForTwoSecondsPrimary n pk wmr = fmap snd . execTestPeerOnRound n pk wmr primaryValidatorAddresses . timeout 2000000
+          runForTwoSecondsSecondary :: Word256 -> PrivateKey -> WMRef -> TestContextM a -> IO TestContext
+          runForTwoSecondsSecondary n pk wmr = fmap snd . execTestPeerOnRound n pk wmr validatorAddresses . timeout 2000000
           runForTwoSecondsWithContext :: TestContext -> TestContextM a -> IO TestContext
           runForTwoSecondsWithContext ctx = fmap snd . flip execTestPeerWithContext ctx . timeout 2000000
-          runSequencersPrimary1 = mapConcurrently (\p -> runForTwoSecondsPrimary 0 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) primaryValidators
-          runSequencersSecondary = mapConcurrently (\p -> runForTwoSecondsSecondary 1000 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) secondaryValidators
+          runSequencersPrimary1 = mapConcurrently (\p -> runForTwoSecondsPrimary 0 (_p2pPeerPrivKey p) (_p2pPeerWireMessageRef p) (_p2pPeerSequencer p)) primaryValidators
+          runSequencersSecondary = mapConcurrently (\p -> runForTwoSecondsSecondary 1000 (_p2pPeerPrivKey p) (_p2pPeerWireMessageRef p) (_p2pPeerSequencer p)) secondaryValidators
           runSequencers1 = concurrently runSequencersPrimary1 runSequencersSecondary
           runSequencers2 ctxs = mapConcurrently (\(ctx, p) -> runForTwoSecondsWithContext ((sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses) ctx) (_p2pPeerSequencer p)) $ zip ctxs peers
           runConnections = mapConcurrently (runConnectionWith $ runForTwoSecondsSecondary 0) connections
@@ -639,9 +650,9 @@ spec = do
             threadDelay 1000000
             for_ secondaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 1000))
       ctxs1 <- uncurry (++) . fst <$> concurrently runSequencers1 (concurrently runConnections $ concurrently postTimeoutPrimary1 postTimeoutSecondary)
-      ifor_ ctxs1 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just (1 :: Word256) else Just 1001)
+      ifor_ ctxs1 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just (1 :: Word256) else Just 1000)
       ctxs2 <- fst <$> concurrently (runSequencers2 ctxs1) (concurrently runConnections $ concurrently postTimeoutPrimary2 postTimeoutSecondary)
-      ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just 1 else Just 1001 :: Maybe Word256)
+      ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1001 :: Maybe Word256)
   
   describe "handleEvents" $ do
     it "should pong a ping" $

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -32,7 +32,6 @@ import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Text (Text)
-import qualified Data.Text                             as T
 import           Text.Printf
 
 import           Blockchain.Blockstanbul
@@ -322,22 +321,15 @@ instance MonadIO m => HasVault (MonadTest m) where
     pk <- use prvKey
     return $ deriveSharedKey pk pub
 
-instance (MonadLogger m, MonadIO m) => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
+instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
   lookup _  k = do
     wms <- readIORef =<< use pbftMessages
-    $logErrorS "WIRE_MESSAGES_REF_LOOKUP" $ T.pack $ show wms
     pure $ if S.member k wms then Just (A.Proxy @(Inbound WireMessage)) else Nothing
-  insert _ k _ = do
-    r <- use pbftMessages
-    ms <- readIORef r
-    $logErrorS "WIRE_MESSAGES_REF_PRE_INSERT" $ T.pack $ show ms
-    atomicModifyIORef' r (\wms ->
-      let s = S.size wms
-          wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
-          wms'' = wms' S.>| k
-       in (wms'', ()))
-    ms' <- readIORef r
-    $logErrorS "WIRE_MESSAGES_REF_POST_INSERT" $ T.pack $ show ms'
+  insert _ k _ = use pbftMessages >>= flip atomicModifyIORef' (\wms ->
+    let s = S.size wms
+        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+        wms'' = wms' S.>| k
+     in (wms'', ()))
   delete _ k = use pbftMessages >>= flip atomicModifyIORef' (\wms -> (S.delete k wms, ()))
 
 instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessage))) (MonadTest m) where
@@ -612,7 +604,7 @@ spec = do
       ifor_ ctxs $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1 :: Maybe Word256)
   
 
-    fit "should update the round number after failing on a divided network first" $ do
+    it "should update the round number after failing on a divided network first" $ do
       let unseqSink = (unseqEvents %=) . (++)
       peers <- traverse (uncurry $ createPeer unseqSink)
         [ ("node1", "1.2.3.4")

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -11,9 +11,10 @@
 {-# LANGUAGE TypeOperators         #-}
 module EventSpec where
 
+import           Prelude hiding (round)
 import           Conduit
 import           Control.Concurrent.STM.TMChan
-import           Control.Lens                          hiding (Context)
+import           Control.Lens                          hiding (Context, view)
 import qualified Control.Monad.Change.Alter            as A
 import qualified Control.Monad.Change.Modify           as Mod
 import           Control.Monad.Reader
@@ -27,6 +28,7 @@ import           Data.Default                          (def)
 import           Data.Foldable                         (for_, toList)
 import           Data.Map.Strict                       (Map)
 import qualified Data.Map.Strict                       as M
+import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Text (Text)
@@ -34,6 +36,7 @@ import           Text.Printf
 
 import           Blockchain.Blockstanbul
 import           Blockchain.Blockstanbul.HTTPAdmin
+import           Blockchain.Blockstanbul.Messages      (round)
 import           Blockchain.Blockstanbul.StateMachine
 import           Blockchain.Context                    hiding (actionTimestamp, blockHeaders, remainingBlockHeaders)
 import           Blockchain.Data.ArbitraryInstances()
@@ -417,12 +420,26 @@ execTestPeer :: PrivateKey
              -> [Address]
              -> TestContextM a
              -> IO (a, TestContext)
-execTestPeer pk as f = do
-  seqCtx <- newSequencerContext $ newBlockstanbulContext (fromPrivateKey pk) as
+execTestPeer = execTestPeerOnRound 0
+
+execTestPeerOnRound :: Word256
+                    -> PrivateKey
+                    -> [Address]
+                    -> TestContextM a
+                    -> IO (a, TestContext)
+execTestPeerOnRound n pk as f = do
+  seqCtx <- newSequencerContext $ (view . round .~ n) (newBlockstanbulContext (fromPrivateKey pk) as)
   wmr <- newIORef (S.empty)
   ctx <- newIORef $ testContext wmr pk seqCtx
   a <- runLoggingT . runResourceT $ runReaderT f ctx
   ctx' <- readIORef ctx
+  return (a, ctx')
+
+execTestPeerWithContext :: TestContextM a -> TestContext -> IO (a, TestContext)
+execTestPeerWithContext f ctx = do
+  ref <- newIORef ctx
+  a <- runLoggingT . runResourceT $ runReaderT f ref
+  ctx' <- readIORef ref
   return (a, ctx')
 
 data P2PPeer m = P2PPeer
@@ -543,6 +560,7 @@ spec = do
       _unseqEvents serverCtx `shouldBe` []
       let clientTxs = [t | IETx _ (IngestTx _ t) <- _unseqEvents clientCtx]
       clientTxs `shouldBe` [otBaseTx otx]
+
     it "should update the round number on every node in the network" $ do
       let unseqSink = (unseqEvents %=) . (++)
       peers <- traverse (uncurry $ createPeer unseqSink)
@@ -577,6 +595,54 @@ spec = do
             for_ validators' (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
       ctxs <- fst <$> concurrently runSequencers (concurrently runConnections postTimeout)
       ifor_ ctxs $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1 :: Maybe Word256)
+  
+
+    fit "should update the round number after failing on a divided network first" $ do
+      let unseqSink = (unseqEvents %=) . (++)
+      peers <- traverse (uncurry $ createPeer unseqSink)
+        [ ("node1", "1.2.3.4")
+        , ("node2", "5.6.7.8")
+        , ("node3", "9.10.11.12")
+        , ("node4", "13.14.15.16")
+        ]
+      connections <- traverse (uncurry createConnection)
+        [ (peers !! 0, peers !! 1)
+        , (peers !! 0, peers !! 2)
+        , (peers !! 0, peers !! 3)
+        , (peers !! 1, peers !! 2)
+        , (peers !! 1, peers !! 3)
+        , (peers !! 2, peers !! 3)
+        ]
+      let validators' = peers
+          primaryValidators = [head validators']
+          secondaryValidators = tail validators'
+          primaryValidatorAddresses = makeValidators primaryValidators
+          validatorAddresses = makeValidators validators'
+          runForTwoSecondsPrimary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
+          runForTwoSecondsPrimary n pk = fmap snd . execTestPeerOnRound n pk primaryValidatorAddresses . timeout 2000000
+          runForTwoSecondsSecondary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
+          runForTwoSecondsSecondary n pk = fmap snd . execTestPeerOnRound n pk validatorAddresses . timeout 2000000
+          runForTwoSecondsWithContext :: TestContext -> TestContextM a -> IO TestContext
+          runForTwoSecondsWithContext ctx = fmap snd . flip execTestPeerWithContext ctx . timeout 2000000
+          runSequencersPrimary1 = mapConcurrently (\p -> runForTwoSecondsPrimary 0 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) primaryValidators
+          runSequencersSecondary = mapConcurrently (\p -> runForTwoSecondsSecondary 1000 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) secondaryValidators
+          runSequencers1 = concurrently runSequencersPrimary1 runSequencersSecondary
+          runSequencers2 ctxs = mapConcurrently (\(ctx, p) -> runForTwoSecondsWithContext ((sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses) ctx) (_p2pPeerSequencer p)) $ zip ctxs peers
+          runConnections = mapConcurrently (runConnectionWith $ runForTwoSecondsSecondary 0) connections
+          postTimeoutPrimary1 = do
+            threadDelay 1000000
+            for_ primaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
+          postTimeoutPrimary2 = do
+            threadDelay 1000000
+            for_ primaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 1))
+          postTimeoutSecondary = do
+            threadDelay 1000000
+            for_ secondaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 1000))
+      ctxs1 <- uncurry (++) . fst <$> concurrently runSequencers1 (concurrently runConnections $ concurrently postTimeoutPrimary1 postTimeoutSecondary)
+      ifor_ ctxs1 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just (1 :: Word256) else Just 1001)
+      ctxs2 <- fst <$> concurrently (runSequencers2 ctxs1) (concurrently runConnections $ concurrently postTimeoutPrimary2 postTimeoutSecondary)
+      ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just 1 else Just 1001 :: Maybe Word256)
+  
   describe "handleEvents" $ do
     it "should pong a ping" $
       runTestPeer $ do


### PR DESCRIPTION
This is the second option for fixing the round number bug: adding a nonce field to the RoundChange message type. It fixes the problem because each RoundChange message triggered by a new timeout in the sequencer gets a different nonce, therefore giving the message a different hash. This allows round change retries to pass through peers' message filters, since the filter watches for message hashes, rather than just the round number contained in the message. This change was less invasive, and shouldn't have any impact on performance, but it introduces a (slight) change to the wire message.