### PR TITLE
Finally add the vm to the simulator

### DIFF
--- a/strato/VM/EVM/ethereum-vm/src/Blockchain/EVM/VMM.hs
+++ b/strato/VM/EVM/ethereum-vm/src/Blockchain/EVM/VMM.hs
@@ -149,6 +149,7 @@ instance (N.NibbleString `A.Alters` N.NibbleString) m => (N.NibbleString `A.Alte
   delete p   = lift . A.delete p
 
 instance ( MonadIO m
+         , MonadLogger m
          , (Maybe Word256 `A.Alters` MP.StateRoot) m
          , (MP.StateRoot `A.Alters` MP.NodeData) m
          , (N.NibbleString `A.Alters` N.NibbleString) m
@@ -193,6 +194,7 @@ instance MonadIO m => HasMemRawStorageDB (VMM m) where
       pure $ s{vmMemDBs=(vmMemDBs s){_storageBlockMap=theMap}}
 
 instance ( MonadIO m
+         , MonadLogger m
          , (Maybe Word256 `A.Alters` MP.StateRoot) m
          , (MP.StateRoot `A.Alters` MP.NodeData) m
          , (N.NibbleString `A.Alters` N.NibbleString) m

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -198,6 +198,7 @@ instance Monad m => HasMemCertDB (SM m) where
   putCertBlockDBMap m = modify $ ssMemDBs . certBlockMap .~ m
 
 instance ( (Maybe Word256 `A.Alters` MP.StateRoot) m
+         , MonadLogger m
          , (MP.StateRoot `A.Alters` MP.NodeData) m
          , (N.NibbleString `A.Alters` N.NibbleString) m
          ) => (RawStorageKey `A.Alters` RawStorageValue) (SM m) where
@@ -207,6 +208,7 @@ instance ( (Maybe Word256 `A.Alters` MP.StateRoot) m
   lookupWithDefault _ = genericLookupWithDefaultRawStorageDB
 
 instance ( (Maybe Word256 `A.Alters` MP.StateRoot) m
+         , MonadLogger m
          , (MP.StateRoot `A.Alters` MP.NodeData) m
          , (N.NibbleString `A.Alters` N.NibbleString) m
          ) => (Account `A.Alters` AddressState) (SM m) where

--- a/strato/core/blockapps-mpdbs/package.yaml
+++ b/strato/core/blockapps-mpdbs/package.yaml
@@ -40,6 +40,7 @@ library:
   - nibblestring
   - solid-vm-model
   - strato-model
+  - text
   - transformers
   - x509-certs
 

--- a/strato/core/blockapps-mpdbs/src/Blockchain/DB/MemAddressStateDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/DB/MemAddressStateDB.hs
@@ -1,6 +1,8 @@
 {-# OPTIONS -fno-warn-redundant-constraints #-} -- todo fixme
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeOperators    #-}
 module Blockchain.DB.MemAddressStateDB (
   HasMemAddressStateDB(..),
@@ -21,8 +23,10 @@ import qualified Control.Monad.Change.Alter     as A
 import           Control.DeepSeq
 import           Data.Maybe
 import qualified Data.Map                       as M
+import qualified Data.Text                      as T
 import GHC.Generics
 
+import           BlockApps.Logging
 import           Blockchain.Data.AddressStateDB
 import qualified Blockchain.DB.AddressStateDB   as DB
 import           Blockchain.DB.HashDB
@@ -54,28 +58,40 @@ class HasMemAddressStateDB m where
 getAddressState :: (Account `A.Alters` AddressState) m => Account -> m AddressState
 getAddressState account = fromMaybe blankAddressState <$> A.lookup A.Proxy account
 
-getAddressStateMaybe :: (HasMemAddressStateDB m, HasStateDB m, HasHashDB m)
+getAddressStateMaybe :: (MonadLogger m, HasMemAddressStateDB m, HasStateDB m, HasHashDB m)
                      => Account -> m (Maybe AddressState)
 getAddressStateMaybe account = do
   theMap <- getAddressStateTxDBMap
   case M.lookup account theMap of
-    Just (ASModification addressState) -> return $ Just addressState
-    Just ASDeleted                     -> return $ Just blankAddressState
+    Just (ASModification addressState) -> do
+      $logInfoS "getAddressStateMaybe" . T.pack $ "Found ASModification in tx map for " ++ format account ++ ": " ++ format addressState
+      return $ Just addressState
+    Just ASDeleted                     -> do
+      $logInfoS "getAddressStateMaybe" . T.pack $ "Found ASDeleted in tx map for " ++ format account
+      return $ Just blankAddressState
     Nothing                            -> do
       theBMap <- getAddressStateBlockDBMap
       case M.lookup account theBMap of
-        Just (ASModification addressState) -> return $ Just addressState
-        Just ASDeleted                     -> return $ Just blankAddressState
-        Nothing                            -> DB.getAddressStateMaybe account
+        Just (ASModification addressState) -> do
+          $logInfoS "getAddressStateMaybe" . T.pack $ "Found ASModification in block map for " ++ format account ++ ": " ++ format addressState
+          return $ Just addressState
+        Just ASDeleted                     -> do
+          $logInfoS "getAddressStateMaybe" . T.pack $ "Found ASDeleted in block map for " ++ format account
+          return $ Just blankAddressState
+        Nothing                            -> do
+          mAddressState <- DB.getAddressStateMaybe account
+          $logInfoS "getAddressStateMaybe" . T.pack $ "Address state for " ++ format account ++ " from database: " ++ format mAddressState
+          pure mAddressState
 
 getAllAddressStates::(HasMemAddressStateDB m, HasHashDB m, HasStateDB m)=>
                      Maybe Word256 -> m [(Account, AddressState)]
 getAllAddressStates = DB.getAllAddressStates
 
-putAddressState :: (HasMemAddressStateDB m, HasStateDB m, HasHashDB m) =>
+putAddressState :: (MonadLogger m, HasMemAddressStateDB m, HasStateDB m, HasHashDB m) =>
                  Account -> AddressState -> m ()
 putAddressState account newState = do
   theMap <- getAddressStateTxDBMap
+  $logInfoS "putAddressState" . T.pack $ "Putting address state for " ++ format account ++ ": " ++ format newState
   putAddressStateTxDBMap (M.insert account (ASModification newState) theMap)
 
 flushMemAddressStateTxToBlockDB :: (HasMemAddressStateDB m, HasStateDB m, HasHashDB m) =>

--- a/strato/core/blockapps-mpdbs/src/Blockchain/DB/MemAddressStateDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/DB/MemAddressStateDB.hs
@@ -1,8 +1,6 @@
 {-# OPTIONS -fno-warn-redundant-constraints #-} -- todo fixme
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeOperators    #-}
 module Blockchain.DB.MemAddressStateDB (
   HasMemAddressStateDB(..),
@@ -23,10 +21,8 @@ import qualified Control.Monad.Change.Alter     as A
 import           Control.DeepSeq
 import           Data.Maybe
 import qualified Data.Map                       as M
-import qualified Data.Text                      as T
 import GHC.Generics
 
-import           BlockApps.Logging
 import           Blockchain.Data.AddressStateDB
 import qualified Blockchain.DB.AddressStateDB   as DB
 import           Blockchain.DB.HashDB
@@ -58,40 +54,28 @@ class HasMemAddressStateDB m where
 getAddressState :: (Account `A.Alters` AddressState) m => Account -> m AddressState
 getAddressState account = fromMaybe blankAddressState <$> A.lookup A.Proxy account
 
-getAddressStateMaybe :: (MonadLogger m, HasMemAddressStateDB m, HasStateDB m, HasHashDB m)
+getAddressStateMaybe :: (HasMemAddressStateDB m, HasStateDB m, HasHashDB m)
                      => Account -> m (Maybe AddressState)
 getAddressStateMaybe account = do
   theMap <- getAddressStateTxDBMap
   case M.lookup account theMap of
-    Just (ASModification addressState) -> do
-      $logInfoS "getAddressStateMaybe" . T.pack $ "Found ASModification in tx map for " ++ format account ++ ": " ++ format addressState
-      return $ Just addressState
-    Just ASDeleted                     -> do
-      $logInfoS "getAddressStateMaybe" . T.pack $ "Found ASDeleted in tx map for " ++ format account
-      return $ Just blankAddressState
+    Just (ASModification addressState) -> return $ Just addressState
+    Just ASDeleted                     -> return $ Just blankAddressState
     Nothing                            -> do
       theBMap <- getAddressStateBlockDBMap
       case M.lookup account theBMap of
-        Just (ASModification addressState) -> do
-          $logInfoS "getAddressStateMaybe" . T.pack $ "Found ASModification in block map for " ++ format account ++ ": " ++ format addressState
-          return $ Just addressState
-        Just ASDeleted                     -> do
-          $logInfoS "getAddressStateMaybe" . T.pack $ "Found ASDeleted in block map for " ++ format account
-          return $ Just blankAddressState
-        Nothing                            -> do
-          mAddressState <- DB.getAddressStateMaybe account
-          $logInfoS "getAddressStateMaybe" . T.pack $ "Address state for " ++ format account ++ " from database: " ++ format mAddressState
-          pure mAddressState
+        Just (ASModification addressState) -> return $ Just addressState
+        Just ASDeleted                     -> return $ Just blankAddressState
+        Nothing                            -> DB.getAddressStateMaybe account
 
 getAllAddressStates::(HasMemAddressStateDB m, HasHashDB m, HasStateDB m)=>
                      Maybe Word256 -> m [(Account, AddressState)]
 getAllAddressStates = DB.getAllAddressStates
 
-putAddressState :: (MonadLogger m, HasMemAddressStateDB m, HasStateDB m, HasHashDB m) =>
+putAddressState :: (HasMemAddressStateDB m, HasStateDB m, HasHashDB m) =>
                  Account -> AddressState -> m ()
 putAddressState account newState = do
   theMap <- getAddressStateTxDBMap
-  $logInfoS "putAddressState" . T.pack $ "Putting address state for " ++ format account ++ ": " ++ format newState
   putAddressStateTxDBMap (M.insert account (ASModification newState) theMap)
 
 flushMemAddressStateTxToBlockDB :: (HasMemAddressStateDB m, HasStateDB m, HasHashDB m) =>

--- a/strato/core/strato-conf/src/Blockchain/CoreFlags.hs
+++ b/strato/core/strato-conf/src/Blockchain/CoreFlags.hs
@@ -10,4 +10,6 @@ import           HFlags
 {-# RULES "make_this_orphan" id = id :: MakeThisOrphan -> MakeThisOrphan #-}
 
 defineFlag "difficultyBomb" False "turn difficulty bomb on or off"
+defineFlag "network" (""::String) "Choose a network to join"
+defineFlag "networkID" (-1::Int) "set a custom network ID for the client"
 defineFlag "testnet" False "connect to testnet"

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -100,19 +100,23 @@ tests:
       - QuickCheck
       - base16-bytestring
       - blockapps-datadefs
+      - blockapps-mpdbs
       - blockapps-privacy
       - blockstanbul
       - bytestring
       - conduit
       - containers
       - data-default
+      - debugger
       - ethereum-discovery
       - hflags
       - hspec
       - hspec-expectations-lifted
       - lens
+      - merkle-patricia-db
       - monad-alter
       - mtl
+      - nibblestring
       - ordered-containers
       - seqevents
       - stm-chans
@@ -122,4 +126,6 @@ tests:
       - strato-sequencer
       - text
       - unliftio
+      - vm-runner
+      - vm-tools
   

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -118,6 +118,7 @@ tests:
       - mtl
       - nibblestring
       - ordered-containers
+      - secp256k1-haskell
       - seqevents
       - stm-chans
       - stm-conduit

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -118,6 +118,7 @@ tests:
       - mtl
       - nibblestring
       - ordered-containers
+      - raw-strings-qq
       - secp256k1-haskell
       - seqevents
       - stm-chans

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -121,6 +121,7 @@ tests:
       - seqevents
       - stm-chans
       - stm-conduit
+      - strato-index
       - strato-model
       - strato-p2p
       - strato-sequencer

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -109,6 +109,7 @@ tests:
       - data-default
       - debugger
       - ethereum-discovery
+      - ethereum-rlp
       - hflags
       - hspec
       - hspec-expectations-lifted

--- a/strato/core/strato-p2p/src/Blockchain/Context.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Context.hs
@@ -165,7 +165,6 @@ withPeerAddress f = PeerAddress . f . unPeerAddress
 
 data Context = Context
   { contextKafkaState     :: K.KafkaState
-  , vmTrace               :: [String]
   , blockHeaders          :: [BlockData]
   , remainingBlockHeaders :: RemainingBlockHeaders
   , actionTimestamp       :: ActionTimestamp
@@ -496,7 +495,6 @@ initContext = Context
   , contextKafkaState = mkConfiguredKafkaState "strato-p2p"
   , blockHeaders = []
   , remainingBlockHeaders = RemainingBlockHeaders []
-  , vmTrace=[]
   , _blockstanbulPeerAddr = PeerAddress Nothing
   , _outboundWireMessages = S.empty
   }

--- a/strato/core/strato-p2p/src/Blockchain/Options.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Options.hs
@@ -5,6 +5,7 @@ module Blockchain.Options where
 import           Data.ByteString.Internal
 import           HFlags
 
+import           Blockchain.CoreFlags
 import           Blockchain.Participation (ParticipationMode(..))
 import           Blockchain.Strato.Model.Util
 
@@ -15,7 +16,6 @@ data AuthorizationMode = IPOnly | PubkeyOnly | StrongAuth | FlexibleAuth derivin
 
 defineFlag "a:address" ("127.0.0.1" :: String) "Connect to server at address"
 defineFlag "l:listen" (30303 :: Int) "Listen on port"
-defineFlag "testnet" False "connect to testnet"
 defineFlag "sqlPeers" False "Choose peers from the SQL DB, not the config file"
 defineFlag "network" (""::String) "Choose a network to join"
 defineFlag "networkID" (-1::Int) "set a custom network ID for the client"

--- a/strato/core/strato-p2p/src/Blockchain/Options.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Options.hs
@@ -17,8 +17,6 @@ data AuthorizationMode = IPOnly | PubkeyOnly | StrongAuth | FlexibleAuth derivin
 defineFlag "a:address" ("127.0.0.1" :: String) "Connect to server at address"
 defineFlag "l:listen" (30303 :: Int) "Listen on port"
 defineFlag "sqlPeers" False "Choose peers from the SQL DB, not the config file"
-defineFlag "network" (""::String) "Choose a network to join"
-defineFlag "networkID" (-1::Int) "set a custom network ID for the client"
 defineFlag "syncBacktrackNumber" (10::Integer) "block number to go back when syncing"
 defineFlag "debugFail" True "Fail on errors we're not supposed to reach. If false, just log insteand and go on"
 defineFlag "maxConn" (20::Int) "Maximum number of client connections."

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -90,7 +90,7 @@ import           Blockchain.Strato.Indexer.TxrIndexer
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ExtendedWord
-import           Blockchain.Strato.Model.Keccak256     (Keccak256, zeroHash, unsafeCreateKeccak256FromWord256)
+import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.Strato.Model.Secp256k1
 import qualified Blockchain.TxRunResultCache           as TRC
 
@@ -146,6 +146,7 @@ data TestContext = TestContext
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
   , _vmContext             :: MemContext
+  , _apiChainInfoMap       :: Map Word256 ChainInfo
   }
 
 makeLenses ''TestContext
@@ -665,9 +666,9 @@ instance MonadIO m => (Keccak256 `A.Alters` API OutputTx) (MonadTest m) where
   insert _ _ _ = pure ()
 
 instance MonadIO m => (Word256 `A.Alters` API ChainInfo) (MonadTest m) where
-  lookup _ _   = pure Nothing
-  delete _ _   = pure ()
-  insert _ _ _ = pure ()
+  lookup _ k         = fmap API <$> use (apiChainInfoMap . at k)
+  delete _ k         = apiChainInfoMap . at k .= Nothing
+  insert _ k (API v) = apiChainInfoMap . at k ?= v
 
 instance MonadIO m => (Keccak256 `A.Alters` API OutputBlock) (MonadTest  m) where
   lookup _ _   = pure Nothing
@@ -755,6 +756,7 @@ testContext prv seqCtx vmCtx = TestContext
   , _unseqEvents           = []
   , _sequencerContext      = seqCtx
   , _vmContext             = vmCtx
+  , _apiChainInfoMap       = M.empty
   }
 
 testPeer :: DataPeer.PPeer
@@ -828,6 +830,9 @@ runNode p =
                      (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerP2pIndexer)))
       (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerTxrIndexer)))
 
+postEvent :: SeqLoopEvent -> P2PPeer -> IO ()
+postEvent e p = atomically $ writeTQueue (_p2pPeerUnseqSource p) e
+
 createPeer :: PrivateKey
            -> [Address]
            -> ([IngestEvent] -> TestContextM ())
@@ -854,7 +859,34 @@ createPeer privKey initialValidators unseqSink name ipAddr = do
                                )
   let vm = do
         MP.initializeBlank
+        let genesisBlock = OutputBlock
+              { obOrigin              = Origin.API
+              , obTotalDifficulty     = 0
+              , obBlockData           = DataDefs.BlockData
+                  zeroHash
+                  zeroHash
+                  (Address 0)
+                  MP.emptyTriePtr
+                  MP.emptyTriePtr
+                  MP.emptyTriePtr
+                  ""
+                  1
+                  0
+                  10000
+                  1
+                  DataPeer.jamshidBirth
+                  ""
+                  12345
+                  zeroHash
+              , obReceiptTransactions = []
+              , obBlockUncles         = []
+              }
+            genHash = rlpHash genesisBlock
         setStateDBStateRoot Nothing MP.emptyTriePtr
+        (BlockHashRoot bhr) <- bootstrapChainDB genHash [(Nothing, MP.emptyTriePtr)]
+        (X509.CertRoot cr) <- X509.bootstrapCertDB genHash
+        Mod.put (Mod.Proxy @BlockHashRoot) $ BlockHashRoot bhr
+        Mod.put (Mod.Proxy @X509.CertRoot) $ X509.CertRoot cr
         runConduit $ sourceTQueue seqVmSource
                   .| (awaitForever $ yield . foldr VMEvent.insertInBatch VMEvent.newInBatch)
                   .| handleVmEvents False
@@ -978,6 +1010,11 @@ runConnection connection = do
       rClient = runLoggingT . runResourceT . flip runReaderT (connection ^. clientP2PPeer . p2pTestContext) $ connection ^. runClient
   concurrently rServer rClient
 
+runNetwork :: [P2PPeer] -> [P2PConnection] -> IO ()
+runNetwork nodes connections =
+  concurrently_ (mapConcurrently runNode nodes)
+                (mapConcurrently runConnection connections)
+
 makeValidators :: [PrivateKey] -> [Address]
 makeValidators = map fromPrivateKey
 
@@ -1043,12 +1080,10 @@ spec = do
         , (peers !! 1, peers !! 5)
         ]
       let runForTwoSeconds = void . timeout 2000000
-          runNodes = mapConcurrently runNode peers
-          runConnections = mapConcurrently runConnection connections
           postTimeout = do
             threadDelay 1000000
-            for_ validators' (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
-      runForTwoSeconds $ concurrently_ (concurrently_ runNodes runConnections) postTimeout
+            for_ validators' $ postEvent (TimerFire 0)
+      runForTwoSeconds $ concurrently_ (runNetwork peers connections) postTimeout
       ctxs <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1 :: Maybe Word256)
   
@@ -1080,23 +1115,21 @@ spec = do
                                ( (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
                                . (sequencerContext . blockstanbulContext . _Just . view . round .~ 1000))
       let runForTwoSeconds = void . timeout 2000000
-          runNodes = mapConcurrently runNode peers
-          runConnections = mapConcurrently runConnection connections
           postTimeoutPrimary1 = do
             threadDelay 1000000
-            for_ primaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
+            for_ primaryValidators $ postEvent (TimerFire 0)
           postTimeoutPrimary2 = do
             threadDelay 1000000
-            for_ primaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 1))
+            for_ primaryValidators $ postEvent (TimerFire 1)
           postTimeoutSecondary = do
             threadDelay 1000000
-            for_ secondaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 1000))
-      runForTwoSeconds $ concurrently_ (concurrently_ runNodes runConnections) (concurrently_ postTimeoutPrimary1 postTimeoutSecondary)
+            for_ secondaryValidators $ postEvent (TimerFire 1000)
+      runForTwoSeconds $ concurrently_ (runNetwork peers connections) (concurrently_ postTimeoutPrimary1 postTimeoutSecondary)
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs1 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just (1 :: Word256) else Just 1000)
       atomically $ modifyTVar' ((peers !! 0) ^. p2pTestContext)
                                (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
-      runForTwoSeconds $ concurrently_ (concurrently_ runNodes runConnections) (concurrently_ postTimeoutPrimary2 postTimeoutSecondary)
+      runForTwoSeconds $ concurrently_ (runNetwork peers connections) (concurrently_ postTimeoutPrimary2 postTimeoutSecondary)
       ctxs2 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1001 :: Maybe Word256)
   
@@ -1121,6 +1154,44 @@ spec = do
         -- Now that the peer is known to be addr, we should only send if they are designated
         shouldSendToPeer addr `L.shouldReturn` True
         shouldSendToPeer 0xa `L.shouldReturn` False
+
+    it "Can index a ChainInfo" $ do
+      let unseqSink = (unseqEvents %=) . (++)
+      privKeys <- traverse (const newPrivateKey) [(1 :: Integer)..3]
+      let validators' = makeValidators privKeys
+      peers <- traverse (\(p,(n,i)) -> createPeer p validators' unseqSink n i) $ zip privKeys
+        [ ("node1", "1.2.3.4")
+        , ("node2", "5.6.7.8")
+        , ("node3", "9.10.11.12")
+        ]
+      connections <- traverse (uncurry createConnection)
+        [ (peers !! 0, peers !! 1)
+        , (peers !! 0, peers !! 2)
+        , (peers !! 1, peers !! 2)
+        ]
+      let runForTwoSeconds = void . timeout 2000000
+          src = "contract A {}"
+          contractName = "A"
+          enode = readEnode "enode://abcd@1.2.3.4:30303"
+          chainInfo' = ChainInfo
+            UnsignedChainInfo { chainLabel     = "My test chain!"
+                              , accountInfo    = [ContractNoStorage (Address 0x100) 10000000000 (SolidVMCode contractName $ hash src)]
+                              , codeInfo       = [CodeInfo "" src $ Just contractName]
+                              , members        = M.singleton (validators' !! 0) enode
+                              , parentChain    = Nothing
+                              , creationBlock  = zeroHash
+                              , chainNonce     = 123456789
+                              , chainMetadata  = M.singleton "VM" "SolidVM"
+                              }
+            Nothing
+          chainId = keccak256ToWord256 $ rlpHash chainInfo'
+          postChainInfo = do
+            threadDelay 1000000
+            flip postEvent (peers !! 0) . UnseqEvent . IEGenesis $ IngestGenesis Origin.API (chainId, chainInfo')
+
+      runForTwoSeconds $ concurrently_ (runNetwork peers connections) postChainInfo
+      ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
+      ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at chainId) `shouldBe` (i, if i == 0 then Just chainInfo' else Nothing)
 
     it "should broadcast blockstanbul messages" $ property $ withMaxSuccess 10 $ \wm ->
       runTestPeer $ do

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -81,6 +81,11 @@ import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Monad
 
 import qualified Blockchain.Strato.Discovery.Data.Peer as DataPeer
+import           Blockchain.Strato.Indexer.ApiIndexer
+import           Blockchain.Strato.Indexer.IContext    (API(..), P2P(..), IndexerException(..))
+import           Blockchain.Strato.Indexer.Model
+import           Blockchain.Strato.Indexer.P2PIndexer
+import           Blockchain.Strato.Indexer.TxrIndexer
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ExtendedWord
@@ -577,6 +582,45 @@ instance MonadIO m => Mod.Accessible TRC.Cache (MonadTest m) where
 instance MonadIO m => (MonadTest m) `Mod.Yields` DataDefs.TransactionResult where
   yield = const (pure ())
 
+instance MonadIO m => (Keccak256 `A.Alters` API OutputTx) (MonadTest m) where
+  lookup _ _   = pure Nothing
+  delete _ _   = pure ()
+  insert _ _ _ = pure ()
+
+instance MonadIO m => (Word256 `A.Alters` API ChainInfo) (MonadTest m) where
+  lookup _ _   = pure Nothing
+  delete _ _   = pure ()
+  insert _ _ _ = pure ()
+
+instance MonadIO m => (Keccak256 `A.Alters` API OutputBlock) (MonadTest  m) where
+  lookup _ _   = pure Nothing
+  delete _ _   = pure ()
+  insert _ _ _ = pure ()
+
+instance MonadIO m => (Keccak256 `A.Alters` P2P (Private (Word256, OutputTx))) (MonadTest m) where
+  lookup _ _ = liftIO . throwIO $ Lookup "P2P" "Keccak256" "Private (Word256, OutputTx)"
+  delete _ _ = liftIO . throwIO $ Delete "P2P" "Keccak256" "Private (Word256, OutputTx)"
+  insert _ k (P2P v) = privateTxMap . at k ?= v
+
+instance MonadIO m => (Keccak256 `A.Alters` P2P OutputBlock) (MonadTest m) where
+  lookup _ _ = liftIO . throwIO $ Lookup "P2P" "Keccak256" "OutputBlock"
+  delete _ _ = liftIO . throwIO $ Delete "P2P" "Keccak256" "OutputBlock"
+  insert _ _ _ = pure ()
+
+instance MonadIO m => Mod.Modifiable (P2P BestBlock) (MonadTest m) where
+  get _          = liftIO . throwIO $ Lookup "P2P" "()" "BestBlock"
+  put _ (P2P bb) = bestBlock .= bb
+
+instance MonadIO m => (Word256 `A.Alters` P2P ChainInfo) (MonadTest m) where
+  lookup _ _   = liftIO . throwIO $ Lookup "P2P" "Word256" "ChainInfo"
+  delete _ _   = liftIO . throwIO $ Delete "P2P" "Word256" "ChainInfo"
+  insert _ cId (P2P cInfo) = chainInfoMap . at cId ?= cInfo
+
+instance MonadIO m => (Word256 `A.Alters` P2P ChainMembers) (MonadTest m) where
+  lookup _ _   = liftIO . throwIO $ Lookup "P2P" "Word256" "ChainMembers"
+  delete _ _   = liftIO . throwIO $ Delete "P2P" "Word256" "ChainMembers"
+  insert _ cId (P2P mems) = chainMembersMap . at cId ?= mems
+
 startingCheckpoint :: [Address] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
 
@@ -689,15 +733,33 @@ data P2PPeer m = P2PPeer
   , _p2pPeerPPeer       :: DataPeer.PPeer
   , _p2pPeerWireMessageRef :: WMRef
   , _p2pPeerUnseqSource :: TQueue SeqLoopEvent
-  , _p2pPeerSeqP2pSource :: TMChan P2pEvent
+  , _p2pPeerSeqP2pSource :: TMChan (Either TxrResult P2pEvent)
   , _p2pPeerSeqVmSource :: TQueue [VmEvent]
+  , _p2pPeerApiIndexSource :: TQueue [IndexEvent]
+  , _p2pPeerP2pIndexSource :: TQueue [IndexEvent]
+  , _p2pPeerTxrIndexSource :: TQueue IndexEvent
   , _p2pPeerUnseqSink   :: [IngestEvent] -> m ()
   , _p2pPeerName        :: String
   , _p2pPeerSequencer   :: m ()
   , _p2pPeerVm          :: m ()
+  , _p2pPeerApiIndexer  :: m ()
+  , _p2pPeerP2pIndexer  :: m ()
+  , _p2pPeerTxrIndexer  :: m ()
   }
 
-createPeer :: (Seq.MonadSequencer m , MonadFail m, VMBase m, MonadBagger m)
+createPeer :: ( Seq.MonadSequencer m 
+              , MonadFail m
+              , VMBase m
+              , MonadBagger m
+              , (Keccak256 `A.Alters` API OutputTx) m
+              , (Word256 `A.Alters` API ChainInfo) m
+              , (Keccak256 `A.Alters` API OutputBlock) m
+              , (Keccak256 `A.Alters` P2P (Private (Word256, OutputTx))) m
+              , (Keccak256 `A.Alters` P2P OutputBlock) m
+              , Mod.Modifiable (P2P BestBlock) m
+              , (Word256 `A.Alters` P2P ChainInfo) m
+              , (Word256 `A.Alters` P2P ChainMembers) m
+              )
            => ([IngestEvent] -> m ())
            -> String
            -> String
@@ -708,10 +770,13 @@ createPeer unseqSink name ipAddr = do
   unseqSource <- newTQueueIO
   seqP2pSource <- newBroadcastTMChanIO
   seqVmSource <- newTQueueIO
+  apiIndexerSource <- newTQueueIO
+  p2pIndexerSource <- newTQueueIO
+  txrIndexerSource <- newTQueueIO
   let sequencer = runConduit $ sourceTQueue unseqSource
                             .| mapMC (Seq.runSequencerBatch . (:[]))
                             .| (awaitForever $ \b -> atomically $ do
-                                  traverse_ (writeTMChan seqP2pSource) $ Seq._toP2p b
+                                  traverse_ (writeTMChan seqP2pSource . Right) $ Seq._toP2p b
                                   writeTQueue seqVmSource $ Seq._toVm b
                                )
   let vm = runConduit $ sourceTQueue seqVmSource
@@ -720,7 +785,27 @@ createPeer unseqSink name ipAddr = do
                      .| (awaitForever $ yield . flip VMEvent.insertOutBatch VMEvent.newOutBatch)
                      .| (awaitForever $ \b -> atomically $ do
                           traverse_ (writeTQueue unseqSource) $ UnseqEvent . IEBlock . blockToIngestBlock Origin.Quarry . outputBlockToBlock <$> toList (VMEvent.outBlocks b)
+                          writeTQueue apiIndexerSource $ toList (VMEvent.outIndexEvents b)
+                          writeTQueue p2pIndexerSource $ toList (VMEvent.outIndexEvents b)
+                          traverse_ (writeTQueue txrIndexerSource) $ toList (VMEvent.outIndexEvents b)
                         )
+      apiIndexer' = runConduit $ sourceTQueue apiIndexerSource
+                              .| (awaitForever $ lift . indexAPI)
+      p2pIndexer' = runConduit $ sourceTQueue p2pIndexerSource
+                              .| (awaitForever $ lift . indexP2P)
+      txrIndexer' = runConduit $ sourceTQueue txrIndexerSource
+                              .| (awaitForever $ yieldMany . indexEventToTxrResults)
+                              .| (awaitForever $ \case
+                                    AddMember _ -> pure () --(Right (cId, addr, enode)) -> pure ()
+                                    RemoveMember _ -> pure () --(Right (cId, addr)) -> pure ()
+                                    RegisterCertificate _ -> pure () --(Right (addr, certState)) -> pure ()
+                                    CertificateRevoked _ -> pure () --(Right addr) -> pure ()
+                                    CertificateRegistryInitialized _ -> pure () --(Right ()) -> pure ()
+                                    TerminateChain _ -> pure ()
+                                    PutLogDB _ -> pure ()
+                                    PutEventDB _ -> pure ()
+                                    PutTxResult _ -> pure ()
+                                 )
       pubkeystr = BC.unpack $ B16.encode $ B.drop 1 $ exportPublicKey False $ derivePublicKey privKey
       ppeer = DataPeer.buildPeer ( Just pubkeystr
                                  , ipAddr
@@ -736,10 +821,16 @@ createPeer unseqSink name ipAddr = do
     unseqSource
     seqP2pSource
     seqVmSource
+    apiIndexerSource
+    p2pIndexerSource
+    txrIndexerSource
     unseq
     name
     sequencer
     vm
+    apiIndexer'
+    p2pIndexer'
+    txrIndexer'
 
 data P2PConnection m = P2PConnection
   { _serverToClient :: TQueue B.ByteString
@@ -762,13 +853,13 @@ createConnection server client = do
   let runServer = runEthServerConduit (_p2pPeerPPeer client)
                                       (sourceTQueue clientToServer)
                                       (sinkTQueue serverToClient)
-                                      (sourceTMChan serverSeqSource)
+                                      (sourceTMChan serverSeqSource .| (awaitForever $ either (const $ pure ()) yield))
                                       (_p2pPeerUnseqSink server)
                                       (_p2pPeerName server ++ " -> " ++ _p2pPeerName client)
       runClient = runEthClientConduit (_p2pPeerPPeer server)
                                       (sourceTQueue serverToClient)
                                       (sinkTQueue clientToServer)
-                                      (sourceTMChan clientSeqSource)
+                                      (sourceTMChan clientSeqSource .| (awaitForever $ either (const $ pure ()) yield))
                                       (_p2pPeerUnseqSink client)
                                       (_p2pPeerName client ++ " -> " ++ _p2pPeerName server)
   pure $ P2PConnection
@@ -816,7 +907,7 @@ spec = do
       otx <- (\o -> o{otBaseTx = clearChainId (otBaseTx o), otOrigin = Origin.API}) <$> liftIO (generate arbitrary)
       let runForTwoSeconds pk wmr = execTestPeer pk wmr validatorAddresses . timeout 2000000
           run = runConnectionWith runForTwoSeconds connection
-          postTx = threadDelay 500000 >> (atomically $ writeTMChan (_p2pPeerSeqP2pSource server) (P2pTx otx))
+          postTx = threadDelay 500000 >> (atomically $ writeTMChan (_p2pPeerSeqP2pSource server) (Right $ P2pTx otx))
       ((_, serverCtx), (_, clientCtx)) <- fst <$> concurrently run postTx
       _unseqEvents serverCtx `shouldBe` []
       let clientTxs = [t | IETx _ (IngestTx _ t) <- _unseqEvents clientCtx]

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PackageImports        #-}
+{-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE Rank2Types            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
@@ -31,7 +32,7 @@ import           Data.Default
 import           Data.Foldable                         (for_, toList, traverse_)
 import           Data.Map.Strict                       (Map)
 import qualified Data.Map.Strict                       as M
-import           Data.Maybe                            (fromMaybe)
+import           Data.Maybe                            (fromJust, fromMaybe, isJust)
 import qualified Data.NibbleString                     as N
 import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
@@ -113,6 +114,7 @@ import           Executable.StratoP2PServer
 import           Test.Hspec
 import qualified Test.Hspec.Expectations.Lifted        as L
 import           Test.QuickCheck
+import           Text.RawString.QQ
 
 import           UnliftIO
 import           UnliftIO.Concurrent                   (threadDelay)
@@ -893,9 +895,19 @@ createPeer privKey initialValidators unseqSink name ipAddr = do
         A.insert (A.Proxy @EmittedBlock) genHash alreadyEmittedBlock
         runConduit $ sourceTQueue unseqSource
                   .| mapMC (Seq.runSequencerBatch . (:[]))
-                  .| (awaitForever $ \b -> atomically $ do
-                        traverse_ (writeTMChan seqP2pSource . Right) $ Seq._toP2p b
-                        writeTQueue seqVmSource $ Seq._toVm b
+                  .| (awaitForever $ \b -> do
+                        chainIds <- lift $ unGetChainsDB <$> Mod.get (Mod.Proxy @GetChainsDB)
+                        txHashes <- lift $ unGetTransactionsDB <$> Mod.get (Mod.Proxy @GetTransactionsDB)
+                        let chainIdsList = toList chainIds
+                            txHashesList = toList txHashes
+                            getChains = if null chainIdsList then [] else [P2pGetChain chainIdsList]
+                            getTxs = if null txHashesList then [] else [P2pGetTx txHashesList]
+                            toP2p' = getChains ++ getTxs ++ Seq._toP2p b
+                        atomically $ do
+                          traverse_ (writeTMChan seqP2pSource . Right) $ toP2p'
+                          writeTQueue seqVmSource $ Seq._toVm b
+                        lift clearGetChainsDB
+                        lift clearGetTransactionsDB
                      )
   let vm = do
         MP.initializeBlank
@@ -1043,6 +1055,42 @@ runNetwork nodes connections =
 makeValidators :: [PrivateKey] -> [Address]
 makeValidators = map fromPrivateKey
 
+mkSignedTx :: PrivateKey -> U.UnsignedTransaction -> Transaction
+mkSignedTx privKey utx =
+  let Nonce n = U.unsignedTransactionNonce utx
+      Gas gl = U.unsignedTransactionGasLimit utx
+      cId = unChainId <$> U.unsignedTransactionChainId utx
+      Wei gp = U.unsignedTransactionGasPrice utx
+      Wei val = U.unsignedTransactionValue utx
+      (r', s', v') = getSigVals . signMsg privKey $ U.rlpHash utx
+   in if isJust $ U.unsignedTransactionTo utx
+        then let Code c = U.unsignedTransactionInitOrData utx
+              in MessageTX
+                   { transactionNonce    = fromIntegral n
+                   , transactionGasPrice = fromIntegral gp
+                   , transactionGasLimit = fromIntegral gl
+                   , transactionTo       = fromJust $ U.unsignedTransactionTo utx
+                   , transactionValue    = fromIntegral val
+                   , transactionData     = c
+                   , transactionChainId  = cId
+                   , transactionR        = fromIntegral r'
+                   , transactionS        = fromIntegral s'
+                   , transactionV        = v'
+                   , transactionMetadata = Just $ M.fromList [("VM","SolidVM")]
+                   }
+        else ContractCreationTX
+                   { transactionNonce    = fromIntegral n
+                   , transactionGasPrice = fromIntegral gp
+                   , transactionGasLimit = fromIntegral gl
+                   , transactionValue    = fromIntegral val
+                   , transactionInit     = U.unsignedTransactionInitOrData utx
+                   , transactionChainId  = cId
+                   , transactionR        = fromIntegral r'
+                   , transactionS        = fromIntegral s'
+                   , transactionV        = v'
+                   , transactionMetadata = Just $ M.fromList [("VM","SolidVM")]
+                   }
+
 -- endlessStreamOfIPAddresses :: [String]
 -- endlessStreamOfIPAddresses = generateThem
 --   where galois x = let y = (7*chx) `mod` 256 in x : galois y
@@ -1158,7 +1206,7 @@ spec = do
       ctxs2 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1001 :: Maybe Word256)
 
-    it "can add a new now to a chain" $ do
+    it "can add a new node to a chain" $ do
       let unseqSink = (unseqEvents %=) . (++)
       privKeys <- traverse (const newPrivateKey) [(1 :: Integer)..3]
       let validators' = makeValidators privKeys
@@ -1173,7 +1221,15 @@ spec = do
         , (peers !! 1, peers !! 2)
         ]
       let runForThreeSeconds = void . timeout 3000000
-          src = "pragma solidvm 3.2; contract A { event MemberAdded(address addr, string enode); function addMember(address _addr, string _enode) { emit MemberAdded(_addr, _enode); } }"
+          src = [r|
+pragma solidvm 3.2;
+contract A {
+  event MemberAdded(address addr, string enode);
+  function addMember(address _addr, string _enode) {
+    emit MemberAdded(_addr, _enode);
+  }
+}
+|]
           contractName = "A"
           enode1 = readEnode "enode://abcd@1.2.3.4:30303"
           enode2 = "enode://abcd@5.6.7.8:30303"
@@ -1202,20 +1258,9 @@ spec = do
             , U.unsignedTransactionInitOrData = Code ""
             , U.unsignedTransactionChainId    = Just $ ChainId chainId
             }
-          (r, s, v) = getSigVals . signMsg (privKeys !! 0) $ U.rlpHash utx'
-          tx' = MessageTX
-            { transactionNonce     = 0
-            , transactionGasPrice = 1
-            , transactionGasLimit = 1000000000
-            , transactionTo       = (Address 0x100)
-            , transactionValue    = 0
-            , transactionData     = ""
-            , transactionChainId  = Just chainId
-            , transactionR        = fromIntegral r
-            , transactionS        = fromIntegral s
-            , transactionV        = v
-            , transactionMetadata = Just $ M.fromList [("VM","SolidVM"),("funcName","addMember"),("args",args)]
-            }
+          tx'' = mkSignedTx (privKeys !! 0) utx'
+          txMd = M.fromList [("funcName","addMember"),("args",args)]
+          tx' = tx''{transactionMetadata = M.union txMd <$> transactionMetadata tx''}
           ietx = IETx ts $ IngestTx Origin.API tx'
           routine = do
             threadDelay 500000
@@ -1227,6 +1272,157 @@ spec = do
       runForThreeSeconds $ concurrently_ (runNetwork peers connections) routine
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at chainId) `shouldBe` (i, if i == 2 then Nothing else Just chainInfo')
+
+    it "can sync a new node to a chain after running multiple transactions on that chain" $ do
+      let unseqSink = (unseqEvents %=) . (++)
+      privKeys <- traverse (const newPrivateKey) [(1 :: Integer)..3]
+      let validators' = makeValidators privKeys
+      peers <- traverse (\(p,(n,i)) -> createPeer p validators' unseqSink n i) $ zip privKeys
+        [ ("node1", "1.2.3.4")
+        , ("node2", "5.6.7.8")
+        , ("node3", "9.10.11.12")
+        ]
+      connections <- traverse (uncurry createConnection)
+        [ (peers !! 0, peers !! 1)
+        , (peers !! 0, peers !! 2)
+        , (peers !! 1, peers !! 2)
+        ]
+      let runForThirtySeconds = void . timeout 30000000
+          src = [r|
+pragma solidvm 3.2;
+contract A {
+  event MemberAdded(address addr, string enode);
+  uint x = 0;
+  function addMember(address _addr, string _enode) {
+    emit MemberAdded(_addr, _enode);
+  }
+
+  function incX() {
+    x++;
+  }
+}
+|]
+          contractName = "A"
+          mainChainSrc = [r|
+pragma solidvm 3.2;
+contract B {
+  uint y;
+
+  constructor() {
+    y = 47;
+  }
+}
+|]
+          mainChainContractName = "B"
+          enode1 = readEnode "enode://abcd@1.2.3.4:30303"
+          enode2 = readEnode "enode://abcd@5.6.7.8:30303"
+          enode3 = "enode://abcd@9.10.11.12:30303"
+          chainInfo' = ChainInfo
+            UnsignedChainInfo { chainLabel     = "My test chain!"
+                              , accountInfo    = [ ContractNoStorage (Address 0x100) 1000000000000000000000 (SolidVMCode contractName $ hash src)
+                                                 , NonContract (validators' !! 0) 1000000000000000000000
+                                                 , NonContract (validators' !! 1) 1000000000000000000000
+                                                 ]
+                              , codeInfo       = [CodeInfo "" src $ Just contractName]
+                              , members        = M.fromList [ (validators' !! 0, enode1)
+                                                            , (validators' !! 1, enode2)
+                                                            ]
+                              , parentChain    = Nothing
+                              , creationBlock  = zeroHash
+                              , chainNonce     = 123456789
+                              , chainMetadata  = M.singleton "VM" "SolidVM"
+                              }
+            Nothing
+          chainId = keccak256ToWord256 $ rlpHash chainInfo'
+      ts <- liftIO getCurrentMicrotime
+      let incXArgs = "()"
+          incXUtx = U.UnsignedTransaction
+            { U.unsignedTransactionNonce      = Nonce 0
+            , U.unsignedTransactionGasPrice   = Wei 1
+            , U.unsignedTransactionGasLimit   = Gas 1000000000
+            , U.unsignedTransactionTo         = Just $ Address 0x100
+            , U.unsignedTransactionValue      = Wei 0
+            , U.unsignedTransactionInitOrData = Code ""
+            , U.unsignedTransactionChainId    = Just $ ChainId chainId
+            }
+          incXUtx0 = incXUtx
+          incXUtx1 = incXUtx{U.unsignedTransactionNonce = Nonce 1}
+          incXUtx2 = incXUtx{U.unsignedTransactionNonce = Nonce 2}
+          incXUtx3 = incXUtx{U.unsignedTransactionNonce = Nonce 3}
+          incXUtx4 = incXUtx{U.unsignedTransactionNonce = Nonce 4}
+          txMd = M.fromList [("funcName","incX"),("args",incXArgs)]
+          addMd t = t{transactionMetadata = M.union txMd <$> transactionMetadata t}
+          incXTx0 = addMd $ mkSignedTx (privKeys !! 0) incXUtx0
+          incXTx1 = addMd $ mkSignedTx (privKeys !! 0) incXUtx1
+          incXTx2 = addMd $ mkSignedTx (privKeys !! 0) incXUtx2
+          incXTx3 = addMd $ mkSignedTx (privKeys !! 0) incXUtx3
+          incXTx4 = addMd $ mkSignedTx (privKeys !! 0) incXUtx4
+      let mainChainArgs = "()"
+          mainChainUtx = U.UnsignedTransaction
+            { U.unsignedTransactionNonce      = Nonce 0
+            , U.unsignedTransactionGasPrice   = Wei 1
+            , U.unsignedTransactionGasLimit   = Gas 1000000000
+            , U.unsignedTransactionTo         = Nothing
+            , U.unsignedTransactionValue      = Wei 0
+            , U.unsignedTransactionInitOrData = Code $ BC.pack mainChainSrc
+            , U.unsignedTransactionChainId    = Nothing
+            }
+          mainChainTxMd = M.fromList [("src", mainChainSrc), ("name", mainChainContractName), ("args", mainChainArgs)]
+          mainChainAddMd t = t{transactionMetadata = M.union mainChainTxMd <$> transactionMetadata t}
+          mkMainChainTx n = let utx = mainChainUtx{U.unsignedTransactionNonce = Nonce n}
+                             in mainChainAddMd $ mkSignedTx (privKeys !! 0) utx
+      let addMemberArgs = "(0x" <> T.pack (formatAddressWithoutColor (validators' !! 2)) <> ",\"" <> T.pack enode3 <> "\")"
+          addMemberUtx = U.UnsignedTransaction
+            { U.unsignedTransactionNonce      = Nonce 5
+            , U.unsignedTransactionGasPrice   = Wei 1
+            , U.unsignedTransactionGasLimit   = Gas 1000000000
+            , U.unsignedTransactionTo         = Just $ Address 0x100
+            , U.unsignedTransactionValue      = Wei 0
+            , U.unsignedTransactionInitOrData = Code ""
+            , U.unsignedTransactionChainId    = Just $ ChainId chainId
+            }
+          addMemberTxMd = M.fromList [("funcName","addMember"),("args",addMemberArgs)]
+          addMemberMd t = t{transactionMetadata = M.union addMemberTxMd <$> transactionMetadata t}
+          addMemberTx = addMemberMd $ mkSignedTx (privKeys !! 0) addMemberUtx
+          toIetx = IETx ts . IngestTx Origin.API
+          routine = do
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . IEGenesis $ IngestGenesis Origin.API (chainId, chainInfo')
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx0
+            for_ peers $ postEvent (TimerFire 0)
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 0
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 1
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 2
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 3
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 4
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx1
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 5
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx2
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 6
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx3
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 7
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx4
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 8
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx addMemberTx
+
+      runForThirtySeconds $ concurrently_ (runNetwork peers connections) routine
+      ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
+      ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at chainId) `shouldBe` (i, Just chainInfo')
   
   describe "handleEvents" $ do
     it "should pong a ping" $

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -27,7 +27,7 @@ import qualified Data.ByteString.Base16                as B16
 import qualified Data.ByteString.Char8                 as BC
 import           Data.Conduit.TMChan
 import           Data.Conduit.TQueue                   hiding (newTQueueIO)
-import           Data.Default                          (def)
+import           Data.Default
 import           Data.Foldable                         (for_, toList, traverse_)
 import           Data.Map.Strict                       (Map)
 import qualified Data.Map.Strict                       as M
@@ -37,11 +37,11 @@ import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Text (Text)
+import qualified Data.Text                             as T
 import           Data.Traversable                      (for)
 import           Text.Printf
 
 import           BlockApps.Logging
-import           Blockchain.Bagger
 import           Blockchain.Bagger.BaggerState
 import           Blockchain.Blockstanbul
 import           Blockchain.Blockstanbul.HTTPAdmin
@@ -69,7 +69,7 @@ import qualified Blockchain.DB.X509CertDB              as X509
 import "strato-p2p" Blockchain.Event
 import qualified "vm-runner" Blockchain.Event          as VMEvent
 import           Blockchain.MemVMContext               hiding (getMemContext, get, gets, put, modify, modify', dbsGet, dbsGets, dbsPut, dbsModify, dbsModify', contextGet, contextGets, contextPut, contextModify, contextModify')
-import           Blockchain.VMContext                  (VMBase, IsBlockstanbul(..), baggerState)
+import           Blockchain.VMContext                  (IsBlockstanbul(..), baggerState)
 import           Blockchain.Options                    (AuthorizationMode(..))
 import           Blockchain.Privacy
 import qualified Blockchain.Sequencer                  as Seq
@@ -107,14 +107,26 @@ import           Test.QuickCheck
 import           UnliftIO
 import           UnliftIO.Concurrent                   (threadDelay)
 
-data TestContext = TestContext
-  { _blocks                :: [Block]
-  , _blockHeaders          :: [DataDefs.BlockData]
+data P2PContext = P2PContext
+  { _blockHeaders          :: [DataDefs.BlockData]
   , _remainingBlockHeaders :: RemainingBlockHeaders
   , _actionTimestamp       :: ActionTimestamp
+  , _peerAddr              :: PeerAddress
+  , _outboundPbftMessages  :: S.OSet (Text, Keccak256)
+  }
+makeLenses ''P2PContext
+
+instance Default P2PContext where
+  def = P2PContext []
+                   (RemainingBlockHeaders [])
+                   emptyActionTimestamp
+                   (PeerAddress Nothing)
+                   S.empty
+
+data TestContext = TestContext
+  { _blocks                :: [Block]
   , _connectionTimeout     :: ConnectionTimeout
   , _maxReturnedHeaders    :: MaxReturnedHeaders
-  , _peerAddr              :: PeerAddress
   , _prvKey                :: PrivateKey
   , _shaBlockDataMap       :: Map Keccak256 DataDefs.BlockData
   , _p2pWorldBestBlock     :: WorldBestBlock
@@ -130,7 +142,6 @@ data TestContext = TestContext
   , _bestBlockNumber       :: BestBlockNumber
   , _stringPPeerMap        :: Map String DataPeer.PPeer
   , _pbftMessages          :: S.OSet Keccak256
-  , _outboundPbftMessages  :: S.OSet (Text, Keccak256)
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
   , _vmContext             :: MemContext
@@ -142,12 +153,18 @@ type TestContextM = ReaderT (TVar TestContext) (ResourceT (LoggingT IO))
 
 type MonadTest m = ReaderT (TVar TestContext) m
 
+type MonadP2PTest m = ReaderT (IORef P2PContext) m
+
 instance {-# OVERLAPPING #-} MonadIO m => State.MonadState TestContext (MonadTest m) where
   state f = ask >>= \ctx -> liftIO . atomically $ do
     s <- readTVar ctx
     let (a, s') = f s
     writeTVar ctx s'
     pure a
+
+instance {-# OVERLAPPING #-} MonadIO m => State.MonadState P2PContext (MonadP2PTest m) where
+  state f = ask >>= liftIO . flip atomicModifyIORef' (swap . f)
+    where swap ~(a,b) = (b,a)
 
 instance MonadIO m => Stacks Block (MonadTest m) where
   takeStack _ n = take n <$> use blocks
@@ -196,35 +213,38 @@ instance MonadIO m => Mod.Accessible GenesisBlockHash (MonadTest m) where
 instance MonadIO m => Mod.Accessible BestBlockNumber (MonadTest m) where
   access _ = use bestBlockNumber
 
-instance MonadIO m => Mod.Modifiable ActionTimestamp (MonadTest m) where
+instance MonadIO m => Mod.Modifiable ActionTimestamp (MonadP2PTest m) where
   get _ = use actionTimestamp
   put _ = assign actionTimestamp
 
-instance MonadIO m => Mod.Accessible ActionTimestamp (MonadTest m) where
+instance MonadIO m => Mod.Accessible ActionTimestamp (MonadP2PTest m) where
   access _ = Mod.get (Mod.Proxy @ActionTimestamp)
 
-instance MonadIO m => Mod.Modifiable [DataDefs.BlockData] (MonadTest m) where
+instance MonadIO m => Mod.Modifiable [DataDefs.BlockData] (MonadP2PTest m) where
   get _ = use blockHeaders
   put _ = assign blockHeaders
 
-instance MonadIO m => Mod.Accessible [DataDefs.BlockData] (MonadTest m) where
+instance MonadIO m => Mod.Accessible [DataDefs.BlockData] (MonadP2PTest m) where
   access _ = Mod.get (Mod.Proxy @[DataDefs.BlockData])
 
-instance MonadIO m => Mod.Modifiable RemainingBlockHeaders (MonadTest m) where
+instance MonadIO m => Mod.Modifiable RemainingBlockHeaders (MonadP2PTest m) where
   get _ = use remainingBlockHeaders
   put _ = assign remainingBlockHeaders
 
-instance MonadIO m => Mod.Accessible RemainingBlockHeaders (MonadTest m) where
+instance MonadIO m => Mod.Accessible RemainingBlockHeaders (MonadP2PTest m) where
   access _ = Mod.get (Mod.Proxy @RemainingBlockHeaders)
 
 instance MonadIO m => Mod.Accessible MaxReturnedHeaders (MonadTest m) where
   access _ = use maxReturnedHeaders
 
-instance MonadIO m => Mod.Modifiable PeerAddress (MonadTest m) where
+instance (Monad m, Mod.Accessible MaxReturnedHeaders m) => Mod.Accessible MaxReturnedHeaders (MonadP2PTest m) where
+  access p = lift $ Mod.access p
+
+instance MonadIO m => Mod.Modifiable PeerAddress (MonadP2PTest m) where
   get _ = use peerAddr
   put _ = assign peerAddr
 
-instance MonadIO m => Mod.Accessible PeerAddress (MonadTest m) where
+instance MonadIO m => Mod.Accessible PeerAddress (MonadP2PTest m) where
   access _ = Mod.get (Mod.Proxy @PeerAddress)
 
 instance MonadIO m => Mod.Accessible ConnectionTimeout (MonadTest m) where
@@ -232,6 +252,56 @@ instance MonadIO m => Mod.Accessible ConnectionTimeout (MonadTest m) where
 
 instance MonadIO m => A.Selectable String DataPeer.PPeer (MonadTest m) where
   select _ tx = M.lookup tx <$> use stringPPeerMap
+
+instance (Monad m, Stacks Block m) => Stacks Block (MonadP2PTest m) where
+  takeStack a b = lift $ takeStack a b
+  pushStack bs  = lift $ pushStack bs
+
+instance (Keccak256 `A.Alters` DataDefs.BlockData) m => (Keccak256 `A.Alters` DataDefs.BlockData) (MonadP2PTest m) where
+  lookup p k   = lift $ A.lookup p k
+  insert p k v = lift $ A.insert p k v
+  delete p k   = lift $ A.delete p k
+
+instance Mod.Modifiable WorldBestBlock m => Mod.Modifiable WorldBestBlock (MonadP2PTest m) where
+  get p   = lift $ Mod.get p
+  put p k = lift $ Mod.put p k
+
+instance Mod.Modifiable BestBlock m => Mod.Modifiable BestBlock (MonadP2PTest m) where
+  get p   = lift $ Mod.get p
+  put p k = lift $ Mod.put p k
+
+instance A.Selectable Integer (Canonical DataDefs.BlockData) m => A.Selectable Integer (Canonical DataDefs.BlockData) (MonadP2PTest m) where
+  select p i = lift $ A.select p i
+
+instance A.Selectable IPAddress IPChains m => A.Selectable IPAddress IPChains (MonadP2PTest m) where
+  select p ip = lift $ A.select p ip
+
+instance A.Selectable OrgId OrgIdChains m => A.Selectable OrgId OrgIdChains (MonadP2PTest m) where
+  select p ip = lift $ A.select p ip
+
+instance A.Selectable Keccak256 ChainTxsInBlock m => A.Selectable Keccak256 ChainTxsInBlock (MonadP2PTest m) where
+  select p sha = lift $ A.select p sha
+
+instance A.Selectable Word256 ChainMembers m => A.Selectable Word256 ChainMembers (MonadP2PTest m) where
+  select p cid = lift $ A.select p cid
+
+instance A.Selectable Word256 ChainInfo m => A.Selectable Word256 ChainInfo (MonadP2PTest m) where
+  select p cid = lift $ A.select p cid
+
+instance A.Selectable Keccak256 (Private (Word256, OutputTx)) m => A.Selectable Keccak256 (Private (Word256, OutputTx)) (MonadP2PTest m) where
+  select p tx = lift $ A.select p tx
+
+instance (Monad m, Mod.Accessible GenesisBlockHash m) => Mod.Accessible GenesisBlockHash (MonadP2PTest m) where
+  access p = lift $ Mod.access p
+
+instance (Monad m, Mod.Accessible BestBlockNumber m) => Mod.Accessible BestBlockNumber (MonadP2PTest m) where
+  access p = lift $ Mod.access p
+
+instance (Monad m, Mod.Accessible ConnectionTimeout m) => Mod.Accessible ConnectionTimeout (MonadP2PTest m) where
+  access p = lift $ Mod.access p
+
+instance A.Selectable String DataPeer.PPeer m => A.Selectable String DataPeer.PPeer (MonadP2PTest m) where
+  select p tx = lift $ A.select p tx
 
 instance MonadIO m => Mod.Modifiable GetChainsDB (MonadTest m) where
   get _ = use $ sequencerContext . getChainsDB
@@ -274,6 +344,11 @@ instance MonadIO m => (Keccak256 `A.Alters` OutputBlock) (MonadTest m) where
   lookup = genericTestLookup $ sequencerContext . blockHashRegistry
   insert = genericTestInsert $ sequencerContext . blockHashRegistry
   delete = genericTestDelete $ sequencerContext . blockHashRegistry
+
+instance (Keccak256 `A.Alters` OutputBlock) m => (Keccak256 `A.Alters` OutputBlock) (MonadP2PTest m) where
+  lookup p k   = lift $ A.lookup p k
+  insert p k v = lift $ A.insert p k v
+  delete p k   = lift $ A.delete p k
 
 instance MonadIO m => (Keccak256 `A.Alters` EmittedBlock) (MonadTest m) where
   lookup = genericTestLookup $ sequencerContext . emittedBlockRegistry
@@ -352,6 +427,11 @@ instance MonadIO m => HasVault (MonadTest m) where
     pk <- use prvKey
     return $ deriveSharedKey pk pub
 
+instance HasVault m => HasVault (MonadP2PTest m) where
+  sign bs = lift $ sign bs
+  getPub = lift getPub
+  getShared pub = lift $ getShared pub
+
 instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
   lookup _  k = do
     wms <- use pbftMessages
@@ -362,7 +442,12 @@ instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (Mo
      in wms' S.>| k)
   delete _ k = pbftMessages %= S.delete k
 
-instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessage))) (MonadTest m) where
+instance (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadP2PTest m) where
+  lookup p k   = lift $ A.lookup p k
+  insert p k v = lift $ A.insert p k v
+  delete p k   = lift $ A.delete p k
+
+instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessage))) (MonadP2PTest m) where
   lookup _  k = do
     wms <- use outboundPbftMessages
     pure $ if S.member k wms then Just (A.Proxy @(Outbound WireMessage)) else Nothing
@@ -649,12 +734,8 @@ newSequencerContext bc = do
 testContext :: PrivateKey -> SequencerContext -> MemContext -> TestContext
 testContext prv seqCtx vmCtx = TestContext
   { _blocks                = []
-  , _blockHeaders          = []
-  , _remainingBlockHeaders = RemainingBlockHeaders []
-  , _actionTimestamp       = emptyActionTimestamp
   , _connectionTimeout     = ConnectionTimeout 60
   , _maxReturnedHeaders    = MaxReturnedHeaders 1000
-  , _peerAddr              = PeerAddress Nothing
   , _prvKey                = prv
   , _shaBlockDataMap       = M.empty
   , _p2pWorldBestBlock     = WorldBestBlock (BestBlock zeroHash (-1) 0)
@@ -670,7 +751,6 @@ testContext prv seqCtx vmCtx = TestContext
   , _bestBlockNumber       = BestBlockNumber 0
   , _stringPPeerMap        = M.empty
   , _pbftMessages          = S.empty
-  , _outboundPbftMessages  = S.empty
   , _unseqEvents           = []
   , _sequencerContext      = seqCtx
   , _vmContext             = vmCtx
@@ -679,14 +759,15 @@ testContext prv seqCtx vmCtx = TestContext
 testPeer :: DataPeer.PPeer
 testPeer = DataPeer.buildPeer (Nothing, "0.0.0.0", 1212)
 
-runTestPeer :: TestContextM a -> IO ()
+runTestPeer :: MonadP2PTest TestContextM a -> IO ()
 runTestPeer f = do
   seqCtx <- newSequencerContext emptyBlockstanbulContext
   cache <- TRC.new 64
   let cstate = def & txRunResultsCache .~ cache
       vmCtx = MemContext def cstate
   ctx <- newTVarIO $ testContext undefined seqCtx vmCtx
-  void . runNoLoggingT . runResourceT $ runReaderT f ctx
+  p2pCtx <- newIORef def
+  void . runNoLoggingT . runResourceT . flip runReaderT ctx $ runReaderT f p2pCtx
 
 execTestPeer :: PrivateKey
              -> [Address]
@@ -716,50 +797,55 @@ execTestPeerWithContext f ctx = do
   ctx' <- readTVarIO ref
   return (a, ctx')
 
-data P2PPeer m = P2PPeer
-  { _p2pPeerPrivKey     :: PrivateKey
-  , _p2pPeerPPeer       :: DataPeer.PPeer
-  , _p2pPeerUnseqSource :: TQueue SeqLoopEvent
-  , _p2pPeerSeqP2pSource :: TMChan (Either TxrResult P2pEvent)
-  , _p2pPeerSeqVmSource :: TQueue [VmEvent]
+data P2PPeer = P2PPeer
+  { _p2pPeerPrivKey        :: PrivateKey
+  , _p2pPeerPPeer          :: DataPeer.PPeer
+  , _p2pPeerUnseqSource    :: TQueue SeqLoopEvent
+  , _p2pPeerSeqP2pSource   :: TMChan (Either TxrResult P2pEvent)
+  , _p2pPeerSeqVmSource    :: TQueue [VmEvent]
   , _p2pPeerApiIndexSource :: TQueue [IndexEvent]
   , _p2pPeerP2pIndexSource :: TQueue [IndexEvent]
   , _p2pPeerTxrIndexSource :: TQueue IndexEvent
-  , _p2pPeerUnseqSink   :: [IngestEvent] -> m ()
-  , _p2pPeerName        :: String
-  , _p2pPeerSequencer   :: m ()
-  , _p2pPeerVm          :: m ()
-  , _p2pPeerApiIndexer  :: m ()
-  , _p2pPeerP2pIndexer  :: m ()
-  , _p2pPeerTxrIndexer  :: m ()
+  , _p2pPeerUnseqSink      :: [IngestEvent] -> TestContextM ()
+  , _p2pPeerName           :: String
+  , _p2pTestContext        :: TVar TestContext
+  , _p2pPeerSequencer      :: TestContextM ()
+  , _p2pPeerVm             :: TestContextM ()
+  , _p2pPeerApiIndexer     :: TestContextM ()
+  , _p2pPeerP2pIndexer     :: TestContextM ()
+  , _p2pPeerTxrIndexer     :: TestContextM ()
   }
+makeLenses ''P2PPeer
 
-createPeer :: ( Seq.MonadSequencer m 
-              , MonadFail m
-              , VMBase m
-              , MonadBagger m
-              , (Keccak256 `A.Alters` API OutputTx) m
-              , (Word256 `A.Alters` API ChainInfo) m
-              , (Keccak256 `A.Alters` API OutputBlock) m
-              , (Keccak256 `A.Alters` P2P (Private (Word256, OutputTx))) m
-              , (Keccak256 `A.Alters` P2P OutputBlock) m
-              , Mod.Modifiable (P2P BestBlock) m
-              , (Word256 `A.Alters` P2P ChainInfo) m
-              , (Word256 `A.Alters` P2P ChainMembers) m
-              , State.MonadState TestContext m
-              )
-           => ([IngestEvent] -> m ())
+runNode :: P2PPeer -> IO ()
+runNode p =
+  race_
+    (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerSequencer))
+    --(race_ (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerSequencer))
+           --(runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerVm)))
+    (race_ 
+      (race_ (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerApiIndexer))
+             (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerP2pIndexer)))
+      (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerTxrIndexer)))
+
+createPeer :: PrivateKey
+           -> [Address]
+           -> ([IngestEvent] -> TestContextM ())
            -> String
            -> String
-           -> IO (P2PPeer m)
-createPeer unseqSink name ipAddr = do
-  privKey <- newPrivateKey
+           -> IO P2PPeer
+createPeer privKey initialValidators unseqSink name ipAddr = do
   unseqSource <- newTQueueIO
   seqP2pSource <- newBroadcastTMChanIO
   seqVmSource <- newTQueueIO
   apiIndexerSource <- newTQueueIO
   p2pIndexerSource <- newTQueueIO
   txrIndexerSource <- newTQueueIO
+  seqCtx <- newSequencerContext $ newBlockstanbulContext (fromPrivateKey privKey) initialValidators
+  cache <- TRC.new 64
+  let cstate = def & txRunResultsCache .~ cache
+      vmCtx = MemContext def cstate
+  testContextTVar <- newTVarIO $ testContext privKey seqCtx vmCtx
   let sequencer = runConduit $ sourceTQueue unseqSource
                             .| mapMC (Seq.runSequencerBatch . (:[]))
                             .| (awaitForever $ \b -> atomically $ do
@@ -777,11 +863,17 @@ createPeer unseqSink name ipAddr = do
                           traverse_ (writeTQueue txrIndexerSource) $ toList (VMEvent.outIndexEvents b)
                         )
       apiIndexer' = runConduit $ sourceTQueue apiIndexerSource
-                              .| (awaitForever $ lift . indexAPI)
+                              .| (awaitForever $ \evs -> do
+                                    $logInfoS "testApiIndexer" . T.pack $ show evs
+                                    lift $ indexAPI evs)
       p2pIndexer' = runConduit $ sourceTQueue p2pIndexerSource
-                              .| (awaitForever $ lift . indexP2P)
+                              .| (awaitForever $ \evs -> do
+                                    $logInfoS "testP2pIndexer" . T.pack $ show evs
+                                    lift $ indexP2P evs)
       txrIndexer' = runConduit $ sourceTQueue txrIndexerSource
-                              .| (awaitForever $ yieldMany . indexEventToTxrResults)
+                              .| (awaitForever $ \ev -> do
+                                    $logInfoS "testTxrIndexer" . T.pack $ show ev
+                                    yieldMany $ indexEventToTxrResults ev)
                               .| (awaitForever $ \case
                                     AddMember (Right (cId, addr, enode)) -> do
                                       chainMembersMap %= (\m -> case M.lookup cId m of
@@ -827,62 +919,64 @@ createPeer unseqSink name ipAddr = do
     txrIndexerSource
     unseq
     name
+    testContextTVar
     sequencer
     vm
     apiIndexer'
     p2pIndexer'
     txrIndexer'
 
-data P2PConnection m = P2PConnection
+data P2PConnection = P2PConnection
   { _serverToClient :: TQueue B.ByteString
   , _clientToServer :: TQueue B.ByteString
-  , _serverP2PPeer  :: P2PPeer m
-  , _clientP2PPeer  :: P2PPeer m
-  , _runServer      :: m (Maybe SomeException)
-  , _runClient      :: m (Maybe SomeException) 
+  , _serverP2PPeer  :: P2PPeer
+  , _clientP2PPeer  :: P2PPeer
+  , _runServer      :: TestContextM (Maybe SomeException)
+  , _runClient      :: TestContextM (Maybe SomeException) 
   }
+makeLenses ''P2PConnection
 
-createConnection :: MonadP2P m
-                 => P2PPeer m
-                 -> P2PPeer m
-                 -> IO (P2PConnection m)
+createConnection :: P2PPeer
+                 -> P2PPeer
+                 -> IO P2PConnection
 createConnection server client = do
-  serverToClient <- newTQueueIO
-  clientToServer <- newTQueueIO
+  serverToClientTQueue <- newTQueueIO
+  clientToServerTQueue <- newTQueueIO
   serverSeqSource <- atomically . dupTMChan $ _p2pPeerSeqP2pSource server
   clientSeqSource <- atomically . dupTMChan $ _p2pPeerSeqP2pSource client
-  let runServer = runEthServerConduit (_p2pPeerPPeer client)
-                                      (sourceTQueue clientToServer)
-                                      (sinkTQueue serverToClient)
-                                      (sourceTMChan serverSeqSource .| (awaitForever $ either (const $ pure ()) yield))
-                                      (_p2pPeerUnseqSink server)
-                                      (_p2pPeerName server ++ " -> " ++ _p2pPeerName client)
-      runClient = runEthClientConduit (_p2pPeerPPeer server)
-                                      (sourceTQueue serverToClient)
-                                      (sinkTQueue clientToServer)
-                                      (sourceTMChan clientSeqSource .| (awaitForever $ either (const $ pure ()) yield))
-                                      (_p2pPeerUnseqSink client)
-                                      (_p2pPeerName client ++ " -> " ++ _p2pPeerName server)
+  serverCtx <- newIORef (def :: P2PContext)
+  clientCtx <- newIORef (def :: P2PContext)
+  let rServer :: MonadP2PTest TestContextM (Maybe SomeException)
+      rServer = runEthServerConduit (_p2pPeerPPeer client)
+                                    (sourceTQueue clientToServerTQueue)
+                                    (sinkTQueue serverToClientTQueue)
+                                    (sourceTMChan serverSeqSource .| (awaitForever $ either (const $ pure ()) yield))
+                                    (lift . _p2pPeerUnseqSink server)
+                                    (_p2pPeerName server ++ " -> " ++ _p2pPeerName client)
+      rClient :: MonadP2PTest TestContextM (Maybe SomeException)
+      rClient = runEthClientConduit (_p2pPeerPPeer server)
+                                    (sourceTQueue serverToClientTQueue)
+                                    (sinkTQueue clientToServerTQueue)
+                                    (sourceTMChan clientSeqSource .| (awaitForever $ either (const $ pure ()) yield))
+                                    (lift . _p2pPeerUnseqSink client)
+                                    (_p2pPeerName client ++ " -> " ++ _p2pPeerName server)
   pure $ P2PConnection
-    serverToClient
-    clientToServer
+    serverToClientTQueue
+    clientToServerTQueue
     server
     client
-    runServer
-    runClient
+    (runReaderT rServer serverCtx)
+    (runReaderT rClient clientCtx)
 
-runConnectionWith :: (PrivateKey -> m (Maybe SomeException) -> IO b) 
-                  -> P2PConnection m 
-                  -> IO (b, b)
-runConnectionWith f connection =
-  let server = _serverP2PPeer connection
-      client = _clientP2PPeer connection
-      runServer = f (_p2pPeerPrivKey server) $ _runServer connection
-      runClient = f (_p2pPeerPrivKey client) $ _runClient connection
-   in concurrently runServer runClient
+runConnection :: P2PConnection
+              -> IO (Maybe SomeException, Maybe SomeException)
+runConnection connection = do
+  let rServer = runLoggingT . runResourceT . flip runReaderT (connection ^. serverP2PPeer . p2pTestContext) $ connection ^. runServer
+      rClient = runLoggingT . runResourceT . flip runReaderT (connection ^. clientP2PPeer . p2pTestContext) $ connection ^. runClient
+  concurrently rServer rClient
 
-makeValidators :: [P2PPeer m] -> [Address]
-makeValidators = map (fromPrivateKey . _p2pPeerPrivKey)
+makeValidators :: [PrivateKey] -> [Address]
+makeValidators = map fromPrivateKey
 
 -- endlessStreamOfIPAddresses :: [String]
 -- endlessStreamOfIPAddresses = generateThem
@@ -897,26 +991,33 @@ spec = do
   describe "network simulation" $ do
     it "should send a transaction from server to client" $ do
       let unseqSink = (unseqEvents %=) . (++)
-      server <- createPeer unseqSink "server" "1.2.3.4"
-      client <- createPeer unseqSink "client" "5.6.7.8"
-      let validatorAddresses = makeValidators [server, client]
+      serverPKey <- newPrivateKey
+      clientPKey <- newPrivateKey
+      let validatorAddresses = makeValidators [serverPKey, clientPKey]
+      server <- createPeer serverPKey validatorAddresses unseqSink "server" "1.2.3.4"
+      client <- createPeer clientPKey validatorAddresses unseqSink "client" "5.6.7.8"
       connection <- createConnection server client
       let clearChainId tx = case tx of
             MessageTX{} -> tx{transactionChainId = Nothing}
             ContractCreationTX{} -> tx{transactionChainId = Nothing}
             PrivateHashTX{} -> tx
       otx <- (\o -> o{otBaseTx = clearChainId (otBaseTx o), otOrigin = Origin.API}) <$> liftIO (generate arbitrary)
-      let runForTwoSeconds pk = execTestPeer pk validatorAddresses . timeout 2000000
-          run = runConnectionWith runForTwoSeconds connection
+      let runForTwoSeconds = timeout 2000000
+          run = runForTwoSeconds $ runConnection connection
           postTx = threadDelay 500000 >> (atomically $ writeTMChan (_p2pPeerSeqP2pSource server) (Right $ P2pTx otx))
-      ((_, serverCtx), (_, clientCtx)) <- fst <$> concurrently run postTx
+      concurrently_ run postTx
+      serverCtx <- readTVarIO $ server ^. p2pTestContext
+      clientCtx <- readTVarIO $ client ^. p2pTestContext
       _unseqEvents serverCtx `shouldBe` []
       let clientTxs = [t | IETx _ (IngestTx _ t) <- _unseqEvents clientCtx]
       clientTxs `shouldBe` [otBaseTx otx]
 
     it "should update the round number on every node in the network" $ do
       let unseqSink = (unseqEvents %=) . (++)
-      peers <- traverse (uncurry $ createPeer unseqSink)
+      privKeys <- traverse (const newPrivateKey) [(1 :: Integer)..7]
+      let validatorsPrivKeys' = take 2 privKeys
+          validatorAddresses = makeValidators validatorsPrivKeys'
+      peers <- traverse (\(p,(n,i)) -> createPeer p validatorAddresses unseqSink n i) $ zip privKeys
         [ ("node1", "1.2.3.4")
         , ("node2", "5.6.7.8")
         , ("node3", "9.10.11.12")
@@ -925,6 +1026,7 @@ spec = do
         , ("node6", "21.22.23.24")
         , ("node7", "25.26.27.28")
         ]
+      let validators' = take 2 peers
       connections <- traverse (uncurry createConnection)
         [ (peers !! 0, peers !! 1)
         , (peers !! 0, peers !! 2)
@@ -937,47 +1039,48 @@ spec = do
         , (peers !! 1, peers !! 4)
         , (peers !! 1, peers !! 5)
         ]
-      let validators' = take 2 peers
-          validatorAddresses = makeValidators validators'
-          runForTwoSeconds :: PrivateKey -> TestContextM a -> IO TestContext
-          runForTwoSeconds pk = fmap snd . execTestPeer pk validatorAddresses . timeout 2000000
-          runSequencers = mapConcurrently (\p -> runForTwoSeconds (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) peers
-          runConnections = mapConcurrently (runConnectionWith runForTwoSeconds) connections
+      let runForTwoSeconds = void . timeout 5000000
+          runNodes = mapConcurrently runNode peers
+          runConnections = traverse runConnection connections
           postTimeout = do
             threadDelay 1000000
             for_ validators' (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
-      ctxs <- fst <$> concurrently runSequencers (concurrently runConnections postTimeout)
+      runForTwoSeconds $ concurrently_ (concurrently_ runNodes runConnections) postTimeout
+      ctxs <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1 :: Maybe Word256)
   
 
     it "should update the round number after failing on a divided network first" $ do
       let unseqSink = (unseqEvents %=) . (++)
-      peers <- traverse (uncurry $ createPeer unseqSink)
+      privKeys <- traverse (const newPrivateKey) [(1 :: Integer)..3]
+      let validatorsPrivKeys' = privKeys
+          primaryValidatorsPrivKeys = [head validatorsPrivKeys']
+          primaryValidatorAddresses = makeValidators primaryValidatorsPrivKeys
+          validatorAddresses = makeValidators validatorsPrivKeys'
+      peers <- traverse (\(p,(n,i)) -> createPeer p primaryValidatorAddresses unseqSink n i) $ zip privKeys
         [ ("node1", "1.2.3.4")
         , ("node2", "5.6.7.8")
         , ("node3", "9.10.11.12")
         ]
+      let validators' = peers
+          primaryValidators = [head validators']
+          secondaryValidators = tail validators'
       connections <- traverse (uncurry createConnection)
         [ (peers !! 0, peers !! 1)
         , (peers !! 0, peers !! 2)
         , (peers !! 1, peers !! 2)
         ]
-      let validators' = peers
-          primaryValidators = [head validators']
-          secondaryValidators = tail validators'
-          primaryValidatorAddresses = makeValidators primaryValidators
-          validatorAddresses = makeValidators validators'
-          runForTwoSecondsPrimary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
-          runForTwoSecondsPrimary n pk = fmap snd . execTestPeerOnRound n pk primaryValidatorAddresses . timeout 2000000
-          runForTwoSecondsSecondary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
-          runForTwoSecondsSecondary n pk = fmap snd . execTestPeerOnRound n pk validatorAddresses . timeout 2000000
-          runForTwoSecondsWithContext :: TestContext -> TestContextM a -> IO TestContext
-          runForTwoSecondsWithContext ctx = fmap snd . flip execTestPeerWithContext ctx . timeout 2000000
-          runSequencersPrimary1 = mapConcurrently (\p -> runForTwoSecondsPrimary 0 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) primaryValidators
-          runSequencersSecondary = mapConcurrently (\p -> runForTwoSecondsSecondary 1000 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) secondaryValidators
-          runSequencers1 = concurrently runSequencersPrimary1 runSequencersSecondary
-          runSequencers2 ctxs = mapConcurrently (\(ctx, p) -> runForTwoSecondsWithContext ((sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses) ctx) (_p2pPeerSequencer p)) $ zip ctxs peers
-          runConnections = mapConcurrently (runConnectionWith $ runForTwoSecondsSecondary 0) connections
+      rnRef2 <- _latestRoundNumber . _sequencerContext <$> readTVarIO ((peers !! 1) ^. p2pTestContext)
+      writeIORef rnRef2 1000
+      atomically $ modifyTVar' ((peers !! 1) ^. p2pTestContext)
+                               (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
+      rnRef3 <- _latestRoundNumber . _sequencerContext <$> readTVarIO ((peers !! 2) ^. p2pTestContext)
+      writeIORef rnRef3 1000
+      atomically $ modifyTVar' ((peers !! 2) ^. p2pTestContext)
+                               (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
+      let runForTwoSeconds = void . timeout 5000000
+          runNodes = traverse runNode peers
+          runConnections = traverse runConnection connections
           postTimeoutPrimary1 = do
             threadDelay 1000000
             for_ primaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
@@ -987,9 +1090,13 @@ spec = do
           postTimeoutSecondary = do
             threadDelay 1000000
             for_ secondaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 1000))
-      ctxs1 <- uncurry (++) . fst <$> concurrently runSequencers1 (concurrently runConnections $ concurrently postTimeoutPrimary1 postTimeoutSecondary)
+      runForTwoSeconds $ concurrently_ (concurrently_ runNodes runConnections) (concurrently_ postTimeoutPrimary1 postTimeoutSecondary)
+      ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs1 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just (1 :: Word256) else Just 1000)
-      ctxs2 <- fst <$> concurrently (runSequencers2 ctxs1) (concurrently runConnections $ concurrently postTimeoutPrimary2 postTimeoutSecondary)
+      atomically $ modifyTVar' ((peers !! 2) ^. p2pTestContext)
+                               (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
+      runForTwoSeconds $ concurrently_ (concurrently_ runNodes runConnections) (concurrently_ postTimeoutPrimary2 postTimeoutSecondary)
+      ctxs2 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1001 :: Maybe Word256)
   
   describe "handleEvents" $ do

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -43,13 +43,14 @@ import           Text.Printf
 
 import           BlockApps.Logging
 import           Blockchain.Bagger.BaggerState
+import           Blockchain.Bagger
 import           Blockchain.Blockstanbul
 import           Blockchain.Blockstanbul.HTTPAdmin
 import           Blockchain.Blockstanbul.Messages      (round)
 import           Blockchain.Blockstanbul.StateMachine
 import           Blockchain.Context                    hiding (actionTimestamp, blockHeaders, remainingBlockHeaders)
 import           Blockchain.Data.AddressStateDB
-import           Blockchain.Data.AlternateTransaction  (UnsignedTransaction(..))
+import qualified Blockchain.Data.AlternateTransaction  as U
 import           Blockchain.Data.ArbitraryInstances()
 import           Blockchain.Data.Block                 hiding (bestBlockNumber)
 import           Blockchain.Data.BlockDB()
@@ -58,6 +59,7 @@ import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.Control
 import qualified Blockchain.Data.DataDefs              as DataDefs
 import           Blockchain.Data.Enode
+import           Blockchain.Data.Transaction           (getSigVals)
 import           Blockchain.Data.TransactionDef
 import qualified Blockchain.Data.TXOrigin              as Origin
 import           Blockchain.Data.Wire
@@ -71,7 +73,7 @@ import qualified Blockchain.DB.X509CertDB              as X509
 import "strato-p2p" Blockchain.Event
 import qualified "vm-runner" Blockchain.Event          as VMEvent
 import           Blockchain.MemVMContext               hiding (getMemContext, get, gets, put, modify, modify', dbsGet, dbsGets, dbsPut, dbsModify, dbsModify', contextGet, contextGets, contextPut, contextModify, contextModify')
-import           Blockchain.VMContext                  (IsBlockstanbul(..), baggerState)
+import           Blockchain.VMContext                  (IsBlockstanbul(..), ContextBestBlockInfo(..), baggerState, putContextBestBlockInfo)
 import           Blockchain.Options                    (AuthorizationMode(..))
 import           Blockchain.Privacy
 import qualified Blockchain.Sequencer                  as Seq
@@ -90,9 +92,15 @@ import           Blockchain.Strato.Indexer.P2PIndexer
 import           Blockchain.Strato.Indexer.TxrIndexer
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
+import           Blockchain.Strato.Model.ChainId
+import           Blockchain.Strato.Model.Code
 import           Blockchain.Strato.Model.ExtendedWord
+import           Blockchain.Strato.Model.Gas
 import           Blockchain.Strato.Model.Keccak256
+import           Blockchain.Strato.Model.MicroTime
+import           Blockchain.Strato.Model.Nonce
 import           Blockchain.Strato.Model.Secp256k1
+import           Blockchain.Strato.Model.Wei
 import qualified Blockchain.TxRunResultCache           as TRC
 
 import           Debugger                              (DebugSettings)
@@ -146,6 +154,8 @@ data TestContext = TestContext
   , _pbftMessages          :: S.OSet Keccak256
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
+  , _blockPeriod           :: BlockPeriod
+  , _roundPeriod           :: RoundPeriod
   , _vmContext             :: MemContext
   , _apiChainInfoMap       :: Map Word256 ChainInfo
   }
@@ -394,10 +404,10 @@ instance MonadIO m => Mod.Accessible (TMChan RoundNumber) (MonadTest m) where
   access _ = pure (error "MonadTest: Accessing (TMChan RoundNumber)")
 
 instance MonadIO m => Mod.Accessible BlockPeriod (MonadTest m) where
-  access _ = pure (error "MonadTest: Accessing BlockPeriod")
+  access _ = use blockPeriod
 
 instance MonadIO m => Mod.Accessible RoundPeriod (MonadTest m) where
-  access _ = pure (error "MonadTest: Accessing RoundPeriod")
+  access _ = use roundPeriod
 
 instance MonadIO m => Mod.Accessible (TQueue CandidateReceived) (MonadTest m) where
   access _ = pure (error "MonadTest: Accessing (TQueue CandidateReceived)")
@@ -756,6 +766,8 @@ testContext prv seqCtx vmCtx = TestContext
   , _pbftMessages          = S.empty
   , _unseqEvents           = []
   , _sequencerContext      = seqCtx
+  , _blockPeriod           = BlockPeriod 0
+  , _roundPeriod           = RoundPeriod 0
   , _vmContext             = vmCtx
   , _apiChainInfoMap       = M.empty
   }
@@ -851,64 +863,73 @@ createPeer privKey initialValidators unseqSink name ipAddr = do
   cache <- TRC.new 64
   let cstate = def & txRunResultsCache .~ cache
       vmCtx = MemContext def cstate
+      genesisBlock = DataDefs.BlockData
+        zeroHash
+        zeroHash
+        (Address 0)
+        MP.emptyTriePtr
+        MP.emptyTriePtr
+        MP.emptyTriePtr
+        ""
+        1
+        0
+        100000000000000000000000000
+        1
+        DataPeer.jamshidBirth
+        ""
+        12345
+        zeroHash
+      genHash = rlpHash genesisBlock
+      genesisOutputBlock = OutputBlock
+        { obOrigin              = Origin.API
+        , obTotalDifficulty     = 0
+        , obBlockData           = genesisBlock
+        , obReceiptTransactions = []
+        , obBlockUncles         = []
+        }
   testContextTVar <- newTVarIO $ testContext privKey seqCtx vmCtx
-  let sequencer = runConduit $ sourceTQueue unseqSource
-                            .| mapMC (Seq.runSequencerBatch . (:[]))
-                            .| (awaitForever $ \b -> atomically $ do
-                                  traverse_ (writeTMChan seqP2pSource . Right) $ Seq._toP2p b
-                                  writeTQueue seqVmSource $ Seq._toVm b
-                               )
+  let sequencer = do
+        DBDB.bootstrapGenesisBlock genHash 1
+        A.insert (A.Proxy @EmittedBlock) genHash alreadyEmittedBlock
+        runConduit $ sourceTQueue unseqSource
+                  .| mapMC (Seq.runSequencerBatch . (:[]))
+                  .| (awaitForever $ \b -> atomically $ do
+                        traverse_ (writeTMChan seqP2pSource . Right) $ Seq._toP2p b
+                        writeTQueue seqVmSource $ Seq._toVm b
+                     )
   let vm = do
         MP.initializeBlank
-        let genesisBlock = OutputBlock
-              { obOrigin              = Origin.API
-              , obTotalDifficulty     = 0
-              , obBlockData           = DataDefs.BlockData
-                  zeroHash
-                  zeroHash
-                  (Address 0)
-                  MP.emptyTriePtr
-                  MP.emptyTriePtr
-                  MP.emptyTriePtr
-                  ""
-                  1
-                  0
-                  10000
-                  1
-                  DataPeer.jamshidBirth
-                  ""
-                  12345
-                  zeroHash
-              , obReceiptTransactions = []
-              , obBlockUncles         = []
-              }
-            genHash = rlpHash genesisBlock
         setStateDBStateRoot Nothing MP.emptyTriePtr
+        writeBlockSummary genesisOutputBlock
         (BlockHashRoot bhr) <- bootstrapChainDB genHash [(Nothing, MP.emptyTriePtr)]
         (X509.CertRoot cr) <- X509.bootstrapCertDB genHash
+        putContextBestBlockInfo $ ContextBestBlockInfo (genHash, genesisBlock, 0, 0, 0)
         Mod.put (Mod.Proxy @BlockHashRoot) $ BlockHashRoot bhr
         Mod.put (Mod.Proxy @X509.CertRoot) $ X509.CertRoot cr
+        processNewBestBlock genHash genesisBlock [] -- bootstrap Bagger with genesis block
         runConduit $ sourceTQueue seqVmSource
                   .| (awaitForever $ yield . foldr VMEvent.insertInBatch VMEvent.newInBatch)
                   .| handleVmEvents False
                   .| (awaitForever $ yield . flip VMEvent.insertOutBatch VMEvent.newOutBatch)
-                  .| (awaitForever $ \b -> atomically $ do
-                       traverse_ (writeTQueue unseqSource) $ UnseqEvent . IEBlock . blockToIngestBlock Origin.Quarry . outputBlockToBlock <$> toList (VMEvent.outBlocks b)
-                       writeTQueue apiIndexerSource $ toList (VMEvent.outIndexEvents b)
-                       writeTQueue p2pIndexerSource $ toList (VMEvent.outIndexEvents b)
-                       traverse_ (writeTQueue txrIndexerSource) $ toList (VMEvent.outIndexEvents b)
+                  .| (awaitForever $ \b -> do
+                        $logInfoS (T.pack name <> "/vm") . T.pack $ show $ toList (VMEvent.outEvents b)
+                        atomically $ do
+                          traverse_ (writeTQueue unseqSource) $ UnseqEvent . IEBlock . blockToIngestBlock Origin.Quarry . outputBlockToBlock <$> toList (VMEvent.outBlocks b)
+                          writeTQueue apiIndexerSource $ toList (VMEvent.outIndexEvents b)
+                          writeTQueue p2pIndexerSource $ toList (VMEvent.outIndexEvents b)
+                          traverse_ (writeTQueue txrIndexerSource) $ toList (EventDBEntry <$> toList (VMEvent.outEvents b))
                      )
       apiIndexer' = runConduit $ sourceTQueue apiIndexerSource
                               .| (awaitForever $ \evs -> do
-                                    $logInfoS "testApiIndexer" . T.pack $ show evs
+                                    $logInfoS (T.pack name <> "/testApiIndexer") . T.pack $ show evs
                                     lift $ indexAPI evs)
       p2pIndexer' = runConduit $ sourceTQueue p2pIndexerSource
                               .| (awaitForever $ \evs -> do
-                                    $logInfoS "testP2pIndexer" . T.pack $ show evs
+                                    $logInfoS (T.pack name <> "/testP2pIndexer") . T.pack $ show evs
                                     lift $ indexP2P evs)
       txrIndexer' = runConduit $ sourceTQueue txrIndexerSource
                               .| (awaitForever $ \ev -> do
-                                    $logInfoS "testTxrIndexer" . T.pack $ show ev
+                                    $logInfoS (T.pack name <> "/testTxrIndexer") . T.pack $ show ev
                                     yieldMany $ indexEventToTxrResults ev)
                               .| (awaitForever $ \case
                                     AddMember (Right (cId, addr, enode)) -> do
@@ -921,6 +942,7 @@ createPeer privKey initialValidators unseqSink name ipAddr = do
                                       orgIdChainsMap %= (\m -> case M.lookup (pubKey enode) m of
                                         Nothing -> M.insert (pubKey enode) (OrgIdChains $ Set.singleton cId) m
                                         Just (OrgIdChains s) -> M.insert (pubKey enode) (OrgIdChains $ Set.insert cId s) m)
+                                      atomically . writeTQueue unseqSource . UnseqEvent $ IENewChainMember cId addr enode
                                     RemoveMember (Right (cId, addr)) -> do
                                       mEnode <- join . fmap (M.lookup addr . unChainMembers) <$> use (chainMembersMap . at cId)
                                       chainMembersMap . at cId . _Just %= ChainMembers . M.delete addr . unChainMembers
@@ -934,7 +956,9 @@ createPeer privKey initialValidators unseqSink name ipAddr = do
                                     PutLogDB _ -> pure ()
                                     PutEventDB _ -> pure ()
                                     PutTxResult _ -> pure ()
-                                    _ -> pure ()
+                                    ev -> do
+                                      $logInfoS (T.pack name <> "/testTxrIndexer") . T.pack $ show ev
+                                      pure ()
                                  )
       pubkeystr = BC.unpack $ B16.encode $ B.drop 1 $ exportPublicKey False $ derivePublicKey privKey
       ppeer = DataPeer.buildPeer ( Just pubkeystr
@@ -1148,14 +1172,16 @@ spec = do
         , (peers !! 0, peers !! 2)
         , (peers !! 1, peers !! 2)
         ]
-      let runForTwoSeconds = void . timeout 2000000
+      let runForThreeSeconds = void . timeout 3000000
           src = "pragma solidvm 3.2; contract A { event MemberAdded(address addr, string enode); function addMember(address _addr, string _enode) { emit MemberAdded(_addr, _enode); } }"
           contractName = "A"
           enode1 = readEnode "enode://abcd@1.2.3.4:30303"
-          enode2 = readEnode "enode://abcd@5.6.7.8:30303"
+          enode2 = "enode://abcd@5.6.7.8:30303"
           chainInfo' = ChainInfo
             UnsignedChainInfo { chainLabel     = "My test chain!"
-                              , accountInfo    = [ContractNoStorage (Address 0x100) 10000000000 (SolidVMCode contractName $ hash src)]
+                              , accountInfo    = [ ContractNoStorage (Address 0x100) 1000000000000000000000 (SolidVMCode contractName $ hash src)
+                                                 , NonContract (validators' !! 0) 1000000000000000000000
+                                                 ]
                               , codeInfo       = [CodeInfo "" src $ Just contractName]
                               , members        = M.singleton (validators' !! 0) enode1
                               , parentChain    = Nothing
@@ -1166,17 +1192,17 @@ spec = do
             Nothing
           chainId = keccak256ToWord256 $ rlpHash chainInfo'
       ts <- liftIO getCurrentMicrotime
-      let args = "(" <> T.pack (formatAddressWithoutColor (validators' !! 1)) <> "," <> T.pack enode2 <> ")"
-          utx' = UnsignedTransaction
-            { unsignedTransactionNonce      = 0
-            , unsignedTransactionGasPrice   = 1
-            , unsignedTransactionGasLimit   = 1000000000
-            , unsignedTransactionTo         = (Address 0x100)
-            , unsignedTransactionValue      = 0
-            , unsignedTransactionInitOrData = Code ""
-            , unsignedTransactionChainId    = Just chainId
+      let args = "(0x" <> T.pack (formatAddressWithoutColor (validators' !! 1)) <> ",\"" <> T.pack enode2 <> "\")"
+          utx' = U.UnsignedTransaction
+            { U.unsignedTransactionNonce      = Nonce 0
+            , U.unsignedTransactionGasPrice   = Wei 1
+            , U.unsignedTransactionGasLimit   = Gas 1000000000
+            , U.unsignedTransactionTo         = Just $ Address 0x100
+            , U.unsignedTransactionValue      = Wei 0
+            , U.unsignedTransactionInitOrData = Code ""
+            , U.unsignedTransactionChainId    = Just $ ChainId chainId
             }
-          (Signature (CompactRecSig r s v)) = signMsg $ rlpHash utx'
+          (r, s, v) = getSigVals . signMsg (privKeys !! 0) $ U.rlpHash utx'
           tx' = MessageTX
             { transactionNonce     = 0
             , transactionGasPrice = 1
@@ -1185,8 +1211,8 @@ spec = do
             , transactionValue    = 0
             , transactionData     = ""
             , transactionChainId  = Just chainId
-            , transactionR        = r
-            , transactionS        = s
+            , transactionR        = fromIntegral r
+            , transactionS        = fromIntegral s
             , transactionV        = v
             , transactionMetadata = Just $ M.fromList [("VM","SolidVM"),("funcName","addMember"),("args",args)]
             }
@@ -1196,8 +1222,9 @@ spec = do
             flip postEvent (peers !! 0) . UnseqEvent . IEGenesis $ IngestGenesis Origin.API (chainId, chainInfo')
             threadDelay 500000
             flip postEvent (peers !! 0) $ UnseqEvent ietx
+            for_ peers $ postEvent (TimerFire 0)
 
-      runForTwoSeconds $ concurrently_ (runNetwork peers connections) routine
+      runForThreeSeconds $ concurrently_ (runNetwork peers connections) routine
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at chainId) `shouldBe` (i, if i == 2 then Nothing else Just chainInfo')
   

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module EventSpec where
 
 import           Prelude hiding (round)
@@ -60,6 +61,7 @@ import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.Control
 import qualified Blockchain.Data.DataDefs              as DataDefs
 import           Blockchain.Data.Enode
+import           Blockchain.Data.RLP
 import           Blockchain.Data.Transaction           (getSigVals)
 import           Blockchain.Data.TransactionDef
 import qualified Blockchain.Data.TXOrigin              as Origin
@@ -110,6 +112,7 @@ import           Executable.EthereumVM
 import           Executable.StratoP2PClient
 import           Executable.StratoP2PServer
 
+import           System.IO.Unsafe (unsafePerformIO)
 
 import           Test.Hspec
 import qualified Test.Hspec.Expectations.Lifted        as L
@@ -698,9 +701,15 @@ instance MonadIO m => (Keccak256 `A.Alters` P2P OutputBlock) (MonadTest m) where
   delete _ _ = liftIO . throwIO $ Delete "P2P" "Keccak256" "OutputBlock"
   insert _ _ _ = pure ()
 
+bestBlockRef :: IORef BestBlock
+bestBlockRef = unsafePerformIO . newIORef $ BestBlock zeroHash 0 0
+{-# NOINLINE bestBlockRef #-}
+
 instance MonadIO m => Mod.Modifiable (P2P BestBlock) (MonadTest m) where
   get _          = liftIO . throwIO $ Lookup "P2P" "()" "BestBlock"
-  put _ (P2P bb) = bestBlock .= bb
+  put _ (P2P bb) = do
+    bestBlock .= bb
+    liftIO $ writeIORef bestBlockRef bb
 
 instance MonadIO m => (Word256 `A.Alters` P2P ChainInfo) (MonadTest m) where
   lookup _ _   = liftIO . throwIO $ Lookup "P2P" "Word256" "ChainInfo"
@@ -848,6 +857,11 @@ runNode p =
 postEvent :: SeqLoopEvent -> P2PPeer -> IO ()
 postEvent e p = atomically $ writeTQueue (_p2pPeerUnseqSource p) e
 
+instance (MP.StateRoot `A.Alters` MP.NodeData) (State.State (a, Map MP.StateRoot MP.NodeData)) where
+  lookup _ k   = M.lookup k <$> State.gets snd
+  insert _ k v = State.modify' $ \(a, b) -> (a, M.insert k v b)
+  delete _ k   = State.modify' $ \(a, b) -> (a, M.delete k b)
+
 createPeer :: PrivateKey
            -> [Address]
            -> ([IngestEvent] -> TestContextM ())
@@ -863,13 +877,21 @@ createPeer privKey initialValidators unseqSink name ipAddr = do
   txrIndexerSource <- newTQueueIO
   seqCtx <- newSequencerContext $ newBlockstanbulContext (fromPrivateKey privKey) initialValidators
   cache <- TRC.new 64
+  let (stateRoot, mpMap) = flip State.execState (MP.emptyTriePtr, M.empty :: Map MP.StateRoot MP.NodeData) $ do
+        MP.initializeBlank
+        for_ initialValidators $ \addr -> do
+          sr <- State.gets fst
+          let key = addressAsNibbleString addr
+              val = rlpEncode . rlpSerialize . rlpEncode $ blankAddressState{addressStateBalance = 1000000000000000000000000}
+          sr' <- MP.putKeyVal sr key val
+          State.modify' $ \(_,b) -> (sr',b)
   let cstate = def & txRunResultsCache .~ cache
       vmCtx = MemContext def cstate
       genesisBlock = DataDefs.BlockData
         zeroHash
         zeroHash
         (Address 0)
-        MP.emptyTriePtr
+        stateRoot
         MP.emptyTriePtr
         MP.emptyTriePtr
         ""
@@ -911,9 +933,10 @@ createPeer privKey initialValidators unseqSink name ipAddr = do
                      )
   let vm = do
         MP.initializeBlank
-        setStateDBStateRoot Nothing MP.emptyTriePtr
+        setStateDBStateRoot Nothing stateRoot
         writeBlockSummary genesisOutputBlock
-        (BlockHashRoot bhr) <- bootstrapChainDB genHash [(Nothing, MP.emptyTriePtr)]
+        for_ (M.toList mpMap) $ \(k,v) -> A.insert (A.Proxy @MP.NodeData) k v
+        (BlockHashRoot bhr) <- bootstrapChainDB genHash [(Nothing, stateRoot)]
         (X509.CertRoot cr) <- X509.bootstrapCertDB genHash
         putContextBestBlockInfo $ ContextBestBlockInfo (genHash, genesisBlock, 0, 0, 0)
         Mod.put (Mod.Proxy @BlockHashRoot) $ BlockHashRoot bhr
@@ -1287,8 +1310,7 @@ contract A {
         , (peers !! 0, peers !! 2)
         , (peers !! 1, peers !! 2)
         ]
-      let runForThirtySeconds = void . timeout 60000000
-          src = [r|
+      let src = [r|
 pragma solidvm 3.2;
 contract A {
   event MemberAdded(address addr, string enode);
@@ -1317,7 +1339,7 @@ contract B {
           enode1 = readEnode "enode://abcd@1.2.3.4:30303"
           enode2 = readEnode "enode://abcd@5.6.7.8:30303"
           enode3 = "enode://abcd@9.10.11.12:30303"
-          chainInfo' = ChainInfo
+          mkChainInfo bHash = ChainInfo
             UnsignedChainInfo { chainLabel     = "My test chain!"
                               , accountInfo    = [ ContractNoStorage (Address 0x100) 1000000000000000000000 (SolidVMCode contractName $ hash src)
                                                  , NonContract (validators' !! 0) 1000000000000000000000
@@ -1328,15 +1350,15 @@ contract B {
                                                             , (validators' !! 1, enode2)
                                                             ]
                               , parentChain    = Nothing
-                              , creationBlock  = zeroHash
+                              , creationBlock  = bHash
                               , chainNonce     = 123456789
                               , chainMetadata  = M.singleton "VM" "SolidVM"
                               }
             Nothing
-          chainId = keccak256ToWord256 $ rlpHash chainInfo'
+          mkChainId = keccak256ToWord256 . rlpHash
       ts <- liftIO getCurrentMicrotime
       let incXArgs = "()"
-          incXUtx = U.UnsignedTransaction
+          incXUtx chainId = U.UnsignedTransaction
             { U.unsignedTransactionNonce      = Nonce 0
             , U.unsignedTransactionGasPrice   = Wei 1
             , U.unsignedTransactionGasLimit   = Gas 1000000000
@@ -1345,18 +1367,18 @@ contract B {
             , U.unsignedTransactionInitOrData = Code ""
             , U.unsignedTransactionChainId    = Just $ ChainId chainId
             }
-          incXUtx0 = incXUtx
-          incXUtx1 = incXUtx{U.unsignedTransactionNonce = Nonce 1}
-          incXUtx2 = incXUtx{U.unsignedTransactionNonce = Nonce 2}
-          incXUtx3 = incXUtx{U.unsignedTransactionNonce = Nonce 3}
-          incXUtx4 = incXUtx{U.unsignedTransactionNonce = Nonce 4}
+          incXUtx0 chainId = (incXUtx chainId) 
+          incXUtx1 chainId = (incXUtx chainId){U.unsignedTransactionNonce = Nonce 1}
+          incXUtx2 chainId = (incXUtx chainId){U.unsignedTransactionNonce = Nonce 2}
+          incXUtx3 chainId = (incXUtx chainId){U.unsignedTransactionNonce = Nonce 3}
+          incXUtx4 chainId = (incXUtx chainId){U.unsignedTransactionNonce = Nonce 4}
           txMd = M.fromList [("funcName","incX"),("args",incXArgs)]
           addMd t = t{transactionMetadata = M.union txMd <$> transactionMetadata t}
-          incXTx0 = addMd $ mkSignedTx (privKeys !! 0) incXUtx0
-          incXTx1 = addMd $ mkSignedTx (privKeys !! 0) incXUtx1
-          incXTx2 = addMd $ mkSignedTx (privKeys !! 0) incXUtx2
-          incXTx3 = addMd $ mkSignedTx (privKeys !! 0) incXUtx3
-          incXTx4 = addMd $ mkSignedTx (privKeys !! 0) incXUtx4
+          incXTx0 = addMd . mkSignedTx (privKeys !! 0) . incXUtx0
+          incXTx1 = addMd . mkSignedTx (privKeys !! 0) . incXUtx1
+          incXTx2 = addMd . mkSignedTx (privKeys !! 0) . incXUtx2
+          incXTx3 = addMd . mkSignedTx (privKeys !! 0) . incXUtx3
+          incXTx4 = addMd . mkSignedTx (privKeys !! 0) . incXUtx4
       let mainChainArgs = "()"
           mainChainUtx = U.UnsignedTransaction
             { U.unsignedTransactionNonce      = Nonce 0
@@ -1371,8 +1393,10 @@ contract B {
           mainChainAddMd t = t{transactionMetadata = M.union mainChainTxMd <$> transactionMetadata t}
           mkMainChainTx n = let utx = mainChainUtx{U.unsignedTransactionNonce = Nonce n}
                              in mainChainAddMd $ mkSignedTx (privKeys !! 0) utx
+      cIdRef <- newIORef undefined
+      cInfoRef <- newIORef undefined
       let addMemberArgs = "(0x" <> T.pack (formatAddressWithoutColor (validators' !! 2)) <> ",\"" <> T.pack enode3 <> "\")"
-          addMemberUtx = U.UnsignedTransaction
+          addMemberUtx chainId = U.UnsignedTransaction
             { U.unsignedTransactionNonce      = Nonce 5
             , U.unsignedTransactionGasPrice   = Wei 1
             , U.unsignedTransactionGasLimit   = Gas 1000000000
@@ -1383,46 +1407,49 @@ contract B {
             }
           addMemberTxMd = M.fromList [("funcName","addMember"),("args",addMemberArgs)]
           addMemberMd t = t{transactionMetadata = M.union addMemberTxMd <$> transactionMetadata t}
-          addMemberTx = addMemberMd $ mkSignedTx (privKeys !! 0) addMemberUtx
+          addMemberTx cId = addMemberMd $ mkSignedTx (privKeys !! 0) (addMemberUtx cId)
           toIetx = IETx ts . IngestTx Origin.API
+          mainChainRoutine n = do
+            threadDelay 200000
+            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx n
+            mainChainRoutine $ n + 1
           routine = do
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . IEGenesis $ IngestGenesis Origin.API (chainId, chainInfo')
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx0
+            threadDelay 5000000
             for_ peers $ postEvent (TimerFire 0)
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 0
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 1
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 2
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 3
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 4
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx1
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 5
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx2
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 6
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx3
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 7
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx4
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 8
-            threadDelay 2000000
-            flip postEvent (peers !! 0) . UnseqEvent $ toIetx addMemberTx
-
-      runForThirtySeconds $ concurrently_ (runNetwork peers connections) routine
+            threadDelay 5000000
+            bHash <- bestBlockHash <$> readIORef bestBlockRef
+            let cInfo = mkChainInfo bHash
+                cId = mkChainId cInfo
+            writeIORef cIdRef cId
+            writeIORef cInfoRef cInfo
+            flip postEvent (peers !! 0) . UnseqEvent . IEGenesis $ IngestGenesis Origin.API (cId, cInfo)
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx0 cId
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx1 cId
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx2 cId
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx3 cId
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx4 cId
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ addMemberTx cId
+          
+      void . timeout 60000000 $ concurrently_ (runNetwork peers connections) (concurrently_ routine $ mainChainRoutine 0)
+      cId <- readIORef cIdRef
+      cInfo <- readIORef cInfoRef
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
-      ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at chainId) `shouldBe` (i, Just chainInfo')
+      ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at cId) `shouldBe` (i, Just cInfo)
+      --privKey4 <- newPrivateKey
+      --peer4 <- createPeer privKey4 validators' unseqSink "node4" "13.14.15.16"
+      --let peers' = peers ++ [peer4]
+      --connections4 <- traverse (uncurry createConnection)
+      --  [ (peers' !! 0, peers' !! 3)
+      --  , (peers' !! 1, peers' !! 3)
+      --  , (peers' !! 2, peers' !! 3)
+      --  ]
+      --let connections' = connections ++ connections4
   
   describe "handleEvents" $ do
     it "should pong a ping" $

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -595,7 +595,7 @@ instance MonadIO m => (MP.StateRoot `A.Alters` MP.NodeData) (MonadTest m) where
   insert _ sr nd = dbsModify' $ stateDB . at sr ?~ nd
   delete _ sr    = dbsModify' $ stateDB . at sr .~ Nothing
 
-instance MonadIO m => (Account `A.Alters` AddressState) (MonadTest m) where
+instance (MonadIO m, MonadLogger m) => (Account `A.Alters` AddressState) (MonadTest m) where
   lookup _ = getAddressStateMaybe
   insert _ = putAddressState
   delete _ = deleteAddressState
@@ -646,7 +646,7 @@ instance MonadIO m => HasMemRawStorageDB (MonadTest m) where
   getMemRawStorageBlockDB = gets $ Lens.view $ memDBs . storageBlockMap
   putMemRawStorageBlockMap theMap = modify $ memDBs . storageBlockMap .~ theMap
 
-instance MonadIO m => (RawStorageKey `A.Alters` RawStorageValue) (MonadTest m) where
+instance (MonadIO m, MonadLogger m) => (RawStorageKey `A.Alters` RawStorageValue) (MonadTest m) where
   lookup _ = genericLookupRawStorageDB
   insert _ = genericInsertRawStorageDB
   delete _ = genericDeleteRawStorageDB
@@ -1287,7 +1287,7 @@ contract A {
         , (peers !! 0, peers !! 2)
         , (peers !! 1, peers !! 2)
         ]
-      let runForThirtySeconds = void . timeout 30000000
+      let runForThirtySeconds = void . timeout 60000000
           src = [r|
 pragma solidvm 3.2;
 contract A {
@@ -1386,38 +1386,38 @@ contract B {
           addMemberTx = addMemberMd $ mkSignedTx (privKeys !! 0) addMemberUtx
           toIetx = IETx ts . IngestTx Origin.API
           routine = do
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . IEGenesis $ IngestGenesis Origin.API (chainId, chainInfo')
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx0
             for_ peers $ postEvent (TimerFire 0)
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 0
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 1
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 2
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 3
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 4
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx1
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 5
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx2
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 6
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx3
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 7
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx incXTx4
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent . toIetx $ mkMainChainTx 8
-            threadDelay 500000
+            threadDelay 2000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx addMemberTx
 
       runForThirtySeconds $ concurrently_ (runNetwork peers connections) routine

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -107,8 +107,6 @@ import           Test.QuickCheck
 import           UnliftIO
 import           UnliftIO.Concurrent                   (threadDelay)
 
-type WMRef = IORef (S.OSet Keccak256)
-
 data TestContext = TestContext
   { _blocks                :: [Block]
   , _blockHeaders          :: [DataDefs.BlockData]
@@ -131,7 +129,7 @@ data TestContext = TestContext
   , _genesisBlockHash      :: GenesisBlockHash
   , _bestBlockNumber       :: BestBlockNumber
   , _stringPPeerMap        :: Map String DataPeer.PPeer
-  , _pbftMessages          :: WMRef
+  , _pbftMessages          :: S.OSet Keccak256
   , _outboundPbftMessages  :: S.OSet (Text, Keccak256)
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
@@ -140,13 +138,16 @@ data TestContext = TestContext
 
 makeLenses ''TestContext
 
-type TestContextM = ReaderT (IORef TestContext) (ResourceT (LoggingT IO))
+type TestContextM = ReaderT (TVar TestContext) (ResourceT (LoggingT IO))
 
-type MonadTest m = ReaderT (IORef TestContext) m
+type MonadTest m = ReaderT (TVar TestContext) m
 
 instance {-# OVERLAPPING #-} MonadIO m => State.MonadState TestContext (MonadTest m) where
-  state f = ask >>= liftIO . flip atomicModifyIORef' (swap . f)
-    where swap ~(a,b) = (b,a)
+  state f = ask >>= \ctx -> liftIO . atomically $ do
+    s <- readTVar ctx
+    let (a, s') = f s
+    writeTVar ctx s'
+    pure a
 
 instance MonadIO m => Stacks Block (MonadTest m) where
   takeStack _ n = take n <$> use blocks
@@ -353,14 +354,13 @@ instance MonadIO m => HasVault (MonadTest m) where
 
 instance MonadIO m => (Keccak256 `A.Alters` (A.Proxy (Inbound WireMessage))) (MonadTest m) where
   lookup _  k = do
-    wms <- readIORef =<< use pbftMessages
+    wms <- use pbftMessages
     pure $ if S.member k wms then Just (A.Proxy @(Inbound WireMessage)) else Nothing
-  insert _ k _ = use pbftMessages >>= flip atomicModifyIORef' (\wms ->
+  insert _ k _ = pbftMessages %= (\wms ->
     let s = S.size wms
         wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
-        wms'' = wms' S.>| k
-     in (wms'', ()))
-  delete _ k = use pbftMessages >>= flip atomicModifyIORef' (\wms -> (S.delete k wms, ()))
+     in wms' S.>| k)
+  delete _ k = pbftMessages %= S.delete k
 
 instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessage))) (MonadTest m) where
   lookup _  k = do
@@ -375,7 +375,7 @@ instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessa
   delete _ k = outboundPbftMessages %= S.delete k
 
 getMemContext :: MonadIO m => MonadTest m MemContext
-getMemContext = ask >>= fmap _vmContext . readIORef
+getMemContext = ask >>= fmap _vmContext . readTVarIO
 
 get :: MonadIO m => MonadTest m ContextState
 get = _state <$> getMemContext
@@ -386,15 +386,15 @@ gets f = f <$> get
 {-# INLINE gets #-}
 
 put :: MonadIO m => ContextState -> MonadTest m ()
-put c = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . state .~ c)
+put c = ask >>= \i -> atomically . modifyTVar' i $ vmContext . state .~ c
 {-# INLINE put #-}
 
 modify :: MonadIO m => (ContextState -> ContextState) -> MonadTest m ()
-modify f = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . state %~ f)
+modify f = ask >>= \i -> atomically . modifyTVar' i $ vmContext . state %~ f
 {-# INLINE modify #-}
 
 modify' :: MonadIO m => (ContextState -> ContextState) -> MonadTest m ()
-modify' f = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . state %~ f)
+modify' f = ask >>= \i -> atomically . modifyTVar' i $ vmContext . state %~ f
 {-# INLINE modify' #-}
 
 dbsGet :: MonadIO m => MonadTest m MemContextDBs
@@ -406,15 +406,15 @@ dbsGets f = f <$> dbsGet
 {-# INLINE dbsGets #-}
 
 dbsPut :: MonadIO m => MemContextDBs -> (MonadTest m) ()
-dbsPut c = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . dbs .~ c)
+dbsPut c = ask >>= \i -> atomically . modifyTVar' i $ vmContext . dbs .~ c
 {-# INLINE dbsPut #-}
 
 dbsModify :: MonadIO m => (MemContextDBs -> MemContextDBs) -> MonadTest m ()
-dbsModify f = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . dbs %~ f)
+dbsModify f = ask >>= \i -> atomically . modifyTVar' i $ vmContext . dbs %~ f
 {-# INLINE dbsModify #-}
 
 dbsModify' :: MonadIO m => (MemContextDBs -> MemContextDBs) -> MonadTest m ()
-dbsModify' f = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . dbs %~ f)
+dbsModify' f = ask >>= \i -> atomically . modifyTVar' i $ vmContext . dbs %~ f
 {-# INLINE dbsModify' #-}
 
 contextGet :: MonadIO m => MonadTest m ContextState
@@ -457,15 +457,6 @@ instance MonadIO m => Mod.Accessible MemDBs (MonadTest m) where
 instance MonadIO m => Mod.Modifiable MemDBs (MonadTest m) where
   get _    = gets $ Lens.view memDBs
   put _ md = modify $ memDBs .~ md
-
-vmBlockHashRootKey :: B.ByteString
-vmBlockHashRootKey = "block_hash_root"
-
-vmGenesisRootKey :: B.ByteString
-vmGenesisRootKey = "genesis_root"
-
-vmBestBlockRootKey :: B.ByteString
-vmBestBlockRootKey = "best_block_root"
 
 instance MonadIO m => Mod.Modifiable BlockHashRoot (MonadTest m) where
   get _     = dbsGets $ Lens.view blockHashRoot
@@ -655,8 +646,8 @@ newSequencerContext bc = do
 
 -- testContext is useful for testing because it doesn't require
 -- Kafka, postgres, redis, or ethconf.
-testContext :: WMRef -> PrivateKey -> SequencerContext -> MemContext -> TestContext
-testContext wireMessagesRef prv seqCtx vmCtx = TestContext
+testContext :: PrivateKey -> SequencerContext -> MemContext -> TestContext
+testContext prv seqCtx vmCtx = TestContext
   { _blocks                = []
   , _blockHeaders          = []
   , _remainingBlockHeaders = RemainingBlockHeaders []
@@ -678,7 +669,7 @@ testContext wireMessagesRef prv seqCtx vmCtx = TestContext
   , _genesisBlockHash      = GenesisBlockHash zeroHash
   , _bestBlockNumber       = BestBlockNumber 0
   , _stringPPeerMap        = M.empty
-  , _pbftMessages          = wireMessagesRef
+  , _pbftMessages          = S.empty
   , _outboundPbftMessages  = S.empty
   , _unseqEvents           = []
   , _sequencerContext      = seqCtx
@@ -694,12 +685,10 @@ runTestPeer f = do
   cache <- TRC.new 64
   let cstate = def & txRunResultsCache .~ cache
       vmCtx = MemContext def cstate
-  wmr <- newIORef (S.empty)
-  ctx <- newIORef $ testContext wmr undefined seqCtx vmCtx
+  ctx <- newTVarIO $ testContext undefined seqCtx vmCtx
   void . runNoLoggingT . runResourceT $ runReaderT f ctx
 
 execTestPeer :: PrivateKey
-             -> WMRef
              -> [Address]
              -> TestContextM a
              -> IO (a, TestContext)
@@ -707,31 +696,29 @@ execTestPeer = execTestPeerOnRound 0
 
 execTestPeerOnRound :: Word256
                     -> PrivateKey
-                    -> WMRef
                     -> [Address]
                     -> TestContextM a
                     -> IO (a, TestContext)
-execTestPeerOnRound n pk wmr as f = do
+execTestPeerOnRound n pk as f = do
   seqCtx <- newSequencerContext $ (view . round .~ n) (newBlockstanbulContext (fromPrivateKey pk) as)
   cache <- TRC.new 64
   let cstate = def & txRunResultsCache .~ cache
       vmCtx = MemContext def cstate
-  ctx <- newIORef $ testContext wmr pk seqCtx vmCtx
+  ctx <- newTVarIO $ testContext pk seqCtx vmCtx
   a <- runLoggingT . runResourceT $ runReaderT f ctx
-  ctx' <- readIORef ctx
+  ctx' <- readTVarIO ctx
   return (a, ctx')
 
 execTestPeerWithContext :: TestContextM a -> TestContext -> IO (a, TestContext)
 execTestPeerWithContext f ctx = do
-  ref <- newIORef ctx
+  ref <- newTVarIO ctx
   a <- runLoggingT . runResourceT $ runReaderT f ref
-  ctx' <- readIORef ref
+  ctx' <- readTVarIO ref
   return (a, ctx')
 
 data P2PPeer m = P2PPeer
   { _p2pPeerPrivKey     :: PrivateKey
   , _p2pPeerPPeer       :: DataPeer.PPeer
-  , _p2pPeerWireMessageRef :: WMRef
   , _p2pPeerUnseqSource :: TQueue SeqLoopEvent
   , _p2pPeerSeqP2pSource :: TMChan (Either TxrResult P2pEvent)
   , _p2pPeerSeqVmSource :: TQueue [VmEvent]
@@ -759,6 +746,7 @@ createPeer :: ( Seq.MonadSequencer m
               , Mod.Modifiable (P2P BestBlock) m
               , (Word256 `A.Alters` P2P ChainInfo) m
               , (Word256 `A.Alters` P2P ChainMembers) m
+              , State.MonadState TestContext m
               )
            => ([IngestEvent] -> m ())
            -> String
@@ -766,7 +754,6 @@ createPeer :: ( Seq.MonadSequencer m
            -> IO (P2PPeer m)
 createPeer unseqSink name ipAddr = do
   privKey <- newPrivateKey
-  wmr <- newIORef (S.empty)
   unseqSource <- newTQueueIO
   seqP2pSource <- newBroadcastTMChanIO
   seqVmSource <- newTQueueIO
@@ -796,8 +783,22 @@ createPeer unseqSink name ipAddr = do
       txrIndexer' = runConduit $ sourceTQueue txrIndexerSource
                               .| (awaitForever $ yieldMany . indexEventToTxrResults)
                               .| (awaitForever $ \case
-                                    AddMember _ -> pure () --(Right (cId, addr, enode)) -> pure ()
-                                    RemoveMember _ -> pure () --(Right (cId, addr)) -> pure ()
+                                    AddMember (Right (cId, addr, enode)) -> do
+                                      chainMembersMap %= (\m -> case M.lookup cId m of
+                                        Nothing -> M.insert cId (ChainMembers $ M.singleton addr enode) m
+                                        Just (ChainMembers cm) -> M.insert cId (ChainMembers $ M.insert addr enode cm) m)
+                                      ipAddressIpChainsMap %= (\m -> case M.lookup (ipAddress enode) m of
+                                        Nothing -> M.insert (ipAddress enode) (IPChains $ Set.singleton cId) m
+                                        Just (IPChains s) -> M.insert (ipAddress enode) (IPChains $ Set.insert cId s) m)
+                                      orgIdChainsMap %= (\m -> case M.lookup (pubKey enode) m of
+                                        Nothing -> M.insert (pubKey enode) (OrgIdChains $ Set.singleton cId) m
+                                        Just (OrgIdChains s) -> M.insert (pubKey enode) (OrgIdChains $ Set.insert cId s) m)
+                                    RemoveMember (Right (cId, addr)) -> do
+                                      mEnode <- join . fmap (M.lookup addr . unChainMembers) <$> use (chainMembersMap . at cId)
+                                      chainMembersMap . at cId . _Just %= ChainMembers . M.delete addr . unChainMembers
+                                      for_ mEnode $ \enode -> do
+                                        ipAddressIpChainsMap . at (ipAddress enode) . _Just %= IPChains . Set.delete cId . unIPChains
+                                        orgIdChainsMap . at (pubKey enode) . _Just %= OrgIdChains . Set.delete cId . unOrgIdChains
                                     RegisterCertificate _ -> pure () --(Right (addr, certState)) -> pure ()
                                     CertificateRevoked _ -> pure () --(Right addr) -> pure ()
                                     CertificateRegistryInitialized _ -> pure () --(Right ()) -> pure ()
@@ -805,6 +806,7 @@ createPeer unseqSink name ipAddr = do
                                     PutLogDB _ -> pure ()
                                     PutEventDB _ -> pure ()
                                     PutTxResult _ -> pure ()
+                                    _ -> pure ()
                                  )
       pubkeystr = BC.unpack $ B16.encode $ B.drop 1 $ exportPublicKey False $ derivePublicKey privKey
       ppeer = DataPeer.buildPeer ( Just pubkeystr
@@ -817,7 +819,6 @@ createPeer unseqSink name ipAddr = do
   pure $ P2PPeer
     privKey
     ppeer
-    wmr
     unseqSource
     seqP2pSource
     seqVmSource
@@ -870,14 +871,14 @@ createConnection server client = do
     runServer
     runClient
 
-runConnectionWith :: (PrivateKey -> WMRef -> m (Maybe SomeException) -> IO b) 
+runConnectionWith :: (PrivateKey -> m (Maybe SomeException) -> IO b) 
                   -> P2PConnection m 
                   -> IO (b, b)
 runConnectionWith f connection =
   let server = _serverP2PPeer connection
       client = _clientP2PPeer connection
-      runServer = f (_p2pPeerPrivKey server) (_p2pPeerWireMessageRef server) $ _runServer connection
-      runClient = f (_p2pPeerPrivKey client) (_p2pPeerWireMessageRef client) $ _runClient connection
+      runServer = f (_p2pPeerPrivKey server) $ _runServer connection
+      runClient = f (_p2pPeerPrivKey client) $ _runClient connection
    in concurrently runServer runClient
 
 makeValidators :: [P2PPeer m] -> [Address]
@@ -905,7 +906,7 @@ spec = do
             ContractCreationTX{} -> tx{transactionChainId = Nothing}
             PrivateHashTX{} -> tx
       otx <- (\o -> o{otBaseTx = clearChainId (otBaseTx o), otOrigin = Origin.API}) <$> liftIO (generate arbitrary)
-      let runForTwoSeconds pk wmr = execTestPeer pk wmr validatorAddresses . timeout 2000000
+      let runForTwoSeconds pk = execTestPeer pk validatorAddresses . timeout 2000000
           run = runConnectionWith runForTwoSeconds connection
           postTx = threadDelay 500000 >> (atomically $ writeTMChan (_p2pPeerSeqP2pSource server) (Right $ P2pTx otx))
       ((_, serverCtx), (_, clientCtx)) <- fst <$> concurrently run postTx
@@ -938,9 +939,9 @@ spec = do
         ]
       let validators' = take 2 peers
           validatorAddresses = makeValidators validators'
-          runForTwoSeconds :: PrivateKey -> WMRef -> TestContextM a -> IO TestContext
-          runForTwoSeconds pk wmr = fmap snd . execTestPeer pk wmr validatorAddresses . timeout 2000000
-          runSequencers = mapConcurrently (\p -> runForTwoSeconds (_p2pPeerPrivKey p) (_p2pPeerWireMessageRef p) (_p2pPeerSequencer p)) peers
+          runForTwoSeconds :: PrivateKey -> TestContextM a -> IO TestContext
+          runForTwoSeconds pk = fmap snd . execTestPeer pk validatorAddresses . timeout 2000000
+          runSequencers = mapConcurrently (\p -> runForTwoSeconds (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) peers
           runConnections = mapConcurrently (runConnectionWith runForTwoSeconds) connections
           postTimeout = do
             threadDelay 1000000
@@ -966,14 +967,14 @@ spec = do
           secondaryValidators = tail validators'
           primaryValidatorAddresses = makeValidators primaryValidators
           validatorAddresses = makeValidators validators'
-          runForTwoSecondsPrimary :: Word256 -> PrivateKey -> WMRef -> TestContextM a -> IO TestContext
-          runForTwoSecondsPrimary n pk wmr = fmap snd . execTestPeerOnRound n pk wmr primaryValidatorAddresses . timeout 2000000
-          runForTwoSecondsSecondary :: Word256 -> PrivateKey -> WMRef -> TestContextM a -> IO TestContext
-          runForTwoSecondsSecondary n pk wmr = fmap snd . execTestPeerOnRound n pk wmr validatorAddresses . timeout 2000000
+          runForTwoSecondsPrimary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
+          runForTwoSecondsPrimary n pk = fmap snd . execTestPeerOnRound n pk primaryValidatorAddresses . timeout 2000000
+          runForTwoSecondsSecondary :: Word256 -> PrivateKey -> TestContextM a -> IO TestContext
+          runForTwoSecondsSecondary n pk = fmap snd . execTestPeerOnRound n pk validatorAddresses . timeout 2000000
           runForTwoSecondsWithContext :: TestContext -> TestContextM a -> IO TestContext
           runForTwoSecondsWithContext ctx = fmap snd . flip execTestPeerWithContext ctx . timeout 2000000
-          runSequencersPrimary1 = mapConcurrently (\p -> runForTwoSecondsPrimary 0 (_p2pPeerPrivKey p) (_p2pPeerWireMessageRef p) (_p2pPeerSequencer p)) primaryValidators
-          runSequencersSecondary = mapConcurrently (\p -> runForTwoSecondsSecondary 1000 (_p2pPeerPrivKey p) (_p2pPeerWireMessageRef p) (_p2pPeerSequencer p)) secondaryValidators
+          runSequencersPrimary1 = mapConcurrently (\p -> runForTwoSecondsPrimary 0 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) primaryValidators
+          runSequencersSecondary = mapConcurrently (\p -> runForTwoSecondsSecondary 1000 (_p2pPeerPrivKey p) (_p2pPeerSequencer p)) secondaryValidators
           runSequencers1 = concurrently runSequencersPrimary1 runSequencersSecondary
           runSequencers2 ctxs = mapConcurrently (\(ctx, p) -> runForTwoSecondsWithContext ((sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses) ctx) (_p2pPeerSequencer p)) $ zip ctxs peers
           runConnections = mapConcurrently (runConnectionWith $ runForTwoSecondsSecondary 0) connections

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -49,6 +49,7 @@ import           Blockchain.Blockstanbul.Messages      (round)
 import           Blockchain.Blockstanbul.StateMachine
 import           Blockchain.Context                    hiding (actionTimestamp, blockHeaders, remainingBlockHeaders)
 import           Blockchain.Data.AddressStateDB
+import           Blockchain.Data.AlternateTransaction  (UnsignedTransaction(..))
 import           Blockchain.Data.ArbitraryInstances()
 import           Blockchain.Data.Block                 hiding (bestBlockNumber)
 import           Blockchain.Data.BlockDB()
@@ -1132,6 +1133,73 @@ spec = do
       runForTwoSeconds $ concurrently_ (runNetwork peers connections) (concurrently_ postTimeoutPrimary2 postTimeoutSecondary)
       ctxs2 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs2 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 1001 :: Maybe Word256)
+
+    it "can add a new now to a chain" $ do
+      let unseqSink = (unseqEvents %=) . (++)
+      privKeys <- traverse (const newPrivateKey) [(1 :: Integer)..3]
+      let validators' = makeValidators privKeys
+      peers <- traverse (\(p,(n,i)) -> createPeer p validators' unseqSink n i) $ zip privKeys
+        [ ("node1", "1.2.3.4")
+        , ("node2", "5.6.7.8")
+        , ("node3", "9.10.11.12")
+        ]
+      connections <- traverse (uncurry createConnection)
+        [ (peers !! 0, peers !! 1)
+        , (peers !! 0, peers !! 2)
+        , (peers !! 1, peers !! 2)
+        ]
+      let runForTwoSeconds = void . timeout 2000000
+          src = "pragma solidvm 3.2; contract A { event MemberAdded(address addr, string enode); function addMember(address _addr, string _enode) { emit MemberAdded(_addr, _enode); } }"
+          contractName = "A"
+          enode1 = readEnode "enode://abcd@1.2.3.4:30303"
+          enode2 = readEnode "enode://abcd@5.6.7.8:30303"
+          chainInfo' = ChainInfo
+            UnsignedChainInfo { chainLabel     = "My test chain!"
+                              , accountInfo    = [ContractNoStorage (Address 0x100) 10000000000 (SolidVMCode contractName $ hash src)]
+                              , codeInfo       = [CodeInfo "" src $ Just contractName]
+                              , members        = M.singleton (validators' !! 0) enode1
+                              , parentChain    = Nothing
+                              , creationBlock  = zeroHash
+                              , chainNonce     = 123456789
+                              , chainMetadata  = M.singleton "VM" "SolidVM"
+                              }
+            Nothing
+          chainId = keccak256ToWord256 $ rlpHash chainInfo'
+      ts <- liftIO getCurrentMicrotime
+      let args = "(" <> T.pack (formatAddressWithoutColor (validators' !! 1)) <> "," <> T.pack enode2 <> ")"
+          utx' = UnsignedTransaction
+            { unsignedTransactionNonce      = 0
+            , unsignedTransactionGasPrice   = 1
+            , unsignedTransactionGasLimit   = 1000000000
+            , unsignedTransactionTo         = (Address 0x100)
+            , unsignedTransactionValue      = 0
+            , unsignedTransactionInitOrData = Code ""
+            , unsignedTransactionChainId    = Just chainId
+            }
+          (Signature (CompactRecSig r s v)) = signMsg $ rlpHash utx'
+          tx' = MessageTX
+            { transactionNonce     = 0
+            , transactionGasPrice = 1
+            , transactionGasLimit = 1000000000
+            , transactionTo       = (Address 0x100)
+            , transactionValue    = 0
+            , transactionData     = ""
+            , transactionChainId  = Just chainId
+            , transactionR        = r
+            , transactionS        = s
+            , transactionV        = v
+            , transactionMetadata = Just $ M.fromList [("VM","SolidVM"),("funcName","addMember"),("args",args)]
+            }
+          ietx = IETx ts $ IngestTx Origin.API tx'
+          routine = do
+            threadDelay 500000
+            flip postEvent (peers !! 0) . UnseqEvent . IEGenesis $ IngestGenesis Origin.API (chainId, chainInfo')
+            threadDelay 500000
+            flip postEvent (peers !! 0) $ UnseqEvent ietx
+
+      runForTwoSeconds $ concurrently_ (runNetwork peers connections) routine
+      ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
+      ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at chainId) `shouldBe` (i, if i == 2 then Nothing else Just chainInfo')
   
   describe "handleEvents" $ do
     it "should pong a ping" $
@@ -1154,44 +1222,6 @@ spec = do
         -- Now that the peer is known to be addr, we should only send if they are designated
         shouldSendToPeer addr `L.shouldReturn` True
         shouldSendToPeer 0xa `L.shouldReturn` False
-
-    it "Can index a ChainInfo" $ do
-      let unseqSink = (unseqEvents %=) . (++)
-      privKeys <- traverse (const newPrivateKey) [(1 :: Integer)..3]
-      let validators' = makeValidators privKeys
-      peers <- traverse (\(p,(n,i)) -> createPeer p validators' unseqSink n i) $ zip privKeys
-        [ ("node1", "1.2.3.4")
-        , ("node2", "5.6.7.8")
-        , ("node3", "9.10.11.12")
-        ]
-      connections <- traverse (uncurry createConnection)
-        [ (peers !! 0, peers !! 1)
-        , (peers !! 0, peers !! 2)
-        , (peers !! 1, peers !! 2)
-        ]
-      let runForTwoSeconds = void . timeout 2000000
-          src = "contract A {}"
-          contractName = "A"
-          enode = readEnode "enode://abcd@1.2.3.4:30303"
-          chainInfo' = ChainInfo
-            UnsignedChainInfo { chainLabel     = "My test chain!"
-                              , accountInfo    = [ContractNoStorage (Address 0x100) 10000000000 (SolidVMCode contractName $ hash src)]
-                              , codeInfo       = [CodeInfo "" src $ Just contractName]
-                              , members        = M.singleton (validators' !! 0) enode
-                              , parentChain    = Nothing
-                              , creationBlock  = zeroHash
-                              , chainNonce     = 123456789
-                              , chainMetadata  = M.singleton "VM" "SolidVM"
-                              }
-            Nothing
-          chainId = keccak256ToWord256 $ rlpHash chainInfo'
-          postChainInfo = do
-            threadDelay 1000000
-            flip postEvent (peers !! 0) . UnseqEvent . IEGenesis $ IngestGenesis Origin.API (chainId, chainInfo')
-
-      runForTwoSeconds $ concurrently_ (runNetwork peers connections) postChainInfo
-      ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
-      ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at chainId) `shouldBe` (i, if i == 0 then Just chainInfo' else Nothing)
 
     it "should broadcast blockstanbul messages" $ property $ withMaxSuccess 10 $ \wm ->
       runTestPeer $ do

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -65,6 +65,7 @@ import           Blockchain.DB.ChainDB
 import           Blockchain.DB.CodeDB
 import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.DB.RawStorageDB
+import           Blockchain.DB.StateDB                 (setStateDBStateRoot)
 import qualified Blockchain.DB.X509CertDB              as X509
 import "strato-p2p" Blockchain.Event
 import qualified "vm-runner" Blockchain.Event          as VMEvent
@@ -819,13 +820,12 @@ makeLenses ''P2PPeer
 
 runNode :: P2PPeer -> IO ()
 runNode p =
-  race_
-    (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerSequencer))
-    --(race_ (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerSequencer))
-           --(runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerVm)))
-    (race_ 
-      (race_ (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerApiIndexer))
-             (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerP2pIndexer)))
+  concurrently_
+    (concurrently_ (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerSequencer))
+                   (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerVm)))
+    (concurrently_ 
+      (concurrently_ (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerApiIndexer))
+                     (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerP2pIndexer)))
       (runLoggingT . runResourceT $ flip runReaderT (p ^. p2pTestContext) (p ^. p2pPeerTxrIndexer)))
 
 createPeer :: PrivateKey
@@ -852,16 +852,19 @@ createPeer privKey initialValidators unseqSink name ipAddr = do
                                   traverse_ (writeTMChan seqP2pSource . Right) $ Seq._toP2p b
                                   writeTQueue seqVmSource $ Seq._toVm b
                                )
-  let vm = runConduit $ sourceTQueue seqVmSource
-                     .| (awaitForever $ yield . foldr VMEvent.insertInBatch VMEvent.newInBatch)
-                     .| handleVmEvents
-                     .| (awaitForever $ yield . flip VMEvent.insertOutBatch VMEvent.newOutBatch)
-                     .| (awaitForever $ \b -> atomically $ do
-                          traverse_ (writeTQueue unseqSource) $ UnseqEvent . IEBlock . blockToIngestBlock Origin.Quarry . outputBlockToBlock <$> toList (VMEvent.outBlocks b)
-                          writeTQueue apiIndexerSource $ toList (VMEvent.outIndexEvents b)
-                          writeTQueue p2pIndexerSource $ toList (VMEvent.outIndexEvents b)
-                          traverse_ (writeTQueue txrIndexerSource) $ toList (VMEvent.outIndexEvents b)
-                        )
+  let vm = do
+        MP.initializeBlank
+        setStateDBStateRoot Nothing MP.emptyTriePtr
+        runConduit $ sourceTQueue seqVmSource
+                  .| (awaitForever $ yield . foldr VMEvent.insertInBatch VMEvent.newInBatch)
+                  .| handleVmEvents False
+                  .| (awaitForever $ yield . flip VMEvent.insertOutBatch VMEvent.newOutBatch)
+                  .| (awaitForever $ \b -> atomically $ do
+                       traverse_ (writeTQueue unseqSource) $ UnseqEvent . IEBlock . blockToIngestBlock Origin.Quarry . outputBlockToBlock <$> toList (VMEvent.outBlocks b)
+                       writeTQueue apiIndexerSource $ toList (VMEvent.outIndexEvents b)
+                       writeTQueue p2pIndexerSource $ toList (VMEvent.outIndexEvents b)
+                       traverse_ (writeTQueue txrIndexerSource) $ toList (VMEvent.outIndexEvents b)
+                     )
       apiIndexer' = runConduit $ sourceTQueue apiIndexerSource
                               .| (awaitForever $ \evs -> do
                                     $logInfoS "testApiIndexer" . T.pack $ show evs
@@ -1039,9 +1042,9 @@ spec = do
         , (peers !! 1, peers !! 4)
         , (peers !! 1, peers !! 5)
         ]
-      let runForTwoSeconds = void . timeout 5000000
+      let runForTwoSeconds = void . timeout 2000000
           runNodes = mapConcurrently runNode peers
-          runConnections = traverse runConnection connections
+          runConnections = mapConcurrently runConnection connections
           postTimeout = do
             threadDelay 1000000
             for_ validators' (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
@@ -1070,17 +1073,15 @@ spec = do
         , (peers !! 0, peers !! 2)
         , (peers !! 1, peers !! 2)
         ]
-      rnRef2 <- _latestRoundNumber . _sequencerContext <$> readTVarIO ((peers !! 1) ^. p2pTestContext)
-      writeIORef rnRef2 1000
       atomically $ modifyTVar' ((peers !! 1) ^. p2pTestContext)
-                               (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
-      rnRef3 <- _latestRoundNumber . _sequencerContext <$> readTVarIO ((peers !! 2) ^. p2pTestContext)
-      writeIORef rnRef3 1000
+                               ( (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
+                               . (sequencerContext . blockstanbulContext . _Just . view . round .~ 1000))
       atomically $ modifyTVar' ((peers !! 2) ^. p2pTestContext)
-                               (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
-      let runForTwoSeconds = void . timeout 5000000
-          runNodes = traverse runNode peers
-          runConnections = traverse runConnection connections
+                               ( (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
+                               . (sequencerContext . blockstanbulContext . _Just . view . round .~ 1000))
+      let runForTwoSeconds = void . timeout 2000000
+          runNodes = mapConcurrently runNode peers
+          runConnections = mapConcurrently runConnection connections
           postTimeoutPrimary1 = do
             threadDelay 1000000
             for_ primaryValidators (\p -> atomically $ writeTQueue (_p2pPeerUnseqSource p) (TimerFire 0))
@@ -1093,7 +1094,7 @@ spec = do
       runForTwoSeconds $ concurrently_ (concurrently_ runNodes runConnections) (concurrently_ postTimeoutPrimary1 postTimeoutSecondary)
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs1 $ \i ctx -> (i, _round . _view <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, if i == 0 then Just (1 :: Word256) else Just 1000)
-      atomically $ modifyTVar' ((peers !! 2) ^. p2pTestContext)
+      atomically $ modifyTVar' ((peers !! 0) ^. p2pTestContext)
                                (sequencerContext . blockstanbulContext . _Just . validators .~ Set.fromList validatorAddresses)
       runForTwoSeconds $ concurrently_ (concurrently_ runNodes runConnections) (concurrently_ postTimeoutPrimary2 postTimeoutSecondary)
       ctxs2 <- atomically $ traverse (readTVar . _p2pTestContext) peers

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -4,9 +4,11 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE Rank2Types            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
 module EventSpec where
@@ -15,34 +17,42 @@ import           Prelude hiding (round)
 import           Conduit
 import           Control.Concurrent.STM.TMChan
 import           Control.Lens                          hiding (Context, view)
+import qualified Control.Lens                          as Lens
 import qualified Control.Monad.Change.Alter            as A
 import qualified Control.Monad.Change.Modify           as Mod
 import           Control.Monad.Reader
-import           Control.Monad.State
+import qualified Control.Monad.State                   as State
 import qualified Data.ByteString                       as B
 import qualified Data.ByteString.Base16                as B16
 import qualified Data.ByteString.Char8                 as BC
 import           Data.Conduit.TMChan
 import           Data.Conduit.TQueue                   hiding (newTQueueIO)
 import           Data.Default                          (def)
-import           Data.Foldable                         (for_, toList)
+import           Data.Foldable                         (for_, toList, traverse_)
 import           Data.Map.Strict                       (Map)
 import qualified Data.Map.Strict                       as M
+import           Data.Maybe                            (fromMaybe)
+import qualified Data.NibbleString                     as N
 import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
 import           Data.Text (Text)
+import           Data.Traversable                      (for)
 import           Text.Printf
 
 import           BlockApps.Logging
+import           Blockchain.Bagger
+import           Blockchain.Bagger.BaggerState
 import           Blockchain.Blockstanbul
 import           Blockchain.Blockstanbul.HTTPAdmin
 import           Blockchain.Blockstanbul.Messages      (round)
 import           Blockchain.Blockstanbul.StateMachine
 import           Blockchain.Context                    hiding (actionTimestamp, blockHeaders, remainingBlockHeaders)
+import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.ArbitraryInstances()
 import           Blockchain.Data.Block                 hiding (bestBlockNumber)
 import           Blockchain.Data.BlockDB()
+import           Blockchain.Data.BlockSummary
 import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.Control
 import qualified Blockchain.Data.DataDefs              as DataDefs
@@ -50,7 +60,16 @@ import           Blockchain.Data.Enode
 import           Blockchain.Data.TransactionDef
 import qualified Blockchain.Data.TXOrigin              as Origin
 import           Blockchain.Data.Wire
-import           Blockchain.Event
+import qualified Blockchain.Database.MerklePatricia    as MP
+import           Blockchain.DB.ChainDB
+import           Blockchain.DB.CodeDB
+import           Blockchain.DB.MemAddressStateDB
+import           Blockchain.DB.RawStorageDB
+import qualified Blockchain.DB.X509CertDB              as X509
+import "strato-p2p" Blockchain.Event
+import qualified "vm-runner" Blockchain.Event          as VMEvent
+import           Blockchain.MemVMContext               hiding (getMemContext, get, gets, put, modify, modify', dbsGet, dbsGets, dbsPut, dbsModify, dbsModify', contextGet, contextGets, contextPut, contextModify, contextModify')
+import           Blockchain.VMContext                  (VMBase, IsBlockstanbul(..), baggerState)
 import           Blockchain.Options                    (AuthorizationMode(..))
 import           Blockchain.Privacy
 import qualified Blockchain.Sequencer                  as Seq
@@ -62,11 +81,16 @@ import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Monad
 
 import qualified Blockchain.Strato.Discovery.Data.Peer as DataPeer
+import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ExtendedWord
-import           Blockchain.Strato.Model.Keccak256     (Keccak256, zeroHash)
+import           Blockchain.Strato.Model.Keccak256     (Keccak256, zeroHash, unsafeCreateKeccak256FromWord256)
 import           Blockchain.Strato.Model.Secp256k1
+import qualified Blockchain.TxRunResultCache           as TRC
 
+import           Debugger                              (DebugSettings)
+
+import           Executable.EthereumVM
 import           Executable.StratoP2PClient
 import           Executable.StratoP2PServer
 
@@ -90,7 +114,7 @@ data TestContext = TestContext
   , _peerAddr              :: PeerAddress
   , _prvKey                :: PrivateKey
   , _shaBlockDataMap       :: Map Keccak256 DataDefs.BlockData
-  , _worldBestBlock        :: WorldBestBlock
+  , _p2pWorldBestBlock     :: WorldBestBlock
   , _bestBlock             :: BestBlock
   , _canonicalBlockDataMap :: Map Integer (Canonical DataDefs.BlockData)
   , _ipAddressIpChainsMap  :: Map IPAddress IPChains
@@ -106,6 +130,7 @@ data TestContext = TestContext
   , _outboundPbftMessages  :: S.OSet (Text, Keccak256)
   , _unseqEvents           :: [IngestEvent]
   , _sequencerContext      :: SequencerContext
+  , _vmContext             :: MemContext
   }
 
 makeLenses ''TestContext
@@ -114,7 +139,7 @@ type TestContextM = ReaderT (IORef TestContext) (ResourceT (LoggingT IO))
 
 type MonadTest m = ReaderT (IORef TestContext) m
 
-instance {-# OVERLAPPING #-} MonadIO m => MonadState TestContext (MonadTest m) where
+instance {-# OVERLAPPING #-} MonadIO m => State.MonadState TestContext (MonadTest m) where
   state f = ask >>= liftIO . flip atomicModifyIORef' (swap . f)
     where swap ~(a,b) = (b,a)
 
@@ -131,8 +156,8 @@ instance MonadIO m => (Keccak256 `A.Alters` DataDefs.BlockData) (MonadTest m) wh
   delete _ k   = shaBlockDataMap %= M.delete k
 
 instance MonadIO m => Mod.Modifiable WorldBestBlock (MonadTest m) where
-  get _ = use worldBestBlock
-  put _ = assign worldBestBlock
+  get _ = use p2pWorldBestBlock
+  put _ = assign p2pWorldBestBlock
 
 instance MonadIO m => Mod.Modifiable BestBlock (MonadTest m) where
   get _ = use bestBlock
@@ -215,7 +240,7 @@ instance MonadIO m => HasPrivateHashDB (MonadTest m) where
   requestTransaction = insertGetTransactionsDB
 
 
-genericTestLookup :: (MonadState s m, Ord k)
+genericTestLookup :: (State.MonadState s m, Ord k)
                   => Lens' s (Map k (Modification a))
                   -> Mod.Proxy a
                   -> k
@@ -224,7 +249,7 @@ genericTestLookup registry _ k = use (registry . at k) >>= \case
   Just (Modification a) -> pure $ Just a
   _ -> pure Nothing
 
-genericTestInsert :: (MonadState s m, Ord k)
+genericTestInsert :: (State.MonadState s m, Ord k)
                   => Lens' s (Map k (Modification a))
                   -> Mod.Proxy a
                   -> k
@@ -232,7 +257,7 @@ genericTestInsert :: (MonadState s m, Ord k)
                   -> m ()
 genericTestInsert registry _ k a = registry . at k ?= Modification a
 
-genericTestDelete :: (MonadState s m, Ord k)
+genericTestDelete :: (State.MonadState s m, Ord k)
                   => Lens' s (Map k (Modification a))
                   -> Mod.Proxy a
                   -> k
@@ -344,6 +369,214 @@ instance MonadIO m => ((Text, Keccak256) `A.Alters` (A.Proxy (Outbound WireMessa
     assign outboundPbftMessages wms''
   delete _ k = outboundPbftMessages %= S.delete k
 
+getMemContext :: MonadIO m => MonadTest m MemContext
+getMemContext = ask >>= fmap _vmContext . readIORef
+
+get :: MonadIO m => MonadTest m ContextState
+get = _state <$> getMemContext
+{-# INLINE get #-}
+
+gets :: MonadIO m => (ContextState -> a) -> MonadTest m a
+gets f = f <$> get
+{-# INLINE gets #-}
+
+put :: MonadIO m => ContextState -> MonadTest m ()
+put c = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . state .~ c)
+{-# INLINE put #-}
+
+modify :: MonadIO m => (ContextState -> ContextState) -> MonadTest m ()
+modify f = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . state %~ f)
+{-# INLINE modify #-}
+
+modify' :: MonadIO m => (ContextState -> ContextState) -> MonadTest m ()
+modify' f = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . state %~ f)
+{-# INLINE modify' #-}
+
+dbsGet :: MonadIO m => MonadTest m MemContextDBs
+dbsGet = _dbs <$> getMemContext
+{-# INLINE dbsGet #-}
+
+dbsGets :: MonadIO m => (MemContextDBs -> a) -> MonadTest m a
+dbsGets f = f <$> dbsGet
+{-# INLINE dbsGets #-}
+
+dbsPut :: MonadIO m => MemContextDBs -> (MonadTest m) ()
+dbsPut c = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . dbs .~ c)
+{-# INLINE dbsPut #-}
+
+dbsModify :: MonadIO m => (MemContextDBs -> MemContextDBs) -> MonadTest m ()
+dbsModify f = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . dbs %~ f)
+{-# INLINE dbsModify #-}
+
+dbsModify' :: MonadIO m => (MemContextDBs -> MemContextDBs) -> MonadTest m ()
+dbsModify' f = ask >>= \i -> atomicModifyIORef' i $ (,()) . (vmContext . dbs %~ f)
+{-# INLINE dbsModify' #-}
+
+contextGet :: MonadIO m => MonadTest m ContextState
+contextGet = get
+{-# INLINE contextGet #-}
+
+contextGets :: MonadIO m => (ContextState -> a) -> MonadTest m a
+contextGets = gets
+{-# INLINE contextGets #-}
+
+contextPut :: MonadIO m => ContextState -> MonadTest m ()
+contextPut = put
+{-# INLINE contextPut #-}
+
+contextModify :: MonadIO m => (ContextState -> ContextState) -> MonadTest m ()
+contextModify = modify
+{-# INLINE contextModify #-}
+
+contextModify' :: MonadIO m => (ContextState -> ContextState) -> MonadTest m ()
+contextModify' = modify'
+{-# INLINE contextModify' #-}
+
+instance MonadIO m => Mod.Modifiable ContextState (MonadTest m) where
+  get _ = get
+  put _ = put
+
+instance MonadIO m => Mod.Accessible MemContext (MonadTest m) where
+  access _ = getMemContext
+
+instance MonadIO m => Mod.Modifiable (Maybe DebugSettings) (MonadTest m) where
+  get _    = gets $ Lens.view debugSettings
+  put _ ds = modify $ debugSettings .~ ds
+
+instance MonadIO m => Mod.Accessible ContextState (MonadTest m) where
+  access _ = get
+
+instance MonadIO m => Mod.Accessible MemDBs (MonadTest m) where
+  access _ = gets $ Lens.view memDBs
+
+instance MonadIO m => Mod.Modifiable MemDBs (MonadTest m) where
+  get _    = gets $ Lens.view memDBs
+  put _ md = modify $ memDBs .~ md
+
+vmBlockHashRootKey :: B.ByteString
+vmBlockHashRootKey = "block_hash_root"
+
+vmGenesisRootKey :: B.ByteString
+vmGenesisRootKey = "genesis_root"
+
+vmBestBlockRootKey :: B.ByteString
+vmBestBlockRootKey = "best_block_root"
+
+instance MonadIO m => Mod.Modifiable BlockHashRoot (MonadTest m) where
+  get _     = dbsGets $ Lens.view blockHashRoot
+  put _ bhr = dbsModify' $ blockHashRoot .~ bhr
+
+instance MonadIO m => Mod.Modifiable GenesisRoot (MonadTest m) where
+  get _    = dbsGets $ Lens.view genesisRoot
+  put _ gr = dbsModify' $ genesisRoot .~ gr
+
+instance MonadIO m => Mod.Modifiable BestBlockRoot (MonadTest m) where
+  get _     = dbsGets $ Lens.view bestBlockRoot
+  put _ bbr = dbsModify' $ bestBlockRoot .~ bbr
+
+instance MonadIO m => Mod.Modifiable X509.CertRoot (MonadTest m) where
+  get _     = dbsGets $ Lens.view certRoot
+  put _ bbr = dbsModify' $ certRoot .~ bbr
+
+instance MonadIO m => Mod.Modifiable CurrentBlockHash (MonadTest m) where
+  get _    = fmap (fromMaybe (CurrentBlockHash $ unsafeCreateKeccak256FromWord256 0)) . gets $ Lens.view $ memDBs . currentBlock
+  put _ bh = modify $ memDBs . currentBlock ?~ bh
+
+instance MonadIO m => HasMemAddressStateDB (MonadTest m) where
+  getAddressStateTxDBMap = gets $ Lens.view $ memDBs . stateTxMap
+  putAddressStateTxDBMap theMap = modify $ memDBs . stateTxMap .~ theMap
+  getAddressStateBlockDBMap = gets $ Lens.view $ memDBs . stateBlockMap
+  putAddressStateBlockDBMap theMap = modify $ memDBs . stateBlockMap .~ theMap
+
+instance MonadIO m => X509.HasMemCertDB (MonadTest m) where
+  getCertTxDBMap = gets $ Lens.view $ memDBs . certTxMap
+  putCertTxDBMap theMap = modify $ memDBs . certTxMap .~ theMap
+  getCertBlockDBMap = gets $ Lens.view $ memDBs . certBlockMap
+  putCertBlockDBMap theMap = modify $ memDBs . certBlockMap .~ theMap
+
+instance MonadIO m => (MP.StateRoot `A.Alters` MP.NodeData) (MonadTest m) where
+  lookup _ sr    = dbsGets $ Lens.view (stateDB . at sr)
+  insert _ sr nd = dbsModify' $ stateDB . at sr ?~ nd
+  delete _ sr    = dbsModify' $ stateDB . at sr .~ Nothing
+
+instance MonadIO m => (Account `A.Alters` AddressState) (MonadTest m) where
+  lookup _ = getAddressStateMaybe
+  insert _ = putAddressState
+  delete _ = deleteAddressState
+
+instance MonadIO m => (Maybe Word256 `A.Alters` MP.StateRoot) (MonadTest m) where
+  lookup _ chainId = do
+    mBH <- gets $ Lens.view $ memDBs . currentBlock
+    fmap join . for mBH $ \(CurrentBlockHash bh) -> do
+      mSR <- gets $ Lens.view $ memDBs . stateRoots . at (bh, chainId)
+      case mSR of
+        Just sr -> pure $ Just sr
+        Nothing -> getChainStateRoot chainId bh
+  insert _ chainId sr = do
+    mBH <- gets $ Lens.view $ memDBs . currentBlock
+    case mBH of
+      Nothing -> pure ()
+      Just (CurrentBlockHash bh) -> do
+        modify $ memDBs . stateRoots %~ M.insert (bh, chainId) sr
+        putChainStateRoot chainId bh sr
+  delete _ chainId = do
+    mBH <- gets $ Lens.view $ memDBs . currentBlock
+    case mBH of
+      Nothing -> pure ()
+      Just (CurrentBlockHash bh) -> do
+        modify $ memDBs . stateRoots %~ M.delete (bh, chainId)
+        deleteChainStateRoot chainId bh
+
+instance MonadIO m => (Keccak256 `A.Alters` DBCode) (MonadTest m) where
+  lookup _ k   = dbsGets $ Lens.view (codeDB . at k)
+  insert _ k c = dbsModify' $ codeDB . at k ?~ c
+  delete _ k   = dbsModify' $ codeDB . at k .~ Nothing
+
+instance MonadIO m => (Address `A.Alters` X509.X509Certificate) (MonadTest m) where
+  lookup _ k = do
+    mBH <- gets $ Lens.view $ memDBs . currentBlock
+    fmap join . for mBH $ \(CurrentBlockHash bh) -> X509.getCertMaybe k bh
+  insert _ = X509.putCert
+  delete _ = X509.deleteCert
+
+instance MonadIO m => (N.NibbleString `A.Alters` N.NibbleString) (MonadTest m) where
+  lookup _ n1    = dbsGets $ Lens.view (hashDB . at n1)
+  insert _ n1 n2 = dbsModify' $ hashDB . at n1 ?~ n2
+  delete _ n1    = dbsModify' $ hashDB . at n1 .~ Nothing
+
+instance MonadIO m => HasMemRawStorageDB (MonadTest m) where
+  getMemRawStorageTxDB = gets $ Lens.view $ memDBs . storageTxMap
+  putMemRawStorageTxMap theMap = modify $ memDBs . storageTxMap .~ theMap
+  getMemRawStorageBlockDB = gets $ Lens.view $ memDBs . storageBlockMap
+  putMemRawStorageBlockMap theMap = modify $ memDBs . storageBlockMap .~ theMap
+
+instance MonadIO m => (RawStorageKey `A.Alters` RawStorageValue) (MonadTest m) where
+  lookup _ = genericLookupRawStorageDB
+  insert _ = genericInsertRawStorageDB
+  delete _ = genericDeleteRawStorageDB
+  lookupWithDefault _ = genericLookupWithDefaultRawStorageDB
+
+instance MonadIO m => (Keccak256 `A.Alters` BlockSummary) (MonadTest m) where
+  lookup _ k    = dbsGets $ Lens.view (blockSummaryDB . at k)
+  insert _ k bs = dbsModify' $ blockSummaryDB . at k ?~ bs
+  delete _ k    = dbsModify' $ blockSummaryDB . at k .~ Nothing
+
+instance MonadIO m => Mod.Accessible (Maybe WorldBestBlock) (MonadTest m) where
+  access _ = dbsGets $ Lens.view worldBestBlock
+
+instance MonadIO m => Mod.Accessible IsBlockstanbul (MonadTest m) where
+  access _ = IsBlockstanbul <$> contextGets _hasBlockstanbul
+
+instance MonadIO m => Mod.Modifiable BaggerState (MonadTest m) where
+  get _   = contextGets _baggerState
+  put _ s = contextModify $ baggerState .~ s
+
+instance MonadIO m => Mod.Accessible TRC.Cache (MonadTest m) where
+  access _ = contextGets _txRunResultsCache
+
+instance MonadIO m => (MonadTest m) `Mod.Yields` DataDefs.TransactionResult where
+  yield = const (pure ())
+
 startingCheckpoint :: [Address] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
 
@@ -378,8 +611,8 @@ newSequencerContext bc = do
 
 -- testContext is useful for testing because it doesn't require
 -- Kafka, postgres, redis, or ethconf.
-testContext :: WMRef -> PrivateKey -> SequencerContext -> TestContext
-testContext wireMessagesRef prv ctx = TestContext
+testContext :: WMRef -> PrivateKey -> SequencerContext -> MemContext -> TestContext
+testContext wireMessagesRef prv seqCtx vmCtx = TestContext
   { _blocks                = []
   , _blockHeaders          = []
   , _remainingBlockHeaders = RemainingBlockHeaders []
@@ -389,7 +622,7 @@ testContext wireMessagesRef prv ctx = TestContext
   , _peerAddr              = PeerAddress Nothing
   , _prvKey                = prv
   , _shaBlockDataMap       = M.empty
-  , _worldBestBlock        = WorldBestBlock (BestBlock zeroHash (-1) 0)
+  , _p2pWorldBestBlock     = WorldBestBlock (BestBlock zeroHash (-1) 0)
   , _bestBlock             = BestBlock zeroHash (-1) 0
   , _canonicalBlockDataMap = M.empty
   , _ipAddressIpChainsMap  = M.empty
@@ -404,7 +637,8 @@ testContext wireMessagesRef prv ctx = TestContext
   , _pbftMessages          = wireMessagesRef
   , _outboundPbftMessages  = S.empty
   , _unseqEvents           = []
-  , _sequencerContext      = ctx
+  , _sequencerContext      = seqCtx
+  , _vmContext             = vmCtx
   }
 
 testPeer :: DataPeer.PPeer
@@ -413,8 +647,11 @@ testPeer = DataPeer.buildPeer (Nothing, "0.0.0.0", 1212)
 runTestPeer :: TestContextM a -> IO ()
 runTestPeer f = do
   seqCtx <- newSequencerContext emptyBlockstanbulContext
+  cache <- TRC.new 64
+  let cstate = def & txRunResultsCache .~ cache
+      vmCtx = MemContext def cstate
   wmr <- newIORef (S.empty)
-  ctx <- newIORef $ testContext wmr undefined seqCtx
+  ctx <- newIORef $ testContext wmr undefined seqCtx vmCtx
   void . runNoLoggingT . runResourceT $ runReaderT f ctx
 
 execTestPeer :: PrivateKey
@@ -432,7 +669,10 @@ execTestPeerOnRound :: Word256
                     -> IO (a, TestContext)
 execTestPeerOnRound n pk wmr as f = do
   seqCtx <- newSequencerContext $ (view . round .~ n) (newBlockstanbulContext (fromPrivateKey pk) as)
-  ctx <- newIORef $ testContext wmr pk seqCtx
+  cache <- TRC.new 64
+  let cstate = def & txRunResultsCache .~ cache
+      vmCtx = MemContext def cstate
+  ctx <- newIORef $ testContext wmr pk seqCtx vmCtx
   a <- runLoggingT . runResourceT $ runReaderT f ctx
   ctx' <- readIORef ctx
   return (a, ctx')
@@ -449,13 +689,15 @@ data P2PPeer m = P2PPeer
   , _p2pPeerPPeer       :: DataPeer.PPeer
   , _p2pPeerWireMessageRef :: WMRef
   , _p2pPeerUnseqSource :: TQueue SeqLoopEvent
-  , _p2pPeerSeqSource   :: TMChan P2pEvent
+  , _p2pPeerSeqP2pSource :: TMChan P2pEvent
+  , _p2pPeerSeqVmSource :: TQueue [VmEvent]
   , _p2pPeerUnseqSink   :: [IngestEvent] -> m ()
   , _p2pPeerName        :: String
   , _p2pPeerSequencer   :: m ()
+  , _p2pPeerVm          :: m ()
   }
 
-createPeer :: Seq.MonadSequencer m
+createPeer :: (Seq.MonadSequencer m , MonadFail m, VMBase m, MonadBagger m)
            => ([IngestEvent] -> m ())
            -> String
            -> String
@@ -464,11 +706,21 @@ createPeer unseqSink name ipAddr = do
   privKey <- newPrivateKey
   wmr <- newIORef (S.empty)
   unseqSource <- newTQueueIO
-  seqSource <- newBroadcastTMChanIO
+  seqP2pSource <- newBroadcastTMChanIO
+  seqVmSource <- newTQueueIO
   let sequencer = runConduit $ sourceTQueue unseqSource
                             .| mapMC (Seq.runSequencerBatch . (:[]))
-                            .| (awaitForever $ yieldMany . Seq._toP2p)
-                            .| sinkTMChan seqSource
+                            .| (awaitForever $ \b -> atomically $ do
+                                  traverse_ (writeTMChan seqP2pSource) $ Seq._toP2p b
+                                  writeTQueue seqVmSource $ Seq._toVm b
+                               )
+  let vm = runConduit $ sourceTQueue seqVmSource
+                     .| (awaitForever $ yield . foldr VMEvent.insertInBatch VMEvent.newInBatch)
+                     .| handleVmEvents
+                     .| (awaitForever $ yield . flip VMEvent.insertOutBatch VMEvent.newOutBatch)
+                     .| (awaitForever $ \b -> atomically $ do
+                          traverse_ (writeTQueue unseqSource) $ UnseqEvent . IEBlock . blockToIngestBlock Origin.Quarry . outputBlockToBlock <$> toList (VMEvent.outBlocks b)
+                        )
       pubkeystr = BC.unpack $ B16.encode $ B.drop 1 $ exportPublicKey False $ derivePublicKey privKey
       ppeer = DataPeer.buildPeer ( Just pubkeystr
                                  , ipAddr
@@ -482,10 +734,12 @@ createPeer unseqSink name ipAddr = do
     ppeer
     wmr
     unseqSource
-    seqSource
+    seqP2pSource
+    seqVmSource
     unseq
     name
     sequencer
+    vm
 
 data P2PConnection m = P2PConnection
   { _serverToClient :: TQueue B.ByteString
@@ -503,8 +757,8 @@ createConnection :: MonadP2P m
 createConnection server client = do
   serverToClient <- newTQueueIO
   clientToServer <- newTQueueIO
-  serverSeqSource <- atomically . dupTMChan $ _p2pPeerSeqSource server
-  clientSeqSource <- atomically . dupTMChan $ _p2pPeerSeqSource client
+  serverSeqSource <- atomically . dupTMChan $ _p2pPeerSeqP2pSource server
+  clientSeqSource <- atomically . dupTMChan $ _p2pPeerSeqP2pSource client
   let runServer = runEthServerConduit (_p2pPeerPPeer client)
                                       (sourceTQueue clientToServer)
                                       (sinkTQueue serverToClient)
@@ -562,7 +816,7 @@ spec = do
       otx <- (\o -> o{otBaseTx = clearChainId (otBaseTx o), otOrigin = Origin.API}) <$> liftIO (generate arbitrary)
       let runForTwoSeconds pk wmr = execTestPeer pk wmr validatorAddresses . timeout 2000000
           run = runConnectionWith runForTwoSeconds connection
-          postTx = threadDelay 500000 >> (atomically $ writeTMChan (_p2pPeerSeqSource server) (P2pTx otx))
+          postTx = threadDelay 500000 >> (atomically $ writeTMChan (_p2pPeerSeqP2pSource server) (P2pTx otx))
       ((_, serverCtx), (_, clientCtx)) <- fst <$> concurrently run postTx
       _unseqEvents serverCtx `shouldBe` []
       let clientTxs = [t | IETx _ (IngestTx _ t) <- _unseqEvents clientCtx]

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -1340,7 +1340,7 @@ contract B {
           enode2 = readEnode "enode://abcd@5.6.7.8:30303"
           enode3 = "enode://abcd@9.10.11.12:30303"
           mkChainInfo bHash = ChainInfo
-            UnsignedChainInfo { chainLabel     = "My test chain!"
+            UnsignedChainInfo { chainLabel     = "My parent test chain!"
                               , accountInfo    = [ ContractNoStorage (Address 0x100) 1000000000000000000000 (SolidVMCode contractName $ hash src)
                                                  , NonContract (validators' !! 0) 1000000000000000000000
                                                  , NonContract (validators' !! 1) 1000000000000000000000
@@ -1350,6 +1350,20 @@ contract B {
                                                             , (validators' !! 1, enode2)
                                                             ]
                               , parentChain    = Nothing
+                              , creationBlock  = bHash
+                              , chainNonce     = 123456789
+                              , chainMetadata  = M.singleton "VM" "SolidVM"
+                              }
+            Nothing
+          mkChainInfo2 bHash pChain = ChainInfo
+            UnsignedChainInfo { chainLabel     = "My child test chain!"
+                              , accountInfo    = [ ContractNoStorage (Address 0x100) 1000000000000000000000 (SolidVMCode contractName $ hash src)
+                                                 , NonContract (validators' !! 0) 1000000000000000000000
+                                                 ]
+                              , codeInfo       = [CodeInfo "" src $ Just contractName]
+                              , members        = M.fromList [ (validators' !! 0, enode1)
+                                                            ]
+                              , parentChain    = Just pChain
                               , creationBlock  = bHash
                               , chainNonce     = 123456789
                               , chainMetadata  = M.singleton "VM" "SolidVM"
@@ -1395,6 +1409,8 @@ contract B {
                              in mainChainAddMd $ mkSignedTx (privKeys !! 0) utx
       cIdRef <- newIORef undefined
       cInfoRef <- newIORef undefined
+      cId2Ref <- newIORef undefined
+      cInfo2Ref <- newIORef undefined
       let addMemberArgs = "(0x" <> T.pack (formatAddressWithoutColor (validators' !! 2)) <> ",\"" <> T.pack enode3 <> "\")"
           addMemberUtx chainId = U.UnsignedTransaction
             { U.unsignedTransactionNonce      = Nonce 5
@@ -1429,18 +1445,39 @@ contract B {
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx1 cId
             threadDelay 5000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx2 cId
+            bHash2 <- bestBlockHash <$> readIORef bestBlockRef
+            let cInfo2 = mkChainInfo2 bHash2 cId
+                cId2 = mkChainId cInfo2
+            writeIORef cId2Ref cId2
+            writeIORef cInfo2Ref cInfo2
+            flip postEvent (peers !! 0) . UnseqEvent . IEGenesis $ IngestGenesis Origin.API (cId2, cInfo2)
             threadDelay 5000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx3 cId
             threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx0 cId2
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx1 cId2
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx2 cId2
+            threadDelay 5000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx4 cId
             threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx3 cId2
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ incXTx4 cId2
+            threadDelay 5000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ addMemberTx cId
+            threadDelay 5000000
+            flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ addMemberTx cId2
           
-      void . timeout 60000000 $ concurrently_ (runNetwork peers connections) (concurrently_ routine $ mainChainRoutine 0)
+      void . timeout 80000000 $ concurrently_ (runNetwork peers connections) (concurrently_ routine $ mainChainRoutine 0)
       cId <- readIORef cIdRef
       cInfo <- readIORef cInfoRef
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at cId) `shouldBe` (i, Just cInfo)
+      cId2 <- readIORef cId2Ref
+      cInfo2 <- readIORef cInfo2Ref
+      ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at cId2) `shouldBe` (i, if i == 1 then Nothing else Just cInfo2)
       --privKey4 <- newPrivateKey
       --peer4 <- createPeer privKey4 validators' unseqSink "node4" "13.14.15.16"
       --let peers' = peers ++ [peer4]

--- a/strato/core/strato-p2p/test/Main.hs
+++ b/strato/core/strato-p2p/test/Main.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-overlapping-patterns #-}
 module Main where
 
+import Blockchain.VMOptions()
 import HFlags
 import Test.Hspec.Runner
 

--- a/strato/core/strato-p2p/test/Main.hs
+++ b/strato/core/strato-p2p/test/Main.hs
@@ -3,6 +3,7 @@
 module Main where
 
 import Blockchain.VMOptions()
+import Executable.EVMFlags()
 import HFlags
 import Test.Hspec.Runner
 

--- a/strato/core/strato-sequencer/package.yaml
+++ b/strato/core/strato-sequencer/package.yaml
@@ -20,6 +20,7 @@ library:
     - binary
     - blockapps-data
     - blockapps-datadefs
+    - blockapps-init
     - blockapps-privacy
     - blockapps-vault-wrapper-api
     - blockapps-vault-wrapper-client

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer/Metrics.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer/Metrics.hs
@@ -3,14 +3,12 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Blockchain.Sequencer.Metrics where
 
+import BlockApps.Init()
 import Control.Monad.IO.Class
-import Control.Monad.Trans.Resource
 import Data.Ratio ((%))
 import Data.Text
 import Prometheus
 import System.Clock (Clock(..), diffTimeSpec, getTime, toNanoSecs)
-
-import BlockApps.Logging
 
 seqLdbBatchWrites :: Counter
 seqLdbBatchWrites = unsafeRegister $ counter (Info "seq_ldb_batch_writes" "Sequencer counter for ldb batch writes")
@@ -160,6 +158,3 @@ timeAction metric act = do
     let duration = toNanoSecs (end `diffTimeSpec` start) % 1000000000
     observe metric (fromRational duration)
     return res
-
-instance MonadMonitor (ResourceT (LoggingT IO)) where
-    doIO = liftIO

--- a/strato/core/vm-runner/package.yaml
+++ b/strato/core/vm-runner/package.yaml
@@ -15,6 +15,7 @@ library:
   source-dirs: src/
   exposed-modules:
     - Blockchain.BlockChain
+    - Blockchain.Event
     - Executable.EthereumVM
   ghc-options: -Wall -O2
   dependencies:

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -141,6 +141,8 @@ addBlocks unfiltered = do
       timerToUse = Just vmBlockInsertionMined
   unless (null unfiltered) $ yieldMany $ OutIndexEvent . RanBlock <$> unfiltered
   bbi <- getContextBestBlockInfo
+  $logInfoS "addBlocks" $ T.pack ("Unfiltered count: " ++ show (length unfiltered))
+  $logInfoS "addBlocks" $ T.pack ("Filtered count: " ++ show (length filtered))
   case (filtered, bbi) of
     ([], _) -> return ()
     (_, Unspecified) -> return ()
@@ -548,23 +550,23 @@ outputTransactionResult b hashFunction (TxRunResult ot@OutputTx{otHash=theHash} 
       gasUsed = fromInteger $ transactionGasLimit t - gasRemaining
       etherUsed = gasUsed * fromInteger (transactionGasPrice t)
 
-  when flags_createTransactionResults $ do
-    let chainId = txChainId t
-        beforeAddresses = S.fromList [ x | (x, ASModification _) <-  M.toList beforeMap ]
-        beforeDeletes = S.fromList [ x | (x, ASDeleted) <-  M.toList beforeMap ]
-        afterAddresses = S.fromList [ x | (x, ASModification _) <-  M.toList afterMap ]
-        afterDeletes = S.fromList [ x | (x, ASDeleted) <-  M.toList afterMap ]
-        ranBlockHash = hashFunction b
-        mkLogEntry Log{..} = LogDB ranBlockHash theHash chainId (account ^. accountAddress) (topics `indexMaybe` 0) (topics `indexMaybe` 1) (topics `indexMaybe` 2) (topics `indexMaybe` 3) logData bloom
-        mkEventEntry Event{..} = EventDB chainId evName $ map snd evArgs -- drop the field names, only slipstream needs them
-        (!response, theTrace', theLogs, theEvents) =
-          case result of
-            Left _ -> (BSS.empty, [], [], []) --TODO keep the trace when the run fails
-            Right r ->
-              (fromMaybe BSS.empty $ erReturnVal r, unlines $ reverse $ erTrace r, erLogs r, erEvents r)
+      chainId = txChainId t
+      beforeAddresses = S.fromList [ x | (x, ASModification _) <-  M.toList beforeMap ]
+      beforeDeletes = S.fromList [ x | (x, ASDeleted) <-  M.toList beforeMap ]
+      afterAddresses = S.fromList [ x | (x, ASModification _) <-  M.toList afterMap ]
+      afterDeletes = S.fromList [ x | (x, ASDeleted) <-  M.toList afterMap ]
+      ranBlockHash = hashFunction b
+      mkLogEntry Log{..} = LogDB ranBlockHash theHash chainId (account ^. accountAddress) (topics `indexMaybe` 0) (topics `indexMaybe` 1) (topics `indexMaybe` 2) (topics `indexMaybe` 3) logData bloom
+      mkEventEntry Event{..} = EventDB chainId evName $ map snd evArgs -- drop the field names, only slipstream needs them
+      (!response, theTrace', theLogs, theEvents) =
+        case result of
+          Left _ -> (BSS.empty, [], [], []) --TODO keep the trace when the run fails
+          Right r ->
+            (fromMaybe BSS.empty $ erReturnVal r, unlines $ reverse $ erTrace r, erLogs r, erEvents r)
 
-    yieldMany $ OutLog . mkLogEntry <$> theLogs
-    yieldMany $ OutEvent . mkEventEntry <$> theEvents
+  yieldMany $ OutLog . mkLogEntry <$> theLogs
+  yieldMany $ OutEvent . mkEventEntry <$> theEvents
+  when flags_createTransactionResults $ do
     yield . OutTXR $
            TransactionResult { transactionResultBlockHash        = ranBlockHash
                              , transactionResultTransactionHash  = theHash
@@ -583,8 +585,8 @@ outputTransactionResult b hashFunction (TxRunResult ot@OutputTx{otHash=theHash} 
                              , transactionResultChainId          = chainId
                              , transactionResultKind             = erKind <$> eitherToMaybe result
                              }
-    when flags_diffPublish $ do
-      traverse_ (yield . OutAction) $ either (const Nothing) erAction result
+  when flags_diffPublish $ do
+    traverse_ (yield . OutAction) $ either (const Nothing) erAction result
 
 multilineLog :: MonadLogger m =>
                 T.Text -> String -> m ()

--- a/strato/core/vm-runner/src/Blockchain/Event.hs
+++ b/strato/core/vm-runner/src/Blockchain/Event.hs
@@ -28,6 +28,7 @@ import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.Strato.StateDiff
 import           Blockchain.Stream.Action           (Action)
+import qualified Data.ByteString                    as B
 import qualified Data.DList                         as DL
 import           Data.Map                           (Map)
 
@@ -66,6 +67,7 @@ data VmOutEvent = OutAction Action
                 | OutEvent EventDB
                 | OutTXR TransactionResult
                 | OutASM (Map Account AddressStateModification)
+                | OutJSONRPC String B.ByteString
 
 data VmOutEventBatch = OutBatch
   { outActions      :: DL.DList Action
@@ -77,10 +79,12 @@ data VmOutEventBatch = OutBatch
   , outEvents       :: DL.DList EventDB
   , outTXRs         :: DL.DList TransactionResult
   , outASMs         :: DL.DList (Map Account AddressStateModification)
+  , outJSONRPCs     :: DL.DList (String, B.ByteString)
   }
 
 newOutBatch :: VmOutEventBatch
 newOutBatch = OutBatch DL.empty
+                       DL.empty
                        DL.empty
                        DL.empty
                        DL.empty
@@ -101,4 +105,5 @@ insertOutBatch e b = case e of
   OutEvent a           -> b{ outEvents = outEvents b `DL.snoc` a }
   OutTXR a             -> b{ outTXRs = outTXRs b `DL.snoc` a }
   OutASM a             -> b{ outASMs = outASMs b `DL.snoc` a }
+  OutJSONRPC x y       -> b{ outJSONRPCs = outJSONRPCs b `DL.snoc` (x,y) }
 

--- a/strato/core/vm-runner/src/Blockchain/JsonRpcCommand.hs
+++ b/strato/core/vm-runner/src/Blockchain/JsonRpcCommand.hs
@@ -5,7 +5,9 @@
 {-# LANGUAGE TypeOperators     #-}
 
 module Blockchain.JsonRpcCommand (
-  runJsonRpcCommand
+  produceResponse,
+  runJsonRpcCommand,
+  runJsonRpcCommand'
   ) where
 
 import           Prelude                         hiding (id)
@@ -22,11 +24,7 @@ import           Network.Kafka.Producer
 
 import           BlockApps.Logging
 import           Blockchain.Data.AddressStateDB
-import           Blockchain.Data.DataDefs
 import           Blockchain.DB.CodeDB
-import           Blockchain.DB.DetailsDB
-import           Blockchain.DB.SQLDB
-import           Blockchain.DB.StateDB
 import           Blockchain.DB.StorageDB
 import           Blockchain.EthConf
 import           Blockchain.KafkaTopics
@@ -47,39 +45,32 @@ produceResponse id theData = do
         Right _ -> return ()
 
 
-runJsonRpcCommand :: ( MonadLogger m
-                     , HasSQLDB m
-                     , HasStateDB m
+runJsonRpcCommand :: ( MonadIO m
+                     , MonadLogger m
                      , HasCodeDB m
                      , HasStorageDB m
                      , (Account `A.Alters` AddressState) m
                      )
                   => JsonRpcCommand -> m ()
 runJsonRpcCommand = liftIO . uncurry produceResponse
-                <=< runJsonRpcCommand' getBestBlock
+                <=< runJsonRpcCommand'
 
 runJsonRpcCommand' :: ( MonadLogger m
-                      , HasStateDB m
                       , HasCodeDB m
                       , HasStorageDB m
                       , (Account `A.Alters` AddressState) m
                       )
-                   => m BlockDataRef
-                   -> JsonRpcCommand
+                   => JsonRpcCommand
                    -> m (String, B.ByteString)
-runJsonRpcCommand' mBestBlock c@JRCGetBalance{jrcAddress=address, jrcId=id} = do
+runJsonRpcCommand' c@JRCGetBalance{jrcAddress=address, jrcId=id} = do
   $logInfoS "runJsonRpcCommand.JRCGetBalance" . T.pack $ "running command: " ++ show c
-  bestBlock <- mBestBlock
-  setStateDBStateRoot Nothing $ blockDataRefStateRoot bestBlock
   response <- show . addressStateBalance <$>
     A.lookupWithDefault (A.Proxy @AddressState) (Account address Nothing)
   $logInfoS "runJsonRpcCommand'.JRCGetBalance" $ T.pack response
   return (id, BC.pack response)
 
-runJsonRpcCommand' mBestBlock c@JRCGetCode{jrcAddress=address, jrcId=id} = do
+runJsonRpcCommand' c@JRCGetCode{jrcAddress=address, jrcId=id} = do
   $logInfoS "runJsonRpcCommand'.JRCGetCode" . T.pack $ "running command: " ++ show c
-  bestBlock <- mBestBlock
-  setStateDBStateRoot Nothing $ blockDataRefStateRoot bestBlock
   codeHash <- addressStateCodeHash <$>
     A.lookupWithDefault (A.Proxy @AddressState) (Account address Nothing)
   code <- getEVMCode $
@@ -88,20 +79,16 @@ runJsonRpcCommand' mBestBlock c@JRCGetCode{jrcAddress=address, jrcId=id} = do
                  _ -> error "runJsonRpcCommand currently only supported for the EVM"
   return (id, code)
 
-runJsonRpcCommand' mBestBlock c@JRCGetTransactionCount{jrcAddress=address, jrcId=id} = do
+runJsonRpcCommand' c@JRCGetTransactionCount{jrcAddress=address, jrcId=id} = do
   $logInfoS "runJsonRpcCommand'.JRCGetTransactionCount" . T.pack $ "running command: " ++ show c
-  bestBlock <- mBestBlock
-  setStateDBStateRoot Nothing $ blockDataRefStateRoot bestBlock
   response <- show . addressStateNonce <$>
     A.lookupWithDefault (A.Proxy @AddressState) (Account address Nothing)
   $logInfoS "runJsonRpcCommand'.JRCGetTransactionCount" $ T.pack response
   return (id, BC.pack response)
 
-runJsonRpcCommand' mBestBlock c@JRCGetStorageAt{jrcAddress=address, jrcKey=key, jrcId=id} = do
+runJsonRpcCommand' c@JRCGetStorageAt{jrcAddress=address, jrcKey=key, jrcId=id} = do
   $logInfoS "runJsonRpcCommand'.JRCGetStorageAt" . T.pack $ "running command: " ++ show c
-  bestBlock <- mBestBlock
-  setStateDBStateRoot Nothing $ blockDataRefStateRoot bestBlock
   value <- getStorageKeyVal' (Account address Nothing) $ bytesToWord256 $ key
   $logInfoS "runJsonRpcCommand'.JRCGetStorageAt" . T.pack $ show value
   return (id, word256ToBytes value)
-runJsonRpcCommand' _ (JRCCall _ _ _) = error "unsupported RPC command call"
+runJsonRpcCommand' (JRCCall _ _ _) = error "unsupported RPC command call"

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -9,7 +9,8 @@
 
 module Executable.EthereumVM (
   ethereumVM,
-  handleVmEvents
+  handleVmEvents,
+  writeBlockSummary
 ) where
 
 import           Conduit

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -120,7 +120,7 @@ ethereumVM d = void . execContextM d $ do
 
         let vmInEventBatch = foldr insertInBatch newInBatch seqEvents
         outBatch <- runConduit $ yield vmInEventBatch
-                              .| handleVmEvents
+                              .| handleVmEvents flags_useSyncMode
                               .| fold (flip insertOutBatch) newOutBatch
         
         loopTimeit "compactContextM" $ compactContextM
@@ -138,8 +138,8 @@ microtimeCutoff = secondsToMicrotime flags_mempoolLivenessCutoff
 {-# NOINLINE microtimeCutoff #-}
 
 handleVmEvents :: (MonadFail m, VMBase m, Bagger.MonadBagger m, MonadMonitor m)
-               => ConduitT VmInEventBatch VmOutEvent m ()
-handleVmEvents = awaitForever $ \InBatch{..} -> do
+               => Bool -> ConduitT VmInEventBatch VmOutEvent m ()
+handleVmEvents useSyncMode = awaitForever $ \InBatch{..} -> do
   rpcResps <- lift $ do
     mapM_ (uncurry3 queuePendingVote) votesToMake
     bbHash <- maybe Keccak256.zeroHash fst <$> getChainBestBlock Nothing
@@ -156,12 +156,12 @@ handleVmEvents = awaitForever $ \InBatch{..} -> do
     Mod.modify_ (Mod.Proxy @ContextState) $ pure . (blockRequested ||~ createBlock)
     -- todo: perhaps we shouldnt even add TXs to the mempool, it might make for a VERY large checkpoint
     -- todo: which may fail
-    isCaughtUp <- shouldProcessNewTransactions
+    isCaughtUp <- shouldProcessNewTransactions useSyncMode
     bState <- Bagger.getBaggerState
     pbft <- _hasBlockstanbul <$> Mod.get (Mod.Proxy @ContextState)
     reqd <- _blockRequested <$> Mod.get (Mod.Proxy @ContextState)
     hasVotes <- (/= 0) . fst <$> peekPendingVote
-    let makeLazyBlocks = lazyBlocks $ quarryConfig ethConf
+    let makeLazyBlocks = False --lazyBlocks $ quarryConfig ethConf -- TODO?: Remove reference to ethConf
         pending = B.pending bState
         priv = toList . B.privateHashes $ B.miningCache bState
         hasTxs = (numPoolable > 0) || not (M.null pending) || not (null priv)
@@ -428,9 +428,9 @@ shouldProcessNewTransactions :: ( MonadLogger m
                                 , Mod.Accessible (Maybe WorldBestBlock) m
                                 , HasBlockSummaryDB m
                                 )
-                             => m Bool -- todo: probably shouldn't do it by number, but tdiff.
-shouldProcessNewTransactions =
-  if flags_useSyncMode
+                             => Bool -> m Bool -- todo: probably shouldn't do it by number, but tdiff.
+shouldProcessNewTransactions useSyncMode =
+  if useSyncMode
     then do
       worldBestBlock <- fmap unWorldBestBlock <$> Mod.access (Mod.Proxy @(Maybe WorldBestBlock))
       case worldBestBlock of
@@ -446,7 +446,7 @@ shouldProcessNewTransactions =
           $logInfoS "shouldProcessNewTransactions" (T.pack msg)
           return didRunBest  -- todo, verify TDiff etc.
     else do
-      $logInfoS "shouldProcessNewTransactions" "flags_useSyncMode == false, will process all new TXs"
+      $logInfoS "shouldProcessNewTransactions" "useSyncMode == false, will process all new TXs"
       return True
 
 logEventSummaries :: MonadLogger m => [VmEvent] -> m ()

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -121,6 +121,8 @@ ethereumVM d = void . execContextM d $ do
         outBatch <- runConduit $ yield vmInEventBatch
                               .| handleVmEvents
                               .| fold (flip insertOutBatch) newOutBatch
+        
+        loopTimeit "compactContextM" $ compactContextM
         sendOutEvents outBatch
 
         let newOffset = cpOffset + fromIntegral (length seqEvents)
@@ -134,25 +136,29 @@ microtimeCutoff :: Microtime
 microtimeCutoff = secondsToMicrotime flags_mempoolLivenessCutoff
 {-# NOINLINE microtimeCutoff #-}
 
-handleVmEvents :: ConduitT VmInEventBatch VmOutEvent ContextM ()
+handleVmEvents :: (MonadFail m, VMBase m, Bagger.MonadBagger m, MonadMonitor m)
+               => ConduitT VmInEventBatch VmOutEvent m ()
 handleVmEvents = awaitForever $ \InBatch{..} -> do
-  lift $ do
+  rpcResps <- lift $ do
     mapM_ (uncurry3 queuePendingVote) votesToMake
-    mapM_ runJsonRpcCommand rpcCommands
+    bbHash <- maybe Keccak256.zeroHash fst <$> getChainBestBlock Nothing
+    resps <- withCurrentBlockHash bbHash $ traverse runJsonRpcCommand' rpcCommands
     recordSeqEventCount bLen tLen
+    pure resps
+  yieldMany $ uncurry OutJSONRPC <$> rpcResps
 
   numPoolable <- uncurry (*>) . (yieldMany *** pure) =<< lift (processTransactions txPairs)
   yieldMany $ outputPrivateTransactions privateTxs
   processBlocksAndNewChains blocksAndNewChains
 
   mNewBlock <- lift $ do
-    contextModify $ blockRequested ||~ createBlock
+    Mod.modify_ (Mod.Proxy @ContextState) $ pure . (blockRequested ||~ createBlock)
     -- todo: perhaps we shouldnt even add TXs to the mempool, it might make for a VERY large checkpoint
     -- todo: which may fail
     isCaughtUp <- shouldProcessNewTransactions
     bState <- Bagger.getBaggerState
-    pbft <- contextGets _hasBlockstanbul
-    reqd <- contextGets _blockRequested
+    pbft <- _hasBlockstanbul <$> Mod.get (Mod.Proxy @ContextState)
+    reqd <- _blockRequested <$> Mod.get (Mod.Proxy @ContextState)
     hasVotes <- (/= 0) . fst <$> peekPendingVote
     let makeLazyBlocks = lazyBlocks $ quarryConfig ethConf
         pending = B.pending bState
@@ -168,7 +174,7 @@ handleVmEvents = awaitForever $ \InBatch{..} -> do
         "(isCaughtUp, pbft, reqd, hasTxs, makeLazyBlocks, shouldOutputBlocks) = " ++ show
          (isCaughtUp, pbft, reqd, hasTxs, makeLazyBlocks, shouldOutputBlocks)
     when (pbft && shouldOutputBlocks) $
-      contextModify $ blockRequested .~ False
+      Mod.modify_ (Mod.Proxy @ContextState) $ pure . (blockRequested .~ False)
     $logDebugS "evm/loop/newBlock" $ T.pack $ "Queued: " ++ show numPoolable
     $logDebugS "evm/loop/newBlock" $ T.pack $ "Pending: " ++ show (length pending)
     if shouldOutputBlocks
@@ -178,10 +184,6 @@ handleVmEvents = awaitForever $ \InBatch{..} -> do
         pure $ Just newBlock
       else pure Nothing
   traverse_ (yield . OutBlock) mNewBlock
-
-  -- todo: is this the best place to put this?
-  lift $ do
-    loopTimeit "compactContextM" $ compactContextM
 
 spanLeft :: [Either a b] -> ([a], [Either a b])
 spanLeft (Left x:xs') = let (ys,zs) = spanLeft xs' in (x:ys,zs)
@@ -196,17 +198,18 @@ groupEithers [] = []
 groupEithers (Left x:xs) = let (ys,zs) = spanLeft xs in Left (x:ys) : groupEithers zs
 groupEithers (Right x:xs) = let (ys,zs) = spanRight xs in Right (x:ys) : groupEithers zs
 
-processBlocksAndNewChains :: [Either OutputGenesis OutputBlock] -> ConduitT a VmOutEvent ContextM ()
+processBlocksAndNewChains :: (MonadFail m, Bagger.MonadBagger m, MonadMonitor m)
+                          => [Either OutputGenesis OutputBlock]
+                          -> ConduitT a VmOutEvent m ()
 processBlocksAndNewChains blocksAndChains = do
   let grouped = groupEithers blocksAndChains
   for_ grouped $ \case
     Left newChains -> outputNewChains =<< lift (insertNewChains newChains)
     Right blocks -> processBlocks blocks
 
-insertNewChains :: (
-                   )
+insertNewChains :: VMBase m
                 => [OutputGenesis]
-                -> ContextM [(Word256, ChainInfo, Keccak256, [Action])]
+                -> m [(Word256, ChainInfo, Keccak256, [Action])]
 insertNewChains ogs = fmap catMaybes . forM ogs $ \OutputGenesis{..} -> do
   let (cId, cInfo) = ogGenesisInfo
   $logInfoS "insertNewChains" $ T.pack $ "Inserting Chain ID: " ++ CL.yellow (format cId)
@@ -239,7 +242,7 @@ insertNewChains ogs = fmap catMaybes . forM ogs $ \OutputGenesis{..} -> do
             _ -> return (sr', [])
         Just (cId, cInfo, bHash, mAction) <$ putChainGenesisInfo (Just cId) cBlock sr pChain
 
-outputNewChains :: [(Word256, ChainInfo, Keccak256, [Action])] -> ConduitT a VmOutEvent ContextM ()
+outputNewChains :: VMBase m => [(Word256, ChainInfo, Keccak256, [Action])] -> ConduitT a VmOutEvent m ()
 outputNewChains = traverse_ $ \(cId, cInfo, bHash, actions) -> do
   yield . OutIndexEvent $ NewChainInfo cId cInfo
   yield $ OutToStateDiff cId cInfo bHash

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -8,7 +8,8 @@
 {-# LANGUAGE TypeOperators     #-}
 
 module Executable.EthereumVM (
-  ethereumVM
+  ethereumVM,
+  handleVmEvents
 ) where
 
 import           Conduit
@@ -503,6 +504,7 @@ sendOutEvents OutBatch{..} = do
           }
         _ -> Nothing
   
+  for_ outJSONRPCs $ liftIO . uncurry produceResponse
   for_ outToStateDiffs $ \(cId, cInfo, bHash) ->
     withCurrentBlockHash bHash $ initializeChainDBs (Just cId) cInfo
   traverse_ commitSqlDiffs outStateDiffs

--- a/strato/core/vm-tools/package.yaml
+++ b/strato/core/vm-tools/package.yaml
@@ -10,6 +10,7 @@ dependencies:
   - base
   - blockapps-data
   - blockapps-datadefs
+  - blockapps-init
   - blockstanbul
   - containers
   - exceptions

--- a/strato/core/vm-tools/src/Blockchain/Bagger.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger.hs
@@ -26,7 +26,6 @@ import           Data.Time.Clock
 import           Data.Time.Clock.POSIX              (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
 import qualified Data.Set                           as S
 import           Data.Word
-import           Numeric                            (readHex)
 
 import           BlockApps.Logging
 import           Blockchain.Constants
@@ -48,7 +47,6 @@ import           Blockchain.DB.ModifyStateDB
 import           Blockchain.DB.StorageDB
 import           Blockchain.DB.X509CertDB           (migrateBlockHeaderCertDB)
 import           Blockchain.Database.MerklePatricia (StateRoot (..))
-import qualified Blockchain.EthConf                 as Conf
 import           Blockchain.Sequencer.Event         (OutputBlock (..), OutputTx (..))
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
@@ -555,9 +553,6 @@ buildFromMiningCache = do
                        , obBlockData = rewardedBlockData
                        }
 
-ourCoinbase :: Address
-ourCoinbase = fromInteger . fst . head . readHex . Conf.coinbaseAddress . Conf.quarryConfig $ Conf.ethConf
-
 buildNextBlockHeader :: DD.BlockData
                      -> Keccak256
                      -> [DD.BlockData]
@@ -576,7 +571,7 @@ buildNextBlockHeader parentHeader parentHash uncles stateRoot txs time isPBFT co
         in DD.BlockData { DD.blockDataParentHash       = parentHash
                         , DD.blockDataUnclesHash       = V.ommersVerificationValue uncles
                         -- TODO: when `isPBFT`, coinbase and nonce should be set from a queue of pending votes
-                        , DD.blockDataCoinbase         = if isPBFT then coinbaseAddr else ourCoinbase
+                        , DD.blockDataCoinbase         = coinbaseAddr -- TODO?: Removed case for PoW because it relied on ethConf, but should really come from Vault now
                         , DD.blockDataStateRoot        = stateRoot
                         , DD.blockDataTransactionsRoot = V.transactionsVerificationValue (otBaseTx <$> txs)
                         , DD.blockDataReceiptsRoot     = V.receiptsVerificationValue ()

--- a/strato/core/vm-tools/src/Blockchain/MemVMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/MemVMContext.hs
@@ -17,7 +17,23 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 {-# OPTIONS -fno-warn-deprecations #-}
 
-module Blockchain.MemVMContext where
+module Blockchain.MemVMContext
+  ( module Blockchain.MemVMContext
+  , CurrentBlockHash(..)
+  , MemDBs(..)
+  , ContextState(..)
+  , currentBlock
+  , txRunResultsCache
+  , debugSettings
+  , memDBs
+  , stateRoots
+  , stateTxMap
+  , stateBlockMap
+  , storageTxMap
+  , storageBlockMap
+  , certTxMap
+  , certBlockMap
+  ) where
 
 import           Control.DeepSeq
 import           Control.Lens
@@ -26,17 +42,16 @@ import qualified Control.Monad.Change.Modify        as Mod
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import qualified Data.ByteString                    as B
+import           Data.Default
 import qualified Data.Map                           as M
 import           Data.Maybe                         (fromMaybe)
 import qualified Data.NibbleString                  as N
-import qualified Data.Sequence                      as Q
 import           Data.Traversable                   (for)
 import           Debugger
 import           GHC.Generics
 import           Prometheus
 
 import           BlockApps.Logging
-import           Blockchain.Bagger.BaggerState      (defaultBaggerState)
 import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.Block
 import           Blockchain.Data.BlockSummary
@@ -54,10 +69,10 @@ import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Strato.Model.Keccak256
 import qualified Blockchain.TxRunResultCache        as TRC
 import           Blockchain.VMContext               ( CurrentBlockHash(..)
-                                                    , ContextBestBlockInfo(..)
                                                     , MemDBs(..)
                                                     , ContextState(..)
                                                     , currentBlock
+                                                    , txRunResultsCache
                                                     , debugSettings
                                                     , memDBs
                                                     , stateRoots
@@ -85,6 +100,20 @@ data MemContextDBs = MemContextDBs
   } deriving (Generic)
 makeLenses ''MemContextDBs
 
+instance Default MemContextDBs where
+  def = MemContextDBs
+          { _stateDB        = M.empty
+          , _hashDB         = M.empty
+          , _codeDB         = M.empty
+          , _x509CertDB     = M.empty
+          , _blockSummaryDB = M.empty
+          , _blockHashRoot  = BlockHashRoot MP.emptyTriePtr
+          , _genesisRoot    = GenesisRoot MP.emptyTriePtr
+          , _bestBlockRoot  = BestBlockRoot MP.emptyTriePtr
+          , _certRoot       = CertRoot MP.emptyTriePtr
+          , _worldBestBlock = Nothing
+          }
+
 instance NFData MemContextDBs where
   rnf MemContextDBs{..} =
     _stateDB `seq`
@@ -103,6 +132,9 @@ data MemContext = MemContext
   , _state :: ContextState
   } deriving (Generic, NFData)
 makeLenses ''MemContext
+
+instance Default MemContext where
+  def = MemContext def def
 
 type MemContextM = ReaderT (IORef MemContext) (LoggingT IO) -- I hope we can get rid of the IO dependency someday
 
@@ -313,19 +345,7 @@ instance MonadMonitor (LoggingT IO) where
 runMemContextM :: Maybe DebugSettings
                -> MemContextM a
                -> LoggingT IO (a, MemContext)
-runMemContextM = runMemContextMWith cdbs
-  where cdbs = MemContextDBs
-          { _stateDB        = M.empty
-          , _hashDB         = M.empty
-          , _codeDB         = M.empty
-          , _x509CertDB     = M.empty
-          , _blockSummaryDB = M.empty
-          , _blockHashRoot  = BlockHashRoot MP.emptyTriePtr
-          , _genesisRoot    = GenesisRoot MP.emptyTriePtr
-          , _bestBlockRoot  = BestBlockRoot MP.emptyTriePtr
-          , _certRoot       = CertRoot MP.emptyTriePtr
-          , _worldBestBlock = Nothing
-          }
+runMemContextM = runMemContextMWith def
 
 runMemContextMWith :: MemContextDBs
                    -> Maybe DebugSettings
@@ -333,30 +353,10 @@ runMemContextMWith :: MemContextDBs
                    -> LoggingT IO (a, MemContext)
 runMemContextMWith cdbs dSettings f = do
   cache <- liftIO $ TRC.new 64
-  let cmemDBs = MemDBs
-        { _stateTxMap      = M.empty
-        , _stateBlockMap   = M.empty
-        , _storageTxMap    = M.empty
-        , _storageBlockMap = M.empty
-        , _certTxMap       = M.empty
-        , _certBlockMap    = M.empty
-        , _stateRoots      = M.empty
-        , _currentBlock    = Nothing
-        }
-      cstate = ContextState
-        { _memDBs            = cmemDBs
-        , _baggerState       = defaultBaggerState
-        , _bestBlockInfo     = Unspecified
-        , _hasBlockstanbul   = False
-        , _blockRequested    = False
-        , _coinbaseQueue     = Q.empty
-        , _txRunResultsCache = cache
-        , _debugSettings     = dSettings
-        }
-      ctx = MemContext
-        { _dbs   = cdbs
-        , _state = cstate
-        }
+  let cstate = def
+             & txRunResultsCache .~ cache
+             & debugSettings .~ dSettings
+      ctx = MemContext cdbs cstate
   ctxRef <- newIORef ctx
   a <- flip runReaderT ctxRef $ do
     MP.initializeBlank

--- a/strato/core/vm-tools/src/Blockchain/VMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMContext.hs
@@ -269,11 +269,11 @@ gets f = f <$> get
 {-# INLINE gets #-}
 
 put :: ContextState -> ContextM ()
-put c = view state >>= \i -> atomicWriteIORef i c
+put c = view state >>= \i -> atomicModifyIORef' i (const (c, ()))
 {-# INLINE put #-}
 
 modify :: (ContextState -> ContextState) -> ContextM ()
-modify f = view state >>= \i -> atomicModifyIORef i (\a -> (f a, ()))
+modify f = view state >>= \i -> atomicModifyIORef' i (\a -> (f a, ()))
 {-# INLINE modify #-}
 
 modify' :: (ContextState -> ContextState) -> ContextM ()

--- a/strato/core/vm-tools/src/Blockchain/VMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMContext.hs
@@ -82,7 +82,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import           Control.Monad.Trans.Resource
 import qualified Data.ByteString                    as B
-import           Data.Default                       (def)
+import           Data.Default
 import qualified Data.Map                           as M
 import           Data.Maybe                         (fromMaybe)
 import qualified Data.NibbleString                  as N
@@ -99,8 +99,8 @@ import qualified Network.Kafka                      as K
 import qualified Network.Kafka.Protocol             as K
 import           System.Directory
 import           Text.PrettyPrint.ANSI.Leijen       hiding ((<$>), (</>))
-import           Prometheus
 
+import           BlockApps.Init()
 import           BlockApps.Logging
 import           Blockchain.Bagger.BaggerState      (BaggerState, defaultBaggerState)
 import           Blockchain.Blockstanbul.Authentication as Auth
@@ -177,6 +177,18 @@ data MemDBs = MemDBs
   } deriving (Generic, NFData, Show)
 makeLenses ''MemDBs
 
+instance Default MemDBs where
+  def = MemDBs
+    { _stateTxMap      = M.empty
+    , _stateBlockMap   = M.empty
+    , _storageTxMap    = M.empty
+    , _storageBlockMap = M.empty
+    , _certTxMap       = M.empty
+    , _certBlockMap    = M.empty
+    , _stateRoots      = M.empty
+    , _currentBlock    = Nothing
+    }
+
 data ContextState = ContextState
   { _memDBs            :: MemDBs
   , _baggerState       :: !BaggerState
@@ -188,6 +200,18 @@ data ContextState = ContextState
   , _debugSettings     :: Maybe DebugSettings
   } deriving (Generic, NFData)
 makeLenses ''ContextState
+
+instance Default ContextState where
+  def = ContextState
+    { _memDBs            = def
+    , _baggerState       = defaultBaggerState
+    , _bestBlockInfo     = Unspecified
+    , _hasBlockstanbul   = True
+    , _blockRequested    = False
+    , _coinbaseQueue     = Q.empty
+    , _txRunResultsCache = error "Default ContextState: accessing uninitialized txRunResultsCache"
+    , _debugSettings     = Nothing
+    }
 
 data Context = Context
   { _dbs   :: ContextDBs
@@ -483,9 +507,6 @@ instance Mod.Accessible (Maybe WorldBestBlock) ContextM where
     for mRBB $ \(RedisBestBlock sha num diff) ->
       return . WorldBestBlock $ BestBlock sha num diff
 
-instance MonadMonitor (ResourceT (LoggingT IO)) where
-    doIO = liftIO
-
 runTestContextM :: ( MonadIO m
                    , MonadUnliftIO m
                    , HasStateDB (ReaderT Context (ResourceT m))
@@ -594,27 +615,10 @@ runContextM dSettings f = do
             , _sqldb          = conn
             }
 
-      let cmemDBs = MemDBs
-            { _stateTxMap      = M.empty
-            , _stateBlockMap   = M.empty
-            , _storageTxMap    = M.empty
-            , _storageBlockMap = M.empty
-            , _certTxMap       = M.empty
-            , _certBlockMap    = M.empty
-            , _stateRoots      = M.empty
-            , _currentBlock    = Nothing
-            }
-
-      cstate <- newIORef $ ContextState
-            { _memDBs            = cmemDBs
-            , _baggerState       = defaultBaggerState
-            , _bestBlockInfo     = Unspecified
-            , _hasBlockstanbul   = flags_blockstanbul
-            , _blockRequested    = False
-            , _coinbaseQueue     = Q.empty
-            , _txRunResultsCache = cache
-            , _debugSettings     = dSettings
-            }
+      cstate <- newIORef $ def
+                         & txRunResultsCache .~ cache
+                         & debugSettings .~ dSettings
+                         & hasBlockstanbul .~ flags_blockstanbul
 
       let ctx = Context
             { _dbs   = cdbs

--- a/strato/core/vm-tools/src/Blockchain/VMOptions.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMOptions.hs
@@ -52,5 +52,3 @@ defineFlag "cacheTransactionResults" True "Keep transaction results in an LRU ca
 defineEQFlag "miner" [| Instant :: MinerType |] "MINER" "What mining algorithm"
 defineFlag "gasOn" (True::Bool) "Whether to charge for transactions or not"
 defineFlag "evmCompatible" (False::Bool) "Whether to turn off STRATO enhancements or not"
-defineFlag "network" (""::String) "Choose a network to join"
-defineFlag "networkID" (-1::Int) "set a custom network ID for the client"

--- a/strato/indexer/strato-index/src/Blockchain/Strato/Indexer/IContext.hs
+++ b/strato/indexer/strato-index/src/Blockchain/Strato/Indexer/IContext.hs
@@ -11,6 +11,7 @@
 
 module Blockchain.Strato.Indexer.IContext
     ( IContext(..)
+    , IndexerException(..)
     , API(..)
     , P2P(..)
     , TXR(..)

--- a/strato/libs/prometheus/blockapps-init/package.yaml
+++ b/strato/libs/prometheus/blockapps-init/package.yaml
@@ -6,7 +6,10 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
+  - common-log
   - cross-monitoring
+  - prometheus-client
+  - resourcet
   - text
   - unix
 

--- a/strato/libs/prometheus/blockapps-init/src/BlockApps/Init.hs
+++ b/strato/libs/prometheus/blockapps-init/src/BlockApps/Init.hs
@@ -1,16 +1,26 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module BlockApps.Init ( blockappsInit ) where
 
+import BlockApps.Logging (LoggingT)
 import Control.Concurrent
 import Control.Monad
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Resource (ResourceT)
 import Data.List (intercalate)
 import Data.Text hiding (intercalate)
 import Foreign hiding (void)
 import Foreign.C
 import GHC.Environment
+import Prometheus
 import System.IO
 import System.Posix.Signals
 
 import Blockapps.Crossmon
+
+instance MonadMonitor (ResourceT (LoggingT IO)) where
+    doIO = liftIO
 
 foreign import ccall unsafe "execvp"
   c_execvp :: CString -> Ptr CString -> IO CInt


### PR DESCRIPTION
~It looks like I have the x509 db changes in here, but those should go away once they're merged into develop~
Now they're gone since the other branch was merged

Finally added the VM and the {API, P2P, TXR} indexers to the simulator, and was able to write some interesting tests using them, including calling an `addMember` function and seeing another node index it, and have a new node sync a child chain after being added, with other main chain and private chain txs interleaved.

The simulator's interface is a lot better now too. Instead of having to manually setup every thread, you can now just create a bunch of peers with `createPeer`, connections with `createConnection`, and then run everything with `runNetwork peers connections`