### PR TITLE
STRATO-2618 Add "revokeCert(address _cert)" function to CertificateRegistry Dapp

### DIFF
--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -17,6 +17,7 @@ module Blockchain.Strato.RedisBlockDB
     , getChainMembers, putChainMembers
     , addChainMember, removeChainMember
     , registerCertificate
+    , revokeCertificate
     , getChainTxsInBlock, putChainTxsInBlock, addChainTxsInBlock
     , getIPChains, addIPChain, removeIPChain
     , getOrgIdChains, addOrgIdChain, removeOrgIdChain
@@ -61,7 +62,7 @@ import           Data.Foldable                         (foldl')
 import           Data.Functor                          ((<&>))
 import           Data.Functor.Compose
 import qualified Data.Map.Strict                       as M
-import           Data.Maybe                            (catMaybes, fromJust, fromMaybe, isJust, isNothing)
+import           Data.Maybe                            (catMaybes, fromJust, fromMaybe, isJust, isNothing, listToMaybe)
 import qualified Data.Set                              as S
 import qualified Data.Text                             as T
 import           Database.Redis
@@ -225,6 +226,22 @@ registerCertificate userAddress x509CertInfoState = do
                             TxAborted -> pure . Left $ SingleLine (S8.pack "registerCertificate - Aborted adding children")
                             TxError e -> pure . Left $ SingleLine (S8.pack $ "registerCertificate - Error adding children" <> e)
 
+revokeCertificate :: Address -> Redis (Either Reply Status)                            
+revokeCertificate userAddress = do
+    mCertInfoState <- getCertificate userAddress
+    case mCertInfoState of
+        Nothing ->  pure . Left $ SingleLine (S8.pack "registerCertificate - userAddress invalid")
+        Just certInfoState -> do
+            let newInfoState = certInfoState{isValid  = False}
+            res <- multiExec $ set (inNamespace X509Certificates $ toKey userAddress) (toValue newInfoState)
+            case res of
+                TxSuccess _ -> do
+                        res2 <- mapM revokeCertificate (children certInfoState)
+                        pure $ fmap (fromMaybe Ok . listToMaybe) (sequenceA res2)
+                TxAborted -> pure . Left $ SingleLine (S8.pack "registerCertificate - Aborted revoking cert")
+                TxError e -> pure . Left $ SingleLine (S8.pack $ "registerCertificate - Error revoking cert" <> e)
+                        
+                
 getCertificate :: Address -> Redis (Maybe X509CertInfoState)
 getCertificate userAddress = getInNamespace X509Certificates userAddress >>= \case ---or inNamespace?
         Left _          -> return Nothing

--- a/strato/indexer/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/strato/indexer/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -83,12 +83,20 @@ doRemoveMember chainId address = do
 
 doRegisterCertificate :: Address -> X509CertInfoState -> IContextM ()
 doRegisterCertificate userAddress x509CertInfoState = do
-  logF [ "Registering X.509 Certificate -- key/userAddress: " 
+  logF [ "Registering X.509 Certificate -- key/userAddress: "
        , format userAddress
        , "; value/x509CertInfoState: "
        , format x509CertInfoState
        ]
   void . RBDB.withRedisBlockDB $ RBDB.registerCertificate userAddress x509CertInfoState
+
+doRevokeCertificate :: Address -> IContextM ()
+doRevokeCertificate userAddress = do
+  logF [ "Revoking X.509 Certificate -- key/userAddress: "
+        , format userAddress
+        ]
+  void . RBDB.withRedisBlockDB $ RBDB.revokeCertificate userAddress
+
 
 txrIndexer :: LoggingT IO ()
 txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
@@ -104,6 +112,7 @@ txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
 data TxrResult = AddMember (Either String (Word256, Address, Enode))
                | RemoveMember (Either String (Word256, Address))
                | RegisterCertificate (Either String (Address, X509CertInfoState))
+               | CertificateRevoked (Either String Address)
                | TerminateChain (Either String Word256)
                | PutLogDB LogDB
                | PutEventDB EventDB
@@ -141,14 +150,19 @@ indexEventToTxrResults = \case
       (Just chainId, "MemberRemoved", [addressStr]) -> case stringAddress addressStr of
         Nothing -> Just . RemoveMember . Left $ "failed to parse address for MemberRemoved event: " ++ addressStr
         Just address -> Just . RemoveMember $ Right (chainId, address)
-      (Nothing, "CertificateRegistered", [certString]) -> 
+      (Nothing, "CertificateRegistered", [certString]) ->
         let cert = bsToCert . C8.pack $ certString
             userAddress = fmap (fromPublicKey . subPub) $ getCertSubject =<< eitherToMaybe cert
-        in case (cert, userAddress) of 
+        in case (cert, userAddress) of
             (Left s, Nothing) -> Just . RegisterCertificate . Left $ "Failed to parse the certString for the CertificateRegistered event: " <> s
             (Left s, Just ua) -> Just . RegisterCertificate . Left $ "Failed to parse the certString for the CertificateRegistered event: " <> s <> "; " <> show ua
             (Right s, Nothing) -> Just . RegisterCertificate . Left $ "Failed to parse the certString's userAddress for the CertificateRegistered event: " <> show s
             (Right c, Just ua) -> Just . RegisterCertificate . Right $ (ua, X509CertInfoState{userAddress=ua, certificate=c, isValid=True, children=[]})
+      (Nothing, "CertificateRevoked", [certString]) ->
+        let userAddress = stringAddress certString
+        in case userAddress of
+            Nothing -> Just . CertificateRevoked . Left $ "Failed to parse the certString for the CertificateRevoked event: " <> certString
+            Just ua -> Just . CertificateRevoked . Right $ ua
       _ -> Nothing
   TxResult r -> [PutTxResult r]
   _ -> []
@@ -163,6 +177,9 @@ txrResultHandler = \case
     Left err -> $logErrorS "txrIndexer" $ T.pack err
   RegisterCertificate e -> case e of
     Right (ua, certInfoState) -> doRegisterCertificate ua certInfoState
+    Left err -> $logErrorS "txrIndexer" $ T.pack err
+  CertificateRevoked e -> case e of
+    Right address -> doRevokeCertificate address
     Left err -> $logErrorS "txrIndexer" $ T.pack err
   TerminateChain e -> case e of
     Right chainId -> lift $ terminateChain chainId

--- a/strato/tools/x509-certs/exec_src/X509CertRegistry.hs
+++ b/strato/tools/x509-certs/exec_src/X509CertRegistry.hs
@@ -256,6 +256,7 @@ contract CertificateRegistry {
     bool initialized;
 
     event CertificateRegistered(address userAddress, address contractAddress);
+    event CertificateRevoked(address userAddress);
 
     constructor(string _rootCert) {
         require(account(this, "self").chainId == 0, "You must post this contract on the main chain!");
@@ -315,5 +316,6 @@ contract CertificateRegistry {
         if (myCert.isChild(tx.certificate)) {
             myCert.revoke();
         }
+        emit CertificateRevoked(certAddr);
     }
 }|]


### PR DESCRIPTION
Addressing Jira ticket [STRATO-2618](https://blockapps.atlassian.net/browse/STRATO-2618):

- Add revokeCert to CertificateRegistry contract & revoke in Certificate contract
- Implement it in RedisBlockDB.hs, TxrIndexer.hs, and X509CertRegistry.hs