### PR TITLE
Fix devnet stateRoot Mismatch by changing modifier error behavior on older pragmas (release/7.7.0)

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -420,8 +420,10 @@ functionModifiers = do
       <|> (reserved "payable"  >> return SolidVM.Payable)
       )
     constructorCallModifiersOrOtherModifiers = do 
+      pVersion <- getPragmaVersion
       name <- stringToLabel <$> identifier
       exps <- optionMaybe (parens $ commaSep expression)
+      when ((pVersion == "3.0" || pVersion == "") && isNothing exps) $ fail "modifiers are not supported below pragma solidvm 3.0"
       return (name, fromMaybe [] exps) 
 
 -- | A common pattern: code enclosed in braces, allowing nested braces.


### PR DESCRIPTION
This change keeps the old behavior of having a parse error on valid modifier text on versions 3.0 and below