### PR TITLE
Responsive navbar

### DIFF
--- a/smd-ui/src/App/App.scss
+++ b/smd-ui/src/App/App.scss
@@ -21,14 +21,6 @@ body {
   font-family: 'Roboto', sans-serif !important;
 }
 
-#outer-container {
-  position: relative;
-  top: 48px;
-  margin-left: 320px;
-  padding: 0px 12px;
-}
-
-
 .smd-full-width {
   width: 100%;
 }

--- a/smd-ui/src/App/index.js
+++ b/smd-ui/src/App/index.js
@@ -31,10 +31,11 @@ class App extends Component {
   
 
   render() {
+    const collapsePoint = 800; //in px
     return (
       <div className="App" >
         <LoadingBar style={{ top: '0px', backgroundColor: '#62d96b', zIndex: 999, height: '4px' }} />
-        <MenuBar />
+        <MenuBar sidebarCollapsed={(window.innerWidth < collapsePoint)}/>
         <SideBar />
         <main id="outer-container">
           {scenes}

--- a/smd-ui/src/App/index.js
+++ b/smd-ui/src/App/index.js
@@ -28,15 +28,24 @@ class App extends Component {
     }
   }
 
-  
+  constructor(){
+    super()
+    this.state = {
+      isCollapsed: true
+    }
+  }
+
+  toggleCollapse = () => {
+    this.setState(prevState => ({isCollapsed: !prevState.isCollapsed}))
+  }
 
   render() {
     const collapsePoint = 800; //in px
     return (
       <div className="App" >
         <LoadingBar style={{ top: '0px', backgroundColor: '#62d96b', zIndex: 999, height: '4px' }} />
-        <MenuBar sidebarCollapsed={(window.innerWidth < collapsePoint)}/>
-        <SideBar />
+        <MenuBar isCollapsed={this.state.isCollapsed} toggleCollapse={this.toggleCollapse}/>
+        <SideBar isCollapsed={this.state.isCollapsed} toggleCollapse={this.toggleCollapse}/>
         <main id="outer-container">
           {scenes}
         </main>

--- a/smd-ui/src/components/MenuBar/index.js
+++ b/smd-ui/src/components/MenuBar/index.js
@@ -16,11 +16,12 @@ import {
 import HexText from '../HexText';
 
 class MenuBar extends Component {
-  constructor() {
+  constructor(props) {
     super()
     this.state = {
      searchQuery:"",
-     isUserMenuOpen: false
+     isUserMenuOpen: false,
+     sidebarCollapsed: props.sidebarCollapsed
     }
   }
   componentWillReceiveProps(newProps) {
@@ -75,6 +76,14 @@ class MenuBar extends Component {
     )
   }
 
+  toggleCollapse = () => {
+    const sidebar = document.querySelector('#sidebar');
+    const outerContainer = document.querySelector('#outer-container');
+    sidebar.style.display = this.state.sidebarCollapsed ? "block" : "none";
+    outerContainer.style.marginLeft = this.state.sidebarCollapsed? '260px' : '0px';
+
+    this.state.sidebarCollapsed = !this.state.sidebarCollapsed;
+  }
 
   handleKeyDown = (e) => {
 
@@ -171,6 +180,7 @@ class MenuBar extends Component {
 
     return (
       <nav className="pt-navbar pt-dark smd-menu-bar" >
+        <i className="fa fa-bars" id="menu-burger" onClick={this.toggleCollapse}></i>
         <div className="pt-navbar-group pt-align-left col-sm-2 ">
           <div>
             <Link to="/home">

--- a/smd-ui/src/components/MenuBar/index.js
+++ b/smd-ui/src/components/MenuBar/index.js
@@ -20,8 +20,7 @@ class MenuBar extends Component {
     super()
     this.state = {
      searchQuery:"",
-     isUserMenuOpen: false,
-     sidebarCollapsed: props.sidebarCollapsed
+     isUserMenuOpen: false
     }
   }
   componentWillReceiveProps(newProps) {
@@ -74,15 +73,6 @@ class MenuBar extends Component {
         <pre>{certificateString}</pre>
       </div>      
     )
-  }
-
-  toggleCollapse = () => {
-    const sidebar = document.querySelector('#sidebar');
-    const outerContainer = document.querySelector('#outer-container');
-    sidebar.style.display = this.state.sidebarCollapsed ? "block" : "none";
-    outerContainer.style.marginLeft = this.state.sidebarCollapsed? '260px' : '0px';
-
-    this.state.sidebarCollapsed = !this.state.sidebarCollapsed;
   }
 
   handleKeyDown = (e) => {
@@ -180,7 +170,10 @@ class MenuBar extends Component {
 
     return (
       <nav className="pt-navbar pt-dark smd-menu-bar" >
-        <i className="fa fa-bars" id="menu-burger" onClick={this.toggleCollapse}></i>
+        <div 
+          id="menu-burger" 
+          onClick={this.props.toggleCollapse}
+          className={this.props.isCollapsed? '' : 'burger-x'}><span></span></div>
         <div className="pt-navbar-group pt-align-left col-sm-2 ">
           <div>
             <Link to="/home">

--- a/smd-ui/src/components/MenuBar/menubar.scss
+++ b/smd-ui/src/components/MenuBar/menubar.scss
@@ -8,6 +8,8 @@
 .smd-menu-bar {
   position: fixed !important;
   width: 100%;
+  display: flex;
+  align-items: center;
 }
 
 .menubar-button {

--- a/smd-ui/src/components/MenuBar/menubar.scss
+++ b/smd-ui/src/components/MenuBar/menubar.scss
@@ -10,6 +10,7 @@
   width: 100%;
   display: flex;
   align-items: center;
+  justify-content: space-between;
 }
 
 .menubar-button {
@@ -30,4 +31,9 @@
 .select-chain {
   min-width: 230px !important;
   max-width: 350px !important;
+}
+
+.pt-icon-user {
+  height: 50px;
+  overflow: hidden; 
 }

--- a/smd-ui/src/components/SideBar/index.js
+++ b/smd-ui/src/components/SideBar/index.js
@@ -29,7 +29,7 @@ class SideBar extends Component {
     );
 
     return (
-      <aside id="sidebar">
+      <aside id="sidebar" className={this.props.isCollapsed ? '' : 'sidebar-expand'}>
         <div className="menu">
           {
             navLinksData.map(data =>
@@ -39,7 +39,7 @@ class SideBar extends Component {
                 to={data.path}
                 className="menu-item"
                 activeClassName="active-menu-item"
-                onClick={() => { mixpanelWrapper.track('nav_link_' + data.id + '_click') }}
+                onClick={this.props.toggleCollapse}
               >
                 <i className={'fa ' + data.icon}> </i>
                 <span className="menu-text"> {data.label}</span>

--- a/smd-ui/src/components/SideBar/index.js
+++ b/smd-ui/src/components/SideBar/index.js
@@ -29,7 +29,7 @@ class SideBar extends Component {
     );
 
     return (
-      <aside>
+      <aside id="sidebar">
         <div className="menu">
           {
             navLinksData.map(data =>

--- a/smd-ui/src/components/SideBar/sidebar.scss
+++ b/smd-ui/src/components/SideBar/sidebar.scss
@@ -24,13 +24,6 @@ aside {
   display: block;
 }
 
-#menu-burger {
-  color: $pt-dark-text-color;
-  font-size: 1.25em;
-  padding-left: 16px;
-  cursor: pointer;
-}
-
 .menu-text {
   margin-left: 8px;
 }
@@ -141,7 +134,19 @@ $burgerSize: 35px;
       }
       &:before {
         transform: rotate(45deg);
-      }
+      }​
+27
+#menu-burger {
+28
+  color: $pt-dark-text-color;
+29
+  font-size: 1.25em;
+30
+  padding-left: 16px;
+31
+  cursor: pointer;
+32
+}
       &:after {
         transform: rotate(-45deg);
       }

--- a/smd-ui/src/components/SideBar/sidebar.scss
+++ b/smd-ui/src/components/SideBar/sidebar.scss
@@ -27,7 +27,7 @@ aside {
 #menu-burger {
   color: $pt-dark-text-color;
   font-size: 1.25em;
-  padding: 8px 16px;
+  padding-left: 16px;
   cursor: pointer;
 }
 

--- a/smd-ui/src/components/SideBar/sidebar.scss
+++ b/smd-ui/src/components/SideBar/sidebar.scss
@@ -1,6 +1,7 @@
 @import "~@blueprintjs/core/dist/blueprint.css";
 @import "../../../node_modules/@blueprintjs/core/dist/variables.scss";
 
+$navbarWidth: 260px;
 aside {
   position: fixed;
   height: 100%;
@@ -8,9 +9,10 @@ aside {
   left: 0px;
   background: #394b59;
   padding: 20px;
-  width: 320px;
+  width: $navbarWidth;
   margin-top: 48px;
   box-shadow: inset 0 0 2px 1px rgba(16, 22, 26, 0.2), 0 1px 2px rgba(16, 22, 26, 0.4);
+  z-index: 9;
 }
 
 .menu-item{
@@ -20,6 +22,13 @@ aside {
   padding: 8px 16px;
   text-decoration: none;
   display: block;
+}
+
+#menu-burger {
+  color: $pt-dark-text-color;
+  font-size: 1.25em;
+  padding: 8px 16px;
+  cursor: pointer;
 }
 
 .menu-text {
@@ -47,7 +56,6 @@ aside {
 }
 
 .menu {
-  padding: 0px 20px;
   min-height: 35vh;
   max-height: 60vh;
   overflow-y: auto;
@@ -74,4 +82,31 @@ aside {
 
 .send-tokens-dialog .chain-field {
   width: 100%;
+}
+
+#outer-container {
+  position: relative;
+  top: 48px;
+  margin-left: $navbarWidth;
+  padding: 0px 12px;
+}
+
+$collapsePoint: 800px;
+@media only screen and (max-width: $collapsePoint) {
+  #sidebar {
+    display: none;
+  }
+  #outer-container {
+    margin-left: 0px;
+  }
+}
+
+@media only screen and (min-width: $collapsePoint) {
+  aside {
+    display: block;
+    visibility: visible;
+  }
+  #outer-container {
+    margin-left: $navbarWidth;
+  }
 }

--- a/smd-ui/src/components/SideBar/sidebar.scss
+++ b/smd-ui/src/components/SideBar/sidebar.scss
@@ -134,19 +134,7 @@ $burgerSize: 35px;
       }
       &:before {
         transform: rotate(45deg);
-      }​
-27
-#menu-burger {
-28
-  color: $pt-dark-text-color;
-29
-  font-size: 1.25em;
-30
-  padding-left: 16px;
-31
-  cursor: pointer;
-32
-}
+      }
       &:after {
         transform: rotate(-45deg);
       }

--- a/smd-ui/src/components/SideBar/sidebar.scss
+++ b/smd-ui/src/components/SideBar/sidebar.scss
@@ -91,7 +91,12 @@ aside {
   padding: 0px 12px;
 }
 
+#menu-burger {
+  display: none;
+}
+
 $collapsePoint: 800px;
+$burgerSize: 35px;
 @media only screen and (max-width: $collapsePoint) {
   #sidebar {
     display: none;
@@ -99,14 +104,47 @@ $collapsePoint: 800px;
   #outer-container {
     margin-left: 0px;
   }
-}
-
-@media only screen and (min-width: $collapsePoint) {
-  aside {
+  #sidebar.sidebar-expand {
     display: block;
-    visibility: visible;
+    width: 100%;
   }
-  #outer-container {
-    margin-left: $navbarWidth;
+  #menu-burger {
+    display: block;
+    height: $burgerSize;
+    width: $burgerSize;
+    padding: 15px;
+    cursor: pointer;
+    span,
+    span:before,
+    span:after {
+      cursor: pointer;
+      border-radius: 1px;
+      height: 5px;
+      width: $burgerSize;
+      background: $pt-dark-text-color;
+      position: absolute;
+      display: block;
+      content: '';
+      transition: all 300ms ease-in-out;
+    }
+    span:before {
+      top: -10px;
+    }
+    span:after {
+      bottom: -10px;
+    }
+    &.burger-x span {
+      background-color: transparent;
+      &:before,
+      &:after {
+        top: 0;
+      }
+      &:before {
+        transform: rotate(45deg);
+      }
+      &:after {
+        transform: rotate(-45deg);
+      }
+    }
   }
 }

--- a/smd-ui/src/tests/App/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/App/__snapshots__/index.spec.js.snap
@@ -10,7 +10,7 @@ Object {
 exports[`App: index componentDidMount1 1`] = `
 "<div className=\\"App\\">
   <Connect(LoadingBar) style={{...}} />
-  <withRouter(Connect(MenuBar)) />
+  <withRouter(Connect(MenuBar)) sidebarCollapsed={false} />
   <SideBar />
   <main id=\\"outer-container\\">
     <Switch>
@@ -40,7 +40,7 @@ exports[`App: index componentDidMount1 1`] = `
 exports[`App: index componentDidMount2 1`] = `
 "<div className=\\"App\\">
   <Connect(LoadingBar) style={{...}} />
-  <withRouter(Connect(MenuBar)) />
+  <withRouter(Connect(MenuBar)) sidebarCollapsed={false} />
   <SideBar />
   <main id=\\"outer-container\\">
     <Switch>
@@ -70,7 +70,7 @@ exports[`App: index componentDidMount2 1`] = `
 exports[`App: index render component 1`] = `
 "<div className=\\"App\\">
   <Connect(LoadingBar) style={{...}} />
-  <withRouter(Connect(MenuBar)) />
+  <withRouter(Connect(MenuBar)) sidebarCollapsed={false} />
   <SideBar />
   <main id=\\"outer-container\\">
     <Switch>

--- a/smd-ui/src/tests/App/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/App/__snapshots__/index.spec.js.snap
@@ -10,8 +10,8 @@ Object {
 exports[`App: index componentDidMount1 1`] = `
 "<div className=\\"App\\">
   <Connect(LoadingBar) style={{...}} />
-  <withRouter(Connect(MenuBar)) sidebarCollapsed={false} />
-  <SideBar />
+  <withRouter(Connect(MenuBar)) isCollapsed={true} toggleCollapse={[Function]} />
+  <SideBar isCollapsed={true} toggleCollapse={[Function]} />
   <main id=\\"outer-container\\">
     <Switch>
       <Route exact={true} path=\\"/\\" component={[undefined]}>
@@ -40,8 +40,8 @@ exports[`App: index componentDidMount1 1`] = `
 exports[`App: index componentDidMount2 1`] = `
 "<div className=\\"App\\">
   <Connect(LoadingBar) style={{...}} />
-  <withRouter(Connect(MenuBar)) sidebarCollapsed={false} />
-  <SideBar />
+  <withRouter(Connect(MenuBar)) isCollapsed={true} toggleCollapse={[Function]} />
+  <SideBar isCollapsed={true} toggleCollapse={[Function]} />
   <main id=\\"outer-container\\">
     <Switch>
       <Route exact={true} path=\\"/\\" component={[undefined]}>
@@ -70,8 +70,8 @@ exports[`App: index componentDidMount2 1`] = `
 exports[`App: index render component 1`] = `
 "<div className=\\"App\\">
   <Connect(LoadingBar) style={{...}} />
-  <withRouter(Connect(MenuBar)) sidebarCollapsed={false} />
-  <SideBar />
+  <withRouter(Connect(MenuBar)) isCollapsed={true} toggleCollapse={[Function]} />
+  <SideBar isCollapsed={true} toggleCollapse={[Function]} />
   <main id=\\"outer-container\\">
     <Switch>
       <Route exact={true} path=\\"/\\" component={[undefined]}>

--- a/smd-ui/src/tests/MenuBar/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/MenuBar/__snapshots__/index.spec.js.snap
@@ -2,7 +2,9 @@
 
 exports[`MenuBar: index renders Oauth mode component with values 1`] = `
 "<nav className=\\"pt-navbar pt-dark smd-menu-bar\\">
-  <i className=\\"fa fa-bars\\" id=\\"menu-burger\\" onClick={[Function]} />
+  <div id=\\"menu-burger\\" onClick={[undefined]} className=\\"burger-x\\">
+    <span />
+  </div>
   <div className=\\"pt-navbar-group pt-align-left col-sm-2 \\">
     <div>
       <Link to=\\"/home\\" replace={false}>
@@ -59,7 +61,9 @@ exports[`MenuBar: index renders Oauth mode component with values 1`] = `
 
 exports[`MenuBar: index renders Oauth mode component without values 1`] = `
 "<nav className=\\"pt-navbar pt-dark smd-menu-bar\\">
-  <i className=\\"fa fa-bars\\" id=\\"menu-burger\\" onClick={[Function]} />
+  <div id=\\"menu-burger\\" onClick={[undefined]} className=\\"burger-x\\">
+    <span />
+  </div>
   <div className=\\"pt-navbar-group pt-align-left col-sm-2 \\">
     <div>
       <Link to=\\"/home\\" replace={false}>

--- a/smd-ui/src/tests/MenuBar/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/MenuBar/__snapshots__/index.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`MenuBar: index renders Oauth mode component with values 1`] = `
 "<nav className=\\"pt-navbar pt-dark smd-menu-bar\\">
+  <i className=\\"fa fa-bars\\" id=\\"menu-burger\\" onClick={[Function]} />
   <div className=\\"pt-navbar-group pt-align-left col-sm-2 \\">
     <div>
       <Link to=\\"/home\\" replace={false}>
@@ -58,6 +59,7 @@ exports[`MenuBar: index renders Oauth mode component with values 1`] = `
 
 exports[`MenuBar: index renders Oauth mode component without values 1`] = `
 "<nav className=\\"pt-navbar pt-dark smd-menu-bar\\">
+  <i className=\\"fa fa-bars\\" id=\\"menu-burger\\" onClick={[Function]} />
   <div className=\\"pt-navbar-group pt-align-left col-sm-2 \\">
     <div>
       <Link to=\\"/home\\" replace={false}>

--- a/smd-ui/src/tests/SideBar/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/SideBar/__snapshots__/index.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SideBar: index render component for non oauth mode 1`] = `
-"<aside id=\\"sidebar\\">
+"<aside id=\\"sidebar\\" className=\\"sidebar-expand\\">
   <div className=\\"menu\\">
-    <NavLink id=\\"app_store\\" to=\\"/appstore\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"app_store\\" to=\\"/appstore\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-window-restore\\">
          
       </i>
@@ -12,7 +12,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
         AppStore
       </span>
     </NavLink>
-    <NavLink id=\\"dapplets\\" to=\\"/home\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"dapplets\\" to=\\"/home\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-arrow-circle-right\\">
          
       </i>
@@ -21,7 +21,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
         Dapplets
       </span>
     </NavLink>
-    <NavLink id=\\"network_stats\\" to=\\"/stats\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"network_stats\\" to=\\"/stats\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-rocket\\">
          
       </i>
@@ -30,7 +30,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
         Network Stats
       </span>
     </NavLink>
-    <NavLink id=\\"accounts\\" to=\\"/accounts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"accounts\\" to=\\"/accounts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-users\\">
          
       </i>
@@ -39,7 +39,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
         Users
       </span>
     </NavLink>
-    <NavLink id=\\"transactions\\" to=\\"/transactions\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"transactions\\" to=\\"/transactions\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-exchange\\">
          
       </i>
@@ -48,7 +48,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
         Transactions
       </span>
     </NavLink>
-    <NavLink id=\\"shards\\" to=\\"/shards\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"shards\\" to=\\"/shards\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-user-secret\\">
          
       </i>
@@ -57,7 +57,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
         Shards
       </span>
     </NavLink>
-    <NavLink id=\\"contracts\\" to=\\"/contracts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"contracts\\" to=\\"/contracts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-file\\">
          
       </i>
@@ -66,7 +66,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
         Contracts
       </span>
     </NavLink>
-    <NavLink id=\\"blocks\\" to=\\"/blocks\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"blocks\\" to=\\"/blocks\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-link\\">
          
       </i>
@@ -75,7 +75,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
         Blocks
       </span>
     </NavLink>
-    <NavLink id=\\"code_editor\\" to=\\"/code_editor\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"code_editor\\" to=\\"/code_editor\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-code\\">
          
       </i>
@@ -102,9 +102,9 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
 `;
 
 exports[`SideBar: index render component for public mode 1`] = `
-"<aside id=\\"sidebar\\">
+"<aside id=\\"sidebar\\" className=\\"sidebar-expand\\">
   <div className=\\"menu\\">
-    <NavLink id=\\"app_store\\" to=\\"/appstore\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"app_store\\" to=\\"/appstore\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-window-restore\\">
          
       </i>
@@ -113,7 +113,7 @@ exports[`SideBar: index render component for public mode 1`] = `
         AppStore
       </span>
     </NavLink>
-    <NavLink id=\\"dapplets\\" to=\\"/home\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"dapplets\\" to=\\"/home\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-arrow-circle-right\\">
          
       </i>
@@ -122,7 +122,7 @@ exports[`SideBar: index render component for public mode 1`] = `
         Dapplets
       </span>
     </NavLink>
-    <NavLink id=\\"network_stats\\" to=\\"/stats\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"network_stats\\" to=\\"/stats\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-rocket\\">
          
       </i>
@@ -131,7 +131,7 @@ exports[`SideBar: index render component for public mode 1`] = `
         Network Stats
       </span>
     </NavLink>
-    <NavLink id=\\"accounts\\" to=\\"/accounts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"accounts\\" to=\\"/accounts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-users\\">
          
       </i>
@@ -140,7 +140,7 @@ exports[`SideBar: index render component for public mode 1`] = `
         Users
       </span>
     </NavLink>
-    <NavLink id=\\"transactions\\" to=\\"/transactions\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"transactions\\" to=\\"/transactions\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-exchange\\">
          
       </i>
@@ -149,7 +149,7 @@ exports[`SideBar: index render component for public mode 1`] = `
         Transactions
       </span>
     </NavLink>
-    <NavLink id=\\"shards\\" to=\\"/shards\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"shards\\" to=\\"/shards\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-user-secret\\">
          
       </i>
@@ -158,7 +158,7 @@ exports[`SideBar: index render component for public mode 1`] = `
         Shards
       </span>
     </NavLink>
-    <NavLink id=\\"contracts\\" to=\\"/contracts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"contracts\\" to=\\"/contracts\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-file\\">
          
       </i>
@@ -167,7 +167,7 @@ exports[`SideBar: index render component for public mode 1`] = `
         Contracts
       </span>
     </NavLink>
-    <NavLink id=\\"blocks\\" to=\\"/blocks\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"blocks\\" to=\\"/blocks\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-link\\">
          
       </i>
@@ -176,7 +176,7 @@ exports[`SideBar: index render component for public mode 1`] = `
         Blocks
       </span>
     </NavLink>
-    <NavLink id=\\"code_editor\\" to=\\"/code_editor\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
+    <NavLink id=\\"code_editor\\" to=\\"/code_editor\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[undefined]}>
       <i className=\\"fa fa-code\\">
          
       </i>
@@ -199,7 +199,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode eighth po
   activeClassName="active-menu-item"
   className="menu-item"
   id="blocks"
-  onClick={[Function]}
+  onClick={undefined}
   to="/blocks"
 >
   <i
@@ -221,7 +221,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode fifth pos
   activeClassName="active-menu-item"
   className="menu-item"
   id="transactions"
-  onClick={[Function]}
+  onClick={undefined}
   to="/transactions"
 >
   <i
@@ -243,7 +243,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode first pos
   activeClassName="active-menu-item"
   className="menu-item"
   id="app_store"
-  onClick={[Function]}
+  onClick={undefined}
   to="/appstore"
 >
   <i
@@ -265,7 +265,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode fourth po
   activeClassName="active-menu-item"
   className="menu-item"
   id="accounts"
-  onClick={[Function]}
+  onClick={undefined}
   to="/accounts"
 >
   <i
@@ -287,7 +287,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode ninth pos
   activeClassName="active-menu-item"
   className="menu-item"
   id="code_editor"
-  onClick={[Function]}
+  onClick={undefined}
   to="/code_editor"
 >
   <i
@@ -309,7 +309,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode second po
   activeClassName="active-menu-item"
   className="menu-item"
   id="dapplets"
-  onClick={[Function]}
+  onClick={undefined}
   to="/home"
 >
   <i
@@ -331,7 +331,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode seventh p
   activeClassName="active-menu-item"
   className="menu-item"
   id="contracts"
-  onClick={[Function]}
+  onClick={undefined}
   to="/contracts"
 >
   <i
@@ -353,7 +353,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode sixth pos
   activeClassName="active-menu-item"
   className="menu-item"
   id="shards"
-  onClick={[Function]}
+  onClick={undefined}
   to="/shards"
 >
   <i
@@ -396,7 +396,7 @@ exports[`SideBar: index sequence of links for oauth and non-oauth mode third pos
   activeClassName="active-menu-item"
   className="menu-item"
   id="network_stats"
-  onClick={[Function]}
+  onClick={undefined}
   to="/stats"
 >
   <i

--- a/smd-ui/src/tests/SideBar/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/SideBar/__snapshots__/index.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SideBar: index render component for non oauth mode 1`] = `
-"<aside>
+"<aside id=\\"sidebar\\">
   <div className=\\"menu\\">
     <NavLink id=\\"app_store\\" to=\\"/appstore\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
       <i className=\\"fa fa-window-restore\\">
@@ -102,7 +102,7 @@ exports[`SideBar: index render component for non oauth mode 1`] = `
 `;
 
 exports[`SideBar: index render component for public mode 1`] = `
-"<aside>
+"<aside id=\\"sidebar\\">
   <div className=\\"menu\\">
     <NavLink id=\\"app_store\\" to=\\"/appstore\\" className=\\"menu-item\\" activeClassName=\\"active-menu-item\\" onClick={[Function: onClick]}>
       <i className=\\"fa fa-window-restore\\">


### PR DESCRIPTION
As the first step towards making SMD more mobile friendly, the menu bar is now dynamic. It is collapsible, and on window resize, it will collapse/expand (at the arbitrary width of 800px; do let me know if that should be changed). Note that once you being toggling the collapse, the window resize will no longer have an effect, but this shouldn't be a problem since presumably the user at this point should know they can toggle again to their preference.

In the video demo, the window is full screen, and then the menu collapses when the window shrinks. Then it shows how you can toggle the expansion and how afterwards, it won't collapse dynamically collapse anymore. Lastly, it shows that if you start the screen in a small mode, the menu starts off collapsed.
[responsive-navbar-demo.webm](https://user-images.githubusercontent.com/31707474/230451328-e4a88e8a-103f-436f-b6fb-c38b6f4b54a3.webm)
