### PR TITLE
SMD Contract View Fixes

### DIFF
--- a/smd-ui/src/components/Accounts/components/OauthAccounts/index.js
+++ b/smd-ui/src/components/Accounts/components/OauthAccounts/index.js
@@ -70,7 +70,7 @@ class OauthAccounts extends Component {
       <div>
         <div className="row">
           <div className="col-sm-4 text-left">
-            <h3>Accounts</h3>
+            <h3>Users</h3>
           </div>
           <div className="col-sm-8 text-right">
             <div className="pt-button-group">
@@ -85,7 +85,7 @@ class OauthAccounts extends Component {
               <input
                 className="pt-input"
                 type="search"
-                placeholder="Search accounts"
+                placeholder="Search users"
                 onChange={e => this.updateFilter(e.target.value.toLowerCase())}
                 dir="auto" />
             </div>
@@ -100,7 +100,7 @@ class OauthAccounts extends Component {
                   <table>
                     <tbody>
                       <tr>
-                        <td colSpan={3}>No Accounts</td>
+                        <td colSpan={3}>No Users</td>
                       </tr>
                     </tbody>
                   </table>

--- a/smd-ui/src/components/ContractQuery/contractQuery.actions.js
+++ b/smd-ui/src/components/ContractQuery/contractQuery.actions.js
@@ -41,12 +41,12 @@ export const clearQueryString = function () {
   }
 }
 
-export const queryCirrus = function (name, queryString, chainId) {
+export const queryCirrus = function (tableName, contractName, queryString) {
   return {
     type: QUERY_CIRRUS_REQUEST,
-    contractName: name,
+    tableName,
+    contractName,
     queryString: queryString,
-    chainId: chainId
   };
 }
 

--- a/smd-ui/src/components/ContractQuery/contractQuery.saga.js
+++ b/smd-ui/src/components/ContractQuery/contractQuery.saga.js
@@ -16,18 +16,12 @@ import { env } from '../../env.js'
 import { handleErrors } from '../../lib/handleErrors';
 import { createUrl } from '../../lib/url';
 
-const cirrusUrl = env.CIRRUS_URL + '/:contractName?:queryString:chainid';
+const cirrusUrl = env.CIRRUS_URL + '/:contractName?:queryString';
 
-export function queryCirrusRequest(name, queryString, chainId) {
-  let chain;
-  if (queryString === '') {
-    chain = chainId ? `chainId=eq.${chainId}` : ``;
-  } else {
-    chain = chainId ? `&chainId=eq.${chainId}` : ``;
-  }
+export function queryCirrusRequest(name, queryString) {
 
   return fetch(
-    cirrusUrl.replace(":contractName", name).replace(':queryString', queryString).replace(':chainid', chain),
+    cirrusUrl.replace(":contractName", name).replace(':queryString', queryString),
     {
       method: 'GET',
       credentials: "include",
@@ -101,7 +95,7 @@ export function* queryCirrusVars(action) {
 
 export function* queryCirrus(action) {
   try {
-    const response = yield call(queryCirrusRequest, action.contractName, action.queryString, action.chainId);
+    const response = yield call(queryCirrusRequest, action.tableName, action.queryString);
     yield put(queryCirrusSuccess(response));
   }
   catch (err) {

--- a/smd-ui/src/components/ContractQuery/index.js
+++ b/smd-ui/src/components/ContractQuery/index.js
@@ -11,7 +11,7 @@ import {
 } from './contractQuery.actions.js';
 import { env } from '../../env.js';
 import mixpanelWrapper from '../../lib/mixpanelWrapper';
-import { Button } from '@blueprintjs/core';
+import { Button, NonIdealState, Switch } from '@blueprintjs/core';
 
 class ContractQuery extends Component {
   constructor(props) {
@@ -19,7 +19,12 @@ class ContractQuery extends Component {
     this.state = {
       field: 'Select field',
       operator: 'eq',
-      value: ''
+      value: '',
+      orgName: '',
+      appName: '',
+      history: false,
+      eventName: '',
+      tableName: ''
     }
 
     this.handleFieldChange = this.handleFieldChange.bind(this);
@@ -28,6 +33,12 @@ class ContractQuery extends Component {
     this.handleAddTag = this.handleAddTag.bind(this);
     this.handleKeyUp = this.handleKeyUp.bind(this);
     this.handleRemoveTag = this.handleRemoveTag.bind(this);
+    this.handleOrgNameChange = this.handleOrgNameChange.bind(this);
+    this.handleAppNameChange = this.handleAppNameChange.bind(this);
+    this.toggleHistory = this.toggleHistory.bind(this);
+    this.handleEventNameChange = this.handleEventNameChange.bind(this);
+    this.buildTableName = this.buildTableName.bind(this);
+    this.submitTableQuery = this.submitTableQuery.bind(this);
   }
 
   handleKeyUp(event) {
@@ -76,85 +87,99 @@ class ContractQuery extends Component {
 
   componentDidMount() {
     mixpanelWrapper.track('contract_query_load');
-    this.props.queryCirrus(this.props.match.params.name, this.props.contractQuery.queryString, this.props.selectedChain);
+    this.props.queryCirrus(this.props.match.params.name, this.props.contractQuery.queryString);
+    this.setState({tableName: this.props.match.params.name})
   }
   
   componentWillMount() {
     this.props.clearQueryString();
-    this.props.queryCirrusVars(this.props.match.params.name);
+    // this.props.queryCirrusVars(this.props.match.params.name);
+    this.setState({tableName: this.props.match.params.name})
   }
 
   componentWillReceiveProps(nextProps) {
     if(this.props.contractQuery.queryString !== nextProps.contractQuery.queryString) {
-      this.props.queryCirrus(nextProps.match.params.name, nextProps.contractQuery.queryString, nextProps.selectedChain);
-    }
-    if(this.props.selectedChain !== nextProps.selectedChain) {
-      this.props.queryCirrus(nextProps.match.params.name, nextProps.contractQuery.queryString, nextProps.selectedChain);
+      this.props.queryCirrus(nextProps.match.params.name, nextProps.contractQuery.queryString);
     }
   }
 
+  handleOrgNameChange(org) {
+    this.setState({orgName: org})
+  }
+
+  handleAppNameChange(app) {
+    this.setState({appName: app})
+  }
+
+  toggleHistory() {
+    this.setState({history: !this.state.history})
+  }
+
+  handleEventNameChange(event) {
+    this.setState({eventName: event})
+  }
+  
+  buildTableName(contractName, orgName=undefined, appName=undefined, history=false, eventName=undefined) {
+    let historyPrefix = ""
+    let orgPrefix = ""
+    let appPrefix = ""
+    let eventSuffix = ""
+    if (history) {
+      historyPrefix = "history@"
+    }
+    if (orgName) {
+      orgPrefix = orgName + '-'
+    }
+    if (appName) {
+      appPrefix = appName + '-'
+    }
+    if (eventName) {
+      eventSuffix = "." + eventName
+    }
+    return historyPrefix + orgPrefix + appPrefix + contractName + eventSuffix
+  }
+
+  submitTableQuery() {
+    const finalTableName = this.buildTableName(this.props.match.params.name, this.state.orgName, this.state.appName, this.state.history, this.state.eventName)
+    this.setState({tableName: finalTableName})
+    this.props.queryCirrus(finalTableName, this.props.contractQuery.queryString)
+  }
+
+  
   render() {
     const self = this;
     const name = this.props.match.params.name;
 
-    let selectFields = null;
-    let columns = [
-      <Column
-        key="column-address"
-        name="address"
-        renderCell={
-          (row) => 
-            <Cell>
-              <TruncatedFormat>
-                {self.props.contractQuery.queryResults[row].address}
-              </TruncatedFormat>
-            </Cell>
+    let selectFields = this.props.contractQuery && this.props.contractQuery.queryResults && 
+      Object.keys(this.props.contractQuery.queryResults[0] || [])
+      .map((propertyName) => {
+        return (<option key={name + '-field-' + propertyName} value={propertyName}>{propertyName}</option>);
+      });
+    let columns = this.props.contractQuery && this.props.contractQuery.queryResults && 
+      Object.keys(self.props.contractQuery.queryResults[0] || []).map((propertyName) => {
+        if (propertyName == "chainId") {
+          propertyName = "Shard ID"
         }
-      />
-    ];
+      return (
+        <Column
+          key={'column-'+propertyName}
+          name={propertyName}
+          renderCell={
+            (row) => 
+              <Cell truncated={true} tooltip={
+                self.props.contractQuery.queryResults[row][propertyName]}>
+                <TruncatedFormat>
+                  {self.props.contractQuery.queryResults[row][propertyName]}
+                </TruncatedFormat>
+              </Cell>
+          }
+        />
+    );
+    })
 
     if(this.props.contractQuery.vars) {
-      selectFields = Object
-        .getOwnPropertyNames(this.props.contractQuery.vars)
-        .filter((propertyName) => {
-          return this.props.contractQuery.vars[propertyName].type !== 'Mapping'
-            && this.props.contractQuery.vars[propertyName].type !== 'Array';
-        })
-        .map((propertyName) => {
-          return (<option key={name + '-field-' + propertyName} value={propertyName}>{propertyName}</option>);
-        });
-      columns = columns.concat(
-        Object
-          .getOwnPropertyNames(this.props.contractQuery.vars)
-          .filter((propertyName) => {
-            return this.props.contractQuery.vars[propertyName].type !== 'Mapping'
-          })
-          .map((propertyName) => {
-            return (
-              <Column
-                key={'column-'+propertyName}
-                name={propertyName}
-                renderCell={
-                  (row) => 
-                    <Cell>
-                      {
-                        self.props.contractQuery.vars[propertyName].type === 'Mapping' ||
-                        self.props.contractQuery.vars[propertyName].type === 'Array' ||
-                        self.props.contractQuery.vars[propertyName].type === 'Struct' ?
-                          <JSONFormat>
-                            {self.props.contractQuery.queryResults[row][propertyName]}
-                          </JSONFormat>
-                          :
-                          <TruncatedFormat>
-                            {self.props.contractQuery.queryResults[row][propertyName]}
-                          </TruncatedFormat>
-                      }
-                    </Cell>
-                }
-              />
-          );
-          })
-        );
+      selectFields 
+      
     }
 
     const tags = this.props.contractQuery.tags.map((tag, i) => {
@@ -165,13 +190,12 @@ class ContractQuery extends Component {
         </span>
       )
     })
-
     const addFilterEnabled = this.state.value !== '' && this.state.field !== 'Select field';
     return (
       <div className="container-fluid pt-dark">
         <div className="row">
           <div className="col-sm-6">
-            <h3>Query {name}</h3>
+            <h3>{name} Table</h3>
           </div>
           <div className="col-sm-6 smd-pad-16 text-right">
             <Button
@@ -187,6 +211,58 @@ class ContractQuery extends Component {
           </div>
         </div>
         <div className="row">
+          <div className='col-sm-2'>
+              <h4>Table Specification</h4>
+          </div>
+          <div className='col-sm-8'>
+            <div className="pt-control-group smd-full-width smd-vertical-center" >
+              <label className='pt-label pt-inline' style={{marginRight: '15px'}}>
+                Org Name:
+                <input
+                  type="text"
+                  className="pt-input"
+                  placeholder="Org Name"
+                  value={this.state.orgName}
+                  onChange={e => this.handleOrgNameChange(e.target.value)}
+                  />
+              </label>
+              <label className='pt-label pt-inline' style={{marginRight: '15px'}}>
+                App Name:
+                <input
+                  type="text"
+                  className="pt-input"
+                  placeholder="App Name"
+                  value={this.state.appName}
+                  onChange={e => this.handleAppNameChange(e.target.value)}
+                  />
+              </label>
+              <label className='pt-label pt-inline' style={{marginRight: '15px'}}>
+                Event Name:
+                <input
+                  type="text"
+                  className="pt-input"
+                  placeholder="Event Name"
+                  value={this.state.eventName}
+                  onChange={e => this.handleEventNameChange(e.target.value)}
+                  />
+              </label>
+              <div>
+                <Switch
+                  checked={this.state.history}
+                  onChange={this.toggleHistory}
+                  label="Query Contract History"
+                  />
+              </div>
+            </div>
+          </div>
+            <div className='col-sm-2'>
+              <Button className='pt-intent-primary' onClick={this.submitTableQuery}>
+                Go
+              </Button>
+            </div>
+
+        </div>
+        <div className="row">
           <div className="col-sm-12 smd-pad-8">
             <div className="pt-control-group smd-full-width">
               <div className="pt-select">
@@ -196,7 +272,8 @@ class ContractQuery extends Component {
                   onChange={this.handleFieldChange}
                 >
                   <option>Select field</option>
-                  <option value="address">address</option>
+                  <option value="address">Address</option>
+                  <option value="chainId">Shard ID</option>
                   {selectFields}
                 </select>
               </div>
@@ -213,6 +290,7 @@ class ContractQuery extends Component {
                   <option value="gte">&gt;=</option>
                   <option value="in">IN</option>
                   <option value="like">LIKE</option>
+                  <option value="ilike">ILIKE</option>
                 </select>
               </div>
               <input
@@ -245,7 +323,7 @@ class ContractQuery extends Component {
         <div className="row">
           <div className="col-sm-12 smd-pad-8">
             <code>
-              Query URL: { env.CIRRUS_URL + '/' + name + '?' + this.props.contractQuery.queryString + '&chainId=' + this.props.selectedChain }
+              Query URL: { env.CIRRUS_URL + '/' + this.state.tableName + '?' + this.props.contractQuery.queryString }
             </code>
           </div>
         </div>
@@ -253,12 +331,33 @@ class ContractQuery extends Component {
         <div className="row">
         </div>
         <div className="row">
-          <div className="col-sm-12">
-            <Table numRows={this.props.contractQuery.queryResults ?
-                this.props.contractQuery.queryResults.length : 0}>
-              {columns}
-            </Table>
-          </div>
+        {
+          this.props.contractQuery.queryResults &&
+            this.props.contractQuery.queryResults.length > 0 ?
+            <div className="col-sm-12">
+              <Table 
+                numRows={this.props.contractQuery.queryResults ?
+                  this.props.contractQuery.queryResults.length : 0}
+                className='pt-striped'
+                  >
+                {columns}
+              </Table>
+            </div> 
+            : <NonIdealState 
+              visual="pt-icon-folder-open" 
+              title="No Results" 
+              description={
+                <div>
+                  <p>
+                    There was no data found in the selected table name. 
+                  </p>
+                  <hr/>
+                  <p>
+                    Try adding the Organization that created this Contract or the App Name that this Contract is a part of.
+                  </p>  
+                </div>
+              } />
+        }
         </div>
       </div>
     )

--- a/smd-ui/src/components/Contracts/components/ContractCard/index.js
+++ b/smd-ui/src/components/Contracts/components/ContractCard/index.js
@@ -21,13 +21,11 @@ class ContractCard extends Component {
     this.state = { isOpen: false };
   }
 
-  componentWillMount() {
-    this.props.fetchCirrusInstances(this.props.contract.name, this.props.selectedChain);
-  }
-
   render() {
     let cardData = [];
     const name = this.props.contract.name;
+    console.log(this.props.contract)
+    console.log(name)
     const contract = this.props.contract.contract;
     const instances = contract && contract.instances ? contract.instances : [];
     const self = this;
@@ -52,14 +50,6 @@ class ContractCard extends Component {
           >
             <td style={{ border: 'none' }}>
               <HexText value={instance.address} classes="small smd-pad-4" />
-            </td>
-            <td style={{ border: 'none' }}>
-              {instance.fromBloc ?
-                <span className="pt-tag pt-intent-success smd-margin-right-4">Bloc</span> : ''
-              }
-              {instance.fromCirrus ?
-                <span className="pt-tag pt-intent-primary">Cirrus</span> : ''
-              }
             </td>
           </tr>
         );
@@ -87,12 +77,27 @@ class ContractCard extends Component {
           const symbolState = instance.state[symbol];
           symbolTable.push(
             <tr key={symbol + ' ' + i}>
+              {
+                typeof symbolState === 'string' && symbolState.startsWith('function') ?
+                <td style={{ verticalAlign: 'middle' }}>
+                  <ContractMethodCall
+                    key={'methodCall' + symbol + instance.address}
+                    lookup={'methodCall' + symbol + instance.address}
+                    contractName={name}
+                    contractAddress={instance.address}
+                    symbolName={symbol}
+                    fromCirrus={instance.fromCirrus}
+                    fromBloc={instance.fromBloc}
+                    chainId={self.props.selectedChain}
+                  />
+                </td>
+                :
               <td
                 style={{
                   verticalAlign: 'middle',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
-                  maxWidth: '90px'
+                  maxWidth: '120px'
                 }}>
                 <Tooltip
                   content={symbol}
@@ -100,7 +105,8 @@ class ContractCard extends Component {
                   {symbol}
                 </Tooltip>
               </td>
-              <td style={{ maxWidth: '300px' }}>
+              }
+              <td style={{ maxWidth: '500px' }}>
                 <pre>
                   {
                     typeof symbolState === 'string' ?
@@ -109,22 +115,7 @@ class ContractCard extends Component {
                   }
                 </pre>
               </td>
-              <td style={{ verticalAlign: 'middle' }}>
-                {
-                  typeof symbolState === 'string' && symbolState.startsWith('function') ?
-                    <ContractMethodCall
-                      key={'methodCall' + symbol + instance.address}
-                      lookup={'methodCall' + symbol + instance.address}
-                      contractName={name}
-                      contractAddress={instance.address}
-                      symbolName={symbol}
-                      fromCirrus={instance.fromCirrus}
-                      fromBloc={instance.fromBloc}
-                      chainId={self.props.selectedChain}
-                    />
-                    : null
-                }
-              </td>
+              
             </tr>
           );
         })
@@ -134,7 +125,7 @@ class ContractCard extends Component {
         <div className="pt-card pt-elevation-2">
           <div className="row">
             <div className="col-sm-12 text-right">
-              <span className="pt-monospace-text"> {instance && instance.balance ? <div> Balance: {instance.balance} wei </div> : ''} </span>
+              <span className="pt-monospace-text"> {instance && instance.balance ? <div> Contract Balance: {instance.balance} wei </div> : ''} </span>
             </div>
           </div>
           <div className="row">
@@ -174,21 +165,22 @@ class ContractCard extends Component {
               <div className="col-sm-4"><h4>{name}</h4></div>
               <div className="col-sm-8 text-right">
                 <div className="pt-button-group">
-                  {
-                    showQueryBuilder ?
-                      <Link to={'/contracts/' + name + '/query'}>
-                        <Button type="Button" className="pt-intent-primary">
-                          Query Builder
-                        </Button>
-                      </Link>
-                      : null
-                  }
+                    <Button 
+                      type="Button" 
+                      className="pt-intent-primary pt-icon-th" 
+                      onClick={() => {
+                        this.props.history.push('/contracts/' + name + '/query')
+                      }}
+                    >
+                      Tabular Data
+                    </Button>
                   <Button type="button"
                     className="pt-icon-double-caret-vertical btn-sm"
                     onClick={() => {
                       mixpanelWrapper.track("contracts_toggle_collapse_click");
-                      if(this.state.isOpen)
+                      if(this.state.isOpen) {
                         this.props.selectContractInstance(name, null);
+                      }
                       this.setState({
                         isOpen: !this.state.isOpen
                       })
@@ -208,7 +200,6 @@ class ContractCard extends Component {
                     <thead>
                       <tr>
                         <th>Contract Address</th>
-                        <th></th>
                       </tr>
                     </thead>
                     <tbody>{cardData}</tbody>

--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
@@ -15,6 +15,7 @@ import './contractMethodCall.css';
 import ValueInput from "../../../ValueInput";
 import { fetchChainIds, getLabelIds } from '../../../Chains/chains.actions';
 import { isOauthEnabled } from '../../../../lib/checkMode';
+import HexText from '../../../HexText';
 
 class ContractMethodCall extends Component {
 
@@ -240,15 +241,15 @@ class ContractMethodCall extends Component {
             </div>
           }
         >
-        <AnchorButton
-          className="pt-minimal pt-small pt-intent-primary"
-          onClick={(e) => {
-            e.stopPropagation();
-            e.preventDefault();
-            this.handleOpenModal();
-          }}
-          disabled={!this.props.userCertificate}
-          text={"Call Method"}
+          <AnchorButton
+            className="pt-intent-primary pt-icon-send-to-graph"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              this.handleOpenModal();
+            }}
+            disabled={!this.props.userCertificate}
+            text={this.props.symbolName}
           />
         </Popover>
         <form>
@@ -277,7 +278,7 @@ class ContractMethodCall extends Component {
                   </label>
                 </div>
                 <div className="col-sm-9 smd-pad-4">
-                  {this.props.selectedChain || "Main Chain"}
+                  {this.props.selectedChain ? <HexText value={this.props.selectedChain}/> : "Main Chain"}
                 </div>
               </div>
               <div className="row">

--- a/smd-ui/src/components/Contracts/index.js
+++ b/smd-ui/src/components/Contracts/index.js
@@ -218,7 +218,7 @@ class Contracts extends Component {
         <Tour steps={tourSteps} name="contracts" finalStepSelector='#transactions' nextPage='transactions' />
         <div className="row pt-dark" >
           <div className="col-sm-2 text-left">
-            <h2>Contracts</h2>
+            <h3>Contracts</h3>
           </div>
         <div className="col-sm-6 smd-pad-16">
             <div className="pt-input-group pt-dark pt-large">
@@ -230,9 +230,6 @@ class Contracts extends Component {
                 onChange={e => this.updateFilter(e.target.value.toLowerCase())}
                 dir="auto" />
             </div>
-          </div>
-          <div className="col-sm-4 text-right smd-pad-8">
-            <CreateContract />
           </div>
     
         </div>

--- a/smd-ui/src/components/Dashboard/index.js
+++ b/smd-ui/src/components/Dashboard/index.js
@@ -164,7 +164,7 @@ class Dashboard extends Component {
               <NumberCard
                 number={contractsCount}
                 description="Contracts"
-                iconClass="fa-gavel"
+                iconClass="fa-file"
                 className="smd-pointer"
               />
             </Link>

--- a/smd-ui/src/components/MenuBar/index.js
+++ b/smd-ui/src/components/MenuBar/index.js
@@ -90,7 +90,7 @@ class MenuBar extends Component {
   afterLoggedIn() {
     const userDropdown =
       <Menu>
-        <MenuItem className="pt-button pt-minimal" onClick={this.toggleDialog} target="_blank" rel="noopener noreferrer" iconName="mugshot" text={this.props.userCertificate ? "My Profile" : "More Info"}/> 
+        <MenuItem className="pt-button pt-minimal" onClick={this.toggleDialog} target="_blank" rel="noopener noreferrer" iconName="user" text={this.props.userCertificate ? "My Profile" : "More Info"}/> 
         <MenuItem className="pt-button pt-minimal" onClick={this.logout} target="_blank" rel="noopener noreferrer" iconName="log-out" text="Logout" /> 
       </Menu>
 
@@ -98,7 +98,7 @@ class MenuBar extends Component {
       <div>
         <Dialog
           className="pt-dark"
-          iconName="mugshot"
+          iconName="user"
           isOpen={this.state.isUserMenuOpen}
           onClose={this.toggleDialog}
           title="My Profile"
@@ -141,7 +141,7 @@ class MenuBar extends Component {
             className={"pt-large pt-minimal " + (this.props.userCertificate ? 'pt-intent-primary' : 'pt-intent-warning')} 
             iconName={"user"} 
             text={this.props.userCertificate ? (this.props.userCertificate.commonName + ', ' + this.props.userCertificate.organization + 
-              (this.props.userCertificate.organizationalUnit ? ': ' + this.props.userCertificate.organizationalUnit : '')) : 'Verification Pending'} />
+              (this.props.userCertificate.organizationalUnit ? ' | ' + this.props.userCertificate.organizationalUnit : '')) : 'Verification Pending'} />
         </Popover>
       </div>
     );

--- a/smd-ui/src/components/SideBar/index.js
+++ b/smd-ui/src/components/SideBar/index.js
@@ -19,10 +19,10 @@ class SideBar extends Component {
         { path: '/appstore', label: 'AppStore', id: 'app_store', icon: "fa-window-restore" },
         { path: '/home', label: 'Dapplets', id: 'dapplets', icon: "fa-arrow-circle-right" },
         { path: '/stats', label: 'Network Stats', id: 'network_stats', icon: "fa-rocket" },
-        { path: '/accounts', label: 'Accounts', id: 'accounts', icon: "fa-users" },
+        { path: '/accounts', label: 'Users', id: 'accounts', icon: "fa-users" },
         { path: '/transactions', label: 'Transactions', id: 'transactions', icon: "fa-exchange" },
         { path: '/shards', label: 'Shards', id: 'shards', icon: "fa-user-secret" },
-        { path: '/contracts', label: 'Contracts', id: 'contracts', icon: "fa-gavel" },
+        { path: '/contracts', label: 'Contracts', id: 'contracts', icon: "fa-file" },
         { path: '/blocks', label: 'Blocks', id: 'blocks', icon: "fa-link" },
         { path: '/code_editor', label: 'Contract Editor', id: 'code_editor', icon: "fa-code" },
       ]

--- a/smd-ui/src/tests/Accounts/components/OauthAccounts/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/Accounts/components/OauthAccounts/__snapshots__/index.spec.js.snap
@@ -92,7 +92,7 @@ exports[`OauthAccounts: index render with empty values 1`] = `
   <div className=\\"row\\">
     <div className=\\"col-sm-4 text-left\\">
       <h3>
-        Accounts
+        Users
       </h3>
     </div>
     <div className=\\"col-sm-8 text-right\\">
@@ -105,7 +105,7 @@ exports[`OauthAccounts: index render with empty values 1`] = `
     <div className=\\"col-sm-4\\">
       <div className=\\"pt-input-group pt-dark pt-large\\">
         <span className=\\"pt-icon pt-icon-search\\" />
-        <input className=\\"pt-input\\" type=\\"search\\" placeholder=\\"Search accounts\\" onChange={[Function: onChange]} dir=\\"auto\\" />
+        <input className=\\"pt-input\\" type=\\"search\\" placeholder=\\"Search users\\" onChange={[Function: onChange]} dir=\\"auto\\" />
       </div>
     </div>
   </div>
@@ -117,7 +117,7 @@ exports[`OauthAccounts: index render with empty values 1`] = `
             <tbody>
               <tr>
                 <td colSpan={3}>
-                  No Accounts
+                  No Users
                 </td>
               </tr>
             </tbody>
@@ -137,7 +137,7 @@ exports[`OauthAccounts: index render with mocked values 1`] = `
   <div className=\\"row\\">
     <div className=\\"col-sm-4 text-left\\">
       <h3>
-        Accounts
+        Users
       </h3>
     </div>
     <div className=\\"col-sm-8 text-right\\">
@@ -150,7 +150,7 @@ exports[`OauthAccounts: index render with mocked values 1`] = `
     <div className=\\"col-sm-4\\">
       <div className=\\"pt-input-group pt-dark pt-large\\">
         <span className=\\"pt-icon pt-icon-search\\" />
-        <input className=\\"pt-input\\" type=\\"search\\" placeholder=\\"Search accounts\\" onChange={[Function: onChange]} dir=\\"auto\\" />
+        <input className=\\"pt-input\\" type=\\"search\\" placeholder=\\"Search users\\" onChange={[Function: onChange]} dir=\\"auto\\" />
       </div>
     </div>
   </div>

--- a/smd-ui/src/tests/ContractQuery/__snapshots__/contractQuery.actions.spec.js.snap
+++ b/smd-ui/src/tests/ContractQuery/__snapshots__/contractQuery.actions.spec.js.snap
@@ -24,9 +24,9 @@ Object {
 
 exports[`ContractQuery: action fetch queryCirrus request 1`] = `
 Object {
-  "chainId": "ff7ef45acb7a775018bc765b6fdeea432aaddfcd846cf6dd9442724266b1eac9",
-  "contractName": "Bid",
-  "queryString": undefined,
+  "contractName": undefined,
+  "queryString": "ff7ef45acb7a775018bc765b6fdeea432aaddfcd846cf6dd9442724266b1eac9",
+  "tableName": "Bid",
   "type": "QUERY_CIRRUS_REQUEST",
 }
 `;

--- a/smd-ui/src/tests/ContractQuery/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/ContractQuery/__snapshots__/index.spec.js.snap
@@ -153,8 +153,8 @@ ShallowWrapper {
             className="col-sm-6"
           >
             <h3>
-              Query 
               Bid
+               Table
             </h3>
           </div>
           <div
@@ -165,6 +165,93 @@ ShallowWrapper {
               onClick={[Function]}
               text="Back"
             />
+          </div>
+        </div>,
+        <div
+          className="row"
+        >
+          <div
+            className="col-sm-2"
+          >
+            <h4>
+              Table Specification
+            </h4>
+          </div>
+          <div
+            className="col-sm-8"
+          >
+            <div
+              className="pt-control-group smd-full-width smd-vertical-center"
+            >
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Org Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Org Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                App Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="App Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Event Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Event Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <div>
+                <Blueprint.Switch
+                  checked={false}
+                  label="Query Contract History"
+                  onChange={[Function]}
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-sm-2"
+          >
+            <Blueprint.Button
+              className="pt-intent-primary"
+              onClick={[Function]}
+            >
+              Go
+            </Blueprint.Button>
           </div>
         </div>,
         <div
@@ -186,6 +273,16 @@ ShallowWrapper {
                 >
                   <option>
                     Select field
+                  </option>
+                  <option
+                    value="address"
+                  >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                   <option
                     value="address"
@@ -266,6 +363,11 @@ ShallowWrapper {
                   >
                     LIKE
                   </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
+                  </option>
                 </select>
               </div>
               <input
@@ -304,7 +406,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?&chainId=undefined
+              http://localhost/cirrus/search/Bid?
             </code>
           </div>
         </div>,
@@ -319,6 +421,7 @@ ShallowWrapper {
           >
             <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -383,8 +486,8 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
                 Bid
+                 Table
               </h3>
             </div>,
             <div
@@ -407,8 +510,8 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <h3>
-                Query 
                 Bid
+                 Table
               </h3>,
               "className": "col-sm-6",
             },
@@ -419,14 +522,14 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  "Query ",
                   "Bid",
+                  " Table",
                 ],
               },
               "ref": null,
               "rendered": Array [
-                "Query ",
                 "Bid",
+                " Table",
               ],
               "type": "h3",
             },
@@ -468,6 +571,450 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
+          "children": Array [
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>,
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>,
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
+            </div>,
+          ],
+          "className": "row",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <h4>
+                Table Specification
+              </h4>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Table Specification",
+              },
+              "ref": null,
+              "rendered": "Table Specification",
+              "type": "h4",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>,
+              "className": "col-sm-8",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>,
+                ],
+                "className": "pt-control-group smd-full-width smd-vertical-center",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Org Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Org Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Org Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "App Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "App Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "App Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Event Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Event Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Event Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />,
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "checked": false,
+                      "label": "Query Contract History",
+                      "onChange": [Function],
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  "type": "div",
+                },
+              ],
+              "type": "div",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": "Go",
+                "className": "pt-intent-primary",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": "Go",
+              "type": [Function],
+            },
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
           "children": <div
             className="col-sm-12 smd-pad-8"
           >
@@ -484,6 +1031,16 @@ ShallowWrapper {
                 >
                   <option>
                     Select field
+                  </option>
+                  <option
+                    value="address"
+                  >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                   <option
                     value="address"
@@ -563,6 +1120,11 @@ ShallowWrapper {
                     value="like"
                   >
                     LIKE
+                  </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
                   </option>
                 </select>
               </div>
@@ -611,6 +1173,16 @@ ShallowWrapper {
                   <option
                     value="address"
                   >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
+                  </option>
+                  <option
+                    value="address"
+                  >
                     address
                   </option>
                   <option
@@ -687,6 +1259,11 @@ ShallowWrapper {
                   >
                     LIKE
                   </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
+                  </option>
                 </select>
               </div>
               <input
@@ -727,6 +1304,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -807,6 +1394,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>,
                 <input
@@ -844,6 +1436,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -891,9 +1493,19 @@ ShallowWrapper {
                       <option
                         value="address"
                       >
-                        address
+                        Address
+                      </option>,
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>,
                       Array [
+                        <option
+                          value="address"
+                        >
+                          address
+                        </option>,
                         <option
                           value="amount"
                         >
@@ -941,6 +1553,30 @@ ShallowWrapper {
                     Object {
                       "instance": null,
                       "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Address",
+                        "value": "address",
+                      },
+                      "ref": null,
+                      "rendered": "Address",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Shard ID",
+                        "value": "chainId",
+                      },
+                      "ref": null,
+                      "rendered": "Shard ID",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": "Bid-field-address",
                       "nodeType": "host",
                       "props": Object {
                         "children": "address",
@@ -1064,6 +1700,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>,
                   "className": "pt-select",
                 },
@@ -1113,6 +1754,11 @@ ShallowWrapper {
                         value="like"
                       >
                         LIKE
+                      </option>,
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
                       </option>,
                     ],
                     "onChange": [Function],
@@ -1216,6 +1862,18 @@ ShallowWrapper {
                       "rendered": "LIKE",
                       "type": "option",
                     },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "ILIKE",
+                        "value": "ilike",
+                      },
+                      "ref": null,
+                      "rendered": "ILIKE",
+                      "type": "option",
+                    },
                   ],
                   "type": "select",
                 },
@@ -1295,7 +1953,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?&chainId=undefined
+              http://localhost/cirrus/search/Bid?
             </code>
           </div>,
           "className": "row",
@@ -1308,7 +1966,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?&chainId=undefined
+              http://localhost/cirrus/search/Bid?
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -1320,13 +1978,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/Bid?&chainId=undefined",
+              "http://localhost/cirrus/search/Bid?",
             ],
             "type": "code",
           },
@@ -1355,6 +2013,7 @@ ShallowWrapper {
           >
             <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -1413,6 +2072,7 @@ ShallowWrapper {
           "props": Object {
             "children": <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -1495,6 +2155,7 @@ ShallowWrapper {
                   renderCell={[Function]}
                 />,
               ],
+              "className": "pt-striped",
               "defaultColumnWidth": 150,
               "defaultRowHeight": 20,
               "enableFocus": false,
@@ -1613,8 +2274,8 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
                 Bid
+                 Table
               </h3>
             </div>
             <div
@@ -1625,6 +2286,93 @@ ShallowWrapper {
                 onClick={[Function]}
                 text="Back"
               />
+            </div>
+          </div>,
+          <div
+            className="row"
+          >
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
             </div>
           </div>,
           <div
@@ -1646,6 +2394,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -1726,6 +2484,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>
                 <input
@@ -1764,7 +2527,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?&chainId=undefined
+                http://localhost/cirrus/search/Bid?
               </code>
             </div>
           </div>,
@@ -1779,6 +2542,7 @@ ShallowWrapper {
             >
               <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -1843,8 +2607,8 @@ ShallowWrapper {
                 className="col-sm-6"
               >
                 <h3>
-                  Query 
                   Bid
+                   Table
                 </h3>
               </div>,
               <div
@@ -1867,8 +2631,8 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": <h3>
-                  Query 
                   Bid
+                   Table
                 </h3>,
                 "className": "col-sm-6",
               },
@@ -1879,14 +2643,14 @@ ShallowWrapper {
                 "nodeType": "host",
                 "props": Object {
                   "children": Array [
-                    "Query ",
                     "Bid",
+                    " Table",
                   ],
                 },
                 "ref": null,
                 "rendered": Array [
-                  "Query ",
                   "Bid",
+                  " Table",
                 ],
                 "type": "h3",
               },
@@ -1928,6 +2692,450 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
+            "children": Array [
+              <div
+                className="col-sm-2"
+              >
+                <h4>
+                  Table Specification
+                </h4>
+              </div>,
+              <div
+                className="col-sm-8"
+              >
+                <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>
+              </div>,
+              <div
+                className="col-sm-2"
+              >
+                <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>
+              </div>,
+            ],
+            "className": "row",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <h4>
+                  Table Specification
+                </h4>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "Table Specification",
+                },
+                "ref": null,
+                "rendered": "Table Specification",
+                "type": "h4",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>,
+                "className": "col-sm-8",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Org Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      App Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Event Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <div>
+                      <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />
+                    </div>,
+                  ],
+                  "className": "pt-control-group smd-full-width smd-vertical-center",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Org Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Org Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Org Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Org Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "App Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="App Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "App Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "App Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Event Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Event Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Event Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Event Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />,
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "checked": false,
+                        "label": "Query Contract History",
+                        "onChange": [Function],
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "children": "Go",
+                  "className": "pt-intent-primary",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": "Go",
+                "type": [Function],
+              },
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
             "children": <div
               className="col-sm-12 smd-pad-8"
             >
@@ -1944,6 +3152,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -2023,6 +3241,11 @@ ShallowWrapper {
                       value="like"
                     >
                       LIKE
+                    </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
                     </option>
                   </select>
                 </div>
@@ -2071,6 +3294,16 @@ ShallowWrapper {
                     <option
                       value="address"
                     >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
+                    </option>
+                    <option
+                      value="address"
+                    >
                       address
                     </option>
                     <option
@@ -2147,6 +3380,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>
                 <input
@@ -2187,6 +3425,16 @@ ShallowWrapper {
                     >
                       <option>
                         Select field
+                      </option>
+                      <option
+                        value="address"
+                      >
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                       <option
                         value="address"
@@ -2267,6 +3515,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>
                   </div>,
                   <input
@@ -2304,6 +3557,16 @@ ShallowWrapper {
                     >
                       <option>
                         Select field
+                      </option>
+                      <option
+                        value="address"
+                      >
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                       <option
                         value="address"
@@ -2351,9 +3614,19 @@ ShallowWrapper {
                         <option
                           value="address"
                         >
-                          address
+                          Address
+                        </option>,
+                        <option
+                          value="chainId"
+                        >
+                          Shard ID
                         </option>,
                         Array [
+                          <option
+                            value="address"
+                          >
+                            address
+                          </option>,
                           <option
                             value="amount"
                           >
@@ -2401,6 +3674,30 @@ ShallowWrapper {
                       Object {
                         "instance": null,
                         "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Address",
+                          "value": "address",
+                        },
+                        "ref": null,
+                        "rendered": "Address",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Shard ID",
+                          "value": "chainId",
+                        },
+                        "ref": null,
+                        "rendered": "Shard ID",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "Bid-field-address",
                         "nodeType": "host",
                         "props": Object {
                           "children": "address",
@@ -2524,6 +3821,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>,
                     "className": "pt-select",
                   },
@@ -2573,6 +3875,11 @@ ShallowWrapper {
                           value="like"
                         >
                           LIKE
+                        </option>,
+                        <option
+                          value="ilike"
+                        >
+                          ILIKE
                         </option>,
                       ],
                       "onChange": [Function],
@@ -2676,6 +3983,18 @@ ShallowWrapper {
                         "rendered": "LIKE",
                         "type": "option",
                       },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "ILIKE",
+                          "value": "ilike",
+                        },
+                        "ref": null,
+                        "rendered": "ILIKE",
+                        "type": "option",
+                      },
                     ],
                     "type": "select",
                   },
@@ -2755,7 +4074,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?&chainId=undefined
+                http://localhost/cirrus/search/Bid?
               </code>
             </div>,
             "className": "row",
@@ -2768,7 +4087,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?&chainId=undefined
+                http://localhost/cirrus/search/Bid?
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -2780,13 +4099,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/Bid?&chainId=undefined",
+                  "http://localhost/cirrus/search/Bid?",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?",
               ],
               "type": "code",
             },
@@ -2815,6 +4134,7 @@ ShallowWrapper {
             >
               <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -2873,6 +4193,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -2955,6 +4276,7 @@ ShallowWrapper {
                     renderCell={[Function]}
                   />,
                 ],
+                "className": "pt-striped",
                 "defaultColumnWidth": 150,
                 "defaultRowHeight": 20,
                 "enableFocus": false,
@@ -3086,14 +4408,12 @@ exports[`ContractQuery: index Table:  render with JSON format column 1`] = `
 <Column name=\\"name\\" renderCell={[Function: renderCell]} />
 
 
-<Column name=\\"id\\" renderCell={[Function: renderCell]} />
-
-
-<Column name=\\"newColumn\\" renderCell={[Function: renderCell]} />"
+<Column name=\\"id\\" renderCell={[Function: renderCell]} />"
 `;
 
 exports[`ContractQuery: index Table:  render with TruncatedFormat column 1`] = `
 <Cell
+  tooltip="eff065f2e1cf483daee729f1f45c92db46fe1092"
   truncated={true}
   wrapText={false}
 >
@@ -3119,6 +4439,7 @@ exports[`ContractQuery: index Table:  render with TruncatedFormat column 1`] = `
 
 exports[`ContractQuery: index Table:  render with TruncatedFormat column 2`] = `
 <Cell
+  tooltip={67}
   truncated={true}
   wrapText={false}
 >
@@ -3322,8 +4643,8 @@ ShallowWrapper {
             className="col-sm-6"
           >
             <h3>
-              Query 
               Bid
+               Table
             </h3>
           </div>
           <div
@@ -3334,6 +4655,93 @@ ShallowWrapper {
               onClick={[Function]}
               text="Back"
             />
+          </div>
+        </div>,
+        <div
+          className="row"
+        >
+          <div
+            className="col-sm-2"
+          >
+            <h4>
+              Table Specification
+            </h4>
+          </div>
+          <div
+            className="col-sm-8"
+          >
+            <div
+              className="pt-control-group smd-full-width smd-vertical-center"
+            >
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Org Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Org Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                App Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="App Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Event Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Event Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <div>
+                <Blueprint.Switch
+                  checked={false}
+                  label="Query Contract History"
+                  onChange={[Function]}
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-sm-2"
+          >
+            <Blueprint.Button
+              className="pt-intent-primary"
+              onClick={[Function]}
+            >
+              Go
+            </Blueprint.Button>
           </div>
         </div>,
         <div
@@ -3355,6 +4763,16 @@ ShallowWrapper {
                 >
                   <option>
                     Select field
+                  </option>
+                  <option
+                    value="address"
+                  >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                   <option
                     value="address"
@@ -3435,6 +4853,11 @@ ShallowWrapper {
                   >
                     LIKE
                   </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
+                  </option>
                 </select>
               </div>
               <input
@@ -3492,7 +4915,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
             </code>
           </div>
         </div>,
@@ -3507,6 +4930,7 @@ ShallowWrapper {
           >
             <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -3571,8 +4995,8 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
                 Bid
+                 Table
               </h3>
             </div>,
             <div
@@ -3595,8 +5019,8 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <h3>
-                Query 
                 Bid
+                 Table
               </h3>,
               "className": "col-sm-6",
             },
@@ -3607,14 +5031,14 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  "Query ",
                   "Bid",
+                  " Table",
                 ],
               },
               "ref": null,
               "rendered": Array [
-                "Query ",
                 "Bid",
+                " Table",
               ],
               "type": "h3",
             },
@@ -3656,6 +5080,450 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
+          "children": Array [
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>,
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>,
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
+            </div>,
+          ],
+          "className": "row",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <h4>
+                Table Specification
+              </h4>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Table Specification",
+              },
+              "ref": null,
+              "rendered": "Table Specification",
+              "type": "h4",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>,
+              "className": "col-sm-8",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>,
+                ],
+                "className": "pt-control-group smd-full-width smd-vertical-center",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Org Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Org Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Org Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "App Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "App Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "App Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Event Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Event Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Event Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />,
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "checked": false,
+                      "label": "Query Contract History",
+                      "onChange": [Function],
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  "type": "div",
+                },
+              ],
+              "type": "div",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": "Go",
+                "className": "pt-intent-primary",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": "Go",
+              "type": [Function],
+            },
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
           "children": <div
             className="col-sm-12 smd-pad-8"
           >
@@ -3672,6 +5540,16 @@ ShallowWrapper {
                 >
                   <option>
                     Select field
+                  </option>
+                  <option
+                    value="address"
+                  >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                   <option
                     value="address"
@@ -3751,6 +5629,11 @@ ShallowWrapper {
                     value="like"
                   >
                     LIKE
+                  </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
                   </option>
                 </select>
               </div>
@@ -3799,6 +5682,16 @@ ShallowWrapper {
                   <option
                     value="address"
                   >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
+                  </option>
+                  <option
+                    value="address"
+                  >
                     address
                   </option>
                   <option
@@ -3875,6 +5768,11 @@ ShallowWrapper {
                   >
                     LIKE
                   </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
+                  </option>
                 </select>
               </div>
               <input
@@ -3915,6 +5813,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -3995,6 +5903,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>,
                 <input
@@ -4032,6 +5945,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -4079,9 +6002,19 @@ ShallowWrapper {
                       <option
                         value="address"
                       >
-                        address
+                        Address
+                      </option>,
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>,
                       Array [
+                        <option
+                          value="address"
+                        >
+                          address
+                        </option>,
                         <option
                           value="amount"
                         >
@@ -4129,6 +6062,30 @@ ShallowWrapper {
                     Object {
                       "instance": null,
                       "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Address",
+                        "value": "address",
+                      },
+                      "ref": null,
+                      "rendered": "Address",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Shard ID",
+                        "value": "chainId",
+                      },
+                      "ref": null,
+                      "rendered": "Shard ID",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": "Bid-field-address",
                       "nodeType": "host",
                       "props": Object {
                         "children": "address",
@@ -4252,6 +6209,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>,
                   "className": "pt-select",
                 },
@@ -4301,6 +6263,11 @@ ShallowWrapper {
                         value="like"
                       >
                         LIKE
+                      </option>,
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
                       </option>,
                     ],
                     "onChange": [Function],
@@ -4402,6 +6369,18 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": "LIKE",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "ILIKE",
+                        "value": "ilike",
+                      },
+                      "ref": null,
+                      "rendered": "ILIKE",
                       "type": "option",
                     },
                   ],
@@ -4586,7 +6565,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
             </code>
           </div>,
           "className": "row",
@@ -4599,7 +6578,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -4611,13 +6590,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678",
             ],
             "type": "code",
           },
@@ -4646,6 +6625,7 @@ ShallowWrapper {
           >
             <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -4704,6 +6684,7 @@ ShallowWrapper {
           "props": Object {
             "children": <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -4786,6 +6767,7 @@ ShallowWrapper {
                   renderCell={[Function]}
                 />,
               ],
+              "className": "pt-striped",
               "defaultColumnWidth": 150,
               "defaultRowHeight": 20,
               "enableFocus": false,
@@ -4904,8 +6886,8 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
                 Bid
+                 Table
               </h3>
             </div>
             <div
@@ -4916,6 +6898,93 @@ ShallowWrapper {
                 onClick={[Function]}
                 text="Back"
               />
+            </div>
+          </div>,
+          <div
+            className="row"
+          >
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
             </div>
           </div>,
           <div
@@ -4937,6 +7006,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -5017,6 +7096,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>
                 <input
@@ -5074,7 +7158,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
               </code>
             </div>
           </div>,
@@ -5089,6 +7173,7 @@ ShallowWrapper {
             >
               <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -5153,8 +7238,8 @@ ShallowWrapper {
                 className="col-sm-6"
               >
                 <h3>
-                  Query 
                   Bid
+                   Table
                 </h3>
               </div>,
               <div
@@ -5177,8 +7262,8 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": <h3>
-                  Query 
                   Bid
+                   Table
                 </h3>,
                 "className": "col-sm-6",
               },
@@ -5189,14 +7274,14 @@ ShallowWrapper {
                 "nodeType": "host",
                 "props": Object {
                   "children": Array [
-                    "Query ",
                     "Bid",
+                    " Table",
                   ],
                 },
                 "ref": null,
                 "rendered": Array [
-                  "Query ",
                   "Bid",
+                  " Table",
                 ],
                 "type": "h3",
               },
@@ -5238,6 +7323,450 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
+            "children": Array [
+              <div
+                className="col-sm-2"
+              >
+                <h4>
+                  Table Specification
+                </h4>
+              </div>,
+              <div
+                className="col-sm-8"
+              >
+                <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>
+              </div>,
+              <div
+                className="col-sm-2"
+              >
+                <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>
+              </div>,
+            ],
+            "className": "row",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <h4>
+                  Table Specification
+                </h4>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "Table Specification",
+                },
+                "ref": null,
+                "rendered": "Table Specification",
+                "type": "h4",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>,
+                "className": "col-sm-8",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Org Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      App Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Event Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <div>
+                      <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />
+                    </div>,
+                  ],
+                  "className": "pt-control-group smd-full-width smd-vertical-center",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Org Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Org Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Org Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Org Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "App Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="App Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "App Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "App Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Event Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Event Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Event Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Event Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />,
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "checked": false,
+                        "label": "Query Contract History",
+                        "onChange": [Function],
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "children": "Go",
+                  "className": "pt-intent-primary",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": "Go",
+                "type": [Function],
+              },
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
             "children": <div
               className="col-sm-12 smd-pad-8"
             >
@@ -5254,6 +7783,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -5333,6 +7872,11 @@ ShallowWrapper {
                       value="like"
                     >
                       LIKE
+                    </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
                     </option>
                   </select>
                 </div>
@@ -5381,6 +7925,16 @@ ShallowWrapper {
                     <option
                       value="address"
                     >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
+                    </option>
+                    <option
+                      value="address"
+                    >
                       address
                     </option>
                     <option
@@ -5457,6 +8011,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>
                 <input
@@ -5497,6 +8056,16 @@ ShallowWrapper {
                     >
                       <option>
                         Select field
+                      </option>
+                      <option
+                        value="address"
+                      >
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                       <option
                         value="address"
@@ -5577,6 +8146,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>
                   </div>,
                   <input
@@ -5614,6 +8188,16 @@ ShallowWrapper {
                     >
                       <option>
                         Select field
+                      </option>
+                      <option
+                        value="address"
+                      >
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                       <option
                         value="address"
@@ -5661,9 +8245,19 @@ ShallowWrapper {
                         <option
                           value="address"
                         >
-                          address
+                          Address
+                        </option>,
+                        <option
+                          value="chainId"
+                        >
+                          Shard ID
                         </option>,
                         Array [
+                          <option
+                            value="address"
+                          >
+                            address
+                          </option>,
                           <option
                             value="amount"
                           >
@@ -5711,6 +8305,30 @@ ShallowWrapper {
                       Object {
                         "instance": null,
                         "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Address",
+                          "value": "address",
+                        },
+                        "ref": null,
+                        "rendered": "Address",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Shard ID",
+                          "value": "chainId",
+                        },
+                        "ref": null,
+                        "rendered": "Shard ID",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "Bid-field-address",
                         "nodeType": "host",
                         "props": Object {
                           "children": "address",
@@ -5834,6 +8452,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>,
                     "className": "pt-select",
                   },
@@ -5883,6 +8506,11 @@ ShallowWrapper {
                           value="like"
                         >
                           LIKE
+                        </option>,
+                        <option
+                          value="ilike"
+                        >
+                          ILIKE
                         </option>,
                       ],
                       "onChange": [Function],
@@ -5984,6 +8612,18 @@ ShallowWrapper {
                         },
                         "ref": null,
                         "rendered": "LIKE",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "ILIKE",
+                          "value": "ilike",
+                        },
+                        "ref": null,
+                        "rendered": "ILIKE",
                         "type": "option",
                       },
                     ],
@@ -6168,7 +8808,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
               </code>
             </div>,
             "className": "row",
@@ -6181,7 +8821,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -6193,13 +8833,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678",
               ],
               "type": "code",
             },
@@ -6228,6 +8868,7 @@ ShallowWrapper {
             >
               <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -6286,6 +8927,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -6368,6 +9010,7 @@ ShallowWrapper {
                     renderCell={[Function]}
                   />,
                 ],
+                "className": "pt-striped",
                 "defaultColumnWidth": 150,
                 "defaultRowHeight": 20,
                 "enableFocus": false,
@@ -6645,8 +9288,8 @@ ShallowWrapper {
             className="col-sm-6"
           >
             <h3>
-              Query 
               Bid
+               Table
             </h3>
           </div>
           <div
@@ -6657,6 +9300,93 @@ ShallowWrapper {
               onClick={[Function]}
               text="Back"
             />
+          </div>
+        </div>,
+        <div
+          className="row"
+        >
+          <div
+            className="col-sm-2"
+          >
+            <h4>
+              Table Specification
+            </h4>
+          </div>
+          <div
+            className="col-sm-8"
+          >
+            <div
+              className="pt-control-group smd-full-width smd-vertical-center"
+            >
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Org Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Org Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                App Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="App Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Event Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Event Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <div>
+                <Blueprint.Switch
+                  checked={false}
+                  label="Query Contract History"
+                  onChange={[Function]}
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-sm-2"
+          >
+            <Blueprint.Button
+              className="pt-intent-primary"
+              onClick={[Function]}
+            >
+              Go
+            </Blueprint.Button>
           </div>
         </div>,
         <div
@@ -6678,6 +9408,16 @@ ShallowWrapper {
                 >
                   <option>
                     Select field
+                  </option>
+                  <option
+                    value="address"
+                  >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                   <option
                     value="address"
@@ -6758,6 +9498,11 @@ ShallowWrapper {
                   >
                     LIKE
                   </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
+                  </option>
                 </select>
               </div>
               <input
@@ -6815,7 +9560,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
             </code>
           </div>
         </div>,
@@ -6830,6 +9575,7 @@ ShallowWrapper {
           >
             <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -6894,8 +9640,8 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
                 Bid
+                 Table
               </h3>
             </div>,
             <div
@@ -6918,8 +9664,8 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <h3>
-                Query 
                 Bid
+                 Table
               </h3>,
               "className": "col-sm-6",
             },
@@ -6930,14 +9676,14 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  "Query ",
                   "Bid",
+                  " Table",
                 ],
               },
               "ref": null,
               "rendered": Array [
-                "Query ",
                 "Bid",
+                " Table",
               ],
               "type": "h3",
             },
@@ -6979,6 +9725,450 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
+          "children": Array [
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>,
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>,
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
+            </div>,
+          ],
+          "className": "row",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <h4>
+                Table Specification
+              </h4>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Table Specification",
+              },
+              "ref": null,
+              "rendered": "Table Specification",
+              "type": "h4",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>,
+              "className": "col-sm-8",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>,
+                ],
+                "className": "pt-control-group smd-full-width smd-vertical-center",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Org Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Org Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Org Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "App Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "App Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "App Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Event Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Event Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Event Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />,
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "checked": false,
+                      "label": "Query Contract History",
+                      "onChange": [Function],
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  "type": "div",
+                },
+              ],
+              "type": "div",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": "Go",
+                "className": "pt-intent-primary",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": "Go",
+              "type": [Function],
+            },
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
           "children": <div
             className="col-sm-12 smd-pad-8"
           >
@@ -6995,6 +10185,16 @@ ShallowWrapper {
                 >
                   <option>
                     Select field
+                  </option>
+                  <option
+                    value="address"
+                  >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                   <option
                     value="address"
@@ -7074,6 +10274,11 @@ ShallowWrapper {
                     value="like"
                   >
                     LIKE
+                  </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
                   </option>
                 </select>
               </div>
@@ -7122,6 +10327,16 @@ ShallowWrapper {
                   <option
                     value="address"
                   >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
+                  </option>
+                  <option
+                    value="address"
+                  >
                     address
                   </option>
                   <option
@@ -7198,6 +10413,11 @@ ShallowWrapper {
                   >
                     LIKE
                   </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
+                  </option>
                 </select>
               </div>
               <input
@@ -7238,6 +10458,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -7318,6 +10548,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>,
                 <input
@@ -7355,6 +10590,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -7402,9 +10647,19 @@ ShallowWrapper {
                       <option
                         value="address"
                       >
-                        address
+                        Address
+                      </option>,
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>,
                       Array [
+                        <option
+                          value="address"
+                        >
+                          address
+                        </option>,
                         <option
                           value="amount"
                         >
@@ -7452,6 +10707,30 @@ ShallowWrapper {
                     Object {
                       "instance": null,
                       "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Address",
+                        "value": "address",
+                      },
+                      "ref": null,
+                      "rendered": "Address",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Shard ID",
+                        "value": "chainId",
+                      },
+                      "ref": null,
+                      "rendered": "Shard ID",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": "Bid-field-address",
                       "nodeType": "host",
                       "props": Object {
                         "children": "address",
@@ -7575,6 +10854,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>,
                   "className": "pt-select",
                 },
@@ -7624,6 +10908,11 @@ ShallowWrapper {
                         value="like"
                       >
                         LIKE
+                      </option>,
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
                       </option>,
                     ],
                     "onChange": [Function],
@@ -7725,6 +11014,18 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": "LIKE",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "ILIKE",
+                        "value": "ilike",
+                      },
+                      "ref": null,
+                      "rendered": "ILIKE",
                       "type": "option",
                     },
                   ],
@@ -7909,7 +11210,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
             </code>
           </div>,
           "className": "row",
@@ -7922,7 +11223,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -7934,13 +11235,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678",
             ],
             "type": "code",
           },
@@ -7969,6 +11270,7 @@ ShallowWrapper {
           >
             <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -8027,6 +11329,7 @@ ShallowWrapper {
           "props": Object {
             "children": <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -8109,6 +11412,7 @@ ShallowWrapper {
                   renderCell={[Function]}
                 />,
               ],
+              "className": "pt-striped",
               "defaultColumnWidth": 150,
               "defaultRowHeight": 20,
               "enableFocus": false,
@@ -8227,8 +11531,8 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
                 Bid
+                 Table
               </h3>
             </div>
             <div
@@ -8239,6 +11543,93 @@ ShallowWrapper {
                 onClick={[Function]}
                 text="Back"
               />
+            </div>
+          </div>,
+          <div
+            className="row"
+          >
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
             </div>
           </div>,
           <div
@@ -8260,6 +11651,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -8340,6 +11741,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>
                 <input
@@ -8397,7 +11803,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
               </code>
             </div>
           </div>,
@@ -8412,6 +11818,7 @@ ShallowWrapper {
             >
               <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -8476,8 +11883,8 @@ ShallowWrapper {
                 className="col-sm-6"
               >
                 <h3>
-                  Query 
                   Bid
+                   Table
                 </h3>
               </div>,
               <div
@@ -8500,8 +11907,8 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": <h3>
-                  Query 
                   Bid
+                   Table
                 </h3>,
                 "className": "col-sm-6",
               },
@@ -8512,14 +11919,14 @@ ShallowWrapper {
                 "nodeType": "host",
                 "props": Object {
                   "children": Array [
-                    "Query ",
                     "Bid",
+                    " Table",
                   ],
                 },
                 "ref": null,
                 "rendered": Array [
-                  "Query ",
                   "Bid",
+                  " Table",
                 ],
                 "type": "h3",
               },
@@ -8561,6 +11968,450 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
+            "children": Array [
+              <div
+                className="col-sm-2"
+              >
+                <h4>
+                  Table Specification
+                </h4>
+              </div>,
+              <div
+                className="col-sm-8"
+              >
+                <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>
+              </div>,
+              <div
+                className="col-sm-2"
+              >
+                <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>
+              </div>,
+            ],
+            "className": "row",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <h4>
+                  Table Specification
+                </h4>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "Table Specification",
+                },
+                "ref": null,
+                "rendered": "Table Specification",
+                "type": "h4",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>,
+                "className": "col-sm-8",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Org Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      App Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Event Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <div>
+                      <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />
+                    </div>,
+                  ],
+                  "className": "pt-control-group smd-full-width smd-vertical-center",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Org Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Org Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Org Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Org Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "App Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="App Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "App Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "App Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Event Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Event Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Event Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Event Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />,
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "checked": false,
+                        "label": "Query Contract History",
+                        "onChange": [Function],
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "children": "Go",
+                  "className": "pt-intent-primary",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": "Go",
+                "type": [Function],
+              },
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
             "children": <div
               className="col-sm-12 smd-pad-8"
             >
@@ -8577,6 +12428,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -8656,6 +12517,11 @@ ShallowWrapper {
                       value="like"
                     >
                       LIKE
+                    </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
                     </option>
                   </select>
                 </div>
@@ -8704,6 +12570,16 @@ ShallowWrapper {
                     <option
                       value="address"
                     >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
+                    </option>
+                    <option
+                      value="address"
+                    >
                       address
                     </option>
                     <option
@@ -8780,6 +12656,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>
                 <input
@@ -8820,6 +12701,16 @@ ShallowWrapper {
                     >
                       <option>
                         Select field
+                      </option>
+                      <option
+                        value="address"
+                      >
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                       <option
                         value="address"
@@ -8900,6 +12791,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>
                   </div>,
                   <input
@@ -8937,6 +12833,16 @@ ShallowWrapper {
                     >
                       <option>
                         Select field
+                      </option>
+                      <option
+                        value="address"
+                      >
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                       <option
                         value="address"
@@ -8984,9 +12890,19 @@ ShallowWrapper {
                         <option
                           value="address"
                         >
-                          address
+                          Address
+                        </option>,
+                        <option
+                          value="chainId"
+                        >
+                          Shard ID
                         </option>,
                         Array [
+                          <option
+                            value="address"
+                          >
+                            address
+                          </option>,
                           <option
                             value="amount"
                           >
@@ -9034,6 +12950,30 @@ ShallowWrapper {
                       Object {
                         "instance": null,
                         "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Address",
+                          "value": "address",
+                        },
+                        "ref": null,
+                        "rendered": "Address",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Shard ID",
+                          "value": "chainId",
+                        },
+                        "ref": null,
+                        "rendered": "Shard ID",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "Bid-field-address",
                         "nodeType": "host",
                         "props": Object {
                           "children": "address",
@@ -9157,6 +13097,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>,
                     "className": "pt-select",
                   },
@@ -9206,6 +13151,11 @@ ShallowWrapper {
                           value="like"
                         >
                           LIKE
+                        </option>,
+                        <option
+                          value="ilike"
+                        >
+                          ILIKE
                         </option>,
                       ],
                       "onChange": [Function],
@@ -9307,6 +13257,18 @@ ShallowWrapper {
                         },
                         "ref": null,
                         "rendered": "LIKE",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "ILIKE",
+                          "value": "ilike",
+                        },
+                        "ref": null,
+                        "rendered": "ILIKE",
                         "type": "option",
                       },
                     ],
@@ -9491,7 +13453,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
               </code>
             </div>,
             "className": "row",
@@ -9504,7 +13466,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -9516,13 +13478,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678",
               ],
               "type": "code",
             },
@@ -9551,6 +13513,7 @@ ShallowWrapper {
             >
               <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -9609,6 +13572,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -9691,6 +13655,7 @@ ShallowWrapper {
                     renderCell={[Function]}
                   />,
                 ],
+                "className": "pt-striped",
                 "defaultColumnWidth": 150,
                 "defaultRowHeight": 20,
                 "enableFocus": false,
@@ -9966,7 +13931,7 @@ ShallowWrapper {
             className="col-sm-6"
           >
             <h3>
-              Query 
+               Table
             </h3>
           </div>
           <div
@@ -9977,6 +13942,93 @@ ShallowWrapper {
               onClick={[Function]}
               text="Back"
             />
+          </div>
+        </div>,
+        <div
+          className="row"
+        >
+          <div
+            className="col-sm-2"
+          >
+            <h4>
+              Table Specification
+            </h4>
+          </div>
+          <div
+            className="col-sm-8"
+          >
+            <div
+              className="pt-control-group smd-full-width smd-vertical-center"
+            >
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Org Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Org Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                App Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="App Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Event Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Event Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <div>
+                <Blueprint.Switch
+                  checked={false}
+                  label="Query Contract History"
+                  onChange={[Function]}
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-sm-2"
+          >
+            <Blueprint.Button
+              className="pt-intent-primary"
+              onClick={[Function]}
+            >
+              Go
+            </Blueprint.Button>
           </div>
         </div>,
         <div
@@ -10002,7 +14054,12 @@ ShallowWrapper {
                   <option
                     value="address"
                   >
-                    address
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                 </select>
               </div>
@@ -10053,6 +14110,11 @@ ShallowWrapper {
                   >
                     LIKE
                   </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
+                  </option>
                 </select>
               </div>
               <input
@@ -10091,7 +14153,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/null?&chainId=undefined
+              http://localhost/cirrus/search/null?
             </code>
           </div>
         </div>,
@@ -10101,39 +14163,21 @@ ShallowWrapper {
         <div
           className="row"
         >
-          <div
-            className="col-sm-12"
-          >
-            <Table
-              allowMultipleSelection={true}
-              defaultColumnWidth={150}
-              defaultRowHeight={20}
-              enableFocus={false}
-              fillBodyWithGhostCells={false}
-              isRowHeaderShown={true}
-              loadingOptions={Array []}
-              minColumnWidth={50}
-              minRowHeight={20}
-              numFrozenColumns={0}
-              numFrozenRows={0}
-              numRows={0}
-              renderMode={1}
-              renderRowHeader={[Function]}
-              selectionModes={
-                Array [
-                  3,
-                  2,
-                  1,
-                  0,
-                ]
-              }
-            >
-              <Column
-                name="address"
-                renderCell={[Function]}
-              />
-            </Table>
-          </div>
+          <NonIdealState
+            description={
+              <div>
+                <p>
+                  There was no data found in the selected table name.
+                </p>
+                <hr />
+                <p>
+                  Try adding the Organization that created this Contract or the App Name that this Contract is a part of.
+                </p>
+              </div>
+            }
+            title="No Results"
+            visual="pt-icon-folder-open"
+          />
         </div>,
       ],
       "className": "container-fluid pt-dark",
@@ -10150,7 +14194,7 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
+                 Table
               </h3>
             </div>,
             <div
@@ -10173,7 +14217,7 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <h3>
-                Query 
+                 Table
               </h3>,
               "className": "col-sm-6",
             },
@@ -10184,14 +14228,14 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  "Query ",
                   null,
+                  " Table",
                 ],
               },
               "ref": null,
               "rendered": Array [
-                "Query ",
                 null,
+                " Table",
               ],
               "type": "h3",
             },
@@ -10233,6 +14277,450 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
+          "children": Array [
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>,
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>,
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
+            </div>,
+          ],
+          "className": "row",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <h4>
+                Table Specification
+              </h4>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Table Specification",
+              },
+              "ref": null,
+              "rendered": "Table Specification",
+              "type": "h4",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>,
+              "className": "col-sm-8",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>,
+                ],
+                "className": "pt-control-group smd-full-width smd-vertical-center",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Org Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Org Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Org Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "App Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "App Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "App Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Event Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Event Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Event Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />,
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "checked": false,
+                      "label": "Query Contract History",
+                      "onChange": [Function],
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  "type": "div",
+                },
+              ],
+              "type": "div",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": "Go",
+                "className": "pt-intent-primary",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": "Go",
+              "type": [Function],
+            },
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
           "children": <div
             className="col-sm-12 smd-pad-8"
           >
@@ -10253,7 +14741,12 @@ ShallowWrapper {
                   <option
                     value="address"
                   >
-                    address
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                 </select>
               </div>
@@ -10303,6 +14796,11 @@ ShallowWrapper {
                     value="like"
                   >
                     LIKE
+                  </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
                   </option>
                 </select>
               </div>
@@ -10351,7 +14849,12 @@ ShallowWrapper {
                   <option
                     value="address"
                   >
-                    address
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                 </select>
               </div>
@@ -10402,6 +14905,11 @@ ShallowWrapper {
                   >
                     LIKE
                   </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
+                  </option>
                 </select>
               </div>
               <input
@@ -10446,7 +14954,12 @@ ShallowWrapper {
                     <option
                       value="address"
                     >
-                      address
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                   </select>
                 </div>,
@@ -10497,6 +15010,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>,
                 <input
@@ -10538,7 +15056,12 @@ ShallowWrapper {
                     <option
                       value="address"
                     >
-                      address
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                   </select>,
                   "className": "pt-select",
@@ -10556,7 +15079,12 @@ ShallowWrapper {
                       <option
                         value="address"
                       >
-                        address
+                        Address
+                      </option>,
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>,
                       null,
                     ],
@@ -10582,11 +15110,23 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "host",
                       "props": Object {
-                        "children": "address",
+                        "children": "Address",
                         "value": "address",
                       },
                       "ref": null,
-                      "rendered": "address",
+                      "rendered": "Address",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Shard ID",
+                        "value": "chainId",
+                      },
+                      "ref": null,
+                      "rendered": "Shard ID",
                       "type": "option",
                     },
                     null,
@@ -10644,6 +15184,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>,
                   "className": "pt-select",
                 },
@@ -10693,6 +15238,11 @@ ShallowWrapper {
                         value="like"
                       >
                         LIKE
+                      </option>,
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
                       </option>,
                     ],
                     "onChange": [Function],
@@ -10796,6 +15346,18 @@ ShallowWrapper {
                       "rendered": "LIKE",
                       "type": "option",
                     },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "ILIKE",
+                        "value": "ilike",
+                      },
+                      "ref": null,
+                      "rendered": "ILIKE",
+                      "type": "option",
+                    },
                   ],
                   "type": "select",
                 },
@@ -10875,7 +15437,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/null?&chainId=undefined
+              http://localhost/cirrus/search/null?
             </code>
           </div>,
           "className": "row",
@@ -10888,7 +15450,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/null?&chainId=undefined
+              http://localhost/cirrus/search/null?
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -10900,13 +15462,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/null?&chainId=undefined",
+                "http://localhost/cirrus/search/null?",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/null?&chainId=undefined",
+              "http://localhost/cirrus/search/null?",
             ],
             "type": "code",
           },
@@ -10930,129 +15492,44 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
-          "children": <div
-            className="col-sm-12"
-          >
-            <Table
-              allowMultipleSelection={true}
-              defaultColumnWidth={150}
-              defaultRowHeight={20}
-              enableFocus={false}
-              fillBodyWithGhostCells={false}
-              isRowHeaderShown={true}
-              loadingOptions={Array []}
-              minColumnWidth={50}
-              minRowHeight={20}
-              numFrozenColumns={0}
-              numFrozenRows={0}
-              numRows={0}
-              renderMode={1}
-              renderRowHeader={[Function]}
-              selectionModes={
-                Array [
-                  3,
-                  2,
-                  1,
-                  0,
-                ]
-              }
-            >
-              <Column
-                name="address"
-                renderCell={[Function]}
-              />
-            </Table>
-          </div>,
+          "children": <NonIdealState
+            description={
+              <div>
+                <p>
+                  There was no data found in the selected table name.
+                </p>
+                <hr />
+                <p>
+                  Try adding the Organization that created this Contract or the App Name that this Contract is a part of.
+                </p>
+              </div>
+            }
+            title="No Results"
+            visual="pt-icon-folder-open"
+          />,
           "className": "row",
         },
         "ref": null,
         "rendered": Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "host",
+          "nodeType": "class",
           "props": Object {
-            "children": <Table
-              allowMultipleSelection={true}
-              defaultColumnWidth={150}
-              defaultRowHeight={20}
-              enableFocus={false}
-              fillBodyWithGhostCells={false}
-              isRowHeaderShown={true}
-              loadingOptions={Array []}
-              minColumnWidth={50}
-              minRowHeight={20}
-              numFrozenColumns={0}
-              numFrozenRows={0}
-              numRows={0}
-              renderMode={1}
-              renderRowHeader={[Function]}
-              selectionModes={
-                Array [
-                  3,
-                  2,
-                  1,
-                  0,
-                ]
-              }
-            >
-              <Column
-                name="address"
-                renderCell={[Function]}
-              />
-            </Table>,
-            "className": "col-sm-12",
+            "description": <div>
+              <p>
+                There was no data found in the selected table name.
+              </p>
+              <hr />
+              <p>
+                Try adding the Organization that created this Contract or the App Name that this Contract is a part of.
+              </p>
+            </div>,
+            "title": "No Results",
+            "visual": "pt-icon-folder-open",
           },
           "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "allowMultipleSelection": true,
-              "children": Array [
-                <Column
-                  name="address"
-                  renderCell={[Function]}
-                />,
-              ],
-              "defaultColumnWidth": 150,
-              "defaultRowHeight": 20,
-              "enableFocus": false,
-              "fillBodyWithGhostCells": false,
-              "isRowHeaderShown": true,
-              "loadingOptions": Array [],
-              "minColumnWidth": 50,
-              "minRowHeight": 20,
-              "numFrozenColumns": 0,
-              "numFrozenRows": 0,
-              "numRows": 0,
-              "renderMode": 1,
-              "renderRowHeader": [Function],
-              "selectionModes": Array [
-                3,
-                2,
-                1,
-                0,
-              ],
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": "column-address",
-                "nodeType": "class",
-                "props": Object {
-                  "name": "address",
-                  "renderCell": [Function],
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-            ],
-            "type": [Function],
-          },
-          "type": "div",
+          "rendered": null,
+          "type": [Function],
         },
         "type": "div",
       },
@@ -11073,7 +15550,7 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
+                 Table
               </h3>
             </div>
             <div
@@ -11084,6 +15561,93 @@ ShallowWrapper {
                 onClick={[Function]}
                 text="Back"
               />
+            </div>
+          </div>,
+          <div
+            className="row"
+          >
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
             </div>
           </div>,
           <div
@@ -11109,7 +15673,12 @@ ShallowWrapper {
                     <option
                       value="address"
                     >
-                      address
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                   </select>
                 </div>
@@ -11160,6 +15729,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>
                 <input
@@ -11198,7 +15772,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/null?&chainId=undefined
+                http://localhost/cirrus/search/null?
               </code>
             </div>
           </div>,
@@ -11208,39 +15782,21 @@ ShallowWrapper {
           <div
             className="row"
           >
-            <div
-              className="col-sm-12"
-            >
-              <Table
-                allowMultipleSelection={true}
-                defaultColumnWidth={150}
-                defaultRowHeight={20}
-                enableFocus={false}
-                fillBodyWithGhostCells={false}
-                isRowHeaderShown={true}
-                loadingOptions={Array []}
-                minColumnWidth={50}
-                minRowHeight={20}
-                numFrozenColumns={0}
-                numFrozenRows={0}
-                numRows={0}
-                renderMode={1}
-                renderRowHeader={[Function]}
-                selectionModes={
-                  Array [
-                    3,
-                    2,
-                    1,
-                    0,
-                  ]
-                }
-              >
-                <Column
-                  name="address"
-                  renderCell={[Function]}
-                />
-              </Table>
-            </div>
+            <NonIdealState
+              description={
+                <div>
+                  <p>
+                    There was no data found in the selected table name.
+                  </p>
+                  <hr />
+                  <p>
+                    Try adding the Organization that created this Contract or the App Name that this Contract is a part of.
+                  </p>
+                </div>
+              }
+              title="No Results"
+              visual="pt-icon-folder-open"
+            />
           </div>,
         ],
         "className": "container-fluid pt-dark",
@@ -11257,7 +15813,7 @@ ShallowWrapper {
                 className="col-sm-6"
               >
                 <h3>
-                  Query 
+                   Table
                 </h3>
               </div>,
               <div
@@ -11280,7 +15836,7 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": <h3>
-                  Query 
+                   Table
                 </h3>,
                 "className": "col-sm-6",
               },
@@ -11291,14 +15847,14 @@ ShallowWrapper {
                 "nodeType": "host",
                 "props": Object {
                   "children": Array [
-                    "Query ",
                     null,
+                    " Table",
                   ],
                 },
                 "ref": null,
                 "rendered": Array [
-                  "Query ",
                   null,
+                  " Table",
                 ],
                 "type": "h3",
               },
@@ -11340,6 +15896,450 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
+            "children": Array [
+              <div
+                className="col-sm-2"
+              >
+                <h4>
+                  Table Specification
+                </h4>
+              </div>,
+              <div
+                className="col-sm-8"
+              >
+                <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>
+              </div>,
+              <div
+                className="col-sm-2"
+              >
+                <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>
+              </div>,
+            ],
+            "className": "row",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <h4>
+                  Table Specification
+                </h4>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "Table Specification",
+                },
+                "ref": null,
+                "rendered": "Table Specification",
+                "type": "h4",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>,
+                "className": "col-sm-8",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Org Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      App Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Event Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <div>
+                      <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />
+                    </div>,
+                  ],
+                  "className": "pt-control-group smd-full-width smd-vertical-center",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Org Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Org Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Org Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Org Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "App Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="App Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "App Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "App Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Event Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Event Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Event Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Event Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />,
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "checked": false,
+                        "label": "Query Contract History",
+                        "onChange": [Function],
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "children": "Go",
+                  "className": "pt-intent-primary",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": "Go",
+                "type": [Function],
+              },
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
             "children": <div
               className="col-sm-12 smd-pad-8"
             >
@@ -11360,7 +16360,12 @@ ShallowWrapper {
                     <option
                       value="address"
                     >
-                      address
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                   </select>
                 </div>
@@ -11410,6 +16415,11 @@ ShallowWrapper {
                       value="like"
                     >
                       LIKE
+                    </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
                     </option>
                   </select>
                 </div>
@@ -11458,7 +16468,12 @@ ShallowWrapper {
                     <option
                       value="address"
                     >
-                      address
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                   </select>
                 </div>
@@ -11509,6 +16524,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>
                 <input
@@ -11553,7 +16573,12 @@ ShallowWrapper {
                       <option
                         value="address"
                       >
-                        address
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                     </select>
                   </div>,
@@ -11604,6 +16629,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>
                   </div>,
                   <input
@@ -11645,7 +16675,12 @@ ShallowWrapper {
                       <option
                         value="address"
                       >
-                        address
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                     </select>,
                     "className": "pt-select",
@@ -11663,7 +16698,12 @@ ShallowWrapper {
                         <option
                           value="address"
                         >
-                          address
+                          Address
+                        </option>,
+                        <option
+                          value="chainId"
+                        >
+                          Shard ID
                         </option>,
                         null,
                       ],
@@ -11689,11 +16729,23 @@ ShallowWrapper {
                         "key": undefined,
                         "nodeType": "host",
                         "props": Object {
-                          "children": "address",
+                          "children": "Address",
                           "value": "address",
                         },
                         "ref": null,
-                        "rendered": "address",
+                        "rendered": "Address",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Shard ID",
+                          "value": "chainId",
+                        },
+                        "ref": null,
+                        "rendered": "Shard ID",
                         "type": "option",
                       },
                       null,
@@ -11751,6 +16803,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>,
                     "className": "pt-select",
                   },
@@ -11800,6 +16857,11 @@ ShallowWrapper {
                           value="like"
                         >
                           LIKE
+                        </option>,
+                        <option
+                          value="ilike"
+                        >
+                          ILIKE
                         </option>,
                       ],
                       "onChange": [Function],
@@ -11903,6 +16965,18 @@ ShallowWrapper {
                         "rendered": "LIKE",
                         "type": "option",
                       },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "ILIKE",
+                          "value": "ilike",
+                        },
+                        "ref": null,
+                        "rendered": "ILIKE",
+                        "type": "option",
+                      },
                     ],
                     "type": "select",
                   },
@@ -11982,7 +17056,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/null?&chainId=undefined
+                http://localhost/cirrus/search/null?
               </code>
             </div>,
             "className": "row",
@@ -11995,7 +17069,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/null?&chainId=undefined
+                http://localhost/cirrus/search/null?
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -12007,13 +17081,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/null?&chainId=undefined",
+                  "http://localhost/cirrus/search/null?",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/null?&chainId=undefined",
+                "http://localhost/cirrus/search/null?",
               ],
               "type": "code",
             },
@@ -12037,129 +17111,44 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <div
-              className="col-sm-12"
-            >
-              <Table
-                allowMultipleSelection={true}
-                defaultColumnWidth={150}
-                defaultRowHeight={20}
-                enableFocus={false}
-                fillBodyWithGhostCells={false}
-                isRowHeaderShown={true}
-                loadingOptions={Array []}
-                minColumnWidth={50}
-                minRowHeight={20}
-                numFrozenColumns={0}
-                numFrozenRows={0}
-                numRows={0}
-                renderMode={1}
-                renderRowHeader={[Function]}
-                selectionModes={
-                  Array [
-                    3,
-                    2,
-                    1,
-                    0,
-                  ]
-                }
-              >
-                <Column
-                  name="address"
-                  renderCell={[Function]}
-                />
-              </Table>
-            </div>,
+            "children": <NonIdealState
+              description={
+                <div>
+                  <p>
+                    There was no data found in the selected table name.
+                  </p>
+                  <hr />
+                  <p>
+                    Try adding the Organization that created this Contract or the App Name that this Contract is a part of.
+                  </p>
+                </div>
+              }
+              title="No Results"
+              visual="pt-icon-folder-open"
+            />,
             "className": "row",
           },
           "ref": null,
           "rendered": Object {
             "instance": null,
             "key": undefined,
-            "nodeType": "host",
+            "nodeType": "class",
             "props": Object {
-              "children": <Table
-                allowMultipleSelection={true}
-                defaultColumnWidth={150}
-                defaultRowHeight={20}
-                enableFocus={false}
-                fillBodyWithGhostCells={false}
-                isRowHeaderShown={true}
-                loadingOptions={Array []}
-                minColumnWidth={50}
-                minRowHeight={20}
-                numFrozenColumns={0}
-                numFrozenRows={0}
-                numRows={0}
-                renderMode={1}
-                renderRowHeader={[Function]}
-                selectionModes={
-                  Array [
-                    3,
-                    2,
-                    1,
-                    0,
-                  ]
-                }
-              >
-                <Column
-                  name="address"
-                  renderCell={[Function]}
-                />
-              </Table>,
-              "className": "col-sm-12",
+              "description": <div>
+                <p>
+                  There was no data found in the selected table name.
+                </p>
+                <hr />
+                <p>
+                  Try adding the Organization that created this Contract or the App Name that this Contract is a part of.
+                </p>
+              </div>,
+              "title": "No Results",
+              "visual": "pt-icon-folder-open",
             },
             "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "allowMultipleSelection": true,
-                "children": Array [
-                  <Column
-                    name="address"
-                    renderCell={[Function]}
-                  />,
-                ],
-                "defaultColumnWidth": 150,
-                "defaultRowHeight": 20,
-                "enableFocus": false,
-                "fillBodyWithGhostCells": false,
-                "isRowHeaderShown": true,
-                "loadingOptions": Array [],
-                "minColumnWidth": 50,
-                "minRowHeight": 20,
-                "numFrozenColumns": 0,
-                "numFrozenRows": 0,
-                "numRows": 0,
-                "renderMode": 1,
-                "renderRowHeader": [Function],
-                "selectionModes": Array [
-                  3,
-                  2,
-                  1,
-                  0,
-                ],
-              },
-              "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": "column-address",
-                  "nodeType": "class",
-                  "props": Object {
-                    "name": "address",
-                    "renderCell": [Function],
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-              ],
-              "type": [Function],
-            },
-            "type": "div",
+            "rendered": null,
+            "type": [Function],
           },
           "type": "div",
         },
@@ -12345,8 +17334,8 @@ ShallowWrapper {
             className="col-sm-6"
           >
             <h3>
-              Query 
               Bid
+               Table
             </h3>
           </div>
           <div
@@ -12357,6 +17346,93 @@ ShallowWrapper {
               onClick={[Function]}
               text="Back"
             />
+          </div>
+        </div>,
+        <div
+          className="row"
+        >
+          <div
+            className="col-sm-2"
+          >
+            <h4>
+              Table Specification
+            </h4>
+          </div>
+          <div
+            className="col-sm-8"
+          >
+            <div
+              className="pt-control-group smd-full-width smd-vertical-center"
+            >
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Org Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Org Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                App Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="App Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <label
+                className="pt-label pt-inline"
+                style={
+                  Object {
+                    "marginRight": "15px",
+                  }
+                }
+              >
+                Event Name:
+                <input
+                  className="pt-input"
+                  onChange={[Function]}
+                  placeholder="Event Name"
+                  type="text"
+                  value=""
+                />
+              </label>
+              <div>
+                <Blueprint.Switch
+                  checked={false}
+                  label="Query Contract History"
+                  onChange={[Function]}
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-sm-2"
+          >
+            <Blueprint.Button
+              className="pt-intent-primary"
+              onClick={[Function]}
+            >
+              Go
+            </Blueprint.Button>
           </div>
         </div>,
         <div
@@ -12378,6 +17454,16 @@ ShallowWrapper {
                 >
                   <option>
                     Select field
+                  </option>
+                  <option
+                    value="address"
+                  >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                   <option
                     value="address"
@@ -12457,6 +17543,11 @@ ShallowWrapper {
                     value="like"
                   >
                     LIKE
+                  </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
                   </option>
                 </select>
               </div>
@@ -12524,7 +17615,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P
             </code>
           </div>
         </div>,
@@ -12539,6 +17630,7 @@ ShallowWrapper {
           >
             <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -12603,8 +17695,8 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
                 Bid
+                 Table
               </h3>
             </div>,
             <div
@@ -12627,8 +17719,8 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <h3>
-                Query 
                 Bid
+                 Table
               </h3>,
               "className": "col-sm-6",
             },
@@ -12639,14 +17731,14 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  "Query ",
                   "Bid",
+                  " Table",
                 ],
               },
               "ref": null,
               "rendered": Array [
-                "Query ",
                 "Bid",
+                " Table",
               ],
               "type": "h3",
             },
@@ -12688,6 +17780,450 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
+          "children": Array [
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>,
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>,
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
+            </div>,
+          ],
+          "className": "row",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <h4>
+                Table Specification
+              </h4>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Table Specification",
+              },
+              "ref": null,
+              "rendered": "Table Specification",
+              "type": "h4",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>,
+              "className": "col-sm-8",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>,
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>,
+                ],
+                "className": "pt-control-group smd-full-width smd-vertical-center",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Org Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Org Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Org Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "App Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "App Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "App Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "Event Name:",
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />,
+                    ],
+                    "className": "pt-label pt-inline",
+                    "style": Object {
+                      "marginRight": "15px",
+                    },
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "Event Name:",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "className": "pt-input",
+                        "onChange": [Function],
+                        "placeholder": "Event Name",
+                        "type": "text",
+                        "value": "",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": "input",
+                    },
+                  ],
+                  "type": "label",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />,
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "checked": false,
+                      "label": "Query Contract History",
+                      "onChange": [Function],
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  "type": "div",
+                },
+              ],
+              "type": "div",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>,
+              "className": "col-sm-2",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": "Go",
+                "className": "pt-intent-primary",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": "Go",
+              "type": [Function],
+            },
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
           "children": <div
             className="col-sm-12 smd-pad-8"
           >
@@ -12704,6 +18240,16 @@ ShallowWrapper {
                 >
                   <option>
                     Select field
+                  </option>
+                  <option
+                    value="address"
+                  >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
                   </option>
                   <option
                     value="address"
@@ -12783,6 +18329,11 @@ ShallowWrapper {
                     value="like"
                   >
                     LIKE
+                  </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
                   </option>
                 </select>
               </div>
@@ -12831,6 +18382,16 @@ ShallowWrapper {
                   <option
                     value="address"
                   >
+                    Address
+                  </option>
+                  <option
+                    value="chainId"
+                  >
+                    Shard ID
+                  </option>
+                  <option
+                    value="address"
+                  >
                     address
                   </option>
                   <option
@@ -12907,6 +18468,11 @@ ShallowWrapper {
                   >
                     LIKE
                   </option>
+                  <option
+                    value="ilike"
+                  >
+                    ILIKE
+                  </option>
                 </select>
               </div>
               <input
@@ -12947,6 +18513,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -13027,6 +18603,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>,
                 <input
@@ -13064,6 +18645,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -13111,9 +18702,19 @@ ShallowWrapper {
                       <option
                         value="address"
                       >
-                        address
+                        Address
+                      </option>,
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>,
                       Array [
+                        <option
+                          value="address"
+                        >
+                          address
+                        </option>,
                         <option
                           value="amount"
                         >
@@ -13161,6 +18762,30 @@ ShallowWrapper {
                     Object {
                       "instance": null,
                       "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Address",
+                        "value": "address",
+                      },
+                      "ref": null,
+                      "rendered": "Address",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Shard ID",
+                        "value": "chainId",
+                      },
+                      "ref": null,
+                      "rendered": "Shard ID",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": "Bid-field-address",
                       "nodeType": "host",
                       "props": Object {
                         "children": "address",
@@ -13284,6 +18909,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>,
                   "className": "pt-select",
                 },
@@ -13333,6 +18963,11 @@ ShallowWrapper {
                         value="like"
                       >
                         LIKE
+                      </option>,
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
                       </option>,
                     ],
                     "onChange": [Function],
@@ -13434,6 +19069,18 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": "LIKE",
+                      "type": "option",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "ILIKE",
+                        "value": "ilike",
+                      },
+                      "ref": null,
+                      "rendered": "ILIKE",
                       "type": "option",
                     },
                   ],
@@ -13668,7 +19315,7 @@ ShallowWrapper {
           >
             <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P
             </code>
           </div>,
           "className": "row",
@@ -13681,7 +19328,7 @@ ShallowWrapper {
           "props": Object {
             "children": <code>
               Query URL: 
-              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+              http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P
             </code>,
             "className": "col-sm-12 smd-pad-8",
           },
@@ -13693,13 +19340,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P",
               ],
             },
             "ref": null,
             "rendered": Array [
               "Query URL: ",
-              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+              "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P",
             ],
             "type": "code",
           },
@@ -13728,6 +19375,7 @@ ShallowWrapper {
           >
             <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -13786,6 +19434,7 @@ ShallowWrapper {
           "props": Object {
             "children": <Table
               allowMultipleSelection={true}
+              className="pt-striped"
               defaultColumnWidth={150}
               defaultRowHeight={20}
               enableFocus={false}
@@ -13868,6 +19517,7 @@ ShallowWrapper {
                   renderCell={[Function]}
                 />,
               ],
+              "className": "pt-striped",
               "defaultColumnWidth": 150,
               "defaultRowHeight": 20,
               "enableFocus": false,
@@ -13986,8 +19636,8 @@ ShallowWrapper {
               className="col-sm-6"
             >
               <h3>
-                Query 
                 Bid
+                 Table
               </h3>
             </div>
             <div
@@ -13998,6 +19648,93 @@ ShallowWrapper {
                 onClick={[Function]}
                 text="Back"
               />
+            </div>
+          </div>,
+          <div
+            className="row"
+          >
+            <div
+              className="col-sm-2"
+            >
+              <h4>
+                Table Specification
+              </h4>
+            </div>
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="pt-control-group smd-full-width smd-vertical-center"
+              >
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Org Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Org Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  App Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="App Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <label
+                  className="pt-label pt-inline"
+                  style={
+                    Object {
+                      "marginRight": "15px",
+                    }
+                  }
+                >
+                  Event Name:
+                  <input
+                    className="pt-input"
+                    onChange={[Function]}
+                    placeholder="Event Name"
+                    type="text"
+                    value=""
+                  />
+                </label>
+                <div>
+                  <Blueprint.Switch
+                    checked={false}
+                    label="Query Contract History"
+                    onChange={[Function]}
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="col-sm-2"
+            >
+              <Blueprint.Button
+                className="pt-intent-primary"
+                onClick={[Function]}
+              >
+                Go
+              </Blueprint.Button>
             </div>
           </div>,
           <div
@@ -14019,6 +19756,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -14098,6 +19845,11 @@ ShallowWrapper {
                       value="like"
                     >
                       LIKE
+                    </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
                     </option>
                   </select>
                 </div>
@@ -14165,7 +19917,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P
               </code>
             </div>
           </div>,
@@ -14180,6 +19932,7 @@ ShallowWrapper {
             >
               <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -14244,8 +19997,8 @@ ShallowWrapper {
                 className="col-sm-6"
               >
                 <h3>
-                  Query 
                   Bid
+                   Table
                 </h3>
               </div>,
               <div
@@ -14268,8 +20021,8 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": <h3>
-                  Query 
                   Bid
+                   Table
                 </h3>,
                 "className": "col-sm-6",
               },
@@ -14280,14 +20033,14 @@ ShallowWrapper {
                 "nodeType": "host",
                 "props": Object {
                   "children": Array [
-                    "Query ",
                     "Bid",
+                    " Table",
                   ],
                 },
                 "ref": null,
                 "rendered": Array [
-                  "Query ",
                   "Bid",
+                  " Table",
                 ],
                 "type": "h3",
               },
@@ -14329,6 +20082,450 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
+            "children": Array [
+              <div
+                className="col-sm-2"
+              >
+                <h4>
+                  Table Specification
+                </h4>
+              </div>,
+              <div
+                className="col-sm-8"
+              >
+                <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>
+              </div>,
+              <div
+                className="col-sm-2"
+              >
+                <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>
+              </div>,
+            ],
+            "className": "row",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <h4>
+                  Table Specification
+                </h4>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "Table Specification",
+                },
+                "ref": null,
+                "rendered": "Table Specification",
+                "type": "h4",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="pt-control-group smd-full-width smd-vertical-center"
+                >
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Org Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Org Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    App Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="App Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <label
+                    className="pt-label pt-inline"
+                    style={
+                      Object {
+                        "marginRight": "15px",
+                      }
+                    }
+                  >
+                    Event Name:
+                    <input
+                      className="pt-input"
+                      onChange={[Function]}
+                      placeholder="Event Name"
+                      type="text"
+                      value=""
+                    />
+                  </label>
+                  <div>
+                    <Blueprint.Switch
+                      checked={false}
+                      label="Query Contract History"
+                      onChange={[Function]}
+                    />
+                  </div>
+                </div>,
+                "className": "col-sm-8",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Org Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Org Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      App Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="App Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <label
+                      className="pt-label pt-inline"
+                      style={
+                        Object {
+                          "marginRight": "15px",
+                        }
+                      }
+                    >
+                      Event Name:
+                      <input
+                        className="pt-input"
+                        onChange={[Function]}
+                        placeholder="Event Name"
+                        type="text"
+                        value=""
+                      />
+                    </label>,
+                    <div>
+                      <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />
+                    </div>,
+                  ],
+                  "className": "pt-control-group smd-full-width smd-vertical-center",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Org Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Org Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Org Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Org Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "App Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="App Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "App Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "App Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        "Event Name:",
+                        <input
+                          className="pt-input"
+                          onChange={[Function]}
+                          placeholder="Event Name"
+                          type="text"
+                          value=""
+                        />,
+                      ],
+                      "className": "pt-label pt-inline",
+                      "style": Object {
+                        "marginRight": "15px",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      "Event Name:",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "className": "pt-input",
+                          "onChange": [Function],
+                          "placeholder": "Event Name",
+                          "type": "text",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                    ],
+                    "type": "label",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <Blueprint.Switch
+                        checked={false}
+                        label="Query Contract History"
+                        onChange={[Function]}
+                      />,
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "checked": false,
+                        "label": "Query Contract History",
+                        "onChange": [Function],
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <Blueprint.Button
+                  className="pt-intent-primary"
+                  onClick={[Function]}
+                >
+                  Go
+                </Blueprint.Button>,
+                "className": "col-sm-2",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "children": "Go",
+                  "className": "pt-intent-primary",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": "Go",
+                "type": [Function],
+              },
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
             "children": <div
               className="col-sm-12 smd-pad-8"
             >
@@ -14345,6 +20542,16 @@ ShallowWrapper {
                   >
                     <option>
                       Select field
+                    </option>
+                    <option
+                      value="address"
+                    >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
                     </option>
                     <option
                       value="address"
@@ -14424,6 +20631,11 @@ ShallowWrapper {
                       value="like"
                     >
                       LIKE
+                    </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
                     </option>
                   </select>
                 </div>
@@ -14472,6 +20684,16 @@ ShallowWrapper {
                     <option
                       value="address"
                     >
+                      Address
+                    </option>
+                    <option
+                      value="chainId"
+                    >
+                      Shard ID
+                    </option>
+                    <option
+                      value="address"
+                    >
                       address
                     </option>
                     <option
@@ -14548,6 +20770,11 @@ ShallowWrapper {
                     >
                       LIKE
                     </option>
+                    <option
+                      value="ilike"
+                    >
+                      ILIKE
+                    </option>
                   </select>
                 </div>
                 <input
@@ -14588,6 +20815,16 @@ ShallowWrapper {
                     >
                       <option>
                         Select field
+                      </option>
+                      <option
+                        value="address"
+                      >
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                       <option
                         value="address"
@@ -14668,6 +20905,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>
                   </div>,
                   <input
@@ -14705,6 +20947,16 @@ ShallowWrapper {
                     >
                       <option>
                         Select field
+                      </option>
+                      <option
+                        value="address"
+                      >
+                        Address
+                      </option>
+                      <option
+                        value="chainId"
+                      >
+                        Shard ID
                       </option>
                       <option
                         value="address"
@@ -14752,9 +21004,19 @@ ShallowWrapper {
                         <option
                           value="address"
                         >
-                          address
+                          Address
+                        </option>,
+                        <option
+                          value="chainId"
+                        >
+                          Shard ID
                         </option>,
                         Array [
+                          <option
+                            value="address"
+                          >
+                            address
+                          </option>,
                           <option
                             value="amount"
                           >
@@ -14802,6 +21064,30 @@ ShallowWrapper {
                       Object {
                         "instance": null,
                         "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Address",
+                          "value": "address",
+                        },
+                        "ref": null,
+                        "rendered": "Address",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Shard ID",
+                          "value": "chainId",
+                        },
+                        "ref": null,
+                        "rendered": "Shard ID",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "Bid-field-address",
                         "nodeType": "host",
                         "props": Object {
                           "children": "address",
@@ -14925,6 +21211,11 @@ ShallowWrapper {
                       >
                         LIKE
                       </option>
+                      <option
+                        value="ilike"
+                      >
+                        ILIKE
+                      </option>
                     </select>,
                     "className": "pt-select",
                   },
@@ -14974,6 +21265,11 @@ ShallowWrapper {
                           value="like"
                         >
                           LIKE
+                        </option>,
+                        <option
+                          value="ilike"
+                        >
+                          ILIKE
                         </option>,
                       ],
                       "onChange": [Function],
@@ -15075,6 +21371,18 @@ ShallowWrapper {
                         },
                         "ref": null,
                         "rendered": "LIKE",
+                        "type": "option",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "ILIKE",
+                          "value": "ilike",
+                        },
+                        "ref": null,
+                        "rendered": "ILIKE",
                         "type": "option",
                       },
                     ],
@@ -15309,7 +21617,7 @@ ShallowWrapper {
             >
               <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P
               </code>
             </div>,
             "className": "row",
@@ -15322,7 +21630,7 @@ ShallowWrapper {
             "props": Object {
               "children": <code>
                 Query URL: 
-                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined
+                http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P
               </code>,
               "className": "col-sm-12 smd-pad-8",
             },
@@ -15334,13 +21642,13 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   "Query URL: ",
-                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+                  "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P",
                 ],
               },
               "ref": null,
               "rendered": Array [
                 "Query URL: ",
-                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P&chainId=undefined",
+                "http://localhost/cirrus/search/Bid?state=eq.1&amount=eq.5678&name=eq.P",
               ],
               "type": "code",
             },
@@ -15369,6 +21677,7 @@ ShallowWrapper {
             >
               <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -15427,6 +21736,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Table
                 allowMultipleSelection={true}
+                className="pt-striped"
                 defaultColumnWidth={150}
                 defaultRowHeight={20}
                 enableFocus={false}
@@ -15509,6 +21819,7 @@ ShallowWrapper {
                     renderCell={[Function]}
                   />,
                 ],
+                "className": "pt-striped",
                 "defaultColumnWidth": 150,
                 "defaultRowHeight": 20,
                 "enableFocus": false,
@@ -15626,8 +21937,13 @@ ShallowWrapper {
 
 exports[`ContractQuery: index tag add new one 1`] = `
 Object {
+  "appName": "",
+  "eventName": "",
   "field": "Select field",
+  "history": false,
   "operator": "eq",
+  "orgName": "",
+  "tableName": "Bid",
   "value": "",
 }
 `;

--- a/smd-ui/src/tests/ContractQuery/contractQuery.saga.spec.js
+++ b/smd-ui/src/tests/ContractQuery/contractQuery.saga.spec.js
@@ -39,15 +39,14 @@ describe('ContractQuery: saga', () => {
 
   describe('queryCirrus generator', () => {
     const action = {
-      contractName: "Bid",
+      tableName: "Bid",
       queryString: "",
-      chainId: "ff7ef45acb7a775018bc765b6fdeea432aaddfcd846cf6dd9442724266b1eac9",
       type: QUERY_CIRRUS_REQUEST
     }
 
     test('inspection', () => {
       const gen = queryCirrus(action);
-      expect(gen.next().value).toEqual(call(queryCirrusRequest, action.contractName, action.queryString, action.chainId));
+      expect(gen.next().value).toEqual(call(queryCirrusRequest, action.tableName, action.queryString));
       expect(gen.next(queryCirrusMock).value).toEqual(put(queryCirrusSuccess(queryCirrusMock)));
       expect(gen.throw(error).value).toEqual(put(queryCirrusFailure(error)));
       expect(gen.next().done).toBe(true);
@@ -79,7 +78,8 @@ describe('ContractQuery: saga', () => {
     expect(gen.next().done).toBe(true);
   });
 
-  describe('queryCirrusVars generator', () => {
+  // skipped since we don't fetch cirrus vars anymore in a separate call
+  xdescribe('queryCirrusVars generator', () => {
 
     const action = {
       type: QUERY_CIRRUS_VARS_REQUEST,

--- a/smd-ui/src/tests/ContractQuery/index.spec.js
+++ b/smd-ui/src/tests/ContractQuery/index.spec.js
@@ -121,8 +121,8 @@ describe('ContractQuery: index', () => {
       );
       wrapper.find('select').at(0).simulate('change', { target: { value: 'state' } });
       wrapper.find('select').at(1).simulate('change', { target: { value: '=' } });
-      wrapper.find('input').simulate('change', { target: { value: 2 } });
-      wrapper.find('input').simulate('keyup', { target: { value: 2 }, key: 'Enter' });
+      wrapper.find('input').at(3).simulate('change', { target: { value: 2 } });
+      wrapper.find('input').at(3).simulate('keyup', { target: { value: 2 }, key: 'Enter' });
       wrapper.find('button').at(0).simulate('click');
       expect(props.addQueryFilter).toHaveBeenCalled();
       expect(props.addQueryFilter.mock.calls.length).toBe(2);
@@ -191,7 +191,7 @@ describe('ContractQuery: index', () => {
       const wrapper = shallow(
         <ContractQuery.WrappedComponent {...props} />
       );
-      wrapper.find('Button').simulate('click');
+      wrapper.find('Button').at(0).simulate('click');
       expect(props.history.goBack).toHaveBeenCalled();
       expect(props.history.goBack.mock.calls.length).toBe(1);
       expect(wrapper).toMatchSnapshot();
@@ -212,7 +212,7 @@ describe('ContractQuery: index', () => {
       const wrapper = shallow(
         <ContractQuery.WrappedComponent {...props} />
       );
-      wrapper.find('input').simulate('keyup', { target: { value: 2 }, key: 'Enter' });
+      wrapper.find('input').at(3).simulate('keyup', { target: { value: 2 }, key: 'Enter' });
       expect(props.addQueryFilter).not.toHaveBeenCalled();
     });
 
@@ -342,7 +342,6 @@ describe('ContractQuery: index', () => {
         contractQuery: {
           queryString: 'state=eq.1&amount=eq.5678&name=eq.P',
         },
-        selectedChain: "ff7ef45acb7a775018bc765b6fdeea432aaddfcd846cf6dd9442724266b1ear8",
         ...matchMock
       };
       const wrapper = shallow(
@@ -350,7 +349,7 @@ describe('ContractQuery: index', () => {
       );
       wrapper.instance().componentWillReceiveProps(newProps);
       expect(props.queryCirrus).toHaveBeenCalled();
-      expect(props.queryCirrus.mock.calls.length).toBe(3);
+      expect(props.queryCirrus.mock.calls.length).toBe(2);
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -448,9 +447,6 @@ describe('ContractQuery: index', () => {
       wrapper.instance().componentWillMount();
       expect(props.clearQueryString).toHaveBeenCalled();
       expect(props.clearQueryString.mock.calls.length).toBe(2);
-      expect(props.queryCirrusVars).toHaveBeenCalled();
-      expect(props.queryCirrusVars.mock.calls).toEqual([["Bid"], ["Bid"]]);
-      expect(props.queryCirrusVars.mock.calls.length).toBe(2);
     });
 
   });

--- a/smd-ui/src/tests/Contracts/component/ContractCard/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/__snapshots__/index.spec.js.snap
@@ -67,6 +67,13 @@ ShallowWrapper {
                   className="pt-button-group"
                 >
                   <Blueprint.Button
+                    className="pt-intent-primary pt-icon-th"
+                    onClick={[Function]}
+                    type="Button"
+                  >
+                    Tabular Data
+                  </Blueprint.Button>
+                  <Blueprint.Button
                     className="pt-icon-double-caret-vertical btn-sm"
                     onClick={[Function]}
                     type="button"
@@ -98,7 +105,6 @@ ShallowWrapper {
                         <th>
                           Contract Address
                         </th>
-                        <th />
                       </tr>
                     </thead>
                     <tbody>
@@ -117,16 +123,6 @@ ShallowWrapper {
                             classes="small smd-pad-4"
                             value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                           />
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "border": "none",
-                            }
-                          }
-                        >
-                          
-                          
                         </td>
                       </tr>
                     </tbody>
@@ -169,6 +165,13 @@ ShallowWrapper {
                   className="pt-button-group"
                 >
                   <Blueprint.Button
+                    className="pt-intent-primary pt-icon-th"
+                    onClick={[Function]}
+                    type="Button"
+                  >
+                    Tabular Data
+                  </Blueprint.Button>
+                  <Blueprint.Button
                     className="pt-icon-double-caret-vertical btn-sm"
                     onClick={[Function]}
                     type="button"
@@ -200,7 +203,6 @@ ShallowWrapper {
                         <th>
                           Contract Address
                         </th>
-                        <th />
                       </tr>
                     </thead>
                     <tbody>
@@ -219,16 +221,6 @@ ShallowWrapper {
                             classes="small smd-pad-4"
                             value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                           />
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "border": "none",
-                            }
-                          }
-                        >
-                          
-                          
                         </td>
                       </tr>
                     </tbody>
@@ -263,6 +255,13 @@ ShallowWrapper {
                     className="pt-button-group"
                   >
                     <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
+                    >
+                      Tabular Data
+                    </Blueprint.Button>
+                    <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
                       type="button"
@@ -294,7 +293,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -313,16 +311,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -354,6 +342,13 @@ ShallowWrapper {
                     <div
                       className="pt-button-group"
                     >
+                      <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
+                      >
+                        Tabular Data
+                      </Blueprint.Button>
                       <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
@@ -402,6 +397,13 @@ ShallowWrapper {
                       className="pt-button-group"
                     >
                       <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
+                      >
+                        Tabular Data
+                      </Blueprint.Button>
+                      <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
                         type="button"
@@ -419,7 +421,13 @@ ShallowWrapper {
                     "nodeType": "host",
                     "props": Object {
                       "children": Array [
-                        null,
+                        <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
+                        >
+                          Tabular Data
+                        </Blueprint.Button>,
                         <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
@@ -433,7 +441,20 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": Array [
-                      null,
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "children": "Tabular Data",
+                          "className": "pt-intent-primary pt-icon-th",
+                          "onClick": [Function],
+                          "type": "Button",
+                        },
+                        "ref": null,
+                        "rendered": "Tabular Data",
+                        "type": [Function],
+                      },
                       Object {
                         "instance": null,
                         "key": undefined,
@@ -485,7 +506,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -504,16 +524,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -543,7 +553,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -562,16 +571,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -593,7 +592,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -612,16 +610,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -644,7 +632,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>,
                         <tbody>
@@ -664,16 +651,6 @@ ShallowWrapper {
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
                             </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
-                            </td>
                           </tr>
                         </tbody>,
                       ],
@@ -690,7 +667,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>,
                         },
                         "ref": null,
@@ -699,36 +675,22 @@ ShallowWrapper {
                           "key": undefined,
                           "nodeType": "host",
                           "props": Object {
-                            "children": Array [
-                              <th>
-                                Contract Address
-                              </th>,
-                              <th />,
-                            ],
+                            "children": <th>
+                              Contract Address
+                            </th>,
                           },
                           "ref": null,
-                          "rendered": Array [
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": "Contract Address",
-                              },
-                              "ref": null,
-                              "rendered": "Contract Address",
-                              "type": "th",
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Contract Address",
                             },
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {},
-                              "ref": null,
-                              "rendered": null,
-                              "type": "th",
-                            },
-                          ],
+                            "ref": null,
+                            "rendered": "Contract Address",
+                            "type": "th",
+                          },
                           "type": "tr",
                         },
                         "type": "thead",
@@ -755,16 +717,6 @@ ShallowWrapper {
                                   value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                                 />
                               </td>
-                              <td
-                                style={
-                                  Object {
-                                    "border": "none",
-                                  }
-                                }
-                              >
-                                
-                                
-                              </td>
                             </tr>,
                           ],
                         },
@@ -775,84 +727,50 @@ ShallowWrapper {
                             "key": "card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-0",
                             "nodeType": "host",
                             "props": Object {
-                              "children": Array [
-                                <td
-                                  style={
-                                    Object {
-                                      "border": "none",
-                                    }
+                              "children": <td
+                                style={
+                                  Object {
+                                    "border": "none",
                                   }
-                                >
-                                  <HexText
-                                    classes="small smd-pad-4"
-                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                  />
-                                </td>,
-                                <td
-                                  style={
-                                    Object {
-                                      "border": "none",
-                                    }
-                                  }
-                                >
-                                  
-                                  
-                                </td>,
-                              ],
+                                }
+                              >
+                                <HexText
+                                  classes="small smd-pad-4"
+                                  value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                />
+                              </td>,
                               "className": "",
                               "onClick": [Function],
                             },
                             "ref": null,
-                            "rendered": Array [
-                              Object {
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": <HexText
+                                  classes="small smd-pad-4"
+                                  value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                />,
+                                "style": Object {
+                                  "border": "none",
+                                },
+                              },
+                              "ref": null,
+                              "rendered": Object {
                                 "instance": null,
                                 "key": undefined,
-                                "nodeType": "host",
+                                "nodeType": "class",
                                 "props": Object {
-                                  "children": <HexText
-                                    classes="small smd-pad-4"
-                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                  />,
-                                  "style": Object {
-                                    "border": "none",
-                                  },
+                                  "classes": "small smd-pad-4",
+                                  "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
                                 },
                                 "ref": null,
-                                "rendered": Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "class",
-                                  "props": Object {
-                                    "classes": "small smd-pad-4",
-                                    "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
-                                  },
-                                  "ref": null,
-                                  "rendered": null,
-                                  "type": [Function],
-                                },
-                                "type": "td",
+                                "rendered": null,
+                                "type": [Function],
                               },
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": Array [
-                                    "",
-                                    "",
-                                  ],
-                                  "style": Object {
-                                    "border": "none",
-                                  },
-                                },
-                                "ref": null,
-                                "rendered": Array [
-                                  "",
-                                  "",
-                                ],
-                                "type": "td",
-                              },
-                            ],
+                              "type": "td",
+                            },
                             "type": "tr",
                           },
                         ],
@@ -917,6 +835,13 @@ ShallowWrapper {
                     className="pt-button-group"
                   >
                     <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
+                    >
+                      Tabular Data
+                    </Blueprint.Button>
+                    <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
                       type="button"
@@ -948,7 +873,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -967,16 +891,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -1019,6 +933,13 @@ ShallowWrapper {
                     className="pt-button-group"
                   >
                     <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
+                    >
+                      Tabular Data
+                    </Blueprint.Button>
+                    <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
                       type="button"
@@ -1050,7 +971,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -1069,16 +989,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -1113,6 +1023,13 @@ ShallowWrapper {
                       className="pt-button-group"
                     >
                       <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
+                      >
+                        Tabular Data
+                      </Blueprint.Button>
+                      <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
                         type="button"
@@ -1144,7 +1061,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -1163,16 +1079,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
                             </td>
                           </tr>
                         </tbody>
@@ -1204,6 +1110,13 @@ ShallowWrapper {
                       <div
                         className="pt-button-group"
                       >
+                        <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
+                        >
+                          Tabular Data
+                        </Blueprint.Button>
                         <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
@@ -1252,6 +1165,13 @@ ShallowWrapper {
                         className="pt-button-group"
                       >
                         <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
+                        >
+                          Tabular Data
+                        </Blueprint.Button>
+                        <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
                           type="button"
@@ -1269,7 +1189,13 @@ ShallowWrapper {
                       "nodeType": "host",
                       "props": Object {
                         "children": Array [
-                          null,
+                          <Blueprint.Button
+                            className="pt-intent-primary pt-icon-th"
+                            onClick={[Function]}
+                            type="Button"
+                          >
+                            Tabular Data
+                          </Blueprint.Button>,
                           <Blueprint.Button
                             className="pt-icon-double-caret-vertical btn-sm"
                             onClick={[Function]}
@@ -1283,7 +1209,20 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": Array [
-                        null,
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "class",
+                          "props": Object {
+                            "children": "Tabular Data",
+                            "className": "pt-intent-primary pt-icon-th",
+                            "onClick": [Function],
+                            "type": "Button",
+                          },
+                          "ref": null,
+                          "rendered": "Tabular Data",
+                          "type": [Function],
+                        },
                         Object {
                           "instance": null,
                           "key": undefined,
@@ -1335,7 +1274,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -1354,16 +1292,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
                             </td>
                           </tr>
                         </tbody>
@@ -1393,7 +1321,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -1412,16 +1339,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
                             </td>
                           </tr>
                         </tbody>
@@ -1443,7 +1360,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -1462,16 +1378,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
                             </td>
                           </tr>
                         </tbody>
@@ -1494,7 +1400,6 @@ ShallowWrapper {
                               <th>
                                 Contract Address
                               </th>
-                              <th />
                             </tr>
                           </thead>,
                           <tbody>
@@ -1514,16 +1419,6 @@ ShallowWrapper {
                                   value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                                 />
                               </td>
-                              <td
-                                style={
-                                  Object {
-                                    "border": "none",
-                                  }
-                                }
-                              >
-                                
-                                
-                              </td>
                             </tr>
                           </tbody>,
                         ],
@@ -1540,7 +1435,6 @@ ShallowWrapper {
                               <th>
                                 Contract Address
                               </th>
-                              <th />
                             </tr>,
                           },
                           "ref": null,
@@ -1549,36 +1443,22 @@ ShallowWrapper {
                             "key": undefined,
                             "nodeType": "host",
                             "props": Object {
-                              "children": Array [
-                                <th>
-                                  Contract Address
-                                </th>,
-                                <th />,
-                              ],
+                              "children": <th>
+                                Contract Address
+                              </th>,
                             },
                             "ref": null,
-                            "rendered": Array [
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": "Contract Address",
-                                },
-                                "ref": null,
-                                "rendered": "Contract Address",
-                                "type": "th",
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "Contract Address",
                               },
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {},
-                                "ref": null,
-                                "rendered": null,
-                                "type": "th",
-                              },
-                            ],
+                              "ref": null,
+                              "rendered": "Contract Address",
+                              "type": "th",
+                            },
                             "type": "tr",
                           },
                           "type": "thead",
@@ -1605,16 +1485,6 @@ ShallowWrapper {
                                     value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                                   />
                                 </td>
-                                <td
-                                  style={
-                                    Object {
-                                      "border": "none",
-                                    }
-                                  }
-                                >
-                                  
-                                  
-                                </td>
                               </tr>,
                             ],
                           },
@@ -1625,84 +1495,50 @@ ShallowWrapper {
                               "key": "card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-0",
                               "nodeType": "host",
                               "props": Object {
-                                "children": Array [
-                                  <td
-                                    style={
-                                      Object {
-                                        "border": "none",
-                                      }
+                                "children": <td
+                                  style={
+                                    Object {
+                                      "border": "none",
                                     }
-                                  >
-                                    <HexText
-                                      classes="small smd-pad-4"
-                                      value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                    />
-                                  </td>,
-                                  <td
-                                    style={
-                                      Object {
-                                        "border": "none",
-                                      }
-                                    }
-                                  >
-                                    
-                                    
-                                  </td>,
-                                ],
+                                  }
+                                >
+                                  <HexText
+                                    classes="small smd-pad-4"
+                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  />
+                                </td>,
                                 "className": "",
                                 "onClick": [Function],
                               },
                               "ref": null,
-                              "rendered": Array [
-                                Object {
+                              "rendered": Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": <HexText
+                                    classes="small smd-pad-4"
+                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  />,
+                                  "style": Object {
+                                    "border": "none",
+                                  },
+                                },
+                                "ref": null,
+                                "rendered": Object {
                                   "instance": null,
                                   "key": undefined,
-                                  "nodeType": "host",
+                                  "nodeType": "class",
                                   "props": Object {
-                                    "children": <HexText
-                                      classes="small smd-pad-4"
-                                      value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                    />,
-                                    "style": Object {
-                                      "border": "none",
-                                    },
+                                    "classes": "small smd-pad-4",
+                                    "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
                                   },
                                   "ref": null,
-                                  "rendered": Object {
-                                    "instance": null,
-                                    "key": undefined,
-                                    "nodeType": "class",
-                                    "props": Object {
-                                      "classes": "small smd-pad-4",
-                                      "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
-                                    },
-                                    "ref": null,
-                                    "rendered": null,
-                                    "type": [Function],
-                                  },
-                                  "type": "td",
+                                  "rendered": null,
+                                  "type": [Function],
                                 },
-                                Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "host",
-                                  "props": Object {
-                                    "children": Array [
-                                      "",
-                                      "",
-                                    ],
-                                    "style": Object {
-                                      "border": "none",
-                                    },
-                                  },
-                                  "ref": null,
-                                  "rendered": Array [
-                                    "",
-                                    "",
-                                  ],
-                                  "type": "td",
-                                },
-                              ],
+                                "type": "td",
+                              },
                               "type": "tr",
                             },
                           ],
@@ -1816,6 +1652,13 @@ ShallowWrapper {
                   className="pt-button-group"
                 >
                   <Blueprint.Button
+                    className="pt-intent-primary pt-icon-th"
+                    onClick={[Function]}
+                    type="Button"
+                  >
+                    Tabular Data
+                  </Blueprint.Button>
+                  <Blueprint.Button
                     className="pt-icon-double-caret-vertical btn-sm"
                     onClick={[Function]}
                     type="button"
@@ -1847,7 +1690,6 @@ ShallowWrapper {
                         <th>
                           Contract Address
                         </th>
-                        <th />
                       </tr>
                     </thead>
                     <tbody>
@@ -1866,16 +1708,6 @@ ShallowWrapper {
                             classes="small smd-pad-4"
                             value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                           />
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "border": "none",
-                            }
-                          }
-                        >
-                          
-                          
                         </td>
                       </tr>
                     </tbody>
@@ -1940,42 +1772,6 @@ ShallowWrapper {
                       <td
                         style={
                           Object {
-                            "maxWidth": "90px",
-                            "overflow": "hidden",
-                            "textOverflow": "ellipsis",
-                            "verticalAlign": "middle",
-                          }
-                        }
-                      >
-                        <Blueprint.Tooltip
-                          content="greet"
-                          hoverCloseDelay={0}
-                          hoverOpenDelay={100}
-                          isDisabled={false}
-                          openOnTargetFocus={true}
-                          position={0}
-                          rootElementTag="span"
-                          transitionDuration={100}
-                          useSmartArrowPositioning={true}
-                          useSmartPositioning={false}
-                        >
-                          greet
-                        </Blueprint.Tooltip>
-                      </td>
-                      <td
-                        style={
-                          Object {
-                            "maxWidth": "300px",
-                          }
-                        }
-                      >
-                        <pre>
-                          function () returns (String)
-                        </pre>
-                      </td>
-                      <td
-                        style={
-                          Object {
                             "verticalAlign": "middle",
                           }
                         }
@@ -1990,12 +1786,23 @@ ShallowWrapper {
                           symbolName="greet"
                         />
                       </td>
+                      <td
+                        style={
+                          Object {
+                            "maxWidth": "500px",
+                          }
+                        }
+                      >
+                        <pre>
+                          function () returns (String)
+                        </pre>
+                      </td>
                     </tr>
                     <tr>
                       <td
                         style={
                           Object {
-                            "maxWidth": "90px",
+                            "maxWidth": "120px",
                             "overflow": "hidden",
                             "textOverflow": "ellipsis",
                             "verticalAlign": "middle",
@@ -2020,7 +1827,7 @@ ShallowWrapper {
                       <td
                         style={
                           Object {
-                            "maxWidth": "300px",
+                            "maxWidth": "500px",
                           }
                         }
                       >
@@ -2028,13 +1835,6 @@ ShallowWrapper {
                           sadasd
                         </pre>
                       </td>
-                      <td
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                      />
                     </tr>
                   </tbody>
                 </table>
@@ -2072,6 +1872,13 @@ ShallowWrapper {
                   className="pt-button-group"
                 >
                   <Blueprint.Button
+                    className="pt-intent-primary pt-icon-th"
+                    onClick={[Function]}
+                    type="Button"
+                  >
+                    Tabular Data
+                  </Blueprint.Button>
+                  <Blueprint.Button
                     className="pt-icon-double-caret-vertical btn-sm"
                     onClick={[Function]}
                     type="button"
@@ -2103,7 +1910,6 @@ ShallowWrapper {
                         <th>
                           Contract Address
                         </th>
-                        <th />
                       </tr>
                     </thead>
                     <tbody>
@@ -2122,16 +1928,6 @@ ShallowWrapper {
                             classes="small smd-pad-4"
                             value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                           />
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "border": "none",
-                            }
-                          }
-                        >
-                          
-                          
                         </td>
                       </tr>
                     </tbody>
@@ -2166,6 +1962,13 @@ ShallowWrapper {
                     className="pt-button-group"
                   >
                     <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
+                    >
+                      Tabular Data
+                    </Blueprint.Button>
+                    <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
                       type="button"
@@ -2197,7 +2000,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -2216,16 +2018,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -2257,6 +2049,13 @@ ShallowWrapper {
                     <div
                       className="pt-button-group"
                     >
+                      <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
+                      >
+                        Tabular Data
+                      </Blueprint.Button>
                       <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
@@ -2305,6 +2104,13 @@ ShallowWrapper {
                       className="pt-button-group"
                     >
                       <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
+                      >
+                        Tabular Data
+                      </Blueprint.Button>
+                      <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
                         type="button"
@@ -2322,7 +2128,13 @@ ShallowWrapper {
                     "nodeType": "host",
                     "props": Object {
                       "children": Array [
-                        null,
+                        <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
+                        >
+                          Tabular Data
+                        </Blueprint.Button>,
                         <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
@@ -2336,7 +2148,20 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": Array [
-                      null,
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "children": "Tabular Data",
+                          "className": "pt-intent-primary pt-icon-th",
+                          "onClick": [Function],
+                          "type": "Button",
+                        },
+                        "ref": null,
+                        "rendered": "Tabular Data",
+                        "type": [Function],
+                      },
                       Object {
                         "instance": null,
                         "key": undefined,
@@ -2388,7 +2213,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -2407,16 +2231,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -2446,7 +2260,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -2465,16 +2278,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -2496,7 +2299,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -2515,16 +2317,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -2547,7 +2339,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>,
                         <tbody>
@@ -2567,16 +2358,6 @@ ShallowWrapper {
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
                             </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
-                            </td>
                           </tr>
                         </tbody>,
                       ],
@@ -2593,7 +2374,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>,
                         },
                         "ref": null,
@@ -2602,36 +2382,22 @@ ShallowWrapper {
                           "key": undefined,
                           "nodeType": "host",
                           "props": Object {
-                            "children": Array [
-                              <th>
-                                Contract Address
-                              </th>,
-                              <th />,
-                            ],
+                            "children": <th>
+                              Contract Address
+                            </th>,
                           },
                           "ref": null,
-                          "rendered": Array [
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": "Contract Address",
-                              },
-                              "ref": null,
-                              "rendered": "Contract Address",
-                              "type": "th",
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Contract Address",
                             },
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {},
-                              "ref": null,
-                              "rendered": null,
-                              "type": "th",
-                            },
-                          ],
+                            "ref": null,
+                            "rendered": "Contract Address",
+                            "type": "th",
+                          },
                           "type": "tr",
                         },
                         "type": "thead",
@@ -2658,16 +2424,6 @@ ShallowWrapper {
                                   value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                                 />
                               </td>
-                              <td
-                                style={
-                                  Object {
-                                    "border": "none",
-                                  }
-                                }
-                              >
-                                
-                                
-                              </td>
                             </tr>,
                           ],
                         },
@@ -2678,84 +2434,50 @@ ShallowWrapper {
                             "key": "card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-0",
                             "nodeType": "host",
                             "props": Object {
-                              "children": Array [
-                                <td
-                                  style={
-                                    Object {
-                                      "border": "none",
-                                    }
+                              "children": <td
+                                style={
+                                  Object {
+                                    "border": "none",
                                   }
-                                >
-                                  <HexText
-                                    classes="small smd-pad-4"
-                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                  />
-                                </td>,
-                                <td
-                                  style={
-                                    Object {
-                                      "border": "none",
-                                    }
-                                  }
-                                >
-                                  
-                                  
-                                </td>,
-                              ],
+                                }
+                              >
+                                <HexText
+                                  classes="small smd-pad-4"
+                                  value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                />
+                              </td>,
                               "className": "selected",
                               "onClick": [Function],
                             },
                             "ref": null,
-                            "rendered": Array [
-                              Object {
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": <HexText
+                                  classes="small smd-pad-4"
+                                  value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                />,
+                                "style": Object {
+                                  "border": "none",
+                                },
+                              },
+                              "ref": null,
+                              "rendered": Object {
                                 "instance": null,
                                 "key": undefined,
-                                "nodeType": "host",
+                                "nodeType": "class",
                                 "props": Object {
-                                  "children": <HexText
-                                    classes="small smd-pad-4"
-                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                  />,
-                                  "style": Object {
-                                    "border": "none",
-                                  },
+                                  "classes": "small smd-pad-4",
+                                  "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
                                 },
                                 "ref": null,
-                                "rendered": Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "class",
-                                  "props": Object {
-                                    "classes": "small smd-pad-4",
-                                    "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
-                                  },
-                                  "ref": null,
-                                  "rendered": null,
-                                  "type": [Function],
-                                },
-                                "type": "td",
+                                "rendered": null,
+                                "type": [Function],
                               },
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": Array [
-                                    "",
-                                    "",
-                                  ],
-                                  "style": Object {
-                                    "border": "none",
-                                  },
-                                },
-                                "ref": null,
-                                "rendered": Array [
-                                  "",
-                                  "",
-                                ],
-                                "type": "td",
-                              },
-                            ],
+                              "type": "td",
+                            },
                             "type": "tr",
                           },
                         ],
@@ -2832,42 +2554,6 @@ ShallowWrapper {
                       <td
                         style={
                           Object {
-                            "maxWidth": "90px",
-                            "overflow": "hidden",
-                            "textOverflow": "ellipsis",
-                            "verticalAlign": "middle",
-                          }
-                        }
-                      >
-                        <Blueprint.Tooltip
-                          content="greet"
-                          hoverCloseDelay={0}
-                          hoverOpenDelay={100}
-                          isDisabled={false}
-                          openOnTargetFocus={true}
-                          position={0}
-                          rootElementTag="span"
-                          transitionDuration={100}
-                          useSmartArrowPositioning={true}
-                          useSmartPositioning={false}
-                        >
-                          greet
-                        </Blueprint.Tooltip>
-                      </td>
-                      <td
-                        style={
-                          Object {
-                            "maxWidth": "300px",
-                          }
-                        }
-                      >
-                        <pre>
-                          function () returns (String)
-                        </pre>
-                      </td>
-                      <td
-                        style={
-                          Object {
                             "verticalAlign": "middle",
                           }
                         }
@@ -2882,12 +2568,23 @@ ShallowWrapper {
                           symbolName="greet"
                         />
                       </td>
+                      <td
+                        style={
+                          Object {
+                            "maxWidth": "500px",
+                          }
+                        }
+                      >
+                        <pre>
+                          function () returns (String)
+                        </pre>
+                      </td>
                     </tr>
                     <tr>
                       <td
                         style={
                           Object {
-                            "maxWidth": "90px",
+                            "maxWidth": "120px",
                             "overflow": "hidden",
                             "textOverflow": "ellipsis",
                             "verticalAlign": "middle",
@@ -2912,7 +2609,7 @@ ShallowWrapper {
                       <td
                         style={
                           Object {
-                            "maxWidth": "300px",
+                            "maxWidth": "500px",
                           }
                         }
                       >
@@ -2920,13 +2617,6 @@ ShallowWrapper {
                           sadasd
                         </pre>
                       </td>
-                      <td
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                      />
                     </tr>
                   </tbody>
                 </table>
@@ -2991,42 +2681,6 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
-                              "overflow": "hidden",
-                              "textOverflow": "ellipsis",
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        >
-                          <Blueprint.Tooltip
-                            content="greet"
-                            hoverCloseDelay={0}
-                            hoverOpenDelay={100}
-                            isDisabled={false}
-                            openOnTargetFocus={true}
-                            position={0}
-                            rootElementTag="span"
-                            transitionDuration={100}
-                            useSmartArrowPositioning={true}
-                            useSmartPositioning={false}
-                          >
-                            greet
-                          </Blueprint.Tooltip>
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "maxWidth": "300px",
-                            }
-                          }
-                        >
-                          <pre>
-                            function () returns (String)
-                          </pre>
-                        </td>
-                        <td
-                          style={
-                            Object {
                               "verticalAlign": "middle",
                             }
                           }
@@ -3041,12 +2695,23 @@ ShallowWrapper {
                             symbolName="greet"
                           />
                         </td>
+                        <td
+                          style={
+                            Object {
+                              "maxWidth": "500px",
+                            }
+                          }
+                        >
+                          <pre>
+                            function () returns (String)
+                          </pre>
+                        </td>
                       </tr>
                       <tr>
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
+                              "maxWidth": "120px",
                               "overflow": "hidden",
                               "textOverflow": "ellipsis",
                               "verticalAlign": "middle",
@@ -3071,7 +2736,7 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "300px",
+                              "maxWidth": "500px",
                             }
                           }
                         >
@@ -3079,13 +2744,6 @@ ShallowWrapper {
                             sadasd
                           </pre>
                         </td>
-                        <td
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        />
                       </tr>
                     </tbody>
                   </table>
@@ -3190,42 +2848,6 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
-                              "overflow": "hidden",
-                              "textOverflow": "ellipsis",
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        >
-                          <Blueprint.Tooltip
-                            content="greet"
-                            hoverCloseDelay={0}
-                            hoverOpenDelay={100}
-                            isDisabled={false}
-                            openOnTargetFocus={true}
-                            position={0}
-                            rootElementTag="span"
-                            transitionDuration={100}
-                            useSmartArrowPositioning={true}
-                            useSmartPositioning={false}
-                          >
-                            greet
-                          </Blueprint.Tooltip>
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "maxWidth": "300px",
-                            }
-                          }
-                        >
-                          <pre>
-                            function () returns (String)
-                          </pre>
-                        </td>
-                        <td
-                          style={
-                            Object {
                               "verticalAlign": "middle",
                             }
                           }
@@ -3240,12 +2862,23 @@ ShallowWrapper {
                             symbolName="greet"
                           />
                         </td>
+                        <td
+                          style={
+                            Object {
+                              "maxWidth": "500px",
+                            }
+                          }
+                        >
+                          <pre>
+                            function () returns (String)
+                          </pre>
+                        </td>
                       </tr>
                       <tr>
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
+                              "maxWidth": "120px",
                               "overflow": "hidden",
                               "textOverflow": "ellipsis",
                               "verticalAlign": "middle",
@@ -3270,7 +2903,7 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "300px",
+                              "maxWidth": "500px",
                             }
                           }
                         >
@@ -3278,13 +2911,6 @@ ShallowWrapper {
                             sadasd
                           </pre>
                         </td>
-                        <td
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        />
                       </tr>
                     </tbody>
                   </table>
@@ -3325,42 +2951,6 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
-                              "overflow": "hidden",
-                              "textOverflow": "ellipsis",
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        >
-                          <Blueprint.Tooltip
-                            content="greet"
-                            hoverCloseDelay={0}
-                            hoverOpenDelay={100}
-                            isDisabled={false}
-                            openOnTargetFocus={true}
-                            position={0}
-                            rootElementTag="span"
-                            transitionDuration={100}
-                            useSmartArrowPositioning={true}
-                            useSmartPositioning={false}
-                          >
-                            greet
-                          </Blueprint.Tooltip>
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "maxWidth": "300px",
-                            }
-                          }
-                        >
-                          <pre>
-                            function () returns (String)
-                          </pre>
-                        </td>
-                        <td
-                          style={
-                            Object {
                               "verticalAlign": "middle",
                             }
                           }
@@ -3375,12 +2965,23 @@ ShallowWrapper {
                             symbolName="greet"
                           />
                         </td>
+                        <td
+                          style={
+                            Object {
+                              "maxWidth": "500px",
+                            }
+                          }
+                        >
+                          <pre>
+                            function () returns (String)
+                          </pre>
+                        </td>
                       </tr>
                       <tr>
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
+                              "maxWidth": "120px",
                               "overflow": "hidden",
                               "textOverflow": "ellipsis",
                               "verticalAlign": "middle",
@@ -3405,7 +3006,7 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "300px",
+                              "maxWidth": "500px",
                             }
                           }
                         >
@@ -3413,13 +3014,6 @@ ShallowWrapper {
                             sadasd
                           </pre>
                         </td>
-                        <td
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        />
                       </tr>
                     </tbody>
                   </table>,
@@ -3457,42 +3051,6 @@ ShallowWrapper {
                           <td
                             style={
                               Object {
-                                "maxWidth": "90px",
-                                "overflow": "hidden",
-                                "textOverflow": "ellipsis",
-                                "verticalAlign": "middle",
-                              }
-                            }
-                          >
-                            <Blueprint.Tooltip
-                              content="greet"
-                              hoverCloseDelay={0}
-                              hoverOpenDelay={100}
-                              isDisabled={false}
-                              openOnTargetFocus={true}
-                              position={0}
-                              rootElementTag="span"
-                              transitionDuration={100}
-                              useSmartArrowPositioning={true}
-                              useSmartPositioning={false}
-                            >
-                              greet
-                            </Blueprint.Tooltip>
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "maxWidth": "300px",
-                              }
-                            }
-                          >
-                            <pre>
-                              function () returns (String)
-                            </pre>
-                          </td>
-                          <td
-                            style={
-                              Object {
                                 "verticalAlign": "middle",
                               }
                             }
@@ -3507,12 +3065,23 @@ ShallowWrapper {
                               symbolName="greet"
                             />
                           </td>
+                          <td
+                            style={
+                              Object {
+                                "maxWidth": "500px",
+                              }
+                            }
+                          >
+                            <pre>
+                              function () returns (String)
+                            </pre>
+                          </td>
                         </tr>
                         <tr>
                           <td
                             style={
                               Object {
-                                "maxWidth": "90px",
+                                "maxWidth": "120px",
                                 "overflow": "hidden",
                                 "textOverflow": "ellipsis",
                                 "verticalAlign": "middle",
@@ -3537,7 +3106,7 @@ ShallowWrapper {
                           <td
                             style={
                               Object {
-                                "maxWidth": "300px",
+                                "maxWidth": "500px",
                               }
                             }
                           >
@@ -3545,13 +3114,6 @@ ShallowWrapper {
                               sadasd
                             </pre>
                           </td>
-                          <td
-                            style={
-                              Object {
-                                "verticalAlign": "middle",
-                              }
-                            }
-                          />
                         </tr>
                       </tbody>,
                     ],
@@ -3662,42 +3224,6 @@ ShallowWrapper {
                             <td
                               style={
                                 Object {
-                                  "maxWidth": "90px",
-                                  "overflow": "hidden",
-                                  "textOverflow": "ellipsis",
-                                  "verticalAlign": "middle",
-                                }
-                              }
-                            >
-                              <Blueprint.Tooltip
-                                content="greet"
-                                hoverCloseDelay={0}
-                                hoverOpenDelay={100}
-                                isDisabled={false}
-                                openOnTargetFocus={true}
-                                position={0}
-                                rootElementTag="span"
-                                transitionDuration={100}
-                                useSmartArrowPositioning={true}
-                                useSmartPositioning={false}
-                              >
-                                greet
-                              </Blueprint.Tooltip>
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "maxWidth": "300px",
-                                }
-                              }
-                            >
-                              <pre>
-                                function () returns (String)
-                              </pre>
-                            </td>
-                            <td
-                              style={
-                                Object {
                                   "verticalAlign": "middle",
                                 }
                               }
@@ -3712,12 +3238,23 @@ ShallowWrapper {
                                 symbolName="greet"
                               />
                             </td>
+                            <td
+                              style={
+                                Object {
+                                  "maxWidth": "500px",
+                                }
+                              }
+                            >
+                              <pre>
+                                function () returns (String)
+                              </pre>
+                            </td>
                           </tr>,
                           <tr>
                             <td
                               style={
                                 Object {
-                                  "maxWidth": "90px",
+                                  "maxWidth": "120px",
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "verticalAlign": "middle",
@@ -3742,7 +3279,7 @@ ShallowWrapper {
                             <td
                               style={
                                 Object {
-                                  "maxWidth": "300px",
+                                  "maxWidth": "500px",
                                 }
                               }
                             >
@@ -3750,13 +3287,6 @@ ShallowWrapper {
                                 sadasd
                               </pre>
                             </td>
-                            <td
-                              style={
-                                Object {
-                                  "verticalAlign": "middle",
-                                }
-                              }
-                            />
                           </tr>,
                         ],
                       },
@@ -3768,42 +3298,6 @@ ShallowWrapper {
                           "nodeType": "host",
                           "props": Object {
                             "children": Array [
-                              <td
-                                style={
-                                  Object {
-                                    "maxWidth": "90px",
-                                    "overflow": "hidden",
-                                    "textOverflow": "ellipsis",
-                                    "verticalAlign": "middle",
-                                  }
-                                }
-                              >
-                                <Blueprint.Tooltip
-                                  content="greet"
-                                  hoverCloseDelay={0}
-                                  hoverOpenDelay={100}
-                                  isDisabled={false}
-                                  openOnTargetFocus={true}
-                                  position={0}
-                                  rootElementTag="span"
-                                  transitionDuration={100}
-                                  useSmartArrowPositioning={true}
-                                  useSmartPositioning={false}
-                                >
-                                  greet
-                                </Blueprint.Tooltip>
-                              </td>,
-                              <td
-                                style={
-                                  Object {
-                                    "maxWidth": "300px",
-                                  }
-                                }
-                              >
-                                <pre>
-                                  function () returns (String)
-                                </pre>
-                              </td>,
                               <td
                                 style={
                                   Object {
@@ -3821,86 +3315,21 @@ ShallowWrapper {
                                   symbolName="greet"
                                 />
                               </td>,
+                              <td
+                                style={
+                                  Object {
+                                    "maxWidth": "500px",
+                                  }
+                                }
+                              >
+                                <pre>
+                                  function () returns (String)
+                                </pre>
+                              </td>,
                             ],
                           },
                           "ref": null,
                           "rendered": Array [
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": <Blueprint.Tooltip
-                                  content="greet"
-                                  hoverCloseDelay={0}
-                                  hoverOpenDelay={100}
-                                  isDisabled={false}
-                                  openOnTargetFocus={true}
-                                  position={0}
-                                  rootElementTag="span"
-                                  transitionDuration={100}
-                                  useSmartArrowPositioning={true}
-                                  useSmartPositioning={false}
-                                >
-                                  greet
-                                </Blueprint.Tooltip>,
-                                "style": Object {
-                                  "maxWidth": "90px",
-                                  "overflow": "hidden",
-                                  "textOverflow": "ellipsis",
-                                  "verticalAlign": "middle",
-                                },
-                              },
-                              "ref": null,
-                              "rendered": Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "class",
-                                "props": Object {
-                                  "children": "greet",
-                                  "content": "greet",
-                                  "hoverCloseDelay": 0,
-                                  "hoverOpenDelay": 100,
-                                  "isDisabled": false,
-                                  "openOnTargetFocus": true,
-                                  "position": 0,
-                                  "rootElementTag": "span",
-                                  "transitionDuration": 100,
-                                  "useSmartArrowPositioning": true,
-                                  "useSmartPositioning": false,
-                                },
-                                "ref": null,
-                                "rendered": "greet",
-                                "type": [Function],
-                              },
-                              "type": "td",
-                            },
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": <pre>
-                                  function () returns (String)
-                                </pre>,
-                                "style": Object {
-                                  "maxWidth": "300px",
-                                },
-                              },
-                              "ref": null,
-                              "rendered": Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": "function () returns (String)",
-                                },
-                                "ref": null,
-                                "rendered": "function () returns (String)",
-                                "type": "pre",
-                              },
-                              "type": "td",
-                            },
                             Object {
                               "instance": null,
                               "key": undefined,
@@ -3939,6 +3368,32 @@ ShallowWrapper {
                               },
                               "type": "td",
                             },
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": <pre>
+                                  function () returns (String)
+                                </pre>,
+                                "style": Object {
+                                  "maxWidth": "500px",
+                                },
+                              },
+                              "ref": null,
+                              "rendered": Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": "function () returns (String)",
+                                },
+                                "ref": null,
+                                "rendered": "function () returns (String)",
+                                "type": "pre",
+                              },
+                              "type": "td",
+                            },
                           ],
                           "type": "tr",
                         },
@@ -3951,7 +3406,7 @@ ShallowWrapper {
                               <td
                                 style={
                                   Object {
-                                    "maxWidth": "90px",
+                                    "maxWidth": "120px",
                                     "overflow": "hidden",
                                     "textOverflow": "ellipsis",
                                     "verticalAlign": "middle",
@@ -3976,7 +3431,7 @@ ShallowWrapper {
                               <td
                                 style={
                                   Object {
-                                    "maxWidth": "300px",
+                                    "maxWidth": "500px",
                                   }
                                 }
                               >
@@ -3984,13 +3439,6 @@ ShallowWrapper {
                                   sadasd
                                 </pre>
                               </td>,
-                              <td
-                                style={
-                                  Object {
-                                    "verticalAlign": "middle",
-                                  }
-                                }
-                              />,
                             ],
                           },
                           "ref": null,
@@ -4015,7 +3463,7 @@ ShallowWrapper {
                                   greeting
                                 </Blueprint.Tooltip>,
                                 "style": Object {
-                                  "maxWidth": "90px",
+                                  "maxWidth": "120px",
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "verticalAlign": "middle",
@@ -4054,7 +3502,7 @@ ShallowWrapper {
                                   sadasd
                                 </pre>,
                                 "style": Object {
-                                  "maxWidth": "300px",
+                                  "maxWidth": "500px",
                                 },
                               },
                               "ref": null,
@@ -4069,20 +3517,6 @@ ShallowWrapper {
                                 "rendered": "sadasd",
                                 "type": "pre",
                               },
-                              "type": "td",
-                            },
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": null,
-                                "style": Object {
-                                  "verticalAlign": "middle",
-                                },
-                              },
-                              "ref": null,
-                              "rendered": null,
                               "type": "td",
                             },
                           ],
@@ -4136,6 +3570,13 @@ ShallowWrapper {
                     className="pt-button-group"
                   >
                     <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
+                    >
+                      Tabular Data
+                    </Blueprint.Button>
+                    <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
                       type="button"
@@ -4167,7 +3608,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -4186,16 +3626,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -4260,42 +3690,6 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
-                              "overflow": "hidden",
-                              "textOverflow": "ellipsis",
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        >
-                          <Blueprint.Tooltip
-                            content="greet"
-                            hoverCloseDelay={0}
-                            hoverOpenDelay={100}
-                            isDisabled={false}
-                            openOnTargetFocus={true}
-                            position={0}
-                            rootElementTag="span"
-                            transitionDuration={100}
-                            useSmartArrowPositioning={true}
-                            useSmartPositioning={false}
-                          >
-                            greet
-                          </Blueprint.Tooltip>
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "maxWidth": "300px",
-                            }
-                          }
-                        >
-                          <pre>
-                            function () returns (String)
-                          </pre>
-                        </td>
-                        <td
-                          style={
-                            Object {
                               "verticalAlign": "middle",
                             }
                           }
@@ -4310,12 +3704,23 @@ ShallowWrapper {
                             symbolName="greet"
                           />
                         </td>
+                        <td
+                          style={
+                            Object {
+                              "maxWidth": "500px",
+                            }
+                          }
+                        >
+                          <pre>
+                            function () returns (String)
+                          </pre>
+                        </td>
                       </tr>
                       <tr>
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
+                              "maxWidth": "120px",
                               "overflow": "hidden",
                               "textOverflow": "ellipsis",
                               "verticalAlign": "middle",
@@ -4340,7 +3745,7 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "300px",
+                              "maxWidth": "500px",
                             }
                           }
                         >
@@ -4348,13 +3753,6 @@ ShallowWrapper {
                             sadasd
                           </pre>
                         </td>
-                        <td
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        />
                       </tr>
                     </tbody>
                   </table>
@@ -4392,6 +3790,13 @@ ShallowWrapper {
                     className="pt-button-group"
                   >
                     <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
+                    >
+                      Tabular Data
+                    </Blueprint.Button>
+                    <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
                       type="button"
@@ -4423,7 +3828,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -4442,16 +3846,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            
-                            
                           </td>
                         </tr>
                       </tbody>
@@ -4486,6 +3880,13 @@ ShallowWrapper {
                       className="pt-button-group"
                     >
                       <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
+                      >
+                        Tabular Data
+                      </Blueprint.Button>
+                      <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
                         type="button"
@@ -4517,7 +3918,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -4536,16 +3936,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
                             </td>
                           </tr>
                         </tbody>
@@ -4577,6 +3967,13 @@ ShallowWrapper {
                       <div
                         className="pt-button-group"
                       >
+                        <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
+                        >
+                          Tabular Data
+                        </Blueprint.Button>
                         <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
@@ -4625,6 +4022,13 @@ ShallowWrapper {
                         className="pt-button-group"
                       >
                         <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
+                        >
+                          Tabular Data
+                        </Blueprint.Button>
+                        <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
                           type="button"
@@ -4642,7 +4046,13 @@ ShallowWrapper {
                       "nodeType": "host",
                       "props": Object {
                         "children": Array [
-                          null,
+                          <Blueprint.Button
+                            className="pt-intent-primary pt-icon-th"
+                            onClick={[Function]}
+                            type="Button"
+                          >
+                            Tabular Data
+                          </Blueprint.Button>,
                           <Blueprint.Button
                             className="pt-icon-double-caret-vertical btn-sm"
                             onClick={[Function]}
@@ -4656,7 +4066,20 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": Array [
-                        null,
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "class",
+                          "props": Object {
+                            "children": "Tabular Data",
+                            "className": "pt-intent-primary pt-icon-th",
+                            "onClick": [Function],
+                            "type": "Button",
+                          },
+                          "ref": null,
+                          "rendered": "Tabular Data",
+                          "type": [Function],
+                        },
                         Object {
                           "instance": null,
                           "key": undefined,
@@ -4708,7 +4131,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -4727,16 +4149,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
                             </td>
                           </tr>
                         </tbody>
@@ -4766,7 +4178,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -4785,16 +4196,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
                             </td>
                           </tr>
                         </tbody>
@@ -4816,7 +4217,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -4835,16 +4235,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              
-                              
                             </td>
                           </tr>
                         </tbody>
@@ -4867,7 +4257,6 @@ ShallowWrapper {
                               <th>
                                 Contract Address
                               </th>
-                              <th />
                             </tr>
                           </thead>,
                           <tbody>
@@ -4887,16 +4276,6 @@ ShallowWrapper {
                                   value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                                 />
                               </td>
-                              <td
-                                style={
-                                  Object {
-                                    "border": "none",
-                                  }
-                                }
-                              >
-                                
-                                
-                              </td>
                             </tr>
                           </tbody>,
                         ],
@@ -4913,7 +4292,6 @@ ShallowWrapper {
                               <th>
                                 Contract Address
                               </th>
-                              <th />
                             </tr>,
                           },
                           "ref": null,
@@ -4922,36 +4300,22 @@ ShallowWrapper {
                             "key": undefined,
                             "nodeType": "host",
                             "props": Object {
-                              "children": Array [
-                                <th>
-                                  Contract Address
-                                </th>,
-                                <th />,
-                              ],
+                              "children": <th>
+                                Contract Address
+                              </th>,
                             },
                             "ref": null,
-                            "rendered": Array [
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": "Contract Address",
-                                },
-                                "ref": null,
-                                "rendered": "Contract Address",
-                                "type": "th",
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "Contract Address",
                               },
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {},
-                                "ref": null,
-                                "rendered": null,
-                                "type": "th",
-                              },
-                            ],
+                              "ref": null,
+                              "rendered": "Contract Address",
+                              "type": "th",
+                            },
                             "type": "tr",
                           },
                           "type": "thead",
@@ -4978,16 +4342,6 @@ ShallowWrapper {
                                     value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                                   />
                                 </td>
-                                <td
-                                  style={
-                                    Object {
-                                      "border": "none",
-                                    }
-                                  }
-                                >
-                                  
-                                  
-                                </td>
                               </tr>,
                             ],
                           },
@@ -4998,84 +4352,50 @@ ShallowWrapper {
                               "key": "card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-0",
                               "nodeType": "host",
                               "props": Object {
-                                "children": Array [
-                                  <td
-                                    style={
-                                      Object {
-                                        "border": "none",
-                                      }
+                                "children": <td
+                                  style={
+                                    Object {
+                                      "border": "none",
                                     }
-                                  >
-                                    <HexText
-                                      classes="small smd-pad-4"
-                                      value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                    />
-                                  </td>,
-                                  <td
-                                    style={
-                                      Object {
-                                        "border": "none",
-                                      }
-                                    }
-                                  >
-                                    
-                                    
-                                  </td>,
-                                ],
+                                  }
+                                >
+                                  <HexText
+                                    classes="small smd-pad-4"
+                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  />
+                                </td>,
                                 "className": "selected",
                                 "onClick": [Function],
                               },
                               "ref": null,
-                              "rendered": Array [
-                                Object {
+                              "rendered": Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": <HexText
+                                    classes="small smd-pad-4"
+                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  />,
+                                  "style": Object {
+                                    "border": "none",
+                                  },
+                                },
+                                "ref": null,
+                                "rendered": Object {
                                   "instance": null,
                                   "key": undefined,
-                                  "nodeType": "host",
+                                  "nodeType": "class",
                                   "props": Object {
-                                    "children": <HexText
-                                      classes="small smd-pad-4"
-                                      value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                    />,
-                                    "style": Object {
-                                      "border": "none",
-                                    },
+                                    "classes": "small smd-pad-4",
+                                    "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
                                   },
                                   "ref": null,
-                                  "rendered": Object {
-                                    "instance": null,
-                                    "key": undefined,
-                                    "nodeType": "class",
-                                    "props": Object {
-                                      "classes": "small smd-pad-4",
-                                      "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
-                                    },
-                                    "ref": null,
-                                    "rendered": null,
-                                    "type": [Function],
-                                  },
-                                  "type": "td",
+                                  "rendered": null,
+                                  "type": [Function],
                                 },
-                                Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "host",
-                                  "props": Object {
-                                    "children": Array [
-                                      "",
-                                      "",
-                                    ],
-                                    "style": Object {
-                                      "border": "none",
-                                    },
-                                  },
-                                  "ref": null,
-                                  "rendered": Array [
-                                    "",
-                                    "",
-                                  ],
-                                  "type": "td",
-                                },
-                              ],
+                                "type": "td",
+                              },
                               "type": "tr",
                             },
                           ],
@@ -5152,42 +4472,6 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
-                              "overflow": "hidden",
-                              "textOverflow": "ellipsis",
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        >
-                          <Blueprint.Tooltip
-                            content="greet"
-                            hoverCloseDelay={0}
-                            hoverOpenDelay={100}
-                            isDisabled={false}
-                            openOnTargetFocus={true}
-                            position={0}
-                            rootElementTag="span"
-                            transitionDuration={100}
-                            useSmartArrowPositioning={true}
-                            useSmartPositioning={false}
-                          >
-                            greet
-                          </Blueprint.Tooltip>
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "maxWidth": "300px",
-                            }
-                          }
-                        >
-                          <pre>
-                            function () returns (String)
-                          </pre>
-                        </td>
-                        <td
-                          style={
-                            Object {
                               "verticalAlign": "middle",
                             }
                           }
@@ -5202,12 +4486,23 @@ ShallowWrapper {
                             symbolName="greet"
                           />
                         </td>
+                        <td
+                          style={
+                            Object {
+                              "maxWidth": "500px",
+                            }
+                          }
+                        >
+                          <pre>
+                            function () returns (String)
+                          </pre>
+                        </td>
                       </tr>
                       <tr>
                         <td
                           style={
                             Object {
-                              "maxWidth": "90px",
+                              "maxWidth": "120px",
                               "overflow": "hidden",
                               "textOverflow": "ellipsis",
                               "verticalAlign": "middle",
@@ -5232,7 +4527,7 @@ ShallowWrapper {
                         <td
                           style={
                             Object {
-                              "maxWidth": "300px",
+                              "maxWidth": "500px",
                             }
                           }
                         >
@@ -5240,13 +4535,6 @@ ShallowWrapper {
                             sadasd
                           </pre>
                         </td>
-                        <td
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                        />
                       </tr>
                     </tbody>
                   </table>
@@ -5311,42 +4599,6 @@ ShallowWrapper {
                           <td
                             style={
                               Object {
-                                "maxWidth": "90px",
-                                "overflow": "hidden",
-                                "textOverflow": "ellipsis",
-                                "verticalAlign": "middle",
-                              }
-                            }
-                          >
-                            <Blueprint.Tooltip
-                              content="greet"
-                              hoverCloseDelay={0}
-                              hoverOpenDelay={100}
-                              isDisabled={false}
-                              openOnTargetFocus={true}
-                              position={0}
-                              rootElementTag="span"
-                              transitionDuration={100}
-                              useSmartArrowPositioning={true}
-                              useSmartPositioning={false}
-                            >
-                              greet
-                            </Blueprint.Tooltip>
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "maxWidth": "300px",
-                              }
-                            }
-                          >
-                            <pre>
-                              function () returns (String)
-                            </pre>
-                          </td>
-                          <td
-                            style={
-                              Object {
                                 "verticalAlign": "middle",
                               }
                             }
@@ -5361,12 +4613,23 @@ ShallowWrapper {
                               symbolName="greet"
                             />
                           </td>
+                          <td
+                            style={
+                              Object {
+                                "maxWidth": "500px",
+                              }
+                            }
+                          >
+                            <pre>
+                              function () returns (String)
+                            </pre>
+                          </td>
                         </tr>
                         <tr>
                           <td
                             style={
                               Object {
-                                "maxWidth": "90px",
+                                "maxWidth": "120px",
                                 "overflow": "hidden",
                                 "textOverflow": "ellipsis",
                                 "verticalAlign": "middle",
@@ -5391,7 +4654,7 @@ ShallowWrapper {
                           <td
                             style={
                               Object {
-                                "maxWidth": "300px",
+                                "maxWidth": "500px",
                               }
                             }
                           >
@@ -5399,13 +4662,6 @@ ShallowWrapper {
                               sadasd
                             </pre>
                           </td>
-                          <td
-                            style={
-                              Object {
-                                "verticalAlign": "middle",
-                              }
-                            }
-                          />
                         </tr>
                       </tbody>
                     </table>
@@ -5510,42 +4766,6 @@ ShallowWrapper {
                           <td
                             style={
                               Object {
-                                "maxWidth": "90px",
-                                "overflow": "hidden",
-                                "textOverflow": "ellipsis",
-                                "verticalAlign": "middle",
-                              }
-                            }
-                          >
-                            <Blueprint.Tooltip
-                              content="greet"
-                              hoverCloseDelay={0}
-                              hoverOpenDelay={100}
-                              isDisabled={false}
-                              openOnTargetFocus={true}
-                              position={0}
-                              rootElementTag="span"
-                              transitionDuration={100}
-                              useSmartArrowPositioning={true}
-                              useSmartPositioning={false}
-                            >
-                              greet
-                            </Blueprint.Tooltip>
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "maxWidth": "300px",
-                              }
-                            }
-                          >
-                            <pre>
-                              function () returns (String)
-                            </pre>
-                          </td>
-                          <td
-                            style={
-                              Object {
                                 "verticalAlign": "middle",
                               }
                             }
@@ -5560,12 +4780,23 @@ ShallowWrapper {
                               symbolName="greet"
                             />
                           </td>
+                          <td
+                            style={
+                              Object {
+                                "maxWidth": "500px",
+                              }
+                            }
+                          >
+                            <pre>
+                              function () returns (String)
+                            </pre>
+                          </td>
                         </tr>
                         <tr>
                           <td
                             style={
                               Object {
-                                "maxWidth": "90px",
+                                "maxWidth": "120px",
                                 "overflow": "hidden",
                                 "textOverflow": "ellipsis",
                                 "verticalAlign": "middle",
@@ -5590,7 +4821,7 @@ ShallowWrapper {
                           <td
                             style={
                               Object {
-                                "maxWidth": "300px",
+                                "maxWidth": "500px",
                               }
                             }
                           >
@@ -5598,13 +4829,6 @@ ShallowWrapper {
                               sadasd
                             </pre>
                           </td>
-                          <td
-                            style={
-                              Object {
-                                "verticalAlign": "middle",
-                              }
-                            }
-                          />
                         </tr>
                       </tbody>
                     </table>
@@ -5645,42 +4869,6 @@ ShallowWrapper {
                           <td
                             style={
                               Object {
-                                "maxWidth": "90px",
-                                "overflow": "hidden",
-                                "textOverflow": "ellipsis",
-                                "verticalAlign": "middle",
-                              }
-                            }
-                          >
-                            <Blueprint.Tooltip
-                              content="greet"
-                              hoverCloseDelay={0}
-                              hoverOpenDelay={100}
-                              isDisabled={false}
-                              openOnTargetFocus={true}
-                              position={0}
-                              rootElementTag="span"
-                              transitionDuration={100}
-                              useSmartArrowPositioning={true}
-                              useSmartPositioning={false}
-                            >
-                              greet
-                            </Blueprint.Tooltip>
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "maxWidth": "300px",
-                              }
-                            }
-                          >
-                            <pre>
-                              function () returns (String)
-                            </pre>
-                          </td>
-                          <td
-                            style={
-                              Object {
                                 "verticalAlign": "middle",
                               }
                             }
@@ -5695,12 +4883,23 @@ ShallowWrapper {
                               symbolName="greet"
                             />
                           </td>
+                          <td
+                            style={
+                              Object {
+                                "maxWidth": "500px",
+                              }
+                            }
+                          >
+                            <pre>
+                              function () returns (String)
+                            </pre>
+                          </td>
                         </tr>
                         <tr>
                           <td
                             style={
                               Object {
-                                "maxWidth": "90px",
+                                "maxWidth": "120px",
                                 "overflow": "hidden",
                                 "textOverflow": "ellipsis",
                                 "verticalAlign": "middle",
@@ -5725,7 +4924,7 @@ ShallowWrapper {
                           <td
                             style={
                               Object {
-                                "maxWidth": "300px",
+                                "maxWidth": "500px",
                               }
                             }
                           >
@@ -5733,13 +4932,6 @@ ShallowWrapper {
                               sadasd
                             </pre>
                           </td>
-                          <td
-                            style={
-                              Object {
-                                "verticalAlign": "middle",
-                              }
-                            }
-                          />
                         </tr>
                       </tbody>
                     </table>,
@@ -5777,42 +4969,6 @@ ShallowWrapper {
                             <td
                               style={
                                 Object {
-                                  "maxWidth": "90px",
-                                  "overflow": "hidden",
-                                  "textOverflow": "ellipsis",
-                                  "verticalAlign": "middle",
-                                }
-                              }
-                            >
-                              <Blueprint.Tooltip
-                                content="greet"
-                                hoverCloseDelay={0}
-                                hoverOpenDelay={100}
-                                isDisabled={false}
-                                openOnTargetFocus={true}
-                                position={0}
-                                rootElementTag="span"
-                                transitionDuration={100}
-                                useSmartArrowPositioning={true}
-                                useSmartPositioning={false}
-                              >
-                                greet
-                              </Blueprint.Tooltip>
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "maxWidth": "300px",
-                                }
-                              }
-                            >
-                              <pre>
-                                function () returns (String)
-                              </pre>
-                            </td>
-                            <td
-                              style={
-                                Object {
                                   "verticalAlign": "middle",
                                 }
                               }
@@ -5827,12 +4983,23 @@ ShallowWrapper {
                                 symbolName="greet"
                               />
                             </td>
+                            <td
+                              style={
+                                Object {
+                                  "maxWidth": "500px",
+                                }
+                              }
+                            >
+                              <pre>
+                                function () returns (String)
+                              </pre>
+                            </td>
                           </tr>
                           <tr>
                             <td
                               style={
                                 Object {
-                                  "maxWidth": "90px",
+                                  "maxWidth": "120px",
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "verticalAlign": "middle",
@@ -5857,7 +5024,7 @@ ShallowWrapper {
                             <td
                               style={
                                 Object {
-                                  "maxWidth": "300px",
+                                  "maxWidth": "500px",
                                 }
                               }
                             >
@@ -5865,13 +5032,6 @@ ShallowWrapper {
                                 sadasd
                               </pre>
                             </td>
-                            <td
-                              style={
-                                Object {
-                                  "verticalAlign": "middle",
-                                }
-                              }
-                            />
                           </tr>
                         </tbody>,
                       ],
@@ -5982,42 +5142,6 @@ ShallowWrapper {
                               <td
                                 style={
                                   Object {
-                                    "maxWidth": "90px",
-                                    "overflow": "hidden",
-                                    "textOverflow": "ellipsis",
-                                    "verticalAlign": "middle",
-                                  }
-                                }
-                              >
-                                <Blueprint.Tooltip
-                                  content="greet"
-                                  hoverCloseDelay={0}
-                                  hoverOpenDelay={100}
-                                  isDisabled={false}
-                                  openOnTargetFocus={true}
-                                  position={0}
-                                  rootElementTag="span"
-                                  transitionDuration={100}
-                                  useSmartArrowPositioning={true}
-                                  useSmartPositioning={false}
-                                >
-                                  greet
-                                </Blueprint.Tooltip>
-                              </td>
-                              <td
-                                style={
-                                  Object {
-                                    "maxWidth": "300px",
-                                  }
-                                }
-                              >
-                                <pre>
-                                  function () returns (String)
-                                </pre>
-                              </td>
-                              <td
-                                style={
-                                  Object {
                                     "verticalAlign": "middle",
                                   }
                                 }
@@ -6032,12 +5156,23 @@ ShallowWrapper {
                                   symbolName="greet"
                                 />
                               </td>
+                              <td
+                                style={
+                                  Object {
+                                    "maxWidth": "500px",
+                                  }
+                                }
+                              >
+                                <pre>
+                                  function () returns (String)
+                                </pre>
+                              </td>
                             </tr>,
                             <tr>
                               <td
                                 style={
                                   Object {
-                                    "maxWidth": "90px",
+                                    "maxWidth": "120px",
                                     "overflow": "hidden",
                                     "textOverflow": "ellipsis",
                                     "verticalAlign": "middle",
@@ -6062,7 +5197,7 @@ ShallowWrapper {
                               <td
                                 style={
                                   Object {
-                                    "maxWidth": "300px",
+                                    "maxWidth": "500px",
                                   }
                                 }
                               >
@@ -6070,13 +5205,6 @@ ShallowWrapper {
                                   sadasd
                                 </pre>
                               </td>
-                              <td
-                                style={
-                                  Object {
-                                    "verticalAlign": "middle",
-                                  }
-                                }
-                              />
                             </tr>,
                           ],
                         },
@@ -6088,42 +5216,6 @@ ShallowWrapper {
                             "nodeType": "host",
                             "props": Object {
                               "children": Array [
-                                <td
-                                  style={
-                                    Object {
-                                      "maxWidth": "90px",
-                                      "overflow": "hidden",
-                                      "textOverflow": "ellipsis",
-                                      "verticalAlign": "middle",
-                                    }
-                                  }
-                                >
-                                  <Blueprint.Tooltip
-                                    content="greet"
-                                    hoverCloseDelay={0}
-                                    hoverOpenDelay={100}
-                                    isDisabled={false}
-                                    openOnTargetFocus={true}
-                                    position={0}
-                                    rootElementTag="span"
-                                    transitionDuration={100}
-                                    useSmartArrowPositioning={true}
-                                    useSmartPositioning={false}
-                                  >
-                                    greet
-                                  </Blueprint.Tooltip>
-                                </td>,
-                                <td
-                                  style={
-                                    Object {
-                                      "maxWidth": "300px",
-                                    }
-                                  }
-                                >
-                                  <pre>
-                                    function () returns (String)
-                                  </pre>
-                                </td>,
                                 <td
                                   style={
                                     Object {
@@ -6141,86 +5233,21 @@ ShallowWrapper {
                                     symbolName="greet"
                                   />
                                 </td>,
+                                <td
+                                  style={
+                                    Object {
+                                      "maxWidth": "500px",
+                                    }
+                                  }
+                                >
+                                  <pre>
+                                    function () returns (String)
+                                  </pre>
+                                </td>,
                               ],
                             },
                             "ref": null,
                             "rendered": Array [
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": <Blueprint.Tooltip
-                                    content="greet"
-                                    hoverCloseDelay={0}
-                                    hoverOpenDelay={100}
-                                    isDisabled={false}
-                                    openOnTargetFocus={true}
-                                    position={0}
-                                    rootElementTag="span"
-                                    transitionDuration={100}
-                                    useSmartArrowPositioning={true}
-                                    useSmartPositioning={false}
-                                  >
-                                    greet
-                                  </Blueprint.Tooltip>,
-                                  "style": Object {
-                                    "maxWidth": "90px",
-                                    "overflow": "hidden",
-                                    "textOverflow": "ellipsis",
-                                    "verticalAlign": "middle",
-                                  },
-                                },
-                                "ref": null,
-                                "rendered": Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "class",
-                                  "props": Object {
-                                    "children": "greet",
-                                    "content": "greet",
-                                    "hoverCloseDelay": 0,
-                                    "hoverOpenDelay": 100,
-                                    "isDisabled": false,
-                                    "openOnTargetFocus": true,
-                                    "position": 0,
-                                    "rootElementTag": "span",
-                                    "transitionDuration": 100,
-                                    "useSmartArrowPositioning": true,
-                                    "useSmartPositioning": false,
-                                  },
-                                  "ref": null,
-                                  "rendered": "greet",
-                                  "type": [Function],
-                                },
-                                "type": "td",
-                              },
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": <pre>
-                                    function () returns (String)
-                                  </pre>,
-                                  "style": Object {
-                                    "maxWidth": "300px",
-                                  },
-                                },
-                                "ref": null,
-                                "rendered": Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "host",
-                                  "props": Object {
-                                    "children": "function () returns (String)",
-                                  },
-                                  "ref": null,
-                                  "rendered": "function () returns (String)",
-                                  "type": "pre",
-                                },
-                                "type": "td",
-                              },
                               Object {
                                 "instance": null,
                                 "key": undefined,
@@ -6259,6 +5286,32 @@ ShallowWrapper {
                                 },
                                 "type": "td",
                               },
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": <pre>
+                                    function () returns (String)
+                                  </pre>,
+                                  "style": Object {
+                                    "maxWidth": "500px",
+                                  },
+                                },
+                                "ref": null,
+                                "rendered": Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": "function () returns (String)",
+                                  },
+                                  "ref": null,
+                                  "rendered": "function () returns (String)",
+                                  "type": "pre",
+                                },
+                                "type": "td",
+                              },
                             ],
                             "type": "tr",
                           },
@@ -6271,7 +5324,7 @@ ShallowWrapper {
                                 <td
                                   style={
                                     Object {
-                                      "maxWidth": "90px",
+                                      "maxWidth": "120px",
                                       "overflow": "hidden",
                                       "textOverflow": "ellipsis",
                                       "verticalAlign": "middle",
@@ -6296,7 +5349,7 @@ ShallowWrapper {
                                 <td
                                   style={
                                     Object {
-                                      "maxWidth": "300px",
+                                      "maxWidth": "500px",
                                     }
                                   }
                                 >
@@ -6304,13 +5357,6 @@ ShallowWrapper {
                                     sadasd
                                   </pre>
                                 </td>,
-                                <td
-                                  style={
-                                    Object {
-                                      "verticalAlign": "middle",
-                                    }
-                                  }
-                                />,
                               ],
                             },
                             "ref": null,
@@ -6335,7 +5381,7 @@ ShallowWrapper {
                                     greeting
                                   </Blueprint.Tooltip>,
                                   "style": Object {
-                                    "maxWidth": "90px",
+                                    "maxWidth": "120px",
                                     "overflow": "hidden",
                                     "textOverflow": "ellipsis",
                                     "verticalAlign": "middle",
@@ -6374,7 +5420,7 @@ ShallowWrapper {
                                     sadasd
                                   </pre>,
                                   "style": Object {
-                                    "maxWidth": "300px",
+                                    "maxWidth": "500px",
                                   },
                                 },
                                 "ref": null,
@@ -6389,20 +5435,6 @@ ShallowWrapper {
                                   "rendered": "sadasd",
                                   "type": "pre",
                                 },
-                                "type": "td",
-                              },
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": null,
-                                  "style": Object {
-                                    "verticalAlign": "middle",
-                                  },
-                                },
-                                "ref": null,
-                                "rendered": null,
                                 "type": "td",
                               },
                             ],
@@ -6482,6 +5514,13 @@ ShallowWrapper {
                   className="pt-button-group"
                 >
                   <Blueprint.Button
+                    className="pt-intent-primary pt-icon-th"
+                    onClick={[Function]}
+                    type="Button"
+                  >
+                    Tabular Data
+                  </Blueprint.Button>
+                  <Blueprint.Button
                     className="pt-icon-double-caret-vertical btn-sm"
                     onClick={[Function]}
                     type="button"
@@ -6513,7 +5552,6 @@ ShallowWrapper {
                         <th>
                           Contract Address
                         </th>
-                        <th />
                       </tr>
                     </thead>
                     <tbody>
@@ -6563,6 +5601,13 @@ ShallowWrapper {
                   className="pt-button-group"
                 >
                   <Blueprint.Button
+                    className="pt-intent-primary pt-icon-th"
+                    onClick={[Function]}
+                    type="Button"
+                  >
+                    Tabular Data
+                  </Blueprint.Button>
+                  <Blueprint.Button
                     className="pt-icon-double-caret-vertical btn-sm"
                     onClick={[Function]}
                     type="button"
@@ -6594,7 +5639,6 @@ ShallowWrapper {
                         <th>
                           Contract Address
                         </th>
-                        <th />
                       </tr>
                     </thead>
                     <tbody>
@@ -6636,6 +5680,13 @@ ShallowWrapper {
                     className="pt-button-group"
                   >
                     <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
+                    >
+                      Tabular Data
+                    </Blueprint.Button>
+                    <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
                       type="button"
@@ -6667,7 +5718,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -6706,6 +5756,13 @@ ShallowWrapper {
                     <div
                       className="pt-button-group"
                     >
+                      <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
+                      >
+                        Tabular Data
+                      </Blueprint.Button>
                       <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
@@ -6752,6 +5809,13 @@ ShallowWrapper {
                       className="pt-button-group"
                     >
                       <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
+                      >
+                        Tabular Data
+                      </Blueprint.Button>
+                      <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
                         type="button"
@@ -6769,7 +5833,13 @@ ShallowWrapper {
                     "nodeType": "host",
                     "props": Object {
                       "children": Array [
-                        null,
+                        <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
+                        >
+                          Tabular Data
+                        </Blueprint.Button>,
                         <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
@@ -6783,7 +5853,20 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": Array [
-                      null,
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "children": "Tabular Data",
+                          "className": "pt-intent-primary pt-icon-th",
+                          "onClick": [Function],
+                          "type": "Button",
+                        },
+                        "ref": null,
+                        "rendered": "Tabular Data",
+                        "type": [Function],
+                      },
                       Object {
                         "instance": null,
                         "key": undefined,
@@ -6835,7 +5918,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -6874,7 +5956,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -6905,7 +5986,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -6937,7 +6017,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>,
                         <tbody>
@@ -6964,7 +6043,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>,
                         },
                         "ref": null,
@@ -6973,36 +6051,22 @@ ShallowWrapper {
                           "key": undefined,
                           "nodeType": "host",
                           "props": Object {
-                            "children": Array [
-                              <th>
-                                Contract Address
-                              </th>,
-                              <th />,
-                            ],
+                            "children": <th>
+                              Contract Address
+                            </th>,
                           },
                           "ref": null,
-                          "rendered": Array [
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": "Contract Address",
-                              },
-                              "ref": null,
-                              "rendered": "Contract Address",
-                              "type": "th",
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Contract Address",
                             },
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {},
-                              "ref": null,
-                              "rendered": null,
-                              "type": "th",
-                            },
-                          ],
+                            "ref": null,
+                            "rendered": "Contract Address",
+                            "type": "th",
+                          },
                           "type": "tr",
                         },
                         "type": "thead",
@@ -7113,6 +6177,13 @@ ShallowWrapper {
                     className="pt-button-group"
                   >
                     <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
+                    >
+                      Tabular Data
+                    </Blueprint.Button>
+                    <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
                       type="button"
@@ -7144,7 +6215,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -7194,6 +6264,13 @@ ShallowWrapper {
                     className="pt-button-group"
                   >
                     <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
+                    >
+                      Tabular Data
+                    </Blueprint.Button>
+                    <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
                       type="button"
@@ -7225,7 +6302,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -7267,6 +6343,13 @@ ShallowWrapper {
                       className="pt-button-group"
                     >
                       <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
+                      >
+                        Tabular Data
+                      </Blueprint.Button>
+                      <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
                         type="button"
@@ -7298,7 +6381,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -7337,6 +6419,13 @@ ShallowWrapper {
                       <div
                         className="pt-button-group"
                       >
+                        <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
+                        >
+                          Tabular Data
+                        </Blueprint.Button>
                         <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
@@ -7383,6 +6472,13 @@ ShallowWrapper {
                         className="pt-button-group"
                       >
                         <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
+                        >
+                          Tabular Data
+                        </Blueprint.Button>
+                        <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
                           type="button"
@@ -7400,7 +6496,13 @@ ShallowWrapper {
                       "nodeType": "host",
                       "props": Object {
                         "children": Array [
-                          null,
+                          <Blueprint.Button
+                            className="pt-intent-primary pt-icon-th"
+                            onClick={[Function]}
+                            type="Button"
+                          >
+                            Tabular Data
+                          </Blueprint.Button>,
                           <Blueprint.Button
                             className="pt-icon-double-caret-vertical btn-sm"
                             onClick={[Function]}
@@ -7414,7 +6516,20 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": Array [
-                        null,
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "class",
+                          "props": Object {
+                            "children": "Tabular Data",
+                            "className": "pt-intent-primary pt-icon-th",
+                            "onClick": [Function],
+                            "type": "Button",
+                          },
+                          "ref": null,
+                          "rendered": "Tabular Data",
+                          "type": [Function],
+                        },
                         Object {
                           "instance": null,
                           "key": undefined,
@@ -7466,7 +6581,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -7505,7 +6619,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -7536,7 +6649,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -7568,7 +6680,6 @@ ShallowWrapper {
                               <th>
                                 Contract Address
                               </th>
-                              <th />
                             </tr>
                           </thead>,
                           <tbody>
@@ -7595,7 +6706,6 @@ ShallowWrapper {
                               <th>
                                 Contract Address
                               </th>
-                              <th />
                             </tr>,
                           },
                           "ref": null,
@@ -7604,36 +6714,22 @@ ShallowWrapper {
                             "key": undefined,
                             "nodeType": "host",
                             "props": Object {
-                              "children": Array [
-                                <th>
-                                  Contract Address
-                                </th>,
-                                <th />,
-                              ],
+                              "children": <th>
+                                Contract Address
+                              </th>,
                             },
                             "ref": null,
-                            "rendered": Array [
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": "Contract Address",
-                                },
-                                "ref": null,
-                                "rendered": "Contract Address",
-                                "type": "th",
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "Contract Address",
                               },
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {},
-                                "ref": null,
-                                "rendered": null,
-                                "type": "th",
-                              },
-                            ],
+                              "ref": null,
+                              "rendered": "Contract Address",
+                              "type": "th",
+                            },
                             "type": "tr",
                           },
                           "type": "thead",
@@ -7787,17 +6883,13 @@ ShallowWrapper {
                 <div
                   className="pt-button-group"
                 >
-                  <Link
-                    replace={false}
-                    to="/contracts/Greeter/query"
+                  <Blueprint.Button
+                    className="pt-intent-primary pt-icon-th"
+                    onClick={[Function]}
+                    type="Button"
                   >
-                    <Blueprint.Button
-                      className="pt-intent-primary"
-                      type="Button"
-                    >
-                      Query Builder
-                    </Blueprint.Button>
-                  </Link>
+                    Tabular Data
+                  </Blueprint.Button>
                   <Blueprint.Button
                     className="pt-icon-double-caret-vertical btn-sm"
                     onClick={[Function]}
@@ -7830,7 +6922,6 @@ ShallowWrapper {
                         <th>
                           Contract Address
                         </th>
-                        <th />
                       </tr>
                     </thead>
                     <tbody>
@@ -7849,24 +6940,6 @@ ShallowWrapper {
                             classes="small smd-pad-4"
                             value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                           />
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "border": "none",
-                            }
-                          }
-                        >
-                          <span
-                            className="pt-tag pt-intent-success smd-margin-right-4"
-                          >
-                            Bloc
-                          </span>
-                          <span
-                            className="pt-tag pt-intent-primary"
-                          >
-                            Cirrus
-                          </span>
                         </td>
                       </tr>
                     </tbody>
@@ -7908,17 +6981,13 @@ ShallowWrapper {
                 <div
                   className="pt-button-group"
                 >
-                  <Link
-                    replace={false}
-                    to="/contracts/Greeter/query"
+                  <Blueprint.Button
+                    className="pt-intent-primary pt-icon-th"
+                    onClick={[Function]}
+                    type="Button"
                   >
-                    <Blueprint.Button
-                      className="pt-intent-primary"
-                      type="Button"
-                    >
-                      Query Builder
-                    </Blueprint.Button>
-                  </Link>
+                    Tabular Data
+                  </Blueprint.Button>
                   <Blueprint.Button
                     className="pt-icon-double-caret-vertical btn-sm"
                     onClick={[Function]}
@@ -7951,7 +7020,6 @@ ShallowWrapper {
                         <th>
                           Contract Address
                         </th>
-                        <th />
                       </tr>
                     </thead>
                     <tbody>
@@ -7970,24 +7038,6 @@ ShallowWrapper {
                             classes="small smd-pad-4"
                             value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                           />
-                        </td>
-                        <td
-                          style={
-                            Object {
-                              "border": "none",
-                            }
-                          }
-                        >
-                          <span
-                            className="pt-tag pt-intent-success smd-margin-right-4"
-                          >
-                            Bloc
-                          </span>
-                          <span
-                            className="pt-tag pt-intent-primary"
-                          >
-                            Cirrus
-                          </span>
                         </td>
                       </tr>
                     </tbody>
@@ -8021,17 +7071,13 @@ ShallowWrapper {
                   <div
                     className="pt-button-group"
                   >
-                    <Link
-                      replace={false}
-                      to="/contracts/Greeter/query"
+                    <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
                     >
-                      <Blueprint.Button
-                        className="pt-intent-primary"
-                        type="Button"
-                      >
-                        Query Builder
-                      </Blueprint.Button>
-                    </Link>
+                      Tabular Data
+                    </Blueprint.Button>
                     <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
@@ -8064,7 +7110,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -8083,24 +7128,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            <span
-                              className="pt-tag pt-intent-success smd-margin-right-4"
-                            >
-                              Bloc
-                            </span>
-                            <span
-                              className="pt-tag pt-intent-primary"
-                            >
-                              Cirrus
-                            </span>
                           </td>
                         </tr>
                       </tbody>
@@ -8132,17 +7159,13 @@ ShallowWrapper {
                     <div
                       className="pt-button-group"
                     >
-                      <Link
-                        replace={false}
-                        to="/contracts/Greeter/query"
+                      <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
                       >
-                        <Blueprint.Button
-                          className="pt-intent-primary"
-                          type="Button"
-                        >
-                          Query Builder
-                        </Blueprint.Button>
-                      </Link>
+                        Tabular Data
+                      </Blueprint.Button>
                       <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
@@ -8190,17 +7213,13 @@ ShallowWrapper {
                     "children": <div
                       className="pt-button-group"
                     >
-                      <Link
-                        replace={false}
-                        to="/contracts/Greeter/query"
+                      <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
                       >
-                        <Blueprint.Button
-                          className="pt-intent-primary"
-                          type="Button"
-                        >
-                          Query Builder
-                        </Blueprint.Button>
-                      </Link>
+                        Tabular Data
+                      </Blueprint.Button>
                       <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
@@ -8219,17 +7238,13 @@ ShallowWrapper {
                     "nodeType": "host",
                     "props": Object {
                       "children": Array [
-                        <Link
-                          replace={false}
-                          to="/contracts/Greeter/query"
+                        <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
                         >
-                          <Blueprint.Button
-                            className="pt-intent-primary"
-                            type="Button"
-                          >
-                            Query Builder
-                          </Blueprint.Button>
-                        </Link>,
+                          Tabular Data
+                        </Blueprint.Button>,
                         <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
@@ -8248,29 +7263,13 @@ ShallowWrapper {
                         "key": undefined,
                         "nodeType": "class",
                         "props": Object {
-                          "children": <Blueprint.Button
-                            className="pt-intent-primary"
-                            type="Button"
-                          >
-                            Query Builder
-                          </Blueprint.Button>,
-                          "replace": false,
-                          "to": "/contracts/Greeter/query",
+                          "children": "Tabular Data",
+                          "className": "pt-intent-primary pt-icon-th",
+                          "onClick": [Function],
+                          "type": "Button",
                         },
                         "ref": null,
-                        "rendered": Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "children": "Query Builder",
-                            "className": "pt-intent-primary",
-                            "type": "Button",
-                          },
-                          "ref": null,
-                          "rendered": "Query Builder",
-                          "type": [Function],
-                        },
+                        "rendered": "Tabular Data",
                         "type": [Function],
                       },
                       Object {
@@ -8324,7 +7323,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -8343,24 +7341,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            <span
-                              className="pt-tag pt-intent-success smd-margin-right-4"
-                            >
-                              Bloc
-                            </span>
-                            <span
-                              className="pt-tag pt-intent-primary"
-                            >
-                              Cirrus
-                            </span>
                           </td>
                         </tr>
                       </tbody>
@@ -8390,7 +7370,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -8409,24 +7388,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            <span
-                              className="pt-tag pt-intent-success smd-margin-right-4"
-                            >
-                              Bloc
-                            </span>
-                            <span
-                              className="pt-tag pt-intent-primary"
-                            >
-                              Cirrus
-                            </span>
                           </td>
                         </tr>
                       </tbody>
@@ -8448,7 +7409,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -8467,24 +7427,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            <span
-                              className="pt-tag pt-intent-success smd-margin-right-4"
-                            >
-                              Bloc
-                            </span>
-                            <span
-                              className="pt-tag pt-intent-primary"
-                            >
-                              Cirrus
-                            </span>
                           </td>
                         </tr>
                       </tbody>
@@ -8507,7 +7449,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>,
                         <tbody>
@@ -8527,24 +7468,6 @@ ShallowWrapper {
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
                             </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              <span
-                                className="pt-tag pt-intent-success smd-margin-right-4"
-                              >
-                                Bloc
-                              </span>
-                              <span
-                                className="pt-tag pt-intent-primary"
-                              >
-                                Cirrus
-                              </span>
-                            </td>
                           </tr>
                         </tbody>,
                       ],
@@ -8561,7 +7484,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>,
                         },
                         "ref": null,
@@ -8570,36 +7492,22 @@ ShallowWrapper {
                           "key": undefined,
                           "nodeType": "host",
                           "props": Object {
-                            "children": Array [
-                              <th>
-                                Contract Address
-                              </th>,
-                              <th />,
-                            ],
+                            "children": <th>
+                              Contract Address
+                            </th>,
                           },
                           "ref": null,
-                          "rendered": Array [
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": "Contract Address",
-                              },
-                              "ref": null,
-                              "rendered": "Contract Address",
-                              "type": "th",
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Contract Address",
                             },
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {},
-                              "ref": null,
-                              "rendered": null,
-                              "type": "th",
-                            },
-                          ],
+                            "ref": null,
+                            "rendered": "Contract Address",
+                            "type": "th",
+                          },
                           "type": "tr",
                         },
                         "type": "thead",
@@ -8626,24 +7534,6 @@ ShallowWrapper {
                                   value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                                 />
                               </td>
-                              <td
-                                style={
-                                  Object {
-                                    "border": "none",
-                                  }
-                                }
-                              >
-                                <span
-                                  className="pt-tag pt-intent-success smd-margin-right-4"
-                                >
-                                  Bloc
-                                </span>
-                                <span
-                                  className="pt-tag pt-intent-primary"
-                                >
-                                  Cirrus
-                                </span>
-                              </td>
                             </tr>,
                           ],
                         },
@@ -8654,122 +7544,50 @@ ShallowWrapper {
                             "key": "card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-0",
                             "nodeType": "host",
                             "props": Object {
-                              "children": Array [
-                                <td
-                                  style={
-                                    Object {
-                                      "border": "none",
-                                    }
+                              "children": <td
+                                style={
+                                  Object {
+                                    "border": "none",
                                   }
-                                >
-                                  <HexText
-                                    classes="small smd-pad-4"
-                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                  />
-                                </td>,
-                                <td
-                                  style={
-                                    Object {
-                                      "border": "none",
-                                    }
-                                  }
-                                >
-                                  <span
-                                    className="pt-tag pt-intent-success smd-margin-right-4"
-                                  >
-                                    Bloc
-                                  </span>
-                                  <span
-                                    className="pt-tag pt-intent-primary"
-                                  >
-                                    Cirrus
-                                  </span>
-                                </td>,
-                              ],
+                                }
+                              >
+                                <HexText
+                                  classes="small smd-pad-4"
+                                  value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                />
+                              </td>,
                               "className": "",
                               "onClick": [Function],
                             },
                             "ref": null,
-                            "rendered": Array [
-                              Object {
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": <HexText
+                                  classes="small smd-pad-4"
+                                  value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                />,
+                                "style": Object {
+                                  "border": "none",
+                                },
+                              },
+                              "ref": null,
+                              "rendered": Object {
                                 "instance": null,
                                 "key": undefined,
-                                "nodeType": "host",
+                                "nodeType": "class",
                                 "props": Object {
-                                  "children": <HexText
-                                    classes="small smd-pad-4"
-                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                  />,
-                                  "style": Object {
-                                    "border": "none",
-                                  },
+                                  "classes": "small smd-pad-4",
+                                  "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
                                 },
                                 "ref": null,
-                                "rendered": Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "class",
-                                  "props": Object {
-                                    "classes": "small smd-pad-4",
-                                    "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
-                                  },
-                                  "ref": null,
-                                  "rendered": null,
-                                  "type": [Function],
-                                },
-                                "type": "td",
+                                "rendered": null,
+                                "type": [Function],
                               },
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": Array [
-                                    <span
-                                      className="pt-tag pt-intent-success smd-margin-right-4"
-                                    >
-                                      Bloc
-                                    </span>,
-                                    <span
-                                      className="pt-tag pt-intent-primary"
-                                    >
-                                      Cirrus
-                                    </span>,
-                                  ],
-                                  "style": Object {
-                                    "border": "none",
-                                  },
-                                },
-                                "ref": null,
-                                "rendered": Array [
-                                  Object {
-                                    "instance": null,
-                                    "key": undefined,
-                                    "nodeType": "host",
-                                    "props": Object {
-                                      "children": "Bloc",
-                                      "className": "pt-tag pt-intent-success smd-margin-right-4",
-                                    },
-                                    "ref": null,
-                                    "rendered": "Bloc",
-                                    "type": "span",
-                                  },
-                                  Object {
-                                    "instance": null,
-                                    "key": undefined,
-                                    "nodeType": "host",
-                                    "props": Object {
-                                      "children": "Cirrus",
-                                      "className": "pt-tag pt-intent-primary",
-                                    },
-                                    "ref": null,
-                                    "rendered": "Cirrus",
-                                    "type": "span",
-                                  },
-                                ],
-                                "type": "td",
-                              },
-                            ],
+                              "type": "td",
+                            },
                             "type": "tr",
                           },
                         ],
@@ -8833,17 +7651,13 @@ ShallowWrapper {
                   <div
                     className="pt-button-group"
                   >
-                    <Link
-                      replace={false}
-                      to="/contracts/Greeter/query"
+                    <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
                     >
-                      <Blueprint.Button
-                        className="pt-intent-primary"
-                        type="Button"
-                      >
-                        Query Builder
-                      </Blueprint.Button>
-                    </Link>
+                      Tabular Data
+                    </Blueprint.Button>
                     <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
@@ -8876,7 +7690,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -8895,24 +7708,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            <span
-                              className="pt-tag pt-intent-success smd-margin-right-4"
-                            >
-                              Bloc
-                            </span>
-                            <span
-                              className="pt-tag pt-intent-primary"
-                            >
-                              Cirrus
-                            </span>
                           </td>
                         </tr>
                       </tbody>
@@ -8954,17 +7749,13 @@ ShallowWrapper {
                   <div
                     className="pt-button-group"
                   >
-                    <Link
-                      replace={false}
-                      to="/contracts/Greeter/query"
+                    <Blueprint.Button
+                      className="pt-intent-primary pt-icon-th"
+                      onClick={[Function]}
+                      type="Button"
                     >
-                      <Blueprint.Button
-                        className="pt-intent-primary"
-                        type="Button"
-                      >
-                        Query Builder
-                      </Blueprint.Button>
-                    </Link>
+                      Tabular Data
+                    </Blueprint.Button>
                     <Blueprint.Button
                       className="pt-icon-double-caret-vertical btn-sm"
                       onClick={[Function]}
@@ -8997,7 +7788,6 @@ ShallowWrapper {
                           <th>
                             Contract Address
                           </th>
-                          <th />
                         </tr>
                       </thead>
                       <tbody>
@@ -9016,24 +7806,6 @@ ShallowWrapper {
                               classes="small smd-pad-4"
                               value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                             />
-                          </td>
-                          <td
-                            style={
-                              Object {
-                                "border": "none",
-                              }
-                            }
-                          >
-                            <span
-                              className="pt-tag pt-intent-success smd-margin-right-4"
-                            >
-                              Bloc
-                            </span>
-                            <span
-                              className="pt-tag pt-intent-primary"
-                            >
-                              Cirrus
-                            </span>
                           </td>
                         </tr>
                       </tbody>
@@ -9067,17 +7839,13 @@ ShallowWrapper {
                     <div
                       className="pt-button-group"
                     >
-                      <Link
-                        replace={false}
-                        to="/contracts/Greeter/query"
+                      <Blueprint.Button
+                        className="pt-intent-primary pt-icon-th"
+                        onClick={[Function]}
+                        type="Button"
                       >
-                        <Blueprint.Button
-                          className="pt-intent-primary"
-                          type="Button"
-                        >
-                          Query Builder
-                        </Blueprint.Button>
-                      </Link>
+                        Tabular Data
+                      </Blueprint.Button>
                       <Blueprint.Button
                         className="pt-icon-double-caret-vertical btn-sm"
                         onClick={[Function]}
@@ -9110,7 +7878,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -9129,24 +7896,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              <span
-                                className="pt-tag pt-intent-success smd-margin-right-4"
-                              >
-                                Bloc
-                              </span>
-                              <span
-                                className="pt-tag pt-intent-primary"
-                              >
-                                Cirrus
-                              </span>
                             </td>
                           </tr>
                         </tbody>
@@ -9178,17 +7927,13 @@ ShallowWrapper {
                       <div
                         className="pt-button-group"
                       >
-                        <Link
-                          replace={false}
-                          to="/contracts/Greeter/query"
+                        <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
                         >
-                          <Blueprint.Button
-                            className="pt-intent-primary"
-                            type="Button"
-                          >
-                            Query Builder
-                          </Blueprint.Button>
-                        </Link>
+                          Tabular Data
+                        </Blueprint.Button>
                         <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
@@ -9236,17 +7981,13 @@ ShallowWrapper {
                       "children": <div
                         className="pt-button-group"
                       >
-                        <Link
-                          replace={false}
-                          to="/contracts/Greeter/query"
+                        <Blueprint.Button
+                          className="pt-intent-primary pt-icon-th"
+                          onClick={[Function]}
+                          type="Button"
                         >
-                          <Blueprint.Button
-                            className="pt-intent-primary"
-                            type="Button"
-                          >
-                            Query Builder
-                          </Blueprint.Button>
-                        </Link>
+                          Tabular Data
+                        </Blueprint.Button>
                         <Blueprint.Button
                           className="pt-icon-double-caret-vertical btn-sm"
                           onClick={[Function]}
@@ -9265,17 +8006,13 @@ ShallowWrapper {
                       "nodeType": "host",
                       "props": Object {
                         "children": Array [
-                          <Link
-                            replace={false}
-                            to="/contracts/Greeter/query"
+                          <Blueprint.Button
+                            className="pt-intent-primary pt-icon-th"
+                            onClick={[Function]}
+                            type="Button"
                           >
-                            <Blueprint.Button
-                              className="pt-intent-primary"
-                              type="Button"
-                            >
-                              Query Builder
-                            </Blueprint.Button>
-                          </Link>,
+                            Tabular Data
+                          </Blueprint.Button>,
                           <Blueprint.Button
                             className="pt-icon-double-caret-vertical btn-sm"
                             onClick={[Function]}
@@ -9294,29 +8031,13 @@ ShallowWrapper {
                           "key": undefined,
                           "nodeType": "class",
                           "props": Object {
-                            "children": <Blueprint.Button
-                              className="pt-intent-primary"
-                              type="Button"
-                            >
-                              Query Builder
-                            </Blueprint.Button>,
-                            "replace": false,
-                            "to": "/contracts/Greeter/query",
+                            "children": "Tabular Data",
+                            "className": "pt-intent-primary pt-icon-th",
+                            "onClick": [Function],
+                            "type": "Button",
                           },
                           "ref": null,
-                          "rendered": Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "children": "Query Builder",
-                              "className": "pt-intent-primary",
-                              "type": "Button",
-                            },
-                            "ref": null,
-                            "rendered": "Query Builder",
-                            "type": [Function],
-                          },
+                          "rendered": "Tabular Data",
                           "type": [Function],
                         },
                         Object {
@@ -9370,7 +8091,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -9389,24 +8109,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              <span
-                                className="pt-tag pt-intent-success smd-margin-right-4"
-                              >
-                                Bloc
-                              </span>
-                              <span
-                                className="pt-tag pt-intent-primary"
-                              >
-                                Cirrus
-                              </span>
                             </td>
                           </tr>
                         </tbody>
@@ -9436,7 +8138,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -9455,24 +8156,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              <span
-                                className="pt-tag pt-intent-success smd-margin-right-4"
-                              >
-                                Bloc
-                              </span>
-                              <span
-                                className="pt-tag pt-intent-primary"
-                              >
-                                Cirrus
-                              </span>
                             </td>
                           </tr>
                         </tbody>
@@ -9494,7 +8177,6 @@ ShallowWrapper {
                             <th>
                               Contract Address
                             </th>
-                            <th />
                           </tr>
                         </thead>
                         <tbody>
@@ -9513,24 +8195,6 @@ ShallowWrapper {
                                 classes="small smd-pad-4"
                                 value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "border": "none",
-                                }
-                              }
-                            >
-                              <span
-                                className="pt-tag pt-intent-success smd-margin-right-4"
-                              >
-                                Bloc
-                              </span>
-                              <span
-                                className="pt-tag pt-intent-primary"
-                              >
-                                Cirrus
-                              </span>
                             </td>
                           </tr>
                         </tbody>
@@ -9553,7 +8217,6 @@ ShallowWrapper {
                               <th>
                                 Contract Address
                               </th>
-                              <th />
                             </tr>
                           </thead>,
                           <tbody>
@@ -9573,24 +8236,6 @@ ShallowWrapper {
                                   value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                                 />
                               </td>
-                              <td
-                                style={
-                                  Object {
-                                    "border": "none",
-                                  }
-                                }
-                              >
-                                <span
-                                  className="pt-tag pt-intent-success smd-margin-right-4"
-                                >
-                                  Bloc
-                                </span>
-                                <span
-                                  className="pt-tag pt-intent-primary"
-                                >
-                                  Cirrus
-                                </span>
-                              </td>
                             </tr>
                           </tbody>,
                         ],
@@ -9607,7 +8252,6 @@ ShallowWrapper {
                               <th>
                                 Contract Address
                               </th>
-                              <th />
                             </tr>,
                           },
                           "ref": null,
@@ -9616,36 +8260,22 @@ ShallowWrapper {
                             "key": undefined,
                             "nodeType": "host",
                             "props": Object {
-                              "children": Array [
-                                <th>
-                                  Contract Address
-                                </th>,
-                                <th />,
-                              ],
+                              "children": <th>
+                                Contract Address
+                              </th>,
                             },
                             "ref": null,
-                            "rendered": Array [
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {
-                                  "children": "Contract Address",
-                                },
-                                "ref": null,
-                                "rendered": "Contract Address",
-                                "type": "th",
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "Contract Address",
                               },
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "host",
-                                "props": Object {},
-                                "ref": null,
-                                "rendered": null,
-                                "type": "th",
-                              },
-                            ],
+                              "ref": null,
+                              "rendered": "Contract Address",
+                              "type": "th",
+                            },
                             "type": "tr",
                           },
                           "type": "thead",
@@ -9672,24 +8302,6 @@ ShallowWrapper {
                                     value="0293f9b10a4453667db7fcfe74728c9d821add4b"
                                   />
                                 </td>
-                                <td
-                                  style={
-                                    Object {
-                                      "border": "none",
-                                    }
-                                  }
-                                >
-                                  <span
-                                    className="pt-tag pt-intent-success smd-margin-right-4"
-                                  >
-                                    Bloc
-                                  </span>
-                                  <span
-                                    className="pt-tag pt-intent-primary"
-                                  >
-                                    Cirrus
-                                  </span>
-                                </td>
                               </tr>,
                             ],
                           },
@@ -9700,122 +8312,50 @@ ShallowWrapper {
                               "key": "card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-0",
                               "nodeType": "host",
                               "props": Object {
-                                "children": Array [
-                                  <td
-                                    style={
-                                      Object {
-                                        "border": "none",
-                                      }
+                                "children": <td
+                                  style={
+                                    Object {
+                                      "border": "none",
                                     }
-                                  >
-                                    <HexText
-                                      classes="small smd-pad-4"
-                                      value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                    />
-                                  </td>,
-                                  <td
-                                    style={
-                                      Object {
-                                        "border": "none",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="pt-tag pt-intent-success smd-margin-right-4"
-                                    >
-                                      Bloc
-                                    </span>
-                                    <span
-                                      className="pt-tag pt-intent-primary"
-                                    >
-                                      Cirrus
-                                    </span>
-                                  </td>,
-                                ],
+                                  }
+                                >
+                                  <HexText
+                                    classes="small smd-pad-4"
+                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  />
+                                </td>,
                                 "className": "",
                                 "onClick": [Function],
                               },
                               "ref": null,
-                              "rendered": Array [
-                                Object {
+                              "rendered": Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": <HexText
+                                    classes="small smd-pad-4"
+                                    value="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  />,
+                                  "style": Object {
+                                    "border": "none",
+                                  },
+                                },
+                                "ref": null,
+                                "rendered": Object {
                                   "instance": null,
                                   "key": undefined,
-                                  "nodeType": "host",
+                                  "nodeType": "class",
                                   "props": Object {
-                                    "children": <HexText
-                                      classes="small smd-pad-4"
-                                      value="0293f9b10a4453667db7fcfe74728c9d821add4b"
-                                    />,
-                                    "style": Object {
-                                      "border": "none",
-                                    },
+                                    "classes": "small smd-pad-4",
+                                    "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
                                   },
                                   "ref": null,
-                                  "rendered": Object {
-                                    "instance": null,
-                                    "key": undefined,
-                                    "nodeType": "class",
-                                    "props": Object {
-                                      "classes": "small smd-pad-4",
-                                      "value": "0293f9b10a4453667db7fcfe74728c9d821add4b",
-                                    },
-                                    "ref": null,
-                                    "rendered": null,
-                                    "type": [Function],
-                                  },
-                                  "type": "td",
+                                  "rendered": null,
+                                  "type": [Function],
                                 },
-                                Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "host",
-                                  "props": Object {
-                                    "children": Array [
-                                      <span
-                                        className="pt-tag pt-intent-success smd-margin-right-4"
-                                      >
-                                        Bloc
-                                      </span>,
-                                      <span
-                                        className="pt-tag pt-intent-primary"
-                                      >
-                                        Cirrus
-                                      </span>,
-                                    ],
-                                    "style": Object {
-                                      "border": "none",
-                                    },
-                                  },
-                                  "ref": null,
-                                  "rendered": Array [
-                                    Object {
-                                      "instance": null,
-                                      "key": undefined,
-                                      "nodeType": "host",
-                                      "props": Object {
-                                        "children": "Bloc",
-                                        "className": "pt-tag pt-intent-success smd-margin-right-4",
-                                      },
-                                      "ref": null,
-                                      "rendered": "Bloc",
-                                      "type": "span",
-                                    },
-                                    Object {
-                                      "instance": null,
-                                      "key": undefined,
-                                      "nodeType": "host",
-                                      "props": Object {
-                                        "children": "Cirrus",
-                                        "className": "pt-tag pt-intent-primary",
-                                      },
-                                      "ref": null,
-                                      "rendered": "Cirrus",
-                                      "type": "span",
-                                    },
-                                  ],
-                                  "type": "td",
-                                },
-                              ],
+                                "type": "td",
+                              },
                               "type": "tr",
                             },
                           ],

--- a/smd-ui/src/tests/Contracts/component/ContractCard/index.spec.js
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/index.spec.js
@@ -148,7 +148,7 @@ describe('ContractCard: index', () => {
     const wrapper = shallow(
       <ContractCard.WrappedComponent {...props} />
     );
-    wrapper.find('Button').simulate('click');
+    wrapper.find('Button').at(1).simulate('click');
     expect(wrapper.instance().state.isOpen).toBe(true);
   });
 

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/index.spec.js.snap
@@ -96,7 +96,7 @@ Object {
 exports[`ContractMethodCall: index renders contracts card (Oauth mode) 1`] = `
 "<div>
   <Blueprint.Popover isDisabled={false} interactionKind={2} position={10} content={{...}} arrowSize={30} className=\\"\\" defaultIsOpen={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} inline={false} isModal={false} openOnTargetFocus={true} popoverClassName=\\"\\" rootElementTag=\\"span\\" transitionDuration={300} useSmartArrowPositioning={true} useSmartPositioning={false}>
-    <Blueprint.AnchorButton className=\\"pt-minimal pt-small pt-intent-primary\\" onClick={[Function: onClick]} disabled={true} text=\\"Call Method\\" />
+    <Blueprint.AnchorButton className=\\"pt-intent-primary pt-icon-send-to-graph\\" onClick={[Function: onClick]} disabled={true} text={[undefined]} />
   </Blueprint.Popover>
   <form>
     <Blueprint.Dialog iconName=\\"exchange\\" isOpen={false} onClose={[Function]} title=\\"Call \\\\'undefined\\\\' on undefined\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
@@ -212,7 +212,7 @@ exports[`ContractMethodCall: index renders contracts card (Oauth mode) 1`] = `
 exports[`ContractMethodCall: index renders contracts card (non Oauth mode) 1`] = `
 "<div>
   <Blueprint.Popover isDisabled={false} interactionKind={2} position={10} content={{...}} arrowSize={30} className=\\"\\" defaultIsOpen={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} inline={false} isModal={false} openOnTargetFocus={true} popoverClassName=\\"\\" rootElementTag=\\"span\\" transitionDuration={300} useSmartArrowPositioning={true} useSmartPositioning={false}>
-    <Blueprint.AnchorButton className=\\"pt-minimal pt-small pt-intent-primary\\" onClick={[Function: onClick]} disabled={true} text=\\"Call Method\\" />
+    <Blueprint.AnchorButton className=\\"pt-intent-primary pt-icon-send-to-graph\\" onClick={[Function: onClick]} disabled={true} text={[undefined]} />
   </Blueprint.Popover>
   <form>
     <Blueprint.Dialog iconName=\\"exchange\\" isOpen={false} onClose={[Function]} title=\\"Call \\\\'undefined\\\\' on undefined\\" className=\\"pt-dark\\" canOutsideClickClose={true}>

--- a/smd-ui/src/tests/Dashboard/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/Dashboard/__snapshots__/index.spec.js.snap
@@ -267,7 +267,7 @@ ShallowWrapper {
               <withRouter(Connect(NumberCard))
                 className="smd-pointer"
                 description="Contracts"
-                iconClass="fa-gavel"
+                iconClass="fa-file"
                 number={2}
               />
             </Link>
@@ -626,7 +626,7 @@ ShallowWrapper {
                 <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={2}
                 />
               </Link>
@@ -787,7 +787,7 @@ ShallowWrapper {
                 <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={2}
                 />
               </Link>,
@@ -802,7 +802,7 @@ ShallowWrapper {
                 "children": <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={2}
                 />,
                 "replace": false,
@@ -816,7 +816,7 @@ ShallowWrapper {
                 "props": Object {
                   "className": "smd-pointer",
                   "description": "Contracts",
-                  "iconClass": "fa-gavel",
+                  "iconClass": "fa-file",
                   "number": 2,
                 },
                 "ref": null,
@@ -1670,7 +1670,7 @@ ShallowWrapper {
                 <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={2}
                 />
               </Link>
@@ -2029,7 +2029,7 @@ ShallowWrapper {
                   <withRouter(Connect(NumberCard))
                     className="smd-pointer"
                     description="Contracts"
-                    iconClass="fa-gavel"
+                    iconClass="fa-file"
                     number={2}
                   />
                 </Link>
@@ -2190,7 +2190,7 @@ ShallowWrapper {
                   <withRouter(Connect(NumberCard))
                     className="smd-pointer"
                     description="Contracts"
-                    iconClass="fa-gavel"
+                    iconClass="fa-file"
                     number={2}
                   />
                 </Link>,
@@ -2205,7 +2205,7 @@ ShallowWrapper {
                   "children": <withRouter(Connect(NumberCard))
                     className="smd-pointer"
                     description="Contracts"
-                    iconClass="fa-gavel"
+                    iconClass="fa-file"
                     number={2}
                   />,
                   "replace": false,
@@ -2219,7 +2219,7 @@ ShallowWrapper {
                   "props": Object {
                     "className": "smd-pointer",
                     "description": "Contracts",
-                    "iconClass": "fa-gavel",
+                    "iconClass": "fa-file",
                     "number": 2,
                   },
                   "ref": null,
@@ -3411,7 +3411,7 @@ ShallowWrapper {
               <withRouter(Connect(NumberCard))
                 className="smd-pointer"
                 description="Contracts"
-                iconClass="fa-gavel"
+                iconClass="fa-file"
                 number={2}
               />
             </Link>
@@ -3770,7 +3770,7 @@ ShallowWrapper {
                 <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={2}
                 />
               </Link>
@@ -3931,7 +3931,7 @@ ShallowWrapper {
                 <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={2}
                 />
               </Link>,
@@ -3946,7 +3946,7 @@ ShallowWrapper {
                 "children": <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={2}
                 />,
                 "replace": false,
@@ -3960,7 +3960,7 @@ ShallowWrapper {
                 "props": Object {
                   "className": "smd-pointer",
                   "description": "Contracts",
-                  "iconClass": "fa-gavel",
+                  "iconClass": "fa-file",
                   "number": 2,
                 },
                 "ref": null,
@@ -4814,7 +4814,7 @@ ShallowWrapper {
                 <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={2}
                 />
               </Link>
@@ -5173,7 +5173,7 @@ ShallowWrapper {
                   <withRouter(Connect(NumberCard))
                     className="smd-pointer"
                     description="Contracts"
-                    iconClass="fa-gavel"
+                    iconClass="fa-file"
                     number={2}
                   />
                 </Link>
@@ -5334,7 +5334,7 @@ ShallowWrapper {
                   <withRouter(Connect(NumberCard))
                     className="smd-pointer"
                     description="Contracts"
-                    iconClass="fa-gavel"
+                    iconClass="fa-file"
                     number={2}
                   />
                 </Link>,
@@ -5349,7 +5349,7 @@ ShallowWrapper {
                   "children": <withRouter(Connect(NumberCard))
                     className="smd-pointer"
                     description="Contracts"
-                    iconClass="fa-gavel"
+                    iconClass="fa-file"
                     number={2}
                   />,
                   "replace": false,
@@ -5363,7 +5363,7 @@ ShallowWrapper {
                   "props": Object {
                     "className": "smd-pointer",
                     "description": "Contracts",
-                    "iconClass": "fa-gavel",
+                    "iconClass": "fa-file",
                     "number": 2,
                   },
                   "ref": null,
@@ -6257,7 +6257,7 @@ ShallowWrapper {
               <withRouter(Connect(NumberCard))
                 className="smd-pointer"
                 description="Contracts"
-                iconClass="fa-gavel"
+                iconClass="fa-file"
                 number={undefined}
               />
             </Link>
@@ -6467,7 +6467,7 @@ ShallowWrapper {
                 <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={undefined}
                 />
               </Link>
@@ -6628,7 +6628,7 @@ ShallowWrapper {
                 <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={undefined}
                 />
               </Link>,
@@ -6643,7 +6643,7 @@ ShallowWrapper {
                 "children": <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={undefined}
                 />,
                 "replace": false,
@@ -6657,7 +6657,7 @@ ShallowWrapper {
                 "props": Object {
                   "className": "smd-pointer",
                   "description": "Contracts",
-                  "iconClass": "fa-gavel",
+                  "iconClass": "fa-file",
                   "number": undefined,
                 },
                 "ref": null,
@@ -7074,7 +7074,7 @@ ShallowWrapper {
                 <withRouter(Connect(NumberCard))
                   className="smd-pointer"
                   description="Contracts"
-                  iconClass="fa-gavel"
+                  iconClass="fa-file"
                   number={undefined}
                 />
               </Link>
@@ -7284,7 +7284,7 @@ ShallowWrapper {
                   <withRouter(Connect(NumberCard))
                     className="smd-pointer"
                     description="Contracts"
-                    iconClass="fa-gavel"
+                    iconClass="fa-file"
                     number={undefined}
                   />
                 </Link>
@@ -7445,7 +7445,7 @@ ShallowWrapper {
                   <withRouter(Connect(NumberCard))
                     className="smd-pointer"
                     description="Contracts"
-                    iconClass="fa-gavel"
+                    iconClass="fa-file"
                     number={undefined}
                   />
                 </Link>,
@@ -7460,7 +7460,7 @@ ShallowWrapper {
                   "children": <withRouter(Connect(NumberCard))
                     className="smd-pointer"
                     description="Contracts"
-                    iconClass="fa-gavel"
+                    iconClass="fa-file"
                     number={undefined}
                   />,
                   "replace": false,
@@ -7474,7 +7474,7 @@ ShallowWrapper {
                   "props": Object {
                     "className": "smd-pointer",
                     "description": "Contracts",
-                    "iconClass": "fa-gavel",
+                    "iconClass": "fa-file",
                     "number": undefined,
                   },
                   "ref": null,

--- a/smd-ui/src/tests/MenuBar/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/MenuBar/__snapshots__/index.spec.js.snap
@@ -17,7 +17,7 @@ exports[`MenuBar: index renders Oauth mode component with values 1`] = `
   </div>
   <div className=\\"pt-navbar-group pt-align-right\\">
     <div>
-      <Blueprint.Dialog className=\\"pt-dark\\" iconName=\\"mugshot\\" isOpen={false} onClose={[Function]} title=\\"My Profile\\" canOutsideClickClose={true}>
+      <Blueprint.Dialog className=\\"pt-dark\\" iconName=\\"user\\" isOpen={false} onClose={[Function]} title=\\"My Profile\\" canOutsideClickClose={true}>
         <div className=\\"pt-dialog-body\\">
           <div>
             <h4>
@@ -73,7 +73,7 @@ exports[`MenuBar: index renders Oauth mode component without values 1`] = `
   </div>
   <div className=\\"pt-navbar-group pt-align-right\\">
     <div>
-      <Blueprint.Dialog className=\\"pt-dark\\" iconName=\\"mugshot\\" isOpen={false} onClose={[Function]} title=\\"My Profile\\" canOutsideClickClose={true}>
+      <Blueprint.Dialog className=\\"pt-dark\\" iconName=\\"user\\" isOpen={false} onClose={[Function]} title=\\"My Profile\\" canOutsideClickClose={true}>
         <div className=\\"pt-dialog-body\\">
           <div>
             <h4>

--- a/smd-ui/src/tests/SideBar/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/SideBar/__snapshots__/index.spec.js.snap
@@ -36,7 +36,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
       </i>
       <span className=\\"menu-text\\">
          
-        Accounts
+        Users
       </span>
     </NavLink>
     <NavLink id=\\"transactions\\" to=\\"/transactions\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
@@ -58,7 +58,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
       </span>
     </NavLink>
     <NavLink id=\\"contracts\\" to=\\"/contracts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
-      <i className=\\"fa fa-gavel\\">
+      <i className=\\"fa fa-file\\">
          
       </i>
       <span className=\\"menu-text\\">
@@ -137,7 +137,7 @@ exports[`SideBar: index render component for public mode 1`] = `
       </i>
       <span className=\\"menu-text\\">
          
-        Accounts
+        Users
       </span>
     </NavLink>
     <NavLink id=\\"transactions\\" to=\\"/transactions\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
@@ -159,7 +159,7 @@ exports[`SideBar: index render component for public mode 1`] = `
       </span>
     </NavLink>
     <NavLink id=\\"contracts\\" to=\\"/contracts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
-      <i className=\\"fa fa-gavel\\">
+      <i className=\\"fa fa-file\\">
          
       </i>
       <span className=\\"menu-text\\">
@@ -277,7 +277,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode fourth po
     className="menu-text"
   >
      
-    Accounts
+    Users
   </span>
 </NavLink>
 `;
@@ -335,7 +335,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode seventh p
   to="/contracts"
 >
   <i
-    className="fa fa-gavel"
+    className="fa fa-file"
   >
      
   </i>


### PR DESCRIPTION
It started off with a fix how did it end up like this (it was only a fix (it was only a fix))...

- contract call button now shows contract name and a neat little icon
- Shard ID properly truncated in function call modal
- remove tags for cirrus/bloc in contract instance cards
- Change text to "tabular data" instead of "query builder"; no longer guarded behind existence of cirrus table
- Remove create contract button from contracts tab
- Contract query view: (this allows you to actually use this page for Mercata nodes)
  - Add selectors for App Name, Org Name, Event name, and history tables
  - Show all table columns instead of just state vars
  - show proper cirrus URL
  - Change title to "<Contract> Table"
  - Hover over cell shows full values
  - Values now truncated if oversize
  - Add error indicator when there are no rows/table doesnt exist with helper text
- Change "contracts" icon from hammer to file
- Change "accounts" to "users"
- Change separator between commonName and Org to "|"


https://user-images.githubusercontent.com/12687494/227644909-1d816ab5-69c3-4690-8ba6-58ea6b94e7fc.mp4

