### PR TITLE
SolidVM can now do a multiple arguments hash

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1711,8 +1711,16 @@ callBuiltin "uint" args _ = return $ intBuiltin args
 callBuiltin "int" args _ = return $ intBuiltin args
 callBuiltin "push" [v] (Just o) = typeError "push (called as func, not as method)" (v, o)
 callBuiltin "identity" [v] Nothing = return v
-callBuiltin "keccak256" [SString buf] Nothing = do
-  return . SString . BC.unpack . keccak256ToByteString . hash . BC.pack $ buf
+callBuiltin "keccak256" args Nothing = do
+  let allStrings [] = True
+      allStrings ((SString _):xs) = True && (allStrings xs)
+      allStrings _ = False
+      customConcat [] = ""
+      customConcat ((SString str):ys) = str ++ customConcat ys
+      customConcat _ = invalidArguments "cannot use a non string arguments in keccak256" args
+  case allStrings args of
+    False -> invalidArguments "cannot use a non string arguments in keccak256" args
+    True ->  return . SString . BC.unpack . keccak256ToByteString . hash . BC.pack $ customConcat args
 callBuiltin "require" (SBool cond :msg) Nothing = do
   case msg of
     [] -> require cond Nothing

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -448,7 +448,6 @@ spec = do
         ]
 
     it "can hash multiple arguments" . runTest $ do
-      liftIO $ pendingWith "TODO(blockapps.atlassian.net/browse/STRATO-1520)"
       runBS [r|
 contract qq {
   bytes32 hsh;


### PR DESCRIPTION
Quick fix to allow multiple arguments in the `keccak256` function so that the unit test that was already written will pass. It does this by simply concatenating all the arguments and then using the regular hashing procedure.