### PR TITLE
Strato-P2P Memory Leak Fix Pt.2

### DIFF
--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -34,6 +34,7 @@ library:
   dependencies:
     - SafeSemaphore
     - aeson
+    - async
     - alarmclock
     - ansi-wl-pprint
     - base16-bytestring

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -19,6 +19,7 @@ module Executable.StratoP2PClient
 
 import           Blockchain.RLPx
 import           Control.Concurrent                    hiding (yield)
+import           Control.Concurrent.Async              as Async
 import           Control.Concurrent.SSem               (SSem)
 import qualified Control.Concurrent.SSem               as SSem
 import           Control.Exception.Base                (ErrorCall(..))
@@ -157,10 +158,10 @@ stratoP2PClient runner = runner $ \_ -> do
         unless isRunning $ do
           (liftIO (SSem.tryWait sem)) >>= \case
             Nothing -> return ()
-            Just _  -> void . liftIO . forkIO . runLoggingT . runner $ \sSource -> do
-              result <- try $ runPeerInList p sSource
-              liftIO (SSem.signal sem)
+            Just _  -> do
+              result <- try $ liftIO $ Async.withAsync (runLoggingT . runner $ \sSource -> runPeerInList p sSource) $ \res -> Async.waitCatch res
               handleRunPeerResult p result
+              liftIO (SSem.signal sem)
 
       handleRunPeerResult :: MonadP2P m => PPeer -> Either SomeException a -> m ()
       handleRunPeerResult thePeer = \case


### PR DESCRIPTION
This PR attempts to fix another strato-p2p memory leak by changing how threading works in p2p client. Suspicions were that threads were not being destroyed properly and resources were left dangling in memory.

https://hackage.haskell.org/package/async-2.2.4/docs/Control-Concurrent-Async.html
(From above documentation) async's high-level API spawns lexically scoped threads, ensuring the following key poperties that make it safer to use than using plain [forkIO](https://hackage.haskell.org/package/base-4.14.1.0/docs/Control-Concurrent.html#v:forkIO):

1. No exception is swallowed (waiting for results propagates exceptions).
2. No thread is leaked (left running unintentionally).

## Before: 
Thanks to @neelkanthpoosa for generating this for me despite his laptop almost exploding syncing. Note the gradual increase of memory along with the block of memory that is always retained throughout. The timeline here is about 104 minutes but this is syncing to around 150k blocks for neel.
![image](https://user-images.githubusercontent.com/35944722/229914432-1d0033db-c20e-4352-8fd1-24f27281f540.png)

## After: 
You can see that after retrieving all the blocks from p2p and even after fully syncing, the heap is cleared and no dangling memory is held.
![image](https://user-images.githubusercontent.com/35944722/229857560-04d637d3-58b0-42b0-8d17-4644fa0fb14d.png)
![image](https://user-images.githubusercontent.com/35944722/229857679-8127346f-95f1-48ec-9081-512fe8562db2.png)

Fixes: https://blockapps.atlassian.net/browse/STRATO-3064