### PR TITLE
strato doit.sh to wait for postgres availability

### DIFF
--- a/strato/doit.sh
+++ b/strato/doit.sh
@@ -19,6 +19,13 @@ if [ "${SLIPSTREAM_DEBUG:-false}" == true ] ; then
 fi
 
 PSQL_CONNECTION_PARAMS="-h ${postgres_host} -p ${postgres_port} -U ${postgres_user}"
+echo 'Waiting for Postgres to be available...'
+until pg_isready ${PSQL_CONNECTION_PARAMS}
+do
+  echo "Check at $(date)"
+  sleep 0.5
+done
+echo 'Postgres is available'
 # Check if this container was initialized before
 if [ ! -f _container_initialized ]; then
   # Check if need to wipe slipstream ("cirrus") db (NOT REQUIRED if in-place update with containers re-created and all volumes intact; REQUIRED in case of re-sync after --drop-chains)


### PR DESCRIPTION
This is to prevent STRATO container restarting on the first start due to race condition of strato and postgres starting simultaneously and causing strato to crash due to PG unavailability.