### PR TITLE
Prevent pre-hydrated private txs from being stored in Redis block bodies db

### DIFF
--- a/core-strato/privacy/src/Blockchain/Privacy/Event.hs
+++ b/core-strato/privacy/src/Blockchain/Privacy/Event.hs
@@ -416,6 +416,7 @@ hydratePrivateHashes chainF b = do
                                 , " where it will fail."
                                 ]
                           let tx' = tx{ otAnchorChain = AnchoredPrivate cId
+                                      , otSigner = otSigner ptx
                                       , otPrivatePayload = Just $ otBaseTx ptx
                                       }
                           return (tx', st)

--- a/core-strato/privacy/src/Blockchain/Privacy/Event.hs
+++ b/core-strato/privacy/src/Blockchain/Privacy/Event.hs
@@ -415,8 +415,10 @@ hydratePrivateHashes chainF b = do
                                 , " but still sending transaction to the VM,"
                                 , " where it will fail."
                                 ]
-                          let ptx' = ptx{otAnchorChain = AnchoredPrivate cId}
-                          return (ptx', st)
+                          let tx' = tx{ otAnchorChain = AnchoredPrivate cId
+                                      , otPrivatePayload = Just $ otBaseTx ptx
+                                      }
+                          return (tx', st)
 
   -- we have to filter out lingering transactions that weren't initially discluded,
   -- but were discluded by a subsequent missing transcation

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -13,7 +13,7 @@ import           Data.Aeson                                hiding (encode)
 import           Data.Binary
 import           Data.Data
 import           Data.List                                 (intercalate)
-import           Data.Maybe                                (fromJust, isNothing)
+import           Data.Maybe                                (fromJust, fromMaybe, isNothing)
 import           Test.QuickCheck
 import           Test.QuickCheck.Arbitrary.Generic
 
@@ -384,6 +384,11 @@ outputBlockHash = blockHeaderHash . obBlockData
 
 outputBlockToBlock :: OutputBlock -> BDB.Block
 outputBlockToBlock OutputBlock{obBlockData=bd,obReceiptTransactions=txs,obBlockUncles=us}= BDB.Block bd (otBaseTx <$> txs) us
+
+outputBlockToBlockRetainPayloads :: OutputBlock -> BDB.Block
+outputBlockToBlockRetainPayloads OutputBlock{obBlockData=bd,obReceiptTransactions=txs,obBlockUncles=us} =
+  let payload t = fromMaybe (otBaseTx t) (otPrivatePayload t)
+   in BDB.Block bd (payload <$> txs) us
 
 quarryBlockToOutputBlock :: Monad m => (Keccak256 -> m (Maybe Word256)) -> BDB.Block -> m OutputBlock
 quarryBlockToOutputBlock f BDB.Block{BDB.blockBlockData=bd,BDB.blockReceiptTransactions=txs,BDB.blockBlockUncles=us} = do

--- a/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/core-strato/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -213,6 +213,7 @@ data OutputTx = OutputTx { otOrigin      :: TO.TXOrigin
                          , otSigner      :: A.Address
                          , otAnchorChain :: AnchorChain
                          , otBaseTx      :: TX.Transaction
+                         , otPrivatePayload :: Maybe TX.Transaction
                          } deriving (Eq, Read, Show, GHCG.Generic, NFData, Data)
 
 data OutputTx' = OutputTx' { ot'Origin      :: TO.TXOrigin
@@ -220,13 +221,15 @@ data OutputTx' = OutputTx' { ot'Origin      :: TO.TXOrigin
                            , ot'Signer      :: A.Address
                            , ot'AnchorChain :: AnchorChain
                            , ot'BaseTx      :: Transaction'
+                           , ot'PrivatePayload :: Maybe Transaction'
                            } deriving (Eq, Show, GHCG.Generic)
 
 otxToOtxPrime :: OutputTx -> OutputTx'
-otxToOtxPrime (OutputTx o h s a b) = (OutputTx' o h s a (Transaction' b))
+otxToOtxPrime (OutputTx o h s a b p) = (OutputTx' o h s a (Transaction' b) (Transaction' <$> p))
 
 otxPrimeToOtx :: OutputTx' -> OutputTx
-otxPrimeToOtx (OutputTx' o h s a (Transaction' b)) = OutputTx o h s a b
+otxPrimeToOtx (OutputTx' o h s a b mp) = OutputTx o h s a (unTransaction' b) (unTransaction' <$> mp)
+  where unTransaction' (Transaction' t) = t
 
 data OutputBlock = OutputBlock { obOrigin              :: TO.TXOrigin
                                , obTotalDifficulty     :: Integer
@@ -309,6 +312,7 @@ wrapTransaction f tx@IngestTx{} = do
         , otSigner = signer
         , otAnchorChain = anchor
         , otBaseTx = baseTx
+        , otPrivatePayload = Nothing
         }
 
 wrapTransactionUnanchored :: IngestTx -> Maybe OutputTx
@@ -324,6 +328,7 @@ wrapTransactionUnanchored tx@IngestTx{} =
                 , otSigner = signer
                 , otAnchorChain = anchor
                 , otBaseTx = baseTx
+                , otPrivatePayload = Nothing
                 }
 
 wrapIngestBlockTransaction :: Monad m => (Keccak256 -> m (Maybe Word256)) -> Keccak256 -> TX.Transaction -> m (Maybe OutputTx)
@@ -338,6 +343,7 @@ wrapIngestBlockTransaction f hash tx =
         , otBaseTx = tx
         , otAnchorChain = anchor
         , otHash   = TX.transactionHash tx
+        , otPrivatePayload = Nothing
         }
 
 wrapIngestBlockTransactionUnanchored :: Keccak256 -> TX.Transaction -> Maybe OutputTx
@@ -352,6 +358,7 @@ wrapIngestBlockTransactionUnanchored hash tx =
             , otBaseTx = tx
             , otAnchorChain = anchor
             , otHash   = TX.transactionHash tx
+            , otPrivatePayload = Nothing
             }
 
 parentHashBS :: SequencedBlock -> BS.ByteString
@@ -397,6 +404,7 @@ quarryBlockToOutputBlock f BDB.Block{BDB.blockBlockData=bd,BDB.blockReceiptTrans
               , otSigner = fromJust . TX.whoSignedThisTransaction $ t
               , otAnchorChain = anchor
               , otHash   = TX.transactionHash t
+              , otPrivatePayload = Nothing
               }
 
 instance Witnessable IngestTx where
@@ -504,6 +512,7 @@ instance TransactionLike OutputTx where
                          , otSigner = fromJust (txSigner t) -- todo: D A N G E R
                          , otAnchorChain = runIdentity $ getAnchorChain (const (Identity Nothing)) t
                          , otBaseTx = morphTx t
+                         , otPrivatePayload = Nothing
                          }
 
 instance RLPSerializable OutputBlock where

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/IContext.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/IContext.hs
@@ -95,11 +95,11 @@ instance (Word256 `A.Alters` API ChainInfo) IContextM where
 instance (Keccak256 `A.Alters` API OutputBlock) IContextM where
   lookup     _ _          = liftIO . throwIO $ Lookup "API" "Keccak256" "OutputBlock"
   delete     _ _          = liftIO . throwIO $ Delete "API" "Keccak256" "OutputBlock"
-  insert     _ _ (API ob) = void . lift $ putBlocks [(outputBlockToBlock ob, obTotalDifficulty ob)] False
+  insert     _ _ (API ob) = void . lift $ putBlocks [(outputBlockToBlockRetainPayloads ob, obTotalDifficulty ob)] False
   insertMany _            = void
                           . lift
                           . flip putBlocks False
-                          . map ((outputBlockToBlock &&& obTotalDifficulty) . unAPI)
+                          . map ((outputBlockToBlockRetainPayloads &&& obTotalDifficulty) . unAPI)
                           . M.elems
 
 instance (Keccak256 `A.Alters` P2P (Private (Word256, OutputTx))) IContextM where

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Bootstrap.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Bootstrap.hs
@@ -55,6 +55,7 @@ bootstrapSequencer Block{blockBlockData = bd,
                    , otBaseTx = t
                    , otHash   = TX.transactionHash t
                    , otAnchorChain = Public
+                   , otPrivatePayload = Nothing
                    }
   initLevelDB :: CablePackage -> IO ()
   initLevelDB pkg = do

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -13,6 +13,7 @@ import           Data.IORef
 import           Data.Maybe                          (fromMaybe, isNothing)
 import           Data.Time.Clock.POSIX
 import qualified Data.Map                            as M
+import           Data.Maybe                          (isJust)
 import           Data.ByteString.Base16              as B16
 import           Numeric                             (showHex)
 
@@ -166,8 +167,8 @@ feedBackOutputsToInput = map rebox
     where rebox (VmTx ts t) = IETx ts $ unboxTx t
           rebox (VmBlock (OutputBlock origin _ header txs uncles)) = IEBlock $ IngestBlock origin header (unboxBlockTx <$> txs) uncles
           rebox x = error $ "why are we testing against " ++ show x
-          unboxTx (OutputTx origin _ _ _ base) = IngestTx origin base
-          unboxBlockTx (OutputTx _ _ _ _ base) = base
+          unboxTx (OutputTx origin _ _ _ base _) = IngestTx origin base
+          unboxBlockTx (OutputTx _ _ _ _ base _) = base
 
 mkBlk :: Keccak256 -> Integer -> SequencerM Block
 mkBlk parent num = do
@@ -488,8 +489,10 @@ spec = do
         BatchSeqEvent{..} <- runBatch $ checkForUnseq [IETx 0 (IngestTx TO.Morphism hashTx)]
         let txs = [tx | VmTx _ tx <- _toVm]
         map txType txs `shouldBe` [PrivateHash]
+        map (isJust . otPrivatePayload) txs `shouldBe` [False]
         let txs' = [tx | P2pTx tx <- _toP2p]
         map txType txs' `shouldBe` [PrivateHash]
+        map (isJust . otPrivatePayload) txs' `shouldBe` [False]
 
       it "should forward a private transaction hash only once" . runTestM $ do
         th <- fmap Keccak256.hash . liftIO $ getEntropy 32
@@ -499,8 +502,10 @@ spec = do
         BatchSeqEvent{..} <- runBatch $ checkForUnseq [ietx,ietx]
         let txs = [tx | VmTx _ tx <- _toVm]
         map txType txs `shouldBe` [PrivateHash]
+        map (isJust . otPrivatePayload) txs `shouldBe` [False]
         let txs' = [tx | P2pTx tx <- _toP2p]
         map txType txs' `shouldBe` [PrivateHash]
+        map (isJust . otPrivatePayload) txs' `shouldBe` [False]
 
       it "should create a PrivateHashTX for a private transaction" . runTestM $ do
         BatchSeqEvent{..} <- runBatch $ do
@@ -508,8 +513,10 @@ spec = do
           checkForUnseq [IETx 0 (IngestTx TO.API tx1)]
         let txs = [tx | VmTx _ tx <- _toVm]
         map txType txs `shouldBe` [PrivateHash]
+        map (isJust . otPrivatePayload) txs `shouldBe` [False]
         let txs' = [tx | P2pTx tx <- _toP2p]
         map txType txs' `shouldBe` [Message, PrivateHash]
+        map (isJust . otPrivatePayload) txs' `shouldBe` [False, False]
 
       it "should run Blockstanbul with private transactions" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev1' h
@@ -520,7 +527,7 @@ spec = do
         let bs = [b | P2pBlockstanbul (WireMessage _ (Preprepare _ b)) <- _toP2p]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash]]
         let obs = [b | VmBlock b <- _toVm]
-        map (map txType . obReceiptTransactions) obs `shouldBe` [[Message]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs `shouldBe` [[Just Message]]
 
       it "should run Blockstanbul with delayed private transactions" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev1' h
@@ -533,7 +540,7 @@ spec = do
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash]]
         b2 <- runBatch $ checkForUnseq [IETx 0 (IngestTx TO.Morphism tx1)]
         let obs' = [b | VmBlock b <- _toVm b2]
-        map (map txType . obReceiptTransactions) obs' `shouldBe` [[Message]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs' `shouldBe` [[Just Message]]
 
       it "should not split up block when all chains are known" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev2' h
@@ -545,8 +552,8 @@ spec = do
         let bs = [b | P2pBlockstanbul (WireMessage _ (Preprepare _ b)) <- _toP2p]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash, PrivateHash]]
         let obs = [b | VmBlock b <- _toVm]
-        map (map txType . obReceiptTransactions) obs `shouldBe`
-          [[Message,Message]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs `shouldBe`
+          [[Just Message, Just Message]]
 
       it "should split up block when chain infos are delayed" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev2' h
@@ -560,7 +567,9 @@ spec = do
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash,PrivateHash]]
         b2 <- runBatch $ checkForUnseq [chainDetails1, chainDetails2]
         let obs' = [b | VmBlock b <- _toVm b2]
-        map (map txType . obReceiptTransactions) obs' `shouldBe` [[Message, PrivateHash],[Message, Message]]
+        map (map txType . obReceiptTransactions) obs' `shouldBe` [[PrivateHash, PrivateHash],[PrivateHash, PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs' `shouldBe`
+          [[Just Message, Nothing], [Just Message, Just Message]]
 
       it "should split up block when chain infos are staggered" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev2' h
@@ -572,10 +581,14 @@ spec = do
         map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash,PrivateHash]]
         b2 <- runBatch $ checkForUnseq [chainDetails1]
         let obs' = [b | VmBlock b <- _toVm b2]
-        map (map txType . obReceiptTransactions) obs' `shouldBe` [[Message, PrivateHash]]
+        map (map txType . obReceiptTransactions) obs' `shouldBe` [[PrivateHash, PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs' `shouldBe`
+          [[Just Message, Nothing]]
         b3 <- runBatch $ checkForUnseq [chainDetails2]
         let obs'' = [b | VmBlock b <- _toVm b3]
-        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message, Message]]
+        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[PrivateHash, PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
+          [[Just Message, Just Message]]
 
       it "should hydrate child chain transaction when parent chain is known" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev4' h
@@ -584,7 +597,9 @@ spec = do
         let bs = [b | P2pBlockstanbul (WireMessage _ (Preprepare _ b)) <- _toP2p b1]
         map (map txType . blockReceiptTransactions) bs `shouldBe` [[PrivateHash]]
         let obs = [b | VmBlock b <- _toVm b1]
-        map (map txType . obReceiptTransactions) obs `shouldBe` [[Message]]
+        map (map txType . obReceiptTransactions) obs `shouldBe` [[PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs `shouldBe`
+          [[Just Message]]
 
       it "should withhold child chain transactions when parent chain is missing" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev3' h
@@ -599,7 +614,9 @@ spec = do
         map (map txType . obReceiptTransactions) obs' `shouldBe` []
         b3 <- runBatch $ checkForUnseq [chainDetails1]
         let obs'' = [b | VmBlock b <- _toVm b3]
-        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message, PrivateHash], [Message, Message]]
+        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[PrivateHash, PrivateHash], [PrivateHash, PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
+          [[Just Message, Nothing], [Just Message, Just Message]]
 
       it "should withhold child chain transactions when parent chain is missing even when there are no transactions on the parent chain" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev4' h
@@ -614,7 +631,9 @@ spec = do
         map (map txType . obReceiptTransactions) obs' `shouldBe` []
         b3 <- runBatch $ checkForUnseq [chainDetails1]
         let obs'' = [b | VmBlock b <- _toVm b3]
-        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message]]
+        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
+          [[Just Message]]
 
       it "should withhold child chain transactions when parent chain parent chain transactions are missing" . runPBFTTestMWithGenesis $ \h -> do
         let b5' = makeBlockWithTransactions [hashTx1]
@@ -645,7 +664,9 @@ spec = do
         map (map txType . obReceiptTransactions) obs' `shouldBe` [[PrivateHash]]
         b3 <- runBatch $ checkForUnseq [ietx tx1]
         let obs'' = [b | VmBlock b <- _toVm b3]
-        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message], [Message]]
+        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[PrivateHash], [PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
+          [[Just Message], [Just Message]]
 
       it "should withhold child chain transactions when parent chain parent chain info is missing" . runPBFTTestMWithGenesis $ \h -> do
         let b5' = makeBlockWithTransactions [hashTx1]
@@ -676,7 +697,9 @@ spec = do
         map (map txType . obReceiptTransactions) obs' `shouldBe` [[PrivateHash]]
         b3 <- runBatch $ checkForUnseq [chainDetails1]
         let obs'' = [b | VmBlock b <- _toVm b3]
-        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message], [Message]]
+        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[PrivateHash], [PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
+          [[Just Message], [Just Message]]
 
       it "should re-run blocks when chain info is delayed" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev1' h
@@ -693,7 +716,9 @@ spec = do
         txHashes `shouldBe` S.singleton (txHash tx1)
         b3 <- runBatch $ checkForUnseq [ietx tx1]
         let obs'' = [b | VmBlock b <- _toVm b3]
-        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[Message]]
+        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
+          [[Just Message]]
 
       it "should emit chain info when creation block has already been emitted" . runPBFTTestMWithGenesis $ \h -> do
         let cInfo' = getChainInfo "emittable"

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -497,26 +497,34 @@ runCodeForTransaction isRunningTests' isHomestead b availableGas tAcct t =
 
 
 codeOrDataLength :: OutputTx -> Int
-codeOrDataLength OutputTx{otBaseTx=bt} | isMessageTX bt = B.length $ transactionData bt
-codeOrDataLength OutputTx{otBaseTx=bt} = codeLength $ transactionInit bt --is ContractCreationTX
+codeOrDataLength t =
+  let bt = fromMaybe (otBaseTx t) (otPrivatePayload t)
+   in if isMessageTX bt
+        then B.length $ transactionData bt
+        else codeLength $ transactionInit bt --is ContractCreationTX
 
 zeroBytesLength :: OutputTx -> Int
-zeroBytesLength OutputTx{otBaseTx=bt} | isMessageTX bt = length $ filter (==0) $ B.unpack $ transactionData bt
-zeroBytesLength OutputTx{otBaseTx=bt} = length $ filter (==0) $ B.unpack codeBytes' --is ContractCreationTX
-                  where
-                    codeBytes' = case transactionInit bt of
-                      Code cb -> cb
-                      PtrToCode _ -> "" -- TODO: lookup code?
+zeroBytesLength t =
+  let bt = fromMaybe (otBaseTx t) (otPrivatePayload t)
+   in if isMessageTX bt
+        then length $ filter (==0) $ B.unpack $ transactionData bt
+        else length $ filter (==0) $ B.unpack $ codeBytes' bt --is ContractCreationTX
+  where
+    codeBytes' bt = case transactionInit bt of
+      Code cb -> cb
+      PtrToCode _ -> "" -- TODO: lookup code?
 
 calculateIntrinsicGas' :: Integer -> OutputTx -> Gas
 calculateIntrinsicGas' blockNum = intrinsicGas (blockIsHomestead blockNum)
 
 intrinsicGas :: Bool -> OutputTx -> Gas
-intrinsicGas isHomestead t@OutputTx{otBaseTx=bt} = gTXDATAZERO * zeroLen + gTXDATANONZERO * (fromIntegral (codeOrDataLength t) - zeroLen) + txCost bt
-    where
-      zeroLen = fromIntegral $ zeroBytesLength t
-      txCost t' | isMessageTX t' = gTX
-      txCost _  = if isHomestead then gCREATETX else gTX
+intrinsicGas isHomestead t =
+  let bt = fromMaybe (otBaseTx t) (otPrivatePayload t)
+   in gTXDATAZERO * zeroLen + gTXDATANONZERO * (fromIntegral (codeOrDataLength t) - zeroLen) + txCost bt
+  where
+    zeroLen = fromIntegral $ zeroBytesLength t
+    txCost t' | isMessageTX t' = gTX
+    txCost _  = if isHomestead then gCREATETX else gTX
 
 setNewAddresses :: VMBase m => TxRunResult -> m TxRunResult
 setNewAddresses trr@(TxRunResult _ result _ before after _) = do
@@ -542,8 +550,9 @@ outputTransactionResult :: VMBase m
                         -> (BlockData -> Keccak256)
                         -> TxRunResult
                         -> ConduitT a VmOutEvent m ()
-outputTransactionResult b hashFunction (TxRunResult OutputTx{otHash=theHash, otBaseTx=t} result deltaT beforeMap afterMap newAddresses) = do
-  let (txrStatus, message, gasRemaining) =
+outputTransactionResult b hashFunction (TxRunResult ot@OutputTx{otHash=theHash} result deltaT beforeMap afterMap newAddresses) = do
+  let t = fromMaybe (otBaseTx ot) (otPrivatePayload ot)
+      (txrStatus, message, gasRemaining) =
         case result of
           Left err -> let fmt = format err in (Failure "Execution" Nothing (ExecutionFailure fmt) Nothing Nothing (Just fmt), fmt, 0) -- TODO Also include the trace
           Right r  -> case erException r of
@@ -599,8 +608,9 @@ multilineLog source theLines = do
 
 printTransactionMessage::MonadLogger m=>
                          OutputTx->Either TransactionFailureCause ExecResults->NominalDiffTime->Maybe Word256 ->  m ()
-printTransactionMessage OutputTx{otSigner=tAddr, otBaseTx=baseTx, otHash=theHash} (Left errMsg) deltaT cid = do
-  let tNonce = transactionNonce baseTx
+printTransactionMessage ot@OutputTx{otSigner=tAddr, otHash=theHash} (Left errMsg) deltaT cid = do
+  let baseTx = fromMaybe (otBaseTx ot) (otPrivatePayload ot)
+      tNonce = transactionNonce baseTx
   multilineLog "printTx/err" $ boringBox
     [ "Adding transaction signed by: " ++ format tAddr
     , "Tx hash:  " ++ format theHash
@@ -610,8 +620,9 @@ printTransactionMessage OutputTx{otSigner=tAddr, otBaseTx=baseTx, otHash=theHash
     , "t = " ++ printf "%.5f" (realToFrac deltaT::Double) ++ "s"
     ]
 
-printTransactionMessage OutputTx{otBaseTx=t, otSigner=tAddr, otHash=theHash} (Right results) deltaT cid = do
-    let tNonce = transactionNonce t
+printTransactionMessage ot@OutputTx{otSigner=tAddr, otHash=theHash} (Right results) deltaT cid = do
+    let t = fromMaybe (otBaseTx ot) (otPrivatePayload ot)
+        tNonce = transactionNonce t
         extra =
           if isMessageTX t
           then ""
@@ -636,6 +647,7 @@ indexMaybe (_:rest) i = indexMaybe rest (i-1)
 
 replaceBestIfBetter :: (VMBase m, Bagger.MonadBagger m) => OutputBlock -> m (Bool, M.Map Word256 (Integer, Keccak256), (Keccak256, Integer, Integer))
 replaceBestIfBetter b@OutputBlock{obBlockData = bd, obTotalDifficulty = td, obReceiptTransactions=txs, obBlockUncles=uncles} = do
+    let txPayloads = (\t -> fromMaybe (otBaseTx t) (otPrivatePayload t)) <$> txs
     bbi <- getContextBestBlockInfo
 
     case bbi of
@@ -655,7 +667,7 @@ replaceBestIfBetter b@OutputBlock{obBlockData = bd, obTotalDifficulty = td, obRe
                             || (newNumber > oldNumber)
                             || ((newNumber == oldNumber) && (td > oldBestDifficulty))
                             || ((newNumber == oldNumber) && (td == oldBestDifficulty) && (newTxCount > oldTxCount))
-            ranPriv = M.fromSet (const (newNumber, bH)) . S.fromList . catMaybes $ map txChainId txs
+            ranPriv = M.fromSet (const (newNumber, bH)) . S.fromList . catMaybes $ map txChainId txPayloads
 
         $logInfoS "replaceBestIfBetter" . T.pack $ "shouldReplace = " ++ show shouldReplace ++ ", newNumber = " ++ show newNumber ++ ", oldBestNumber = " ++ show (blockDataNumber oldBestBlock)
 

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -244,7 +244,7 @@ addBlockTransactions :: (VMBase m, Bagger.MonadBagger m, MonadMonitor m) => Outp
 addBlockTransactions OutputBlock{obBlockData = bd, obReceiptTransactions = transactions} = do
   $logDebugS "addBlockTransactions" . T.pack $ "All transactions: " ++ show transactions
   $logDebugS "addBlockTransactions" . T.pack $ "AnchorChains: " ++ show (map (otAnchorChain &&& txType) transactions)
-  let txs = filter ((/= PrivateHash) . txType)
+  let txs = filter (\t -> (txType t /= PrivateHash) || (isJust $ otPrivatePayload t))
           $ filter (isAnchored . otAnchorChain) transactions
   -- TODO: Run the checks Bagger does reject invalid transactions for private chains
   addTransactions bd txs
@@ -265,7 +265,8 @@ addTransactions blockData txs =
 
   where
     go _ [] trrs _ = return $ DL.toList trrs
-    go blockGas (t@OutputTx{otBaseTx=bt}:rest) trrs x509s = do
+    go blockGas (t:rest) trrs x509s = do
+      let bt = fromMaybe (otBaseTx t) (otPrivatePayload t)
       flushMemAddressStateTxToBlockDB
       flushMemStorageTxDBToBlockDB
       beforeMap <- getAddressStateTxDBMap
@@ -303,7 +304,8 @@ mineTransactions bd remGas otxs = do
   
 mineTransactions' :: (VMBase m, MonadMonitor m) => BlockData -> Integer -> DL.DList TxRunResult -> [OutputTx] -> m Bagger.TxMiningResult
 mineTransactions' _ remGas ran [] = return $ Bagger.TxMiningResult Nothing (DL.toList ran) [] remGas
-mineTransactions' header remGas ran unran@(tx@OutputTx{otBaseTx=bt}:txs) = do
+mineTransactions' header remGas ran unran@(tx:txs) = do
+    let bt = fromMaybe (otBaseTx tx) (otPrivatePayload tx)
     beforeMap <- getAddressStateTxDBMap
     beforeX509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
     (!time', !result) <- timeIt . runExceptT $ addTransaction Nothing False header remGas tx
@@ -333,13 +335,14 @@ addTransaction :: (VMBase m, MonadMonitor m)
                -> Integer
                -> OutputTx
                -> ExceptT TransactionFailureCause m ExecResults
-addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx{otBaseTx=bt,otSigner=tAddr} = do
+addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx{otSigner=tAddr} = do
 
     nonceValid <- lift $ isNonceValid t
 
     let isHomestead   = blockIsHomestead $ blockDataNumber b
         intrinsicGas' = intrinsicGas isHomestead t
         tAcct = Account tAddr chainId
+        bt = fromMaybe (otBaseTx t) (otPrivatePayload t)
 
     when flags_debug $ do
         $logDebugS "addTx" . T.pack $ "bytes cost: " ++ show (gTXDATAZERO * fromIntegral (zeroBytesLength t) + gTXDATANONZERO * (fromIntegral (codeOrDataLength t) - fromIntegral (zeroBytesLength t)))
@@ -415,78 +418,80 @@ runCodeForTransaction :: VMBase m
                       -> Account
                       -> OutputTx
                       -> ExceptT TransactionFailureCause m ExecResults
-runCodeForTransaction isRunningTests' isHomestead b availableGas tAcct OutputTx{otBaseTx=ut} | isContractCreationTX ut = do
-  when flags_debug $ $logInfoS "runCodeForTransaction" "runCodeForTransaction: ContractCreationTX"
+runCodeForTransaction isRunningTests' isHomestead b availableGas tAcct t =
+  let ut = fromMaybe (otBaseTx t) (otPrivatePayload t)
+   in if isContractCreationTX ut
+        then do
+          when flags_debug $ $logInfoS "runCodeForTransaction" "runCodeForTransaction: ContractCreationTX"
 
-  let create =
-        case join $ fmap (M.lookup "VM") $ transactionMetadata ut of
-          Just "EVM" -> EVM.create
-          Just "SolidVM" -> SolidVM.create
-          Nothing -> EVM.create --EVM is the default
-          Just vmName -> -- Return a dummy VM that just complains that the requested VM doesn't exist
-            \_ _ _ _ _ _ _ _ _ ag _ _ _ _ _ ->
-                         return $ evmErrorResults (toInteger ag) (UnsupportedVM vmName)
+          let create =
+                case join $ fmap (M.lookup "VM") $ transactionMetadata ut of
+                  Just "EVM" -> EVM.create
+                  Just "SolidVM" -> SolidVM.create
+                  Nothing -> EVM.create --EVM is the default
+                  Just vmName -> -- Return a dummy VM that just complains that the requested VM doesn't exist
+                    \_ _ _ _ _ _ _ _ _ ag _ _ _ _ _ ->
+                                 return $ evmErrorResults (toInteger ag) (UnsupportedVM vmName)
 
-  --TODO- The new address state should be created in the VM itself....  Currently the EVM doesn't do this (and could be cleaned up by doing so), SolidVM does do this.  I will calculate this value here, but then ignore the value in SolidVM (and recalculate it there).  Eventually this should be moved into the EVM also
-  nonce <- lift $ addressStateNonce <$> A.lookupWithDefault (Proxy @AddressState) tAcct
-  let newAddress = getNewAddress_unsafe (tAcct ^. accountAddress) (nonce-1) --nonce has already been incremented, so subtract 1 here to get the proper value (this is directly specified in the yellowpaper)
-      newAccount = Account newAddress (txChainId ut)
+          --TODO- The new address state should be created in the VM itself....  Currently the EVM doesn't do this (and could be cleaned up by doing so), SolidVM does do this.  I will calculate this value here, but then ignore the value in SolidVM (and recalculate it there).  Eventually this should be moved into the EVM also
+          nonce <- lift $ addressStateNonce <$> A.lookupWithDefault (Proxy @AddressState) tAcct
+          let newAddress = getNewAddress_unsafe (tAcct ^. accountAddress) (nonce-1) --nonce has already been incremented, so subtract 1 here to get the proper value (this is directly specified in the yellowpaper)
+              newAccount = Account newAddress (txChainId ut)
 
-  lift $ create isRunningTests'
-           isHomestead
-           S.empty
-           b
-           0
-           tAcct
-           tAcct
-           (transactionValue ut)
-           (fromInteger $ transactionGasPrice ut)
-           availableGas
-           newAccount
-           (transactionInit ut)
-           (txHash ut)
-           (txChainId ut)
-           (txMetadata ut)
+          lift $ create isRunningTests'
+                   isHomestead
+                   S.empty
+                   b
+                   0
+                   tAcct
+                   tAcct
+                   (transactionValue ut)
+                   (fromInteger $ transactionGasPrice ut)
+                   availableGas
+                   newAccount
+                   (transactionInit ut)
+                   (txHash ut)
+                   (txChainId ut)
+                   (txMetadata ut)
+        else do
+          when flags_debug $ $logInfoS "runCodeForTransaction"  $ T.pack $ "runCodeForTransaction: MessageTX caller: " ++ format tAcct ++ ", address: " ++ format (transactionTo ut)
 
-runCodeForTransaction isRunningTests' isHomestead b availableGas tAcct o@OutputTx{otBaseTx=ut} = do --MessageTX
-  when flags_debug $ $logInfoS "runCodeForTransaction"  $ T.pack $ "runCodeForTransaction: MessageTX caller: " ++ format tAcct ++ ", address: " ++ format (transactionTo ut)
+          let owner = Account (transactionTo ut) (txChainId ut)
 
-  let owner = Account (transactionTo ut) (txChainId ut)
+          codeHash <- lift $ addressStateCodeHash <$> A.lookupWithDefault (Proxy @AddressState) owner
+          resolvedCodeHash <- lift $ resolveCodePtr (owner ^. accountChainId) codeHash
 
-  codeHash <- lift $ addressStateCodeHash <$> A.lookupWithDefault (Proxy @AddressState) owner
-  resolvedCodeHash <- lift $ resolveCodePtr (owner ^. accountChainId) codeHash
+          let eCall =
+                case codeHash of
+                  EVMCode _ -> Right EVM.call
+                  SolidVMCode _ _ ->  Right SolidVM.call
+                  CodeAtAccount acct name -> case resolvedCodeHash of
+                    Just (EVMCode _) -> Right EVM.call
+                    Just (SolidVMCode _ _) -> Right SolidVM.call
+                    Just (CodeAtAccount acct' name') -> Left (acct', name')
+                    Nothing -> Left (acct, name)
 
-  let eCall =
-        case codeHash of
-          EVMCode _ -> Right EVM.call
-          SolidVMCode _ _ ->  Right SolidVM.call
-          CodeAtAccount acct name -> case resolvedCodeHash of
-            Just (EVMCode _) -> Right EVM.call
-            Just (SolidVMCode _ _) -> Right SolidVM.call
-            Just (CodeAtAccount acct' name') -> Left (acct', name')
-            Nothing -> Left (acct, name)
-
-  case eCall of
-    Left (acct, name) -> throwE $ TFCodeCollectionNotFound acct name o
-    Right call -> lift $
-      call isRunningTests'
-        isHomestead
-        False
-        False
-        S.empty
-        b
-        0
-        owner
-        owner
-        tAcct
-        (fromInteger $ transactionValue ut)
-        (fromInteger $ transactionGasPrice ut)
-        (transactionData ut)
-        (fromIntegral availableGas)
-        tAcct
-        (txHash ut)
-        (txChainId ut)
-        (txMetadata ut)
+          case eCall of
+            Left (acct, name) -> throwE $ TFCodeCollectionNotFound acct name t
+            Right call -> lift $
+              call isRunningTests'
+                isHomestead
+                False
+                False
+                S.empty
+                b
+                0
+                owner
+                owner
+                tAcct
+                (fromInteger $ transactionValue ut)
+                (fromInteger $ transactionGasPrice ut)
+                (transactionData ut)
+                (fromIntegral availableGas)
+                tAcct
+                (txHash ut)
+                (txChainId ut)
+                (txMetadata ut)
 
 ----------------
 

--- a/core-strato/vm-runner/src/Blockchain/Verifier.hs
+++ b/core-strato/vm-runner/src/Blockchain/Verifier.hs
@@ -9,6 +9,7 @@ module Blockchain.Verifier (
 
 import           Control.Monad
 import qualified Control.Monad.Change.Alter                  as A
+import           Data.Maybe                                  (fromMaybe)
 
 import           Blockchain.Constants
 import           Blockchain.Data.AddressStateDB
@@ -126,6 +127,7 @@ checkValidity isHomestead parentBSum b = do
 -}
 
 isNonceValid :: (Account `A.Alters` AddressState) f => OutputTx -> f Bool
-isNonceValid OutputTx{otBaseTx=base, otSigner=txAddr} =
-  let tNonce = transactionNonce base
+isNonceValid ot@OutputTx{otSigner=txAddr} =
+  let base = fromMaybe (otBaseTx ot) (otPrivatePayload ot)
+      tNonce = transactionNonce base
    in (== tNonce) . addressStateNonce <$> A.lookupWithDefault A.Proxy (Account txAddr (txChainId base))


### PR DESCRIPTION
Background on this ticket:
In the sequencer, if a block has private transactions that are ready to run, the sequencer will replace the private hash tx in the block with the full private transaction payload, in place. This lets the VM not worry about which transactions it should run - if there is a payload, run it. However, this creates a critical bug, because the block gets stored in Redis with the private payloads already filled in. When a new peer syncs to a peer with one of these blocks stored in Redis, the peer will receive the payloads of the transactions automatically, even if it shouldn't have access to the private chain. This is a big problem! Thankfully, the p2p code automatically throws out this data as the hydrated transactions wind up producing a different transactions root than what is in the block (derived using the unhydrated transactions). However, this problem should be fixed immediately as it is a potential security vulnerability.

The solution is to retain the PrivateHashTX portion of the transaction when sending the block to the VM. To accomplish this, I've added an extra field to the `OutputTx` type, `otPrivatePayload`, which is where private tx payloads will now be hydrated. This means `otBaseTx` will always by the `PrivateHashTX` component, so the indexer's behavior is fixed without modification.

NB: the large change at the bottom of the PR, in `runCodeForTransaction`, is just indentation