### PR TITLE
Guard additional features behind pragma solidvm 3.2

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -355,6 +355,7 @@ initializeStorage root value = do
      x -> setVar root x
 -}
 
+
 call :: SolidVMBase m
      => Bool
      -> Bool
@@ -1168,6 +1169,7 @@ expToVar' (CC.Unitary _ "--" e) = do
   setVar var next
   return $ Constant next
 
+
 expToVar' (CC.Binary _ "+=" lhs rhs) = addAndAssign lhs rhs
 expToVar' (CC.Binary _ "-=" lhs rhs) = binopAssign (-) lhs rhs
 expToVar' (CC.Binary _ "*=" lhs rhs) = binopAssign (*) lhs rhs
@@ -1251,14 +1253,20 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
           ps -> do
             addr <- accountOnUnspecifiedChain <$> getCurrentAccount
             return $ Constant $ SContractFunction (Just $ CC._contractName $ last ps) addr method
-      (SAccount a, "chainId") ->  case (a ^. namedAccountChainId) of
-        UnspecifiedChain ->  do 
-          cid2 <- view accountChainId <$> getCurrentAccount
-          case cid2 of
-            Nothing -> return $ Constant $ SInteger 0 
-            Just cid3 -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid3
-        MainChain ->  return $ Constant $ SInteger 0 
-        ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
+      (SAccount a, "chainId") -> do
+        contract' <- getCurrentContract
+        case CC._vmVersion contract' == "svm3.2" of
+          True ->
+            case (a ^. namedAccountChainId) of
+              UnspecifiedChain -> do 
+                cid2 <- view accountChainId <$> getCurrentAccount
+                case cid2 of
+                  Nothing -> return $ Constant $ SInteger 0 
+                  Just cid3 -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid3
+              MainChain ->  return $ Constant $ SInteger 0 
+              ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
+          False ->
+            typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
       (SAccount addr, itemName) -> do --return $ Constant $ SContractItem addr itemName
         from <- getCurrentAccount
         let address = namedAccountToAccount (from ^. accountChainId) addr
@@ -1267,6 +1275,11 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
 
       (SContract _ a, funcName) -> return $ Constant $ SContractFunction Nothing a funcName
       (r@(SReference _), "push") -> return $ Constant $ SPush r Nothing
+        {-
+        contract' <- getCurrentContract
+        if (CC._vmVersion contract' == "svm3.2")
+          then return $ Constant $ SPush r Nothing
+          else typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show r) -}
       (a@(SArray _ _), "push") -> return $ Constant $ SPush a (Just var)
       (SArray _ theVector, "length") -> return $ Constant $ SInteger $ fromIntegral $ V.length theVector
       (SString s, "length") -> return . Constant . SInteger . fromIntegral $ length s
@@ -2045,10 +2058,15 @@ encodeForReturn (SString s) = do
 -- Value: |offset_str1|encoded_int|offset_str2|str1EncLen|   str1Enc  |str2EncLen|   str2Enc  |
 
 -- This is a hacky way to encode arrays, only works for returning just the array
-encodeForReturn (SArray _ items) = do
-  let encLen = word256ToBytes $ fromIntegral $ (V.length items)
-  bs <- encodeVector items
-  return $ (word256ToBytes $ fromIntegral (32::Integer)) `B.append` (encLen `B.append` bs)
+encodeForReturn x@(SArray _ items) = do
+  contract' <- getCurrentContract
+  if CC._vmVersion contract' == "svm3.2" 
+    then do
+      let encLen = word256ToBytes $ fromIntegral $ (V.length items)
+      bs <- encodeVector items
+      return $ (word256ToBytes $ fromIntegral (32::Integer)) `B.append` (encLen `B.append` bs)
+    else
+      todo "Please use pragma solidvm 3.2 or greater to access array encoding for return " x
 
 encodeForReturn (STuple items) = encodeVector items
 

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -355,7 +355,6 @@ initializeStorage root value = do
      x -> setVar root x
 -}
 
-
 call :: SolidVMBase m
      => Bool
      -> Bool
@@ -1168,7 +1167,6 @@ expToVar' (CC.Unitary _ "--" e) = do
   logAssigningVariable next
   setVar var next
   return $ Constant next
-
 
 expToVar' (CC.Binary _ "+=" lhs rhs) = addAndAssign lhs rhs
 expToVar' (CC.Binary _ "-=" lhs rhs) = binopAssign (-) lhs rhs

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/Builtins.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/Builtins.hs
@@ -8,6 +8,7 @@ import           Blockchain.SolidVM.SM
 import           Blockchain.VM.SolidException
 import qualified SolidVM.Model.Storable as MS
 import           SolidVM.Model.Value
+import qualified SolidVM.Model.CodeCollection as CC
 
 import           Data.Vector as V
 
@@ -26,10 +27,16 @@ push (SReference apt) _ (OrderedVals [av]) = do
 
 
 push (SArray varType vec) (Just (Variable ref)) (OrderedVals [av]) = do
-  let newVar = Constant av
-      newArr = V.snoc vec newVar 
-  setVar (Variable ref) (SArray varType newArr)
-  return $ Constant (SInteger $ fromIntegral $ V.length newArr)
+  contract' <- getCurrentContract
+  if CC._vmVersion contract' == "svm3.2"
+    then do
+      let newVar = Constant av
+          newArr = V.snoc vec newVar 
+      setVar (Variable ref) (SArray varType newArr)
+      return $ Constant (SInteger $ fromIntegral $ V.length newArr)
+    else do
+      invalidArguments "please use pragma solidvm 3.2 or greater" (OrderedVals [av]) 
+
 --  liftIO $ putStrLn $ "address = " ++ show address
 --  liftIO $ putStrLn $ "apt = " ++ show apt
 --  liftIO $ putStrLn $ "vallist = " ++ show newVal

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -1361,6 +1361,7 @@ contract qq {
 
   it "can push to memory arrays" . runTest $ do
     runCall "pushMem" "([3, 5])" [r|
+pragma solidvm 3.2;
 contract qq {
   uint x;
   function pushMem(uint[] memory ts) public {
@@ -2989,6 +2990,7 @@ contract qq {
       ]
   it "can get the chainId from the account type" . runTest $ do
     runBS [r|
+pragma solidvm 3.2;
 contract qq {
   account a1;
   account a2;
@@ -3007,8 +3009,8 @@ contract qq {
 }|]
     getFields ["cid1", "cid2", "cid3"] `shouldReturn`
       [ BInteger 0xfeedbeef
-      , BInteger 0
-      , BInteger 0
+      , BDefault
+      , BDefault
       ]
 
   it "can't assign a value to an unallocated index in an array" $ (runTest (runBS [r|


### PR DESCRIPTION
As discussed this PR gates the three additional features of
>  account.chainId
> pushing to memory arrays
> encoding arrays for return
behind the pragma solidvm 3.2; 