### PR TITLE
Added vault-proxy tests

### DIFF
--- a/strato/vault-proxy/server/package.yaml
+++ b/strato/vault-proxy/server/package.yaml
@@ -106,12 +106,16 @@ tests:
     main: Spec.hs
     ghc-options: -dynamic
     dependencies:
+      - async
       - blockapps-data
       - blockapps-vault-proxy-server
       - bytestring
+      - cache
       - clockwork
       - cryptonite
       - hspec
       - labeled-error
+      - mtl
       - secp256k1-haskell
+      - stm
       - strato-model

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -10,6 +10,7 @@ import           Control.Concurrent.STM
 import           Control.Concurrent.Lock  as L
 import           Control.Monad
 import           Control.Monad.Catch
+import qualified Control.Monad.Catch      as C
 import           Control.Monad.IO.Class
 import           Data.ByteString.Base64   as B64
 import           Data.Cache               as C
@@ -47,8 +48,14 @@ instance HasVirginTokenCall IO where
       --Convert the server response to the VaultToken type
       pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
 
---This will get the correct token and will get a cached token if it is still valid
-getAwesomeToken :: (MonadIO m, MonadThrow m, HasVirginTokenCall m) => Bool -> L.Lock -> VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
+-- -- Helper function to handle lock acquisition and release
+-- withLock :: L.Lock -> IO a -> IO a
+-- withLock lock action = liftIO $ E.bracket_
+--   (L.acquire lock)
+--   (L.release lock)
+--   action
+
+getAwesomeToken :: (MonadIO m, MonadMask m, HasVirginTokenCall m) => Bool -> L.Lock -> VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
 getAwesomeToken debuggingOn awesomeLock squirrel clientId clientSecret reserveTime additionalOauth = do
     --Get the current STM time and the check if the item in memory needs to be cleared, clear it if needed
     cache <- liftIO . atomically $ do 
@@ -61,27 +68,22 @@ getAwesomeToken debuggingOn awesomeLock squirrel clientId clientSecret reserveTi
         Just c -> do
             vaultProxyDebug debuggingOn "Got my token from the cache, not from the remote server."
             pure c
-        --If the token was old destroy the old token and get a new one, block all threads except one to update the token
         Nothing -> do 
-            --Create a locking mechanism that can prevent other threads from trying to request information from the thread simultaneously
             traceM "Try and acquire a lock to change the token"
             doIHaveControl <- liftIO $ L.tryAcquire awesomeLock
-            if doIHaveControl then do
-                traceM "One thread got control and is getting the new token"
-                
-                traceM "Trying to get a new token from OAuth provider"
-                -- Get the virgin token from the provider
-                virToken <- getVirginToken clientId clientSecret additionalOauth
-                --Calculate the time that the token will expire
-                vaultProxyDebug debuggingOn  "Trying to calculate the expry time of the token"
-                exTime <- makeExpry virToken reserveTime
-                --Insert the new token into the STM cache
-                vaultProxyDebug debuggingOn "Trying to insert the new token into the cache"
-                liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
-                traceM "Successfully inserted the new token into the cache, releasing lock and notifiying other threads"
-                liftIO $ L.release awesomeLock
-                pure virToken
-              else do
+            if doIHaveControl then
+                (do traceM "One thread got control and is getting the new token"
+                      
+                    traceM "Trying to get a new token from OAuth provider"
+                    virToken <- getVirginToken clientId clientSecret additionalOauth
+                    vaultProxyDebug debuggingOn  "Trying to calculate the expry time of the token"
+                    exTime <- makeExpry virToken reserveTime
+                    vaultProxyDebug debuggingOn "Trying to insert the new token into the cache"
+                    liftIO . atomically $ insertSTM clientId virToken squirrel (Just exTime)
+                    traceM "Successfully inserted the new token into the cache, releasing lock and notifiying other threads"
+                    pure virToken
+                ) `C.finally` (liftIO $ L.release awesomeLock)
+            else do
                 traceM "Waiting until my neighbor thread updates the token"
                 liftIO $ L.wait awesomeLock
                 traceM "Lock is released, will try to get the token again."
@@ -105,7 +107,7 @@ makeExpry token reserveTime = do
     pure expry
 
 --Get the vault token more easily
-vaulty :: (MonadIO m, MonadThrow m, HasVirginTokenCall m) => VaultConnection -> m VaultToken
+vaulty :: (MonadIO m, MonadMask m, HasVirginTokenCall m) => VaultConnection -> m VaultToken
 vaulty vaultConn = getAwesomeToken db ll tc cid csec rs ao
     where
         cid = oauthClientId vaultConn

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -26,27 +26,29 @@ import           Text.URI                as URI
 
 import           Strato.VaultProxy.DataTypes
 
+class HasVirginTokenCall m where
+  getVirginToken :: T.Text -> T.Text -> RawOauth -> m VaultToken 
 
---This will get a fresh brand new, minty fresh clean token from the OAuth provider,
---User never really needs to use this function, it is mostly called by getAwesomeToken 
-getVirginToken ::  (MonadIO m, MonadThrow m) => T.Text -> T.Text -> RawOauth -> m VaultToken --OAuth2Token ---Might need to include the discovery URL later
-getVirginToken clientId clientSecret additionalOauth = do --virginToken
-    --Conver the token endpoint to a URI
-    uri <- URI.mkURI $ token_endpoint additionalOauth
-    --Encode all of the parameters, get ready to send to server
-    let (url, _) = fromJust (useHttpsURI $ uri)
-        authHeadr = R.header "Authorization" $ TE.encodeUtf8 $ T.concat [T.pack "Basic ", B64.encodeBase64 $ TE.encodeUtf8 $ T.concat [clientId, ":", clientSecret]]
-        contType = R.header "Content-Type" $ TE.encodeUtf8 $ T.pack "application/x-www-form-urlencoded"
-        urlEncodedPart = ReqBodyUrlEnc $ "grant_type" =: ("client_credentials" :: String)
-    --Connect to the server
-    makeHttpCall <- runReq defaultHttpConfig $ do
-        response <- R.req R.POST url urlEncodedPart (jsonResponse) (authHeadr <> contType )
-        pure response
-    --Convert the server response to the VaultToken type
-    pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
+instance HasVirginTokenCall IO where
+  --This will get a fresh brand new, minty fresh clean token from the OAuth provider,
+  --User never really needs to use this function, it is mostly called by getAwesomeToken 
+  getVirginToken clientId clientSecret additionalOauth = do --virginToken
+      --Conver the token endpoint to a URI
+      uri <- URI.mkURI $ token_endpoint additionalOauth
+      --Encode all of the parameters, get ready to send to server
+      let (url, _) = fromJust (useHttpsURI $ uri)
+          authHeadr = R.header "Authorization" $ TE.encodeUtf8 $ T.concat [T.pack "Basic ", B64.encodeBase64 $ TE.encodeUtf8 $ T.concat [clientId, ":", clientSecret]]
+          contType = R.header "Content-Type" $ TE.encodeUtf8 $ T.pack "application/x-www-form-urlencoded"
+          urlEncodedPart = ReqBodyUrlEnc $ "grant_type" =: ("client_credentials" :: String)
+      --Connect to the server
+      makeHttpCall <- runReq defaultHttpConfig $ do
+          response <- R.req R.POST url urlEncodedPart (jsonResponse) (authHeadr <> contType )
+          pure response
+      --Convert the server response to the VaultToken type
+      pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
 
 --This will get the correct token and will get a cached token if it is still valid
-getAwesomeToken :: (MonadIO m, MonadThrow m) => Bool -> L.Lock -> VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
+getAwesomeToken :: (MonadIO m, MonadThrow m, HasVirginTokenCall m) => Bool -> L.Lock -> VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
 getAwesomeToken debuggingOn awesomeLock squirrel clientId clientSecret reserveTime additionalOauth = do
     --Get the current STM time and the check if the item in memory needs to be cleared, clear it if needed
     cache <- liftIO . atomically $ do 
@@ -103,7 +105,7 @@ makeExpry token reserveTime = do
     pure expry
 
 --Get the vault token more easily
-vaulty :: (MonadIO m, MonadThrow m) => VaultConnection -> m VaultToken
+vaulty :: (MonadIO m, MonadThrow m, HasVirginTokenCall m) => VaultConnection -> m VaultToken
 vaulty vaultConn = getAwesomeToken db ll tc cid csec rs ao
     where
         cid = oauthClientId vaultConn

--- a/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
+++ b/strato/vault-proxy/server/src/Strato/VaultProxy/Server/Token.hs
@@ -48,13 +48,6 @@ instance HasVirginTokenCall IO where
       --Convert the server response to the VaultToken type
       pure $ HTC.responseBody $ toVanillaResponse makeHttpCall
 
--- -- Helper function to handle lock acquisition and release
--- withLock :: L.Lock -> IO a -> IO a
--- withLock lock action = liftIO $ E.bracket_
---   (L.acquire lock)
---   (L.release lock)
---   action
-
 getAwesomeToken :: (MonadIO m, MonadMask m, HasVirginTokenCall m) => Bool -> L.Lock -> VaultCache -> T.Text -> T.Text -> Int -> RawOauth -> m VaultToken
 getAwesomeToken debuggingOn awesomeLock squirrel clientId clientSecret reserveTime additionalOauth = do
     --Get the current STM time and the check if the item in memory needs to be cleared, clear it if needed

--- a/strato/vault-proxy/server/test/Spec.hs
+++ b/strato/vault-proxy/server/test/Spec.hs
@@ -31,7 +31,7 @@ instance HasVirginTokenCall (ReaderT Sock IO) where
     unless b . liftIO $ throwIO SockException
     pure $ VaultToken {
       accessToken = "",
-      expiresIn = 0,
+      expiresIn = 300,
       refreshExpiresIn = 0,
       refreshToken = "",
       tokenType = "",
@@ -62,7 +62,7 @@ main = hspec $ do
           vaultUrl = "",
           httpManager = error "httpManager",
           oauthUrl = "",
-          oauthClientId = "",
+          oauthClientId = "dev",
           oauthClientSecret = "",
           oauthReserveSeconds = 13,
           vaultProxyUrl = "",
@@ -74,12 +74,18 @@ main = hspec $ do
       }
       i <- newTQueueIO
       o <- newTQueueIO
-      r <- newIORef (0 :: Int)
+      oauthCallRef <- newIORef (0 :: Int)
+      threadsCompleteRef <- newIORef (0 :: Int)
       let sock = Sock i o
-      race_ (runGoodServer sock r)
-            (mapConcurrently_ (\_ -> void . flip runReaderT sock $ vaulty vaultConnection) [1..(10 :: Int)])
-      n <- readIORef r
-      n `shouldBe` 10
+      race_ (runGoodServer sock oauthCallRef)
+            (mapConcurrently_ (\_ -> do
+              void . flip runReaderT sock $ vaulty vaultConnection
+              atomicModifyIORef' threadsCompleteRef (\n -> (n+1,())))
+              [1..(10 :: Int)])
+      oauthCalls <- readIORef oauthCallRef
+      oauthCalls `shouldBe` 1
+      threadsComplete <- readIORef threadsCompleteRef
+      threadsComplete `shouldBe` 10
     it "Can call vaulty successfully even if a request to the oauth server fails" $ do
       vaultLock <- liftIO $ L.new
       tokenCash <- atomically $ C.newCacheSTM Nothing
@@ -99,14 +105,19 @@ main = hspec $ do
       }
       i <- newTQueueIO
       o <- newTQueueIO
-      r <- newIORef (0 :: Int)
+      oauthCallRef <- newIORef (0 :: Int)
+      threadsCompleteRef <- newIORef (0 :: Int)
       let sock = Sock i o
-      race_ (race_ (runBadServer sock r) (threadDelay 3000000))
+      race_ (race_ (runBadServer sock oauthCallRef) (threadDelay 3000000))
             (mapConcurrently_ (\_ -> do
-               e <- try . flip runReaderT sock $ vaulty vaultConnection
+               e <- try $ do
+                 void . flip runReaderT sock $ vaulty vaultConnection
+                 atomicModifyIORef' threadsCompleteRef (\n -> (n+1,()))
                case e of
                 Left (ex :: SomeException) -> putStrLn $ show ex
                 _ -> pure ()
                ) [1..(10 :: Int)])
-      n <- readIORef r
-      n `shouldBe` 1 -- really should be 9
+      oauthCalls <- readIORef oauthCallRef
+      oauthCalls `shouldBe` 1 -- really should be 2
+      threadsComplete <- readIORef threadsCompleteRef
+      threadsComplete `shouldBe` 0 -- really should be 9

--- a/strato/vault-proxy/server/test/Spec.hs
+++ b/strato/vault-proxy/server/test/Spec.hs
@@ -118,6 +118,6 @@ main = hspec $ do
                 _ -> pure ()
                ) [1..(10 :: Int)])
       oauthCalls <- readIORef oauthCallRef
-      oauthCalls `shouldBe` 1 -- really should be 2
+      oauthCalls `shouldBe` 2 
       threadsComplete <- readIORef threadsCompleteRef
-      threadsComplete `shouldBe` 0 -- really should be 9
+      threadsComplete `shouldBe` 9

--- a/strato/vault-proxy/server/test/Spec.hs
+++ b/strato/vault-proxy/server/test/Spec.hs
@@ -1,7 +1,112 @@
-import Test.Hspec
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import           Control.Concurrent.Async
+import           Control.Concurrent
+import           Control.Concurrent.STM
+import           Control.Concurrent.Lock  as L
+import           Control.Exception
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Control.Monad.Reader
+import           Data.Cache               as C
+import           Data.IORef
+import           Test.Hspec
+
+import           Strato.VaultProxy.DataTypes
+import           Strato.VaultProxy.Server.Token
+
+data Sock = Sock (TQueue ()) (TQueue Bool)
+
+data SockException = SockException deriving (Show)
+
+instance Exception SockException
+
+instance HasVirginTokenCall (ReaderT Sock IO) where
+  getVirginToken _ _ _ = do
+    Sock i o <- ask
+    liftIO . atomically $ writeTQueue i ()
+    b <- liftIO . atomically $ readTQueue o
+    unless b . liftIO $ throwIO SockException
+    pure $ VaultToken {
+      accessToken = "",
+      expiresIn = 0,
+      refreshExpiresIn = 0,
+      refreshToken = "",
+      tokenType = "",
+      notBeforePolicy = 0,
+      sessionState = "",
+      scone = ""
+    }
+
+runGoodServer :: Sock -> IORef Int -> IO ()
+runGoodServer (Sock i o) r = forever $ do
+  void . atomically $ readTQueue i
+  atomicModifyIORef' r $ \n -> (n+1,())
+  atomically $ writeTQueue o True
+
+runBadServer :: Sock -> IORef Int -> IO ()
+runBadServer (Sock i o) r = forever $ do
+  void . atomically $ readTQueue i
+  n' <- atomicModifyIORef' r $ \n -> (n+1,n)
+  atomically . writeTQueue o $ n' /= 0
 
 main :: IO ()
 main = hspec $ do
-  describe "Testing is not created yet for vault-proxy" $ do
-    it "returns the first element of a list" $ do
-      head [23 ..] `shouldBe` (23 :: Int)
+  describe "Token tests" $ do
+    it "Can call vaulty 10 times successfully" $ do
+      vaultLock <- liftIO $ L.new
+      tokenCash <- atomically $ C.newCacheSTM Nothing
+      let vaultConnection = VaultConnection {
+          vaultUrl = "",
+          httpManager = error "httpManager",
+          oauthUrl = "",
+          oauthClientId = "",
+          oauthClientSecret = "",
+          oauthReserveSeconds = 13,
+          vaultProxyUrl = "",
+          vaultProxyPort = 0,
+          tokenCache = tokenCash,
+          additionalOauth = RawOauth "" "",
+          superLock = vaultLock,
+          debuggingOn = False
+      }
+      i <- newTQueueIO
+      o <- newTQueueIO
+      r <- newIORef (0 :: Int)
+      let sock = Sock i o
+      race_ (runGoodServer sock r)
+            (mapConcurrently_ (\_ -> void . flip runReaderT sock $ vaulty vaultConnection) [1..(10 :: Int)])
+      n <- readIORef r
+      n `shouldBe` 10
+    it "Can call vaulty successfully even if a request to the oauth server fails" $ do
+      vaultLock <- liftIO $ L.new
+      tokenCash <- atomically $ C.newCacheSTM Nothing
+      let vaultConnection = VaultConnection {
+          vaultUrl = "",
+          httpManager = error "httpManager",
+          oauthUrl = "",
+          oauthClientId = "",
+          oauthClientSecret = "",
+          oauthReserveSeconds = 13,
+          vaultProxyUrl = "",
+          vaultProxyPort = 0,
+          tokenCache = tokenCash,
+          additionalOauth = RawOauth "" "",
+          superLock = vaultLock,
+          debuggingOn = False
+      }
+      i <- newTQueueIO
+      o <- newTQueueIO
+      r <- newIORef (0 :: Int)
+      let sock = Sock i o
+      race_ (race_ (runBadServer sock r) (threadDelay 3000000))
+            (mapConcurrently_ (\_ -> do
+               e <- try . flip runReaderT sock $ vaulty vaultConnection
+               case e of
+                Left (ex :: SomeException) -> putStrLn $ show ex
+                _ -> pure ()
+               ) [1..(10 :: Int)])
+      n <- readIORef r
+      n `shouldBe` 1 -- really should be 9


### PR DESCRIPTION
This branch adds two unit tests to vault-proxy to test the service token fetching process.

The first test tests the happy path: 10 successive calls to oauth, with the lock being released each time. With the old locking mechanism, that one passes, as expected.
The second test intentionally throws an exception after the first call to oauth. As expected, with the current locking mechanism, the lock is never released and the rest of the threads wait indefinitely. The correct behavior would be for the other 9 threads to eventually make their respective calls to the oauth server. 
