### PR TITLE
[STRATO-2569] Enable the use of `account(this, "self").chainId`

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1372,18 +1372,17 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
         return . Constant . fromMaybe SNULL $ result
       (SContractItem a _, "chainId") -> do
         contract' <- getCurrentContract
-        case CC._vmVersion contract' == "svm3.2" of
-          True ->
-            case (a ^. namedAccountChainId) of
-              UnspecifiedChain -> do 
-                cid2 <- view accountChainId <$> getCurrentAccount
-                case cid2 of
-                  Nothing -> return $ Constant $ SInteger 0 
-                  Just cid3 -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid3
-              MainChain ->  return $ Constant $ SInteger 0 
-              ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
-          False ->
-            typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
+        if CC._vmVersion contract' /= "svm3.2" then do
+          typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
+        else do
+          case (a ^. namedAccountChainId) of
+            UnspecifiedChain -> do 
+              curCid <- view accountChainId <$> getCurrentAccount
+              case curCid of
+                Nothing -> return $ Constant $ SInteger 0 
+                Just cid -> return $ Constant $ SInteger $ fromIntegral cid
+            MainChain ->  return $ Constant $ SInteger 0 
+            ExplicitChain cid -> return $ Constant $ SInteger $ fromIntegral cid
       (SContract _ a, funcName) -> return $ Constant $ SContractFunction Nothing a funcName
       (r@(SReference _), "push") -> return $ Constant $ SPush r Nothing
         {-

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1376,7 +1376,136 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
         let address = namedAccountToAccount (from ^. accountChainId) addr
         result <- callWrapper from address Nothing itemName False (CC.OrderedArgs [])  
         return . Constant . fromMaybe SNULL $ result
+      (SContractItem a _, "codehash") -> do
+        -- Get the chainId for the account
+        cid <- case (a ^. namedAccountChainId) of 
+          UnspecifiedChain -> do
+            cid1 <- view accountChainId <$> getCurrentAccount
+            case cid1 of
+              Nothing -> return Nothing
+              Just cid2 -> return $ Just cid2
+          MainChain -> return Nothing
+          ExplicitChain cid -> return $ Just cid
+        let realAccount = namedAccountToAccount cid a
+        -- Retreive and resolve the codehash
+        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
+        resolvedCodeHash <- resolveCodePtr cid codeHash'
+        case resolvedCodeHash of
+          Just (SolidVMCode _ ch') -> return (Constant $ SString . keccak256ToHex $ ch')
+          Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
+          Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
+      (SContractItem a _, "code") -> do
+        -- Get the code at the address
+        cid <- case (a ^. namedAccountChainId) of 
+          UnspecifiedChain -> do
+            cid1 <- view accountChainId <$> getCurrentAccount
+            case cid1 of
+              Nothing -> return Nothing
+              Just cid2 -> return $ Just cid2
+          MainChain -> return Nothing
+          ExplicitChain cid -> return $ Just cid
+        let realAccount = namedAccountToAccount cid a
+        -- Retreive and resolve the codehash
+        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
+        resolvedCodeHash <- resolveCodePtr cid codeHash'
+        let ch' = case resolvedCodeHash of
+              Just (SolidVMCode _ ch1') -> ch1' 
+              Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
+              Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
+        -- Find the code using the codehash
+        cd <- A.lookup (A.Proxy @DBCode) ch'
+        let cd' = case cd of
+              Just (_,bs) -> bs
+              Nothing -> missingCodeCollection "Could not locate SolidVM code collection at account" (format realAccount)
+        let decodeCD = DT.decodeUtf8 cd'
+        -- Format the result  
+        return $ Constant $ SString $ T.unpack decodeCD
+      (SContractItem a _, "balance") -> do 
+        cid <- case (a ^. namedAccountChainId) of 
+          UnspecifiedChain -> do
+            cid1 <- view accountChainId <$> getCurrentAccount
+            case cid1 of
+              Nothing -> return Nothing
+              Just cid2 -> return $ Just cid2
+          MainChain -> return Nothing
+          ExplicitChain cid -> return $ Just cid
+        let realAccount = namedAccountToAccount cid a
+        bal <- A.lookup (A.Proxy @AddressState) realAccount
+        case bal of
+          Just as -> return $ Constant $ SInteger $ addressStateBalance as
+          _ -> return $ Constant $ SInteger 0 
       (SContractItem a _, "chainId") -> do
+        contract' <- getCurrentContract
+        if CC._vmVersion contract' /= "svm3.2" then do
+          typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
+        else do
+          case (a ^. namedAccountChainId) of
+            UnspecifiedChain -> do 
+              curCid <- view accountChainId <$> getCurrentAccount
+              case curCid of
+                Nothing -> return $ Constant $ SInteger 0 
+                Just cid -> return $ Constant $ SInteger $ fromIntegral cid
+            MainChain ->  return $ Constant $ SInteger 0 
+            ExplicitChain cid -> return $ Constant $ SInteger $ fromIntegral cid
+      (SContract _ a, "codehash") -> do
+        -- Get the chainId for the account
+        cid <- case (a ^. namedAccountChainId) of 
+          UnspecifiedChain -> do
+            cid1 <- view accountChainId <$> getCurrentAccount
+            case cid1 of
+              Nothing -> return Nothing
+              Just cid2 -> return $ Just cid2
+          MainChain -> return Nothing
+          ExplicitChain cid -> return $ Just cid
+        let realAccount = namedAccountToAccount cid a
+        -- Retreive and resolve the codehash
+        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
+        resolvedCodeHash <- resolveCodePtr cid codeHash'
+        case resolvedCodeHash of
+          Just (SolidVMCode _ ch') -> return (Constant $ SString . keccak256ToHex $ ch')
+          Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
+          Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
+      (SContract _ a, "code") -> do
+        -- Get the code at the address
+        cid <- case (a ^. namedAccountChainId) of 
+          UnspecifiedChain -> do
+            cid1 <- view accountChainId <$> getCurrentAccount
+            case cid1 of
+              Nothing -> return Nothing
+              Just cid2 -> return $ Just cid2
+          MainChain -> return Nothing
+          ExplicitChain cid -> return $ Just cid
+        let realAccount = namedAccountToAccount cid a
+        -- Retreive and resolve the codehash
+        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
+        resolvedCodeHash <- resolveCodePtr cid codeHash'
+        let ch' = case resolvedCodeHash of
+              Just (SolidVMCode _ ch1') -> ch1' 
+              Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
+              Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
+        -- Find the code using the codehash
+        cd <- A.lookup (A.Proxy @DBCode) ch'
+        let cd' = case cd of
+              Just (_,bs) -> bs
+              Nothing -> missingCodeCollection "Could not locate SolidVM code collection at account" (format realAccount)
+        let decodeCD = DT.decodeUtf8 cd'
+        -- Format the result  
+        return $ Constant $ SString $ T.unpack decodeCD
+      (SContract _ a, "balance") -> do 
+        cid <- case (a ^. namedAccountChainId) of 
+          UnspecifiedChain -> do
+            cid1 <- view accountChainId <$> getCurrentAccount
+            case cid1 of
+              Nothing -> return Nothing
+              Just cid2 -> return $ Just cid2
+          MainChain -> return Nothing
+          ExplicitChain cid -> return $ Just cid
+        let realAccount = namedAccountToAccount cid a
+        bal <- A.lookup (A.Proxy @AddressState) realAccount
+        case bal of
+          Just as -> return $ Constant $ SInteger $ addressStateBalance as
+          _ -> return $ Constant $ SInteger 0 
+      (SContract _ a, "chainId") -> do
         contract' <- getCurrentContract
         if CC._vmVersion contract' /= "svm3.2" then do
           typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1297,9 +1297,9 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
             addr <- accountOnUnspecifiedChain <$> getCurrentAccount
             return $ Constant $ SContractFunction (Just $ CC._contractName $ last ps) addr method
   
-      (SAccount a _, name) -> evaluateAccountMember a False name
-      (SContractItem a _, name) -> evaluateAccountMember a False name
-      (SContract _ a, name) -> evaluateAccountMember a True name
+      (SAccount a _, memberName) -> evaluateAccountMember a False memberName
+      (SContractItem a _, memberName) -> evaluateAccountMember a False memberName
+      (SContract _ a, memberName) -> evaluateAccountMember a True memberName
       (r@(SReference _), "push") -> return $ Constant $ SPush r Nothing
         {-
         contract' <- getCurrentContract
@@ -1735,7 +1735,7 @@ evaluateAccountMember a _ "balance" = do
 evaluateAccountMember a _ "chainId" = do 
   contract' <- getCurrentContract
   if CC._vmVersion contract' /= "svm3.2"
-    then typeError "illegal member access: svm3.2 required to use .chainId member" ("parsed as " ++ (show (a, "chainId")))
+    then typeError "illegal member access: svm3.2 required to use .chainId member" ("parsed as " ++ show a ++ ".chainId")
     else case (a ^. namedAccountChainId) of
             UnspecifiedChain -> do 
               curCid <- view accountChainId <$> getCurrentAccount

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1297,9 +1297,9 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
             addr <- accountOnUnspecifiedChain <$> getCurrentAccount
             return $ Constant $ SContractFunction (Just $ CC._contractName $ last ps) addr method
   
-      (SAccount a _, memberName) -> evaluateAccountMember a False memberName
-      (SContractItem a _, memberName) -> evaluateAccountMember a False memberName
-      (SContract _ a, memberName) -> evaluateAccountMember a True memberName
+      (SAccount a _, n) -> evaluateAccountMember a False n
+      (SContractItem a _, n) -> evaluateAccountMember a False n
+      (SContract _ a, n) -> evaluateAccountMember a True n
       (r@(SReference _), "push") -> return $ Constant $ SPush r Nothing
         {-
         contract' <- getCurrentContract

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1735,7 +1735,7 @@ evaluateAccountMember a _ "balance" = do
 evaluateAccountMember a _ "chainId" = do 
   contract' <- getCurrentContract
   if CC._vmVersion contract' /= "svm3.2"
-    then typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
+    then typeError "illegal member access: svm3.2 required to use .chainId member" ("parsed as " ++ (show (a, "chainId")))
     else case (a ^. namedAccountChainId) of
             UnspecifiedChain -> do 
               curCid <- view accountChainId <$> getCurrentAccount

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1297,228 +1297,9 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
             addr <- accountOnUnspecifiedChain <$> getCurrentAccount
             return $ Constant $ SContractFunction (Just $ CC._contractName $ last ps) addr method
   
-      (SAccount a _, "codehash") -> do
-        -- Get the chainId for the account
-        cid <- case (a ^. namedAccountChainId) of 
-          UnspecifiedChain -> do
-            cid1 <- view accountChainId <$> getCurrentAccount
-            case cid1 of
-              Nothing -> return Nothing
-              Just cid2 -> return $ Just cid2
-          MainChain -> return Nothing
-          ExplicitChain cid -> return $ Just cid
-        let realAccount = namedAccountToAccount cid a
-        -- Retreive and resolve the codehash
-        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
-        resolvedCodeHash <- resolveCodePtr cid codeHash'
-        case resolvedCodeHash of
-          Just (SolidVMCode _ ch') -> return (Constant $ SString . keccak256ToHex $ ch')
-          Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
-          Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
- 
-      (SAccount a _, "code") -> do
-        -- Get the code at the address
-        cid <- case (a ^. namedAccountChainId) of 
-          UnspecifiedChain -> do
-            cid1 <- view accountChainId <$> getCurrentAccount
-            case cid1 of
-              Nothing -> return Nothing
-              Just cid2 -> return $ Just cid2
-          MainChain -> return Nothing
-          ExplicitChain cid -> return $ Just cid
-        let realAccount = namedAccountToAccount cid a
-        -- Retreive and resolve the codehash
-        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
-        resolvedCodeHash <- resolveCodePtr cid codeHash'
-        let ch' = case resolvedCodeHash of
-              Just (SolidVMCode _ ch1') -> ch1' 
-              Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
-              Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
-        -- Find the code using the codehash
-        cd <- A.lookup (A.Proxy @DBCode) ch'
-        let cd' = case cd of
-              Just (_,bs) -> bs
-              Nothing -> missingCodeCollection "Could not locate SolidVM code collection at account" (format realAccount)
-        let decodeCD = DT.decodeUtf8 cd'
-        -- Format the result  
-        return $ Constant $ SString $ T.unpack decodeCD
-
-      (SAccount a _, "balance") -> do 
-        cid <- case (a ^. namedAccountChainId) of 
-          UnspecifiedChain -> do
-            cid1 <- view accountChainId <$> getCurrentAccount
-            case cid1 of
-              Nothing -> return Nothing
-              Just cid2 -> return $ Just cid2
-          MainChain -> return Nothing
-          ExplicitChain cid -> return $ Just cid
-        let realAccount = namedAccountToAccount cid a
-        bal <- A.lookup (A.Proxy @AddressState) realAccount
-        case bal of
-          Just as -> return $ Constant $ SInteger $ addressStateBalance as
-          _ -> return $ Constant $ SInteger 0 
-        
-      (SAccount a _, "chainId") -> do
-        contract' <- getCurrentContract
-        if CC._vmVersion contract' /= "svm3.2" then do
-          typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
-        else do
-          case (a ^. namedAccountChainId) of
-            UnspecifiedChain -> do 
-              curCid <- view accountChainId <$> getCurrentAccount
-              case curCid of
-                Nothing -> return $ Constant $ SInteger 0 
-                Just cid -> return $ Constant $ SInteger $ fromIntegral cid
-            MainChain ->  return $ Constant $ SInteger 0 
-            ExplicitChain cid -> return $ Constant $ SInteger $ fromIntegral cid
-      (SAccount addr _, itemName) -> do --return $ Constant $ SContractItem addr itemName
-        from <- getCurrentAccount
-        let address = namedAccountToAccount (from ^. accountChainId) addr
-        result <- callWrapper from address Nothing itemName False (CC.OrderedArgs [])  
-        return . Constant . fromMaybe SNULL $ result
-      (SContractItem a _, "codehash") -> do
-        -- Get the chainId for the account
-        cid <- case (a ^. namedAccountChainId) of 
-          UnspecifiedChain -> do
-            cid1 <- view accountChainId <$> getCurrentAccount
-            case cid1 of
-              Nothing -> return Nothing
-              Just cid2 -> return $ Just cid2
-          MainChain -> return Nothing
-          ExplicitChain cid -> return $ Just cid
-        let realAccount = namedAccountToAccount cid a
-        -- Retreive and resolve the codehash
-        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
-        resolvedCodeHash <- resolveCodePtr cid codeHash'
-        case resolvedCodeHash of
-          Just (SolidVMCode _ ch') -> return (Constant $ SString . keccak256ToHex $ ch')
-          Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
-          Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
-      (SContractItem a _, "code") -> do
-        -- Get the code at the address
-        cid <- case (a ^. namedAccountChainId) of 
-          UnspecifiedChain -> do
-            cid1 <- view accountChainId <$> getCurrentAccount
-            case cid1 of
-              Nothing -> return Nothing
-              Just cid2 -> return $ Just cid2
-          MainChain -> return Nothing
-          ExplicitChain cid -> return $ Just cid
-        let realAccount = namedAccountToAccount cid a
-        -- Retreive and resolve the codehash
-        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
-        resolvedCodeHash <- resolveCodePtr cid codeHash'
-        let ch' = case resolvedCodeHash of
-              Just (SolidVMCode _ ch1') -> ch1' 
-              Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
-              Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
-        -- Find the code using the codehash
-        cd <- A.lookup (A.Proxy @DBCode) ch'
-        let cd' = case cd of
-              Just (_,bs) -> bs
-              Nothing -> missingCodeCollection "Could not locate SolidVM code collection at account" (format realAccount)
-        let decodeCD = DT.decodeUtf8 cd'
-        -- Format the result  
-        return $ Constant $ SString $ T.unpack decodeCD
-      (SContractItem a _, "balance") -> do 
-        cid <- case (a ^. namedAccountChainId) of 
-          UnspecifiedChain -> do
-            cid1 <- view accountChainId <$> getCurrentAccount
-            case cid1 of
-              Nothing -> return Nothing
-              Just cid2 -> return $ Just cid2
-          MainChain -> return Nothing
-          ExplicitChain cid -> return $ Just cid
-        let realAccount = namedAccountToAccount cid a
-        bal <- A.lookup (A.Proxy @AddressState) realAccount
-        case bal of
-          Just as -> return $ Constant $ SInteger $ addressStateBalance as
-          _ -> return $ Constant $ SInteger 0 
-      (SContractItem a _, "chainId") -> do
-        contract' <- getCurrentContract
-        if CC._vmVersion contract' /= "svm3.2" then do
-          typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
-        else do
-          case (a ^. namedAccountChainId) of
-            UnspecifiedChain -> do 
-              curCid <- view accountChainId <$> getCurrentAccount
-              case curCid of
-                Nothing -> return $ Constant $ SInteger 0 
-                Just cid -> return $ Constant $ SInteger $ fromIntegral cid
-            MainChain ->  return $ Constant $ SInteger 0 
-            ExplicitChain cid -> return $ Constant $ SInteger $ fromIntegral cid
-      (SContract _ a, "codehash") -> do
-        -- Get the chainId for the account
-        cid <- case (a ^. namedAccountChainId) of 
-          UnspecifiedChain -> do
-            cid1 <- view accountChainId <$> getCurrentAccount
-            case cid1 of
-              Nothing -> return Nothing
-              Just cid2 -> return $ Just cid2
-          MainChain -> return Nothing
-          ExplicitChain cid -> return $ Just cid
-        let realAccount = namedAccountToAccount cid a
-        -- Retreive and resolve the codehash
-        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
-        resolvedCodeHash <- resolveCodePtr cid codeHash'
-        case resolvedCodeHash of
-          Just (SolidVMCode _ ch') -> return (Constant $ SString . keccak256ToHex $ ch')
-          Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
-          Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
-      (SContract _ a, "code") -> do
-        -- Get the code at the address
-        cid <- case (a ^. namedAccountChainId) of 
-          UnspecifiedChain -> do
-            cid1 <- view accountChainId <$> getCurrentAccount
-            case cid1 of
-              Nothing -> return Nothing
-              Just cid2 -> return $ Just cid2
-          MainChain -> return Nothing
-          ExplicitChain cid -> return $ Just cid
-        let realAccount = namedAccountToAccount cid a
-        -- Retreive and resolve the codehash
-        codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
-        resolvedCodeHash <- resolveCodePtr cid codeHash'
-        let ch' = case resolvedCodeHash of
-              Just (SolidVMCode _ ch1') -> ch1' 
-              Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
-              Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
-        -- Find the code using the codehash
-        cd <- A.lookup (A.Proxy @DBCode) ch'
-        let cd' = case cd of
-              Just (_,bs) -> bs
-              Nothing -> missingCodeCollection "Could not locate SolidVM code collection at account" (format realAccount)
-        let decodeCD = DT.decodeUtf8 cd'
-        -- Format the result  
-        return $ Constant $ SString $ T.unpack decodeCD
-      (SContract _ a, "balance") -> do 
-        cid <- case (a ^. namedAccountChainId) of 
-          UnspecifiedChain -> do
-            cid1 <- view accountChainId <$> getCurrentAccount
-            case cid1 of
-              Nothing -> return Nothing
-              Just cid2 -> return $ Just cid2
-          MainChain -> return Nothing
-          ExplicitChain cid -> return $ Just cid
-        let realAccount = namedAccountToAccount cid a
-        bal <- A.lookup (A.Proxy @AddressState) realAccount
-        case bal of
-          Just as -> return $ Constant $ SInteger $ addressStateBalance as
-          _ -> return $ Constant $ SInteger 0 
-      (SContract _ a, "chainId") -> do
-        contract' <- getCurrentContract
-        if CC._vmVersion contract' /= "svm3.2" then do
-          typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
-        else do
-          case (a ^. namedAccountChainId) of
-            UnspecifiedChain -> do 
-              curCid <- view accountChainId <$> getCurrentAccount
-              case curCid of
-                Nothing -> return $ Constant $ SInteger 0 
-                Just cid -> return $ Constant $ SInteger $ fromIntegral cid
-            MainChain ->  return $ Constant $ SInteger 0 
-            ExplicitChain cid -> return $ Constant $ SInteger $ fromIntegral cid
-      (SContract _ a, funcName) -> return $ Constant $ SContractFunction Nothing a funcName
+      (SAccount a _, name) -> evaluateAccountMember a False name
+      (SContractItem a _, name) -> evaluateAccountMember a False name
+      (SContract _ a, name) -> evaluateAccountMember a True name
       (r@(SReference _), "push") -> return $ Constant $ SPush r Nothing
         {-
         contract' <- getCurrentContract
@@ -1887,6 +1668,88 @@ SimpleStatement (ExpressionStatement (Binary "=" (Variable "tickets") (FunctionC
 expToVar' x = todo "expToVar/unhandled" x
 
 --------------
+
+evaluateAccountMember :: MonadSM m
+                      => NamedAccount
+                      -> Bool -- Is SContract
+                      -> String
+                      -> m Variable
+evaluateAccountMember a _ "codehash" = do
+  -- Get the chainId for the account
+  cid <- case (a ^. namedAccountChainId) of 
+    UnspecifiedChain -> do
+      cid1 <- view accountChainId <$> getCurrentAccount
+      case cid1 of
+        Nothing -> return Nothing
+        Just cid2 -> return $ Just cid2
+    MainChain -> return Nothing
+    ExplicitChain cid -> return $ Just cid
+  let realAccount = namedAccountToAccount cid a
+  -- Retreive and resolve the codehash
+  codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
+  resolvedCodeHash <- resolveCodePtr cid codeHash'
+  case resolvedCodeHash of
+    Just (SolidVMCode _ ch') -> return (Constant $ SString . keccak256ToHex $ ch')
+    Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
+    Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
+evaluateAccountMember a _ "code" = do 
+  -- Get the code at the address
+  cid <- case (a ^. namedAccountChainId) of 
+    UnspecifiedChain -> do
+      cid1 <- view accountChainId <$> getCurrentAccount
+      case cid1 of
+        Nothing -> return Nothing
+        Just cid2 -> return $ Just cid2
+    MainChain -> return Nothing
+    ExplicitChain cid -> return $ Just cid
+  let realAccount = namedAccountToAccount cid a
+  -- Retreive and resolve the codehash
+  codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
+  resolvedCodeHash <- resolveCodePtr cid codeHash'
+  let ch' = case resolvedCodeHash of
+      Just (SolidVMCode _ ch1') -> ch1' 
+      Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
+      Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
+  -- Find the code using the codehash
+  cd <- A.lookup (A.Proxy @DBCode) ch'
+  let cd' = case cd of
+      Just (_,bs) -> bs
+      Nothing -> missingCodeCollection "Could not locate SolidVM code collection at account" (format realAccount)
+  let decodeCD = DT.decodeUtf8 cd'
+  -- Format the result  
+  return $ Constant $ SString $ T.unpack decodeCD
+evaluateAccountMember a _ "balance" = do 
+  cid <- case (a ^. namedAccountChainId) of 
+    UnspecifiedChain -> do
+      cid1 <- view accountChainId <$> getCurrentAccount
+      case cid1 of
+        Nothing -> return Nothing
+        Just cid2 -> return $ Just cid2
+    MainChain -> return Nothing
+    ExplicitChain cid -> return $ Just cid
+  let realAccount = namedAccountToAccount cid a
+  bal <- A.lookup (A.Proxy @AddressState) realAccount
+  case bal of
+    Just as -> return $ Constant $ SInteger $ addressStateBalance as
+    _ -> return $ Constant $ SInteger 0 
+evaluateAccountMember a _ "chainId" = do 
+  contract' <- getCurrentContract
+  if CC._vmVersion contract' /= "svm3.2"
+    then typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
+    else case (a ^. namedAccountChainId) of
+            UnspecifiedChain -> do 
+              curCid <- view accountChainId <$> getCurrentAccount
+              case curCid of
+                Nothing -> return $ Constant $ SInteger 0 
+                Just cid -> return $ Constant $ SInteger $ fromIntegral cid
+            MainChain ->  return $ Constant $ SInteger 0 
+            ExplicitChain cid -> return $ Constant $ SInteger $ fromIntegral cid
+evaluateAccountMember a True funcName = return $ Constant $ SContractFunction Nothing a funcName
+evaluateAccountMember a False itemName = do --return $ Constant $ SContractItem addr itemName
+  from <- getCurrentAccount
+  let address = namedAccountToAccount (from ^. accountChainId) a
+  result <- callWrapper from address Nothing itemName False (CC.OrderedArgs [])  
+  return . Constant . fromMaybe SNULL $ result
 
 expToVarAdd :: MonadSM m => CC.Expression -> CC.Expression -> m Variable
 expToVarAdd expr1 expr2 = do

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1370,7 +1370,20 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
         let address = namedAccountToAccount (from ^. accountChainId) addr
         result <- callWrapper from address Nothing itemName False (CC.OrderedArgs [])  
         return . Constant . fromMaybe SNULL $ result
-
+      (SContractItem a _, "chainId") -> do
+        contract' <- getCurrentContract
+        case CC._vmVersion contract' == "svm3.2" of
+          True ->
+            case (a ^. namedAccountChainId) of
+              UnspecifiedChain -> do 
+                cid2 <- view accountChainId <$> getCurrentAccount
+                case cid2 of
+                  Nothing -> return $ Constant $ SInteger 0 
+                  Just cid3 -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid3
+              MainChain ->  return $ Constant $ SInteger 0 
+              ExplicitChain cid -> return $ Constant $ intBuiltin $ flip (:) [] $ SString $ B.foldr showHex "" $ word256ToBytes cid
+          False ->
+            typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ (show (val, name)))
       (SContract _ a, funcName) -> return $ Constant $ SContractFunction Nothing a funcName
       (r@(SReference _), "push") -> return $ Constant $ SPush r Nothing
         {-

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1707,14 +1707,14 @@ evaluateAccountMember a _ "code" = do
   codeHash' <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) realAccount
   resolvedCodeHash <- resolveCodePtr cid codeHash'
   let ch' = case resolvedCodeHash of
-      Just (SolidVMCode _ ch1') -> ch1' 
-      Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
-      Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
+              Just (SolidVMCode _ ch1') -> ch1' 
+              Just cp -> missingCodeCollection "Account is not a SolidVM contract" (format cp)
+              Nothing -> missingCodeCollection "Could not resolve code pointer for account" (format realAccount)
   -- Find the code using the codehash
   cd <- A.lookup (A.Proxy @DBCode) ch'
   let cd' = case cd of
-      Just (_,bs) -> bs
-      Nothing -> missingCodeCollection "Could not locate SolidVM code collection at account" (format realAccount)
+              Just (_,bs) -> bs
+              Nothing -> missingCodeCollection "Could not locate SolidVM code collection at account" (format realAccount)
   let decodeCD = DT.decodeUtf8 cd'
   -- Format the result  
   return $ Constant $ SString $ T.unpack decodeCD

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -544,6 +544,11 @@ typecheckMember (Static (SVMType.Struct _ struct) x) n = do
       , " is not a field of "
       , struct
       ]) <$ x
+-- I'm intentionally leaving out send and transfer for Contract types, since we don't have a payable flag for them yet
+typecheckMember (Static (SVMType.Contract _) x) "balance" = pure $ Static (SVMType.Int Nothing Nothing) x
+typecheckMember (Static (SVMType.Contract _) x) "code" = pure $ Static (SVMType.Bytes Nothing Nothing) x
+typecheckMember (Static (SVMType.Contract _) x) "codehash" = pure $ Static (SVMType.String Nothing) x
+typecheckMember (Static (SVMType.Contract _) x) "chainId" = pure $ Static (SVMType.Int Nothing Nothing) x
 typecheckMember (Static (SVMType.Contract c) x) n = lookupContractFunction x c n
 typecheckMember (Static (SVMType.Label c') x) n = do
   let c = T.pack c'

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -3476,6 +3476,25 @@ contract qq {
       , BDefault
       , BDefault
       ]
+  it "can get the chainId directly from the account constructor" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq {
+  uint a1;
+  uint a2;
+  uint a3;
+  uint a4;
+  uint a5;
+  constructor() public {
+    a1 = account(0xdeadbeef, 0xfeedbeef).chainId;
+    a2 = account(0x123, "main").chainId;
+    a3 = account(0x124, "self").chainId;
+    a4 = account(0x125).chainId;
+    a5 = account(this, "self").chainId;
+  }
+}|]
+    getFields ["a1", "a2", "a3", "a4", "a5"] `shouldReturn`
+      [ BInteger 0xfeedbeef, BDefault, BDefault, BDefault, BDefault ]
   it "can get the balance from an address" . runTest $ do
     -- Post contract
     runBS [r|

--- a/core-strato/solid-vm/tests/TypecheckerSpec.hs
+++ b/core-strato/solid-vm/tests/TypecheckerSpec.hs
@@ -641,3 +641,21 @@ contract qq {
 
 }|]
     in length anns `shouldBe` 1
+  it "can typecheck account(this, \"self\").chainId" $
+    let anns = runTypechecker [r|
+pragma solidvm 3.2;
+contract qq {
+  uint a1;
+  uint a2;
+  uint a3;
+  uint a4;
+  uint a5;
+  constructor() public {
+    a1 = account(0xdeadbeef, 0xfeedbeef).chainId;
+    a2 = account(0x123, "main").chainId;
+    a3 = account(0x124, "self").chainId;
+    a4 = account(0x125).chainId;
+    a5 = account(this, "self").chainId;
+  }
+}|]
+    in length anns `shouldBe` 0


### PR DESCRIPTION
https://blockapps.atlassian.net/browse/STRATO-2569

The expression `account(this, "self").chainId` now functions. The expression `account(this, "self")` turns into a `SContractItem` instead of an `SAccount`. Adding a pattern match for `SContractItem`'s `chainId` lets us retrieve the `chainId`. Here is an example of this in use

```
constructor () {
    require(account(this, "self").chainId == 0, "You must post this contract on the main chain!");
}
```