### PR TITLE
Try/Catch Statements, the Solidity Way and The SolidVM way (Trademark pending)

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Statement.hs
@@ -31,6 +31,8 @@ import GHC.Generics
 import SolidVM.Model.SolidString
 import SolidVM.Model.Type
 
+
+
 data StatementF a =
   IfStatement (ExpressionF a) [StatementF a] (Maybe [StatementF a]) a -- if then else
   | WhileStatement (ExpressionF a) [StatementF a] a
@@ -46,6 +48,8 @@ data StatementF a =
   | SimpleStatement (SimpleStatementF a) a
   | RevertStatement (Maybe String) (ArgListF a) a
   | UncheckedStatement [StatementF a] a
+  | SolidityTryCatchStatement (ExpressionF a) (Maybe [(String, Type)]) [StatementF a] (Map.Map String (Maybe (String, Type), [StatementF a])) a
+  | TryCatchStatement [StatementF a] (Map.Map String [StatementF a]) a
   deriving (Show, Eq, Generic, Functor, ToJSON, FromJSON)
 
 extractStatement :: StatementF a -> a
@@ -63,6 +67,8 @@ extractStatement (AssemblyStatement _ a) = a
 extractStatement (SimpleStatement _ a) = a
 extractStatement (RevertStatement _ _ a) = a
 extractStatement (UncheckedStatement _ a) = a
+extractStatement (TryCatchStatement _ _ a) = a
+extractStatement (SolidityTryCatchStatement _ _ _ _ a) = a
 
 type Statement = Positioned StatementF
 

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
@@ -14,6 +14,7 @@ import           Text.Parsec.Expr
 import           SolidVM.Model.CodeCollection.Statement
 import           SolidVM.Model.SolidString
 import           SolidVM.Model.Type
+import qualified SolidVM.Model.Type as SVMType
 import           SolidVM.Solidity.Parse.Lexer
 import           SolidVM.Solidity.Parse.ParserTypes
 import           SolidVM.Solidity.Parse.Types
@@ -25,6 +26,9 @@ statement :: SolidityParser Statement
 statement = do
   ifStatement
   <|> whileStatement
+  <|> (do
+    reserved "try"
+    (solidityTryCatchStatement <|> tryCatchStatement)) -- hack to get it to differentiate between the two before parsing to avoid ambiguity
   <|> doWhileStatement
   <|> forStatement
   <|> (do
@@ -59,6 +63,58 @@ Statement = IfStatement | WhileStatement | ForStatement | Block | InlineAssembly
               Throw | EmitStatement | RevertStatement | SimpleStatement ) ';'
 -}
 
+
+solidityTryCatchStatement :: SolidityParser Statement
+solidityTryCatchStatement = do
+  ~(a, (tryExpression, returnsDecl, statementsForSuccess, catchArr)) <- withPosition $ do
+--    reserved "try"
+    e <- expression
+    mReturns <- optionMaybe $ do
+      reserved "returns"
+      tp <- tupleDeclaration'
+      pure tp
+    sms <- statements
+    catchs <- many1 $ do
+      reserved "catch"
+      mIdent <- optionMaybe identifier
+      mtps <- optionMaybe tupleDeclaration'
+      ss <- statements
+      (i,tps) <- case (mIdent, mtps) of 
+        (Just "Error" , Just [(a,b)] ) -> if (case b of (SVMType.String _) -> True; _ -> False;) then pure ("Error", Just (a,b) ) else fail "'Error' catch statement parameter type must be string"
+        (Just "Error" , Just xs ) -> if Prelude.length xs < 2 then pure ("Error", Nothing) else fail "'Error' catch statement must only have one or zero parameters"
+        (Just "Error" , Nothing ) -> pure ("Error", Nothing)
+        (Just "Panic" , Just [(a,b)] ) -> if (case b of (SVMType.Int _ _) -> True; _ -> False;) then pure ("Panic", Just (a,b)) else fail "'Panic' catch statement parameter type must be uint"
+        (Just "Panic" , Just xs ) -> if Prelude.length xs < 2 then pure ("Panic", Nothing) else fail "'Panic' catch statement must only have one or zero parameters"
+        (Just "Panic" , Nothing ) -> pure ("Panic", Nothing)
+        (Nothing , Just [(a,b)] ) -> if (case b of (SVMType.Bytes _ _) -> True; _ -> False;) then pure ("Nill", Just (a,b)) else fail "the empty catch statement parameter type must be bytes"
+        (Nothing , Just xs ) -> if Prelude.length xs < 2 then pure ("Nill", Nothing) else fail "the empty catch statement must only have one or zero parameters"
+        (Nothing , Nothing ) -> pure ("Nill", Nothing)
+        _ -> fail "catch statement must have a valid identifier such as 'Error' or 'Panic'"
+      pure (i, (tps, ss))
+    pure (e, mReturns, sms, catchs)
+  pure $ SolidityTryCatchStatement tryExpression returnsDecl statementsForSuccess (Map.fromList catchArr) a
+
+tupleDeclaration' :: SolidityParser [(String, SVMType.Type)]
+tupleDeclaration' = parens $ commaSep $ do
+  partType <- simpleTypeExpression
+  optional $ reserved "indexed" <|>
+             reserved "storage" <|>
+             reserved "memory"
+  partName <- option "" identifier
+  return (partName, partType)
+
+tryCatchStatement :: SolidityParser Statement
+tryCatchStatement = do
+    ~(a, (test1, test2)) <- withPosition $ do
+--      reserved "try"
+      s <- statements
+      catchs <- many1 $ do
+        reserved "catch"
+        ident <- identifier
+        ss <- statements
+        pure (ident, ss)
+      pure (s, catchs)
+    pure $ TryCatchStatement test1 (Map.fromList test2) a
 
 ifStatement :: SolidityParser Statement
 ifStatement = do

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -205,6 +205,10 @@ unparseStatementWith f (RevertStatement customErr (NamedArgs argList) a) =
 unparseStatementWith f (UncheckedStatement code a) = f a $
   "unchecked {\n" ++ tab (unlines $ map (unparseStatementWith f) code) ++ "\n}"
 
+unparseStatementWith f (TryCatchStatement tryBlock catchBlockMap a) = f a $
+  "try {\n" ++ tab (unlines $ map (unparseStatementWith f) tryBlock) ++ "\n}" ++ " catch " ++ (List.intercalate " " (map (\(name, block) -> "catch " ++ name ++ " {\n" ++ tab (unlines $ map (unparseStatementWith f) block) ++ "\n}") (Map.toList catchBlockMap)))
+unparseStatementWith f (SolidityTryCatchStatement expr mtpl tryBlock catchBlockMap a) = f a $
+  "try " ++ unparseExpression expr ++ " " ++  (show (fromMaybe [] mtpl)) ++ " {\n" ++ tab (unlines $ map (unparseStatementWith f) tryBlock) ++ "\n}" ++ " catch " ++ show (Map.toList catchBlockMap)
 -- unparseStatementWith _ x = internalError "missing case in call to unparseStatementWith" $ show x
 
 unparseVarDefEntry :: VarDefEntryF a -> String

--- a/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
@@ -101,9 +101,6 @@ spec = do
                  , ("var x = [];", SimpleStatement $
                       VariableDefinition [VarDefEntry Nothing Nothing "x" ()] $ Just $
                       ArrayExpression () [])
-                 , ("type(C).runTimeCode;", SimpleStatement $
-                      VariableDefinition [VarDefEntry Nothing Nothing "C" ()] $ Just $
-                      MemberAccess () (Variable () "type") "runTimeCode")
                   , ("revert f(x, y);", RevertStatement (Just "f") (OrderedArgs [(Variable () "x"), (Variable () "y")]) )
                   , ("revert(\"e\");", RevertStatement (Nothing) (OrderedArgs [StringLiteral () "e"]) )
                   , ("revert f({ x: y , q: z });",  RevertStatement (Just "f") (NamedArgs [("x", Variable () "y"), ("q", Variable () "z")]) )

--- a/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
@@ -100,6 +100,9 @@ spec = do
                  , ("var x = [];", SimpleStatement $
                       VariableDefinition [VarDefEntry Nothing Nothing "x" ()] $ Just $
                       ArrayExpression () [])
+                 , ("type(C).runTimeCode;", SimpleStatement $
+                      VariableDefinition [VarDefEntry Nothing Nothing "C" ()] $ Just $
+                      MemberAccess () (Variable () "type") "runTimeCode")
                   , ("revert f(x, y);", RevertStatement (Just "f") (OrderedArgs [(Variable () "x"), (Variable () "y")]) )
                   , ("revert(\"e\");", RevertStatement (Nothing) (OrderedArgs [StringLiteral () "e"]) )
                   , ("revert f({ x: y , q: z });",  RevertStatement (Just "f") (NamedArgs [("x", Variable () "y"), ("q", Variable () "z")]) )

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/BooleanLiterals.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/BooleanLiterals.hs
@@ -29,6 +29,15 @@ statementHelper (IfStatement cond thens mElse _) =
       ts = concat $ statementHelper <$> thens
       es = concat $ maybe [] (map statementHelper) mElse
    in concat [cs, ts, es]
+statementHelper (TryCatchStatement statements catches _) =
+  let ts = concat $ statementHelper <$> statements
+      cs = concat $ statementHelper <$> (concatMap snd (M.toList catches))
+   in concat [ts, cs]
+statementHelper (SolidityTryCatchStatement expr _ successStatements catchesMap _) =
+  let es = expressionHelper expr
+      ts = concat $ statementHelper <$> successStatements
+      cs = concat $ statementHelper <$> (concatMap (snd . snd) (M.toList catchesMap))
+   in concat [es, ts, cs]
 statementHelper (WhileStatement cond body _) =
   let cs = expressionHelper cond
       bs = concat $ statementHelper <$> body

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/DivideBeforeMultiply.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/DivideBeforeMultiply.hs
@@ -29,6 +29,15 @@ statementHelper (IfStatement cond thens mElse _) =
       ts = concat $ statementHelper <$> thens
       es = concat $ maybe [] (map statementHelper) mElse
    in concat [cs, ts, es]
+statementHelper (TryCatchStatement statements catches _) =
+  let ts = concat $ statementHelper <$> statements
+      cs = concat $ statementHelper <$> (concatMap snd (M.toList catches))
+   in concat [ts, cs]
+statementHelper (SolidityTryCatchStatement expr _ successStatements catchesMap _) =
+  let es = expressionHelper expr
+      ts = concat $ statementHelper <$> successStatements
+      cs = concat $ statementHelper <$> (concatMap (snd . snd) (M.toList catchesMap))
+   in concat [es, ts, cs]
 statementHelper (WhileStatement cond body _) =
   let cs = expressionHelper cond
       bs = concat $ statementHelper <$> body

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Functions/ConstantFunctions.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Functions/ConstantFunctions.hs
@@ -91,6 +91,15 @@ statementHelper (IfStatement cond thens mElse _) = do
   ts <- statementsHelper' thens
   es <- maybe (pure []) statementsHelper' mElse
   pure $ concat [cs, ts, es]
+statementHelper (TryCatchStatement try catchMap _) = do
+  ts <- statementsHelper' try
+  cs <- statementsHelper' (concatMap snd (M.toList catchMap))
+  pure $ concat [ts, cs]
+statementHelper (SolidityTryCatchStatement expr _ successStatements catchMap _) = do
+  cs <- expressionHelper expr
+  ts <- statementsHelper' successStatements
+  es <- statementsHelper' (concatMap (snd . snd) (M.toList catchMap))
+  pure $ concat [cs, ts, es]
 statementHelper (WhileStatement cond body _) = do
   cs <- expressionHelper cond
   bs <- statementsHelper' body

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Functions/Unimplemented/Continue.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Functions/Unimplemented/Continue.hs
@@ -25,6 +25,8 @@ functionHelper Func{..} = case funcContents of
 
 statementHelper :: Statement -> [SourceAnnotation Text]
 statementHelper (IfStatement _ thens mElse _) = concat $ (statementHelper <$> thens) ++ (maybe [] (map statementHelper) mElse)
+statementHelper (TryCatchStatement tryBlock catches _) = concat $ (statementHelper <$> tryBlock) ++ (statementHelper <$> (concatMap snd (M.toList catches)))
+statementHelper (SolidityTryCatchStatement _ _ successStatements catchMap _) = concat $ (statementHelper <$> successStatements) ++ (statementHelper <$> (concatMap (snd . snd) (M.toList catchMap)))
 statementHelper (WhileStatement _ body _) = concat $ statementHelper <$> body
 statementHelper (ForStatement _ _ _ body _) = concat $ statementHelper <$> body
 statementHelper (Block _) = []

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/StateVariableShadowing.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/StateVariableShadowing.hs
@@ -31,6 +31,14 @@ statementHelper vars (IfStatement _ thens mElse _) =
   let ts = concat $ statementHelper vars <$> thens
       es = concat $ maybe [] (map $ statementHelper vars) mElse
    in concat [ts, es]
+statementHelper vars (TryCatchStatement statements catches _) =
+  let ts = concat $ statementHelper vars <$> statements
+      cs = concat $ statementHelper vars <$> (concatMap snd (M.toList catches))
+   in concat [ts, cs]
+statementHelper vars (SolidityTryCatchStatement _ _ successStatements catchesMap _) =
+  let ts = concat $ statementHelper vars <$> successStatements
+      cs = concat $ statementHelper vars <$> (concatMap (snd . snd) (M.toList catchesMap))
+   in concat [ts, cs]
 statementHelper vars (WhileStatement _ body _) =
   concat $ statementHelper vars <$> body
 statementHelper vars (ForStatement mInit _ _ body _) =

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/UninitializedLocalVariables.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/UninitializedLocalVariables.hs
@@ -28,6 +28,15 @@ statementHelper (IfStatement _ thens mElse _) =
   let ts = concat $ statementHelper <$> thens
       es = concat $ maybe [] (map statementHelper) mElse
    in concat [ts, es]
+statementHelper (TryCatchStatement statements catches _) =
+  let ts = concat $ statementHelper <$> statements
+      cs = concat $ statementHelper <$> concatMap snd (M.toList catches)
+   in concat [ts, cs]
+statementHelper (SolidityTryCatchStatement _ _ successStatements catchesMap _) =
+  let ts = concat $ statementHelper <$> successStatements
+      cs = concat $ statementHelper <$> (concatMap (snd . snd) (M.toList catchesMap))
+   in concat [ts, cs]
+
 statementHelper (WhileStatement _ body _) =
   concat $ statementHelper <$> body
 statementHelper (ForStatement mInit _ _ body a) =

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/WriteAfterWrite.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/WriteAfterWrite.hs
@@ -67,6 +67,29 @@ statementHelper (DoWhileStatement body cond _) = do
   bs <- statementsHelper' body
   put M.empty
   pure $ concat [bs, cs]
+statementHelper (TryCatchStatement body catches _) = do
+  s <- get
+  bs <- statementsHelper' body
+  sTry <- get
+  put $ M.intersection s sTry
+  css <- forM (M.toList catches) $ \(_, cas) -> do
+    sCatch <- get
+    put $ M.intersection s sCatch
+    statementsHelper' cas
+  pure $ concat [bs, (concat css)]
+statementHelper (SolidityTryCatchStatement expr _ successStatements catchMap _) = do
+  s <- get
+  e <- expressionHelper expr
+  sTry <- get
+  put $ M.intersection s sTry
+  ss <- statementsHelper' successStatements
+  sCatch <- get
+  put $ M.intersection s sCatch
+  css <- forM (M.toList catchMap) $ \(_, (_, cas)) -> do
+    sCatch' <- get
+    put $ M.intersection s sCatch'
+    statementsHelper' cas
+  pure $ concat [e, ss, (concat css)]
 statementHelper (Continue _) = pure []
 statementHelper (Break _) = pure []
 statementHelper (Return mExpr _) =
@@ -82,6 +105,7 @@ statementHelper (UncheckedStatement body _) =
   statementsHelper' body
 statementHelper (AssemblyStatement _ _) = pure []
 statementHelper (SimpleStatement stmt _) = simpleStatementHelper stmt
+
 
 simpleStatementHelper :: SimpleStatement -> SSS [SourceAnnotation Text]
 simpleStatementHelper (VariableDefinition vs mExpr) = case mExpr of

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -952,8 +952,19 @@ statementHelper (TryCatchStatement tryStatmenets catchMap x) = do
   ts <- statementsHelper' x tryStatmenets
   es <- statementsHelper' x (concatMap snd (M.toList catchMap))
   pure $ reduceType' x [ts, es]
-statementHelper (SolidityTryCatchStatement expr _ successStatements catchMap x) = do
+statementHelper (SolidityTryCatchStatement expr mtpl successStatements catchMap x) = do
   cs <- tcExpr expr
+  
+  let errValsToVarDefs :: [Maybe (String, SVMType.Type)] -> [Annotated VarDefEntryF]
+      errValsToVarDefs [] = []
+      errValsToVarDefs (Nothing : xs) = errValsToVarDefs xs
+      errValsToVarDefs ((Just (name, ty)):xs) = (VarDefEntry (Just ty) Nothing name x) : (errValsToVarDefs xs)
+      successValsToVarDefs :: Maybe [(String, SVMType.Type)] -> [Annotated VarDefEntryF]
+      successValsToVarDefs Nothing = []
+      successValsToVarDefs (Just xs) = errValsToVarDefs $ map Just xs
+  let localVarDefs =  (errValsToVarDefs $ (map (fst . snd) (M.toList catchMap))) ++ successValsToVarDefs mtpl
+  pushLocalVariables localVarDefs
+  
   ts <- statementsHelper' x successStatements
   es <- statementsHelper' x (concatMap (snd . snd) (M.toList catchMap))
   pure $ reduceType' x [cs, ts, es]

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -948,6 +948,15 @@ statementHelper (IfStatement cond thens mElse x) = do
   ts <- statementsHelper' x thens
   es <- statementsHelper' x $ fromMaybe [] mElse
   pure $ reduceType' x [cs, ts, es]
+statementHelper (TryCatchStatement tryStatmenets catchMap x) = do
+  ts <- statementsHelper' x tryStatmenets
+  es <- statementsHelper' x (concatMap snd (M.toList catchMap))
+  pure $ reduceType' x [ts, es]
+statementHelper (SolidityTryCatchStatement expr _ successStatements catchMap x) = do
+  cs <- tcExpr expr
+  ts <- statementsHelper' x successStatements
+  es <- statementsHelper' x (concatMap (snd . snd) (M.toList catchMap))
+  pure $ reduceType' x [cs, ts, es]
 statementHelper (WhileStatement cond body x) = do
   cs <- tcExpr cond
   bs <- statementsHelper' x body

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Variables/StateVariables.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Variables/StateVariables.hs
@@ -78,6 +78,15 @@ statementHelper (IfStatement cond thens mElse _) = do
   ts <- statementsHelper thens
   es <- maybe (pure []) statementsHelper mElse
   pure $ concat [cs, ts, es]
+statementHelper (TryCatchStatement try catchMap _) = do
+  ts <- statementsHelper try
+  cs <- statementsHelper (concatMap snd (M.toList catchMap))
+  pure $ concat [ts, cs]
+statementHelper (SolidityTryCatchStatement expr _ successStatements catchMap _) = do
+  cs <- expressionHelper expr
+  ts <- statementsHelper successStatements
+  es <- statementsHelper (concatMap (snd . snd) (M.toList catchMap))
+  pure $ concat [cs, ts, es]
 statementHelper (WhileStatement cond body _) = do
   cs <- expressionHelper cond
   bs <- statementsHelper body

--- a/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
+++ b/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
@@ -50,6 +50,9 @@ statementCrawler = \case
                                     ++ maybe [] expressionCrawler mTest
                                     ++ maybe [] expressionCrawler mInc
                                     ++ concatMap statementCrawler blk
+  TryCatchStatement _ _ _ -> ["TryCatchStatement"]
+  SolidityTryCatchStatement _ _ _ _ _ -> ["SolidityTryCatchStatement"]
+
 
 expressionCrawler :: ExpressionF a -> [T.Text]
 expressionCrawler = \case

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2989,7 +2989,57 @@ solidityExceptionHandler catchBlockMap ex = do
               addLocalVariable varType varName (SInteger 19)
               res <- runStatements block
               return res
-    _ -> error "unhandled solid exception" (show ex)
+    (ParseError s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> parseError s1 s2
+            Just (_, stmts) -> do
+              res' <- runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <- runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 20)
+              res <- runStatements block
+              return res
+    (UnknownConstant s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> unknownConstant s1 s2
+            Just (_, stmts) -> do
+              res' <- runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <- runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 21)
+              res <- runStatements block
+              return res
+    (UnknownStatement s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> unknownStatement s1 s2
+            Just (_, stmts) -> do
+              res' <- runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <- runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 22)
+              res <- runStatements block
+              return res
 
 solidVMExceptionHandler :: (MonadSM m) => (M.Map String [CC.Statement]) -> SolidException -> m (Maybe Value)
 solidVMExceptionHandler catchBlockMap ex = case ex of

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2625,146 +2625,60 @@ encodeVector v = do
         bs <- encodeForReturn val'
         return (headers `B.append` bs, strings)
 
+
+
+
+
+
+
+
+
 {- BEN WILL REFACTOR THIS -}
 solidityExceptionHandler :: MonadSM m => (M.Map String (Maybe (String, SVMType.Type), [CC.Statement])) -> SolidException -> m (Maybe Value)
 solidityExceptionHandler catchBlockMap ex = do
+  let solidityExceptionHandlerHelper cbm s1 s2 errCode errFunc = do
+        case M.lookup "Panic" cbm of
+          Nothing -> do
+            case M.lookup "Nill" cbm of 
+              Nothing -> errFunc s1 s2
+              Just (_, stmts) -> do
+                res' <-  runStatements stmts
+                return res'
+          Just (mVar, block) -> do
+            case mVar of 
+              Nothing -> do
+                res' <-  runStatements block
+                return res'
+              Just (varName, varType) -> do
+                addLocalVariable varType varName (SInteger errCode)
+                res <- runStatements block
+                return res
+                
   case ex of
     (InternalError s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> internalError s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 1)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 1 internalError
+      return res
     (TypeError s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> typeError s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <- runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 2)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 2 typeError
+      return res
     (InvalidArguments s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> invalidArguments s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 3)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 3 invalidArguments
+      return res
     (IndexOutOfBounds s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> indexOutOfBounds s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 4)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 4 indexOutOfBounds
+      return res
     (TODO s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> todo s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 5)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 5 todo
+      return res
     (MissingField s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> missingField s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 6)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 6 missingField
+      return res
     (MissingType s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> missingType s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 7)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 7 missingType
+      return res
     (DuplicateDefinition s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> duplicateDefinition s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 8)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 8 duplicateDefinition
+      return res
     (ArityMismatch s1 i1 i2) -> do
       case M.lookup "Panic" catchBlockMap of
         Nothing -> do
@@ -2783,39 +2697,11 @@ solidityExceptionHandler catchBlockMap ex = do
               res <- runStatements block
               return res
     (UnknownFunction s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> unknownFunction s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 10)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 10 unknownFunction
+      return res
     (UnknownVariable s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> unknownVariable s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 11)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 11 unknownVariable
+      return res
     (DivideByZero s1) -> do
       case M.lookup "Panic" catchBlockMap of
         Nothing -> do
@@ -2872,192 +2758,38 @@ solidityExceptionHandler catchBlockMap ex = do
               res <- runStatements block
               return res
     (MissingCodeCollection s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> missingCodeCollection s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 13)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 13 missingCodeCollection
+      return res
     (InaccessibleChain s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> inaccessibleChain s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 14)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 14 inaccessibleChain
+      return res
     (InvalidWrite s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> invalidWrite s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 15)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 15 invalidWrite
+      return res
     (InvalidCertificate s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> invalidCertificate s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do 
-              addLocalVariable varType varName (SInteger 16)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 16 invalidCertificate
+      return res
     (MalformedData s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> malformedData s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 17)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 17 malformedData
+      return res
     (TooMuchGas s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> tooMuchGas s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <-  runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 18)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 18 tooMuchGas
+      return res
     (PaymentError s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> paymentError s1 s2
-            Just (_, stmts) -> do
-              res' <-  runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <- runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 19)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 19 paymentError
+      return res
     (ParseError s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> parseError s1 s2
-            Just (_, stmts) -> do
-              res' <- runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <- runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 20)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 20 parseError
+      return res
     (UnknownConstant s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> unknownConstant s1 s2
-            Just (_, stmts) -> do
-              res' <- runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <- runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 21)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 21 unknownConstant
+      return res
     (UnknownStatement s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> unknownStatement s1 s2
-            Just (_, stmts) -> do
-              res' <- runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <- runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 22)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 22 unknownStatement
+      return res
     (ReservedWordError s1 s2) -> do
-      case M.lookup "Panic" catchBlockMap of
-        Nothing -> do
-          case M.lookup "Nill" catchBlockMap of 
-            Nothing -> reservedWordError s1 s2
-            Just (_, stmts) -> do
-              res' <- runStatements stmts
-              return res'
-        Just (mVar, block) -> do
-          case mVar of 
-            Nothing -> do
-              res' <- runStatements block
-              return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SInteger 23)
-              res <- runStatements block
-              return res
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 23 reservedWordError
+      return res
 
 solidVMExceptionHandler :: (MonadSM m) => (M.Map String [CC.Statement]) -> SolidException -> m (Maybe Value)
 solidVMExceptionHandler catchBlockMap ex = case ex of

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -3041,6 +3041,23 @@ solidityExceptionHandler catchBlockMap ex = do
               addLocalVariable varType varName (SInteger 22)
               res <- runStatements block
               return res
+    (ReservedWordError s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> reservedWordError s1 s2
+            Just (_, stmts) -> do
+              res' <- runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <- runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 23)
+              res <- runStatements block
+              return res
 
 solidVMExceptionHandler :: (MonadSM m) => (M.Map String [CC.Statement]) -> SolidException -> m (Maybe Value)
 solidVMExceptionHandler catchBlockMap ex = case ex of
@@ -3156,4 +3173,6 @@ solidVMExceptionHandler catchBlockMap ex = case ex of
         Just block -> do
           res <- runStatements block
           return res
+    
     _ -> error "unhandled solid exception" (show ex)
+

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -991,6 +991,41 @@ runStatement s@(CC.SimpleStatement (CC.VariableDefinition entries maybeExpressio
 
   return Nothing
 
+runStatement (CC.SolidityTryCatchStatement tryExpression returnsDecl statementsForSuccess catchBlockMap _) = do
+  mRes <- EUnsafe.try $ do
+    expResultVal <- getVar =<< expToVar tryExpression
+    return expResultVal
+  case mRes of
+    Left ex -> do
+      res1 <- solidityExceptionHandler catchBlockMap ex
+      return res1
+    Right aRealVal -> do
+      case returnsDecl of
+        Nothing -> do
+          sfsRes <- runStatements statementsForSuccess
+          return $ sfsRes
+        Just xs -> do
+          case aRealVal of
+            STuple vecOfVars -> do
+              let vars = V.toList vecOfVars
+              if length vars /= length returnsDecl
+                then typeError "try/catch statement expected a tuple of the same length as the returns statement" (tryExpression, aRealVal)
+                else do
+                  forM_ (zip vars xs) $ \(var, (name, ty)) -> do
+                    val <- getVar var 
+                    addLocalVariable ty name val
+                  sfsRes' <- runStatements statementsForSuccess
+                  return sfsRes'
+            _ -> typeError "try/catch statement expected a tuple" (tryExpression, aRealVal)
+
+runStatement (CC.TryCatchStatement tryBlock catchBlockMap _) = do 
+  mRes <- EUnsafe.try (runStatements tryBlock)
+  case mRes of
+    Left ex -> do
+      res1 <- solidVMExceptionHandler catchBlockMap ex
+      return res1
+    Right res -> return res
+
 runStatement (CC.IfStatement condition code' maybeElseCode pos) = do
   solidVMBreakpoint pos
   conditionResult <- getBool =<< expToVar condition
@@ -2588,3 +2623,486 @@ encodeVector v = do
       val' -> do
         bs <- encodeForReturn val'
         return (headers `B.append` bs, strings)
+
+{- BEN WILL REFACTOR THIS -}
+solidityExceptionHandler :: MonadSM m => (M.Map String (Maybe (String, SVMType.Type), [CC.Statement])) -> SolidException -> m (Maybe Value)
+solidityExceptionHandler catchBlockMap ex = do
+  case ex of
+    (InternalError s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> internalError s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 1)
+              res <- runStatements block
+              return res
+    (TypeError s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> typeError s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <- runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 2)
+              res <- runStatements block
+              return res
+    (InvalidArguments s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> invalidArguments s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 3)
+              res <- runStatements block
+              return res
+    (IndexOutOfBounds s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> indexOutOfBounds s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 4)
+              res <- runStatements block
+              return res
+    (TODO s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> todo s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 5)
+              res <- runStatements block
+              return res
+    (MissingField s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> missingField s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 6)
+              res <- runStatements block
+              return res
+    (MissingType s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> missingType s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 7)
+              res <- runStatements block
+              return res
+    (DuplicateDefinition s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> duplicateDefinition s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 8)
+              res <- runStatements block
+              return res
+    (ArityMismatch s1 i1 i2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> arityMismatch s1 i1 i2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 9)
+              res <- runStatements block
+              return res
+    (UnknownFunction s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> unknownFunction s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 10)
+              res <- runStatements block
+              return res
+    (UnknownVariable s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> unknownVariable s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 11)
+              res <- runStatements block
+              return res
+    (DivideByZero s1) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> divideByZero s1
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 12)
+              res <- runStatements block
+              return res
+    (Require s1) -> do
+      case M.lookup "Error" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> do
+              _ <- require False s1
+              return Nothing
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SString (fromMaybe "Require Error" s1))
+              res <- runStatements block
+              return res
+    (Assert) -> do
+      case M.lookup "Error" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> do
+              _ <- assert False
+              return Nothing
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SString "Assertion Error")
+              res <- runStatements block
+              return res
+    (MissingCodeCollection s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> missingCodeCollection s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 13)
+              res <- runStatements block
+              return res
+    (InaccessibleChain s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> inaccessibleChain s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 14)
+              res <- runStatements block
+              return res
+    (InvalidWrite s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> invalidWrite s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 15)
+              res <- runStatements block
+              return res
+    (InvalidCertificate s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> invalidCertificate s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do 
+              addLocalVariable varType varName (SInteger 16)
+              res <- runStatements block
+              return res
+    (MalformedData s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> malformedData s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 17)
+              res <- runStatements block
+              return res
+    (TooMuchGas s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> tooMuchGas s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <-  runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 18)
+              res <- runStatements block
+              return res
+    (PaymentError s1 s2) -> do
+      case M.lookup "Panic" catchBlockMap of
+        Nothing -> do
+          case M.lookup "Nill" catchBlockMap of 
+            Nothing -> paymentError s1 s2
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
+        Just (mVar, block) -> do
+          case mVar of 
+            Nothing -> do
+              res' <- runStatements block
+              return res'
+            Just (varName, varType) -> do
+              addLocalVariable varType varName (SInteger 19)
+              res <- runStatements block
+              return res
+    _ -> error "unhandled solid exception" (show ex)
+
+solidVMExceptionHandler :: (MonadSM m) => (M.Map String [CC.Statement]) -> SolidException -> m (Maybe Value)
+solidVMExceptionHandler catchBlockMap ex = case ex of
+    (InternalError s1 s2) -> do
+      case M.lookup "InternalError" catchBlockMap of
+        Nothing -> internalError s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (InvalidArguments s1 s2) -> 
+      case M.lookup "InvalidArguments" catchBlockMap of
+        Nothing -> invalidArguments s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (IndexOutOfBounds s1 s2) -> 
+      case M.lookup "IndexOutOfBounds" catchBlockMap of
+        Nothing -> indexOutOfBounds s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (ParseError s1 s2) -> 
+      case M.lookup "ParseError" catchBlockMap of
+        Nothing -> parseError s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (Require s1) -> 
+      case M.lookup "Require" catchBlockMap of
+        Nothing -> do 
+          _ <- require False s1
+          return Nothing
+        Just block -> do
+          res <- runStatements block
+          return res
+    (Assert) -> 
+      case M.lookup "Assert" catchBlockMap of
+        Nothing -> do
+          _ <- assert False
+          return Nothing
+        Just block -> do
+          res <- runStatements block
+          return res
+    (UnknownFunction s1 s2) -> 
+      case M.lookup "UnknownFunction" catchBlockMap of
+        Nothing -> unknownFunction s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (UnknownConstant s1 s2) -> 
+      case M.lookup "UnknownConstant" catchBlockMap of
+        Nothing -> unknownConstant s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (UnknownVariable s1 s2) -> 
+      case M.lookup "UnknownVariable" catchBlockMap of
+        Nothing -> unknownVariable s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (UnknownStatement s1 s2) -> 
+      case M.lookup "UnknownStatement" catchBlockMap of
+        Nothing -> unknownStatement s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (DivideByZero s1) -> 
+      case M.lookup "DivideByZero" catchBlockMap of
+        Nothing -> divideByZero s1
+        Just block -> do
+          res <- runStatements block
+          return res
+    (MissingCodeCollection s1 s2) -> 
+      case M.lookup "MissingCodeCollection" catchBlockMap of
+        Nothing -> missingCodeCollection s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (InaccessibleChain s1 s2) -> 
+      case M.lookup "InaccessibleChain" catchBlockMap of
+        Nothing -> inaccessibleChain s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (InvalidWrite s1 s2) -> 
+      case M.lookup "InvalidWrite" catchBlockMap of
+        Nothing -> invalidWrite s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (InvalidCertificate s1 s2) -> 
+      case M.lookup "InvalidCertificate" catchBlockMap of
+        Nothing -> invalidCertificate s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (MalformedData s1 s2) -> 
+      case M.lookup "MalformedData" catchBlockMap of
+        Nothing -> malformedData s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (TooMuchGas s1 s2) -> 
+      case M.lookup "TooMuchGas" catchBlockMap of
+        Nothing -> tooMuchGas s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    (PaymentError s1 s2) ->
+      case M.lookup "PaymentError" catchBlockMap of
+        Nothing -> paymentError s1 s2
+        Just block -> do
+          res <- runStatements block
+          return res
+    _ -> error "unhandled solid exception" (show ex)

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4399,6 +4399,7 @@ contract qq{
 
   it "can use a try catch statment to catch a divide by zero error the Solidity Way (trademark very much in effect)" . runTest $ do
     runBS [r| 
+pragma solidvm 3.2;
 contract Divisor {
   function doTheDivide() public returns (uint) {
     return (1 / 0);

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4368,7 +4368,7 @@ contract qq{
     getFields ["mynum"] `shouldReturn` [BInteger 3]
 
   it "can use a try catch statment to catch a divide by zero error the Solidity Way (trademark very much in effect)" . runTest $ do
-    runBS [r|
+    runBS [r| 
 contract Divisor {
   function doTheDivide() public returns (uint) {
     return (1 / 0);

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4351,3 +4351,58 @@ contract qq{
   }
 }|]
     getFields ["weiUnit", "szaboUnit", "finneyUnit", "etherUnit"] `shouldReturn` [BInteger 2, BInteger 2000000000000, BInteger 2000000000000000, BInteger 2000000000000000000]
+
+  it "can use a try catch statment to catch a divide by zero error the SolidVM Way (trademark pending)" . runTest $ do
+    runBS [r|
+pragma solidvm 3.2;
+contract qq{
+  uint mynum = 5;
+  constructor() public {
+    try {
+      mynum = 1 / 0;
+    } catch DivideByZero {
+      mynum = 3;
+    }
+  }
+}|]
+    getFields ["mynum"] `shouldReturn` [BInteger 3]
+
+  it "can use a try catch statment to catch a divide by zero error the Solidity Way (trademark very much in effect)" . runTest $ do
+    runBS [r|
+contract Divisor {
+  function doTheDivide() public returns (uint) {
+    return (1 / 0);
+  }
+}
+
+contract qq {
+  uint myNum = 5;
+  uint otherNum = 7;
+  uint errorCount = 0;
+  constructor() public returns (uint,bool) {
+    Divisor d =  new Divisor();
+    try d.doTheDivide() returns (uint v) {
+          return (v, true);
+        } catch Error(string memory amsg) { 
+            // This is executed in case
+            // revert was called inside getData
+            // and a reason string was provided.
+            errorCount++;
+            return (0, false);
+        } catch Panic(uint errCode) {
+            // This is executed in case of a panic,
+            // i.e. a serious error like division by zero
+            // or overflow. The error code can be used
+            // to determine the kind of error.
+            errorCount++;
+            myNum = 3;
+            otherNum = errCode;
+            return (0, false);
+        } catch (bytes bigTest) {
+            // This is executed in case revert() was used.
+            errorCount++;
+            return (0, false);
+        }
+  }
+}|]
+    getFields ["myNum", "otherNum", "errorCount"] `shouldReturn` [BInteger 3, BInteger 12, BInteger 1]


### PR DESCRIPTION
This PR implements two different ways of doing try catch statements, 

**The Solidity Way**

```
contract` Divisor {
  function doTheDivide() public returns (uint) {
    return (1 / 0);
  }
}

contract qq {
  constructor() public returns (uint,bool) {
    Divisor d =  new Divisor();
    try d.doTheDivide() returns (uint v) {
          return (v, true);
        } catch Error(string memory itsamessage) { 
            // This is executed in case
            // revert was called inside doTheDivide()
            // and a reason string was provided.
            errorCount++;
            return (0, false);
        } catch Panic(uint errCode) {
            // This is executed in case of a panic,
            // i.e. a serious error like division by zero
            // or overflow. The error code can be used
            // to determine the kind of error.
            errorCount++;            return (errCode, false);
        } catch (bytes bigTest) {
            // This is executed in case revert() was used.
            errorCount++;
            return (0, false);
        }
  }

```
This way is verbose, and can only be used on a single expression at a time, the expression must be an outside function call or contract creation, most Errors fall into the _Panic_ designation and thus I have given all the `SolidExceptions` arbitrary error codes (see below for details)

**The SolidVM Way**

```
pragma solidvm 3.2;
contract qq{
  uint mynum = 5;
  constructor() public {
    try {
      mynum = 1 / 0;
    } catch DivideByZero {
      mynum = 3;
    }
  }
}
```

One can use any `SolidException` as a catch identifier and now you are no longer limited to just running a single expression in the try block, and instead can use any number of statements. 

Appendix:
`
                    TypeError  1
                    | InternalError  2
                    | InvalidArguments 3
                    | IndexOutOfBounds 4
                    | TODO 5
                    | MissingField 6
                    | MissingType 7
                    | DuplicateDefinition 8
                    | ArityMismatch 9
                    | Require not numbered
                    | Assert not Numbered                   
                    | UnknownFunction 10
                    | UnknownVariable 11
                    | DivideByZero 12
                    | MissingCodeCollection 13
                    | InaccessibleChain 14
                    | InvalidWrite 15
                    | InvalidCertificate 16
                    | MalformedData 17
                    | TooMuchGas 18
                    | PaymentError 19
                    | ParseError 20
                    | UnknownConstant 21
                    | UnknownStatement 22

`