### PR TITLE
removed account from reseved words

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
@@ -79,7 +79,7 @@ solidityLanguage = javaStyle {
      "wei", "finney", "szabo", "ether",
      "seconds", "minutes", "hours", "days", "weeks", "years",
      --The following are protected as they are also names for cirrus columns
-     "account", "block_number", "block_timestamp", "block_hash",
+     "block_number", "block_timestamp", "block_hash",
      "record_id", "transaction_hash", "transaction_sender"
      ],
   P.reservedOpNames = [

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -713,16 +713,17 @@ contract qq {
    }
 }|]) `shouldThrow` anyParseError
 
-    it "throw an error when there is an 'account' variable name" $ runTest (do
-      runBS [r|
-contract qq {
-   function f();
-   string account;
-   constructor()
-   {
-      account = "hello";
-   }
-}|]) `shouldThrow` anyParseError
+--TODO:
+--     it "throw an error when there is an 'account' variable name" $ runTest (do
+--       runBS [r|
+-- contract qq {
+--    function f();
+--    string account;
+--    constructor()
+--    {
+--       account = "hello";
+--    }
+-- }|]) `shouldThrow` anyParseError
 
     it "throw an error when there is an 'address' variable name" $ runTest (do
       runBS [r|


### PR DESCRIPTION
This PR removes "account" from the reserved words in Lexer.hs, thus allowing the devnet to sync