### PR TITLE
Implement sha256 builtin function in SolidVM

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
@@ -71,7 +71,7 @@ solidityLanguage = javaStyle {
      "function", "returns", "return", "modifier", "revert",
      "delete", "constant", "storage", "memory", "calldata",
      "if", "else", "while", "for", "break", "continue",
-     "call", "callcode", "length", "sha3", "sha256", "ripemd160", "ecrecover",
+     "call", "callcode", "length", "sha3", "ripemd160", "ecrecover",
      "suicide", "this",
      "block", --"coinbase", "difficulty", "gaslimit", "number", "blockhash", "timestamp", "now"
      "msg", --"data", "gas", "sender", "value",

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -776,6 +776,9 @@ byteArgs x = intType' x
 keccak256Args :: SourceAnnotation Text -> Type'
 keccak256Args x = MultiVariate (stringType' x) x
 
+sha256Args :: SourceAnnotation Text -> Type'
+sha256Args x = MultiVariate (stringType' x) x
+
 --This function should have multivariate type that represents any amount of string types
 stringConcatArgs :: SourceAnnotation Text -> Type'
 stringConcatArgs x = MultiVariate (stringType' x) x
@@ -841,6 +844,7 @@ getVarType' "byte" ctx =  pure $ Function (byteArgs ctx) (intType' ctx) ctx
 getVarType' "push" ctx =  pure $ Function (topType' ctx) (Product [] ctx) ctx
 getVarType' "identity" ctx =  pure $ Function (topType' ctx) (topType' ctx) ctx
 getVarType' "keccak256" ctx =  pure $ Function (keccak256Args ctx) (stringType' ctx) ctx
+getVarType' "sha256" ctx =  pure $ Function (sha256Args ctx) (stringType' ctx) ctx
 getVarType' "require" ctx =  pure $ Function (requireArgs ctx) (Product [] ctx) ctx
 getVarType' "assert" ctx =  pure $ Function (assertArgs ctx) (Product [] ctx) ctx
 getVarType' "registerCert" ctx =  pure $ Function (registerCertArgs ctx) (accountType' ctx) ctx

--- a/strato/VM/SolidVM/solid-vm/package.yaml
+++ b/strato/VM/SolidVM/solid-vm/package.yaml
@@ -22,6 +22,7 @@ library:
   - bytestring
   - common-log
   - containers
+  - cryptohash
   - data-default
   - debugger
   - deepseq

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -95,6 +95,7 @@ import qualified Blockchain.Stream.Action             as Action
 
 import           Blockchain.VMContext
 import           Blockchain.VMOptions
+import qualified Crypto.Hash.SHA256                   as SHA256
 import qualified LabeledError
 import qualified Text.Colors                          as C
 import           Text.Format
@@ -2007,6 +2008,16 @@ callBuiltin "keccak256" args Nothing = do
   case allStrings args of
     False -> invalidArguments "cannot use a non string arguments in keccak256" args
     True ->  return . SString . BC.unpack . keccak256ToByteString . hash . BC.pack $ customConcat args
+callBuiltin "sha256" args Nothing = do
+  let allStrings [] = True
+      allStrings ((SString _):xs) = True && (allStrings xs)
+      allStrings _ = False
+      customConcat [] = ""
+      customConcat ((SString str):ys) = str ++ customConcat ys
+      customConcat _ = invalidArguments "cannot use a non string arguments in sha256" args
+  case allStrings args of
+    False -> invalidArguments "cannot use a non string arguments in sha256" args
+    True ->  return . SString . BC.unpack . SHA256.hash . BC.pack $ customConcat args
 callBuiltin pb@("payable") [SAccount a _] _ = do 
   contract' <- getCurrentContract
   if CC._vmVersion contract' == "svm3.2"

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4257,3 +4257,16 @@ contract qq {
     return 2;
   }
 }|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
+
+  it "can use builtin sha256 function" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq {
+  bytes32 hsh;
+  constructor() public {
+    string username = "uname";
+    hsh = sha256(username);
+  }
+}
+|]
+    getFields ["hsh"] `shouldReturn` [BString $ word256ToBytes 0x5C0BE87ED7434D69005F8BBD84CAD8AE6ABFD49121B4AAEEB4C1F4A2E2987711]


### PR DESCRIPTION
This PR implements sha256 for use in a contract like the contract below:

```
pragma solidvm 3.2;
contract qq {
  bytes32 hsh;
  constructor() public {
    string username = "uname";
    hsh = sha256(username);
  }
}
```