### PR TITLE
Strato 2756 docker network

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -27,7 +27,7 @@ services:
     - ssl=${ssl:-false}
     build: .
     image: ${SMD_IMAGE:-<REPO_URL>smd:<VERSION>}
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:
@@ -54,7 +54,7 @@ services:
     - vaultWrapperHost=vault-wrapper:8000
     build: .
     image: ${APEX_IMAGE:-<REPO_URL>apex:<VERSION>}
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:
@@ -63,7 +63,7 @@ services:
   redis:
     command: [redis-server, --appendonly, "yes"]
     image: redis:3.2
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:
@@ -84,7 +84,7 @@ services:
     - VAULTWRAPPER_DEBUG=${VAULTWRAPPER_DEBUG}
     build: .
     image: ${VAULTWRAPPER_IMAGE:-<REPO_URL>vault-wrapper:<VERSION>}
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:
@@ -174,7 +174,7 @@ services:
     ports:
     - 30303:30303
     - 30303:30303/udp
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:
@@ -195,7 +195,7 @@ services:
     - POSTGREST_LOG_LEVEL=${POSTGREST_LOG_LEVEL:-error}
     build: .
     image: ${POSTGREST_IMAGE:-<REPO_URL>postgrest:<VERSION>}
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:
@@ -213,7 +213,7 @@ services:
       - "max_connections=300"
       - "-c"
       - "shared_buffers=512MB"
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:
@@ -253,7 +253,7 @@ services:
     - ${HTTPS_PORT:-443}:443 #TAG_REMOVE_WHEN_NO_SSL
     volumes:
     - ./ssl:/tmp/ssl:ro
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:
@@ -263,7 +263,7 @@ services:
     environment:
     - API_URL=/strato-api/eth/v1.2/swagger.json
     image: swaggerapi/swagger-ui:v3.22.1
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:
@@ -271,7 +271,7 @@ services:
         max-file: "3"
   zookeeper:
     image: wurstmeister/zookeeper:3.4.6
-    restart: always
+    restart: unless-stopped
     volumes:
       - zookeeperdata:/opt/zookeeper-3.4.6/data
     logging:
@@ -295,7 +295,7 @@ services:
       KAFKA_MAX_REQUEST_SIZE: ${KAFKA_MAX_REQUEST_SIZE:-100663296}
       KAFKA_MESSAGE_MAX_BYTES: ${KAFKA_MESSAGE_MAX_BYTES:-100663296}
     image: wurstmeister/kafka:1.1.0
-    restart: always
+    restart: unless-stopped
     volumes:
     - kafkadata:/kafka
     logging:
@@ -310,7 +310,7 @@ services:
     image: ${PROMETHEUS_IMAGE:-<REPO_URL>prometheus:<VERSION>}
     volumes:
     - prometheusdata:/prometheus
-    restart: always
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -34,7 +34,7 @@ services:
         max-size: "100m"
         max-file: "3"
   apex:
-    links:
+    depends_on:
     - postgres
     - prometheus
     - strato
@@ -72,7 +72,7 @@ services:
     volumes:
       - redisdata:/data
   vault-wrapper:
-    links:
+    depends_on:
     - postgres
     environment:
     - keyStoreCacheTimeout=${keyStoreCacheTimeout:-60}
@@ -91,7 +91,7 @@ services:
         max-size: "100m"
         max-file: "3"
   strato:
-    links:
+    depends_on:
     - kafka
     - postgres
     - redis
@@ -183,7 +183,7 @@ services:
     volumes:
       - stratodata:/var/lib/strato
   postgrest:
-    links:
+    depends_on:
     - postgres
     environment:
     - blocHost=${blocHost:-strato:3000}
@@ -220,7 +220,7 @@ services:
         max-size: "100m"
         max-file: "3"
   nginx:
-    links:
+    depends_on:
     - apex
     - docs
     - postgrest
@@ -280,7 +280,7 @@ services:
         max-size: "100m"
         max-file: "3"
   kafka:
-    links:
+    depends_on:
     - zookeeper
     environment:
       KAFKA_ADVERTISED_HOST_NAME: kafka

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -2,10 +2,6 @@
 #strato-getting-started-min-version:2.7
 version: "3"
 volumes:
-  blocdata:
-    driver: local
-  dapps:
-    driver: local
   pgdata:
     driver: local
   prometheusdata:

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -335,7 +335,6 @@ services:
     image: wurstmeister/kafka:1.1.0
     restart: always
     volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
     - kafkadata:/kafka
     logging:
       driver: "json-file"

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -18,11 +18,6 @@ volumes:
     driver: local
   zookeeperdata:
     driver: local
-networks:
-  static:
-    ipam:
-      config:
-        - subnet: 172.20.0.0/16
 services:
   smd:
     depends_on:
@@ -42,11 +37,8 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.1
   apex:
-    depends_on:
+    links:
     - postgres
     - prometheus
     - strato
@@ -72,9 +64,6 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.2
   redis:
     command: [redis-server, --appendonly, "yes"]
     image: redis:3.2
@@ -84,13 +73,10 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.5
     volumes:
       - redisdata:/data
   vault-wrapper:
-    depends_on:
+    links:
     - postgres
     environment:
     - keyStoreCacheTimeout=${keyStoreCacheTimeout:-60}
@@ -108,11 +94,8 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.6
   strato:
-    depends_on:
+    links:
     - kafka
     - postgres
     - redis
@@ -201,13 +184,10 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.7
     volumes:
       - stratodata:/var/lib/strato
   postgrest:
-    depends_on:
+    links:
     - postgres
     environment:
     - blocHost=${blocHost:-strato:3000}
@@ -225,9 +205,6 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.8
   postgres:
     environment:
       - POSTGRES_PASSWORD=${postgres_password:-api}
@@ -246,12 +223,10 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.9
   nginx:
-    depends_on:
+    links:
     - apex
+    - docs
     - postgrest
     - prometheus
     - smd
@@ -288,9 +263,6 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.10
   docs:
     environment:
     - API_URL=/strato-api/eth/v1.2/swagger.json
@@ -301,9 +273,6 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.11
   zookeeper:
     image: wurstmeister/zookeeper:3.4.6
     restart: always
@@ -314,11 +283,8 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.12
   kafka:
-    depends_on:
+    links:
     - zookeeper
     environment:
       KAFKA_ADVERTISED_HOST_NAME: kafka
@@ -341,9 +307,6 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.13
   prometheus:
     build: .
     environment:
@@ -357,6 +320,3 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    networks:
-      static:
-        ipv4_address: 172.20.20.14

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -298,12 +298,6 @@ http {
         add_header Content-Type text/plain;      #TEMPLATE_MARK_LOGS
       }                                          #TEMPLATE_MARK_LOGS
                                                  #TEMPLATE_MARK_LOGS
-      location /logs/bloc/ {                     #TEMPLATE_MARK_LOGS
-        rewrite_by_lua_file lua/openid.lua;      #TEMPLATE_MARK_LOGS
-        proxy_pass http://bloc:7065/;            #TEMPLATE_MARK_LOGS
-        add_header Content-Type text/plain;      #TEMPLATE_MARK_LOGS
-      }                                          #TEMPLATE_MARK_LOGS
-                                                 #TEMPLATE_MARK_LOGS
       location /strato-api/eth/v1.2/docs {
         proxy_read_timeout 300;
         proxy_set_header Accept-Encoding "";


### PR DESCRIPTION
This PR has some good Docker-related optimization in STRATO and makes it easier to run STRATO in orchestrated environments by :
- removal of the static docker network and static IPs pre-assigned to each container;
- adding harder container dependencies by switching from `depends_on` (supported by docker-compose only) to docker `links`
- removal of the docker socket volumed into kafka container (which is originally done to enable kafka container to control adjacent containers which we don't use)
- removal of redundant docker volumes which are no longer used (`blocdata`, `dapps`)
- change `restart` policy in docker-compose from `always` to `unless-stopped`

Plus some minor nginx config cleanup.

After doing some manual testing and after the jenkins tests things look good. Nothing changed from the user's standpoint
