### PR TITLE
STRATO-3026-seqevents-spamming-the-prometheus-metrics-causing-node-to-be-unhealthy

### DIFF
--- a/strato/core/seqevents/src/Blockchain/Sequencer/Kafka.hs
+++ b/strato/core/seqevents/src/Blockchain/Sequencer/Kafka.hs
@@ -59,7 +59,6 @@ assertTopicCreation = do
 readUnseqEvents :: K.Kafka k => KP.Offset -> k [IngestEvent]
 readUnseqEvents off = do
   events <- readUnseqEventsFromTopic unseqEventsTopicName off
-  recordEvents' unseqReads $ show <$> events
   return events
 
 readUnseqEventsFromTopic :: K.Kafka k => KP.TopicName -> KP.Offset -> k [IngestEvent]
@@ -88,7 +87,6 @@ readSeqP2pEventsFromTopic = readFromTopic'
 
 writeUnseqEvents :: K.Kafka k => [IngestEvent] -> k [KP.ProduceResponse]
 writeUnseqEvents events = do
-  recordEvents' unseqWrites $ show <$> events
   KW.produceMessagesAsSingletonSets $
       (K.TopicAndMessage unseqEventsTopicName . KW.makeMessage . BL.toStrict . encode) <$> events
 


### PR DESCRIPTION
Hi,

This PR is with respect to the bug reported, that caused node to become unhealthy because of unwanted logging of events. As documented in [[Source](https://blockapps.atlassian.net/browse/STRATO-3026)], the unseq read and write events' logging information has been removed. 

Further, `curl strato:8050/metrics` and `curl strato:10248/metrics` fetched results quickly and node was healthy.

Feel free to drop any suggestions, so I can work around to remove additional logging.