### PR TITLE
Rework OrgName and OrgUnit types

### DIFF
--- a/strato/core/blockapps-data/src/Blockchain/Data/Enode.hs
+++ b/strato/core/blockapps-data/src/Blockchain/Data/Enode.hs
@@ -65,8 +65,8 @@ instance Arbitrary IPAddress where
   arbitrary = genericArbitrary
 
 newtype OrgId = OrgId { unOrgId :: B.ByteString } deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary, Data)
-newtype OrgName = OrgName { unOrgName :: B.ByteString } deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary, Data)
-newtype OrgUnit = OrgUnit { unOrgUnit :: Maybe B.ByteString } deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary, Data)
+newtype OrgName = OrgName { unOrgName :: String } deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary, Data)
+newtype OrgUnit = OrgUnit { unOrgUnit :: Maybe String } deriving (Show, Read, Eq, Ord, GHCG.Generic, NFData, Binary, Data)
 
 instance RLPSerializable OrgId where
   rlpEncode (OrgId bs) = rlpEncode bs

--- a/strato/core/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/strato/core/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -40,7 +40,6 @@ import qualified Blockchain.Blockstanbul.HTTPAdmin         as PBFT
 import           Blockchain.Sequencer.DB.Witnessable
 import qualified Data.ByteString                           as BS
 import qualified Data.ByteString.Lazy                      as B
-import qualified Data.ByteString.Char8                     as C8
 
 import           Blockchain.Sequencer.BinaryInstances      ()
 
@@ -111,7 +110,7 @@ data IngestEvent = IETx Timestamp IngestTx
                  | IEBlock IngestBlock
                  | IEGenesis IngestGenesis
                  | IENewChainMember Word256 A.Address Enode
-                 | IENewChainOrgName Word256 (BS.ByteString, Maybe BS.ByteString)
+                 | IENewChainOrgName Word256 (String, Maybe String)
                  | IEBlockstanbul PBFT.WireMessage
                  | IEForcedConfigChange PBFT.ForcedConfigChange
                  | IEValidatorBehavior PBFT.ForcedValidatorChange
@@ -143,7 +142,7 @@ instance Format IngestEvent where
   format (IEBlock o) = format o
   format (IEGenesis o) = show o
   format (IENewChainMember c a e) = intercalate ", " [CL.yellow $ format c, format a, show e]
-  format (IENewChainOrgName c (n, u)) = intercalate ", " [CL.yellow $ format c, format n, C8.unpack $ fromMaybe BS.empty u]
+  format (IENewChainOrgName c (n, u)) = intercalate ", " [CL.yellow $ format c, show n, fromMaybe "" u]
   format (IEBlockstanbul o) = format o
   format (IEForcedConfigChange o) = format o
   format (IEValidatorBehavior o) = show o
@@ -186,7 +185,7 @@ data P2pEvent =
   | P2pGetChain [Word256]
   | P2pGetTx [Keccak256]
   | P2pNewChainMember Word256 A.Address Enode
-  | P2pNewOrgName Word256 (BS.ByteString, Maybe BS.ByteString)
+  | P2pNewOrgName Word256 (String, Maybe String)
   | P2pBlockstanbul PBFT.WireMessage
   -- Ask and push for inclusive ranges of blocks
   | P2pAskForBlocks {askStart :: Integer, askEnd :: Integer, askPeer :: A.Address}
@@ -200,7 +199,7 @@ instance Format P2pEvent where
   format (P2pGetChain cids)        = "[" ++ (intercalate "," $ map (CL.yellow . format) cids) ++ "]"
   format (P2pGetTx shas)           = "[" ++ (intercalate "," $ map format shas) ++ "]"
   format (P2pNewChainMember c a e) = intercalate ", " [CL.yellow $ format c, format a, show e]
-  format (P2pNewOrgName c (n, u)) = intercalate ", " [CL.yellow $ format c, format n, C8.unpack $ fromMaybe BS.empty u]
+  format (P2pNewOrgName c (n, u)) = intercalate ", " [CL.yellow $ format c, show n, fromMaybe "" u]
   format (P2pBlockstanbul o)       = format o
   format x                          = show x
 

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -431,7 +431,7 @@ handleEvents peer = awaitForever $ \case
           for_ mcInfo $ yieldR . ChainDetails . (:[])
       P2pNewOrgName cId org -> do
         let formatted = CL.yellow $ format cId
-            orgFormat = CL.blue $ format org
+            orgFormat = CL.blue $ show org
         peerCheck <- lift $ checkPeerIsMember peer (ChainMembers M.empty)
         when peerCheck $ do
           $logInfoS "handleEvents/P2pNewOrgName" $ T.pack $ "New organization associated with chain " ++ formatted ++ " for org " ++ orgFormat
@@ -601,7 +601,7 @@ checkPeerIsMember' mode peer mems = do
   peerCert <- getPeerX509 peer
   orgChains <- case peerCert of
     Nothing  -> return $ OrgNameChains S.empty
-    Just cIs -> selectWithDefault (Proxy @OrgNameChains) $ (OrgName . BS8.pack . orgName &&& OrgUnit . fmap BS8.pack . orgUnit) cIs
+    Just cIs -> selectWithDefault (Proxy @OrgNameChains) $ (OrgName . orgName &&& OrgUnit . orgUnit) cIs
 
   return $ checkPeerIsMember'' mode peer mems peerCert orgChains
 
@@ -632,9 +632,7 @@ peerIPAddress = readIP . T.unpack . pPeerIp
 
 -- extract the organization name from the cert
 certOrgTuple :: Maybe X509CertInfoState -> (OrgName, OrgUnit)
-certOrgTuple = maybe
-  (OrgName BS8.empty, OrgUnit Nothing)
-  (OrgName . BS8.pack . orgName &&& OrgUnit . fmap BS8.pack . orgUnit)
+certOrgTuple = maybe (OrgName "", OrgUnit Nothing) (OrgName . orgName &&& OrgUnit . orgUnit)
 
 {- to reduce redundant computations on dividing block chunks under txsLimit
 splitNeededHeaders :: [BlockHeader] -> [[BlockHeader]]

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -1837,7 +1837,7 @@ contract RegisterCert {
 
           -- Node 1's cert was registered in the contract so it should receive the chain ID
           (ctxs1 !! 1) ^. orgNameChainsMap `shouldBe`
-            M.singleton (OrgName $ BC.pack "Blockapps", OrgUnit $ Just (BC.pack "engineering")) (OrgNameChains $ Set.singleton testCid)
+            M.singleton (OrgName "Blockapps", OrgUnit $ Just "engineering") (OrgNameChains $ Set.singleton testCid)
 
           -- Node 2's cert is not registered so it should not have any in the set
           (ctxs1 !! 2) ^. orgNameChainsMap `shouldBe` M.empty

--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -392,14 +392,14 @@ removeOrgIdChain ip cId = do
         TxAborted   -> pure . Left $ SingleLine (S8.pack $ "removeOrgIdChain - Aborted")
         TxError e   -> pure . Left $ SingleLine (S8.pack $ "removeOrgIdChain - Error" ++ e)
 
-getOrgNameChains :: (S8.ByteString, Maybe S8.ByteString)
+getOrgNameChains :: (String, Maybe String)
                  -> Redis (S.Set Word256)
 getOrgNameChains org = getInNamespace PrivateOrgNameChains org <&> \case
     Right (Just rchains) -> let RedisOrgNameChains chains = fromValue rchains
                             in chains
     _                    -> S.empty
 
-addOrgNameChain :: (S8.ByteString, Maybe S8.ByteString)
+addOrgNameChain :: (String, Maybe String)
                 -> Word256
                 -> Redis (Either Reply Status)
 addOrgNameChain org cId = do
@@ -411,7 +411,7 @@ addOrgNameChain org cId = do
         TxAborted   -> pure . Left $ SingleLine (S8.pack $ "addOrgNameChain - Aborted")
         TxError e   -> pure . Left $ SingleLine (S8.pack $ "addOrgNameChain - Error" ++ e)
 
-removeOrgNameChain :: (S8.ByteString, Maybe S8.ByteString)
+removeOrgNameChain :: (String, Maybe String)
                    -> Word256
                    -> Redis (Either Reply Status)
 removeOrgNameChain org cId = do
@@ -957,9 +957,9 @@ runStratoRedisIO r = liftIO $ do
   runRedis conn r
 
 -- Retrieve a organization name and unit associated with an address
-addressToOrg :: Address -> Redis (Maybe (S8.ByteString, Maybe S8.ByteString))
+addressToOrg :: Address -> Redis (Maybe (String, Maybe String))
 addressToOrg addr = do
     cIs <- getCertificate addr
     case cIs of
         Nothing -> return Nothing
-        Just c  -> return $ Just . (S8.pack *** fmap S8.pack) $ (orgName &&& orgUnit) c
+        Just c  -> return . Just $ (orgName &&& orgUnit) c

--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB/Models.hs
@@ -58,7 +58,7 @@ instance RedisDBValuable Bool where
     toValue True = S8.singleton 't'
     toValue False = S8.empty
     fromValue = not . S8.null
-    
+
 instance RedisDBValuable Account where
     toValue = toStrict . encode
     fromValue = decode . fromStrict
@@ -66,11 +66,11 @@ instance RedisDBValuable Account where
 instance RedisDBKeyable S8.ByteString where
     toKey = SB16.encode
 
-instance RedisDBKeyable (S8.ByteString, Maybe S8.ByteString) where
-    toKey (n, u) = SB16.encode $ S8.concat [n, maybeSnd] 
+instance RedisDBKeyable (String, Maybe String) where
+    toKey (n, u) = SB16.encode . S8.pack $ (n ++ maybeSnd)
         where maybeSnd = case u of
-                Nothing -> S8.empty
-                Just a  -> S8.concat [S8.pack "/", a] 
+                Nothing -> ""
+                Just a  -> "/" ++ a
 instance RedisDBValuable S8.ByteString where
     toValue   = SB16.encode
     fromValue x = case SB16.decode x of

--- a/strato/indexer/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
+++ b/strato/indexer/strato-index/src/Blockchain/Strato/Indexer/TxrIndexer.hs
@@ -82,24 +82,24 @@ doRemoveMember chainId address = do
   lift $ removeMember chainId address
   void . RBDB.withRedisBlockDB $ RBDB.removeChainMember chainId address
 
-doAddOrgName :: Word256 -> (BS.ByteString, Maybe BS.ByteString) -> IContextM ()
+doAddOrgName :: Word256 -> (String, Maybe String) -> IContextM ()
 doAddOrgName chainId org = do
   logF [ "Adding chain "
        , formatChainId $ Just chainId
        , " to org "
-       , C8.unpack $ fst org
-       , maybe "" ((++) "/" . C8.unpack) (snd org)
+       , fst org
+       , maybe "" ("/" ++) (snd org)
        ]
   void . RBDB.withRedisBlockDB $ RBDB.addOrgNameChain org chainId
   void . withKafkaRetry1s $ writeUnseqEvents [IENewChainOrgName chainId org]
 
-doRemoveOrgName :: Word256 -> (BS.ByteString, Maybe BS.ByteString) -> IContextM ()
+doRemoveOrgName :: Word256 -> (String, Maybe String) -> IContextM ()
 doRemoveOrgName chainId org = do
   logF [ "Removing chain "
        , formatChainId $ Just chainId
        , " from org "
-       , C8.unpack $ fst org
-       , maybe "" ((++) "/" . C8.unpack) (snd org)
+       , fst org
+       , maybe "" ("/" ++) (snd org)
        ]
   void . RBDB.withRedisBlockDB $ RBDB.removeOrgNameChain org chainId
 
@@ -137,8 +137,8 @@ txrIndexer = runIContextM "strato-txr-indexer" . forever $ do
 
 data TxrResult = AddMember (Either String (Word256, Address, Enode))
                | RemoveMember (Either String (Word256, Address))
-               | AddOrgName (Either String (Word256, (BS.ByteString, Maybe BS.ByteString)))
-               | RemoveOrgName (Either String (Word256, (BS.ByteString, Maybe BS.ByteString)))
+               | AddOrgName (Either String (Word256, (String, Maybe String)))
+               | RemoveOrgName (Either String (Word256, (String, Maybe String)))
                | RegisterCertificate (Either String (Account, Address, X509CertInfoState))
                | CertificateRevoked (Either String (Account, Address))
                | CertificateRegistryInitialized (Either String Account)
@@ -180,12 +180,12 @@ indexEventToTxrResults = \case
         Nothing -> Just . RemoveMember . Left $ "failed to parse address for MemberRemoved event: " ++ addressStr
         Just address -> Just . RemoveMember $ Right (chainId, address)
       (Just chainId, "OrganizationAdded", _) -> case eventDBArgs ev of
-        (n:u:_) -> Just . AddOrgName $ Right (chainId, (C8.pack n, Just $ C8.pack u))
-        (n:_)   -> Just . AddOrgName $ Right (chainId, (C8.pack n, Nothing))
+        (n:u:_) -> Just . AddOrgName $ Right (chainId, (n, Just u))
+        (n:_)   -> Just . AddOrgName $ Right (chainId, (n, Nothing))
         []      -> Just . AddOrgName . Left $ "failed to provide any arguments for OrganizationAdded event"
       (Just chainId, "OrganizationRemoved", _) -> case eventDBArgs ev of
-        (n:u:_) -> Just . RemoveOrgName $ Right (chainId, (C8.pack n, Just $ C8.pack u))
-        (n:_)   -> Just . RemoveOrgName $ Right (chainId, (C8.pack n, Nothing))
+        (n:u:_) -> Just . RemoveOrgName $ Right (chainId, (n, Just u))
+        (n:_)   -> Just . RemoveOrgName $ Right (chainId, (n, Nothing))
         []      -> Just . RemoveOrgName . Left $ "failed to provide any arguments for OrganizationRemoved event"
       (Nothing, "CertificateRegistered", [certString]) ->
         let cert = bsToCert . C8.pack $ certString


### PR DESCRIPTION
I had originally given these types `ByteString` for some reason and now that @davidnallapu is working with them I realize that it was a bit overkill, so I'm switching them to `String`'s. In fact, it cleans up a lot of the code since packing/unpacking isn't necessary anymore. No functionality changed.