### PR TITLE
Morin river fix

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -223,7 +223,7 @@ solidVMBreakpoint ann = do
 -- end debugger-related code
 
 requireOriginCert :: MonadSM m => Account -> m ()
-requireOriginCert acct = unless (not flags_requireCerts || acct ^. accountAddress == fromPublicKey rootPubKey) $ do
+requireOriginCert acct = when flags_requireCerts $ do
   originHasCert <- isJust <$> (A.select (A.Proxy @X509Certificate) $ acct ^. accountAddress)
   unless originHasCert $ missingCertificate "Sender doesn't have a registered cert" acct
 
@@ -716,7 +716,12 @@ callWrapper' from to mContract functionName isRCC argExps  = do
   initializeAction to (labelToString $ CC._contractName contract) (labelToString parentName') hsh
 
 --  grab the org from the senders account and set it to the codeAddress
-  org <- getOrg to
+  orgAccount <- if isRCC
+    then addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) to >>= \case
+           CodeAtAccount{} -> pure to
+           _ -> pure from
+    else pure to
+  org <- getOrg orgAccount
   Mod.modifyStatefully_ (Mod.Proxy @Action) $
     Action.actionData %= M.adjust (Action.actionDataOrganization .~ (T.pack org)) to
   when (isRCC) $

--- a/strato/core/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE MonoLocalBinds    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -23,7 +24,6 @@ import           Control.Monad.Change.Modify
 import           Control.Monad.IO.Class
 import           Crypto.Util                          (i2bs_unsized)
 import           Data.ByteString                      as BS hiding (zip, map)
-import qualified Data.ByteString.Char8                as BC
 import qualified Data.ByteString.Lazy.Char8           as BLC
 import qualified Data.Map                             as Map
 import           Data.Maybe                           (catMaybes, fromMaybe)
@@ -290,8 +290,10 @@ initializeChainDBs :: ( MonadLogger m
                       )
                    => Maybe Word256
                    -> ChainInfo
+                   -> T.Text
+                   -> T.Text
                    -> m ()
-initializeChainDBs chainId (ChainInfo UnsignedChainInfo{..} _) = do
+initializeChainDBs chainId (ChainInfo UnsignedChainInfo{..} _) org app = do
   sRoot <- A.lookupWithDefault (A.Proxy @StateRoot) chainId
   genAddrStates <- getAllAddressStates chainId
   accountDiffs <- mapM eventualAccountState . Map.fromList $ genAddrStates
@@ -306,8 +308,16 @@ initializeChainDBs chainId (ChainInfo UnsignedChainInfo{..} _) = do
   }
   commitSqlDiffs diff
 
-  forM_ [ (src, name) | CodeInfo{codeInfoSource=src, codeInfoName=name} <- codeInfo] $ \(src, name) ->
-    produceVMEvents [CodeCollectionAdded src (SolidVMCode (fromMaybe "" $ fmap T.unpack name) $ hash $ BC.pack $ T.unpack src) "" "" []]
+  let resolveAndProduce cp = resolveCodePtr chainId cp >>= \case
+        Just (SolidVMCode name ch) -> fmap (T.decodeUtf8' . snd) <$> getCode ch >>= \case
+          Just (Right src) -> void $ produceVMEvents [CodeCollectionAdded src (SolidVMCode name ch) org app []]
+          _ -> pure ()
+        _ -> pure ()
+  forM_ accountInfo $ \case
+    ContractNoStorage _ _ cp -> resolveAndProduce cp
+    ContractWithStorage _ _ cp _ -> resolveAndProduce cp
+    SolidVMContractWithStorage _ _ cp _ -> resolveAndProduce cp
+    _ -> pure ()
 
   let metadatas = Map.fromList $ flip map codeInfo $ \ci ->
         let cHash = hash $ codeInfoCode ci

--- a/strato/core/vm-runner/src/Blockchain/Event.hs
+++ b/strato/core/vm-runner/src/Blockchain/Event.hs
@@ -31,6 +31,7 @@ import           Blockchain.Stream.Action           (Action)
 import qualified Data.ByteString                    as B
 import qualified Data.DList                         as DL
 import           Data.Map                           (Map)
+import           Data.Text                          (Text)
 
 type VmInEvent = VmEvent
 
@@ -59,7 +60,7 @@ insertInBatch e b = case e of
 data VmOutEvent = OutAction Action
                 | OutBlock OutputBlock
                 | OutIndexEvent IndexEvent
-                | OutToStateDiff Word256 ChainInfo Keccak256
+                | OutToStateDiff Word256 ChainInfo Keccak256 Text Text
                 | OutStateDiff StateDiff
                 | OutLog LogDB
                 | OutEvent EventDB
@@ -72,7 +73,7 @@ data VmOutEventBatch = OutBatch
   , outExecResults  :: DL.DList ExecResults
   , outBlocks       :: DL.DList OutputBlock
   , outIndexEvents  :: DL.DList IndexEvent
-  , outToStateDiffs :: DL.DList (Word256, ChainInfo, Keccak256)
+  , outToStateDiffs :: DL.DList (Word256, ChainInfo, Keccak256, Text, Text)
   , outStateDiffs   :: DL.DList StateDiff
   , outLogs         :: DL.DList LogDB
   , outEvents       :: DL.DList EventDB
@@ -96,13 +97,13 @@ newOutBatch = OutBatch DL.empty
 
 insertOutBatch :: VmOutEvent -> VmOutEventBatch -> VmOutEventBatch
 insertOutBatch e b = case e of
-  OutAction a          -> b{ outActions = outActions b `DL.snoc` a }
-  OutBlock a           -> b{ outBlocks = outBlocks b `DL.snoc` a }
-  OutIndexEvent a      -> b{ outIndexEvents = outIndexEvents b `DL.snoc` a }
-  OutToStateDiff x y z -> b{ outToStateDiffs = outToStateDiffs b `DL.snoc` (x,y,z) }
-  OutStateDiff a       -> b{ outStateDiffs = outStateDiffs b `DL.snoc` a }
-  OutLog a             -> b{ outLogs = outLogs b `DL.snoc` a }
-  OutEvent a           -> b{ outEvents = outEvents b `DL.snoc` a }
-  OutTXR a             -> b{ outTXRs = outTXRs b `DL.snoc` a }
-  OutASM a             -> b{ outASMs = outASMs b `DL.snoc` a }
-  OutJSONRPC x y       -> b{ outJSONRPCs = outJSONRPCs b `DL.snoc` (x,y) }
+  OutAction a              -> b{ outActions = outActions b `DL.snoc` a }
+  OutBlock a               -> b{ outBlocks = outBlocks b `DL.snoc` a }
+  OutIndexEvent a          -> b{ outIndexEvents = outIndexEvents b `DL.snoc` a }
+  OutToStateDiff v w x y z -> b{ outToStateDiffs = outToStateDiffs b `DL.snoc` (v,w,x,y,z) }
+  OutStateDiff a           -> b{ outStateDiffs = outStateDiffs b `DL.snoc` a }
+  OutLog a                 -> b{ outLogs = outLogs b `DL.snoc` a }
+  OutEvent a               -> b{ outEvents = outEvents b `DL.snoc` a }
+  OutTXR a                 -> b{ outTXRs = outTXRs b `DL.snoc` a }
+  OutASM a                 -> b{ outASMs = outASMs b `DL.snoc` a }
+  OutJSONRPC x y           -> b{ outJSONRPCs = outJSONRPCs b `DL.snoc` (x,y) }

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -305,7 +305,17 @@ insertNewChains ogs = fmap catMaybes . forM ogs $ \OutputGenesis{..} -> do
 outputNewChains :: VMBase m => [(Word256, ChainInfo, Keccak256, [ExecResults])] -> ConduitT a VmOutEvent m ()
 outputNewChains = traverse_ $ \(cId, cInfo, bHash, execr) -> do
   yield . OutIndexEvent $ NewChainInfo cId cInfo
-  yield $ OutToStateDiff cId cInfo bHash
+  let org = fromMaybe "" $ do
+        e <- listToMaybe execr
+        a <- erAction e
+        d <- listToMaybe . M.toList $ a ^. Action.actionData
+        pure $ d ^. _2 . Action.actionDataOrganization
+      app = fromMaybe "" $ do
+        e <- listToMaybe execr
+        a <- erAction e
+        d <- listToMaybe . M.toList $ a ^. Action.actionData
+        pure $ d ^. _2 . Action.actionDataApplication
+  yield $ OutToStateDiff cId cInfo bHash org app
   for_ (catMaybes $ erAction <$> execr) $ yield . OutAction
   for_ (concatMap erEvents execr) $ yield . OutEvent . mkEventEntry (Just cId)
 
@@ -564,8 +574,8 @@ sendOutEvents OutBatch{..} = do
         _ -> Nothing
   
   for_ outJSONRPCs $ liftIO . uncurry produceResponse
-  for_ outToStateDiffs $ \(cId, cInfo, bHash) ->
-    withCurrentBlockHash bHash $ initializeChainDBs (Just cId) cInfo
+  for_ outToStateDiffs $ \(cId, cInfo, bHash, org, app) ->
+    withCurrentBlockHash bHash $ initializeChainDBs (Just cId) cInfo org app
   traverse_ commitSqlDiffs outStateDiffs
   when (not flags_sqlDiff) $
     timeit "updateSQLBalanceAndNonce" (Just vmBlockInsertionMined) $


### PR DESCRIPTION
Correctly create namespaced tables during chain creation, with orgname-appname if codeptr isn't a CodeAtAccount, and orgname-appname-contractname if it is

Also removed the BlockApps root account backdoor in requireOriginCert now that the cert should be in the genesis block