### PR TITLE
Strato 2695 create revert statement functionality

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
@@ -31,6 +31,7 @@ module Blockchain.VM.SolidException
   , tooMuchGas
   , paymentError
   , reservedWordError
+  , revertError
   , immutableError
   ) where
 
@@ -48,6 +49,7 @@ data SolidException = TypeError String String
                     | IndexOutOfBounds String String
                     | TODO String String
                     | MissingField String String
+                    | RevertError String String
                     | CustomError String String [B.BasicValue]
                     | MissingType String String
                     | DuplicateDefinition String String
@@ -82,6 +84,7 @@ showSolidException (InvalidArguments m v) = printf "invalid arguments: %s: %s" m
 showSolidException (IndexOutOfBounds a b)= printf "index out of bounds: %s: %s" a b
 showSolidException (MissingField m v) = printf "missing field: %s: %s" m v
 showSolidException (MissingType m v) = printf "missing type: %s: %s" m v
+showSolidException (RevertError m v) = printf "revert: %s %s:" m v
 showSolidException (DuplicateDefinition m v) = printf "duplicate definition: %s: %s" m v
 showSolidException (ParseError m v) = printf "parse error: %s: %s" m v
 showSolidException (ModifierError m v) = printf "modifier error: %s: %s" m v
@@ -126,6 +129,9 @@ indexOutOfBounds = toThrower IndexOutOfBounds
 
 missingField :: (Show v) => String -> v -> a
 missingField = toThrower MissingField
+
+revertError :: (Show v) =>  String -> v -> a
+revertError = toThrower RevertError
 
 customError :: String -> String -> [B.BasicValue] -> a
 customError msg nm vals = throw $ CustomError msg nm vals

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -928,7 +928,17 @@ runStatement (CC.SimpleStatement (CC.ExpressionStatement (CC.PlusPlus e))) = do
   return Nothing
 -}
 
-
+runStatement (CC.RevertStatement mString theArgs _) = do -- TODO make work with multiple args
+  case mString of 
+    Just x -> do todo "customError Functions to be implemented" x 
+    Nothing -> case theArgs of
+      CC.OrderedArgs xs -> do
+        newList <- forM xs $ \x -> do
+          y <- expToVar x
+          z <- getVar y
+          return z
+        revertError "REVERT" newList
+      CC.NamedArgs xs -> todo "Should handle named args" xs
 
 -- Assignment to an index into an array or mapping
 runStatement st@(CC.SimpleStatement (CC.ExpressionStatement (CC.Binary _ "=" dst@(CC.IndexAccess _ parent (Just indExp)) src)) pos) = do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -930,7 +930,30 @@ runStatement (CC.SimpleStatement (CC.ExpressionStatement (CC.PlusPlus e))) = do
 
 runStatement (CC.RevertStatement mString theArgs _) = do -- TODO make work with multiple args
   case mString of 
-    Just x -> do todo "customError Functions to be implemented" x 
+    Just x -> do
+      -- (hsh,cc) <- getCurrentCodeCollection
+      g <- getCurrentContract
+      err <- case M.lookup mString $ CC._errors g of
+        Just e -> do
+          ag <- case theArgs of
+                CC.OrderedArgs xs -> do
+                    newList <- forM xs $ \x -> do
+                      y <- expToVar x
+                      z <- getVar y
+                      return z
+                    pure $ newList
+                CC.NamedArgs ns -> do
+                    newList <- forM ns $ \x -> do
+                      y <- expToVar x
+                      z <- getVar y
+                      return z
+                    pure $ newList
+          let listOfVals = case ag of
+                CC.OrderedArgs ov -> map (\x -> toBasic x) ov
+                CC.NamedArgs nv -> map (\(_, y) -> toBasic y) nv
+          return $ customError "Reverting based on  Error" mString listOfVals    
+        Nothing -> revertError "REVERT" "Going back to Initial State"
+    
     Nothing -> case theArgs of
       CC.OrderedArgs xs -> do
         newList <- forM xs $ \x -> do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -928,40 +928,42 @@ runStatement (CC.SimpleStatement (CC.ExpressionStatement (CC.PlusPlus e))) = do
   return Nothing
 -}
 
-runStatement (CC.RevertStatement mString theArgs _) = do -- TODO make work with multiple args
-  case mString of 
-    Just x -> do todo "handle custom errors" x
-      -- -- (hsh,cc) <- getCurrentCodeCollection
-      -- g <- getCurrentContract
-      -- err <- case M.lookup mString $ CC._errors g of
-      --   Just e -> do
-      --     ag <- case theArgs of
-      --           CC.OrderedArgs xs -> do
-      --               newList <- forM xs $ \x -> do
-      --                 y <- expToVar x
-      --                 z <- getVar y
-      --                 return z
-      --               pure $ newList
-      --           CC.NamedArgs ns -> do
-      --               newList <- forM ns $ \x -> do
-      --                 y <- expToVar x
-      --                 z <- getVar y
-      --                 return z
-      --               pure $ newList
-      --     let listOfVals = case ag of
-      --           CC.OrderedArgs ov -> map (\x -> toBasic x) ov
-      --           CC.NamedArgs nv -> map (\(_, y) -> toBasic y) nv
-      --     return $ customError "Reverting based on  Error" mString listOfVals    
-      --   Nothing -> revertError "REVERT" "Going back to Initial State"
+
+-- Below defined logic works well for REVERT statement use-cases:
+--    revert();
+
+--    revert(args);
+    --    revert("error message") i.e. OrderedArgs 
+    --    revert({x:"Message"}) i.e. NamedArgs
+
+--    revert customError(args);
+    --    revert customError("error message") i.e. OrderedArgs 
+    --    revert customError({x:"Message"}) i.e. NamedArgs 
+runStatement (CC.RevertStatement mString theArgs _) = do
+  case mString of
+    Just name -> do 
+      g <- getCurrentContract
+      err <- case M.lookup name $ CC._errors g of
+        Just _ -> do
+          argVals <- case theArgs of
+            CC.OrderedArgs as -> OrderedVals <$> mapM (getVar <=< expToVar) as
+            CC.NamedArgs ns -> NamedVals <$> mapM (mapM $ getVar <=< expToVar) ns
+          let listOfVals = case argVals of
+                OrderedVals ov -> map (\x -> toBasic x) ov
+                NamedVals nv -> map (\(_, y) -> toBasic y) nv
+              
+          return $ customError "Reverting based on  Error Method:" name listOfVals
+        Nothing -> do revertError "REVERT: to initial state" name
+      pure $ err
     
-    Nothing -> case theArgs of
-      CC.OrderedArgs xs -> do
-        newList <- forM xs $ \x -> do
-          y <- expToVar x
-          z <- getVar y
-          return z
-        revertError "REVERT" newList
-      CC.NamedArgs xs -> todo "Should handle named args" xs
+    Nothing -> do
+          argVals <- case theArgs of
+            CC.OrderedArgs as -> OrderedVals <$> mapM (getVar <=< expToVar) as
+            CC.NamedArgs ns -> NamedVals <$> mapM (mapM $ getVar <=< expToVar) ns
+          let listOfVals = case argVals of
+                OrderedVals ov -> map (\x -> toBasic x) ov
+                NamedVals nv -> map (\(_, y) -> toBasic y) nv    
+          return $ revertError "REVERT" listOfVals    
 
 -- Assignment to an index into an array or mapping
 runStatement st@(CC.SimpleStatement (CC.ExpressionStatement (CC.Binary _ "=" dst@(CC.IndexAccess _ parent (Just indExp)) src)) pos) = do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -930,29 +930,29 @@ runStatement (CC.SimpleStatement (CC.ExpressionStatement (CC.PlusPlus e))) = do
 
 runStatement (CC.RevertStatement mString theArgs _) = do -- TODO make work with multiple args
   case mString of 
-    Just x -> do
-      -- (hsh,cc) <- getCurrentCodeCollection
-      g <- getCurrentContract
-      err <- case M.lookup mString $ CC._errors g of
-        Just e -> do
-          ag <- case theArgs of
-                CC.OrderedArgs xs -> do
-                    newList <- forM xs $ \x -> do
-                      y <- expToVar x
-                      z <- getVar y
-                      return z
-                    pure $ newList
-                CC.NamedArgs ns -> do
-                    newList <- forM ns $ \x -> do
-                      y <- expToVar x
-                      z <- getVar y
-                      return z
-                    pure $ newList
-          let listOfVals = case ag of
-                CC.OrderedArgs ov -> map (\x -> toBasic x) ov
-                CC.NamedArgs nv -> map (\(_, y) -> toBasic y) nv
-          return $ customError "Reverting based on  Error" mString listOfVals    
-        Nothing -> revertError "REVERT" "Going back to Initial State"
+    Just x -> do todo "handle custom errors" x
+      -- -- (hsh,cc) <- getCurrentCodeCollection
+      -- g <- getCurrentContract
+      -- err <- case M.lookup mString $ CC._errors g of
+      --   Just e -> do
+      --     ag <- case theArgs of
+      --           CC.OrderedArgs xs -> do
+      --               newList <- forM xs $ \x -> do
+      --                 y <- expToVar x
+      --                 z <- getVar y
+      --                 return z
+      --               pure $ newList
+      --           CC.NamedArgs ns -> do
+      --               newList <- forM ns $ \x -> do
+      --                 y <- expToVar x
+      --                 z <- getVar y
+      --                 return z
+      --               pure $ newList
+      --     let listOfVals = case ag of
+      --           CC.OrderedArgs ov -> map (\x -> toBasic x) ov
+      --           CC.NamedArgs nv -> map (\(_, y) -> toBasic y) nv
+      --     return $ customError "Reverting based on  Error" mString listOfVals    
+      --   Nothing -> revertError "REVERT" "Going back to Initial State"
     
     Nothing -> case theArgs of
       CC.OrderedArgs xs -> do

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -5421,13 +5421,33 @@ contract qq {
   } 
 }|]) `shouldThrow` anyRevertError
 
-  it "Revert customError TODO" $ runTest (do
+  it "revert sucessfully when invoked with namedargs" $ runTest (do
     runBS [r|
 pragma solidvm 3.3;
 contract qq {
   
   uint a;
   
+  constructor()
+  {
+    a=1;
+    randomFunction(1);
+  }
+
+  function randomFunction(uint checker)
+  {
+    if(a==checker)
+      revert({x:"logic flag"}); 
+  } 
+}|]) `shouldThrow` anyRevertError
+
+  it "Revert customError" $ runTest (do
+    runBS [r|
+pragma solidvm 3.3;
+contract qq {
+  
+  uint a;
+  error f (string message);
   constructor()
   {
     a=1;
@@ -5439,15 +5459,15 @@ contract qq {
     if(a==checker)
       revert f("ERROR"); 
   } 
-}|]) `shouldThrow` anyTODO
+}|]) `shouldThrow` anyCustomError
 
-  it "Revert customError  TODO" $ runTest (do
+  it "Revert customError  namedargs" $ runTest (do
     runBS [r|
 pragma solidvm 3.3;
 contract qq {
   
   uint a;
-  
+  error f(string x,string y);
   constructor()
   {
     a=1;
@@ -5459,4 +5479,4 @@ contract qq {
     if(a==checker)
       revert f({x:'a',y:'b'}); 
   } 
-}|]) `shouldThrow` anyTODO
+}|]) `shouldThrow` anyCustomError

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -80,6 +80,10 @@ anyParseError :: Selector HandledException
 anyParseError (HE ParseError{}) = True
 anyParseError _ = False
 
+anyRevertError :: Selector HandledException
+anyRevertError (HE Blockchain.SolidVM.Exception.RevertError{}) = True
+anyRevertError _ = False
+
 anyUnknownFunc :: Selector HandledException
 anyUnknownFunc (HE UnknownFunction{}) = True
 anyUnknownFunc _ = False
@@ -5376,3 +5380,83 @@ contract qq {
      }
   }
 }|]) `shouldThrow` anyTypeError
+
+  it "revert sucessfully when invoked without arguments" $ runTest (do
+    runBS [r|
+pragma solidvm 3.3;
+contract qq {
+  
+  uint a;
+  
+  constructor()
+  {
+    a=1;
+    randomFunction(1);
+  }
+
+  function randomFunction(uint checker)
+  {
+    if(a==checker)
+      revert(); 
+  } 
+}|]) `shouldThrow` anyRevertError
+
+  it "revert sucessfully when invoked with arguments" $ runTest (do
+    runBS [r|
+pragma solidvm 3.3;
+contract qq {
+  
+  uint a;
+  
+  constructor()
+  {
+    a=1;
+    randomFunction(1);
+  }
+
+  function randomFunction(uint checker)
+  {
+    if(a==checker)
+      revert("logic flag"); 
+  } 
+}|]) `shouldThrow` anyRevertError
+
+  it "Revert customError TODO" $ runTest (do
+    runBS [r|
+pragma solidvm 3.3;
+contract qq {
+  
+  uint a;
+  
+  constructor()
+  {
+    a=1;
+    randomFunction(1);
+  }
+
+  function randomFunction(uint checker)
+  {
+    if(a==checker)
+      revert f("ERROR"); 
+  } 
+}|]) `shouldThrow` anyTODO
+
+  it "Revert customError  TODO" $ runTest (do
+    runBS [r|
+pragma solidvm 3.3;
+contract qq {
+  
+  uint a;
+  
+  constructor()
+  {
+    a=1;
+    randomFunction(1);
+  }
+
+  function randomFunction(uint checker)
+  {
+    if(a==checker)
+      revert f({x:'a',y:'b'}); 
+  } 
+}|]) `shouldThrow` anyTODO

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -5439,7 +5439,7 @@ contract qq {
     if(a==checker)
       revert f("ERROR"); 
   } 
-}|]) `shouldThrow` anyTODO
+}|]) `shouldThrow` anyCustomError
 
   it "Revert customError  TODO" $ runTest (do
     runBS [r|
@@ -5459,4 +5459,4 @@ contract qq {
     if(a==checker)
       revert f({x:'a',y:'b'}); 
   } 
-}|]) `shouldThrow` anyTODO
+}|]) `shouldThrow` anyCustomError

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -5439,7 +5439,7 @@ contract qq {
     if(a==checker)
       revert f("ERROR"); 
   } 
-}|]) `shouldThrow` anyCustomError
+}|]) `shouldThrow` anyTODO
 
   it "Revert customError  TODO" $ runTest (do
     runBS [r|
@@ -5459,4 +5459,4 @@ contract qq {
     if(a==checker)
       revert f({x:'a',y:'b'}); 
   } 
-}|]) `shouldThrow` anyCustomError
+}|]) `shouldThrow` anyTODO


### PR DESCRIPTION
This PR deals with revert() functionality implementation. Revert() can be used in polymorphic way as follows:

1. revert()
2. revert("err")
3. revert errFunctionName(<parameters>)

Revert functionality helps you handle exceptions within a complex logic. Ideally, it offers you to throw exceptions in a custom fashion too. With the help of parsing definition defined in Statement.hs (revertStatement), the revert invocation has been handled in the SolidVM.hs file. This PR handles the first two use cases of revert. Further update will come soon that also handles the final use-case of the revert to handle the error functions. 

Below are the verified tests that confirm the functionality:


```
  it "revert sucessfully when invoked without arguments" $ runTest (do
    runBS [r|
pragma solidvm 3.3;
contract qq {
  
  uint a;
  
  constructor()
  {
    a=1;
    randomFunction(1);
  }

  function randomFunction(uint checker)
  {
    if(a==checker)
      revert(); 
  } 
}|]) `shouldThrow` anyRevertError
```
```
  it "revert sucessfully when invoked with arguments" $ runTest (do
    runBS [r|
pragma solidvm 3.3;
contract qq {
  
  uint a;
  
  constructor()
  {
    a=1;
    randomFunction(1);
  }

  function randomFunction(uint checker)
  {
    if(a==checker)
      revert("logic flag"); 
  } 
}|]) `shouldThrow` anyRevertError
```
```
  it "Revert customError TODO" $ runTest (do
    runBS [r|
pragma solidvm 3.3;
contract qq {
  
  uint a;
  
  constructor()
  {
    a=1;
    randomFunction(1);
  }

  function randomFunction(uint checker)
  {
    if(a==checker)
      revert f("ERROR"); 
  } 
}|]) `shouldThrow` anyTODO
```
```
  it "Revert customError  TODO" $ runTest (do
    runBS [r|
pragma solidvm 3.3;
contract qq {
  
  uint a;
  
  constructor()
  {
    a=1;
    randomFunction(1);
  }

  function randomFunction(uint checker)
  {
    if(a==checker)
      revert f({x:a,y:b}); 
  } 
}|]) `shouldThrow` anyTODO
```
