### PR TITLE
quick fix for dynamic linking bug

### DIFF
--- a/strato/tools/x509-tools/package.yaml
+++ b/strato/tools/x509-tools/package.yaml
@@ -33,30 +33,35 @@ dependencies:
   - x509-certs
 
 
-ghc-options: -Wall -Werror -dynamic
+ghc-options: -Wall -Werror
 
 executables:
   x509-generator:
     source-dirs: exec_src/
+    ghc-options: -dynamic
     main: X509CertGenerator.hs
     other-modules: []
 
   x509-keygen:
     source-dirs: exec_src/
+    ghc-options: -dynamic
     main: X509Keygen.hs
     other-modules: []
 
   x509-info:
     source-dirs: exec_src/
+    ghc-options: -dynamic
     main: X509CertInfo.hs
     other-modules: []
 
   x509-certificate-registry:
     source-dirs: exec_src/
+    ghc-options: -dynamic
     main: X509CertRegistry.hs
     other-modules: []
 
   x509-saltine-decrypt:
     source-dirs: exec_src/
+    ghc-options: -dynamic
     main: X509SaltineDecrypt.hs
     other-modules: []

--- a/strato/tools/x509-tools/package.yaml
+++ b/strato/tools/x509-tools/package.yaml
@@ -33,7 +33,7 @@ dependencies:
   - x509-certs
 
 
-ghc-options: -Wall -Werror
+ghc-options: -Wall -Werror -dynamic
 
 executables:
   x509-generator:


### PR DESCRIPTION
@ayaabdelgawad revealed that the dynamic ghc-option flag would also be needed for compiling the x509-tools and running the `stack run x509-generator` command, so this should fix the issue