### PR TITLE
Get bloc transaction result partial function bug fix

### DIFF
--- a/strato/api/bloc2/src/BlockApps/Bloc22/Server/TransactionResult.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Server/TransactionResult.hs
@@ -114,10 +114,13 @@ getBlocTransactionResult' hashes@(txh:_) resolve =
     then do
       promises <- forM hashes $ \h -> async (getBlocTransactionResult h True)
       results <- mapM wait promises
-      $logDebugLS "getBlockTransactionResult'/results" results
-      case filter ((== Success) . blocTransactionStatus) results of
-        (winner:_) -> return winner
-        [] -> return $ head results
+      $logDebugLS "getBlocTransactionResult'/results" results
+      case results of 
+        [] -> throwIO $ AnError "Empty list provided: no resolved transactions"
+        _ -> case filter ((== Success) . blocTransactionStatus) results of
+          (winner:_) -> return winner
+          [] -> return $ BlocTransactionResult Failure emptyHash Nothing Nothing 
+        
     else return $ BlocTransactionResult Pending txh Nothing Nothing
 
 getBlocTransactionResult :: ( MonadIO m

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Server/TransactionResult.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Server/TransactionResult.hs
@@ -116,7 +116,7 @@ getBlocTransactionResult' hashes@(txh:_) resolve =
       results <- mapM wait promises
       $logDebugLS "getBlocTransactionResult'/results" results
       case results of 
-        [] -> throwIO $ AnError "Empty list provided: no resolved transactions"
+        [] -> throwIO $ AnError "Empty list provided: results is empty"
         _ -> case filter ((== Success) . blocTransactionStatus) results of
           (winner:_) -> return winner
           [] -> return $ BlocTransactionResult Failure emptyHash Nothing Nothing 

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Server/TransactionResult.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Server/TransactionResult.hs
@@ -117,9 +117,9 @@ getBlocTransactionResult' hashes@(txh:_) resolve =
       $logDebugLS "getBlocTransactionResult'/results" results
       case results of 
         [] -> throwIO $ AnError "Empty list provided: results is empty"
-        _ -> case filter ((== Success) . blocTransactionStatus) results of
+        (fstResult:_) -> case filter ((== Success) . blocTransactionStatus) results of
           (winner:_) -> return winner
-          [] -> return $ BlocTransactionResult Failure emptyHash Nothing Nothing 
+          [] -> return $ fstResult
         
     else return $ BlocTransactionResult Pending txh Nothing Nothing
 


### PR DESCRIPTION
Perhaps due to `async`, sending a lot of transactions at once using the block generating script would cause the empty list case on the former line 20 to throw an error on `head results` even though `results` is should not be empty at this point in the logic. Nonetheless it can be and the changes return a definite value in this case with a failed TransactionResult instead of applying the partial function `head`.