### PR TITLE
BA-rest Update Solidity Parser Package

### DIFF
--- a/blockapps-rest/package.json
+++ b/blockapps-rest/package.json
@@ -47,7 +47,7 @@
     "rsa-pem-from-mod-exp": "^0.8.4",
     "sha3": "^2.1.3",
     "simple-oauth2": "2.2.1",
-    "solidity-parser-antlr": "^0.4.1",
+    "@solidity-parser/parser": "^0.14.1",
     "sync-request": "6.0.0",
     "tcp-port-used": "^1.0.1",
     "unix-time": "1.0.1"

--- a/blockapps-rest/src/util/solidityParser.ts
+++ b/blockapps-rest/src/util/solidityParser.ts
@@ -1,4 +1,4 @@
-import * as parser from 'solidity-parser-antlr'
+import * as parser from '@solidity-parser/parser'
 
 /**
  * This is the solidityParser interface


### PR DESCRIPTION
This provides the same exact functionality as before except it uses a forked version of the same parsing library that does not have the warning of 'INVALID_ALT_NUMBER'  as before.