### PR TITLE
Fix empty for loops

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1046,7 +1046,7 @@ runStatement (CC.ForStatement maybeInitStatement maybeConditionExp maybeLoopExp 
   let loopExp =
         case maybeLoopExp of
           Just x -> x
-          Nothing -> (CC.NumberLiteral pos 1 Nothing)
+          Nothing -> todo "loop expressions" loopExp
 
   let condition = getBool =<< expToVar conditionExp
 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1046,7 +1046,7 @@ runStatement (CC.ForStatement maybeInitStatement maybeConditionExp maybeLoopExp 
   let loopExp =
         case maybeLoopExp of
           Just x -> x
-          Nothing -> todo "loop expressions" loopExp
+          Nothing -> (CC.NumberLiteral pos 1 Nothing)
 
   let condition = getBool =<< expToVar conditionExp
 

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -2372,8 +2372,8 @@ contract qq {
     getFields ["a"] `shouldReturn` [bAddress 74]
 
   it "can have a for loop with no fields" . runTest $ do
-    liftIO $ pendingWith "re-fix loops"
     runBS [r|
+pragma solidvm 3.2;
 contract qq {
   uint i;
   constructor() public {

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -2372,8 +2372,8 @@ contract qq {
     getFields ["a"] `shouldReturn` [bAddress 74]
 
   it "can have a for loop with no fields" . runTest $ do
+    liftIO $ pendingWith "re-fix loops"
     runBS [r|
-pragma solidvm 3.2;
 contract qq {
   uint i;
   constructor() public {


### PR DESCRIPTION
This PR allows the following contract to run without error

```
pragma solidvm 3.2;
contract qq {
  uint i;
  constructor() public {
    for (;;) {
      i += 3;
      if (i % 5 == 0) {
        break;
      }
    }
  }
}
```

Before this change, this contract would lazily produce infinite `todo` error's causing vm-runner to use up 100% of CPU and stop responding