### PR TITLE
One can Declare File level Enums and Structs in SolidVM 

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -69,7 +69,6 @@ parseSourceWithAnnotations = withAnnotations . parseSource
 compileSourceNoInheritance :: Map T.Text T.Text -> Either ParseTypeCheckOrSolidVMError CodeCollection
 compileSourceNoInheritance initCodeMap = do
   let getNamedContracts sourceUnits structsOrEnumsMap = do
---        sourceUnits <- parseSource fileName src
         let pragmas = \case
               Pragma _ n v -> Just (n, v)
               _ -> Nothing

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -44,6 +44,7 @@ import           SolidVM.Model.CodeCollection
 import           SolidVM.Solidity.Parse.Declarations
 import           SolidVM.Solidity.Parse.File
 import           SolidVM.Solidity.Detectors.Typechecker as TC
+import           SolidVM.Solidity.Xabi (XabiF (..)) 
 
 data ParseTypeCheckOrSolidVMError = PEx ParseError
                          | TCEx [SourceAnnotation T.Text]
@@ -67,16 +68,16 @@ parseSourceWithAnnotations = withAnnotations . parseSource
 
 compileSourceNoInheritance :: Map T.Text T.Text -> Either ParseTypeCheckOrSolidVMError CodeCollection
 compileSourceNoInheritance initCodeMap = do
-  let getNamedContracts fileName src = do
-        sourceUnits <- parseSource fileName src
+  let getNamedContracts sourceUnits structsOrEnumsMap = do
+--        sourceUnits <- parseSource fileName src
         let pragmas = \case
               Pragma _ n v -> Just (n, v)
               _ -> Nothing
             vmVersion' = if (Just ("solidvm","3.2")) `elem` (pragmas <$> sourceUnits) then "svm3.2" else (if (Just ("solidvm","3.0")) `elem` (pragmas <$> sourceUnits) then "svm3.0" else "")
         fmap catMaybes . for sourceUnits $ \case
-          NamedXabi name (xabi, parents') -> do
+          NamedXabi name ((Xabi funcs constrs vars consts types mods evs kind using ctx), parents') -> do
             ctrct <- first SVMEx
-                   $ xabiToContract (T.unpack name) (map T.unpack parents') vmVersion' xabi
+                   $ xabiToContract (T.unpack name) (map T.unpack parents') vmVersion' (Xabi funcs constrs vars consts (M.union types structsOrEnumsMap) mods evs kind using ctx)
             pure $ Just (T.unpack name, ctrct)
           _ -> pure Nothing
       throwDuplicate (cName, contract) m = case M.lookup cName m of
@@ -84,7 +85,10 @@ compileSourceNoInheritance initCodeMap = do
         Just _ ->  Left . PEx
                  $ newErrorMessage (Message $ "Duplicate contract found: " ++ cName)
                                    (fromSourcePosition $ _sourceAnnotationStart $ _contractContext contract)
-  allContracts <- fmap concat . traverse (uncurry getNamedContracts) $ M.toList initCodeMap
+  sUnits <-  mapM (uncurry parseSource) (M.toList initCodeMap)
+  let sUnits' = concat sUnits
+  let flsoeMap = M.fromList $ catMaybes $ map (\x -> case x of FileLevelSructOrEnum y -> Just y; _ -> Nothing) sUnits'
+  allContracts <- (getNamedContracts sUnits' flsoeMap)
   deduplicatedContracts <- foldrM throwDuplicate M.empty allContracts
   pure $ CodeCollection {
     _contracts = deduplicatedContracts

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -38,7 +38,9 @@ import           Blockchain.VM.SolidException
 
 data SourceUnitF a = Pragma a Identifier String
                    | Import a Text.Text
+                   | FileLevelSructOrEnum (Text.Text, SolidVM.Def)
                    | NamedXabi Text.Text (XabiF a, [Text.Text])
+--                   | FileLevelConstant Text.Text SolidVM.Def
                    deriving (Eq, Show, Generic, Functor)
 
 type SourceUnit = Positioned SourceUnitF
@@ -177,6 +179,17 @@ enumDeclaration = do
         SolidVM.context = a
         }
     )
+
+structOrEnum :: SolidityParser SourceUnit
+structOrEnum = do
+  enumOrStruct <- (enumDeclaration <|> structDeclaration)
+  let enumOrStructForReturn = case enumOrStruct of
+        (name, StructDeclaration struct) -> (Text.pack name, struct)
+        (name, EnumDeclaration enum) -> (Text.pack name, enum)
+        _ -> error "structOrEnum: unexpected"
+  return $ FileLevelSructOrEnum enumOrStructForReturn
+
+
 
 usingDeclaration :: SolidityParser (String, Declaration)
 usingDeclaration = do

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/File.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/File.hs
@@ -19,7 +19,6 @@ import           Data.SemVer
 import qualified Data.Text                             as T
 import           GHC.Generics
 import           Text.Parsec
---import           Data.Map                              as Map
 
 
 import           SolidVM.Solidity.Parse.Declarations
@@ -27,7 +26,6 @@ import           SolidVM.Solidity.Parse.Imports
 import           SolidVM.Solidity.Parse.Lexer
 import           SolidVM.Solidity.Parse.ParserTypes
 import           SolidVM.Solidity.Parse.Pragmas
---import           SolidVM.Solidity.Xabi (XabiF (..))
 
 
 newtype File = File {

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/File.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/File.hs
@@ -19,6 +19,7 @@ import           Data.SemVer
 import qualified Data.Text                             as T
 import           GHC.Generics
 import           Text.Parsec
+--import           Data.Map                              as Map
 
 
 import           SolidVM.Solidity.Parse.Declarations
@@ -26,22 +27,24 @@ import           SolidVM.Solidity.Parse.Imports
 import           SolidVM.Solidity.Parse.Lexer
 import           SolidVM.Solidity.Parse.ParserTypes
 import           SolidVM.Solidity.Parse.Pragmas
+--import           SolidVM.Solidity.Xabi (XabiF (..))
 
 
 newtype File = File {
   unsourceUnits :: [SourceUnit]
 } deriving (Show, Generic)
 
+
 solidityFile :: SolidityParser File
 solidityFile = do
   whiteSpace
-  units <- many (solidityPragma <|> solidityImport <|> solidityContract)
+  units <- many (solidityPragma <|> solidityImport <|> solidityContract <|> structOrEnum)
   eof
   return . File $ units
 
 
 decideVersion :: File -> SolcVersion
-decideVersion = maximum . (ZeroPointFour:) . mapMaybe go . unsourceUnits
+decideVersion = maximum . (ZeroPointFour:) . Data.Maybe.mapMaybe go . unsourceUnits
   where go :: SourceUnit -> Maybe SolcVersion
         go (Pragma _ pragmaName rest) = do
           guard $ pragmaName == "solidity"

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -35,6 +35,7 @@ unparse (File units) = List.concat $ List.map unparseSourceUnit units
 unparseSourceUnit :: SourceUnit -> String
 unparseSourceUnit (Pragma _ ident contents) = "pragma " ++ ident ++ " " ++ contents ++ ";\n"
 unparseSourceUnit (Import _ path) = "import \"" ++ Text.unpack path ++ "\";\n"
+unparseSourceUnit (FileLevelSructOrEnum x) = unparseTypes x
 unparseSourceUnit (NamedXabi name (contract,inherited)) =
      (case xabiKind contract of
         ContractKind -> "contract "

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -3931,3 +3931,44 @@ contract qq{
     }
 }|]
     getFields ["x"] `shouldReturn` [BInteger 2]
+
+
+  it "can declare enums at the file level" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.2;
+enum Color { red, green, blue }
+contract A {
+    function value() public returns (uint) {
+        return 0xa;
+    }
+}
+
+enum Letter { a, b, c }
+contract B {
+    function value() public returns (uint) {
+        return 0xb;
+    }
+}
+contract qq {
+  function a() public returns (Letter) {
+    return Letter.c;
+  }
+}
+
+|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
+
+  it "can declare structs at the file level" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.2;
+struct Point {
+  uint x;
+  uint y;
+}
+contract qq {
+  function a() public returns (uint) {
+    Point p;
+    p.x = 1;
+    p.y = 2;
+    return p.x;
+  }
+}|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 1)


### PR DESCRIPTION
Remade the branch because I was having issues with refactoring the previous branch.

File level Struct and Enum definitions are now shared between all contracts even ones not in the file, and every occurrence is replaced by the respective value if the namespace is shared. This is how solidity handles file level definitions. 

Note: A separate PR for file level constants is forthcoming.