### PR TITLE
Implement number unit suffixes in SolidVM

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
@@ -24,6 +24,7 @@ module SolidVM.Solidity.Parse.Lexer (
   colon,
   comma,
   braces,
+  symbol,
   solidityLanguage,
   whiteSpace
   ) where
@@ -44,6 +45,7 @@ natural = P.natural solidityLexer
 integer = P.integer solidityLexer
 braces = P.braces solidityLexer
 parens = P.parens solidityLexer
+symbol = P.symbol solidityLexer
 brackets = P.brackets solidityLexer
 comma = P.comma solidityLexer
 commaSep = P.commaSep solidityLexer

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
@@ -318,7 +318,7 @@ numberUnit :: SolidityParser NumberUnit
 numberUnit = do
   (reserved "wei" >> return Wei)
     <|> (reserved "szabo" >> return Szabo)
-    <|> (reserved "finny" >> return Finney)
+    <|> (reserved "finney" >> return Finney)
     <|> (reserved "ether" >> return Ether)
 
 parseArgs :: SolidityParser [Expression]

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
@@ -297,11 +297,22 @@ primaryExpression = do
     <|> (uncurry Variable <$> withPosition (stringToLabel <$> identifier))
     <|> (do 
             ~(a, (val, nu)) <- withPosition $ do
-              val <- integer
+              val <- scientificInteger
               nu <- optionMaybe numberUnit
               pure (val, nu)
             pure $ NumberLiteral a val nu)
     <|> (uncurry StringLiteral <$> withPosition stringLiteral)
+
+scientific :: SolidityParser Integer
+scientific = do 
+    leftVal <- integer
+    _ <- symbol "e" 
+    rightVal <- integer
+    pure $ leftVal * (10 ^ rightVal)
+
+scientificInteger :: SolidityParser Integer
+scientificInteger = do
+  (try scientific) <|> integer
 
 numberUnit :: SolidityParser NumberUnit
 numberUnit = do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -607,7 +607,11 @@ argsToVals ctract fn args =
         eval t x = do
           case x of
             CC.NumberLiteral _ n Nothing -> return . coerceType ctract t $ SInteger n
-            CC.NumberLiteral _ n (Just nu) -> todo "Number literal with units" (n, nu)
+            CC.NumberLiteral _ n (Just nu) -> case nu of
+              CC.Wei -> return . coerceType ctract t $ SInteger n
+              CC.Szabo -> return . coerceType ctract t $ SInteger (n * (10 ^ (12 :: Integer)))
+              CC.Finney -> return . coerceType ctract t $ SInteger (n * (10 ^ (15 :: Integer))) 
+              CC.Ether -> return . coerceType ctract t $ SInteger (n * (10 ^ (18 :: Integer))) 
             CC.BoolLiteral _ b -> return . coerceType ctract t $ SBool b
             CC.StringLiteral _ s -> return . coerceType ctract t $ SString s
             CC.ArrayExpression _ as -> case t of
@@ -645,7 +649,11 @@ argsToVals ctract fn args =
         eval32 t x = do
           case x of
             CC.NumberLiteral _ n Nothing   -> return . coerceType ctract t $ SInteger n
-            CC.NumberLiteral _ n (Just nu) -> todo "Number literal with units" (n, nu)
+            CC.NumberLiteral _ n (Just nu) -> case nu of
+              CC.Wei -> return . coerceType ctract t $ SInteger n
+              CC.Szabo -> return . coerceType ctract t $ SInteger (n * (10 ^ (12 :: Integer)))
+              CC.Finney -> return . coerceType ctract t $ SInteger (n * (10 ^ (15 :: Integer))) 
+              CC.Ether -> return . coerceType ctract t $ SInteger (n * (10 ^ (18 :: Integer)))
             CC.BoolLiteral _ b             -> return . coerceType ctract t $ SBool b
             CC.StringLiteral _ s           -> return . coerceType ctract t $ SString s
             CC.ArrayExpression _ as        -> case t of
@@ -1249,6 +1257,11 @@ expToVar x = do
 
 expToVar' :: MonadSM m => CC.Expression -> m Variable
 expToVar' (CC.NumberLiteral _ v Nothing) = return . Constant $ SInteger v
+expToVar' (CC.NumberLiteral _ v (Just nu)) = case nu of
+  CC.Wei -> return . Constant $ SInteger v
+  CC.Szabo -> return . Constant $ SInteger (v * (10 ^ (12 :: Integer)))
+  CC.Finney -> return . Constant $ SInteger (v * (10 ^ (15 :: Integer))) 
+  CC.Ether -> return . Constant $ SInteger (v * (10 ^ (18 :: Integer)))
 expToVar' (CC.StringLiteral _ s) = return $ Constant $ SString s
 expToVar' (CC.BoolLiteral _ b) = return $ Constant $ SBool b
 expToVar' (CC.Variable _ "bytes32ToString") = return $ Constant $ SHexDecodeAndTrim

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4308,3 +4308,20 @@ contract qq{
   }
 }|]
     getFields ["mynum"] `shouldReturn` [BInteger 1000000000000]
+
+  it "can use ether number unit suffixes" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq{
+  uint weiUnit;
+  uint szaboUnit;
+  uint finneyUnit;
+  uint etherUnit;
+  constructor() public {
+    weiUnit = 2 wei;
+    szaboUnit = 2 szabo;
+    finneyUnit = 2 finney;
+    etherUnit = 2 ether;
+  }
+}|]
+    getFields ["weiUnit", "szaboUnit", "finneyUnit", "etherUnit"] `shouldReturn` [BInteger 2, BInteger 2000000000000, BInteger 2000000000000000, BInteger 2000000000000000000]

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4282,3 +4282,14 @@ contract qq {
   }
 }|]
     getFields ["hsh"] `shouldReturn` [BString $ B.pack $ word160ToBytes 0x63f4a6f6005b0ded8c5fc7e62ddf2550e9320410]
+
+  it "can use 1e_ notation to get a number" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq{
+  uint mynum;
+  constructor() public {
+    mynum = 1e12;
+  }
+}|]
+    getFields ["mynum"] `shouldReturn` [BInteger 1000000000000]


### PR DESCRIPTION
This PR implements the use of number unit suffixes (wei, szabo, finney, ether).
Example contract:

```
contract qq{
  uint weiUnit;
  uint szaboUnit;
  uint finneyUnit;
  uint etherUnit;
  constructor() public {
    weiUnit = 2 wei;          
    szaboUnit = 2 szabo;       
    finneyUnit = 2 finney;          
    etherUnit = 2 ether;          
  }
}
```

This PR also implements the use of the "e" scientific notation for exponents.
Example contract:

```
contract qq{
  uint mynum;
  constructor() public {
    mynum = 1e12;
  }
}
```