### PR TITLE
Strato 2407 remove chain id from solid vm environment

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -239,7 +239,6 @@ create _ _ _ blockData _ sender' origin' _ _ _ newAddress code txHash' chainId' 
         Env.sender = sender',
         Env.origin = origin',
         Env.txHash=txHash',
-        Env.chainId=chainId',
         Env.metadata=metadata
       }
 
@@ -249,7 +248,7 @@ create _ _ _ blockData _ sender' origin' _ _ _ newAddress code txHash' chainId' 
       hsh <- codePtrToSHA chainId' cp
       fromMaybe "" . fmap snd . join <$> traverse getCode hsh
 
-  fmap (either solidvmErrorResults id) . runSM (Just initCode) env' $ do
+  fmap (either solidvmErrorResults id) . runSM (Just initCode) env' chainId' $ do
     let maybeContractName = M.lookup "name" =<< metadata
         !contractName' = T.unpack $ fromMaybe (missingField "TX is missing a metadata parameter called 'name'" $ show metadata) maybeContractName
 
@@ -386,11 +385,10 @@ call _ _ _ isRCC _ blockData _ _ codeAddress sender' _ _ _ _ origin' txHash' cha
         Env.sender = sender',
         Env.origin = origin',
         Env.txHash=txHash',
-        Env.chainId=chainId',
         Env.metadata=metadata
         }
 
-  fmap (either solidvmErrorResults id) . runSM Nothing env' $ do
+  fmap (either solidvmErrorResults id) . runSM Nothing env' chainId' $ do
     let maybeFuncName = M.lookup "funcName" =<< metadata
         !funcName = T.unpack $ fromMaybe (missingField "TX is missing a metadata parameter called 'funcName'" $ show metadata) maybeFuncName
         maybeArgString = M.lookup "args" =<< metadata

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/Environment.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/Environment.hs
@@ -10,7 +10,6 @@ import qualified Data.Map                                    as M
 import qualified Data.Text                                   as T
 
 import           Blockchain.Data.DataDefs (BlockData(..))
---import           Blockchain.ExtWord
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Keccak256
 
@@ -22,7 +21,6 @@ data Environment =
     origin :: Account,
     blockHeader :: BlockData,
     txHash :: Keccak256,
---    chainId :: Maybe Word256,
     metadata :: Maybe (M.Map T.Text T.Text)
     }
 

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/Environment.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/Environment.hs
@@ -10,7 +10,7 @@ import qualified Data.Map                                    as M
 import qualified Data.Text                                   as T
 
 import           Blockchain.Data.DataDefs (BlockData(..))
-import           Blockchain.ExtWord
+--import           Blockchain.ExtWord
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Keccak256
 
@@ -22,7 +22,7 @@ data Environment =
     origin :: Account,
     blockHeader :: BlockData,
     txHash :: Keccak256,
-    chainId :: Maybe Word256,
+--    chainId :: Maybe Word256,
     metadata :: Maybe (M.Map T.Text T.Text)
     }
 

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -279,9 +279,10 @@ runSM :: ( MonadIO m
          )
       => (Maybe ByteString)
       -> Env.Environment
+      -> Maybe Word256
       -> SM m a
       -> m (Either SolidException a)
-runSM maybeCode env f = do
+runSM maybeCode env chainId' f = do
   csMemDBs <- _memDBs <$> Mod.get (Mod.Proxy @ContextState)
 
   let startingState =
@@ -291,7 +292,7 @@ runSM maybeCode env f = do
         ssEvents = Q.empty,
         _ssNewX509Certs = M.empty,
         _ssMemDBs = csMemDBs,
-        _action = startingAction maybeCode env
+        _action = startingAction maybeCode env chainId'
         }
 
   eValState <- try $ runStateT f startingState
@@ -323,13 +324,13 @@ pushSender newSender mv = do
   Mod.put (Mod.Proxy @Env.Sender) oldSender
   return $ ret
 
-startingAction :: Maybe ByteString -> Env.Environment -> Action
-startingAction maybeCode env' = Action.Action
+startingAction :: Maybe ByteString -> Env.Environment -> Maybe Word256 -> Action
+startingAction maybeCode env' chainId' = Action.Action
   { _blockHash                = blockHeaderHash $ Env.blockHeader env'
   , _blockTimestamp           = blockHeaderTimestamp $ Env.blockHeader env'
   , _blockNumber              = blockHeaderBlockNumber $ Env.blockHeader env'
   , _transactionHash          = Env.txHash env'
-  , _transactionChainId       = Env.chainId env'
+  , _transactionChainId       = chainId'
   , _transactionSender        = Env.sender env'
   , _actionData               = M.empty
   , _metadata                 =


### PR DESCRIPTION
This change removes the `chainId` field from the `Environment` Data type and removes all the places where the `Environment` `chainId` was used