### PR TITLE
[STRATO-2904] History Tables always set to true

### DIFF
--- a/smd-ui/src/components/CreateContract/index.js
+++ b/smd-ui/src/components/CreateContract/index.js
@@ -449,33 +449,6 @@ class CreateContract extends Component {
                   {this.props.codeType}
                 </div>
               </div>}
-              {contracts && <div className="row">
-                <div className="col-sm-3 text-right">
-                  <label className="pt-label smd-pad-4">
-                    History
-                  </label>
-                </div>
-                <div className="col-sm-9 smd-pad-4">
-                  {contracts.map((value, index) => {
-                    return (
-                      <label className="pt-control pt-checkbox">
-                        <Field
-                          id={value}
-                          className="form-width"
-                          name={"history@" + value}
-                          type="checkbox"
-                          component="input"
-                          dir="auto"
-                          title="History"
-                        />
-                        <span className="pt-control-indicator"></span>
-                        {value}
-                      </label>
-                    )
-                  })
-                  }
-                </div>
-              </div>}
               <div className="row">
                 <div className="col-sm-3 text-right">
                   <label className="pt-label smd-pad-4">

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Server/Transaction.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Server/Transaction.hs
@@ -324,6 +324,7 @@ postBlocTransaction' cacheNonce mUserName chainId resolve (PostBlocTransactionRe
           [x] -> do
             p <- fromContract x
             let md = contractpayloadMetadata p
+                cn = fromMaybe "unnamed_contract" (contractpayloadContract p)
                 bcp = ContractParameters
                         addr
                         (getSrc p)
@@ -331,7 +332,14 @@ postBlocTransaction' cacheNonce mUserName chainId resolve (PostBlocTransactionRe
                         (contractpayloadArgs p)
                         (contractpayloadValue p)
                         (mergeTxParams (contractpayloadTxParams p) txParams)
-                        (contractpayloadMetadata p)
+                        {-
+                          History tables are always enabled
+                          'contractpayloadContract p' should always return a name but in the case that it doesn't 
+                            it will go in the history table unnamed
+                        -}
+                        (case md of 
+                          Nothing -> Just $ Map.singleton "history" cn
+                          Just m -> Just $ Map.insert "history" cn m)
                         (contractpayloadChainid p <|> chainId)
                         resolve
                 poster = case Map.lookup "VM" =<< md of
@@ -348,12 +356,18 @@ postBlocTransaction' cacheNonce mUserName chainId resolve (PostBlocTransactionRe
             ps <- mapM fromContract xs
             let bclp = ContractListParameters
                         addr
-                        (map (\p@(ContractPayload _ c a v x cid m) ->
+                        (map (\p@(ContractPayload _ c a v x cid m) -> do
+                                let cn = fromMaybe "unnamed_contract" c
                                 UploadListContract (fromJust c)
                                                    (getSrc p)
                                                    (fromMaybe Map.empty a)
                                                    (mergeTxParams x txParams)
-                                                   v cid m) ps)
+                                                   v 
+                                                   cid 
+                                                   (case m of
+                                                    Nothing -> Just $ Map.singleton "history" cn
+                                                    Just h -> Just $ Map.insert "history" cn h)) 
+                                                   ps)
                         chainId
                         resolve
                 md = contractpayloadMetadata $ head ps --Determine VM option by the metadata of the first tx in list

--- a/strato/indexer/slipstream/src/Slipstream/Globals.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Globals.hs
@@ -20,6 +20,7 @@ module Slipstream.Globals
     getSolidVMInfo,
     forceGlobalEval,
     newGlobals,
+    isHistoric,
     module Slipstream.Data.Globals
   ) where
 
@@ -93,6 +94,13 @@ getTableColumns :: MonadIO m => IORef Globals -> TableName -> m (Maybe TableColu
 getTableColumns globalsIORef tableName = do
   Globals{..} <- readIORef globalsIORef
   return $ M.lookup tableName createdTables
+
+isHistoric :: (MonadLogger m, MonadIO m) => IORef Globals -> TableName -> m Bool
+isHistoric globalsIORef name = do
+  Globals{..} <- readIORef globalsIORef
+  let h = M.findWithDefault False name historyList
+  $logInfoS "isHistoric" $ T.pack $ show name ++ ": " ++ show h
+  return h
 
 setHistoryTable :: (MonadIO m, MonadLogger m) => IORef Globals -> TableName -> Bool -> m ()
 setHistoryTable g tableName b = do

--- a/strato/indexer/slipstream/src/Slipstream/Globals.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Globals.hs
@@ -14,7 +14,6 @@ module Slipstream.Globals
     xabiToText,
     flushPendingWrites,
     getContractState,
-    isHistoric,
     setHistoryTable,
     historyStatusCreated,
     setSolidVMInfo,
@@ -94,13 +93,6 @@ getTableColumns :: MonadIO m => IORef Globals -> TableName -> m (Maybe TableColu
 getTableColumns globalsIORef tableName = do
   Globals{..} <- readIORef globalsIORef
   return $ M.lookup tableName createdTables
-
-isHistoric :: (MonadLogger m, MonadIO m) => IORef Globals -> TableName -> m Bool
-isHistoric globalsIORef name = do
-  Globals{..} <- readIORef globalsIORef
-  let h = M.findWithDefault False name historyList
-  $logInfoS "isHistoric" $ T.pack $ show name ++ ": " ++ show h
-  return h
 
 setHistoryTable :: (MonadIO m, MonadLogger m) => IORef Globals -> TableName -> Bool -> m ()
 setHistoryTable g tableName b = do

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -535,16 +535,14 @@ insertHistoryTable :: OutputM m
                    -> [ProcessedContract]
                    -> ConduitM () Text m ()
 insertHistoryTable _ [] = return () --no data, do nothing
-insertHistoryTable globalsIORef contracts@(x:_) = do
+insertHistoryTable _ contracts@(x:_) = do
   let tableName = historyTableName
           (organization x)
           (application x)
           (contractName x)
-  history <- isHistoric globalsIORef tableName
 
-  when history $ do
-    $logInfoS "insertHistoryTable" $ T.pack $ "Inserting row in history table for: " ++ show tableName
-    yield $ insertHistoryTableQuery contracts
+  $logInfoS "insertHistoryTable" $ T.pack $ "Inserting row in history table for: " ++ show tableName
+  yield $ insertHistoryTableQuery contracts
 
 createIndexTableQuery :: Contract -> (Text, Text, Text) -> Text
 createIndexTableQuery contract (o, a, n) =

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -535,14 +535,16 @@ insertHistoryTable :: OutputM m
                    -> [ProcessedContract]
                    -> ConduitM () Text m ()
 insertHistoryTable _ [] = return () --no data, do nothing
-insertHistoryTable _ contracts@(x:_) = do
+insertHistoryTable globalsIORef contracts@(x:_) = do
   let tableName = historyTableName
           (organization x)
           (application x)
           (contractName x)
+  history <- isHistoric globalsIORef tableName
 
-  $logInfoS "insertHistoryTable" $ T.pack $ "Inserting row in history table for: " ++ show tableName
-  yield $ insertHistoryTableQuery contracts
+  when history $ do
+    $logInfoS "insertHistoryTable" $ T.pack $ "Inserting row in history table for: " ++ show tableName
+    yield $ insertHistoryTableQuery contracts
 
 createIndexTableQuery :: Contract -> (Text, Text, Text) -> Text
 createIndexTableQuery contract (o, a, n) =

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -456,14 +456,13 @@ processTheMessages env sqlEnv conn g messages = do
 
                 let htn = historyTableName o a n
                     historyTableNames = map (historyTableName o a) hl
-                    historyEnabled = htn `elem` historyTableNames
                 $logInfoS "processTheMessages/historyTableNames" $ T.pack $ show historyTableNames
 
                 -- If the table name is found in globals, then keep history as it is, otherwise set it to respective value from this creation
                 historyStatus <- historyStatusCreated g htn
                 when (not historyStatus) $ do
-                  -- history status is not defined, so set it to whether or not this is found in the history list
-                  setHistoryTable g htn historyEnabled
+                  -- creates a history table for all contracts in the CodeCollection
+                  setHistoryTable g htn True
 
                 hasHistoryTable <- isHistoric g htn
 

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -303,20 +303,17 @@ rowToInsert gref abiid row cont oldState = do
   setContractState gref (actionAccount row) newState
   return $ processedContract abiid (Map.fromList $ newState) row
 
-rowToHistories :: (MonadIO m, MonadLogger m) =>
-                  IORef Globals -> ABIID -> AggregateAction -> [AggregateAction] -> OLD.Contract
+rowToHistories :: (MonadIO m) =>
+                  IORef Globals -> ABIID -> [AggregateAction] -> OLD.Contract
                -> [(Text, Value)]
                -> m [ProcessedContract]
-rowToHistories gref abiid row actions cont oldState = do
-  hist <- isHistoric gref $ historyTableName (actionOrganization row) (actionApplication row) (aiName abiid)
-  if not hist
-    then pure []
-    else flip evalStateT oldState . forM actions $ \hRow -> do
-      modify $ case actionStorage hRow of
-                  Action.EVMDiff mp -> SVR.decodeCacheValues cont (flip Map.lookup mp)
-                  Action.SolidVMDiff mp -> SolidVM.decodeCacheValues mp
-      newMap <- gets Map.fromList
-      return $ processedContract abiid newMap hRow
+rowToHistories _ abiId actions cont oldState = do
+  flip evalStateT oldState . forM actions $ \hRow -> do
+    modify $ case actionStorage hRow of
+                Action.EVMDiff mp -> SVR.decodeCacheValues cont (flip Map.lookup mp)
+                Action.SolidVMDiff mp -> SolidVM.decodeCacheValues mp
+    newMap <- gets Map.fromList
+    return $ processedContract abiId newMap hRow
 
 -- Parses xabi event declarations to create a table,
 -- ignoring indexes and anonymous flag
@@ -417,7 +414,7 @@ getEVMInserts g row actions acct = do
       -- adjustGlobals g row details
       oldState <- readPreviousEVMState g acct cont
       indexContract <- rowToInsert g abiid row cont oldState
-      hs <- rowToHistories g abiid row actions cont oldState
+      hs <- rowToHistories g abiid actions cont oldState
       pure . Right $ BatchedInserts indexContract hs
 
 getInsertsIgnoreEVM :: (Monad m) => IORef Globals -> AggregateAction -> [AggregateAction] -> Account -> m (Either Text BatchedInserts)
@@ -464,16 +461,13 @@ processTheMessages env sqlEnv conn g messages = do
                   -- creates a history table for all contracts in the CodeCollection
                   setHistoryTable g htn True
 
-                hasHistoryTable <- isHistoric g htn
-
-                $logInfoS "processTheMessages" $ "New Contract Added: org=" <> o <> ", app=" <> a <> ", name=" <> n <> " (fields: " <> T.pack (show $ Map.toList $ fmap _varType $ c ^. storageDefs) <> ")" <> if hasHistoryTable then " HAS HISTORY TABLE" else ""
+                $logInfoS "processTheMessages" $ "New Contract Added: org=" <> o <> ", app=" <> a <> ", name=" <> n <> " (fields: " <> T.pack (show $ Map.toList $ fmap _varType $ c ^. storageDefs) <> ")"
                 let nameParts = (o, a, n)
 
                 deferredForeignKeys <- outputData conn $ createExpandIndexTable g c nameParts
 
 -- mark
-                when hasHistoryTable $
-                  outputData' conn $ createExpandHistoryTable g c nameParts
+                outputData' conn $ createExpandHistoryTable g c nameParts
 
                 outputData conn . createEventTables g $ contractToEventTables nameParts c
 
@@ -515,7 +509,7 @@ processTheMessages env sqlEnv conn g messages = do
           $logDebugLS "Contract name is: " $ show name
           oldState <- readPreviousSolidVMState g acct
           indexContract <- rowToInsert g abiid row cont oldState
-          hs <- rowToHistories g abiid row actions cont oldState
+          hs <- rowToHistories g abiid actions cont oldState
           $logDebugLS "History inserts are: " $ show hs
           pure . Right $ BatchedInserts indexContract hs
 


### PR DESCRIPTION
Set history tables to be created with every contract posted to the network (these tables keep track of the contract state at any change).

- API will always pass "history" metadata field as true
- Slipstream will create a history table for every new contract in a posted CodeCollection
- Removed any unnecessary checks for history tables now that every contract will have one
- Remove history checkbox button in SMD
