### PR TITLE
Strato 2590 root certs handshake

### DIFF
--- a/core-strato/strato-p2p/package.yaml
+++ b/core-strato/strato-p2p/package.yaml
@@ -24,6 +24,7 @@ executables:
       - strato-p2p
       - wai-middleware-prometheus
       - warp
+      - x509-certs
       
 library:
   source-dirs: src
@@ -90,6 +91,7 @@ library:
     - unliftio
     - vm-tools
     - warp
+    - x509-certs
 
 
 tests:

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -162,21 +162,44 @@ handleMsgClientConduit myId peer = do
         Just Hello{} ->
             yield =<< lift (Mod.get (Mod.Proxy @BestBlock) >>= \(BestBlock bHash _ tdiff) -> do
               (GenesisBlockHash genHash) <- Mod.access (Mod.Proxy @GenesisBlockHash)
-              return $ Right Status {
-                protocolVersion = fromIntegral ethVersion,
-                networkID       = computeNetworkID,
-                totalDifficulty = fromIntegral tdiff,
-                latestHash      = bHash,
-                genesisHash     = genHash,
-                rootCerts       = rootCerts'
-              })
+              -- TODO remove distinction between new status messages and old ones once entire protocol is complete
+
+              let s = if flags_useNodeCerts then NewStatus {
+                                          protocolVersion = fromIntegral ethVersion,
+                                          networkID       = computeNetworkID,
+                                          totalDifficulty = fromIntegral tdiff,
+                                          latestHash      = bHash,
+                                          genesisHash     = genHash,
+                                          rootCerts       = rootCerts'
+                                        } else Status {
+                                          protocolVersion = fromIntegral ethVersion,
+                                          networkID       = computeNetworkID,
+                                          totalDifficulty = fromIntegral tdiff,
+                                          latestHash      = bHash,
+                                          genesisHash     = genHash
+                                        }
+              return $ Right s
+            )
         other -> assertHandshake other
     awaitMsg >>= \case
-        Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID', rootCerts=rcs} -> do
+        -- TODO remove distinction between new status messages and old ones once entire protocol is complete
+        Just NewStatus{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID', rootCerts=rcs} -> do
                 (GenesisBlockHash genHash) <- lift $ Mod.access (Mod.Proxy @GenesisBlockHash)
                 when (peerGH /= genHash) $ throwIO WrongGenesisBlock
                 when (networkID' /= computeNetworkID) $ error "networkID mismatch"
                 when (rcs /= rootCerts') $ error "rootCerts mismatch"
+                -- we set to 0 cause we dont necessarily know the number yet
+                lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
+                (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
+                mrh <- lift $ unMaxReturnedHeaders <$> Mod.access (Mod.Proxy @MaxReturnedHeaders)
+                yield . Right $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) 0)) mrh 0 Forward
+                yield . Right $ GetChainDetails []
+                handleGetChainDetails peer S.empty
+                lift stampActionTimestamp
+        Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID'} -> do
+                (GenesisBlockHash genHash) <- lift $ Mod.access (Mod.Proxy @GenesisBlockHash)
+                when (peerGH /= genHash) $ throwIO WrongGenesisBlock
+                when (networkID' /= computeNetworkID) $ error "networkID mismatch"
                 -- we set to 0 cause we dont necessarily know the number yet
                 lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
                 (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
@@ -207,7 +230,8 @@ handleMsgServerConduit myPubkey peer = do
             yield $ Right helloMsg'
         other -> assertHandshake $ other
     awaitMsg >>= \case
-        Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID', rootCerts=rcs} -> do
+        -- TODO remove distinction between new status messages and old ones once entire protocol is complete
+        Just NewStatus{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID', rootCerts=rcs} -> do
             $logInfoS "serverHandshake/Status{}" "received status"
             yield =<< lift (Mod.get (Mod.Proxy @BestBlock) >>= \(BestBlock bHash _ tdiff) -> do
               (GenesisBlockHash genHash) <- Mod.access (Mod.Proxy @GenesisBlockHash)
@@ -217,13 +241,29 @@ handleMsgServerConduit myPubkey peer = do
 
               -- we set to 0 cause we dont necessarily know the number yet
               Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
-              return $ Right Status {
+              return $ Right NewStatus {
                   protocolVersion = fromIntegral ethVersion,
                   networkID = computeNetworkID,
                   totalDifficulty = fromIntegral tdiff,
                   latestHash = bHash,
                   genesisHash = genHash,
                   rootCerts= rootCerts'
+              })
+        Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID'} -> do
+            $logInfoS "serverHandshake/Status{}" "received status"
+            yield =<< lift (Mod.get (Mod.Proxy @BestBlock) >>= \(BestBlock bHash _ tdiff) -> do
+              (GenesisBlockHash genHash) <- Mod.access (Mod.Proxy @GenesisBlockHash)
+              when (genHash /= peerGH) $ error "peer has a different genesis block than we do!"
+              when (networkID' /= computeNetworkID) $ error "networkID mismatch"
+
+              -- we set to 0 cause we dont necessarily know the number yet
+              Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
+              return $ Right Status {
+                  protocolVersion = fromIntegral ethVersion,
+                  networkID = computeNetworkID,
+                  totalDifficulty = fromIntegral tdiff,
+                  latestHash = bHash,
+                  genesisHash = genHash
               })
         other -> assertHandshake other
     handleEvents peer .| filterMC (either (const $ return True) checkOutbound)

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -61,8 +61,11 @@ import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.TimerSource
 import           Blockchain.Util
 import           Blockchain.Watchdog
+import           BlockApps.X509
 
-
+-- This is a placeholder until the root certs can be held in a proper database
+rootCerts' :: [X509Certificate] 
+rootCerts' = [rootCert]
 
 ethVersion :: Int
 ethVersion = 62
@@ -164,14 +167,16 @@ handleMsgClientConduit myId peer = do
                 networkID       = computeNetworkID,
                 totalDifficulty = fromIntegral tdiff,
                 latestHash      = bHash,
-                genesisHash     = genHash
+                genesisHash     = genHash,
+                rootCerts       = rootCerts'
               })
         other -> assertHandshake other
     awaitMsg >>= \case
-        Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID'} -> do
+        Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID', rootCerts=rcs} -> do
                 (GenesisBlockHash genHash) <- lift $ Mod.access (Mod.Proxy @GenesisBlockHash)
                 when (peerGH /= genHash) $ throwIO WrongGenesisBlock
                 when (networkID' /= computeNetworkID) $ error "networkID mismatch"
+                when (rcs /= rootCerts') $ error "rootCerts mismatch"
                 -- we set to 0 cause we dont necessarily know the number yet
                 lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
                 (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
@@ -202,12 +207,14 @@ handleMsgServerConduit myPubkey peer = do
             yield $ Right helloMsg'
         other -> assertHandshake $ other
     awaitMsg >>= \case
-        Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID'} -> do
+        Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID', rootCerts=rcs} -> do
             $logInfoS "serverHandshake/Status{}" "received status"
             yield =<< lift (Mod.get (Mod.Proxy @BestBlock) >>= \(BestBlock bHash _ tdiff) -> do
               (GenesisBlockHash genHash) <- Mod.access (Mod.Proxy @GenesisBlockHash)
               when (genHash /= peerGH) $ error "peer has a different genesis block than we do!"
               when (networkID' /= computeNetworkID) $ error "networkID mismatch"
+              when (rcs /= rootCerts') $ error "rootCerts mismatch"
+
               -- we set to 0 cause we dont necessarily know the number yet
               Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
               return $ Right Status {
@@ -215,7 +222,8 @@ handleMsgServerConduit myPubkey peer = do
                   networkID = computeNetworkID,
                   totalDifficulty = fromIntegral tdiff,
                   latestHash = bHash,
-                  genesisHash = genHash
+                  genesisHash = genHash,
+                  rootCerts= rootCerts'
               })
         other -> assertHandshake other
     handleEvents peer .| filterMC (either (const $ return True) checkOutbound)

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -187,7 +187,7 @@ handleMsgClientConduit myId peer = do
                 (GenesisBlockHash genHash) <- lift $ Mod.access (Mod.Proxy @GenesisBlockHash)
                 when (peerGH /= genHash) $ throwIO WrongGenesisBlock
                 when (networkID' /= computeNetworkID) $ throwIO $ NetworkIDMismatch networkID' computeNetworkID
-                when (rcs /= rootCerts') $ throwIO RootCertificateMismatch
+                when (S.difference rcs rootCerts' /= S.empty) $ throwIO RootCertificateMismatch
                 -- we set to 0 cause we dont necessarily know the number yet
                 lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
                 (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
@@ -237,7 +237,7 @@ handleMsgServerConduit myPubkey peer = do
               (GenesisBlockHash genHash) <- Mod.access (Mod.Proxy @GenesisBlockHash)
               when (genHash /= peerGH) $ throwIO WrongGenesisBlock
               when (networkID' /= computeNetworkID) $ throwIO $ NetworkIDMismatch networkID' computeNetworkID
-              when (rcs /= rootCerts') $ throwIO RootCertificateMismatch
+              when (S.difference rcs rootCerts' /= S.empty) $ throwIO RootCertificateMismatch
 
               -- we set to 0 cause we dont necessarily know the number yet
               Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD

--- a/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/core-strato/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -64,8 +64,8 @@ import           Blockchain.Watchdog
 import           BlockApps.X509
 
 -- This is a placeholder until the root certs can be held in a proper database
-rootCerts' :: [X509Certificate] 
-rootCerts' = [rootCert]
+rootCerts' :: S.Set X509Certificate 
+rootCerts' = S.fromList [rootCert] 
 
 ethVersion :: Int
 ethVersion = 62
@@ -186,8 +186,8 @@ handleMsgClientConduit myId peer = do
         Just NewStatus{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID', rootCerts=rcs} -> do
                 (GenesisBlockHash genHash) <- lift $ Mod.access (Mod.Proxy @GenesisBlockHash)
                 when (peerGH /= genHash) $ throwIO WrongGenesisBlock
-                when (networkID' /= computeNetworkID) $ error "networkID mismatch"
-                when (rcs /= rootCerts') $ error "rootCerts mismatch"
+                when (networkID' /= computeNetworkID) $ throwIO $ NetworkIDMismatch networkID' computeNetworkID
+                when (rcs /= rootCerts') $ throwIO RootCertificateMismatch
                 -- we set to 0 cause we dont necessarily know the number yet
                 lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
                 (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
@@ -199,7 +199,7 @@ handleMsgClientConduit myId peer = do
         Just Status{totalDifficulty=peerTD, genesisHash=peerGH, latestHash=peerBestHash, networkID=networkID'} -> do
                 (GenesisBlockHash genHash) <- lift $ Mod.access (Mod.Proxy @GenesisBlockHash)
                 when (peerGH /= genHash) $ throwIO WrongGenesisBlock
-                when (networkID' /= computeNetworkID) $ error "networkID mismatch"
+                when (networkID' /= computeNetworkID) $ throwIO $ NetworkIDMismatch networkID' computeNetworkID
                 -- we set to 0 cause we dont necessarily know the number yet
                 lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
                 (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
@@ -235,9 +235,9 @@ handleMsgServerConduit myPubkey peer = do
             $logInfoS "serverHandshake/Status{}" "received status"
             yield =<< lift (Mod.get (Mod.Proxy @BestBlock) >>= \(BestBlock bHash _ tdiff) -> do
               (GenesisBlockHash genHash) <- Mod.access (Mod.Proxy @GenesisBlockHash)
-              when (genHash /= peerGH) $ error "peer has a different genesis block than we do!"
-              when (networkID' /= computeNetworkID) $ error "networkID mismatch"
-              when (rcs /= rootCerts') $ error "rootCerts mismatch"
+              when (genHash /= peerGH) $ throwIO WrongGenesisBlock
+              when (networkID' /= computeNetworkID) $ throwIO $ NetworkIDMismatch networkID' computeNetworkID
+              when (rcs /= rootCerts') $ throwIO RootCertificateMismatch
 
               -- we set to 0 cause we dont necessarily know the number yet
               Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
@@ -253,8 +253,8 @@ handleMsgServerConduit myPubkey peer = do
             $logInfoS "serverHandshake/Status{}" "received status"
             yield =<< lift (Mod.get (Mod.Proxy @BestBlock) >>= \(BestBlock bHash _ tdiff) -> do
               (GenesisBlockHash genHash) <- Mod.access (Mod.Proxy @GenesisBlockHash)
-              when (genHash /= peerGH) $ error "peer has a different genesis block than we do!"
-              when (networkID' /= computeNetworkID) $ error "networkID mismatch"
+              when (genHash /= peerGH) $ throwIO WrongGenesisBlock
+              when (networkID' /= computeNetworkID) $ throwIO $ NetworkIDMismatch networkID' computeNetworkID
 
               -- we set to 0 cause we dont necessarily know the number yet
               Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD

--- a/core-strato/strato-p2p/src/Blockchain/Data/Wire.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Data/Wire.hs
@@ -30,7 +30,7 @@ import           Blockchain.Util
 import           Blockchain.ExtWord
 import qualified Text.Colors                  as CL
 import           Text.Format
-
+import           BlockApps.X509
 data Capability = ETH Integer               -- | Base Ethereum P2P protocol
                 | IST Integer               -- | Istanbul/Blockstanbul/PBFT messages.
                 | UNKNOWNCAP String Integer -- ¯\_(ツ)_/¯
@@ -151,13 +151,26 @@ instance RLPSerializable TransactionRequest where
 
 data Message =
   --p2p wire protocol
-  Hello { version::Int, clientId::String, capability::[Capability], port::Int, nodeId::Point } |
+  Hello {
+    version::Int, 
+    clientId::String,
+    capability::[Capability],
+    port::Int, 
+    nodeId::Point
+  } |
   Disconnect TerminationReason |
   Ping |
   Pong |
 
   --ethereum wire protocol
-  Status { protocolVersion::Int, networkID::Integer, totalDifficulty::Integer, latestHash::Keccak256, genesisHash:: Keccak256 } |
+  Status { 
+    protocolVersion::Int, 
+    networkID::Integer, 
+    totalDifficulty::Integer, 
+    latestHash::Keccak256, 
+    genesisHash:: Keccak256,
+    rootCerts :: [X509Certificate]
+    } |
   NewBlockHashes [(Keccak256, Int)] |
   Transactions [Transaction] |
   GetBlockHeaders {block::BlockHashOrNumber, maxHeaders::Int, skip::Int, direction::Direction} |
@@ -186,13 +199,14 @@ instance Format Message where
   format Pong = CL.blue "Pong"
 
   --ethereum wire protocol
-  format Status{ protocolVersion=ver, networkID=nID, totalDifficulty=d, latestHash=lh, genesisHash=gh } =
+  format Status{ protocolVersion=ver, networkID=nID, totalDifficulty=d, latestHash=lh, genesisHash=gh, rootCerts = rcs} =
     CL.blue "Status" ++
       "    protocolVersion: " ++ show ver ++ "\n" ++
       "    networkID: " ++ show nID ++ "\n" ++
       "    totalDifficulty: " ++ show d ++ "\n" ++
       "    latestHash: " ++ format lh ++ "\n" ++
-      "    genesisHash: " ++ format gh
+      "    genesisHash: " ++ format gh ++ "\n" ++
+      "    rootCerts: " ++ show rcs
 
   format (NewBlockHashes items) = CL.blue "NewBlockHashes"  ++ tab("\n" ++ intercalate "\n    " ((\(hash', number') -> "(" ++ format hash' ++ ", " ++ show number' ++ ")") <$> items))
   format (Transactions transactions) =
@@ -245,13 +259,14 @@ obj2WireMessage 0x1 (RLPArray [reason]) =
 obj2WireMessage 0x2 (RLPArray []) = Ping
 obj2WireMessage 0x2 (RLPArray [RLPArray []]) = Ping
 obj2WireMessage 0x3 (RLPArray []) = Pong
-obj2WireMessage 0x10 (RLPArray [ver, nID, d, lh, gh]) =
+obj2WireMessage 0x10 (RLPArray [ver, nID, d, lh, gh, rcs]) =
     Status {
   protocolVersion=fromInteger $ rlpDecode ver,
   networkID = fromInteger $ rlpDecode nID,
   totalDifficulty = rlpDecode d,
   latestHash=rlpDecode lh,
-  genesisHash=rlpDecode gh
+  genesisHash=rlpDecode gh,
+  rootCerts=rlpDecode rcs
 }
 
 obj2WireMessage 0x11 (RLPArray items) =
@@ -304,8 +319,8 @@ wireMessage2Obj Hello { version = ver,
 wireMessage2Obj (Disconnect reason) = (0x1, RLPArray [rlpEncode $ terminationReasonToNumber reason])
 wireMessage2Obj Ping = (0x2, RLPArray [])
 wireMessage2Obj Pong = (0x3, RLPArray [])
-wireMessage2Obj (Status ver nID d lh gh) =
-    (0x10, RLPArray [rlpEncode $ toInteger ver, rlpEncode $ toInteger nID, rlpEncode d, rlpEncode lh, rlpEncode gh])
+wireMessage2Obj (Status ver nID d lh gh rcs) =
+    (0x10, RLPArray [rlpEncode $ toInteger ver, rlpEncode $ toInteger nID, rlpEncode d, rlpEncode lh, rlpEncode gh, rlpEncode rcs])
 wireMessage2Obj (NewBlockHashes items) =
   (0x11, RLPArray $ map (\(b, n) -> RLPArray [rlpEncode b, rlpEncode $ toInteger n]) items)
 wireMessage2Obj (GetBlockHeaders b max' skip' direction') =

--- a/core-strato/strato-p2p/src/Blockchain/Data/Wire.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Data/Wire.hs
@@ -168,6 +168,15 @@ data Message =
     networkID::Integer, 
     totalDifficulty::Integer, 
     latestHash::Keccak256, 
+    genesisHash:: Keccak256
+    } |
+-- TODO remove distinction between new status messages and old ones once entire protocol is complete
+
+  NewStatus { 
+    protocolVersion::Int, 
+    networkID::Integer, 
+    totalDifficulty::Integer, 
+    latestHash::Keccak256, 
     genesisHash:: Keccak256,
     rootCerts :: [X509Certificate]
     } |
@@ -199,7 +208,16 @@ instance Format Message where
   format Pong = CL.blue "Pong"
 
   --ethereum wire protocol
-  format Status{ protocolVersion=ver, networkID=nID, totalDifficulty=d, latestHash=lh, genesisHash=gh, rootCerts = rcs} =
+  format Status{ protocolVersion=ver, networkID=nID, totalDifficulty=d, latestHash=lh, genesisHash=gh} =
+    CL.blue "Status" ++
+      "    protocolVersion: " ++ show ver ++ "\n" ++
+      "    networkID: " ++ show nID ++ "\n" ++
+      "    totalDifficulty: " ++ show d ++ "\n" ++
+      "    latestHash: " ++ format lh ++ "\n" ++
+      "    genesisHash: " ++ format gh
+      
+-- TODO remove distinction between new status messages and old ones once entire protocol is complete
+  format NewStatus{ protocolVersion=ver, networkID=nID, totalDifficulty=d, latestHash=lh, genesisHash=gh, rootCerts = rcs} =
     CL.blue "Status" ++
       "    protocolVersion: " ++ show ver ++ "\n" ++
       "    networkID: " ++ show nID ++ "\n" ++
@@ -259,15 +277,24 @@ obj2WireMessage 0x1 (RLPArray [reason]) =
 obj2WireMessage 0x2 (RLPArray []) = Ping
 obj2WireMessage 0x2 (RLPArray [RLPArray []]) = Ping
 obj2WireMessage 0x3 (RLPArray []) = Pong
+-- TODO remove distinction between new status messages and old ones once entire protocol is complete
 obj2WireMessage 0x10 (RLPArray [ver, nID, d, lh, gh, rcs]) =
+    NewStatus {
+      protocolVersion=fromInteger $ rlpDecode ver,
+      networkID = fromInteger $ rlpDecode nID,
+      totalDifficulty = rlpDecode d,
+      latestHash=rlpDecode lh,
+      genesisHash=rlpDecode gh,
+      rootCerts=rlpDecode rcs
+    }
+obj2WireMessage 0x10 (RLPArray [ver, nID, d, lh, gh]) =
     Status {
-  protocolVersion=fromInteger $ rlpDecode ver,
-  networkID = fromInteger $ rlpDecode nID,
-  totalDifficulty = rlpDecode d,
-  latestHash=rlpDecode lh,
-  genesisHash=rlpDecode gh,
-  rootCerts=rlpDecode rcs
-}
+      protocolVersion=fromInteger $ rlpDecode ver,
+      networkID = fromInteger $ rlpDecode nID,
+      totalDifficulty = rlpDecode d,
+      latestHash=rlpDecode lh,
+      genesisHash=rlpDecode gh
+    }
 
 obj2WireMessage 0x11 (RLPArray items) =
   NewBlockHashes $ (\(RLPArray [hash', number']) -> (rlpDecode hash', fromInteger $ rlpDecode number')) <$> items
@@ -319,7 +346,10 @@ wireMessage2Obj Hello { version = ver,
 wireMessage2Obj (Disconnect reason) = (0x1, RLPArray [rlpEncode $ terminationReasonToNumber reason])
 wireMessage2Obj Ping = (0x2, RLPArray [])
 wireMessage2Obj Pong = (0x3, RLPArray [])
-wireMessage2Obj (Status ver nID d lh gh rcs) =
+wireMessage2Obj (Status ver nID d lh gh) =
+    (0x10, RLPArray [rlpEncode $ toInteger ver, rlpEncode $ toInteger nID, rlpEncode d, rlpEncode lh, rlpEncode gh])
+-- TODO remove distinction between new status messages and old ones once entire protocol is complete
+wireMessage2Obj (NewStatus ver nID d lh gh rcs) =
     (0x10, RLPArray [rlpEncode $ toInteger ver, rlpEncode $ toInteger nID, rlpEncode d, rlpEncode lh, rlpEncode gh, rlpEncode rcs])
 wireMessage2Obj (NewBlockHashes items) =
   (0x11, RLPArray $ map (\(b, n) -> RLPArray [rlpEncode b, rlpEncode $ toInteger n]) items)

--- a/core-strato/strato-p2p/src/Blockchain/Data/Wire.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Data/Wire.hs
@@ -15,6 +15,7 @@ module Blockchain.Data.Wire (
 import           Crypto.Types.PubKey.ECC
 import qualified Data.ByteString              as B
 import           Data.List
+import qualified Data.Set                     as S
 import           Data.Word
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
@@ -178,7 +179,7 @@ data Message =
     totalDifficulty::Integer, 
     latestHash::Keccak256, 
     genesisHash:: Keccak256,
-    rootCerts :: [X509Certificate]
+    rootCerts :: S.Set X509Certificate
     } |
   NewBlockHashes [(Keccak256, Int)] |
   Transactions [Transaction] |

--- a/core-strato/strato-p2p/src/Blockchain/Event.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Event.hs
@@ -123,6 +123,8 @@ handleEvents :: MonadP2P m => PPeer -> ConduitM Event (Either P2PCNC Message) m 
 handleEvents peer = awaitForever $ \case
     MsgEvt Hello{}  -> error "A hello message appeared after the handshake"
     MsgEvt Status{} -> error "A status message appeared after the handshake"
+-- TODO remove distinction between new status messages and old ones once entire protocol is complete
+    MsgEvt NewStatus{} -> error "A new status message appeared after the handshake"
     MsgEvt Ping     -> yieldR Pong
 
     MsgEvt (Transactions txs) -> do

--- a/core-strato/strato-p2p/src/Blockchain/EventException.hs
+++ b/core-strato/strato-p2p/src/Blockchain/EventException.hs
@@ -11,6 +11,8 @@ data EventException =
     PeerDisconnected
   | EventBeforeHandshake Message
   | WrongGenesisBlock
+  | NetworkIDMismatch Integer Integer
+  | RootCertificateMismatch
   | NoPeerPubKey deriving (Show)
 
 instance Exception EventException where

--- a/core-strato/strato-p2p/src/Blockchain/Metrics.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Metrics.hs
@@ -69,6 +69,8 @@ recordMessage' msgVect msg = do
                 Ping -> "ping"
                 Pong -> "pong"
                 Status{} -> "status"
+-- TODO remove distinction between new status messages and old ones once entire protocol is complete
+                NewStatus{} -> "new_status"
                 NewBlockHashes _ -> "new_block_hashes"
                 Transactions _ -> "transactions"
                 GetBlockHeaders{} -> "get_block_headers"

--- a/core-strato/strato-p2p/src/Blockchain/Options.hs
+++ b/core-strato/strato-p2p/src/Blockchain/Options.hs
@@ -31,6 +31,8 @@ defineFlag "vaultWrapperUrl" ("http://vault-wrapper:8000/strato/v2.3" :: String)
 defineFlag "txGossipFanout" (-1::Int) "Maxmimum number of peers to forward transactions to. Only\
                                       \ applicable for transactions received from peers, not\
                                       \ originating on this node."
+-- TODO remove distinction between new status messages and old ones once entire protocol is complete
+defineFlag "useNodeCerts" (False :: Bool) "Use new node certificate checking protocol"
 
 defineEQFlag "privateChainAuthorizationMode" [| FlexibleAuth :: AuthorizationMode |] "AUTHORIZATIONMODE"
     "Describes the policy for sharing private chain data. By default, it only checks that the ip address\

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -51,7 +51,7 @@ import qualified Blockchain.Data.TXOrigin              as Origin
 import           Blockchain.Data.Wire
 import           Blockchain.Event
 import           Blockchain.ExtWord
-import           Blockchain.Options                    (AuthorizationMode(..))
+import           Blockchain.Options                    
 import           Blockchain.Output
 import           Blockchain.Privacy
 import qualified Blockchain.Sequencer                  as Seq

--- a/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -48,6 +48,7 @@ import qualified Data.ByteString.Char8              as C8
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Short              as BSS
 
+import qualified Data.Set                           as S
 import           Data.Functor
 import           Data.Either
 import           Data.Maybe
@@ -69,8 +70,10 @@ import           Text.Format
 -----------------------------------------------------------------------------------------------
 
 
-
 newtype X509Certificate = X509Certificate CertificateChain deriving (Show, Eq)
+
+instance Ord X509Certificate where
+    compare a b = compare (certToBytes a) (certToBytes b)
 
 instance NFData X509Certificate where
     rnf (X509Certificate cert) = cert `seq` ()
@@ -133,6 +136,12 @@ instance RLPSerializable X509Certificate where
   
   rlpDecode (RLPString str) = fromRight (error "failed to rlpDecode cert") $ bsToCert str
   rlpDecode x = error $ "rlpDecode for SignedCertificate failed: expected RLPString, got " ++ show x
+
+instance RLPSerializable (S.Set X509Certificate) where
+  rlpEncode s = RLPArray $ rlpEncode <$> (S.toList s)
+  
+  rlpDecode (RLPArray cs) = S.fromList (rlpDecode <$> cs)
+  rlpDecode x = error $ "rlpDecode for SignedCertificate Set failed: expected RLPArray, got " ++ show x
 
 instance ToJSON X509Certificate where
   toJSON = String . T.pack . C8.unpack . certToBytes


### PR DESCRIPTION
Since all networks will now have node certs, we need to ensure that each node connecting has the same root certificates before further connections, otherwise a common trust anchor cannot be established for further certificate validations.

Right now this is guarded behind a flag `useNodeCerts`, which I plan on using to guard all future node-level cert features behind until the feature is fully ready.
When this feature is disabled, it will continue to operate as it did before, and I tested to ensure it makes a connection to the devnet, and it does. (syncing is another beast)
When the feature is turned on, I ensured that no connection was made because my node sent a new Status Message, which the existing nodes did not recognize. However, even when its turned on it will accept old message styles. If you think they should not be accepted at all when enabled, lmk.