### PR TITLE
Strato 2499

### DIFF
--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -28,7 +28,7 @@ import Data.Text.Encoding
 import Data.Time.Clock.POSIX
 import HFlags
 import Numeric
-import Test.Hspec (hspec, Spec, fit, describe, it, xit, pendingWith, anyException, shouldThrow, anyErrorCall, Selector)
+import Test.Hspec (hspec, Spec, describe, it, xit, pendingWith, anyException, shouldThrow, anyErrorCall, Selector)
 import Test.Hspec.Expectations.Lifted
 import Text.Printf
 import Text.RawString.QQ

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -28,7 +28,7 @@ import Data.Text.Encoding
 import Data.Time.Clock.POSIX
 import HFlags
 import Numeric
-import Test.Hspec (hspec, Spec, describe, it, xit, pendingWith, shouldThrow, anyErrorCall, Selector)
+import Test.Hspec (hspec, Spec, fit, describe, it, xit, pendingWith, anyException, shouldThrow, anyErrorCall, Selector)
 import Test.Hspec.Expectations.Lifted
 import Text.Printf
 import Text.RawString.QQ
@@ -955,6 +955,35 @@ contract qq {
   }
 }|]
     getFields ["x"] `shouldReturn` [BInteger 12345]
+  
+  it "can throw exception if omitted parameter name and types are different" $ runTest (do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq {
+  uint x = 0;
+
+  constructor() {
+    x = f(6,5);   
+  }
+  function f(string, uint) public returns (uint) {
+    return 7;
+  }
+}|]) `shouldThrow` anyException
+
+  it "can handle omitted parameter names with correct types" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq {
+  uint x = 0;
+
+  constructor() {
+    x = f(6,5);   
+  }
+  function f(uint, uint) public returns (uint) {
+    return 7;
+  }
+}|] 
+    getFields ["x"] `shouldReturn` [BInteger 7]
 
   it "can unpack tuples" . runTest $ do
     runBS [r|

--- a/core-strato/solid-vm/tests/TypecheckerSpec.hs
+++ b/core-strato/solid-vm/tests/TypecheckerSpec.hs
@@ -627,3 +627,17 @@ contract A {
 }
 |]
      in length anns `shouldSatisfy` (>=3) -- TODO: should be exactly 3
+  it "can throw exception when the types are different from contructor and call" $
+    let anns = runTypechecker [r|
+contract qq {
+  uint x = 0;
+
+  constructor() {
+    x = f(6,5);   
+  }
+  function f(string, uint) public returns (uint) {
+    return 7;
+  }
+
+}|]
+    in length anns `shouldBe` 1


### PR DESCRIPTION
SolidVM parser was already able to allow omitted function argument names. Added three tests to ensure that the functionality was correct.