### PR TITLE
Fix modifier arguments error

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1118,7 +1118,7 @@ runStatement (CC.SolidityTryCatchStatement tryExpression returnsDecl statementsF
 
   if (CC._vmVersion ctract /= "svm3.3")
     then unknownStatement "Try/Catch statements are not supported below pragma solidvm 3.3" tryExpression
-    else withTempCallInfo False $ do
+    else do
       mRes <- EUnsafe.try $ do
         expResultVal <- getVar =<< expToVar tryExpression
         return expResultVal
@@ -1150,7 +1150,7 @@ runStatement (CC.TryCatchStatement tryBlock catchBlockMap _) = do
   -- currentCallInfo <- getCurrentCallInfo
   if (CC._vmVersion ctract /= "svm3.3")
     then unknownStatement "Try/Catch statements are not supported below pragma solidvm 3.3" tryBlock
-    else withTempCallInfo False $ do
+    else do
       mRes <- EUnsafe.try $ do
         val <- runStatements tryBlock
         pure $ val

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2794,7 +2794,7 @@ certificateMap maybeCert cntrct =
                                           ]
           stringToString = SVMType.Mapping { SVMType.dynamic = Nothing
                                         , SVMType.key = SVMType.String Nothing
-                                        , SVMType.value = SVMType.String Nothing }
+                                      , SVMType.value = SVMType.String Nothing }
 {-
 data Func = Func
   { funcArgs :: Map Text CC.IndexedType
@@ -3093,6 +3093,9 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro ff = do
         forM locals $ \(n, (t, v)) -> do
           newVar <- liftIO $ fmap Variable $ newIORef v
           return (n, (t, newVar))
+
+      addCallInfo address' contract' funcName hsh cc (M.fromList localVars1) ro ff -- [(n, (t, Constant v)) | (n, (t, v)) <- locals]
+      
       matchedArgvals <- forM theModifiers $ \modi -> do
         let margList = CC.OrderedArgs 
                 . fromMaybe []
@@ -3126,9 +3129,11 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro ff = do
       --       newVar <- liftIO $ fmap Variable $ newIORef v
       --       myCombinerForEfficiency ((n, (t, newVar)) : xs) ys
 
-      localVars <- myCombinerForEfficiency localVars1 (map (\(x,y) -> (T.unpack x, y)) (concat matchedArgvals))
+      forM_ (map (\(x,y) -> (T.unpack x, y)) (concat matchedArgvals)) $ \(n, (t, v)) -> do
+        addLocalVariable t n v
 
-      addCallInfo address' contract' funcName hsh cc (M.fromList localVars) ro ff -- [(n, (t, Constant v)) | (n, (t, v)) <- locals]
+
+
       -- theCallInfo <- getCurrentCallInfo
       -- when (True || (not $ null matchedArgvals)) $ error (show theCallInfo)
       let !commands = fromMaybe (missingField "Function call: function has been declared but not defined" funcName) $ CC.funcContents theFunction

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1114,9 +1114,11 @@ runStatement s@(CC.SimpleStatement (CC.VariableDefinition entries maybeExpressio
 
 runStatement (CC.SolidityTryCatchStatement tryExpression returnsDecl statementsForSuccess catchBlockMap _) = do
   ctract <- getCurrentContract
+  -- currentCallInfo <- getCurrentCallInfo
+
   if (CC._vmVersion ctract /= "svm3.3")
     then unknownStatement "Try/Catch statements are not supported below pragma solidvm 3.3" tryExpression
-    else do
+    else withTempCallInfo False $ do
       mRes <- EUnsafe.try $ do
         expResultVal <- getVar =<< expToVar tryExpression
         return expResultVal
@@ -1145,9 +1147,10 @@ runStatement (CC.SolidityTryCatchStatement tryExpression returnsDecl statementsF
 
 runStatement (CC.TryCatchStatement tryBlock catchBlockMap _) = do 
   ctract <- getCurrentContract
+  -- currentCallInfo <- getCurrentCallInfo
   if (CC._vmVersion ctract /= "svm3.3")
     then unknownStatement "Try/Catch statements are not supported below pragma solidvm 3.3" tryBlock
-    else do
+    else withTempCallInfo False $ do
       mRes <- EUnsafe.try $ do
         val <- runStatements tryBlock
         pure $ val
@@ -2994,7 +2997,7 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro ff = do
 
   if (CC._vmVersion contract' /= "svm3.3")
     then do
-      _ <- forM theModifierNames $ \name -> do
+      forM_ theModifierNames $ \name -> do
         case M.lookup name (contract'^.CC.modifiers) of
           Just _ -> unknownStatement "modifiers are not supported below pragma solidvm 3.3" name
           Nothing -> return Nothing
@@ -3066,6 +3069,30 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro ff = do
             return $ Just theModifier
           Nothing -> if name `elem` contract' ^. CC.parents then return Nothing else (if (svm3_3) then (missingField "modifier not found" name) else return Nothing)
       let !theModifiers = catMaybes theModifiers'
+
+      let args = case argVals of
+            OrderedVals vs -> let argMeta = 
+                                    map (\(n, CC.IndexedType _ t) -> (fromMaybe "" n, t))
+                                    $ CC.funcArgs theFunction
+                              in zipWith (\(n, t) v -> (n, (t, v))) argMeta vs
+            NamedVals ns ->
+              let strTypes = M.fromList $ map (\(maybeName, y) -> (fromMaybe "" maybeName, y)) $ CC.funcArgs theFunction
+                  typeAndVal = M.merge (M.mapMissing (curry $ invalidArguments "missing argument"))
+                                      (M.mapMissing (curry $ invalidArguments "extra argument"))
+                                      (M.zipWithMatched $ \_k t v -> (t, v))
+                                      strTypes
+                                      $ M.fromList ns
+                  -- These probably don't need to be sorted by argument index, as they are turned into a map
+                  -- when added to the call info.
+                  sortedArgs = map snd . sortWith fst
+                            . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
+                            $ M.toList typeAndVal
+              in sortedArgs
+      let locals = args ++ returns
+      localVars1 <-
+        forM locals $ \(n, (t, v)) -> do
+          newVar <- liftIO $ fmap Variable $ newIORef v
+          return (n, (t, newVar))
       matchedArgvals <- forM theModifiers $ \modi -> do
         let margList = CC.OrderedArgs 
                 . fromMaybe []
@@ -3088,39 +3115,22 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro ff = do
                           . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
                           $ M.toList typeAndVal
             return sortedArgs
-
-      let args = case argVals of
-            OrderedVals vs -> let argMeta = 
-                                    map (\(n, CC.IndexedType _ t) -> (fromMaybe "" n, t))
-                                    $ CC.funcArgs theFunction
-                              in zipWith (\(n, t) v -> (n, (t, v))) argMeta vs
-            NamedVals ns ->
-              let strTypes = M.fromList $ map (\(maybeName, y) -> (fromMaybe "" maybeName, y)) $ CC.funcArgs theFunction
-                  typeAndVal = M.merge (M.mapMissing (curry $ invalidArguments "missing argument"))
-                                      (M.mapMissing (curry $ invalidArguments "extra argument"))
-                                      (M.zipWithMatched $ \_k t v -> (t, v))
-                                      strTypes
-                                      $ M.fromList ns
-                  -- These probably don't need to be sorted by argument index, as they are turned into a map
-                  -- when added to the call info.
-                  sortedArgs = map snd . sortWith fst
-                            . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
-                            $ M.toList typeAndVal
-              in sortedArgs
-
-          locals = args ++ returns ++ (map (\(x,y) -> (T.unpack x, y)) (concat matchedArgvals)) --modArgsToBeLocals
+       -- ++ (map (\(x,y) -> (T.unpack x, y)) (concat matchedArgvals)) --modArgsToBeLocals
 
       onTraced $ do
         liftIO $ putStrLn $ "            args: " ++ show (map fst args)
         when (not $ null returns) $ liftIO $ putStrLn $ "    named return: " ++ show (map fst returns)
 
-      localVars <-
-        forM locals $ \(n, (t, v)) -> do
-          newVar <- liftIO $ fmap Variable $ newIORef v
-          return (n, (t, newVar))
+      -- let myCombinerForEfficiency xs [] = return xs
+      --     myCombinerForEfficiency xs ((n,(t,v)):ys) = do
+      --       newVar <- liftIO $ fmap Variable $ newIORef v
+      --       myCombinerForEfficiency ((n, (t, newVar)) : xs) ys
+
+      localVars <- myCombinerForEfficiency localVars1 (map (\(x,y) -> (T.unpack x, y)) (concat matchedArgvals))
 
       addCallInfo address' contract' funcName hsh cc (M.fromList localVars) ro ff -- [(n, (t, Constant v)) | (n, (t, v)) <- locals]
-
+      -- theCallInfo <- getCurrentCallInfo
+      -- when (True || (not $ null matchedArgvals)) $ error (show theCallInfo)
       let !commands = fromMaybe (missingField "Function call: function has been declared but not defined" funcName) $ CC.funcContents theFunction
       let modContentsList = map (\m -> fromMaybe (missingField "Function call: Modifier has been declared but not defined" m) (CC.modifierContents m)) theModifiers
       let isNotModExec = \case

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -100,6 +100,10 @@ anyInvalidArgumentsError :: Selector HandledException
 anyInvalidArgumentsError (HE Blockchain.SolidVM.Exception.InvalidArguments{}) = True
 anyInvalidArgumentsError _ = False
 
+anyRequireError :: Selector HandledException
+anyRequireError (HE Blockchain.SolidVM.Exception.Require{}) = True
+anyRequireError _ = False
+
 anyInternalError :: Selector HandledException
 anyInternalError (HE Blockchain.SolidVM.Exception.InternalError{}) = True
 anyInternalError _ = False
@@ -4561,7 +4565,7 @@ contract qq {
     getFields ["x"] `shouldReturn` [BInteger 5]
 
 
-  it "can use a modifier  that takes arguments as part of a function" . runTest $ do
+  it "can use a modifier that takes arguments as part of a function" . runTest $ do
     runCall "a" "()" [r|
 pragma solidvm 3.3;
 contract qq {
@@ -5199,7 +5203,38 @@ contract qq {
 
 |] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
 
-  it "can use a modifier" . runTest $ do
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  it "can use a modifier with a functions argument as it's argument" $ runTest (do
     runCall "changeHost" "(0)" [r|
 pragma solidvm 3.3;
 contract qq {
@@ -5230,7 +5265,7 @@ contract qq {
         return 2;
     }
 }
-|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
+|]) `shouldThrow` anyRequireError
 
   it "can declare structs at the file level" . runTest $ do
     runCall "a" "()" [r|

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -5199,6 +5199,39 @@ contract qq {
 
 |] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
 
+  it "can use a modifier" . runTest $ do
+    runCall "changeHost" "(0)" [r|
+pragma solidvm 3.3;
+contract qq {
+    // We will use these variables to demonstrate how to use
+    // modifiers.
+    address public  host;
+    uint    public  x = 10;
+    bool    public  locked;
+
+    constructor() public {
+        // Set the transaction sender as the host of the contract.
+        host = msg.sender;
+    }
+
+    modifier onlyHost() {
+        require(msg.sender == host, "Not host");
+        _;
+    }
+
+    //Inputs can be passed to a modifier
+    modifier validAddress(address _addr) {
+        require(_addr != address(0), "Not a valid address");
+        _;
+    }
+
+    function changeHost(address _newHost) public onlyHost validAddress(_newHost) returns (uint) {
+        host = _newHost;
+        return 2;
+    }
+}
+|] `shouldReturn` Just (SB.toShort $ B.replicate 31 0x0 <> B.singleton 2)
+
   it "can declare structs at the file level" . runTest $ do
     runCall "a" "()" [r|
 pragma solidvm 3.3;


### PR DESCRIPTION
This PR fixes the` Error running the transaction: internal error: getVariableValue called with an empty stack: "_newHost"` you would get when running a function that uses it's arguments as an argument to a modifier like in the contract below.

Thanks to @trdancer for finding and bringing this bug to my attention

```
contract FuncModifier {
    // We will use these variables to demonstrate how to use
    // modifiers.
    address public  host;
    uint    public  x = 10;
    bool    public  locked;

    constructor() public {
        // Set the transaction sender as the host of the contract.
        host = msg.sender;
    }

    modifier onlyHost() {
        require(msg.sender == host, "Not host");
        _;
    }

    //Inputs can be passed to a modifier
    modifier validAddress(address _addr) {
        require(_addr != address(0), "Not a valid address");
        _;
    }

    function changeHost(address _newHost) public onlyHost validAddress(_newHost) {
        host = _newHost;
    }
}
```
