### PR TITLE
removed log message clogging up the vm-runner logs

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1516,7 +1516,6 @@ decrementGas gas = do
       liftIO $ putStrLn $ C.red $ msg
       tooMuchGas (show (_gasInitalAllotment gasInfo')) gasInfo'
     else do
-      onTraced $ liftIO $ putStrLn $ C.green $ "with gasInfo: " ++ show gasInfo'
       return ()
 
 expToVar' :: MonadSM m => CC.Expression -> m Variable


### PR DESCRIPTION
This log message was left in the release and really clogs up the vm-runner logs when svmTrace is on