### PR TITLE
Added string.concat() function and multivariate function args to the Typechecker

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1226,6 +1226,9 @@ expToVar' (CC.MemberAccess _ (CC.Variable _ "Util") "bytes32ToString") = do
 expToVar' (CC.MemberAccess _ (CC.Variable _ "Util") "b32") = do --TODO- remove this hardcoded case
   return $ Constant $ SBuiltinFunction "identity" Nothing
 
+expToVar' (CC.MemberAccess _ (CC.Variable _ "string") "concat") = do
+  return $ Constant $ SStringConcat 
+
 expToVar' x@(CC.MemberAccess _ expr name) = do
   var <- expToVar expr
   val <- getVar var
@@ -1726,6 +1729,15 @@ expToVar' (CC.FunctionCall _ e args) = do
               _ -> typeError "called enum constructor with improper args" argVals
 
           Constant (SPush theArray mvar) -> Builtins.push theArray mvar argVals
+
+          Constant SStringConcat -> do
+            case argVals of
+              OrderedVals xs -> do
+                when (any (\x -> case x of
+                                  (SString _) -> False
+                                  _ -> True) xs) $ typeError "string concat" argVals
+                return $ Constant $ SString $ concatMap (\x -> case x of (SString s) -> s; _ -> "") xs
+              _ -> typeError "called string concat with improper args" argVals
 
           Constant SHexDecodeAndTrim ->
               case argVals of

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -277,7 +277,7 @@ context' Static{..}        = staticContext
 context' Product{..}       = productContext
 context' Function{..}      = functionContext
 context' (Sum (a :| _))    = context' a
-context' (MultiVariate _ _)  = error "context' MultiVariate"
+context' (MultiVariate _ _)  = multiVariateContext
 
 
 typecheck' :: Monad m => (SourceAnnotation Text -> String -> Type -> m Type') -> Type' -> Type' -> m Type'

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -768,8 +768,7 @@ byteArgs :: SourceAnnotation Text -> Type'
 byteArgs x = intType' x
 
 keccak256Args :: SourceAnnotation Text -> Type'
-keccak256Args x = stringType' x
-
+keccak256Args x = MultiVariate (stringType' x) x
 
 --This function should have multivariate type that represents any amount of string types
 stringConcatArgs :: SourceAnnotation Text -> Type'

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -51,6 +51,9 @@ data TypeF' a = Top { topName :: (S.Set String)
               | Product { productTypes :: [TypeF' a]
                         , productContext :: a
                         }
+              | MultiVariate { multiVariateType :: (TypeF' a)
+                             , multiVariateContext :: a
+                             }
               | Sum { sumTypes :: NonEmpty (TypeF' a)
                     }
               | Function { functionArgType :: TypeF' a
@@ -107,6 +110,11 @@ showType' (Function a r _) =
            , " returns "
            , showType' r
            ]
+showType' (MultiVariate a _) = T.concat
+                              [ "("
+                              , showType' a
+                              , ")"
+                              ]
 
 varDefsToType' :: Annotated VarDefEntryF -> Type' -> Type'
 varDefsToType' BlankEntry t                   = Product [topType' (context' t), t] (context' t)
@@ -269,6 +277,7 @@ context' Static{..}        = staticContext
 context' Product{..}       = productContext
 context' Function{..}      = functionContext
 context' (Sum (a :| _))    = context' a
+context' (MultiVariate _ _)  = error "context' MultiVariate"
 
 
 typecheck' :: Monad m => (SourceAnnotation Text -> String -> Type -> m Type') -> Type' -> Type' -> m Type'
@@ -289,6 +298,9 @@ typecheck' f r1 r2 = case (r1, r2) of
   (Product t1 x, Product t2 _) -> typecheckProduct f x t1 t2
   (Product [a] _, b) -> typecheck' f a b
   (a, Product [b] _) -> typecheck' f a b
+  (MultiVariate a _, MultiVariate b _) -> typecheck' f a b
+  (MultiVariate a _, Product xs x) -> typecheckProduct f x xs (replicate (length xs) a)
+  (Product xs x, MultiVariate a _) -> typecheckProduct f x xs (replicate (length xs) a)
   (Function a1 v1 x, Function a2 v2 _) -> do
     a <- typecheck' f a1 a2
     v <- typecheck' f v1 v2
@@ -489,6 +501,7 @@ typecheckMember (Static (SVMType.Array _ _) x) n = pure . bottom $ ("Unknown mem
 typecheckMember (Static (SVMType.Bytes _ _) x) "length" = pure $ Static (SVMType.Int Nothing Nothing) x
 typecheckMember (Static (SVMType.Label "Util") x) "bytes32ToString" = pure $ Function (Static (SVMType.Bytes Nothing (Just 32)) x) (Static (SVMType.String Nothing) x) x
 typecheckMember (Static (SVMType.Label "Util") x) "b32" = pure $ Function (Static (SVMType.Bytes Nothing (Just 32)) x) (Static (SVMType.Bytes Nothing (Just 32)) x) x
+typecheckMember (Static (SVMType.Label "string") x) "concat" = pure $ Function (stringConcatArgs x) (Static (SVMType.String Nothing) x) x
 typecheckMember (Static (SVMType.Label "msg") x) "sender" = pure $ Static (SVMType.Account False) x 
 typecheckMember (Static (SVMType.Label "tx") x) "origin" = pure $ Static (SVMType.Account False) x 
 typecheckMember (Static (SVMType.Label "tx") x) "username" = pure $ Static (SVMType.String Nothing) x
@@ -712,6 +725,7 @@ intArgs x = Sum $ enumType' x :|
                 , stringType' x
                 ]
 
+
 stringArgs :: SourceAnnotation Text -> Type'
 stringArgs x = Sum $ stringType' x :|
                    [ addressType' x
@@ -755,6 +769,11 @@ byteArgs x = intType' x
 
 keccak256Args :: SourceAnnotation Text -> Type'
 keccak256Args x = stringType' x
+
+
+--This function should have multivariate type that represents any amount of string types
+stringConcatArgs :: SourceAnnotation Text -> Type'
+stringConcatArgs x = MultiVariate (stringType' x) x
 
 requireArgs :: SourceAnnotation Text -> Type'
 requireArgs x = Sum $ boolType' x :|
@@ -802,7 +821,8 @@ getVarType' s@('i':'n':'t':n) ctx = case n of
     Nothing -> getVarTypeByName' s ctx
 getVarType' "address" ctx =  pure $ Function (addressArgs ctx) (Static (SVMType.Account False) ctx) ctx
 getVarType' "account" ctx =  pure $ Function (accountArgs ctx) (Static (SVMType.Account False) ctx) ctx
-getVarType' "string" ctx =  pure $ Function (stringArgs ctx) (stringType' ctx) ctx
+--This is either the string() function or the string.member() function
+getVarType' "string" ctx =  pure $ Sum $ (Function (stringArgs ctx) (stringType' ctx) ctx) :| [Static (SVMType.Label "string") ctx]
 getVarType' "bool" ctx =  pure $ Function (boolArgs ctx) (boolType' ctx) ctx
 getVarType' s@('b':'y':'t':'e':'s':n) ctx = case n of
   [] -> pure $ Function (byteArgs ctx) (Static (SVMType.Bytes Nothing Nothing) ctx) ctx

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -277,7 +277,7 @@ context' Static{..}        = staticContext
 context' Product{..}       = productContext
 context' Function{..}      = functionContext
 context' (Sum (a :| _))    = context' a
-context' (MultiVariate _ _)  = multiVariateContext
+context' MultiVariate{..}  = multiVariateContext
 
 
 typecheck' :: Monad m => (SourceAnnotation Text -> String -> Type -> m Type') -> Type' -> Type' -> m Type'
@@ -301,6 +301,8 @@ typecheck' f r1 r2 = case (r1, r2) of
   (MultiVariate a _, MultiVariate b _) -> typecheck' f a b
   (MultiVariate a _, Product xs x) -> typecheckProduct f x xs (replicate (length xs) a)
   (Product xs x, MultiVariate a _) -> typecheckProduct f x xs (replicate (length xs) a)
+  (MultiVariate a _, b) -> typecheck' f a b
+  (a, MultiVariate b _) -> typecheck' f a b
   (Function a1 v1 x, Function a2 v2 _) -> do
     a <- typecheck' f a1 a2
     v <- typecheck' f v1 v2

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -4058,3 +4058,12 @@ contract qq {
     assert(w == "helloworld and friends");
   }
 }|] 
+
+  it "can use the builtin keccak256 function with any amount of string arguments" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.2;
+contract qq {
+  function a() public returns (bytes32) {
+    return keccak256("hello", "world");
+  }
+}|] `shouldReturn` Just "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL \NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL1\195\186&\195\155|\194\168^\194\173\&9\194\146\SYN\195\167\195\134\&1k\195\133\SO\195\146C\194\147\195\131\DC2+X'5\195\167\195\179\194\176\195\185\ESC\194\147\195\176"

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -4043,3 +4043,18 @@ contract qq {
     return X;
   }
 }|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 1)
+
+  it "can use string.concat(x,y) to concatenate any amount of strings" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.2;
+contract qq {
+  function a() public {
+    string x = "hello";
+    string y = "world";
+    string z = " and friends";
+    string s = string.concat(x, y);
+    string w = string.concat(x, y, z);
+    assert(s == "helloworld");
+    assert(w == "helloworld and friends");
+  }
+}|] 

--- a/core-strato/solid-vm/tests/TypecheckerSpec.hs
+++ b/core-strato/solid-vm/tests/TypecheckerSpec.hs
@@ -641,3 +641,26 @@ contract qq {
 
 }|]
     in length anns `shouldBe` 1
+
+  it "can use the string.concat(x,y) function and succeeds when the types are strings" $
+    let anns = runTypechecker [r|
+contract A {
+  function f() {
+    string x = "hello";
+    string y = "world";
+    string z = string.concat(x,y);
+  }
+}
+|]
+    in length anns `shouldBe` 0
+
+  it "can use the string.concat(x,y) function and fails when the types are not strings" $
+    let anns = runTypechecker [r|
+contract A {
+  function f() {
+    string x = "hello";
+    string z = string.concat(x,7);
+  }
+}
+|]
+    in length anns `shouldBe` 1

--- a/shared-util/solid-vm-model/src/SolidVM/Model/Value.hs
+++ b/shared-util/solid-vm-model/src/SolidVM/Model/Value.hs
@@ -126,6 +126,7 @@ data Value =
                               -- can be canonicalized
   | SHexDecodeAndTrim -- Hack to implement blockapps-sol's bytes32ToString without
                       -- supporting indexing into bytes32s.
+  | SStringConcat -- for easy concat of multiple arguments
   | SAddressToAscii -- Hack to implement addressToAsciiString without supporting indexing into bytes
   | SMappingSentinel
   | SBreak


### PR DESCRIPTION
This PR adds the `string.concat()` member function, which is a multivariate function that takes any amount of strings and concatenates them. In order to implement this I added the ability to have multivariate arguments to the type checker which if you declare a multivariate function args of type string, it allows the function to take any amount of string arguments.