### PR TITLE
new jenkins does not accept the master tag for main node

### DIFF
--- a/Jenkinsfile.cleanup
+++ b/Jenkinsfile.cleanup
@@ -39,7 +39,7 @@ def cleanOldWorkspaces(Integer olderThanNumDays = 5) {
 }
 
 pipeline {
-  agent { label "master" }
+  agent { label "utility" }
   options {
     disableConcurrentBuilds()
     timestamps()


### PR DESCRIPTION
Also, repurposed some of our test nodes to be utility nodes and removed the agent on the main node (called the "built-in") following Jenkins' security recommendation