### PR TITLE
Strato 3077 long cirrus request url fix

### DIFF
--- a/nginx-packager/Dockerfile
+++ b/nginx-packager/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
-    opm get zmartzone/lua-resty-openidc=1.7.4 && \
+    opm get zmartzone/lua-resty-openidc=1.7.5 && \
     opm remove bungle/lua-resty-session && \
-    opm get bungle/lua-resty-session=3.10    
+    opm get bungle/lua-resty-session=3.10
     # ^ Remove lines to reinstall lua-resty-session once switched to lua-resty-openidc=1.7.6-3 (when 1.7.6 is available in OPM, see here in the bottoms: https://opm.openresty.org/package/zmartzone/lua-resty-openidc/ )
     # ^ Additional dependency issue context: https://github.com/zmartzone/lua-resty-openidc/issues/463
     # ^ NOTE: There is a same workaround used in VAULT nginx

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -239,6 +239,10 @@ http {
         limit_except GET {
           deny all;
         }
+        # adjust proxy buffer size as postgrest can return long headers with Content-Location including the full url path
+        proxy_buffer_size   128k;
+        proxy_buffers   4 256k;
+        proxy_busy_buffers_size   256k;
         rewrite_by_lua_file lua/openid.lua;
 #         auth_request /_api_counter;                                         #TEMPLATE_MARK_STATS_ENABLED
         proxy_set_header Accept-Encoding "";


### PR DESCRIPTION
tCommerce folks reported that the cirrus/search/ requests with long request paths return 502 Bad Gateway response.

Because postgrest itself can handle these requests just fine, I made the fix to nginx to proxy this properly.