### PR TITLE
Strato 2746 random order list of named args passed to function does not typecheck

### DIFF
--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -210,10 +210,11 @@ apply' funcArgTypes funcValTypes overloads args argNames funcArgNames = do
   let reorderedArgs = case argNames of
         Nothing -> args
         Just a -> let zipped = M.fromList $ zip a $ productTypes args
-                  in flip Product (productContext args) $ map (\(Just x) -> case M.lookup x zipped of
-                                                                  Nothing -> error "Argument name does not exist" x
-                                                                  Just y -> y
-                                                              ) funcArgNames
+                      newOrder = map (\(Just x) -> case M.lookup x zipped of
+                                                      Nothing -> error "Argument name does not exist" x
+                                                      Just y -> y
+                                      ) funcArgNames
+                  in flip Product (productContext args) newOrder
   p <- case argNames of
     Nothing -> typecheck funcArgTypes args
     _ -> typecheck funcArgTypes reorderedArgs

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -64,6 +64,7 @@ data TypeF' a = Top { topName :: (S.Set SolidString)
                          , functionReturnType :: TypeF' a
                          , functionContext :: a
                          , functionOverloads :: [TypeF' a]
+                         , functionArgNames :: [Maybe SolidString]
                          }
   deriving (Eq, Show, Functor)
 
@@ -109,11 +110,11 @@ showType' (Sum ts) = T.concat
                        , T.intercalate " | " $ showType' <$> NE.toList ts
                        , ")"
                        ]
-showType' (Function a (Product [] _) _ _) =
+showType' (Function a (Product [] _) _ _ _) =
   T.concat [ "function "
            , showType' a
            ]
-showType' (Function a r _ _) =
+showType' (Function a r _ _ _) =
   T.concat [ "function ("
            , showType' a
            , " returns "
@@ -174,7 +175,7 @@ lookupContractFunction x cName fName = do
             ]) <$ x
           Just VariableDecl{..} ->
             if varIsPublic
-              then pure $ Function (Product [] x) (Static varType x) x []
+              then pure $ Function (Product [] x) (Static varType x) x [] []
               else pure . bottom $ (T.concat
                 [ "Contract variable "
                 , labelToText cName
@@ -195,7 +196,7 @@ lookupContractFunction x cName fName = do
           ]) <$ x
         _ -> let fArgs = flip Product x $ flip Static x . indexedTypeType . snd <$> funcArgs
                  fRets = flip Product x $ flip Static x . indexedTypeType . snd <$> funcVals
-              in pure $ Function fArgs fRets x []
+              in pure $ Function fArgs fRets x [] []
 
 productType' :: SourceAnnotation Text -> [Type'] -> Type'
 productType' _ [Bottom es] = Bottom es
@@ -204,26 +205,35 @@ productType' x ts = case reduceType' x ts of
   Bottom es -> Bottom es
   _ -> Product ts x
 
-apply' :: Type' -> Type' -> [Type'] -> Type' -> SSS Type'
-apply' argTypes valTypes overloads args = do
-  p <- typecheck argTypes args
-  case (p, valTypes) of
+apply' :: Type' -> Type' -> [Type'] -> Type' -> Maybe [SolidString] -> [Maybe SolidString] -> SSS Type'
+apply' funcArgTypes funcValTypes overloads args argNames funcArgNames = do
+  let reorderedArgs = case argNames of
+        Nothing -> args
+        Just a -> let zipped = M.fromList $ zip a $ productTypes args
+                  in flip Product (productContext args) $ map (\(Just x) -> case M.lookup x zipped of
+                                                                  Nothing -> error "Argument name does not exist" x
+                                                                  Just y -> y
+                                                              ) funcArgNames
+  p <- case argNames of
+    Nothing -> typecheck funcArgTypes args
+    _ -> typecheck funcArgTypes reorderedArgs
+  case (p, funcValTypes) of
     (Bottom es, Bottom ess) -> pure $ Bottom (es <> ess)
     (Bottom es, _) -> case overloads of
                         [] -> pure $ Bottom es
-                        (x:xs) -> apply' (functionArgType x) (functionReturnType x) xs args
-    _ -> pure $ valTypes
+                        (x:xs) -> apply' (functionArgType x) (functionReturnType x) xs args argNames (functionArgNames x)
+    _ -> pure $ funcValTypes
 
-apply :: Type' -> Type' -> SSS Type'
-apply (Bottom es) (Bottom ess) = pure $ Bottom (es <> ess)
-apply (Bottom es) _            = pure $ Bottom es
-apply _ (Bottom ess)           = pure $ Bottom ess
-apply (Function argTypes valTypes _ overloads) args = apply' argTypes valTypes overloads args
-apply (Sum types@(t :| _)) args =
-  let isFunction (Function _ _ _ _) = True
+apply :: Type' -> Type' -> Maybe [SolidString] -> SSS Type'
+apply (Bottom es) (Bottom ess) _ = pure $ Bottom (es <> ess)
+apply (Bottom es) _ _            = pure $ Bottom es
+apply _ (Bottom ess) _           = pure $ Bottom ess
+apply (Function funcArgTypes funcValTypes _ overloads funcArgNames) args argNames = apply' funcArgTypes funcValTypes overloads args argNames funcArgNames
+apply (Sum types@(t :| _)) args argList =
+  let isFunction (Function _ _ _ _ _) = True
       isFunction _ = False
-   in pickType' (context' t) <$> traverse (flip apply args) (filter isFunction $ NE.toList types)
-apply x _ = pure . bottom $ "trying to apply function to a non-function type" <$ context' x
+   in pickType' (context' t) <$> traverse (\x -> apply x args argList) (filter isFunction $ NE.toList types)
+apply x _ _ = pure . bottom $ "trying to apply function to a non-function type" <$ context' x
 
 bottom :: a -> TypeF' a
 bottom a = Bottom $ a :| []
@@ -324,14 +334,14 @@ typecheck' f r1 r2 = case (r1, r2) of
   (Product xs x, MultiVariate a _) -> typecheckProduct f x xs (replicate (length xs) a)
   (MultiVariate a _, b) -> typecheck' f a b
   (a, MultiVariate b _) -> typecheck' f a b
-  (Function a1 v1 x _, Function a2 v2 _ _) -> do
+  (Function a1 v1 x _ _, Function a2 v2 _ _ _) -> do
     a <- typecheck' f a1 a2
     v <- typecheck' f v1 v2
     pure $ case (a, v) of
       (Bottom es, Bottom ess) -> Bottom (es <> ess)
       (Bottom es, _) -> Bottom es
       (_, Bottom ess) -> Bottom ess
-      _ -> Function a v x []
+      _ -> Function a v x [] []
   (a, b) -> pure . bottom $ (T.concat
               [ "could not match types "
               , showType' a
@@ -525,12 +535,12 @@ typecheckMember :: Type' -> SolidString -> SSS Type'
 typecheckMember (Bottom es) _ = pure $ Bottom es
 typecheckMember (Sum ts'@(t :| _)) n = pickType' (context' t) <$> traverse (flip typecheckMember n) (NE.toList ts')
 typecheckMember (Static (SVMType.Array _ _) x) "length" = pure $ Static (SVMType.Int Nothing Nothing) x
-typecheckMember (Static (SVMType.Array t _) x) "push" = pure $ Function (Static t x) (Product [] x) x []
+typecheckMember (Static (SVMType.Array t _) x) "push" = pure $ Function (Static t x) (Product [] x) x [] []
 typecheckMember (Static (SVMType.Array _ _) x) n = pure . bottom $ ("Unknown member of SVMType.Array: " <> labelToText n) <$ x
 typecheckMember (Static (SVMType.Bytes _ _) x) "length" = pure $ Static (SVMType.Int Nothing Nothing) x
-typecheckMember (Static (SVMType.UnknownLabel "Util" Nothing) x) "bytes32ToString" = pure $ Function (Static (SVMType.Bytes Nothing (Just 32)) x) (Static (SVMType.String Nothing) x) x []
-typecheckMember (Static (SVMType.UnknownLabel "Util" Nothing) x) "b32" = pure $ Function (Static (SVMType.Bytes Nothing (Just 32)) x) (Static (SVMType.Bytes Nothing (Just 32)) x) x []
-typecheckMember (Static (SVMType.UnknownLabel "string" Nothing) x) "concat" = pure $ Function (stringConcatArgs x) (Static (SVMType.String Nothing) x) x []
+typecheckMember (Static (SVMType.UnknownLabel "Util" Nothing) x) "bytes32ToString" = pure $ Function (Static (SVMType.Bytes Nothing (Just 32)) x) (Static (SVMType.String Nothing) x) x [] []
+typecheckMember (Static (SVMType.UnknownLabel "Util" Nothing) x) "b32" = pure $ Function (Static (SVMType.Bytes Nothing (Just 32)) x) (Static (SVMType.Bytes Nothing (Just 32)) x) x [] []
+typecheckMember (Static (SVMType.UnknownLabel "string" Nothing) x) "concat" = pure $ Function (stringConcatArgs x) (Static (SVMType.String Nothing) x) x [] []
 typecheckMember (Static (SVMType.UnknownLabel "msg" Nothing) x) "sender" = pure $ Static (SVMType.Account False) x 
 typecheckMember (Static (SVMType.UnknownLabel "tx" Nothing) x) "origin" = pure $ Static (SVMType.Account False) x 
 typecheckMember (Static (SVMType.UnknownLabel "tx" Nothing) x) "username" = pure $ Static (SVMType.String Nothing) x
@@ -555,7 +565,8 @@ typecheckMember (Static (SVMType.UnknownLabel "super" Nothing) x) method = do
         Just Func{..} ->
           let fArgs = flip Product x $ flip Static x . indexedTypeType . snd <$> funcArgs
               fRets = flip Product x $ flip Static x . indexedTypeType . snd <$> funcVals
-           in pure $ Function fArgs fRets x []
+              fArgNames = fst <$> funcArgs
+           in pure $ Function fArgs fRets x [] fArgNames
 typecheckMember (Static e@(SVMType.Enum _ enum mNames) x) n = do
   names <- case mNames of
     Just names -> pure names
@@ -571,8 +582,8 @@ typecheckMember (Static e@(SVMType.Enum _ enum mNames) x) n = do
 
 -- Function: argType, returnType, contextType
 -- Static: argType, ContextType
-typecheckMember (Static (SVMType.Account True ) x) "transfer" = pure $ Function (Static (SVMType.Int Nothing Nothing) x) (Product [] x) x []
-typecheckMember (Static (SVMType.Account True ) x) "send" = pure $ Function (Static (SVMType.Int Nothing Nothing) x) (Static (SVMType.Bool) x) x []
+typecheckMember (Static (SVMType.Account True ) x) "transfer" = pure $ Function (Static (SVMType.Int Nothing Nothing) x) (Product [] x) x [] []
+typecheckMember (Static (SVMType.Account True ) x) "send" = pure $ Function (Static (SVMType.Int Nothing Nothing) x) (Static (SVMType.Bool) x) x [] []
 typecheckMember (Static (SVMType.Account _) x) "balance" = pure $ Static (SVMType.Int Nothing Nothing) x
 typecheckMember (Static (SVMType.Account _) x) "code" = pure $ Static (SVMType.Bytes Nothing Nothing) x
 typecheckMember (Static (SVMType.Account _) x) "codehash" = pure $ Static (SVMType.String Nothing) x
@@ -626,10 +637,10 @@ getConstructorType' x l  = do
         Just _ -> pure $ Top (S.singleton l) x
 
     Just c -> case _constructor c of
-      Nothing -> pure $ Function (Product [] x) (Static (SVMType.Contract l) x) x []
+      Nothing -> pure $ Function (Product [] x) (Static (SVMType.Contract l) x) x [] []
       Just Func{..} ->
         let fArgs = flip Product x $ flip Static x . indexedTypeType . snd <$> funcArgs
-         in pure $ Function fArgs (Static (SVMType.Contract l) x) x []
+         in pure $ Function fArgs (Static (SVMType.Contract l) x) x [] []
 
 
 
@@ -692,7 +703,7 @@ functionHelper :: Annotated CodeCollectionF
                -> Annotated FuncF
                -> Type'
 functionHelper cc c funcName f@Func{..} = case funcContents of
-  Nothing -> Function (Product [] funcContext) (Product [] funcContext) funcContext []
+  Nothing -> Function (Product [] funcContext) (Product [] funcContext) funcContext [] []
   Just stmts ->
     if funcName == "receive"
       then case (funcArgs, funcVals, funcStateMutability, funcVisibility) of
@@ -769,7 +780,7 @@ statementsHelper args ss = do
         cCalls <- for (M.assocs $ funcConstructorCalls f) $ \(cName, exprs) -> do
           let constructorArgs = getConstructorType' x cName 
               givenArgs = flip Product x <$> traverse tcExpr exprs
-              givenFunc = (\t-> Function t (Static (SVMType.Contract cName) x) x []) <$> givenArgs
+              givenFunc = (\t-> Function t (Static (SVMType.Contract cName) x) x [] []) <$> givenArgs
           constructorArgs <~> givenFunc
         stmts' <- traverse statementHelper ss
         pure $ concat [stmts', cCalls]
@@ -919,44 +930,44 @@ parseCertArgs x = stringType' x
 getVarType' :: String -> SourceAnnotation Text -> SSS Type'
 getVarType' "this" ctx = pure $ Static (SVMType.Account False) ctx
 getVarType' s@('u':'i':'n':'t':n) ctx = case n of
-  [] -> pure $ Function (intArgs ctx) (Static (SVMType.Int (Just False) Nothing) ctx) ctx []
+  [] -> pure $ Function (intArgs ctx) (Static (SVMType.Int (Just False) Nothing) ctx) ctx [] []
   _ -> case readMaybe n of
-    Just n' -> pure $ Function (intArgs ctx) (Static (SVMType.Int (Just False) (Just n')) ctx) ctx []
+    Just n' -> pure $ Function (intArgs ctx) (Static (SVMType.Int (Just False) (Just n')) ctx) ctx [] []
     Nothing -> getVarTypeByName' (stringToLabel s) ctx
 getVarType' s@('i':'n':'t':n) ctx = case n of
-  [] -> pure $ Function (intArgs ctx) (Static (SVMType.Int (Just True) Nothing) ctx) ctx []
+  [] -> pure $ Function (intArgs ctx) (Static (SVMType.Int (Just True) Nothing) ctx) ctx [] []
   _ -> case readMaybe n of
-    Just n' -> pure $ Function (intArgs ctx) (Static (SVMType.Int (Just True) (Just n')) ctx) ctx []
+    Just n' -> pure $ Function (intArgs ctx) (Static (SVMType.Int (Just True) (Just n')) ctx) ctx [] []
     Nothing -> getVarTypeByName' (stringToLabel s) ctx
-getVarType' "address" ctx =  pure $ Function (addressArgs ctx) (Static (SVMType.Account False) ctx) ctx []
-getVarType' "account" ctx =  pure $ Function (accountArgs ctx) (Static (SVMType.Account False) ctx) ctx []
+getVarType' "address" ctx =  pure $ Function (addressArgs ctx) (Static (SVMType.Account False) ctx) ctx [] []
+getVarType' "account" ctx =  pure $ Function (accountArgs ctx) (Static (SVMType.Account False) ctx) ctx [] []
 --This is either the string() function or the string.member() function
-getVarType' "string" ctx =  pure $ Sum $ (Function (stringArgs ctx) (stringType' ctx) ctx []) :| [Static (SVMType.UnknownLabel "string" Nothing) ctx]
-getVarType' "bool" ctx =  pure $ Function (boolArgs ctx) (boolType' ctx) ctx []
+getVarType' "string" ctx =  pure $ Sum $ (Function (stringArgs ctx) (stringType' ctx) ctx [] []) :| [Static (SVMType.UnknownLabel "string" Nothing) ctx]
+getVarType' "bool" ctx =  pure $ Function (boolArgs ctx) (boolType' ctx) ctx [] []
 getVarType' s@('b':'y':'t':'e':'s':n) ctx = case n of
-  [] -> pure $ Function (byteArgs ctx) (Static (SVMType.Bytes Nothing Nothing) ctx) ctx []
+  [] -> pure $ Function (byteArgs ctx) (Static (SVMType.Bytes Nothing Nothing) ctx) ctx [] []
   _ -> case readMaybe n of
-    Just n' -> pure $ Function (byteArgs ctx) (Static (SVMType.Bytes Nothing (Just n')) ctx) ctx []
+    Just n' -> pure $ Function (byteArgs ctx) (Static (SVMType.Bytes Nothing (Just n')) ctx) ctx [] []
     Nothing -> getVarTypeByName' (stringToLabel s) ctx
-getVarType' "byte" ctx =  pure $ Function (byteArgs ctx) (intType' ctx) ctx []
-getVarType' "push" ctx =  pure $ Function (topType' ctx) (Product [] ctx) ctx []
-getVarType' "identity" ctx =  pure $ Function (topType' ctx) (topType' ctx) ctx []
-getVarType' "keccak256" ctx =  pure $ Function (keccak256Args ctx) (stringType' ctx) ctx []
-getVarType' "sha256" ctx =  pure $ Function (sha256Args ctx) (stringType' ctx) ctx []
-getVarType' "ripemd160" ctx =  pure $ Function (ripemd160Args ctx) (stringType' ctx) ctx []
-getVarType' "selfdestruct" ctx = pure $ Function (selfdestructArgs ctx) (boolType' ctx) ctx  []
-getVarType' "require" ctx =  pure $ Function (requireArgs ctx) (Product [] ctx) ctx []
-getVarType' "assert" ctx =  pure $ Function (assertArgs ctx) (Product [] ctx) ctx []
-getVarType' "registerCert" ctx =  pure $ Function (registerCertArgs ctx) (accountType' ctx) ctx []
-getVarType' "verifyCert" ctx =  pure $ Function (verifyCertArgs ctx) (boolType' ctx) ctx []
-getVarType' "verifyCertSignedBy" ctx =  pure $ Function (verifyCertSignedByArgs ctx) (boolType' ctx) ctx []
-getVarType' "verifySignature" ctx =  pure $ Function (verifySignatureArgs ctx) (boolType' ctx) ctx []
-getVarType' "getUserCert" ctx =  pure $ Function (getUserCertArgs ctx) (certType' ctx) ctx []
-getVarType' "addmod" ctx =  pure $ Function (addmodArgs ctx) (intType' ctx) ctx []
-getVarType' "mulmod" ctx =  pure $ Function (mulmodArgs ctx) (intType' ctx) ctx []
-getVarType' "payable" ctx =  pure $ Function (payableArgs ctx) (Static (SVMType.Account True) ctx) ctx []
-getVarType' "blockhash" ctx = pure $ Function (blockhashArgs ctx) (stringType' ctx) ctx []
-getVarType' "parseCert" ctx =  pure $ Function (parseCertArgs ctx) (certType' ctx) ctx []
+getVarType' "byte" ctx =  pure $ Function (byteArgs ctx) (intType' ctx) ctx [] []
+getVarType' "push" ctx =  pure $ Function (topType' ctx) (Product [] ctx) ctx [] []
+getVarType' "identity" ctx =  pure $ Function (topType' ctx) (topType' ctx) ctx [] []
+getVarType' "keccak256" ctx =  pure $ Function (keccak256Args ctx) (stringType' ctx) ctx [] []
+getVarType' "sha256" ctx =  pure $ Function (sha256Args ctx) (stringType' ctx) ctx [] []
+getVarType' "ripemd160" ctx =  pure $ Function (ripemd160Args ctx) (stringType' ctx) ctx [] []
+getVarType' "selfdestruct" ctx = pure $ Function (selfdestructArgs ctx) (boolType' ctx) ctx  [] []
+getVarType' "require" ctx =  pure $ Function (requireArgs ctx) (Product [] ctx) ctx [] []
+getVarType' "assert" ctx =  pure $ Function (assertArgs ctx) (Product [] ctx) ctx [] []
+getVarType' "registerCert" ctx =  pure $ Function (registerCertArgs ctx) (accountType' ctx) ctx [] []
+getVarType' "verifyCert" ctx =  pure $ Function (verifyCertArgs ctx) (boolType' ctx) ctx [] []
+getVarType' "verifyCertSignedBy" ctx =  pure $ Function (verifyCertSignedByArgs ctx) (boolType' ctx) ctx [] []
+getVarType' "verifySignature" ctx =  pure $ Function (verifySignatureArgs ctx) (boolType' ctx) ctx [] []
+getVarType' "getUserCert" ctx =  pure $ Function (getUserCertArgs ctx) (certType' ctx) ctx [] []
+getVarType' "addmod" ctx =  pure $ Function (addmodArgs ctx) (intType' ctx) ctx [] []
+getVarType' "mulmod" ctx =  pure $ Function (mulmodArgs ctx) (intType' ctx) ctx [] []
+getVarType' "payable" ctx =  pure $ Function (payableArgs ctx) (Static (SVMType.Account True) ctx) ctx [] []
+getVarType' "blockhash" ctx = pure $ Function (blockhashArgs ctx) (stringType' ctx) ctx [] []
+getVarType' "parseCert" ctx =  pure $ Function (parseCertArgs ctx) (certType' ctx) ctx [] []
 getVarType' "Util" ctx = pure $ Static (SVMType.UnknownLabel "Util" Nothing) ctx
 getVarType' "msg" ctx = pure $ Static (SVMType.UnknownLabel "msg" Nothing) ctx
 getVarType' "tx" ctx = pure $ Static (SVMType.UnknownLabel "tx" Nothing) ctx
@@ -987,22 +998,22 @@ getVarTypeByName' name ctx = do
       case mVarDecl of
         Just (e@(SVMType.Enum{}), ctx') -> pure . Sum $
           (Static e ctx') :|
-          [ Function (Static e ctx') (Static e ctx') ctx' []
-          , Function (intType' ctx') (Static e ctx') ctx' []
+          [ Function (Static e ctx') (Static e ctx') ctx' [] []
+          , Function (intType' ctx') (Static e ctx') ctx' [] []
           ]
         Just (s@(SVMType.Struct _ struct), ctx') -> do
           fields <- fmap snd <$> lookupStruct struct
           let fArgs = flip Product ctx $ flip Static ctx <$> fields
           pure . Sum $
             (Static s ctx') :|
-            [ Function fArgs (Static s ctx') ctx' []
+            [ Function fArgs (Static s ctx') ctx' [] []
             ]
         Just (e@(SVMType.Error _ err), ctx') -> do
           args <- fmap snd <$> lookupError err
           let eArgs = flip Product ctx $ flip Static ctx <$> args
           pure . Sum $
             (Static e ctx') :|
-            [ Function eArgs (Static e ctx') ctx' []
+            [ Function eArgs (Static e ctx') ctx' [] []
             ] 
         Just (t, ctx') -> pure $ Static t ctx'
         Nothing -> do
@@ -1010,10 +1021,11 @@ getVarTypeByName' name ctx = do
             Just theFunc->
               let fArgs = flip Product ctx $ flip Static ctx . indexedTypeType . snd <$> funcArgs theFunc
                   fRets = flip Product ctx $ flip Static ctx . indexedTypeType . snd <$> funcVals theFunc
+                  fArgNames = fst <$> funcArgs theFunc
                   allFuncOverloads = case M.lookup name $ _flFuncs cc of
                     Just freeFunc -> (fmap buildOverloads $ funcOverload theFunc) ++ [buildOverloads freeFunc] ++ (fmap buildOverloads $ funcOverload freeFunc)
                     Nothing -> fmap buildOverloads $ funcOverload theFunc
-              in pure $ Function fArgs fRets ctx allFuncOverloads
+              in pure $ Function fArgs fRets ctx allFuncOverloads fArgNames
             Nothing -> do
               pure $ case M.lookup name $ _contracts cc of
                 Just _->
@@ -1023,13 +1035,15 @@ getVarTypeByName' name ctx = do
                           [Function (Sum (Static (SVMType.Account False) ctx :| [ctrct, lbl]))
                             ctrct
                             ctx
+                            []
                             []]
                 Nothing -> do
                   case M.lookup name $ _flFuncs cc of
                       Just Func{..} ->
                         let fArgs = flip Product ctx $ flip Static ctx . indexedTypeType . snd <$> funcArgs
                             fRets = flip Product ctx $ flip Static ctx . indexedTypeType . snd <$> funcVals
-                        in Function fArgs fRets ctx $ fmap buildOverloads funcOverload
+                            fArgNames = fst <$> funcArgs
+                        in Function fArgs fRets ctx (fmap buildOverloads funcOverload) fArgNames
                       Nothing -> bottom $ ("Unknown variable: " <> labelToText name) <$ ctx
             
   where lookupVar m Nothing = M.lookup name m
@@ -1038,6 +1052,7 @@ getVarTypeByName' name ctx = do
                                    , functionReturnType = flip Product ctx $ flip Static ctx . indexedTypeType . snd <$> funcVals overloadFunc
                                    , functionContext = funcContext overloadFunc
                                    , functionOverloads = []
+                                   , functionArgNames = fst <$> funcArgs overloadFunc
                                    }
 
 setVarType' :: SourceAnnotation Text -> SolidString -> Type -> SSS Type'
@@ -1260,7 +1275,9 @@ tcExpr (FunctionCall x expr args) = do
   a <- case args of
          OrderedArgs es -> productType' x <$> traverse tcExpr es
          NamedArgs es -> productType' x <$> traverse (tcExpr . snd) es
-  apply e a
+  case args of
+    NamedArgs es -> apply e a $ Just (fst <$> es)
+    _ -> apply e a Nothing
 tcExpr (Unitary x "-" a) = intType' x ~> tcExpr a
 tcExpr (Unitary x "++" a) = intType' x ~> tcExpr a
 tcExpr (Unitary x "--" a) = intType' x ~> tcExpr a

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2009,42 +2009,34 @@ expToVar' (CC.FunctionCall _ e args) = do
             where
               testMatch :: MonadSM m => CC.Func -> m Bool
               testMatch tf = do
-                let argPairing = generateArgPairs $ CC.funcArgs tf
-                    argPairLength = length $ mapArgs tf
-                doArgsMatch <- mapM testNameAndTypes argPairing
-                pure $ ((argPairLength) == (length $ CC.funcArgs tf)) 
-                           && ((argPairLength) == (argCount))
-                           && (all (== True) doArgsMatch)
-              testNameAndTypes :: MonadSM m => (Maybe SolidString, Value, Maybe SolidString, CC.IndexedType) -> m Bool
-              testNameAndTypes (n1, v1, n2, t) = 
-                if (n1 == n2) 
-                  then do
-                    -- These cases might not be all inclusive of all valid combinations.
-                    case (v1, (CC.indexedTypeType t)) of
-                      (SInteger _, SVMType.Int _ _) -> pure $ True
-                      (SString _, SVMType.String _) -> pure $ True
-                      (SString _, SVMType.Bytes _ _) -> pure $ True
-                      (SBool _, SVMType.Bool) -> pure $ True
-                      (SAccount _ _, SVMType.Address _) -> pure $ True
-                      (SAccount _ _, SVMType.Account _) -> pure $ True
-                      (SStruct _ _, SVMType.UnknownLabel _ _) -> pure $ True
-                      (SContract x _, SVMType.UnknownLabel y _) -> pure $ x == y
-                      (SArray x _, SVMType.Array y _) -> pure $ x == y
-                      (SReference addressedPath, _) -> do
-                        refType <- getXabiValueType addressedPath
-                        if (refType == (CC.indexedTypeType t))
-                          then pure $ True
-                          else 
-                            case (refType, (CC.indexedTypeType t)) of
-                              (SVMType.UnknownLabel x _, SVMType.UnknownLabel y _) -> pure $ x == y
-                              (SVMType.Array x _, SVMType.Array y _) -> pure $ x == y 
-                              _ -> pure $ False
-                      _ -> pure $ False
-                  else pure $ False
-              generateArgPairs :: [(Maybe SolidString, CC.IndexedType)] -> [(Maybe SolidString, Value, Maybe SolidString, CC.IndexedType)]
-              generateArgPairs functionArgs = case argVals of
-                  OrderedVals ov -> concatMap (\(v1, (Just n, t)) -> [(Just n, v1, Just n, t)]) (zip ov functionArgs)
-                  NamedVals nv -> concatMap (\((s1, t1), (Just s2, t2)) -> [(Just s1, t1, Just s2, t2)]) (zip nv functionArgs)
+                let argMapping = mapArgs tf
+                doArgsMatch <- mapM testNameAndTypes argMapping
+                pure $ ((length argMapping) == (length $ CC.funcArgs tf)) 
+                       && ((length argMapping) == (argCount))
+                       && (all (== True) doArgsMatch)
+              testNameAndTypes :: MonadSM m => (String, (SVMType.Type, Value)) -> m Bool
+              testNameAndTypes (_, (t, v)) = 
+                -- These cases might not be all inclusive of all valid combinations.
+                case (v, t) of
+                  (SInteger _, SVMType.Int _ _) -> pure $ True
+                  (SString _, SVMType.String _) -> pure $ True
+                  (SString _, SVMType.Bytes _ _) -> pure $ True
+                  (SBool _, SVMType.Bool) -> pure $ True
+                  (SAccount _ _, SVMType.Address _) -> pure $ True
+                  (SAccount _ _, SVMType.Account _) -> pure $ True
+                  (SStruct _ _, SVMType.UnknownLabel _ _) -> pure $ True
+                  (SContract x _, SVMType.UnknownLabel y _) -> pure $ x == y
+                  (SArray x _, SVMType.Array y _) -> pure $ x == y
+                  (SReference addressedPath, _) -> do
+                    refType <- getXabiValueType addressedPath
+                    if (refType == t)
+                      then pure $ True
+                      else 
+                        case (refType, t) of
+                          (SVMType.UnknownLabel x _, SVMType.UnknownLabel y _) -> pure $ x == y
+                          (SVMType.Array x _, SVMType.Array y _) -> pure $ x == y 
+                          _ -> pure $ False
+                  _ -> pure $ False
               mapArgs :: CC.FuncF a -> [(String, (SVMType.Type, Value))]
               mapArgs theFunc = case argVals of
                 OrderedVals vs -> let argMeta = 
@@ -2058,8 +2050,6 @@ expToVar' (CC.FunctionCall _ e args) = do
                                           (M.zipWithMatched $ \_k t v -> (t, v))
                                           strTypes
                                           $ M.fromList ns
-                      -- These probably don't need to be sorted by argument index, as they are turned into a map
-                      -- when added to the call info.
                       sortedArgs = map snd . sortWith fst
                                 . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
                                 $ M.toList typeAndVal

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4915,6 +4915,49 @@ contract qq{
   }
 }|]
     getFields ["myNum", "myString", "myStatus"] `shouldReturn` [BInteger 5, BString "hi", BBool True]
+
+  it "can use randomly ordered named argument function calls" . runTest $ do
+    runBS [r|
+pragma solidvm 3.3;
+contract qq{
+  uint myNum = 0;
+  bool myStatus;
+  constructor() public {
+    addToNum({y: true, x: 3});
+  }
+
+  function addToNum (uint x, bool y) {
+    myNum += x;
+    myStatus = y;
+  }
+}|]
+    getFields ["myNum", "myStatus"] `shouldReturn` [BInteger 3, BBool True]
+    
+
+  it "can use randomly ordered named argument function calls with overloading" . runTest $ do
+    runBS [r|
+pragma solidvm 3.3;
+contract qq{
+  uint myNum = 0;
+  bool myStatus;
+  string myString;
+  constructor() public {
+    addToNum({y: true, x: 3});
+    addToNum({x: 3, y: "hi"});
+    addToNum({y: " world", x: 3});
+  }
+
+  function addToNum (uint x, string y) {
+    myNum += x;
+    myString += y;
+  }
+
+  function addToNum (uint x, bool y) {
+    myNum += x;
+    myStatus = y;
+  }
+}|]
+    getFields ["myNum", "myStatus", "myString"] `shouldReturn` [BInteger 9, BBool True, BString "hi world"]
     
   it "should catch invalid function overloads" $ runTest (do
     runBS [r|


### PR DESCRIPTION
This PR fixes a bug in SolidVM typechecker which prevented users from being able to use a random ordered list of named arguments in a function call. This bug only occurs in `pragma solidvm 3.2` and above because the typechecker is only enabled  for `pragma solidvm 3.2` and above.

For example, if there was a function:
`function addToNum(uint x, string y)...`

And if the function was called as such:
`addToNum({y: "hi", x: 3});`

Before this fix, the above call would fail to typecheck and throw a typecheck error. This is because the typechecker did not have a check in place for the order of named arguments.

After the fix, the typechecker now includes a check for the correct ordering of named arguments and a random ordered named argument function call is now possible even with overloaded functions.
