### PR TITLE
no solcs in buildbase, Makefile cleanup

### DIFF
--- a/Dockerfile.buildbase
+++ b/Dockerfile.buildbase
@@ -21,7 +21,3 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8B1DA6120C2BF624 &&
     make install && \
     cd .. && \
     rm -rf secp256k1 
-
-# package the pre-built solc (e.g. required for 'stack test blockapps-bloc22-server')
-COPY ./solc /usr/local/bin/
-COPY ./solc-0.5 /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,7 @@ endif
 $(info REPO_URL is "${REPO_URL}" (${REPO}))
 
 STACK_RESOLVER=$(shell cat stack.yaml | grep "resolver:" | awk '{print $$2}')
-TMPDIR=/tmp/$(shell whoami)/strato-docker-dummy
 FAKEROOT=$(shell pwd)/.docker-work
-BLOCDIR=${FAKEROOT}/bloc
 STRATODIR=${FAKEROOT}/strato
 VAULTDIR=${FAKEROOT}/vault-wrapper
 
@@ -60,37 +58,32 @@ smd:
 	BASIL_DOCKER_TAG=${REPO_URL}smd:${VERSION} STRATO_VERSION=${VERSION} make --directory=smd-ui/
 
 get_solcs:
+	@echo checking solcs and pulling them if required...
 	@if [ ! -f "${FAKEROOT}/usr/local/bin/solc" ]; then\
 		bash -c "\
-			mkdir -p ${TMPDIR} ${FAKEROOT}/usr/local/bin ;\
-			blockapps-haskell/pull_solc.sh 0.4.25 ${TMPDIR}/solc-0.4 ${TMPDIR}/license-solc-0.4 ;\
-			blockapps-haskell/pull_solc.sh 0.5.2 ${TMPDIR}/solc-0.5 ${TMPDIR}/license-solc-0.5 ;\
-			cp ${TMPDIR}/solc-0.4 ${FAKEROOT}/usr/local/bin ;\
-			cp ${TMPDIR}/solc-0.5 ${FAKEROOT}/usr/local/bin ;\
-			cp -fr ${TMPDIR}/license* ${FAKEROOT} ;\
+			mkdir -p ${FAKEROOT}/usr/local/bin ;\
+			blockapps-haskell/pull_solc.sh 0.4.25 ${FAKEROOT}/usr/local/bin/solc-0.4 ${FAKEROOT}/license-solc-0.4 ;\
+			blockapps-haskell/pull_solc.sh 0.5.2 ${FAKEROOT}/usr/local/bin/solc-0.5 ${FAKEROOT}/license-solc-0.5 ;\
 			ln -f ${FAKEROOT}/usr/local/bin/solc-0.4 ${FAKEROOT}/usr/local/bin/solc \
 		" ;\
 	fi
 
-build_buildbase: get_solcs
-	mkdir -p ${TMPDIR}
-	cp -f Dockerfile.buildbase ${TMPDIR}
-	docker build --build-arg STACK_RESOLVER=${STACK_RESOLVER} --tag=strato-buildbase:${STACK_RESOLVER} -f ${TMPDIR}/Dockerfile.buildbase ${TMPDIR}
+build_buildbase:
+	@echo building buildbase...
+	docker build --build-arg STACK_RESOLVER=${STACK_RESOLVER} --tag=strato-buildbase:${STACK_RESOLVER} - < Dockerfile.buildbase
 
 build_common: get_solcs build_buildbase
 	@echo building haskell libraries and creating directories
-	mkdir -p ${FAKEROOT}/bloc
-	mkdir -p ${FAKEROOT}/strato
-	mkdir -p ${FAKEROOT}/vault-wrapper
+	mkdir -p ${STRATODIR}
+	mkdir -p ${VAULTDIR}
 	stack build \
 		--test --no-run-tests \
 		--copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin
 
 build_common_profiled: get_solcs build_buildbase
 	@echo building haskell libraries and creating directories
-	mkdir -p ${FAKEROOT}/bloc
-	mkdir -p ${FAKEROOT}/strato
-	mkdir -p ${FAKEROOT}/vault-wrapper
+	mkdir -p ${STRATODIR}
+	mkdir -p ${VAULTDIR}
 	stack build \
 		--profile --work-dir .stack-work-profile \
 		--copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin


### PR DESCRIPTION
since solcs are not required in buildbase image anymore (only in final containers), I was able to cleanup the Makefile.
This will help avoid situations with non-existent files during `make all` after /tmp was cleaned on the machine.