### PR TITLE
Strato 2838 ecrecover fix

### DIFF
--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -960,7 +960,7 @@ blockhashArgs :: SourceAnnotation Text -> Type'
 blockhashArgs x = intType' x
 
 ecrecoverArgs :: SourceAnnotation Text -> Type'
-ecrecoverArgs x = Product [stringType' x, intType' x, intType' x, intType' x] x
+ecrecoverArgs x = Product [stringType' x, intType' x, stringType' x, stringType' x] x
 
 addmodArgs  :: SourceAnnotation Text -> Type'
 addmodArgs x = Product [intType' x, intType' x, intType' x] x

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -43,6 +43,7 @@ import qualified Data.ByteString.Base16               as B16
 import qualified Data.ByteString.Char8                as BC
 import qualified Data.ByteString.Short                as BSS
 import qualified Data.ByteString.UTF8                 as UTF8
+-- import qualified Data.ByteString.UTF8                 as BSU
 import           Data.ByteString.Internal             (c2w)
 import           Data.Char                            as CHAR
 import           Data.Either.Extra                    (eitherToMaybe)
@@ -2664,13 +2665,20 @@ callBuiltin "keccak256" args Nothing = do
   case allStrings args of
     False -> invalidArguments "cannot use a non string arguments in keccak256" args
     True ->  return . SString . BC.unpack . keccak256ToByteString . hash . BC.pack $ customConcat args
-callBuiltin ecrecover@("ecrecover") [SString h, SInteger r, SInteger s, SInteger v] _ = do
+callBuiltin ecrecover@("ecrecover") [SString h, SInteger v, SString r, SString s] _ = do
   contract' <- getCurrentContract
   if CC._vmVersion contract' == "svm3.4"
     then do 
       let intHash = intBuiltin [SString h]
       bytestringHash <- encodeForReturn intHash
-      let theSignerAddress = whoSignedThisTransactionEcrecover (unsafeCreateKeccak256FromByteString bytestringHash) r s v
+      -- let bytestringHash = BSU.fromString h
+      let rIntHash = intBuiltin [SString r]
+      rByteStringHash <- encodeForReturn rIntHash
+      let sIntHash = intBuiltin [SString s]
+      sByteStringHash <- encodeForReturn sIntHash      
+      -- let rByteStringHash = BSU.fromString r
+      -- let sByteStringHash = BSU.fromString s
+      let theSignerAddress = whoSignedThisTransactionEcrecover (bytestringHash) rByteStringHash sByteStringHash v
       let theZero ::  Integer
           theZero = 0
       case theSignerAddress of

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -43,7 +43,7 @@ import qualified Data.ByteString.Base16               as B16
 import qualified Data.ByteString.Char8                as BC
 import qualified Data.ByteString.Short                as BSS
 import qualified Data.ByteString.UTF8                 as UTF8
--- import qualified Data.ByteString.UTF8                 as BSU
+import qualified Numeric                              (readHex)
 import           Data.ByteString.Internal             (c2w)
 import           Data.Char                            as CHAR
 import           Data.Either.Extra                    (eitherToMaybe)
@@ -2671,14 +2671,13 @@ callBuiltin ecrecover@("ecrecover") [SString h, SInteger v, SString r, SString s
     then do 
       let intHash = intBuiltin [SString h]
       bytestringHash <- encodeForReturn intHash
-      -- let bytestringHash = BSU.fromString h
-      let rIntHash = intBuiltin [SString r]
-      rByteStringHash <- encodeForReturn rIntHash
-      let sIntHash = intBuiltin [SString s]
-      sByteStringHash <- encodeForReturn sIntHash      
-      -- let rByteStringHash = BSU.fromString r
-      -- let sByteStringHash = BSU.fromString s
-      let theSignerAddress = whoSignedThisTransactionEcrecover (bytestringHash) rByteStringHash sByteStringHash v
+      rIntHash <-case Numeric.readHex r of
+        [(x, "")] -> return x
+        _ -> invalidArguments "parseHex: error parsing r: " r
+      sIntHash <- case Numeric.readHex s of
+        [(y, "")] -> return y
+        _ -> invalidArguments "parseHex: error parsing s: " s
+      let theSignerAddress = whoSignedThisTransactionEcrecover (unsafeCreateKeccak256FromByteString bytestringHash) rIntHash sIntHash v
       let theZero ::  Integer
           theZero = 0
       case theSignerAddress of

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -5274,10 +5274,22 @@ contract qq {
   
   address addr;
   constructor() {
-  addr = ecrecover("3a5d3354533658145308bb0d64dbc1508fc09cdfb776fbd3ef69c5733efff993",62426968875534762403852209127290402186903754337050088741962154937967930754218,50195776013273436178497944053297375925820829706569486652594540226567378884053,27);
+  addr = ecrecover("ca678fcee68aa0b4b1e0bf01b24a0beff75133284f0ad84f1e8cc70d5a9959bc",27,"c99b861c7a2d47bcf5a8423b94cc962b585f340a53e88c91b86a53effd10dc58","3dfd7acaf4625c69df55a2f4cf4f7d63da25bb495abd8dfcc9bd53481c0ccaeb");
   }
 }|]
-    getFields ["addr"] `shouldReturn` [BAccount (NamedAccount 0xe2b74b933b1fbe7f3736ad437b60a7828bcc4b80 UnspecifiedChain)]
+    getFields ["addr"] `shouldReturn` [BAccount (NamedAccount 0x91bc5385f9cfa1f4c9c9805102d54c7f77bde902 UnspecifiedChain)] -- 666171f931111ae3aed54595fc9776699e5eb03d
+
+--   it "returns 0  for invalid ecrecover call" . runTest $ do
+--     runBS [r|
+-- pragma solidvm 3.4;
+-- contract qq {
+  
+--   address addr;
+--   constructor() {
+--   addr = ecrecover("ca678fcee68aa0b4b1e0bf01b24a0beff75133284f0ad84f1e8cc70d5a9959bc",27,"efd16e46ceb4851861b89aa5fddb18e18a70bdaf029d77482bdd9b2242854b59","3dfd7acaf4625c69df55a2f4cf4f7d63da25bb495abd8dfcc9bd53481c0ccaeb");
+--   }
+-- }|]
+--     getFields ["addr"] `shouldReturn` [BDefault]
 
   it "can use builtin sha256 function" . runTest $ do
     runBS [r|

--- a/strato/core/blockapps-data/src/Blockchain/Data/Transaction.hs
+++ b/strato/core/blockapps-data/src/Blockchain/Data/Transaction.hs
@@ -269,14 +269,11 @@ whoSignedThisTransaction tx = case tx of
           sig = EC.Signature (SEC.CompactRecSig (intToBSS $ transactionR t) (intToBSS $ transactionS t) ((transactionV t) - 0x1b))
           mesg = keccak256ToByteString $ partialTransactionHash t
 
-whoSignedThisTransactionEcrecover :: Keccak256 -> Integer -> Integer -> Integer -> Maybe Address
+whoSignedThisTransactionEcrecover :: B.ByteString -> B.ByteString -> B.ByteString  -> Integer -> Maybe Address
 whoSignedThisTransactionEcrecover hsh r s v = fromPublicKey <$> EC.recoverPub sig mesg
         where
-          intToBSS = BSS.toShort . word256ToBytes . fromInteger
-          newV :: Word8
-          newV = fromInteger v
-          sig = EC.Signature (SEC.CompactRecSig (intToBSS $ r) (intToBSS $ s) ((newV) - 0x1b))
-          mesg = keccak256ToByteString $ hsh
+          sig = EC.Signature (SEC.CompactRecSig (BSS.toShort $ r) (BSS.toShort $ s) (((fromInteger v) :: Word8) - 0x1b))
+          mesg = hsh
 {-
 whoSignedThisTransaction::Transaction->Maybe Address -- Signatures can be malformed, hence the Maybe
 whoSignedThisTransaction tx = case tx of

--- a/strato/core/blockapps-data/src/Blockchain/Data/Transaction.hs
+++ b/strato/core/blockapps-data/src/Blockchain/Data/Transaction.hs
@@ -269,11 +269,12 @@ whoSignedThisTransaction tx = case tx of
           sig = EC.Signature (SEC.CompactRecSig (intToBSS $ transactionR t) (intToBSS $ transactionS t) ((transactionV t) - 0x1b))
           mesg = keccak256ToByteString $ partialTransactionHash t
 
-whoSignedThisTransactionEcrecover :: B.ByteString -> B.ByteString -> B.ByteString  -> Integer -> Maybe Address
+whoSignedThisTransactionEcrecover :: Keccak256 -> Integer -> Integer  -> Integer -> Maybe Address
 whoSignedThisTransactionEcrecover hsh r s v = fromPublicKey <$> EC.recoverPub sig mesg
         where
-          sig = EC.Signature (SEC.CompactRecSig (BSS.toShort $ r) (BSS.toShort $ s) (((fromInteger v) :: Word8) - 0x1b))
-          mesg = hsh
+          intToBSS = BSS.toShort . word256ToBytes . fromInteger
+          sig = EC.Signature (SEC.CompactRecSig (intToBSS $ r) (intToBSS $ s) (((fromInteger v) :: Word8) - 0x1b))
+          mesg = keccak256ToByteString $ hsh
 {-
 whoSignedThisTransaction::Transaction->Maybe Address -- Signatures can be malformed, hence the Maybe
 whoSignedThisTransaction tx = case tx of


### PR DESCRIPTION
`ecrecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s)`: The function signature has been fixed.

There are certain issues to be looked into:

- Technically, the implementation is dependent on extracting `partialTransactionHash` from the given hash input in the function prototype. Additionally, the usage of extracting the partial transaction hash requires to be of type `transaction object`. 
- The above step's `partialTransactionHash` is converted into `ByteString`, which is used to drive the helper function to recover the `owner` address. 
- Problem exists with the dependence on `partialTransactionHash` method. 
- Unit tests pass the `complete tx hash`. Therefore, it sends garbage address. 