### PR TITLE
Add cache back in to fix api memory leak related to

### DIFF
--- a/strato/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Database/Queries.hs
@@ -38,7 +38,9 @@ import qualified Crypto.Saltine.Core.SecretBox   as SecretBox
 import           Data.Aeson                      (Result(..), fromJSON)
 import qualified Data.ByteString                 as B
 import qualified Data.ByteString.Char8           as BC
+import qualified Data.Cache                      as Cache
 import           Data.Either                     (fromRight)
+import           Data.Foldable                   (for_)
 import           Data.Map.Strict                 (Map)
 import qualified Data.Map.Strict                 as Map
 import           Data.Maybe
@@ -53,6 +55,7 @@ import           Database.PostgreSQL.Simple.FromField hiding (name, format)
 import           Opaleye                         hiding (not, null, index, FromField)
 import qualified Opaleye as O
 import           Opaleye.Internal.PGTypesExternal
+import           System.Clock
 import           Text.Format
 import           UnliftIO
 
@@ -162,12 +165,24 @@ insertContractDetailsQuery sourceList =
 
 getContractDetailsByCodeHash :: ( A.Selectable Account AddressState m
                                 , (Keccak256 `A.Alters` SourceMap) m
+                                , HasBlocEnv m
                                 , MonadLogger m
                                 , HasBlocSQL m
                                 )
                              => CodePtr -> m (Either Text ContractDetails)
 getContractDetailsByCodeHash codePtr = do
-  runExceptT $ do
+  srcCache <- fmap globalCodePtrCache getBlocEnv
+  now' <- liftIO $ getTime Monotonic
+  let later = (now' +) <$> Cache.defaultExpiration srcCache
+  mCachedDetails <- atomically $ do
+    Cache.purgeExpiredSTM srcCache now' -- todo: this should probably go somewhere else, like a worker thread,
+                                       --       but we need this to prevent the cache growing unboundedly
+    r <- Cache.lookupSTM True codePtr srcCache now'
+    for_ r $ \v -> Cache.insertSTM codePtr v srcCache later -- refresh to timestamp of this item
+    pure r
+  runExceptT $ case mCachedDetails of
+    Just cachedDetails -> pure cachedDetails
+    Nothing -> do
       mDetails <- lift (unsafeResolveCodePtrSelect codePtr) >>= \mcp -> flip traverse mcp $ \codeHash -> do
         ~(shouldCompile, name, ch) <- case codeHash of
           EVMCode ch -> lift (evmContractByCodeHash ch) >>= \case
@@ -191,7 +206,9 @@ getContractDetailsByCodeHash codePtr = do
             Just d -> pure d
       case mDetails of
         Nothing -> throwE $ "Could not resolve code pointer " <> Text.pack (format codePtr)
-        Just details -> pure details
+        Just details -> do
+          liftIO $ Cache.insert srcCache codePtr details
+          pure details
 
 evmContractSolidVMError :: Text
 evmContractSolidVMError = Text.concat
@@ -204,12 +221,25 @@ getContractDetailsForContract :: ( A.Selectable Account AddressState m
                                  , (Keccak256 `A.Alters` SourceMap) m
                                  , MonadLogger m
                                  , HasBlocSQL m
+                                 , HasBlocEnv m
                                  )
                               => Text -> SourceMap -> Maybe Text -> m (Maybe (Text, ContractDetails))
 getContractDetailsForContract theVM src mContract = do
   let shouldCompile = if theVM == "EVM" then Do Compile else Don't Compile
+      cacheKey = (theVM, src)
+  srcCache <- fmap globalSourceCache getBlocEnv
+  now' <- liftIO $ getTime Monotonic
+  let later = (now' +) <$> Cache.defaultExpiration srcCache
+  mCachedDetails <- atomically $ do
+    Cache.purgeExpiredSTM srcCache now' -- todo: this should probably go somewhere else, like a worker thread,
+                                       --       but we need this to prevent the cache growing unboundedly
+    r <- Cache.lookupSTM True cacheKey srcCache now'
+    for_ r $ \v -> Cache.insertSTM cacheKey v srcCache later -- refresh to timestamp of this item
+    pure r
 
-  idsAndDetails <- do
+  idsAndDetails <- case mCachedDetails of
+    Just cachedDetails -> pure cachedDetails
+    Nothing -> do
       details <- if hasAnyNonEmptySources src
                    then sourceToContractDetails shouldCompile src
                    else return Map.empty

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Monad.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Monad.hs
@@ -37,10 +37,12 @@ module BlockApps.Bloc22.Monad (
 import           Control.Monad.Reader
 import           Data.Cache
 import           Data.Foldable
+import           Data.Map.Strict                    (Map)
 import           Data.Pool                          (withResource)
 import           Data.Profunctor.Product.Default
 import           Data.Text                          (Text)
 import qualified Data.Text                          as Text
+import           Data.Source.Map
 import           Database.PostgreSQL.Simple         (Connection,
                                                      withTransaction)
 import           GHC.Stack
@@ -55,7 +57,9 @@ import           BlockApps.Bloc22.API.Transaction
 import           BlockApps.Logging
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.ChainId
+import           Blockchain.Strato.Model.CodePtr
 import           Blockchain.Strato.Model.Nonce
+import           BlockApps.Solidity.Xabi
 
 import           Control.Monad.Change.Modify        hiding (modify)
 import           Control.Monad.Composable.BlocSQL
@@ -75,6 +79,8 @@ data BlocEnv = BlocEnv
   , gasOn              :: Bool
   , evmCompatible      :: Bool
   , globalNonceCounter :: Cache Account Nonce
+  , globalSourceCache  :: Cache (Text, SourceMap) (Map Text ContractDetails)
+  , globalCodePtrCache :: Cache CodePtr ContractDetails
   , txTBQueue          :: TBQueue (Maybe Text, Maybe ChainId, Bool, PostBlocTransactionRequest)
   }
 

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Server/Chain.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Server/Chain.hs
@@ -91,6 +91,7 @@ governanceAddress = Address 0x100
 createChainInfo :: ( A.Selectable Account AddressState m
                    , (Keccak256 `A.Alters` SourceMap) m
                    , MonadLogger m
+                   , HasBlocEnv m
                    , HasBlocSQL m
                    , HasVault m
                    )
@@ -215,6 +216,7 @@ postChainInfo mJwtToken chainInput = case mJwtToken of
 postChainInfos :: ( A.Selectable Account AddressState m
                   , (Keccak256 `A.Alters` SourceMap) m
                   , MonadLogger m
+                  , HasBlocEnv m
                   , HasBlocSQL m
                   , HasSQL m
                   , HasVault m

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Server/Contracts.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Server/Contracts.hs
@@ -109,6 +109,7 @@ getContractsContract :: ( A.Selectable Account AddressState m
                         , MonadLogger m
                         , HasBlocSQL m
                         , HasSQL m
+                        , HasBlocEnv m
                         )
                      => ContractName -> Address -> Maybe ChainId -> m ContractDetails
 getContractsContract name addr chainId = do
@@ -252,6 +253,7 @@ getContractsDetails' :: ( A.Selectable Account AddressState m
                         , MonadLogger m
                         , HasSQL m
                         , HasBlocSQL m
+                        , HasBlocEnv m
                         )
                      => Address -> Maybe ChainId -> m ContractDetails
 getContractsDetails' contractAddress chainId = do
@@ -279,6 +281,7 @@ getContractsDetails :: ( A.Selectable Account AddressState m
                        , (Keccak256 `A.Alters` SourceMap) m
                        , MonadLogger m
                        , HasSQL m
+                       , HasBlocEnv m
                        , HasBlocSQL m
                        )
                     => Address -> Maybe ChainId -> m ContractDetails
@@ -289,6 +292,7 @@ getContractXabi :: ( A.Selectable Account AddressState m
                    , (Keccak256 `A.Alters` SourceMap) m
                    , MonadLogger m
                    , HasSQL m
+                   , HasBlocEnv m
                    , HasBlocSQL m
                    )
                 => Account -> m Xabi
@@ -298,6 +302,7 @@ getContractsFunctions :: ( A.Selectable Account AddressState m
                          , (Keccak256 `A.Alters` SourceMap) m
                          , MonadLogger m
                          , HasSQL m
+                         , HasBlocEnv m
                          , HasBlocSQL m
                          )
                       => ContractName -> Address -> Maybe ChainId -> m [FunctionName]
@@ -309,6 +314,7 @@ getContractsSymbols :: ( A.Selectable Account AddressState m
                        , (Keccak256 `A.Alters` SourceMap) m
                        , MonadLogger m
                        , HasSQL m
+                       , HasBlocEnv m
                        , HasBlocSQL m
                        )
                     => ContractName -> Address -> Maybe ChainId -> m [SymbolName]
@@ -320,6 +326,7 @@ getContractsEnum :: ( A.Selectable Account AddressState m
                     , (Keccak256 `A.Alters` SourceMap) m
                     , MonadLogger m
                     , HasSQL m
+                    , HasBlocEnv m
                     , HasBlocSQL m
                     )
                  => ContractName -> Address -> EnumName -> Maybe ChainId -> m [EnumValue]

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Server/Transaction.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Server/Transaction.hs
@@ -872,8 +872,13 @@ getAccountTxParams cacheNonce addr chainId mTxParams = do
       cacheKey = Account addr (unChainId <$> chainId)
   nonceCache <- fmap globalNonceCounter getBlocEnv
   now <- liftIO $ getTime Monotonic
+  let later = (now +) <$> Cache.defaultExpiration nonceCache
   mCachedNonce <- case cacheNonce of
-    Do CacheNonce -> atomically $ cacheLookup nonceCache now cacheKey
+    Do CacheNonce -> atomically $ do
+      Cache.purgeExpiredSTM nonceCache now
+      r <- Cache.lookupSTM True cacheKey nonceCache now
+      for_ r $ \v -> Cache.insertSTM cacheKey v nonceCache later
+      pure r  
     Don't CacheNonce -> pure Nothing
   nonceMap <- case mCachedNonce of
                 Just n -> pure $ Map.singleton chainId n

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Server/Transaction.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Server/Transaction.hs
@@ -1039,6 +1039,7 @@ getSolidityType av Xabi.Mapping{}            = Left $ Text.pack $ "Expected Obje
 getResultAndRespond :: ( A.Selectable Account AddressState m
                        , (Keccak256 `A.Alters` SourceMap) m
                        , MonadLogger m
+                       , HasBlocEnv m
                        , HasBlocSQL m
                        , HasSQL m
                        )

--- a/strato/api/bloc2/src/BlockApps/Bloc22/Server/TransactionResult.hs
+++ b/strato/api/bloc2/src/BlockApps/Bloc22/Server/TransactionResult.hs
@@ -112,6 +112,7 @@ getBlocTransactionResult' :: ( (Keccak256 `A.Alters` SourceMap) m
                              , MonadLogger m
                              , HasBlocSQL m
                              , HasSQL m
+                             , HasBlocEnv m
                              )
                           => [Keccak256] -> Bool -> m BlocTransactionResult
 getBlocTransactionResult' [] _ = throwIO $ AnError "getBlockTransactionResult': no TX hashes"
@@ -134,6 +135,7 @@ getBlocTransactionResult :: ( (Keccak256 `A.Alters` SourceMap) m
                             , MonadLogger m
                             , HasBlocSQL m
                             , HasSQL m
+                            , HasBlocEnv m
                             )
                          => Keccak256 -> Bool -> m BlocTransactionResult
 getBlocTransactionResult txHash resolve = fmap head $ postBlocTransactionResults resolve [txHash]
@@ -144,6 +146,7 @@ getBatchBlocTransactionResult' :: ( (Keccak256 `A.Alters` SourceMap) m
                                   , MonadLogger m
                                   , HasBlocSQL m
                                   , HasSQL m
+                                  , HasBlocEnv m
                                   )
                                => [Keccak256] -> Bool -> m [BlocTransactionResult]
 getBatchBlocTransactionResult' hashes resolve =
@@ -156,6 +159,7 @@ postBlocTransactionResults :: ( (Keccak256 `A.Alters` SourceMap) m
                               , MonadLogger m
                               , HasBlocSQL m
                               , HasSQL m
+                              , HasBlocEnv m
                               )
                            => Bool -> [Keccak256] -> m [BlocTransactionResult]
 postBlocTransactionResults resolve hashes = recurseTRDs resolve hashes >>= evalAndReturn
@@ -223,6 +227,7 @@ evalAndReturn :: ( (Keccak256 `A.Alters` SourceMap) m
                  , A.Selectable Account AddressState m
                  , MonadLogger m
                  , HasBlocSQL m
+                 , HasBlocEnv m
                  )
               => [TRD] -> m [BlocTransactionResult]
 evalAndReturn list = forStateT emptyBatchState list $
@@ -246,6 +251,7 @@ contractResult :: ( A.Selectable Account AddressState m
                   , (Keccak256 `A.Alters` SourceMap) m
                   , MonadLogger m
                   , HasBlocSQL m
+                  , HasBlocEnv m
                   )
                => Integer
                -> Keccak256
@@ -297,6 +303,7 @@ functionResult :: ( A.Selectable Account AddressState m
                   , (Keccak256 `A.Alters` SourceMap) m
                   , MonadLogger m
                   , HasBlocSQL m
+                  , HasBlocEnv m
                   )
                => Integer
                -> Keccak256

--- a/strato/api/strato-api/app/Main.hs
+++ b/strato/api/strato-api/app/Main.hs
@@ -235,9 +235,12 @@ main = do
 
   let stateFetchLimit'=100
       nonceCounterTimeout=10
+      sourceCacheTimeout=60
       txQueueSize=4096
 
   nonceCache <- Cache.newCache . Just $ TimeSpec nonceCounterTimeout 0
+  codePtrCache <- Cache.newCache . Just $ TimeSpec sourceCacheTimeout 0
+  sourceCache <- Cache.newCache . Just $ TimeSpec sourceCacheTimeout 0
   tbqueue <- newTBQueueIO txQueueSize
 
   sqlEnv <- createSQLEnv
@@ -249,6 +252,8 @@ main = do
           evmCompatible= flags_evmCompatible,
           stateFetchLimit = stateFetchLimit',
           globalNonceCounter = nonceCache,
+          globalCodePtrCache = codePtrCache,
+          globalSourceCache = sourceCache,
           txTBQueue = tbqueue
           }
   run 3000 $ app env sqlEnv blocSQLEnv theDoc

--- a/strato/indexer/slipstream/exec_src/Main.hs
+++ b/strato/indexer/slipstream/exec_src/Main.hs
@@ -16,6 +16,7 @@ import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Resource
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
+import Data.Cache
 import qualified Data.Map as M
 import           Data.Maybe
 import qualified Data.Text as T
@@ -28,6 +29,7 @@ import HFlags
 import Network.Kafka hiding (runKafka)
 import Network.Wai.Handler.Warp
 import Network.Wai.Middleware.Prometheus
+import System.Clock
 import Text.Printf
 import Text.RawString.QQ
 
@@ -52,12 +54,17 @@ workerConnStr :: ConnectionString
 workerConnStr = BC.pack $ printf "host=%s port=%d user=%s password=%s dbname=%s"
                         flags_pghost flags_pgport flags_pguser flags_password flags_database
 
+
 createBlocEnv :: MonadIO m => m BlocEnv
 createBlocEnv = liftIO $ do
+  codePtrCache <- newCache . Just $ TimeSpec 60  0
+  sourceCache <- newCache . Just $ TimeSpec 60 0
   return BlocEnv { stateFetchLimit = 0
                  , gasOn=error("gasOn shouldn't be needed in slipstream, it is undefined")
                  , evmCompatible=False
                  , globalNonceCounter=error("globalNonceCounter shouldn't be needed in slipstream, it is undefined")
+                 , globalSourceCache=sourceCache
+                 , globalCodePtrCache=codePtrCache
                  , txTBQueue=error("txTBQueue shouldn't be needed in slipstream, it is undefined")
     }
 

--- a/strato/indexer/slipstream/exec_src/Main.hs
+++ b/strato/indexer/slipstream/exec_src/Main.hs
@@ -16,7 +16,6 @@ import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Resource
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
-import Data.Cache
 import qualified Data.Map as M
 import           Data.Maybe
 import qualified Data.Text as T
@@ -29,7 +28,6 @@ import HFlags
 import Network.Kafka hiding (runKafka)
 import Network.Wai.Handler.Warp
 import Network.Wai.Middleware.Prometheus
-import System.Clock
 import Text.Printf
 import Text.RawString.QQ
 
@@ -57,14 +55,12 @@ workerConnStr = BC.pack $ printf "host=%s port=%d user=%s password=%s dbname=%s"
 
 createBlocEnv :: MonadIO m => m BlocEnv
 createBlocEnv = liftIO $ do
-  codePtrCache <- newCache . Just $ TimeSpec 60  0
-  sourceCache <- newCache . Just $ TimeSpec 60 0
   return BlocEnv { stateFetchLimit = 0
                  , gasOn=error("gasOn shouldn't be needed in slipstream, it is undefined")
                  , evmCompatible=False
                  , globalNonceCounter=error("globalNonceCounter shouldn't be needed in slipstream, it is undefined")
-                 , globalSourceCache=sourceCache
-                 , globalCodePtrCache=codePtrCache
+                 , globalSourceCache=error("globalSourceCache shouldn't be needed in slipstream, it is undefined")
+                 , globalCodePtrCache=error("globalCodePtrCache shouldn't be needed in slipstream, it is undefined")
                  , txTBQueue=error("txTBQueue shouldn't be needed in slipstream, it is undefined")
     }
 

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -69,6 +69,7 @@ import Blockchain.Strato.Model.Keccak256
 import qualified Blockchain.Stream.Action as Action
 import Blockchain.Stream.VMEvent
 
+import Control.Monad.Change.Modify              hiding (modify)
 import Control.Monad.Composable.BlocSQL
 import Control.Monad.Composable.SQL
 import Control.Monad.Composable.CoreAPI
@@ -207,6 +208,7 @@ lookupT k = MaybeT . return . Map.lookup k
 
 -- EVM details are not cached, because the cache links all the contracts in a source blob by source hash, and we only have source hashes for SolidVM code pointers. 
 getEVMDetailsForRow :: ( MonadLogger m
+                       , Accessible BlocEnv m
                        , HasBlocSQL m
                        , Selectable Account AddressState m
                        , (Keccak256 `Alters` SourceMap) m
@@ -388,6 +390,7 @@ getCodeCollection f cp ccString = do
 
 getEVMInserts :: (
   MonadLogger m,
+  Accessible BlocEnv m,
   HasBlocSQL m,
   Selectable Account AddressState m,
   (Keccak256 `Alters` SourceMap) m) => IORef Globals -> AggregateAction -> [AggregateAction] -> Account -> m (Either Text BatchedInserts)


### PR DESCRIPTION
The code in this PR use to be in `develop` . Nothing in here is new.

To recreate the API memory leak, Jin figured out to run the t commerce tests in a loop. The below are screenshots are from the eventlog produced from running that configuration. 


Memory before cache 

Note I stopped running the tests twice. That is why there are those two large drops, but once the tests were started again, the heap would go back to where it was. 


![image](https://user-images.githubusercontent.com/54577107/230264049-8f070bdf-8870-463f-a2f7-8b695dbe9dcf.png)

![image](https://user-images.githubusercontent.com/54577107/230264535-cbf9fcab-83da-46d7-9a5f-aea7043c7fc4.png)


After Cache
![image](https://user-images.githubusercontent.com/54577107/230266748-f65086b4-b10e-4cd5-849f-978e88ef613f.png)

![image](https://user-images.githubusercontent.com/54577107/230266799-4f34d1c0-2a73-4e4c-a1d0-7bcfadef7044.png)


