### PR TITLE
Strato-2689: Add pragma solidvm 3.3 and guard new post 7.6 features behind it

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
@@ -204,7 +204,7 @@ valEquals ct lhs rhs = case (lhs, rhs) of
   (SEnumVal e1 _ n1, SEnumVal e2 _ n2) -> e1 == e2 && n1 == n2
   (SContract _ a1, SAccount a2 _) -> a1 == a2
   (SAccount a1 _, SContract _ a2) -> a1 == a2
-  (SContract _ a1, SContract _ a2) ->  if ((CC._vmVersion ct == "svm3.0") || (CC._vmVersion ct == "svm3.2")) then (a1 == a2) else todo "unsupported type combination in valEquals: " (lhs, rhs)
+  (SContract _ a1, SContract _ a2) ->  if ((CC._vmVersion ct == "svm3.0") || (CC._vmVersion ct == "svm3.2") || (CC._vmVersion ct == "svm3.3")) then (a1 == a2) else todo "unsupported type combination in valEquals: " (lhs, rhs)
   (SBuiltinVariable v1, SBuiltinVariable v2) ->
     todo "comparison of builtin vars requires evaluation: " (v1, v2)
   _ -> todo "unsupported type combination in valEquals: " (lhs, rhs)

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -514,5 +514,6 @@ isReservedWord version reservedWord = do
         "record_id" -> True
         "transaction_hash" -> True
         "transaction_sender" -> True
+        "salt" -> True
         _ -> isReservedWord "3.2" reservedWord
     _ -> False

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -327,26 +327,30 @@ eventDeclaration = do
 -- that use modifiers.
 modifierDeclaration :: SolidityParser (String, Declaration)
 modifierDeclaration = do
+  pragmaVersion' <- getPragmaVersion
   start <- getSourcePosition
   reserved "modifier"
   name <- identifier
-  args <- option [] tupleDeclaration
-  contents <- Just <$> statements <|> (reservedOp ";" >> return Nothing)
-  end <- getSourcePosition
-  let ctx = SourceAnnotation start end ()
-      nameUnnamed (_name,ty) i = if Text.null _name then (Text.pack ('#' : show i),ty) else (_name,ty)
-  return
-    (
-      name,
-      ModifierDeclaration Xabi.Modifier{
-        Xabi.modifierArgs = -- undefined args -- :: Map Text SolidVM.IndexedType
-           Map.fromList $
-             zipWith (\x i -> fmap (SolidVM.IndexedType i) (nameUnnamed x i)) args [0..]
-      , Xabi.modifierSelector = Text.pack name -- ? -- undefined -- :: Text
-      , Xabi.modifierContents = contents -- :: Maybe [Statement]
-      , Xabi.modifierContext = ctx
-      }
-    )
+  if pragmaVersion' /= "3.3"
+    then unknownStatement "modifiers are not supported below pragma solidvm 3.3" name
+    else do
+      args <- option [] tupleDeclaration
+      contents <- Just <$> statements <|> (reservedOp ";" >> return Nothing)
+      end <- getSourcePosition
+      let ctx = SourceAnnotation start end ()
+          nameUnnamed (_name,ty) i = if Text.null _name then (Text.pack ('#' : show i),ty) else (_name,ty)
+      return
+        (
+          name,
+          ModifierDeclaration Xabi.Modifier{
+            Xabi.modifierArgs = -- undefined args -- :: Map Text SolidVM.IndexedType
+              Map.fromList $
+                zipWith (\x i -> fmap (SolidVM.IndexedType i) (nameUnnamed x i)) args [0..]
+          , Xabi.modifierSelector = Text.pack name -- ? -- undefined -- :: Text
+          , Xabi.modifierContents = contents -- :: Maybe [Statement]
+          , Xabi.modifierContext = ctx
+          }
+        )
 
 {- Not really declarations -}
 

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -506,4 +506,13 @@ isReservedWord version reservedWord = do
       case reservedWord of
         "account" -> True
         _ -> False
+    "3.3" -> do
+      case reservedWord of
+        "block_number" -> True
+        "block_timestamp" -> True
+        "block_hash" -> True
+        "record_id" -> True
+        "transaction_hash" -> True
+        "transaction_sender" -> True
+        _ -> isReservedWord "3.2" reservedWord
     _ -> False

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -522,7 +522,5 @@ isReservedWord version reservedWord = do
         "transaction_hash" -> True
         "transaction_sender" -> True
         "salt" -> True
-        "receive" -> True
-        "fallback" -> True
         _ -> isReservedWord "3.2" reservedWord
     _ -> False

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
@@ -63,7 +63,7 @@ solidityLexer = P.makeTokenParser solidityLanguage
 
 solidityLanguage = javaStyle {
   P.reservedNames = [
-     "pragma", "import", "library", "using", "salt",
+     "pragma", "import", "library", "using", -- "salt",
      "contract", "is", "public", "internal", "private", "external", "import", "payable",
      "event", "indexed", "anonymous",
      "bool", "true", "false",

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
@@ -79,11 +79,11 @@ solidityLanguage = javaStyle {
      "msg", --"data", "gas", "sender", "value",
      "tx", --"gasprice", "origin",
      "wei", "finney", "szabo", "ether",
-     "seconds", "minutes", "hours", "days", "weeks", "years",
+     "seconds", "minutes", "hours", "days", "weeks", "years"
      --The following are protected as they are also names for cirrus columns
-     "block_number", "block_timestamp", "block_hash",
-     "record_id", "transaction_hash", "transaction_sender"
-     ],
+    --"block_number", "block_timestamp", "block_hash",
+    --"record_id", "transaction_hash", "transaction_sender"
+    ],
   P.reservedOpNames = [
     "!", "&&", "||", "==", "!=",
     "<=", ">=", "<", ">", "&", "|", "^", "~", "+", "*", "-", "/"," %", "**",

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
@@ -79,11 +79,11 @@ solidityLanguage = javaStyle {
      "msg", --"data", "gas", "sender", "value",
      "tx", --"gasprice", "origin",
      "wei", "finney", "szabo", "ether",
-     "seconds", "minutes", "hours", "days", "weeks", "years"
+     "seconds", "minutes", "hours", "days", "weeks", "years",
      --The following are protected as they are also names for cirrus columns
     --"block_number", "block_timestamp", "block_hash",
     --"record_id", "transaction_hash", "transaction_sender"
-    --"receive", "fallback"
+     "receive", "fallback"
     ],
   P.reservedOpNames = [
     "!", "&&", "||", "==", "!=",

--- a/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
+++ b/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
@@ -119,11 +119,11 @@ main = do
   let pragmas = \case
         Pragma _ n v -> Just (n, v)
         _ -> Nothing
-  let vmVersion' = if (Just ("solidvm","3.2")) `elem` (pragmas <$> parsedFile) then "svm3.2" else (if (Just ("solidvm","3.0")) `elem` (pragmas <$> parsedFile) then "svm3.0" else "")
+  let vmVersion' = if (Just ("solidvm","3.3")) `elem` (pragmas <$> parsedFile) then "svm3.3" else (if (Just ("solidvm","3.2")) `elem` (pragmas <$> parsedFile) then "svm3.2" else (if (Just ("solidvm","3.0")) `elem` (pragmas <$> parsedFile) then "svm3.0" else ""))
       namedContracts = [(textToLabel name, either (throw . fst) id $ xabiToContract (textToLabel name) (map textToLabel parents') vmVersion' xabi)
                        | NamedXabi name (xabi, parents') <- parsedFile]
       cc = CodeCollection $ M.fromList namedContracts
-      typecheck = if vmVersion' == "svm3.2" then TC.detector cc else []
+      typecheck = if (vmVersion' == "svm3.2" || vmVersion' == "svm3.3") then TC.detector cc else []
       nodes = codeCollectionCrawler cc
   putStrLn (show typecheck) --when (not null typecheck)
   mapM_ (putStrLn . T.unpack) nodes

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1104,39 +1104,47 @@ runStatement s@(CC.SimpleStatement (CC.VariableDefinition entries maybeExpressio
 
 
 runStatement (CC.SolidityTryCatchStatement tryExpression returnsDecl statementsForSuccess catchBlockMap _) = do
-  mRes <- EUnsafe.try $ do
-    expResultVal <- getVar =<< expToVar tryExpression
-    return expResultVal
-  case mRes of
-    Left ex -> do
-      res1 <- solidityExceptionHandler catchBlockMap ex
-      return res1
-    Right aRealVal -> do
-      case returnsDecl of
-        Nothing -> do
-          sfsRes <- runStatements statementsForSuccess
-          return $ sfsRes
-        Just xs -> do
-          case aRealVal of
-            STuple vecOfVars -> do
-              let vars = V.toList vecOfVars
-              if length vars /= length returnsDecl
-                then typeError "try/catch statement expected a tuple of the same length as the returns statement" (tryExpression, aRealVal)
-                else do
-                  forM_ (zip vars xs) $ \(var, (name, ty)) -> do
-                    val <- getVar var 
-                    addLocalVariable ty name val
-                  sfsRes' <- runStatements statementsForSuccess
-                  return sfsRes'
-            _ -> typeError "try/catch statement expected a tuple" (tryExpression, aRealVal)
+  ctract <- getCurrentContract
+  if (CC._vmVersion ctract /= "svm3.3")
+    then unknownStatement "Try/Catch statements are not supported below pragma solidvm 3.3" tryExpression
+    else do
+      mRes <- EUnsafe.try $ do
+        expResultVal <- getVar =<< expToVar tryExpression
+        return expResultVal
+      case mRes of
+        Left ex -> do
+          res1 <- solidityExceptionHandler catchBlockMap ex
+          return res1
+        Right aRealVal -> do
+          case returnsDecl of
+            Nothing -> do
+              sfsRes <- runStatements statementsForSuccess
+              return $ sfsRes
+            Just xs -> do
+              case aRealVal of
+                STuple vecOfVars -> do
+                  let vars = V.toList vecOfVars
+                  if length vars /= length returnsDecl
+                    then typeError "try/catch statement expected a tuple of the same length as the returns statement" (tryExpression, aRealVal)
+                    else do
+                      forM_ (zip vars xs) $ \(var, (name, ty)) -> do
+                        val <- getVar var 
+                        addLocalVariable ty name val
+                      sfsRes' <- runStatements statementsForSuccess
+                      return sfsRes'
+                _ -> typeError "try/catch statement expected a tuple" (tryExpression, aRealVal)
 
 runStatement (CC.TryCatchStatement tryBlock catchBlockMap _) = do 
-  mRes <- EUnsafe.try (runStatements tryBlock)
-  case mRes of
-    Left ex -> do
-      res1 <- solidVMExceptionHandler catchBlockMap ex
-      return res1
-    Right res -> return res
+  ctract <- getCurrentContract
+  if (CC._vmVersion ctract /= "svm3.3")
+    then unknownStatement "Try/Catch statements are not supported below pragma solidvm 3.3" tryBlock
+    else do
+      mRes <- EUnsafe.try (runStatements tryBlock)
+      case mRes of
+        Left ex -> do
+          res1 <- solidVMExceptionHandler catchBlockMap ex
+          return res1
+        Right res -> return res
 
 runStatement (CC.IfStatement condition code' maybeElseCode pos) = do
   solidVMBreakpoint pos

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2657,31 +2657,47 @@ runTheConstructors from to hsh cc contractName' argExps = do
   _ <-
     case contract'^.CC.constructor of
       Just theFunction -> do
-        --argVals <- forM argExps evaluate
-        --_ <- call' address contract' theFunction argVals
-        let theModifierNames =  map fst $ (CC.funcModifiers theFunction) 
-        !theModifiers' <- forM theModifierNames $ \name -> do
-          case M.lookup name (contract'^.CC.modifiers) of
-            Just theModifier -> do
-              --args' <- argsToVals contract' theModifier argExps
-              return $ Just theModifier
-            Nothing -> do
-              if name `elem` contract'^.CC.parents then return Nothing else (if (svm3_2 || svm3_3) then (missingField "modifier not found" name) else return Nothing)
-        let theModifiers = catMaybes theModifiers'
-        !commands <- case CC.funcContents theFunction of
-          Nothing -> missingField "contract constructor has been declared but not defined" contractName'
-          Just cms -> pure cms
-       -- let modifierArgs = map CC.modifierArgs theModifiers
-        let !modContentsList = map (\m -> fromMaybe (missingField "Function call: Modifier has been declared but not defined" m) (CC.modifierContents m)) theModifiers
-        let isNotModExec = \case
-              CC.ModifierExecutor _ -> False
-              _ -> True
-        let (lhs,rhs) = foldr (\(a,b) (c,d) -> (a++c,b++d)) ([],[]) (map (span isNotModExec) modContentsList)
-        logVals lhs rhs
-        _ <- runStatements' lhs
-        _ <- pushSender from $ runStatements commands
-        _ <- runStatements' rhs
-        return ()
+        if (CC._vmVersion contract' == "svm3.3")
+          then do
+            --argVals <- forM argExps evaluate
+            --_ <- call' address contract' theFunction argVals
+            let theModifierNames =  map fst $ (CC.funcModifiers theFunction) 
+            !theModifiers' <- forM theModifierNames $ \name -> do
+              case M.lookup name (contract'^.CC.modifiers) of
+                Just theModifier -> do
+                  --args' <- argsToVals contract' theModifier argExps
+                  return $ Just theModifier
+                Nothing -> do
+                  if name `elem` contract'^.CC.parents then return Nothing else (if (svm3_2 || svm3_3) then (missingField "modifier not found" name) else return Nothing)
+            let theModifiers = catMaybes theModifiers'
+            !commands <- case CC.funcContents theFunction of
+              Nothing -> missingField "contract constructor has been declared but not defined" contractName'
+              Just cms -> pure cms
+          -- let modifierArgs = map CC.modifierArgs theModifiers
+            let !modContentsList = map (\m -> fromMaybe (missingField "Function call: Modifier has been declared but not defined" m) (CC.modifierContents m)) theModifiers
+            let isNotModExec = \case
+                  CC.ModifierExecutor _ -> False
+                  _ -> True
+            let (lhs,rhs) = foldr (\(a,b) (c,d) -> (a++c,b++d)) ([],[]) (map (span isNotModExec) modContentsList)
+            logVals lhs rhs
+            _ <- runStatements' lhs
+            _ <- pushSender from $ runStatements commands
+            _ <- runStatements' rhs
+            return ()
+          else do
+            let theModifierNames =  map fst $ (CC.funcModifiers theFunction) 
+            !_ <- forM theModifierNames $ \name -> do
+              case M.lookup name (contract'^.CC.modifiers) of
+                Just _ -> do
+                  --args' <- argsToVals contract' theModifier argExps
+                  unknownStatement "modifiers are not supported below pragma solidvm 3.3" name
+                Nothing -> do
+                  return Nothing
+            commands <- case CC.funcContents theFunction of
+              Nothing -> missingField "contract constructor has been declared but not defined" contractName'
+              Just cms -> pure cms
+            _ <- pushSender from $ runStatements commands
+            return ()
 
       Nothing -> return ()
 
@@ -2720,105 +2736,173 @@ runTheCall :: MonadSM m
 runTheCall address' contract' funcName hsh cc theFunction argVals ro = do
   let returns = [(n, (t, defaultValue contract' t)) | (Just n, CC.IndexedType _ t) <- CC.funcVals theFunction]
       theModifierNames = map fst $ (CC.funcModifiers theFunction) 
-      svm3_2 = CC._vmVersion contract' == "svm3.2"
       svm3_3 = CC._vmVersion contract' == "svm3.3"
-  theModifiers' <- forM theModifierNames $ \name -> do
-    case M.lookup name (contract'^.CC.modifiers) of
-      Just theModifier -> do
-        return $ Just theModifier
-      Nothing -> if name `elem` contract' ^. CC.parents then return Nothing else (if (svm3_2 || svm3_3) then (missingField "modifier not found" name) else return Nothing)
-  let !theModifiers = catMaybes theModifiers'
-  matchedArgvals <- forM theModifiers $ \modi -> do
-    let margList = CC.OrderedArgs 
-            . fromMaybe []
-            $ M.lookup (T.unpack (CC.modifierSelector modi)) $ M.fromList $ CC.funcModifiers theFunction
-    margVals <- argsToValsModifiers contract' modi margList
-    case margVals of
-      OrderedVals vs -> do
-        let argMeta = map (\(n, CC.IndexedType _ t) -> (n, t)) $ M.toList $ CC.modifierArgs modi
-        return (zipWith (\(n, t) v -> (n, (t, v))) argMeta vs)
-      NamedVals ns -> do
-        let strTypes = M.fromList $ map (\(theName, y) -> (theName, y)) $ M.toList $ CC.modifierArgs modi
-            typeAndVal = M.merge (M.mapMissing (curry $ invalidArguments "missing argument"))
-                                 (M.mapMissing (curry $ invalidArguments "extra argument"))
-                                 (M.zipWithMatched $ \_k t v -> (t, v))
-                                 strTypes
-                                 $ M.mapKeys T.pack $ M.fromList ns
-            -- These probably don't need to be sorted by argument index, as they are turned into a map
-            -- when added to the call info.
-            sortedArgs = map snd . sortWith fst
-                      . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
-                      $ M.toList typeAndVal
-        return sortedArgs
 
-  let args = case argVals of
-        OrderedVals vs -> let argMeta = 
-                                map (\(n, CC.IndexedType _ t) -> (fromMaybe "" n, t))
-                                $ CC.funcArgs theFunction
-                          in zipWith (\(n, t) v -> (n, (t, v))) argMeta vs
-        NamedVals ns ->
-          let strTypes = M.fromList $ map (\(maybeName, y) -> (fromMaybe "" maybeName, y)) $ CC.funcArgs theFunction
-              typeAndVal = M.merge (M.mapMissing (curry $ invalidArguments "missing argument"))
-                                   (M.mapMissing (curry $ invalidArguments "extra argument"))
-                                   (M.zipWithMatched $ \_k t v -> (t, v))
-                                   strTypes
-                                   $ M.fromList ns
-              -- These probably don't need to be sorted by argument index, as they are turned into a map
-              -- when added to the call info.
-              sortedArgs = map snd . sortWith fst
-                         . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
-                         $ M.toList typeAndVal
-          in sortedArgs
+  if (CC._vmVersion contract' /= "svm3.3")
+    then do
+      _ <- forM theModifierNames $ \name -> do
+        case M.lookup name (contract'^.CC.modifiers) of
+          Just _ -> unknownStatement "modifiers are not supported below pragma solidvm 3.3" name
+          Nothing -> return Nothing
+      let args = case argVals of
+            OrderedVals vs -> let argMeta = 
+                                    map (\(n, CC.IndexedType _ t) -> (fromMaybe "" n, t))
+                                    $ CC.funcArgs theFunction
+                              in zipWith (\(n, t) v -> (n, (t, v))) argMeta vs
+            NamedVals ns ->
+              let strTypes = M.fromList $ map (\(maybeName, y) -> (fromMaybe "" maybeName, y)) $ CC.funcArgs theFunction
+                  typeAndVal = M.merge (M.mapMissing (curry $ invalidArguments "missing argument"))
+                                      (M.mapMissing (curry $ invalidArguments "extra argument"))
+                                      (M.zipWithMatched $ \_k t v -> (t, v))
+                                      strTypes
+                                      $ M.fromList ns
+                  -- These probably don't need to be sorted by argument index, as they are turned into a map
+                  -- when added to the call info.
+                  sortedArgs = map snd . sortWith fst
+                            . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
+                            $ M.toList typeAndVal
+              in sortedArgs
 
-      locals = args ++ returns ++ (map (\(x,y) -> (T.unpack x, y)) (concat matchedArgvals)) --modArgsToBeLocals
+          locals = args ++ returns
 
-  onTraced $ do
-    liftIO $ putStrLn $ "            args: " ++ show (map fst args)
-    when (not $ null returns) $ liftIO $ putStrLn $ "    named return: " ++ show (map fst returns)
+      onTraced $ do
+        liftIO $ putStrLn $ "            args: " ++ show (map fst args)
+        when (not $ null returns) $ liftIO $ putStrLn $ "    named return: " ++ show (map fst returns)
 
-  localVars <-
-    forM locals $ \(n, (t, v)) -> do
-      newVar <- liftIO $ fmap Variable $ newIORef v
-      return (n, (t, newVar))
+      localVars <-
+        forM locals $ \(n, (t, v)) -> do
+          newVar <- liftIO $ fmap Variable $ newIORef v
+          return (n, (t, newVar))
 
-  addCallInfo address' contract' funcName hsh cc (M.fromList localVars) ro -- [(n, (t, Constant v)) | (n, (t, v)) <- locals]
+      addCallInfo address' contract' funcName hsh cc (M.fromList localVars) ro -- [(n, (t, Constant v)) | (n, (t, v)) <- locals]
 
-  let !commands = fromMaybe (missingField "Function call: function has been declared but not defined" funcName) $ CC.funcContents theFunction
-  let modContentsList = map (\m -> fromMaybe (missingField "Function call: Modifier has been declared but not defined" m) (CC.modifierContents m)) theModifiers
-  let isNotModExec = \case
-              CC.ModifierExecutor _ -> False
-              _ -> True
-  let (lhs,rhs) = foldr (\(a,b) (c,d) -> (a++c,b++d)) ([],[]) (map (span isNotModExec) modContentsList)
-  logVals lhs rhs
-  _ <- runStatements' lhs
-  val   <- runStatements commands
-  _ <- runStatements' rhs
+      let !commands = fromMaybe (missingField "Function call: function has been declared but not defined" funcName) $ CC.funcContents theFunction
+      val <- runStatements commands
+      let findNamedReturns = do
+            case returns of
+              [] -> return Nothing
+              [(name,_)] -> do -- We have to break this up because
+                              -- SolidVM cannot distinguish between
+                              -- a value and single-tupled value
+                currentCallInfo <- getCurrentCallInfo
+                let mReturnVar = M.lookup name $ localVariables currentCallInfo
+                case mReturnVar of
+                  Nothing -> unknownVariable "findNamedReturns" name
+                  Just returnVar -> Just <$> getVar (snd returnVar)
+              xs -> Just . STuple . V.fromList <$> do
+                currentCallInfo <- getCurrentCallInfo
+                for (fst <$> xs) $ \name -> do
+                  let mReturnVar = M.lookup name $ localVariables currentCallInfo
+                  case mReturnVar of
+                    Nothing -> unknownVariable "findNamedReturns" name
+                    Just returnVar -> Constant <$> getVar (snd returnVar)
 
-  let findNamedReturns = do
-        case returns of
-          [] -> return Nothing
-          [(name,_)] -> do -- We have to break this up because
-                           -- SolidVM cannot distinguish between
-                           -- a value and single-tupled value
-            currentCallInfo <- getCurrentCallInfo
-            let mReturnVar = M.lookup name $ localVariables currentCallInfo
-            case mReturnVar of
-              Nothing -> unknownVariable "findNamedReturns" name
-              Just returnVar -> Just <$> getVar (snd returnVar)
-          xs -> Just . STuple . V.fromList <$> do
-            currentCallInfo <- getCurrentCallInfo
-            for (fst <$> xs) $ \name -> do
-              let mReturnVar = M.lookup name $ localVariables currentCallInfo
-              case mReturnVar of
-                Nothing -> unknownVariable "findNamedReturns" name
-                Just returnVar -> Constant <$> getVar (snd returnVar)
-  val' <- case val of
-             Nothing -> findNamedReturns
-             Just SNULL -> findNamedReturns
-             Just{} -> return val
-  popCallInfo
+      val' <- case val of
+                Nothing -> findNamedReturns
+                Just SNULL -> findNamedReturns
+                Just{} -> return val
+      popCallInfo
+      return val' 
+      
+    else do
 
-  return val'
+      theModifiers' <- forM theModifierNames $ \name -> do
+        case M.lookup name (contract'^.CC.modifiers) of
+          Just theModifier -> do
+            return $ Just theModifier
+          Nothing -> if name `elem` contract' ^. CC.parents then return Nothing else (if (svm3_3) then (missingField "modifier not found" name) else return Nothing)
+      let !theModifiers = catMaybes theModifiers'
+      matchedArgvals <- forM theModifiers $ \modi -> do
+        let margList = CC.OrderedArgs 
+                . fromMaybe []
+                $ M.lookup (T.unpack (CC.modifierSelector modi)) $ M.fromList $ CC.funcModifiers theFunction
+        margVals <- argsToValsModifiers contract' modi margList
+        case margVals of
+          OrderedVals vs -> do
+            let argMeta = map (\(n, CC.IndexedType _ t) -> (n, t)) $ M.toList $ CC.modifierArgs modi
+            return (zipWith (\(n, t) v -> (n, (t, v))) argMeta vs)
+          NamedVals ns -> do
+            let strTypes = M.fromList $ map (\(theName, y) -> (theName, y)) $ M.toList $ CC.modifierArgs modi
+                typeAndVal = M.merge (M.mapMissing (curry $ invalidArguments "missing argument"))
+                                    (M.mapMissing (curry $ invalidArguments "extra argument"))
+                                    (M.zipWithMatched $ \_k t v -> (t, v))
+                                    strTypes
+                                    $ M.mapKeys T.pack $ M.fromList ns
+                -- These probably don't need to be sorted by argument index, as they are turned into a map
+                -- when added to the call info.
+                sortedArgs = map snd . sortWith fst
+                          . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
+                          $ M.toList typeAndVal
+            return sortedArgs
+
+      let args = case argVals of
+            OrderedVals vs -> let argMeta = 
+                                    map (\(n, CC.IndexedType _ t) -> (fromMaybe "" n, t))
+                                    $ CC.funcArgs theFunction
+                              in zipWith (\(n, t) v -> (n, (t, v))) argMeta vs
+            NamedVals ns ->
+              let strTypes = M.fromList $ map (\(maybeName, y) -> (fromMaybe "" maybeName, y)) $ CC.funcArgs theFunction
+                  typeAndVal = M.merge (M.mapMissing (curry $ invalidArguments "missing argument"))
+                                      (M.mapMissing (curry $ invalidArguments "extra argument"))
+                                      (M.zipWithMatched $ \_k t v -> (t, v))
+                                      strTypes
+                                      $ M.fromList ns
+                  -- These probably don't need to be sorted by argument index, as they are turned into a map
+                  -- when added to the call info.
+                  sortedArgs = map snd . sortWith fst
+                            . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
+                            $ M.toList typeAndVal
+              in sortedArgs
+
+          locals = args ++ returns ++ (map (\(x,y) -> (T.unpack x, y)) (concat matchedArgvals)) --modArgsToBeLocals
+
+      onTraced $ do
+        liftIO $ putStrLn $ "            args: " ++ show (map fst args)
+        when (not $ null returns) $ liftIO $ putStrLn $ "    named return: " ++ show (map fst returns)
+
+      localVars <-
+        forM locals $ \(n, (t, v)) -> do
+          newVar <- liftIO $ fmap Variable $ newIORef v
+          return (n, (t, newVar))
+
+      addCallInfo address' contract' funcName hsh cc (M.fromList localVars) ro -- [(n, (t, Constant v)) | (n, (t, v)) <- locals]
+
+      let !commands = fromMaybe (missingField "Function call: function has been declared but not defined" funcName) $ CC.funcContents theFunction
+      let modContentsList = map (\m -> fromMaybe (missingField "Function call: Modifier has been declared but not defined" m) (CC.modifierContents m)) theModifiers
+      let isNotModExec = \case
+                  CC.ModifierExecutor _ -> False
+                  _ -> True
+      let (lhs,rhs) = foldr (\(a,b) (c,d) -> (a++c,b++d)) ([],[]) (map (span isNotModExec) modContentsList)
+      logVals lhs rhs
+      _ <- runStatements' lhs
+      val   <- runStatements commands
+      _ <- runStatements' rhs
+
+      let findNamedReturns = do
+            case returns of
+              [] -> return Nothing
+              [(name,_)] -> do -- We have to break this up because
+                              -- SolidVM cannot distinguish between
+                              -- a value and single-tupled value
+                currentCallInfo <- getCurrentCallInfo
+                let mReturnVar = M.lookup name $ localVariables currentCallInfo
+                case mReturnVar of
+                  Nothing -> unknownVariable "findNamedReturns" name
+                  Just returnVar -> Just <$> getVar (snd returnVar)
+              xs -> Just . STuple . V.fromList <$> do
+                currentCallInfo <- getCurrentCallInfo
+                for (fst <$> xs) $ \name -> do
+                  let mReturnVar = M.lookup name $ localVariables currentCallInfo
+                  case mReturnVar of
+                    Nothing -> unknownVariable "findNamedReturns" name
+                    Just returnVar -> Constant <$> getVar (snd returnVar)
+      val' <- case val of
+                Nothing -> findNamedReturns
+                Just SNULL -> findNamedReturns
+                Just{} -> return val
+      popCallInfo
+
+      return val'
 
 
 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -152,7 +152,7 @@ onTraced = when flags_svmTrace
 -- TODO: Do not add default values to RawStorageDBs for SolidVM > 3.
 onTracedSM :: MonadSM m => CC.Contract -> m () -> m ()
 onTracedSM cntrct m = do
-      let svm3_0 = CC._vmVersion cntrct == "svm3.0" || (CC._vmVersion cntrct == "svm3.2")
+      let svm3_0 = CC._vmVersion cntrct == "svm3.0" || (CC._vmVersion cntrct == "svm3.2") || (CC._vmVersion cntrct == "svm3.3")
       when (flags_svmTrace && not svm3_0) m
       when (flags_svmTrace && svm3_0) $
         liftIO $ putStrLn $ "svmTrace statement(s) is absent because contract " 
@@ -288,7 +288,7 @@ create' creator newAccount ch cc contractName' argExps x509s = do
 
   A.adjustWithDefault_ (A.Proxy @AddressState) newAccount $ \newAddressState ->
     pure newAddressState{ addressStateContractRoot = MP.emptyTriePtr
-                        , addressStateCodeHash = if ((vmVersion' == "svm3.0" || vmVersion' == "svm3.2")  && contractName' /= stringToLabel parentName && not (null parentName)) then CodeAtAccount creator (labelToString contractName') else SolidVMCode (labelToString contractName') ch
+                        , addressStateCodeHash = if ((vmVersion' == "svm3.0" || vmVersion' == "svm3.2" || vmVersion' == "svm3.3")  && contractName' /= stringToLabel parentName && not (null parentName)) then CodeAtAccount creator (labelToString contractName') else SolidVMCode (labelToString contractName') ch
                         }
 
   onTraced $ liftIO $ putStrLn $ C.red $ "Creating Contract: " ++ show newAccount ++ " of type " ++ labelToString contractName'
@@ -451,12 +451,13 @@ setCreator creator contract cntrct blockNumber = do
   
   let hasSvm3_0 = CC._vmVersion cntrct == "svm3.0"
       hasSvm3_2 = CC._vmVersion cntrct == "svm3.2"
-  when hasSvm3_2 $ do
+      hasSvm3_3 = CC._vmVersion cntrct == "svm3.3"
+  when (hasSvm3_2 || hasSvm3_3) $ do
     liftIO $ putStrLn $ "setCreator/address ---> Setting creatorAddress to: " ++ show creator ++ " solidVM version: " ++ (show $ CC._vmVersion cntrct)
-    putSolidStorageKeyVal' hasSvm3_2 contract (MS.StoragePath [MS.Field ":creatorAddress"]) (MS.BAccount (accountToNamedAccount' creator))
+    putSolidStorageKeyVal' (hasSvm3_2 || hasSvm3_3) contract (MS.StoragePath [MS.Field ":creatorAddress"]) (MS.BAccount (accountToNamedAccount' creator))
   let putCreatorField org = do
         liftIO $ putStrLn $ "setCreator/versioning ---> setting the org as " ++ (show org) ++ " solidVM version: " ++ (show $ CC._vmVersion cntrct)
-        putSolidStorageKeyVal' (hasSvm3_0 || hasSvm3_2) contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
+        putSolidStorageKeyVal' (hasSvm3_0 || hasSvm3_2 || hasSvm3_3) contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
 
   if _org /= "" then putCreatorField _org else do
       liftIO $ putStrLn $ C.red $ "Ignoring creator field for empty org field"
@@ -481,7 +482,7 @@ computeNetworkID =
 -- get the org for the Cirrus table name
 getOrg :: MonadSM m => Account -> String -> m (String)
 getOrg caller vers = do
-  if ((vers /= "svm3.0") && (vers /= "svm3.2")) 
+  if ((vers /= "svm3.0") && (vers /= "svm3.2") && (vers /= "svm3.3")) 
     then return ""
   else do
     liftIO $ putStrLn $ "getOrg/versioning ---> Getting org for the caller " ++ format caller
@@ -577,7 +578,7 @@ logFunctionCall args address contract functionName f = do
 
 argsToValsModifiers :: MonadSM m => CC.Contract -> CC.Modifier -> CC.ArgList -> m ValList
 argsToValsModifiers ctract md args = 
-  if CC._vmVersion ctract == "svm3.2" 
+  if (CC._vmVersion ctract == "svm3.2" || CC._vmVersion ctract == "svm3.3")
     then 
       case args of
         CC.OrderedArgs xs -> do
@@ -610,7 +611,7 @@ argsToValsModifiers ctract md args =
         eval :: MonadSM m => SVMType.Type -> CC.Expression -> m Value
         eval t x = case x of
            CC.NumberLiteral _ n Nothing -> return . coerceType ctract t $ SInteger n
-           CC.NumberLiteral _ n (Just nu) -> todo "Number literal with units" (n, nu)
+           CC.NumberLiteral _ n (Just nu) -> unknownStatement "Unit suffixes are not supported below pragma solidvm 3.3" (n, nu)
            CC.BoolLiteral _ b -> return . coerceType ctract t $ SBool b
            CC.StringLiteral _ s -> return . coerceType ctract t $ SString s
            CC.ArrayExpression _ as -> case t of
@@ -626,7 +627,13 @@ argsToValsModifiers ctract md args =
         eval32 t x = do
           case x of
             CC.NumberLiteral _ n Nothing   -> return . coerceType ctract t $ SInteger n
-            CC.NumberLiteral _ n (Just nu) -> todo "Number literal with units" (n, nu)
+            CC.NumberLiteral _ n (Just nu) -> if (CC._vmVersion ctract == "svm3.3") 
+                                                then case nu of
+                                                CC.Wei -> return . coerceType ctract t $ SInteger n
+                                                CC.Szabo -> return . coerceType ctract t $ SInteger (n * (10 ^ (12 :: Integer)))
+                                                CC.Finney -> return . coerceType ctract t $ SInteger (n * (10 ^ (15 :: Integer))) 
+                                                CC.Ether -> return . coerceType ctract t $ SInteger (n * (10 ^ (18 :: Integer)))
+                                                else unknownStatement "Unit suffixes are not supported below pragma solidvm 3.3" (n, nu)
             CC.BoolLiteral _ b             -> return . coerceType ctract t $ SBool b
             CC.StringLiteral _ s           -> return . coerceType ctract t $ SString s
             CC.ArrayExpression _ as        -> case t of
@@ -662,7 +669,7 @@ argsToValsModifiers ctract md args =
 
 argsToVals :: MonadSM m => CC.Contract -> CC.Func -> CC.ArgList -> m ValList
 argsToVals ctract fn args = 
-  if CC._vmVersion ctract == "svm3.2" 
+  if (CC._vmVersion ctract == "svm3.2" || CC._vmVersion ctract == "svm3.3")
     then 
       case args of
         CC.OrderedArgs xs -> do
@@ -696,11 +703,7 @@ argsToVals ctract fn args =
         eval t x = do
           case x of
             CC.NumberLiteral _ n Nothing -> return . coerceType ctract t $ SInteger n
-            CC.NumberLiteral _ n (Just nu) -> case nu of
-              CC.Wei -> return . coerceType ctract t $ SInteger n
-              CC.Szabo -> return . coerceType ctract t $ SInteger (n * (10 ^ (12 :: Integer)))
-              CC.Finney -> return . coerceType ctract t $ SInteger (n * (10 ^ (15 :: Integer))) 
-              CC.Ether -> return . coerceType ctract t $ SInteger (n * (10 ^ (18 :: Integer))) 
+            CC.NumberLiteral _ n (Just nu) -> unknownStatement "Unit suffixes are not supported below pragma solidvm 3.3" (n, nu)
             CC.BoolLiteral _ b -> return . coerceType ctract t $ SBool b
             CC.StringLiteral _ s -> return . coerceType ctract t $ SString s
             CC.ArrayExpression _ as -> case t of
@@ -738,11 +741,13 @@ argsToVals ctract fn args =
         eval32 t x = do
           case x of
             CC.NumberLiteral _ n Nothing   -> return . coerceType ctract t $ SInteger n
-            CC.NumberLiteral _ n (Just nu) -> case nu of
-              CC.Wei -> return . coerceType ctract t $ SInteger n
-              CC.Szabo -> return . coerceType ctract t $ SInteger (n * (10 ^ (12 :: Integer)))
-              CC.Finney -> return . coerceType ctract t $ SInteger (n * (10 ^ (15 :: Integer))) 
-              CC.Ether -> return . coerceType ctract t $ SInteger (n * (10 ^ (18 :: Integer)))
+            CC.NumberLiteral _ n (Just nu) -> if (CC._vmVersion ctract == "svm3.3") 
+                                                then case nu of
+                                                  CC.Wei -> return . coerceType ctract t $ SInteger n
+                                                  CC.Szabo -> return . coerceType ctract t $ SInteger (n * (10 ^ (12 :: Integer)))
+                                                  CC.Finney -> return . coerceType ctract t $ SInteger (n * (10 ^ (15 :: Integer))) 
+                                                  CC.Ether -> return . coerceType ctract t $ SInteger (n * (10 ^ (18 :: Integer)))
+                                                else unknownStatement "Unit suffixes are not supported below pragma solidvm 3.3" (n, nu)
             CC.BoolLiteral _ b             -> return . coerceType ctract t $ SBool b
             CC.StringLiteral _ s           -> return . coerceType ctract t $ SString s
             CC.ArrayExpression _ as        -> case t of
@@ -806,6 +811,7 @@ callWrapper from to mContract functionName isRCC argExps  = do
   let contract = fromMaybe contract' $ mContract >>= \c -> M.lookup c $ CC._contracts cc
       parentName' = if parentName == (CC._contractName contract) then "" else parentName
       isSvm3_2 =  (CC._vmVersion contract == "svm3.2")
+      isSvm3_3 =  (CC._vmVersion contract == "svm3.3")
   
   initializeAction to (labelToString $ CC._contractName contract) (labelToString parentName') hsh
 
@@ -834,7 +840,7 @@ callWrapper from to mContract functionName isRCC argExps  = do
             let f' = (if from == to then id else pushSender from) $ runTheCall to contract functionName hsh cc theFunction args' ro
             return (f', args')
           _ -> do --Maybe the function is actually a getter
-            case (M.lookup functionName $ contract^.CC.storageDefs,isSvm3_2) of
+            case (M.lookup functionName $ contract^.CC.storageDefs,(isSvm3_2 || isSvm3_3)) of
               (Just _, True) -> do 
                   liftIO $ putStrLn ("callWrapper/getter " ++ labelToString functionName) 
                   addCallInfo to contract functionName hsh cc M.empty True
@@ -933,7 +939,7 @@ runStatement st@(CC.SimpleStatement (CC.ExpressionStatement (CC.Binary _ "=" dst
   -- If it's an array, calling (expToVar dst) gives us
   -- the value at the index, NOT a reference that we can
   -- assign to....so we need to make a new vector and reset the whole array
-  if CC._vmVersion cntrct == "svm3.2"
+  if (CC._vmVersion cntrct == "svm3.2" || CC._vmVersion cntrct == "svm3.3")
     then do
       case pVal of
         SArray typ fs -> do
@@ -1078,7 +1084,7 @@ runStatement s@(CC.SimpleStatement (CC.VariableDefinition entries maybeExpressio
       checkArity "var declaration tuple" (V.length variables) (length entries)
       let nonBlanks = [(ensureType t, n, v) | (CC.VarDefEntry t _ n _, v) <- zip entries $ V.toList variables]
       ctrct <- getCurrentContract
-      if CC._vmVersion ctrct == "svm3.2"
+      if (CC._vmVersion ctrct == "svm3.2" || CC._vmVersion ctrct == "svm3.3")
         then do
           --We get the values first so in the case of (x,y) = (y,x) we can still set the variables to the correct values
           nonBlanks' <- forM nonBlanks $ \(t, n, v) -> do
@@ -1160,7 +1166,7 @@ runStatement (CC.WhileStatement condition code pos) = do
 runStatement x@(CC.DoWhileStatement code condition pos) = do
   solidVMBreakpoint pos
   cntrct <- getCurrentContract
-  if ( (CC._vmVersion cntrct) /= "svm3.2") then 
+  if ( (CC._vmVersion cntrct) /= "svm3.2" && (CC._vmVersion cntrct) /= "svm3.3") then 
     unknownStatement "unknown statement in call to runStatement: " (show x)
   else do
     doWhile (getBool =<< expToVar condition) $ do
@@ -1198,12 +1204,12 @@ runStatement (CC.ForStatement maybeInitStatement maybeConditionExp maybeLoopExp 
 
 runStatement x@(CC.Break _) = do
   cntrct <- getCurrentContract
-  if ( not ((CC._vmVersion cntrct == "svm3.0") || (CC._vmVersion cntrct == "svm3.2")) ) then unknownStatement "unknown statement in call to runStatement: " (show x) else do
+  if ( not ((CC._vmVersion cntrct == "svm3.0") || (CC._vmVersion cntrct == "svm3.2") || (CC._vmVersion cntrct == "svm3.3")) ) then unknownStatement "unknown statement in call to runStatement: " (show x) else do
     return $ Just SBreak
 
 runStatement x@(CC.Continue _) = do 
   cntrct <- getCurrentContract
-  if ( not ((CC._vmVersion cntrct == "svm3.0") || (CC._vmVersion cntrct == "svm3.2")) ) then unknownStatement "unknown statement in call to runStatement: " (show x) else do
+  if ( not ((CC._vmVersion cntrct == "svm3.0") || (CC._vmVersion cntrct == "svm3.2") || (CC._vmVersion cntrct == "svm3.3")) ) then unknownStatement "unknown statement in call to runStatement: " (show x) else do
     return $ Just SContinue
 
 runStatement (CC.Return maybeExpression pos) = do
@@ -1212,7 +1218,7 @@ runStatement (CC.Return maybeExpression pos) = do
 
   case maybeExpression of
     Just e -> do
-      if (not ((CC._vmVersion cntrct == "svm3.2"))) 
+      if (not ((CC._vmVersion cntrct == "svm3.2") || (CC._vmVersion cntrct == "svm3.3"))) 
         then do
           ql <- expToVar e
           qlql <- getVar ql
@@ -1294,7 +1300,7 @@ while condition code = do
   if c
     then do
       result <- code
-      if ( not (CC._vmVersion cntrct == "svm3.2")) then 
+      if ( not (CC._vmVersion cntrct == "svm3.2" || CC._vmVersion cntrct == "svm3.3")) then 
         case result of
           Nothing -> while condition code
           _ -> return result
@@ -1402,11 +1408,15 @@ expToVar x = do
 
 expToVar' :: MonadSM m => CC.Expression -> m Variable
 expToVar' (CC.NumberLiteral _ v Nothing) = return . Constant $ SInteger v
-expToVar' (CC.NumberLiteral _ v (Just nu)) = case nu of
-  CC.Wei -> return . Constant $ SInteger v
-  CC.Szabo -> return . Constant $ SInteger (v * (10 ^ (12 :: Integer)))
-  CC.Finney -> return . Constant $ SInteger (v * (10 ^ (15 :: Integer))) 
-  CC.Ether -> return . Constant $ SInteger (v * (10 ^ (18 :: Integer)))
+expToVar' (CC.NumberLiteral _ v (Just nu)) = do
+  cntract <- getCurrentContract
+  if (CC._vmVersion cntract == "svm3.3") 
+    then case nu of
+      CC.Wei -> return . Constant $ SInteger v
+      CC.Szabo -> return . Constant $ SInteger (v * (10 ^ (12 :: Integer)))
+      CC.Finney -> return . Constant $ SInteger (v * (10 ^ (15 :: Integer))) 
+      CC.Ether -> return . Constant $ SInteger (v * (10 ^ (18 :: Integer)))
+    else unknownStatement "Unit suffixes are not supported below pragma solidvm 3.3" (v, nu)
 expToVar' (CC.StringLiteral _ s) = return $ Constant $ SString s
 expToVar' (CC.BoolLiteral _ b) = return $ Constant $ SBool b
 expToVar' (CC.Variable _ "bytes32ToString") = return $ Constant $ SHexDecodeAndTrim
@@ -1420,7 +1430,7 @@ expToVar' (CC.Variable _ name) = do
 
 expToVar' (CC.Unitary _ "-" e) = do
   cntrct <- getCurrentContract
-  if ( not ((CC._vmVersion cntrct == "svm3.0") || (CC._vmVersion cntrct == "svm3.2"))) then invalidArguments "To use standard negative number declaration use the svm3.0 pragma" e else do
+  if ( not ((CC._vmVersion cntrct == "svm3.0") || (CC._vmVersion cntrct == "svm3.2") || (CC._vmVersion cntrct == "svm3.3"))) then invalidArguments "To use standard negative number declaration use the svm3.0 pragma" e else do
     var <- expToVar e
     value <- getInt var
     return $ Constant $ SInteger (value * (-1))
@@ -1549,18 +1559,18 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
       (SBuiltinVariable "block", "number") -> (Constant . SInteger . blockDataNumber . Env.blockHeader) <$> getEnv
 
       m@(SBuiltinVariable "block", "coinbase") ->
-        if CC._vmVersion contract'' == "svm3.2"
+        if (CC._vmVersion contract'' == "svm3.2" || CC._vmVersion contract'' == "svm3.3")
           then (Constant . ((flip SAccount) True) . (accountToNamedAccount chainId) . ((flip Account) Nothing) . blockDataCoinbase . Env.blockHeader) <$> getEnv
           else typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m)
         
 
       m@(SBuiltinVariable "block", "difficulty") -> 
-        if CC._vmVersion contract'' == "svm3.2"
+        if (CC._vmVersion contract'' == "svm3.2" || CC._vmVersion contract'' == "svm3.3")
           then (Constant . SInteger . blockDataDifficulty . Env.blockHeader) <$> getEnv
           else typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m)
 
       m@(SBuiltinVariable "block", "gaslimit") -> 
-        if CC._vmVersion contract'' == "svm3.2"
+        if (CC._vmVersion contract'' == "svm3.2" || CC._vmVersion contract'' == "svm3.3")
           then (Constant . SInteger . blockDataGasLimit . Env.blockHeader) <$> getEnv
           else typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m)
         
@@ -2060,8 +2070,8 @@ evaluateAccountMember a _ "balance" = do
     _ -> return $ Constant $ SInteger 0 
 evaluateAccountMember a _ "chainId" = do 
   contract' <- getCurrentContract
-  if CC._vmVersion contract' /= "svm3.2"
-    then typeError "illegal member access: svm3.2 required to use .chainId member" ("parsed as " ++ show a ++ ".chainId")
+  if (CC._vmVersion contract' /= "svm3.2" && CC._vmVersion contract' /= "svm3.3")
+    then typeError "illegal member access: svm3.2+ required to use .chainId member" ("parsed as " ++ show a ++ ".chainId")
     else case (a ^. namedAccountChainId) of
             UnspecifiedChain -> do 
               curCid <- view accountChainId <$> getCurrentAccount
@@ -2161,7 +2171,7 @@ callBuiltin "account" [SInteger a, SString "grandparent"] _          = unspecifi
 callBuiltin "account" [SInteger a, SString "ancestor", SInteger n] _ = unspecifiedChain (fromIntegral a) `castToAncestor` n
 callBuiltin "account" [SInteger a, SString ('0':'x':xs)] _ = do
   contract' <- getCurrentContract
-  if CC._vmVersion contract' == "svm3.2" 
+  if (CC._vmVersion contract' == "svm3.2" || CC._vmVersion contract' == "svm3.3")
     then 
       return . ((flip SAccount) False) $ explicitChain (fromIntegral a) (fromIntegral $ base16ToIntegral xs)
     else
@@ -2183,31 +2193,39 @@ callBuiltin "account" [(SAccount a _), SString ('0':'x':xs)] _ = return . ((flip
 callBuiltin "account" [(SAccount _ _) , SString b] _ = invalidArguments "the chainId string must be a hexString beggining with \"0x\" " b
 callBuiltin am@("addmod") [SInteger a, SInteger b, SInteger c] _ = do 
   contract' <- getCurrentContract
-  if CC._vmVersion contract' == "svm3.2"
+  if (CC._vmVersion contract' == "svm3.2" || CC._vmVersion contract' == "svm3.3")
     then return . SInteger $ (a + b) `mod` c
     else unknownFunction "callBuiltin" am
 callBuiltin mm@("mulmod") [SInteger a, SInteger b, SInteger c] _ = do 
   contract' <- getCurrentContract
-  if CC._vmVersion contract' == "svm3.2"
+  if (CC._vmVersion contract' == "svm3.2" || CC._vmVersion contract' == "svm3.3")
     then return . SInteger $ (a * b) `mod` c
     else unknownFunction "callBuiltin" mm
   
-callBuiltin "blockhash" [SInteger blockNum] _ = do
-  when (blockNum<0) (invalidArguments "Does not Exist" [blockNum])
-  env' <- getEnv
-  let curBlock = Env.blockHeader env'
-  maybeTheHash  <- getBlockHashWithNumber blockNum (blockDataParentHash curBlock)
-  --theHash :: Maybe Keccak256
-  maybe (invalidArguments "the block number given does not exist" [blockNum]) (return . SString . BC.unpack . keccak256ToByteString) maybeTheHash
+callBuiltin bh@("blockhash") [SInteger blockNum] _ = do
+  contract' <- getCurrentContract
+  if (CC._vmVersion contract' == "svm3.3")
+    then do
+      when (blockNum<0) (invalidArguments "Does not Exist" [blockNum])
+      env' <- getEnv
+      let curBlock = Env.blockHeader env'
+      maybeTheHash  <- getBlockHashWithNumber blockNum (blockDataParentHash curBlock)
+      --theHash :: Maybe Keccak256
+      maybe (invalidArguments "the block number given does not exist" [blockNum]) (return . SString . BC.unpack . keccak256ToByteString) maybeTheHash
+  else unknownFunction "callBuiltin" bh
 
-callBuiltin "selfdestruct" [SAccount a _] _ = do
-  contract' <- getCurrentAccount
-  contractBalance <- addressStateBalance <$> A.lookupWithDefault (A.Proxy @AddressState) contract' 
-  _destroyRes <- A.adjustWithDefault_ (A.Proxy @AddressState) contract' $ \newAddressState ->
-    pure newAddressState{ addressStateCodeHash = SolidVMCode "Code_0" $ unsafeCreateKeccak256FromWord256 0}
-  sendRes <- pay "selfdestruct function" contract' (namedAccountToAccount Nothing a) contractBalance
-  _purgeRes <- purgeStorageMap contract'
-  return $ SBool sendRes
+callBuiltin sd@("selfdestruct") [SAccount a _] _ = do
+  contract'' <- getCurrentContract
+  if (CC._vmVersion contract'' == "svm3.3")
+    then do
+      contract' <- getCurrentAccount
+      contractBalance <- addressStateBalance <$> A.lookupWithDefault (A.Proxy @AddressState) contract' 
+      _destroyRes <- A.adjustWithDefault_ (A.Proxy @AddressState) contract' $ \newAddressState ->
+        pure newAddressState{ addressStateCodeHash = SolidVMCode "Code_0" $ unsafeCreateKeccak256FromWord256 0}
+      sendRes <- pay "selfdestruct function" contract' (namedAccountToAccount Nothing a) contractBalance
+      _purgeRes <- purgeStorageMap contract'
+      return $ SBool sendRes
+  else unknownFunction "callBuiltin" sd
 
 callBuiltin "account" vs _ = typeError "account cast" vs
 callBuiltin "bool" [SBool b] _ = return $ SBool b
@@ -2231,29 +2249,37 @@ callBuiltin "keccak256" args Nothing = do
   case allStrings args of
     False -> invalidArguments "cannot use a non string arguments in keccak256" args
     True ->  return . SString . BC.unpack . keccak256ToByteString . hash . BC.pack $ customConcat args
-callBuiltin "sha256" args Nothing = do
-  let allStrings [] = True
-      allStrings ((SString _):xs) = True && (allStrings xs)
-      allStrings _ = False
-      customConcat [] = ""
-      customConcat ((SString str):ys) = str ++ customConcat ys
-      customConcat _ = invalidArguments "cannot use a non string arguments in sha256" args
-  case allStrings args of
-    False -> invalidArguments "cannot use a non string arguments in sha256" args
-    True ->  return . SString . BC.unpack . SHA256.hash . BC.pack $ customConcat args
-callBuiltin "ripemd160" args Nothing = do
-  let allStrings [] = True
-      allStrings ((SString _):xs) = True && (allStrings xs)
-      allStrings _ = False
-      customConcat [] = ""
-      customConcat ((SString str):ys) = str ++ customConcat ys
-      customConcat _ = invalidArguments "cannot use a non string arguments in ripemd160" args
-  case allStrings args of
-    False -> invalidArguments "cannot use a non string arguments in ripemd160" args
-    True ->  return . SString . BC.unpack . RIPEMD160.hash . BC.pack $ customConcat args
+callBuiltin sha256@("sha256") args Nothing = do
+  contract' <- getCurrentContract
+  if (CC._vmVersion contract' == "svm3.3")
+    then do
+      let allStrings [] = True
+          allStrings ((SString _):xs) = True && (allStrings xs)
+          allStrings _ = False
+          customConcat [] = ""
+          customConcat ((SString str):ys) = str ++ customConcat ys
+          customConcat _ = invalidArguments "cannot use a non string arguments in sha256" args
+      case allStrings args of
+        False -> invalidArguments "cannot use a non string arguments in sha256" args
+        True ->  return . SString . BC.unpack . SHA256.hash . BC.pack $ customConcat args
+  else unknownFunction "callBuiltin" sha256
+callBuiltin ripemd160@("ripemd160") args Nothing = do
+  contract' <- getCurrentContract
+  if (CC._vmVersion contract' == "svm3.3")
+    then do
+      let allStrings [] = True
+          allStrings ((SString _):xs) = True && (allStrings xs)
+          allStrings _ = False
+          customConcat [] = ""
+          customConcat ((SString str):ys) = str ++ customConcat ys
+          customConcat _ = invalidArguments "cannot use a non string arguments in ripemd160" args
+      case allStrings args of
+        False -> invalidArguments "cannot use a non string arguments in ripemd160" args
+        True ->  return . SString . BC.unpack . RIPEMD160.hash . BC.pack $ customConcat args
+  else unknownFunction "callBuiltin" ripemd160
 callBuiltin pb@("payable") [SAccount a _] _ = do 
   contract' <- getCurrentContract
-  if CC._vmVersion contract' == "svm3.2"
+  if (CC._vmVersion contract' == "svm3.2" || CC._vmVersion contract' == "svm3.3")
     then return $ SAccount a True
     else unknownFunction "callBuiltin" pb
 callBuiltin "require" (SBool cond :msg) Nothing = do
@@ -2264,7 +2290,7 @@ callBuiltin "require" (SBool cond :msg) Nothing = do
 callBuiltin "assert" [SBool cond] Nothing = SNULL <$ assert cond
 callBuiltin rc@("registerCert") [(SAccount a _), SString cert] _ = do
   contract' <- getCurrentContract
-  if CC._vmVersion contract' == "svm3.2" 
+  if (CC._vmVersion contract' == "svm3.2"  || CC._vmVersion contract' == "svm3.3")
     then unknownFunction "callBuiltin" rc
     else do
       curAccount <- getCurrentAccount
@@ -2290,7 +2316,7 @@ callBuiltin rc@("registerCert") [(SAccount a _), SString cert] _ = do
 callBuiltin rc'@("registerCert") [SString cert] _ = do
   contract' <- getCurrentContract
   let rootAddress = fromPublicKey rootPubKey
-  if CC._vmVersion contract' /= "svm3.2" 
+  if (CC._vmVersion contract' /= "svm3.2" && CC._vmVersion contract' /= "svm3.3")
     then unknownFunction "callBuiltin" rc'
     else do
       curAccount <- getCurrentAccount
@@ -2400,7 +2426,7 @@ callBuiltin "getUserCert" [SAccount a _] _ = do
 -- Raises an error if it can't parse either argument, however perhaps that should't happen...
 callBuiltin vc@"verifyCert" [SString cert, SString pubkey] _ = do
   curContract <- getCurrentContract
-  if CC._vmVersion curContract == "svm3.2" then do
+  if (CC._vmVersion curContract == "svm3.2" || CC._vmVersion curContract == "svm3.3") then do
     let ex509Cert = bsToCert . BC.pack $ cert
     let ePublicKey = bsToPub $ BC.pack pubkey
     case (ex509Cert, ePublicKey) of 
@@ -2421,7 +2447,7 @@ callBuiltin vc@"verifyCert" [SString cert, SString pubkey] _ = do
 -- Raises an error if it can't parse either argument, however perhaps that should't happen...
 callBuiltin vc@"verifyCertSignedBy" [SString cert, SString pubkey] _ = do
   curContract <- getCurrentContract
-  if CC._vmVersion curContract == "svm3.2" then do
+  if (CC._vmVersion curContract == "svm3.2" || CC._vmVersion curContract == "svm3.3") then do
     let ex509Cert = bsToCert . BC.pack $ cert
     let ePublicKey = bsToPub $ BC.pack pubkey
     case (ex509Cert, ePublicKey) of 
@@ -2441,7 +2467,7 @@ callBuiltin vc@"verifyCertSignedBy" [SString cert, SString pubkey] _ = do
 -- Raises an error if it can't parse either argument, however perhaps that should't happen...
 callBuiltin vs@"verifySignature" [SString msg, SString signature, SString pubkey] _ = do
   curContract <- getCurrentContract
-  if CC._vmVersion curContract == "svm3.2" then do
+  if (CC._vmVersion curContract == "svm3.2" || CC._vmVersion curContract == "svm3.3") then do
     let eMesgBs = B16.decode $ BC.pack msg 
     case eMesgBs of 
       Right mesgBs -> do
@@ -2561,6 +2587,7 @@ runTheConstructors from to hsh cc contractName' argExps = do
                                   argExps
   let einval = invalidArguments "named arguments to contract without constructor" (contractName', argVals)
   let svm3_2 = CC._vmVersion contract' == "svm3.2"
+  let svm3_3 = CC._vmVersion contract' == "svm3.3"
   zipped <-
     case argVals of
       OrderedVals vals ->
@@ -2621,7 +2648,7 @@ runTheConstructors from to hsh cc contractName' argExps = do
               --args' <- argsToVals contract' theModifier argExps
               return $ Just theModifier
             Nothing -> do
-              if name `elem` contract'^.CC.parents then return Nothing else (if svm3_2 then (missingField "modifier not found" name) else return Nothing)
+              if name `elem` contract'^.CC.parents then return Nothing else (if (svm3_2 || svm3_3) then (missingField "modifier not found" name) else return Nothing)
         let theModifiers = catMaybes theModifiers'
         !commands <- case CC.funcContents theFunction of
           Nothing -> missingField "contract constructor has been declared but not defined" contractName'
@@ -2676,11 +2703,12 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro = do
   let returns = [(n, (t, defaultValue contract' t)) | (Just n, CC.IndexedType _ t) <- CC.funcVals theFunction]
       theModifierNames = map fst $ (CC.funcModifiers theFunction) 
       svm3_2 = CC._vmVersion contract' == "svm3.2"
+      svm3_3 = CC._vmVersion contract' == "svm3.3"
   theModifiers' <- forM theModifierNames $ \name -> do
     case M.lookup name (contract'^.CC.modifiers) of
       Just theModifier -> do
         return $ Just theModifier
-      Nothing -> if name `elem` contract' ^. CC.parents then return Nothing else (if svm3_2 then (missingField "modifier not found" name) else return Nothing)
+      Nothing -> if name `elem` contract' ^. CC.parents then return Nothing else (if (svm3_2 || svm3_3) then (missingField "modifier not found" name) else return Nothing)
   let !theModifiers = catMaybes theModifiers'
   matchedArgvals <- forM theModifiers $ \modi -> do
     let margList = CC.OrderedArgs 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2430,12 +2430,13 @@ callBuiltin "registerCert" [SString cert, (SContract "Certificate" na)] _ = do
 
 
 callBuiltin "getUserCert" [SAccount a _] _ = do
+  curContract <- getCurrentContract
   -- TODO remove level db check, use redis instead
   x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
   maybeCertLevelDB <- x509CertDBGet $ _namedAccountAddress a
   let maybeCertBlockDB = M.lookup (_namedAccountAddress a) x509s
       maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-  return $ certificateMap (fmap (BC.unpack . certToBytes) maybeCert)
+  return $ certificateMap (fmap (BC.unpack . certToBytes) maybeCert) curContract
 
 -- SolidVM built in function that verifies that the root cert is signed by the key
 -- verifyCert checks that the root of a chained cert is signed by the public key.
@@ -2505,37 +2506,60 @@ callBuiltin vs@"verifySignature" [SString msg, SString signature, SString pubkey
       Left err -> malformedData "Could not decode hex string" err
   else unknownFunction "callBuiltin" vs
   
-callBuiltin "parseCert" [SString cert] _ = return $ certificateMap (Just cert)
+callBuiltin "parseCert" [SString cert] _ = do
+  curContract <- getCurrentContract
+  return $ certificateMap (Just cert) curContract
 
 callBuiltin x _ _ = unknownFunction "callBuiltin" x
 
 
 
-certificateMap :: Maybe String -> Value
-certificateMap maybeCert = case maybeCert of
-    Nothing -> SMap stringToString emptyCertMap
-    Just cert -> SMap stringToString (fromMaybe emptyCertMap $ fmap (certMap cert) (subject cert))
+certificateMap :: Maybe String -> CC.Contract -> Value
+certificateMap maybeCert cntrct = 
+    case maybeCert of
+      Nothing -> SMap stringToString emptyCertMap
+      Just cert -> SMap stringToString (fromMaybe emptyCertMap $ fmap (certMap cert) (subject cert))
     where subject cert = getCertSubject =<< (eitherToMaybe . bsToCert . BC.pack $ cert)
-          certMap cert sub = M.fromList [ (SString "commonName", Constant . SString $ subCommonName sub)
-                                   , (SString "country", Constant . SString $ fromMaybe "" $ subCountry sub)
-                                   , (SString "organization", Constant . SString $ subOrg sub)
-                                   , (SString "group", Constant . SString $ fromMaybe "" $ subUnit sub)
-                                   , (SString "organizationalUnit", Constant . SString $ fromMaybe "" $ subUnit sub)
-                                   , (SString "publicKey", Constant . SString $ BC.unpack $ pubToBytes $ subPub sub)
-                                   , (SString "userAddress", Constant . SString $ show $ fromPublicKey $ subPub sub)
-                                   , (SString "certString", Constant . SString $ cert)
-                                   , (SString "parent", Constant . SString $ maybe "0" show (getParentUserAddress =<< (eitherToMaybe . bsToCert . BC.pack $ cert)))
-                                   ]
-          emptyCertMap = M.fromList [ (SString "commonName", Constant . SString $ "")
-                             , (SString "country", Constant . SString $ "")
-                             , (SString "organization", Constant . SString $ "")
-                             , (SString "group", Constant . SString $ "")
-                             , (SString "organizationalUnit", Constant . SString $ "")
-                             , (SString "publicKey", Constant . SString $ "")
-                             , (SString "userAddress", Constant . SString $ "")
-                             , (SString "certString", Constant . SString $ "")
-                             , (SString "parent", Constant . SString $ "")
-                             ]
+          certMap cert sub = if (CC._vmVersion cntrct == "svm3.3")
+                              then M.fromList [ (SString "commonName", Constant . SString $ subCommonName sub)
+                                              , (SString "country", Constant . SString $ fromMaybe "" $ subCountry sub)
+                                              , (SString "organization", Constant . SString $ subOrg sub)
+                                              , (SString "group", Constant . SString $ fromMaybe "" $ subUnit sub)
+                                              , (SString "organizationalUnit", Constant . SString $ fromMaybe "" $ subUnit sub)
+                                              , (SString "publicKey", Constant . SString $ BC.unpack $ pubToBytes $ subPub sub)
+                                              , (SString "userAddress", Constant . SString $ show $ fromPublicKey $ subPub sub)
+                                              , (SString "certString", Constant . SString $ cert)
+                                              , (SString "parent", Constant . SString $ maybe "0" show (getParentUserAddress =<< (eitherToMaybe . bsToCert . BC.pack $ cert)))
+                                              ]
+                              else M.fromList [ (SString "commonName", Constant . SString $ subCommonName sub)
+                                              , (SString "country", Constant . SString $ fromMaybe "" $ subCountry sub)
+                                              , (SString "organization", Constant . SString $ subOrg sub)
+                                              , (SString "group", Constant . SString $ fromMaybe "" $ subUnit sub)
+                                              , (SString "publicKey", Constant . SString $ BC.unpack $ pubToBytes $ subPub sub)
+                                              , (SString "userAddress", Constant . SString $ show $ fromPublicKey $ subPub sub)
+                                              , (SString "certString", Constant . SString $ cert)
+                                              , (SString "parent", Constant . SString $ maybe "0" show (getParentUserAddress =<< (eitherToMaybe . bsToCert . BC.pack $ cert)))
+                                              ]
+          emptyCertMap = if (CC._vmVersion cntrct == "svm3.3")
+                          then M.fromList [ (SString "commonName", Constant . SString $ "")
+                                          , (SString "country", Constant . SString $ "")
+                                          , (SString "organization", Constant . SString $ "")
+                                          , (SString "group", Constant . SString $ "")
+                                          , (SString "organizationalUnit", Constant . SString $ "")
+                                          , (SString "publicKey", Constant . SString $ "")
+                                          , (SString "userAddress", Constant . SString $ "")
+                                          , (SString "certString", Constant . SString $ "")
+                                          , (SString "parent", Constant . SString $ "")
+                                          ]
+                          else M.fromList [ (SString "commonName", Constant . SString $ "")
+                                          , (SString "country", Constant . SString $ "")
+                                          , (SString "organization", Constant . SString $ "")
+                                          , (SString "group", Constant . SString $ "")
+                                          , (SString "publicKey", Constant . SString $ "")
+                                          , (SString "userAddress", Constant . SString $ "")
+                                          , (SString "certString", Constant . SString $ "")
+                                          , (SString "parent", Constant . SString $ "")
+                                          ]
           stringToString = SVMType.Mapping { SVMType.dynamic = Nothing
                                         , SVMType.key = SVMType.String Nothing
                                         , SVMType.value = SVMType.String Nothing }

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1825,18 +1825,22 @@ expToVar' (CC.FunctionCall _ (CC.NewExpression _ (SVMType.UnknownLabel contractN
     $  erNewContractAccount execResults
 
 expToVar' (CC.FunctionCall _ (CC.NewExpression _ (SVMType.UnknownLabel contractName' (Just saltExpressionText))) args) = do
-  ro <- readOnly <$> getCurrentCallInfo
-  when ro $ invalidWrite "Invalid contract creation during read-only access" $ "contractName: " ++ show contractName' ++ ", args: " ++ show args
-  creator <- getCurrentAccount
-  (hsh, cc) <- getCurrentCodeCollection
-  let contractNameString = labelToString contractName'
-  salt <- saltTextToValue saltExpressionText
-  newAddress <- getNewAddressWithSalt creator salt contractNameString hsh
-  x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-  execResults <- create' creator newAddress hsh cc contractName' args x509s'
-  return $ Constant $ SContract contractName' $ accountOnUnspecifiedChain
-    $ fromMaybe (internalError "a call to create did not create an address" execResults)
-    $  erNewContractAccount execResults
+  ctract <- getCurrentContract
+  if CC._vmVersion ctract == "svm3.3"
+    then do
+      ro <- readOnly <$> getCurrentCallInfo
+      when ro $ invalidWrite "Invalid contract creation during read-only access" $ "contractName: " ++ show contractName' ++ ", args: " ++ show args
+      creator <- getCurrentAccount
+      (hsh, cc) <- getCurrentCodeCollection
+      let contractNameString = labelToString contractName'
+      salt <- saltTextToValue saltExpressionText
+      newAddress <- getNewAddressWithSalt creator salt contractNameString hsh
+      x509s' <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+      execResults <- create' creator newAddress hsh cc contractName' args x509s'
+      return $ Constant $ SContract contractName' $ accountOnUnspecifiedChain
+        $ fromMaybe (internalError "a call to create did not create an address" execResults)
+        $  erNewContractAccount execResults
+    else unknownStatement "Salted contract creation is not supported below pragma solidvm 3.3" (contractName' ++ "(salt: " ++ saltExpressionText ++ ")")
   where
     saltTextToValue saltText = do
       let stringParser = do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1530,18 +1530,24 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
                                              let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
                                                  maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
                                              return . Constant . SString . fromMaybe "" $ subUnit =<< getCertSubject =<< maybeCert
-      (SBuiltinVariable "tx", "organizationalUnit") -> do env' <- getEnv
-                                                          x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-                                                          maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
-                                                          let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
-                                                              maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-                                                          return . Constant . SString . fromMaybe "" $ subUnit =<< getCertSubject =<< maybeCert
-      (SBuiltinVariable "tx", "certificate") -> do env' <- getEnv
-                                                   x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
-                                                   maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
-                                                   let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
-                                                       maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
-                                                   return . Constant . SString . fromMaybe "" $ fmap (BC.unpack . certToBytes) maybeCert
+      m@(SBuiltinVariable "tx", "organizationalUnit") -> if (CC._vmVersion contract'' == "svm3.3") 
+                                                            then do 
+                                                              env' <- getEnv
+                                                              x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+                                                              maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
+                                                              let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
+                                                                  maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
+                                                              return . Constant . SString . fromMaybe "" $ subUnit =<< getCertSubject =<< maybeCert
+                                                            else typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m)
+      m@(SBuiltinVariable "tx", "certificate") -> if (CC._vmVersion contract'' == "svm3.3")
+                                                    then do 
+                                                      env' <- getEnv
+                                                      x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))
+                                                      maybeCertLevelDB <- x509CertDBGet $ _accountAddress $ Env.origin env'
+                                                      let maybeCertBlockDB = M.lookup (_accountAddress $ Env.origin env') x509s
+                                                          maybeCert = maybeCertBlockDB <|> maybeCertLevelDB
+                                                      return . Constant . SString . fromMaybe "" $ fmap (BC.unpack . certToBytes) maybeCert
+                                                    else typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m)
       (SStruct _ theMap, fieldName) -> case M.lookup fieldName theMap of
           Nothing -> missingField "struct member access" fieldName
           Just v -> return v

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/Builtins.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/Builtins.hs
@@ -28,7 +28,7 @@ push (SReference apt) _ (OrderedVals [av]) = do
 
 push (SArray varType vec) (Just (Variable ref)) (OrderedVals [av]) = do
   contract' <- getCurrentContract
-  if CC._vmVersion contract' == "svm3.2"
+  if (CC._vmVersion contract' == "svm3.2" || CC._vmVersion contract' == "svm3.3")
     then do
       let newVar = Constant av
           newArr = V.snoc vec newVar 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -75,7 +75,7 @@ compileSourceNoInheritance initCodeMap = do
         let pragmas = \case
               Pragma _ n v -> Just (n, v)
               _ -> Nothing
-            vmVersion' = if (Just ("solidvm","3.2")) `elem` (pragmas <$> sourceUnits) then "svm3.2" else (if (Just ("solidvm","3.0")) `elem` (pragmas <$> sourceUnits) then "svm3.0" else "")
+            vmVersion' = if (Just ("solidvm","3.3")) `elem` (pragmas <$> sourceUnits) then "svm3.3" else (if (Just ("solidvm","3.2")) `elem` (pragmas <$> sourceUnits) then "svm3.2" else (if (Just ("solidvm","3.0")) `elem` (pragmas <$> sourceUnits) then "svm3.0" else ""))
         fmap catMaybes . for sourceUnits $ \case
           NamedXabi name (xabi, parents') -> do
             ctrct <- first SVMEx
@@ -102,11 +102,17 @@ hasSvm3_2 cc = any (=="svm3.2") vmVers
     contractList = map snd $ M.toList (cc ^. contracts )
     vmVers = map (^. vmVersion ) contractList
 
+hasSvm3_3 :: CodeCollection -> Bool
+hasSvm3_3 cc = any (=="svm3.3") vmVers
+  where
+    contractList = map snd $ M.toList (cc ^. contracts )
+    vmVers = map (^. vmVersion ) contractList
+
 compileSource :: Map T.Text T.Text -> Either ParseTypeCheckOrSolidVMError CodeCollection
 compileSource mTT = do
   let applyInheritanceE = first SVMEx . applyInheritance
   case ((applyInheritanceE <=< compileSourceNoInheritance) mTT) of   
-    Right cc -> if hasSvm3_2 cc then typeCheckDetector cc else Right cc
+    Right cc -> if ((hasSvm3_2 cc) || (hasSvm3_3 cc)) then typeCheckDetector cc else Right cc
     Left x -> Left x
     where 
       typeCheckDetector ecc = case TC.detector ecc of

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -164,7 +164,7 @@ setVal dst@(SReference addressedPath@(AccountPath addr path)) src = do
                         _         -> toBasic src
   markDiffForAction addr path basicSrc
   contract <- getCurrentContract
-  let svm3_0 = CC._vmVersion contract == "svm3.0" || CC._vmVersion contract == "svm3.2"
+  let svm3_0 = CC._vmVersion contract == "svm3.0" || CC._vmVersion contract == "svm3.2" || CC._vmVersion contract == "svm3.3"
   putSolidStorageKeyVal' svm3_0 addr path basicSrc
 
 
@@ -235,7 +235,7 @@ getVar (Constant (SReference addressedPath@(AccountPath addr key))) = do
 
 getVar (Constant (SStruct s ma)) = do
   cntrct <- getCurrentContract
-  if ( not (CC._vmVersion cntrct == "svm3.2") ) then return (SStruct s ma) else do
+  if ( not (CC._vmVersion cntrct == "svm3.2" || CC._vmVersion cntrct == "svm3.3") ) then return (SStruct s ma) else do
     resolved <- mapM (\var -> do
         v <- getVar var
         return $ Constant v
@@ -244,7 +244,7 @@ getVar (Constant (SStruct s ma)) = do
 
 getVar (Constant (SArray typ vc)) = do
   cntrct <- getCurrentContract
-  if ( not (CC._vmVersion cntrct == "svm3.2")) then return (SArray typ vc) else do
+  if ( not (CC._vmVersion cntrct == "svm3.2" || CC._vmVersion cntrct == "svm3.3")) then return (SArray typ vc) else do
     resolved <- V.mapM (\var -> do
         v <- getVar var
         return $ Constant v
@@ -253,7 +253,7 @@ getVar (Constant (SArray typ vc)) = do
 
 getVar (Constant (STuple vct)) = do
   cntrct <- getCurrentContract
-  if (not (CC._vmVersion cntrct == "svm3.2")) then return (STuple vct) else do
+  if (not (CC._vmVersion cntrct == "svm3.2" || CC._vmVersion cntrct == "svm3.3")) then return (STuple vct) else do
     resolved <- V.mapM (\var -> do
         v <- getVar var
         return $ Constant v
@@ -262,7 +262,7 @@ getVar (Constant (STuple vct)) = do
   
 getVar (Constant (SMap ty mp)) = do
   cntrct <- getCurrentContract
-  if ( not (CC._vmVersion cntrct == "svm3.2")) then return (SMap ty mp) else do
+  if ( not (CC._vmVersion cntrct == "svm3.2" || CC._vmVersion cntrct == "svm3.3")) then return (SMap ty mp) else do
     resolved <- mapM (\var -> do
         v <- getVar var
         return $ Constant v
@@ -271,7 +271,7 @@ getVar (Constant (SMap ty mp)) = do
 
 getVar (Constant (SPush v (Just var))) = do
   cntrct <- getCurrentContract
-  if ( not (CC._vmVersion cntrct == "svm3.2")) then return (SPush v (Just var)) else do
+  if ( not (CC._vmVersion cntrct == "svm3.2" || CC._vmVersion cntrct == "svm3.3")) then return (SPush v (Just var)) else do
     resolved <- getVar var
     return $ SPush v (Just $ Constant resolved)
 
@@ -310,7 +310,7 @@ deleteVar (Constant (SReference a@(AccountPath addr path))) = do
       when ro $ invalidWrite "Invalid delete during read-only access" $ "addr: " ++ show addr ++ ", path: " ++ show path
       markDiffForAction addr path $ MS.BDefault
       contract <- getCurrentContract
-      let svm3_0 = CC._vmVersion contract == "svm3.0" || CC._vmVersion contract == "svm3.2"
+      let svm3_0 = CC._vmVersion contract == "svm3.0" || CC._vmVersion contract == "svm3.2" || CC._vmVersion contract == "svm3.3"
       putSolidStorageKeyVal' svm3_0 addr path $ MS.BDefault
 
 deleteVar v = todo "deleteVar not yet supported for local variables" $ show v

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -3979,7 +3979,7 @@ contract qq {
       ]
   it "can get a users cert" . runTest $ do
     void $ runArgsWithOrigin rootAcc sender "()" [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
     account myAccount = account(0x74f014FEF932D2728c6c7E2B4d3B88ac37A7E1d0);
     

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4409,7 +4409,7 @@ contract qq {
 
   it "can declare a custom modifier and use it in a contract" $ (runTest $ do
     (runBS [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
   modifier myModifier() {  // line 4
     require(false);
@@ -4425,7 +4425,7 @@ contract qq {
 
   it "can declare a custom modifier and use it in a contract" $ (runTest $ do
     (runBS [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
   modifier myModifier() {  // line 4
     return 7;
@@ -4443,7 +4443,7 @@ contract qq {
 
   it "can use a modifier as part of a function" . runTest $ do
     runCall "decrement" "(1)" [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
     // We will use these variables to demonstrate how to use
     // modifiers.
@@ -4498,7 +4498,7 @@ contract qq {
 
   it "can use a modifier and require something after and before the function is run" . runTest $ do
     runBS [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
   uint x = 3;
   modifier myModifier() {  
@@ -4517,7 +4517,7 @@ contract qq {
 
   it "can use a modifier multiple modifiers and they occur in order" . runTest $ do
     runBS [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
   uint x = 3;
   modifier myModifier() {  
@@ -4543,7 +4543,7 @@ contract qq {
 
   it "can use a modifier  that takes arguments as part of a function" . runTest $ do
     runCall "a" "()" [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
   uint x = 3;
   modifier myModifier(uint _x) {  

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4726,6 +4726,7 @@ contract qq{
 
   it "can create salted contract" . runTest $ do
     runBS [r|
+pragma solidvm 3.3;
 contract X {
   string public xNum;
 }
@@ -4740,7 +4741,7 @@ contract qq {
   X public z;
   bytes32 salt';
   constructor() public {
-    salt' = 0x12345678;
+    salt' = "salt";
     x = new X{salt: salt'}();
     y = new Y{salt: salt'}();
     z = new X{salt: "something"}();
@@ -4748,9 +4749,9 @@ contract qq {
   }
 }|]
     getFields ["x", "y", "z"] `shouldReturn` 
-      [ bContract "X" 0x1e9abebf7e4e73283a531d44a33f7eb6371cf820
-      , bContract "Y" 0x3911f467237f82a56973a5f4d87aa67107479626
-      , bContract "X" 0x33945db5a537463004fbed0bde21ac30d46ad052
+      [ bContract "X" 0x2facc7c9bda88a8261d4ed20fab790a017f52ca0
+      , bContract "Y" 0x43fb24796bed33a219bef6919a82c4929dd7899d
+      , bContract "X" 0x58d79e1e4170a7d37980fdcd7f660e3504ad67c5
       ]
       
   it "can use a try catch statment to catch a divide by zero error the SolidVM Way (trademark pending)" . runTest $ do

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -703,33 +703,39 @@ contract qq {
 
     it "throw an error when there is an 'block_timestamp' variable name" $ runTest (do
       runBS [r|
+pragma solidvm 3.3;
+
 contract qq {
    string block_timestamp;
    constructor()
    {
       block_timestamp = "hello";
    }
-}|]) `shouldThrow` anyParseError
+}|]) `shouldThrow` anyReservedWordError
 
     it "throw an error when there is an 'block_hash' variable name" $ runTest (do
       runBS [r|
+pragma solidvm 3.3;
+
 contract qq {
    string block_hash;
    constructor()
    {
       block_hash = "hello";
    }
-}|]) `shouldThrow` anyParseError
+}|]) `shouldThrow` anyReservedWordError
 
     it "throw an error when there is an 'block_number' variable name" $ runTest (do
       runBS [r|
+pragma solidvm 3.3;
+
 contract qq {
    string block_number;
    constructor()
    {
       block_number = "hello";
    }
-}|]) `shouldThrow` anyParseError
+}|]) `shouldThrow` anyReservedWordError
 
 
     it "throw an error when there is an 'address' variable name" $ runTest (do
@@ -740,21 +746,27 @@ contract qq {
 
     it "throw an error when there is an 'record_id' variable name" $ runTest (do
       runBS [r|
+pragma solidvm 3.3;
+
 contract qq {
    uint record_id;
-}|]) `shouldThrow` anyParseError
+}|]) `shouldThrow` anyReservedWordError
 
     it "throw an error when there is an 'transaction_hash' variable name" $ runTest (do
       runBS [r|
+pragma solidvm 3.3;
+
 contract qq {
    uint transaction_hash;
-}|]) `shouldThrow` anyParseError
+}|]) `shouldThrow` anyReservedWordError
 
     it "throw an error when there is an 'transaction_sender' variable name" $ runTest (do
       runBS [r|
+pragma solidvm 3.3;
+
 contract qq {
    uint transaction_sender;
-}|]) `shouldThrow` anyParseError
+}|]) `shouldThrow` anyReservedWordError
 
     it "can multiline require" . runTest $ do
       runBS [r|
@@ -4571,7 +4583,7 @@ contract qq {
 
   it "cannot allow negative block number" $ runTest (do
     runBS [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
   constructor() public returns (bytes32) {
     return blockhash(-1);
@@ -4605,7 +4617,7 @@ contract qq {
 
   it "can use builtin sha256 function" . runTest $ do
     runBS [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
   bytes32 hsh;
   constructor() public {
@@ -4618,7 +4630,7 @@ contract qq {
     
   it "can use the builtin ripemd160 function" . runTest $ do
     runBS [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
   bytes20 hsh;
   constructor() public {
@@ -4630,7 +4642,7 @@ contract qq {
 
   it "can use the selfdestruct function" . runTest $ do
     let contract = [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq {
   account contract';
   account payable contractPay;
@@ -4697,7 +4709,7 @@ contract qq{
 
   it "can use ether number unit suffixes" . runTest $ do
     runBS [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq{
   uint weiUnit;
   uint szaboUnit;

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -2418,8 +2418,14 @@ contract qq {
 }|]
     getFields ["i"] `shouldReturn` [BInteger 8]
 
-  it "can accept modifiers" $ (runTest $ runBS [r| contract qq { modifier m() { _; } }|])
-    `shouldReturn` ()
+  it "can accept modifiers" $ runTest (do
+      runBS [r| 
+  pragma solidvm 3.3; 
+  contract qq { 
+    modifier m() {
+       _; 
+      } 
+}|]) `shouldReturn` ()
 
   it "catches parse errors" $ (runTest $ runBS [r| contract { |]) `shouldThrow` anyParseError
 
@@ -3814,6 +3820,7 @@ contract qq {
 
   it "can parse an X509 certificate" . runTest $ do
     runBS [r|
+pragma solidvm 3.3;
 contract qq {
 
     string myNewCertificate = "-----BEGIN CERTIFICATE-----\nMIIBiDCCAS2gAwIBAgIQCgO76hC29iXEFXJNco5ekjAMBggqhkjOPQQDAgUAMEYx\nDDAKBgNVBAMMA2RhbjEMMAoGA1UEBgwDVVNBMRIwEAYDVQQKDAlibG9ja2FwcHMx\nFDASBgNVBAsMC2VuZ2luZWVyaW5nMB4XDTIxMDMxODE1NDgwN1oXDTIyMDMxODE1\nNDgwN1owRjEMMAoGA1UEAwwDZGFuMQwwCgYDVQQGDANVU0ExEjAQBgNVBAoMCWJs\nb2NrYXBwczEUMBIGA1UECwwLZW5naW5lZXJpbmcwVjAQBgcqhkjOPQIBBgUrgQQA\nCgNCAAQY4p67l1IIEUdVC7L+rUDwF5Nv30bze0NV5y8ced7qwp+YFk3UAiOGkcYo\n7ba8F92rd0yf9AGpvZN1H3Dda8xdMAwGCCqGSM49BAMCBQADRwAwRAIgbKXO8tZ5\noPhBusPQFkNEQDnLO/MRru4KjtCpPnVb5sACIE0TwBJ7yeIGuPc/8G50/858Pf3a\n0t1hHbhYnJarPkNA\n-----END CERTIFICATE-----";

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4755,7 +4755,7 @@ contract qq {
       
   it "can use a try catch statment to catch a divide by zero error the SolidVM Way (trademark pending)" . runTest $ do
     runBS [r|
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract qq{
   uint mynum = 5;
   constructor() public {
@@ -4770,7 +4770,7 @@ contract qq{
 
   it "can use a try catch statment to catch a divide by zero error the Solidity Way (trademark very much in effect)" . runTest $ do
     runBS [r| 
-pragma solidvm 3.2;
+pragma solidvm 3.3;
 contract Divisor {
   function doTheDivide() public returns (uint) {
     return (1 / 0);

--- a/strato/VM/SolidVM/solid-vm/tests/StaticAnalysisSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/StaticAnalysisSpec.hs
@@ -14,7 +14,6 @@ import qualified SolidVM.Solidity.StaticAnalysis.Expressions.BooleanLiterals    
 import qualified SolidVM.Solidity.StaticAnalysis.Expressions.DivideBeforeMultiply       as DivideBeforeMultiply
 import qualified SolidVM.Solidity.StaticAnalysis.Pragmas.IncorrectSolidityVersion       as IncorrectSolidityVersion
 import qualified SolidVM.Solidity.StaticAnalysis.Functions.ConstantFunctions            as ConstantFunctions
-import qualified SolidVM.Solidity.StaticAnalysis.Functions.Unimplemented.Modifiers      as Modifiers
 import qualified SolidVM.Solidity.StaticAnalysis.Statements.StateVariableShadowing      as StateVariableShadowing
 import qualified SolidVM.Solidity.StaticAnalysis.Statements.UninitializedLocalVariables as UninitializedLocalVariables
 import qualified SolidVM.Solidity.StaticAnalysis.Statements.WriteAfterWrite             as WriteAfterWrite
@@ -328,22 +327,6 @@ contract A {
 contract B {
   function f() {
     x = 8;
-  }
-}
-|]
-       in length anns `shouldBe` 1
-
-  describe "Unimplemented function modifiers" $ do
-    it "warns for the use of custom function modifiers" $
-      let anns = Modifiers.detector `forContract` [r|
-contract A {
-  address owner;
-  modifier onlyOwner() {
-    require(msg.sender == owner, "You are not the owner.");
-    _;
-  }
-
-  function f() onlyOwner {
   }
 }
 |]


### PR DESCRIPTION
This PR implements the pragma version 3.3 for solidvm. Version 3.3 inherits existing features of version 3.0 and version 3.2. Version 3.3 also guards new features post 7.6 release such as function modifiers, sha256 hash function, blockhash function, etc. Develop branch can now properly sync to the devnet.

`pragma solidvm 3.3;`