### PR TITLE
Store orgName and appName in TransactionResult type

### DIFF
--- a/strato/VM/EVM/ethereum-vm/src/Blockchain/EVM.hs
+++ b/strato/VM/EVM/ethereum-vm/src/Blockchain/EVM.hs
@@ -1100,6 +1100,8 @@ runVMM isRunningTests' isHomestead preExistingSuicideList cDepth env availableGa
         , erKind               = EVM
         -- , erNewX509Certs       = M.empty
         , erPragmas            = []
+        , erOrgName            = ""
+        , erAppName            = ""
         }
     Right _ -> do
       vmState'@VMState{..} <- readIORef vmStateRef
@@ -1482,6 +1484,8 @@ vmStateToExecResults vmState = do
       , erKind               = EVM
       -- , erNewX509Certs       = M.empty
       , erPragmas            =[]
+      , erOrgName            = ""
+      , erAppName            = ""
       }
 
 getEVMCode' :: HasCodeDB m => CodePtr -> m BC.ByteString

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -355,7 +355,9 @@ create' creator newAccount ch cc contractName' argExps = do
     erAction = Just finalAct,
     erException = Nothing,
     erKind = SolidVM,
-    erPragmas = CC._pragmas cc
+    erPragmas = CC._pragmas cc,
+    erOrgName = org,
+    erAppName = parentName
     }
 
 {-
@@ -424,7 +426,8 @@ call _ _ _ isRCC _ blockData _ _ codeAddress sender' _ _ _ availableGas origin' 
         maybeArgs = runParser parseArgs (ParserState "" "" M.empty) "" argString
         !args = either (parseError "call arguments") CC.OrderedArgs maybeArgs
 
-    returnVal <- fmap Just . maybe (return "()") encodeForReturn =<< callWrapper sender' codeAddress Nothing funcName isRCC args
+    ((orgName, appName), returnVal) <- traverse (fmap Just . maybe (return "()") encodeForReturn)
+                                   =<< callWrapper' sender' codeAddress Nothing funcName isRCC args
 
     finalAct <- Mod.get (Mod.Proxy @Action)
     finalEvs <- Mod.get (Mod.Proxy @(Q.Seq Event))
@@ -441,7 +444,9 @@ call _ _ _ isRCC _ blockData _ _ codeAddress sender' _ _ _ availableGas origin' 
       erAction = Just $ finalAct,
       erException = Nothing,      -- tells me if theres an exception
       erKind = SolidVM,
-      erPragmas=[]
+      erPragmas=[],
+      erOrgName = orgName,
+      erAppName = appName
       }
 
 
@@ -704,7 +709,10 @@ expressionType (CC.ArrayExpression _ xs) = SVMType.Array (expressionType (head x
 expressionType ex = typeError "Cannot deduce a type from" (ex, ex)
 
 callWrapper :: MonadSM m => Account -> Account -> Maybe SolidString -> SolidString -> Bool -> CC.ArgList -> m (Maybe Value)
-callWrapper from to mContract functionName isRCC argExps  = do
+callWrapper from to mContract functionName isRCC argExps  = snd <$> callWrapper' from to mContract functionName isRCC argExps
+
+callWrapper' :: MonadSM m => Account -> Account -> Maybe SolidString -> SolidString -> Bool -> CC.ArgList -> m ((SolidString, SolidString), Maybe Value)
+callWrapper' from to mContract functionName isRCC argExps  = do
   let fromChain = from ^. accountChainId
       toChain = to ^. accountChainId
   isAccessibleChain <- toChain `isAncestorChainOf` fromChain
@@ -725,22 +733,12 @@ callWrapper from to mContract functionName isRCC argExps  = do
   
   initializeAction to (labelToString $ CC._contractName contract) (labelToString parentName') hsh
 
--- grab the org for this codeAddress
-  when (not isRCC) $ do
-    org <- getOrg to
-    Mod.modifyStatefully_ (Mod.Proxy @Action) $
-      Action.actionData %= M.adjust (Action.actionDataOrganization .~ (T.pack org)) to
-    liftIO $ putStrLn $ "callWrapper/versioning --->  we are calling " ++ (labelToString $ CC._contractName contract) ++ 
-          " in app " ++ (show parentName) ++ " of org " ++ show org
-
 --  grab the org from the senders account and set it to the codeAddress
-  when (isRCC) $ do
-    org <- getOrg from
-    Mod.modifyStatefully_ (Mod.Proxy @Action) $
-      Action.actionData %= M.adjust (Action.actionDataOrganization .~ (T.pack org)) to
+  org <- getOrg to
+  Mod.modifyStatefully_ (Mod.Proxy @Action) $
+    Action.actionData %= M.adjust (Action.actionDataOrganization .~ (T.pack org)) to
+  when (isRCC) $
     (\env -> setCreator (Env.origin env) to contract (blockDataNumber $ Env.blockHeader env)) =<< getEnv
-    liftIO $ putStrLn $ "callWrapper/versioning --->  we are calling " ++ (labelToString $ CC._contractName contract) ++ 
-          " in app " ++ (show parentName) ++ " of org " ++ show org
 
 
   let functionsIncludingConstructor =
@@ -748,7 +746,7 @@ callWrapper from to mContract functionName isRCC argExps  = do
           Nothing -> M.insert "<constructor>" emptyFunction $ contract^.CC.functions                  --contract^. M.empty $ CC.functions 
           Just c -> M.insert "<constructor>" c $ contract^.CC.functions
         where
-          emptyFunction = CC.Func [] [] Nothing Nothing Nothing M.empty [] dummyAnnotation False [] 
+          emptyFunction = CC.Func [] [] Nothing (Just []) Nothing M.empty [] dummyAnnotation False [] 
           dummyAnnotation :: SourceAnnotation ()
           dummyAnnotation =
             SourceAnnotation
@@ -810,7 +808,7 @@ callWrapper from to mContract functionName isRCC argExps  = do
                     SVMType.Array _ _-> return ()
                     _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n]) MS.BDefault
                 popCallInfo)
-  logFunctionCall args to contract functionName f
+  ((org, parentName'),) <$> logFunctionCall args to contract functionName f
   
 
 runStatements' :: MonadSM m => [CC.Statement] -> m (Maybe Value)

--- a/strato/core/blockapps-data/src/Blockchain/Data/TransactionResult.hs
+++ b/strato/core/blockapps-data/src/Blockchain/Data/TransactionResult.hs
@@ -78,6 +78,8 @@ exampleTxResult = TransactionResult (hash "blockHask")
                                     Nothing
                                     Nothing
                                     (Just SolidVM)
+                                    "BlockApps"
+                                    "Sample App"
 
 
 instance ToSchema TransactionResult where

--- a/strato/core/blockapps-datadefs/src/Blockchain/Data/DataDefs.txt
+++ b/strato/core/blockapps-datadefs/src/Blockchain/Data/DataDefs.txt
@@ -107,6 +107,8 @@ TransactionResult json
     status TransactionResultStatus Maybe
     chainId Word256 Maybe
     kind CodeKind Maybe
+    orgName String
+    appName String
     deriving Eq Read Show Generic
 
 UserN json

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -550,13 +550,13 @@ outputTransactionResult :: VMBase m
                         -> ConduitT a VmOutEvent m ()
 outputTransactionResult b hashFunction (TxRunResult ot@OutputTx{otHash=theHash} result deltaT beforeMap afterMap newAddresses) = do
   let t = fromMaybe (otBaseTx ot) (otPrivatePayload ot)
-      (txrStatus, message, gasRemaining) =
+      (txrStatus, message, gasRemaining, orgName, appName) =
         case result of
-          Left err -> let fmt = format err in (Failure "Execution" Nothing (ExecutionFailure fmt) Nothing Nothing (Just fmt), fmt, 0) -- TODO Also include the trace
+          Left err -> let fmt = format err in (Failure "Execution" Nothing (ExecutionFailure fmt) Nothing Nothing (Just fmt), fmt, 0, "", "") -- TODO Also include the trace
           Right r  -> case erException r of
-                        Nothing -> (Success, "Success!", erRemainingTxGas r)
+                        Nothing -> (Success, "Success!", erRemainingTxGas r, erOrgName r, erAppName r)
                         Just ex -> let fmt = either show show ex
-                                    in (Failure "Execution" Nothing (ExecutionFailure $ show ex) Nothing Nothing (Just fmt), fmt, 0)
+                                    in (Failure "Execution" Nothing (ExecutionFailure $ show ex) Nothing Nothing (Just fmt), fmt, 0, "", "")
       gasUsed = fromInteger $ transactionGasLimit t - gasRemaining
       etherUsed = gasUsed * fromInteger (transactionGasPrice t)
 
@@ -592,6 +592,8 @@ outputTransactionResult b hashFunction (TxRunResult ot@OutputTx{otHash=theHash} 
                              , transactionResultStatus           = Just txrStatus
                              , transactionResultChainId          = chainId
                              , transactionResultKind             = erKind <$> eitherToMaybe result
+                             , transactionResultOrgName          = orgName
+                             , transactionResultAppName          = appName
                              }
   when flags_diffPublish $ do
     traverse_ (yield . OutAction) $ either (const Nothing) erAction result

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -254,6 +254,9 @@ insertNewChains ogs = fmap catMaybes . forM ogs $ \OutputGenesis{..} -> do
           [] -> do
             yieldMany . concat $ map (OutLog . mkLogEntry bHash tHash (Just cId)) . erLogs <$> mExecResults
             yieldMany . concat $ map (OutEvent . mkEventEntry (Just cId)) . erEvents <$> mExecResults
+            let (orgName, appName) = case mExecResults of
+                                       [] -> ("","")
+                                       x:_ -> (erOrgName x, erAppName x)
             when flags_createTransactionResults $
               yield . OutTXR $
                      TransactionResult { transactionResultBlockHash        = cBlock
@@ -274,6 +277,8 @@ insertNewChains ogs = fmap catMaybes . forM ogs $ \OutputGenesis{..} -> do
                                        , transactionResultStatus           = Just Success
                                        , transactionResultChainId          = Just cId
                                        , transactionResultKind             = Just kind
+                                       , transactionResultOrgName          = orgName
+                                       , transactionResultAppName          = appName
                                        }
             Just (cId, cInfo, bHash, mExecResults) <$ putChainGenesisInfo (Just cId) cBlock sr pChains
           x:_ -> do
@@ -298,6 +303,8 @@ insertNewChains ogs = fmap catMaybes . forM ogs $ \OutputGenesis{..} -> do
                                        , transactionResultStatus           = Just $ Failure "Execution" Nothing (ExecutionFailure fmt) Nothing Nothing (Just fmt)
                                        , transactionResultChainId          = Just cId
                                        , transactionResultKind             = Just kind
+                                       , transactionResultOrgName          = ""
+                                       , transactionResultAppName          = ""
                                        }
             return Nothing
 

--- a/strato/core/vm-tools/src/Blockchain/Bagger.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger.hs
@@ -148,6 +148,8 @@ txsDroppedCallback rejections bestBlockShas = forM_ rejections $ \rejection -> d
                                , transactionResultStatus           = Just (txRejectionToAPIFailureCause rejection)
                                , transactionResultChainId          = txChainId . otBaseTx $ rejectedTx rejection
                                , transactionResultKind             = Nothing
+                               , transactionResultOrgName          = ""
+                               , transactionResultAppName          = ""
                                }
 
 -- Would it make more sense to expand the MiningCache than to introduce a separate cache?

--- a/strato/core/vm-tools/src/Blockchain/Data/ExecResults.hs
+++ b/strato/core/vm-tools/src/Blockchain/Data/ExecResults.hs
@@ -42,7 +42,9 @@ data ExecResults =
     erException          :: Maybe (Either SolidException VMException),
     erKind               :: CodeKind,
     -- erNewX509Certs       :: M.Map Address X509Certificate,
-    erPragmas            :: [(String, String)]
+    erPragmas            :: [(String, String)],
+    erOrgName            :: String,
+    erAppName            :: String
     } deriving (Eq, Show, Generic)
 
 instance NFData ExecResults
@@ -80,6 +82,8 @@ errorResults ck remainingGas e =
     , erKind = ck
     -- , erNewX509Certs = M.empty
     , erPragmas=[]
+    , erOrgName = ""
+    , erAppName = ""
     }
 
 


### PR DESCRIPTION
The purpose of this change is to allow apps to know which Cirrus table to query for their contracts. When creating an asset called "Cow" from an app called "CowApp" deployed by organization "BlockApps", the "Cow" contract state will be accessible in a Cirrus table named "BlockApps-CowApp-Cow". The app must have a way of knowing the Cirrus table name prefix, or it won't be able to retrieve its data.
The solution is to add the contract's orgName and appName values to the TransactionResult in which it was created. For normal contract creations, this will be returned as part of the normal API response. However, for chain creations, an extra query to the API is needed, since the POST /chain endpoints only return the chainId, and changing it would require updating a bunch of tests, apps, and blockapps-rest. Instead, to retrieve the orgName and appName after creating a chain, call the /strato-api/eth/v1.2/transactionResult/{hash} endpoint, and pass the chainId in as the {hash}. The values will be stored in the `orgName` and `appName` fields, respectively.