### PR TITLE
SolidVM Mappings can now be assigned by index, even if they are not a contract variable

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -775,6 +775,11 @@ runStatement st@(CC.SimpleStatement (CC.ExpressionStatement (CC.Binary _ "=" dst
           setVar pVar (SArray typ newVec)
           return Nothing
         _ -> typeError ("array index value (" ++ (show indVal) ++ ") is not an integer") (unparseStatement st)
+    SMap typ theMap -> do
+      theIndex <- getVar =<< expToVar indExp
+      let newMap = M.insert theIndex srcVar theMap
+      setVar pVar (SMap typ newMap)
+      return Nothing
     _ -> do -- If it's a mapping, (expToVar dst) IS a reference, so we can set directly to it
       dstVar <- expToVar dst
       setVar dstVar srcVal
@@ -2299,15 +2304,15 @@ encodeForReturn (SString s) = do
 -- Value: |offset_str1|encoded_int|offset_str2|str1EncLen|   str1Enc  |str2EncLen|   str2Enc  |
 
 -- This is a hacky way to encode arrays, only works for returning just the array
-encodeForReturn (SArray _ items) = do
-  let encLen = word256ToBytes $ fromIntegral $ (V.length items)
-  bs <- encodeVector items
-  return $ (word256ToBytes $ fromIntegral (32::Integer)) `B.append` (encLen `B.append` bs)
-  -- contract' <- getCurrentContract
-  -- if CC._vmVersion contract' == "svm3.2" 
-  --   then do
-  --   else
-  --     todo "Please use pragma solidvm 3.2 or greater to access array encoding for return " x
+encodeForReturn x@(SArray _ items) = do
+  contract' <- getCurrentContract
+  if CC._vmVersion contract' == "svm3.2" 
+    then do
+      let encLen = word256ToBytes $ fromIntegral $ (V.length items)
+      bs <- encodeVector items
+      return $ (word256ToBytes $ fromIntegral (32::Integer)) `B.append` (encLen `B.append` bs)
+    else
+      todo "Please use pragma solidvm 3.2 or greater to access array encoding for return " x
 
 encodeForReturn (STuple items) = encodeVector items
 

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -2304,15 +2304,15 @@ encodeForReturn (SString s) = do
 -- Value: |offset_str1|encoded_int|offset_str2|str1EncLen|   str1Enc  |str2EncLen|   str2Enc  |
 
 -- This is a hacky way to encode arrays, only works for returning just the array
-encodeForReturn x@(SArray _ items) = do
-  contract' <- getCurrentContract
-  if CC._vmVersion contract' == "svm3.2" 
-    then do
-      let encLen = word256ToBytes $ fromIntegral $ (V.length items)
-      bs <- encodeVector items
-      return $ (word256ToBytes $ fromIntegral (32::Integer)) `B.append` (encLen `B.append` bs)
-    else
-      todo "Please use pragma solidvm 3.2 or greater to access array encoding for return " x
+encodeForReturn (SArray _ items) = do
+  let encLen = word256ToBytes $ fromIntegral $ (V.length items)
+  bs <- encodeVector items
+  return $ (word256ToBytes $ fromIntegral (32::Integer)) `B.append` (encLen `B.append` bs)
+  -- contract' <- getCurrentContract
+  -- if CC._vmVersion contract' == "svm3.2" 
+  --   then do
+  --   else
+  --     todo "Please use pragma solidvm 3.2 or greater to access array encoding for return " x
 
 encodeForReturn (STuple items) = encodeVector items
 

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -4087,3 +4087,29 @@ contract qq {
     return X;
   }
 }|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 1)
+
+  it "can set values in a mapping that's a member of a struct" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.2;
+contract qq {
+  struct Data {
+    mapping(uint => bool) flags;
+  }
+  function a() public returns (bool) {
+    Data d;
+    d.flags[1] = true;
+    return d.flags[1];
+  }
+}|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 1)
+
+  it "can set values in a mapping that's a local variable" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.2;
+contract qq {
+  function a() public returns (bool) {
+    mapping(int => bool) flags;
+    flags[1] = true;
+    return flags[1];
+  }
+}|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 1)
+

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -4113,3 +4113,14 @@ contract qq {
   }
 }|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 1)
 
+  it "can set values in a mapping that's a contract variable" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.2;
+contract qq {
+  mapping(int => bool) flags;
+  function a() public returns (bool) {
+    flags[1] = true;
+    return flags[1];
+  }
+}|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 1)
+


### PR DESCRIPTION
The user can now declare a mapping anywhere and directly set the value via `myMapping[7] = "Hello World"` previously this was only possible if the mapping was a contract variable, but it now works in any case (member of a file level struct, local variable etc.)