### PR TITLE
Strato 2576 shared vault fix metadata endpoint

### DIFF
--- a/strato/api/core-api2/src/Handlers/Metadata.hs
+++ b/strato/api/core-api2/src/Handlers/Metadata.hs
@@ -23,7 +23,6 @@ module Handlers.Metadata
 
 import           Data.Aeson                     hiding (Success)
 
-import qualified Data.Text                      as T
 import           Data.Swagger                   hiding (url)
        
 import           Control.Monad.Composable.SQL
@@ -61,11 +60,9 @@ data MetadataResponse = MetadataResponse
   } deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
 
-type API = "metadata"
-  :> Servant.Header "X-USER-UNIQUE-NAME" T.Text
-  :> Get '[JSON] MetadataResponse
+type API = "metadata" :> Get '[JSON] MetadataResponse
 
-getMetaDataClient :: Maybe T.Text -> ClientM MetadataResponse
+getMetaDataClient :: ClientM MetadataResponse
 getMetaDataClient = client (Proxy @API)
 
 server :: (HasVault m, MonadLogger m, HasSQL m) => ServerT API m
@@ -83,13 +80,12 @@ getMetaData :: (  MonadIO m
                 , HasVault m
                 , Accessible [Address] m
                 , HasSQL m )
-                =>   Maybe T.Text  
-                ->   m MetadataResponse
-getMetaData token = 
+                =>   m MetadataResponse
+getMetaData  = 
   do
   validators <- access (Proxy @[Address])
   isSynced <- checkIsSynced
-  mAddressAndKey <- getPubKeyAndAddress token
+  mAddressAndKey <- getPubKeyAndAddress
   case mAddressAndKey of
     Left  _      -> pure $ (MetadataResponse " "  "Error" validators False False) 
     Right addressAndKey -> pure $ (MetadataResponse 
@@ -111,11 +107,8 @@ blocVaultWrapper client' = do
     liftIO $ runClientM client' (mkClientEnv mgr url)
   either (blocError . VaultWrapperError) return resultEither
 
-getPubKeyAndAddress ::  (MonadIO m, MonadLogger m, MonadUnliftIO m, HasVault m) => Maybe T.Text -> m (Either VaultWrapperError (PublicKey, Address))
-getPubKeyAndAddress mAccessToken =
-  case mAccessToken of
-    Nothing -> throwIO $ InvalidArgs $ "Did not find X-USER-UNIQUE-NAME in the header" 
-    Just _  -> try $ fmap unaddressAndUnkey .  blocVaultWrapper $ getKey  "nodekey" Nothing
+getPubKeyAndAddress ::  (MonadIO m, MonadLogger m, MonadUnliftIO m, HasVault m) =>  m (Either VaultWrapperError (PublicKey, Address))
+getPubKeyAndAddress  = try $ fmap unaddressAndUnkey .  blocVaultWrapper $ getKey  "nodekey" Nothing
 
 unaddressAndUnkey :: AddressAndKey -> (PublicKey, Address)
 unaddressAndUnkey addressAndKey = (Strato.Strato23.API.Types.unPubKey addressAndKey ,Strato.Strato23.API.Types.unAddress addressAndKey) 

--- a/strato/core/blockapps-datadefs/src/Blockchain/Data/DataDefs.txt
+++ b/strato/core/blockapps-datadefs/src/Blockchain/Data/DataDefs.txt
@@ -18,6 +18,7 @@ BlockData
 
 ValidatorRef
     address Address
+    UniqueAddress_ address
     deriving Eq Read Show
 
 BlockDataRef

--- a/strato/vault/api/src/Strato/Strato23/API/Signature.hs
+++ b/strato/vault/api/src/Strato/Strato23/API/Signature.hs
@@ -23,8 +23,3 @@ type PostSignature' = "signature"
                     :> Header' '[Required, Strict] "X-IDENTITY-PROVIDER-ID"    Text
                     :> ReqBody '[JSON] MsgHash
                     :> Post '[JSON] Signature
-
-
--- curl http://mydomainorip:8000/strato/v2.3/signature 
--- curl http://vault-wrapper:8000/strato/v2.3/createCert -H 'X-USER-UNIQUE-NAME: user1@example.com' -d '{"subject": {"subCommonName":"Luke","subOrg":"BlockApps","subPub":"04cb13876cac3f5220e492884e681872f6fa3dddff44cf5068faa5bb8bf812208646e4187bb8638aac18be092591548d8c84e72e8f88da4f549d94' -i
-


### PR DESCRIPTION
Fix: 

- There was a case when starting and stopping a Strato root node would cause duplicate validators in the validatorRef db. Thus, the metadata endpoint would should a duplicate address in the list of validators.  To fix this the configuration of the  ValidatorRef db was made so that addresses are unique. This was heavily tested.
- Also the metadata endpoint had a header argument that needed to be removed.