### PR TITLE
Removed Account Payable Boolean flag from BasicValue type

### DIFF
--- a/blockapps-haskell/solidity/src/BlockApps/SolidVMStorageDecoder.hs
+++ b/blockapps-haskell/solidity/src/BlockApps/SolidVMStorageDecoder.hs
@@ -196,7 +196,7 @@ fromBasic = \case
   BBool b -> SimpleValue $ ValueBool b
   BInteger n -> SimpleValue $! valueInt n
   BString bs -> SimpleValue $! valueBytes bs
-  BAccount a _ -> SimpleValue $! ValueAccount a
+  BAccount a -> SimpleValue $! ValueAccount a
   BContract _ c -> ValueContract c
   BEnumVal tipe name num -> ValueEnum tipe name (fromIntegral num)
 

--- a/blockapps-haskell/solidity/test/BlockApps/SolidVMStorageDecoderSpec.hs
+++ b/blockapps-haskell/solidity/test/BlockApps/SolidVMStorageDecoderSpec.hs
@@ -49,10 +49,10 @@ address :: Address -> V.Value
 address = SimpleValue . ValueAccount . unspecifiedChain
 
 bAccount :: Address -> BasicValue
-bAccount = ((flip BAccount) False) . unspecifiedChain
+bAccount = BAccount . unspecifiedChain
 
 bAccountPayable :: Address -> BasicValue
-bAccountPayable = ((flip BAccount) True) . unspecifiedChain
+bAccountPayable = BAccount . unspecifiedChain
 
 bContract :: Text -> Address -> BasicValue
 bContract t = BContract t . unspecifiedChain

--- a/core-strato/blockapps-mpdbs/test/StorageSpec.hs
+++ b/core-strato/blockapps-mpdbs/test/StorageSpec.hs
@@ -226,7 +226,7 @@ storageSpec = do
     solidIdTest "0"               (MS.BInteger 0)
     solidIdTest "empty string"    (MS.BString "")
     solidIdTest "False"           (MS.BBool False)
-    solidIdTest "zero account"    (MS.BAccount (unspecifiedChain 0) False)
+    solidIdTest "zero account"    (MS.BAccount (unspecifiedChain 0))
     solidIdTest "zero enum value" (MS.BEnumVal "myEnum" "myEnumKey" 0)
     solidIdTest "zero contract"   (MS.BContract "MyContractName" $ unspecifiedChain 0)
     solidIdTest "BDefault"        (MS.BDefault)

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -445,7 +445,7 @@ setCreator creator contract cntrct blockNumber = do
       hasSvm3_2 = CC._vmVersion cntrct == "svm3.2"
   when hasSvm3_2 $ do
     liftIO $ putStrLn $ "setCreator/address ---> Setting creatorAddress to: " ++ show creator 
-    putSolidStorageKeyVal' hasSvm3_2 contract (MS.StoragePath [MS.Field ":creatorAddress"]) (MS.BAccount (accountToNamedAccount' creator) False)
+    putSolidStorageKeyVal' hasSvm3_2 contract (MS.StoragePath [MS.Field ":creatorAddress"]) (MS.BAccount (accountToNamedAccount' creator))
   let putCreatorField org = do
         liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show org)
         putSolidStorageKeyVal' (hasSvm3_0 || hasSvm3_2) contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
@@ -1940,7 +1940,7 @@ callBuiltin rc'@("registerCert") [SString cert] _ = do
         Account{..} -> do
           mCreatorAddress <- getSolidStorageKeyVal' curAccount $ MS.StoragePath [MS.Field ":creatorAddress"]
           case mCreatorAddress of
-            (MS.BAccount creatorAccount _) -> do
+            (MS.BAccount creatorAccount) -> do
               onTraced $ liftIO $ putStrLn $ "    Creator Address: " <> (show $ _namedAccountAddress creatorAccount)
               onTraced $ liftIO $ putStrLn $ "    Root Address: " <> (show rootAddress)
               if ((_namedAccountAddress creatorAccount) /= rootAddress) then invalidWrite "Only a function in a contract posted by the BlockApps Root Address may call registerCert" creatorAccount

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -75,7 +75,7 @@ fromBasic = \case
   MS.BInteger i -> SInteger i
   MS.BString s -> SString . BC.unpack $ s
   MS.BBool b -> SBool b
-  MS.BAccount a b -> SAccount a b
+  MS.BAccount a -> SAccount a False
   MS.BContract n a -> SContract (T.unpack n) a
   MS.BEnumVal k v num -> SEnumVal (T.unpack k) (T.unpack v) num
   MS.BMappingSentinel -> SMappingSentinel
@@ -98,7 +98,7 @@ toBasic = \case
   SInteger i -> MS.BInteger i
   SString s -> MS.BString (BC.pack s)
   SBool b -> MS.BBool b
-  SAccount a b -> MS.BAccount a b
+  SAccount a _ -> MS.BAccount a
   SContract n a -> MS.BContract (T.pack n) a
   SEnumVal k t num -> MS.BEnumVal (T.pack k) (T.pack t) num
   SMappingSentinel -> MS.BMappingSentinel

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -360,7 +360,7 @@ getFields2 :: [BC.ByteString] -> ContextM [BasicValue]
 getFields2 = getAll2 . map (\t -> [Field t])
 
 bAddress :: Address -> BasicValue
-bAddress = ((flip BAccount) False) . unspecifiedChain
+bAddress = BAccount . unspecifiedChain
 
 bContract :: T.Text -> Address -> BasicValue
 bContract t a =
@@ -381,7 +381,7 @@ bAccount a =
   let u = accountOnUnspecifiedChain a
    in if u == unspecifiedChain 0
         then BDefault
-        else (BAccount u False)
+        else (BAccount u)
 
 iAddress :: Address -> IndexType
 iAddress = IAccount . unspecifiedChain
@@ -1354,7 +1354,9 @@ contract qq {
 }|]
     getFields ["x"] `shouldReturn` [bContract "X" 0xdeadbeef]
 
-  it "can parse account payable type" . runTest $ do
+
+-- This test only works when BAccount has the payable flag
+  {-it "can parse account payable type" . runTest $ do
     runBS [r|
 contract qq {
   account y;
@@ -1366,8 +1368,8 @@ contract qq {
     x = payable(y);
   }
 }|]
-    getFields ["x"] `shouldReturn` [BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) True]
-  
+    getFields ["x"] `shouldReturn` [BAccount (NamedAccount 0xdeadbeef UnspecifiedChain)]
+  -}
 
   it "can call methods of superclasses" . runTest $ do
     runBS [r|
@@ -3099,12 +3101,12 @@ contract qq {
   }
 }|]
     getFields ["sce", "scm", "scu", "sde", "sdm", "sdu"] `shouldReturn`
-      [ BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedbeef)) False
-      , BAccount (NamedAccount 0xdeadbeef MainChain) False
-      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) False
-      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) False
-      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) False
-      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) False
+      [ BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedbeef)) 
+      , BAccount (NamedAccount 0xdeadbeef MainChain) 
+      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) 
+      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) 
+      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) 
+      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) 
       ]
   
   it "can cast strings to chainIds" . runTest $ do
@@ -3121,9 +3123,9 @@ contract qq {
   }
 }|]
     getFields ["sce", "scm", "scu"] `shouldReturn`
-      [ BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedbeef)) False
-      , BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedb33f)) False
-      , BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xf33dbeef)) False
+      [ BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedbeef)) 
+      , BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedb33f)) 
+      , BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xf33dbeef)) 
       ]
 
   it "can cast strings to bool" . runTest $ do
@@ -3164,7 +3166,7 @@ contract qq{
     }
 }|]
     -- Get the contract's account
-    [ BAccount a _] <- getFields ["a"]
+    [ BAccount a] <- getFields ["a"]
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 13 })
     -- Check return of balance
@@ -3191,7 +3193,7 @@ contract qq{
     }
 }|]
     -- Get the contract's account
-    [ BAccount a _] <- getFields ["a"]
+    [ BAccount a] <- getFields ["a"]
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 7 })
     -- Check return of balance
@@ -3218,7 +3220,7 @@ contract qq{
     }
 }|]
     -- Get the contract's account
-    [ BAccount a _] <- getFields ["a"]
+    [ BAccount a] <- getFields ["a"]
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 13 })
     -- Check return of balance
@@ -3245,7 +3247,7 @@ contract qq{
     }
 }|]
     -- Get the contract's account
-    [ BAccount a _] <- getFields ["a"]
+    [ BAccount a] <- getFields ["a"]
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 0 })
     -- Check return of balance
@@ -3270,7 +3272,7 @@ contract qq{
     }
 }|]
     -- Get the contract's account
-    [ BAccount a _] <- getFields ["a"]
+    [ BAccount a] <- getFields ["a"]
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 26 })
     -- Check return of balance
@@ -3294,7 +3296,7 @@ contract qq{
     }
 }|]
     -- Get the contract's account
-    [ BAccount a _] <- getFields ["a"]
+    [ BAccount a] <- getFields ["a"]
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 26 })
     -- Check return of balance
@@ -3336,7 +3338,7 @@ contract qq{
     }
 }|]
     -- Get the contract's accounts
-    [ BAccount a _, BAccount b _, BAccount c _] <- getFields ["a", "b", "c"]
+    [ BAccount a, BAccount b, BAccount c] <- getFields ["a", "b", "c"]
     -- Adjust the preset balances
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 14 })
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing c) (\cs -> pure $ cs { addressStateBalance = 13 })
@@ -3385,7 +3387,7 @@ contract qq{
     }
 }|]
     -- Get the contract's accounts
-    [ BAccount a _, BAccount b _, BAccount c _ ] <- getFields ["a", "b", "c"]
+    [ BAccount a, BAccount b, BAccount c] <- getFields ["a", "b", "c"]
     -- Adjust the preset balances
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 14 })
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing c) (\cs -> pure $ cs { addressStateBalance = 13 })
@@ -3430,7 +3432,7 @@ contract qq{
     }
 }|]
     -- Get the contract's accounts
-    [ BAccount a _, BAccount b _, BAccount c _ ] <- getFields ["a", "b", "c"]
+    [ BAccount a, BAccount b, BAccount c] <- getFields ["a", "b", "c"]
     -- Adjust the preset balances
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 14 })
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing c) (\cs -> pure $ cs { addressStateBalance = 13 })
@@ -3475,7 +3477,7 @@ contract qq{
     }
 }|]
     -- Get the contract's accounts
-    [ BAccount a _, BAccount b _, BAccount c _ ] <- getFields ["a", "b", "c"]
+    [ BAccount a, BAccount b, BAccount c] <- getFields ["a", "b", "c"]
     -- Adjust the preset balances
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 14 })
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing c) (\cs -> pure $ cs { addressStateBalance = 13 })
@@ -3550,7 +3552,7 @@ contract qq{
   }
 }|]
     -- Get the contract's account
-    [ BAccount a _ ] <- getFields ["a"]
+    [ BAccount a] <- getFields ["a"]
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 13 })
     -- Check return of balance
@@ -3650,8 +3652,8 @@ contract qq{
   }
 }|]
     -- Get both of the contracts
-    [ BAccount a _] <- getFields ["a"]
-    [ BAccount b _chainIdInfo] <- getFields ["b"]
+    [ BAccount a] <- getFields ["a"]
+    [ BAccount b] <- getFields ["b"]
     -- Set the balance and instantiate both of the accounts the accounts
     -- Account a should start with 13 and b should have 0 at the start.
     -- The transfer member should be able to send the balance of to account b
@@ -4037,7 +4039,7 @@ contract qq{
     return;        
   }
 }|]
-    getFields ["blockNumber", "a1", "timestamp", "gaslimit", "diff"] `shouldReturn` [BInteger 8033, (BAccount (NamedAccount 0x0 UnspecifiedChain) True), BInteger 16384, BInteger 1000000, BInteger 900]
+    getFields ["blockNumber", "a1", "timestamp", "gaslimit", "diff"] `shouldReturn` [BInteger 8033, BDefault, BInteger 16384, BInteger 1000000, BInteger 900]
 
   it "can use the builtin addmod function" . runTest $ do
     runBS [r|

--- a/shared-util/solid-vm-model/src/SolidVM/Model/Storable.hs
+++ b/shared-util/solid-vm-model/src/SolidVM/Model/Storable.hs
@@ -35,7 +35,7 @@ import           Text.Format
 data BasicValue = BInteger !Integer
                 | BString !B.ByteString
                 | BBool !Bool
-                | BAccount !NamedAccount Bool
+                | BAccount !NamedAccount 
                 | BEnumVal !T.Text !T.Text !Word32
                 | BContract !T.Text !NamedAccount
                   -- The sole purpose of this sentinel is to make slipstream reserve
@@ -48,7 +48,7 @@ isDefault :: BasicValue -> Bool
 isDefault (BInteger i)     = i == 0
 isDefault (BString bs)     = B.null bs
 isDefault (BBool b)        = not b
-isDefault (BAccount a b)     = a == unspecifiedChain 0x0 && b == False
+isDefault (BAccount a)     = a == unspecifiedChain 0x0 
 isDefault (BEnumVal _ _ w) = w == 0
 isDefault (BContract _ a)  = a == unspecifiedChain 0x0
 isDefault BMappingSentinel = False
@@ -59,7 +59,7 @@ instance Format BasicValue where
   format (BString s) = ('"':) . (++"\"") $ UTF8.toString s
   format (BBool True) = "true"
   format (BBool False) = "false"
-  format (BAccount a b) = "account(" ++ show a ++ ")" ++ (if b then " payable" else "")
+  format (BAccount a) = "account(" ++ show a ++ ")"
   format (BEnumVal n1 n2 _) = T.unpack n1 ++ "." ++ T.unpack n2
   format (BContract n a) = T.unpack n ++ "(" ++ format a ++ ")"
   format BMappingSentinel = "<MappingSentinel>"
@@ -259,7 +259,7 @@ instance RLPSerializable BasicValue where
     BInteger n -> RLPArray [RLPScalar 0, rlpEncode n]
     BString t -> RLPArray [RLPScalar 1, rlpEncode t]
     BBool b -> RLPArray [RLPScalar 2, rlpEncode b]
-    BAccount a b -> RLPArray [RLPScalar 3, rlpEncode a, rlpEncode b]
+    BAccount a -> RLPArray [RLPScalar 3, rlpEncode a]
     BContract n a -> RLPArray [RLPScalar 4, rlpEncode n, rlpEncode a]
     BEnumVal a b c -> RLPArray [RLPScalar 5, rlpEncode a, rlpEncode b, rlpEncode c]
     BMappingSentinel -> RLPArray [RLPScalar 6]
@@ -268,7 +268,7 @@ instance RLPSerializable BasicValue where
       (0, [f]) -> BInteger $ rlpDecode f
       (1, [f]) -> BString $ rlpDecode f
       (2, [f]) -> BBool $ rlpDecode f
-      (3, [f, b']) -> BAccount (rlpDecode f) (rlpDecode b')
+      (3, [f]) -> BAccount $ rlpDecode f
       (4, [f, a']) -> BContract (rlpDecode f) (rlpDecode a')
       (5, [f, s', c']) -> BEnumVal (rlpDecode f) (rlpDecode s') (rlpDecode c')
       (6, []) -> BMappingSentinel

--- a/shared-util/solid-vm-model/test/StorageTest.hs
+++ b/shared-util/solid-vm-model/test/StorageTest.hs
@@ -95,9 +95,9 @@ spec = do
       let examples = [ BInteger 3399293429
                      , BString "This is text"
                      , BBool True
-                     , BAccount (unspecifiedChain 0x23421421421341232341bbbb) False
-                     , BAccount (mainChain 0x23421421421341232341bbbb) False
-                     , BAccount (explicitChain 0x23421421421341232341bbbb 0xdeadbeefd00d) False
+                     , BAccount (unspecifiedChain 0x23421421421341232341bbbb) 
+                     , BAccount (mainChain 0x23421421421341232341bbbb) 
+                     , BAccount (explicitChain 0x23421421421341232341bbbb 0xdeadbeefd00d) 
                      , BContract "Wings!" (unspecifiedChain 0xdeadbeef)
                      , BContract "Wings!" (mainChain 0xdeadbeef)
                      , BContract "Wings!" (explicitChain 0xdeadbeef 0x1234567890)


### PR DESCRIPTION
As discussed in the SolidVM Versioning discussion, this PR removes the ability to distinguish between payable and non payable accounts outside of the SolidVM typing system