### PR TITLE
Use upsert instead of insertMany for createAcount

### DIFF
--- a/strato/core/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
+++ b/strato/core/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
@@ -73,8 +73,8 @@ createAccount blockNumber accountDiffs =
   where
     tryCreates = do
       let newAccounts = map (uncurry addrRef) accountDiffs
-      $logInfoS "commitSqlDiffs/createAccount" . T.pack $ "Creating accounts: " ++ (unlines $ map show newAccounts)
-      addrIDs <- SQL.insertMany newAccounts
+      $logDebugS "commitSqlDiffs/createAccount" . T.pack $ "Creating accounts: " ++ (unlines $ map show newAccounts)
+      addrIDs <- map SQL.entityKey <$> traverse (`SQL.upsert` []) newAccounts
 
       newStorage <-
         forM (zip accountDiffs addrIDs) $ \(accountDiff, addrID) -> do
@@ -85,7 +85,7 @@ createAccount blockNumber accountDiffs =
             SolidVMDiff m -> return [Storage addrID SolidVM (HexStorage k) (HexStorage v)
                                     | (k, Value v) <- Map.toList m]
 
-      $logInfoS "commitSqlDiffs/createAccount" . T.pack $ "Inserting storage: " ++ (unlines $ map show (concat newStorage))
+      $logDebugS "commitSqlDiffs/createAccount" . T.pack $ "Inserting storage: " ++ (unlines $ map show (concat newStorage))
       SQL.insertMany_ (concat newStorage)
     addrRef account diff = AddressStateRef{
       addressStateRefAddress = account ^. accountAddress,


### PR DESCRIPTION
Should help prevent a duplicate key violation error that intermittently occurs in statediff