### PR TITLE
Temp no https check vault proxy

### DIFF
--- a/strato/doit.sh
+++ b/strato/doit.sh
@@ -465,17 +465,18 @@ if [[ -z ${VAULT_URL} ]] ; then
   exit 1
 fi
 
-# This will check if the link provided is valid format, and if it is HTTPS
-if [[ "$VAULT_URL" == "https"* ]]; then
-    echo "VAULT_URL provided is using secure https connection."
-else
-    if [[ "$VAULT_URL" == *"172.17.0.1"* ]]; then
-        echo "VAULT_URL provided is http with local docker ip for debugging."
-    else 
-        echo "VAULT_URL provided is not valid, expected the value starting with 'https://' or 'http://172.17.0.1'"
-        exit 3
-    fi
-fi
+# TODO: the check is temporarily disabled until issues with urls are resolved
+## This will check if the link provided is valid format, and if it is HTTPS
+#if [[ "$VAULT_URL" == "https"* ]]; then
+#    echo "VAULT_URL provided is using secure https connection."
+#else
+#    if [[ "$VAULT_URL" == *"172.17.0.1"* ]]; then
+#        echo "VAULT_URL provided is http with local docker ip for debugging."
+#    else 
+#        echo "VAULT_URL provided is not valid, expected the value starting with 'https://' or 'http://172.17.0.1'"
+#        exit 3
+#    fi
+#fi
 
 stratoBootnode=${bootnode:+--stratoBootnode=$bootnode}
 [[ -n $bootnode ]] && addBootnodes=true

--- a/strato/vault-proxy/server/app/Main.hs
+++ b/strato/vault-proxy/server/app/Main.hs
@@ -61,7 +61,7 @@ main = do
   -- $logInfoS "Vault-Proxy is Starting"
   when (flags_VAULT_URL == "") $ error "There is no shared vault connection 😓"
   vaultProxyDebug flags_VAULT_PROXY_DEBUG "Checking if the connection to the VAULT is https encrypted"
-  inspectVaultUrl flags_VAULT_URL
+  -- inspectVaultUrl flags_VAULT_URL
   --Initialize a new connection manager, ensure TLS communication as everything is sensitive info from here on out.
   mgr <- HCLI.newManager HCON.tlsManagerSettings
   --Initialize a new locking mechanism, this will be shared among all threads that are currently using the vault proxy
@@ -164,12 +164,12 @@ checkXuat rev vc = do
 bearerBS :: ByteString
 bearerBS = TE.encodeUtf8 "Bearer "
 
-inspectVaultUrl :: T.Text -> IO ()
-inspectVaultUrl url = do
-  vaultProxyDebug flags_VAULT_PROXY_DEBUG "Inspecting the vault url"
-  purl <- S.parseBaseUrl $ T.unpack url
-  if | (S.baseUrlHost purl == "172.17.0.1") -> do
-        traceM ("There was a special url provided (" ++ showBaseUrl purl ++ "),  I will allow any types of connections to this url.")
-        pure ()
-     | (S.baseUrlScheme purl /= S.Https) -> error $ "The provided url (" ++ show purl ++ ") is http, please use https, I will not change it for you, I am quitting. 🙎"
-     | otherwise -> pure ()
+-- inspectVaultUrl :: T.Text -> IO ()
+-- inspectVaultUrl url = do
+--   vaultProxyDebug flags_VAULT_PROXY_DEBUG "Inspecting the vault url"
+--   purl <- S.parseBaseUrl $ T.unpack url
+--   if | (S.baseUrlHost purl == "172.17.0.1") -> do
+--         traceM ("There was a special url provided (" ++ showBaseUrl purl ++ "),  I will allow any types of connections to this url.")
+--         pure ()
+--      | (S.baseUrlScheme purl /= S.Https) -> error $ "The provided url (" ++ show purl ++ ") is http, please use https, I will not change it for you, I am quitting. 🙎"
+--      | otherwise -> pure ()


### PR DESCRIPTION
I suggest that we temporary disable the protocol validation for VAULT_URL until we come up with the list of IPs that need to be white-listed.
172.17.0.1 is not the only one that we need to allow.

just for reference here, we should do:
- `172.17.*.*`
- `docker.for.mac.localhost`
