### PR TITLE
Detect cycles in code ptrs

### DIFF
--- a/core-strato/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
@@ -29,6 +29,7 @@ import           Control.Monad
 import           Control.Monad.Change.Alter
 import           Data.Default
 import           Data.Maybe                         (maybeToList)
+import qualified Data.Set                           as Set
 
 import           Control.DeepSeq
 import           GHC.Generics
@@ -43,7 +44,7 @@ import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.Strato.Model.CodePtr
 import           Blockchain.Util
-import qualified Text.Colors                      as CL
+import qualified Text.Colors                        as CL
 import           Text.Format
 
 data AddressState =
@@ -102,22 +103,29 @@ instance RLPSerializable AddressState where
     resolveCodePtr fails when there is a circular reference of code pointers on the same chain
     possible solution is to have a helper function that keeps track of all previously visited codepointers and termiantes if it visits the same one twice (aka cycle detection)
 --}
-resolveCodePtr :: ( Selectable (Maybe Word256) ParentChainId m
+resolveCodePtr' :: ( Selectable (Maybe Word256) ParentChainId m
                   , (Account `Alters` AddressState) m
                   )
-               => Maybe Word256 -> CodePtr -> m (Maybe CodePtr)
-resolveCodePtr chainId (CodeAtAccount acct name) = do
+               => Set.Set CodePtr -> Maybe Word256 -> CodePtr -> m (Maybe CodePtr)
+resolveCodePtr' visited chainId (CodeAtAccount acct name) = do
   lookup Proxy acct >>= \case
     Nothing -> pure Nothing
     Just AddressState{..} -> do
       let codeAccountChainId = (acct ^. accountChainId)
       isAccessibleChain <- codeAccountChainId `isAncestorChainOf` chainId
-      if isAccessibleChain
-        then resolveCodePtr codeAccountChainId addressStateCodeHash >>= \case
+      if isAccessibleChain && (Set.notMember addressStateCodeHash visited)
+        then resolveCodePtr' (Set.insert addressStateCodeHash visited) codeAccountChainId addressStateCodeHash >>= \case
           Just e@(EVMCode _) -> pure $ Just e
           Just (SolidVMCode _ d) -> pure . Just $ SolidVMCode name d
           _ -> pure Nothing
         else pure Nothing
+resolveCodePtr' _ cid cp = resolveCodePtr cid cp
+   
+resolveCodePtr :: ( Selectable (Maybe Word256) ParentChainId m
+                  , (Account `Alters` AddressState) m
+                  )
+               => Maybe Word256 -> CodePtr -> m (Maybe CodePtr)
+resolveCodePtr chainId coa@(CodeAtAccount _ _) = resolveCodePtr' Set.empty chainId coa
 
 -- for solidVM/EVM code
 resolveCodePtr _ cp = pure $ Just cp

--- a/core-strato/blockapps-mpdbs/test/StorageSpec.hs
+++ b/core-strato/blockapps-mpdbs/test/StorageSpec.hs
@@ -321,3 +321,18 @@ storageSpec = do
                       , CodeAtAccount (accts !! 1) "Ptr_1"]
       insertMany (Proxy @AddressState) . M.fromList $ zip accts $ map (\cp -> blankAddressState{addressStateCodeHash = cp}) codePtrs
       resolveCodePtr (Just 2) (codePtrs !! 2) `shouldReturn` Nothing
+    it "should detect cycles in codeptrs (pointer1 to pointer2, pointer2 to pointer1)" . runStorM $ do
+      let chainRelationships = [ (Just (0 :: Word256), ParentChainId $ Nothing)
+                               , (Just (1 :: Word256), ParentChainId $ Just 0)
+                               ]
+      insertMany (Proxy @ParentChainId) $ M.fromList chainRelationships
+      let accts = [ Account 0xabc (Just 0)
+                  , Account 0xdef (Just 0)
+                  , Account 0xfff (Just 1)
+                  ]
+      let codePtrs = [ CodeAtAccount (accts !! 1) "Ptr_0"
+                     , CodeAtAccount (accts !! 0) "Ptr_1"
+                     , CodeAtAccount (accts !! 0) "Ptr_2"
+                     ]
+      insertMany (Proxy @AddressState) . M.fromList $ zip accts $ map (\cp -> blankAddressState{addressStateCodeHash = cp}) codePtrs
+      resolveCodePtr (Just 1) (codePtrs !! 2) `shouldReturn` Nothing


### PR DESCRIPTION
Ok, so this is actually a patch for my first platform bug 😁 However its really a patch for a non-issue, but if in the future we open up codeptrs to be usable in more than just governance contracts, than this function will be ready for that and won't need to be changed (in theory).
Basically this fixes codeptrs possibly pointing to each other, but for reasons explained in my comment on the corresponding Jira ticket (https://blockapps.atlassian.net/browse/STRATO-2050), this basically is impossible.
¯\\\_(ツ)_/¯