### PR TITLE
Unparser upgrade

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -2,6 +2,7 @@
 -- Module: UnParser
 -- Description: The Solidity source unparser to render Xabi into a Solidity Source File
 -- Maintainer: Charles Crain <charles@blockapps.net>
+-- Maintainer: Steven Glasford <steven_glasford@blockapps.net>
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -286,13 +287,6 @@ unparseStatementWith f (TryCatchStatement tryBlock catchBlockMap a) = f a $
   (show (fromMaybe [] params)) ++ " {\n" ++ tab (unlines $ map (unparseStatementWith f) block) ++ "\n}") (Map.toList catchBlockMap)))
 unparseStatementWith f (SolidityTryCatchStatement expr mtpl tryBlock catchBlockMap a) = f a $
   "try " ++ unparseExpression expr ++ " " ++  (show (fromMaybe [] mtpl)) ++ " {\n" ++ tab (unlines $ map (unparseStatementWith f) tryBlock) ++ "\n}" ++ " catch " ++ show (Map.toList catchBlockMap)
--- unparseStatementWith _ x = internalError "missing case in call to unparseStatementWith" $ show x
-
-
-
--- unparseContract :: ContractF a -> String
--- --Use a many statement to go through the list items contained in the ContractF. Making sure everything is able to touched
--- unparseContract = 
 
 unparseVarDefEntry :: VarDefEntryF a -> String
 unparseVarDefEntry BlankEntry = ""

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -47,7 +47,7 @@ unparseSourceUnit (FLEnum name decl) = (("\n    " <>) . unparseTypes) (Text.unpa
 unparseSourceUnit (FLError name args) = (("\n    " <>) . unparseTypes) (Text.unpack name, args)
 unparseSourceUnit (DummySourceUnit) = "DummySourceUnit"
 unparseSourceUnit (NamedXabi name (contract,inherited)) =
-     (case _xabiKind contract of
+     (case xabiKind contract of
         ContractKind -> "contract "
         InterfaceKind -> "interface "
         LibraryKind -> "library ")
@@ -57,16 +57,16 @@ unparseSourceUnit (NamedXabi name (contract,inherited)) =
         xs -> " is " <> Text.unpack (Text.intercalate ", " xs)
      )
   <> " {\n"
-  <> concatMap (("\n    " <>) . unparseVar) (Map.toList $ _xabiVars contract)
-  <> concatMap (("\n    " <>) . unparseConstant) (Map.toList $ _xabiConstants contract)
+  <> concatMap (("\n    " <>) . unparseVar) (Map.toList $ xabiVars contract)
+  <> concatMap (("\n    " <>) . unparseConstant) (Map.toList $ xabiConstants contract)
 
 --  <> concatMap (("\n    " <>) . unparseVar) (sortWith (varTypeAtBytes . snd) $ Map.toList $ xabiVars contract)
-  <> concatMap (("\n    " <>) . unparseTypes) (Map.toList $ _xabiTypes contract)
-  <> concatMap (("\n    " <>) . unparseModifier) (Map.toList $ _xabiModifiers contract)
-  <> concatMap (("\n    " <>) . unparseEvent) (Map.toList $ _xabiEvents contract)
-  <> concatMap (("\n    " <>) . unparseUsing) (Map.toList $ _xabiUsing contract)
-  <> concatMap (("\n    " <>) . unparseCtor) (Map.elems $ _xabiConstr contract)
-  <> concatMap (("\n    " <>) . unparseFunc) (Map.toList $ _xabiFuncs contract)
+  <> concatMap (("\n    " <>) . unparseTypes) (Map.toList $ xabiTypes contract)
+  <> concatMap (("\n    " <>) . unparseModifier) (Map.toList $ xabiModifiers contract)
+  <> concatMap (("\n    " <>) . unparseEvent) (Map.toList $ xabiEvents contract)
+  <> concatMap (("\n    " <>) . unparseUsing) (Map.toList $ xabiUsing contract)
+  <> concatMap (("\n    " <>) . unparseCtor) (Map.elems $ xabiConstr contract)
+  <> concatMap (("\n    " <>) . unparseFunc) (Map.toList $ xabiFuncs contract)
   <> "\n}"
 unparseSourceUnit (FLFunc n a) = unparseFunc (n, a)
 
@@ -173,7 +173,7 @@ unparseFuncOverload name funcs = unlines $ map (unparseFunc . (name,)) funcs
 
 unparseFunc :: (SolidString, Func) -> String
 unparseFunc (name, f) = 
-  if (length (f ^. funcOverload) > 1) then Text.unpack $ unparseFuncWithOverload name f
+  if (length (funcOverload f) > 1) then Text.unpack $ unparseFuncWithOverload name f
         else 
           Text.unpack $ "function " <> labelToText name <> " " <> unparseFuncWithoutName f
 
@@ -192,33 +192,33 @@ unparseFuncDeep deepName Func{..} =
           "("
         else 
           "function " <> labelToText deepName <> " (")
-    <> Text.intercalate ", " (List.map unparseArgs (sortWith (indexedTypeIndex . snd) $ map (\(maybeName, v) -> (fromMaybe "" $ fmap labelToText maybeName , v)) _funcArgs))
+    <> Text.intercalate ", " (List.map unparseArgs (sortWith (indexedTypeIndex . snd) $ map (\(maybeName, v) -> (fromMaybe "" $ fmap labelToText maybeName , v)) funcArgs))
     <> ") "
-    <> case _funcStateMutability of
+    <> case funcStateMutability of
         Just sm -> tShow sm <> " "
         Nothing -> ""
-    <> case _funcVisibility of
+    <> case funcVisibility of
         Just Private -> "private "
         Just Public -> "public "
         Just Internal -> "internal "
         Just External -> "external "
         _ -> ""
-    <> case _funcModifiers of
+    <> case funcModifiers of
         [] -> ""
         xs ->
           "modifiers " <> (Text.intercalate ", " (map Text.pack (map (\(name, args) -> labelToString name <> Text.unpack ("(" <> Text.intercalate ", " (map Text.pack (map unparseExpression args)) <> ")")) xs))) <> " "
-    <> case _funcVals of
+    <> case funcVals of
         [] -> ""
         vals ->
               "returns ("
           <> Text.intercalate ", " (List.map unparseVals $ map (\(maybeName, v) -> (fromMaybe "" $ fmap labelToText maybeName , v)) vals)
           <> ") "
     <> "{\n    "
-    <> case _funcContents of
+    <> case funcContents of
         Just contents -> Text.pack $ tab . tab $ unlines $ map unparseStatement contents --(Text.concat . Text.lines $ contents)
         Nothing -> "\n"
     <> "}"
-    <> case _funcOverload of
+    <> case funcOverload of
           [] -> Text.pack ""
           as -> "\n" <> (Text.unlines $ map (unparseFuncDeep deepName) as)
     -- <> (Text.pack $ show func)
@@ -353,9 +353,9 @@ unparseModifier (name, Modifier{..}) = Text.unpack $
      "modifier "
   <> labelToText name
   <> "("
-  <> Text.intercalate ", " (List.map unparseArgs (Map.toList _modifierArgs))
+  <> Text.intercalate ", " (List.map unparseArgs (Map.toList modifierArgs))
   <> ") {\n        "
-  <> case _modifierContents of
+  <> case modifierContents of
         Just contents -> Text.pack $ tab . tab $ unlines $ map unparseStatement contents --(Text.concat . Text.lines $ contents)
         Nothing -> ""
   <> "}"
@@ -365,9 +365,9 @@ unparseEvent (name, Event{..}) = Text.unpack $
      "event "
   <> labelToText name
   <> "(\n    "
-  <> Text.intercalate ",\n    " (List.map unparseArgs _eventLogs)
+  <> Text.intercalate ",\n    " (List.map unparseArgs eventLogs)
   <> ")"
-  <> (if _eventAnonymous then "anonymous" else "")
+  <> (if eventAnonymous then "anonymous" else "")
   <> ";"
 
 unparseUsing :: (Text, UsingF a) -> String

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -5,18 +5,23 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 module SolidVM.Solidity.Parse.UnParser where
 
+import           Control.Lens               hiding (op)
 import           Data.Maybe
 import           Data.Text  (Text)
 import qualified Data.Text                  as Text
 import qualified Data.List                  as List
 import           Data.Map                   ()
 import qualified Data.Map                   as Map
+import           Data.Source.Annotation
 import           Text.Printf
 
 import           SolidVM.Model.CodeCollection
 import qualified SolidVM.Model.CodeCollection.Def as SolidVM
+import qualified SolidVM.Model.CodeCollection.VarDef as SolidVM
+import           SolidVM.Model.CodeCollection.Contract as SolidVM
 import           SolidVM.Model.SolidString
 import           SolidVM.Model.Type (Type)
 import qualified SolidVM.Model.Type as SVMType
@@ -42,7 +47,7 @@ unparseSourceUnit (FLEnum name decl) = (("\n    " <>) . unparseTypes) (Text.unpa
 unparseSourceUnit (FLError name args) = (("\n    " <>) . unparseTypes) (Text.unpack name, args)
 unparseSourceUnit (DummySourceUnit) = "DummySourceUnit"
 unparseSourceUnit (NamedXabi name (contract,inherited)) =
-     (case xabiKind contract of
+     (case _xabiKind contract of
         ContractKind -> "contract "
         InterfaceKind -> "interface "
         LibraryKind -> "library ")
@@ -52,16 +57,16 @@ unparseSourceUnit (NamedXabi name (contract,inherited)) =
         xs -> " is " <> Text.unpack (Text.intercalate ", " xs)
      )
   <> " {\n"
-  <> concatMap (("\n    " <>) . unparseVar) (Map.toList $ xabiVars contract)
-  <> concatMap (("\n    " <>) . unparseConstant) (Map.toList $ xabiConstants contract)
+  <> concatMap (("\n    " <>) . unparseVar) (Map.toList $ _xabiVars contract)
+  <> concatMap (("\n    " <>) . unparseConstant) (Map.toList $ _xabiConstants contract)
 
 --  <> concatMap (("\n    " <>) . unparseVar) (sortWith (varTypeAtBytes . snd) $ Map.toList $ xabiVars contract)
-  <> concatMap (("\n    " <>) . unparseTypes) (Map.toList $ xabiTypes contract)
-  <> concatMap (("\n    " <>) . unparseModifier) (Map.toList $ xabiModifiers contract)
-  <> concatMap (("\n    " <>) . unparseEvent) (Map.toList $ xabiEvents contract)
-  <> concatMap (("\n    " <>) . unparseUsing) (Map.toList $ xabiUsing contract)
-  <> concatMap (("\n    " <>) . unparseCtor) (Map.elems $ xabiConstr contract)
-  <> concatMap (("\n    " <>) . unparseFunc) (Map.toList $ xabiFuncs contract)
+  <> concatMap (("\n    " <>) . unparseTypes) (Map.toList $ _xabiTypes contract)
+  <> concatMap (("\n    " <>) . unparseModifier) (Map.toList $ _xabiModifiers contract)
+  <> concatMap (("\n    " <>) . unparseEvent) (Map.toList $ _xabiEvents contract)
+  <> concatMap (("\n    " <>) . unparseUsing) (Map.toList $ _xabiUsing contract)
+  <> concatMap (("\n    " <>) . unparseCtor) (Map.elems $ _xabiConstr contract)
+  <> concatMap (("\n    " <>) . unparseFunc) (Map.toList $ _xabiFuncs contract)
   <> "\n}"
 unparseSourceUnit (FLFunc n a) = unparseFunc (n, a)
 
@@ -98,6 +103,49 @@ unparseConstant (name, (ConstantDecl theType isPublic expression _)) =
   <> (" = " ++ unparseExpression expression)
   <> ";"
 
+unparseContract :: SolidVM.Contract -> String
+unparseContract contr = 
+-- TODO: need to recursively retrieve all of the parent contracts
+     "contract "
+  <> labelToString (contr ^. contractName)
+  -- <> if (contr ^. parents )
+  <> " {\n  "
+  <> (List.intercalate "\n  " $ List.map unparseConstant (Map.assocs $ contr ^. constants)) -- ( contr ^. constants , contr ^. constants))
+  <> (List.intercalate "\n  " $ List.map unparseVar (Map.assocs $ contr ^. storageDefs))
+  <> (List.intercalate "\n  " $ List.map unparseEnum (fmap (fmap fst) (Map.assocs $ contr ^. enums)))
+  <> (List.intercalate "\n  " $ List.map unparseStruct (Map.assocs $ contr ^. structs))
+  <> (List.intercalate "\n  " $ List.map unparseEvent (Map.assocs $ contr ^. events))
+  <> (List.intercalate "\n  " $ List.map unparseFunc (Map.assocs $ contr ^. functions))
+  <> case (contr ^. constructor) of
+    Just funf -> ("\n  " ++ (unparseCtor funf))
+    Nothing -> "\n  // no constructor found"
+  <> (List.intercalate "\n  " $ List.map unparseModifier (Map.assocs $ contr ^. modifiers))
+  <> "\n}"
+
+
+unparseStruct :: (SolidString ,[(SolidString, SolidVM.FieldType, SourceAnnotation ())]) -> String
+unparseStruct (name, fields) =
+     "struct "
+  <> labelToString name
+  <> " {\n  "
+  <> (List.intercalate "  " $ List.map unparseStructField fields)
+  <> "}"
+
+unparseStructField :: (SolidString, SolidVM.FieldType, SourceAnnotation ()) -> String
+unparseStructField (name, theType, _) =
+     unparseVarType (fieldTypeType theType)
+  <> " "
+  <> labelToString name
+  <> ";\n"
+
+unparseEnum :: (SolidString, [SolidString]) -> String
+unparseEnum (name, values) =
+     "enum "
+  <> labelToString name
+  <> " {\n  "
+  <> (List.intercalate ",\n  " $ List.map labelToString values)
+  <> "\n}"
+
 unparseVarType :: Type -> String
 unparseVarType (SVMType.Int (Just True) (Just n)) = "int" <> show (8*n)
 unparseVarType (SVMType.Int (Just True) Nothing) = "int"
@@ -120,45 +168,64 @@ unparseVarType (SVMType.Contract contractName') = labelToString contractName'
 unparseVarType (SVMType.Struct _ n) = "struct " ++ labelToString n
 unparseVarType _ = "TYPE_NOT_IMPLEMENED"
 
+unparseFuncOverload :: SolidString -> [Func] -> String
+unparseFuncOverload name funcs = unlines $ map (unparseFunc . (name,)) funcs
+
 unparseFunc :: (SolidString, Func) -> String
-unparseFunc (name, f) = Text.unpack $ "function " <> labelToText name <> unparseFuncWithoutName f
+unparseFunc (name, f) = 
+  if (length (f ^. funcOverload) > 1) then Text.unpack $ unparseFuncWithOverload name f
+        else 
+          Text.unpack $ "function " <> labelToText name <> " " <> unparseFuncWithoutName f
 
 unparseCtor :: Func -> String
-unparseCtor f = Text.unpack $ "constructor" <> unparseFuncWithoutName f
+unparseCtor f = Text.unpack $ "constructor " <> unparseFuncWithoutName f
 
-unparseFuncWithoutName :: Func -> Text
-unparseFuncWithoutName Func{..} =
-       "("
-    <> Text.intercalate ", " (List.map unparseArgs (sortWith (indexedTypeIndex . snd) $ map (\(maybeName, v) -> (fromMaybe "" $ fmap labelToText maybeName , v)) funcArgs))
+unparseFuncWithOverload :: SolidString -> Func -> Text
+unparseFuncWithOverload name myFunction = unparseFuncDeep name myFunction
+
+unparseFuncWithoutName:: Func -> Text
+unparseFuncWithoutName f = unparseFuncDeep "" f
+
+unparseFuncDeep :: SolidString -> Func -> Text
+unparseFuncDeep deepName Func{..} =
+       (if (deepName == "") then
+          "("
+        else 
+          "function " <> labelToText deepName <> " (")
+    <> Text.intercalate ", " (List.map unparseArgs (sortWith (indexedTypeIndex . snd) $ map (\(maybeName, v) -> (fromMaybe "" $ fmap labelToText maybeName , v)) _funcArgs))
     <> ") "
-    <> case funcStateMutability of
+    <> case _funcStateMutability of
         Just sm -> tShow sm <> " "
         Nothing -> ""
-    <> case funcVisibility of
+    <> case _funcVisibility of
         Just Private -> "private "
         Just Public -> "public "
         Just Internal -> "internal "
         Just External -> "external "
         _ -> ""
-    <> case funcModifiers of
+    <> case _funcModifiers of
         [] -> ""
         xs ->
           "modifiers " <> (Text.intercalate ", " (map Text.pack (map (\(name, args) -> labelToString name <> Text.unpack ("(" <> Text.intercalate ", " (map Text.pack (map unparseExpression args)) <> ")")) xs))) <> " "
-    <> case funcVals of
+    <> case _funcVals of
         [] -> ""
         vals ->
               "returns ("
           <> Text.intercalate ", " (List.map unparseVals $ map (\(maybeName, v) -> (fromMaybe "" $ fmap labelToText maybeName , v)) vals)
           <> ") "
-    <> "{\n        "
-    <> case funcContents of
+    <> "{\n    "
+    <> case _funcContents of
         Just contents -> Text.pack $ tab . tab $ unlines $ map unparseStatement contents --(Text.concat . Text.lines $ contents)
-        Nothing -> ""
+        Nothing -> "\n"
     <> "}"
+    <> case _funcOverload of
+          [] -> Text.pack ""
+          as -> "\n" <> (Text.unlines $ map (unparseFuncDeep deepName) as)
+    -- <> (Text.pack $ show func)
 
 tab :: String -> String
 tab [] = []
-tab ('\n':rest) = "\n    " ++ tab rest
+tab ('\n':rest) = "\n  " ++ tab rest
 tab (x:rest) = x:tab rest
 
 unparseStatement :: Show a => StatementF a -> String
@@ -221,6 +288,12 @@ unparseStatementWith f (SolidityTryCatchStatement expr mtpl tryBlock catchBlockM
   "try " ++ unparseExpression expr ++ " " ++  (show (fromMaybe [] mtpl)) ++ " {\n" ++ tab (unlines $ map (unparseStatementWith f) tryBlock) ++ "\n}" ++ " catch " ++ show (Map.toList catchBlockMap)
 -- unparseStatementWith _ x = internalError "missing case in call to unparseStatementWith" $ show x
 
+
+
+-- unparseContract :: ContractF a -> String
+-- --Use a many statement to go through the list items contained in the ContractF. Making sure everything is able to touched
+-- unparseContract = 
+
 unparseVarDefEntry :: VarDefEntryF a -> String
 unparseVarDefEntry BlankEntry = ""
 unparseVarDefEntry (VarDefEntry maybeType maybeLoc theName _) =
@@ -280,9 +353,9 @@ unparseModifier (name, Modifier{..}) = Text.unpack $
      "modifier "
   <> labelToText name
   <> "("
-  <> Text.intercalate ", " (List.map unparseArgs (Map.toList modifierArgs))
+  <> Text.intercalate ", " (List.map unparseArgs (Map.toList _modifierArgs))
   <> ") {\n        "
-  <> case modifierContents of
+  <> case _modifierContents of
         Just contents -> Text.pack $ tab . tab $ unlines $ map unparseStatement contents --(Text.concat . Text.lines $ contents)
         Nothing -> ""
   <> "}"
@@ -292,9 +365,9 @@ unparseEvent (name, Event{..}) = Text.unpack $
      "event "
   <> labelToText name
   <> "(\n    "
-  <> Text.intercalate ",\n    " (List.map unparseArgs eventLogs)
+  <> Text.intercalate ",\n    " (List.map unparseArgs _eventLogs)
   <> ")"
-  <> (if eventAnonymous then "anonymous" else "")
+  <> (if _eventAnonymous then "anonymous" else "")
   <> ";"
 
 unparseUsing :: (Text, UsingF a) -> String
@@ -335,9 +408,12 @@ unparseArgs (name, theType) = unparseIndexedType theType <> " " <>  name
 unparseVals :: (Text, IndexedType) -> Text
 unparseVals (name, theType) =
      unparseIndexedType theType
-  <> if Text.head name == '#'
-     then ""
-     else " " <> name
+  <> if ((Text.length name) > 0) then 
+    if Text.head name == '#' then
+      ""
+    else " " <> name
+    else " " <> name 
+
 
 unparseIndexedType :: IndexedType -> Text
 unparseIndexedType = Text.pack . unparseVarType . indexedTypeType


### PR DESCRIPTION
This is a fork from STRATO-2514 that adds more functionality to the unparser, with especial care taken to enhance the process of unparsing a contract. NOTE: this cannot unparse contracts that have inheritance, the reasoning is that a contract with inheritance has a more complicated event flow when using call functions as a contract that needs other contracts from other sources might have chains that don't belong to the current chain, among other problems. A fix to allow for call functions to recursively find other inherited contracts is in the works, but remains a distant foresight at the moment.