### PR TITLE
Change LTS 20.10 -> 20.13

### DIFF
--- a/strato/core/strato-init/package.yaml
+++ b/strato/core/strato-init/package.yaml
@@ -114,6 +114,7 @@ executables:
   genesis-builder:
     source-dirs: exec_src/
     main: GenesisBuilder.hs
+    ghc-options: -dynamic
     dependencies:
       - aeson
       - bytestring

--- a/strato/stack.yaml
+++ b/strato/stack.yaml
@@ -105,7 +105,7 @@ flags:
     ecdh: true
     recovery: true
 
-resolver: lts-20.12 #also duplicated in docker section below
+resolver: lts-20.13 #also duplicated in docker section below
 compiler-check: newer-minor
 extra-include-dirs:
 - /usr/local/include
@@ -130,7 +130,7 @@ ghc-options:
 
 docker:
   enable: true
-  image: "strato-buildbase:lts-20.12"
+  image: "strato-buildbase:lts-20.13"
   set-user: true
   run-args: ["--ulimit=nofile=60000"]
 

--- a/strato/stack.yaml
+++ b/strato/stack.yaml
@@ -105,7 +105,7 @@ flags:
     ecdh: true
     recovery: true
 
-resolver: lts-20.10 #also duplicated in docker section below
+resolver: lts-20.12 #also duplicated in docker section below
 compiler-check: newer-minor
 extra-include-dirs:
 - /usr/local/include
@@ -130,7 +130,7 @@ ghc-options:
 
 docker:
   enable: true
-  image: "strato-buildbase:lts-20.10"
+  image: "strato-buildbase:lts-20.12"
   set-user: true
   run-args: ["--ulimit=nofile=60000"]
 


### PR DESCRIPTION
This Changes the stack resolver to LTS 20.13 which upgrades our GHC version from  9.2.5 -> 9.2.7 as well as updates many important packages such as `bytestring`