### PR TITLE
Fix parsed set function inconsistency in Redis

### DIFF
--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -1843,7 +1843,7 @@ contract A {
             let ietx = IETx tsNow $ IngestTx Origin.API tx'
             flip postEvent (peers !! 0) $ UnseqEvent ietx
 
-      runForSeconds 10 $ concurrently_ (runNetwork peers connections) routine
+      runForSeconds 15 $ concurrently_ (runNetwork peers connections) routine
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at chainId) `shouldBe` (i, if i == 2 then Nothing else Just chainInfo')
 
@@ -2065,7 +2065,7 @@ contract A {
             threadDelay 5000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ addMemberTx cId2
 
-      void . timeout 80000000 $ concurrently_ (runNetwork peers connections) routine
+      void . timeout 100000000 $ concurrently_ (runNetwork peers connections) routine
       cId <- readIORef cIdRef
       cInfo <- readIORef cInfoRef
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
@@ -2142,7 +2142,7 @@ contract RegisterCert {
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx tx1
             threadDelay 1000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx tx2
-      void . timeout 3000000 $ concurrently_ (runNetwork peers connections) routine
+      void . timeout 5000000 $ concurrently_ (runNetwork peers connections) routine
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       for_ ctxs1 $ \ctx -> (ctx ^. x509certMap) `shouldNotBe` M.empty
 
@@ -2203,7 +2203,7 @@ contract RegisterCert {
           dt <- liftIO dateCurrent
           cIdRef <- newIORef undefined
           cInfoRef <- newIORef undefined
-          let runForNineSeconds = void . timeout 9000000
+          let runForTwelveSeconds = void . timeout 12000000
               -- enode1 = readEnode "enode://abcd@1.2.3.4:30303"
               chainMember1 :: ChainMembers
               chainMember1 = (ChainMembers $ Set.singleton $ (CommonName (T.pack "BlockApps") (T.pack "Engineering") (T.pack "David Nallapu") True))
@@ -2305,7 +2305,7 @@ contract RegisterCert {
                 threadDelay 200000
                 flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ signedPrivTx cId -- Add organization to private chain
 
-          runForNineSeconds $ concurrently_ (runNetwork peers connections) routine
+          runForTwelveSeconds $ concurrently_ (runNetwork peers connections) routine
           ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
           testCid <- readIORef cIdRef
 

--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -397,14 +397,14 @@ removeOrgNameChain cm cId = do
         TxError e   -> pure . Left $ SingleLine (S8.pack $ "removeOrgNameChain - Error" ++ e)
 
 getOrgUnitsForOrg :: CM.ChainMemberParsedSet -> Redis ([CM.ChainMemberParsedSet])
-getOrgUnitsForOrg (CM.Org o _) = getInNamespace ParsedSetWhitePage (CM.Org o False) <&> \case
+getOrgUnitsForOrg (CM.Org o _) = getInNamespace ParsedSetWhitePage (CM.Org o True) <&> \case
     Right (Just runits) -> let RedisOrgUnits units = fromValue runits
                            in units
     _ -> []
 getOrgUnitsForOrg _ = pure $ []
 
 getMembersInOrgUnit :: CM.ChainMemberParsedSet -> Redis ([CM.ChainMemberParsedSet])
-getMembersInOrgUnit (CM.OrgUnit o u _) = getInNamespace ParsedSetWhitePage (CM.OrgUnit o u False) <&> \case
+getMembersInOrgUnit (CM.OrgUnit o u _) = getInNamespace ParsedSetWhitePage (CM.OrgUnit o u True) <&> \case
     Right (Just rmems) -> let RedisOrgUnitMembers mems = fromValue rmems
                           in mems
     _ -> []
@@ -426,7 +426,7 @@ getChainMembersFromSet cm =
             pure $ Nothing
 
 getCertFromParsedSet :: CM.ChainMemberParsedSet -> Redis (Maybe X509CertInfoState)
-getCertFromParsedSet (CM.CommonName o u c _) = getInNamespace ParsedSetToX509 (CM.CommonName o u c False) >>= \case
+getCertFromParsedSet (CM.CommonName o u c _) = getInNamespace ParsedSetToX509 (CM.CommonName o u c True) >>= \case
     Right (Just state) -> let certInfoState = fromValue state
                           in pure $ Just certInfoState
     _ -> pure $ Nothing
@@ -478,7 +478,7 @@ modifyParsedSetFromCert certInfo@(X509CertInfoState _ _ _ _ o u c) = do
 
 removeCertFromParsedSet :: X509CertInfoState -> Redis (Either Reply Status)
 removeCertFromParsedSet (X509CertInfoState addr cert _ children o u c) = do
-    let parsedSet = CM.CommonName (T.pack o) (T.pack $ fromMaybe "Nothing" u) (T.pack c) False
+    let parsedSet = CM.CommonName (T.pack o) (T.pack $ fromMaybe "Nothing" u) (T.pack c) True
     res <- multiExec $ set (inNamespace ParsedSetToX509 parsedSet) $ toValue (X509CertInfoState addr cert False children o u c)
     case res of
         TxSuccess _ -> pure $ Right Ok

--- a/strato/simulator/strato-lite/tests/SimulatorSpec.hs
+++ b/strato/simulator/strato-lite/tests/SimulatorSpec.hs
@@ -192,7 +192,7 @@ spec = do
       
       registryTs <- liftIO getCurrentMicrotime
 
-      let runForThreeSeconds = void . timeout 3000000
+      let runForSeconds n = void . timeout (n * 1000000)
           toIetx = IETx registryTs . IngestTx Origin.API
           chainMember1 = (CM.ChainMembers $ Set.singleton $ (CM.CommonName (T.pack "BlockApps") (T.pack "engineering") (T.pack "David Nallapu") True))
                 -- Create a certificate registry on the main chain
@@ -281,7 +281,7 @@ contract A {
             flip postEvent (peers !! 0) $ UnseqEvent ietx
             for_ peers $ postEvent (TimerFire 0)
 
-      runForThreeSeconds $ concurrently_ (runNetworkOld peers connections') routine
+      runForSeconds 15 $ concurrently_ (runNetworkOld peers connections') routine
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       ifor_ ctxs1 $ \i ctx -> (i, ctx ^. apiChainInfoMap . at chainId) `shouldBe` (i, if i == 2 then Nothing else Just chainInfo')
 
@@ -495,7 +495,7 @@ contract A {
             threadDelay 5000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ addMemberTx cId2
           
-      void . timeout 80000000 $ concurrently_ (runNetworkOld peers connections') routine
+      void . timeout 100000000 $ concurrently_ (runNetworkOld peers connections') routine
       cId <- readIORef cIdRef
       cInfo <- readIORef cInfoRef
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
@@ -572,7 +572,7 @@ contract RegisterCert {
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx tx1
             threadDelay 1000000
             flip postEvent (peers !! 0) . UnseqEvent $ toIetx tx2
-      void . timeout 3000000 $ concurrently_ (runNetworkOld peers connections') routine
+      void . timeout 5000000 $ concurrently_ (runNetworkOld peers connections') routine
       ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
       for_ ctxs1 $ \ctx -> (ctx ^. x509certMap) `shouldNotBe` M.empty
 
@@ -593,7 +593,7 @@ contract RegisterCert {
         ts <- liftIO getCurrentMicrotime
         cIdRef <- newIORef undefined
         cInfoRef <- newIORef undefined
-        let runForThreeSeconds = void . timeout 5000000
+        let runForTwelveSeconds = void . timeout 12000000
             toIetx = IETx ts . IngestTx Origin.API
             mkChainId = keccak256ToWord256 . rlpHash
 
@@ -690,7 +690,7 @@ contract RegisterCert {
               threadDelay 200000
               flip postEvent (peers !! 0) . UnseqEvent $ toIetx $ signedPrivTx cId -- Add organization to private chain
 
-        runForThreeSeconds $ concurrently_ (runNetworkOld peers connections') routine
+        runForTwelveSeconds $ concurrently_ (runNetworkOld peers connections') routine
         ctxs1 <- atomically $ traverse (readTVar . _p2pTestContext) peers
         testCid <- readIORef cIdRef
 


### PR DESCRIPTION
This PR fixes the boolean inconsistency in the lookup functions in Redis for `ParsedSetWhitePage`. The inconsistency would have prevented any results to be returned due to the field mismatches.