### PR TITLE
Event callbacks in SolidVM

### DIFF
--- a/core-strato/blockapps-mpdbs/src/Blockchain/DB/SubscriptionsDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/DB/SubscriptionsDB.hs
@@ -1,0 +1,326 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeOperators              #-}
+
+module Blockchain.DB.SubscriptionsDB
+  ( SubscriptionsRoot(..)
+  , bootstrapSubscriptionsDB
+  , putBlockHeaderInSubscriptionsDB
+  , migrateBlockHeaderSubscriptions
+  , getSubscriptionsRootForBlock
+  , getSubscriptionsBlockHashInfo
+  , putSubscriptionsRootForBlock
+  , getSubscriptionsList
+  , putSubscriptionsList
+  , deleteSubscriptionsList
+  , getSubscriptionsListLength
+  , getSubscriptionAtIndex
+  , getIndexOfSubscription
+  , traverseSubscriptionList
+  , subscribe
+  , unsubscribe
+  ) where
+
+import           Control.DeepSeq
+import           Control.Monad.Change.Alter           hiding (lookup)
+import           Control.Monad.Change.Modify
+
+import           Data.Maybe                           (catMaybes, fromMaybe)
+import qualified Data.NibbleString                    as N
+import           Data.Text                            (Text)
+import           Data.Traversable                     (for)
+
+import qualified Blockchain.Database.MerklePatricia   as MP
+import           Blockchain.Data.RLP
+
+import           Blockchain.Strato.Model.Account
+import           Blockchain.Strato.Model.Class
+import           Blockchain.Strato.Model.Keccak256    (Keccak256, keccak256ToByteString, rlpHash, zeroHash)
+
+import           GHC.Generics
+import           Text.Format
+
+
+
+{-
+|-------------------------------------------------------------------------------|
+|                          The Subscriptions DB                                 |
+|-------------------------------------------------------------------------------|
+| First, each (Account, Event name) pair will have a subscription root, where   |
+| the keys are the indices of the subscriptions, and the values are the         |
+| (Account, Function name) pair of the subscription:                            |
+|                  subscription root                                            |
+|                          /\                                                   |
+|                         /  \                                                  |
+|                        /\  /\                                                 |
+|                    subscriptions                                              |
+|                                                                               |
+| Next, each subscription will have an index trie, where the keys are the hash  |
+| of the (Account, Function name) pair of the subscription, and the value is    |
+| the index of the subscription within the events subscriptions list. This trie |
+| is used to unsubscribe from an event in O(1) time.                            |
+|                      index root                                               |
+|                          /\                                                   |
+|                         /  \                                                  |
+|                        /\  /\                                                 |
+|                       indices                                                 |
+|                                                                               |
+| Then, each event definition will have an entry in the subscriptions trie,     |
+| where the keys are the (Account, Event name) pair of the event, and the       |
+| values are the triple of the event's subscription root, index root, and       |
+| length of the subscriptions list. When an event is fired, the VM will load    |
+| the subscription root and length from this trie, read the first <length>      |
+| entries from the subscription trie, and run the callbacks defined at the      |
+| (Account, Function name) pair of each subscription.                           |
+|                  subscriptions root                                           |
+|                          /\                                                   |
+|                         /  \                                                  |
+|                        /\  /\                                                 |
+|             (subscription root, index root, length)                           |
+| Finally, to keep track of subscriptions roots across blocks, we'll store the  |
+| subscriptions roots in a trie, keyed by block hash:                           |
+|            subscriptions block hash root                                      |
+|                          /\                                                   |
+|                         /  \                                                  |
+|                        /\  /\                                                 |
+|       (block hash, (parent hash, subscriptions root))                         |
+|-------------------------------------------------------------------------------|
+-}
+
+type EventName = Text
+type FunctionName = Text
+
+newtype SubscriptionsRoot = SubscriptionsRoot { unSubscriptionsRoot :: MP.StateRoot }
+  deriving (Eq, Ord, Show, Generic)
+  deriving newtype (Format, NFData)
+
+newtype Subscription = Subscription { unSubscription :: (Account, FunctionName) }
+  deriving (Eq, Ord, Show, Generic)
+  deriving newtype (Format, NFData)
+
+instance RLPSerializable Subscription where
+  rlpEncode (Subscription (acct, fName)) = RLPArray [rlpEncode acct, rlpEncode fName]
+  rlpDecode (RLPArray [acct, fName]) = Subscription (rlpDecode acct, rlpDecode fName)
+  rlpDecode o = error ("Error in rlpDecode for Subscription: bad RLPObject: " ++ show o)
+
+newtype EventSource = EventSource { unEventSource :: (Account, EventName) } -- could be a better name?
+  deriving (Eq, Ord, Show, Generic)
+  deriving newtype (Format, NFData)
+
+instance RLPSerializable EventSource where
+  rlpEncode (EventSource (acct, eName)) = RLPArray [rlpEncode acct, rlpEncode eName]
+  rlpDecode (RLPArray [acct, eName]) = EventSource (rlpDecode acct, rlpDecode eName)
+  rlpDecode o = error ("Error in rlpDecode for EventSource: bad RLPObject: " ++ show o)
+
+data SubscriptionsList = SubscriptionsList
+  { subscriptionsTrie       :: !MP.StateRoot
+  , indicesTrie             :: !MP.StateRoot
+  , subscriptionsListLength :: !Integer
+  }
+  deriving (Eq, Ord, Show, Generic, NFData)
+
+instance Format SubscriptionsList where
+  format (SubscriptionsList s i l) = concat
+    [ "SubscriptionsList ("
+    , format s
+    , ", "
+    , format i
+    , ", "
+    , show l
+    , ")"
+    ]
+
+instance RLPSerializable SubscriptionsList where
+  rlpEncode (SubscriptionsList s i l) = RLPArray [rlpEncode s, rlpEncode i, rlpEncode l]
+  rlpDecode (RLPArray [s, i, l]) = SubscriptionsList (rlpDecode s) (rlpDecode i) (rlpDecode l)
+  rlpDecode o = error ("Error in rlpDecode for SubscriptionsList: bad RLPObject: " ++ show o)
+
+emptySubscriptionsList :: SubscriptionsList
+emptySubscriptionsList = SubscriptionsList MP.emptyTriePtr MP.emptyTriePtr 0
+
+toMPKey :: RLPSerializable a => a -> N.NibbleString
+toMPKey = N.EvenNibbleString . keccak256ToByteString . rlpHash
+
+getkv :: ( RLPSerializable a
+         , (MP.StateRoot `Alters` MP.NodeData) m
+         )
+      => MP.StateRoot -> N.NibbleString -> m (Maybe a)
+getkv sr = fmap (fmap rlpDecode) . MP.getKeyVal sr
+
+putkv :: ( RLPSerializable a
+         , (MP.StateRoot `Alters` MP.NodeData) m
+         )
+      => MP.StateRoot -> N.NibbleString -> a -> m MP.StateRoot
+putkv sr k = MP.putKeyVal sr k . rlpEncode
+
+bootstrapSubscriptionsDB :: ( Modifiable SubscriptionsRoot m
+                            , (MP.StateRoot `Alters` MP.NodeData) m
+                            )
+                         => Keccak256 -> m SubscriptionsRoot
+bootstrapSubscriptionsDB genesisHash = do
+  putSubscriptionsRootForBlock genesisHash zeroHash MP.emptyTriePtr
+  get (Proxy @SubscriptionsRoot)
+
+putBlockHeaderInSubscriptionsDB :: ( BlockHeaderLike h
+                                   , Modifiable SubscriptionsRoot m
+                                   , (MP.StateRoot `Alters` MP.NodeData) m
+                                   )
+                                => h -> m ()
+putBlockHeaderInSubscriptionsDB b = do
+  let p = blockHeaderParentHash b
+      h = blockHeaderHash b
+  putBlockHashInSubscriptionsDB p h
+
+putBlockHashInSubscriptionsDB :: ( Modifiable SubscriptionsRoot m
+                                 , (MP.StateRoot `Alters` MP.NodeData) m
+                                 )
+                              => Keccak256 -> Keccak256 -> m ()
+putBlockHashInSubscriptionsDB p h =
+  putSubscriptionsRootForBlock h p =<< fromMaybe MP.emptyTriePtr <$> getSubscriptionsRootForBlock p
+
+migrateBlockHeaderSubscriptions :: ( BlockHeaderLike h
+                                   , Modifiable SubscriptionsRoot m
+                                   , (MP.StateRoot `Alters` MP.NodeData) m
+                                   )
+                                => h -> Keccak256 -> m ()
+migrateBlockHeaderSubscriptions oldBD newH = do
+  let oldH = blockHeaderHash oldBD
+      oldP = blockHeaderParentHash oldBD
+  mExistingSubscriptionsRoot <- getSubscriptionsRootForBlock oldH
+  case mExistingSubscriptionsRoot of
+    Nothing -> putBlockHeaderInSubscriptionsDB oldBD >> migrateBlockHeaderSubscriptions oldBD newH
+    Just ssr -> putSubscriptionsRootForBlock newH oldP ssr
+
+getSubscriptionsRootForBlock :: ( Modifiable SubscriptionsRoot m
+                                , (MP.StateRoot `Alters` MP.NodeData) m
+                                )
+                             => Keccak256 -> m (Maybe MP.StateRoot)
+getSubscriptionsRootForBlock = fmap (fmap snd) . getSubscriptionsBlockHashInfo
+
+getSubscriptionsBlockHashInfo :: ( Modifiable SubscriptionsRoot m
+                                 , (MP.StateRoot `Alters` MP.NodeData) m
+                                 )
+                              => Keccak256 -> m (Maybe (Keccak256, MP.StateRoot))
+getSubscriptionsBlockHashInfo h = do
+  ssr <- unSubscriptionsRoot <$> get Proxy
+  getkv ssr (N.EvenNibbleString $ keccak256ToByteString h)
+
+putSubscriptionsRootForBlock :: ( Modifiable SubscriptionsRoot m
+                                , (MP.StateRoot `Alters` MP.NodeData) m
+                                )
+                             => Keccak256 -> Keccak256 -> MP.StateRoot -> m ()
+putSubscriptionsRootForBlock h parentHash sr = do
+  ssr <- unSubscriptionsRoot <$> get Proxy
+  newSubscriptionsRoot <- putkv ssr (N.EvenNibbleString $ keccak256ToByteString h) (parentHash, sr)
+  put Proxy $ SubscriptionsRoot newSubscriptionsRoot
+
+getSubscriptionsList :: ( Modifiable SubscriptionsRoot m
+                        , (MP.StateRoot `Alters` MP.NodeData) m
+                        )
+                     => EventSource -> Keccak256 -> m SubscriptionsList
+getSubscriptionsList evSource bh = go bh
+  where go bHash = do
+          mSubsRoot <- getSubscriptionsBlockHashInfo bHash
+          fmap (fromMaybe emptySubscriptionsList) . for mSubsRoot $ \(parentHash, subsRoot) -> do
+            mSubRoot <- getkv subsRoot (toMPKey evSource)
+            case mSubRoot of
+              Just sl -> pure sl
+              Nothing -> do
+                subList' <- if parentHash == zeroHash
+                  then pure emptySubscriptionsList
+                  else go parentHash
+                putSubscriptionsList evSource bHash subList'
+                pure subList'
+
+putSubscriptionsList :: ( Modifiable SubscriptionsRoot m
+                     , (MP.StateRoot `Alters` MP.NodeData) m
+                     )
+                  => EventSource -> Keccak256 -> SubscriptionsList -> m ()
+putSubscriptionsList evSource bHash subList = do
+  mSubsRoot <- getSubscriptionsBlockHashInfo bHash
+  case mSubsRoot of
+    Nothing -> pure ()
+    Just (parentHash, subsRoot) -> do
+      newSubsRoot <- putkv subsRoot (toMPKey evSource) subList
+      putSubscriptionsRootForBlock bHash parentHash newSubsRoot
+
+deleteSubscriptionsList :: ( Modifiable SubscriptionsRoot m
+                           , (MP.StateRoot `Alters` MP.NodeData) m
+                           )
+                        => EventSource -> Keccak256 -> m ()
+deleteSubscriptionsList evSource bHash = do
+  mSubsRoot <- getSubscriptionsBlockHashInfo bHash
+  case mSubsRoot of
+    Nothing -> pure ()
+    Just (parentHash, subsRoot) -> do
+      newSubsRoot <- MP.deleteKey subsRoot (toMPKey evSource)
+      putSubscriptionsRootForBlock bHash parentHash newSubsRoot
+
+getSubscriptionsListLength :: ( Modifiable SubscriptionsRoot m
+                              , (MP.StateRoot `Alters` MP.NodeData) m
+                              )
+                           => EventSource -> Keccak256 -> m Integer
+getSubscriptionsListLength evSource bh = do
+  ~(SubscriptionsList _ _ len) <- getSubscriptionsList evSource bh
+  pure len
+
+getSubscriptionAtIndex :: ( Modifiable SubscriptionsRoot m
+                          , (MP.StateRoot `Alters` MP.NodeData) m
+                          )
+                       => EventSource -> Integer -> Keccak256 -> m (Maybe Subscription)
+getSubscriptionAtIndex evSource index bh = do
+  ~(SubscriptionsList subTrie _ _) <- getSubscriptionsList evSource bh
+  getkv subTrie (toMPKey index)
+
+getIndexOfSubscription :: ( Modifiable SubscriptionsRoot m
+                          , (MP.StateRoot `Alters` MP.NodeData) m
+                          )
+                       => EventSource -> Subscription -> Keccak256 -> m (Maybe Integer)
+getIndexOfSubscription evSource subscription bh = do
+  ~(SubscriptionsList _ iTrie _) <- getSubscriptionsList evSource bh
+  getkv iTrie (toMPKey subscription)
+
+traverseSubscriptionList :: ( Modifiable SubscriptionsRoot m
+                            , (MP.StateRoot `Alters` MP.NodeData) m
+                            )
+                         => EventSource -> Keccak256 -> (Subscription -> m a) -> m [a]
+traverseSubscriptionList evSource bh f = do
+  ~(SubscriptionsList subTrie _ len) <- getSubscriptionsList evSource bh
+  fmap catMaybes . for [0..len-1] $ \index -> do
+    mSubscription <- getkv subTrie (toMPKey index)
+    traverse f mSubscription
+
+subscribe :: ( Modifiable SubscriptionsRoot m
+             , (MP.StateRoot `Alters` MP.NodeData) m
+             )
+          => EventSource -> Subscription -> Keccak256 -> m ()
+subscribe evSource subscription bh = do
+  ~(SubscriptionsList subTrie iTrie len) <- getSubscriptionsList evSource bh
+  mIndex <- getkv iTrie (toMPKey subscription)
+  case mIndex of
+    Just (_ :: Integer) -> pure ()
+    Nothing -> do
+      newSubTrie <- putkv subTrie (toMPKey len) subscription
+      newIndexTrie <- putkv iTrie (toMPKey subscription) len
+      putSubscriptionsList evSource bh $ SubscriptionsList newSubTrie newIndexTrie (len + 1)
+
+unsubscribe :: ( Modifiable SubscriptionsRoot m
+               , (MP.StateRoot `Alters` MP.NodeData) m
+               )
+            => EventSource -> Subscription -> Keccak256 -> m ()
+unsubscribe evSource subscription bh = do
+  ~(SubscriptionsList subTrie iTrie len) <- getSubscriptionsList evSource bh
+  mIndex <- getkv iTrie (toMPKey subscription)
+  case mIndex of
+    Nothing -> pure ()
+    Just (index :: Integer) -> do
+      newSubTrie <- MP.deleteKey subTrie (toMPKey index)
+      newIndexTrie <- MP.deleteKey iTrie (toMPKey subscription)
+      putSubscriptionsList evSource bh $ SubscriptionsList newSubTrie newIndexTrie len

--- a/core-strato/blockapps-mpdbs/src/Blockchain/DB/SubscriptionsDB.hs
+++ b/core-strato/blockapps-mpdbs/src/Blockchain/DB/SubscriptionsDB.hs
@@ -11,6 +11,9 @@
 
 module Blockchain.DB.SubscriptionsDB
   ( SubscriptionsRoot(..)
+  , Subscription(..)
+  , EventSource(..)
+  , SubscriptionsList(..)
   , bootstrapSubscriptionsDB
   , putBlockHeaderInSubscriptionsDB
   , migrateBlockHeaderSubscriptions

--- a/core-strato/privacy/src/Blockchain/Privacy/Event.hs
+++ b/core-strato/privacy/src/Blockchain/Privacy/Event.hs
@@ -59,6 +59,7 @@ type HasPrivacyRegistries m = ( (Keccak256 `Alters` OutputBlock) m
                               , (Keccak256 `Alters` OutputTx) m
                               , (Keccak256 `Alters` ChainHashEntry) m
                               , (Word256 `Alters` ChainIdEntry) m
+                              , (Integer `Alters` Keccak256) m -- Block number to block hash
                               , Selectable (Maybe Word256) ParentChainId m
                               )
 
@@ -259,45 +260,35 @@ runBlocks :: ( MonadLogger m
              , HasFullPrivacy m
              )
           => Word256 -> m [OutputBlock]
-runBlocks chainId = go Nothing
+runBlocks chainId = getAllBlocksToRun chainId >>= \btr ->
+  fmap (fromMaybe []) . traverse go $
+    if S.null btr
+      then Nothing
+      else Just $ S.elemAt 0 btr
   where
-    go mPreviousBlock = do
-      btr <- getAllBlocksToRun chainId
-      if S.null btr
-        then return []
-        else do
-          let b0 = S.elemAt 0 btr
-          if Just b0 == mPreviousBlock
-            then do
-              $logWarnS "Privacy/runBlocks" . T.pack $ concat
-                [ "Failed to clear previous block from cache: "
-                , format b0
-                , ". Breaking to prevent infinite loop."
-                , " This probably means this node was removed from the private chain "
-                , format chainId
-                , "."
-                ]
-              pure []
-            else do
-              mBlock <- lookup (Proxy @OutputBlock) (_bhash b0)
-              fmap (fromMaybe [] . join) . for mBlock $ \block -> do
-                mHydrated <- hydratePrivateHashes (Just chainId) block
-                for mHydrated $ \b -> do
-                  logFF "Privacy/runBlocks" $ concat
-                    [ "blocksToRun deleting "
-                    , format b0
-                    , " for private chain "
-                    , format chainId
-                    , " and its ancestors."
-                    ]
-                  let chainIds = S.toList
-                               . (S.\\ (S.singleton Nothing))
-                               . S.fromList
-                               . (Just chainId :) -- It's possible that there aren't any transactions with this chainId in the block
-                               $ txChainId <$> obReceiptTransactions b
-                  for_ chainIds $ \(Just cId) -> forAncestorChains cId . flip (adjustStatefully_ (Proxy @ChainIdEntry)) $
-                    blocksToRun %= S.delete b0
-                  (b:) <$> go (Just b0)
+    go b0 = do
+      mBlock <- lookup (Proxy @OutputBlock) (_bhash b0)
+      fmap (fromMaybe [] . join) . for mBlock $ \block -> do
+        mHydrated <- hydratePrivateHashes (Just chainId) block
+        for mHydrated $ \b -> do
+          logFF "Privacy/runBlocks" $ concat
+            [ "blocksToRun deleting "
+            , format b0
+            , " for private chain "
+            , format chainId
+            , " and its ancestors."
+            ]
+          let chainIds = S.toList
+                       . (S.\\ (S.singleton Nothing))
+                       . S.fromList
+                       . (Just chainId :) -- It's possible that there aren't any transactions with this chainId in the block
+                       $ txChainId <$> obReceiptTransactions b
+          for_ chainIds $ \(Just cId) -> forAncestorChains cId . flip (adjustStatefully_ (Proxy @ChainIdEntry)) $
+            blocksToRun %= S.delete b0
+          let nextBlockNum = _bordering b0 + 1
+          lookup (Proxy @Keccak256) nextBlockNum >>= \case
+            Nothing -> pure [b]
+            Just bHash -> (b:) <$> go (BlockInfo bHash nextBlockNum)
 
 hasAllAncestorChains :: (Word256 `Alters` ChainIdEntry) m
                      => Maybe Word256 -> m Bool
@@ -341,6 +332,7 @@ hydratePrivateHashes chainF b = do
       bHash = blockHeaderHash $ blockHeader b
       bOrdering = blockOrdering b
       bInfo = BlockInfo bHash bOrdering
+  insert (Proxy @Keccak256) bOrdering bHash
   when (any isPrivateHashTX $ blockTransactions b) $
     insert (Proxy @OutputBlock) bHash b
   let discluded cs cid = foldrM (\x y -> if y then pure y else x `isAncestorChainOf` cid) False (S.elems cs)

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -72,7 +72,9 @@ import           Blockchain.DB.CodeDB
 import           Blockchain.DB.ModifyStateDB          (pay)
 import           Blockchain.DB.X509CertDB
 import           Blockchain.DB.SolidStorageDB
+import           Blockchain.DB.SubscriptionsDB
 import           Blockchain.ExtWord
+import           Blockchain.Output
 import qualified Blockchain.SolidVM.Builtins          as Builtins
 import           Blockchain.SolidVM.CodeCollectionDB
 import qualified Blockchain.SolidVM.Environment       as Env
@@ -1017,7 +1019,8 @@ runStatement st@(CC.EmitStatement eventName exptups pos) = do
   curInfo <- getCurrentCallInfo
   curCnct <- getCurrentContract
   let evs = CC._events curCnct
-      mEv = M.lookup (T.pack eventName) evs
+      tEventName = T.pack eventName
+      mEv = M.lookup tEventName evs
   case mEv of
     Nothing ->
       missingType "no corresponding event has been declared for the following emit statement: " (unparseStatement st)
@@ -1045,6 +1048,17 @@ runStatement st@(CC.EmitStatement eventName exptups pos) = do
               " of org " ++ show org
 
         addEvent $ Event org parentName (CC._contractName curCnct) account eventName pairs
+        acct <- getCurrentAccount
+        let args = CC.OrderedArgs $ snd <$> exptups
+            e = EventSource (acct, tEventName)
+        bHash <- unCurrentBlockHash <$> Mod.access (Mod.Proxy @CurrentBlockHash)
+        void . traverseSubscriptionList e bHash $ \s@(Subscription (callbackAcct, fName)) -> do
+          isAncestor <- (acct ^. accountChainId) `isAncestorChainOf` (callbackAcct ^. accountChainId)
+          if isAncestor
+            then do
+              $logDebugS "runStatement/EmitStatement" . T.pack $ "Running callback for " ++ format e ++ " at " ++ format s
+              void $ callWrapper acct callbackAcct Nothing (T.unpack fName) False args 
+            else $logWarnS "runStatement/EmitStatement" . T.pack $ "Inaccessible chain registered callback for " ++ format e ++ " at " ++ format s
         return Nothing
 
 runStatement (CC.UncheckedStatement code pos) = do

--- a/core-strato/solid-vm/src/Blockchain/SolidVM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM.hs
@@ -632,13 +632,16 @@ expressionType (CC.ArrayExpression _ xs) = SVMType.Array (expressionType (head x
 
 expressionType ex = typeError "Cannot deduce a type from" (ex, ex)
 
+callWrapper :: MonadSM m => Account -> Account -> Maybe String -> String -> Bool -> CC.ArgList -> m (Maybe Value)
+callWrapper = callWrapper' False
 
-callWrapper  :: MonadSM m => Account -> Account -> Maybe String -> String -> Bool -> CC.ArgList -> m (Maybe Value)
-callWrapper from to mContract functionName isRCC argExps  = do
+callWrapper' :: MonadSM m => Bool -> Account -> Account -> Maybe String -> String -> Bool -> CC.ArgList -> m (Maybe Value)
+callWrapper' isCallback from to mContract functionName isRCC argExps  = do
   let fromChain = from ^. accountChainId
       toChain = to ^. accountChainId
-  isAccessibleChain <- toChain `isAncestorChainOf` fromChain
-  unless isAccessibleChain $ inaccessibleChain "Inaccessible chain violation" $ "from: " ++ show from ++ ", to: " ++ show to
+  unless isCallback $ do
+    isAccessibleChain <- toChain `isAncestorChainOf` fromChain
+    unless isAccessibleChain $ inaccessibleChain "Inaccessible chain violation" $ "from: " ++ show from ++ ", to: " ++ show to
 
   (contract', hsh, cc) <- getCodeAndCollection to
   parentName <- fromMaybeM (return "") $ runMaybeT
@@ -677,7 +680,9 @@ callWrapper from to mContract functionName isRCC argExps  = do
             mCallInfo <- getCurrentCallInfoIfExists
             let ro = case mCallInfo of
                        Nothing -> False
-                       Just ci -> if fromChain == toChain then readOnly ci else True
+                       Just ci -> if isCallback
+                                    then False
+                                    else if fromChain == toChain then readOnly ci else True
             let f' = (if from == to then id else pushSender from) $ runTheCall to contract functionName hsh cc theFunction args' ro
             return (f', args')
           _ -> do --Maybe the function is actually a getter
@@ -1052,13 +1057,28 @@ runStatement st@(CC.EmitStatement eventName exptups pos) = do
         let args = CC.OrderedArgs $ snd <$> exptups
             e = EventSource (acct, tEventName)
         bHash <- unCurrentBlockHash <$> Mod.access (Mod.Proxy @CurrentBlockHash)
-        void . traverseSubscriptionList e bHash $ \s@(Subscription (callbackAcct, fName)) -> do
-          isAncestor <- (acct ^. accountChainId) `isAncestorChainOf` (callbackAcct ^. accountChainId)
+        cbChains <- fmap (S.fromList . catMaybes) . traverseSubscriptionList e bHash $ \s@(Subscription (callbackAcct, fName)) -> do
+          let callbackChain = callbackAcct ^. accountChainId
+          isAncestor <- (acct ^. accountChainId) `isAncestorChainOf` callbackChain
           if isAncestor
             then do
               $logDebugS "runStatement/EmitStatement" . T.pack $ "Running callback for " ++ format e ++ " at " ++ format s
-              void $ callWrapper acct callbackAcct Nothing (T.unpack fName) False args 
-            else $logWarnS "runStatement/EmitStatement" . T.pack $ "Inaccessible chain registered callback for " ++ format e ++ " at " ++ format s
+              eErr <- EUnsafe.try . void $ callWrapper' True acct callbackAcct Nothing (T.unpack fName) False args 
+              case eErr of
+                Right _ -> pure ()
+                Left err -> $logErrorS "runStatement/EmitStatement" . T.pack $ concat
+                              [ "Exception while running callback for "
+                              , format e
+                              , " at "
+                              , format s
+                              , ": "
+                              , show (err :: SolidException)
+                              ]
+              pure callbackChain
+            else do
+              $logErrorS "runStatement/EmitStatement" . T.pack $ "Inaccessible chain registered callback for " ++ format e ++ " at " ++ format s
+              pure Nothing
+        Mod.modifyStatefully_ (Mod.Proxy @MemDBs) $ callbackChains %= flip S.union cbChains
         return Nothing
 
 runStatement (CC.UncheckedStatement code pos) = do
@@ -2030,6 +2050,22 @@ callBuiltin vs@"verifySignature" [SString msg, SString signature, SString pubkey
   else unknownFunction "callBuiltin" vs
   
 callBuiltin "parseCert" [SString cert] _ = return $ certificateMap (Just cert)
+callBuiltin "subscribe" [SAccount namedA _, SString eventName, SString callbackName] _ = do
+  acct <- getCurrentAccount
+  bHash <- unCurrentBlockHash <$> Mod.access (Mod.Proxy @CurrentBlockHash)
+  let a = namedAccountToAccount (acct ^. accountChainId) namedA
+      e = EventSource (a, T.pack eventName)
+      c = Subscription (acct, T.pack callbackName)
+  subscribe e c bHash
+  pure SNULL
+callBuiltin "unsubscribe" [SAccount namedA _, SString eventName, SString callbackName] _ = do
+  acct <- getCurrentAccount
+  bHash <- unCurrentBlockHash <$> Mod.access (Mod.Proxy @CurrentBlockHash)
+  let a = namedAccountToAccount (acct ^. accountChainId) namedA
+      e = EventSource (a, T.pack eventName)
+      c = Subscription (acct, T.pack callbackName)
+  unsubscribe e c bHash
+  pure SNULL
 
 callBuiltin x _ _ = unknownFunction "callBuiltin" x
 

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -387,7 +387,8 @@ getVariableOfName name = do
                                                   , "require", "revert", "assert", "sha3"
                                                   , "sha256", "ecrecover", "addmod", "mulmod"
                                                   , "selfdestruct", "suicide", "bytes32ToString"
-                                                  , "registerCert", "getUserCert", "parseCert", "verifyCert", "verifySignature"]) $
+                                                  , "registerCert", "getUserCert", "parseCert", "verifyCert", "verifySignature"
+                                                  , "subscribe", "unsubscribe"]) $
         t "builtin function" $ Constant $ SBuiltinFunction name Nothing
 
       maybeBuiltinVariable :: Maybe Variable

--- a/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/core-strato/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -78,6 +78,7 @@ import qualified Blockchain.Database.MerklePatricia as MP
 import           Blockchain.DB.CodeDB
 import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.DB.RawStorageDB
+import           Blockchain.DB.SubscriptionsDB
 import           Blockchain.DB.X509CertDB
 import           Blockchain.ExtWord
 import           Blockchain.Output
@@ -154,6 +155,7 @@ type MonadSM m = ( (Account `A.Alters` AddressState) m
                  , HasMemAddressStateDB m
                  , HasMemRawStorageDB m
                  , Mod.Accessible Env.Environment m
+                 , Mod.Accessible CurrentBlockHash m
                  , Mod.Modifiable (M.Map Address X509Certificate) m
                  , Mod.Modifiable MemDBs m
                  , Mod.Modifiable Env.Sender m
@@ -161,6 +163,7 @@ type MonadSM m = ( (Account `A.Alters` AddressState) m
                  , Mod.Modifiable Action m
                  , Mod.Modifiable (Q.Seq Event) m
                  , Mod.Modifiable (Maybe DebugSettings) m
+                 , Mod.Modifiable SubscriptionsRoot m
                  , MonadIO m --todo: remove
                  , MonadCatch m
                  , MonadLogger m
@@ -215,6 +218,13 @@ instance (Maybe Word256 `A.Alters` MP.StateRoot) m
 instance Monad m => Mod.Modifiable CurrentBlockHash (SM m) where
   get _    = fromMaybe (CurrentBlockHash $ unsafeCreateKeccak256FromWord256 0) . _currentBlock <$> Mod.get (Mod.Proxy @MemDBs)
   put _ md = Mod.modifyStatefully_ (Mod.Proxy @MemDBs) $ currentBlock ?= md
+
+instance Monad m => Mod.Accessible CurrentBlockHash (SM m) where
+  access _ = fromMaybe (CurrentBlockHash $ unsafeCreateKeccak256FromWord256 0) . _currentBlock <$> Mod.get (Mod.Proxy @MemDBs)
+
+instance (Monad m, Mod.Modifiable SubscriptionsRoot m) => Mod.Modifiable SubscriptionsRoot (SM m) where
+  get   = lift . Mod.get
+  put p = lift . Mod.put p
 
 instance A.Selectable (Maybe Word256) ParentChainId m => A.Selectable (Maybe Word256) ParentChainId (SM m) where
   select p = lift . A.select p

--- a/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
+++ b/core-strato/solid-vm/src/SolidVM/Solidity/Detectors/Typechecker.hs
@@ -813,6 +813,9 @@ payableArgs x = accountType' x
 parseCertArgs :: SourceAnnotation Text -> Type'
 parseCertArgs x = stringType' x
 
+subscribeArgs  :: SourceAnnotation Text -> Type'
+subscribeArgs x = Product [accountType' x, stringType' x, stringType' x] x
+
 getVarType' :: String -> SourceAnnotation Text -> SSS Type'
 getVarType' "this" ctx = pure $ Static (SVMType.Account False) ctx
 getVarType' s@('u':'i':'n':'t':n) ctx = case n of
@@ -849,6 +852,8 @@ getVarType' "addmod" ctx =  pure $ Function (addmodArgs ctx) (intType' ctx) ctx
 getVarType' "mulmod" ctx =  pure $ Function (mulmodArgs ctx) (intType' ctx) ctx
 getVarType' "payable" ctx =  pure $ Function (payableArgs ctx) (Static (SVMType.Account True) ctx) ctx
 getVarType' "parseCert" ctx =  pure $ Function (parseCertArgs ctx) (certType' ctx) ctx
+getVarType' "subscribe" ctx =  pure $ Function (subscribeArgs ctx) (Product [] ctx) ctx
+getVarType' "unsubscribe" ctx =  pure $ Function (subscribeArgs ctx) (Product [] ctx) ctx
 getVarType' "Util" ctx = pure $ Static (SVMType.Label "Util") ctx
 getVarType' "msg" ctx = pure $ Static (SVMType.Label "msg") ctx
 getVarType' "tx" ctx = pure $ Static (SVMType.Label "tx") ctx

--- a/core-strato/strato-p2p/test/EventSpec.hs
+++ b/core-strato/strato-p2p/test/EventSpec.hs
@@ -264,6 +264,11 @@ instance MonadIO m => (Word256 `A.Alters` ChainIdEntry) (MonadTest m) where
   insert = genericTestInsert $ sequencerContext . chainIdRegistry
   delete = genericTestDelete $ sequencerContext . chainIdRegistry
 
+instance MonadIO m => (Integer `A.Alters` Keccak256) (MonadTest m) where
+  lookup = genericTestLookup $ sequencerContext . blockNumberRegistry
+  insert = genericTestInsert $ sequencerContext . blockNumberRegistry
+  delete = genericTestDelete $ sequencerContext . blockNumberRegistry
+
 instance MonadIO m => (Keccak256 `A.Alters` DBDB.DependentBlockEntry) (MonadTest m) where
   lookup _ k = use $ sequencerContext . dbeRegistry . at k
   insert _ k v = sequencerContext . dbeRegistry . at k ?= v
@@ -368,6 +373,7 @@ newSequencerContext bc = do
       , _txHashRegistry      = M.empty
       , _chainHashRegistry   = M.empty
       , _chainIdRegistry     = M.empty
+      , _blockNumberRegistry = M.empty
       , _getChainsDB         = emptyGetChainsDB
       , _getTransactionsDB   = emptyGetTransactionsDB
       , _ldbBatchOps         = Q.empty

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Metrics.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Metrics.hs
@@ -137,6 +137,13 @@ chainIdRegistrySize = unsafeRegister
             . gauge
             $ Info "chain_id_registry" "Size count for private chain chain id registry"
 
+{-# NOINLINE blockNumberRegistrySize #-}
+blockNumberRegistrySize :: Vector Text Gauge
+blockNumberRegistrySize = unsafeRegister
+            . vector "block_number_registry"
+            . gauge
+            $ Info "block_number_registry" "Size count for private chain block number registry"
+
 {-# NOINLINE getChainsDbSize #-}
 getChainsDbSize :: Vector Text Gauge
 getChainsDbSize = unsafeRegister

--- a/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/core-strato/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -54,6 +54,7 @@ module Blockchain.Sequencer.Monad
   , txHashRegistry
   , chainHashRegistry
   , chainIdRegistry
+  , blockNumberRegistry
   , getChainsDB
   , getTransactionsDB
   , ldbBatchOps
@@ -129,6 +130,7 @@ data SequencerContext = SequencerContext
   , _txHashRegistry      :: !(Map Keccak256 (Modification OutputTx))
   , _chainHashRegistry   :: !(Map Keccak256 (Modification ChainHashEntry))
   , _chainIdRegistry     :: !(Map Word256 (Modification ChainIdEntry))
+  , _blockNumberRegistry :: !(Map Integer (Modification Keccak256))
   , _getChainsDB         :: !GetChainsDB
   , _getTransactionsDB   :: !GetTransactionsDB
   , _ldbBatchOps         :: !(Q.Seq LDB.BatchOp)
@@ -225,6 +227,10 @@ instance HasNamespace ChainHashEntry where
 instance HasNamespace ChainIdEntry where
   type NSKey ChainIdEntry = Word256
   namespace _ = "ci:"
+
+instance HasNamespace Keccak256 where
+  type NSKey Keccak256 = Integer
+  namespace _ = "bn:"
 
 lookupInLDB :: (Binary a, HasNamespace a, MonadIO m, Mod.Accessible LDB.DB m)
             => Mod.Proxy a -> NSKey a -> m (Maybe a)
@@ -336,6 +342,17 @@ instance (Word256 `A.Alters` ChainIdEntry) SequencerM where
     sz <- M.size <$> use chainIdRegistry
     liftIO $ withLabel chainIdRegistrySize "chain_id_registry" (flip setGauge (fromIntegral sz))
 
+instance (Integer `A.Alters` Keccak256) SequencerM where
+  lookup = genericLookupSequencer blockNumberRegistry
+  insert p k v = do
+    genericInsertSequencer blockNumberRegistry p k v
+    sz <- M.size <$> use blockNumberRegistry
+    liftIO $ withLabel blockNumberRegistrySize "block_number_registry" (flip setGauge (fromIntegral sz))
+  delete p k = do
+    genericDeleteSequencer blockNumberRegistry p k
+    sz <- M.size <$> use blockNumberRegistry
+    liftIO $ withLabel blockNumberRegistrySize "block_number_registry" (flip setGauge (fromIntegral sz))
+
 instance (Keccak256 `A.Alters` DependentBlockEntry) SequencerM where
   lookup _ k = do
     mv <- use $ dbeRegistry . at k
@@ -431,6 +448,7 @@ prunePrivacyDBs = do
   prune txHashRegistry
   prune chainHashRegistry
   prune chainIdRegistry
+  prune blockNumberRegistry
   setTo initialEmittedBlockCache emittedBlockRegistry
   where prune = setTo M.empty
         setTo s r = modify' $ r .~ s
@@ -454,6 +472,7 @@ runSequencerM c mbc m = do
             , _txHashRegistry      = M.empty
             , _chainHashRegistry   = M.empty
             , _chainIdRegistry     = M.empty
+            , _blockNumberRegistry = M.empty
             , _getChainsDB         = emptyGetChainsDB
             , _getTransactionsDB   = emptyGetTransactionsDB
             , _ldbBatchOps         = Q.empty

--- a/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/core-strato/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -154,7 +154,7 @@ withTemporaryDepBlockDB pbft genesisBlock m = do
           bootstrapGenesisBlock hsh difficulty
           A.insert (A.Proxy @EmittedBlock) hsh alreadyEmittedBlock
     fromLeft (error "webserver completed") <$>
-      race (runNoLoggingT (runSequencerM cfg mCtx (boot >> m)))
+      race (runLoggingT (runSequencerM cfg mCtx (boot >> m)))
            ( run testWebserverPort
                . logStdoutDev
                . prometheus def
@@ -695,11 +695,13 @@ spec = do
         map (map txType . blockReceiptTransactions) bs' `shouldBe` [[PrivateHash]]
         let obs' = [b | VmBlock b <- _toVm b2]
         map (map txType . obReceiptTransactions) obs' `shouldBe` [[PrivateHash]]
+        map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs' `shouldBe`
+          [[Nothing]]
         b3 <- runBatch $ checkForUnseq [chainDetails1]
         let obs'' = [b | VmBlock b <- _toVm b3]
-        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[PrivateHash], [PrivateHash]]
+        map (map txType . obReceiptTransactions) obs'' `shouldBe` [[PrivateHash], [PrivateHash], [PrivateHash]]
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
-          [[Just Message], [Just Message]]
+          [[Just Message], [Nothing], [Just Message]]
 
       it "should re-run blocks when chain info is delayed" . runPBFTTestMWithGenesis $ \h -> do
         let iev = iev1' h

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -68,6 +68,7 @@ import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.DB.ModifyStateDB
 import           Blockchain.DB.RawStorageDB
 import           Blockchain.DB.StorageDB
+import           Blockchain.DB.SubscriptionsDB
 import           Blockchain.DB.X509CertDB
 import           Blockchain.EVM.Code
 import qualified Blockchain.EVM                          as EVM
@@ -203,6 +204,7 @@ addBlock b@OutputBlock{obBlockData = bd, obBlockUncles = uncles, obReceiptTransa
         Just cr -> $logDebugS "addBlock" $ T.pack $ "Old chain root: " ++ format cr
 
     putBlockHeaderInChainDB bd
+    putBlockHeaderInSubscriptionsDB bd
 
     when flags_debug $ do
       bhr' <- Mod.get (Proxy @BlockHashRoot)

--- a/core-strato/vm-runner/src/Blockchain/BlockChain.hs
+++ b/core-strato/vm-runner/src/Blockchain/BlockChain.hs
@@ -655,6 +655,7 @@ replaceBestIfBetter b@OutputBlock{obBlockData = bd, obTotalDifficulty = td, obRe
     case bbi of
       Unspecified -> error $ "Trying to replace an Unspecified Best Block"
       ContextBestBlockInfo (oldBestSha, oldBestBlock, oldBestDifficulty, oldTxCount, _) -> do
+        cbChains <- _callbackChains <$> Mod.get (Mod.Proxy @MemDBs)
 
         let newNumber     = blockDataNumber bd
             newStateRoot  = blockDataStateRoot bd
@@ -669,7 +670,9 @@ replaceBestIfBetter b@OutputBlock{obBlockData = bd, obTotalDifficulty = td, obRe
                             || (newNumber > oldNumber)
                             || ((newNumber == oldNumber) && (td > oldBestDifficulty))
                             || ((newNumber == oldNumber) && (td == oldBestDifficulty) && (newTxCount > oldTxCount))
-            ranPriv = M.fromSet (const (newNumber, bH)) . S.fromList . catMaybes $ map txChainId txPayloads
+            ranPrivTxSet = S.fromList . catMaybes $ map txChainId txPayloads
+            allChainsRun = ranPrivTxSet <> cbChains
+            ranPriv = M.fromSet (const (newNumber, bH)) allChainsRun
 
         $logInfoS "replaceBestIfBetter" . T.pack $ "shouldReplace = " ++ show shouldReplace ++ ", newNumber = " ++ show newNumber ++ ", oldBestNumber = " ++ show (blockDataNumber oldBestBlock)
 

--- a/core-strato/vm-runner/src/Executable/EthereumVM.hs
+++ b/core-strato/vm-runner/src/Executable/EthereumVM.hs
@@ -51,6 +51,7 @@ import           Blockchain.Data.DataDefs              (blockDataExtraData, bloc
 import           Blockchain.Data.GenesisBlock
 import           Blockchain.DB.BlockSummaryDB
 import           Blockchain.DB.ChainDB
+import           Blockchain.DB.SubscriptionsDB
 import           Blockchain.EthConf
 import           Blockchain.Event
 import           Blockchain.ExtWord
@@ -103,6 +104,7 @@ ethereumVM d = void . execContextM d $ do
 
     putContextBestBlockInfo cpBBI
     Mod.put Proxy $ BlockHashRoot cpSR
+    void $ bootstrapSubscriptionsDB cpHash
 
     Bagger.processNewBestBlock cpHash cpHead [] -- bootstrap Bagger with genesis block
 

--- a/core-strato/vm-tools/src/Blockchain/Bagger.hs
+++ b/core-strato/vm-tools/src/Blockchain/Bagger.hs
@@ -46,6 +46,7 @@ import           Blockchain.DB.ChainDB
 import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.DB.ModifyStateDB
 import           Blockchain.DB.StorageDB
+import           Blockchain.DB.SubscriptionsDB
 import           Blockchain.Database.MerklePatricia (StateRoot (..))
 import qualified Blockchain.EthConf                 as Conf
 import           Blockchain.ExtWord
@@ -249,6 +250,7 @@ processNewBestBlock bh bd txShas = do
                                        }
     putBaggerState $ state { B.seen = S.empty, B.miningCache = newMiningCache }
     migrateBlockHeader bd baggerBlockHash
+    migrateBlockHeaderSubscriptions bd baggerBlockHash
     withBagger $ do
       demoteUnexecutables
       promoteExecutables

--- a/core-strato/vm-tools/src/Blockchain/MemVMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/MemVMContext.hs
@@ -31,6 +31,7 @@ import qualified Data.Map                           as M
 import           Data.Maybe                         (fromMaybe)
 import qualified Data.NibbleString                  as N
 import qualified Data.Sequence                      as Q
+import qualified Data.Set                           as S
 import           Data.Traversable                   (for)
 import           Debugger
 import           GHC.Generics
@@ -336,6 +337,7 @@ runMemContextMWith cdbs dSettings f = do
         , _storageBlockMap = M.empty
         , _stateRoots      = M.empty
         , _currentBlock    = Nothing
+        , _callbackChains  = S.empty
         }
       cstate = ContextState
         { _memDBs            = cmemDBs

--- a/core-strato/vm-tools/src/Blockchain/MemVMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/MemVMContext.hs
@@ -47,6 +47,7 @@ import           Blockchain.DB.CodeDB
 import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.DB.RawStorageDB
 import           Blockchain.DB.StateDB
+import           Blockchain.DB.SubscriptionsDB
 import           Blockchain.DB.X509CertDB
 import           Blockchain.ExtWord
 import           Blockchain.Strato.Model.Account
@@ -79,6 +80,7 @@ data MemContextDBs = MemContextDBs
   , _blockHashRoot  :: BlockHashRoot
   , _genesisRoot    :: GenesisRoot
   , _bestBlockRoot  :: BestBlockRoot
+  , _subscriptionsRoot :: SubscriptionsRoot
   , _worldBestBlock :: Maybe WorldBestBlock
   } deriving (Generic)
 makeLenses ''MemContextDBs
@@ -212,6 +214,10 @@ instance Mod.Modifiable BestBlockRoot MemContextM where
   get _     = dbsGets $ view bestBlockRoot
   put _ bbr = dbsModify' $ bestBlockRoot .~ bbr
 
+instance Mod.Modifiable SubscriptionsRoot MemContextM where
+  get _     = dbsGets $ view subscriptionsRoot
+  put _ bbr = dbsModify' $ subscriptionsRoot .~ bbr
+
 instance Mod.Modifiable CurrentBlockHash MemContextM where
   get _    = fmap (fromMaybe (CurrentBlockHash $ unsafeCreateKeccak256FromWord256 0)) . gets $ view $ memDBs . currentBlock
   put _ bh = modify $ memDBs . currentBlock ?~ bh
@@ -313,6 +319,7 @@ runMemContextM = runMemContextMWith cdbs
           , _blockHashRoot  = BlockHashRoot MP.emptyTriePtr
           , _genesisRoot    = GenesisRoot MP.emptyTriePtr
           , _bestBlockRoot  = BestBlockRoot MP.emptyTriePtr
+          , _subscriptionsRoot = SubscriptionsRoot MP.emptyTriePtr
           , _worldBestBlock = Nothing
           }
 

--- a/core-strato/vm-tools/src/Blockchain/VMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMContext.hs
@@ -119,6 +119,7 @@ import           Blockchain.DB.RawStorageDB
 import           Blockchain.DB.SQLDB
 import           Blockchain.DB.StateDB
 import           Blockchain.DB.StorageDB
+import           Blockchain.DB.SubscriptionsDB
 import           Blockchain.DB.X509CertDB
 import           Blockchain.EthConf
 import           Blockchain.ExtWord
@@ -202,6 +203,7 @@ type VMBase m = ( MonadIO m
                 , Mod.Modifiable GenesisRoot m
                 , Mod.Modifiable BestBlockRoot m
                 , Mod.Modifiable CurrentBlockHash m
+                , Mod.Modifiable SubscriptionsRoot m
                 , HasMemAddressStateDB m
                 , A.Selectable (Maybe Word256) ParentChainId m
                 , (Maybe Word256 `A.Alters` MP.StateRoot) m
@@ -340,6 +342,9 @@ vmGenesisRootKey = "genesis_root"
 vmBestBlockRootKey :: B.ByteString
 vmBestBlockRootKey = "best_block_root"
 
+vmSubscriptionsRootKey :: B.ByteString
+vmSubscriptionsRootKey = "subscriptions_root"
+
 instance Mod.Modifiable BlockHashRoot ContextM where
   get _ = do
     db <- getStateDB
@@ -363,6 +368,14 @@ instance Mod.Modifiable BestBlockRoot ContextM where
   put _ (BestBlockRoot (MP.StateRoot sr)) = do
     db <- getStateDB
     DB.put db def vmBestBlockRootKey sr
+
+instance Mod.Modifiable SubscriptionsRoot ContextM where
+  get _ = do
+    db <- getStateDB
+    SubscriptionsRoot . maybe MP.emptyTriePtr MP.StateRoot <$> DB.get db def vmSubscriptionsRootKey
+  put _ (SubscriptionsRoot (MP.StateRoot sr)) = do
+    db <- getStateDB
+    DB.put db def vmSubscriptionsRootKey sr
 
 instance Mod.Modifiable K.KafkaState ContextM where
   get _    = readIORef =<< view (dbs . kafkaState)

--- a/core-strato/vm-tools/src/Blockchain/VMContext.hs
+++ b/core-strato/vm-tools/src/Blockchain/VMContext.hs
@@ -40,6 +40,7 @@ module Blockchain.VMContext
     , storageBlockMap
     , stateRoots
     , currentBlock
+    , callbackChains
     , memDBs
     , baggerState
     , bestBlockInfo
@@ -86,6 +87,7 @@ import qualified Data.Map                           as M
 import           Data.Maybe                         (fromMaybe)
 import qualified Data.NibbleString                  as N
 import qualified Data.Sequence                      as Q
+import qualified Data.Set                           as S
 import           Data.Word
 import qualified Data.Text                          as T
 import           Data.Traversable                   (for)
@@ -166,6 +168,7 @@ data MemDBs = MemDBs
   , _storageBlockMap :: M.Map (Account, B.ByteString) B.ByteString
   , _stateRoots      :: M.Map (Keccak256, Maybe Word256) MP.StateRoot
   , _currentBlock    :: Maybe CurrentBlockHash
+  , _callbackChains  :: S.Set Word256
   } deriving (Generic, NFData, Show)
 makeLenses ''MemDBs
 
@@ -527,6 +530,7 @@ runTestContextM f = withSystemTempDirectory "test_evm_context" $ \tmpdir ->
             , _storageBlockMap = M.empty
             , _stateRoots      = M.empty
             , _currentBlock    = Nothing
+            , _callbackChains  = S.empty
             }
 
       cstate <- newIORef $ ContextState
@@ -592,6 +596,7 @@ runContextM dSettings f = do
             , _storageBlockMap = M.empty
             , _stateRoots      = M.empty
             , _currentBlock    = Nothing
+            , _callbackChains  = S.empty
             }
 
       cstate <- newIORef $ ContextState

--- a/shared-util/format/package.yaml
+++ b/shared-util/format/package.yaml
@@ -11,3 +11,4 @@ library:
     - base16-bytestring
     - bytestring
     - nibblestring    
+    - text

--- a/shared-util/format/src/Text/Format.hs
+++ b/shared-util/format/src/Text/Format.hs
@@ -9,11 +9,18 @@ import qualified Data.ByteString        as B
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8  as BC
 import qualified Data.NibbleString      as N
+import qualified Data.Text              as T
 
 import           Numeric
 
 class Format a where
   format::a->String
+
+instance Format String where
+  format = id
+
+instance Format T.Text where
+  format = T.unpack
 
 instance Format B.ByteString where
   format = BC.unpack . B16.encode


### PR DESCRIPTION
This PR implements the ability to subscribe to events being emitted by a particular contract account, and run a callback when the contract account emits the event. This is achieved by introducing the `subscribe` and `unsubscribe` builtins in SolidVM.
Take the following two contracts:
```js
contract ContractThatEmitsEvents {
    event MyEvent(string theEventArg);

    function triggerEvent(string myInput) {
      emit MyEvent(myInput);    
    }
}

contract ContractThatSubscribesToEvents {
    string myStringVal = "This is the initial value.";
    uint counter = 0;
    address eventAddress;
    
    constructor(address eventTriggerAddress) {
        eventAddress = eventTriggerAddress;
        subscribe(account(eventAddress, "main"), "MyEvent", "myCallback");
    }

    function myCallback(string _newVal) {
        myStringVal = _newVal;
        counter++;
    }
}
```
After creating `ContractThatEmitsEvents` on the main chain, and creating `ContractThatSubscribesToEvents` on a private chain with the address of `ContractThatEmitsEvents` passed in to the constructor, the instance of `ContractThatSubscribesToEvents` on the private chain will now run `myCallback` every time the main chain contract emits a `MyEvent` event. This allows us to do a variety of things atomically that previously required multiple API requests/transactions, including automatically adding new members to chains when their cert is registered on the main chain, or automatically removing an old member and adding a new member when a change of ownership occurs (think `currentCPA` changing in Upbring, or the asset owner changing in Seismic).
The event/callback model is pretty flexible: subscriptions can be made for any contract, on any chain, and the callback can occur on the same chain, or any descendant chain, of the event. Furthermore, callbacks can be chained: if an event is emitted within a callback, downstream callbacks will also be run. Contracts can subscribe to multiple events, and can unsubscribe/resubscribe at will.