### PR TITLE
User's can access chainID from account type directly in solidVM

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1178,8 +1178,8 @@ expToVar' x@(Xabi.MemberAccess _ expr name) = do
           ps -> do
             addr <- accountOnUnspecifiedChain <$> getCurrentAccount
             return $ Constant $ SContractFunction (Just $ _contractName $ last ps) addr method
-      (SAccount a, "chainID") ->  case (a ^. namedAccountChainId) of
-        UnspecifiedChain ->  internalError "Can't access the ChainID of an account with an unspecified ChainID"  (a)
+      (SAccount a, "chainId") ->  case (a ^. namedAccountChainId) of
+        UnspecifiedChain ->  internalError "Can't access the ChainId of an account with an unspecified ChainID"  (a)
         MainChain ->  return $ Constant $ SInteger 0 
         ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
       (SAccount addr, itemName) -> return $ Constant $ SContractItem addr itemName

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -92,7 +92,8 @@ import           Blockchain.SolidVM.SM
 import qualified Text.Colors                          as C
 import           Text.Format
 import           Text.Tools
-
+import           Blockchain.Strato.Model.ExtendedWord()
+import           Numeric  (showHex)
 import qualified SolidVM.Model.Storable as MS
 
 import           SolidVM.Solidity.Parse.Statement
@@ -1177,7 +1178,10 @@ expToVar' x@(Xabi.MemberAccess _ expr name) = do
           ps -> do
             addr <- accountOnUnspecifiedChain <$> getCurrentAccount
             return $ Constant $ SContractFunction (Just $ _contractName $ last ps) addr method
-
+      (SAccount a, "chainID") ->  case (a ^. namedAccountChainId) of
+        UnspecifiedChain ->  internalError "Can't access the ChainID of an account with an unspecified ChainID"  (0 :: Integer)
+        MainChain ->  return $ Constant $ SInteger 0 
+        ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
       (SAccount addr, itemName) -> return $ Constant $ SContractItem addr itemName
 
       (SContract _ a, funcName) -> return $ Constant $ SContractFunction Nothing a funcName

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1179,7 +1179,7 @@ expToVar' x@(Xabi.MemberAccess _ expr name) = do
             addr <- accountOnUnspecifiedChain <$> getCurrentAccount
             return $ Constant $ SContractFunction (Just $ _contractName $ last ps) addr method
       (SAccount a, "chainID") ->  case (a ^. namedAccountChainId) of
-        UnspecifiedChain ->  internalError "Can't access the ChainID of an account with an unspecified ChainID"  (0 :: Integer)
+        UnspecifiedChain ->  internalError "Can't access the ChainID of an account with an unspecified ChainID"  (a)
         MainChain ->  return $ Constant $ SInteger 0 
         ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
       (SAccount addr, itemName) -> return $ Constant $ SContractItem addr itemName

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1179,7 +1179,11 @@ expToVar' x@(Xabi.MemberAccess _ expr name) = do
             addr <- accountOnUnspecifiedChain <$> getCurrentAccount
             return $ Constant $ SContractFunction (Just $ _contractName $ last ps) addr method
       (SAccount a, "chainId") ->  case (a ^. namedAccountChainId) of
-        UnspecifiedChain ->  internalError "Can't access the ChainId of an account with an unspecified ChainID"  (a)
+        UnspecifiedChain ->  do 
+          cid2 <- view accountChainId <$> getCurrentAccount
+          case cid2 of
+            Nothing -> return $ Constant $ SInteger 0 
+            Just cid3 -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid3
         MainChain ->  return $ Constant $ SInteger 0 
         ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
       (SAccount addr, itemName) -> return $ Constant $ SContractItem addr itemName

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/Value.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/Value.hs
@@ -243,7 +243,7 @@ createDefaultValue _ x = todo "createDefaultValue" x
 
 
 {-
-byteStringToValue :: ByteString -> Maybe Value
+byteStringToValue :: B.ByteString -> Maybe Value
 byteStringToValue x | x == B.singleton 128 = Nothing
 byteStringToValue x = Just . SInteger . rlpDecode . rlpDeserialize $ x
 

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -2894,29 +2894,24 @@ contract qq {
 contract qq {
   account a1;
   account a2;
+  account a3;
   uint cid1;
   uint cid2;
-  constructor() public {
-    a1 = account(0xdeadbeef, 0xfeedbeef);
-    a2 = account(0x123, "main");
-    cid1 = a1.chainId;
-    cid2 = a2.chainId;
-  }
-}|]
-    getFields ["cid1", "cid2"] `shouldReturn`
-      [ BInteger 0xfeedbeef
-      , BInteger 0
-      ]
-
-  it "can't access the chainId of an account with an Unknown ChainID" $ (runTest (runBS [r|
-contract qq {
-  account a3;
   uint cid3;
   constructor() public {
+    a1 = account(0xdeadbeef, 0xfeedbeef);
+    a2 = account(0x123, "main");    
     a3 = account(0x124);
+    cid1 = a1.chainId;
+    cid2 = a2.chainId;
     cid3 = a3.chainId;
   }
-}|])) `shouldThrow` anyInternalError 
+}|]
+    getFields ["cid1", "cid2", "cid3"] `shouldReturn`
+      [ BInteger 0xfeedbeef
+      , BInteger 0
+      , BInteger 0
+      ]
 
   it "can parse an X509 certificate" . runTest $ do
     runBS [r|

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -2889,7 +2889,7 @@ contract qq {
       , BBool True
       , BDefault
       ]
-  it "can get the chainID from the account type" . runTest $ do
+  it "can get the chainId from the account type" . runTest $ do
     runBS [r|
 contract qq {
   account a1;
@@ -2899,8 +2899,8 @@ contract qq {
   constructor() public {
     a1 = account(0xdeadbeef, 0xfeedbeef);
     a2 = account(0x123, "main");
-    cid1 = a1.chainID;
-    cid2 = a2.chainID;
+    cid1 = a1.chainId;
+    cid2 = a2.chainId;
   }
 }|]
     getFields ["cid1", "cid2"] `shouldReturn`
@@ -2908,13 +2908,13 @@ contract qq {
       , BInteger 0
       ]
 
-  it "can't access the chainID of an account with an Unknown ChainID" $ (runTest (runBS [r|
+  it "can't access the chainId of an account with an Unknown ChainID" $ (runTest (runBS [r|
 contract qq {
   account a3;
   uint cid3;
   constructor() public {
     a3 = account(0x124);
-    cid3 = a3.chainID;
+    cid3 = a3.chainId;
   }
 }|])) `shouldThrow` anyInternalError 
 

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -77,6 +77,10 @@ anyInvalidWriteError :: Selector HandledException
 anyInvalidWriteError (HE Blockchain.SolidVM.Exception.InvalidWrite{}) = True
 anyInvalidWriteError _ = False
 
+anyInternalError :: Selector HandledException
+anyInternalError (HE Blockchain.SolidVM.Exception.InternalError{}) = True
+anyInternalError _ = False
+
 anyIndexOOBError :: Selector HandledException
 anyIndexOOBError (HE Blockchain.SolidVM.Exception.IndexOutOfBounds{}) = True
 anyIndexOOBError _ = False
@@ -2885,6 +2889,34 @@ contract qq {
       , BBool True
       , BDefault
       ]
+  it "can get the chainID from the account type" . runTest $ do
+    runBS [r|
+contract qq {
+  account a1;
+  account a2;
+  uint cid1;
+  uint cid2;
+  constructor() public {
+    a1 = account(0xdeadbeef, 0xfeedbeef);
+    a2 = account(0x123, "main");
+    cid1 = a1.chainID;
+    cid2 = a2.chainID;
+  }
+}|]
+    getFields ["cid1", "cid2"] `shouldReturn`
+      [ BInteger 0xfeedbeef
+      , BInteger 0
+      ]
+
+  it "can't access the chainID of an account with an Unknown ChainID" $ (runTest (runBS [r|
+contract qq {
+  account a3;
+  uint cid3;
+  constructor() public {
+    a3 = account(0x124);
+    cid3 = a3.chainID;
+  }
+}|])) `shouldThrow` anyInternalError 
 
   it "can parse an X509 certificate" . runTest $ do
     runBS [r|


### PR DESCRIPTION
This PR adds the functionality for users to access the chainID of an account type in solidVM 