### PR TITLE
support for x509 certs from subject json files with unicode

### DIFF
--- a/strato/tools/x509-tools/exec_src/X509CertGenerator.hs
+++ b/strato/tools/x509-tools/exec_src/X509CertGenerator.hs
@@ -17,7 +17,6 @@ import           Data.Maybe
 import           Time.Types
 import           Data.Hourglass
 import qualified Data.ByteString                    as B
-import qualified Data.ByteString.Char8              as C8
 import           Data.Either
 import           Data.Foldable                      (foldlM)
 import           System.Console.GetOpt
@@ -76,8 +75,8 @@ options =
   , Option ['s'] ["subject"]
       (ReqArg
        (\s opts -> do
-          subStr <- readFile s
-          let eSub = Ae.eitherDecodeStrict (C8.pack subStr) :: Either String Subject
+          subStr <- B.readFile s
+          let eSub = Ae.eitherDecodeStrict subStr :: Either String Subject
               !sub = fromRight (error "invalid subject JSON") eSub
           return opts{optSubjectInfo = sub}
        ) "Subject")


### PR DESCRIPTION
modified the way X509CertGenerator.hs reads in subject json files to support unicode characters. Tested on Arabic characters, letters with accents, emojis, and traditional Chinese characters.