### PR TITLE
[UserX] Strato 3057 disable buttons no cert

### DIFF
--- a/smd-ui/src/App/App.scss
+++ b/smd-ui/src/App/App.scss
@@ -1,6 +1,16 @@
 @import "../../node_modules/@blueprintjs/core/dist/variables.scss";
 @import "../../node_modules/plottable/plottable.css";
 
+:root {
+  --blockapps-primary-navy: #001B71;
+  --blockapps-primary-blue: #3452FF;
+  --blockapps-primary-red: #FF3300;
+  --blockapps-secondary-blue: #00AEEF;
+  --blockapps-secondary-purple: #6B36C4;
+  --blockapps-secondary-yellow: #F0C452;
+  --blockapps-secondary-green: #36C487;
+}
+
 html {
   height: 100%;
 }

--- a/smd-ui/src/App/index.js
+++ b/smd-ui/src/App/index.js
@@ -28,11 +28,7 @@ class App extends Component {
     }
   }
 
-  componentWillReceiveProps(newProps) {
-    if (newProps.oauthUser && newProps.oauthUser.address && !this.props.userCertificate) {
-      this.props.getUserCertificateRequest(newProps.oauthUser.address)
-    }
-  }
+  
 
   render() {
     return (
@@ -58,5 +54,4 @@ export function mapStateToProps(state) {
 
 export default withRouter(connect(mapStateToProps, {
   getOrCreateOauthUserRequest,
-  getUserCertificateRequest,
 })(App));

--- a/smd-ui/src/components/Accounts/components/SendTokens/index.js
+++ b/smd-ui/src/components/Accounts/components/SendTokens/index.js
@@ -7,7 +7,7 @@ import {
   toUsernameChange
 } from './sendTokens.actions';
 import { fetchAccounts, fetchUserAddresses, fetchBalanceRequest } from '../../accounts.actions';
-import { Button, Dialog } from '@blueprintjs/core';
+import { Button, Dialog, AnchorButton, Popover, PopoverInteractionKind, Position } from '@blueprintjs/core';
 import { Field, reduxForm, formValueSelector } from 'redux-form';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -334,18 +334,33 @@ class SendTokens extends Component {
     const toUserAddresses = this.props.accounts && this.props.toUsername ?
       Object.getOwnPropertyNames(this.props.accounts[this.props.toUsername])
       : [];
-
     return (
       <div className="smd-pad-16">
-        <Button onClick={() => {
-          mixpanelWrapper.track("send_ether_open_click");
-          // TODO: remove public mode
-          isModeOauth && (this.props.initialValues.fromAddress != "Certification Pending") && this.props.fetchBalanceRequest(this.props.initialValues.fromAddress);
-          this.props.fetchChainIds();
-          this.props.sendTokensOpenModal();
-          this.props.reset();
-        }} className="pt-intent-primary pt-icon-add"
-          text="Send Tokens" />
+        <Popover 
+          isDisabled={!!this.props.userCertificate}
+          interactionKind={PopoverInteractionKind.HOVER}
+          position={Position.LEFT}
+          content={
+            <div className='pt-dark pt-callout smd-pad-8 pt-icon-info-sign pt-intent-warning'>
+              <h5 className="pt-callout-title">Verification Required</h5>
+                Your identity must be verified before you can do this action.
+            </div>
+          }
+        >
+          <AnchorButton 
+            onClick={() => {
+              mixpanelWrapper.track("send_ether_open_click");
+              // TODO: remove public mode
+              isModeOauth && (this.props.initialValues.fromAddress != "Verification Pending") && this.props.fetchBalanceRequest(this.props.initialValues.fromAddress);
+              this.props.fetchChainIds();
+              this.props.sendTokensOpenModal();
+              this.props.reset();
+            }} 
+            className="pt-intent-primary pt-icon-add"
+            disabled={!this.props.userCertificate}
+            text={"Send Tokens"} 
+          />
+        </Popover>
         <form>
           <Dialog
             iconName="inbox"
@@ -470,7 +485,8 @@ export function mapStateToProps(state) {
     },
     balance: state.accounts.currentUserBalance,
     chainLabel: state.chains.listChain,
-    chainLabelIds: state.chains.listLabelIds
+    chainLabelIds: state.chains.listLabelIds,
+    userCertificate: state.user.userCertificate,
   };
 }
 

--- a/smd-ui/src/components/CodeEditor/index.js
+++ b/smd-ui/src/components/CodeEditor/index.js
@@ -314,9 +314,10 @@ class CodeEditor extends Component {
           <div className="col-md-2 text-left">
             <h3>Contract Editor</h3>
           </div>
-          <div className="text-right">
+          <div className="text-right col-md-10">
+            <div className='smd-pad-16 ' style={{display: "inline-block"}}>
+
             <Popover
-              className="h-align"
               position={Position.BOTTOM}
               content={
                 <div>
@@ -328,14 +329,15 @@ class CodeEditor extends Component {
                   onClick={() => {this.compileCode("EVM")}}/>
                 </div>
               }
-            >
+              >
               <Button
-                className="pt-intent-primary smd-margin-8"
+                className="pt-intent-primary"
                 disabled={false}
                 text="Compile">
                   <Icon style={{margin: 0, padding: 0}} iconName="caret-down"/>
               </Button>
             </Popover>
+            </div>
           
             <DeployDapp
               onChangeEditorContractName={this.props.contractNameChange}

--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Dialog } from '@blueprintjs/core';
+import { Button, Dialog, PopoverInteractionKind, Position, AnchorButton, Popover } from '@blueprintjs/core';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import mixpanelWrapper from '../../../../lib/mixpanelWrapper';
@@ -87,8 +87,8 @@ class ContractMethodCall extends Component {
         disabled={isModeOauth}
         required
       >
-        <option value={isModeOauth && this.props.oAuthUser ? this.props.oAuthUser.commonName : "Certification Pending"}>
-          {isModeOauth && this.props.oAuthUser ? this.props.oAuthUser.commonName : "Certification Pending"}
+        <option value={isModeOauth && this.props.userCertificate ? this.props.userCertificate.commonName : "Verification Pending"}>
+          {isModeOauth && this.props.userCertificate ? this.props.userCertificate.commonName : "Verification Pending"}
         </option>
         {
           users.map((user, i) => {
@@ -113,8 +113,8 @@ class ContractMethodCall extends Component {
         disabled={isModeOauth}
         required
       >
-        <option value={isModeOauth && this.props.oAuthUser ? this.props.oAuthUser.address : "Certification Pending"}>
-          {isModeOauth && this.props.oAuthUser ? this.props.oAuthUser.address : "Certification Pending"}
+        <option value={isModeOauth && this.props.userCertificate ? this.props.userCertificate.userAddress : "Verification Pending"}>
+          {isModeOauth && this.props.userCertificate ? this.props.userCertificate.userAddress : "Verification Pending"}
         </option>
         {
           userAddresses.map((address, i) => {
@@ -229,16 +229,28 @@ class ContractMethodCall extends Component {
 
     return (
       <div>
-        <Button
+        <Popover 
+          isDisabled={!!this.props.userCertificate}
+          interactionKind={PopoverInteractionKind.HOVER}
+          position={Position.LEFT}
+          content={
+            <div className='pt-dark pt-callout smd-pad-8 pt-icon-info-sign pt-intent-warning'>
+              <h5 className="pt-callout-title">Verification Required</h5>
+                Your identity must be verified before you can do this action.
+            </div>
+          }
+        >
+        <AnchorButton
           className="pt-minimal pt-small pt-intent-primary"
           onClick={(e) => {
             e.stopPropagation();
             e.preventDefault();
             this.handleOpenModal();
           }}
-        >
-          Call Method
-        </Button>
+          disabled={!this.props.userCertificate}
+          text={"Call Method"}
+          />
+        </Popover>
         <form>
           <Dialog
             iconName="exchange"
@@ -390,6 +402,7 @@ export function mapStateToProps(state, ownProps) {
     chainLabel: state.chains.listChain,
     chainLabelIds: state.chains.listLabelIds,
     oAuthUser: state.user.oauthUser,
+    userCertificate: state.user.userCertificate,
     selectedChain: state.chains.selectedChain,
   };
 }

--- a/smd-ui/src/components/CreateChain/index.js
+++ b/smd-ui/src/components/CreateChain/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { openCreateChainOverlay, closeCreateChainOverlay, createChain, resetError, compileChainContract, resetContract, contractNameChange } from './createChain.actions';
-import { Button, Dialog, Intent } from '@blueprintjs/core';
+import { Button, Dialog, Intent, Popover, AnchorButton, PopoverInteractionKind, Position } from '@blueprintjs/core';
 import { Field, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -390,13 +390,27 @@ class CreateChain extends Component {
 
     return (
       <div className="smd-pad-16">
-        <Button onClick={() => {
-          mixpanelWrapper.track('create_chain_open_click');
-          this.props.reset();
-          this.props.openCreateChainOverlay();
-        }} className="pt-intent-primary pt-icon-add"
+        <Popover 
+          isDisabled={!!this.props.userCertificate}
+          interactionKind={PopoverInteractionKind.HOVER}
+          position={Position.LEFT}
+          content={
+            <div className='pt-dark pt-callout smd-pad-8 pt-icon-info-sign pt-intent-warning'>
+              <h5 className="pt-callout-title">Verification Required</h5>
+                Your identity must be verified before you can do this action.
+            </div>
+          }
+        >
+
+          <AnchorButton onClick={() => {
+            mixpanelWrapper.track('create_chain_open_click');
+            this.props.reset();
+            this.props.openCreateChainOverlay();
+          }} className="pt-intent-primary pt-icon-add"
           id="chains-create-chain-button"
-          text="Create Shard" />
+          disabled={!this.props.userCertificate}
+          text={"Create Shard"} />
+        </Popover>
 
         <Dialog
           iconName="flows"
@@ -685,6 +699,7 @@ export function mapStateToProps(state) {
     abi: state.createChain.abi,
     contractName: state.createChain.contractName,
     publicKey: state.user.publicKey,
+    userCertificate: state.user.userCertificate,
   };
 }
 

--- a/smd-ui/src/components/CreateContract/index.js
+++ b/smd-ui/src/components/CreateContract/index.js
@@ -12,7 +12,7 @@ import {
 } from './createContract.actions';
 import { fetchAccounts, fetchUserAddresses } from '../Accounts/accounts.actions';
 import { fetchContracts } from '../Contracts/contracts.actions';
-import { Button, Dialog } from '@blueprintjs/core';
+import { Button, Dialog, Popover, PopoverInteractionKind, Position, AnchorButton } from '@blueprintjs/core';
 import Dropzone from 'react-dropzone'
 import { Field, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
@@ -289,7 +289,19 @@ class CreateContract extends Component {
 
     return (
       <div className="smd-pad-16" style={{ display: 'inline-block' }}>
-        <Button onClick={() => {
+        <Popover 
+          isDisabled={!!this.props.userCertificate}
+          interactionKind={PopoverInteractionKind.HOVER}
+          position={Position.LEFT}
+          content={
+            <div className='pt-dark pt-callout pt-icon-info-sign pt-intent-warning'>
+              <h5 className="pt-callout-title">Verification Required</h5>
+                Your identity must be verified before you can do this action.
+            </div>
+          }
+        >
+
+        <AnchorButton onClick={() => {
           mixpanelWrapper.track("create_contract_open_click");
           this.props.contractOpenModal();
           this.props.initialize(this.props.initialValues);
@@ -297,9 +309,10 @@ class CreateContract extends Component {
         }}
           id="tour-create-contract-button"
           className="pt-intent-primary pt-icon-add"
-          text="Create Contract"
-          disabled={(this.props.enableCreateContract !== undefined && !this.props.enableCreateContract) ? true : false}
+          text={"Create Contract"}
+          disabled={!this.props.userCertificate}
         />
+        </Popover>
         <form>
           <Dialog
             iconName="inbox"
@@ -538,14 +551,15 @@ export function mapStateToProps(state) {
     usingSampleContract: state.createContract.usingSampleContract,
     codeType: state.codeEditor.codeType,
     initialValues: {
-      commonName: state.user.oauthUser ? state.user.oauthUser.commonName : 'Certification Pending',
-      address: state.user.oauthUser ? state.user.oauthUser.address : 'Certification Pending',
+      commonName: state.user.userCertificate ? state.user.userCertificate.commonName : 'Verification Pending',
+      address: state.user.userCertificate ? state.user.userCertificate.userAddress : 'Verification Pending',
       chainLabel: state.chains.selectedChain ? selectedChainData.label || '' : '',
       chainId: state.chains.selectedChain ? state.chains.selectedChain : ''
     },
     chainLabel: state.chains.listChain,
     chainLabelIds: state.chains.listLabelIds,
     selectedChain: state.chains.selectedChain,
+    userCertificate: state.user.userCertificate,
   };
 }
 

--- a/smd-ui/src/components/Dapplets/Dapplets.scss
+++ b/smd-ui/src/components/Dapplets/Dapplets.scss
@@ -16,6 +16,6 @@
 }
 
 .neutral {
-  color: $turquoise4;
-  border-bottom: 5px solid $turquoise4;
+  color: var(--blockapps-secondary-blue);
+  border-bottom: 5px solid var(--blockapps-secondary-blue);
 }

--- a/smd-ui/src/components/DeployDapp/index.js
+++ b/smd-ui/src/components/DeployDapp/index.js
@@ -8,7 +8,7 @@ import {
   chainNameChange,
   resetError
 } from './deployDapp.actions';
-import { Button, Dialog } from '@blueprintjs/core';
+import { Button, Dialog, Popover, PopoverInteractionKind, Position, AnchorButton } from '@blueprintjs/core';
 import { Field, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -357,15 +357,29 @@ class DeployDapp extends Component {
 
     return (
       <div className="smd-pad-16" style={{ display: 'inline-block' }}>
-        <Button onClick={() => {
-          mixpanelWrapper.track("deploy_dapp_open_click");
-          this.props.deployDappOpenModal();
-        }}
+        <Popover 
+          isDisabled={!!this.props.userCertificate}
+          interactionKind={PopoverInteractionKind.HOVER}
+          position={Position.LEFT}
+          content={
+            <div className='pt-dark pt-callout smd-pad-8 pt-icon-info-sign pt-intent-warning'>
+              <h5 className="pt-callout-title">Verification Required</h5>
+                Your identity must be verified before you can do this action.
+            </div>
+          }
+        >
+
+        <AnchorButton 
+          onClick={() => {
+            mixpanelWrapper.track("deploy_dapp_open_click");
+            this.props.deployDappOpenModal();
+          }}
           id="tour-deploy-dapp-button"
           className="pt-intent-primary pt-icon-add"
-          text="Deploy DApp"
-          disabled={(this.props.enableCreateContract !== undefined && !this.props.enableCreateContract) ? true : false}
-        />
+          text={"Deploy DApp"}
+          disabled={!this.props.userCertificate}
+          />
+        </Popover>
         <form>
           <Dialog
             iconName="inbox"
@@ -564,6 +578,7 @@ export function mapStateToProps(state) {
     codeType: state.codeEditor.codeType,
     initialValues: {
     },
+    userCertificate: state.user.userCertificate,
   };
 }
 

--- a/smd-ui/src/components/MenuBar/index.js
+++ b/smd-ui/src/components/MenuBar/index.js
@@ -9,12 +9,21 @@ import { Popover, Button, Menu, Position, MenuItem } from '@blueprintjs/core';
 import {
   searchQueryRequest,
 } from '../SearchResults/searchresults.actions';
+import {
+  getUserCertificateRequest,
+} from "../User/user.actions"
 
 class MenuBar extends Component {
   constructor() {
     super()
     this.state = {
      searchQuery:""
+    }
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (newProps.oauthUser && !newProps.userCertificate) {
+      this.props.getUserCertificateRequest(newProps.oauthUser.address)
     }
   }
 
@@ -38,9 +47,6 @@ class MenuBar extends Component {
     }
   }
   
-  // on-submit search function calls searchQueryRequest
-  // TODO move this to userCertificate state/props
-
   afterLoggedIn() {
     const userDropdown =
       <Menu>
@@ -52,7 +58,7 @@ class MenuBar extends Component {
         <Popover content={userDropdown} position={Position.BOTTOM_RIGHT}>
           <Button 
             className={"pt-large pt-minimal " + (this.props.userCertificate ? 'pt-intent-primary' : 'pt-intent-warning')} 
-            iconName={this.props.userCertificate ? "user" : "social-media"} 
+            iconName={"user"} 
             text={this.props.userCertificate ? (this.props.userCertificate.commonName + ', ' + this.props.userCertificate.organization + 
               (this.props.userCertificate.organizationalUnit ? ': ' + this.props.userCertificate.organizationalUnit : '')) : 'Verification Pending'} />
         </Popover>
@@ -136,6 +142,9 @@ export function mapStateToProps(state) {
   };
 }
 
-const connected = connect(mapStateToProps, {searchQueryRequest})(MenuBar);
+const connected = connect(mapStateToProps, {
+  searchQueryRequest, 
+  getUserCertificateRequest,
+})(MenuBar);
 
 export default withRouter(connected);

--- a/smd-ui/src/components/MenuBar/menubar.scss
+++ b/smd-ui/src/components/MenuBar/menubar.scss
@@ -2,7 +2,7 @@
 
 .smd-menu-logo {
   cursor: pointer;
-  margin-right: 15px;
+  margin-left: 15px;
 }
 
 .smd-menu-bar {


### PR DESCRIPTION
- Disable buttons that allow you to do transactions
- Provide a pop-up for info when they are disabled
- Change when user cert is being fetched into menuBar component
- Change icon of un-verified user to profile so its less confusing that that is the user menu button, not a status icon
- Change color of cards to the blockapps secondary blue

This video has a bug where users can create shards when they don't have a cert and vice versa (the logic is backwards) but since recording I fixed that bug (trust me) 

https://user-images.githubusercontent.com/12687494/225758396-0b48ad0a-7aee-40ae-9564-0a923e6395e5.mp4

