### PR TITLE
Fixed governance contract's contract variables no getting initialized

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -864,14 +864,21 @@ callWrapper from to mContract functionName isRCC argExps  = do
                 return (pure val, OrderedVals [])
               Nothing -> unknownFunction "logFunctionCall" (functionName, contract^.CC.contractName)-}
 
-  when isRCC (
-    forM_ [(n, theType) | (n, CC.VariableDecl theType _ Nothing _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, theType) -> do
-      case theType of
-        SVMType.Mapping _ _ _-> return ()
-        SVMType.Array _ _-> return ()
-        _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n]) MS.BDefault)
-  logFunctionCall args to contract functionName f
 
+
+  when isRCC (do
+                addCallInfo to contract' (stringToLabel $ labelToString (contract'^.CC.contractName) ++ " constructor") hsh cc M.empty False
+                forM_ [(n, e) | (n, CC.VariableDecl _ _ (Just e) _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, e) -> do
+                  v <- expToVar e
+                  setVar (Constant (SReference (AccountPath to $ MS.StoragePath [MS.Field $ BC.pack $ labelToString n]))) =<< getVar v
+                forM_ [(n, theType) | (n, CC.VariableDecl theType _ Nothing _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, theType) -> do
+                  case theType of
+                    SVMType.Mapping _ _ _-> return ()
+                    SVMType.Array _ _-> return ()
+                    _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n]) MS.BDefault
+                popCallInfo)
+  logFunctionCall args to contract functionName f
+  
 
 runStatements' :: MonadSM m => [CC.Statement] -> m (Maybe Value)
 runStatements' [] = return Nothing

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -866,10 +866,10 @@ callWrapper from to mContract functionName isRCC argExps  = do
               
   when isRCC (do
                 addCallInfo to contract' (stringToLabel $ labelToString (contract'^.CC.contractName) ++ " constructor") hsh cc M.empty False
-                forM_ [(n, e) | (n, CC.VariableDecl _ _ (Just e) _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, e) -> do
+                forM_ [(n, e) | (n, CC.VariableDecl _ _ (Just e) _ _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, e) -> do
                   v <- expToVar e
                   setVar (Constant (SReference (AccountPath to $ MS.StoragePath [MS.Field $ BC.pack $ labelToString n]))) =<< getVar v
-                forM_ [(n, theType) | (n, CC.VariableDecl theType _ Nothing _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, theType) -> do
+                forM_ [(n, theType) | (n, CC.VariableDecl theType _ Nothing _ _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, theType) -> do
                   case theType of
                     SVMType.Mapping _ _ _-> return ()
                     SVMType.Array _ _-> return ()


### PR DESCRIPTION
This PR fixes the issue wherein contract level variables with given initial values were not being initialized properly when going through the `runChainConstructors` governance contract pipeline. Thus now a contract like this properly sets `x` to `6` and `data` to `['a','b','c']`

```
pragma solidvm 3.2;
contract StateArr1 {
  string[] data = ["a", "b", "c"];
  uint x = 6;
  constructor() {}
  function isIn(string _char) returns (bool) {
    for (int i = 0; i < data.length; i++) {
        if (data[i] == _char) return true;
    }
    return false;
  } 
}
```

