### PR TITLE
Added list Splicing to SolidVM

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -744,9 +744,6 @@ runStatement (CC.SimpleStatement (CC.ExpressionStatement (CC.PlusPlus e))) = do
   return Nothing
 -}
 
-
-
--- Assignment to an index into an array or mapping
 runStatement st@(CC.SimpleStatement (CC.ExpressionStatement (CC.Binary _ "=" dst@(CC.IndexAccess _ parent (Just indExp)) src)) pos) = do
   solidVMBreakpoint pos
   srcVar <- expToVar src
@@ -1421,27 +1418,54 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
 expToVar' x@(CC.IndexAccess _ _ (Nothing)) = missingField "index value cannot be empty" (unparseExpression x)
 
 -- TODO(tim): When this is a string constant, we can index into the string directly for SInteger
-expToVar' x@(CC.IndexAccess _ parent (Just mIndex)) = do
-  var <- expToVar parent
 
-  case var of
-    (Constant (SReference _)) -> Constant . SReference <$> expToPath x
---    (Constant (SArray theType theVector)) -> do
-    _ -> do
-      theIndex <- getVar =<< expToVar mIndex
-      val <- getVar var
-      case (val, theIndex) of
-        (SArray _ theVector, SInteger i) -> do
-          if (fromIntegral i) >= length theVector then
-            indexOutOfBounds ("index value was " ++ (show i) ++ ", but the array length was " ++ (show $ length theVector)) $ unparseExpression x
-          else
-            return $ theVector V.! fromIntegral i
-        (SMap _ theMap, _) -> do maybe (indexOutOfBounds ("index value was " ++ (show theIndex) ++ ", but the valid indexes were " ++ (show $ M.keys theMap)) $ unparseExpression x)
-                                               return
-                                               (theMap M.!? theIndex)
-        (SReference _, _) -> Constant . SReference <$> expToPath x
+expToVar' x@(CC.IndexAccess pos1 parent (Just mIndex)) = do
+  case (mIndex) of
+    (CC.Binary pos2 ":" lhs rhs) -> do
+      var <- expToVar parent
+      lhsInt <- getVar =<< expToVar lhs
+      rhsInt <- getVar =<< expToVar rhs
+      case (lhsInt, rhsInt) of
+        (SInteger lhsInt', SInteger rhsInt') -> do
+          let lhsInt'' = fromIntegral lhsInt'
+          let rhsInt'' = fromIntegral rhsInt'
+          let rangeOfIndexesToGet = [lhsInt' .. (rhsInt' - 1)]
+          when ((lhsInt'' < 0) || (rhsInt'' < 0)) $ indexOutOfBounds ("index range was [" ++ (show lhsInt'') ++ " : " ++ (show rhsInt'') ++ "]") $ unparseExpression x
+          typeOfArr <- getValueType =<< (expToPath (CC.IndexAccess pos1 parent (Just (CC.NumberLiteral pos2 (head rangeOfIndexesToGet) Nothing))))
+          case var of
+            (Constant (SReference _)) -> do
+              listForReturn <- mapM (\idx -> (Constant . SReference <$> expToPath (CC.IndexAccess pos1 parent (Just (CC.NumberLiteral pos2 idx Nothing))))) rangeOfIndexesToGet
+              return . Constant . SArray (basicTypeToSVMType typeOfArr) $ V.fromList listForReturn
+            _ -> do
+              val <- getVar var
+              case val of
+                (SArray theType theVector) -> do
+                  if (lhsInt'' < 0) || (rhsInt'' < 0) || (lhsInt'' >= V.length theVector) || (rhsInt'' >= V.length theVector)
+                    then indexOutOfBounds ("index range was [" ++ (show lhsInt'') ++ " : " ++ (show rhsInt'') ++ "], but the array length was " ++ (show $ length theVector)) $ unparseExpression x
+                    else do
+                      let theVector' = V.fromList $ map (\i -> theVector V.! (fromIntegral i)) rangeOfIndexesToGet
+                      return . Constant . SArray theType $ theVector'
+                _ -> typeError "unsupported type for index splicing" $ unparseExpression x
         _ -> typeError "unsupported types for index access" $ unparseExpression x
---    _ -> error $ "unknown case in expToVar' for IndexAccess: " ++ show var
+    _ -> do
+      var <- expToVar parent
+      case var of
+        (Constant (SReference _)) -> Constant . SReference <$> expToPath x
+        _ -> do
+          theIndex <- getVar =<< expToVar mIndex
+          val <- getVar var
+          case (val, theIndex) of
+            (SArray _ theVector, SInteger i) -> do
+              if (fromIntegral i) >= length theVector then
+                indexOutOfBounds ("index value was " ++ (show i) ++ ", but the array length was " ++ (show $ length theVector)) $ unparseExpression x
+              else
+                return $ theVector V.! fromIntegral i
+            (SMap _ theMap, _) -> do maybe (indexOutOfBounds ("index value was " ++ (show theIndex) ++ ", but the valid indexes were " ++ (show $ M.keys theMap)) $ unparseExpression x)
+                                                  return
+                                                  (theMap M.!? theIndex)
+            (SReference _, _) -> Constant . SReference <$> expToPath x
+            _ -> typeError "unsupported types for index access" $ unparseExpression x
+    --    _ -> error $ "unknown case in expToVar' for IndexAccess: " ++ show var
 
 
 expToVar' (CC.Binary _ "+" expr1 expr2) = expToVarAdd expr1 expr2
@@ -2283,3 +2307,17 @@ encodeVector v = do
       val' -> do
         bs <- encodeForReturn val'
         return (headers `B.append` bs, strings)
+
+basicTypeToSVMType :: BasicType -> SVMType.Type
+basicTypeToSVMType basic = case basic of
+  TBool -> SVMType.Bool
+  TInteger -> SVMType.Int Nothing Nothing
+  TAccount -> SVMType.Account False
+  TString -> SVMType.String Nothing
+  TEnumVal s -> SVMType.Enum Nothing (T.pack s) Nothing
+  TContract s-> SVMType.Contract $ T.pack s
+  TStruct _ _ -> typeError "TStruct" basic
+  TComplex -> typeError "TComplex" basic
+  Todo s -> typeError "todo " $ T.pack s
+
+

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Statement.hs
@@ -167,6 +167,40 @@ expression =
     [Postfix (do
                  ~(a, (e1, e2)) <- withPosition $ do
                    reservedOp "?"
+                   e1 <- expressionNoCons
+                   reservedOp ":"
+                   e2 <- expression
+                   pure (e1, e2)
+                 pure (\e -> Ternary (extractExpression e <> a) e e1 e2)
+             )],
+    [binary "=", binary "|=", binary "^=", binary "&=", binary "<<=", binary ">>=", binary "+=", binary "-=", binary "*=", binary "/=", binary "%="],
+    [binary "&&"],
+    [binary "||"],
+    [binary ":"]
+  ]
+  (tuple <|> array <|> primaryExpression)
+
+
+expressionNoCons :: SolidityParser Expression
+expressionNoCons =
+  buildExpressionParser
+  [
+    [postfix $ choice [functionCall, memberAccess, arrayIndex]],
+    [Postfix (PlusPlus <$> position (reservedOp "++"))],
+    [Postfix (MinusMinus <$> position (reservedOp "--"))],
+    [prefix "!", prefix "~", prefix "delete", prefix "++", prefix "--", prefix "+", prefix "-"],
+    [binary "**"],
+    [binary "*", binary "/", binary "%"],
+    [binary "+", binary "-"],
+    [binary "<<", binary ">>"],
+    [binary "&"],
+    [binary "^"],
+    [binary "|"],
+    [binary "==", binary "!="],
+    [binary "<", binary ">", binary "<=", binary ">="],
+    [Postfix (do
+                 ~(a, (e1, e2)) <- withPosition $ do
+                   reservedOp "?"
                    e1 <- expression
                    reservedOp ":"
                    e2 <- expression

--- a/core-strato/solid-vm/tests/ParserSpec.hs
+++ b/core-strato/solid-vm/tests/ParserSpec.hs
@@ -35,6 +35,7 @@ spec = do
                 , ("x + y", Binary () "+" (Variable () "x") (Variable () "y"))
                 , ("x ** y", Binary () "**" (Variable () "x") (Variable () "y"))
                 , ("x[q]", IndexAccess () (Variable () "x") (Just $ Variable () "q"))
+                , ("x[5 : 6]", IndexAccess () (Variable () "x") (Just $ Binary () ":" (NumberLiteral () 5 Nothing) (NumberLiteral () 6 Nothing)))
                 , ("x[a][b][c]", IndexAccess () (
                                    IndexAccess () (
                                      IndexAccess ()
@@ -87,6 +88,10 @@ spec = do
                  , ("(z, w) = (q, r);", SimpleStatement $ ExpressionStatement
                       $ Binary () "=" (TupleExpression () $ map (Just . Variable ()) ["z", "w"])
                                    (TupleExpression () $ map (Just . Variable ()) ["q", "r"]))
+                 , ("b = a[1:3];", SimpleStatement $ ExpressionStatement
+                      $ Binary () "=" (Variable () "b")
+                                   (IndexAccess () (Variable () "a")
+                                                (Just $ Binary () ":" (NumberLiteral () 1 Nothing) (NumberLiteral () 3 Nothing))))
                  , ("(z, ) = (q, r);", SimpleStatement $ ExpressionStatement
                       $ Binary () "=" (TupleExpression () $ [Just $ Variable () "z", Nothing])
                                    (TupleExpression () $ map (Just . Variable ()) ["q", "r"]))
@@ -110,3 +115,5 @@ spec = do
     let fcases = ["assembly {}", "assembly { dst := mload(src) }", "assembly { dst := add(src, 32) }"]
     forM_ fcases $ \input -> do
       it ("cannot parse " ++ input) $ parseStatement input `shouldSatisfy` isLeft
+
+

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -3662,3 +3662,62 @@ contract qq {
     isValid = verifySignature(msgHash, signature, pubkey);
   }
 }|]) `shouldThrow` anyMalformedDataError
+
+
+  it "can declare multidimensional arrays" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq {
+  uint[2][2] a = [ [1, 2], [3, 4] ];
+  uint b;
+  uint c;
+  
+  constructor () {
+    a[0][0] = 5;
+    a[0][1] = 6;
+    a[1][0] = 7;
+    a[1][1] = 8;
+    b = a[0][0];
+    c = a[1][1];
+  }
+}|]
+    getFields ["b", "c"] `shouldReturn` [ BInteger 5, BInteger 8 ] 
+
+  it "can declare multidimensional arrays with empty elements" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq {
+  uint[2][2] a = [ [], [] ];
+  uint b;
+  uint c;
+
+  constructor () {
+    a[0][0] = 5;
+    a[0][1] = 6;
+    a[1][0] = 7;
+    a[1][1] = 8;
+    b = a[0][0];
+    c = a[0][1];
+
+  }
+}|]
+    getFields ["b", "c"] `shouldReturn` [ BInteger 5, BInteger 6 ]
+
+  it "can splice a list of uints" . runTest $ do
+    runBS [r|
+contract qq {
+  uint[] a = [1, 2, 3, 4, 5];
+  
+  uint[] b;
+  uint c;
+  uint d;
+  constructor () {
+    b = a[2:4];
+    c = b[0];
+    d = b[1];
+  }
+}|];
+    getFields ["c", "d"] `shouldReturn` [ BInteger 3 ,BInteger 4 ]
+
+
+    


### PR DESCRIPTION
This PR adds list splicing to SolidVM, There probably exists a better way to check the type of an array than the roundabout method I am using, although it was not clear to me how to get the type of the array when the source array is a reference.