### PR TITLE
Vault-Proxy Require Https

### DIFF
--- a/strato/doit.sh
+++ b/strato/doit.sh
@@ -444,6 +444,23 @@ if [[ -z ${VAULT_URL} ]] ; then
   exit 1
 fi
 
+# This will check if the link provided is valid format, and if it is HTTPS
+vaultUrlRegex='^(https|HTTPS):\/\/[-[:alnum:]\+&@#\/%?=~_|!:,.;]*[-[:alnum:]\+&@#\/%=~_|]'
+vaultUrlExceptionRegex='[ -~]*172\.17\.0\.1*[ -~]' ##172.17.0.1 is the only ip address that it should allow everything
+##There are also checks within the vault-proxy to detect if the VAULT_URL is valid, this one is just a basic check
+if [[ $VAULT_URL =~ $vaultUrlRegex ]]
+then 
+    echo "VAULT_URL provided is valid, check https"
+else
+    if [[ $VAULT_URL =~ $vaultUrlExceptionRegex ]]
+    then 
+        echo "Special case: VAULT_URL provided is valid"
+    else
+        echo "VAULT_URL provided is not valid"
+        exit 1
+    fi
+fi
+
 stratoBootnode=${bootnode:+--stratoBootnode=$bootnode}
 [[ -n $bootnode ]] && addBootnodes=true
 [[ -n $network ]] && addBootnodes=true

--- a/strato/doit.sh
+++ b/strato/doit.sh
@@ -445,18 +445,15 @@ if [[ -z ${VAULT_URL} ]] ; then
 fi
 
 # This will check if the link provided is valid format, and if it is HTTPS
-vaultUrlRegex='^(https|HTTPS):\/\/[-[:alnum:]\+&@#\/%?=~_|!:,.;]*[-[:alnum:]\+&@#\/%=~_|]'
-vaultUrlExceptionRegex='[ -~]*172\.17\.0\.1*[ -~]' ##172.17.0.1 is the only ip address that it should allow everything
-##There are also checks within the vault-proxy to detect if the VAULT_URL is valid, this one is just a basic check
-if [[ $VAULT_URL =~ $vaultUrlRegex ]]
-then 
-    echo "VAULT_URL provided is valid, check https"
+if [[ "$VAULT_URL" =~ "https"* ]]
+then
+    echo "VAULT_URL provided is likely valid"
 else
-    if [[ $VAULT_URL =~ $vaultUrlExceptionRegex ]]
-    then 
-        echo "Special case: VAULT_URL provided is valid"
-    else
-        echo "VAULT_URL provided is not valid"
+    if [[ "$VAULT_URL" =~ *"172.17.0.1"* ]]
+    then
+        echo "VAULT_URL is special case."
+    else 
+        echo "VAULT_URL provided is not valid, it should be https"
         exit 1
     fi
 fi

--- a/strato/vault-proxy/server/app/Main.hs
+++ b/strato/vault-proxy/server/app/Main.hs
@@ -10,6 +10,7 @@
 module Main where
 
 import           Control.Concurrent.Lock                as L
+-- import           Control.Lens
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.ByteString                        as B hiding (putStrLn, map, filter)
@@ -23,16 +24,16 @@ import qualified Network.HTTP.Client                    as HCLI
 import           Network.HTTP.Conduit                   as HCON hiding (Request)
 import           Network.HTTP.ReverseProxy
 import           Network.HTTP.Types.Header              as TH
-import           Network.Wai.Handler.Warp              (run)
-import           Network.Wai                           as W
+import           Network.Wai.Handler.Warp               (run)
+import           Network.Wai                            as W
 import           System.IO                              (BufferMode (..),
                                                         hSetBuffering, stderr,
                                                         stdout)
 
 import           BlockApps.Init
-import           Servant.Client
-import           Strato.VaultProxy.DataTypes              as VaultProxy
-import           Strato.VaultProxy.RawOauth               as RO
+import           Servant.Client                         as S 
+import           Strato.VaultProxy.DataTypes            as VaultProxy
+import           Strato.VaultProxy.RawOauth             as RO
 import           Strato.VaultProxy.Server.Token
 
 import           Options
@@ -59,6 +60,8 @@ main = do
   _ <- $initHFlags "Setup Vault Proxy flags"
   -- $logInfoS "Vault-Proxy is Starting"
   when (flags_VAULT_URL == "") $ error "There is no shared vault connection 😓"
+  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Checking if the connection to the VAULT is https encrypted"
+  inspectVaultUrl flags_VAULT_URL
   --Initialize a new connection manager, ensure TLS communication as everything is sensitive info from here on out.
   mgr <- HCLI.newManager HCON.tlsManagerSettings
   --Initialize a new locking mechanism, this will be shared among all threads that are currently using the vault proxy
@@ -160,3 +163,13 @@ checkXuat rev vc = do
 
 bearerBS :: ByteString
 bearerBS = TE.encodeUtf8 "Bearer "
+
+inspectVaultUrl :: T.Text -> IO ()
+inspectVaultUrl url = do
+  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Inspecting the vault url"
+  purl <- S.parseBaseUrl $ T.unpack url
+  if | (S.baseUrlHost purl == "172.17.0.1") -> do
+        traceM ("There was a special url provided (" ++ showBaseUrl purl ++ "),  I will allow any types of connections to this url.")
+        pure ()
+     | (S.baseUrlScheme purl == S.Http) -> error $ "The provided url (" ++ show purl ++ ") is http, please use https, I will not change it for you, I am quitting. 🙎"
+     | otherwise -> pure ()

--- a/strato/vault-proxy/server/app/Main.hs
+++ b/strato/vault-proxy/server/app/Main.hs
@@ -171,5 +171,5 @@ inspectVaultUrl url = do
   if | (S.baseUrlHost purl == "172.17.0.1") -> do
         traceM ("There was a special url provided (" ++ showBaseUrl purl ++ "),  I will allow any types of connections to this url.")
         pure ()
-     | (S.baseUrlScheme purl == S.Http) -> error $ "The provided url (" ++ show purl ++ ") is http, please use https, I will not change it for you, I am quitting. 🙎"
+     | (S.baseUrlScheme purl /= S.Https) -> error $ "The provided url (" ++ show purl ++ ") is http, please use https, I will not change it for you, I am quitting. 🙎"
      | otherwise -> pure ()

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -85,7 +85,7 @@ getAwesomeToken debuggingOn awesomeLock squirrel clientId clientSecret reserveTi
               else do
                 traceM "Waiting until my neighbor thread updates the token"
                 liftIO $ L.wait awesomeLock
-                vaultProxyDebug debuggingOn "My neighbor thread updated the token, I will now get the token from the cache"
+                traceM "Lock is released, will try to get the token again."
                 checkTokenAgain <- getAwesomeToken debuggingOn awesomeLock squirrel clientId clientSecret reserveTime additionalOauth
                 pure checkTokenAgain
 


### PR DESCRIPTION
To whom it may concern:

I write this PR in response to the Jira ticket 2991 (STRATO-2991). This ticket wants to enforce HTTPS traffic that goes through the vault-proxy.

When vault-proxy is starting up it will inspect the incoming URL, it will look at throw a generic error if the connection is not HTTPS, this will cause vault-proxy to just stop. It requires HTTPS on all connections except for connections to 172.17.0.1 .

Also, I added the logging statements after the lock is released for threads wanting to get a new token, I did this as it was a little confusing in the log statements that it would show that the threads were waiting to get a token, but then it wouldn't say it actually got the token.

This PR also adds a check in the doit.sh script that checks if the url entered is valid, and then checks if the VAULT_URL is https protected, if it not https protected then it checks if the url is 172.17.0.1 (which is a special case). The vault-proxy checks it again in a much more precise method that abstracts away any regex to ensure it works properly, but this simply method of checking in the bash works well for a simple check. 

Sincerely,
Me