### PR TITLE
Strato 2697 be able to catch custom error types the solid vm way

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
@@ -11,6 +11,7 @@ module Blockchain.VM.SolidException
   , internalError
   , invalidArguments
   , missingField
+  , customError
   , missingType
   , duplicateDefinition
   , parseError
@@ -41,12 +42,13 @@ import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics
 import Text.Printf (printf)
 
-data SolidException = TypeError String String
+data SolidException a = TypeError String String
                     | InternalError String String
                     | InvalidArguments String String
                     | IndexOutOfBounds String String
                     | TODO String String
                     | MissingField String String
+                    | CustomError String String a
                     | MissingType String String
                     | DuplicateDefinition String String
                     | ArityMismatch String Int Int
@@ -70,10 +72,10 @@ data SolidException = TypeError String String
                     | ImmutableError String String
                     deriving (Eq, Exception, Generic, NFData, ToJSON, FromJSON)
 
-instance Show SolidException where
+instance Show (SolidException a) where
   show = showSolidException
 
-showSolidException :: SolidException -> String
+showSolidException :: SolidException a -> String
 showSolidException (ArityMismatch m got want) = printf "arity mismatch: %s: got %d, want %d" m got want
 showSolidException (InternalError m v) = printf "internal error: %s: %s" m v
 showSolidException (InvalidArguments m v) = printf "invalid arguments: %s: %s" m v
@@ -86,6 +88,7 @@ showSolidException (ModifierError m v) = printf "modifier error: %s: %s" m v
 showSolidException (Require Nothing) = printf "solidity require failed"
 showSolidException (Require (Just m)) = printf "solidity require failed: %s" m
 showSolidException Assert = printf "solidity assert failed"
+showSolidException (CustomError m v _) = printf "custom user error: %s %s" m v
 showSolidException (TODO m v) = printf "Unimplemented feature in SolidVM: %s: %s" m v
 showSolidException (TypeError a b) = printf "type error: %s: %s" a b
 showSolidException (UnknownConstant a b) = printf "unknown constant: %s: %s" a b
@@ -103,7 +106,7 @@ showSolidException (PaymentError a b) = printf "There was an error sending %s we
 showSolidException (ReservedWordError a b) = printf "%s is a reserved word in version %s and up." b a
 showSolidException (ImmutableError a b) = printf "%s is an immutable variable in line '%s'" a b
 
-toThrower :: (Show v) => (String -> String -> SolidException) -> String -> v -> a
+toThrower :: (Show v) => (String -> String -> SolidException a) -> String -> v -> a
 toThrower cont msg = throw . cont msg . show
 
 typeError :: (Show v) => String -> v -> a
@@ -123,6 +126,9 @@ indexOutOfBounds = toThrower IndexOutOfBounds
 
 missingField :: (Show v) => String -> v -> a
 missingField = toThrower MissingField
+
+customError :: (Show v) => String -> v -> a -> b
+customError a = toThrower $ CustomError a
 
 missingType :: (Show v) => String -> v -> a
 missingType = toThrower MissingType

--- a/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
@@ -72,7 +72,7 @@ data SolidException = TypeError String String
                     | ImmutableError String String
                     deriving (Eq, Exception, Generic, NFData)
 
-instance Show (SolidException) where
+instance Show SolidException where
   show = showSolidException
 
 showSolidException :: SolidException -> String
@@ -130,7 +130,6 @@ missingField = toThrower MissingField
 customError :: String -> String -> [B.BasicValue] -> a
 customError msg nm vals = throw $ CustomError msg nm vals
 
--- MissingType :: String -> String -> SolidException
 missingType :: (Show v) => String -> v -> a
 missingType = toThrower MissingType
 

--- a/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
@@ -38,17 +38,17 @@ import Control.DeepSeq
 import Control.Exception (throw, throwIO, Exception)
 import Control.Monad (unless, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.Aeson (ToJSON, FromJSON)
 import GHC.Generics
 import Text.Printf (printf)
+import qualified SolidVM.Model.Storable as B
 
-data SolidException a = TypeError String String
+data SolidException = TypeError String String
                     | InternalError String String
                     | InvalidArguments String String
                     | IndexOutOfBounds String String
                     | TODO String String
                     | MissingField String String
-                    | CustomError String String a
+                    | CustomError String String [B.BasicValue]
                     | MissingType String String
                     | DuplicateDefinition String String
                     | ArityMismatch String Int Int
@@ -70,12 +70,12 @@ data SolidException a = TypeError String String
                     | PaymentError String String
                     | ReservedWordError String String
                     | ImmutableError String String
-                    deriving (Eq, Exception, Generic, NFData, ToJSON, FromJSON)
+                    deriving (Eq, Exception, Generic, NFData)
 
-instance Show (SolidException a) where
+instance Show (SolidException) where
   show = showSolidException
 
-showSolidException :: SolidException a -> String
+showSolidException :: SolidException -> String
 showSolidException (ArityMismatch m got want) = printf "arity mismatch: %s: got %d, want %d" m got want
 showSolidException (InternalError m v) = printf "internal error: %s: %s" m v
 showSolidException (InvalidArguments m v) = printf "invalid arguments: %s: %s" m v
@@ -106,7 +106,7 @@ showSolidException (PaymentError a b) = printf "There was an error sending %s we
 showSolidException (ReservedWordError a b) = printf "%s is a reserved word in version %s and up." b a
 showSolidException (ImmutableError a b) = printf "%s is an immutable variable in line '%s'" a b
 
-toThrower :: (Show v) => (String -> String -> SolidException a) -> String -> v -> a
+toThrower :: (Show v) => (String -> String -> SolidException) -> String -> v -> a
 toThrower cont msg = throw . cont msg . show
 
 typeError :: (Show v) => String -> v -> a
@@ -127,9 +127,10 @@ indexOutOfBounds = toThrower IndexOutOfBounds
 missingField :: (Show v) => String -> v -> a
 missingField = toThrower MissingField
 
-customError :: (Show v) => String -> v -> a -> b
-customError a = toThrower $ CustomError a
+customError :: String -> String -> [B.BasicValue] -> a
+customError msg nm vals = throw $ CustomError msg nm vals
 
+-- MissingType :: String -> String -> SolidException
 missingType :: (Show v) => String -> v -> a
 missingType = toThrower MissingType
 

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
@@ -110,7 +110,6 @@ data Value =
   | SBuiltinFunction SolidString (Maybe Value)
   | SBuiltinVariable SolidString
   | SSetterGetter String (Maybe Value)
-  | SError String String
   | SContractDef SolidString
   | SContractItem NamedAccount SolidString
   | SContract SolidString NamedAccount

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
@@ -110,6 +110,7 @@ data Value =
   | SBuiltinFunction SolidString (Maybe Value)
   | SBuiltinVariable SolidString
   | SSetterGetter String (Maybe Value)
+  | SError String String
   | SContractDef SolidString
   | SContractItem NamedAccount SolidString
   | SContract SolidString NamedAccount

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1069,7 +1069,6 @@ statementHelper (IfStatement cond thens mElse x) = do
   ts <- statementsHelper' x thens
   es <- statementsHelper' x $ fromMaybe [] mElse
   pure $ reduceType' x [cs, ts, es]
--- [[(("ten",IndexedType {indexedTypeIndex = 0, indexedTypeType = Int {signed = Just True, bytes = Nothing}},(line 5, column 3) - (line 5, column 39): "" ),"vall"),(("message",IndexedType {indexedTypeIndex = 1, indexedTypeType = String {dynamic = Just True}},(line 5, column 3) - (line 5, column 39): "" ),"mes")]]
 statementHelper (TryCatchStatement tryStatmenets catchMap x) = do
   cc <- asks codeCollection
   cntrct <- asks contract

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1069,7 +1069,23 @@ statementHelper (IfStatement cond thens mElse x) = do
   ts <- statementsHelper' x thens
   es <- statementsHelper' x $ fromMaybe [] mElse
   pure $ reduceType' x [cs, ts, es]
+-- [[(("ten",IndexedType {indexedTypeIndex = 0, indexedTypeType = Int {signed = Just True, bytes = Nothing}},(line 5, column 3) - (line 5, column 39): "" ),"vall"),(("message",IndexedType {indexedTypeIndex = 1, indexedTypeType = String {dynamic = Just True}},(line 5, column 3) - (line 5, column 39): "" ),"mes")]]
 statementHelper (TryCatchStatement tryStatmenets catchMap x) = do
+  cc <- asks codeCollection
+  cntrct <- asks contract
+  let errorParams = concatMap (\y -> case M.lookup y $ _errors cntrct of
+                                  Just z -> pure $ z
+                                  Nothing -> case M.lookup y $ _flErrors cc of
+                                    Just z -> pure $ z
+                                    Nothing -> []
+                                ) $ M.keys catchMap
+      zipped = map (\(y, Just z) -> zip y z) $ zip errorParams $ map (fst . snd) (M.toList catchMap)
+      paramsToDefs :: [((String, IndexedType, a), String)] -> [Annotated VarDefEntryF]
+      paramsToDefs [] = []
+      paramsToDefs (((_, a, _), b):xs) = (VarDefEntry (Just $ indexedTypeType a) Nothing b x) : (paramsToDefs xs)
+      localVarDefs = concatMap paramsToDefs zipped
+
+  pushLocalVariables localVarDefs
   ts <- statementsHelper' x tryStatmenets
   es <- statementsHelper' x (concatMap (snd . snd) (M.toList catchMap))
   pure $ reduceType' x [ts, es]

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1151,8 +1151,6 @@ runStatement (CC.TryCatchStatement tryBlock catchBlockMap _) = do
       mRes <- EUnsafe.try $ do
         val <- runStatements tryBlock
         pure $ val
-      callInfo <- getCurrentCallInfo
-      when (True) (internalError "stuff" callInfo)
       case mRes of
         Left ex -> do
           res1 <- solidVMExceptionHandler catchBlockMap ex
@@ -1255,7 +1253,6 @@ runStatement (CC.Return maybeExpression pos) = do
 
 runStatement (CC.Throw expr _) = do
   ctract <- getCurrentContract
-  (_, cc) <- getCurrentCodeCollection
   if (CC._vmVersion ctract /= "svm3.3")
     then unknownStatement "Throw statements are not supported below pragma solidvm 3.3" expr
     else do
@@ -1263,18 +1260,13 @@ runStatement (CC.Throw expr _) = do
         case expr of
           CC.FunctionCall _ (CC.Variable _ n) a -> pure (n, a) 
           _ -> invalidArguments "Invalid argument for throw." expr
-      errDec <- case M.lookup name $ CC._errors ctract of
-        Just e -> pure $ e 
-        Nothing -> case M.lookup name $ CC._flErrors cc of
-          Just e -> pure $ e 
-          Nothing -> invalidArguments "Invalid error type." name
       argVals <- case args of
         CC.OrderedArgs as -> OrderedVals <$> mapM (getVar <=< expToVar) as
         CC.NamedArgs ns -> NamedVals <$> mapM (mapM $ getVar <=< expToVar) ns
-      _ <- case argVals of
-        OrderedVals ov -> mapM (\((x, (CC.IndexedType _ b), _), z) -> addLocalVariable b x z) $ zip errDec ov
-        NamedVals nv -> mapM (\((w, (CC.IndexedType _ b), _), (_, z)) -> addLocalVariable b w z) $ zip errDec nv
-      customError "Custom user error thrown" name
+      let listOfVals = case argVals of
+            OrderedVals ov -> map (\x -> toBasic x) ov
+            NamedVals nv -> map (\(_, y) -> toBasic y) nv
+      customError "Custom user error thrown" name listOfVals
 
 runStatement (CC.AssemblyStatement (CC.MloadAdd32 dst src) pos) = do
   solidVMBreakpoint pos
@@ -3123,11 +3115,7 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro ff = do
       let (lhs,rhs) = foldr (\(a,b) (c,d) -> (a++c,b++d)) ([],[]) (map (span isNotModExec) modContentsList)
       logVals lhs rhs
       _ <- runStatements' lhs
-      val   <- do
-        res <- runStatements commands
-        case res of 
-          Just (SError msg nm) -> customError msg nm
-          _ -> pure $ res
+      val   <- runStatements commands
       _ <- runStatements' rhs
 
       let findNamedReturns = do
@@ -3532,11 +3520,25 @@ solidVMExceptionHandler catchBlockMap ex = case ex of
         Just (_, block) -> do
           res <- runStatements block
           return res
-    (CustomError s1 s2) -> do
+    (CustomError s1 s2 vals) -> do
       let name = T.unpack $ T.replace "\"" "" $ T.pack s2
       case M.lookup name catchBlockMap of
-        Nothing -> customError s1 name
-        Just (_, block) -> do
+        Nothing -> customError s1 name vals
+        Just (args, block) -> do
+          ctract <- getCurrentContract
+          (_, cc) <- getCurrentCodeCollection
+          let basicToVals = map (\x -> fromBasic x) vals
+              zipped = case M.lookup name $ CC._errors ctract of
+                        Just e -> zip e basicToVals 
+                        Nothing -> case M.lookup name $ CC._flErrors cc of
+                          Just e -> zip e basicToVals 
+                          Nothing -> invalidArguments "Invalid error type." name
+              argsToSolidString = case args of
+                Just a -> map stringToLabel a
+                Nothing -> []
+          _ <- if length args > 0
+                then mapM (\(x, ((_, (CC.IndexedType _ y), _), z)) -> addLocalVariable y x z) $ zip argsToSolidString zipped
+                else pure $ [()]
           res <- runStatements block
           return res
       

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1155,8 +1155,7 @@ runStatement (CC.TryCatchStatement tryBlock catchBlockMap _) = do
         Left ex -> do
           res1 <- solidVMExceptionHandler catchBlockMap ex
           return res1
-        Right res -> 
-          return res
+        Right res -> return res
 
 runStatement (CC.IfStatement condition code' maybeElseCode pos) = do
   solidVMBreakpoint pos

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1148,12 +1148,17 @@ runStatement (CC.TryCatchStatement tryBlock catchBlockMap _) = do
   if (CC._vmVersion ctract /= "svm3.3")
     then unknownStatement "Try/Catch statements are not supported below pragma solidvm 3.3" tryBlock
     else do
-      mRes <- EUnsafe.try (runStatements tryBlock)
+      mRes <- EUnsafe.try $ do
+        val <- runStatements tryBlock
+        pure $ val
+      callInfo <- getCurrentCallInfo
+      when (True) (internalError "stuff" callInfo)
       case mRes of
         Left ex -> do
           res1 <- solidVMExceptionHandler catchBlockMap ex
           return res1
-        Right res -> return res
+        Right res -> 
+          return res
 
 runStatement (CC.IfStatement condition code' maybeElseCode pos) = do
   solidVMBreakpoint pos
@@ -1265,11 +1270,11 @@ runStatement (CC.Throw expr _) = do
           Nothing -> invalidArguments "Invalid error type." name
       argVals <- case args of
         CC.OrderedArgs as -> OrderedVals <$> mapM (getVar <=< expToVar) as
-        CC.NamedArgs ns -> NamedVals <$> mapM (mapM $ getVar <=< expToVar) ns 
+        CC.NamedArgs ns -> NamedVals <$> mapM (mapM $ getVar <=< expToVar) ns
       _ <- case argVals of
         OrderedVals ov -> mapM (\((x, (CC.IndexedType _ b), _), z) -> addLocalVariable b x z) $ zip errDec ov
         NamedVals nv -> mapM (\((w, (CC.IndexedType _ b), _), (_, z)) -> addLocalVariable b w z) $ zip errDec nv
-      pure $ Just SNULL
+      customError "Custom user error thrown" name
 
 runStatement (CC.AssemblyStatement (CC.MloadAdd32 dst src) pos) = do
   solidVMBreakpoint pos
@@ -3118,7 +3123,11 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro ff = do
       let (lhs,rhs) = foldr (\(a,b) (c,d) -> (a++c,b++d)) ([],[]) (map (span isNotModExec) modContentsList)
       logVals lhs rhs
       _ <- runStatements' lhs
-      val   <- runStatements commands
+      val   <- do
+        res <- runStatements commands
+        case res of 
+          Just (SError msg nm) -> customError msg nm
+          _ -> pure $ res
       _ <- runStatements' rhs
 
       let findNamedReturns = do
@@ -3407,6 +3416,7 @@ solidityExceptionHandler catchBlockMap ex = do
     (ImmutableError s1 s2) -> do
       res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 25 immutableError
       return res
+    _ -> error "unhandled solid exception" (show ex)
 
 solidVMExceptionHandler :: (MonadSM m) => (M.Map String (Maybe [String], [CC.Statement])) -> SolidException -> m (Maybe Value)
 solidVMExceptionHandler catchBlockMap ex = case ex of
@@ -3522,6 +3532,13 @@ solidVMExceptionHandler catchBlockMap ex = case ex of
         Just (_, block) -> do
           res <- runStatements block
           return res
-    
+    (CustomError s1 s2) -> do
+      let name = T.unpack $ T.replace "\"" "" $ T.pack s2
+      case M.lookup name catchBlockMap of
+        Nothing -> customError s1 name
+        Just (_, block) -> do
+          res <- runStatements block
+          return res
+      
     _ -> error "unhandled solid exception" (show ex)
 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -398,6 +398,8 @@ getVariableOfName name = do
       vars = localVariables currentCallInfo
       t s v = ('x':s, v) `seq` v
 
+  -- when (name == "vall") (internalError "M. Night Shyamalan presents" currentCallInfo)
+
   let maybeLocalValue = fmap snd $ M.lookup name vars
 
   let maybeContractFunction :: Maybe Variable

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -398,7 +398,7 @@ getVariableOfName name = do
       vars = localVariables currentCallInfo
       t s v = ('x':s, v) `seq` v
 
-  -- when (name == "vall") (internalError "M. Night Shyamalan presents" currentCallInfo)
+  -- when (name == "theSixthSense") (internalError "M. Night Shyamalan presents" currentCallInfo)
 
   let maybeLocalValue = fmap snd $ M.lookup name vars
 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -24,7 +24,9 @@ module Blockchain.SolidVM.SetGet (
 -}
   deleteVar,
 
-  
+  toBasic,
+  fromBasic,
+    
   showSM
   ) where
 

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -114,6 +114,10 @@ anyDivideByZeroError :: Selector HandledException
 anyDivideByZeroError (HE Blockchain.SolidVM.Exception.DivideByZero{}) = True
 anyDivideByZeroError _ = False
 
+anyCustomError :: Selector HandledException
+anyCustomError (HE Blockchain.SolidVM.Exception.CustomError{}) = True
+anyCustomError _ = False
+
 anyMissingTypeError :: Selector HandledException
 anyMissingTypeError (HE Blockchain.SolidVM.Exception.MissingType{}) = True
 anyMissingTypeError _ = False
@@ -5220,12 +5224,11 @@ contract qq {
   }
 }|]
 
-  it "can throw custom errors" . runTest $ do
+  it "can throw custom errors" $ runTest ( do
     runBS [r|
 pragma solidvm 3.3;
 
 contract qq {
-  string myString;
   error myError (string message);
   constructor() {
     throwsError();
@@ -5233,7 +5236,40 @@ contract qq {
   
   function throwsError() {
     throw myError("lmao pranked");
-    myString = "lmao pranked";
+  }
+}|])  `shouldThrow` anyCustomError
+
+  it "can catch custom errors the SOLIDVM WAY" . runTest $ do
+    runBS [r|
+pragma solidvm 3.3;
+
+contract qq {
+  error IsTen (int ten, string message);
+  int val;
+  string myString;
+
+  constructor() {
+    setVal(10);
+    setString();
+  }
+
+  function checkTen(int _val) returns (int) {
+     if (_val == 10) {
+        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen"); 
+     }
+     return _val;
+  }
+
+  function setString() {
+    myString = "hello";
+  }
+
+  function setVal(int _val) returns (int) {
+     try {
+        val = checkTen(_val);
+     } catch IsTen(vall, mes) { 
+        val = vall + 1;
+     }
   }
 }|]
-    getFields ["myString"] `shouldReturn` [BDefault]
+    getFields ["val"] `shouldReturn` [BInteger 11]

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -5246,6 +5246,7 @@ pragma solidvm 3.3;
 contract qq {
   error IsTen (int ten, string message);
   int val;
+  string errorMsg;
   string myString;
 
   constructor() {
@@ -5269,7 +5270,72 @@ contract qq {
         val = checkTen(_val);
      } catch IsTen(vall, mes) { 
         val = vall + 1;
+        errorMsg = mes;
+     }
+  }
+}|]
+    getFields ["val", "myString", "errorMsg"] `shouldReturn` [BInteger 11, BString "hello", BString "Stop trying to make ten happen, its not going to happen"]
+
+  it "can catch custom errors the SOLIDVM WAY, also allows less aliases" . runTest $ do
+    runBS [r|
+pragma solidvm 3.3;
+
+contract qq {
+  error IsTen (int ten, string message);
+  int val;
+
+  constructor() {
+    setVal(10);
+  }
+
+  function checkTen(int _val) returns (int) {
+     if (_val == 10) {
+        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen"); 
+     }
+     return _val;
+  }
+
+  function setVal(int _val) returns (int) {
+     try {
+        val = checkTen(_val);
+     } catch IsTen(vall) { 
+        val = vall + 1;
      }
   }
 }|]
     getFields ["val"] `shouldReturn` [BInteger 11]
+
+  it "can catch custom errors the SOLIDVM WAY and catch too many aliases" $ runTest ( do
+    runBS [r|
+pragma solidvm 3.3;
+
+contract qq {
+  error IsTen (int ten, string message);
+  int val;
+  string myString;
+
+  constructor() {
+    setVal(10);
+    setString();
+  }
+
+  function checkTen(int _val) returns (int) {
+     if (_val == 10) {
+        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen"); 
+     }
+     return _val;
+  }
+
+  function setString() {
+    myString = "hello";
+  }
+
+  function setVal(int _val) returns (int) {
+     try {
+        val = checkTen(_val);
+     } catch IsTen(vall, mes, bad) { 
+        val = vall + 1;
+        myString = bad;
+     }
+  }
+}|]) `shouldThrow` anyTypeError


### PR DESCRIPTION
This PR implements the ability for SolidVM to catch custom user defined errors thrown in a try/catch block. This is a feature that is not a part of Solidity which makes us better :). We can access the arguments of the error thrown in the catch block through the use of aliases. 

You can have less than or equal to the number of parameters the custom error is declared with in a catch. For example:
```
error myError (int one, int two);
...
catch myError(arg1) {   // arg1 == myError.one
...
}
catch myError(arg1, arg2) {    // (arg1 == myError.one) && (arg2 == myError.two)
...
}
```

Example Contract:
```
contract qq {
  error IsTen (int ten, string message);
  int val;
  string errorMsg;
  string myString;

  constructor() {
    setVal(10);
    setString();
  }

  function checkTen(int _val) returns (int) {
     if (_val == 10) {
        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen"); 
     }
     return _val;
  }

  function setString() {
    myString = "hello";
  }

  function setVal(int _val) returns (int) {
     try {
        val = checkTen(_val);
     } catch IsTen(vall, mes) { 
        val = vall + 1;
        errorMsg = mes;
     }
  }
} 
```