### PR TITLE
Flush cert db everywhere that MemAddressStateDB gets flushed

### DIFF
--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -133,6 +133,12 @@ instance (Monad m, HasMemRawStorageDB m) => HasMemRawStorageDB (ConduitT i o m) 
   getMemRawStorageBlockDB  = lift getMemRawStorageBlockDB
   putMemRawStorageBlockMap = lift. putMemRawStorageBlockMap
 
+instance (Monad m, HasMemCertDB m) => HasMemCertDB (ConduitT i o m) where
+  getCertTxDBMap    = lift getCertTxDBMap
+  putCertTxDBMap    = lift . putCertTxDBMap
+  getCertBlockDBMap = lift getCertBlockDBMap
+  putCertBlockDBMap = lift . putCertBlockDBMap 
+
 -- todo: lovely!
 
 addBlocks :: (MonadFail m, VMBase m, Bagger.MonadBagger m, MonadMonitor m) => [OutputBlock] -> ConduitT a VmOutEvent m ()
@@ -724,12 +730,14 @@ completeDiff :: ( MonadLogger m
                 , Mod.Modifiable MemDBs m
                 , Mod.Modifiable CurrentBlockHash m
                 , Mod.Modifiable BestBlockRoot m
+                , Mod.Modifiable CertRoot m
                 , HasMemAddressStateDB m
                 , (MP.StateRoot `A.Alters` MP.NodeData) m
                 , (Account `A.Alters` AddressState) m
                 , (Maybe Word256 `A.Alters` MP.StateRoot) m
                 , HasMemRawStorageDB m
                 , (RawStorageKey `A.Alters` RawStorageValue) m
+                , HasMemCertDB m
                 )
              => ToDiff -> m SD.StateDiff
 completeDiff (src, dst, hsh, num) = withCurrentBlockHash hsh $ do

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -53,7 +53,7 @@ import           Blockchain.Data.DataDefs              (blockDataExtraData, bloc
 import           Blockchain.Data.GenesisBlock
 import           Blockchain.DB.BlockSummaryDB
 import           Blockchain.DB.ChainDB
-import           Blockchain.DB.X509CertDB              (CertRoot(..), bootstrapCertDB)
+import           Blockchain.DB.X509CertDB              (CertRoot(..), bootstrapCertDB, flushMemCertDB)
 import           Blockchain.EthConf
 import           Blockchain.Event
 import           Blockchain.JsonRpcCommand

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -383,6 +383,7 @@ runChainConstructors cId cInfo = do
 
   flushMemStorageDB
   Mem.flushMemAddressStateDB
+  flushMemCertDB . unCurrentBlockHash =<< Mod.get (Mod.Proxy @CurrentBlockHash)
 
   sr <- A.lookupWithDefault (Proxy @MP.StateRoot) (Just cId)
   return (sr, actions)

--- a/strato/core/vm-tools/src/Blockchain/Bagger.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger.hs
@@ -99,6 +99,7 @@ runFromStateRoot mineTransactions remainingGas theBlockHeader txs = do
       $ mineTransactions theBlockHeader remainingGas txs
     timeit "flushMemStorageDB bagger" (Just vmBlockInsertionMined) flushMemStorageDB
     timeit "flushMemAddressStateDB bagger" (Just vmBlockInsertionMined) flushMemAddressStateDB
+    timeit "flushMemCertDB bagger" (Just vmBlockInsertionMined) $ flushMemCertDB baggerBlockHash
     newStateRoot <- A.lookupWithDefault (A.Proxy @StateRoot) (Nothing :: Maybe Word256)
     let recoverable f = Left (RecoverableFailure (tfToBaggerTxRejection f) ranTxs unranTxs newStateRoot newGas)
     return $ case res of -- currently only get GasLimit errors out of mineTransactions'
@@ -119,6 +120,7 @@ rewardCoinbases us uncles ourNumber = do
         return ()
     flushMemStorageDB
     flushMemAddressStateDB
+    flushMemCertDB baggerBlockHash
     A.lookupWithDefault (A.Proxy @StateRoot) (Nothing :: Maybe Word256)
 
 -- todo batch insert results

--- a/strato/core/vm-tools/src/Blockchain/Bagger.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger.hs
@@ -45,7 +45,7 @@ import           Blockchain.DB.ChainDB
 import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.DB.ModifyStateDB
 import           Blockchain.DB.StorageDB
-import           Blockchain.DB.X509CertDB           (migrateBlockHeaderCertDB)
+import           Blockchain.DB.X509CertDB           (migrateBlockHeaderCertDB, flushMemCertDB)
 import           Blockchain.Database.MerklePatricia (StateRoot (..))
 import           Blockchain.Sequencer.Event         (OutputBlock (..), OutputTx (..))
 import           Blockchain.Strato.Model.Account

--- a/strato/core/vm-tools/src/Blockchain/VMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMContext.hs
@@ -268,6 +268,7 @@ withCurrentBlockHash bh f = do
   a <- f
   flushMemStorageDB
   flushMemAddressStateDB
+  flushMemCertDB bh
   Mod.modifyStatefully_ (Mod.Proxy @MemDBs) $ stateRoots .= M.empty
   Mod.put (Mod.Proxy @CurrentBlockHash) cbh
   pure a

--- a/strato/core/vm-tools/src/Blockchain/VMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMContext.hs
@@ -253,6 +253,7 @@ type VMBase m = ( MonadIO m
 withCurrentBlockHash :: ( MonadLogger m
                         , Mod.Modifiable MemDBs m
                         , Mod.Modifiable CurrentBlockHash m
+                        , Mod.Modifiable CertRoot m
                         , HasMemAddressStateDB m
                         , (Maybe Word256 `A.Alters` MP.StateRoot) m
                         , (MP.StateRoot `A.Alters` MP.NodeData) m
@@ -260,6 +261,7 @@ withCurrentBlockHash :: ( MonadLogger m
                         , (N.NibbleString `A.Alters` N.NibbleString) m
                         , HasMemRawStorageDB m
                         , (RawStorageKey `A.Alters` RawStorageValue) m
+                        , HasMemCertDB m
                         )
                      => Keccak256 -> m a -> m a
 withCurrentBlockHash bh f = do


### PR DESCRIPTION
This should fix the crash we saw on the devnet, where the root node crashed after proposing and committing a block that included cert registrations