### PR TITLE
Strato 2458 isolate contract source code parsing and insertion into bloc

### DIFF
--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -294,6 +294,8 @@ compileContract sourceList = do
     insertEvmContractNameQuery ch contrName srcHash
     pure (contrName, cds)
 
+  A.insert (A.Proxy @SourceMap) srcHash sourceList
+
   pure $ Map.fromList details
 
 -- SolidVM only

--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -294,7 +294,6 @@ compileContract sourceList = do
     insertEvmContractNameQuery ch contrName srcHash
     pure (contrName, cds)
 
-  A.insert (A.Proxy @SourceMap) srcHash sourceList
   pure $ Map.fromList details
 
 -- SolidVM only

--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -131,16 +131,16 @@ insertEvmContractNameQuery codeHash cName srcHash = do
       , constant srcHash
       )]
 
-insertContractDetailsQuery :: ( MonadIO m
-                         , HasBlocSQL m
-                         , MonadLogger m 
-                         ) 
-                      => SourceMap -> m ()
+insertContractDetailsQuery 
+  :: (A.Alters Keccak256 SourceMap m)
+  => SourceMap 
+  -> m ()
 insertContractDetailsQuery sourceList = do
   let encodedSrc = serializeSourceMap sourceList
-      srcHash = hash (Text.encodeUtf8 encodedSrc)
-
+      srcHash    = hash (Text.encodeUtf8 encodedSrc)
+  
   A.insert (A.Proxy @SourceMap) srcHash sourceList
+
 
 
 getContractDetailsByCodeHash :: ( A.Selectable Account AddressState m
@@ -298,7 +298,6 @@ compileContract sourceList = do
 
 -- SolidVM only
 createMetadataNoCompile :: ( MonadIO m
-                           , (Keccak256 `A.Alters` SourceMap) m
                            , MonadLogger m
                            )
                         => SourceMap -> m (Map Text ContractDetails)

--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -294,6 +294,7 @@ compileContract sourceList = do
     insertEvmContractNameQuery ch contrName srcHash
     pure (contrName, cds)
 
+  A.insert (A.Proxy @SourceMap) srcHash sourceList
   pure $ Map.fromList details
 
 -- SolidVM only

--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -302,6 +302,7 @@ compileContract sourceList = do
 -- SolidVM only
 createMetadataNoCompile :: ( MonadIO m
                            , MonadLogger m
+                           , (Keccak256 `A.Alters` SourceMap) m
                            )
                         => SourceMap -> m (Map Text ContractDetails)
 createMetadataNoCompile sourceList = do
@@ -324,6 +325,7 @@ createMetadataNoCompile sourceList = do
         , contractdetailsXabi = xabi
         }
 
+  A.insert (A.Proxy @SourceMap) srcHash sourceList
   pure details
 
 instance QueryRunnerColumnDefault PGBytea Address where

--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -135,12 +135,13 @@ insertContractDetailsQuery
   :: (A.Alters Keccak256 SourceMap m)
   => SourceMap 
   -> m ()
-insertContractDetailsQuery sourceList = do
-  let encodedSrc = serializeSourceMap sourceList
-      srcHash    = hash (Text.encodeUtf8 encodedSrc)
-  
-  A.insert (A.Proxy @SourceMap) srcHash sourceList
-
+insertContractDetailsQuery sourceList = 
+  void $ insertQuery 
+  where insertQuery = do
+          let encodedSrc = serializeSourceMap sourceList
+              srcHash    = hash (Text.encodeUtf8 encodedSrc)
+    
+          A.insert (A.Proxy @SourceMap) srcHash sourceList
 
 
 getContractDetailsByCodeHash :: ( A.Selectable Account AddressState m

--- a/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -18,6 +18,7 @@ module BlockApps.Bloc22.Database.Queries
   , evmContractByCodeHash
   , evmCodeHashByName
   , insertEvmContractNameQuery
+  , insertContractDetailsQuery
   , sourceToContractDetails
   , getContractDetailsForContract
   , getContractDetailsByCodeHash
@@ -129,6 +130,18 @@ insertEvmContractNameQuery codeHash cName srcHash = do
       , constant cName
       , constant srcHash
       )]
+
+insertContractDetailsQuery :: ( MonadIO m
+                         , HasBlocSQL m
+                         , MonadLogger m 
+                         ) 
+                      => SourceMap -> m ()
+insertContractDetailsQuery sourceList = do
+  let encodedSrc = serializeSourceMap sourceList
+      srcHash = hash (Text.encodeUtf8 encodedSrc)
+
+  A.insert (A.Proxy @SourceMap) srcHash sourceList
+
 
 getContractDetailsByCodeHash :: ( A.Selectable Account AddressState m
                                 , (Keccak256 `A.Alters` SourceMap) m
@@ -281,7 +294,6 @@ compileContract sourceList = do
     insertEvmContractNameQuery ch contrName srcHash
     pure (contrName, cds)
 
-  A.insert (A.Proxy @SourceMap) srcHash sourceList
   pure $ Map.fromList details
 
 -- SolidVM only
@@ -310,7 +322,6 @@ createMetadataNoCompile sourceList = do
         , contractdetailsXabi = xabi
         }
 
-  A.insert (A.Proxy @SourceMap) srcHash sourceList
   pure details
 
 instance QueryRunnerColumnDefault PGBytea Address where

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -204,23 +204,6 @@ processedContract ABIID{..} state AggregateAction{..} =
 lookupT :: (Monad m, Ord k) => k -> Map.Map k v -> MaybeT m v
 lookupT k = MaybeT . return . Map.lookup k
 
--- Inserts the contract source into the Bloc DB.
---  If they're not in the cache but they are in bloc database or action metadata,
---  it reparses the whole source blob, and caches the info for every contract
-insertContractBloc_ :: ( MonadIO m
-                           , MonadLogger m
-                           , HasBlocSQL m
-                           )
-                        => IORef Globals -> AggregateAction -> m ()
-insertContractBloc_ g row = void $ runMaybeT  
-   $  checkCache 
-  
-  where checkCache = do
-          $logInfoS "insertContractBloc_" . T.pack $ "Checking cache for contract info"
-          MaybeT $ getSolidVMInfo g codePtr
-        
-        codePtr = actionCodeHash row
-
 
 -- EVM details are not cached, because the cache links all the contracts in a source blob by source hash, and we only have source hashes for SolidVM code pointers. 
 getEVMDetailsForRow :: ( MonadIO m
@@ -506,8 +489,11 @@ processTheMessages env sqlEnv conn g messages = do
 
       case actionStorage row of
         Action.EVMDiff{} -> evmInsertsF g row actions acct
-        Action.SolidVMDiff{} -> do
-          insertContractBloc_ g row
+        Action.SolidVMDiff{} -> do    
+          void . runMaybeT $ do
+              src <- lookupT "src" $ actionMetadata row
+              lift $ insertContractDetailsQuery (deserializeSourceMap src)
+            
           let cid = maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
               (SolidVMCode name _) = actionCodeHash row
               abiid = ABIID {

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -209,42 +209,16 @@ lookupT k = MaybeT . return . Map.lookup k
 --  it reparses the whole source blob, and caches the info for every contract
 insertContractBloc_ :: ( MonadIO m
                            , MonadLogger m
-                           , Accessible BlocEnv m
                            , HasBlocSQL m
-                           , Selectable Account AddressState m
-                           , (Keccak256 `Alters` SourceMap) m
                            )
                         => IORef Globals -> AggregateAction -> m ()
 insertContractBloc_ g row = void $ runMaybeT  
    $  checkCache 
-  <|> checkMetadata
-  <|> checkBloc 
   
   where checkCache = do
           $logInfoS "insertContractBloc_" . T.pack $ "Checking cache for contract info"
           MaybeT $ getSolidVMInfo g codePtr
         
-        checkMetadata = do
-          $logInfoS "insertContractBloc_" . T.pack $ "Checking metadata for contract info"
-          src <- lookupT "src" $ actionMetadata row 
-          parseAndSet $ deserializeSourceMap src
-        
-        checkBloc = do
-          $logInfoS "insertContractBloc_" . T.pack $ "Checking bloc database for contract info"
-          details <- (MaybeT $ either (const Nothing) Just <$> getContractDetailsByCodeHash codePtr)
-          parseAndSet $ OLD.contractdetailsSrc details
-
-        -- parse source code into a map, add the map of name -> contract to cache
-        -- this call is needed to insert the contract into bloc db contracts_source table
-        -- But since the contract_source table takes a serialized list of contracts from a code collection, we need to 
-        -- parse it first before inserting, since codeCollection could be multiple contracts.
-        parseAndSet src = do
-          details <- lift $ sourceToContractDetails (Don't Compile) src -- :: Map Text ContractDetails
-          lift $ insertContractDetailsQuery src -- insert contract details into bloc db contracts_source table
-          let infoMap = fmap OLD.contractdetailsCodeHash details
-          setSolidVMInfo g codePtr infoMap
-          pure infoMap
-          
         codePtr = actionCodeHash row
 
 

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -240,7 +240,7 @@ insertContractBloc_ g row = void $ runMaybeT
         -- parse it first before inserting, since codeCollection could be multiple contracts.
         parseAndSet src = do
           details <- lift $ sourceToContractDetails (Don't Compile) src -- :: Map Text ContractDetails
-          insertContractDetailsQuery src -- insert contract details into bloc db contracts_source table
+          lift $ insertContractDetailsQuery src -- insert contract details into bloc db contracts_source table
           let infoMap = fmap OLD.contractdetailsCodeHash details
           setSolidVMInfo g codePtr infoMap
           pure infoMap

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -240,6 +240,7 @@ insertContractBloc_ g row = void $ runMaybeT
         -- parse it first before inserting, since codeCollection could be multiple contracts.
         parseAndSet src = do
           details <- lift $ sourceToContractDetails (Don't Compile) src -- :: Map Text ContractDetails
+          insertContractDetailsQuery src -- insert contract details into bloc db contracts_source table
           let infoMap = fmap OLD.contractdetailsCodeHash details
           setSolidVMInfo g codePtr infoMap
           pure infoMap

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -207,45 +207,19 @@ lookupT k = MaybeT . return . Map.lookup k
 -- Inserts the contract source into the Bloc DB.
 --  If they're not in the cache but they are in bloc database or action metadata,
 --  it reparses the whole source blob, and caches the info for every contract
-insertContractBloc_ :: ( MonadIO m
-                           , MonadLogger m
-                           , Accessible BlocEnv m
-                           , HasBlocSQL m
-                           , Selectable Account AddressState m
-                           , (Keccak256 `Alters` SourceMap) m
-                           )
-                        => IORef Globals -> AggregateAction -> m ()
-insertContractBloc_ g row = void $ runMaybeT  
-   $  checkCache 
-  <|> checkMetadata
-  <|> checkBloc 
+--insertContractBloc_ :: ( MonadIO m
+--                           , MonadLogger m
+--                           , HasBlocSQL m
+--
+--                           )
+--                        => IORef Globals -> AggregateAction -> m ()
+--insertContractBloc_ g row = void $ runMaybeT $ checkCache 
   
-  where checkCache = do
-          $logInfoS "insertContractBloc_" . T.pack $ "Checking cache for contract info"
-          MaybeT $ getSolidVMInfo g codePtr
+  --where checkCache = do
+    --      $logInfoS "insertContractBloc_" . T.pack $ "Checking cache for contract info"
+      --    MaybeT $ getSolidVMInfo g codePtr
         
-        checkMetadata = do
-          $logInfoS "insertContractBloc_" . T.pack $ "Checking metadata for contract info"
-          src <- lookupT "src" $ actionMetadata row 
-          parseAndSet $ deserializeSourceMap src
-        
-        checkBloc = do
-          $logInfoS "insertContractBloc_" . T.pack $ "Checking bloc database for contract info"
-          details <- (MaybeT $ either (const Nothing) Just <$> getContractDetailsByCodeHash codePtr)
-          parseAndSet $ OLD.contractdetailsSrc details
-
-        -- parse source code into a map, add the map of name -> contract to cache
-        -- this call is needed to insert the contract into bloc db contracts_source table
-        -- But since the contract_source table takes a serialized list of contracts from a code collection, we need to 
-        -- parse it first before inserting, since codeCollection could be multiple contracts.
-        parseAndSet src = do
-          details <- lift $ sourceToContractDetails (Don't Compile) src -- :: Map Text ContractDetails
-          lift $ insertContractDetailsQuery src -- insert contract details into bloc db contracts_source table
-          let infoMap = fmap OLD.contractdetailsCodeHash details
-          setSolidVMInfo g codePtr infoMap
-          pure infoMap
-          
-        codePtr = actionCodeHash row
+        --codePtr = actionCodeHash row
 
 
 -- EVM details are not cached, because the cache links all the contracts in a source blob by source hash, and we only have source hashes for SolidVM code pointers. 
@@ -533,7 +507,7 @@ processTheMessages env sqlEnv conn g messages = do
       case actionStorage row of
         Action.EVMDiff{} -> evmInsertsF g row actions acct
         Action.SolidVMDiff{} -> do
-          insertContractBloc_ g row
+          --insertContractBloc_ g row
           let cid = maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
               (SolidVMCode name _) = actionCodeHash row
               abiid = ABIID {

--- a/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
+++ b/blockapps-haskell/slipstream/src/Slipstream/Processor.hs
@@ -207,19 +207,45 @@ lookupT k = MaybeT . return . Map.lookup k
 -- Inserts the contract source into the Bloc DB.
 --  If they're not in the cache but they are in bloc database or action metadata,
 --  it reparses the whole source blob, and caches the info for every contract
---insertContractBloc_ :: ( MonadIO m
---                           , MonadLogger m
---                           , HasBlocSQL m
---
---                           )
---                        => IORef Globals -> AggregateAction -> m ()
---insertContractBloc_ g row = void $ runMaybeT $ checkCache 
+insertContractBloc_ :: ( MonadIO m
+                           , MonadLogger m
+                           , Accessible BlocEnv m
+                           , HasBlocSQL m
+                           , Selectable Account AddressState m
+                           , (Keccak256 `Alters` SourceMap) m
+                           )
+                        => IORef Globals -> AggregateAction -> m ()
+insertContractBloc_ g row = void $ runMaybeT  
+   $  checkCache 
+  <|> checkMetadata
+  <|> checkBloc 
   
-  --where checkCache = do
-    --      $logInfoS "insertContractBloc_" . T.pack $ "Checking cache for contract info"
-      --    MaybeT $ getSolidVMInfo g codePtr
+  where checkCache = do
+          $logInfoS "insertContractBloc_" . T.pack $ "Checking cache for contract info"
+          MaybeT $ getSolidVMInfo g codePtr
         
-        --codePtr = actionCodeHash row
+        checkMetadata = do
+          $logInfoS "insertContractBloc_" . T.pack $ "Checking metadata for contract info"
+          src <- lookupT "src" $ actionMetadata row 
+          parseAndSet $ deserializeSourceMap src
+        
+        checkBloc = do
+          $logInfoS "insertContractBloc_" . T.pack $ "Checking bloc database for contract info"
+          details <- (MaybeT $ either (const Nothing) Just <$> getContractDetailsByCodeHash codePtr)
+          parseAndSet $ OLD.contractdetailsSrc details
+
+        -- parse source code into a map, add the map of name -> contract to cache
+        -- this call is needed to insert the contract into bloc db contracts_source table
+        -- But since the contract_source table takes a serialized list of contracts from a code collection, we need to 
+        -- parse it first before inserting, since codeCollection could be multiple contracts.
+        parseAndSet src = do
+          details <- lift $ sourceToContractDetails (Don't Compile) src -- :: Map Text ContractDetails
+          lift $ insertContractDetailsQuery src -- insert contract details into bloc db contracts_source table
+          let infoMap = fmap OLD.contractdetailsCodeHash details
+          setSolidVMInfo g codePtr infoMap
+          pure infoMap
+          
+        codePtr = actionCodeHash row
 
 
 -- EVM details are not cached, because the cache links all the contracts in a source blob by source hash, and we only have source hashes for SolidVM code pointers. 
@@ -507,7 +533,7 @@ processTheMessages env sqlEnv conn g messages = do
       case actionStorage row of
         Action.EVMDiff{} -> evmInsertsF g row actions acct
         Action.SolidVMDiff{} -> do
-          --insertContractBloc_ g row
+          insertContractBloc_ g row
           let cid = maybe "" (T.pack . chainIdString . ChainId) $ (actionAccount row ^. accountChainId)
               (SolidVMCode name _) = actionCodeHash row
               abiid = ABIID {


### PR DESCRIPTION
Separated the database insertion functionality of `sourceToContractDetails` into a new function, `insertContractDetailsQuery`, so that now `sourceToContractDetails` only parses.