### PR TITLE
Implement ripemd160 function

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
@@ -71,7 +71,7 @@ solidityLanguage = javaStyle {
      "function", "returns", "return", "modifier", "revert",
      "delete", "constant", "storage", "memory", "calldata",
      "if", "else", "while", "for", "break", "continue",
-     "call", "callcode", "length", "sha3", "ripemd160", "ecrecover",
+     "call", "callcode", "length", "sha3", "ecrecover",
      "suicide", "this",
      "block", --"coinbase", "difficulty", "gaslimit", "number", "blockhash", "timestamp", "now"
      "msg", --"data", "gas", "sender", "value",

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -779,6 +779,9 @@ keccak256Args x = MultiVariate (stringType' x) x
 sha256Args :: SourceAnnotation Text -> Type'
 sha256Args x = MultiVariate (stringType' x) x
 
+ripemd160Args :: SourceAnnotation Text -> Type'
+ripemd160Args x = MultiVariate (stringType' x) x
+
 --This function should have multivariate type that represents any amount of string types
 stringConcatArgs :: SourceAnnotation Text -> Type'
 stringConcatArgs x = MultiVariate (stringType' x) x
@@ -845,6 +848,7 @@ getVarType' "push" ctx =  pure $ Function (topType' ctx) (Product [] ctx) ctx
 getVarType' "identity" ctx =  pure $ Function (topType' ctx) (topType' ctx) ctx
 getVarType' "keccak256" ctx =  pure $ Function (keccak256Args ctx) (stringType' ctx) ctx
 getVarType' "sha256" ctx =  pure $ Function (sha256Args ctx) (stringType' ctx) ctx
+getVarType' "ripemd160" ctx =  pure $ Function (ripemd160Args ctx) (stringType' ctx) ctx
 getVarType' "require" ctx =  pure $ Function (requireArgs ctx) (Product [] ctx) ctx
 getVarType' "assert" ctx =  pure $ Function (assertArgs ctx) (Product [] ctx) ctx
 getVarType' "registerCert" ctx =  pure $ Function (registerCertArgs ctx) (accountType' ctx) ctx

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -95,6 +95,7 @@ import qualified Blockchain.Stream.Action             as Action
 
 import           Blockchain.VMContext
 import           Blockchain.VMOptions
+import qualified Crypto.Hash.RIPEMD160                as RIPEMD160
 import qualified Crypto.Hash.SHA256                   as SHA256
 import qualified LabeledError
 import qualified Text.Colors                          as C
@@ -2018,6 +2019,16 @@ callBuiltin "sha256" args Nothing = do
   case allStrings args of
     False -> invalidArguments "cannot use a non string arguments in sha256" args
     True ->  return . SString . BC.unpack . SHA256.hash . BC.pack $ customConcat args
+callBuiltin "ripemd160" args Nothing = do
+  let allStrings [] = True
+      allStrings ((SString _):xs) = True && (allStrings xs)
+      allStrings _ = False
+      customConcat [] = ""
+      customConcat ((SString str):ys) = str ++ customConcat ys
+      customConcat _ = invalidArguments "cannot use a non string arguments in ripemd160" args
+  case allStrings args of
+    False -> invalidArguments "cannot use a non string arguments in ripemd160" args
+    True ->  return . SString . BC.unpack . RIPEMD160.hash . BC.pack $ customConcat args
 callBuiltin pb@("payable") [SAccount a _] _ = do 
   contract' <- getCurrentContract
   if CC._vmVersion contract' == "svm3.2"

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -374,7 +374,7 @@ getVariableOfName name = do
 
       maybeBuiltinFunction :: Maybe Variable
       maybeBuiltinFunction = toMaybe (name `elem` ["address", "account", "uint", "int", "bool", "byte", "bytes"
-                                                  , "string", "keccak256", "payable"
+                                                  , "string", "keccak256", "ripemd160", "payable"
                                                   , "require", "revert", "assert", "sha3"
                                                   , "sha256", "ecrecover", "addmod", "mulmod"
                                                   , "selfdestruct", "suicide", "bytes32ToString"

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4270,3 +4270,15 @@ contract qq {
 }
 |]
     getFields ["hsh"] `shouldReturn` [BString $ word256ToBytes 0x5C0BE87ED7434D69005F8BBD84CAD8AE6ABFD49121B4AAEEB4C1F4A2E2987711]
+    
+  it "can use the builtin ripemd160 function" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq {
+  bytes20 hsh;
+  constructor() public {
+    string username = "uname";
+    hsh = ripemd160(username);
+  }
+}|]
+    getFields ["hsh"] `shouldReturn` [BString $ B.pack $ word160ToBytes 0x63f4a6f6005b0ded8c5fc7e62ddf2550e9320410]


### PR DESCRIPTION
This PR implements the builtin ripemd160 function for SolidVM. Used for contracts such as:

```
contract qq {
  bytes20 hsh;
  constructor() public {
    string username = "uname";
    hsh = ripemd160(username);
  }
}
```