### PR TITLE
Genesis block json additions

### DIFF
--- a/strato/core/strato-genesis/src/Blockchain/Data/GenesisInfo.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Data/GenesisInfo.hs
@@ -49,9 +49,9 @@ data GenesisInfo =
     genesisInfoExtraData        :: Integer,
     genesisInfoMixHash          :: Keccak256,
     genesisInfoNonce            :: Word64,
-    genesisValidators           :: [ChainMemberParsedSet],
-    genesisAdmins               :: [ChainMemberParsedSet],
-    genesisCertificates         :: [X509Certificate]
+    genesisInfoValidators       :: [ChainMemberParsedSet],
+    genesisInfoBlockstanbulAdmins :: [ChainMemberParsedSet],
+    genesisInfoCertificates     :: [X509Certificate]
 } deriving (Show, Read, Eq, Generic)
 
 nullStateRoot :: StateRoot
@@ -77,9 +77,9 @@ defaultGenesisInfo =
     genesisInfoExtraData = 0,
     genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
     genesisInfoNonce = 42,
-    genesisValidators = [],
-    genesisAdmins = [],
-    genesisCertificates = []
+    genesisInfoValidators = [],
+    genesisInfoBlockstanbulAdmins = [],
+    genesisInfoCertificates = []
 }
 
 instance FromJSON GenesisInfo where

--- a/strato/core/strato-genesis/src/Blockchain/Data/GenesisInfo.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Data/GenesisInfo.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE TupleSections        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE TemplateHaskell      #-}
@@ -26,6 +27,8 @@ import           Blockchain.Database.MerklePatricia
 import           Blockchain.Strato.Model.ChainMember
 import           Blockchain.Strato.Model.Keccak256
 
+import           BlockApps.X509.Certificate
+
 import qualified LabeledError
 
 data GenesisInfo =
@@ -45,7 +48,10 @@ data GenesisInfo =
     genesisInfoTimestamp        :: UTCTime,
     genesisInfoExtraData        :: Integer,
     genesisInfoMixHash          :: Keccak256,
-    genesisInfoNonce            :: Word64
+    genesisInfoNonce            :: Word64,
+    genesisValidators           :: [ChainMemberParsedSet],
+    genesisAdmins               :: [ChainMemberParsedSet],
+    genesisCertificates         :: [X509Certificate]
 } deriving (Show, Read, Eq, Generic)
 
 nullStateRoot :: StateRoot
@@ -70,7 +76,10 @@ defaultGenesisInfo =
     genesisInfoTimestamp = read "1970-01-01 00:00:00 UTC"  ::  UTCTime,
     genesisInfoExtraData = 0,
     genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
-    genesisInfoNonce = 42
+    genesisInfoNonce = 42,
+    genesisValidators = [],
+    genesisAdmins = [],
+    genesisCertificates = []
 }
 
 instance FromJSON GenesisInfo where
@@ -91,7 +100,10 @@ instance FromJSON GenesisInfo where
     o .: "timestamp" <*>
     o .: "extraData" <*>
     o .: "mixHash" <*>
-    o .: "nonce"
+    o .: "nonce" <*>
+    o .: "validators" .!= [] <*>
+    o .: "blockstanbulAdmins" .!= [] <*>
+    o .: "certificates" .!=[]
   parseJSON x = error $ "couldn't parse JSON for genesis block: " ++ show x
 
 instance ToJSON GenesisInfo where
@@ -116,5 +128,8 @@ genesisParser = GenesisInfo
             <*> "extraData" JS..: JS.value
             <*> "mixHash" JS..: JS.value
             <*> "nonce" JS..: JS.value
+            <*> ("validators" JS..: JS.value JS..| [])
+            <*> ("blockstanbulAdmins" JS..: JS.value JS..| [])
+            <*> ("certificates" JS..: JS.value JS..| [])
 
 

--- a/strato/core/strato-genesis/test/JsonSpec.hs
+++ b/strato/core/strato-genesis/test/JsonSpec.hs
@@ -110,7 +110,10 @@ spec = do
             genesisInfoTimestamp = UTCTime (fromGregorian 1970 0 1) (secondsToDiffTime 0),
             genesisInfoExtraData = 0,
             genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
-            genesisInfoNonce = 42
+            genesisInfoNonce = 42,
+            genesisValidators = [],
+            genesisAdmins = [],
+            genesisCertificates = []
           }
           got = eitherDecode input
        in got `shouldBe` want
@@ -162,7 +165,11 @@ spec = do
             genesisInfoTimestamp = UTCTime (fromGregorian 1970 0 1) (secondsToDiffTime 0),
             genesisInfoExtraData = 0,
             genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
-            genesisInfoNonce = 42
+            genesisInfoNonce = 42,
+            genesisValidators = [],
+            genesisAdmins = [],
+            genesisCertificates = []
+
           }]
           got = JS.parseLazyByteString genesisParser input
        in got `shouldBe` want

--- a/strato/core/strato-genesis/test/JsonSpec.hs
+++ b/strato/core/strato-genesis/test/JsonSpec.hs
@@ -111,9 +111,9 @@ spec = do
             genesisInfoExtraData = 0,
             genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
             genesisInfoNonce = 42,
-            genesisValidators = [],
-            genesisAdmins = [],
-            genesisCertificates = []
+            genesisInfoValidators = [],
+            genesisInfoBlockstanbulAdmins = [],
+            genesisInfoCertificates = []
           }
           got = eitherDecode input
        in got `shouldBe` want
@@ -166,9 +166,9 @@ spec = do
             genesisInfoExtraData = 0,
             genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
             genesisInfoNonce = 42,
-            genesisValidators = [],
-            genesisAdmins = [],
-            genesisCertificates = []
+            genesisInfoValidators = [],
+            genesisInfoBlockstanbulAdmins = [],
+            genesisInfoCertificates = []
 
           }]
           got = JS.parseLazyByteString genesisParser input

--- a/strato/core/strato-init/exec_src/InitWorker.hs
+++ b/strato/core/strato-init/exec_src/InitWorker.hs
@@ -20,6 +20,9 @@ import Blockchain.Init.Worker
 import Blockchain.Strato.Model.ChainMember
 import Blockchain.Data.GenesisInfo
 
+import Data.List (nub)
+
+
 defineFlag "K:kafkahost" (""  ::  String) "Kafka hostname"
 defineFlag "vaultWrapperUrl" ("http://localhost:8013/strato/v2.3" :: String) "The Vault-Wrapper URL"
 defineFlag "genesisBlockTestCert" (False :: Bool) "Generate a test X509 Certificate using this node's public key - ideal for test networks"
@@ -56,4 +59,4 @@ main = do
           (Just networkParams, Right []) -> map Net.identity networkParams
           (_, Right v) -> v
           (_, Left e) -> error $ "invalid admins: " ++ e
-  runLoggingT $ runWorker (validators' ++ genesisValidators theJSON) (genesisAdmins theJSON ++ admins') kaddr
+  runLoggingT $ runWorker (nub $ validators' ++ genesisInfoValidators theJSON) (nub $ genesisInfoBlockstanbulAdmins theJSON ++ admins') kaddr

--- a/strato/core/strato-init/exec_src/InitWorker.hs
+++ b/strato/core/strato-init/exec_src/InitWorker.hs
@@ -2,9 +2,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 
+
+import Control.Monad.IO.Class
+
 import qualified Data.Aeson as Ae
 import Data.ByteString.Base64
 import qualified Data.ByteString.Char8 as C8
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import qualified Data.JsonStream.Parser as JS
 import Data.Either.Extra
 import Data.String
 import HFlags
@@ -13,6 +18,7 @@ import qualified Blockchain.Network as Net
 import BlockApps.Logging
 import Blockchain.Init.Worker
 import Blockchain.Strato.Model.ChainMember
+import Blockchain.Data.GenesisInfo
 
 defineFlag "K:kafkahost" (""  ::  String) "Kafka hostname"
 defineFlag "vaultWrapperUrl" ("http://localhost:8013/strato/v2.3" :: String) "The Vault-Wrapper URL"
@@ -21,6 +27,7 @@ defineFlag "network" ("" :: String) "The network that strato will join"
 defineFlag "validators" ("[]" :: String) "JSON encoded addresses of Blockstanbul validators"
 defineFlag "blockstanbul_admins" ("[]" :: String) "JSON encoded addresses of network admins. Admins can, for instance, nominate a new validator"
 defineFlag "genesisCerts" ("[]" :: String) "Extra certs passed into the genesis block"
+defineFlag "genesisBlockName" ("gettingStartedGenesis.json" :: String) "The genesis block to initialize"
 $(return [])
 
 main :: IO ()
@@ -30,6 +37,11 @@ main = do
                   "" -> ("kafka", 9092)
                   _ -> (fromString flags_kafkahost, 9092)
   maybeNetworkParams <- Net.getParams flags_network
+  theJSONString <- liftIO . BLC.readFile $ flags_genesisBlockName
+  let genesis = JS.parseLazyByteString genesisParser theJSONString
+      theJSON = case genesis of
+                      [x] -> x
+                      _ -> error $ "invalid genesis: " ++ show genesis
   --  Allow these flags to accept base64-encoded JSONs optionally
   let b64decode inp = if isBase64 inp then (fromRight inp . decodeBase64) inp else inp
       eValidators = (Ae.eitherDecodeStrict . b64decode) (C8.pack flags_validators) :: Either String [ChainMemberParsedSet]
@@ -44,4 +56,4 @@ main = do
           (Just networkParams, Right []) -> map Net.identity networkParams
           (_, Right v) -> v
           (_, Left e) -> error $ "invalid admins: " ++ e
-  runLoggingT $ runWorker validators' admins' kaddr
+  runLoggingT $ runWorker (validators' ++ genesisValidators theJSON) (genesisAdmins theJSON ++ admins') kaddr

--- a/strato/core/strato-init/genesisBlocks/gettingStartedGenesis.json
+++ b/strato/core/strato-init/genesisBlocks/gettingStartedGenesis.json
@@ -13,5 +13,24 @@
   "timestamp":"1970-01-01T00:00:00.000Z",
   "coinbase":"00000000000000000000",
   "parentHash":"0000000000000000000000000000000000000000000000000000000000000000",
-  "nonce":42
+  "nonce":42,
+  "validators": [
+    {
+            "orgName": "BlockApps",
+            "orgUnit": "Engineering",
+            "commonName": "Test",
+            "access": true
+    }
+  ],        
+  "blockstanbulAdmins": [
+      {
+              "orgName": "BlockApps",
+              "orgUnit": "Engineering",
+              "commonName": "Test",
+              "access": true
+      }
+  ],
+  "certificates": [
+      "-----BEGIN CERTIFICATE-----\nMIIBjDCCATGgAwIBAgIQV9e8CIDXoadx1ybR1sp9iDAMBggqhkjOPQQDAgUAMEgx\nDjAMBgNVBAMMBUFkbWluMRIwEAYDVQQKDAlCbG9ja0FwcHMxFDASBgNVBAsMC0Vu\nZ2luZWVyaW5nMQwwCgYDVQQGDANVU0EwHhcNMjMwMTA5MDM1NTM2WhcNMjQwMTA5\nMDM1NTM2WjBIMQ4wDAYDVQQDDAVub2RlMjESMBAGA1UECgwJQmxvY2tBcHBzMRQw\nEgYDVQQLDAtFbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMFYwEAYHKoZIzj0CAQYF\nK4EEAAoDQgAEsZDZqMA+bRrdoXJ3dd13uSNalJmI/KxWUkOgHEgDuEFxXqprNnN6\npJFUrM1cUrZHNjnilxhKfC0I6IIJSbwSiDAMBggqhkjOPQQDAgUAA0cAMEQCIDd5\nxBwKvjNyGOCD/rhaEl4uEIkomtDLVbZeztuMFgMuAiBghZboZ8Ma8S184TFzUV2y\nI3Y7Rtsh2F3EqkpSSSz+Og==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBjTCCATKgAwIBAgIRAOPPkVoBp/GnwZGR32jcIjwwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyMDE3NTcxM1oXDTIzMDQy\nMDE3NTcxM1owSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANHADBEAiA8\nR0UERQZbF3qJUt5A0ZFf2ZmB0l/ZPjIvM383gOF3xwIgbxbQ8NLkDEe2mWJ/qa4n\nN8txKc8G9R27ZYAUuz15zF0=\n-----END CERTIFICATE-----\n"
+  ]
 }

--- a/strato/core/strato-init/package.yaml
+++ b/strato/core/strato-init/package.yaml
@@ -106,6 +106,8 @@ executables:
       - common-log
       - extra
       - hflags
+      - json-stream
+      - strato-genesis
       - strato-init
       - strato-model
       - strato-networks

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -23,6 +23,7 @@ import qualified Data.ByteString.Char8                        as C8
 import qualified Data.ByteString.Char8                        as BC
 import qualified Data.ByteString.Lazy.Char8                   as BLC
 import           Data.Either                                  (isLeft, fromRight)
+import           Data.List                                    (nub)
 import           Data.Map.Strict                              (Map)
 import           Data.Maybe
 import qualified Data.JsonStream.Parser                       as JS
@@ -144,8 +145,8 @@ getGenesisBlockAndPopulateInitialMPs genesisBlockName extraFaucets validators ad
           cert <- makeSignedCert Nothing (Just rootCert) (fromJust . getCertIssuer $ rootCert) testCertSubject
           return [cert]
         else return []
-    let extraCerts = genesisCerts ++ extraCerts' ++ genesisCertificates theJSON
-        theJSON' = insertMercataGovernanceContract (validators ++ genesisValidators theJSON) (admins ++ genesisAdmins theJSON)
+    let extraCerts = nub $ genesisCerts ++ extraCerts' ++ genesisInfoCertificates theJSON
+        theJSON' = insertMercataGovernanceContract (nub $ validators ++ genesisInfoValidators theJSON) (nub $ admins ++ genesisInfoBlockstanbulAdmins theJSON)
                  . insertCertRegistryContract extraCerts
                  $ theJSON{genesisInfoAccountInfo = faucetAccounts ++ (genesisInfoAccountInfo theJSON)}
     extraAccounts <- liftIO . readSupplementaryAccounts $ genesisBlockName
@@ -164,7 +165,7 @@ getGenesisBlockAndPopulateInitialMPs genesisBlockName extraFaucets validators ad
       pure (ua', c')
       ) extraCerts
 
-    insertValidators <- RBDB.withRedisBlockDB $ RBDB.addValidators (validators ++ genesisValidators theJSON)
+    insertValidators <- RBDB.withRedisBlockDB $ RBDB.addValidators (nub $ validators ++ genesisInfoValidators theJSON)
     case insertValidators of 
       Right _ -> $logInfoS "Redis/certInsertion" $ T.pack "Certificate insertion was successful"
       Left  e -> $logInfoS "Redis/certInsertion" $ T.pack $ "Certificate insertion failed: " ++ show e

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -144,8 +144,8 @@ getGenesisBlockAndPopulateInitialMPs genesisBlockName extraFaucets validators ad
           cert <- makeSignedCert Nothing (Just rootCert) (fromJust . getCertIssuer $ rootCert) testCertSubject
           return [cert]
         else return []
-    let extraCerts = genesisCerts ++ extraCerts'
-        theJSON' = insertMercataGovernanceContract validators admins
+    let extraCerts = genesisCerts ++ extraCerts' ++ genesisCertificates theJSON
+        theJSON' = insertMercataGovernanceContract (validators ++ genesisValidators theJSON) (admins ++ genesisAdmins theJSON)
                  . insertCertRegistryContract extraCerts
                  $ theJSON{genesisInfoAccountInfo = faucetAccounts ++ (genesisInfoAccountInfo theJSON)}
     extraAccounts <- liftIO . readSupplementaryAccounts $ genesisBlockName
@@ -164,7 +164,7 @@ getGenesisBlockAndPopulateInitialMPs genesisBlockName extraFaucets validators ad
       pure (ua', c')
       ) extraCerts
 
-    insertValidators <- RBDB.withRedisBlockDB $ RBDB.addValidators validators
+    insertValidators <- RBDB.withRedisBlockDB $ RBDB.addValidators (validators ++ genesisValidators theJSON)
     case insertValidators of 
       Right _ -> $logInfoS "Redis/certInsertion" $ T.pack "Certificate insertion was successful"
       Left  e -> $logInfoS "Redis/certInsertion" $ T.pack $ "Certificate insertion failed: " ++ show e

--- a/strato/core/strato-init/test/JsonSpec.hs
+++ b/strato/core/strato-init/test/JsonSpec.hs
@@ -110,7 +110,10 @@ spec = do
             genesisInfoTimestamp = UTCTime (fromGregorian 1970 0 1) (secondsToDiffTime 0),
             genesisInfoExtraData = 0,
             genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
-            genesisInfoNonce = 42
+            genesisInfoNonce = 42,
+            genesisValidators = [],
+            genesisAdmins = [],
+            genesisCertificates = []
           }
           got = eitherDecode input
        in got `shouldBe` want
@@ -162,7 +165,11 @@ spec = do
             genesisInfoTimestamp = UTCTime (fromGregorian 1970 0 1) (secondsToDiffTime 0),
             genesisInfoExtraData = 0,
             genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
-            genesisInfoNonce = 42
+            genesisInfoNonce = 42,
+            genesisValidators = [],
+            genesisAdmins = [],
+            genesisCertificates = []
+
           }]
           got = JS.parseLazyByteString genesisParser input
        in got `shouldBe` want

--- a/strato/core/strato-init/test/JsonSpec.hs
+++ b/strato/core/strato-init/test/JsonSpec.hs
@@ -111,9 +111,9 @@ spec = do
             genesisInfoExtraData = 0,
             genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
             genesisInfoNonce = 42,
-            genesisValidators = [],
-            genesisAdmins = [],
-            genesisCertificates = []
+            genesisInfoValidators = [],
+            genesisInfoBlockstanbulAdmins = [],
+            genesisInfoCertificates = []
           }
           got = eitherDecode input
        in got `shouldBe` want
@@ -166,9 +166,9 @@ spec = do
             genesisInfoExtraData = 0,
             genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
             genesisInfoNonce = 42,
-            genesisValidators = [],
-            genesisAdmins = [],
-            genesisCertificates = []
+            genesisInfoValidators = [],
+            genesisInfoBlockstanbulAdmins = [],
+            genesisInfoCertificates = []
 
           }]
           got = JS.parseLazyByteString genesisParser input

--- a/strato/libs/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/strato/libs/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -134,6 +134,9 @@ instance Binary X509Certificate where
   put = (put :: C8.ByteString -> Put) <$> certToBytes
   get = (fromRight (error "The certificate couldn't be decoded") . bsToCert) <$> (get :: Get C8.ByteString)
 
+instance Read X509Certificate where
+  readsPrec = error "Read X509Certificate is not supported, sorry"
+
 -- | The information we store in Redis DB. We store the information of the certificate, as well
 -- as the two state values `isValid` and `children`. We keep `userAddress` around for convenience,
 -- as parsing the X509Certificate is non-deterministic.


### PR DESCRIPTION
A bit of a hacky fix for the release (will clean up for develop) but this removes the need to add the flurry of flags that the startup scripts have now and `BlockstanbulAdmins`, `validators`, and `certificates` can be passed as objects in the `genesis-block.json` now instead of their own individual flags.