### PR TITLE
allow any shard to be selected

### DIFF
--- a/smd-ui/src/components/Accounts/components/SendTokens/index.js
+++ b/smd-ui/src/components/Accounts/components/SendTokens/index.js
@@ -269,7 +269,7 @@ class SendTokens extends Component {
           <div className="row">
             <div className="col-sm-4 text-right">
               <label className="pt-label smd-pad-4">
-                Chain
+                Shard
               </label>
             </div>
             <div className="col-sm-8 smd-pad-4">
@@ -298,7 +298,7 @@ class SendTokens extends Component {
           <div className="row">
             <div className="col-sm-4 text-right">
               <label className="pt-label smd-pad-4">
-                Chain IDs
+                Shard IDs
               </label>
             </div>
             <div className="col-sm-8 smd-pad-4">

--- a/smd-ui/src/components/Chains/chains.reducer.js
+++ b/smd-ui/src/components/Chains/chains.reducer.js
@@ -93,16 +93,25 @@ const reducer = function (state = initialState, action) {
         error: state.error
       }
     case FETCH_SELECT_CHAIN_DETAIL_SUCCESS:
+      const chainLabelIds_2 = {};
+      action.detail.forEach((chain) => {
+        console.log(chain)
+        const id = chain.id;
+        const label = chain.info.label;
+        if (!chainLabelIds_2[label]) {
+          chainLabelIds_2[label] = {};
+          chainLabelIds_2[label][id] = {};
+        } else {
+          chainLabelIds_2[label][id] = {};
+        }
+      });
       return {
         ...state,
-        chains: {
-          [action.detail[0].label]: {
-            [action.detail[0].id]: {
-              ...action.detail[0]
-            }
-          }
-        },
-        selectedChain: action.detail[0].id
+        chains: chainLabelIds_2,
+        labelIds: chainLabelIds_2,
+        chainIds: [action.detail[0], ...state.chainIds],
+        selectedChain: action.detail[0].id,
+        isLoading: false,
       }
     case RESET_CHAIN_ID:
       return {

--- a/smd-ui/src/components/Chains/index.js
+++ b/smd-ui/src/components/Chains/index.js
@@ -32,7 +32,7 @@ class Chains extends Component {
     super()
     this.state = {
       selected: null,
-      limit: 2,
+      limit: 25,
       offset: 0,
       useChainIdSearch: false,
       chainId: "",

--- a/smd-ui/src/components/Chains/index.js
+++ b/smd-ui/src/components/Chains/index.js
@@ -32,7 +32,7 @@ class Chains extends Component {
     super()
     this.state = {
       selected: null,
-      limit: 25,
+      limit: 2,
       offset: 0,
       useChainIdSearch: false,
       chainId: "",

--- a/smd-ui/src/components/CodeEditor/index.js
+++ b/smd-ui/src/components/CodeEditor/index.js
@@ -24,7 +24,7 @@ class CodeEditor extends Component {
     this.timeout = null;
     this.saveLocalState = null
     this.state = {
-      chainLimit: 25,
+      chainLimit: 2,
       chainOffset: 0,
       useSearch: true,
       chainSearchQueryField: "chainid",
@@ -264,7 +264,7 @@ class CodeEditor extends Component {
       </div>) : 
       
           <div className='row smd-margin-16 col-sm-8' style={{ display: 'flex', alignItems: 'center', margin: '16px 0'}}>
-              <h4 className="text-left" style={{margin: '0 auto'}}>Chain:</h4>
+              <h4 className="text-left" style={{margin: '0 auto'}}>Shard:</h4>
               <div className="pt-select" style={{margin: '0 5px'}}>
                 <Field
                   className="pt-input select-chain"
@@ -353,21 +353,19 @@ class CodeEditor extends Component {
           </div>
         </div>
         <div className='row'>
-            {this.props.chainIds ?
-                  <div className='row pt-dark chain-wrapper smd-pad-8' style={{ display: 'flex', alignItems: 'center', marginLeft: '8px'}}>
-                    {chainSelector}
-                    <div className="smd-pad-8 col-sm-6" style={{display: 'flex', alignItems: 'center'}}>
-                      <Switch
-                        checked={this.state.useSearch}
-                        onChange={this.toggleChainQueryType}
-                        label="Use Shard Search"
-                        />
-                      </div>
-                    <div className='col-sm-4 text-left'>
-                      <strong>Shard ID:</strong> { this.props.selectedChain ? <HexText value={this.props.selectedChain}></HexText> : 'Main Chain'}
-                    </div>
-                  </div>
-            : ''}
+            <div className='row pt-dark chain-wrapper smd-pad-8' style={{ display: 'flex', alignItems: 'center', marginLeft: '8px'}}>
+              {chainSelector}
+              <div className="smd-pad-8 col-sm-6" style={{display: 'flex', alignItems: 'center'}}>
+                <Switch
+                  checked={this.state.useSearch}
+                  onChange={this.toggleChainQueryType}
+                  label="Search by Shard ID"
+                  />
+                </div>
+              <div className='col-sm-4 text-left'>
+                <strong>Shard:</strong> { this.props.selectedChain ? <HexText value={this.props.selectedChain}></HexText> : 'Main Chain'}
+              </div>
+            </div>
         </div>
         {this.renderFileHandlerButtons()}
         <div className="row">

--- a/smd-ui/src/components/CodeEditor/index.js
+++ b/smd-ui/src/components/CodeEditor/index.js
@@ -24,7 +24,7 @@ class CodeEditor extends Component {
     this.timeout = null;
     this.saveLocalState = null
     this.state = {
-      chainLimit: 2,
+      chainLimit: 25,
       chainOffset: 0,
       useSearch: true,
       chainSearchQueryField: "chainid",

--- a/smd-ui/src/components/Contracts/index.js
+++ b/smd-ui/src/components/Contracts/index.js
@@ -171,7 +171,7 @@ class Contracts extends Component {
       </div>) : 
       
           <div className='row smd-margin-16' style={{ display: 'flex', alignItems: 'center', marginRight: '8'}}>
-              <h4 className="text-left" style={{margin: '0 auto'}}>Shard Selection:</h4>
+              <h4 className="text-left" style={{margin: '0 auto'}}>Shard:</h4>
               <div className="pt-select" style={{margin: '0 5px'}}>
                 <Field
                   className="pt-input select-chain"
@@ -242,7 +242,7 @@ class Contracts extends Component {
                         <Switch
                           checked={this.state.useSearch}
                           onChange={this.toggleChainQueryType}
-                          label="Use Shard Search"
+                          label="Search by Shard ID"
                         />
                         </div>
                       <div className='col-sm-4 text-left'>

--- a/smd-ui/src/tests/Accounts/components/SendTokens/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/Accounts/components/SendTokens/__snapshots__/index.spec.js.snap
@@ -230,7 +230,7 @@ exports[`SendTokens: index render Oauth mode with values 1`] = `
           <div className=\\"row\\">
             <div className=\\"col-sm-4 text-right\\">
               <label className=\\"pt-label smd-pad-4\\">
-                Chain
+                Shard
               </label>
             </div>
             <div className=\\"col-sm-8 smd-pad-4\\">
@@ -307,7 +307,7 @@ exports[`SendTokens: index render Oauth mode with values 1`] = `
           <div className=\\"row\\">
             <div className=\\"col-sm-4 text-right\\">
               <label className=\\"pt-label smd-pad-4\\">
-                Chain IDs
+                Shard IDs
               </label>
             </div>
             <div className=\\"col-sm-8 smd-pad-4\\">
@@ -418,7 +418,7 @@ exports[`SendTokens: index render Oauth mode without values 1`] = `
           <div className=\\"row\\">
             <div className=\\"col-sm-4 text-right\\">
               <label className=\\"pt-label smd-pad-4\\">
-                Chain
+                Shard
               </label>
             </div>
             <div className=\\"col-sm-8 smd-pad-4\\">
@@ -495,7 +495,7 @@ exports[`SendTokens: index render Oauth mode without values 1`] = `
           <div className=\\"row\\">
             <div className=\\"col-sm-4 text-right\\">
               <label className=\\"pt-label smd-pad-4\\">
-                Chain IDs
+                Shard IDs
               </label>
             </div>
             <div className=\\"col-sm-8 smd-pad-4\\">


### PR DESCRIPTION
This fixes an issue where a user could not search for a shard unless it was on the first page of the shards list, because the create contract modal was looking for the chain label in the labelIds state, but the selected shard's label was not present there. So I added it as necessary.

Also allows the selected shard to display the proper value as soon as its selected, rather than requiring the input to change

Also change a few instances of chain to shard