### PR TITLE
STRATO-2609-change-verify-cert-to-compare-against-a-provided-public-key

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2254,7 +2254,7 @@ callBuiltin vc@"verifyCert" [SString cert, SString pubkey] _ = do
       (Left q, _) -> invalidCertificate "Could not parse X.509 certificate" q
       (_, Left r) -> malformedData "Could not parse public key" r
       (Right x509Cert, Right publicKey) -> do
-        let isValid = verifyCert publicKey x509Cert
+        let isValid = verifyCertSignedBy publicKey x509Cert
         onTraced $ liftIO $ putStrLn $ (if isValid then 
                 C.green "The certificate is valid."
                 else C.red "The certificate is invalid")

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2242,10 +2242,33 @@ callBuiltin "getUserCert" [SAccount a _] _ = do
       maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
   return $ certificateMap (fmap (BC.unpack . certToBytes) maybeCert)
 
--- SolidVM built in function that verifies a cert is signed by a given key
+-- SolidVM built in function that verifies that the root cert is signed by the key
+-- verifyCert checks that the root of a chained cert is signed by the public key.
+-- But verifyCertSignedBy checks that the target of a chained cert is signed by the public key.
 -- Expects the public key to be in PEM format
 -- Raises an error if it can't parse either argument, however perhaps that should't happen...
 callBuiltin vc@"verifyCert" [SString cert, SString pubkey] _ = do
+  curContract <- getCurrentContract
+  if CC._vmVersion curContract == "svm3.2" then do
+    let ex509Cert = bsToCert . BC.pack $ cert
+    let ePublicKey = bsToPub $ BC.pack pubkey
+    case (ex509Cert, ePublicKey) of 
+      (Left q, _) -> invalidCertificate "Could not parse X.509 certificate" q
+      (_, Left r) -> malformedData "Could not parse public key" r
+      (Right x509Cert, Right publicKey) -> do
+        let isValid = verifyCert publicKey x509Cert
+        onTraced $ liftIO $ putStrLn $ (if isValid then 
+                C.green "The certificate is valid."
+                else C.red "The certificate is invalid")
+        return $ SBool isValid
+  else unknownFunction "callBuiltin" vc
+
+-- SolidVM built in function that verifies a cert that if it's signed by a given key
+-- verifyCert checks that the root of a chained cert is signed by the public key.
+-- But verifyCertSignedBy checks that the target of a chained cert is signed by the public key.
+-- Expects the public key to be in PEM format
+-- Raises an error if it can't parse either argument, however perhaps that should't happen...
+callBuiltin vc@"verifyCertSignedBy" [SString cert, SString pubkey] _ = do
   curContract <- getCurrentContract
   if CC._vmVersion curContract == "svm3.2" then do
     let ex509Cert = bsToCert . BC.pack $ cert

--- a/strato/core/blockapps-mpdbs/src/Blockchain/DB/X509CertDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/DB/X509CertDB.hs
@@ -20,6 +20,7 @@ module Blockchain.DB.X509CertDB (
   , pubToBytes
   , bsToPub
   , verifyCert
+  , verifyCertSignedBy
   , verifyBlockApps
   , X509CertDB(..)
   , HasX509CertDB

--- a/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/strato/tools/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -19,6 +19,7 @@ module BlockApps.X509.Certificate (
   makeCert,
   verifyCert,
   verifyCertAgainstCerts,
+  verifyCertSignedBy,
   verifyBlockApps,
   verifyCertM,
   makeSignedCert,
@@ -376,6 +377,16 @@ verifyCertAgainstCerts certs cert =  any (`verifyCert` cert) pkeys
 
 verifyCert :: PublicKey -> X509Certificate -> Bool
 verifyCert pkey (X509Certificate (CertificateChain cs)) = verifyCertChain pkey cs
+
+verifyCertSignedBy :: PublicKey -> X509Certificate -> Bool
+verifyCertSignedBy pkey (X509Certificate (CertificateChain (c:_))) = 
+  let signed = getSigned c
+      mesgBS = B.pack $ BA.unpack $ hashWith CH.SHA256 (getSignedData c)
+  in
+  case importSignature' $ signedSignature signed of
+    Nothing -> False
+    Just sig -> verifySig pkey sig mesgBS
+verifyCertSignedBy _ _ = False ---error ("Cannot verify cert " <> show cs <> " against " <> show pkey)
 
 verifyCertChain :: PublicKey -> [SignedCertificate] -> Bool
 verifyCertChain _ [] = False


### PR DESCRIPTION
Addressing Jira Ticket [STRATO-2609](https://blockapps.atlassian.net/browse/STRATO-2609):
VerifyCert builtin checks if the Cert is signed by an intermediate cert.