### PR TITLE
[STRATO-2568] Add extra register cert logging

### DIFF
--- a/Jenkinsfile.autobuild
+++ b/Jenkinsfile.autobuild
@@ -178,7 +178,7 @@ pipeline {
                 rm -rf strato-api-tests
                 git clone -b develop https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-api-tests.git
                 cd strato-api-tests
-                # git checkout strato-2464-registerCert # Replace with custom branch here if made changes to API and strato-api-tests repo code
+                # git checkout strato-2483-registercert-caller # Replace with custom branch here if made changes to API and strato-api-tests repo code
                 docker build --tag strato-api-tests .
                 docker run \
                   -e OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/strato-devel/.well-known/openid-configuration \

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -442,15 +442,18 @@ setCreator creator contract cntrct blockNumber = do
 
     Nothing -> liftIO $ putStrLn $ C.red $ "setCreator/versioning ---> No cert found for " ++ (format creator)
   
-  let hasSvm3_0 = CC._vmVersion cntrct == "svm3.0" || CC._vmVersion cntrct == "svm3.2"
+  let hasSvm3_0 = CC._vmVersion cntrct == "svm3.0"
+      hasSvm3_2 = CC._vmVersion cntrct == "svm3.2"
+  liftIO $ putStrLn $ "setCreator/address ---> Setting creatorAddress to: " ++ show creator 
+  putSolidStorageKeyVal' hasSvm3_2 contract (MS.StoragePath [MS.Field ":creatorAddress"]) (MS.BAccount $ accountToNamedAccount' creator)
   let putCreatorField org = do
         liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show org)
-        putSolidStorageKeyVal' hasSvm3_0 contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
+        putSolidStorageKeyVal' (hasSvm3_0 || hasSvm3_0) contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
 
   if _org /= "" then putCreatorField _org else do
       liftIO $ putStrLn $ C.red $ "Ignoring creator field for empty org field"
 
-      -- hardcoded delete storage value if on the very bad, not good block
+      -- hardcoded delete storage value if on the very bad, no good block
       when (blockNumber == 287472 && computeNetworkID == 30460620967655047776835626356) $ do
         liftIO $ putStrLn $ "DEVNET EXCEPTION Deleting \":creator\" field."
         deleteSolidStorageKeyVal' contract (MS.StoragePath [MS.Field ":creator"])
@@ -1803,31 +1806,37 @@ callBuiltin rc@"registerCert" [SAccount a, SString cert] _ = do
 
 callBuiltin rc'@("registerCert") [SString cert] _ = do
   contract' <- getCurrentContract
+  let rootAddress = fromPublicKey rootPubKey
   if CC._vmVersion contract' /= "svm3.2" 
     then unknownFunction "callBuiltin" rc'
     else do
       curAccount <- getCurrentAccount
-      case _accountChainId curAccount of
-        Just cid -> invalidWrite "Cannot register X.509 certificates on private chains" cid
-        Nothing -> do
-          let ex509Cert = bsToCert . BC.pack $ cert
-          case ex509Cert of 
-            Left q -> invalidCertificate "Could not parse X.509 certificate" q
-            Right x509Cert -> do
-              if not $ verifyBlockApps x509Cert 
-                then invalidCertificate "Certificate is not signed by the BlockApps Root Certificate" (getCertIssuer x509Cert)
-                else do
-                  let mSubject = getCertSubject x509Cert
-                  case mSubject of 
-                    Nothing -> invalidCertificate "No or invalid subject" x509Cert
-                    (Just subject) -> do
-                      let subjectAddress = fromPublicKey $ subPub subject
-                      onTraced $ liftIO $ putStrLn $ "    Registering cert to address derived from the subject's public key: " ++ 
-                        format subjectAddress ++ " as Common Name:" ++ show (subCommonName subject) ++ "; Organization: " ++ show (subOrg subject)
-                      x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-                      Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert subjectAddress x509Cert x509s
-                      return $ SAccount (NamedAccount subjectAddress UnspecifiedChain)
-
+      case curAccount of
+        Account{_accountChainId=Just cid} -> invalidWrite "Cannot register X.509 certificates on private chains" cid
+        Account{..} -> do
+          mCreatorAddress <- getSolidStorageKeyVal' curAccount $ MS.StoragePath [MS.Field ":creatorAddress"]
+          case mCreatorAddress of
+            (MS.BAccount creatorAddress) -> do
+              if ((_namedAccountAddress creatorAddress) /= rootAddress) then invalidWrite "Only a function in a contract posted by the BlockApps Root Address may call registerCert" curAccount
+              else do
+                let ex509Cert = bsToCert . BC.pack $ cert
+                case ex509Cert of 
+                  Left q -> invalidCertificate "Could not parse X.509 certificate" q
+                  Right x509Cert -> do
+                    if not $ verifyBlockApps x509Cert 
+                      then invalidCertificate "Certificate is not signed by the BlockApps Root Certificate" (getCertIssuer x509Cert)
+                      else do
+                        let mSubject = getCertSubject x509Cert
+                        case mSubject of 
+                          Nothing -> invalidCertificate "No or invalid subject" x509Cert
+                          (Just subject) -> do
+                            let subjectAddress = fromPublicKey $ subPub subject
+                            onTraced $ liftIO $ putStrLn $ "    Registering cert to address derived from the subject's public key: " ++ 
+                              format subjectAddress ++ " as Common Name:" ++ show (subCommonName subject) ++ "; Organization: " ++ show (subOrg subject)
+                            x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+                            Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert subjectAddress x509Cert x509s
+                            return $ SAccount (NamedAccount subjectAddress UnspecifiedChain)
+            typ -> internalError "creatorAddress field has not been set or is not an account type" typ
 callBuiltin "getUserCert" [SAccount a] _ = do
   x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
   maybeCertLevelDB <- x509CertDBGet $ _namedAccountAddress a

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1300,7 +1300,20 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
         let address = namedAccountToAccount (from ^. accountChainId) addr
         result <- callWrapper from address Nothing itemName False (CC.OrderedArgs [])  
         return . Constant . fromMaybe SNULL $ result
-
+      (SContractItem a _, "chainId") -> do
+        contract' <- getCurrentContract
+        case CC._vmVersion contract' == "svm3.2" of
+          True ->
+            case (a ^. namedAccountChainId) of
+              UnspecifiedChain -> do 
+                cid2 <- view accountChainId <$> getCurrentAccount
+                case cid2 of
+                  Nothing -> return $ Constant $ SInteger 0 
+                  Just cid3 -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid3
+              MainChain ->  return $ Constant $ SInteger 0 
+              ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
+          False ->
+            typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
       (SContract _ a, funcName) -> return $ Constant $ SContractFunction Nothing a funcName
       (r@(SReference _), "push") -> return $ Constant $ SPush r Nothing
         {-

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -444,11 +444,12 @@ setCreator creator contract cntrct blockNumber = do
   
   let hasSvm3_0 = CC._vmVersion cntrct == "svm3.0"
       hasSvm3_2 = CC._vmVersion cntrct == "svm3.2"
-  liftIO $ putStrLn $ "setCreator/address ---> Setting creatorAddress to: " ++ show creator 
-  putSolidStorageKeyVal' hasSvm3_2 contract (MS.StoragePath [MS.Field ":creatorAddress"]) (MS.BAccount $ accountToNamedAccount' creator)
+  when hasSvm3_2 $ do
+    liftIO $ putStrLn $ "setCreator/address ---> Setting creatorAddress to: " ++ show creator 
+    putSolidStorageKeyVal' hasSvm3_2 contract (MS.StoragePath [MS.Field ":creatorAddress"]) (MS.BAccount $ accountToNamedAccount' creator)
   let putCreatorField org = do
         liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show org)
-        putSolidStorageKeyVal' (hasSvm3_0 || hasSvm3_0) contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
+        putSolidStorageKeyVal' (hasSvm3_0 || hasSvm3_2) contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
 
   if _org /= "" then putCreatorField _org else do
       liftIO $ putStrLn $ C.red $ "Ignoring creator field for empty org field"

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -428,7 +428,7 @@ setCreator creator contract cntrct blockNumber = do
   maybeCertLevelDB <- x509CertDBGet $ creatorAddress
   let maybeCertBlockDB = M.lookup creatorAddress x509s'
       maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-      _org = fromMaybe "" $ fmap subOrg $ listToMaybe =<< getCertSubject =<< maybeCert
+      _org = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
   case maybeCertBlockDB of
     (Just _) -> onTraced $ liftIO $ putStrLn $ C.green "setCreator/versioning ---> Cache hit for x509 cert"
 
@@ -484,7 +484,7 @@ getOrg caller vers = do
         maybeCertLevelDB <- x509CertDBGet $ _accountAddress caller
         let maybeCertBlockDB = M.lookup (_accountAddress caller) x509s'
             maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-        let org' = fromMaybe "" $ fmap subOrg $ listToMaybe =<< getCertSubject =<< maybeCert
+        let org' = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
         liftIO $ putStrLn $ "getOrg/versioning ---> They are a user of org " ++ (show org')
         return org'
       x -> do
@@ -1235,19 +1235,19 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
                                                 maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
                                                 let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
                                                     maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-                                                return . Constant . SString . fromMaybe "" . fmap subCommonName $ listToMaybe =<< getCertSubject =<< maybeCert
+                                                return . Constant . SString . fromMaybe "" . fmap subCommonName $ getCertSubject =<< maybeCert
       (SBuiltinVariable "tx", "organization") -> do env' <- getEnv
                                                     x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
                                                     maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
                                                     let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
                                                         maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-                                                    return . Constant . SString . fromMaybe "" . fmap subOrg $ listToMaybe =<< getCertSubject =<< maybeCert
+                                                    return . Constant . SString . fromMaybe "" . fmap subOrg $ getCertSubject =<< maybeCert
       (SBuiltinVariable "tx", "group") -> do env' <- getEnv
                                              x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
                                              maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
                                              let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
                                                  maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-                                             return . Constant . SString . fromMaybe "" $ subUnit =<< listToMaybe =<< getCertSubject =<< maybeCert
+                                             return . Constant . SString . fromMaybe "" $ subUnit =<< getCertSubject =<< maybeCert
       (SStruct _ theMap, fieldName) -> case M.lookup fieldName theMap of
           Nothing -> missingField "struct member access" fieldName
           Just v -> return v
@@ -1811,7 +1811,7 @@ callBuiltin rc@"registerCert" [SAccount a, SString cert] _ = do
                 x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
                 let theAddress = _accountAddress $ namedAccountToAccount Nothing a
                 Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert theAddress x509Cert x509s
-                onTraced $ liftIO $ putStrLn $ "    registering cert to address: " ++ format theAddress ++ " as " ++ show (fmap subCommonName $ listToMaybe =<< getCertSubject x509Cert)
+                onTraced $ liftIO $ putStrLn $ "    registering cert to address: " ++ format theAddress ++ " as " ++ show (fmap subCommonName $ getCertSubject x509Cert)
                 return SNULL
 
 callBuiltin rc'@("registerCert") [SString cert] _ = do
@@ -1830,7 +1830,7 @@ callBuiltin rc'@("registerCert") [SString cert] _ = do
               if not $ verifyBlockApps x509Cert 
                 then invalidCertificate "Certificate is not signed by the BlockApps Root Certificate" (getCertIssuer x509Cert)
                 else do
-                  let mSubject = listToMaybe =<< getCertSubject x509Cert
+                  let mSubject = getCertSubject x509Cert
                   case mSubject of 
                     Nothing -> invalidCertificate "No or invalid subject" x509Cert
                     (Just subject) -> do
@@ -1903,7 +1903,7 @@ certificateMap :: Maybe String -> Value
 certificateMap maybeCert = case maybeCert of
     Nothing -> SMap stringToString emptyCertMap
     Just cert -> SMap stringToString (fromMaybe emptyCertMap $ fmap (certMap cert) (subject cert))
-    where subject cert = listToMaybe =<< getCertSubject =<< (eitherToMaybe . bsToCert . BC.pack $ cert)
+    where subject cert = getCertSubject =<< (eitherToMaybe . bsToCert . BC.pack $ cert)
           certMap cert sub = M.fromList [ (SString "commonName", Constant . SString $ subCommonName sub)
                                    , (SString "country", Constant . SString $ fromMaybe "" $ subCountry sub)
                                    , (SString "organization", Constant . SString $ subOrg sub)

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -428,7 +428,7 @@ setCreator creator contract cntrct blockNumber = do
   maybeCertLevelDB <- x509CertDBGet $ creatorAddress
   let maybeCertBlockDB = M.lookup creatorAddress x509s'
       maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-      _org = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
+      _org = fromMaybe "" $ fmap subOrg $ listToMaybe =<< getCertSubject =<< maybeCert
   case maybeCertBlockDB of
     (Just _) -> onTraced $ liftIO $ putStrLn $ C.green "setCreator/versioning ---> Cache hit for x509 cert"
 
@@ -484,7 +484,7 @@ getOrg caller vers = do
         maybeCertLevelDB <- x509CertDBGet $ _accountAddress caller
         let maybeCertBlockDB = M.lookup (_accountAddress caller) x509s'
             maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-        let org' = fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
+        let org' = fromMaybe "" $ fmap subOrg $ listToMaybe =<< getCertSubject =<< maybeCert
         liftIO $ putStrLn $ "getOrg/versioning ---> They are a user of org " ++ (show org')
         return org'
       x -> do
@@ -1235,19 +1235,19 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
                                                 maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
                                                 let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
                                                     maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-                                                return . Constant . SString . fromMaybe "" . fmap subCommonName $ getCertSubject =<< maybeCert
+                                                return . Constant . SString . fromMaybe "" . fmap subCommonName $ listToMaybe =<< getCertSubject =<< maybeCert
       (SBuiltinVariable "tx", "organization") -> do env' <- getEnv
                                                     x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
                                                     maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
                                                     let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
                                                         maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-                                                    return . Constant . SString . fromMaybe "" . fmap subOrg $ getCertSubject =<< maybeCert
+                                                    return . Constant . SString . fromMaybe "" . fmap subOrg $ listToMaybe =<< getCertSubject =<< maybeCert
       (SBuiltinVariable "tx", "group") -> do env' <- getEnv
                                              x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
                                              maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
                                              let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
                                                  maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-                                             return . Constant . SString . fromMaybe "" $ subUnit =<< getCertSubject =<< maybeCert
+                                             return . Constant . SString . fromMaybe "" $ subUnit =<< listToMaybe =<< getCertSubject =<< maybeCert
       (SStruct _ theMap, fieldName) -> case M.lookup fieldName theMap of
           Nothing -> missingField "struct member access" fieldName
           Just v -> return v
@@ -1798,7 +1798,7 @@ callBuiltin rc@"registerCert" [SAccount a, SString cert] _ = do
                 x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
                 let theAddress = _accountAddress $ namedAccountToAccount Nothing a
                 Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert theAddress x509Cert x509s
-                onTraced $ liftIO $ putStrLn $ "    registering cert to address: " ++ format theAddress ++ " as " ++ show (fmap subCommonName $ getCertSubject x509Cert)
+                onTraced $ liftIO $ putStrLn $ "    registering cert to address: " ++ format theAddress ++ " as " ++ show (fmap subCommonName $ listToMaybe =<< getCertSubject x509Cert)
                 return SNULL
 
 callBuiltin rc'@("registerCert") [SString cert] _ = do
@@ -1817,7 +1817,7 @@ callBuiltin rc'@("registerCert") [SString cert] _ = do
               if not $ verifyBlockApps x509Cert 
                 then invalidCertificate "Certificate is not signed by the BlockApps Root Certificate" (getCertIssuer x509Cert)
                 else do
-                  let mSubject = getCertSubject x509Cert
+                  let mSubject = listToMaybe =<< getCertSubject x509Cert
                   case mSubject of 
                     Nothing -> invalidCertificate "No or invalid subject" x509Cert
                     (Just subject) -> do
@@ -1890,7 +1890,7 @@ certificateMap :: Maybe String -> Value
 certificateMap maybeCert = case maybeCert of
     Nothing -> SMap stringToString emptyCertMap
     Just cert -> SMap stringToString (fromMaybe emptyCertMap $ fmap (certMap cert) (subject cert))
-    where subject cert = getCertSubject =<< (eitherToMaybe . bsToCert . BC.pack $ cert)
+    where subject cert = listToMaybe =<< getCertSubject =<< (eitherToMaybe . bsToCert . BC.pack $ cert)
           certMap cert sub = M.fromList [ (SString "commonName", Constant . SString $ subCommonName sub)
                                    , (SString "country", Constant . SString $ fromMaybe "" $ subCountry sub)
                                    , (SString "organization", Constant . SString $ subOrg sub)

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1831,7 +1831,10 @@ callBuiltin rc'@("registerCert") [SString cert] _ = do
           mCreatorAddress <- getSolidStorageKeyVal' curAccount $ MS.StoragePath [MS.Field ":creatorAddress"]
           case mCreatorAddress of
             (MS.BAccount creatorAddress) -> do
-              if ((_namedAccountAddress creatorAddress) /= rootAddress) then invalidWrite "Only a function in a contract posted by the BlockApps Root Address may call registerCert" curAccount
+              onTraced $ liftIO $ putStrLn $ "   Here is my creatorAddress " <> show $ _namedAccountAddress creatorAddress
+              onTraced $ liftIO $ putStrLn $ "   Here is my rootAddress " <> show rootAddress
+              onTraced $ liftIO $ putStrLn $ "   Here is my currentAccount " <> show curAccount
+              if ((_namedAccountAddress creatorAddress) /= rootAddress) then invalidWrite "Only a function in a contract posted by the BlockApps Root Address may call registerCert" creatorAddress
               else do
                 let ex509Cert = bsToCert . BC.pack $ cert
                 case ex509Cert of 

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -24,6 +24,7 @@ import Data.Coerce
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
+import Data.Char
 import Data.Text.Encoding
 import Data.Time.Clock.POSIX
 import HFlags
@@ -3314,6 +3315,66 @@ contract qq {
       isValid = verifyCert(cert, pubkey);
     }
 }|])) `shouldThrow` anyMalformedDataError
+
+  it "verifyCert succeeds with a chained cert" . runTest $ do
+    let cert = T.pack $ filter (\c -> not (isSpace c) || c == ' ') [r|-----BEGIN CERTIFICATE-----\nMIIBgzCCASegAwIBAgIQ
+JN1cZoLJ4yhjGrEHRxzPNDAMBggqhkjOPQQDAgUAMEMx\nDjAMBgNVBAMMBUNOT25lMREwDwYDVQQKDAhDTk9uZU9yZzEQMA4GA1UECwwHT25l\nVW5pdDE
+MMAoGA1UEBgwDVVNBMB4XDTIyMDUxMDE5MTcwMloXDTIzMDUxMDE5MTcw\nMlowQzEOMAwGA1UEAwwFQ05Ud28xETAPBgNVBAoMCENOVHdvT3JnMRAwDgYD
+VQQL\nDAdUd29Vbml0MQwwCgYDVQQGDANVU0EwVjAQBgcqhkjOPQIBBgUrgQQACgNCAATk\niocODuRYeg5AZT80BwIAdH+ScbFdsUG9xhjOfG82c4TeuCM
+soUslu4JsvL6MfaV8\nU7l8Lw0M6yiTGb0DPveZMAwGCCqGSM49BAMCBQADSAAwRQIhAKr7MLKSXJ1bOpGO\nfbLV+n+dzQjd2gQXXqP0OMIIDjuGAiBaea
+dbSMOTJRYIJ4PV9C0oyyk/Xrvv4/R/\nEyun8du+BQ==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBiTCCAS2gAwIBA
+gIRAN7G0Wzu8Z4GkKgUUNkz4kEwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdp
+bmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDUxMDE5MTY1OVoXDTIzMDUx\nMDE5MTY1OVowQzEOMAwGA1UEAwwFQ05PbmUxETAPBgNVBAoMCENOT25lT
+3JnMRAw\nDgYDVQQLDAdPbmVVbml0MQwwCgYDVQQGDANVU0EwVjAQBgcqhkjOPQIBBgUrgQQA\nCgNCAARaBoYAP4TNHMD7Nkgs8PNHMMmJRF9Nhhn89iPH
+bppw4AooeNfoeQ1SVWAn\nQ3/Wh4w9hGFeba0MaBm3pVtLWJ/zMAwGCCqGSM49BAMCBQADSAAwRQIhAPmPkkFv\n5nGnvprxgxOqW9xQiuCdTzBSTGELvlz
+we2CIAiBFjj1qyTywdRej7fSOfG9il421\ndB2DWeHbCK7C6S6PvQ==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBjT
+CCATKgAwIBAgIRAOPPkVoBp/GnwZGR32jcIjwwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQ
+LDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyMDE3NTcxM1oXDTIzMDQy\nMDE3NTcxM1owSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBA
+oMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6c
+DeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANHADBEAiA8\nR0UERQZbF3qJUt5A0ZFf
+2ZmB0l/ZPjIvM383gOF3xwIgbxbQ8NLkDEe2mWJ/qa4n\nN8txKc8G9R27ZYAUuz15zF0=\n-----END CERTIFICATE-----|]
+        contract = T.unpack $ T.replace "$CERT" cert [r|
+pragma solidvm 3.2;
+contract qq {
+    bool isValid = false;
+    constructor() {
+      string cert = "$CERT";
+      string pubkey = "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUhJR4x+wZiX+xZK2m/pwN40cvCS0UA7Z\n0DB7sny5ZnNLw43JgKz0URDY2yYOPkhoIApxFK9UU3Bc4BRANDWmdQ==\n-----END PUBLIC KEY-----";
+      isValid = verifyCert(cert, pubkey);
+    }
+}|] 
+    runBS contract
+    getFields ["isValid"] `shouldReturn` [ BBool True ]
+
+  it "verifyCert fails with a chained cert and the wrong public key" . runTest $ do
+    let cert = T.pack $ filter (\c -> not (isSpace c) || c == ' ') [r|-----BEGIN CERTIFICATE-----\nMIIBgzCCASegAwIBAgIQ
+JN1cZoLJ4yhjGrEHRxzPNDAMBggqhkjOPQQDAgUAMEMx\nDjAMBgNVBAMMBUNOT25lMREwDwYDVQQKDAhDTk9uZU9yZzEQMA4GA1UECwwHT25l\nVW5pdDE
+MMAoGA1UEBgwDVVNBMB4XDTIyMDUxMDE5MTcwMloXDTIzMDUxMDE5MTcw\nMlowQzEOMAwGA1UEAwwFQ05Ud28xETAPBgNVBAoMCENOVHdvT3JnMRAwDgYD
+VQQL\nDAdUd29Vbml0MQwwCgYDVQQGDANVU0EwVjAQBgcqhkjOPQIBBgUrgQQACgNCAATk\niocODuRYeg5AZT80BwIAdH+ScbFdsUG9xhjOfG82c4TeuCM
+soUslu4JsvL6MfaV8\nU7l8Lw0M6yiTGb0DPveZMAwGCCqGSM49BAMCBQADSAAwRQIhAKr7MLKSXJ1bOpGO\nfbLV+n+dzQjd2gQXXqP0OMIIDjuGAiBaea
+dbSMOTJRYIJ4PV9C0oyyk/Xrvv4/R/\nEyun8du+BQ==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBiTCCAS2gAwIBA
+gIRAN7G0Wzu8Z4GkKgUUNkz4kEwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdp
+bmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDUxMDE5MTY1OVoXDTIzMDUx\nMDE5MTY1OVowQzEOMAwGA1UEAwwFQ05PbmUxETAPBgNVBAoMCENOT25lT
+3JnMRAw\nDgYDVQQLDAdPbmVVbml0MQwwCgYDVQQGDANVU0EwVjAQBgcqhkjOPQIBBgUrgQQA\nCgNCAARaBoYAP4TNHMD7Nkgs8PNHMMmJRF9Nhhn89iPH
+bppw4AooeNfoeQ1SVWAn\nQ3/Wh4w9hGFeba0MaBm3pVtLWJ/zMAwGCCqGSM49BAMCBQADSAAwRQIhAPmPkkFv\n5nGnvprxgxOqW9xQiuCdTzBSTGELvlz
+we2CIAiBFjj1qyTywdRej7fSOfG9il421\ndB2DWeHbCK7C6S6PvQ==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBjT
+CCATKgAwIBAgIRAOPPkVoBp/GnwZGR32jcIjwwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQ
+LDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyMDE3NTcxM1oXDTIzMDQy\nMDE3NTcxM1owSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBA
+oMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6c
+DeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANHADBEAiA8\nR0UERQZbF3qJUt5A0ZFf
+2ZmB0l/ZPjIvM383gOF3xwIgbxbQ8NLkDEe2mWJ/qa4n\nN8txKc8G9R27ZYAUuz15zF0=\n-----END CERTIFICATE-----|]
+        contract = T.unpack $ T.replace "$CERT" cert [r|
+pragma solidvm 3.2;
+contract qq {
+    bool isValid = false;
+    constructor() {
+      string cert = "$CERT";
+      string pubkey = "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAlGfMOmhI+AjQlfxve8YoEXhZErFdkCx\nc8OkTB1TP6giwof4fWG+Fua8b2W0YjOQkrQojwnKbBDt3CQeqU+bPA==\n-----END PUBLIC KEY-----";
+      isValid = verifyCert(cert, pubkey);
+    }
+}|] 
+    runBS contract
+    getFields ["isValid"] `shouldReturn` [ BDefault ]
 
   it "can call builtin function verifySignature" . runTest $ do
     runBS [r|

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -122,7 +122,7 @@ sender :: Account
 sender = Account 0xdeadbeef Nothing
 
 privateChainAcc :: Account 
-privateChainAcc = Account 0xdeadbeee (Just 0x776622233444)
+privateChainAcc = Account 0xdeadbeef (Just 0x776622233444)
 
 rootAcc :: Account 
 rootAcc = Account (fromPublicKey X509.rootPubKey) Nothing
@@ -205,6 +205,41 @@ runArgsWithSender acc args bs = do
 
   newAddress <- getNewAddress acc
   er <- SVM.create isTest isHomestead suicides blockData callDepth sender origin
+          value gasPrice availableGas newAddress code txHash chainId metadata
+  rethrowEx er
+  return er
+
+runArgsWithOrigin :: Account -> Account -> T.Text -> String -> ContextM ExecResults
+runArgsWithOrigin orig acc args bs = do
+  let code = Code $ UTF8.fromString bs
+      isTest = error "TODO: isTest"
+      isHomestead = error "TODO: isHomestead"
+      suicides = error "TODO: suicides"
+      blockData = BlockData { blockDataParentHash = unsafeCreateKeccak256FromWord256 0x0
+                            , blockDataUnclesHash = unsafeCreateKeccak256FromWord256 0x0
+                            , blockDataCoinbase = Address 0x0
+                            , blockDataStateRoot = ""
+                            , blockDataTransactionsRoot = ""
+                            , blockDataReceiptsRoot = ""
+                            , blockDataLogBloom = ""
+                            , blockDataDifficulty = 900
+                            , blockDataNumber = 8033
+                            , blockDataGasLimit = 1000000
+                            , blockDataGasUsed = 10000
+                            , blockDataExtraData = ""
+                            , blockDataNonce = 22
+                            , blockDataMixHash = unsafeCreateKeccak256FromWord256 0x0
+                            , blockDataTimestamp = posixSecondsToUTCTime 0x4000 }
+      callDepth = 0
+      value = error "TODO: value"
+      gasPrice = error "TODO: gasPrice"
+      availableGas = error "TODO: availableGas"
+      txHash = unsafeCreateKeccak256FromWord256 0x776622233444
+      chainId = Nothing
+      metadata = Just $ M.fromList [("name",  "qq"), ("args", args)]
+
+  newAddress <- getNewAddress acc
+  er <- SVM.create isTest isHomestead suicides blockData callDepth sender orig
           value gasPrice availableGas newAddress code txHash chainId metadata
   rethrowEx er
   return er
@@ -3171,57 +3206,21 @@ contract qq {
       , BString "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGOKeu5dSCBFHVQuy/q1A8BeTb99G83tD\nVecvHHne6sKfmBZN1AIjhpHGKO22vBfdq3dMn/QBqb2TdR9w3WvMXQ==\n-----END PUBLIC KEY-----\n"
       ]
 
---   it "can post a X509 certificate and grab cert fields" . runTest $ do
---     runBS [r|
--- contract qq {
---     account myAccount = account(tx.origin, "main");
-    
---     string myNewCertificate = "-----BEGIN CERTIFICATE-----\nMIIBiDCCAS2gAwIBAgIQCgO76hC29iXEFXJNco5ekjAMBggqhkjOPQQDAgUAMEYx\nDDAKBgNVBAMMA2RhbjEMMAoGA1UEBgwDVVNBMRIwEAYDVQQKDAlibG9ja2FwcHMx\nFDASBgNVBAsMC2VuZ2luZWVyaW5nMB4XDTIxMDMxODE1NDgwN1oXDTIyMDMxODE1\nNDgwN1owRjEMMAoGA1UEAwwDZGFuMQwwCgYDVQQGDANVU0ExEjAQBgNVBAoMCWJs\nb2NrYXBwczEUMBIGA1UECwwLZW5naW5lZXJpbmcwVjAQBgcqhkjOPQIBBgUrgQQA\nCgNCAAQY4p67l1IIEUdVC7L+rUDwF5Nv30bze0NV5y8ced7qwp+YFk3UAiOGkcYo\n7ba8F92rd0yf9AGpvZN1H3Dda8xdMAwGCCqGSM49BAMCBQADRwAwRAIgbKXO8tZ5\noPhBusPQFkNEQDnLO/MRru4KjtCpPnVb5sACIE0TwBJ7yeIGuPc/8G50/858Pf3a\n0t1hHbhYnJarPkNA\n-----END CERTIFICATE-----";
-
---     string myUsername          = "";
---     string myOrganization      = "";
---     string myGroup             = "";
-    
---     string myCommonName   = "";
---     string myCountry      = "";
---     string myOrganization = "";
---     string myGroup        = "";
---     string myPublicKey    = "";
---     string myCertificate  = "";
-
---     constructor() {
---         registerCert(myAccount, myNewCertificate); 
-
---         myUsername     = tx.username;
---         myOrganization = tx.organization;
---         myGroup        = tx.group;
-        
---         myCommonName   = getUserCert(myAccount)["commonName"];
---         myCountry      = getUserCert(myAccount)["country"];
---         myOrganization = getUserCert(myAccount)["organization"];
---         myGroup        = getUserCert(myAccount)["group"];
---         myPublicKey    = getUserCert(myAccount)["publicKey"];
---         myCertificate  = getUserCert(myAccount)["certString"];
---     }
--- }|]
---     getFields ["myUsername", "myOrganization", "myGroup", "myCommonName", "myCountry", "myOrganization", "myGroup", "myPublicKey", "myCertificate"] `shouldReturn`
---       [ BString "dan"
---       , BString "blockapps"
---       , BString "engineering"
---       , BString "dan"
---       , BString "USA"
---       , BString "blockapps"
---       , BString "engineering"
---       , BString "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGOKeu5dSCBFHVQuy/q1A8BeTb99G83tD\nVecvHHne6sKfmBZN1AIjhpHGKO22vBfdq3dMn/QBqb2TdR9w3WvMXQ==\n-----END PUBLIC KEY-----\n"
---       , BString "-----BEGIN CERTIFICATE-----\nMIIBiDCCAS2gAwIBAgIQCgO76hC29iXEFXJNco5ekjAMBggqhkjOPQQDAgUAMEYx\nDDAKBgNVBAMMA2RhbjEMMAoGA1UEBgwDVVNBMRIwEAYDVQQKDAlibG9ja2FwcHMx\nFDASBgNVBAsMC2VuZ2luZWVyaW5nMB4XDTIxMDMxODE1NDgwN1oXDTIyMDMxODE1\nNDgwN1owRjEMMAoGA1UEAwwDZGFuMQwwCgYDVQQGDANVU0ExEjAQBgNVBAoMCWJs\nb2NrYXBwczEUMBIGA1UECwwLZW5naW5lZXJpbmcwVjAQBgcqhkjOPQIBBgUrgQQA\nCgNCAAQY4p67l1IIEUdVC7L+rUDwF5Nv30bze0NV5y8ced7qwp+YFk3UAiOGkcYo\n7ba8F92rd0yf9AGpvZN1H3Dda8xdMAwGCCqGSM49BAMCBQADRwAwRAIgbKXO8tZ5\noPhBusPQFkNEQDnLO/MRru4KjtCpPnVb5sACIE0TwBJ7yeIGuPc/8G50/858Pf3a\n0t1hHbhYnJarPkNA\n-----END CERTIFICATE-----\n"
---       ]
-
-
-  it "can only post X509 certificates to the address of the public key" . runTest $ do
+  it "only a contract posted by the root user can call registerCert" $ (runTest $ do
     runBS [r|
 pragma solidvm 3.2;
 contract qq {
-    account public certAddr = account(0x74f014FEF932D2728c6c7E2B4d3B88ac37A7E1d0);
+    string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBjjCCATKgAwIBAgIRANJH2FERGO/3JvoPHo52I3IwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyNTE0NTIwMloXDTIzMDQy\nNTE0NTIwMlowSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANIADBFAiEA\n9sjaARt+VEUCjZv3NAuEENoD744fZIuuUTt6qwM7fKQCIDLp02y/lSHtLfOOgCW5\n40qEIDYu2UO1JqSuyGvIUOoc\n-----END CERTIFICATE-----";
+    constructor() {
+        registerCert(myCertificate);
+    }
+}|]) `shouldThrow` anyInvalidWriteError
+
+  it "can only post X509 certificates to the address of the public key" . runTest $ do
+    void $ runArgsWithOrigin rootAcc sender "()" [r|
+pragma solidvm 3.2;
+contract qq {
+    account public certAddr = account(0x74f014FEF932D2728c6c7E2B4d3B88ac37A7E1d0, "main");
     string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBjTCCATKgAwIBAgIRAOPPkVoBp/GnwZGR32jcIjwwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyMDE3NTcxM1oXDTIzMDQy\nMDE3NTcxM1owSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANHADBEAiA8\nR0UERQZbF3qJUt5A0ZFf2ZmB0l/ZPjIvM383gOF3xwIgbxbQ8NLkDEe2mWJ/qa4n\nN8txKc8G9R27ZYAUuz15zF0=\n-----END CERTIFICATE-----";
     string public certName;
     string public certOrg;
@@ -3229,7 +3228,6 @@ contract qq {
         registerCert(myCertificate);
         certName = getUserCert(certAddr)["commonName"];
         certOrg = getUserCert(certAddr)["organization"];
-
     }
 }|]
     getFields ["certName", "certOrg"] `shouldReturn`
@@ -3238,7 +3236,7 @@ contract qq {
       ]
 
   it "cannot post X509 certificates not signed by the BlockApps private key" $ (runTest $ do
-    runBS [r|
+    void $ runArgsWithOrigin rootAcc sender "()" [r|
 pragma solidvm 3.2;
 contract qq {
     account public certAddr = account(0xe79beda3078bcb66524f91f74de982d2fcc89287);
@@ -3252,8 +3250,8 @@ contract qq {
     }
 }|]) `shouldThrow` anyInvalidCertError
 
-  it "can't register a x509 certificate on a private chain" $ (runTest $ do
-    void $ runArgsWithSender privateChainAcc "()" [r|
+  it "cannot register a x509 certificate on a private chain" $ (runTest $ do
+    void $ runArgsWithOrigin rootAcc privateChainAcc "()" [r|
 pragma solidvm 3.2;
 contract qq {
     account myAccount = account("deadbeef:feedbeef");
@@ -3290,6 +3288,52 @@ contract qq {
       }
   }|])) `shouldThrow` anyUnknownFunc
 
+  it "can get a users cert" . runTest $ do
+    void $ runArgsWithOrigin rootAcc sender "()" [r|
+pragma solidvm 3.2;
+contract qq {
+    account myAccount = account(0x74f014FEF932D2728c6c7E2B4d3B88ac37A7E1d0);
+    
+    string myNewCertificate = "-----BEGIN CERTIFICATE-----\nMIIBjTCCATKgAwIBAgIRAOPPkVoBp/GnwZGR32jcIjwwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyMDE3NTcxM1oXDTIzMDQy\nMDE3NTcxM1owSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANHADBEAiA8\nR0UERQZbF3qJUt5A0ZFf2ZmB0l/ZPjIvM383gOF3xwIgbxbQ8NLkDEe2mWJ/qa4n\nN8txKc8G9R27ZYAUuz15zF0=\n-----END CERTIFICATE-----";
+
+    string myUsername          = "";
+    string myOrganization      = "";
+    string myGroup             = "";
+    
+    string myCommonName   = "";
+    string myCountry      = "";
+    string myOrganization = "";
+    string myGroup        = "";
+    string myPublicKey    = "";
+    string myCertificate  = "";
+
+    constructor() {
+        registerCert(myNewCertificate); 
+
+        myUsername     = tx.username;
+        myOrganization = tx.organization;
+        myGroup        = tx.group;
+        
+        myCommonName   = getUserCert(myAccount)["commonName"];
+        myCountry      = getUserCert(myAccount)["country"];
+        myOrganization = getUserCert(myAccount)["organization"];
+        myGroup        = getUserCert(myAccount)["group"];
+        myPublicKey    = getUserCert(myAccount)["publicKey"];
+        myCertificate  = getUserCert(myAccount)["certString"];
+    }
+}|]
+    getFields ["myUsername", "myOrganization", "myGroup", "myCommonName", "myCountry", "myOrganization", "myGroup", "myPublicKey", "myCertificate"] `shouldReturn`
+      [ BString "Admin"
+      , BString "BlockApps"
+      , BString "Engineering"
+      , BString "Admin"
+      , BString "USA"
+      , BString "BlockApps"
+      , BString "Engineering"
+      , BString "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUhJR4x+wZiX+xZK2m/pwN40cvCS0UA7Z\n0DB7sny5ZnNLw43JgKz0URDY2yYOPkhoIApxFK9UU3Bc4BRANDWmdQ==\n-----END PUBLIC KEY-----\n"
+      , BString "-----BEGIN CERTIFICATE-----\nMIIBjTCCATKgAwIBAgIRAOPPkVoBp/GnwZGR32jcIjwwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyMDE3NTcxM1oXDTIzMDQy\nMDE3NTcxM1owSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANHADBEAiA8\nR0UERQZbF3qJUt5A0ZFf2ZmB0l/ZPjIvM383gOF3xwIgbxbQ8NLkDEe2mWJ/qa4n\nN8txKc8G9R27ZYAUuz15zF0=\n-----END CERTIFICATE-----\n"
+      ]
+    
   it "can call builtin function verifyCert" . runTest $ do
     runBS [r|
 pragma solidvm 3.2;

--- a/core-strato/strato-model/src/Blockchain/Strato/Model/Account.hs
+++ b/core-strato/strato-model/src/Blockchain/Strato/Model/Account.hs
@@ -18,6 +18,7 @@ module Blockchain.Strato.Model.Account
     , namedAccountAddress
     , namedAccountToAccount
     , accountToNamedAccount
+    , accountToNamedAccount'
     , accountOnUnspecifiedChain
     , unspecifiedChain
     , mainChain
@@ -182,6 +183,10 @@ namedAccountToAccount _   (NamedAccount a (ExplicitChain cid)) = Account a (Just
 accountToNamedAccount :: Maybe Word256 -> Account -> NamedAccount
 accountToNamedAccount c (Account a c') | c == c'   = NamedAccount a UnspecifiedChain
                                        | otherwise = NamedAccount a (maybe MainChain ExplicitChain c')
+
+accountToNamedAccount' :: Account -> NamedAccount
+accountToNamedAccount' (Account a Nothing) = NamedAccount a MainChain
+accountToNamedAccount' (Account a (Just cid)) = NamedAccount a (ExplicitChain cid)
 
 accountOnUnspecifiedChain :: Account -> NamedAccount
 accountOnUnspecifiedChain (Account a _) = NamedAccount a UnspecifiedChain

--- a/x509-certs/exec_src/X509CertGenerator.hs
+++ b/x509-certs/exec_src/X509CertGenerator.hs
@@ -111,23 +111,20 @@ main = do
 -------------------------------------- GENERATE CERT ---------------------------------------
 --------------------------------------------------------------------------------------------
 
-  let issuer = case optIssuerCert of
-        Nothing -> Issuer
+  let issuer = case (optIssuerCert, getCertSubject =<< optIssuerCert) of
+        (Nothing, _) -> Issuer
           { issCommonName = subCommonName optSubjectInfo
           , issCountry    = subCountry optSubjectInfo
           , issOrg        = subOrg optSubjectInfo
           , issUnit       = subUnit optSubjectInfo
           }
-        Just cert -> 
-          let subject = listToMaybe =<< getCertSubject cert
-          in case subject of
-            Just (Subject{..}) -> Issuer
-                { issCommonName = subCommonName
-                , issCountry    = subCountry
-                , issOrg        = subOrg
-                , issUnit       = subUnit
-                } 
-            _ -> error "missing commonName or orgName in issuer cert"
+        (Just _, Just (Subject{..})) -> Issuer
+          { issCommonName = subCommonName
+          , issCountry    = subCountry
+          , issOrg        = subOrg
+          , issUnit       = subUnit
+          } 
+        _ -> error "missing commonName or orgName in issuer cert"
   
   -- generate and write cert
   flip runReaderT optKey $ do

--- a/x509-certs/exec_src/X509CertGenerator.hs
+++ b/x509-certs/exec_src/X509CertGenerator.hs
@@ -17,7 +17,6 @@ import qualified Data.ByteString                    as B
 import qualified Data.ByteString.Char8              as C8
 import           Data.Either
 import           Data.Foldable                      (foldlM)
-import           Data.Maybe
 import           System.Console.GetOpt
 import           System.Environment
 

--- a/x509-certs/exec_src/X509CertGenerator.hs
+++ b/x509-certs/exec_src/X509CertGenerator.hs
@@ -123,6 +123,6 @@ main = do
   
   -- generate and write cert
   flip runReaderT optKey $ do
-    cert <- makeSignedCert issuer optSubjectInfo
+    cert <- makeSignedCert optIssuerCert issuer optSubjectInfo
     liftIO $ B.writeFile "outputCert.pem" $ certToBytes $ cert
     liftIO $ putStrLn "Done. Cert was written to outputCert.pem"

--- a/x509-certs/exec_src/X509CertGenerator.hs
+++ b/x509-certs/exec_src/X509CertGenerator.hs
@@ -119,7 +119,7 @@ main = do
           , issUnit       = subUnit optSubjectInfo
           }
         Just cert -> 
-          fromMaybe (error "missing commonName or orgName in issuer cert") (getCertIssuer cert)
+          head $ fromMaybe (error "missing commonName or orgName in issuer cert") (getCertIssuer cert)
   
   -- generate and write cert
   flip runReaderT optKey $ do

--- a/x509-certs/exec_src/X509CertGenerator.hs
+++ b/x509-certs/exec_src/X509CertGenerator.hs
@@ -119,7 +119,15 @@ main = do
           , issUnit       = subUnit optSubjectInfo
           }
         Just cert -> 
-          head $ fromMaybe (error "missing commonName or orgName in issuer cert") (getCertIssuer cert)
+          let subject = listToMaybe =<< getCertSubject cert
+          in case subject of
+            Just (Subject{..}) -> Issuer
+                { issCommonName = subCommonName
+                , issCountry    = subCountry
+                , issOrg        = subOrg
+                , issUnit       = subUnit
+                } 
+            _ -> error "missing commonName or orgName in issuer cert"
   
   -- generate and write cert
   flip runReaderT optKey $ do

--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -45,11 +45,13 @@ import qualified Data.ByteString.Char8              as C8
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Short              as BSS
 
+import           Data.Functor
 import           Data.Either
 import           Data.Maybe
 import           Data.PEM
 import qualified Data.Text                      as T
 import           Data.X509
+import           Data.Traversable
 import           Time.Types
 import           Time.System
 import qualified Text.Colors       as CL
@@ -65,7 +67,7 @@ import           Text.Format
 
 
 
-newtype X509Certificate = X509Certificate SignedCertificate deriving (Show, Eq)
+newtype X509Certificate = X509Certificate CertificateChain deriving (Show, Eq)
 
 instance NFData X509Certificate where
     rnf (X509Certificate cert) = cert `seq` ()
@@ -156,15 +158,14 @@ rootCert = let eCert = bsToCert $ C8.pack $ unlines
 --------------------------------------- IMPORT/EXPORT ----------------------------------------
 ----------------------------------------------------------------------------------------------
 
-
 certToBytes :: X509Certificate -> B.ByteString
-certToBytes = pemWriteBS . certToPem
+certToBytes x = C8.concat . fmap pemWriteBS . certsToPems $ x
 
-certToPem :: X509Certificate -> PEM
-certToPem (X509Certificate cert) = PEM 
+certsToPems :: X509Certificate -> [PEM]
+certsToPems (X509Certificate (CertificateChain certs)) = certs <&> \c -> PEM 
   { pemName = "CERTIFICATE"
   , pemHeader = []
-  , pemContent = encodeSignedObject cert
+  , pemContent = encodeSignedObject c
   }
 
 
@@ -173,9 +174,9 @@ bsToCert bs =
   case (pemParseBS bs) of
     Left str -> Left str
     Right [] -> Left "nothing parsed...but no errors?"
-    Right (pem:_) -> 
-      case (decodeSignedCertificate $ pemContent pem) of
-        Left str -> Left str
+    Right pems -> 
+      case (decodeCertificateChain $ CertificateChainRaw $ pemContent <$> pems) of
+        Left (i, str) -> Left $ str <> " : cert " <> show i
         Right cert -> Right $ X509Certificate cert
 
 
@@ -187,7 +188,7 @@ bsToCert bs =
 
 
 makeSignedCert :: (MonadIO m, HasVault m) => Issuer -> Subject -> m (X509Certificate)
-makeSignedCert iss sub = makeCert iss sub >>= signCert >>= return . X509Certificate
+makeSignedCert iss sub = makeCert iss sub >>= signCert >>= return . X509Certificate . CertificateChain . (\x -> [x])
 
 signCert :: (MonadIO m, HasVault m) => Certificate -> m (SignedCertificate)
 signCert cert = objectToSignedExactF (ecdsaWithSHA256) cert
@@ -278,31 +279,31 @@ getCertPub = serializeAndWrap . subPub
 
 
 -- without cn and org, subject and issuer are invalid, but the other fields can be Nothing
-getCertSubject :: X509Certificate -> Maybe Subject
-getCertSubject (X509Certificate cert) = do
+getCertSubject :: X509Certificate -> Maybe [Subject]
+getCertSubject (X509Certificate (CertificateChain certs)) = for certs $ \cert -> do
   pubKey <- unserializeAndUnwrap . certPubKey $ getCertificate cert
-  cn     <- extractDn DnCommonName
-  org    <- extractDn DnOrganization
+  cn     <- extractDn cert DnCommonName
+  org    <- extractDn cert DnOrganization
   return $ Subject { subCommonName = cn
                    , subOrg        = org
-                   , subUnit       = extractDn DnOrganizationUnit
-                   , subCountry    = extractDn DnCountry
+                   , subUnit       = extractDn cert DnOrganizationUnit
+                   , subCountry    = extractDn cert DnCountry
                    , subPub        = pubKey 
                    }
-  where extractDn :: DnElement -> Maybe String
-        extractDn dn = fmap fromASN1CS . getDnElement dn . certSubjectDN $ getCertificate cert   
+  where extractDn :: SignedCertificate -> DnElement -> Maybe String
+        extractDn cert dn = fmap fromASN1CS . getDnElement dn . certSubjectDN $ getCertificate cert   
 
-getCertIssuer :: X509Certificate -> Maybe Issuer
-getCertIssuer (X509Certificate cert) = do
-  cn     <- extractDn DnCommonName
-  org    <- extractDn DnOrganization
+getCertIssuer :: X509Certificate -> Maybe [Issuer]
+getCertIssuer (X509Certificate (CertificateChain certs)) = for certs $ \cert -> do
+  cn     <- extractDn cert DnCommonName
+  org    <- extractDn cert DnOrganization
   return $ Issuer { issCommonName = cn
                   , issOrg        = org
-                  , issUnit       = extractDn DnOrganizationUnit 
-                  , issCountry    = extractDn DnCountry
+                  , issUnit       = extractDn cert DnOrganizationUnit 
+                  , issCountry    = extractDn cert DnCountry
                   }
-  where extractDn :: DnElement -> Maybe String
-        extractDn dn = fmap fromASN1CS . getDnElement dn . certIssuerDN $ getCertificate cert
+  where extractDn :: SignedCertificate -> DnElement -> Maybe String
+        extractDn cert dn = fmap fromASN1CS . getDnElement dn . certIssuerDN $ getCertificate cert
 
 
 --------------------------------------------------------------------------------------------
@@ -310,22 +311,45 @@ getCertIssuer (X509Certificate cert) = do
 --------------------------------------------------------------------------------------------
 
 -- Verify that a cert was signed by given public key
+-- We perform a chain validation and expect pkey to be our trust anchor. The process is 
+-- combersomly detailed in RFC 5280 section 6
+-- The first certificate in X509Certificate is the target cert, and the last one is the
+-- the trust anchor (the one signed by the public key)
 verifyCert :: PublicKey -> X509Certificate -> Bool
-verifyCert pkey (X509Certificate signedCert) = 
-  let signed = getSigned signedCert
-      mesgBS = B.pack $ BA.unpack $ hashWith CH.SHA256 (getSignedData signedCert)
+verifyCert _ (X509Certificate (CertificateChain [])) = False
+verifyCert pkey (X509Certificate (CertificateChain [c])) = 
+  let signed = getSigned c
+      mesgBS = B.pack $ BA.unpack $ hashWith CH.SHA256 (getSignedData c)
   in
   case importSignature' $ signedSignature signed of 
     Nothing -> False
     Just sig -> verifySig pkey sig mesgBS
+verifyCert pkey (X509Certificate (CertificateChain (c:c':cs))) = 
+  and [
+      getCertIssuer (X509Certificate (CertificateChain [c])) `issSubEq` getCertSubject (X509Certificate (CertificateChain [c]))
+    , c `signedBy` c'
+    , verifyCert pkey (X509Certificate (CertificateChain (c':cs)))
+  ]
+  where issSubEq :: Maybe [Issuer] -> Maybe [Subject] -> Bool
+        issSubEq (Just [Issuer{..}]) (Just [Subject{..}]) = 
+          (issCommonName, issOrg, issUnit, issCountry) == (subCommonName, subOrg, subUnit, subCountry)
+        issSubEq _ _ = False
+
+        signedBy :: SignedCertificate -> SignedCertificate -> Bool
+        signedBy sc sc' = case sc'pubKey of
+            Nothing -> False
+            Just sc'pkey -> verifyCert sc'pkey (X509Certificate (CertificateChain [sc]))
+          where sc'pubKey :: Maybe PublicKey
+                sc'pubKey = fmap subPub $ listToMaybe =<< getCertSubject (X509Certificate (CertificateChain [sc']))
 
 verifyBlockApps :: X509Certificate -> Bool 
 verifyBlockApps = verifyCert rootPubKey
 
 verifyCertM :: MonadIO m => PublicKey -> X509Certificate -> m Bool
-verifyCertM pkey cert@(X509Certificate signedCert) = do
-  let signed    = getSigned signedCert
-      mesgBS    = B.pack $ BA.unpack $ hashWith CH.SHA256 (getSignedData signedCert)
+verifyCertM _ (X509Certificate (CertificateChain [])) = pure False
+verifyCertM pkey cert@(X509Certificate (CertificateChain [c])) = do
+  let signed    = getSigned c
+      mesgBS    = B.pack $ BA.unpack $ hashWith CH.SHA256 (getSignedData c)
       signature@(Signature (SEC.CompactRecSig r s _)) = fromMaybe (error "Could not decode signature from DER format") (importSignature' $ signedSignature signed)
       isValid   = verifySig pkey signature mesgBS
   liftIO $ putStrLn $ format (getCertIssuer cert)
@@ -337,8 +361,29 @@ verifyCertM pkey cert@(X509Certificate signedCert) = do
   
   case getCertSubject cert of 
     Nothing -> liftIO $ putStrLn $ "No Subject"
-    Just subject -> do 
+    Just [] -> liftIO $ putStrLn $ "No Subject"
+    Just (subject:_) -> do 
       liftIO $ putStrLn $ format subject
       liftIO $ putStrLn $ "Subject Address: " ++ (format $ fromPublicKey $ subPub subject) 
   return isValid
+verifyCertM pkey (X509Certificate (CertificateChain (c:c':cs))) = do
+  rec <- verifyCertM pkey (X509Certificate (CertificateChain (c':cs)))
+  sig <- c `signedBy` c'
+  return $ and [
+        getCertIssuer (X509Certificate (CertificateChain [c])) `issSubEq` getCertSubject (X509Certificate (CertificateChain [c]))
+      , sig
+      , rec
+    ]
+  where issSubEq :: Maybe [Issuer] -> Maybe [Subject] -> Bool
+        issSubEq (Just [Issuer{..}]) (Just [Subject{..}]) = 
+          (issCommonName, issOrg, issUnit, issCountry) == (subCommonName, subOrg, subUnit, subCountry)
+        issSubEq _ _ = False
+
+        signedBy :: MonadIO m => SignedCertificate -> SignedCertificate -> m Bool
+        signedBy sc sc' = case sc'pubKey of
+            Nothing -> pure False
+            Just sc'pkey -> verifyCertM sc'pkey (X509Certificate (CertificateChain [sc]))
+          where sc'pubKey :: Maybe PublicKey
+                sc'pubKey = fmap subPub $ listToMaybe =<< getCertSubject (X509Certificate (CertificateChain [sc']))
+
   

--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -330,7 +330,7 @@ verifyCert pkey (X509Certificate (CertificateChain [c])) =
     Just sig -> verifySig pkey sig mesgBS
 verifyCert pkey (X509Certificate (CertificateChain (c:c':cs))) = 
   and [
-      getCertIssuer (X509Certificate (CertificateChain [c])) `issSubEq` getCertSubject (X509Certificate (CertificateChain [c]))
+      getCertIssuer (X509Certificate (CertificateChain [c])) `issSubEq` getCertSubject (X509Certificate (CertificateChain [c']))
     , c `signedBy` c'
     , verifyCert pkey (X509Certificate (CertificateChain (c':cs)))
   ]
@@ -374,7 +374,7 @@ verifyCertM pkey (X509Certificate (CertificateChain (c:c':cs))) = do
   rec <- verifyCertM pkey (X509Certificate (CertificateChain (c':cs)))
   sig <- c `signedBy` c'
   return $ and [
-        getCertIssuer (X509Certificate (CertificateChain [c])) `issSubEq` getCertSubject (X509Certificate (CertificateChain [c]))
+        getCertIssuer (X509Certificate (CertificateChain [c])) `issSubEq` getCertSubject (X509Certificate (CertificateChain [c']))
       , sig
       , rec
     ]

--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -31,6 +31,7 @@ import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Strato.Model.Address
 import           BlockApps.X509.Keys
 import           Control.DeepSeq
+import           Control.Monad
 import           Control.Monad.IO.Class
 import           Crypto.Random.Entropy
 import           Crypto.Hash
@@ -47,7 +48,6 @@ import qualified Data.ByteString.Char8              as C8
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Short              as BSS
 
-import           Data.Functor
 import           Data.Either
 import           Data.Maybe
 import           Data.PEM
@@ -74,6 +74,11 @@ newtype X509Certificate = X509Certificate CertificateChain deriving (Show, Eq)
 instance NFData X509Certificate where
     rnf (X509Certificate cert) = cert `seq` ()
 
+signedsToX509 :: [SignedCertificate] -> X509Certificate
+signedsToX509 = X509Certificate . CertificateChain
+
+x509ToSigneds :: X509Certificate -> [SignedCertificate]
+x509ToSigneds (X509Certificate (CertificateChain cs)) = cs
 
 data Issuer = Issuer
   {
@@ -159,15 +164,14 @@ rootCert = let eCert = bsToCert $ C8.pack $ unlines
 ----------------------------------------------------------------------------------------------
 --------------------------------------- IMPORT/EXPORT ----------------------------------------
 ----------------------------------------------------------------------------------------------
-
 certToBytes :: X509Certificate -> B.ByteString
-certToBytes x = C8.concat . fmap pemWriteBS . certsToPems $ x
+certToBytes cert = C8.concat $ pemWriteBS . signedCertToPem <$> x509ToSigneds cert
 
-certsToPems :: X509Certificate -> [PEM]
-certsToPems (X509Certificate (CertificateChain certs)) = certs <&> \c -> PEM 
+signedCertToPem :: SignedCertificate -> PEM
+signedCertToPem cert = PEM 
   { pemName = "CERTIFICATE"
   , pemHeader = []
-  , pemContent = encodeSignedObject c
+  , pemContent = encodeSignedObject cert
   }
 
 
@@ -190,10 +194,7 @@ bsToCert bs =
 
 
 makeSignedCert :: (MonadIO m, HasVault m) => Maybe X509Certificate -> Issuer -> Subject -> m (X509Certificate)
-makeSignedCert parentCerts iss sub = makeCert iss sub >>= signCert >>= return . X509Certificate . CertificateChain . (\x -> x:parentCerts' parentCerts)
-  where parentCerts' :: Maybe X509Certificate -> [SignedCertificate]
-        parentCerts' (Just (X509Certificate (CertificateChain cs))) = cs
-        parentCerts' Nothing = []
+makeSignedCert parentCert iss sub = makeCert iss sub >>= signCert >>= return . X509Certificate . CertificateChain . (:(join . maybeToList $ x509ToSigneds <$> parentCert))
 
 
 signCert :: (MonadIO m, HasVault m) => Certificate -> m (SignedCertificate)
@@ -290,7 +291,7 @@ getCertSubject cert = listToMaybe =<< getCertSubjects cert
 
 -- without cn and org, subject and issuer are invalid, but the other fields can be Nothing
 getCertSubjects :: X509Certificate -> Maybe [Subject]
-getCertSubjects (X509Certificate (CertificateChain certs)) = for certs $ \cert -> do
+getCertSubjects certs = for (x509ToSigneds certs) $ \cert -> do
   pubKey <- unserializeAndUnwrap . certPubKey $ getCertificate cert
   cn     <- extractDn cert DnCommonName
   org    <- extractDn cert DnOrganization
@@ -308,7 +309,7 @@ getCertIssuer :: X509Certificate -> Maybe Issuer
 getCertIssuer cert = listToMaybe =<< getCertIssuers cert
 
 getCertIssuers :: X509Certificate -> Maybe [Issuer]
-getCertIssuers (X509Certificate (CertificateChain certs)) = for certs $ \cert -> do
+getCertIssuers certs = for (x509ToSigneds certs) $ \cert -> do
   cn     <- extractDn cert DnCommonName
   org    <- extractDn cert DnOrganization
   return $ Issuer { issCommonName = cn
@@ -340,21 +341,21 @@ verifyCert pkey (X509Certificate (CertificateChain [c])) =
     Just sig -> verifySig pkey sig mesgBS
 verifyCert pkey (X509Certificate (CertificateChain (c:c':cs))) = 
   and [
-      getCertIssuer (X509Certificate (CertificateChain [c])) `issSubEq` getCertSubject (X509Certificate (CertificateChain [c']))
+      getCertIssuer (signedsToX509 [c]) `issSubEq` getCertSubject (signedsToX509 [c'])
     , c `signedBy` c'
-    , verifyCert pkey (X509Certificate (CertificateChain (c':cs)))
+    , verifyCert pkey (signedsToX509 (c':cs))
   ]
-  where issSubEq :: Maybe [Issuer] -> Maybe [Subject] -> Bool
-        issSubEq (Just [Issuer{..}]) (Just [Subject{..}]) = 
+  where issSubEq :: Maybe Issuer -> Maybe Subject -> Bool
+        issSubEq (Just Issuer{..}) (Just Subject{..}) = 
           (issCommonName, issOrg, issUnit, issCountry) == (subCommonName, subOrg, subUnit, subCountry)
         issSubEq _ _ = False
 
         signedBy :: SignedCertificate -> SignedCertificate -> Bool
         signedBy sc sc' = case sc'pubKey of
             Nothing -> False
-            Just sc'pkey -> verifyCert sc'pkey (X509Certificate (CertificateChain [sc]))
+            Just sc'pkey -> verifyCert sc'pkey (signedsToX509 [sc])
           where sc'pubKey :: Maybe PublicKey
-                sc'pubKey = fmap subPub $ getCertSubject (X509Certificate (CertificateChain [sc']))
+                sc'pubKey = fmap subPub $ getCertSubject (signedsToX509 [sc'])
 
 verifyBlockApps :: X509Certificate -> Bool 
 verifyBlockApps = verifyCert rootPubKey
@@ -375,29 +376,28 @@ verifyCertM pkey cert@(X509Certificate (CertificateChain [c])) = do
   
   case getCertSubject cert of 
     Nothing -> liftIO $ putStrLn $ "No Subject"
-    Just [] -> liftIO $ putStrLn $ "No Subject"
-    Just (subject:_) -> do 
+    Just subject -> do
       liftIO $ putStrLn $ format subject
       liftIO $ putStrLn $ "Subject Address: " ++ (format $ fromPublicKey $ subPub subject) 
   return isValid
 verifyCertM pkey (X509Certificate (CertificateChain (c:c':cs))) = do
-  rec <- verifyCertM pkey (X509Certificate (CertificateChain (c':cs)))
+  rec <- verifyCertM pkey (signedsToX509 (c':cs))
   sig <- c `signedBy` c'
   return $ and [
-        getCertIssuer (X509Certificate (CertificateChain [c])) `issSubEq` getCertSubject (X509Certificate (CertificateChain [c']))
+        getCertIssuer (signedsToX509 [c]) `issSubEq` getCertSubject (signedsToX509 [c'])
       , sig
       , rec
     ]
-  where issSubEq :: Maybe [Issuer] -> Maybe [Subject] -> Bool
-        issSubEq (Just [Issuer{..}]) (Just [Subject{..}]) = 
+  where issSubEq :: Maybe Issuer -> Maybe Subject -> Bool
+        issSubEq (Just Issuer{..}) (Just Subject{..}) = 
           (issCommonName, issOrg, issUnit, issCountry) == (subCommonName, subOrg, subUnit, subCountry)
         issSubEq _ _ = False
 
         signedBy :: MonadIO m => SignedCertificate -> SignedCertificate -> m Bool
         signedBy sc sc' = case sc'pubKey of
             Nothing -> pure False
-            Just sc'pkey -> verifyCertM sc'pkey (X509Certificate (CertificateChain [sc]))
+            Just sc'pkey -> verifyCertM sc'pkey (signedsToX509 [sc])
           where sc'pubKey :: Maybe PublicKey
-                sc'pubKey = fmap subPub $ getCertSubject (X509Certificate (CertificateChain [sc']))
+                sc'pubKey = fmap subPub $ getCertSubject (signedsToX509 [sc'])
 
   

--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -48,6 +48,7 @@ import qualified Data.ByteString.Char8              as C8
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Short              as BSS
 
+import           Data.Functor
 import           Data.Either
 import           Data.Maybe
 import           Data.PEM
@@ -102,6 +103,9 @@ data Subject = Subject
 instance Format Subject where
   format = CL.blue . show
 
+issuerEqSubject :: Issuer -> Subject -> Bool
+issuerEqSubject Issuer{..} Subject{..} = 
+  (issCommonName, issOrg, issUnit, issCountry) == (subCommonName, subOrg, subUnit, subCountry)
 
 instance ToJSON Subject where
   toJSON (Subject cn o ou c pub) = 
@@ -331,73 +335,46 @@ getCertIssuers certs = for (x509ToSigneds certs) $ \cert -> do
 -- The first certificate in X509Certificate is the target cert, and the last one is the
 -- the trust anchor (the one signed by the public key)
 verifyCert :: PublicKey -> X509Certificate -> Bool
-verifyCert _ (X509Certificate (CertificateChain [])) = False
-verifyCert pkey (X509Certificate (CertificateChain [c])) = 
+verifyCert pkey (X509Certificate (CertificateChain cs)) = verifyCertChain pkey cs
+
+verifyCertChain :: PublicKey -> [SignedCertificate] -> Bool
+verifyCertChain _ [] = False
+verifyCertChain pkey [c] = 
   let signed = getSigned c
       mesgBS = B.pack $ BA.unpack $ hashWith CH.SHA256 (getSignedData c)
   in
   case importSignature' $ signedSignature signed of 
     Nothing -> False
     Just sig -> verifySig pkey sig mesgBS
-verifyCert pkey (X509Certificate (CertificateChain (c:c':cs))) = 
-  and [
-      getCertIssuer (signedsToX509 [c]) `issSubEq` getCertSubject (signedsToX509 [c'])
-    , c `signedBy` c'
-    , verifyCert pkey (signedsToX509 (c':cs))
-  ]
-  where issSubEq :: Maybe Issuer -> Maybe Subject -> Bool
-        issSubEq (Just Issuer{..}) (Just Subject{..}) = 
-          (issCommonName, issOrg, issUnit, issCountry) == (subCommonName, subOrg, subUnit, subCountry)
-        issSubEq _ _ = False
+verifyCertChain pkey (c:c':cs) = issuerMatchesSubject c c' && signedBy c c' && verifyCertChain pkey (c':cs)
 
-        signedBy :: SignedCertificate -> SignedCertificate -> Bool
-        signedBy sc sc' = case sc'pubKey of
-            Nothing -> False
-            Just sc'pkey -> verifyCert sc'pkey (signedsToX509 [sc])
-          where sc'pubKey :: Maybe PublicKey
-                sc'pubKey = fmap subPub $ getCertSubject (signedsToX509 [sc'])
+-- Verify that c's issuer match c''s subject
+issuerMatchesSubject :: SignedCertificate -> SignedCertificate -> Bool
+issuerMatchesSubject c c' = fromMaybe False $ issuerEqSubject <$> getCertIssuer (signedsToX509 [c]) <*> getCertSubject (signedsToX509 [c'])
+
+-- Verify that c signed by c'
+signedBy :: SignedCertificate -> SignedCertificate -> Bool
+signedBy c c' = fromMaybe False $ (\k -> verifyCertChain k [c]) . subPub <$> getCertSubject (signedsToX509 [c'])
 
 verifyBlockApps :: X509Certificate -> Bool 
 verifyBlockApps = verifyCert rootPubKey
 
 verifyCertM :: MonadIO m => PublicKey -> X509Certificate -> m Bool
-verifyCertM _ (X509Certificate (CertificateChain [])) = pure False
-verifyCertM pkey cert@(X509Certificate (CertificateChain [c])) = do
-  let signed    = getSigned c
-      mesgBS    = B.pack $ BA.unpack $ hashWith CH.SHA256 (getSignedData c)
-      signature@(Signature (SEC.CompactRecSig r s _)) = fromMaybe (error "Could not decode signature from DER format") (importSignature' $ signedSignature signed)
-      isValid   = verifySig pkey signature mesgBS
-  liftIO $ putStrLn $ format (getCertIssuer cert)
-  liftIO $ putStrLn $ "Signature:"
-  liftIO $ putStrLn $ "   R: " ++ (show $ B16.encode $ BSS.fromShort r)
-  liftIO $ putStrLn $ "   S: " ++ (show $ B16.encode $ BSS.fromShort s)
-  liftIO $ putStrLn $ "Signature (DER Encoding): " ++ (show $ B16.encode $ signedSignature signed )
-  liftIO $ putStrLn $ "Certificate Hash: " ++ (show $ B16.encode mesgBS)
+verifyCertM pkey (X509Certificate (CertificateChain cs)) = mapM_ printCertDetails cs $> verifyCertChain pkey cs
+  where printCertDetails :: MonadIO m => SignedCertificate -> m ()
+        printCertDetails c = do
+          let signed    = getSigned c
+              mesgBS    = B.pack $ BA.unpack $ hashWith CH.SHA256 (getSignedData c)
+              (Signature (SEC.CompactRecSig r s _)) = fromMaybe (error "Could not decode signature from DER format") (importSignature' $ signedSignature signed)
+          liftIO $ putStrLn $ format (getCertIssuer $ signedsToX509 [c])
+          liftIO $ putStrLn $ "Signature:"
+          liftIO $ putStrLn $ "   R: " ++ (show $ B16.encode $ BSS.fromShort r)
+          liftIO $ putStrLn $ "   S: " ++ (show $ B16.encode $ BSS.fromShort s)
+          liftIO $ putStrLn $ "Signature (DER Encoding): " ++ (show $ B16.encode $ signedSignature signed )
+          liftIO $ putStrLn $ "Certificate Hash: " ++ (show $ B16.encode mesgBS)
   
-  case getCertSubject cert of 
-    Nothing -> liftIO $ putStrLn $ "No Subject"
-    Just subject -> do
-      liftIO $ putStrLn $ format subject
-      liftIO $ putStrLn $ "Subject Address: " ++ (format $ fromPublicKey $ subPub subject) 
-  return isValid
-verifyCertM pkey (X509Certificate (CertificateChain (c:c':cs))) = do
-  rec <- verifyCertM pkey (signedsToX509 (c':cs))
-  sig <- c `signedBy` c'
-  return $ and [
-        getCertIssuer (signedsToX509 [c]) `issSubEq` getCertSubject (signedsToX509 [c'])
-      , sig
-      , rec
-    ]
-  where issSubEq :: Maybe Issuer -> Maybe Subject -> Bool
-        issSubEq (Just Issuer{..}) (Just Subject{..}) = 
-          (issCommonName, issOrg, issUnit, issCountry) == (subCommonName, subOrg, subUnit, subCountry)
-        issSubEq _ _ = False
-
-        signedBy :: MonadIO m => SignedCertificate -> SignedCertificate -> m Bool
-        signedBy sc sc' = case sc'pubKey of
-            Nothing -> pure False
-            Just sc'pkey -> verifyCertM sc'pkey (signedsToX509 [sc])
-          where sc'pubKey :: Maybe PublicKey
-                sc'pubKey = fmap subPub $ getCertSubject (signedsToX509 [sc'])
-
-  
+          case getCertSubject $ signedsToX509 [c] of 
+            Nothing -> liftIO $ putStrLn $ "No Subject"
+            Just subject -> do
+              liftIO $ putStrLn $ format subject
+              liftIO $ putStrLn $ "Subject Address: " ++ (format $ fromPublicKey $ subPub subject) 

--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -187,8 +187,12 @@ bsToCert bs =
 
 
 
-makeSignedCert :: (MonadIO m, HasVault m) => Issuer -> Subject -> m (X509Certificate)
-makeSignedCert iss sub = makeCert iss sub >>= signCert >>= return . X509Certificate . CertificateChain . (\x -> [x])
+makeSignedCert :: (MonadIO m, HasVault m) => Maybe X509Certificate -> Issuer -> Subject -> m (X509Certificate)
+makeSignedCert parentCerts iss sub = makeCert iss sub >>= signCert >>= return . X509Certificate . CertificateChain . (\x -> x:parentCerts' parentCerts)
+  where parentCerts' :: Maybe X509Certificate -> [SignedCertificate]
+        parentCerts' (Just (X509Certificate (CertificateChain cs))) = cs
+        parentCerts' Nothing = []
+
 
 signCert :: (MonadIO m, HasVault m) => Certificate -> m (SignedCertificate)
 signCert cert = objectToSignedExactF (ecdsaWithSHA256) cert

--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -19,7 +19,9 @@ module BlockApps.X509.Certificate (
   verifyCertM,
   makeSignedCert,
   getCertSubject,
-  getCertIssuer
+  getCertSubjects,
+  getCertIssuer,
+  getCertIssuers
  ) where
 
 
@@ -282,9 +284,13 @@ getCertPub :: Subject -> PubKey
 getCertPub = serializeAndWrap . subPub
 
 
+-- Get the (first) subject of the certificate
+getCertSubject :: X509Certificate -> Maybe Subject
+getCertSubject cert = listToMaybe =<< getCertSubjects cert
+
 -- without cn and org, subject and issuer are invalid, but the other fields can be Nothing
-getCertSubject :: X509Certificate -> Maybe [Subject]
-getCertSubject (X509Certificate (CertificateChain certs)) = for certs $ \cert -> do
+getCertSubjects :: X509Certificate -> Maybe [Subject]
+getCertSubjects (X509Certificate (CertificateChain certs)) = for certs $ \cert -> do
   pubKey <- unserializeAndUnwrap . certPubKey $ getCertificate cert
   cn     <- extractDn cert DnCommonName
   org    <- extractDn cert DnOrganization
@@ -297,8 +303,12 @@ getCertSubject (X509Certificate (CertificateChain certs)) = for certs $ \cert ->
   where extractDn :: SignedCertificate -> DnElement -> Maybe String
         extractDn cert dn = fmap fromASN1CS . getDnElement dn . certSubjectDN $ getCertificate cert   
 
-getCertIssuer :: X509Certificate -> Maybe [Issuer]
-getCertIssuer (X509Certificate (CertificateChain certs)) = for certs $ \cert -> do
+
+getCertIssuer :: X509Certificate -> Maybe Issuer
+getCertIssuer cert = listToMaybe =<< getCertIssuers cert
+
+getCertIssuers :: X509Certificate -> Maybe [Issuer]
+getCertIssuers (X509Certificate (CertificateChain certs)) = for certs $ \cert -> do
   cn     <- extractDn cert DnCommonName
   org    <- extractDn cert DnOrganization
   return $ Issuer { issCommonName = cn
@@ -344,7 +354,7 @@ verifyCert pkey (X509Certificate (CertificateChain (c:c':cs))) =
             Nothing -> False
             Just sc'pkey -> verifyCert sc'pkey (X509Certificate (CertificateChain [sc]))
           where sc'pubKey :: Maybe PublicKey
-                sc'pubKey = fmap subPub $ listToMaybe =<< getCertSubject (X509Certificate (CertificateChain [sc']))
+                sc'pubKey = fmap subPub $ getCertSubject (X509Certificate (CertificateChain [sc']))
 
 verifyBlockApps :: X509Certificate -> Bool 
 verifyBlockApps = verifyCert rootPubKey
@@ -388,6 +398,6 @@ verifyCertM pkey (X509Certificate (CertificateChain (c:c':cs))) = do
             Nothing -> pure False
             Just sc'pkey -> verifyCertM sc'pkey (X509Certificate (CertificateChain [sc]))
           where sc'pubKey :: Maybe PublicKey
-                sc'pubKey = fmap subPub $ listToMaybe =<< getCertSubject (X509Certificate (CertificateChain [sc']))
+                sc'pubKey = fmap subPub $ getCertSubject (X509Certificate (CertificateChain [sc']))
 
   

--- a/x509-certs/test/Spec.hs
+++ b/x509-certs/test/Spec.hs
@@ -61,11 +61,11 @@ spec = do
       rlpDecode rlp `shouldBe` cert
       rlpEncode cert `shouldBe` rlp
     it "can verify cert signatures" $ do
-      cert <- flip runReaderT priv $ makeSignedCert iss sub
+      (X509Certificate (CertificateChain (cert:_))) <- flip runReaderT priv $ makeSignedCert iss sub
       let sigVerification = verifySignedSignature (coerce cert) (certPubKey $ getCertificate $ coerce cert)
       sigVerification `shouldBe` SignaturePass
     it "can reject invalid signatures" $ do
-      cert <- flip runReaderT priv $ makeSignedCert iss sub
+      (X509Certificate (CertificateChain (cert:_))) <- flip runReaderT priv $ makeSignedCert iss sub
       fakePriv <- newPrivateKey
       let fakeSerialPub = SerializedPoint $ exportPublicKey False (derivePublicKey fakePriv)
           fakePub = PubKeyEC $ PubKeyEC_Named SEC_p256k1 fakeSerialPub

--- a/x509-certs/test/Spec.hs
+++ b/x509-certs/test/Spec.hs
@@ -71,3 +71,52 @@ spec = do
           fakePub = PubKeyEC $ PubKeyEC_Named SEC_p256k1 fakeSerialPub
           sigVerification = verifySignedSignature (coerce cert) fakePub
       sigVerification `shouldBe` SignatureFailed SignatureInvalid
+    it "can verify chained certificates" $ do
+      -- Create certificate one
+      priv1 <- newPrivateKey
+      let iss0 = iss
+          pub1 = derivePublicKey priv1
+          sub1 = Subject "a" "15" (Just "44") (Just "17") pub1
+          iss1 = (\(Subject a b c d _) -> Issuer a b c d) sub1
+      cert1 <- flip runReaderT priv $ makeSignedCert Nothing iss0 sub1
+
+      -- Create certificate two
+      priv2 <- newPrivateKey
+      let pub2 = derivePublicKey priv2
+          sub2 = Subject "y" "6" (Just "1") (Just "10") pub2
+          iss2 = (\(Subject a b c d _) -> Issuer a b c d) sub2
+      cert2 <- flip runReaderT priv1 $ makeSignedCert (Just cert1) iss1 sub2
+
+      -- Create certificate three
+      priv3 <- newPrivateKey
+      let pub3 = derivePublicKey priv3
+          sub3 = Subject "z" "7" (Just "2") (Just "11") pub3
+      cert3 <- flip runReaderT priv2 $ makeSignedCert (Just cert2) iss2 sub3
+
+      verifyCert pub cert3 `shouldBe` True
+    it "can reject invalid chained certificates" $ do
+      fakePriv <- newPrivateKey
+
+      -- Create certificate one using the fake private key
+      priv1 <- newPrivateKey
+      let iss0 = iss
+          pub1 = derivePublicKey priv1
+          sub1 = Subject "a" "15" (Just "44") (Just "17") pub1
+          iss1 = (\(Subject a b c d _) -> Issuer a b c d) sub1
+      cert1 <- flip runReaderT fakePriv $ makeSignedCert Nothing iss0 sub1
+
+      -- Create certificate two
+      priv2 <- newPrivateKey
+      let pub2 = derivePublicKey priv2
+          sub2 = Subject "y" "6" (Just "1") (Just "10") pub2
+          iss2 = (\(Subject a b c d _) -> Issuer a b c d) sub2
+      cert2 <- flip runReaderT priv1 $ makeSignedCert (Just cert1) iss1 sub2
+
+      -- Create certificate three
+      priv3 <- newPrivateKey
+      let pub3 = derivePublicKey priv3
+          sub3 = Subject "z" "7" (Just "2") (Just "11") pub3
+      cert3 <- flip runReaderT priv2 $ makeSignedCert (Just cert2) iss2 sub3
+      
+      verifyCert pub cert3 `shouldBe` False
+

--- a/x509-certs/test/Spec.hs
+++ b/x509-certs/test/Spec.hs
@@ -49,23 +49,23 @@ spec = do
       certPub `shouldBe` PubKeyEC exPub
       inPub `shouldBe` pub
     it "can do JSON encoding roundtrips" $ do
-      cert <- flip runReaderT priv $ makeSignedCert iss sub
+      cert <- flip runReaderT priv $ makeSignedCert Nothing iss sub
       Ae.decode (Ae.encode sub) `shouldBe` Just sub
       Ae.decode (Ae.encode cert) `shouldBe` Just cert 
     it "can do PEM encoding roundtrips" $ do
-      cert <- flip runReaderT priv $ makeSignedCert iss sub
+      cert <- flip runReaderT priv $ makeSignedCert Nothing iss sub
       Right cert `shouldBe` bsToCert (certToBytes cert)
     it "can do RLP encoding roundtrips" $ do
-      cert <- flip runReaderT priv $ makeSignedCert iss sub
+      cert <- flip runReaderT priv $ makeSignedCert Nothing iss sub
       let rlp = rlpEncode cert
       rlpDecode rlp `shouldBe` cert
       rlpEncode cert `shouldBe` rlp
     it "can verify cert signatures" $ do
-      (X509Certificate (CertificateChain (cert:_))) <- flip runReaderT priv $ makeSignedCert iss sub
+      (X509Certificate (CertificateChain (cert:_))) <- flip runReaderT priv $ makeSignedCert Nothing iss sub
       let sigVerification = verifySignedSignature (coerce cert) (certPubKey $ getCertificate $ coerce cert)
       sigVerification `shouldBe` SignaturePass
     it "can reject invalid signatures" $ do
-      (X509Certificate (CertificateChain (cert:_))) <- flip runReaderT priv $ makeSignedCert iss sub
+      (X509Certificate (CertificateChain (cert:_))) <- flip runReaderT priv $ makeSignedCert Nothing iss sub
       fakePriv <- newPrivateKey
       let fakeSerialPub = SerializedPoint $ exportPublicKey False (derivePublicKey fakePriv)
           fakePub = PubKeyEC $ PubKeyEC_Named SEC_p256k1 fakeSerialPub


### PR DESCRIPTION
https://blockapps.atlassian.net/browse/STRATO-2568

In the `registerCert` builtin we wish to display more logging information, such as the `creatorAddress`, `rootAddress`, and the `currentAccount`.

