### PR TITLE
[BuilderX] Shard Creation to include self by default

### DIFF
--- a/smd-ui/src/components/CreateChain/index.js
+++ b/smd-ui/src/components/CreateChain/index.js
@@ -48,6 +48,17 @@ class CreateChain extends Component {
   }
 
   submit = (values) => {
+    if (this.props.oauthUser && !this.state.members.some(e => e.orgName === this.props.oauthUser.organization 
+      && e.orgUnit === this.props.oauthUser.organizationUnit
+      && e.commonName === this.props.oauthUser.commonName)) {
+        let newMembers = this.state.members.push(
+          { orgName: this.props.oauthUser.organization,
+            orgUnit: this.props.oauthUser.organizationalUnit,
+            commonName: this.props.oauthUser.commonName,
+            access: true
+          })
+        this.setState({ members: newMembers })
+    }
     values.members = this.state.members;
     values.integrations = this.state.integrations;
     values.governanceContract = this.state.governanceContract;
@@ -203,7 +214,7 @@ class CreateChain extends Component {
     else {
       return (
         <div className="pt-dialog-header no-member">
-          <span className="pt-dialog-header-title">No Members</span>
+          <span className="pt-dialog-header-title">No Addtional Members</span>
         </div>
       );
     }

--- a/smd-ui/src/tests/CreateChain/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/CreateChain/__snapshots__/index.spec.js.snap
@@ -190,7 +190,7 @@ exports[`CreateChain: index render component with empty values 1`] = `
             </label>
             <div className=\\"pt-dialog-header no-member\\">
               <span className=\\"pt-dialog-header-title\\">
-                No Members
+                No Addtional Members
               </span>
             </div>
             <span className=\\"error-text\\" />
@@ -341,7 +341,7 @@ exports[`CreateChain: index render component with values 1`] = `
             </label>
             <div className=\\"pt-dialog-header no-member\\">
               <span className=\\"pt-dialog-header-title\\">
-                No Members
+                No Addtional Members
               </span>
             </div>
             <span className=\\"error-text\\" />


### PR DESCRIPTION
This PR will solve the confusion that arises from the Mercata quickstart guide where it states that the current user will be automatically included in the chain by default. Instead of manually adding everyone or themselves to create the shard, now the user themselves will be included by default at shard creation.