### PR TITLE
Vault-Proxy Thread Fix && VAULT_PROXY_DEBUG convert to Bool

### DIFF
--- a/strato/doit.sh
+++ b/strato/doit.sh
@@ -435,7 +435,7 @@ setEnv vmDebug ${vmDebug:-false}
 setEnv wsDebug ${wsDebug:-false}
 setEnv debugPort ${debugPort:-8051}
 setEnv debugWSPort ${debugWSPort:-8052}
-setEnv VAULT_PROXY_DEBUG ${VAULT_PROXY_DEBUG:-0}
+setEnv VAULT_PROXY_DEBUG ${VAULT_PROXY_DEBUG:-false}
 
 setEnv STRATO_API_LOCAL_ROOT_PATH http://localhost:3000/eth/v1.2
 

--- a/strato/vault-proxy/api/package.yaml
+++ b/strato/vault-proxy/api/package.yaml
@@ -16,6 +16,7 @@ description:         Please see the README on GitHub at <https://github.com/gith
 
 dependencies:
   - base
+  - concurrent-extra
 
 ghc-options: -Wall -Werror -threaded
 

--- a/strato/vault-proxy/api/package.yaml
+++ b/strato/vault-proxy/api/package.yaml
@@ -16,6 +16,7 @@ description:         Please see the README on GitHub at <https://github.com/gith
 
 dependencies:
   - base
+  - lens
 
 ghc-options: -Wall -Werror -threaded
 
@@ -30,7 +31,6 @@ library:
   - cryptonite
   - http-client
   - labeled-error
-  - lens
   - saltine
   - scientific
   - servant

--- a/strato/vault-proxy/api/package.yaml
+++ b/strato/vault-proxy/api/package.yaml
@@ -16,7 +16,6 @@ description:         Please see the README on GitHub at <https://github.com/gith
 
 dependencies:
   - base
-  - lens
 
 ghc-options: -Wall -Werror -threaded
 
@@ -31,6 +30,7 @@ library:
   - cryptonite
   - http-client
   - labeled-error
+  - lens
   - saltine
   - scientific
   - servant

--- a/strato/vault-proxy/api/src/Strato/VaultProxy/API/Types.hs
+++ b/strato/vault-proxy/api/src/Strato/VaultProxy/API/Types.hs
@@ -14,25 +14,16 @@ module Strato.VaultProxy.API.Types
   , SharedKey(..) --       same
   ) where
 
--- import           Control.Lens                 hiding ((.=))
--- import           Data.Aeson.Casing
--- import           Data.Aeson.Casing.Internal   (dropFPrefix)
 import           Data.Aeson.Types             hiding (fieldLabelModifier)
--- import qualified Data.ByteString              as B
--- import qualified Data.ByteString.Base16       as B16
--- import qualified Data.ByteString.Char8        as C8
 import           Data.Cache
--- import           Data.Scientific              as Scientific
 import qualified Data.Text                    as T
 import           Data.Swagger
--- import           Data.Swagger.Internal.Schema (named)
 
 import           GHC.Generics
 
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.Secp256k1
 import           Strato.VaultProxy.DataTypes
--- import qualified LabeledError
 
 
 data User = User

--- a/strato/vault-proxy/api/src/Strato/VaultProxy/API/Types.hs
+++ b/strato/vault-proxy/api/src/Strato/VaultProxy/API/Types.hs
@@ -27,6 +27,7 @@ import qualified Data.Text                    as T
 import           Data.Swagger
 -- import           Data.Swagger.Internal.Schema (named)
 
+-- import           GHC.Conc
 import           GHC.Generics
 
 import           Blockchain.Strato.Model.Address

--- a/strato/vault-proxy/api/src/Strato/VaultProxy/API/Types.hs
+++ b/strato/vault-proxy/api/src/Strato/VaultProxy/API/Types.hs
@@ -27,7 +27,6 @@ import qualified Data.Text                    as T
 import           Data.Swagger
 -- import           Data.Swagger.Internal.Schema (named)
 
--- import           GHC.Conc
 import           GHC.Generics
 
 import           Blockchain.Strato.Model.Address

--- a/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
+++ b/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
@@ -2,14 +2,6 @@ module Strato.VaultProxy.DataTypes (
     VaultToken(..),
     VaultConnection(..),
     RawOauth(..)
-    -- accessToken,
-    -- expiresIn,
-    -- refreshExpiresIn,
-    -- refreshToken,
-    -- tokenType,
-    -- notBeforePolicy,
-    -- sessionState,
-    -- sconce
 ) where
 
 -- import           Control.Lens
@@ -89,7 +81,7 @@ instance FromJSON VaultToken where
 --TODO: use lenses (not important but would be nice)
 data VaultConnection = VaultConnection {
     vaultUrl :: T.Text,
-    httpManager :: Manager, --Please don't export this, not useful to the user (unless we put this not in its own executable, but then we shouldn't have this)
+    httpManager :: Manager,
     oauthUrl :: T.Text,
     oauthClientId :: T.Text,
     oauthClientSecret :: T.Text,

--- a/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
+++ b/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
@@ -1,37 +1,48 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 module Strato.VaultProxy.DataTypes (
     VaultToken(..),
     VaultConnection(..),
-    RawOauth(..)
-    -- accessToken,
-    -- expiresIn,
-    -- refreshExpiresIn,
-    -- refreshToken,
-    -- tokenType,
-    -- notBeforePolicy,
-    -- sessionState,
-    -- sconce
-) where
+    RawOauth(..),
+    accessToken,
+    expiresIn,
+    refreshExpiresIn,
+    refreshToken,
+    tokenType,
+    notBeforePolicy,
+    sessionState,
+    scone
+  ) where
 
--- import           Control.Lens
+import           Control.Lens
+import           GHC.Generics
 import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Cache
 import           Data.Text          as T
 import           Data.Scientific    as Scientific
+-- import           GHC.Conc
 import           Network.HTTP.Client
 
 --This is the received information from the OpenId Connect response
+-- data Stupid = Stupid {
+--     _stupid :: T.Text
+-- } deriving (Eq, Show, Generic)
+-- makeLenses ''Stupid
+
 data VaultToken = VaultToken {
-    accessToken :: T.Text,
-    expiresIn :: Integer,
-    refreshExpiresIn :: Integer,
-    refreshToken :: T.Text,
-    tokenType :: T.Text,
-    notBeforePolicy :: Integer,
-    sessionState :: T.Text,
-    scone :: T.Text
-} deriving (Eq, Show)
--- makeLenses ''VaultToken
+    _accessToken :: T.Text,
+    _expiresIn :: Integer,
+    _refreshExpiresIn :: Integer,
+    _refreshToken :: T.Text,
+    _tokenType :: T.Text,
+    _notBeforePolicy :: Integer,
+    _sessionState :: T.Text,
+    _scone :: T.Text
+  } deriving (Eq, Show, Generic)
+makeLenses ''VaultToken
 
 instance FromJSON VaultToken where
   parseJSON (Object o) = do

--- a/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
+++ b/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
@@ -98,7 +98,8 @@ data VaultConnection = VaultConnection {
     vaultProxyPort :: Int,
     tokenCache :: Cache T.Text VaultToken,
     additionalOauth :: RawOauth,
-    superLock :: L.Lock
+    superLock :: L.Lock,
+    debuggingOn :: Bool
 }
 
 data RawOauth = RawOauth {

--- a/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
+++ b/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
@@ -1,48 +1,37 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 module Strato.VaultProxy.DataTypes (
     VaultToken(..),
     VaultConnection(..),
-    RawOauth(..),
-    accessToken,
-    expiresIn,
-    refreshExpiresIn,
-    refreshToken,
-    tokenType,
-    notBeforePolicy,
-    sessionState,
-    scone
-  ) where
+    RawOauth(..)
+    -- accessToken,
+    -- expiresIn,
+    -- refreshExpiresIn,
+    -- refreshToken,
+    -- tokenType,
+    -- notBeforePolicy,
+    -- sessionState,
+    -- sconce
+) where
 
-import           Control.Lens
-import           GHC.Generics
+-- import           Control.Lens
 import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Cache
 import           Data.Text          as T
 import           Data.Scientific    as Scientific
--- import           GHC.Conc
 import           Network.HTTP.Client
 
 --This is the received information from the OpenId Connect response
--- data Stupid = Stupid {
---     _stupid :: T.Text
--- } deriving (Eq, Show, Generic)
--- makeLenses ''Stupid
-
 data VaultToken = VaultToken {
-    _accessToken :: T.Text,
-    _expiresIn :: Integer,
-    _refreshExpiresIn :: Integer,
-    _refreshToken :: T.Text,
-    _tokenType :: T.Text,
-    _notBeforePolicy :: Integer,
-    _sessionState :: T.Text,
-    _scone :: T.Text
-  } deriving (Eq, Show, Generic)
-makeLenses ''VaultToken
+    accessToken :: T.Text,
+    expiresIn :: Integer,
+    refreshExpiresIn :: Integer,
+    refreshToken :: T.Text,
+    tokenType :: T.Text,
+    notBeforePolicy :: Integer,
+    sessionState :: T.Text,
+    scone :: T.Text
+} deriving (Eq, Show)
+-- makeLenses ''VaultToken
 
 instance FromJSON VaultToken where
   parseJSON (Object o) = do

--- a/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
+++ b/strato/vault-proxy/api/src/Strato/VaultProxy/DataTypes.hs
@@ -13,6 +13,7 @@ module Strato.VaultProxy.DataTypes (
 ) where
 
 -- import           Control.Lens
+import           Control.Concurrent.Lock as L
 import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Cache
@@ -96,7 +97,8 @@ data VaultConnection = VaultConnection {
     vaultProxyUrl :: T.Text,
     vaultProxyPort :: Int,
     tokenCache :: Cache T.Text VaultToken,
-    additionalOauth :: RawOauth
+    additionalOauth :: RawOauth,
+    superLock :: L.Lock
 }
 
 data RawOauth = RawOauth {

--- a/strato/vault-proxy/server/app/Main.hs
+++ b/strato/vault-proxy/server/app/Main.hs
@@ -9,6 +9,7 @@
 
 module Main where
 
+import           Control.Concurrent.Lock                as L
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.ByteString                        as B hiding (putStrLn, map, filter)
@@ -63,6 +64,9 @@ main = do
   when (flags_VAULT_URL == "") $ error "There is no shared vault connection 😓"
   --Initialize a new connection manager, ensure TLS communication as everything is sensitive info from here on out.
   mgr <- HCLI.newManager HCON.tlsManagerSettings
+  --Initialize a new locking mechanism, this will be shared among all threads that are currently using the vault proxy
+    --and will prevent multiple threads from attempting to reach the OAUTH provider at the same time.
+  vaultLock <- liftIO $ L.new
   --Initialize the token cache
   tokenCash <- atomically $ Cache.newCacheSTM Nothing
   traceM "Trying to parse the oauth url"
@@ -74,7 +78,7 @@ main = do
           Left err -> error $ "Error connecting to the OAUTH server: " ++ show err
           Right val -> return val
   --get the awesome token, awesome token alters the token cash, so a result is not needed
-  _ <- liftIO $ getAwesomeToken tokenCash flags_OAUTH_CLIENT_ID flags_OAUTH_CLIENT_SECRET flags_OAUTH_RESERVE_SECONDS noErrorOauth
+  _ <- liftIO $ getAwesomeToken vaultLock tokenCash flags_OAUTH_CLIENT_ID flags_OAUTH_CLIENT_SECRET flags_OAUTH_RESERVE_SECONDS noErrorOauth
   --Setup the vault connection
   let vaultConnection = VaultConnection {
       vaultUrl = flags_VAULT_URL,
@@ -86,7 +90,8 @@ main = do
       vaultProxyUrl = flags_VAULT_PROXY_URL,
       vaultProxyPort = flags_VAULT_PROXY_PORT,
       tokenCache = tokenCash,
-      additionalOauth = noErrorOauth
+      additionalOauth = noErrorOauth,
+      superLock = vaultLock
   }
   --Create the proxy server
   let app' = (waiProxyTo (app vaultConnection) defaultOnExc)

--- a/strato/vault-proxy/server/app/Main.hs
+++ b/strato/vault-proxy/server/app/Main.hs
@@ -162,8 +162,5 @@ checkXuat rev vc = do
       vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was not present"
       pure Nothing
 
-vaultProxyDebug :: Applicative f => Int -> String -> f()
-vaultProxyDebug debug msg  = when (debug == 1) $ traceM msg
-
 bearerBS :: ByteString
 bearerBS = TE.encodeUtf8 "Bearer "

--- a/strato/vault-proxy/server/app/Main.hs
+++ b/strato/vault-proxy/server/app/Main.hs
@@ -121,11 +121,11 @@ checkHeaders rev vc = do
       vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was present"
       pure xuat
     | otherwise -> do
-      vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was not present, adding the Authorization header"
+      vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN were present, adding the Authorization header"
       goodJwt <- vaulty vc
       let uth = (TH.hAuthorization,) . (bearerBS <>) <$> (Just (TE.encodeUtf8 (accessToken goodJwt)))
       pure uth
-  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Filtering out the old headers, will remove old X-USER-ACCESS-TOKEN and Authorization headers"
+  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Filtering out the old headers, targetting the X-USER-ACCESS-TOKEN and Authorization headers"
   let headers = W.requestHeaders rev
       filteredHeaders = filter (\(a,_) -> a /= "X-USER-ACCESS-TOKEN" && a /= "Authorization") headers
   vaultProxyDebug flags_VAULT_PROXY_DEBUG "Adding the new headers to the request"
@@ -138,17 +138,17 @@ checkHeaders rev vc = do
 
 checkXuat :: Request -> VaultConnection -> IO (Maybe Header)
 checkXuat rev vc = do
-  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Checking if X-USER-ACCESS-TOKEN is in the list of headers in the request."
+  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Inspecting the headers given to the vault-proxy"
   case (lookup "X-USER-ACCESS-TOKEN" $ W.requestHeaders rev) of
     Just b -> do
-      vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN is present"
+      vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was present, converting it into an authorization header"
       newB <- case b of
         "" -> do
-          vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN is empty, will get a new token"
+          vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was empty, getting a new one"
           goodJwt <- vaulty vc
           pure (TE.encodeUtf8 (accessToken goodJwt))
         _ -> do
-          vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was not empty, using it instead of using the cache"
+          vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was not empty, using it"
           vaultProxyDebug flags_VAULT_PROXY_DEBUG $ show b
           pure b
       let newXuat = (TH.hAuthorization,) . (bearerBS <>) <$> Just newB

--- a/strato/vault-proxy/server/app/Main.hs
+++ b/strato/vault-proxy/server/app/Main.hs
@@ -14,7 +14,6 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.ByteString                        as B hiding (putStrLn, map, filter)
 import qualified Data.Cache                             as Cache
--- import qualified Data.CaseInsensitive                   as CI
 import           Data.Text                              as T hiding (unlines, map, filter)   
 import           Data.Text.Encoding                     as TE
 import           Debug.Trace
@@ -24,8 +23,6 @@ import qualified Network.HTTP.Client                    as HCLI
 import           Network.HTTP.Conduit                   as HCON hiding (Request)
 import           Network.HTTP.ReverseProxy
 import           Network.HTTP.Types.Header              as TH
--- import           Network.HTTP.Types                     as TH1    
--- import           Network.HTTP.Headers                  as H   
 import           Network.Wai.Handler.Warp              (run)
 import           Network.Wai                           as W
 import           System.IO                              (BufferMode (..),
@@ -77,8 +74,6 @@ main = do
   noErrorOauth <- case rawOauthInfo of
           Left err -> error $ "Error connecting to the OAUTH server: " ++ show err
           Right val -> return val
-  --get the awesome token, awesome token alters the token cash, so a result is not needed
-  _ <- liftIO $ getAwesomeToken vaultLock tokenCash flags_OAUTH_CLIENT_ID flags_OAUTH_CLIENT_SECRET flags_OAUTH_RESERVE_SECONDS noErrorOauth
   --Setup the vault connection
   let vaultConnection = VaultConnection {
       vaultUrl = flags_VAULT_URL,
@@ -91,7 +86,8 @@ main = do
       vaultProxyPort = flags_VAULT_PROXY_PORT,
       tokenCache = tokenCash,
       additionalOauth = noErrorOauth,
-      superLock = vaultLock
+      superLock = vaultLock,
+      debuggingOn = flags_VAULT_PROXY_DEBUG
   }
   --Create the proxy server
   let app' = (waiProxyTo (app vaultConnection) defaultOnExc)

--- a/strato/vault-proxy/server/app/Main.hs
+++ b/strato/vault-proxy/server/app/Main.hs
@@ -121,11 +121,11 @@ checkHeaders rev vc = do
       vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was present"
       pure xuat
     | otherwise -> do
-      vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN were present, adding the Authorization header"
+      vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was not present, adding the Authorization header"
       goodJwt <- vaulty vc
       let uth = (TH.hAuthorization,) . (bearerBS <>) <$> (Just (TE.encodeUtf8 (accessToken goodJwt)))
       pure uth
-  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Filtering out the old headers, targetting the X-USER-ACCESS-TOKEN and Authorization headers"
+  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Filtering out the old headers, will remove old X-USER-ACCESS-TOKEN and Authorization headers"
   let headers = W.requestHeaders rev
       filteredHeaders = filter (\(a,_) -> a /= "X-USER-ACCESS-TOKEN" && a /= "Authorization") headers
   vaultProxyDebug flags_VAULT_PROXY_DEBUG "Adding the new headers to the request"
@@ -138,17 +138,17 @@ checkHeaders rev vc = do
 
 checkXuat :: Request -> VaultConnection -> IO (Maybe Header)
 checkXuat rev vc = do
-  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Inspecting the headers given to the vault-proxy"
+  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Checking if X-USER-ACCESS-TOKEN is in the list of headers in the request."
   case (lookup "X-USER-ACCESS-TOKEN" $ W.requestHeaders rev) of
     Just b -> do
-      vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was present, converting it into an authorization header"
+      vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN is present"
       newB <- case b of
         "" -> do
-          vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was empty, getting a new one"
+          vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN is empty, will get a new token"
           goodJwt <- vaulty vc
           pure (TE.encodeUtf8 (accessToken goodJwt))
         _ -> do
-          vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was not empty, using it"
+          vaultProxyDebug flags_VAULT_PROXY_DEBUG "X-USER-ACCESS-TOKEN was not empty, using it instead of using the cache"
           vaultProxyDebug flags_VAULT_PROXY_DEBUG $ show b
           pure b
       let newXuat = (TH.hAuthorization,) . (bearerBS <>) <$> Just newB

--- a/strato/vault-proxy/server/app/Options.hs
+++ b/strato/vault-proxy/server/app/Options.hs
@@ -13,4 +13,4 @@ defineFlag "OAUTH_RESERVE_SECONDS" (13 :: Int) "How long the system should reser
 defineFlag "VAULT_URL" (T.pack "" :: Text) "The place where I go to visit THE VAULT 🔒."
 defineFlag "VAULT_PROXY_PORT" (8013 :: Int) "This is the port that the vault proxy will listen on."
 defineFlag "VAULT_PROXY_URL" (T.pack "http://localhost" :: Text) "This is the url that the vault proxy will listen on."
-defineFlag "VAULT_PROXY_DEBUG" (0 :: Int) "If this is set to 1 then the proxy will print out the requests and responses, along with other information."
+defineFlag "VAULT_PROXY_DEBUG" (False :: Bool) "If this is set to 1 then the proxy will print out the requests and responses, along with other information."

--- a/strato/vault-proxy/server/package.yaml
+++ b/strato/vault-proxy/server/package.yaml
@@ -24,6 +24,7 @@ dependencies:
 - text
 - http-conduit
 - HTTP
+- lens
 - monad-logger
 - servant-client
 - servant-client-core
@@ -47,7 +48,6 @@ library:
     - exceptions
     - http-client
     - jwt
-    - lens
     - modern-uri
     - monad-alter
     - monad-control

--- a/strato/vault-proxy/server/package.yaml
+++ b/strato/vault-proxy/server/package.yaml
@@ -19,7 +19,6 @@ dependencies:
 - blockapps-vault-proxy-api
 - bytestring
 - common-log
-- concurrency
 - lens
 - postgresql-simple
 - text

--- a/strato/vault-proxy/server/package.yaml
+++ b/strato/vault-proxy/server/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - lens
 - postgresql-simple
 - text
+- hflags
 - http-conduit
 - HTTP
 - monad-logger

--- a/strato/vault-proxy/server/package.yaml
+++ b/strato/vault-proxy/server/package.yaml
@@ -24,7 +24,6 @@ dependencies:
 - text
 - http-conduit
 - HTTP
-- lens
 - monad-logger
 - servant-client
 - servant-client-core
@@ -48,6 +47,7 @@ library:
     - exceptions
     - http-client
     - jwt
+    - lens
     - modern-uri
     - monad-alter
     - monad-control

--- a/strato/vault-proxy/server/package.yaml
+++ b/strato/vault-proxy/server/package.yaml
@@ -19,6 +19,7 @@ dependencies:
 - blockapps-vault-proxy-api
 - bytestring
 - common-log
+- concurrent-extra
 - lens
 - postgresql-simple
 - text

--- a/strato/vault-proxy/server/package.yaml
+++ b/strato/vault-proxy/server/package.yaml
@@ -19,6 +19,7 @@ dependencies:
 - blockapps-vault-proxy-api
 - bytestring
 - common-log
+- concurrency
 - lens
 - postgresql-simple
 - text

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/RawOauth.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/RawOauth.hs
@@ -10,7 +10,6 @@ module Strato.VaultProxy.RawOauth where
 import           Data.Cache               as C
 import           Data.Proxy
 import qualified Data.Text               as T
--- import           GHC.Conc
 import           Servant.API             as SA
 import           Servant.Client
 

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/RawOauth.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/RawOauth.hs
@@ -10,6 +10,7 @@ module Strato.VaultProxy.RawOauth where
 import           Data.Cache               as C
 import           Data.Proxy
 import qualified Data.Text               as T
+-- import           GHC.Conc
 import           Servant.API             as SA
 import           Servant.Client
 

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -10,6 +10,7 @@
 module Strato.VaultProxy.Server.Token where
 
 import           Control.Concurrent.STM
+import           Control.Lens
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Data.ByteString.Base64   as B64
@@ -30,7 +31,7 @@ import           Strato.VaultProxy.DataTypes
 
 --This will get a fresh brand new, minty fresh clean token from the OAuth provider,
 --User never really needs to use this function, it is mostly called by getAwesomeToken 
-getVirginToken ::  (MonadIO m, MonadThrow m) => T.Text -> T.Text -> RawOauth -> m VaultToken --OAuth2Token ---Might need to include the discovery URL later
+getVirginToken ::  (MonadIO m, MonadThrow m) => T.Text -> T.Text -> RawOauth -> m (VaultToken) --OAuth2Token ---Might need to include the discovery URL later
 getVirginToken clientId clientSecret additionalOauth = do --virginToken
     --Conver the token endpoint to a URI
     uri <- URI.mkURI $ token_endpoint additionalOauth
@@ -47,7 +48,7 @@ getVirginToken clientId clientSecret additionalOauth = do --virginToken
     pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
 
 --This will get the correct token and will get a cached token if it is still valid
-getAwesomeToken :: (MonadIO m, MonadThrow m) => VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
+getAwesomeToken :: (MonadIO m, MonadThrow m) => VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m (VaultToken)
 getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
     --Get the current STM time and the check if the item in memory needs to be cleared, clear it if needed
     cache <- liftIO . atomically $ do 
@@ -57,27 +58,32 @@ getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
             Just c -> pure c
             --If the token was old destroy the old token and get a new one
             Nothing -> do 
-                traceM "Got a new token"
-                virToken <- getVirginToken clientId clientSecret additionalOauth
+                traceM "Get a new token"
+                let virToken = getVirginToken clientId clientSecret additionalOauth
+                vtoken <- virToken
                 --Calculate the time that the token will expire
-                exTime <- makeExpry virToken reserveTime
+                exTime <- makeExpry vtoken reserveTime
                 --Insert the new token into the STM cache
-                liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
+                insertSTM clientId virToken (Cache clientId virToken) (Just exTime)
                 traceM "Successfully inserted the new token into the cache"
                 pure virToken
 
     pure cache
+
+makeSTM :: a -> STM a
+makeSTM = pure
 
 --This is the standard expry time for the token, it is 13 seconds less than the expry time from the OAuth provider
 makeExpry :: MonadIO m => VaultToken -> Int -> m TimeSpec 
 --Make the expry negative if the token does not have the expiresIn field set, this will force a new token to be made always
     --Not sure if this will really occur, but it is a good safety net 🕸️
 makeExpry token reserveTime = do 
+    traceM "Calculating the expry time for a token."
     whatTimeIsIt <- liftIO $ getTime Monotonic
     let nanoTime :: Integer
         nanoTime = toNanoSecs (whatTimeIsIt)
         tokenExpry :: Integer
-        tokenExpry =  expiresIn token
+        tokenExpry = token ^. expiresIn
         expry :: TimeSpec
         expry = fromNanoSecs ( nanoTime + (tokenExpry - toInteger reserveTime) * 1000000000)
     pure expry

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -53,25 +53,20 @@ getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
     cache <- liftIO . atomically $ do 
         now <- C.nowSTM
         cash <- lookupSTM True clientId squirrel now
-        pure cash
+        case cash of 
+            Just c -> pure c
+            --If the token was old destroy the old token and get a new one
+            Nothing -> do 
+                traceM "Got a new token"
+                virToken <- getVirginToken clientId clientSecret additionalOauth
+                --Calculate the time that the token will expire
+                exTime <- makeExpry virToken reserveTime
+                --Insert the new token into the STM cache
+                liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
+                traceM "Successfully inserted the new token into the cache"
+                pure virToken
 
-    --If the cache is up to date, then just return the VaultToken
-    vaultToken <- case cache of 
-        Just c -> pure c
-        --If the token was old destroy the old token and get a new one
-        Nothing -> do 
-            traceM "Trying to get a new token"
-            -- Get the virgin token from the provider
-            let vToken = getVirginToken clientId clientSecret additionalOauth
-            traceM "Got a new token"
-            virToken <- vToken
-            --Calculate the time that the token will expire
-            exTime <- makeExpry virToken reserveTime
-            --Insert the new token into the STM cache
-            liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
-            traceM "Successfully inserted the new token into the cache"
-            pure virToken
-    pure vaultToken
+    pure cache
 
 --This is the standard expry time for the token, it is 13 seconds less than the expry time from the OAuth provider
 makeExpry :: MonadIO m => VaultToken -> Int -> m TimeSpec 

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -10,7 +10,6 @@
 module Strato.VaultProxy.Server.Token where
 
 import           Control.Concurrent.STM
-import           Control.Lens
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Data.ByteString.Base64   as B64
@@ -31,7 +30,7 @@ import           Strato.VaultProxy.DataTypes
 
 --This will get a fresh brand new, minty fresh clean token from the OAuth provider,
 --User never really needs to use this function, it is mostly called by getAwesomeToken 
-getVirginToken ::  (MonadIO m, MonadThrow m) => T.Text -> T.Text -> RawOauth -> m (VaultToken) --OAuth2Token ---Might need to include the discovery URL later
+getVirginToken ::  (MonadIO m, MonadThrow m) => T.Text -> T.Text -> RawOauth -> m VaultToken --OAuth2Token ---Might need to include the discovery URL later
 getVirginToken clientId clientSecret additionalOauth = do --virginToken
     --Conver the token endpoint to a URI
     uri <- URI.mkURI $ token_endpoint additionalOauth
@@ -48,7 +47,7 @@ getVirginToken clientId clientSecret additionalOauth = do --virginToken
     pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
 
 --This will get the correct token and will get a cached token if it is still valid
-getAwesomeToken :: (MonadIO m, MonadThrow m) => VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m (VaultToken)
+getAwesomeToken :: (MonadIO m, MonadThrow m) => VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
 getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
     --Get the current STM time and the check if the item in memory needs to be cleared, clear it if needed
     cache <- liftIO . atomically $ do 
@@ -58,32 +57,27 @@ getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
             Just c -> pure c
             --If the token was old destroy the old token and get a new one
             Nothing -> do 
-                traceM "Get a new token"
-                let virToken = getVirginToken clientId clientSecret additionalOauth
-                vtoken <- virToken
+                traceM "Got a new token"
+                virToken <- getVirginToken clientId clientSecret additionalOauth
                 --Calculate the time that the token will expire
-                exTime <- makeExpry vtoken reserveTime
+                exTime <- makeExpry virToken reserveTime
                 --Insert the new token into the STM cache
-                insertSTM clientId virToken (Cache clientId virToken) (Just exTime)
+                liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
                 traceM "Successfully inserted the new token into the cache"
                 pure virToken
 
     pure cache
-
-makeSTM :: a -> STM a
-makeSTM = pure
 
 --This is the standard expry time for the token, it is 13 seconds less than the expry time from the OAuth provider
 makeExpry :: MonadIO m => VaultToken -> Int -> m TimeSpec 
 --Make the expry negative if the token does not have the expiresIn field set, this will force a new token to be made always
     --Not sure if this will really occur, but it is a good safety net 🕸️
 makeExpry token reserveTime = do 
-    traceM "Calculating the expry time for a token."
     whatTimeIsIt <- liftIO $ getTime Monotonic
     let nanoTime :: Integer
         nanoTime = toNanoSecs (whatTimeIsIt)
         tokenExpry :: Integer
-        tokenExpry = token ^. expiresIn
+        tokenExpry =  expiresIn token
         expry :: TimeSpec
         expry = fromNanoSecs ( nanoTime + (tokenExpry - toInteger reserveTime) * 1000000000)
     pure expry

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -11,6 +11,7 @@ module Strato.VaultProxy.Server.Token where
 
 import           Control.Concurrent.STM
 import           Control.Concurrent.Lock  as L
+import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Data.ByteString.Base64   as B64
@@ -86,7 +87,6 @@ getAwesomeToken awesomeLock squirrel clientId clientSecret reserveTime additiona
                 checkTokenAgain <- getAwesomeToken awesomeLock squirrel clientId clientSecret reserveTime additionalOauth
                 pure checkTokenAgain
 
-
     pure vaultToken
 
 --This is the standard expry time for the token, it is 13 seconds less than the expry time from the OAuth provider
@@ -113,3 +113,6 @@ vaulty vaultConn = getAwesomeToken ll tc cid csec rs ao
         rs = oauthReserveSeconds vaultConn
         tc = tokenCache vaultConn
         ll = superLock vaultConn
+
+vaultProxyDebug :: Applicative f => Int -> String -> f()
+vaultProxyDebug debug msg  = when (debug == 1) $ traceM msg

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -10,6 +10,7 @@
 module Strato.VaultProxy.Server.Token where
 
 import           Control.Concurrent.STM
+import           Control.Concurrent.Lock  as L
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Data.ByteString.Base64   as B64
@@ -47,8 +48,8 @@ getVirginToken clientId clientSecret additionalOauth = do --virginToken
     pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
 
 --This will get the correct token and will get a cached token if it is still valid
-getAwesomeToken :: (MonadIO m, MonadThrow m) => VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
-getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
+getAwesomeToken :: (MonadIO m, MonadThrow m) => L.Lock -> VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
+getAwesomeToken awesomeLock squirrel clientId clientSecret reserveTime additionalOauth = do
     --Get the current STM time and the check if the item in memory needs to be cleared, clear it if needed
     cache <- liftIO . atomically $ do 
         now <- C.nowSTM
@@ -58,19 +59,34 @@ getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
     --If the cache is up to date, then just return the VaultToken
     vaultToken <- case cache of 
         Just c -> pure c
-        --If the token was old destroy the old token and get a new one
+        --If the token was old destroy the old token and get a new one, block all threads except one to update the token
         Nothing -> do 
-            traceM "Trying to get a new token"
-            -- Get the virgin token from the provider
-            let vToken = getVirginToken clientId clientSecret additionalOauth
-            traceM "Got a new token"
-            virToken <- vToken
-            --Calculate the time that the token will expire
-            exTime <- makeExpry virToken reserveTime
-            --Insert the new token into the STM cache
-            liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
-            traceM "Successfully inserted the new token into the cache"
-            pure virToken
+            --Create a locking mechanism that can prevent other threads from trying to request information from the thread simultaneously
+            traceM "Create a new lock"
+            doIHaveControl <- liftIO $ L.tryAcquire awesomeLock
+            if doIHaveControl then do
+                traceM "One thread got control and is getting the new token"
+                
+                traceM "Trying to get a new token from OAuth provider"
+                -- Get the virgin token from the provider
+                virToken <- getVirginToken clientId clientSecret additionalOauth
+                --Calculate the time that the token will expire
+                traceM "Trying to calculate the expry time of the token"
+                exTime <- makeExpry virToken reserveTime
+                --Insert the new token into the STM cache
+                traceM "Trying to insert the new token into the cache"
+                liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
+                traceM "Successfully inserted the new token into the cache, releasing lock and notifiying other threads"
+                liftIO $ L.release awesomeLock
+                pure virToken
+              else do
+                traceM "Waiting until my neighbor thread updates the token"
+                liftIO $ L.wait awesomeLock
+                traceM "My neighbor thread updated the token, I will now get the token from the cache"
+                checkTokenAgain <- getAwesomeToken awesomeLock squirrel clientId clientSecret reserveTime additionalOauth
+                pure checkTokenAgain
+
+
     pure vaultToken
 
 --This is the standard expry time for the token, it is 13 seconds less than the expry time from the OAuth provider
@@ -89,10 +105,11 @@ makeExpry token reserveTime = do
 
 --Get the vault token more easily
 vaulty :: (MonadIO m, MonadThrow m) => VaultConnection -> m VaultToken
-vaulty vaultConn = getAwesomeToken tc cid csec rs ao
+vaulty vaultConn = getAwesomeToken ll tc cid csec rs ao
     where
         cid = oauthClientId vaultConn
         csec = oauthClientSecret vaultConn
         ao = additionalOauth vaultConn
         rs = oauthReserveSeconds vaultConn
         tc = tokenCache vaultConn
+        ll = superLock vaultConn

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -13,7 +13,6 @@ import           Control.Concurrent.STM
 import           Control.Lens
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
-import           Control.Monad.STM.Class  hiding (newTVar)
 import           Data.ByteString.Base64   as B64
 import           Data.Cache               as C
 import           Data.Cache.Internal      as C
@@ -21,11 +20,10 @@ import           Data.Maybe
 import qualified Data.Text               as T
 import           Data.Text.Encoding      as TE
 import           Debug.Trace
-import           GHC.Conc
 import           Network.HTTP.Client     as HTC hiding (Proxy)
 import           Network.HTTP.Req        as R
 import           Strato.VaultProxy.RawOauth
-import           System.Clock            as S
+import           System.Clock
 import           Text.URI                as URI
 
 import           Strato.VaultProxy.DataTypes
@@ -49,61 +47,53 @@ getVirginToken clientId clientSecret additionalOauth = do --virginToken
     --Convert the server response to the VaultToken type
     pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
 
-makeSTM :: a -> STM a
-makeSTM = pure
-
 --This will get the correct token and will get a cached token if it is still valid
---run this inside of "atomically" so it might look like: "liftIO $ atomically $ getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth"
-getAwesomeToken :: (MonadIO m, MonadThrow m) => VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> STM (VaultToken)
+getAwesomeToken :: (MonadIO m, MonadThrow m) => VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m (VaultToken)
 getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
     --Get the current STM time and the check if the item in memory needs to be cleared, clear it if needed
-    rightNow <- C.nowSTM
     cache <- liftIO . atomically $ do 
-        cash <- lookupSTM True clientId squirrel rightNow
+        now <- C.nowSTM
+        cash <- lookupSTM True clientId squirrel now
         case cash of 
             Just c -> pure c
             --If the token was old destroy the old token and get a new one
             Nothing -> do 
                 traceM "Get a new token"
-                virToken <- unsafeIOToSTM $ getVirginToken clientId clientSecret additionalOauth
+                let virToken = getVirginToken clientId clientSecret additionalOauth
+                vtoken <- virToken
                 --Calculate the time that the token will expire
-                exTime <- unsafeIOToSTM $ makeExpry (makeSTM virToken) reserveTime
-                rook <- newCacheSTM (Just $ liftIO $ atomically exTime)
+                exTime <- makeExpry vtoken reserveTime
                 --Insert the new token into the STM cache
-                insertSTM clientId virToken rook (Just exTime)
+                insertSTM clientId virToken (Cache clientId virToken) (Just exTime)
                 traceM "Successfully inserted the new token into the cache"
                 pure virToken
 
     pure cache
 
--- unSTM :: STM a -> a
--- unSTM = pure
+makeSTM :: a -> STM a
+makeSTM = pure
 
 --This is the standard expry time for the token, it is 13 seconds less than the expry time from the OAuth provider
-makeExpry :: (MonadIO m, MonadSTM m) => STM VaultToken -> Int -> m (STM TimeSpec)
+makeExpry :: MonadIO m => VaultToken -> Int -> m TimeSpec 
 --Make the expry negative if the token does not have the expiresIn field set, this will force a new token to be made always
     --Not sure if this will really occur, but it is a good safety net 🕸️
 makeExpry token reserveTime = do 
     traceM "Calculating the expry time for a token."
-    whatTimeIsIt <- C.nowSTM
+    whatTimeIsIt <- liftIO $ getTime Monotonic
     let nanoTime :: Integer
         nanoTime = toNanoSecs (whatTimeIsIt)
         tokenExpry :: Integer
-        tokenExpry = (liftIO $ atomically token) ^. expiresIn
+        tokenExpry = token ^. expiresIn
         expry :: TimeSpec
         expry = fromNanoSecs ( nanoTime + (tokenExpry - toInteger reserveTime) * 1000000000)
     pure expry
 
 --Get the vault token more easily
-vaulty :: (MonadIO m, MonadThrow m, MonadSTM m) => VaultConnection -> m VaultToken
-vaulty vaultConn = getAwesomeToken tcSTM cid csec rs ao
-    where cid = oauthClientId vaultConn
-          csec = oauthClientSecret vaultConn
-          ao = additionalOauth vaultConn
-          rs = oauthReserveSeconds vaultConn
-          tcSTM = tokenCache vaultConn
-    -- whatTimeIsIt <- liftIO $ getTime Monotonic
-    -- tc <- lookupSTM False cid tcSTM whatTimeIsIt
-    --Get the token from the cache
-    -- fish <- 
-    -- pure $ 
+vaulty :: (MonadIO m, MonadThrow m) => VaultConnection -> m VaultToken
+vaulty vaultConn = getAwesomeToken tc cid csec rs ao
+    where
+        cid = oauthClientId vaultConn
+        csec = oauthClientSecret vaultConn
+        ao = additionalOauth vaultConn
+        rs = oauthReserveSeconds vaultConn
+        tc = tokenCache vaultConn

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -53,20 +53,25 @@ getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
     cache <- liftIO . atomically $ do 
         now <- C.nowSTM
         cash <- lookupSTM True clientId squirrel now
-        case cash of 
-            Just c -> pure c
-            --If the token was old destroy the old token and get a new one
-            Nothing -> do 
-                traceM "Got a new token"
-                virToken <- getVirginToken clientId clientSecret additionalOauth
-                --Calculate the time that the token will expire
-                exTime <- makeExpry virToken reserveTime
-                --Insert the new token into the STM cache
-                liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
-                traceM "Successfully inserted the new token into the cache"
-                pure virToken
+        pure cash
 
-    pure cache
+    --If the cache is up to date, then just return the VaultToken
+    vaultToken <- case cache of 
+        Just c -> pure c
+        --If the token was old destroy the old token and get a new one
+        Nothing -> do 
+            traceM "Trying to get a new token"
+            -- Get the virgin token from the provider
+            let vToken = getVirginToken clientId clientSecret additionalOauth
+            traceM "Got a new token"
+            virToken <- vToken
+            --Calculate the time that the token will expire
+            exTime <- makeExpry virToken reserveTime
+            --Insert the new token into the STM cache
+            liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
+            traceM "Successfully inserted the new token into the cache"
+            pure virToken
+    pure vaultToken
 
 --This is the standard expry time for the token, it is 13 seconds less than the expry time from the OAuth provider
 makeExpry :: MonadIO m => VaultToken -> Int -> m TimeSpec 

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -13,6 +13,7 @@ import           Control.Concurrent.STM
 import           Control.Lens
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
+import           Control.Monad.STM.Class  hiding (newTVar)
 import           Data.ByteString.Base64   as B64
 import           Data.Cache               as C
 import           Data.Cache.Internal      as C
@@ -20,10 +21,11 @@ import           Data.Maybe
 import qualified Data.Text               as T
 import           Data.Text.Encoding      as TE
 import           Debug.Trace
+import           GHC.Conc
 import           Network.HTTP.Client     as HTC hiding (Proxy)
 import           Network.HTTP.Req        as R
 import           Strato.VaultProxy.RawOauth
-import           System.Clock
+import           System.Clock            as S
 import           Text.URI                as URI
 
 import           Strato.VaultProxy.DataTypes
@@ -47,53 +49,61 @@ getVirginToken clientId clientSecret additionalOauth = do --virginToken
     --Convert the server response to the VaultToken type
     pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
 
+makeSTM :: a -> STM a
+makeSTM = pure
+
 --This will get the correct token and will get a cached token if it is still valid
-getAwesomeToken :: (MonadIO m, MonadThrow m) => VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m (VaultToken)
+--run this inside of "atomically" so it might look like: "liftIO $ atomically $ getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth"
+getAwesomeToken :: (MonadIO m, MonadThrow m) => VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> STM (VaultToken)
 getAwesomeToken squirrel clientId clientSecret reserveTime additionalOauth = do
     --Get the current STM time and the check if the item in memory needs to be cleared, clear it if needed
+    rightNow <- C.nowSTM
     cache <- liftIO . atomically $ do 
-        now <- C.nowSTM
-        cash <- lookupSTM True clientId squirrel now
+        cash <- lookupSTM True clientId squirrel rightNow
         case cash of 
             Just c -> pure c
             --If the token was old destroy the old token and get a new one
             Nothing -> do 
                 traceM "Get a new token"
-                let virToken = getVirginToken clientId clientSecret additionalOauth
-                vtoken <- virToken
+                virToken <- unsafeIOToSTM $ getVirginToken clientId clientSecret additionalOauth
                 --Calculate the time that the token will expire
-                exTime <- makeExpry vtoken reserveTime
+                exTime <- unsafeIOToSTM $ makeExpry (makeSTM virToken) reserveTime
+                rook <- newCacheSTM (Just $ liftIO $ atomically exTime)
                 --Insert the new token into the STM cache
-                insertSTM clientId virToken (Cache clientId virToken) (Just exTime)
+                insertSTM clientId virToken rook (Just exTime)
                 traceM "Successfully inserted the new token into the cache"
                 pure virToken
 
     pure cache
 
-makeSTM :: a -> STM a
-makeSTM = pure
+-- unSTM :: STM a -> a
+-- unSTM = pure
 
 --This is the standard expry time for the token, it is 13 seconds less than the expry time from the OAuth provider
-makeExpry :: MonadIO m => VaultToken -> Int -> m TimeSpec 
+makeExpry :: (MonadIO m, MonadSTM m) => STM VaultToken -> Int -> m (STM TimeSpec)
 --Make the expry negative if the token does not have the expiresIn field set, this will force a new token to be made always
     --Not sure if this will really occur, but it is a good safety net 🕸️
 makeExpry token reserveTime = do 
     traceM "Calculating the expry time for a token."
-    whatTimeIsIt <- liftIO $ getTime Monotonic
+    whatTimeIsIt <- C.nowSTM
     let nanoTime :: Integer
         nanoTime = toNanoSecs (whatTimeIsIt)
         tokenExpry :: Integer
-        tokenExpry = token ^. expiresIn
+        tokenExpry = (liftIO $ atomically token) ^. expiresIn
         expry :: TimeSpec
         expry = fromNanoSecs ( nanoTime + (tokenExpry - toInteger reserveTime) * 1000000000)
     pure expry
 
 --Get the vault token more easily
-vaulty :: (MonadIO m, MonadThrow m) => VaultConnection -> m VaultToken
-vaulty vaultConn = getAwesomeToken tc cid csec rs ao
-    where
-        cid = oauthClientId vaultConn
-        csec = oauthClientSecret vaultConn
-        ao = additionalOauth vaultConn
-        rs = oauthReserveSeconds vaultConn
-        tc = tokenCache vaultConn
+vaulty :: (MonadIO m, MonadThrow m, MonadSTM m) => VaultConnection -> m VaultToken
+vaulty vaultConn = getAwesomeToken tcSTM cid csec rs ao
+    where cid = oauthClientId vaultConn
+          csec = oauthClientSecret vaultConn
+          ao = additionalOauth vaultConn
+          rs = oauthReserveSeconds vaultConn
+          tcSTM = tokenCache vaultConn
+    -- whatTimeIsIt <- liftIO $ getTime Monotonic
+    -- tc <- lookupSTM False cid tcSTM whatTimeIsIt
+    --Get the token from the cache
+    -- fish <- 
+    -- pure $ 

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -49,8 +49,8 @@ getVirginToken clientId clientSecret additionalOauth = do --virginToken
     pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
 
 --This will get the correct token and will get a cached token if it is still valid
-getAwesomeToken :: (MonadIO m, MonadThrow m) => L.Lock -> VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
-getAwesomeToken awesomeLock squirrel clientId clientSecret reserveTime additionalOauth = do
+getAwesomeToken :: (MonadIO m, MonadThrow m) => Bool -> L.Lock -> VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
+getAwesomeToken debuggingOn awesomeLock squirrel clientId clientSecret reserveTime additionalOauth = do
     --Get the current STM time and the check if the item in memory needs to be cleared, clear it if needed
     cache <- liftIO . atomically $ do 
         now <- C.nowSTM
@@ -59,11 +59,13 @@ getAwesomeToken awesomeLock squirrel clientId clientSecret reserveTime additiona
 
     --If the cache is up to date, then just return the VaultToken
     vaultToken <- case cache of 
-        Just c -> pure c
+        Just c -> do
+            vaultProxyDebug debuggingOn "Got my token from the cache, not from the remote server."
+            pure c
         --If the token was old destroy the old token and get a new one, block all threads except one to update the token
         Nothing -> do 
             --Create a locking mechanism that can prevent other threads from trying to request information from the thread simultaneously
-            traceM "Create a new lock"
+            traceM "Try and acquire a lock to change the token"
             doIHaveControl <- liftIO $ L.tryAcquire awesomeLock
             if doIHaveControl then do
                 traceM "One thread got control and is getting the new token"
@@ -72,10 +74,10 @@ getAwesomeToken awesomeLock squirrel clientId clientSecret reserveTime additiona
                 -- Get the virgin token from the provider
                 virToken <- getVirginToken clientId clientSecret additionalOauth
                 --Calculate the time that the token will expire
-                traceM "Trying to calculate the expry time of the token"
+                vaultProxyDebug debuggingOn  "Trying to calculate the expry time of the token"
                 exTime <- makeExpry virToken reserveTime
                 --Insert the new token into the STM cache
-                traceM "Trying to insert the new token into the cache"
+                vaultProxyDebug debuggingOn "Trying to insert the new token into the cache"
                 liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
                 traceM "Successfully inserted the new token into the cache, releasing lock and notifiying other threads"
                 liftIO $ L.release awesomeLock
@@ -83,8 +85,8 @@ getAwesomeToken awesomeLock squirrel clientId clientSecret reserveTime additiona
               else do
                 traceM "Waiting until my neighbor thread updates the token"
                 liftIO $ L.wait awesomeLock
-                traceM "My neighbor thread updated the token, I will now get the token from the cache"
-                checkTokenAgain <- getAwesomeToken awesomeLock squirrel clientId clientSecret reserveTime additionalOauth
+                vaultProxyDebug debuggingOn "My neighbor thread updated the token, I will now get the token from the cache"
+                checkTokenAgain <- getAwesomeToken debuggingOn awesomeLock squirrel clientId clientSecret reserveTime additionalOauth
                 pure checkTokenAgain
 
     pure vaultToken
@@ -105,7 +107,7 @@ makeExpry token reserveTime = do
 
 --Get the vault token more easily
 vaulty :: (MonadIO m, MonadThrow m) => VaultConnection -> m VaultToken
-vaulty vaultConn = getAwesomeToken ll tc cid csec rs ao
+vaulty vaultConn = getAwesomeToken db ll tc cid csec rs ao
     where
         cid = oauthClientId vaultConn
         csec = oauthClientSecret vaultConn
@@ -113,6 +115,7 @@ vaulty vaultConn = getAwesomeToken ll tc cid csec rs ao
         rs = oauthReserveSeconds vaultConn
         tc = tokenCache vaultConn
         ll = superLock vaultConn
+        db = debuggingOn vaultConn
 
-vaultProxyDebug :: Applicative f => Int -> String -> f()
-vaultProxyDebug debug msg  = when (debug == 1) $ traceM msg
+vaultProxyDebug :: Applicative f => Bool -> String -> f()
+vaultProxyDebug debug msg  = when debug $ traceM msg


### PR DESCRIPTION
Hello all,

This PR fixes an issue that previously allowed for multiple threads to request a new token from the OAuth provider if the token was expired. Before this was addressed there would often be many many requests to the OAuth provider if the token expired. If this was allowed to continue it would likely increase the total traffic on the OAuth provider unnecessarily. 

This fix implements a locking mechanism, all threads are able to see if there is a lock on the retrieving of a new token. If one of the threads sees that the thread is locked, the first thread encountering the old token will put a lock in place that will prevent the other threads from also requesting the token. The first thread will get the new token information, and all the other threads will patiently wait until the thread is unlocked. Once the thread has updated the token, then it will send a small notification (this works completely in the background) to the other threads that they can now proceed, they will then try to get the token again (which will most likely be from the cache). If the reserve seconds is greater than the actual amount of expire time it will enter a First In First Out approach to getting the token, but this is unlikely, and unwanted as it will slow down the system considerably, but it will get a new token from the OAuth provider each time instead of getting the token from the cache.

Secondly, this PR also addresses the previous comments that the VAULT_PROXY_DEBUG was using an INT rather than a BOOL to notifiy the proxy that it should print more verbose logging information. 

Also in this PR are some gentle clean ups as well.