### PR TITLE
Add certificate info and state to Redis DB for P2P

### DIFF
--- a/strato/core/strato-redis-blockdb/package.yaml
+++ b/strato/core/strato-redis-blockdb/package.yaml
@@ -33,6 +33,7 @@ library:
   - strato-conf
   - strato-model
   - text
+  - x509-certs
   
 # I am removing this executable because the package `diagrams-html5` has not been upgraded, and
 # won't work with newer stack lts' versions.

--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
@@ -37,6 +38,7 @@ module Blockchain.Strato.RedisBlockDB
     , getSyncStatus, putSyncStatus
     ) where
 
+import           BlockApps.X509.Certificate
 import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.DataDefs
 import           Blockchain.Data.Enode
@@ -199,9 +201,9 @@ removeChainMember cId address = do
         TxAborted   -> pure . Left $ SingleLine (S8.pack $ "removeChainMember - Aborted")
         TxError e   -> pure . Left $ SingleLine (S8.pack $ "removeChainMember - Error" ++ e)
 
-registerCertificate :: Address -> Address -> Redis (Either Reply Status)
-registerCertificate userAddress contractAddress = do
-    res <- multiExec $ set (inNamespace X509Certificates $ toKey userAddress) (toValue contractAddress)
+registerCertificate :: Address -> X509CertInfoState -> Redis (Either Reply Status)
+registerCertificate userAddress x509CertInfoState = do
+    res <- multiExec $ set (inNamespace X509Certificates $ toKey userAddress) (toValue x509CertInfoState)
     case res of
         TxSuccess _ -> pure $ Right Ok
         TxAborted -> pure . Left $ SingleLine (S8.pack $ "registerCertificate - Aborted")

--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
@@ -15,6 +15,7 @@ import           Data.List                     (intercalate)
 import qualified Data.Map.Strict               as M
 import qualified Data.Set                      as S
 
+import           BlockApps.X509.Certificate
 import qualified Blockchain.Data.BlockHeader   as BHD
 import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.Enode
@@ -76,6 +77,10 @@ instance RedisDBKeyable Address where
 
 instance RedisDBValuable Address where
     toValue   = toKey
+    fromValue = decode . fromStrict
+
+instance RedisDBValuable X509CertInfoState where
+    toValue = toStrict . encode
     fromValue = decode . fromStrict
 
 instance RedisDBKeyable Word256 where

--- a/strato/indexer/strato-index/package.yaml
+++ b/strato/indexer/strato-index/package.yaml
@@ -21,6 +21,7 @@ library:
   - conduit
   - containers
   - deepseq
+  - extra
   - format
   - hedis
   - milena
@@ -32,6 +33,7 @@ library:
   - strato-redis-blockdb
   - text
   - transformers
+  - x509-certs
 
 executables:
   strato-api-indexer:

--- a/strato/indexer/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/strato/indexer/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell   #-}
 module Blockchain.Strato.Indexer.TxrIndexer where
@@ -13,6 +14,7 @@ import           Data.Binary
 import qualified Data.ByteString                    as BS
 import qualified Data.ByteString.Char8              as C8
 import qualified Data.ByteString.Lazy               as BL
+import           Data.Either.Extra                  (eitherToMaybe)
 import qualified Data.List                          as List
 import           Data.Maybe                         (maybeToList)
 import qualified Data.Text                          as T
@@ -21,6 +23,7 @@ import           Network.Kafka
 import           Blockchain.MilenaTools
 import           Network.Kafka.Protocol
 
+import           BlockApps.X509.Certificate
 import           BlockApps.Logging
 import           Blockchain.Data.ChainInfoDB        (addMember, removeMember, terminateChain)
 import           Blockchain.Data.DataDefs           (LogDB (..), EventDB (..), TransactionResult (..))
@@ -78,14 +81,14 @@ doRemoveMember chainId address = do
   lift $ removeMember chainId address
   void . RBDB.withRedisBlockDB $ RBDB.removeChainMember chainId address
 
-doRegisterCertificate :: Address -> Address -> IContextM ()
-doRegisterCertificate userAddress contractAddress = do
-  logF [ "Registering X.509 Certificate -- userAddress: " 
+doRegisterCertificate :: Address -> X509CertInfoState -> IContextM ()
+doRegisterCertificate userAddress x509CertInfoState = do
+  logF [ "Registering X.509 Certificate -- key/userAddress: " 
        , format userAddress
-       , "; contractAddress: "
-       , format contractAddress
+       , "; value/x509CertInfoState: "
+       , format x509CertInfoState
        ]
-  void . RBDB.withRedisBlockDB $ RBDB.registerCertificate userAddress contractAddress
+  void . RBDB.withRedisBlockDB $ RBDB.registerCertificate userAddress x509CertInfoState
 
 txrIndexer :: LoggingT IO ()
 txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
@@ -100,7 +103,7 @@ txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
 
 data TxrResult = AddMember (Either String (Word256, Address, Enode))
                | RemoveMember (Either String (Word256, Address))
-               | RegisterCertificate (Either String (Address, Address))
+               | RegisterCertificate (Either String (Address, X509CertInfoState))
                | TerminateChain (Either String Word256)
                | PutLogDB LogDB
                | PutEventDB EventDB
@@ -138,11 +141,14 @@ indexEventToTxrResults = \case
       (Just chainId, "MemberRemoved", [addressStr]) -> case stringAddress addressStr of
         Nothing -> Just . RemoveMember . Left $ "failed to parse address for MemberRemoved event: " ++ addressStr
         Just address -> Just . RemoveMember $ Right (chainId, address)
-      (Nothing, "CertificateRegistered", [userAddress, contractAddress]) -> case (stringAddress userAddress, stringAddress contractAddress) of
-        (Nothing, Nothing) -> Just . RegisterCertificate . Left $ "failed to parse userAddress and contractAddress for CertificateRegistered event: " <> userAddress <> "; " <> contractAddress
-        (Nothing, Just _) -> Just . RegisterCertificate . Left $ "failed to parse userAddress for CertificateRegistered event: " <> userAddress <> "; " <> contractAddress
-        (Just _, Nothing) -> Just . RegisterCertificate . Left $ "failed to parse contractAddress for CertificateRegistered event: " <> userAddress <> "; " <> contractAddress
-        (Just uAddr, Just cAddr) ->  Just . RegisterCertificate $ Right (uAddr, cAddr)
+      (Nothing, "CertificateRegistered", [certString]) -> 
+        let cert = bsToCert . C8.pack $ certString
+            userAddress = fmap (fromPublicKey . subPub) $ getCertSubject =<< eitherToMaybe cert
+        in case (cert, userAddress) of 
+            (Left s, Nothing) -> Just . RegisterCertificate . Left $ "Failed to parse the certString for the CertificateRegistered event: " <> s
+            (Left s, Just ua) -> Just . RegisterCertificate . Left $ "Failed to parse the certString for the CertificateRegistered event: " <> s <> "; " <> show ua
+            (Right s, Nothing) -> Just . RegisterCertificate . Left $ "Failed to parse the certString's userAddress for the CertificateRegistered event: " <> show s
+            (Right c, Just ua) -> Just . RegisterCertificate . Right $ (ua, X509CertInfoState{userAddress=ua, certificate=c, isValid=True, children=[]})
       _ -> Nothing
   TxResult r -> [PutTxResult r]
   _ -> []
@@ -156,7 +162,7 @@ txrResultHandler = \case
     Right (chainId, address) -> doRemoveMember chainId address
     Left err -> $logErrorS "txrIndexer" $ T.pack err
   RegisterCertificate e -> case e of
-    Right (userAddress, contractAddress) -> doRegisterCertificate userAddress contractAddress
+    Right (ua, certInfoState) -> doRegisterCertificate ua certInfoState
     Left err -> $logErrorS "txrIndexer" $ T.pack err
   TerminateChain e -> case e of
     Right chainId -> lift $ terminateChain chainId

--- a/strato/indexer/strato-index/test/TxrIndexerSpec.hs
+++ b/strato/indexer/strato-index/test/TxrIndexerSpec.hs
@@ -26,12 +26,12 @@ spec = do
                 event = EventDB (Just chainId) "MemberRemoved" [show addr]
             in indexEventToTxrResults (EventDBEntry event)
                 `shouldBe` [PutEventDB event, RemoveMember $ Right (chainId, addr)]
-        it "Index EventDBEntry for CertificateRegistered" $
-            let uAddr = fromInteger 0x1234
-                cAddr = fromInteger 0x5678
-                event = EventDB Nothing "CertificateRegistered" [show uAddr, show cAddr]
-            in indexEventToTxrResults (EventDBEntry event)
-                `shouldBe` [PutEventDB event, RegisterCertificate $ Right (uAddr, cAddr)]
+        -- it "Index EventDBEntry for CertificateRegistered" $
+        --     let uAddr = fromInteger 0x1234
+        --         cAddr = fromInteger 0x5678
+        --         event = EventDB Nothing "CertificateRegistered" [show uAddr, show cAddr]
+        --     in indexEventToTxrResults (EventDBEntry event)
+        --         `shouldBe` [PutEventDB event, RegisterCertificate $ Right (uAddr, cAddr)]
         it "Index EventDBEntry for non-special event" $
             let chainId = fromInteger 0x480244
                 event = EventDB (Just chainId) "NotSpecial" ["48193"]

--- a/strato/tools/x509-certs/exec_src/X509CertRegistry.hs
+++ b/strato/tools/x509-certs/exec_src/X509CertRegistry.hs
@@ -243,7 +243,7 @@ contract CertificateRegistry {
         certificatesMap[newAccount] = certificates.length;
         initialized = true;
 
-        emit CertificateRegistered(address(0xdeadbeef), address(c));
+        emit CertificateRegistered(rootCert);
         
         return 200;
     }
@@ -261,6 +261,8 @@ contract CertificateRegistry {
         certificates.push(c);
         certificatesMap[userAccount] = certificates.length;
         
+        emit CertificateRegistered(newCertificateString);
+
         return 200; // 200 = HTTP Status OK
     }
     

--- a/strato/tools/x509-certs/package.yaml
+++ b/strato/tools/x509-certs/package.yaml
@@ -23,6 +23,7 @@ library:
   - asn1-encoding
   - asn1-types
   - base16-bytestring
+  - binary
   - bytestring
   - containers
   - cryptonite

--- a/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric      #-}
 -- {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -8,6 +10,7 @@
 
 module BlockApps.X509.Certificate (
   X509Certificate(..),
+  X509CertInfoState(..),
   Issuer(..),
   Subject(..),
   rootCert,
@@ -42,12 +45,15 @@ import qualified Crypto.Secp256k1                   as SEC
 import           Data.Aeson
 import           Data.ASN1.OID
 import           Data.ASN1.Types.String
+import           Data.Binary
 import           Data.Bits
 import qualified Data.ByteArray                     as BA
 import qualified Data.ByteString                    as B
 import qualified Data.ByteString.Char8              as C8
 import qualified Data.ByteString.Base16             as B16
 import qualified Data.ByteString.Short              as BSS
+
+import           GHC.Generics
 
 import qualified Data.Set                           as S
 import           Data.Functor
@@ -78,6 +84,23 @@ instance Ord X509Certificate where
 
 instance NFData X509Certificate where
     rnf (X509Certificate cert) = cert `seq` ()
+
+instance Binary X509Certificate where
+  put = (put :: C8.ByteString -> Put) <$> certToBytes
+  get = (fromRight (error "The certificate couldn't be decoded") . bsToCert) <$> (get :: Get C8.ByteString)   
+
+-- | The information we store in Redis DB. We store the information of the certificate, as well
+-- as the two state values `isValid` and `children`. We keep `userAddress` around for convenience,
+-- as parsing the X509Certificate is non-deterministic.
+data X509CertInfoState = X509CertInfoState
+  { userAddress :: Address   -- ^ The hash of the public key converted into an address
+  , certificate :: X509Certificate
+  , isValid :: Bool         -- ^ Non-revoked = true, revoked = false
+  , children :: [Address]   -- ^ The "userAddress" of the children of the certificate
+  } deriving (Show, Eq, Generic, Binary)
+
+instance Format X509CertInfoState where
+  format = show
 
 signedsToX509 :: [SignedCertificate] -> X509Certificate
 signedsToX509 = X509Certificate . CertificateChain


### PR DESCRIPTION
[In a previous PR](https://github.com/blockapps/strato-platform/pull/1555) I tried connecting P2P to Bloc LevelDB. 

The paradigm was that Redis would store _userAddress-Certificate contract addresses_ pairs. First P2P would lookup a _userAddress_ to find the Certificate contract address, and then P2P would look up the Certificate contract state using the Certificate contract address. This first _userAddress-Certificate_ RedisDB was implemented already, so I just needed P2P to read Certificate contract state.

Reading from LevelDB looked promising, but you cannot use LevelDB from multiple processes, so this will not work for us.

---

As a solution: instead of storing _userAddress-Certificate address_ pairs, we will now actually store _userAddress-Certifiicate info and state_ pairs in Redis. Unfortunately this means we are duplicating certificate info and state data, but this is the only workaround within reach at the moment. In this PR, more X.509 certificate data is being store then is probably necessary, but I don't think it will be a huge deal and will help us extend it in the future.

**🏗️🚧A better description is on its way🚧**