### PR TITLE
fixed NOINLINE Pragma that was a comment

### DIFF
--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
@@ -45,7 +45,7 @@ recordAuthResult :: MonadIO m => AuthResult -> m ()
 recordAuthResult AuthSuccess = liftIO $ withLabel authResults "success" incCounter
 recordAuthResult AuthFailure{} = liftIO $ withLabel authResults "failure" incCounter
 
-{- NOINLINE proposalCount #-}
+{-# NOINLINE proposalCount #-}
 proposalCount :: Counter
 proposalCount = unsafeRegister
               .  counter


### PR DESCRIPTION
When browsing through the code I found this NOINLINE Pragma that was accidentally missing the [octothorpe](https://en.wiktionary.org/wiki/octothorpe) to make it a pragma, and thus it was valid code because it was read as a braced comment. This seemed unintentional, and it has been in the code for four years, thus the `proposalCount`, prometheus metric should now work which counts the number of blocks the node proposed that were accepted by peers.