### PR TITLE
Added a catch-all case to try-catch the SolidVM Way

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
@@ -113,7 +113,7 @@ tryCatchStatement = do
       s <- statements
       catchs <- many1 $ do
         reserved "catch"
-        err <- identifier
+        err <- option "" identifier
         params <- optionMaybe (parens $ commaSep $ do
             alias <- identifier
             pure $ alias

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -3420,124 +3420,145 @@ solidityExceptionHandler catchBlockMap ex = do
       return res
     _ -> error "unhandled solid exception" (show ex)
 
+
+
+solidVMExceptionHelper :: (MonadSM m) => M.Map String (Maybe [String], [CC.Statement]) -> m (Maybe Value) -> m (Maybe Value)
+solidVMExceptionHelper x y = case M.lookup "" x of
+  Nothing -> y
+  Just (_, block) -> do
+    res <- runStatements block
+    return res
+
+
+
 solidVMExceptionHandler :: (MonadSM m) => (M.Map String (Maybe [String], [CC.Statement])) -> SolidException -> m (Maybe Value)
 solidVMExceptionHandler catchBlockMap ex = case ex of
     (InternalError s1 s2) -> do
       case M.lookup "InternalError" catchBlockMap of
-        Nothing -> internalError s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ internalError s1 s2 
         Just (_, block) -> do
           res <- runStatements block
           return res
     (InvalidArguments s1 s2) -> 
       case M.lookup "InvalidArguments" catchBlockMap of
-        Nothing -> invalidArguments s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ invalidArguments s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (IndexOutOfBounds s1 s2) -> 
       case M.lookup "IndexOutOfBounds" catchBlockMap of
-        Nothing -> indexOutOfBounds s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ indexOutOfBounds s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (ParseError s1 s2) -> 
       case M.lookup "ParseError" catchBlockMap of
-        Nothing -> parseError s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ parseError s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (Require s1) -> 
       case M.lookup "Require" catchBlockMap of
-        Nothing -> do 
-          _ <- require False s1
-          return Nothing
+        Nothing -> do
+          case M.lookup "" catchBlockMap of 
+            Nothing -> do
+              _ <- require False s1
+              return Nothing
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
         Just (_, block) -> do
           res <- runStatements block
           return res
     (Assert) -> 
       case M.lookup "Assert" catchBlockMap of
         Nothing -> do
-          _ <- assert False
-          return Nothing
+          case M.lookup "" catchBlockMap of 
+            Nothing -> do
+              _ <- assert False
+              return Nothing
+            Just (_, stmts) -> do
+              res' <-  runStatements stmts
+              return res'
         Just (_, block) -> do
           res <- runStatements block
           return res
     (UnknownFunction s1 s2) -> 
       case M.lookup "UnknownFunction" catchBlockMap of
-        Nothing -> unknownFunction s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ unknownFunction s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (UnknownConstant s1 s2) -> 
       case M.lookup "UnknownConstant" catchBlockMap of
-        Nothing -> unknownConstant s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ unknownConstant s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (UnknownVariable s1 s2) -> 
       case M.lookup "UnknownVariable" catchBlockMap of
-        Nothing -> unknownVariable s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ unknownVariable s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (UnknownStatement s1 s2) -> 
       case M.lookup "UnknownStatement" catchBlockMap of
-        Nothing -> unknownStatement s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ unknownStatement s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (DivideByZero s1) -> 
       case M.lookup "DivideByZero" catchBlockMap of
-        Nothing -> divideByZero s1
+        Nothing -> solidVMExceptionHelper catchBlockMap $ divideByZero s1
         Just (_, block) -> do
           res <- runStatements block
           return res
     (MissingCodeCollection s1 s2) -> 
       case M.lookup "MissingCodeCollection" catchBlockMap of
-        Nothing -> missingCodeCollection s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ missingCodeCollection s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (InaccessibleChain s1 s2) -> 
       case M.lookup "InaccessibleChain" catchBlockMap of
-        Nothing -> inaccessibleChain s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ inaccessibleChain s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (InvalidWrite s1 s2) -> 
       case M.lookup "InvalidWrite" catchBlockMap of
-        Nothing -> invalidWrite s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ invalidWrite s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (InvalidCertificate s1 s2) -> 
       case M.lookup "InvalidCertificate" catchBlockMap of
-        Nothing -> invalidCertificate s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ invalidCertificate s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (MalformedData s1 s2) -> 
       case M.lookup "MalformedData" catchBlockMap of
-        Nothing -> malformedData s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ malformedData s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (TooMuchGas s1 s2) -> 
       case M.lookup "TooMuchGas" catchBlockMap of
-        Nothing -> tooMuchGas s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ tooMuchGas s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (PaymentError s1 s2) ->
       case M.lookup "PaymentError" catchBlockMap of
-        Nothing -> paymentError s1 s2
+        Nothing -> solidVMExceptionHelper catchBlockMap $ paymentError s1 s2
         Just (_, block) -> do
           res <- runStatements block
           return res
     (CustomError s1 s2 vals) -> do
       let name = T.unpack $ T.replace "\"" "" $ T.pack s2
       case M.lookup name catchBlockMap of
-        Nothing -> customError s1 name vals
+        Nothing -> solidVMExceptionHelper catchBlockMap $ customError s1 name vals
         Just (args, block) -> do
           ctract <- getCurrentContract
           (_, cc) <- getCurrentCodeCollection

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4579,24 +4579,6 @@ contract qq {
   }
 }|] `shouldReturn` Nothing
 
-{-
-  it "can use a modifier that takes in arguments" . runTest $ do
-    runBS [r|
-contract qq {
-  uint x = 3;
-  modifier myModifier(uint _x) {  
-    require(_x == 3 , string.concat('x is not 3 : ', string(_x)));
-    x = 4;
-    _;
-    require(x == 5 , 'x is not 5');
-  }
-  constructor() public myModifier(3) {
-    x = 5;
-    return;
-  }
-}|]
-    getFields ["x"] `shouldReturn` [BInteger 5]
--}
   it "cannot allow negative block number" $ runTest (do
     runBS [r|
 pragma solidvm 3.3;
@@ -4816,6 +4798,21 @@ contract qq{
 }|]
     getFields ["mynum"] `shouldReturn` [BInteger 3]
 
+  it "can use a try catch statment to catch any error the SolidVM Way (trademark pending)" . runTest $ do
+    runBS [r|
+pragma solidvm 3.3;
+contract qq{
+  uint mynum = 5;
+  constructor() public {
+    try {
+      mynum = 1 / 0;
+    } catch {
+      mynum = 3;
+    }
+  }
+}|]
+    getFields ["mynum"] `shouldReturn` [BInteger 3]
+
   it "can use a try catch statment to catch a divide by zero error the Solidity Way (trademark very much in effect)" . runTest $ do
     runBS [r| 
 pragma solidvm 3.3;
@@ -4856,6 +4853,50 @@ contract qq {
   }
 }|]
     getFields ["myNum", "otherNum", "errorCount"] `shouldReturn` [BInteger 3, BInteger 12, BInteger 1]
+
+  it "can use a try catch statment to catch a divide by zero error the Solidity Way (trademark very much in effect) in a function" . runTest $ do
+    runCall "tryTheDivide" "()" [r|
+pragma solidvm 3.3;
+contract Divisor {
+  function doTheDivide() public returns (uint) {
+    return (1 / 0);
+  }
+}
+contract qq {
+  Divisor public d;
+  uint public errCount = 0;
+  uint theError = 0;
+  constructor() public {
+    d = new Divisor();
+  }
+  function tryTheDivide() returns (uint, bool) {
+    try d.doTheDivide() returns (uint v) {
+        return (v, true);
+    } catch Error(string memory itsamessage) { 
+        // This is executed in case
+        // revert was called inside doTheDivide()
+        // and a reason string was provided.
+        errCount++;
+        return (0, false);
+    } catch Panic(uint errCode) {
+        // This is executed in case of a panic,
+        // i.e. a serious error like division by zero
+        // or overflow. The error code can be used
+        // to determine the kind of error.
+        errCount++;
+        theError = errCode;
+        return (errCode, false);
+    } catch (bytes bigTest) {
+        // This is executed in case revert() was used.
+        errCount++;
+        return (0, false);
+    }
+  }
+} 
+|] `shouldReturn` (Just "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\f\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL")
+
+    getFields ["errCount", "theError"] `shouldReturn` [BInteger 1, BInteger 12] 
+
 
   it "allows overloading functions with different number of parameters" . runTest $ do
     runBS [r|


### PR DESCRIPTION
at @trdancer 's suggestion, SolidVM developers can now use just the `catch` keyword to catch any error in the try-catch (SolidVM way) just like you can in the Solidity way.

```
contract qq{
  uint mynum = 5;
  constructor() public {
    try {
      mynum = 1 / 0;
    } catch {
      mynum = 3;
    }
  }
}
```