### PR TITLE
Ethereum-Discovery modifications to minimize calls to the Vault

### DIFF
--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
@@ -104,6 +104,9 @@ instance MonadUnliftIO m => A.Selectable String PPeer (ReaderT ContextLite m) wh
 
         where actions = SQL.selectList [ PPeerIp SQL.==. T.pack ipStr ] []
 
+instance MonadIO m => A.Replaceable T.Text PPeer (ReaderT ContextLite m) where
+  replace p k = liftIO . A.replace p k
+
 instance MonadIO m => A.Replaceable PPeer PeerUdpDisable (ReaderT ContextLite m) where
   replace p k = liftIO . A.replace p k
 
@@ -189,6 +192,7 @@ type MonadDiscovery m = ( HasVault m
                         , A.Selectable IPAsText ClosestPeers m
                         , A.Selectable String PPeer m
                         , A.Replaceable PPeer PeerUdpDisable m
+                        , A.Replaceable T.Text PPeer m
                         , A.Selectable () (B.ByteString, SockAddr) m
                         , A.Replaceable IPAsText PPeer m
                         , A.Replaceable SockAddr B.ByteString m

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts               #-}
 {-# LANGUAGE FlexibleInstances              #-}
 {-# LANGUAGE GADTs                          #-}
+{-# LANGUAGE LambdaCase                     #-}
 {-# LANGUAGE MultiParamTypeClasses          #-}
 {-# LANGUAGE TypeApplications               #-}
 {-# LANGUAGE TypeOperators                  #-}
@@ -18,6 +19,9 @@ module Blockchain.Strato.Discovery.ContextLite
   , addPeer
   , DiscoveryRunner
   , MonadDiscovery
+  , doPeersExist
+  , getPeerByIP'
+  , lengthenPeerDisable'
   ) where
 
 
@@ -88,6 +92,20 @@ instance MonadUnliftIO m => A.Replaceable IPAsText PPeer (ReaderT ContextLite m)
           getPeerByIP :: HasSQLDB m => String -> m (Maybe (SQL.Entity PPeer))
           getPeerByIP ipStr = listToMaybe <$> sqlQuery actions'
             where actions' = SQL.selectList [ PPeerIp SQL.==. T.pack ipStr ] []
+
+instance MonadUnliftIO m => A.Selectable String PPeer (ReaderT ContextLite m) where
+  select _ ip = getPeerByIP ip
+
+    where
+      getPeerByIP :: HasSQLDB m => String -> m (Maybe PPeer)
+      getPeerByIP ipStr = sqlQuery actions >>= \case
+        [] -> return Nothing
+        lst -> return . Just . SQL.entityVal $ head lst
+
+        where actions = SQL.selectList [ PPeerIp SQL.==. T.pack ipStr ] []
+
+instance MonadIO m => A.Replaceable PPeer PeerUdpDisable (ReaderT ContextLite m) where
+  replace p k = liftIO . A.replace p k
 
 instance MonadIO m => A.Replaceable SockAddr B.ByteString (ReaderT ContextLite m) where
   replace _ addr packet = do
@@ -169,6 +187,8 @@ type MonadDiscovery m = ( HasVault m
                         , MonadLogger m
                         , MonadUnliftIO m
                         , A.Selectable IPAsText ClosestPeers m
+                        , A.Selectable String PPeer m
+                        , A.Replaceable PPeer PeerUdpDisable m
                         , A.Selectable () (B.ByteString, SockAddr) m
                         , A.Replaceable IPAsText PPeer m
                         , A.Replaceable SockAddr B.ByteString m
@@ -206,3 +226,24 @@ initContextLite vaultUrl udpPort tcpPort = do
 
 addPeer :: A.Replaceable IPAsText PPeer m => PPeer -> m ()
 addPeer peer = A.replace (A.Proxy @PPeer) (IPAsText $ pPeerIp peer) peer
+
+getPeerByIP' :: (A.Selectable String PPeer m)
+            => String
+            -> m (Maybe PPeer)
+getPeerByIP' ip = A.select (A.Proxy @PPeer) ip
+
+doPeersExist :: (A.Selectable String PPeer m)
+              => [String]
+              -> m (Bool)
+doPeersExist peers = do
+  maybePeer <- traverse doesPeerExist peers
+  pure $ all (== True) maybePeer
+
+doesPeerExist :: (A.Selectable String PPeer m)
+              => String
+              -> m (Bool)
+doesPeerExist peer = do
+  maybePeer <- A.select (A.Proxy @PPeer) peer
+  case maybePeer of
+    Nothing -> pure False
+    Just _ -> pure True

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -333,11 +333,7 @@ lengthenPeerDisable peer' = try $ do
                   else SetPeerDisableTime (TcpEnableTime $ 5 `addUTCTime` currentTime) 5 ((24 * 60 * 60) `addUTCTime` currentTime)
   A.replace (A.Proxy @PeerDisable) peer disable
 
--- A variation of 'lengthenPeerDisable' but for UDP exclusively used for ethereum-discovery.
--- The first time a peer is disabled, the timeout is five seconds. Every subsequent failure that
--- window is doubled, but those windows are reset every day. This prevents a mostly healthy node
--- from building up longer and longer disables, e.g. if it caused an exception once a day
--- by the end of the month it would be disabled for years.
+-- A variation of 'lengthenPeerDisable' but for UDP instead, currently used for ethereum-discovery.
 lengthenPeerDisable' :: (MonadUnliftIO m, A.Replaceable PPeer PeerUdpDisable m)
                     => PPeer -> m (Either SomeException ())
 lengthenPeerDisable' peer' = try $ do

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -67,6 +67,7 @@ PPeer
     activeState Int
     version T.Text
     nextDisableWindowSeconds Int default=5
+    nextUdpDisableWindowSeconds Int default=5
     disableExpiration UTCTime default=now()
     ~enode Enode Maybe
     deriving Show Read Eq
@@ -82,7 +83,7 @@ newtype BondedPeers = BondedPeers { unBondedPeers :: [PPeer] }
 newtype BondedPeersForUDP = BondedPeersForUDP { unBondedPeersForUDP :: [PPeer] }
 newtype UnbondedPeers = UnbondedPeers { unUnbondedPeers :: [PPeer] }
 newtype ClosestPeers = ClosestPeers { unClosestPeers :: [PPeer] }
-newtype UdpEnableTime = UdpEnableTime UTCTime
+newtype UdpEnableTime = UdpEnableTime UTCTime deriving (Eq, Ord)
 newtype TcpEnableTime = TcpEnableTime UTCTime deriving (Eq, Ord)
 newtype NodeID = NodeID B.ByteString deriving (Show, Read, Eq)
 
@@ -95,6 +96,18 @@ data PeerDisable =
     { spdtTcpEnableTime :: TcpEnableTime
     , spdtNextDisableWindowSeconds :: Int
     , spdtDisableExpiration :: UTCTime
+    }
+  deriving (Eq, Ord)
+
+data PeerUdpDisable =
+  ExtendPeerUdpDisableTime
+    { epdtUdpDisableTime :: UdpEnableTime
+    , epdtNextUdpDisableWindowFactor :: Int
+    }
+  | SetPeerUdpDisableTime
+    { epdtUdpDisableTime :: UdpEnableTime
+    , spdtNextUdpDisableWindowSeconds :: Int
+    , spdtUdpDisableExpiration :: UTCTime
     }
   deriving (Eq, Ord)
 
@@ -181,6 +194,20 @@ instance A.Replaceable PPeer PeerDisable IO where
                                  , PPeerDisableExpiration SQL.=. disableExpiration
                                  ]
 
+instance A.Replaceable PPeer PeerUdpDisable IO where
+  replace _ peer d = withGlobalSQLPool $ \sqldb -> do
+    let selector = thisPeer peer
+    flip runSqlPool sqldb $ case d of
+      ExtendPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindowFactor ->
+        SQL.updateWhere selector [ PPeerUdpEnableTime SQL.=. enableTime
+                                 , PPeerNextUdpDisableWindowSeconds SQL.*=. nextDisableWindowFactor
+                                 ]
+      SetPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindow disableExpiration ->
+        SQL.updateWhere selector [ PPeerUdpEnableTime SQL.=. enableTime
+                                 , PPeerNextUdpDisableWindowSeconds SQL.=. nextDisableWindow
+                                 , PPeerDisableExpiration SQL.=. disableExpiration
+                                 ]
+
 pPeerString :: PPeer -> String
 pPeerString PPeer{..} = T.unpack pPeerIp ++ ":" ++ show pPeerTcpPort
 
@@ -212,6 +239,7 @@ buildPeerPoint (pubkeyMaybe, ip, _) =
         pPeerActiveState = 0,
         pPeerVersion = T.pack "61", -- fix
         pPeerNextDisableWindowSeconds = 5,
+        pPeerNextUdpDisableWindowSeconds = 5,
         pPeerDisableExpiration = jamshidBirth,
         pPeerEnode = peerToEnode peer
         }
@@ -304,6 +332,21 @@ lengthenPeerDisable peer' = try $ do
                   then ExtendPeerDisableTime (TcpEnableTime $ fromIntegral (pPeerNextDisableWindowSeconds peer) `addUTCTime` currentTime) 2
                   else SetPeerDisableTime (TcpEnableTime $ 5 `addUTCTime` currentTime) 5 ((24 * 60 * 60) `addUTCTime` currentTime)
   A.replace (A.Proxy @PeerDisable) peer disable
+
+-- A variation of 'lengthenPeerDisable' but for UDP exclusively used for ethereum-discovery.
+-- The first time a peer is disabled, the timeout is five seconds. Every subsequent failure that
+-- window is doubled, but those windows are reset every day. This prevents a mostly healthy node
+-- from building up longer and longer disables, e.g. if it caused an exception once a day
+-- by the end of the month it would be disabled for years.
+lengthenPeerDisable' :: (MonadUnliftIO m, A.Replaceable PPeer PeerUdpDisable m)
+                    => PPeer -> m (Either SomeException ())
+lengthenPeerDisable' peer' = try $ do
+  currentTime <- liftIO getCurrentTime
+  let peer = peer'{pPeerTcpPort=30303}
+      disable = if (currentTime < pPeerDisableExpiration peer)
+                  then ExtendPeerUdpDisableTime (UdpEnableTime $ fromIntegral (pPeerNextUdpDisableWindowSeconds peer) `addUTCTime` currentTime) 2
+                  else SetPeerUdpDisableTime (UdpEnableTime $ 5 `addUTCTime` currentTime) 5 ((24 * 60 * 60) `addUTCTime` currentTime)
+  A.replace (A.Proxy @PeerUdpDisable) peer disable
 
 -- TODO: Allow an empty public key in the Enode type
 peerToEnode :: PPeer -> Maybe Enode

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -109,6 +109,7 @@ data PeerUdpDisable =
     , spdtNextUdpDisableWindowSeconds :: Int
     , spdtUdpDisableExpiration :: UTCTime
     }
+  | ResetPeerUdpDisable
   deriving (Eq, Ord)
 
 instance RLPSerializable NodeID where
@@ -157,7 +158,7 @@ instance Mod.Accessible UnbondedPeers IO where
   access _ = withGlobalSQLPool $ \sqldb -> do
     currentTime <- getCurrentTime
     fmap (UnbondedPeers . map SQL.entityVal) $ flip runSqlPool sqldb $
-      SQL.selectList [PPeerBondState SQL.==. 0, PPeerEnableTime SQL.<. currentTime] []
+      SQL.selectList [PPeerBondState SQL.==. 0, PPeerUdpEnableTime SQL.<. currentTime, PPeerEnableTime SQL.<. currentTime] []
 
 instance A.Selectable IPAsText ClosestPeers IO where
   select _ (IPAsText requesterIP) = withGlobalSQLPool $ \sqldb ->
@@ -197,6 +198,7 @@ instance A.Replaceable PPeer PeerDisable IO where
 instance A.Replaceable PPeer PeerUdpDisable IO where
   replace _ peer d = withGlobalSQLPool $ \sqldb -> do
     let selector = thisPeer peer
+    currentTime <- liftIO getCurrentTime
     flip runSqlPool sqldb $ case d of
       ExtendPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindowFactor ->
         SQL.updateWhere selector [ PPeerUdpEnableTime SQL.=. enableTime
@@ -207,6 +209,16 @@ instance A.Replaceable PPeer PeerUdpDisable IO where
                                  , PPeerNextUdpDisableWindowSeconds SQL.=. nextDisableWindow
                                  , PPeerDisableExpiration SQL.=. disableExpiration
                                  ]
+      ResetPeerUdpDisable ->
+        SQL.updateWhere selector [ PPeerUdpEnableTime SQL.=. currentTime
+                                 , PPeerNextUdpDisableWindowSeconds SQL.=. 5
+                                 , PPeerDisableExpiration SQL.=. currentTime
+                                 ]
+
+instance A.Replaceable T.Text PPeer IO where
+  replace _ message peer = withGlobalSQLPool $ \sqldb -> do
+    flip runSqlPool sqldb $
+      SQL.updateWhere (thisPeer peer) [PPeerLastMsg SQL.=. message]
 
 pPeerString :: PPeer -> String
 pPeerString PPeer{..} = T.unpack pPeerIp ++ ":" ++ show pPeerTcpPort
@@ -358,3 +370,15 @@ getNumAvailablePeers = length . unAvailablePeers <$> Mod.access (Mod.Proxy @Avai
 getPeersClosestTo :: (MonadUnliftIO m, A.Selectable IPAsText ClosestPeers m)
                   => NodeID -> T.Text -> Point -> m [PPeer]
 getPeersClosestTo _ requesterIP _ = take 20 . maybe [] unClosestPeers <$> A.select (A.Proxy @ClosestPeers) (IPAsText requesterIP)
+
+updateLastMessage :: (A.Replaceable T.Text PPeer m)
+                  => T.Text
+                  -> PPeer
+                  -> m ()
+updateLastMessage message peer = A.replace (A.Proxy @PPeer) message peer
+
+resetPeerUdp :: (MonadUnliftIO m, A.Replaceable PPeer PeerUdpDisable m)
+             => PPeer -> m (Either SomeException ())
+resetPeerUdp peer' = try $ do
+  let peer = peer'{pPeerTcpPort=30303}
+  A.replace (A.Proxy @PeerUdpDisable) peer ResetPeerUdpDisable

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
@@ -157,28 +157,43 @@ handleValidPacket addr (UDPPort otherUdpPort) packet otherPubKey = case packet o
           where mkEndpoint PPeer{..} = Endpoint (stringToIAddr $ T.unpack pPeerIp) (UDPPort pPeerUdpPort) (TCPPort pPeerTcpPort)
                 mkNodeId             = pointToNodeID . fromJust . pPeerPubkey
 
-    Neighbors neighbors _ -> forM_ neighbors $ \(Neighbor (Endpoint addr' (UDPPort udpPort) (TCPPort tcpPort)) nodeID) -> do
-        $logDebugS "handleValidPacket/Neighbors" . T.pack $ "Got new neighbors: " ++ show neighbors
-        curTime <- liftIO getCurrentTime
-        let peer = PPeer { pPeerPubkey = Just $ nodeIDToPoint nodeID
-                         , pPeerIp = T.pack $ format addr'
-                         , pPeerUdpPort = udpPort
-                         , pPeerTcpPort = tcpPort
-                         , pPeerNumSessions = 0
-                         , pPeerLastTotalDifficulty = 0
-                         , pPeerLastMsg  = T.pack "msg"
-                         , pPeerLastMsgTime = curTime
-                         , pPeerEnableTime = curTime
-                         , pPeerUdpEnableTime = curTime
-                         , pPeerLastBestBlockHash = unsafeCreateKeccak256FromWord256 0
-                         , pPeerBondState = 0
-                         , pPeerActiveState = 0
-                         , pPeerVersion = T.pack "61" -- fix
-                         , pPeerNextDisableWindowSeconds=5
-                         , pPeerDisableExpiration=posixSecondsToUTCTime 0
-                         , pPeerEnode = peerToEnode peer
-                         }
-        addPeer peer
+    Neighbors neighbors _ -> do
+      let neighborIPs = ((\(Neighbor (Endpoint addr' _ _) _)-> format addr') <$> neighbors)
+          ip = sockAddrToIP addr
+      neighborsExist <- doPeersExist neighborIPs
+      if (neighborsExist == True) 
+        then do
+          $logInfoS "handleValidPacket/Neighbors" . T.pack $ "Got duplicate neighbors from " ++ show addr ++ ", lengthening peer UDP disable." ++ "\n"
+          thePeer <- getPeerByIP' ip
+          case thePeer of
+            Nothing -> $logErrorS "handleValidPacket/Neighbors" . T.pack $ "Something went wrong, can't find the peer I'm currently connected to. *visibly confused*"
+            Just p -> do
+              eErr <- lengthenPeerDisable' p
+              whenLeft eErr $ \err -> $logErrorS "handleValidPacket/Neighbors" . T.pack $ "Unable to disable peer: " ++ show err
+      else 
+        forM_ neighbors $ \(Neighbor (Endpoint addr' (UDPPort udpPort) (TCPPort tcpPort)) nodeID) -> do
+          $logDebugS "handleValidPacket/Neighbors" . T.pack $ "Got new neighbors: " ++ show neighbors
+          curTime <- liftIO getCurrentTime
+          let peer = PPeer { pPeerPubkey = Just $ nodeIDToPoint nodeID
+                           , pPeerIp = T.pack $ format addr'
+                           , pPeerUdpPort = udpPort
+                           , pPeerTcpPort = tcpPort
+                           , pPeerNumSessions = 0
+                           , pPeerLastTotalDifficulty = 0
+                           , pPeerLastMsg  = T.pack "msg"
+                           , pPeerLastMsgTime = curTime
+                           , pPeerEnableTime = curTime
+                           , pPeerUdpEnableTime = curTime
+                           , pPeerLastBestBlockHash = unsafeCreateKeccak256FromWord256 0
+                           , pPeerBondState = 0
+                           , pPeerActiveState = 0
+                           , pPeerVersion = T.pack "61" -- fix
+                           , pPeerNextDisableWindowSeconds=5
+                           , pPeerNextUdpDisableWindowSeconds=5
+                           , pPeerDisableExpiration=posixSecondsToUTCTime 0
+                           , pPeerEnode = peerToEnode peer
+                           }
+          addPeer peer
   where addPeer' (UDPPort peerUdpPort) (TCPPort peerTcpPort) = do
           curTime <- liftIO getCurrentTime
           let ip   = sockAddrToIP addr
@@ -197,6 +212,7 @@ handleValidPacket addr (UDPPort otherUdpPort) packet otherPubKey = case packet o
                           ,  pPeerActiveState = 0
                           ,  pPeerVersion = T.pack "61" -- fix
                           , pPeerNextDisableWindowSeconds=5
+                          , pPeerNextUdpDisableWindowSeconds=5
                           , pPeerDisableExpiration=posixSecondsToUTCTime 0
                           , pPeerEnode = peerToEnode peer
                           }

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
@@ -77,6 +77,7 @@ addPeersIfNeeded minPeers = do
         for_ mPeerAddr $ \peerAddr -> do
           time <- liftIO $ round `fmap` getPOSIXTime
           randomBytes <- liftIO $ getEntropy 64
+          updateLastMessage (T.pack "FindNeighbors") thePeer 
           sendPacket peerAddr $ FindNeighbors (NodeID randomBytes) (time + 50)
           eErr <- disableUDPPeerForSeconds thePeer 10
           whenLeft eErr $ \err -> $logErrorS "addPeersIfNeeded" . T.pack $ "Unable to disable peer: " ++ show err
@@ -96,13 +97,18 @@ attemptBond = do
       case getHostAddress serverAddr of
         Left err -> $logInfoS "attemptBond" $ T.pack . show $ err
         Right hostAddress -> do
-          sendPacket peerAddr $
-                Ping 4
-                   (Endpoint hostAddress udpPort tcpPort)
-                   (Endpoint (stringToIAddr $ T.unpack $ pPeerIp p)
-                             peerUdpPort
-                             (TCPPort . fromIntegral $ pPeerTcpPort p))
-                   (time+50)
+          if (pPeerLastMsg p == T.pack "Ping") then do
+            eErr <- lengthenPeerDisable' p
+            whenLeft eErr $ \err -> $logErrorS "handleValidPacket/attemptBond" . T.pack $ "Unable to disable peer: " ++ show err
+          else do
+            updateLastMessage (T.pack "Ping") p
+            sendPacket peerAddr $
+                  Ping 4
+                    (Endpoint hostAddress udpPort tcpPort)
+                    (Endpoint (stringToIAddr $ T.unpack $ pPeerIp p)
+                              peerUdpPort
+                              (TCPPort . fromIntegral $ pPeerTcpPort p))
+                    (time+50)
 
 udpHandshakeServer :: MonadDiscovery m => Int -> m ()
 udpHandshakeServer minPeers = do
@@ -160,17 +166,15 @@ handleValidPacket addr (UDPPort otherUdpPort) packet otherPubKey = case packet o
     Neighbors neighbors _ -> do
       let neighborIPs = ((\(Neighbor (Endpoint addr' _ _) _)-> format addr') <$> neighbors)
           ip = sockAddrToIP addr
+      thePeer <- getPeerByIP' ip
+      updateLastMessage (T.pack "Neighbors") $ fromJust thePeer
       neighborsExist <- doPeersExist neighborIPs
       if (neighborsExist == True) 
         then do
           $logInfoS "handleValidPacket/Neighbors" . T.pack $ "Got duplicate neighbors from " ++ show addr ++ ", lengthening peer UDP disable." ++ "\n"
-          thePeer <- getPeerByIP' ip
-          case thePeer of
-            Nothing -> $logErrorS "handleValidPacket/Neighbors" . T.pack $ "Something went wrong, can't find the peer I'm currently connected to. *visibly confused*"
-            Just p -> do
-              eErr <- lengthenPeerDisable' p
-              whenLeft eErr $ \err -> $logErrorS "handleValidPacket/Neighbors" . T.pack $ "Unable to disable peer: " ++ show err
-      else 
+          eErr <- lengthenPeerDisable' $ fromJust thePeer
+          whenLeft eErr $ \err -> $logErrorS "handleValidPacket/Neighbors" . T.pack $ "Unable to disable peer: " ++ show err
+      else do
         forM_ neighbors $ \(Neighbor (Endpoint addr' (UDPPort udpPort) (TCPPort tcpPort)) nodeID) -> do
           $logDebugS "handleValidPacket/Neighbors" . T.pack $ "Got new neighbors: " ++ show neighbors
           curTime <- liftIO getCurrentTime
@@ -194,6 +198,8 @@ handleValidPacket addr (UDPPort otherUdpPort) packet otherPubKey = case packet o
                            , pPeerEnode = peerToEnode peer
                            }
           addPeer peer
+        eErr <- resetPeerUdp $ fromJust thePeer
+        whenLeft eErr $ \err -> $logErrorS "handleValidPacket/Neighbors" . T.pack $ "Unable to reset peer disable: " ++ show err
   where addPeer' (UDPPort peerUdpPort) (TCPPort peerTcpPort) = do
           curTime <- liftIO getCurrentTime
           let ip   = sockAddrToIP addr

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
@@ -148,8 +148,12 @@ handleValidPacket addr (UDPPort otherUdpPort) packet otherPubKey = case packet o
         sendPacket addr $ Pong ep 4 (time+50)
 
     Pong{} -> do
-        eErr <- setPeerBondingState (sockAddrToIP addr) otherUdpPort 2
-        whenLeft eErr $ \ err -> do
+        let ip = sockAddrToIP addr
+        thePeer <- getPeerByIP' ip
+        eErr <- resetPeerUdp $ fromJust thePeer
+        whenLeft eErr $ \err -> $logErrorS "handleValidPacket/Pong" . T.pack $ "Unable to reset peer disable: " ++ show err
+        eErr' <- setPeerBondingState (sockAddrToIP addr) otherUdpPort 2
+        whenLeft eErr' $ \ err -> do
             $logErrorS "handleValidPacket" . T.pack $ "Unable to set peer bonding state: " ++ show err
             throwM err
 

--- a/strato/core/strato-p2p/src/Blockchain/EventException.hs
+++ b/strato/core/strato-p2p/src/Blockchain/EventException.hs
@@ -12,7 +12,6 @@ data EventException =
   | EventBeforeHandshake Message
   | WrongGenesisBlock
   | NetworkIDMismatch
-  | PeerDisabled
   | RootCertificateMismatch
   | NoPeerPubKey deriving (Show)
 

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -32,7 +32,6 @@ import           Data.Conduit
 import           Data.Either.Combinators
 import           Data.Maybe
 import qualified Data.Text                             as T
-import           Data.Time.Clock
 import           Data.Traversable                      (for)
 import           GHC.IO.Exception                      
 import           UnliftIO
@@ -62,9 +61,6 @@ runPeer peer sSource = do
   void $ register ender
 
   myPublic <- getPub
-
-  curTime <- liftIO getCurrentTime
-  when ((pPeerEnableTime peer) > curTime) $ throwIO PeerDisabled
   
   otherPubKey <- case (pPeerPubkey peer) of
     Nothing -> do

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -25,7 +25,6 @@ import qualified Data.ByteString                       as B
 import           Data.Either.Combinators
 import           Data.Maybe                            (fromMaybe)
 import qualified Data.Text                             as T
-import           Data.Time.Clock
 import           GHC.IO.Exception
 import           UnliftIO
 
@@ -61,9 +60,6 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
     Nothing -> do
       $logErrorS "runEthServer" . T.pack $ "Didn't see peer in discovery at IP " ++ peerStr ++ ". rejecting violently."
     Just p -> do
-
-      curTime <- liftIO getCurrentTime
-      when ((pPeerEnableTime p) > curTime) $ throwIO PeerDisabled
 
       case pPeerPubkey p of
         Nothing -> do

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -1077,6 +1077,16 @@ instance MonadIO m => A.Replaceable PPeer PeerDisable (MonadTest m) where
 instance (Monad m, A.Replaceable PPeer PeerDisable m) => A.Replaceable PPeer PeerDisable (MonadP2PTest m) where
   replace p k = lift . A.replace p k
 
+instance MonadIO m => A.Replaceable PPeer PeerUdpDisable (MonadTest m) where
+  replace _ peer' d = case d of
+    ExtendPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindowFactor ->
+      stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = pPeerNextUdpDisableWindowSeconds p * nextDisableWindowFactor})
+    SetPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindow disableExpiration ->
+      stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = nextDisableWindow, pPeerDisableExpiration = disableExpiration})
+
+instance (Monad m, A.Replaceable PPeer PeerUdpDisable m) => A.Replaceable PPeer PeerUdpDisable (MonadP2PTest m) where
+  replace p k = lift . A.replace p k
+
 startingCheckpoint :: [ChainMemberParsedSet] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
 

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -1078,13 +1078,23 @@ instance (Monad m, A.Replaceable PPeer PeerDisable m) => A.Replaceable PPeer Pee
   replace p k = lift . A.replace p k
 
 instance MonadIO m => A.Replaceable PPeer PeerUdpDisable (MonadTest m) where
-  replace _ peer' d = case d of
-    ExtendPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindowFactor ->
-      stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = pPeerNextUdpDisableWindowSeconds p * nextDisableWindowFactor})
-    SetPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindow disableExpiration ->
-      stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = nextDisableWindow, pPeerDisableExpiration = disableExpiration})
+  replace _ peer' d = do
+    currentTime <- liftIO getCurrentTime
+    case d of
+      ExtendPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindowFactor ->
+        stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = pPeerNextUdpDisableWindowSeconds p * nextDisableWindowFactor})
+      SetPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindow disableExpiration ->
+        stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = nextDisableWindow, pPeerDisableExpiration = disableExpiration})
+      ResetPeerUdpDisable ->
+        stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = currentTime, pPeerNextUdpDisableWindowSeconds = 5, pPeerDisableExpiration = currentTime})
 
 instance (Monad m, A.Replaceable PPeer PeerUdpDisable m) => A.Replaceable PPeer PeerUdpDisable (MonadP2PTest m) where
+  replace p k = lift . A.replace p k
+
+instance MonadIO m => A.Replaceable T.Text PPeer (MonadTest m) where
+  replace _ message peer' = stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerLastMsg = message})
+
+instance (Monad m, A.Replaceable T.Text PPeer m) => A.Replaceable T.Text PPeer (MonadP2PTest m) where
   replace p k = lift . A.replace p k
 
 startingCheckpoint :: [ChainMemberParsedSet] -> Checkpoint

--- a/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
+++ b/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
@@ -1098,6 +1098,16 @@ instance MonadIO m => A.Replaceable PPeer PeerDisable (MonadTest m) where
 instance (Monad m, A.Replaceable PPeer PeerDisable m) => A.Replaceable PPeer PeerDisable (MonadP2PTest m) where
   replace p k = lift . A.replace p k
 
+instance MonadIO m => A.Replaceable PPeer PeerUdpDisable (MonadTest m) where
+  replace _ peer' d = case d of
+    ExtendPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindowFactor ->
+      stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = pPeerNextUdpDisableWindowSeconds p * nextDisableWindowFactor})
+    SetPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindow disableExpiration ->
+      stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = nextDisableWindow, pPeerDisableExpiration = disableExpiration})
+
+instance (Monad m, A.Replaceable PPeer PeerUdpDisable m) => A.Replaceable PPeer PeerUdpDisable (MonadP2PTest m) where
+  replace p k = lift . A.replace p k
+
 startingCheckpoint :: [ChainMemberParsedSet] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
 

--- a/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
+++ b/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
@@ -1099,13 +1099,23 @@ instance (Monad m, A.Replaceable PPeer PeerDisable m) => A.Replaceable PPeer Pee
   replace p k = lift . A.replace p k
 
 instance MonadIO m => A.Replaceable PPeer PeerUdpDisable (MonadTest m) where
-  replace _ peer' d = case d of
-    ExtendPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindowFactor ->
-      stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = pPeerNextUdpDisableWindowSeconds p * nextDisableWindowFactor})
-    SetPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindow disableExpiration ->
-      stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = nextDisableWindow, pPeerDisableExpiration = disableExpiration})
+  replace _ peer' d = do
+    currentTime <- liftIO getCurrentTime
+    case d of
+      ExtendPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindowFactor ->
+        stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = pPeerNextUdpDisableWindowSeconds p * nextDisableWindowFactor})
+      SetPeerUdpDisableTime (UdpEnableTime enableTime) nextDisableWindow disableExpiration ->
+        stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = enableTime, pPeerNextUdpDisableWindowSeconds = nextDisableWindow, pPeerDisableExpiration = disableExpiration})
+      ResetPeerUdpDisable ->
+          stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerUdpEnableTime = currentTime, pPeerNextUdpDisableWindowSeconds = 5, pPeerDisableExpiration = currentTime})
 
 instance (Monad m, A.Replaceable PPeer PeerUdpDisable m) => A.Replaceable PPeer PeerUdpDisable (MonadP2PTest m) where
+  replace p k = lift . A.replace p k
+
+instance MonadIO m => A.Replaceable T.Text PPeer (MonadTest m) where
+  replace _ message peer' = stringPPeerMap . at (T.unpack $ pPeerIp peer') . _Just %= (\p -> p{pPeerLastMsg = message})
+
+instance (Monad m, A.Replaceable T.Text PPeer m) => A.Replaceable T.Text PPeer (MonadP2PTest m) where
   replace p k = lift . A.replace p k
 
 startingCheckpoint :: [ChainMemberParsedSet] -> Checkpoint


### PR DESCRIPTION
This PR aims to minimize ethereum-discovery's calls to the vault. This PR is the second part to `P2P ddosing vault with POST /signature and /sharedkey`.

What this PR accomplishes:
* Key Changes
  * When a peer returns neighbors for us, we first check if they are all duplicates of ones we already have. If they are just duplicates, we will lengthen the peer's UDP enable time. For every subsequent duplicate neighbor list we get from the same peer, the peer's UDP enable time will be longer and longer growing by a factor of 2 starting at 5 seconds. This growth will be reset to 5 seconds and the enable time will be set to the current time every time we receive a non-duplicate from the peer or just on a daily basis.
  * Prevent the spamming of vault and the peer on redundant connections that return nothing. For example, if we try to ping a peer but the peer is unavailable/timed out for whatever reason, we would keep sending ping packets signed by the vault to the same peer indefinitely. This PR changes that by setting the `last_msg` of a peer we're trying to bond with to the last type of packet we sent and then using that field as a check to prevent the problem that was mentioned before through lengthening the peer's UDP enable time like above with the key difference that if a peer returns a `Pong` message, this will no longer affect them and their UDP enable time and window factor will be reset.
* New helper functions in ethereum-discovery that helps accomplish these changes:
  * Gets a peer by IP
  * Checks if a peer/peers exist already in our `p_peer` table
  * `lengthenPeerDisable'` disables/extends a peer's UDP enable time which functions similarly to the already present `lengthenPeerDisable`
  * `updateLastMessage` which updates a peer's unused `last_msg` field which we can use to determine what the last message we sent was. I.E. if we sent a `Ping` packet already but the peer's being timed out for whatever reason, the `last_msg` field would still be `Ping` so we know to lengthen the peer's UDP disable time as to not spam the peer/vault