### PR TITLE
[BUILDX] Shard-Add-Member-Refinement

### DIFF
--- a/smd-ui/src/components/CreateChain/components/AddMember/index.js
+++ b/smd-ui/src/components/CreateChain/components/AddMember/index.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { Button, Dialog, Intent } from '@blueprintjs/core';
 
 import mixpanelWrapper from '../../../../lib/mixpanelWrapper';
-import { Field, reduxForm } from 'redux-form';
+import { Field, reduxForm, isDirty } from 'redux-form';
 import { openAddMemberModal, closeAddMemberModal } from '../../createChain.actions';
 import { validate } from './validate';
 
@@ -19,7 +19,7 @@ class AddMember extends Component {
       orgUnit: ``,
       commonName: ``,
       access: true,
-      errors: null
+      fieldsChange: false
     }
   }
 
@@ -82,6 +82,7 @@ class AddMember extends Component {
   }
 
   render() {
+    const { fieldsChange } = this.props;
     return (
       <div >
         <Button onClick={() => {
@@ -113,7 +114,7 @@ class AddMember extends Component {
                     <Field
                       id="orgName"
                       className="form-width pt-input"
-                      placeholder="Org Name"
+                      placeholder="Organization Name"
                       name="orgName"
                       component="input"
                       dir="auto"
@@ -138,7 +139,7 @@ class AddMember extends Component {
                       name="orgUnit"
                       component="input"
                       type="text"
-                      placeholder="Org Unit"
+                      placeholder="Organization Unit"
                       value={this.state.orgUnit}
                       className="pt-input form-width"
                       onChange={(e) => this.handleOrgUnitChange(e)}
@@ -223,7 +224,7 @@ class AddMember extends Component {
                 <Button
                   intent={Intent.PRIMARY}
                   onClick={this.submit}
-                  text="Add Member"
+                  text={fieldsChange?"Add Member":"Include All"}
                 />
               </div>
             </div>
@@ -237,6 +238,7 @@ class AddMember extends Component {
 export function mapStateToProps(state) {
   return {
     isOpen: state.createChain.isAddMemberModalOpen,
+    fieldsChange:isDirty("add-member")(state),
     initialValues: {
       orgName: "",
       orgUnit: "",

--- a/smd-ui/src/tests/CreateChain/components/AddMember/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/CreateChain/components/AddMember/__snapshots__/index.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`CreateChain: index mapStateToProps with default state 1`] = `
 Object {
+  "fieldsChange": false,
   "initialValues": Object {
     "access": true,
     "commonName": "",
@@ -16,7 +17,7 @@ exports[`CreateChain: index render component (Oauth mode) form fields with value
 Object {
   "access": true,
   "commonName": "",
-  "errors": null,
+  "fieldsChange": false,
   "form": Object {},
   "orgName": "",
   "orgUnit": "",
@@ -27,7 +28,7 @@ exports[`CreateChain: index render component (Oauth mode) form fields with value
 Object {
   "access": true,
   "commonName": "Engineering",
-  "errors": null,
+  "fieldsChange": false,
   "form": Object {},
   "orgName": "",
   "orgUnit": "BlockApps",
@@ -37,7 +38,7 @@ Object {
 exports[`CreateChain: index render component (Oauth mode) with empty values 1`] = `
 "<div>
   <Blueprint.Button onClick={[Function: onClick]} className=\\"pt-intent-primary pt-icon-add\\" style={{...}} text=\\"Add Member\\" />
-  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
+  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function (anonymous)]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
     <form>
       <div className=\\"pt-dialog-body\\">
         <div className=\\"row\\">
@@ -47,7 +48,7 @@ exports[`CreateChain: index render component (Oauth mode) with empty values 1`] 
             </label>
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
-            <Field id=\\"orgName\\" className=\\"form-width pt-input\\" placeholder=\\"Org Name\\" name=\\"orgName\\" component=\\"input\\" dir=\\"auto\\" title=\\"orgName\\" onChange={[Function: onChange]} required={true} />
+            <Field id=\\"orgName\\" className=\\"form-width pt-input\\" placeholder=\\"Organization Name\\" name=\\"orgName\\" component=\\"input\\" dir=\\"auto\\" title=\\"orgName\\" onChange={[Function: onChange]} required={true} />
             <br />
             <span className=\\"error-text\\" />
           </div>
@@ -60,7 +61,7 @@ exports[`CreateChain: index render component (Oauth mode) with empty values 1`] 
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
             <div className=\\"form-width\\">
-              <Field name=\\"orgUnit\\" component=\\"input\\" type=\\"text\\" placeholder=\\"Org Unit\\" value=\\"\\" className=\\"pt-input form-width\\" onChange={[Function: onChange]} required={true} />
+              <Field name=\\"orgUnit\\" component=\\"input\\" type=\\"text\\" placeholder=\\"Organization Unit\\" value=\\"\\" className=\\"pt-input form-width\\" onChange={[Function: onChange]} required={true} />
               <br />
               <span className=\\"error-text\\" />
             </div>
@@ -101,7 +102,7 @@ exports[`CreateChain: index render component (Oauth mode) with empty values 1`] 
       <div className=\\"pt-dialog-footer\\">
         <div className=\\"pt-dialog-footer-actions\\">
           <Blueprint.Button text=\\"Cancel\\" onClick={[Function: onClick]} />
-          <Blueprint.Button intent={0} onClick={[Function]} text=\\"Add Member\\" />
+          <Blueprint.Button intent={0} onClick={[Function (anonymous)]} text=\\"Include All\\" />
         </div>
       </div>
     </form>
@@ -112,7 +113,7 @@ exports[`CreateChain: index render component (Oauth mode) with empty values 1`] 
 exports[`CreateChain: index render component (Oauth mode) with values 1`] = `
 "<div>
   <Blueprint.Button onClick={[Function: onClick]} className=\\"pt-intent-primary pt-icon-add\\" style={{...}} text=\\"Add Member\\" />
-  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
+  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function (anonymous)]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
     <form>
       <div className=\\"pt-dialog-body\\">
         <div className=\\"row\\">
@@ -122,7 +123,7 @@ exports[`CreateChain: index render component (Oauth mode) with values 1`] = `
             </label>
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
-            <Field id=\\"orgName\\" className=\\"form-width pt-input\\" placeholder=\\"Org Name\\" name=\\"orgName\\" component=\\"input\\" dir=\\"auto\\" title=\\"orgName\\" onChange={[Function: onChange]} required={true} />
+            <Field id=\\"orgName\\" className=\\"form-width pt-input\\" placeholder=\\"Organization Name\\" name=\\"orgName\\" component=\\"input\\" dir=\\"auto\\" title=\\"orgName\\" onChange={[Function: onChange]} required={true} />
             <br />
             <span className=\\"error-text\\" />
           </div>
@@ -135,7 +136,7 @@ exports[`CreateChain: index render component (Oauth mode) with values 1`] = `
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
             <div className=\\"form-width\\">
-              <Field name=\\"orgUnit\\" component=\\"input\\" type=\\"text\\" placeholder=\\"Org Unit\\" value=\\"\\" className=\\"pt-input form-width\\" onChange={[Function: onChange]} required={true} />
+              <Field name=\\"orgUnit\\" component=\\"input\\" type=\\"text\\" placeholder=\\"Organization Unit\\" value=\\"\\" className=\\"pt-input form-width\\" onChange={[Function: onChange]} required={true} />
               <br />
               <span className=\\"error-text\\" />
             </div>
@@ -176,7 +177,7 @@ exports[`CreateChain: index render component (Oauth mode) with values 1`] = `
       <div className=\\"pt-dialog-footer\\">
         <div className=\\"pt-dialog-footer-actions\\">
           <Blueprint.Button text=\\"Cancel\\" onClick={[Function: onClick]} />
-          <Blueprint.Button intent={0} onClick={[Function]} text=\\"Add Member\\" />
+          <Blueprint.Button intent={0} onClick={[Function (anonymous)]} text=\\"Include All\\" />
         </div>
       </div>
     </form>
@@ -192,7 +193,7 @@ exports[`CreateChain: index render component (non Oauth mode) form fields 1`] = 
 Object {
   "access": true,
   "commonName": "",
-  "errors": null,
+  "fieldsChange": false,
   "form": Object {},
   "orgName": "",
   "orgUnit": "",
@@ -203,7 +204,7 @@ exports[`CreateChain: index render component (non Oauth mode) form fields 2`] = 
 Object {
   "access": true,
   "commonName": "Engineering",
-  "errors": null,
+  "fieldsChange": false,
   "form": Object {},
   "orgName": "",
   "orgUnit": "BlockApps",
@@ -214,7 +215,7 @@ exports[`CreateChain: index render component (non Oauth mode) form fields 3`] = 
 Object {
   "access": true,
   "commonName": "Engineering",
-  "errors": null,
+  "fieldsChange": false,
   "form": Object {},
   "orgName": "",
   "orgUnit": "BlockApps",
@@ -224,7 +225,7 @@ Object {
 exports[`CreateChain: index render component (non Oauth mode) with empty values 1`] = `
 "<div>
   <Blueprint.Button onClick={[Function: onClick]} className=\\"pt-intent-primary pt-icon-add\\" style={{...}} text=\\"Add Member\\" />
-  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
+  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function (anonymous)]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
     <form>
       <div className=\\"pt-dialog-body\\">
         <div className=\\"row\\">
@@ -234,7 +235,7 @@ exports[`CreateChain: index render component (non Oauth mode) with empty values 
             </label>
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
-            <Field id=\\"orgName\\" className=\\"form-width pt-input\\" placeholder=\\"Org Name\\" name=\\"orgName\\" component=\\"input\\" dir=\\"auto\\" title=\\"orgName\\" onChange={[Function: onChange]} required={true} />
+            <Field id=\\"orgName\\" className=\\"form-width pt-input\\" placeholder=\\"Organization Name\\" name=\\"orgName\\" component=\\"input\\" dir=\\"auto\\" title=\\"orgName\\" onChange={[Function: onChange]} required={true} />
             <br />
             <span className=\\"error-text\\" />
           </div>
@@ -247,7 +248,7 @@ exports[`CreateChain: index render component (non Oauth mode) with empty values 
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
             <div className=\\"form-width\\">
-              <Field name=\\"orgUnit\\" component=\\"input\\" type=\\"text\\" placeholder=\\"Org Unit\\" value=\\"\\" className=\\"pt-input form-width\\" onChange={[Function: onChange]} required={true} />
+              <Field name=\\"orgUnit\\" component=\\"input\\" type=\\"text\\" placeholder=\\"Organization Unit\\" value=\\"\\" className=\\"pt-input form-width\\" onChange={[Function: onChange]} required={true} />
               <br />
               <span className=\\"error-text\\" />
             </div>
@@ -288,7 +289,7 @@ exports[`CreateChain: index render component (non Oauth mode) with empty values 
       <div className=\\"pt-dialog-footer\\">
         <div className=\\"pt-dialog-footer-actions\\">
           <Blueprint.Button text=\\"Cancel\\" onClick={[Function: onClick]} />
-          <Blueprint.Button intent={0} onClick={[Function]} text=\\"Add Member\\" />
+          <Blueprint.Button intent={0} onClick={[Function (anonymous)]} text=\\"Include All\\" />
         </div>
       </div>
     </form>
@@ -299,7 +300,7 @@ exports[`CreateChain: index render component (non Oauth mode) with empty values 
 exports[`CreateChain: index render component (non Oauth mode) with values 1`] = `
 "<div>
   <Blueprint.Button onClick={[Function: onClick]} className=\\"pt-intent-primary pt-icon-add\\" style={{...}} text=\\"Add Member\\" />
-  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
+  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function (anonymous)]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
     <form>
       <div className=\\"pt-dialog-body\\">
         <div className=\\"row\\">
@@ -309,7 +310,7 @@ exports[`CreateChain: index render component (non Oauth mode) with values 1`] = 
             </label>
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
-            <Field id=\\"orgName\\" className=\\"form-width pt-input\\" placeholder=\\"Org Name\\" name=\\"orgName\\" component=\\"input\\" dir=\\"auto\\" title=\\"orgName\\" onChange={[Function: onChange]} required={true} />
+            <Field id=\\"orgName\\" className=\\"form-width pt-input\\" placeholder=\\"Organization Name\\" name=\\"orgName\\" component=\\"input\\" dir=\\"auto\\" title=\\"orgName\\" onChange={[Function: onChange]} required={true} />
             <br />
             <span className=\\"error-text\\" />
           </div>
@@ -322,7 +323,7 @@ exports[`CreateChain: index render component (non Oauth mode) with values 1`] = 
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
             <div className=\\"form-width\\">
-              <Field name=\\"orgUnit\\" component=\\"input\\" type=\\"text\\" placeholder=\\"Org Unit\\" value=\\"\\" className=\\"pt-input form-width\\" onChange={[Function: onChange]} required={true} />
+              <Field name=\\"orgUnit\\" component=\\"input\\" type=\\"text\\" placeholder=\\"Organization Unit\\" value=\\"\\" className=\\"pt-input form-width\\" onChange={[Function: onChange]} required={true} />
               <br />
               <span className=\\"error-text\\" />
             </div>
@@ -363,7 +364,7 @@ exports[`CreateChain: index render component (non Oauth mode) with values 1`] = 
       <div className=\\"pt-dialog-footer\\">
         <div className=\\"pt-dialog-footer-actions\\">
           <Blueprint.Button text=\\"Cancel\\" onClick={[Function: onClick]} />
-          <Blueprint.Button intent={0} onClick={[Function]} text=\\"Add Member\\" />
+          <Blueprint.Button intent={0} onClick={[Function (anonymous)]} text=\\"Include All\\" />
         </div>
       </div>
     </form>

--- a/smd-ui/src/tests/CreateChain/components/AddMember/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/CreateChain/components/AddMember/__snapshots__/index.spec.js.snap
@@ -38,7 +38,7 @@ Object {
 exports[`CreateChain: index render component (Oauth mode) with empty values 1`] = `
 "<div>
   <Blueprint.Button onClick={[Function: onClick]} className=\\"pt-intent-primary pt-icon-add\\" style={{...}} text=\\"Add Member\\" />
-  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function (anonymous)]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
+  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
     <form>
       <div className=\\"pt-dialog-body\\">
         <div className=\\"row\\">
@@ -102,7 +102,7 @@ exports[`CreateChain: index render component (Oauth mode) with empty values 1`] 
       <div className=\\"pt-dialog-footer\\">
         <div className=\\"pt-dialog-footer-actions\\">
           <Blueprint.Button text=\\"Cancel\\" onClick={[Function: onClick]} />
-          <Blueprint.Button intent={0} onClick={[Function (anonymous)]} text=\\"Include All\\" />
+          <Blueprint.Button intent={0} onClick={[Function]} text=\\"Include All\\" />
         </div>
       </div>
     </form>
@@ -113,7 +113,7 @@ exports[`CreateChain: index render component (Oauth mode) with empty values 1`] 
 exports[`CreateChain: index render component (Oauth mode) with values 1`] = `
 "<div>
   <Blueprint.Button onClick={[Function: onClick]} className=\\"pt-intent-primary pt-icon-add\\" style={{...}} text=\\"Add Member\\" />
-  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function (anonymous)]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
+  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
     <form>
       <div className=\\"pt-dialog-body\\">
         <div className=\\"row\\">
@@ -177,7 +177,7 @@ exports[`CreateChain: index render component (Oauth mode) with values 1`] = `
       <div className=\\"pt-dialog-footer\\">
         <div className=\\"pt-dialog-footer-actions\\">
           <Blueprint.Button text=\\"Cancel\\" onClick={[Function: onClick]} />
-          <Blueprint.Button intent={0} onClick={[Function (anonymous)]} text=\\"Include All\\" />
+          <Blueprint.Button intent={0} onClick={[Function]} text=\\"Include All\\" />
         </div>
       </div>
     </form>
@@ -225,7 +225,7 @@ Object {
 exports[`CreateChain: index render component (non Oauth mode) with empty values 1`] = `
 "<div>
   <Blueprint.Button onClick={[Function: onClick]} className=\\"pt-intent-primary pt-icon-add\\" style={{...}} text=\\"Add Member\\" />
-  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function (anonymous)]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
+  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
     <form>
       <div className=\\"pt-dialog-body\\">
         <div className=\\"row\\">
@@ -289,7 +289,7 @@ exports[`CreateChain: index render component (non Oauth mode) with empty values 
       <div className=\\"pt-dialog-footer\\">
         <div className=\\"pt-dialog-footer-actions\\">
           <Blueprint.Button text=\\"Cancel\\" onClick={[Function: onClick]} />
-          <Blueprint.Button intent={0} onClick={[Function (anonymous)]} text=\\"Include All\\" />
+          <Blueprint.Button intent={0} onClick={[Function]} text=\\"Include All\\" />
         </div>
       </div>
     </form>
@@ -300,7 +300,7 @@ exports[`CreateChain: index render component (non Oauth mode) with empty values 
 exports[`CreateChain: index render component (non Oauth mode) with values 1`] = `
 "<div>
   <Blueprint.Button onClick={[Function: onClick]} className=\\"pt-intent-primary pt-icon-add\\" style={{...}} text=\\"Add Member\\" />
-  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function (anonymous)]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
+  <Blueprint.Dialog iconName=\\"add\\" isOpen={false} onClose={[Function]} title=\\"Add Member\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
     <form>
       <div className=\\"pt-dialog-body\\">
         <div className=\\"row\\">
@@ -364,7 +364,7 @@ exports[`CreateChain: index render component (non Oauth mode) with values 1`] = 
       <div className=\\"pt-dialog-footer\\">
         <div className=\\"pt-dialog-footer-actions\\">
           <Blueprint.Button text=\\"Cancel\\" onClick={[Function: onClick]} />
-          <Blueprint.Button intent={0} onClick={[Function (anonymous)]} text=\\"Include All\\" />
+          <Blueprint.Button intent={0} onClick={[Function]} text=\\"Include All\\" />
         </div>
       </div>
     </form>


### PR DESCRIPTION
This PR enhances the user experience, by letting the end-users see `Include All` option when the Add-Member form remains untouched. If the form is edited, the `Add Member` button will be seen.

### **Before**: The builder behaviour: Create Shard >Enter details>  Add Member : (Confusion on clicking Add Member)> Create Shard
![Screenshot from 2023-03-31 15-18-04](https://user-images.githubusercontent.com/35606645/229210057-ad2e7f17-4a5c-4c0f-ba3a-9a16c6ab9ef8.png)






### **After**: The builder behaviour: Create Shard >Enter details>  Add Member> Create Shard
![Screenshot from 2023-03-31 15-19-12](https://user-images.githubusercontent.com/35606645/229210253-fa756152-e8e1-4458-95e5-7c41fc41292c.png)

![demo](https://user-images.githubusercontent.com/35606645/229209156-a254af5e-5691-47e5-81fe-7fc9b05524e2.gif)
