### PR TITLE
Vscode fixes

### DIFF
--- a/blockapps-rest/package.json
+++ b/blockapps-rest/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@types/simple-oauth2": "^2.2.1",
     "@types/tcp-port-used": "^1.0.0",
+    "@babel/polyfill": "^7.8.3",
     "axios": "^0.21.2",
     "bignumber.js": "^9.0.0",
     "bluebird": "^3.4.6",

--- a/strato-vscode/package.json
+++ b/strato-vscode/package.json
@@ -4,7 +4,8 @@
 	"displayName": "STRATO",
 	"description": "VSCode Integration for BlockApps STRATO",
 	"icon": "resources/balogo.png",
-	"version": "0.1.9",
+	"version": "0.1.15",
+  "repository":"https://github.com/blockapps/strato-platform/strato-vscode",
 	"engines": {
 		"vscode": "^1.53.0"
 	},

--- a/strato-vscode/package.json
+++ b/strato-vscode/package.json
@@ -3,8 +3,8 @@
 	"publisher": "BlockApps",
 	"displayName": "STRATO",
 	"description": "VSCode Integration for BlockApps STRATO",
-        "icon": "resources/balogo.png",
-	"version": "0.1.2",
+	"icon": "resources/balogo.png",
+	"version": "0.1.9",
 	"engines": {
 		"vscode": "^1.53.0"
 	},

--- a/strato-vscode/package.json
+++ b/strato-vscode/package.json
@@ -4,7 +4,7 @@
 	"displayName": "STRATO",
 	"description": "VSCode Integration for BlockApps STRATO",
 	"icon": "resources/balogo.png",
-	"version": "0.1.15",
+	"version": "0.1.16",
   "repository":"https://github.com/blockapps/strato-platform/strato-vscode",
 	"engines": {
 		"vscode": "^1.53.0"

--- a/strato-vscode/src/extension.ts
+++ b/strato-vscode/src/extension.ts
@@ -59,7 +59,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const numFolders = (vscode.workspace.workspaceFolders || []).length;
 		vscode.workspace.updateWorkspaceFolders(0, numFolders, { uri: workspaceFolderUri });
 		await sleep(500);
-		fs.readFile(path.resolve(path.join(process.cwd(), 'resources', 'testupload.sh')).replace('C:\\c:\\','C:\\'), 'utf8', function (err, data) {
+		fs.readFile(path.resolve(path.join(process.cwd(), 'resources', 'testupload.sh')).replace('C:\\c:\\','C:\\').replace('C:\\C:\\','C:\\'), 'utf8', function (err, data) {
 			if (err) {
 				return console.log(err);
 			}
@@ -69,7 +69,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			// fs.writeFile(process.cwd()+'/resources/testupload.sh', result, 'utf8', function(err){
 			// 	if (err) return console.log(err);
 			// })
-			fs.writeFile(path.resolve(path.join(workspaceFolderUri.path, 'testupload.sh')).replace('C:\\c:\\','C:\\'), result, 'utf8', function (err) {
+			fs.writeFile(path.resolve(path.join(workspaceFolderUri.path, 'testupload.sh')).replace('C:\\c:\\','C:\\').replace('C:\\C:\\','C:\\'), result, 'utf8', function (err) {
 				if (err) return console.log(err);
 			})
 		})

--- a/strato-vscode/src/extension.ts
+++ b/strato-vscode/src/extension.ts
@@ -2,6 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as path from 'path';
 import { ContractsProvider } from './contracts';
 import { DeploymentsProvider } from './deployments';
 import { NodesProvider } from './nodes';
@@ -58,7 +59,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const numFolders = (vscode.workspace.workspaceFolders || []).length;
 		vscode.workspace.updateWorkspaceFolders(0, numFolders, { uri: workspaceFolderUri });
 		await sleep(500);
-		fs.readFile(process.cwd() + '/resources/testupload.sh', 'utf8', function (err, data) {
+		fs.readFile(path.resolve(path.join(process.cwd(), 'resources', 'testupload.sh')).replace('C:\\c:\\','C:\\'), 'utf8', function (err, data) {
 			if (err) {
 				return console.log(err);
 			}
@@ -68,7 +69,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			// fs.writeFile(process.cwd()+'/resources/testupload.sh', result, 'utf8', function(err){
 			// 	if (err) return console.log(err);
 			// })
-			fs.writeFile(workspaceFolderUri.path + '/testupload.sh', result, 'utf8', function (err) {
+			fs.writeFile(path.resolve(path.join(workspaceFolderUri.path, 'testupload.sh')).replace('C:\\c:\\','C:\\'), result, 'utf8', function (err) {
 				if (err) return console.log(err);
 			})
 		})

--- a/strato-vscode/src/load.config.ts
+++ b/strato-vscode/src/load.config.ts
@@ -20,6 +20,6 @@ export default function getConfig(): any {
         : cfgPath
         ? path.join(folder, cfgPath, filename)
         : path.join(folder, filename);
-    const config = yaml.load(fs.readFileSync(path.resolve(pathName).replace('C:\\c:\\','C:\\'), 'utf-8'));
+    const config = yaml.load(fs.readFileSync(path.resolve(pathName).replace('C:\\c:\\','C:\\').replace('C:\\C:\\','C:\\'), 'utf-8'));
     return config
 }

--- a/strato-vscode/src/load.config.ts
+++ b/strato-vscode/src/load.config.ts
@@ -1,5 +1,6 @@
 import * as yaml from 'js-yaml';
 import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
 export default function getConfig(): any {
@@ -15,8 +16,10 @@ export default function getConfig(): any {
     // eslint-disable-next-line import/no-mutable-exports
     const pathName = 
       process.env.SERVER
-        ? `${folder}/${cfgPath}/${serverName}.${filename}`
-        : `${folder}${cfgPath ? `/${cfgPath}` : ''}/${filename}`
-    const config = yaml.load(fs.readFileSync(pathName, 'utf-8'));
+        ? path.join(folder, cfgPath, serverName, filename)
+        : cfgPath
+        ? path.join(folder, cfgPath, filename)
+        : path.join(folder, filename);
+    const config = yaml.load(fs.readFileSync(path.resolve(pathName).replace('C:\\c:\\','C:\\'), 'utf-8'));
     return config
 }


### PR DESCRIPTION
Oops, I meant to open a PR for this back when I fixed it for Worley, but forgot to. This fixes the config file path parser on native Windows. It also adds `@babel/polyfill` as a dependency to blockapps-rest, which I'm not sure we want, but the extension breaks without it. I think it is used by the OAuth part of blockapps-rest.