### PR TITLE
fixed org not sent to slipstream correct on private chain creation

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -806,13 +806,22 @@ callWrapper from to mContract functionName isRCC argExps  = do
   
   initializeAction to (labelToString $ CC._contractName contract) (labelToString parentName') hsh
 
-  -- grab the org for this contract
-  org <- getOrg to (contract ^. CC.vmVersion)
-  Mod.modifyStatefully_ (Mod.Proxy @Action) $
-    Action.actionData %= M.adjust (Action.actionDataOrganization .~ (T.pack org)) to
+  -- grab the org for this codeAddress
+  when (not isRCC) $ do
+    org <- getOrg to (contract ^. CC.vmVersion)
+    Mod.modifyStatefully_ (Mod.Proxy @Action) $
+      Action.actionData %= M.adjust (Action.actionDataOrganization .~ (T.pack org)) to
+    liftIO $ putStrLn $ "callWrapper/versioning --->  we are calling " ++ (labelToString $ CC._contractName contract) ++ 
+          " in app " ++ (show parentName) ++ " of org " ++ show org
 
-  liftIO $ putStrLn $ "callWrapper/versioning --->  we are calling " ++ (labelToString $ CC._contractName contract) ++ 
-        " in app " ++ (show parentName) ++ " of org " ++ show org
+--  grab the org from the senders account and set it to the codeAddress
+  when (isRCC) $ do
+    org <- getOrg from (contract ^. CC.vmVersion)
+    Mod.modifyStatefully_ (Mod.Proxy @Action) $
+      Action.actionData %= M.adjust (Action.actionDataOrganization .~ (T.pack org)) to
+    (\env -> setCreator (Env.origin env) to contract (blockDataNumber $ Env.blockHeader env)) =<< getEnv
+    liftIO $ putStrLn $ "callWrapper/versioning --->  we are calling " ++ (labelToString $ CC._contractName contract) ++ 
+          " in app " ++ (show parentName) ++ " of org " ++ show org
 
 
   let functionsIncludingConstructor =

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -819,7 +819,7 @@ callWrapper from to mContract functionName isRCC argExps  = do
     org <- getOrg from (contract ^. CC.vmVersion)
     Mod.modifyStatefully_ (Mod.Proxy @Action) $
       Action.actionData %= M.adjust (Action.actionDataOrganization .~ (T.pack org)) to
-    (\env -> setCreator (Env.origin env) to contract (blockDataNumber $ Env.blockHeader env)) =<< getEnv
+    -- (\env -> setCreator (Env.origin env) to contract (blockDataNumber $ Env.blockHeader env)) =<< getEnv
     liftIO $ putStrLn $ "callWrapper/versioning --->  we are calling " ++ (labelToString $ CC._contractName contract) ++ 
           " in app " ++ (show parentName) ++ " of org " ++ show org
 


### PR DESCRIPTION
Because `runChainConstructors` goes through `SolidVM.Call` rather than `SolidVM.create`, when `Action.actionDataOrganization `is set, it assumes the `codeAtAccount `already has a cert when it doesn’t since this is actually the first time time it sees the governance contract code. To fix this we instead should read the org from the senders account and then set the `codeAtAccount` and `Action.actionDataOrganization` to the senders org when `isRCC`.