### PR TITLE
Only put full payloads into PrivateTransactions namespace

### DIFF
--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -643,12 +643,16 @@ insertBlock sha b = do
         ptxs    = filter
                     (isJust . txAnchorChain)
                     (obReceiptTransactions b)
+        swapPayload otx = case otPrivatePayload otx of
+                                Nothing -> Nothing
+                                Just p -> Just otx{otBaseTx = p}
+        fullPrivateTxs = catMaybes $ swapPayload <$> ptxs
         uncles  = RedisUncles (morphBlockHeader <$> blockUncleHeaders b)
         inNS'   = flip inNamespace sha
-    unless (null ptxs) $ do
+    unless (null fullPrivateTxs) $ do
       void . addPrivateTransactions $
-        map (txHash &&& ((fromJust . txAnchorChain) &&& id)) ptxs
-      forM_ (partitionWith txAnchorChain ptxs) $ \(cId, ptxs') ->
+        map (txHash &&& ((fromJust . txAnchorChain) &&& id)) fullPrivateTxs
+      forM_ (partitionWith txAnchorChain fullPrivateTxs) $ \(cId, ptxs') ->
                          --  ^-- already filtered on (isJust . txChainId)
         addChainTxsInBlock sha (fromJust cId) $ map txHash ptxs'
     res <- multiExec $ do


### PR DESCRIPTION
Since the release is still on hold, this commit should be merged in. This complements the last PR in fixing the private tx passing in p2p