### PR TITLE
Strato 2612 add features to the certificate dapp

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2209,6 +2209,7 @@ certificateMap maybeCert = case maybeCert of
                                    , (SString "publicKey", Constant . SString $ BC.unpack $ pubToBytes $ subPub sub)
                                    , (SString "userAddress", Constant . SString $ show $ fromPublicKey $ subPub sub)
                                    , (SString "certString", Constant . SString $ cert)
+                                   , (SString "parent", Constant . SString $ maybe "" show (getParentUserAddress =<< (eitherToMaybe . bsToCert . BC.pack $ cert)))
                                    ]
           emptyCertMap = M.fromList [ (SString "commonName", Constant . SString $ "")
                              , (SString "country", Constant . SString $ "")
@@ -2217,6 +2218,7 @@ certificateMap maybeCert = case maybeCert of
                              , (SString "publicKey", Constant . SString $ "")
                              , (SString "userAddress", Constant . SString $ "")
                              , (SString "certString", Constant . SString $ "")
+                             , (SString "parent", Constant . SString $ "")
                              ]
           stringToString = SVMType.Mapping { SVMType.dynamic = Nothing
                                         , SVMType.key = SVMType.String Nothing

--- a/strato/core/blockapps-mpdbs/src/Blockchain/DB/X509CertDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/DB/X509CertDB.hs
@@ -29,6 +29,7 @@ module Blockchain.DB.X509CertDB (
   , genericDeleteX509CertDB
   , x509CertDBPut
   , x509CertDBGet
+  , getParentUserAddress
   ) where
 
 

--- a/strato/tools/x509-certs/exec_src/X509CertRegistry.hs
+++ b/strato/tools/x509-certs/exec_src/X509CertRegistry.hs
@@ -181,7 +181,9 @@ contract Certificate {
     address owner;  // The CertificateRegistery Contract
 
     account certificateHolder;
-
+    account parent;
+    account[] children;
+    
     // Store all the fields of a certificate in a Cirrus record
     string commonName;
     string country;
@@ -189,6 +191,7 @@ contract Certificate {
     string organizationalUnit;
     string publicKey;
     string certificateString;
+    bool isValid;
 
     constructor(string _certificateString) {
         owner = msg.sender;
@@ -202,6 +205,16 @@ contract Certificate {
         country = parsedCert["country"];
         publicKey = parsedCert["publicKey"];
         certificateString = parsedCert["certString"];
+        isValid = true;
+        parent = account(parsedCert["parent"]);
+        if (parent != 0x0){
+            Certificate parentContract = Certificate(parent);
+            parentContract.addChild(this);    
+        }
+    }
+    
+    function addChild(account _child){
+        children.push[_child];
     }
 }
 

--- a/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -22,7 +22,8 @@ module BlockApps.X509.Certificate (
   getCertSubject,
   getCertSubjects,
   getCertIssuer,
-  getCertIssuers
+  getCertIssuers,
+  getParentUserAddress
  ) where
 
 
@@ -293,7 +294,9 @@ getValidity = do
       endDate = DateTime dt{dateYear=(dateYear dt) + 1} tm -- all certs are valid for a year
   return (curDate, endDate)
 
-
+  getParentUserAddress :: X509Certificate -> Maybe Address
+  getParentUserAddress (X509Certificate (CertificateChain (_:c2:_))) = fmap (fromPublicKey . subPub) (getCertSubject (X509Certificate (CertificateChain [x2])))
+  getParentUserAddress _ = Nothing
 
 getCertPub :: Subject -> PubKey
 getCertPub = serializeAndWrap . subPub

--- a/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -294,9 +294,9 @@ getValidity = do
       endDate = DateTime dt{dateYear=(dateYear dt) + 1} tm -- all certs are valid for a year
   return (curDate, endDate)
 
-  getParentUserAddress :: X509Certificate -> Maybe Address
-  getParentUserAddress (X509Certificate (CertificateChain (_:c2:_))) = fmap (fromPublicKey . subPub) (getCertSubject (X509Certificate (CertificateChain [c2])))
-  getParentUserAddress _ = Nothing
+getParentUserAddress :: X509Certificate -> Maybe Address
+getParentUserAddress (X509Certificate (CertificateChain (_:c2:_))) = fmap (fromPublicKey . subPub) (getCertSubject (X509Certificate (CertificateChain [c2])))
+getParentUserAddress _ = Nothing
 
 getCertPub :: Subject -> PubKey
 getCertPub = serializeAndWrap . subPub

--- a/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -295,7 +295,7 @@ getValidity = do
   return (curDate, endDate)
 
   getParentUserAddress :: X509Certificate -> Maybe Address
-  getParentUserAddress (X509Certificate (CertificateChain (_:c2:_))) = fmap (fromPublicKey . subPub) (getCertSubject (X509Certificate (CertificateChain [x2])))
+  getParentUserAddress (X509Certificate (CertificateChain (_:c2:_))) = fmap (fromPublicKey . subPub) (getCertSubject (X509Certificate (CertificateChain [c2])))
   getParentUserAddress _ = Nothing
 
 getCertPub :: Subject -> PubKey


### PR DESCRIPTION
Addressing Jira tickets: [STRATO-2621](https://blockapps.atlassian.net/browse/STRATO-2621), [STRATO-2615](https://blockapps.atlassian.net/browse/STRATO-2615), [STRATO-2614](https://blockapps.atlassian.net/browse/STRATO-2614), & [STRATO-2613](https://blockapps.atlassian.net/browse/STRATO-2613)

- Whenever a Certificate is registered, update the necessary children and parent pointers of all related Certificate contracts 
- Add a "account[] children" field to the Certificate contract
- Add a "account parent" field to the Certificate contract
- Add an "bool isValid" field to the Certificate contract