### PR TITLE
Strato 2588 register cert event

### DIFF
--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1965,61 +1965,65 @@ callBuiltin rc'@("registerCert") [SString cert] _ = do
             typ -> internalError "creatorAddress field has not been set or is not an account type" typ
 
 -- Cert string, contract type
-callBuiltin rc''@("registerCert") [SString cert, (SContract "Certificate" na)] _ = do
-  contract' <- getCurrentContract
+callBuiltin "registerCert" [SString cert, (SContract "Certificate" na)] _ = do
+  curContract <- getCurrentContract
+  curAccount <- getCurrentAccount
+  mCreatorAddress <- getSolidStorageKeyVal' curAccount $ MS.StoragePath [MS.Field ":creatorAddress"]
   let rootAddress = fromPublicKey rootPubKey
-  if CC._vmVersion contract' /= "svm3.2" 
-    then unknownFunction "callBuiltin" rc''
-    else do
-      curAccount <- getCurrentAccount
-      case curAccount of
-        Account{_accountChainId=Just cid} -> invalidWrite "Cannot register X.509 certificates on private chains" cid
-        Account{..} -> do
-          mCreatorAddress <- getSolidStorageKeyVal' curAccount $ MS.StoragePath [MS.Field ":creatorAddress"]
-          case mCreatorAddress of
-            (MS.BAccount creatorAccount _) -> do
-              onTraced $ liftIO $ putStrLn $ "    Creator Address: " <> (show $ _namedAccountAddress creatorAccount)
-              onTraced $ liftIO $ putStrLn $ "    Root Address: " <> (show rootAddress)
-              if ((_namedAccountAddress creatorAccount) /= rootAddress) then invalidWrite "Only a function in a contract posted by the BlockApps Root Address may call registerCert" creatorAccount
-              else do
-                let ex509Cert = bsToCert . BC.pack $ cert
-                case ex509Cert of 
-                  Left q -> invalidCertificate "Could not parse X.509 certificate" q
-                  Right x509Cert -> do
-                    if not $ verifyBlockApps x509Cert 
-                      then invalidCertificate "Certificate is not signed by the BlockApps Root Certificate" (getCertIssuer x509Cert)
-                      else do
-                        let mSubject = getCertSubject x509Cert
-                        case mSubject of 
-                          Nothing -> invalidCertificate "No or invalid subject" x509Cert
-                          (Just subject) -> do
-                            let subjectAddress = fromPublicKey $ subPub subject
-                            onTraced $ liftIO $ putStrLn $ "    Registering cert to address derived from the subject's public key: " ++ 
-                              format subjectAddress ++ " as Common Name:" ++ show (subCommonName subject) ++ "; Organization: " ++ show (subOrg subject)
-                            
-                            org <- getOrg curAccount (contract' ^. CC.vmVersion) -- the org of the app
-         
-                            parentName <- fromMaybeM (return "") $ runMaybeT 
-                                $   pure curAccount
-                                >>= MaybeT . A.lookup (A.Proxy @AddressState)
-                                >>= pure  .  addressStateCodeHash
-                                >>= MaybeT . resolveCodePtrParent (curAccount ^. accountChainId)
-                                >>= (\case     
-                                        SolidVMCode name _ | name /= (CC._contractName contract') -> pure name
-                                        _                                                    -> pure "")
-                            
-                            -- TODO remove leveldb insert
-                            x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-                            Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert subjectAddress x509Cert x509s
-                            
-                            addEvent $ Event org parentName (CC._contractName contract') curAccount "CertificateRegistered" [("userAddress", show subjectAddress), ("contractAddress", show (_namedAccountAddress na))]
-                            
-                            liftIO $ putStrLn $ "Emit Event/versioning ---> we are emitting event CertificateRegistered" ++ 
-                                " in contract " ++ (CC._contractName curCnct) ++ " in app " ++ (show parentName) ++ 
-                                " of org " ++ show org
-                            
-                            return $ SAccount (NamedAccount subjectAddress UnspecifiedChain) False
-            typ -> internalError "creatorAddress field has not been set or is not an account type" typ
+      ex509Cert = bsToCert . BC.pack $ cert
+  case (curContract ^. CC.vmVersion, curAccount, mCreatorAddress, ex509Cert) of 
+    -- eventually use a new solidvm version here :)
+    ( "svm3.2", 
+      Account{_accountChainId=Nothing}, 
+      MS.BAccount creatorAddress _,
+      Right x509Cert
+      ) | (_namedAccountAddress creatorAddress) == rootAddress -> do
+        onTraced $ liftIO $ putStrLn $ "    Contract Creator Address: " <> (show $ creatorAddress)
+        onTraced $ liftIO $ putStrLn $ "    Root Address: " <> (show rootAddress)
+        if not $ verifyBlockApps x509Cert 
+          then invalidCertificate "Certificate is not signed by the BlockApps Root Certificate" (getCertIssuer x509Cert)
+          else do
+            let mSubject = getCertSubject x509Cert
+            case mSubject of 
+              Nothing -> invalidCertificate "No or invalid subject" x509Cert
+              (Just subject) -> do
+                let subjectAddress = fromPublicKey $ subPub subject
+                onTraced $ liftIO $ putStrLn $ "    Registering cert to address derived from the subject's public key: " ++ 
+                  format subjectAddress ++ " as Common Name:" ++ show (subCommonName subject) ++ "; Organization: " ++ show (subOrg subject)
+                
+                org <- getOrg curAccount (curContract ^. CC.vmVersion) -- the org of the app
+
+                parentName <- fromMaybeM (return "") $ runMaybeT 
+                    $   pure curAccount
+                    >>= MaybeT . A.lookup (A.Proxy @AddressState)
+                    >>= pure  .  addressStateCodeHash
+                    >>= MaybeT . resolveCodePtrParent (curAccount ^. accountChainId)
+                    >>= (\case     
+                            SolidVMCode name _ | name /= (CC._contractName curContract) -> pure name
+                            _                                                    -> pure "")
+                
+                -- TODO remove leveldb insert
+                x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+                Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert subjectAddress x509Cert x509s
+                
+                addEvent $ Event org parentName (CC._contractName curContract) curAccount "CertificateRegistered" [
+                      ("userAddress", show subjectAddress)
+                    , ("contractAddress", show (_namedAccountAddress na))
+                    ]
+                
+                liftIO $ putStrLn $ "Emit Event/identity ---> we are emitting event CertificateRegistered" ++ 
+                    " in contract " ++ (CC._contractName curContract) ++ " in app " ++ (show parentName) ++ 
+                    " of org " ++ show org
+                
+                return $ SAccount (NamedAccount subjectAddress UnspecifiedChain) False
+
+    (vmVersion, acc, caddr, ccert) -> do
+      invalidWrite ("Cannot call registerCertificate here: " <> (T.unpack $ T.intercalate "\n" (map T.pack [
+        show vmVersion
+        , show acc
+        , show caddr
+        , show ccert
+        ]))) vmVersion
 
 
 callBuiltin "getUserCert" [SAccount a _] _ = do
@@ -2034,8 +2038,8 @@ callBuiltin "getUserCert" [SAccount a _] _ = do
 -- Expects the public key to be in PEM format
 -- Raises an error if it can't parse either argument, however perhaps that should't happen...
 callBuiltin vc@"verifyCert" [SString cert, SString pubkey] _ = do
-  contract' <- getCurrentContract
-  if CC._vmVersion contract' == "svm3.2" then do
+  curContract <- getCurrentContract
+  if CC._vmVersion curContract == "svm3.2" then do
     let ex509Cert = bsToCert . BC.pack $ cert
     let ePublicKey = bsToPub $ BC.pack pubkey
     case (ex509Cert, ePublicKey) of 
@@ -2054,8 +2058,8 @@ callBuiltin vc@"verifyCert" [SString cert, SString pubkey] _ = do
 -- Expects the public key to be in PEM format
 -- Raises an error if it can't parse either argument, however perhaps that should't happen...
 callBuiltin vs@"verifySignature" [SString msg, SString signature, SString pubkey] _ = do
-  contract' <- getCurrentContract
-  if CC._vmVersion contract' == "svm3.2" then do
+  curContract <- getCurrentContract
+  if CC._vmVersion curContract == "svm3.2" then do
     let eMesgBs = B16.decode $ BC.pack msg 
     case eMesgBs of 
       (mesgBs, "") -> do

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1975,7 +1975,7 @@ callBuiltin "registerCert" [SString cert, (SContract "Certificate" na)] _ = do
     -- eventually use a new solidvm version here :)
     ( "svm3.2", 
       Account{_accountChainId=Nothing}, 
-      MS.BAccount creatorAddress _,
+      MS.BAccount creatorAddress,
       Right x509Cert
       ) | (_namedAccountAddress creatorAddress) == rootAddress -> do
         onTraced $ liftIO $ putStrLn $ "    Contract Creator Address: " <> (show $ creatorAddress)

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -1963,7 +1963,67 @@ callBuiltin rc'@("registerCert") [SString cert] _ = do
                             Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert subjectAddress x509Cert x509s
                             return $ SAccount (NamedAccount subjectAddress UnspecifiedChain) False
             typ -> internalError "creatorAddress field has not been set or is not an account type" typ
+
+-- Cert string, contract type
+callBuiltin rc''@("registerCert") [SString cert, (SContract "Certificate" na)] _ = do
+  contract' <- getCurrentContract
+  let rootAddress = fromPublicKey rootPubKey
+  if CC._vmVersion contract' /= "svm3.2" 
+    then unknownFunction "callBuiltin" rc''
+    else do
+      curAccount <- getCurrentAccount
+      case curAccount of
+        Account{_accountChainId=Just cid} -> invalidWrite "Cannot register X.509 certificates on private chains" cid
+        Account{..} -> do
+          mCreatorAddress <- getSolidStorageKeyVal' curAccount $ MS.StoragePath [MS.Field ":creatorAddress"]
+          case mCreatorAddress of
+            (MS.BAccount creatorAccount _) -> do
+              onTraced $ liftIO $ putStrLn $ "    Creator Address: " <> (show $ _namedAccountAddress creatorAccount)
+              onTraced $ liftIO $ putStrLn $ "    Root Address: " <> (show rootAddress)
+              if ((_namedAccountAddress creatorAccount) /= rootAddress) then invalidWrite "Only a function in a contract posted by the BlockApps Root Address may call registerCert" creatorAccount
+              else do
+                let ex509Cert = bsToCert . BC.pack $ cert
+                case ex509Cert of 
+                  Left q -> invalidCertificate "Could not parse X.509 certificate" q
+                  Right x509Cert -> do
+                    if not $ verifyBlockApps x509Cert 
+                      then invalidCertificate "Certificate is not signed by the BlockApps Root Certificate" (getCertIssuer x509Cert)
+                      else do
+                        let mSubject = getCertSubject x509Cert
+                        case mSubject of 
+                          Nothing -> invalidCertificate "No or invalid subject" x509Cert
+                          (Just subject) -> do
+                            let subjectAddress = fromPublicKey $ subPub subject
+                            onTraced $ liftIO $ putStrLn $ "    Registering cert to address derived from the subject's public key: " ++ 
+                              format subjectAddress ++ " as Common Name:" ++ show (subCommonName subject) ++ "; Organization: " ++ show (subOrg subject)
+                            
+                            org <- getOrg curAccount (contract' ^. CC.vmVersion) -- the org of the app
+         
+                            parentName <- fromMaybeM (return "") $ runMaybeT 
+                                $   pure curAccount
+                                >>= MaybeT . A.lookup (A.Proxy @AddressState)
+                                >>= pure  .  addressStateCodeHash
+                                >>= MaybeT . resolveCodePtrParent (curAccount ^. accountChainId)
+                                >>= (\case     
+                                        SolidVMCode name _ | name /= (CC._contractName contract') -> pure name
+                                        _                                                    -> pure "")
+                            
+                            -- TODO remove leveldb insert
+                            x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+                            Mod.put (Mod.Proxy @(M.Map Address X509Certificate)) $ M.insert subjectAddress x509Cert x509s
+                            
+                            addEvent $ Event org parentName (CC._contractName contract') curAccount "CertificateRegistered" [("userAddress", show subjectAddress), ("contractAddress", show (_namedAccountAddress na))]
+                            
+                            liftIO $ putStrLn $ "Emit Event/versioning ---> we are emitting event CertificateRegistered" ++ 
+                                " in contract " ++ (CC._contractName curCnct) ++ " in app " ++ (show parentName) ++ 
+                                " of org " ++ show org
+                            
+                            return $ SAccount (NamedAccount subjectAddress UnspecifiedChain) False
+            typ -> internalError "creatorAddress field has not been set or is not an account type" typ
+
+
 callBuiltin "getUserCert" [SAccount a _] _ = do
+  -- TODO remove level db check, use redis instead
   x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
   maybeCertLevelDB <- x509CertDBGet $ _namedAccountAddress a
   let maybeCertBlockDB = M.lookup (_namedAccountAddress a) x509s
@@ -2031,6 +2091,7 @@ certificateMap maybeCert = case maybeCert of
                                    , (SString "organization", Constant . SString $ subOrg sub)
                                    , (SString "group", Constant . SString $ fromMaybe "" $ subUnit sub)
                                    , (SString "publicKey", Constant . SString $ BC.unpack $ pubToBytes $ subPub sub)
+                                   , (SString "userAddress", Constant . SString $ show $ fromPublicKey $ subPub sub)
                                    , (SString "certString", Constant . SString $ cert)
                                    ]
           emptyCertMap = M.fromList [ (SString "commonName", Constant . SString $ "")
@@ -2038,6 +2099,7 @@ certificateMap maybeCert = case maybeCert of
                              , (SString "organization", Constant . SString $ "")
                              , (SString "group", Constant . SString $ "")
                              , (SString "publicKey", Constant . SString $ "")
+                             , (SString "userAddress", Constant . SString $ "")
                              , (SString "certString", Constant . SString $ "")
                              ]
           stringToString = SVMType.Mapping { SVMType.dynamic = Nothing

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -790,7 +790,10 @@ assertArgs :: SourceAnnotation Text -> Type'
 assertArgs x = boolType' x
 
 registerCertArgs :: SourceAnnotation Text -> Type'
-registerCertArgs x = stringType' x
+registerCertArgs x = Sum $ stringType' x :| 
+                        [ Product [stringType' x, contractType' x] x
+                        , Product [accountType' x, stringType' x] x
+                        ]
 
 verifyCertArgs :: SourceAnnotation Text -> Type'
 verifyCertArgs x = Product [stringType' x, stringType' x] x

--- a/core-strato/solid-vm/tests/SolidVMSpec.hs
+++ b/core-strato/solid-vm/tests/SolidVMSpec.hs
@@ -3796,9 +3796,9 @@ contract qq {
           registerCert(certAddr, myCertificate);
           certPubKey = getUserCert(certAddr)["publicKey"];
       }
-  }|])) `shouldThrow` anyTypeError
+  }|])) `shouldThrow` anyUnknownFunc
 
-  it "cannot use new registerCert on solidvm < 3.2" $ (runTest $ do
+  it "cannot use new registerCert(string _cert) on solidvm < 3.2" $ (runTest $ do
       (runBS [r|
   contract qq {
       account public certAddr = account(0x622EB3792DaA3d3770E3D27D02e53755408aE00b);
@@ -3809,7 +3809,52 @@ contract qq {
           certPubKey = getUserCert(certAddr)["publicKey"];
       }
   }|])) `shouldThrow` anyUnknownFunc
-
+  
+  it "cannot use new registerCert(string _cert, Certificate c) on solidvm < 3.2" $ (runTest $ do
+      (runBS [r|
+  contract Certificate {
+    string name;
+    constructor(string _name) {
+      name = _name;
+    }
+  }
+  contract qq {
+      account public certAddr = account(0x622EB3792DaA3d3770E3D27D02e53755408aE00b);
+      string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBizCCAS+gAwIBAgIQejfmUC0VeygSTQ0htwpDbzAMBggqhkjOPQQDAgUAMEcx\nDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIGA1UECwwLRW5n\naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTAeFw0yMjA0MTQyMTI4NDdaFw0yMzA0MTQy\nMTI4NDdaMEcxDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIG\nA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEGBSuB\nBAAKA0IABCSwiVfrLj1MCa+1bcBXOnGhnLxS5DYo3/1udE/LYFi2hFgDCPQxKYqP\n7LmHV2W35B3ZZw5SQVf1FxjWE0tZqswwDAYIKoZIzj0EAwIFAANIADBFAiEAvbGZ\nqma5fKnHnzpGCI5lc4VYdHBfgqfG7CwqJ5ii66YCIFUT+eXA1fS9q4/jJ+eULQwH\neXbEHHtO6nBOorRsoG3H\n-----END CERTIFICATE-----";
+      string public certPubKey;
+      constructor() {
+          Certificate c = new Certificate("foo");
+          registerCert(myCertificate, c);
+          certPubKey = getUserCert(certAddr)["publicKey"];
+      }
+  }|])) `shouldThrow` anyInvalidWriteError
+  
+  it "can only post X509 certificates to the address of the public key" . runTest $ do
+    void $ runArgsWithOrigin rootAcc sender "()" [r|
+pragma solidvm 3.2;
+contract Certificate {
+    string name;
+    constructor(string _name) {
+      name = _name;
+    }
+  }
+contract qq {
+    event CertificateRegistered(address userAddress, address contractAddress);
+    account public certAddr = account(0x74f014FEF932D2728c6c7E2B4d3B88ac37A7E1d0, "main");
+    string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBjTCCATKgAwIBAgIRAOPPkVoBp/GnwZGR32jcIjwwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyMDE3NTcxM1oXDTIzMDQy\nMDE3NTcxM1owSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANHADBEAiA8\nR0UERQZbF3qJUt5A0ZFf2ZmB0l/ZPjIvM383gOF3xwIgbxbQ8NLkDEe2mWJ/qa4n\nN8txKc8G9R27ZYAUuz15zF0=\n-----END CERTIFICATE-----";
+    string public certName;
+    string public certOrg;
+    constructor() {
+        Certificate c = new Certificate("foo");
+        registerCert(myCertificate, c);
+        certName = getUserCert(certAddr)["commonName"];
+        certOrg = getUserCert(certAddr)["organization"];
+    }
+}|]
+    getFields ["certName", "certOrg"] `shouldReturn`
+      [ BString "Admin",
+        BString "BlockApps"
+      ]
   it "can get a users cert" . runTest $ do
     void $ runArgsWithOrigin rootAcc sender "()" [r|
 pragma solidvm 3.2;
@@ -3855,7 +3900,9 @@ contract qq {
       , BString "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUhJR4x+wZiX+xZK2m/pwN40cvCS0UA7Z\n0DB7sny5ZnNLw43JgKz0URDY2yYOPkhoIApxFK9UU3Bc4BRANDWmdQ==\n-----END PUBLIC KEY-----\n"
       , BString "-----BEGIN CERTIFICATE-----\nMIIBjTCCATKgAwIBAgIRAOPPkVoBp/GnwZGR32jcIjwwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyMDE3NTcxM1oXDTIzMDQy\nMDE3NTcxM1owSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANHADBEAiA8\nR0UERQZbF3qJUt5A0ZFf2ZmB0l/ZPjIvM383gOF3xwIgbxbQ8NLkDEe2mWJ/qa4n\nN8txKc8G9R27ZYAUuz15zF0=\n-----END CERTIFICATE-----\n"
       ]
-    
+  -- TODO change test to use new vm version once it is decided on
+
+
   it "can call builtin function verifyCert" . runTest $ do
     runBS [r|
 pragma solidvm 3.2;

--- a/x509-certs/exec_src/X509CertRegistry.hs
+++ b/x509-certs/exec_src/X509CertRegistry.hs
@@ -33,6 +33,7 @@ import           Blockchain.Strato.Model.Gas
 import           Blockchain.Strato.Model.Nonce
 import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Strato.Model.Wei
+import           Blockchain.Data.DataDefs     (TransactionResult(..))      
 
 -- | The command line options
 data Options 
@@ -93,7 +94,22 @@ entryPoint (Options privPath certPath nonce) = do
 
             -- post it
             result <- runClientM (postRawTransaction Nothing Nothing True request) clientEnv
-            putStrLn $ "\n\nTransaction result: " <> show result
+            -- register the root certs bc orgs of contracts created in the constructor are not supported
+            case result of 
+                Right (BlocTxResult (BlocTransactionResult{
+                    blocTransactionTxResult=Just (TransactionResult{
+                        transactionResultContractsCreated=as
+                        })
+                    }))-> do
+                            let addr = (stringAddress $ T.unpack $ head (T.splitOn "," $ T.pack as))
+                                request' = createFuncTx priv addr cert (nonce + 1) 
+                            result' <- runClientM (postRawTransaction Nothing Nothing True request') clientEnv
+                            case result' of 
+                                Right suc -> putStrLn $ "Registered Root Certs: " <> show suc
+                                Left err -> putStrLn $ "Could not register Root Certs: " <> show err
+
+                e -> putStrLn $ "Could not post Certificate Registry Dapp: " <> show e
+            -- putStrLn $ "\n\nTransaction result: " <> show result
 
             let oops = error "We did not successfully post the CertificateRegistry!"
                 strToAddr x = fromMaybe oops . stringAddress . T.unpack . head . T.splitOn "," $ T.pack x
@@ -116,7 +132,7 @@ postRawTransaction = client (Proxy @ PostBlocTransactionRaw)
 
 
 -- Convert the parsed and retrieved options into a raw transaction request
-optionsToTX :: PrivateKey -> X509Certificate -> Nonce -> PostBlocTransactionRawRequest
+optionsToTX :: PrivateKey -> X509 Certificate -> Nonce -> PostBlocTransactionRawRequest
 optionsToTX priv cert nonce = 
     let unsignedTx = UnsignedTransaction
             { unsignedTransactionNonce      = nonce
@@ -143,8 +159,36 @@ optionsToTX priv cert nonce =
         s
         (Just v)
         (Just $ M.fromList $ [("VM", "SolidVM"), ("name", "CertificateRegistry"), 
-            ("history", "Certificate"), ("args", T.pack $ "(" <> show (certToBytes cert) <> ")")])
+            ("history", "Certificate"), ("args", T.pack $ "()")])
 
+createFuncTx :: PrivateKey -> Maybe Address -> X509Certificate -> Nonce -> PostBlocTransactionRawRequest
+createFuncTx priv addr cert nonce = 
+    let unsignedTx = UnsignedTransaction
+            { unsignedTransactionNonce      = nonce
+            , unsignedTransactionGasPrice   = Wei 10000        -- default val
+            , unsignedTransactionGasLimit   = Gas 29000000000  -- default val
+            , unsignedTransactionTo         = addr
+            , unsignedTransactionValue      = Wei 0 
+            , unsignedTransactionInitOrData = Code $ B.empty
+            , unsignedTransactionChainId    = Nothing
+            }
+        txHash = rlpHash unsignedTx
+        sig = signMsg priv txHash
+        (rr,s,v) = getSigVals sig
+    in PostBlocTransactionRawRequest
+        (fromPrivateKey priv)
+        (unsignedTransactionNonce unsignedTx)
+        (unsignedTransactionGasPrice unsignedTx)
+        (unsignedTransactionGasLimit unsignedTx)
+        (unsignedTransactionTo unsignedTx)
+        (unsignedTransactionValue unsignedTx)
+        (unsignedTransactionInitOrData unsignedTx)
+        (unsignedTransactionChainId unsignedTx)
+        rr
+        s
+        (Just v)
+        (Just $ M.fromList $ [("VM", "SolidVM"), ("funcName", "registerCertificate"), 
+             ("args", T.pack $ "("<> show (certToBytes cert) <> ")"), ("history", "Certificate")])
 
 initializeCertificateRegistryTX :: PrivateKey -> Address -> Nonce -> PostBlocTransactionRawRequest
 initializeCertificateRegistryTX priv addr nonce =
@@ -190,15 +234,16 @@ contract Certificate {
     string publicKey;
     string certificateString;
 
-    constructor(account _newAccount, string _certificateString) {
+    constructor(string _certificateString) {
         owner = msg.sender;
 
-        certificateHolder = _newAccount;
-
         mapping(string => string) parsedCert = parseCert(_certificateString);
+
+        certificateHolder = parsedCert["userAddress"];
         commonName = parsedCert["commonName"];
         organization = parsedCert["organization"];
         group = parsedCert["group"];
+        country = parsedCert["country"];
         publicKey = parsedCert["publicKey"];
         certificateString = parsedCert["certString"];
     }
@@ -206,6 +251,8 @@ contract Certificate {
 
 pragma solidvm 3.2;
 contract CertificateRegistry {
+    // Declare the event that gets silently emitted when a certificate is registered
+    event CertificateRegistered(address userAddress, address contractAddress);
     // The registry maintains a list and mapping of all the certificates
     // We need the extra array in order for us to iterate through our certificates.
     // Solidity mappings are non-iterable.
@@ -213,23 +260,25 @@ contract CertificateRegistry {
     mapping(account => uint) certificatesMap;
 
     string rootCert;
+    string rootPubKey;
     bool initialized;
     
     constructor(string _rootCert) {
         require(account(this, "self").chainId == 0, "You must post this contract on the main chain!");
 
         rootCert = _rootCert;
+        rootPubKey = parseCert(_rootCert)["publicKey"];
         initialized = false;
     }
 
     function initializeCertificateRegistry() returns (int) {
         require(!initialized, "The CertificateRegistry has already been initialized!");
 
-        // Register the root certificate
-        account newAccount = registerCert(rootCert);
-        
         // Create the Certificate record
-        Certificate c = new Certificate(newAccount, rootCert);
+        Certificate c = new Certificate(rootCert);
+
+        // Register the root certificate andemit event
+        registerCert(rootCert, c);
         certificates.push(c);
         certificatesMap[newAccount] = certificates.length;
         initialized = true;
@@ -237,14 +286,16 @@ contract CertificateRegistry {
     
     function registerCertificate(string newCertificateString) returns (int) {
         require(initialized, "You must first initialize with initializeCertificateRegistry!");
-
-        // Register the certificate into LevelDB
-        account newAccount = registerCert(newCertificateString);
+        require(verifyCert(newCertificateString, rootPubKey), "The cert being registered is not verified in the chain of trust");
         
         // Create the new Certificate record
-        Certificate c = new Certificate(newAccount, newCertificateString);
+        Certificate c = new Certificate(newCertificateString);
+        
+        // Register the certificate into LevelDB and emit event
+        registerCert(newCertificateString, c);
+
         certificates.push(c);
-        certificatesMap[newAccount] = certificates.length;
+        certificatesMap[userAccount] = certificates.length;
         
         return 200; // 200 = HTTP Status OK
     }

--- a/x509-certs/exec_src/X509CertRegistry.hs
+++ b/x509-certs/exec_src/X509CertRegistry.hs
@@ -33,7 +33,6 @@ import           Blockchain.Strato.Model.Gas
 import           Blockchain.Strato.Model.Nonce
 import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Strato.Model.Wei
-import           Blockchain.Data.DataDefs     (TransactionResult(..))      
 
 -- | The command line options
 data Options 
@@ -94,22 +93,7 @@ entryPoint (Options privPath certPath nonce) = do
 
             -- post it
             result <- runClientM (postRawTransaction Nothing Nothing True request) clientEnv
-            -- register the root certs bc orgs of contracts created in the constructor are not supported
-            case result of 
-                Right (BlocTxResult (BlocTransactionResult{
-                    blocTransactionTxResult=Just (TransactionResult{
-                        transactionResultContractsCreated=as
-                        })
-                    }))-> do
-                            let addr = (stringAddress $ T.unpack $ head (T.splitOn "," $ T.pack as))
-                                request' = createFuncTx priv addr cert (nonce + 1) 
-                            result' <- runClientM (postRawTransaction Nothing Nothing True request') clientEnv
-                            case result' of 
-                                Right suc -> putStrLn $ "Registered Root Certs: " <> show suc
-                                Left err -> putStrLn $ "Could not register Root Certs: " <> show err
-
-                e -> putStrLn $ "Could not post Certificate Registry Dapp: " <> show e
-            -- putStrLn $ "\n\nTransaction result: " <> show result
+            putStrLn $ "\n\nTransaction result: " <> show result
 
             let oops = error "We did not successfully post the CertificateRegistry!"
                 strToAddr x = fromMaybe oops . stringAddress . T.unpack . head . T.splitOn "," $ T.pack x
@@ -132,7 +116,7 @@ postRawTransaction = client (Proxy @ PostBlocTransactionRaw)
 
 
 -- Convert the parsed and retrieved options into a raw transaction request
-optionsToTX :: PrivateKey -> X509 Certificate -> Nonce -> PostBlocTransactionRawRequest
+optionsToTX :: PrivateKey -> X509Certificate -> Nonce -> PostBlocTransactionRawRequest
 optionsToTX priv cert nonce = 
     let unsignedTx = UnsignedTransaction
             { unsignedTransactionNonce      = nonce
@@ -159,36 +143,8 @@ optionsToTX priv cert nonce =
         s
         (Just v)
         (Just $ M.fromList $ [("VM", "SolidVM"), ("name", "CertificateRegistry"), 
-            ("history", "Certificate"), ("args", T.pack $ "()")])
+            ("history", "Certificate"), ("args", T.pack $ "(" <> show (certToBytes cert) <> ")")])
 
-createFuncTx :: PrivateKey -> Maybe Address -> X509Certificate -> Nonce -> PostBlocTransactionRawRequest
-createFuncTx priv addr cert nonce = 
-    let unsignedTx = UnsignedTransaction
-            { unsignedTransactionNonce      = nonce
-            , unsignedTransactionGasPrice   = Wei 10000        -- default val
-            , unsignedTransactionGasLimit   = Gas 29000000000  -- default val
-            , unsignedTransactionTo         = addr
-            , unsignedTransactionValue      = Wei 0 
-            , unsignedTransactionInitOrData = Code $ B.empty
-            , unsignedTransactionChainId    = Nothing
-            }
-        txHash = rlpHash unsignedTx
-        sig = signMsg priv txHash
-        (rr,s,v) = getSigVals sig
-    in PostBlocTransactionRawRequest
-        (fromPrivateKey priv)
-        (unsignedTransactionNonce unsignedTx)
-        (unsignedTransactionGasPrice unsignedTx)
-        (unsignedTransactionGasLimit unsignedTx)
-        (unsignedTransactionTo unsignedTx)
-        (unsignedTransactionValue unsignedTx)
-        (unsignedTransactionInitOrData unsignedTx)
-        (unsignedTransactionChainId unsignedTx)
-        rr
-        s
-        (Just v)
-        (Just $ M.fromList $ [("VM", "SolidVM"), ("funcName", "registerCertificate"), 
-             ("args", T.pack $ "("<> show (certToBytes cert) <> ")"), ("history", "Certificate")])
 
 initializeCertificateRegistryTX :: PrivateKey -> Address -> Nonce -> PostBlocTransactionRawRequest
 initializeCertificateRegistryTX priv addr nonce =
@@ -239,7 +195,7 @@ contract Certificate {
 
         mapping(string => string) parsedCert = parseCert(_certificateString);
 
-        certificateHolder = parsedCert["userAddress"];
+        certificateHolder = account(parsedCert["userAddress"]);
         commonName = parsedCert["commonName"];
         organization = parsedCert["organization"];
         group = parsedCert["group"];
@@ -273,12 +229,13 @@ contract CertificateRegistry {
 
     function initializeCertificateRegistry() returns (int) {
         require(!initialized, "The CertificateRegistry has already been initialized!");
+        require(verifyCert(rootCert, rootPubKey), "The cert being registered is not verified in the chain of trust");
 
         // Create the Certificate record
         Certificate c = new Certificate(rootCert);
 
         // Register the root certificate andemit event
-        registerCert(rootCert, c);
+        account newAccount = registerCert(rootCert, c);
         certificates.push(c);
         certificatesMap[newAccount] = certificates.length;
         initialized = true;
@@ -292,7 +249,7 @@ contract CertificateRegistry {
         Certificate c = new Certificate(newCertificateString);
         
         // Register the certificate into LevelDB and emit event
-        registerCert(newCertificateString, c);
+        account userAccount = registerCert(newCertificateString, c);
 
         certificates.push(c);
         certificatesMap[userAccount] = certificates.length;

--- a/x509-certs/package.yaml
+++ b/x509-certs/package.yaml
@@ -97,6 +97,7 @@ executables:
       - strato-model
       - text
       - x509-certs
+      - blockapps-datadefs
 
 tests:
   x509-test:


### PR DESCRIPTION
In this commit we introduce yet *another* registerCert function signature (at this point we have 3). 

```
function registerCert(string _cert, Certificate c) returns (account);
```

This new function does the same thing as the previous registerCert function, however now it also silently emits a `CertificateRegistered` event. This will eventually be picked up by the Indexer to insert the event data into a redis db (see #1527). 

Because of the new event, I added the declaration at the top of the CertificateRegistry Dapp. I chose to put the event emission directly within the solidVm source code so that there is now way to register a cert and NOT have it emitted. 

In the future once leveldb is fully gone for certs, I imagine there will be no need for a builtin function call, and simply have registerCert operate like the `memberAdded/removed` events. 

I strictly typed the function so that it will only accept a Certificate contract.

Other improvements include allowing multiple function signatures for the registercert function in the typechecker. I also added the `userAddress` field to the certificate mapping in `parseCert/getUserCert`. This allows us easier address retrieval, rather than having to implement the ethereum protocol within solidity