### PR TITLE
Fix Chain ID Member Access

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -104,8 +104,6 @@ import qualified Data.Text.Encoding                   as DT
 
 import qualified SolidVM.Model.CodeCollection         as CC
 
-import           Numeric  (showHex)
-
 import qualified SolidVM.Model.Storable as MS
 import qualified SolidVM.Model.Type as SVMType
 import           SolidVM.Model.Value
@@ -1353,18 +1351,17 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
         
       (SAccount a _, "chainId") -> do
         contract' <- getCurrentContract
-        case CC._vmVersion contract' == "svm3.2" of
-          True ->
-            case (a ^. namedAccountChainId) of
-              UnspecifiedChain -> do 
-                cid2 <- view accountChainId <$> getCurrentAccount
-                case cid2 of
-                  Nothing -> return $ Constant $ SInteger 0 
-                  Just cid3 -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid3
-              MainChain ->  return $ Constant $ SInteger 0 
-              ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
-          False ->
-            typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
+        if CC._vmVersion contract' /= "svm3.2" then do
+          typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
+        else do
+          case (a ^. namedAccountChainId) of
+            UnspecifiedChain -> do 
+              curCid <- view accountChainId <$> getCurrentAccount
+              case curCid of
+                Nothing -> return $ Constant $ SInteger 0 
+                Just cid -> return $ Constant $ SInteger $ fromIntegral cid
+            MainChain ->  return $ Constant $ SInteger 0 
+            ExplicitChain cid -> return $ Constant $ SInteger $ fromIntegral cid
       (SAccount addr _, itemName) -> do --return $ Constant $ SContractItem addr itemName
         from <- getCurrentAccount
         let address = namedAccountToAccount (from ^. accountChainId) addr

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -30,6 +30,7 @@ module Blockchain.SolidVM.SM (
   getCurrentCallInfo,
   getCurrentCallInfoIfExists,
   getCurrentContract,
+  getCurrentChainId,
   getCurrentFunctionName,
   getCurrentCodeCollection,
   getEnv,
@@ -524,6 +525,13 @@ getCurrentAccount = do
   case cs of
     (currentCallInfo:_) -> return $ currentAccount currentCallInfo
     _ -> internalError "getCurrentAccount called with an empty stack" ()
+
+getCurrentChainId :: MonadSM m => m (Maybe Word256)
+getCurrentChainId = do
+  cs <- Mod.get (Mod.Proxy @[CallInfo])
+  case cs of
+    (currentCallInfo:_) -> return $ _accountChainId $ currentAccount currentCallInfo
+    _ -> internalError "getCurrentChainId called with an empty stack" ()
 
 
 getCurrentFunctionName :: MonadSM m => m String

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -3459,23 +3459,22 @@ contract qq {
   account a1;
   account a2;
   account a3;
+  account a4;
   uint cid1;
   uint cid2;
   uint cid3;
+  uint cid4;
   constructor() public {
     a1 = account(0xdeadbeef, 0xfeedbeef);
     a2 = account(0x123, "main");    
     a3 = account(0x124);
+    a4 = account(0xdeadbeef, "0xdeadbeef");
     cid1 = a1.chainId;
     cid2 = a2.chainId;
     cid3 = a3.chainId;
+    cid4 = a4.chainId;
   }
 }|]
-    getFields ["cid1", "cid2", "cid3"] `shouldReturn`
-      [ BInteger 0xfeedbeef
-      , BDefault
-      , BDefault
-      ]
   it "can get the balance from an address" . runTest $ do
     -- Post contract
     runBS [r|


### PR DESCRIPTION
Chain Id was being turned into a hex string and then parsed as a string,
and then turned into an int.

Now its directly turned into an int