### PR TITLE
recursively resolve variables in getVar, add return value log statement

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -885,9 +885,10 @@ runStatement (Xabi.Return maybeExpression pos) = do
   solidVMBreakpoint pos
   case maybeExpression of
     Just e -> do
-      ql <- expToVar e
-      qlql <- getVar ql
-      return $ Just qlql
+      var <- expToVar e
+      var' <- getVar var
+      onTraced $ liftIO $ putStrLn $ (C.green ">> Returned value: ") ++ show var'
+      return $ Just var'
 --      fmap Just $ getVar =<< expToVar e
     Nothing -> return $ Just SNULL
 
@@ -1874,9 +1875,8 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro = do
 --  forM_ locals $ \(n, (_, v)) -> do
 --    liftIO $ putStrLn "need to initialize the storage 2"
 --    initializeStorage (AddressedPath (Left LocalVar) . MS.singleton $ BC.pack n) v
-  let !commands = fromMaybe (missingField "function call: function has been declared but not defined" funcName) $ Xabi.funcContents theFunction
+  let !commands = fromMaybe (missingField "Function call: function has been declared but not defined" funcName) $ Xabi.funcContents theFunction
   val <- runStatements commands
-
   let findNamedReturns = do
         case returns of
           [] -> return Nothing
@@ -1895,7 +1895,6 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro = do
               case mReturnVar of
                 Nothing -> unknownVariable "findNamedReturns" name
                 Just returnVar -> Constant <$> getVar (snd returnVar)
-
   val' <- case val of
              Nothing -> findNamedReturns
              Just SNULL -> findNamedReturns

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -224,7 +224,41 @@ getVar (Constant (SReference addressedPath@(AccountPath addr key))) = do
                 Xabi.String{} -> return . SString $ UTF8.toString bs
                 _             -> return $ fromBasic theValue
     _ -> return $ fromBasic theValue
+
+getVar (Constant (SStruct s ma)) = do
+  resolved <- mapM (\var -> do
+      v <- getVar var
+      return $ Constant v
+    ) ma
+  return $ SStruct s resolved
+
+getVar (Constant (SArray typ vc)) = do
+  resolved <- V.mapM (\var -> do
+      v <- getVar var
+      return $ Constant v
+    ) vc
+  return $ SArray typ resolved
+
+getVar (Constant (STuple vct)) = do
+  resolved <- V.mapM (\var -> do
+      v <- getVar var
+      return $ Constant v
+    ) vct
+  return $ STuple resolved
+  
+getVar (Constant (SMap ty mp)) = do
+  resolved <- mapM (\var -> do
+      v <- getVar var
+      return $ Constant v
+    ) mp
+  return $ SMap ty resolved
+
+getVar (Constant (SPush v (Just var))) = do
+  resolved <- getVar var
+  return $ SPush v (Just $ Constant resolved)
+
 getVar (Constant v) = return v
+
 getVar (Variable v) = liftIO $ readIORef v
 
 

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -1996,6 +1996,25 @@ contract qq {
   }
 }|] `shouldReturn` Just "Ticket ID already exists\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL"
 
+  it "can return state variables" . runTest $ do
+    runCall "getS" "()" [r|
+contract qq {
+  string s = "The mitochondria is the powerhouse of the cell";
+  function getS() public returns (string) {
+    return s;
+  }
+}|] `shouldReturn` Just "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL \NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL.The mitochondria is the powerhouse of the cell"
+
+  it "can return state variables in tuples" . runTest $ do
+
+    runCall "getSAndB" "()" [r|
+contract qq {
+  string s = "The mitochondria is the powerhouse of the cell";
+  function getSAndB() public returns (string, s) {
+    return (s, s);
+  }
+}|] `shouldReturn` Just "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL@\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\142\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL.The mitochondria is the powerhouse of the cell\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL.The mitochondria is the powerhouse of the cell"
+
   it "can accept string arguments" . runTest $ do
     runCall "set" "(\"deadbeef00000000000000000000000000000000000000000000000000000000\")" [r|
 contract qq {


### PR DESCRIPTION
State variables were not able to be returned in tuples because the function `getVar` only resolved values at the first level. So it returned a tuple of (<referenceValue>, value). Then encodeForReturn could not get the resolved value of this reference since it was not on the stack. Encode for return happens at the very end of a function call, and ideally it shouldn't need any stack info, but just use the pure values in the return type.

Now `getVar` recursively looks in structured values like arrays and structs and resolves and values inside of them. 

However because of the way solidvm stores these values, returns a nested structure like `return (int[], int)` will still return an error, becuase the array reference does not actually contain any value, but each element in the array is stored along this reference path.

In order to keep this ticket simpler, I solved the immediate issue and created a ticket (STRATO-2428) for wider issue of returning reference values. 