### PR TITLE
File Level Structs, Enums, and Constants (+CodeCollection Rework)

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
@@ -9,6 +9,7 @@ module SolidVM.Model.CodeCollection (
   CodeCollection,
   contracts,
   getParents,
+  flConstants,
   
   module SolidVM.Model.CodeCollection.Contract,
   --module SolidVM.Model.CodeCollection.Def,
@@ -42,9 +43,11 @@ import           SolidVM.Model.CodeCollection.VarDef
 import           SolidVM.Model.CodeCollection.VariableDecl
 import           SolidVM.Model.SolidString
 
+
 data CodeCollectionF a =
   CodeCollection {
-    _contracts :: Map SolidString (ContractF a)
+    _contracts :: Map SolidString (ContractF a),
+    _flConstants ::  Map SolidString (ConstantDeclF a)
   } deriving (Show, Generic, Functor)
 
 instance ToJSON a => ToJSON (CodeCollectionF a)

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
@@ -10,6 +10,8 @@ module SolidVM.Model.CodeCollection (
   contracts,
   getParents,
   flConstants,
+  flStructs,
+  flEnums,  
   
   module SolidVM.Model.CodeCollection.Contract,
   --module SolidVM.Model.CodeCollection.Def,
@@ -47,7 +49,10 @@ import           SolidVM.Model.SolidString
 data CodeCollectionF a =
   CodeCollection {
     _contracts :: Map SolidString (ContractF a),
-    _flConstants ::  Map SolidString (ConstantDeclF a)
+    _flConstants ::  Map SolidString (ConstantDeclF a),
+    _flEnums :: Map SolidString ([SolidString], a),
+    _flStructs :: Map SolidString [(SolidString, FieldType, a)]
+
   } deriving (Show, Generic, Functor)
 
 instance ToJSON a => ToJSON (CodeCollectionF a)

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
@@ -18,7 +18,7 @@ module SolidVM.Model.Value (
   ) where
 
 
-import           Control.Lens ((.~))
+import           Control.Lens ((.~), (^.))
 import           Control.Monad (forM, when)
 import           Control.Monad.IO.Class
 import           Data.ByteString (ByteString)
@@ -239,29 +239,39 @@ defaultValue ctract (SVMType.UnknownLabel name _) = fromMaybe (SContract name $ 
 
 defaultValue _ x = todo "defaultValue" x
 
-createDefaultValue :: MonadIO m =>
-                      CC.Contract -> SVMType.Type -> m Value
-createDefaultValue _ (SVMType.Array valType _) = return $ SArray valType V.empty
-createDefaultValue _ (SVMType.Mapping _ _ valType) = return $ SMap valType $ M.empty
-createDefaultValue _ (SVMType.Int _ _) = return $ SInteger 0
-createDefaultValue _ SVMType.Bool = return $ SBool False
-createDefaultValue _ (SVMType.Address _) = return $ (SAccount $ unspecifiedChain (Address 0)) False
-createDefaultValue _ (SVMType.Account _) = return $ (SAccount $ unspecifiedChain (Address 0)) False
-createDefaultValue _ (SVMType.String _) = return $ SString ""
-createDefaultValue _ (SVMType.Bytes _ _) = return $ SString ""
-createDefaultValue ctract (SVMType.UnknownLabel name _) =
+createDefaultValue :: MonadIO m => 
+                      CC.CodeCollection -> CC.Contract -> SVMType.Type -> m Value
+createDefaultValue _ _ (SVMType.Array valType _) = return $ SArray valType V.empty
+createDefaultValue _ _ (SVMType.Mapping _ _ valType) = return $ SMap valType $ M.empty
+createDefaultValue _ _ (SVMType.Int _ _) = return $ SInteger 0
+createDefaultValue _ _ SVMType.Bool = return $ SBool False
+createDefaultValue _ _ (SVMType.Address _) = return $ (SAccount $ unspecifiedChain (Address 0)) False
+createDefaultValue _ _ (SVMType.Account _) = return $ (SAccount $ unspecifiedChain (Address 0)) False
+createDefaultValue _ _ (SVMType.String _) = return $ SString ""
+createDefaultValue _ _ (SVMType.Bytes _ _) = return $ SString ""
+createDefaultValue cc ctract (SVMType.UnknownLabel name _) =
   case (M.lookup name $ CC._enums ctract, M.lookup name $ CC._structs ctract) of
     (Just ((val:_), _), _) -> return $ SEnumVal name val 0x0
     (Nothing, Just sdef) -> do
       items <-
         forM sdef $ \(n, itemType, _) -> do
-          itemVal <- createDefaultValue ctract $ CC.fieldTypeType itemType
+          itemVal <- createDefaultValue cc ctract $ CC.fieldTypeType itemType
           itemVar <- createVar itemVal
           return (n, itemVar)
       return $ SStruct name $ M.fromList items
-    _ -> return $ SContract name (unspecifiedChain 0x0)
+    _ -> do
+      case (M.lookup name $ cc ^. CC.flEnums , M.lookup name $ cc ^. CC.flStructs) of
+        (Just ((val:_), _), _) -> return $ SEnumVal name val 0x0
+        (Nothing, Just sdef) -> do
+          items <-
+            forM sdef $ \(n, itemType, _) -> do
+              itemVal <- createDefaultValue cc ctract $ CC.fieldTypeType itemType
+              itemVar <- createVar itemVal
+              return (n, itemVar)
+          return $ SStruct name $ M.fromList items
+        _ -> return $ SContract name (unspecifiedChain 0x0)
 
-createDefaultValue _ x = todo "createDefaultValue" x
+createDefaultValue _ _ x = todo "createDefaultValue" x
 
 
 

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -42,6 +42,7 @@ import           Blockchain.VM.SolidException
 data SourceUnitF a = Pragma a Identifier String
                    | Import a Text.Text
                    | NamedXabi Text.Text (XabiF a, [Text.Text])
+                   | FLConstant Text.Text SolidVM.ConstantDecl
                    | DummySourceUnit
                    deriving (Eq, Show, Generic, Functor)
 
@@ -223,6 +224,33 @@ public keywords =
         (v1:v2:_) -> fail $ printf "multiple visibilities declared: %s vs %s" (show v1) (show v2)
         [KPublic] -> return True
         _ -> return False
+
+
+solidityFLConstant :: SolidityParser SourceUnit
+solidityFLConstant = do
+  start <- getSourcePosition
+  variableType <- simpleTypeExpression
+  -- We have to remember which variables are "public", because they
+  -- generate accessor functions
+  keywords <- many stateVariableKeyword
+  let isConstant = KConstant `elem` keywords
+  isPublic <- public keywords
+  -- check to see if the "account" variable is being used
+  variableName <- identifier
+  pragmaVersion' <- getPragmaVersion
+  when (isReservedWord pragmaVersion' variableName) $ reservedWordError pragmaVersion' variableName
+  value <- optionMaybe $ do
+    reservedOp "="
+    expression
+  end <- getSourcePosition
+  semi
+  let ctx = SourceAnnotation start end ()
+
+  if isConstant
+    then return $ FLConstant (labelToText variableName) (SolidVM.ConstantDecl variableType isPublic (fromMaybe (parseError "constants must be initialized" variableName) value) ctx)
+    else fail "only constants can be declared in the top level"
+
+
 
 
 -- | Parses the declaration part of a variable definition, which is

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -189,7 +189,7 @@ solidityFLStruct = do
     reserved "struct"
     structName <- identifier
     structFields <- braces $ many1 $ do
-      (fieldName, VariableDeclaration (SolidVM.VariableDecl decl _ _ _)) <- simpleVariableDeclaration
+      (fieldName, VariableDeclaration (SolidVM.VariableDecl decl _ _ _ _)) <- simpleVariableDeclaration
       return (fieldName, decl)
     pure (structName, structFields)
   return $ FLStruct (Text.pack structName) (SolidVM.Struct{ SolidVM.fields = zipWith (\(n, v) i -> (stringToLabel n, SolidVM.FieldType i v)) structFields [0..], SolidVM.bytes = 0, SolidVM.context = a})

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -43,6 +43,8 @@ data SourceUnitF a = Pragma a Identifier String
                    | Import a Text.Text
                    | NamedXabi Text.Text (XabiF a, [Text.Text])
                    | FLConstant Text.Text SolidVM.ConstantDecl
+                   | FLStruct Text.Text SolidVM.Def
+                   | FLEnum Text.Text SolidVM.Def
                    | DummySourceUnit
                    deriving (Eq, Show, Generic, Functor)
 
@@ -168,6 +170,43 @@ structDeclaration = do
         SolidVM.context = a
         }
     )
+
+solidityFLStruct :: SolidityParser SourceUnit
+solidityFLStruct = do
+  ~(a, (structName, structFields)) <- withPosition $ do
+    reserved "struct"
+    structName <- identifier
+    structFields <- braces $ many1 $ do
+      (fieldName, VariableDeclaration (SolidVM.VariableDecl decl _ _ _)) <- simpleVariableDeclaration
+      return (fieldName, decl)
+    pure (structName, structFields)
+  return $ FLStruct (Text.pack structName) (SolidVM.Struct{ SolidVM.fields = zipWith (\(n, v) i -> (stringToLabel n, SolidVM.FieldType i v)) structFields [0..], SolidVM.bytes = 0, SolidVM.context = a})
+    -- (
+    --   structName,
+    --   StructDeclaration SolidVM.Struct{
+    --     SolidVM.fields =
+    --        zipWith (\(n, v) i -> (stringToLabel n, SolidVM.FieldType i v)) structFields [0..],
+    --     SolidVM.bytes = 0,
+    --     SolidVM.context = a
+    --     }
+    -- )
+
+solidityFLEnum :: SolidityParser SourceUnit
+solidityFLEnum = do
+  ~(a, (enumName, enumFields)) <- withPosition $ do
+    reserved "enum"
+    enumName <- identifier
+    enumFields <- braces $ commaSep1 identifier
+    pure (enumName, enumFields)
+  return $ FLEnum (Text.pack enumName) (SolidVM.Enum {SolidVM.names = map stringToLabel enumFields, SolidVM.bytes = 0, SolidVM.context = a})
+    -- (
+    --   enumName,
+    --   EnumDeclaration SolidVM.Enum {
+    --     SolidVM.names = map stringToLabel enumFields,
+    --     SolidVM.bytes = 0,
+    --     SolidVM.context = a
+    --     }
+    -- )
 
 -- | Parses an enum definition
 enumDeclaration :: SolidityParser (String, Declaration)

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/File.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/File.hs
@@ -35,7 +35,7 @@ newtype File = File {
 solidityFile :: SolidityParser File
 solidityFile = do
   whiteSpace
-  units <- many (solidityPragma <|> solidityImport <|> solidityContract <|> solidityFLConstant)
+  units <- many (solidityPragma <|> solidityImport <|> solidityContract <|> solidityFLConstant <|> solidityFLStruct <|> solidityFLEnum)
   eof
   return . File $ units
 

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/File.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/File.hs
@@ -35,7 +35,7 @@ newtype File = File {
 solidityFile :: SolidityParser File
 solidityFile = do
   whiteSpace
-  units <- many (solidityPragma <|> solidityImport <|> solidityContract)
+  units <- many (solidityPragma <|> solidityImport <|> solidityContract <|> solidityFLConstant)
   eof
   return . File $ units
 

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -37,7 +37,8 @@ unparseSourceUnit :: SourceUnit -> String
 unparseSourceUnit (Pragma _ ident contents) = "pragma " ++ ident ++ " " ++ contents ++ ";\n"
 unparseSourceUnit (Import _ path) = "import \"" ++ Text.unpack path ++ "\";\n"
 unparseSourceUnit (FLConstant name conDecl) = (("\n    " <>) . unparseConstant) (Text.unpack name, conDecl)
-
+unparseSourceUnit (FLStruct name decl) = (("\n    " <>) . unparseTypes) (Text.unpack name, decl)
+unparseSourceUnit (FLEnum name decl) = (("\n    " <>) . unparseTypes) (Text.unpack name, decl)
 unparseSourceUnit (DummySourceUnit) = "DummySourceUnit"
 unparseSourceUnit (NamedXabi name (contract,inherited)) =
      (case xabiKind contract of

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -36,6 +36,8 @@ unparse (File units) = List.concat $ List.map unparseSourceUnit units
 unparseSourceUnit :: SourceUnit -> String
 unparseSourceUnit (Pragma _ ident contents) = "pragma " ++ ident ++ " " ++ contents ++ ";\n"
 unparseSourceUnit (Import _ path) = "import \"" ++ Text.unpack path ++ "\";\n"
+unparseSourceUnit (FLConstant name conDecl) = (("\n    " <>) . unparseConstant) (Text.unpack name, conDecl)
+
 unparseSourceUnit (DummySourceUnit) = "DummySourceUnit"
 unparseSourceUnit (NamedXabi name (contract,inherited)) =
      (case xabiKind contract of
@@ -49,6 +51,8 @@ unparseSourceUnit (NamedXabi name (contract,inherited)) =
      )
   <> " {\n"
   <> concatMap (("\n    " <>) . unparseVar) (Map.toList $ xabiVars contract)
+  <> concatMap (("\n    " <>) . unparseConstant) (Map.toList $ xabiConstants contract)
+
 --  <> concatMap (("\n    " <>) . unparseVar) (sortWith (varTypeAtBytes . snd) $ Map.toList $ xabiVars contract)
   <> concatMap (("\n    " <>) . unparseTypes) (Map.toList $ xabiTypes contract)
   <> concatMap (("\n    " <>) . unparseModifier) (Map.toList $ xabiModifiers contract)

--- a/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
@@ -12,8 +12,10 @@ import Text.RawString.QQ
 import SolidVM.Model.CodeCollection.Statement
 import SolidVM.Model.Type
 import SolidVM.Solidity.Parse.Lexer
-import SolidVM.Solidity.Parse.Statement
-import SolidVM.Solidity.Parse.Declarations
+
+-- import SolidVM.Solidity.Parse.Statement
+-- import SolidVM.Solidity.Parse.Declarations
+
 import SolidVM.Model.CodeCollection.Def as Def
 import SolidVM.Solidity.Parse.UnParser
 import SolidVM.Solidity.Parse.ParserTypes 
@@ -114,18 +116,18 @@ spec = do
 -------------------------------------------------------------------------------------------------------------------------------------------------
 -}
 
-  describe "Declaration parsing" $ do
-    let parseDecl = runParser solidityDeclaration (ParserState "" "") ""
-        cases = [ ("int x;", EnumDeclaration $ Def.Enum [] (fromInteger 2) dummyAnnotation)
-                , ("string[] data = ['a', 'b', 'c'];", DummyDeclaration)
-                -- , ("function a() public myModifier returns (bool) {\nx = 5;\nreturn true;\n}" , DummyDeclaration)
-                -- , ("constructor() public returns (bool) {\nreturn true;\n}" , DummyDeclaration)
-                -- , ("contract qq {\nuint x;\nmodifier myModifier() {\n require(false, 'bigTest');\n\n}\nconstructor() myModifier(3) public returns (bool) {\nx = 5;\nreturn true;\n}\n}", DummyDeclaration)
-                -- , ("modifier myModifier() {\n require(false, 'bigTest');\n_;\n}", DummyDeclaration)
-                -- , ("SimpleStorage myContract = new SimpleStorage();", DummyDeclaration)
-                ]
-    forM_ cases $ \(input, want) -> do
-      it ("can parse " ++ input) $ parseDecl input `shouldBe` Right ((show want), want)
+  -- describe "Declaration parsing" $ do
+  --   let parseDecl = runParser solidityDeclaration (ParserState "" "") ""
+  --       cases = [ ("int x;", EnumDeclaration $ Def.Enum [] (fromInteger 2) dummyAnnotation)
+  --               , ("string[] data = ['a', 'b', 'c'];", DummyDeclaration)
+  --               -- , ("function a() public myModifier returns (bool) {\nx = 5;\nreturn true;\n}" , DummyDeclaration)
+  --               -- , ("constructor() public returns (bool) {\nreturn true;\n}" , DummyDeclaration)
+  --               -- , ("contract qq {\nuint x;\nmodifier myModifier() {\n require(false, 'bigTest');\n\n}\nconstructor() myModifier(3) public returns (bool) {\nx = 5;\nreturn true;\n}\n}", DummyDeclaration)
+  --               -- , ("modifier myModifier() {\n require(false, 'bigTest');\n_;\n}", DummyDeclaration)
+  --               -- , ("SimpleStorage myContract = new SimpleStorage();", DummyDeclaration)
+  --               ]
+  --   forM_ cases $ \(input, want) -> do
+  --     it ("can parse " ++ input) $ parseDecl input `shouldBe` Right ((show want), want)
 {-}
 
 --"contract qq {\n  uint x = 3;\n  modifier myModifier(uint _x) {\n      require(_x == 3 , string.concat('x is not 3 : ', string(_x)));\n    x = 4;    _;\n    require(x == 5 , 'x is not 5');\n  }\n\n  constructor() public myModifier(3) {\n    x = 5;\n    return;\n  }\n}\n"

--- a/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
@@ -13,8 +13,8 @@ import SolidVM.Model.CodeCollection.Statement
 import SolidVM.Model.Type
 import SolidVM.Solidity.Parse.Lexer
 import SolidVM.Solidity.Parse.Statement
---import SolidVM.Solidity.Parse.Declarations
---import SolidVM.Model.CodeCollection.Def as Def
+import SolidVM.Solidity.Parse.Declarations
+import SolidVM.Model.CodeCollection.Def as Def
 import SolidVM.Solidity.Parse.UnParser
 import SolidVM.Solidity.Parse.ParserTypes 
 
@@ -58,7 +58,7 @@ spec = do
   describe "Expression parsing" $ do
     let parseExpr = fmap (fmap (const ())) . runParser expression (ParserState "" "") ""
         cases = [ ("x++", PlusPlus () (Variable () "x"))
-                , ("++x", Unitary () "++" (Variable () "x"))
+                , ("['a', 'b', 'c']", Unitary () "++" (Variable () "x"))
                 , ("--x", Unitary () "--" (Variable () "x"))
                 , ("-x", Unitary () "-" (Variable () "x"))
                 , ("x--", MinusMinus () (Variable () "x"))
@@ -113,20 +113,20 @@ spec = do
 
 -------------------------------------------------------------------------------------------------------------------------------------------------
 -}
-{-
+
   describe "Declaration parsing" $ do
-    let parseDecl = runParser solidityDeclaration "" ""
+    let parseDecl = runParser solidityDeclaration (ParserState "" "") ""
         cases = [ ("int x;", EnumDeclaration $ Def.Enum [] (fromInteger 2) dummyAnnotation)
-                , ("int x = 0;", DummyDeclaration)
-                , ("function a() public myModifier returns (bool) {\nx = 5;\nreturn true;\n}" , DummyDeclaration)
-                , ("constructor() public returns (bool) {\nreturn true;\n}" , DummyDeclaration)
-                , ("contract qq {\nuint x;\nmodifier myModifier() {\n require(false, 'bigTest');\n\n}\nconstructor() myModifier(3) public returns (bool) {\nx = 5;\nreturn true;\n}\n}", DummyDeclaration)
-                , ("modifier myModifier() {\n require(false, 'bigTest');\n_;\n}", DummyDeclaration)
-                , ("SimpleStorage myContract = new SimpleStorage();", DummyDeclaration)
+                , ("string[] data = ['a', 'b', 'c'];", DummyDeclaration)
+                -- , ("function a() public myModifier returns (bool) {\nx = 5;\nreturn true;\n}" , DummyDeclaration)
+                -- , ("constructor() public returns (bool) {\nreturn true;\n}" , DummyDeclaration)
+                -- , ("contract qq {\nuint x;\nmodifier myModifier() {\n require(false, 'bigTest');\n\n}\nconstructor() myModifier(3) public returns (bool) {\nx = 5;\nreturn true;\n}\n}", DummyDeclaration)
+                -- , ("modifier myModifier() {\n require(false, 'bigTest');\n_;\n}", DummyDeclaration)
+                -- , ("SimpleStorage myContract = new SimpleStorage();", DummyDeclaration)
                 ]
     forM_ cases $ \(input, want) -> do
       it ("can parse " ++ input) $ parseDecl input `shouldBe` Right ((show want), want)
-
+{-}
 
 --"contract qq {\n  uint x = 3;\n  modifier myModifier(uint _x) {\n      require(_x == 3 , string.concat('x is not 3 : ', string(_x)));\n    x = 4;    _;\n    require(x == 5 , 'x is not 5');\n  }\n\n  constructor() public myModifier(3) {\n    x = 5;\n    return;\n  }\n}\n"
   describe "Contract Parsing" $ do
@@ -141,7 +141,7 @@ spec = do
 
   describe "Statement parsing" $ do
     let parseStatement = fmap (fmap (const ())) . runParser statement (ParserState "" "") ""
-        scases = [ ("x++;", SimpleStatement $ ExpressionStatement $ PlusPlus () $ Variable () "x")
+        scases = [ ("p.x = 1;", SimpleStatement $ ExpressionStatement $ PlusPlus () $ Variable () "x")
                  , ("assembly { dst := mload(add(src, 32)) }",
                       AssemblyStatement $ MloadAdd32 "dst" "src")
                  , ("Nom storage nom = ns[10];", SimpleStatement $

--- a/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
@@ -12,11 +12,11 @@ import Text.RawString.QQ
 import SolidVM.Model.CodeCollection.Statement
 import SolidVM.Model.Type
 import SolidVM.Solidity.Parse.Lexer
+import SolidVM.Solidity.Parse.Statement
 
--- import SolidVM.Solidity.Parse.Statement
 -- import SolidVM.Solidity.Parse.Declarations
+-- import SolidVM.Model.CodeCollection.Def as Def
 
-import SolidVM.Model.CodeCollection.Def as Def
 import SolidVM.Solidity.Parse.UnParser
 import SolidVM.Solidity.Parse.ParserTypes 
 
@@ -60,7 +60,7 @@ spec = do
   describe "Expression parsing" $ do
     let parseExpr = fmap (fmap (const ())) . runParser expression (ParserState "" "") ""
         cases = [ ("x++", PlusPlus () (Variable () "x"))
-                , ("['a', 'b', 'c']", Unitary () "++" (Variable () "x"))
+                , ("++x", Unitary () "++" (Variable () "x"))
                 , ("--x", Unitary () "--" (Variable () "x"))
                 , ("-x", Unitary () "-" (Variable () "x"))
                 , ("x--", MinusMinus () (Variable () "x"))
@@ -143,7 +143,7 @@ spec = do
 
   describe "Statement parsing" $ do
     let parseStatement = fmap (fmap (const ())) . runParser statement (ParserState "" "") ""
-        scases = [ ("p.x = 1;", SimpleStatement $ ExpressionStatement $ PlusPlus () $ Variable () "x")
+        scases = [ ("x++;", SimpleStatement $ ExpressionStatement $ PlusPlus () $ Variable () "x")
                  , ("assembly { dst := mload(add(src, 32)) }",
                       AssemblyStatement $ MloadAdd32 "dst" "src")
                  , ("Nom storage nom = ns[10];", SimpleStatement $

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -133,13 +133,15 @@ varDefsToType' VarDefEntry{..} _              = bottom $ "Could not match variab
 
 lookupEnum :: SolidString -> SSS [SolidString]
 lookupEnum name = do
+  cc <- asks codeCollection
   c <- asks contract
-  pure . maybe [] fst $ M.lookup name (_enums c)
+  pure . maybe [] fst $ msum [(M.lookup name (_enums c)), (M.lookup name (_flEnums cc))]
 
 lookupStruct :: SolidString -> SSS [(SolidString, Type)]
 lookupStruct name = do
+  cc <- asks codeCollection
   c <- asks contract
-  let str = fromMaybe [] $ M.lookup name (_structs c)
+  let str = fromMaybe [] $ msum [(M.lookup name (_structs c))  ,(M.lookup name (_flStructs cc))]
   pure $ f <$> str
   where f (t, ft, _) = (t, fieldTypeType ft)
 
@@ -645,8 +647,9 @@ contractHelper cc c =
       funcsAndConstr = constr <> _functions c
       varTypes' = reduceType' (_contractContext c) $ varDeclHelper cc c <$> M.elems (_storageDefs c)
       constTypes' = reduceType' (_contractContext c) $ constDeclHelper cc c <$> M.elems (_constants c)
+      constTypes'' = reduceType' (_contractContext c) $ constDeclHelper cc c <$> M.elems (_flConstants cc)
       funcTypes' = reduceType' (_contractContext c) $ uncurry (functionHelper cc c) <$> M.toList funcsAndConstr
-   in reduceType' (_contractContext c) [varTypes', constTypes', funcTypes']
+   in reduceType' (_contractContext c) [varTypes', constTypes', funcTypes', constTypes'']
 
 varDeclHelper :: Annotated CodeCollectionF
               -> Annotated ContractF
@@ -957,9 +960,13 @@ getVarTypeByName' name ctx = do
       Nothing -> pure $ Top (S.singleton name) ctx
     Nothing -> do
       c <- asks contract
+      cc <- asks codeCollection
       let mVarDecl = ((varType &&& const ctx) <$> M.lookup name (_storageDefs c))
                  <|> ((constType &&& const ctx) <$> M.lookup name (_constants c))
+                 <|> ((constType &&& const ctx) <$> M.lookup name (_flConstants cc))
                  <|> (const (SVMType.Enum Nothing name Nothing, ctx) <$> M.lookup name (_enums c))
+                 <|> (const (SVMType.Enum Nothing name Nothing, ctx) <$> M.lookup name (_flEnums cc))
+                 <|> (const (SVMType.Struct Nothing name, ctx) <$> M.lookup name (_flStructs cc))
                  <|> (const (SVMType.Struct Nothing name, ctx) <$> M.lookup name (_structs c))
       case mVarDecl of
         Just (e@(SVMType.Enum{}), ctx') -> pure . Sum $
@@ -981,7 +988,6 @@ getVarTypeByName' name ctx = do
                 fRets = flip Product ctx $ flip Static ctx . indexedTypeType . snd <$> funcVals
              in pure $ Function fArgs fRets ctx
           Nothing -> do
-            cc <- asks codeCollection
             pure $ case M.lookup name $ _contracts cc of
               Just _->
                 let ctrct = Static (SVMType.Contract name) ctx

--- a/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
+++ b/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
@@ -122,7 +122,7 @@ main = do
   let vmVersion' = if (Just ("solidvm","3.3")) `elem` (pragmas <$> parsedFile) then "svm3.3" else (if (Just ("solidvm","3.2")) `elem` (pragmas <$> parsedFile) then "svm3.2" else (if (Just ("solidvm","3.0")) `elem` (pragmas <$> parsedFile) then "svm3.0" else ""))
       namedContracts = [(textToLabel name, either (throw . fst) id $ xabiToContract (textToLabel name) (map textToLabel parents') vmVersion' xabi)
                        | NamedXabi name (xabi, parents') <- parsedFile]
-      cc = CodeCollection (M.fromList namedContracts) (M.empty)
+      cc = CodeCollection (M.fromList namedContracts) (M.empty) (M.empty) (M.empty)
       typecheck = if (vmVersion' == "svm3.2" || vmVersion' == "svm3.3") then TC.detector cc else []
       nodes = codeCollectionCrawler cc
   putStrLn (show typecheck) --when (not null typecheck)

--- a/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
+++ b/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
@@ -122,7 +122,7 @@ main = do
   let vmVersion' = if (Just ("solidvm","3.3")) `elem` (pragmas <$> parsedFile) then "svm3.3" else (if (Just ("solidvm","3.2")) `elem` (pragmas <$> parsedFile) then "svm3.2" else (if (Just ("solidvm","3.0")) `elem` (pragmas <$> parsedFile) then "svm3.0" else ""))
       namedContracts = [(textToLabel name, either (throw . fst) id $ xabiToContract (textToLabel name) (map textToLabel parents') vmVersion' xabi)
                        | NamedXabi name (xabi, parents') <- parsedFile]
-      cc = CodeCollection $ M.fromList namedContracts
+      cc = CodeCollection (M.fromList namedContracts) (M.empty)
       typecheck = if (vmVersion' == "svm3.2" || vmVersion' == "svm3.3") then TC.detector cc else []
       nodes = codeCollectionCrawler cc
   putStrLn (show typecheck) --when (not null typecheck)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1052,11 +1052,12 @@ runStatement s@(CC.SimpleStatement (CC.VariableDefinition entries maybeExpressio
   let singleType = case entries of
                       [e] -> fromMaybe (todo "type inference not implemented" s) $ CC.vardefType e
                       _ -> todo "could not evaluate expression without tuple type" s
+  (_, cc) <- getCurrentCodeCollection
   !value <-
     case maybeExpression of
       Nothing -> do
         ctract <- getCurrentContract
-        createDefaultValue ctract singleType
+        createDefaultValue cc ctract singleType
       Just e -> do
         rhs <- weakGetVar =<< expToVar e
         case (maybeLoc, rhs) of
@@ -1505,11 +1506,19 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
       (SEnum enumName, _) -> do
         contract' <- getCurrentContract
         let maybeEnumValues = M.lookup enumName $ contract' ^. CC.enums
-            !enumVals = fromMaybe (missingType "Enum nonexistent type" enumName) maybeEnumValues
-            !num = maybe (missingType "Enum nonexistent member" (enumName, name))
-                         fromIntegral
-                         (name `elemIndex` fst enumVals)
-        return $ Constant $ SEnumVal enumName name num
+        case maybeEnumValues of
+          Nothing -> do
+            cc <- getCurrentCodeCollection
+            let maybeEnumValues' = M.lookup enumName $ (snd cc) ^. CC.flEnums
+                !enumVals' = fromMaybe (missingType "Enum nonexistent type" enumName) maybeEnumValues'
+                !num' = maybe (missingType "Enum nonexistent member" (enumName, name)) fromIntegral (name `elemIndex` fst enumVals')
+            return $ Constant $ SEnumVal enumName name num'
+          Just enumVals -> do
+            let !num = maybe (missingType "Enum nonexistent member" (enumName, name)) fromIntegral (name `elemIndex` fst enumVals)
+            return $ Constant $ SEnumVal enumName name num
+
+
+        
       (SBuiltinVariable "msg", "sender") -> (Constant . ((flip SAccount) False) . accountToNamedAccount chainId . Env.sender) <$> getEnv
       (SBuiltinVariable "tx", "origin") -> (Constant . ((flip SAccount) False) . accountToNamedAccount chainId . Env.origin) <$> getEnv
       (SBuiltinVariable "tx", "username") -> do env' <- getEnv
@@ -1563,7 +1572,9 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
             addr <- accountOnUnspecifiedChain <$> getCurrentAccount
             return $ Constant $ SContractFunction (Just contractName') addr constName
           else case constName `M.lookup` CC._constants cont of
-                  Nothing -> unknownConstant "constant member access" (contractName', constName)
+                  Nothing -> case constName `M.lookup` (cc ^. CC.flConstants) of 
+                    Just (CC.ConstantDecl _ _ constExp _) -> expToVar constExp
+                    Nothing -> unknownConstant "constant member access" (contractName', constName)
                   Just (CC.ConstantDecl _ _ constExp _) -> expToVar constExp
 
       (SBuiltinVariable "block", "timestamp") -> do
@@ -1919,12 +1930,19 @@ expToVar' (CC.FunctionCall _ e args) = do
 
           Constant (SStructDef structName) -> do
             contract' <- getCurrentContract
-            let !vals = fromMaybe (missingType "struct constructor not found" structName)
-                     $ M.lookup structName $ contract'^.CC.structs
-            return . Constant . SStruct structName . fmap Constant . M.fromList $
-              case argVals of
-                OrderedVals as -> zip (map (\(a,_,_) -> a) vals) as
-                NamedVals ns -> ns
+            case M.lookup structName $ contract'^.CC.structs of 
+              Just vals -> do
+                return . Constant . SStruct structName . fmap Constant . M.fromList $
+                  case argVals of
+                    OrderedVals as -> zip (map (\(a,_,_) -> a) vals) as
+                    NamedVals ns -> ns
+              Nothing -> do
+                cc <- getCurrentCodeCollection
+                let !vals' = fromMaybe (missingType "struct constructor not found" structName) $ M.lookup structName $ (snd cc) ^. CC.flStructs        
+                return . Constant . SStruct structName . fmap Constant . M.fromList $
+                  case argVals of
+                    OrderedVals as -> zip (map (\(a,_,_) -> a) vals') as
+                    NamedVals ns -> ns
 
           Constant (SContractDef contractName') -> do
             case argVals of
@@ -1981,11 +1999,18 @@ expToVar' (CC.FunctionCall _ e args) = do
             case argVals of
               OrderedVals [SInteger i] -> do
                 c <- getCurrentContract
-                let !theEnum = fromMaybe (missingType "enum constructor" enumName)
-                            $ M.lookup enumName $ c^.CC.enums
-                case fst theEnum !? fromInteger i of
-                  Nothing -> typeError "enum val out of range" argVals
-                  Just enumVal -> pure . Constant . SEnumVal enumName enumVal $ fromInteger i
+                case M.lookup enumName $ c^.CC.enums  of 
+                  Just theEnum -> do
+                    case fst theEnum !? fromInteger i of
+                      Nothing -> typeError "enum val out of range" argVals
+                      Just enumVal -> pure . Constant . SEnumVal enumName enumVal $ fromInteger i
+                  Nothing -> do
+                    (_, cc) <- getCurrentCodeCollection                            
+                    let !theEnum' = fromMaybe (missingType "enum constructor" enumName)
+                                $ M.lookup enumName $ cc ^.CC.flEnums
+                    case fst theEnum' !? fromInteger i of
+                      Nothing -> typeError "enum val out of range" argVals
+                      Just enumVal -> pure . Constant . SEnumVal enumName enumVal $ fromInteger i
               _ -> typeError "called enum constructor with improper args" argVals
 
           Constant (SPush theArray mvar) -> Builtins.push theArray mvar argVals

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -39,6 +39,7 @@ import           Blockchain.SolidVM.Exception         hiding (assert)
 import           Blockchain.SolidVM.Metrics
 import           Blockchain.Strato.Model.Keccak256
 
+import qualified SolidVM.Model.CodeCollection.Def as Def
 import           SolidVM.CodeCollectionTools
 import           SolidVM.Model.CodeCollection
 import           SolidVM.Model.SolidString
@@ -52,7 +53,7 @@ data ParseTypeCheckOrSolidVMError = PEx ParseError
                          | TCEx [SourceAnnotation T.Text]
                          | SVMEx (Positioned ((,) SolidException)) deriving (Show)
 
-data SUnitIntermediary = Con Contract | FLC ConstantDecl
+data SUnitIntermediary = Con Contract | FLC ConstantDecl | FLS Def.Def | FLE Def.Def
 
 {-# NOINLINE unsafeCodeMapIORef #-}
 unsafeCodeMapIORef :: IORef (Map Keccak256 CodeCollection)
@@ -84,15 +85,22 @@ compileSourceNoInheritance initCodeMap = do
             ctrct <- first SVMEx
                    $ xabiToContract (textToLabel name) (map textToLabel parents') vmVersion' xabi
             pure $ Just $ (textToLabel name, Con ctrct)
-          FLConstant name cnst' -> do
-            let cnst = cnst'
+          FLConstant name cnst -> do
             pure $ Just $ (textToLabel name, FLC cnst)
+          FLStruct name fls -> do
+            pure $ Just $ (textToLabel name, FLS fls)
+          FLEnum name fle -> do
+            pure $ Just $ (textToLabel name, FLE fle)
           _ -> pure Nothing
-      sUnitSorter :: [(SolidString, SUnitIntermediary)] ->  ([(SolidString, ConstantDecl)], [(SolidString, Contract)])
-      sUnitSorter = foldr (\(name, sUnit) (cs, cs2) -> case sUnit of
-        Con ctrct -> (cs, (name, ctrct):cs2)
-        FLC cnst -> ((name, cnst):cs, cs2)
-        ) ([], [])
+--      sUnitSorter :: [(SolidString, SUnitIntermediary)] ->  ([(SolidString, ConstantDecl)], [(SolidString, Contract)], [(SolidString, ([SolidString], a))], [(SolidString, [(SolidString, FieldType, a)])])
+      sUnitSorter = foldr (\(name, sUnit) (cs, cs2, cs3, cs4) -> case sUnit of
+        Con ctrct -> (cs, (name, ctrct):cs2, cs3, cs4)
+        FLC cnst -> ((name, cnst):cs, cs2, cs3, cs4)
+        FLE (Def.Enum vals _ a) -> (cs, cs2, (name, (vals, a)):cs3, cs4)
+        FLS (Def.Struct vals _ a) -> (cs, cs2, cs3, (name, (\(k,v) -> (k,v,a)) <$> vals):cs4) --conversion to match struct form
+        FLE y -> parseError "FLE non Enum should be impossible"   (show y)
+        FLS x -> parseError "FLS non Struct should be impossible" (show x)
+        ) ([], [], [], [])
       throwDuplicate :: (SolidString, Contract) -> Map SolidString Contract -> Either ParseTypeCheckOrSolidVMError (Map SolidString Contract)
       throwDuplicate (cName, unit) m = case M.lookup cName m of
         Nothing -> pure $ M.insert cName unit m
@@ -101,12 +109,13 @@ compileSourceNoInheritance initCodeMap = do
                                    (fromSourcePosition $ _sourceAnnotationStart $ _contractContext unit)
 
   allSUnits <- fmap concat . traverse (uncurry getNamedSUnits) $ M.toList initCodeMap
-  let (allConstants, allContracts) = sUnitSorter allSUnits
+  let (allConstants, allContracts, allEnums, allStructs) = sUnitSorter allSUnits
   deduplicatedContracts <- foldrM throwDuplicate M.empty allContracts
-
   pure $ CodeCollection {
     _contracts = deduplicatedContracts,
-    _flConstants = M.fromList allConstants
+    _flConstants = M.fromList allConstants,
+    _flEnums = M.fromList allEnums,
+    _flStructs = M.fromList allStructs
   }
 
 hasSvm3_2 :: CodeCollection -> Bool

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -46,10 +46,13 @@ import           SolidVM.Solidity.Parse.Declarations
 import           SolidVM.Solidity.Parse.File
 import           SolidVM.Solidity.Parse.ParserTypes
 import           SolidVM.Solidity.StaticAnalysis.Typechecker as TC
+--import           SolidVM.Model.CodeCollection.ConstantDecl
 
 data ParseTypeCheckOrSolidVMError = PEx ParseError
                          | TCEx [SourceAnnotation T.Text]
                          | SVMEx (Positioned ((,) SolidException)) deriving (Show)
+
+data SUnitIntermediary = Con Contract | FLC ConstantDecl
 
 {-# NOINLINE unsafeCodeMapIORef #-}
 unsafeCodeMapIORef :: IORef (Map Keccak256 CodeCollection)
@@ -69,8 +72,8 @@ parseSourceWithAnnotations = withAnnotations . parseSource
 
 compileSourceNoInheritance :: Map T.Text T.Text -> Either ParseTypeCheckOrSolidVMError CodeCollection
 compileSourceNoInheritance initCodeMap = do
-  let getNamedContracts :: T.Text -> T.Text -> Either ParseTypeCheckOrSolidVMError [(SolidString, Contract)]
-      getNamedContracts fileName src = do
+  let getNamedSUnits :: T.Text -> T.Text -> Either ParseTypeCheckOrSolidVMError [(SolidString, SUnitIntermediary)]
+      getNamedSUnits fileName src = do
         sourceUnits <- parseSource fileName src
         let pragmas = \case
               Pragma _ n v -> Just (n, v)
@@ -80,20 +83,30 @@ compileSourceNoInheritance initCodeMap = do
           NamedXabi name (xabi, parents') -> do
             ctrct <- first SVMEx
                    $ xabiToContract (textToLabel name) (map textToLabel parents') vmVersion' xabi
-            pure $ Just (textToLabel name, ctrct)
+            pure $ Just $ (textToLabel name, Con ctrct)
+          FLConstant name cnst' -> do
+            let cnst = cnst'
+            pure $ Just $ (textToLabel name, FLC cnst)
           _ -> pure Nothing
-
+      sUnitSorter :: [(SolidString, SUnitIntermediary)] ->  ([(SolidString, ConstantDecl)], [(SolidString, Contract)])
+      sUnitSorter = foldr (\(name, sUnit) (cs, cs2) -> case sUnit of
+        Con ctrct -> (cs, (name, ctrct):cs2)
+        FLC cnst -> ((name, cnst):cs, cs2)
+        ) ([], [])
       throwDuplicate :: (SolidString, Contract) -> Map SolidString Contract -> Either ParseTypeCheckOrSolidVMError (Map SolidString Contract)
-      throwDuplicate (cName, contract) m = case M.lookup cName m of
-        Nothing -> pure $ M.insert cName contract m
+      throwDuplicate (cName, unit) m = case M.lookup cName m of
+        Nothing -> pure $ M.insert cName unit m
         Just _ ->  Left . PEx
-                 $ newErrorMessage (Message $ "Duplicate contract found: " ++ labelToString cName)
-                                   (fromSourcePosition $ _sourceAnnotationStart $ _contractContext contract)
+                 $ newErrorMessage (Message $ "Duplicate unit found: " ++ labelToString cName)
+                                   (fromSourcePosition $ _sourceAnnotationStart $ _contractContext unit)
 
-  allContracts <- fmap concat . traverse (uncurry getNamedContracts) $ M.toList initCodeMap
-  deduplicatedContracts <- foldrM throwDuplicate M.empty (allContracts :: [(SolidString, Contract)])
+  allSUnits <- fmap concat . traverse (uncurry getNamedSUnits) $ M.toList initCodeMap
+  let (allConstants, allContracts) = sUnitSorter allSUnits
+  deduplicatedContracts <- foldrM throwDuplicate M.empty allContracts
+
   pure $ CodeCollection {
-    _contracts = deduplicatedContracts
+    _contracts = deduplicatedContracts,
+    _flConstants = M.fromList allConstants
   }
 
 hasSvm3_2 :: CodeCollection -> Bool

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -405,7 +405,8 @@ getVariableOfName name = do
       maybeConstant :: Maybe Variable
       maybeConstant = fmap (t "constant constant" . Constant) $ do
         let ctract = currentContract currentCallInfo
-        CC.ConstantDecl{..} <- M.lookup name $ ctract ^. CC.constants
+        let constMap = (codeCollection currentCallInfo) ^. CC.flConstants
+        CC.ConstantDecl{..} <- M.lookup name $ (ctract ^. CC.constants) `M.union` constMap
         return $ coerceType ctract constType $ case constInitialVal of
                                             CC.NumberLiteral _ x _ -> SInteger x
                                             x -> todo "constant initial val" x
@@ -462,7 +463,7 @@ getVariableOfName name = do
       ]
 
 getTypeOfName' :: SolidString -> CC.CodeCollection -> Typo
-getTypeOfName' s (CC.CodeCollection ccs) =
+getTypeOfName' s (CC.CodeCollection ccs _) =
   let lookInContract :: CC.Contract -> [Typo]
       lookInContract (CC.Contract{..}) = catMaybes
         [ fmap StructTypo (fmap (\(a,b,_) -> (a,b)) <$> M.lookup s _structs)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -399,7 +399,7 @@ getVariableOfName name = do
         t "builtin variable" $ Constant $ SBuiltinVariable name
 
       maybeEnum :: Maybe Variable
-      maybeEnum = toMaybe (name `elem` M.keys (currentContract currentCallInfo^.CC.enums)) $
+      maybeEnum = toMaybe (name `elem` M.keys (currentContract currentCallInfo ^.CC.enums) || name `elem` M.keys (codeCollection currentCallInfo^.CC.flEnums)) $
         t "enum" $ Constant $ SEnum name
 
       maybeConstant :: Maybe Variable
@@ -412,7 +412,7 @@ getVariableOfName name = do
                                             x -> todo "constant initial val" x
 
       maybeStructDef :: Maybe Variable
-      maybeStructDef = toMaybe (name `elem` M.keys (currentContract currentCallInfo^.CC.structs)) $
+      maybeStructDef = toMaybe (name `elem` M.keys (currentContract currentCallInfo^.CC.structs) || name `elem` M.keys (codeCollection currentCallInfo^.CC.flStructs)) $
         t "struct def" $ Constant $ SStructDef name
 
       maybeContract :: Maybe Variable
@@ -463,11 +463,13 @@ getVariableOfName name = do
       ]
 
 getTypeOfName' :: SolidString -> CC.CodeCollection -> Typo
-getTypeOfName' s (CC.CodeCollection ccs _) =
+getTypeOfName' s (CC.CodeCollection ccs _ enms strcts) =
   let lookInContract :: CC.Contract -> [Typo]
       lookInContract (CC.Contract{..}) = catMaybes
         [ fmap StructTypo (fmap (\(a,b,_) -> (a,b)) <$> M.lookup s _structs)
         , fmap EnumTypo (fst <$> M.lookup s _enums)
+        , fmap StructTypo (fmap (\(a,b,_) -> (a,b)) <$> M.lookup s strcts)
+        , fmap EnumTypo (fst <$> M.lookup s enms)
         ]
       ctrs = map ContractTypo $ M.keys ccs
    in case concatMap lookInContract ccs ++ ctrs of

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4859,7 +4859,7 @@ contract qq{
 
   it "can declare a constant at the file level and use it" . runTest $ do
     runBS [r|
-//pragma solidvm 3.3;
+pragma solidvm 3.3;
 uint constant myconst = 5;
 contract qq{
   uint mynum = myconst;
@@ -4871,3 +4871,44 @@ contract qq{
 
 
 
+  it "can declare enums at the file level" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.3;
+enum Color { red, green, blue }
+contract A {
+    function value() public returns (uint) {
+        return 0xa;
+    }
+}
+
+enum Letter { a, b, c }
+contract B {
+    function value() public returns (uint) {
+        return 0xb;
+    }
+}
+contract qq {
+  function a() public returns (Letter) {
+    return Letter.c;
+  }
+}
+
+|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
+
+  it "can declare structs at the file level" . runTest $ do
+    runCall "a" "()" [r|
+pragma solidvm 3.3;
+
+struct Point {
+  uint x;
+  uint y;
+}
+
+contract qq {
+  function a() public returns (uint) {
+    Point p;
+    p.x = 1;
+    p.y = 2;
+    return p.x;
+  }
+}|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 1)

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4856,3 +4856,18 @@ contract qq{
   }
 }|]
     getFields ["mynum"] `shouldReturn` [BInteger 9]
+
+  it "can declare a constant at the file level and use it" . runTest $ do
+    runBS [r|
+//pragma solidvm 3.3;
+uint constant myconst = 5;
+contract qq{
+  uint mynum = myconst;
+  constructor() public {
+    mynum = myconst;
+  }
+}|]
+    getFields ["mynum"] `shouldReturn` [BInteger 5]
+
+
+

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -389,7 +389,7 @@ getCodeCollection f cp ccString = do
         Left e ->
           --return $ CodeCollection Map.empty
           return $ Left $ "failed EVM parse: " ++ show e ++ "\n" ++ T.unpack ccString
-        Right v -> return $ Right $ CodeCollection $ f $ snd v
+        Right v -> return $ Right $ (flip CodeCollection) Map.empty $ f $ snd v
     CodeAtAccount _ _ -> return $ Left "Cannot compile or parse code at account"
 
 getEVMInserts :: (

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -389,7 +389,7 @@ getCodeCollection f cp ccString = do
         Left e ->
           --return $ CodeCollection Map.empty
           return $ Left $ "failed EVM parse: " ++ show e ++ "\n" ++ T.unpack ccString
-        Right v -> return $ Right $ (flip CodeCollection) Map.empty $ f $ snd v
+        Right v -> return $ Right $ CodeCollection (f $ snd v) Map.empty Map.empty Map.empty
     CodeAtAccount _ _ -> return $ Left "Cannot compile or parse code at account"
 
 getEVMInserts :: (


### PR DESCRIPTION
This PR implements File Level Structs, Enums, and Constants, These features were originally implemented and included in the STRATO 7.6 release, but unfortunately we had to roll back the changes because of stateroot issues on the devnet. 

Getting these features to sync to the devnet proved quite challenging, as I tried off and on to accomplish this task, so today I started from scratch to rework how they are implemented. 

This time instead of inserting into every contract the file level objects, I instead added them as new records to the `CodeCollection` datatype. This method IMO is cleaner and more analogous to how it is done in solidity anyway. 

One takeaway from this saga, is that I spent way too long investigating why the original PR wasn't syncing (I still don't know) rather than just changing the details of implementation. Regardless (Irregardless?) I am glad this is done, and this should make implementing the next part of the CodeCollection changes (Libraries and Interfaces) much easier

QED
