### PR TITLE
posting transactions in parallel will solve the problem

### DIFF
--- a/strato/vault/server/src/Strato/Strato23/Server/Signature.hs
+++ b/strato/vault/server/src/Strato/Strato23/Server/Signature.hs
@@ -1,19 +1,21 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
 
 module Strato.Strato23.Server.Signature where
 
 import           Control.Monad.Reader                  (asks)
 import qualified Data.ByteString                       as B
 import qualified Data.Cache                            as Cache
-import           Data.Text                             (Text)
+import           Data.Text                             (Text, pack)
 import           Blockchain.Strato.Model.Secp256k1
 import           Strato.Strato23.Monad
 import           Strato.Strato23.API.Types
 import           Strato.Strato23.Crypto
 import           Strato.Strato23.Database.Queries      (getUserKeyQuery)
 import           UnliftIO
+import           BlockApps.Logging
 
 
 
@@ -21,12 +23,14 @@ postSignature :: Text -> MsgHash -> VaultM Signature
 postSignature userName (MsgHash msgBS) = do
   cache <- asks keyStoreCache
   cachedPk <- liftIO $ Cache.lookup cache userName
+  $logInfoS "cachedPk" . pack $ show cachedPk
   (_,nonce,pKey,_) <- case cachedPk of
     Just (KeyStore a b c d) -> pure (a,b,c,d)
     Nothing -> do
       mpk <- vaultTransaction
            . vaultQueryMaybe
            $ getUserKeyQuery userName
+      $logInfoS "mpk" . pack $ show mpk
       (a,b,c,d) <- case mpk of
         Just pk -> return pk
         Nothing -> vaultWrapperError $ UserError ("User " <> userName <> " doesn't exist")
@@ -37,3 +41,4 @@ postSignature userName (MsgHash msgBS) = do
     Just prvKey 
       | B.length msgBS == 32 -> return $ signMsg prvKey msgBS 
       | otherwise -> vaultWrapperError $ AnError "Message was not 32 bytes long"
+    

--- a/strato/vault/server/src/Strato/Strato23/Server/Signature.hs
+++ b/strato/vault/server/src/Strato/Strato23/Server/Signature.hs
@@ -1,21 +1,19 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
 
 module Strato.Strato23.Server.Signature where
 
 import           Control.Monad.Reader                  (asks)
 import qualified Data.ByteString                       as B
 import qualified Data.Cache                            as Cache
-import           Data.Text                             (Text, pack)
+import           Data.Text                             (Text)
 import           Blockchain.Strato.Model.Secp256k1
 import           Strato.Strato23.Monad
 import           Strato.Strato23.API.Types
 import           Strato.Strato23.Crypto
 import           Strato.Strato23.Database.Queries      (getUserKeyQuery)
 import           UnliftIO
-import           BlockApps.Logging
 
 
 
@@ -23,14 +21,12 @@ postSignature :: Text -> MsgHash -> VaultM Signature
 postSignature userName (MsgHash msgBS) = do
   cache <- asks keyStoreCache
   cachedPk <- liftIO $ Cache.lookup cache userName
-  $logInfoS "cachedPk" . pack $ show cachedPk
   (_,nonce,pKey,_) <- case cachedPk of
     Just (KeyStore a b c d) -> pure (a,b,c,d)
     Nothing -> do
       mpk <- vaultTransaction
            . vaultQueryMaybe
            $ getUserKeyQuery userName
-      $logInfoS "mpk" . pack $ show mpk
       (a,b,c,d) <- case mpk of
         Just pk -> return pk
         Nothing -> vaultWrapperError $ UserError ("User " <> userName <> " doesn't exist")


### PR DESCRIPTION
The upbring app test files overwrote the cacheNonce so that the transactions were actually not called by using parallel endpoint. I checked the post transaction api, which never shows parallel endpoint before I changed the test files of the upbring app. After I added cacheNonce=true inside the Options object for all the test files of the upbring app, the post transaction api shows parallel endpoint. I redeploy the app again and test it on develop branch since the cacheNonce branch has been merged into devnet, the VMerror  "rejected transaction because of a more lucrative one in the mempool" disappear. I think the problem has been solved. Please let me know if the error occurs again. 