### PR TITLE
Add Ability to Send Metadata in post-raw-tx tool

### DIFF
--- a/api/strato-api/app/PostRawTransaction.hs
+++ b/api/strato-api/app/PostRawTransaction.hs
@@ -165,7 +165,7 @@ options =
             Nothing -> return opts
             Just r -> return opts{optFunctionArgs = Just (splitOn "," r)}
        ) "(String,String,etc.)")
-    "The comma-separated args of the contract function you want to call" 
+    "The comma-separated args of the contract function/constructor you want to call" 
   , Option ['n'] ["nonce"]
       (ReqArg
        (\n opts -> do 
@@ -216,7 +216,8 @@ postRawTransaction :: Maybe T.Text -> Maybe ChainId -> Bool -> PostBlocTransacti
 postRawTransaction = client (Proxy @ PostBlocTransactionRaw)
 
 
-
+makeArgs :: [String] -> String
+makeArgs as = "(" ++ (intercalate "," as) ++ ")"
 
 
 main :: IO ()
@@ -236,9 +237,15 @@ main = do
  
         CONTRACT -> case (optSourceCode, optContractName) of 
           (Just src, Just name) -> 
-            ( M.fromList $ [("VM", "SolidVM"), ("name", T.pack name)] 
-            , Code $ T.encodeUtf8 $ serializeSourceMap src
-            )
+            let baseTup@(md,cd) = (M.fromList $ [
+                                    ("VM", "SolidVM")
+                                  , ("name", T.pack name)
+                                  ] 
+                                  , Code $ T.encodeUtf8 $ serializeSourceMap src
+                                  )
+            in case optFunctionArgs of 
+              Nothing -> baseTup
+              Just args -> (M.insert "args" (T.pack $ makeArgs args) md, cd)
           _ -> throw $ userError "source code or contract name not given for contract creation"
 
         FUNCTION -> do 
@@ -246,15 +253,13 @@ main = do
             Nothing -> throw $ userError "need a function name to call a function!"
             Just name -> case optFunctionArgs of
               Nothing -> (M.fromList $ [("VM", "SolidVM")], Code $ B.empty)
-              Just lst -> 
-                let argMd = "(" ++ (intercalate "," lst) ++ ")"
-                in (M.fromList $
-                      [ ("VM", "SolidVM")
-                      , ("funcName", T.pack name)
-                      , ("args", T.pack argMd)
-                      ]
-                   , Code $ B.empty
-                   )
+              Just args -> (M.fromList $
+                            [ ("VM", "SolidVM")
+                            , ("funcName", T.pack name)
+                            , ("args", T.pack $ makeArgs args)
+                            ]
+                        , Code $ B.empty
+                        )
         _ -> error "a logical impossibility! We parsed this TX as a GENESIS tx???"
  
 

--- a/api/strato-api/app/PostRawTransaction.hs
+++ b/api/strato-api/app/PostRawTransaction.hs
@@ -71,6 +71,7 @@ data Options = Options
   , optChainId       :: Maybe ChainId
   , optFunctionName  :: Maybe String
   , optFunctionArgs  :: Maybe [String]
+  , optMetadata      :: M.Map T.Text T.Text
   , optNonce         :: Nonce
   , optValue         :: Wei
   , optKey           :: PrivateKey
@@ -88,6 +89,7 @@ defaultOptions = Options
   , optChainId      = Nothing
   , optFunctionName = Nothing
   , optFunctionArgs = Nothing
+  , optMetadata     = M.empty
   , optNonce        = Nonce 0
   , optValue        = Wei 0
   , optKey          = throw $ userError "give me a private key with which to sign the TX" 
@@ -166,6 +168,20 @@ options =
             Just r -> return opts{optFunctionArgs = Just (splitOn "," r)}
        ) "(String,String,etc.)")
     "The comma-separated args of the contract function/constructor you want to call" 
+  , Option ['d'] ["metadata"]
+      (OptArg
+       (\md opts -> 
+          case md of
+            Nothing -> return opts
+            Just metadata -> do
+              let mp = M.fromList $ map (\el ->
+                          let (k:xs) = splitOn ":" el
+                          in
+                            (T.pack k, T.pack $ head xs)
+                        ) $ splitOn "," metadata
+              return opts{optMetadata = mp}
+       ) "Key:Value,Key:Value")
+    "The key-values of the transaction metadata" 
   , Option ['n'] ["nonce"]
       (ReqArg
        (\n opts -> do 
@@ -261,10 +277,8 @@ main = do
                         , Code $ B.empty
                         )
         _ -> error "a logical impossibility! We parsed this TX as a GENESIS tx???"
- 
+  let metadata' = M.union metadata optMetadata
 
-
-       
   -- create the unsigned transaction
   let unsignedTx = UnsignedTransaction
         { unsignedTransactionNonce      = optNonce
@@ -293,7 +307,7 @@ main = do
           r
           s
           (if optOmitV then Nothing else Just v)
-          (Just metadata)
+          (Just metadata')
   
   
   putStrLn $ "Transaction Hash: " ++ format txHash


### PR DESCRIPTION
This is for the non-standard metadata fields like `history`, the `VM` and `args` are already filled in by the existing logic

metadata key values should be put in a comma separated list, and key-values separated by a colon "`:`"
Example: `... --metadata=history:SimpleStorage`