### PR TITLE
STRATO-2506 The user can now declare Enums and Structs at the file level

### DIFF
--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -57,7 +57,6 @@ structOrEnum = do
 -- | Parses an entire Solidity contract
 solidityContract :: SolidityParser SourceUnit
 solidityContract = do
-  --maybeEnumsOrStructs <- optionMaybe $ many (enumDeclaration <|> structDeclaration)
   ~(a, (kind, contractName', baseConstrs)) <- withPosition $ do
     kind <- (reserved "contract" >> return Xabi.ContractKind)
           <|> (reserved "interface" >> return Xabi.InterfaceKind)
@@ -78,9 +77,6 @@ solidityContract = do
   let ctorList = [(Text.pack n, c) | (n, ConstructorDeclaration c) <- declarations]
   let events = [(Text.pack n, e) | (n, EventDeclaration e) <- declarations]
   let using = [(Text.pack n, u) | (n, UsingDeclaration u) <- declarations]
-  --let enumsOrStructs = case (maybeEnumsOrStructs) of
-  --      Nothing -> []
-  --      Just x -> [(Text.pack name, enum) | (name, EnumDeclaration enum) <- x] ++ [(Text.pack name, struct) | (name, StructDeclaration struct) <- x]
   allCtors <- if length ctorList > 1
                   then fail "multiple constructors defined"
                   else return . Map.fromList $ ctorList
@@ -95,7 +91,6 @@ solidityContract = do
                Map.fromList $
                [ (Text.pack name, enum) | (name, EnumDeclaration enum) <- declarations]
                ++ [ (Text.pack name, struct) | (name, StructDeclaration struct) <- declarations]
-               -- ++ enumsOrStructs
              , xabiModifiers = Map.fromList [(Text.pack name, modifier) | (name, ModifierDeclaration modifier) <- declarations]
              , xabiEvents = Map.fromList events
              , xabiKind = kind

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -38,15 +38,26 @@ import           Blockchain.VM.SolidException
 
 data SourceUnitF a = Pragma a Identifier String
                    | Import a Text.Text
+                   | FileLevelSructOrEnum (Text.Text, SolidVM.Def)
                    | NamedXabi Text.Text (XabiF a, [Text.Text])
                    deriving (Eq, Show, Generic, Functor)
 
 type SourceUnit = Positioned SourceUnitF
 
+
+structOrEnum :: SolidityParser SourceUnit
+structOrEnum = do
+  enumOrStruct <- (enumDeclaration <|> structDeclaration)
+  let enumOrStructForReturn = case enumOrStruct of
+        (name, StructDeclaration struct) -> (Text.pack name, struct)
+        (name, EnumDeclaration enum) -> (Text.pack name, enum)
+        _ -> error "structOrEnum: unexpected"
+  return $ FileLevelSructOrEnum enumOrStructForReturn
+
 -- | Parses an entire Solidity contract
 solidityContract :: SolidityParser SourceUnit
 solidityContract = do
-  maybeEnumsOrStructs <- optionMaybe $ many (enumDeclaration <|> structDeclaration)
+  --maybeEnumsOrStructs <- optionMaybe $ many (enumDeclaration <|> structDeclaration)
   ~(a, (kind, contractName', baseConstrs)) <- withPosition $ do
     kind <- (reserved "contract" >> return Xabi.ContractKind)
           <|> (reserved "interface" >> return Xabi.InterfaceKind)
@@ -67,9 +78,9 @@ solidityContract = do
   let ctorList = [(Text.pack n, c) | (n, ConstructorDeclaration c) <- declarations]
   let events = [(Text.pack n, e) | (n, EventDeclaration e) <- declarations]
   let using = [(Text.pack n, u) | (n, UsingDeclaration u) <- declarations]
-  let enumsOrStructs = case (maybeEnumsOrStructs) of
-        Nothing -> []
-        Just x -> [(Text.pack name, enum) | (name, EnumDeclaration enum) <- x] ++ [(Text.pack name, struct) | (name, StructDeclaration struct) <- x]
+  --let enumsOrStructs = case (maybeEnumsOrStructs) of
+  --      Nothing -> []
+  --      Just x -> [(Text.pack name, enum) | (name, EnumDeclaration enum) <- x] ++ [(Text.pack name, struct) | (name, StructDeclaration struct) <- x]
   allCtors <- if length ctorList > 1
                   then fail "multiple constructors defined"
                   else return . Map.fromList $ ctorList
@@ -84,7 +95,7 @@ solidityContract = do
                Map.fromList $
                [ (Text.pack name, enum) | (name, EnumDeclaration enum) <- declarations]
                ++ [ (Text.pack name, struct) | (name, StructDeclaration struct) <- declarations]
-               ++ enumsOrStructs
+               -- ++ enumsOrStructs
              , xabiModifiers = Map.fromList [(Text.pack name, modifier) | (name, ModifierDeclaration modifier) <- declarations]
              , xabiEvents = Map.fromList events
              , xabiKind = kind

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -67,7 +67,6 @@ solidityContract = do
   let ctorList = [(Text.pack n, c) | (n, ConstructorDeclaration c) <- declarations]
   let events = [(Text.pack n, e) | (n, EventDeclaration e) <- declarations]
   let using = [(Text.pack n, u) | (n, UsingDeclaration u) <- declarations]
-
   let enumsOrStructs = case (maybeEnumsOrStructs) of
         Nothing -> []
         Just x -> [(Text.pack name, enum) | (name, EnumDeclaration enum) <- x] ++ [(Text.pack name, struct) | (name, StructDeclaration struct) <- x]
@@ -185,11 +184,7 @@ enumDeclaration = do
         }
     )
 
--- | Parses Enums or Structs until it cannot find any more
--- enumOrStruct :: SolidityParser (Maybe (String, Declaration))
--- enumOrStruct =  
-  
-
+-- | Parses a using declaration
 usingDeclaration :: SolidityParser (String, Declaration)
 usingDeclaration = do
   ~(a, (usingContract', rest)) <- withPosition $ do

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -70,7 +70,6 @@ solidityContract = do
   let enumsOrStructs = case (maybeEnumsOrStructs) of
         Nothing -> []
         Just x -> [(Text.pack name, enum) | (name, EnumDeclaration enum) <- x] ++ [(Text.pack name, struct) | (name, StructDeclaration struct) <- x]
---  Maybe [(name, Declartion x)] -> [(packed name, x)]   
   allCtors <- if length ctorList > 1
                   then fail "multiple constructors defined"
                   else return . Map.fromList $ ctorList

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -46,6 +46,7 @@ type SourceUnit = Positioned SourceUnitF
 -- | Parses an entire Solidity contract
 solidityContract :: SolidityParser SourceUnit
 solidityContract = do
+  maybeEnumsOrStructs <- optionMaybe $ many (enumDeclaration <|> structDeclaration)
   ~(a, (kind, contractName', baseConstrs)) <- withPosition $ do
     kind <- (reserved "contract" >> return Xabi.ContractKind)
           <|> (reserved "interface" >> return Xabi.InterfaceKind)
@@ -66,6 +67,11 @@ solidityContract = do
   let ctorList = [(Text.pack n, c) | (n, ConstructorDeclaration c) <- declarations]
   let events = [(Text.pack n, e) | (n, EventDeclaration e) <- declarations]
   let using = [(Text.pack n, u) | (n, UsingDeclaration u) <- declarations]
+
+  let enumsOrStructs = case (maybeEnumsOrStructs) of
+        Nothing -> []
+        Just x -> [(Text.pack name, enum) | (name, EnumDeclaration enum) <- x] ++ [(Text.pack name, struct) | (name, StructDeclaration struct) <- x]
+--  Maybe [(name, Declartion x)] -> [(packed name, x)]   
   allCtors <- if length ctorList > 1
                   then fail "multiple constructors defined"
                   else return . Map.fromList $ ctorList
@@ -80,6 +86,7 @@ solidityContract = do
                Map.fromList $
                [ (Text.pack name, enum) | (name, EnumDeclaration enum) <- declarations]
                ++ [ (Text.pack name, struct) | (name, StructDeclaration struct) <- declarations]
+               ++ enumsOrStructs
              , xabiModifiers = Map.fromList [(Text.pack name, modifier) | (name, ModifierDeclaration modifier) <- declarations]
              , xabiEvents = Map.fromList events
              , xabiKind = kind
@@ -177,6 +184,11 @@ enumDeclaration = do
         SolidVM.context = a
         }
     )
+
+-- | Parses Enums or Structs until it cannot find any more
+-- enumOrStruct :: SolidityParser (Maybe (String, Declaration))
+-- enumOrStruct =  
+  
 
 usingDeclaration :: SolidityParser (String, Declaration)
 usingDeclaration = do

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/File.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/File.hs
@@ -19,6 +19,8 @@ import           Data.SemVer
 import qualified Data.Text                             as T
 import           GHC.Generics
 import           Text.Parsec
+import           Data.Map                              as Map
+ 
 
 
 import           SolidVM.Solidity.Parse.Declarations
@@ -26,7 +28,7 @@ import           SolidVM.Solidity.Parse.Imports
 import           SolidVM.Solidity.Parse.Lexer
 import           SolidVM.Solidity.Parse.ParserTypes
 import           SolidVM.Solidity.Parse.Pragmas
-
+import           SolidVM.Solidity.Xabi              (XabiF (..))
 
 newtype File = File {
   unsourceUnits :: [SourceUnit]
@@ -35,13 +37,23 @@ newtype File = File {
 solidityFile :: SolidityParser File
 solidityFile = do
   whiteSpace
-  units <- many (solidityPragma <|> solidityImport <|> solidityContract)
+  units <- many (solidityPragma <|> solidityImport <|> solidityContract <|> structOrEnum)
   eof
-  return . File $ units
+  -- This method isn't very Haskellic could probably be done better wiht library functions like liftM?
+  let onlyStructsAndEnumsMap = Map.fromList $ concatMap (\x -> case x of FileLevelSructOrEnum y -> [y]; _ -> []) units
+  let units' = Prelude.filter (\x -> case x of FileLevelSructOrEnum _ -> False; _ -> True) units
+  units'' <- forM units' $ \unit -> do
+    case unit of
+      Import _ _ -> return unit
+      Pragma _ _ _ -> return unit
+      NamedXabi name ((Xabi funcs constrs vars constants types mods events kind using context), namearr) ->
+        return $ NamedXabi name ((Xabi funcs constrs vars constants (Map.union types onlyStructsAndEnumsMap) mods events kind using context), namearr)
+      _ -> error "unexpected FileLevelSructOrEnum"
+  return . File $ units''    
 
 
 decideVersion :: File -> SolcVersion
-decideVersion = maximum . (ZeroPointFour:) . mapMaybe go . unsourceUnits
+decideVersion = maximum . (ZeroPointFour:) . Data.Maybe.mapMaybe go . unsourceUnits
   where go :: SourceUnit -> Maybe SolcVersion
         go (Pragma _ pragmaName rest) = do
           guard $ pragmaName == "solidity"

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -35,6 +35,7 @@ unparse (File units) = List.concat $ List.map unparseSourceUnit units
 unparseSourceUnit :: SourceUnit -> String
 unparseSourceUnit (Pragma _ ident contents) = "pragma " ++ ident ++ " " ++ contents ++ ";\n"
 unparseSourceUnit (Import _ path) = "import \"" ++ Text.unpack path ++ "\";\n"
+unparseSourceUnit (FileLevelSructOrEnum x) = unparseTypes x
 unparseSourceUnit (NamedXabi name (contract,inherited)) =
      (case xabiKind contract of
         ContractKind -> "contract "

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -3372,12 +3372,25 @@ contract qq {
     runCall "a" "()" [r|
 pragma solidvm 3.2;
 enum Color { red, green, blue }
+contract A {
+    function value() public returns (uint) {
+        return 0xa;
+    }
+}
+
 enum Letter { a, b, c }
+contract B {
+    function value() public returns (uint) {
+        return 0xb;
+    }
+}
 contract qq {
   function a() public returns (Letter) {
     return Letter.c;
   }
-}|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
+}
+
+|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
 
   it "can declare structs at the file level" . runTest $ do
     runCall "a" "()" [r|

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -3367,3 +3367,32 @@ contract qq {
     isValid = verifySignature(msgHash, signature, pubkey);
   }
 }|]) `shouldThrow` anyMalformedDataError
+
+  it "can declare enums at the file level" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.2;
+enum Color { red, green, blue }
+enum Letter { a, b, c }
+contract qq {
+  function a() public returns (Letter) {
+    return Letter.c;
+  }
+}|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
+
+  it "can declare structs at the file level" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.2;
+struct Point {
+  uint x;
+  uint y;
+}
+contract qq {
+  function a() public returns (uint) {
+    Point p;
+    p.x = 1;
+    p.y = 2;
+    return p.x;
+  }
+}|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 1)
+
+


### PR DESCRIPTION
The user can now declare structs an enums at the top level of a file before contract declarations. This was a breaking change in Solidity version 0.6.0