### PR TITLE
Attempted fix for API Memory leak

### DIFF
--- a/strato/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE BangPatterns          #-}
 
 module BlockApps.Bloc22.Database.Queries
   ( contractBySourceHash
@@ -352,8 +353,9 @@ instance DefaultFromField PGBytea Address where
 
 instance FromField Address where
   fromField f mdata = do
-    theByteString <- fromField f mdata
-    return $ Address $ bytesToWord160 $ B.unpack theByteString
+    !theByteString <- fromField f mdata
+    let !word160 = bytesToWord160 $ B.unpack theByteString
+    return $ Address word160
 
 instance Default ToFields Address (O.Field PGBytea) where
   def = lmap getBytes def
@@ -365,8 +367,10 @@ instance DefaultFromField PGBytea SecretBox.Nonce where
 
 instance FromField SecretBox.Nonce where
   fromField f mdata = do
-    theByteString <- fromField f mdata
-    return $ fromMaybe (error $ "could not decode address: " ++ show theByteString) $ Saltine.decode theByteString
+    !theByteString <- fromField f mdata
+    -- return $ fromMaybe (error $ "could not decode address: " ++ show theByteString) $ Saltine.decode theByteString
+    let !decoded = fromMaybe (error $ "could not decode address: " ++ show theByteString) $ Saltine.decode theByteString
+    return decoded
 
 instance Default ToFields SecretBox.Nonce (O.Field PGBytea) where
   def = lmap Saltine.encode def
@@ -381,16 +385,20 @@ instance DefaultFromField PGText StateMutability where
 
 instance FromField StateMutability where
   fromField f mdata = do
-    theByteString <- fromField f mdata
-    return $ fromMaybe (error $ "could not decode mutability: " ++ show theByteString) $ tRead $ Text.pack $ BC.unpack theByteString
+    !theByteString <- fromField f mdata
+    -- return $ fromMaybe (error $ "could not decode mutability: " ++ show theByteString) $ tRead $ Text.pack $ BC.unpack theByteString
+    let !decoded = fromMaybe (error $ "could not decode mutability: " ++ show theByteString) $ tRead $ Text.pack $ BC.unpack theByteString
+    return decoded
 
 instance DefaultFromField PGBytea Keccak256 where
   defaultFromField = fromPGSFromField
 
 instance FromField Keccak256 where
   fromField f mdata = do
-    theByteString <- fromField f mdata
-    return $ unsafeCreateKeccak256FromByteString theByteString
+    !theByteString <- fromField f mdata
+    -- return $ unsafeCreateKeccak256FromByteString theByteString
+    let !decoded = unsafeCreateKeccak256FromByteString theByteString
+    return decoded
 
 instance Default ToFields Keccak256 (O.Field PGBytea) where
   def = lmap keccak256ToByteString def
@@ -400,8 +408,10 @@ instance DefaultFromField PGBytea CodePtr where
 
 instance FromField CodePtr where
   fromField f mdata = do
-    theByteString <- fromField f mdata
-    return $ fromRight (error $ "could not decode CodePtr: " ++ show theByteString) $ rlpDeserialize theByteString
+    !theByteString <- fromField f mdata
+    -- return $ fromRight (error $ "could not decode CodePtr: " ++ show theByteString) $ rlpDeserialize theByteString
+    let !decoded = fromRight (error $ "could not decode CodePtr: " ++ show theByteString) $ rlpDeserialize theByteString
+    return decoded
 
 instance Default ToFields CodePtr (O.Field PGBytea) where
   def = lmap rlpSerialize def
@@ -411,8 +421,10 @@ instance DefaultFromField PGBytea (Maybe ChainId) where
 
 instance FromField ChainId where
   fromField f mdata = do
-    theByteString <- fromField f mdata
-    return $ ChainId $ byteStringToWord256 theByteString
+    !theByteString <- fromField f mdata
+    -- return $ ChainId $ byteStringToWord256 theByteString
+    let !decoded = ChainId $ byteStringToWord256 theByteString
+    return decoded
 
 instance Default ToFields (Maybe ChainId) (O.Field PGBytea) where
   def = lmap fromChainId def

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -368,7 +368,6 @@ instance DefaultFromField PGBytea SecretBox.Nonce where
 instance FromField SecretBox.Nonce where
   fromField f mdata = do
     !theByteString <- fromField f mdata
-    -- return $ fromMaybe (error $ "could not decode address: " ++ show theByteString) $ Saltine.decode theByteString
     let !decoded = fromMaybe (error $ "could not decode address: " ++ show theByteString) $ Saltine.decode theByteString
     return decoded
 
@@ -386,7 +385,6 @@ instance DefaultFromField PGText StateMutability where
 instance FromField StateMutability where
   fromField f mdata = do
     !theByteString <- fromField f mdata
-    -- return $ fromMaybe (error $ "could not decode mutability: " ++ show theByteString) $ tRead $ Text.pack $ BC.unpack theByteString
     let !decoded = fromMaybe (error $ "could not decode mutability: " ++ show theByteString) $ tRead $ Text.pack $ BC.unpack theByteString
     return decoded
 
@@ -396,7 +394,6 @@ instance DefaultFromField PGBytea Keccak256 where
 instance FromField Keccak256 where
   fromField f mdata = do
     !theByteString <- fromField f mdata
-    -- return $ unsafeCreateKeccak256FromByteString theByteString
     let !decoded = unsafeCreateKeccak256FromByteString theByteString
     return decoded
 
@@ -409,7 +406,6 @@ instance DefaultFromField PGBytea CodePtr where
 instance FromField CodePtr where
   fromField f mdata = do
     !theByteString <- fromField f mdata
-    -- return $ fromRight (error $ "could not decode CodePtr: " ++ show theByteString) $ rlpDeserialize theByteString
     let !decoded = fromRight (error $ "could not decode CodePtr: " ++ show theByteString) $ rlpDeserialize theByteString
     return decoded
 
@@ -422,7 +418,6 @@ instance DefaultFromField PGBytea (Maybe ChainId) where
 instance FromField ChainId where
   fromField f mdata = do
     !theByteString <- fromField f mdata
-    -- return $ ChainId $ byteStringToWord256 theByteString
     let !decoded = ChainId $ byteStringToWord256 theByteString
     return decoded
 

--- a/strato/vault/server/src/Strato/Strato23/Database/Queries.hs
+++ b/strato/vault/server/src/Strato/Strato23/Database/Queries.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE BangPatterns         #-}
 
 module Strato.Strato23.Database.Queries where
 
@@ -165,9 +166,11 @@ instance DefaultFromField PGBytea Address where
 
 instance FromField Address where
   fromField f mdata = do
-    theByteString <- fromField f mdata
-    return $ fromMaybe (error $ "could not decode address: " ++ show theByteString) $ stringAddress $ C8.unpack theByteString
- 
+    !theByteString <- fromField f mdata
+    -- return $ fromMaybe (error $ "could not decode address: " ++ show theByteString) $ stringAddress $ C8.unpack theByteString
+    let !returnVal = fromMaybe (error $ "could not decode address: " ++ show theByteString) $ stringAddress $ C8.unpack theByteString
+    return returnVal
+
 instance Default ToFields Address (O.Field PGBytea) where
   def = lmap (C8.pack . formatAddressWithoutColor) def
 
@@ -176,8 +179,10 @@ instance DefaultFromField PGBytea SecretBox.Nonce where
 
 instance FromField SecretBox.Nonce where
   fromField f theData = do
-    theByteString <- fromField f theData
-    return $ fromMaybe (error $ "Saltine.decode failed for: " ++ show theByteString) $ Saltine.decode theByteString
+    !theByteString <- fromField f theData
+    -- return $ fromMaybe (error $ "Saltine.decode failed for: " ++ show theByteString) $ Saltine.decode theByteString
+    let !returnVal = fromMaybe (error $ "Saltine.decode failed for: " ++ show theByteString) $ Saltine.decode theByteString
+    return returnVal
 
 instance Default ToFields SecretBox.Nonce (O.Field PGBytea) where
   def = lmap Saltine.encode def

--- a/strato/vault/server/src/Strato/Strato23/Database/Queries.hs
+++ b/strato/vault/server/src/Strato/Strato23/Database/Queries.hs
@@ -167,7 +167,6 @@ instance DefaultFromField PGBytea Address where
 instance FromField Address where
   fromField f mdata = do
     !theByteString <- fromField f mdata
-    -- return $ fromMaybe (error $ "could not decode address: " ++ show theByteString) $ stringAddress $ C8.unpack theByteString
     let !returnVal = fromMaybe (error $ "could not decode address: " ++ show theByteString) $ stringAddress $ C8.unpack theByteString
     return returnVal
 
@@ -180,7 +179,6 @@ instance DefaultFromField PGBytea SecretBox.Nonce where
 instance FromField SecretBox.Nonce where
   fromField f theData = do
     !theByteString <- fromField f theData
-    -- return $ fromMaybe (error $ "Saltine.decode failed for: " ++ show theByteString) $ Saltine.decode theByteString
     let !returnVal = fromMaybe (error $ "Saltine.decode failed for: " ++ show theByteString) $ Saltine.decode theByteString
     return returnVal
 


### PR DESCRIPTION
the `fromField`  method from the PostgreSQL module is leaking memory, 
retaining any reference to the Field argument causes the entire LibPQ.Result to be retained. Thus, implementations of fromField should return results that do not refer to this value after the result have been evaluated to WHNF. https://hackage.haskell.org/package/postgresql-simple-0.6.5/docs/Database-PostgreSQL-Simple-FromField.html#v:fromField



Massive thanks to @jxuan101  who found this

### BEFORE
https://blockappsdev.slack.com/files/U03MFSESL57/F04UH946E2E/strato-api-before.html

### AFTER
https://blockappsdev.slack.com/files/U03MFSESL57/F04V6V3QX5E/strato-api-after.html


![Screenshot from 2023-03-17 11-26-08](https://user-images.githubusercontent.com/29279583/225948662-f11f4156-1f95-429d-9e51-4400afe03283.png)
