### PR TITLE
Implement selfdestruct builtin function in SolidVM

### DIFF
--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -782,6 +782,9 @@ sha256Args x = MultiVariate (stringType' x) x
 ripemd160Args :: SourceAnnotation Text -> Type'
 ripemd160Args x = MultiVariate (stringType' x) x
 
+selfdestructArgs :: SourceAnnotation Text -> Type' 
+selfdestructArgs x = addressType' x
+
 --This function should have multivariate type that represents any amount of string types
 stringConcatArgs :: SourceAnnotation Text -> Type'
 stringConcatArgs x = MultiVariate (stringType' x) x
@@ -852,6 +855,7 @@ getVarType' "identity" ctx =  pure $ Function (topType' ctx) (topType' ctx) ctx
 getVarType' "keccak256" ctx =  pure $ Function (keccak256Args ctx) (stringType' ctx) ctx
 getVarType' "sha256" ctx =  pure $ Function (sha256Args ctx) (stringType' ctx) ctx
 getVarType' "ripemd160" ctx =  pure $ Function (ripemd160Args ctx) (stringType' ctx) ctx
+getVarType' "selfdestruct" ctx = pure $ Function (selfdestructArgs ctx) (addressType' ctx) ctx 
 getVarType' "require" ctx =  pure $ Function (requireArgs ctx) (Product [] ctx) ctx
 getVarType' "assert" ctx =  pure $ Function (assertArgs ctx) (Product [] ctx) ctx
 getVarType' "registerCert" ctx =  pure $ Function (registerCertArgs ctx) (accountType' ctx) ctx

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -782,9 +782,6 @@ sha256Args x = MultiVariate (stringType' x) x
 ripemd160Args :: SourceAnnotation Text -> Type'
 ripemd160Args x = MultiVariate (stringType' x) x
 
-selfdestructArgs :: SourceAnnotation Text -> Type' 
-selfdestructArgs x = addressType' x
-
 --This function should have multivariate type that represents any amount of string types
 stringConcatArgs :: SourceAnnotation Text -> Type'
 stringConcatArgs x = MultiVariate (stringType' x) x
@@ -808,6 +805,9 @@ verifyCertArgs x = Product [stringType' x, stringType' x] x
 
 verifySignatureArgs :: SourceAnnotation Text -> Type'
 verifySignatureArgs x = Product [stringType' x, stringType' x, stringType' x] x
+
+selfdestructArgs :: SourceAnnotation Text -> Type'
+selfdestructArgs x = accountType' x
 
 getUserCertArgs :: SourceAnnotation Text -> Type'
 getUserCertArgs x = accountType' x
@@ -855,7 +855,7 @@ getVarType' "identity" ctx =  pure $ Function (topType' ctx) (topType' ctx) ctx
 getVarType' "keccak256" ctx =  pure $ Function (keccak256Args ctx) (stringType' ctx) ctx
 getVarType' "sha256" ctx =  pure $ Function (sha256Args ctx) (stringType' ctx) ctx
 getVarType' "ripemd160" ctx =  pure $ Function (ripemd160Args ctx) (stringType' ctx) ctx
-getVarType' "selfdestruct" ctx = pure $ Function (selfdestructArgs ctx) (addressType' ctx) ctx 
+getVarType' "selfdestruct" ctx = pure $ Function (selfdestructArgs ctx) (boolType' ctx) ctx 
 getVarType' "require" ctx =  pure $ Function (requireArgs ctx) (Product [] ctx) ctx
 getVarType' "assert" ctx =  pure $ Function (assertArgs ctx) (Product [] ctx) ctx
 getVarType' "registerCert" ctx =  pure $ Function (registerCertArgs ctx) (accountType' ctx) ctx

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1996,7 +1996,16 @@ callBuiltin "blockhash" [SInteger blockNum] _ = do
   maybeTheHash  <- getBlockHashWithNumber blockNum (blockDataParentHash curBlock)
   --theHash :: Maybe Keccak256
   maybe (invalidArguments "the block number given does not exist" [blockNum]) (return . SString . BC.unpack . keccak256ToByteString) maybeTheHash
-            
+
+callBuiltin "selfdestruct" [SAccount a _] _ = do
+  contract' <- getCurrentAccount
+  contractBalance <- addressStateBalance <$> A.lookupWithDefault (A.Proxy @AddressState) contract' 
+  _destroyRes <- A.adjustWithDefault_ (A.Proxy @AddressState) contract' $ \newAddressState ->
+    pure newAddressState{ addressStateCodeHash = SolidVMCode "Code_0" $ unsafeCreateKeccak256FromWord256 0}
+  sendRes <- pay "selfdestruct function" contract' (namedAccountToAccount Nothing a) contractBalance
+  case sendRes of
+    True -> return $ SBool True
+    _ -> return $ SBool False
 
 callBuiltin "account" vs _ = typeError "account cast" vs
 callBuiltin "bool" [SBool b] _ = return $ SBool b

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2023,6 +2023,7 @@ callBuiltin "selfdestruct" [SAccount a _] _ = do
   _destroyRes <- A.adjustWithDefault_ (A.Proxy @AddressState) contract' $ \newAddressState ->
     pure newAddressState{ addressStateCodeHash = SolidVMCode "Code_0" $ unsafeCreateKeccak256FromWord256 0}
   sendRes <- pay "selfdestruct function" contract' (namedAccountToAccount Nothing a) contractBalance
+  _purgeRes <- purgeStorageMap contract'
   case sendRes of
     True -> return $ SBool True
     _ -> return $ SBool False

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2024,9 +2024,7 @@ callBuiltin "selfdestruct" [SAccount a _] _ = do
     pure newAddressState{ addressStateCodeHash = SolidVMCode "Code_0" $ unsafeCreateKeccak256FromWord256 0}
   sendRes <- pay "selfdestruct function" contract' (namedAccountToAccount Nothing a) contractBalance
   _purgeRes <- purgeStorageMap contract'
-  case sendRes of
-    True -> return $ SBool True
-    _ -> return $ SBool False
+  return $ SBool sendRes
 
 callBuiltin "account" vs _ = typeError "account cast" vs
 callBuiltin "bool" [SBool b] _ = return $ SBool b

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4346,7 +4346,7 @@ contract qq {
   string oldCodeHash;
   string newCodeHash;
   bool success;
-  
+
   constructor() public {
     contract' = account(this);
     contractPay = payable(contract');
@@ -4371,12 +4371,12 @@ contract qq {
     -- Check return of balance
     void $ call2 "selfDestructThis" "()" (namedAccountToAccount Nothing contract') 
     getFields ["success", "contractBalance", "ownerBalance", "oldCodeHash", "newCodeHash"] `shouldReturn` 
-    [ BBool True
-    , BDefault
-    , BInteger 24
-    , BString $ BC.pack $ keccak256ToHex $ hash $ UTF8.fromString contract
-    , BString "0000000000000000000000000000000000000000000000000000000000000000" 
-    ]
+      [ BBool True
+      , BDefault
+      , BInteger 24
+      , BString $ BC.pack $ keccak256ToHex $ hash $ UTF8.fromString contract
+      , BString "0000000000000000000000000000000000000000000000000000000000000000" 
+      ]
   
   it "throw an error when the 'account' reserved word is for a variable name." $ runTest (do
       runBS [r|

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4297,3 +4297,34 @@ contract qq {
   }
 }|]
     getFields ["hsh"] `shouldReturn` [BString $ B.pack $ word160ToBytes 0x63f4a6f6005b0ded8c5fc7e62ddf2550e9320410]
+
+ it "can use the selfdestruct function" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq {
+  account contract';
+  account owner;
+  account payable ownerPay;
+  uint contractBalance;
+  uint ownerBalance;
+  bool success;
+  constructor() public {
+    owner = account(this);
+    ownerPay = payable(owner);
+  }
+
+  function selfDestructThis() public returns (bool, uint, uint) {
+    success = selfdestruct(ownerPay);
+    contractBalance = this.balance;
+    ownerBalance = ownerPay.balance;
+    return (success, contractBalance, ownerBalance);
+  } 
+}|]
+    -- Get the contract's accounts
+    [ BAccount contract', BAccount owner] <- getFields ["contract'", "owner"]
+    -- Adjust the preset balances
+    adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing contract') (\as -> pure $ as { addressStateBalance = 14 })
+    adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing owner) (\bs -> pure $ bs { addressStateBalance = 10 })
+    -- Check return of balance
+    void $ call2 "selfDestructThis" "()" (namedAccountToAccount Nothing contract') 
+    getFields ["success", "contractBalance", "ownerBalance"] `shouldReturn` [ BBool True, BInteger 0, BInteger 24 ]

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4298,28 +4298,35 @@ contract qq {
 }|]
     getFields ["hsh"] `shouldReturn` [BString $ B.pack $ word160ToBytes 0x63f4a6f6005b0ded8c5fc7e62ddf2550e9320410]
 
- it "can use the selfdestruct function" . runTest $ do
-    runBS [r|
+  it "can use the selfdestruct function" . runTest $ do
+    let contract = [r|
 pragma solidvm 3.2;
 contract qq {
   account contract';
+  account payable contractPay;
   account owner;
   account payable ownerPay;
   uint contractBalance;
   uint ownerBalance;
+  string oldCodeHash;
+  string newCodeHash;
   bool success;
   constructor() public {
-    owner = account(this);
+    contract' = account(this);
+    contractPay = payable(contract');
+    owner = account(0xdeadbeef);
     ownerPay = payable(owner);
+    oldCodeHash = account(this).codehash;
   }
 
-  function selfDestructThis() public returns (bool, uint, uint) {
+  function selfDestructThis() internal {
     success = selfdestruct(ownerPay);
-    contractBalance = this.balance;
+    contractBalance = contractPay.balance;
     ownerBalance = ownerPay.balance;
-    return (success, contractBalance, ownerBalance);
+    newCodeHash = account(this).codehash;
   } 
 }|]
+    runBS contract
     -- Get the contract's accounts
     [ BAccount contract', BAccount owner] <- getFields ["contract'", "owner"]
     -- Adjust the preset balances
@@ -4327,4 +4334,4 @@ contract qq {
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing owner) (\bs -> pure $ bs { addressStateBalance = 10 })
     -- Check return of balance
     void $ call2 "selfDestructThis" "()" (namedAccountToAccount Nothing contract') 
-    getFields ["success", "contractBalance", "ownerBalance"] `shouldReturn` [ BBool True, BInteger 0, BInteger 24 ]
+    getFields ["success", "contractBalance", "ownerBalance", "oldCodeHash", "newCodeHash"] `shouldReturn` [ BBool True, BDefault, BInteger 24, BString $ BC.pack $ keccak256ToHex $ hash $ UTF8.fromString contract, BString "0000000000000000000000000000000000000000000000000000000000000000" ]

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4341,25 +4341,16 @@ contract qq {
   account payable contractPay;
   account owner;
   account payable ownerPay;
-  uint contractBalance;
-  uint ownerBalance;
-  string oldCodeHash;
-  string newCodeHash;
-  bool success;
 
   constructor() public {
     contract' = account(this);
     contractPay = payable(contract');
     owner = account(0xdeadbeef);
     ownerPay = payable(owner);
-    oldCodeHash = account(this).codehash;
   }
 
   function selfDestructThis() internal {
-    success = selfdestruct(ownerPay);
-    contractBalance = contractPay.balance;
-    ownerBalance = ownerPay.balance;
-    newCodeHash = account(this).codehash;
+    selfdestruct(ownerPay);
   } 
 }|]
     runBS contract
@@ -4370,12 +4361,11 @@ contract qq {
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing owner) (\bs -> pure $ bs { addressStateBalance = 10 })
     -- Check return of balance
     void $ call2 "selfDestructThis" "()" (namedAccountToAccount Nothing contract') 
-    getFields ["success", "contractBalance", "ownerBalance", "oldCodeHash", "newCodeHash"] `shouldReturn` 
-      [ BBool True
+    getFields ["contract'", "contractPay", "owner", "ownerPay"] `shouldReturn` 
+      [ BDefault
       , BDefault
-      , BInteger 24
-      , BString $ BC.pack $ keccak256ToHex $ hash $ UTF8.fromString contract
-      , BString "0000000000000000000000000000000000000000000000000000000000000000" 
+      , BDefault
+      , BDefault
       ]
   
   it "throw an error when the 'account' reserved word is for a variable name." $ runTest (do


### PR DESCRIPTION
This PR implements the solidity builtin function "selfdestruct" that sends the remaining ether in the contract to a target before deleting its storage and code. Afterwards, the self-destructed contract can still receive ether but cannot withdraw ether from it thus becoming sort of an ether sink.

Docs: [https://docs.soliditylang.org/en/v0.8.12/introduction-to-smart-contracts.html?highlight=selfdestruct#deactivate-and-self-destruct](https://docs.soliditylang.org/en/v0.8.12/introduction-to-smart-contracts.html?highlight=selfdestruct#deactivate-and-self-destruct)

The test for selfdestruct pass using this sample contract:

```
pragma solidvm 3.2;
contract qq {
  account contract';
  account payable contractPay;
  account owner;
  account payable ownerPay;

  constructor() public {
    contract' = account(this);
    contractPay = payable(contract');
    owner = account(0xdeadbeef);
    ownerPay = payable(owner);
  }

  function selfDestructThis() internal {
    selfdestruct(ownerPay);
  } 
} 
```