### PR TITLE
Strato 2578 implement msg sig and msg data

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1511,6 +1511,14 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
                          (name `elemIndex` fst enumVals)
         return $ Constant $ SEnumVal enumName name num
       (SBuiltinVariable "msg", "sender") -> (Constant . ((flip SAccount) False) . accountToNamedAccount chainId . Env.sender) <$> getEnv
+      (SBuiltinVariable "msg", "data") -> let env' = getEnv
+                                              metadata =  Env.metadata env'
+                                              maybeArgString = M.lookup "args" =<< metadata
+                                          in Constant . SString . fromMaybe "" . maybeArgString 
+     {- (SBuiltinVariable "msg", "sig") -> let env' = getEnv
+                                             metadata = Env.metadata env'
+                                             maybeFuncName = M.lookup "funcName" =<< metadata
+                                         in Constant . SString . fromMaybe "" . keccak256() -}
       (SBuiltinVariable "tx", "origin") -> (Constant . ((flip SAccount) False) . accountToNamedAccount chainId . Env.origin) <$> getEnv
       (SBuiltinVariable "tx", "username") -> do env' <- getEnv
                                                 x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -117,7 +117,7 @@ import           SolidVM.Model.Value
 import           SolidVM.Solidity.Parse.Statement
 import           SolidVM.Solidity.Parse.Lexer         (stringLiteral)
 import           SolidVM.Solidity.Parse.ParserTypes
-import           SolidVM.Solidity.Parse.UnParser (unparseStatement, unparseExpression)
+import           SolidVM.Solidity.Parse.UnParser (unparseStatement, unparseExpression, unparseVarType)
 
 import           UnliftIO                             hiding (assert)
  
@@ -1511,14 +1511,21 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
                          (name `elemIndex` fst enumVals)
         return $ Constant $ SEnumVal enumName name num
       (SBuiltinVariable "msg", "sender") -> (Constant . ((flip SAccount) False) . accountToNamedAccount chainId . Env.sender) <$> getEnv
-      (SBuiltinVariable "msg", "data") -> let env' = getEnv
-                                              metadata =  Env.metadata env'
-                                              maybeArgString = M.lookup "args" =<< metadata
-                                          in Constant . SString . fromMaybe "" . maybeArgString 
-     {- (SBuiltinVariable "msg", "sig") -> let env' = getEnv
-                                             metadata = Env.metadata env'
-                                             maybeFuncName = M.lookup "funcName" =<< metadata
-                                         in Constant . SString . fromMaybe "" . keccak256() -}
+      (SBuiltinVariable "msg", "data") -> do contract' <- getCurrentContract
+                                             functionName <- getCurrentFunctionName
+                                             callInfo <- getCurrentCallInfo
+                                             let argList = maybe [] CC.funcArgs $ contract' ^. CC.functions . at functionName
+                                                 localVars = localVariables callInfo
+                                             argVals <- forM argList (\(n,_) -> getVar . snd $ localVars M.! (fromMaybe "" n))
+                                             argsToStr <- fmap (intercalate ", ") $ forM argVals showSM
+                                             return . Constant . SString $ "("++argsToStr++")"
+      (SBuiltinVariable "msg", "sig") -> do functionName <- getCurrentFunctionName
+                                            contract' <- getCurrentContract
+                                            let argList = maybe [] CC.funcArgs $ contract' ^. CC.functions . at functionName
+                                                argTypesList = map (\(_, CC.IndexedType _ t) -> t) argList
+                                                argString = labelToString functionName++"("++intercalate "," (map unparseVarType argTypesList)++")"
+                                                calldataHash = fromMaybe emptyHash $ stringKeccak256 argString
+                                            return . Constant . SString $ take 8 $ keccak256ToHex calldataHash 
       (SBuiltinVariable "tx", "origin") -> (Constant . ((flip SAccount) False) . accountToNamedAccount chainId . Env.origin) <$> getEnv
       (SBuiltinVariable "tx", "username") -> do env' <- getEnv
                                                 x509s <- Mod.get (Mod.Proxy @(M.Map Address X509Certificate))

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -24,8 +24,10 @@ import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.UTF8   as UTF8
 import Data.Coerce
 import qualified Data.Map as M
+import Data.Maybe
 import qualified Data.Set as S
 import qualified Data.Text as T
+import qualified Data.List as L
 import Data.Char
 import Data.Text.Encoding
 import Data.Time.Clock.POSIX
@@ -4859,13 +4861,36 @@ contract qq{
 
   it "can use msg.data" . runTest $ do
     runBS [r|
-contract qq {
-  string s;
-  function a(uint _a, string _b, bool _c) pure returns (string) {
+contract X {
+  function func2(uint _a, string _b, bool _c) pure public returns (string) {
     return msg.data;
   }
+}
+
+contract qq {
+  string s;
   constructor() {
-    s = a(10, "hey", false);
+    X x = new X();
+    s = x.func2(10, "hey", false);
   }
 }|]
-    getFields ["s"] `shouldReturn` [BString "(10, \"hey\", False"]
+    getFields ["s"] `shouldReturn` [BString "(10, hey, False)"]
+
+  it "can use msg.sig" . runTest $ do
+    runBS [r|
+contract X {
+  function func2(uint _a, string _b, bool _c) pure public returns (bytes4) {
+    return msg.sig;
+  }
+}
+
+contract qq {
+  bytes4 ss;
+  constructor() {
+    X x = new X();
+    ss = x.func2(10, "hey", false);
+  }
+}|]
+    let calldataHash = fromMaybe emptyHash $ stringKeccak256 "func2(uint,string,bool)"
+    getFields ["ss"] `shouldReturn` [BString $ BC.pack $ L.take 8 $ keccak256ToHex calldataHash ]
+

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4856,3 +4856,16 @@ contract qq{
   }
 }|]
     getFields ["mynum"] `shouldReturn` [BInteger 9]
+
+  it "can use msg.data" . runTest $ do
+    runBS [r|
+contract qq {
+  string s;
+  function a(uint _a, string _b, bool _c) pure returns (string) {
+    return msg.data;
+  }
+  constructor() {
+    s = a(10, "hey", false);
+  }
+}|]
+    getFields ["s"] `shouldReturn` [BString "(10, \"hey\", False"]


### PR DESCRIPTION
Added msg.sig that return 4 bytes of function call data in hex format (funcName(argType1, argType2, ...) and msg.data that returns function call's argument values.