### PR TITLE
reduced max kafka size in order to prevent memory blowup in vm-runner

### DIFF
--- a/strato/libs/kafka/milena/Network/Kafka.hs
+++ b/strato/libs/kafka/milena/Network/Kafka.hs
@@ -131,7 +131,7 @@ defaultMinBytes = MinBytes 0
 
 -- | Default: @32 * 1024 * 1024@
 defaultMaxBytes :: MaxBytes
-defaultMaxBytes = 100 * 1024 * 1024
+defaultMaxBytes = 64 * 1024 * 1024
 
 -- | Default: @0@
 defaultMaxWaitTime :: MaxWaitTime


### PR DESCRIPTION
Note, this is a quick and dirty fix that should in no way be treated as permanent. We should revert/modify/improve this change whenever we are able to better focus on the vm-runner memory blowup issue. For now, this is a nice band-aid. 

It should also be noted that there is a separate issue in the node stall problem where p2p just...stops getting the next block. For now, stopping strato and starting it back up again seems to get it out of that rut. This warrants more investigation in the future, though.