### PR TITLE
Enable encodeForReturn for arrays

### DIFF
--- a/blockapps-haskell/solidity/test/BlockApps/Solidity/ValueSpec.hs
+++ b/blockapps-haskell/solidity/test/BlockApps/Solidity/ValueSpec.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module BlockApps.Solidity.ValueSpec where
+
+-- import Data.Word
+import qualified Data.ByteString.Base16 as Base16
+import Test.Hspec
+
+import qualified Data.IntMap             as I
+
+import BlockApps.Solidity.Value
+import BlockApps.Solidity.Type
+
+{-# ANN module ("HLint: ignore Redundant do" :: String) #-}
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+
+spec :: Spec
+spec = do
+  describe "Convert bytes to values" $ do
+    it "should convert Bool - True" $ do
+      let
+        (b,_) = Base16.decode "01"
+        result = bytesToSimpleValue b TypeBool
+      putStrLn $ show b
+      result `shouldBe` (Just $ ValueBool True)
+    it "should convert Bool - False" $ do
+      let
+        (b,_) = Base16.decode "00"
+        result = bytesToSimpleValue b TypeBool
+      putStrLn $ show b
+      result `shouldBe` (Just $ ValueBool False)
+    it "should convert UInt - 123" $ do
+      let
+        (b,_) = Base16.decode "7B"
+        result = bytesToSimpleValue b $ TypeInt False Nothing
+      putStrLn $ show b
+      result `shouldBe` (Just $ ValueInt False Nothing 123)
+    it "should convert Int - 123" $ do
+      let
+        (b,_) = Base16.decode "7B"
+        result = bytesToSimpleValue b $ TypeInt True Nothing
+      putStrLn $ show b
+      result `shouldBe` (Just $ ValueInt True Nothing 123)
+
+    it "should convert UInt Array - [1, 2, 3]" $ do
+      let
+        (val, _) = Base16.decode "000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000FF000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003" 
+        result = bytesToValue val $ TypeArrayDynamic $ SimpleType $ TypeInt False Nothing
+        expected = I.fromList [(0, SimpleValue $ ValueInt False Nothing 255), 
+          (1, SimpleValue $ ValueInt False Nothing 1), 
+          (2, SimpleValue $ ValueInt False Nothing 2), 
+          (3, SimpleValue $ ValueInt False Nothing 3)
+          ]
+      putStrLn $ show val
+      result `shouldBe` (Just $ ValueArrayDynamic expected)
+    it "should convert Int Array - [1, 2, 3]" $ do
+      let
+        (val, _) = Base16.decode "000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000FF000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003"  
+        result = bytesToValue val $ TypeArrayDynamic $ SimpleType $ TypeInt True Nothing
+        expected = I.fromList [(0, SimpleValue $ ValueInt True Nothing 255), 
+          (1, SimpleValue $ ValueInt True Nothing 1),
+          (2, SimpleValue $ ValueInt True Nothing 2), 
+          (3, SimpleValue $ ValueInt True Nothing 3)
+          ]
+      putStrLn $ show val
+      result `shouldBe` (Just $ ValueArrayDynamic expected)
+
+      

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1955,15 +1955,26 @@ encodeForReturn (SString s) = do
 --
 --   As an example, return type (string, uint, string) would have the following encoding:
 --                                                                            
---                                       (offsetStr1)            (offsetStr2)
---   |     32    |     32    |     32    |    32    | str1EncLen |    32    | str2EncLen |
---   |offset_str1|encoded_int|offset_str2|str1EncLen|   str1Enc  |str2EncLen|   str2Enc  |
+--                                            (offsetStr1)            (offsetStr2)
+-- Size:  |     32    |     32    |     32    |    32    | str1EncLen |    32    | str2EncLen |
+-- Value: |offset_str1|encoded_int|offset_str2|str1EncLen|   str1Enc  |str2EncLen|   str2Enc  |
 
-encodeForReturn (STuple items) = do
-  (headers, strings) <- foldM buildEncoding (B.empty, B.empty) =<< mapM getVar (V.toList items)
+-- This is a hacky way to encode arrays, only works for returning just the array
+encodeForReturn (SArray _ items) = do
+  let encLen = word256ToBytes $ fromIntegral $ (V.length items)
+  bs <- encodeVector items
+  return $ (word256ToBytes $ fromIntegral (32::Integer)) `B.append` (encLen `B.append` bs)
+
+encodeForReturn (STuple items) = encodeVector items
+
+encodeForReturn x = todo "Cannot encode this return type: " x
+
+encodeVector :: MonadSM m => V.Vector Variable -> m ByteString
+encodeVector v = do 
+  (headers, strings) <- foldM buildEncoding (B.empty, B.empty) =<< mapM getVar (V.toList v)
   return $ headers `B.append` strings
   where
-    headerLen = (V.length items) * 32
+    headerLen = (V.length v) * 32
     buildEncoding :: MonadSM m => (ByteString, ByteString) -> Value -> m (ByteString, ByteString)
     buildEncoding (headers, strings) val = case val of
       SString s -> do
@@ -1973,8 +1984,6 @@ encodeForReturn (STuple items) = do
             strBS =  encStrLen `B.append` encStr
         return (headers `B.append` offset, strings `B.append` strBS)
       tup@(STuple _) -> todo "encoding nested tuples as return values" tup 
-      v -> do 
-        bs <- encodeForReturn v
+      val' -> do 
+        bs <- encodeForReturn val'
         return (headers `B.append` bs, strings)
-
-encodeForReturn x = todo "can't encode this return type" x


### PR DESCRIPTION
This enables a simple encoding for solidity dynamic arrays. It is kind of hacky as it does not 'properly' put the offset of its location as a tuple, and then combine that with the offset headers of all the other values in the return structure, rather it hardcodes the offset header of 32 to the beginning of the bytestring, followed by the length of values of the array.
I chose not to completely rework the encoding because there are talks of changing if for solidVm anyways, and not spend extra effort on things not needed. 