### PR TITLE
Strato 2302 assignining unallocated array vals causes crash

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -693,6 +693,7 @@ runStatement st@(Xabi.SimpleStatement (Xabi.ExpressionStatement (Xabi.Binary _ "
       indVal <- getVar =<< expToVar indExp
       case indVal of
         SInteger ind -> do
+          when (ind >= toInteger (V.length fs) || 0 > ind) (invalidWrite "Cannot assign a value outside the allocated space for an array" (unparseStatement st))
           let newVec = fs V.// [(fromIntegral ind, srcVar)]
           setVar pVar (SArray typ newVec)
           return Nothing

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -2886,6 +2886,63 @@ contract qq {
       , BDefault
       ]
 
+  it "testyboi" $ (runTest (runBS [r|
+contract qq {
+  uint[] y;
+  uint z;
+  uint[] x;
+  uint[] myVar;
+  constructor() {
+    myVar = f();
+    z = myVar[0];
+  }
+  function f() returns (uint[]) {
+    // assignment of first value
+    uint[] x;
+    x[0] = 1;
+    return x;
+  }
+  function g() returns (uint[]) {
+    // assignment of second value
+    uint[] x;
+    x[1] = 2;
+    return x;
+  }
+  function h() returns (uint[]) {
+    // assignment of two values
+    uint[] x;
+    x[0] = 1;
+    x[1] = 2;
+    return x;
+  }
+  function i() {
+    // assignment, set state variable
+    uint[] x;
+    x[0] = 1;
+    y = x;
+  }
+  function j() {
+    // assignment of first value, set state variable to array element
+    uint[] x;
+    x[0] = 1;
+    z = x[0];
+  }
+  function k() {
+    // assignment of second value, set state variable to array element
+    uint[] x;
+    x[1] = 2;
+    z = x[1];
+  }
+  }|])) `shouldThrow` anyInvalidWriteError
+--    getFields ["z"] `shouldReturn` [BInteger 1]
+--  getFields ["x"]
+    {-getAll
+      [ [Field "x", Field "length"]
+      , [Field "x",  ArrayIndex 0]
+      ] `shouldReturn` [  BInteger 1
+                        , BInteger 1]-}
+
+
   it "can parse an X509 certificate" . runTest $ do
     runBS [r|
 contract qq {

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -2888,7 +2888,6 @@ contract qq {
 
   it "testyboi" $ (runTest (runBS [r|
 contract qq {
-  uint[] y;
   uint z;
   uint[] x;
   uint[] myVar;
@@ -2902,46 +2901,7 @@ contract qq {
     x[0] = 1;
     return x;
   }
-  function g() returns (uint[]) {
-    // assignment of second value
-    uint[] x;
-    x[1] = 2;
-    return x;
-  }
-  function h() returns (uint[]) {
-    // assignment of two values
-    uint[] x;
-    x[0] = 1;
-    x[1] = 2;
-    return x;
-  }
-  function i() {
-    // assignment, set state variable
-    uint[] x;
-    x[0] = 1;
-    y = x;
-  }
-  function j() {
-    // assignment of first value, set state variable to array element
-    uint[] x;
-    x[0] = 1;
-    z = x[0];
-  }
-  function k() {
-    // assignment of second value, set state variable to array element
-    uint[] x;
-    x[1] = 2;
-    z = x[1];
-  }
   }|])) `shouldThrow` anyInvalidWriteError
---    getFields ["z"] `shouldReturn` [BInteger 1]
---  getFields ["x"]
-    {-getAll
-      [ [Field "x", Field "length"]
-      , [Field "x",  ArrayIndex 0]
-      ] `shouldReturn` [  BInteger 1
-                        , BInteger 1]-}
-
 
   it "can parse an X509 certificate" . runTest $ do
     runBS [r|

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -2886,7 +2886,7 @@ contract qq {
       , BDefault
       ]
 
-  it "testyboi" $ (runTest (runBS [r|
+  it "can't assign a value to an unallocated index in an array" $ (runTest (runBS [r|
 contract qq {
   uint z;
   uint[] x;


### PR DESCRIPTION
This PR adds a bounds check when trying to assign a value to an array index that hasn't been allocated.