### PR TITLE
[STRATO-2587] Add userAddress-x509CertContract key-value storage to Redis

### DIFF
--- a/core-strato/strato-index/package.yaml
+++ b/core-strato/strato-index/package.yaml
@@ -60,3 +60,13 @@ executables:
       - hflags
       - strato-index
     other-modules: []
+
+tests:
+  strato-index-test:
+    source-dirs: test/
+    main: Spec.hs
+    dependencies:
+    - blockapps-data
+    - blockapps-datadefs
+    - hspec
+    - strato-index

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -78,6 +78,15 @@ doRemoveMember chainId address = do
   lift $ removeMember chainId address
   void . RBDB.withRedisBlockDB $ RBDB.removeChainMember chainId address
 
+doRegisterCertificate :: Address -> Address -> IContextM ()
+doRegisterCertificate userAddress contractAddress = do
+  logF [ "Registering X.509 Certificate -- userAddress: " 
+       , format userAddress
+       , "; contractAddress: "
+       , format contractAddress
+       ]
+  void . RBDB.withRedisBlockDB $ RBDB.registerCertificate userAddress contractAddress
+
 txrIndexer :: LoggingT IO ()
 txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
     $logInfoS "txrIndexer" "About to fetch IndexEvents"
@@ -91,6 +100,7 @@ txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
 
 data TxrResult = AddMember (Either String (Word256, Address, Enode))
                | RemoveMember (Either String (Word256, Address))
+               | RegisterCertificate (Either String (Address, Address))
                | TerminateChain (Either String Word256)
                | PutLogDB LogDB
                | PutEventDB EventDB
@@ -127,6 +137,11 @@ indexEventToTxrResults = \case
       ("MemberRemoved", [addressStr]) -> case stringAddress addressStr of
         Nothing -> Just . RemoveMember . Left $ "failed to parse address for MemberRemoved event: " ++ addressStr
         Just address -> Just . RemoveMember $ Right (chainId, address)
+      ("CertificateRegistered", [userAddress, contractAddress]) -> case (stringAddress userAddress, stringAddress contractAddress) of
+        (Nothing, Nothing) -> Just . RegisterCertificate . Left $ "failed to parse userAddress and contractAddress for CertificateRegistered event: " <> userAddress <> "; " <> contractAddress
+        (Nothing, Just _) -> Just . RegisterCertificate . Left $ "failed to parse userAddress for CertificateRegistered event: " <> userAddress <> "; " <> contractAddress
+        (Just _, Nothing) -> Just . RegisterCertificate . Left $ "failed to parse contractAddress for CertificateRegistered event: " <> userAddress <> "; " <> contractAddress
+        (Just uAddr, Just cAddr) ->  Just . RegisterCertificate $ Right (uAddr, cAddr)
       _ -> Nothing
   TxResult r -> [PutTxResult r]
   _ -> []
@@ -138,6 +153,9 @@ txrResultHandler = \case
     Left err -> $logErrorS "txrIndexer" $ T.pack err
   RemoveMember e -> case e of
     Right (chainId, address) -> doRemoveMember chainId address
+    Left err -> $logErrorS "txrIndexer" $ T.pack err
+  RegisterCertificate e -> case e of
+    Right (userAddress, contractAddress) -> doRegisterCertificate userAddress contractAddress
     Left err -> $logErrorS "txrIndexer" $ T.pack err
   TerminateChain e -> case e of
     Right chainId -> lift $ terminateChain chainId

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -105,6 +105,7 @@ data TxrResult = AddMember (Either String (Word256, Address, Enode))
                | PutLogDB LogDB
                | PutEventDB EventDB
                | PutTxResult TransactionResult
+               deriving (Show, Eq)
 
 indexEventToTxrResults :: IndexEvent -> [TxrResult]
 indexEventToTxrResults = \case

--- a/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/core-strato/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -124,9 +124,9 @@ indexEventToTxrResults = \case
          in Just . RemoveMember $ Right (chainId, address)
       Just x | x == keccak256ToWord256 terminateTopic -> Just . TerminateChain $ Right chainId
       _ -> Nothing
-  EventDBEntry ev -> (:) (PutEventDB ev) . maybeToList $ eventDBChainId ev >>= \chainId ->
-     case (eventDBName ev, eventDBArgs ev) of
-      ("MemberAdded", [addressStr, enodeStr]) -> case stringAddress addressStr of
+  EventDBEntry ev -> (:) (PutEventDB ev) . maybeToList $
+     case (eventDBChainId ev, eventDBName ev, eventDBArgs ev) of
+      (Just chainId, "MemberAdded", [addressStr, enodeStr]) -> case stringAddress addressStr of
         Nothing -> Just . AddMember . Left $ "failed to parse address for MemberAdded event: " ++ addressStr
         Just address ->
           --TODO: we don't need this powerful of an evaluation, we just need to improve `readEnode`
@@ -134,10 +134,10 @@ indexEventToTxrResults = \case
            in case eNode of
             Left err -> Just . AddMember . Left $ "failed to parse enode" ++ show err
             Right enode -> Just . AddMember $ Right (chainId, address, enode)
-      ("MemberRemoved", [addressStr]) -> case stringAddress addressStr of
+      (Just chainId, "MemberRemoved", [addressStr]) -> case stringAddress addressStr of
         Nothing -> Just . RemoveMember . Left $ "failed to parse address for MemberRemoved event: " ++ addressStr
         Just address -> Just . RemoveMember $ Right (chainId, address)
-      ("CertificateRegistered", [userAddress, contractAddress]) -> case (stringAddress userAddress, stringAddress contractAddress) of
+      (Nothing, "CertificateRegistered", [userAddress, contractAddress]) -> case (stringAddress userAddress, stringAddress contractAddress) of
         (Nothing, Nothing) -> Just . RegisterCertificate . Left $ "failed to parse userAddress and contractAddress for CertificateRegistered event: " <> userAddress <> "; " <> contractAddress
         (Nothing, Just _) -> Just . RegisterCertificate . Left $ "failed to parse userAddress for CertificateRegistered event: " <> userAddress <> "; " <> contractAddress
         (Just _, Nothing) -> Just . RegisterCertificate . Left $ "failed to parse contractAddress for CertificateRegistered event: " <> userAddress <> "; " <> contractAddress

--- a/core-strato/strato-index/test/Spec.hs
+++ b/core-strato/strato-index/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/core-strato/strato-index/test/TxrIndexerSpec.hs
+++ b/core-strato/strato-index/test/TxrIndexerSpec.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module TxrIndexerSpec where
+
+import           Test.Hspec
+
+import           Blockchain.Data.DataDefs
+import           Blockchain.Data.Enode
+import           Blockchain.Strato.Indexer.Model
+import           Blockchain.Strato.Indexer.TxrIndexer
+
+spec :: Spec
+spec = do
+    describe "indexEventToTxrResults properly indexes events into txr results" $ do
+        it "Index EventDBEntry for MemberAdded" $
+            let addr = fromInteger 0x3023
+                chainId = fromInteger 0x4920
+                orgId = OrgId "6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0"
+                enode = Enode orgId (IPv4 $ fromInteger 192) 80 Nothing
+                event = EventDB (Just chainId) "MemberAdded" [show addr, showEnode enode]
+            in indexEventToTxrResults (EventDBEntry event) 
+                `shouldBe` [PutEventDB event, AddMember $ Right (chainId, addr, enode)]
+        it "Index EventDBEntry for MemberRemoved" $
+            let addr = fromInteger 0x1011
+                chainId = fromInteger 0x8203
+                event = EventDB (Just chainId) "MemberRemoved" [show addr]
+            in indexEventToTxrResults (EventDBEntry event)
+                `shouldBe` [PutEventDB event, RemoveMember $ Right (chainId, addr)]
+        it "Index EventDBEntry for CertificateRegistered" $
+            let uAddr = fromInteger 0x1234
+                cAddr = fromInteger 0x5678
+                event = EventDB Nothing "CertificateRegistered" [show uAddr, show cAddr]
+            in indexEventToTxrResults (EventDBEntry event)
+                `shouldBe` [PutEventDB event, RegisterCertificate $ Right (uAddr, cAddr)]
+        it "Index EventDBEntry for non-special event" $
+            let chainId = fromInteger 0x480244
+                event = EventDB (Just chainId) "NotSpecial" ["48193"]
+            in indexEventToTxrResults (EventDBEntry event)
+                `shouldBe` [PutEventDB event]

--- a/core-strato/strato-redis-blockdb/package.yaml
+++ b/core-strato/strato-redis-blockdb/package.yaml
@@ -17,6 +17,7 @@ library:
   dependencies:
   - QuickCheck
   - base16-bytestring
+  - binary
   - blockapps-util
   - bytestring
   - ethereum-rlp

--- a/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -15,6 +15,7 @@ module Blockchain.Strato.RedisBlockDB
     , getChainInfo, putChainInfo
     , getChainMembers, putChainMembers
     , addChainMember, removeChainMember
+    , registerCertificate
     , getChainTxsInBlock, putChainTxsInBlock, addChainTxsInBlock
     , getIPChains, addIPChain, removeIPChain
     , getOrgIdChains, addOrgIdChain, removeOrgIdChain
@@ -103,6 +104,7 @@ inNamespace ns k = ns' `S8.append` toKey k
             PrivateTxsInBlocks  -> "pb:"
             PrivateIPChains     -> "pic:"
             PrivateOrgIdChains  -> "poc:"
+            X509Certificates    -> "x509:"
 
 findNamespace :: S8.ByteString -> BlockDBNamespace
 findNamespace key = case S8.takeWhile (/= ':') key of
@@ -119,6 +121,7 @@ findNamespace key = case S8.takeWhile (/= ':') key of
   "pb" -> PrivateTxsInBlocks
   "pic" -> PrivateIPChains
   "poc" -> PrivateOrgIdChains
+  "x509" -> X509Certificates
   wut -> error $ "unknown namespace: " ++ show wut
 
 getChainInfo :: Word256
@@ -194,6 +197,14 @@ removeChainMember cId address = do
             Compose (removeOrgIdChain (unOrgId $ pubKey enode) cId)
         TxAborted   -> pure . Left $ SingleLine (S8.pack $ "removeChainMember - Aborted")
         TxError e   -> pure . Left $ SingleLine (S8.pack $ "removeChainMember - Error" ++ e)
+
+registerCertificate :: Address -> Address -> Redis (Either Reply Status)
+registerCertificate userAddress contractAddress = do
+    res <- multiExec $ set (inNamespace X509Certificates $ toKey userAddress) (toValue contractAddress)
+    case res of
+        TxSuccess _ -> pure $ Right Ok
+        TxAborted -> pure . Left $ SingleLine (S8.pack $ "registerCertificate - Aborted")
+        TxError e -> pure . Left $ SingleLine (S8.pack $ "registerCertificate - Error" <> e)
 
 getChainTxsInBlock :: Keccak256
                    -> Redis (M.Map Word256 [Keccak256])

--- a/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
+++ b/core-strato/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
@@ -7,8 +7,10 @@
 {-# OPTIONS -fno-warn-redundant-constraints #-}
 module Blockchain.Strato.RedisBlockDB.Models where
 
+import           Data.Binary
 import qualified Data.ByteString.Base16        as SB16
 import qualified Data.ByteString.Char8         as S8
+import           Data.ByteString.Lazy          (toStrict, fromStrict)
 import           Data.List                     (intercalate)
 import qualified Data.Map.Strict               as M
 import qualified Data.Set                      as S
@@ -38,6 +40,7 @@ data BlockDBNamespace = Headers
                       | PrivateTxsInBlocks
                       | PrivateIPChains
                       | PrivateOrgIdChains
+                      | X509Certificates
     deriving (Eq, Read, Show)
 
 class RedisDBKeyable k where
@@ -67,6 +70,13 @@ instance RedisDBKeyable Keccak256 where
 instance RedisDBValuable Keccak256 where
     toValue   = S8.pack . keccak256ToHex
     fromValue = keccak256FromHex . S8.unpack
+
+instance RedisDBKeyable Address where
+    toKey = toStrict . encode
+
+instance RedisDBValuable Address where
+    toValue   = toKey
+    fromValue = decode . fromStrict
 
 instance RedisDBKeyable Word256 where
     toKey = word256ToBytes
@@ -158,5 +168,6 @@ displayForNamespace ns input = case ns of
     PrivateTxsInBlocks -> let RedisChainTxsInBlocks ctibs = fromValue input in show ctibs
     PrivateIPChains -> let RedisIPChains ipcs = fromValue input in format (S.toList ipcs)
     PrivateOrgIdChains -> let RedisOrgIdChains oics = fromValue input in format (S.toList oics)
+    X509Certificates -> format (fromValue input :: Address)
   where
     readSHA = let x = fromValue input in format (keccak256ToWord256 x)

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -23,6 +23,7 @@ stack test -j1 \
       merkle-patricia-db \
       solid-vm \
       strato-genesis \
+      strato-index \
       strato-init \
       strato-model \
       strato-p2p \

--- a/x509-certs/exec_src/X509CertRegistry.hs
+++ b/x509-certs/exec_src/X509CertRegistry.hs
@@ -214,7 +214,9 @@ contract CertificateRegistry {
 
     string rootCert;
     bool initialized;
-    
+
+    event CertificateRegistered(address userAddress, address contractAddress);
+
     constructor(string _rootCert) {
         require(account(this, "self").chainId == 0, "You must post this contract on the main chain!");
 
@@ -233,6 +235,8 @@ contract CertificateRegistry {
         certificates.push(c);
         certificatesMap[newAccount] = certificates.length;
         initialized = true;
+
+        emit CertificateRegistered(address(0xdeadbeef), address(c));
     }
     
     function registerCertificate(string newCertificateString) returns (int) {


### PR DESCRIPTION
@trdancer I changed the `RegisterCertificate` contract for testing purposes. Go ahead and delete my additions/change things around. I just added the lines for testing purposes.

I would recommend merging in https://github.com/blockapps/strato-platform/pull/1523 first.

Add a userAddress-x509CertContract mapping to Redis for X509. The implementation follows the implementation of the `MemberAdded` and `MemberRemoved` events very closely.

Done