### PR TITLE
Remove user info caching

### DIFF
--- a/smd-ui/src/components/User/user.reducer.js
+++ b/smd-ui/src/components/User/user.reducer.js
@@ -7,10 +7,9 @@ import {
   FETCH_USER_CERT_SUCCESS,
   FETCH_USER_CERT_FAILURE,
 } from './user.actions';
-import { getUserFromLocal } from '../../lib/localStorage';
 
 const initialState = {
-  oauthUser: getUserFromLocal(),
+  oauthUser: undefined,
   publicKey : "abcde",
   certificateLoading: false,
   userCertificate: undefined,

--- a/smd-ui/src/components/User/user.saga.js
+++ b/smd-ui/src/components/User/user.saga.js
@@ -16,35 +16,29 @@ import {
 } from './user.actions';
 import { handleErrors } from '../../lib/handleErrors'; 
 import { env } from '../../env';
-import { getUserFromLocal } from '../../lib/localStorage';
 
 const oauthUserUrl = env.APEX_URL + "/user";
 
 function getOrCreateOauthUserApi() {
-  let user = getUserFromLocal() 
-  if (!user) {
 
-    return fetch(
-      oauthUserUrl,
-      {
-        method: 'POST',
-        credentials: "include",
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({})
-      })
-      .then(handleErrors)
-      .then(function (res) {
-        return res.json();
-      })
-      .catch(function (error) {
-        throw error;
-      });
-  } else {
-    return user
-  }
+  return fetch(
+    oauthUserUrl,
+    {
+      method: 'POST',
+      credentials: "include",
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({})
+    })
+    .then(handleErrors)
+    .then(function (res) {
+      return res.json();
+    })
+    .catch(function (error) {
+      throw error;
+    });
     
 }
 
@@ -97,7 +91,6 @@ export function* getOrCreateOauthUser() {
 
       const user = oauthUser
 
-      localStorage.setItem('user', JSON.stringify(user));
       yield put(getOrCreateOauthUserSuccess(user));
     }
   } catch (e) {

--- a/smd-ui/src/tests/App/index.spec.js
+++ b/smd-ui/src/tests/App/index.spec.js
@@ -14,7 +14,6 @@ describe('App: index', () => {
 
   test('componentDidMount1', () => {
     checkMode.isOauthEnabled = jest.fn().mockReturnValue(false);
-    checkMode.getUserFromLocal = jest.fn().mockReturnValue(false);
 
     const wrapper = shallow(
       <App.WrappedComponent />
@@ -25,7 +24,6 @@ describe('App: index', () => {
 
   test('componentDidMount2', () => {
     checkMode.isOauthEnabled = jest.fn().mockReturnValue(true);
-    checkMode.getUserFromLocal = jest.fn().mockReturnValue(false);
 
     const wrapper = shallow(
       <App.WrappedComponent getOrCreateOauthUserRequest={jest.fn()} />


### PR DESCRIPTION
So there have been a lot of reports of users getting confused because they have been told they have been issued a cert, go to use SMD, and then are presented with the "Verification Pending" icon still there, or even in odd scenarios they would be shown the ID of a previously signed in user (if multiple people are sharing a machine).

This was caused by the caching of the user info that isn't indexed by the username, just they keyword 'user'. So if you logout and login with another user, it will see the generic user cache and read from that. Because it has the same user address as the previously logged in user, it will fetch that user's cert. 

So I just removed the cache because it probably wasn't really saving that much compute time given all the other requests that are made on load, and this is a reasonable one to allow. It could be indexed by user ID/address, but that just would be extra work for something that won't really give much benefi. Plus then the cache could grow for each new user that signs in...