### PR TITLE
Strato 2842 shared vault strato api metadata endpoint fix

### DIFF
--- a/strato/api/core-api2/src/Handlers/Metadata.hs
+++ b/strato/api/core-api2/src/Handlers/Metadata.hs
@@ -16,7 +16,6 @@
 
 module Handlers.Metadata
   (  API
-    --,MetadataResponse
     , getMetaDataClient
     , MetadataResponse
     , server
@@ -39,7 +38,7 @@ import           GHC.Stack
 import           BlockApps.Logging
 
 import           Blockchain.Strato.Model.Address
-import           Blockchain.Strato.RedisBlockDB         (runStratoRedisIO, getSyncStatus)
+import           Blockchain.Strato.RedisBlockDB         (runStratoRedisIO, getSyncStatusNow)
 import           Blockchain.Data.DataDefs
 import           Blockchain.DB.SQLDB
 import           Strato.Strato23.Client   hiding (verifyPassword)
@@ -90,10 +89,15 @@ getMetaData token =
   do
   validators <- access (Proxy @[Address])
   isSynced <- checkIsSynced
-  pubK <- getPubKey token
-  case pubK of
+  mAddressAndKey <- getPubKeyAndAddress token
+  case mAddressAndKey of
     Left  _      -> pure $ (MetadataResponse " "  "Error" validators False False) 
-    Right pubKey -> pure $ (MetadataResponse " "  (show pubKey) validators  isSynced True)
+    Right addressAndKey -> pure $ (MetadataResponse 
+          ((\l -> drop 1 $ take ((length l) -1 )  l )  $ ((\(PublicKey pubkey) ->   show  pubkey ) $ fst addressAndKey )) --probably a better way to pretty print pubkey
+          (show $ snd  addressAndKey) 
+          validators  
+          isSynced 
+          True)
 
 
 
@@ -107,11 +111,14 @@ blocVaultWrapper client' = do
     liftIO $ runClientM client' (mkClientEnv mgr url)
   either (blocError . VaultWrapperError) return resultEither
 
-getPubKey ::  (MonadIO m, MonadLogger m, MonadUnliftIO m, HasVault m) => Maybe T.Text -> m (Either VaultWrapperError Address)
-getPubKey mAccessToken =
+getPubKeyAndAddress ::  (MonadIO m, MonadLogger m, MonadUnliftIO m, HasVault m) => Maybe T.Text -> m (Either VaultWrapperError (PublicKey, Address))
+getPubKeyAndAddress mAccessToken =
   case mAccessToken of
-    Nothing -> throwIO $ InvalidArgs $ "Did not find X-USER-UNIQUE-NAME in the header" -- This may not be needed
-    Just _  -> try $ fmap Strato.Strato23.API.Types.unAddress . blocVaultWrapper $ getKey  "nodekey" Nothing
+    Nothing -> throwIO $ InvalidArgs $ "Did not find X-USER-UNIQUE-NAME in the header" 
+    Just _  -> try $ fmap unaddressAndUnkey .  blocVaultWrapper $ getKey  "nodekey" Nothing
+
+unaddressAndUnkey :: AddressAndKey -> (PublicKey, Address)
+unaddressAndUnkey addressAndKey = (Strato.Strato23.API.Types.unPubKey addressAndKey ,Strato.Strato23.API.Types.unAddress addressAndKey) 
 
 checkIsSynced :: (HasSQL m) => m Bool
-checkIsSynced = (runStratoRedisIO getSyncStatus) >>= \case Nothing -> pure False; Just c ->pure  c; 
+checkIsSynced = (runStratoRedisIO getSyncStatusNow) >>= \case Nothing -> pure False; Just c ->pure  c; 

--- a/strato/api/core-api2/src/Handlers/Metadata.hs
+++ b/strato/api/core-api2/src/Handlers/Metadata.hs
@@ -93,7 +93,7 @@ getMetaData token =
   case mAddressAndKey of
     Left  _      -> pure $ (MetadataResponse " "  "Error" validators False False) 
     Right addressAndKey -> pure $ (MetadataResponse 
-          ((\l -> drop 1 $ take ((length l) -1 )  l )  $ ((\(PublicKey pubkey) ->   show  pubkey ) $ fst addressAndKey )) --probably a better way to pretty print pubkey
+          ((\l -> drop 1 $ init  l )  $ ((\(PublicKey pubkey) ->   show  pubkey ) $ fst addressAndKey )) --pretty prints pubkey
           (show $ snd  addressAndKey) 
           validators  
           isSynced 

--- a/strato/core/blockapps-data/src/Blockchain/Data/ValidatorRef.hs
+++ b/strato/core/blockapps-data/src/Blockchain/Data/ValidatorRef.hs
@@ -18,7 +18,7 @@ import qualified Database.Esqueleto.Legacy          as E
 addRemoveValidator :: HasSQLDB m =>
                             ([Address], [Address]) -> m ()
 addRemoveValidator (remove, add) = do
-  when (add /= []) (forM_ add $ (\x -> sqlQuery $  E.insert ValidatorRef{ validatorRefAddress = x })) 
+  when (add /= []) (forM_ add $ (\x -> sqlQuery $  E.insertUnique ValidatorRef{ validatorRefAddress = x })) 
   if remove /= [] 
     then (forM remove  $ (\x -> sqlQuery $ E.delete $ E.from $ \address -> E.where_ (address E.^. ValidatorRefAddress E.==. (E.val $ x :: E.SqlExpr (E.Value Address))))) >> pure ()                                                                       
     else pure ()        

--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -961,10 +961,11 @@ getSyncStatusNow = do
             worldBestBlock <- getWorldBestBlockInfo
             let nodeTotalDiff  = bestBlockTotalDifficulty <$> nodeBestBlock
                 worldTotalDiff = bestBlockTotalDifficulty <$> worldBestBlock
-            pure $ Just $  case (nodeTotalDiff, worldTotalDiff) of
-                (Just ntd, Just wtd) -> ntd >= wtd
-                (Nothing,  Just _  ) ->  False
-                _ ->  False
+            pure $ Just $  case (status, nodeTotalDiff, worldTotalDiff) of
+                (Just False, Just ntd, Just wtd) -> ntd >= wtd
+                (Nothing,    Just ntd, Just wtd) -> ntd >= wtd
+                (Nothing,    Nothing,  Just _  ) -> False
+                _ ->  True
 
 syncStatusKey :: S8.ByteString
 syncStatusKey = "<sync_status>"

--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -40,7 +40,7 @@ module Blockchain.Strato.RedisBlockDB
     , commonAncestorHelper
     , getWorldBestBlockInfo, updateWorldBestBlockInfo
     , acquireRedlock, releaseRedlock, defaultRedlockTTL
-    , getSyncStatus, putSyncStatus
+    , getSyncStatus, putSyncStatus, getSyncStatusNow
     ) where
 
 import           BlockApps.X509.Certificate
@@ -950,6 +950,21 @@ checkAndUpdateSyncStatus = do
         (Nothing,    Just ntd, Just wtd) -> void $ putSyncStatus (ntd >= wtd)
         (Nothing,    Nothing,  Just _  ) -> void $ putSyncStatus False
         _ -> pure ()
+
+getSyncStatusNow :: Redis (Maybe Bool)
+getSyncStatusNow = do
+    status         <- getSyncStatus
+    if case status of Just True -> True; _ -> False; 
+        then pure  $ Just True
+        else do
+            nodeBestBlock  <- getBestBlockInfo
+            worldBestBlock <- getWorldBestBlockInfo
+            let nodeTotalDiff  = bestBlockTotalDifficulty <$> nodeBestBlock
+                worldTotalDiff = bestBlockTotalDifficulty <$> worldBestBlock
+            pure $ Just $  case (nodeTotalDiff, worldTotalDiff) of
+                (Just ntd, Just wtd) -> ntd >= wtd
+                (Nothing,  Just _  ) ->  False
+                _ ->  False
 
 syncStatusKey :: S8.ByteString
 syncStatusKey = "<sync_status>"


### PR DESCRIPTION
There was a bunch(...too many....) issues with metadata endpoint.

1. list of validators would have a duplicate for the root node
2. Nodekey was not present.
3. Sync status was incorrect

To fix this:
1. . list of validators -> replaced `insert` with  `insertUnique` to the sql query. Note I was never able to replicate the case of returning duplicates in the list of validators.
2.  Nodekey -> This data was already fetched, but not used. Just needed to parse pubkey which did pretty print ideally (When I `show pubkey` it added some extra quotes. Need to drop those from the string. I had trouble using fold, haskell compiler was complaining about not a instance of fold.)  
3. Sync status ->  Added a new function for sync status. Before I was calling `syncStatus` from the redis db, but for the single node case would not produce accurate results. I have not fully tested this. I have to test this for multiple node cases. It uses similar logic from `Transaction.hs` (....so I assume it should work.) Will test this Nov 23rd. 


