### PR TITLE
derive address of registered cert from pub key in cert subject

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1778,7 +1778,9 @@ callBuiltin "require" (SBool cond :msg) Nothing = do
     (m:_) -> require cond (Just $ show m)
   return SNULL
 callBuiltin "assert" [SBool cond] Nothing = SNULL <$ assert cond
-callBuiltin "registerCert" [SAccount a, SString cert] _ = do
+callBuiltin rc@("registerCert") [SAccount a, SString cert] _ = do
+  contract' <- getCurrentContract
+  if CC._vmVersion contract' /= "svm3.2" then do
     curAccount <- getCurrentAccount
     case _accountChainId curAccount of
       Just cid -> invalidWrite "Cannot register X.509 certificates on a private chain" cid
@@ -1792,6 +1794,31 @@ callBuiltin "registerCert" [SAccount a, SString cert] _ = do
               Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert theAddress x509Cert x509s
               onTraced $ liftIO $ putStrLn $ "    registering cert to address: " ++ format theAddress ++ " as " ++ show (fmap subCommonName $ getCertSubject x509Cert)
               return SNULL
+  else unknownFunction "callBuiltin" rc
+
+callBuiltin rc'@("registerCert") [SString cert] _ = do
+  contract' <- getCurrentContract
+  if CC._vmVersion contract' == "svm3.2" then do
+    curAccount <- getCurrentAccount
+    case _accountChainId curAccount of
+      Just cid -> invalidCertificate "Cannot register X.509 certificates on private chains" cid
+      Nothing -> do
+        let ex509Cert = bsToCert . BC.pack $ cert
+        case ex509Cert of 
+          Left q -> invalidCertificate "Could not parse X.509 certificate" q
+          Right x509Cert -> do 
+            let mSubject = getCertSubject x509Cert
+            case mSubject of 
+              (Just subject) -> do
+                let subjectAddress = fromPublicKey $ subPub subject
+                onTraced $ liftIO $ putStrLn $ "    Registering cert to address derived from the subject's public key: " ++ 
+                  format subjectAddress ++ " as Common Name:" ++ show (subCommonName subject) ++ "; Organization: " ++ show (subOrg subject)
+                x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+                Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert subjectAddress x509Cert x509s
+                return SNULL
+              _ -> invalidCertificate "No or invalid subject" x509Cert
+  else unknownFunction "callBuiltin" rc'
+
 callBuiltin "getUserCert" [SAccount a] _ = do
     x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
     maybeCertLevelDB <- x509CertDBGet $ _namedAccountAddress a

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1787,8 +1787,11 @@ callBuiltin rc@("registerCert") [SAccount a, SString cert] _ = do
       Nothing -> do
         let ex509Cert = bsToCert . BC.pack $ cert
         case ex509Cert of
-            Left _         -> return SNULL
+            Left err         -> do 
+              onTraced $ liftIO $ putStrLn $ C.red err
+              return SNULL
             Right x509Cert -> do
+              onTraced $ liftIO $ putStrLn $ C.red "WARNING we are unsafely registering a certificate to an arbitrary address"
               x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
               let theAddress = _accountAddress $ namedAccountToAccount Nothing a
               Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert theAddress x509Cert x509s

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -135,7 +135,7 @@ codeCollectionFromSource initCode = do
                  Right a -> a
                  Left (PEx p) -> parseError "codeCollectionFromSource" p
                  Left (SVMEx (s, _)) -> throw s
-                 Left (TCEx xs) -> typeError "codeCollectionFromSource" (typeErrorToAnnotation xs)
+                 Left (TCEx xs) -> typeError "Typechecker" (typeErrorToAnnotation xs)
       let codeMap' = M.insert hsh cc codeMap
       recordCacheSize $ M.size codeMap'
       liftIO $ writeIORef unsafeCodeMapIORef codeMap'

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -747,7 +747,7 @@ assertArgs :: SourceAnnotation Text -> Type'
 assertArgs x = boolType' x
 
 registerCertArgs :: SourceAnnotation Text -> Type'
-registerCertArgs x = Product [accountType' x, stringType' x] x
+registerCertArgs x = stringType' x
 
 getUserCertArgs :: SourceAnnotation Text -> Type'
 getUserCertArgs x = accountType' x

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -3180,3 +3180,47 @@ contract qq {
     }
 }|]) `shouldThrow` anyInvalidWriteError
 
+  it "can only post X509 certificates to the address of the public key" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq {
+    account public certAddr = account(0x622EB3792DaA3d3770E3D27D02e53755408aE00b);
+    string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBizCCAS+gAwIBAgIQejfmUC0VeygSTQ0htwpDbzAMBggqhkjOPQQDAgUAMEcx\nDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIGA1UECwwLRW5n\naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTAeFw0yMjA0MTQyMTI4NDdaFw0yMzA0MTQy\nMTI4NDdaMEcxDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIG\nA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEGBSuB\nBAAKA0IABCSwiVfrLj1MCa+1bcBXOnGhnLxS5DYo3/1udE/LYFi2hFgDCPQxKYqP\n7LmHV2W35B3ZZw5SQVf1FxjWE0tZqswwDAYIKoZIzj0EAwIFAANIADBFAiEAvbGZ\nqma5fKnHnzpGCI5lc4VYdHBfgqfG7CwqJ5ii66YCIFUT+eXA1fS9q4/jJ+eULQwH\neXbEHHtO6nBOorRsoG3H\n-----END CERTIFICATE-----";
+    string public certName;
+    string public certOrg;
+    constructor() {
+        registerCert(myCertificate);
+        certName = getUserCert(certAddr)["commonName"];
+        certOrg = getUserCert(certAddr)["organization"];
+
+    }
+}|]
+    getFields ["certName", "certOrg"] `shouldReturn`
+      [ BString "Troy",
+        BString "Blockapps"
+      ]
+
+  it "cannot use old registerCert on solidvm 3.2" $ (runTest $ do
+      (runBS [r|
+  pragma solidvm 3.2;
+  contract qq {
+      account public certAddr = account(0x622EB3792DaA3d3770E3D27D02e53755408aE00b);
+      string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBizCCAS+gAwIBAgIQejfmUC0VeygSTQ0htwpDbzAMBggqhkjOPQQDAgUAMEcx\nDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIGA1UECwwLRW5n\naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTAeFw0yMjA0MTQyMTI4NDdaFw0yMzA0MTQy\nMTI4NDdaMEcxDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIG\nA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEGBSuB\nBAAKA0IABCSwiVfrLj1MCa+1bcBXOnGhnLxS5DYo3/1udE/LYFi2hFgDCPQxKYqP\n7LmHV2W35B3ZZw5SQVf1FxjWE0tZqswwDAYIKoZIzj0EAwIFAANIADBFAiEAvbGZ\nqma5fKnHnzpGCI5lc4VYdHBfgqfG7CwqJ5ii66YCIFUT+eXA1fS9q4/jJ+eULQwH\neXbEHHtO6nBOorRsoG3H\n-----END CERTIFICATE-----";
+      string public certPubKey;
+      constructor() {
+          registerCert(certAddr, myCertificate);
+          certPubKey = getUserCert(certAddr)["publicKey"];
+      }
+  }|])) `shouldThrow` anyTypeError
+
+  it "cannot use new registerCert on solidvm < 3.2" $ (runTest $ do
+      (runBS [r|
+  contract qq {
+      account public certAddr = account(0x622EB3792DaA3d3770E3D27D02e53755408aE00b);
+      string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBizCCAS+gAwIBAgIQejfmUC0VeygSTQ0htwpDbzAMBggqhkjOPQQDAgUAMEcx\nDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIGA1UECwwLRW5n\naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTAeFw0yMjA0MTQyMTI4NDdaFw0yMzA0MTQy\nMTI4NDdaMEcxDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIG\nA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEGBSuB\nBAAKA0IABCSwiVfrLj1MCa+1bcBXOnGhnLxS5DYo3/1udE/LYFi2hFgDCPQxKYqP\n7LmHV2W35B3ZZw5SQVf1FxjWE0tZqswwDAYIKoZIzj0EAwIFAANIADBFAiEAvbGZ\nqma5fKnHnzpGCI5lc4VYdHBfgqfG7CwqJ5ii66YCIFUT+eXA1fS9q4/jJ+eULQwH\neXbEHHtO6nBOorRsoG3H\n-----END CERTIFICATE-----";
+      string public certPubKey;
+      constructor() {
+          registerCert(myCertificate);
+          certPubKey = getUserCert(certAddr)["publicKey"];
+      }
+  }|])) `shouldThrow` anyUnknownFunc

--- a/shared-util/solid-vm-model/src/Blockchain/VM/SolidException.hs
+++ b/shared-util/solid-vm-model/src/Blockchain/VM/SolidException.hs
@@ -24,6 +24,7 @@ module Blockchain.VM.SolidException
   , missingCodeCollection
   , inaccessibleChain
   , invalidWrite
+  , invalidCertificate
   ) where
 
 import Control.DeepSeq
@@ -54,6 +55,7 @@ data SolidException = TypeError String String
                     | MissingCodeCollection String String
                     | InaccessibleChain String String
                     | InvalidWrite String String
+                    | InvalidCertificate String String
                     deriving (Eq, Exception, Generic, NFData, ToJSON, FromJSON)
 
 instance Show SolidException where
@@ -81,6 +83,8 @@ showSolidException (DivideByZero a) = printf "divide by zero error: %s" a
 showSolidException (MissingCodeCollection a b) = printf "missing code collection: %s: %s" a b
 showSolidException (InaccessibleChain a b) = printf "inaccessible chain: %s: %s" a b
 showSolidException (InvalidWrite a b) = printf "invalid write: %s: %s" a b
+showSolidException (InvalidCertificate a b) = printf "invalid certificate: %s" a b
+
 
 toThrower :: (Show v) => (String -> String -> SolidException) -> String -> v -> a
 toThrower cont msg = throw . cont msg . show
@@ -147,3 +151,6 @@ inaccessibleChain = toThrower InaccessibleChain
 
 invalidWrite :: (Show v) => String -> v -> a
 invalidWrite = toThrower InvalidWrite
+
+invalidCertificate :: (Show v) => String -> v -> a
+invalidCertificate = toThrower InvalidCertificate 


### PR DESCRIPTION
As per X.509 discussion, we are now limiting cert registration to the address derived from the public key found within the cert's subject field. (Side note, its kinda crazy how perfectly the x509 standard works with the ethereum standard to make this so easy)

This by itself will greatly limit the ability of users accidentally or maliciously changing the cert of a user, as it will require them to know their public key, and paths the way to more features down the line to work seamlessly...

Since certs will soon become a more major part of the VM, I added a new error type for things revolving around certs, `InvalidCertificate`