### PR TITLE
[Do Not Merge] Improve SMD Function Call, Contract View, and Transaction Details

### DIFF
--- a/smd-ui/src/components/Chains/chains.reducer.js
+++ b/smd-ui/src/components/Chains/chains.reducer.js
@@ -95,7 +95,6 @@ const reducer = function (state = initialState, action) {
     case FETCH_SELECT_CHAIN_DETAIL_SUCCESS:
       const chainLabelIds_2 = {};
       action.detail.forEach((chain) => {
-        console.log(chain)
         const id = chain.id;
         const label = chain.info.label;
         if (!chainLabelIds_2[label]) {

--- a/smd-ui/src/components/Chains/index.js
+++ b/smd-ui/src/components/Chains/index.js
@@ -178,7 +178,6 @@ class Chains extends Component {
               onChange={() => {
                 this.setState({useChainIdSearch: !this.state.useChainIdSearch}, () => {
                   if (!this.state.useChainIdSearch) {
-                    console.log('set to label')
                     this.props.fetchChains(this.state.limit, this.state.offset)
                     this.setState({chainId : ""})
                   }

--- a/smd-ui/src/components/Contracts/components/ContractCard/ContractSource/index.js
+++ b/smd-ui/src/components/Contracts/components/ContractCard/ContractSource/index.js
@@ -22,7 +22,7 @@ export default class ContractSource extends Component {
         const contractSource = this.props.contract.bin || ''
         const contractName = this.props.contract.name || ''
         const address = this.props.contract.address || ''
-        const codeHash = this.props.contract.codeHash.digest || ''
+        const codeHash = this.props.contract.codeHash ? this.props.contract.codeHash.digest : ''
         const vm = this.props.contract.codeHash.kind || ''
         return (
             <Button 

--- a/smd-ui/src/components/Contracts/components/ContractCard/ContractSource/index.js
+++ b/smd-ui/src/components/Contracts/components/ContractCard/ContractSource/index.js
@@ -1,0 +1,132 @@
+import React, { Component } from 'react'
+import { Button, Dialog, Tooltip, Position } from '@blueprintjs/core'
+import HexText from '../../../../HexText'
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+
+export default class ContractSource extends Component {
+
+    constructor(props) {
+        super(props)
+        this.state = {
+            isModalOpen: false,
+            srcCopied: false,
+        }
+    }
+
+    toggleModalOpen() {
+        this.setState({isModalOpen : !this.state.isModalOpen})
+    }
+
+    render() {
+
+        const contractSource = this.props.contract.bin || ''
+        const contractName = this.props.contract.name || ''
+        const address = this.props.contract.address || ''
+        const codeHash = this.props.contract.codeHash.digest || ''
+        const vm = this.props.contract.codeHash.kind || ''
+        return (
+            <Button 
+                intent='intent'
+                onClick={() => {this.toggleModalOpen()}}
+                iconName='pt-icon-document-open'
+            >
+                Show More Contract Info
+                <Dialog
+                    title={`${contractName} - Contract Information`}
+                    isOpen={this.state.isModalOpen}
+                    onClose={() => {this.toggleModalOpen()}}
+                    className='pt-dark'
+                >
+                    <div className='pt-dialog-body'>
+                    <div className='row'>
+                        <div className="col-sm-3 text-right">
+                            <label className="pt-label label-margin">
+                                Address
+                            </label>
+                        </div>
+                        <div className="col-sm-9 smd-pad-4">
+                            <HexText
+                                value={address}
+                            />
+                        </div>   
+                    </div>
+                    <div className='row'>
+                        <div className="col-sm-3 text-right">
+                            <label className="pt-label label-margin">
+                                Shard ID
+                            </label>
+                        </div>
+                        <div className="col-sm-9 smd-pad-4">
+                            {
+                                this.props.contract.chainId ?
+                                <HexText
+                                    value={this.props.contract.chainId}
+                                /> 
+                                : 'Main Chain'
+                            }
+                        </div>   
+                    </div>
+                    <div className='row'>
+                        <div className="col-sm-3 text-right">
+                            <label className="pt-label label-margin">
+                                Code Hash
+                            </label>
+                        </div>
+                        <div className="col-sm-9 smd-pad-4">
+                            <HexText
+                                value={codeHash}
+                            />
+                        </div>   
+                    </div>
+                    <div className='row'>
+                        <div className="col-sm-3 text-right">
+                            <label className="pt-label label-margin">
+                                VM
+                            </label>
+                        </div>
+                        <div className="col-sm-9 smd-pad-4">
+                            {vm}
+                        </div>   
+                    </div>
+                    <div className='row'>
+                        <div className='col-sm-12'>
+                            <label className="pt-label label-margin">
+                                Contract Source
+                                <CopyToClipboard
+                                    text={this.props.contract.bin}
+                                    onCopy={() => { this.setState({ srcCopied: true }); }}>
+                                    <span
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            event.preventDefault();
+                                        }}
+                                    >
+                                        <Tooltip
+                                            content={this.state.srcCopied ? 'Copied!' : 'Copy to clipboard'}
+                                            position={Position.TOP}
+                                            className="smd-pointer"
+                                        >
+                                            <span
+                                                className="pt-icon pt-icon-clipboard"
+                                                style={{marginLeft: '4px'}}
+                                                onMouseOut={(e) => { this.setState({ srcCopied: false }); }}>
+                                            </span>
+                                        </Tooltip>
+                                    </span>
+                                </CopyToClipboard>
+                            </label>
+                        </div>
+                    </div>
+                    <div className='row'>
+                        <div className='col-sm-12'>
+                            <pre>
+                                {contractSource}
+                            </pre>
+                        </div>
+                    </div>
+                    </div>
+                </Dialog>
+            </Button>
+        )
+    }
+}

--- a/smd-ui/src/components/Contracts/components/ContractCard/contractCard.actions.js
+++ b/smd-ui/src/components/Contracts/components/ContractCard/contractCard.actions.js
@@ -8,6 +8,9 @@ export const FETCH_CIRRUS_INSTANCES_FAILURE = 'FETCH_CIRRUS_INSTANCES_FAILURE';
 export const FETCH_ACCOUNT_REQUEST = 'FETCH_ACCOUNT_REQUEST';
 export const FETCH_ACCOUNT_SUCCESS = 'FETCH_ACCOUNT_SUCCESS';
 export const FETCH_ACCOUNT_FAILURE = 'FETCH_ACCOUNT_FAILURE';
+export const FETCH_CONTRACT_INFO_REQUEST = 'FETCH_CONTRACT_INFO_REQUEST';
+export const FETCH_CONTRACT_INFO_SUCCESS = 'FETCH_CONTRACT_INFO_SUCCESS';
+export const FETCH_CONTRACT_INFO_FAILURE = 'FETCH_CONTRACT_INFO_FAILURE';
 
 export const fetchState = function (name, address, chainId) {
   return {
@@ -89,5 +92,30 @@ export const fetchAccountFailure = function (contractName, contractAddress, erro
     name: contractName,
     address: contractAddress,
     error: error
+  }
+}
+
+export const fetchContractInfoRequest = function(key, contractName, contractAddress, chainId) {
+  return {
+    type: FETCH_CONTRACT_INFO_REQUEST,
+    key,
+    contractName,
+    contractAddress,
+    chainId,
+  }
+}
+export const fetchContractInfoSuccess = function(key, data) {
+  return {
+    type: FETCH_CONTRACT_INFO_SUCCESS,
+    key,
+    data,
+  }
+}
+
+export const fetchContractInfoFailure = function(key, error) {
+  return {
+    type: FETCH_CONTRACT_INFO_FAILURE,
+    key,
+    error
   }
 }

--- a/smd-ui/src/components/Contracts/components/ContractCard/contractCard.reducer.js
+++ b/smd-ui/src/components/Contracts/components/ContractCard/contractCard.reducer.js
@@ -1,0 +1,37 @@
+
+import {
+    FETCH_CONTRACT_INFO_FAILURE,
+    FETCH_CONTRACT_INFO_SUCCESS
+} from './contractCard.actions'
+
+const initialState = {
+    contractInfos: {}
+}
+
+const reducer = (state = initialState, action) => {
+    switch (action.type) {
+        case FETCH_CONTRACT_INFO_SUCCESS:
+            return {
+                contractInfos: {
+                    ...state.contractInfos,
+                    [action.key]: {
+                        ...state.contractInfos[action.key],
+                        ...action.data
+                    }
+                }
+            }
+        case FETCH_CONTRACT_INFO_FAILURE:
+            return {
+                contractInfos: {
+                    ...state.contractInfos,
+                    [action.key]: {
+                        ...state.contractInfos[action.key],
+                        error: action.error
+                    }
+                }
+            }
+        default:
+            return state
+    }
+}
+export default reducer

--- a/smd-ui/src/components/Contracts/components/ContractCard/contractCard.saga.js
+++ b/smd-ui/src/components/Contracts/components/ContractCard/contractCard.saga.js
@@ -12,7 +12,10 @@ import {
   fetchCirrusInstancesSuccess,
   fetchCirrusInstancesFailure,
   fetchAccountSuccess,
-  fetchAccountFailure
+  fetchAccountFailure,
+  FETCH_CONTRACT_INFO_REQUEST,
+  fetchContractInfoSuccess,
+  fetchContractInfoFailure
 } from './contractCard.actions';
 import { env } from '../../../../env.js'
 import { handleErrors } from '../../../../lib/handleErrors';
@@ -87,6 +90,28 @@ export function getAccount(address) {
     });
 }
 
+export function getContract(contractName, contractAddress, chainid) {
+  const options = { params: { contractName, contractAddress }, query: { chainid } };
+  const url = env.BLOC_URL + createUrl("/contracts/::contractName/::contractAddress", options);
+
+  return fetch(
+    url,
+    {
+      method: 'GET',
+      credentials: "include",
+      headers: {
+        'Accept': 'application/json'
+      },
+    })
+    .then(handleErrors)
+    .then(function (response) {
+      return response.json();
+    })
+    .catch(function (error) {
+      throw error;
+    });
+}
+
 export function* fetchState(action) {
   try {
     let response = yield call(getState, action.name, action.address, action.chainId);
@@ -117,6 +142,16 @@ export function* fetchAccount(action) {
   }
 }
 
+export function* fetchContractInfo(action) {
+  try {
+    const response = yield call(getContract, action.contractName, action.contractAddress, action.chainId);
+    yield put(fetchContractInfoSuccess(action.key, response));
+  }
+  catch (err) {
+    yield put(fetchContractInfoFailure(action.key, err));
+  }
+}
+
 export function* watchFetchCirrusContracts() {
   yield takeEvery(FETCH_CIRRUS_INSTANCES_REQUEST, fetchCirrusInstances);
 }
@@ -127,4 +162,8 @@ export function* watchFetchState() {
 
 export function* watchAccount() {
   yield takeEvery(FETCH_ACCOUNT_REQUEST, fetchAccount);
+}
+
+export function* watchFetchInfo() {
+  yield takeEvery(FETCH_CONTRACT_INFO_REQUEST, fetchContractInfo);
 }

--- a/smd-ui/src/components/Contracts/components/ContractCard/index.js
+++ b/smd-ui/src/components/Contracts/components/ContractCard/index.js
@@ -6,7 +6,8 @@ import {
   selectContractInstance,
   fetchState,
   fetchCirrusInstances,
-  fetchAccount
+  fetchAccount,
+  fetchContractInfoRequest
 } from './contractCard.actions';
 import ContractMethodCall from '../ContractMethodCall';
 import './contractCard.css';
@@ -14,6 +15,7 @@ import mixpanelWrapper from '../../../../lib/mixpanelWrapper';
 import { Link } from 'react-router-dom';
 import HexText from '../../../HexText';
 import { Tooltip, Position } from '@blueprintjs/core';
+import ContractSource from './ContractSource';
 
 class ContractCard extends Component {
   constructor(props) {
@@ -24,8 +26,6 @@ class ContractCard extends Component {
   render() {
     let cardData = [];
     const name = this.props.contract.name;
-    console.log(this.props.contract)
-    console.log(name)
     const contract = this.props.contract.contract;
     const instances = contract && contract.instances ? contract.instances : [];
     const self = this;
@@ -44,6 +44,7 @@ class ContractCard extends Component {
               mixpanelWrapper.track("contract_state_clicked")
               self.props.fetchState(name, instance.address, self.props.selectedChain);
               self.props.fetchAccount(name, instance.address);
+              self.props.fetchContractInfoRequest(`card-data-${instance.address}-${self.props.selectedChain}`, name, instance.address, self.props.selectedChain)
               self.props.selectContractInstance(name, instance.address);
             }}
             key={`card-data-${instance.address}-${index}`}
@@ -67,6 +68,8 @@ class ContractCard extends Component {
 
     if (selectedInstance.length > 0 && selectedInstance[0].state) {
       const instance = selectedInstance[0];
+      const contractKey = `card-data-${instance.address}-${self.props.selectedChain}`
+      const contractInfo = this.props.contractInfos && this.props.contractInfos[contractKey] ? this.props.contractInfos[contractKey] : {}
       const symbolTable = [];
       const symbols = Object.getOwnPropertyNames(instance.state);
       if ((typeof instance.state !== 'string') && symbols.length > 0) {
@@ -82,7 +85,8 @@ class ContractCard extends Component {
                 <td style={{ verticalAlign: 'middle' }}>
                   <ContractMethodCall
                     key={'methodCall' + symbol + instance.address}
-                    lookup={'methodCall' + symbol + instance.address}
+                    contractKey={contractKey}
+                    methodKey={'methodCall' + symbol + instance.address}
                     contractName={name}
                     contractAddress={instance.address}
                     symbolName={symbol}
@@ -123,8 +127,16 @@ class ContractCard extends Component {
       }
       state = (
         <div className="pt-card pt-elevation-2">
-          <div className="row">
-            <div className="col-sm-12 text-right">
+
+            <div className="row">
+            <div className='col-sm-6'>
+              { contractInfo &&
+                <ContractSource
+                  contract={contractInfo}
+                  />
+              }
+            </div>
+            <div className="col-sm-6 text-right">
               <span className="pt-monospace-text"> {instance && instance.balance ? <div> Contract Balance: {instance.balance} wei </div> : ''} </span>
             </div>
           </div>
@@ -155,8 +167,7 @@ class ContractCard extends Component {
         </div>
       );
     }
-
-
+    
     return (
       <div className="row">
         <div className="col-sm-6">
@@ -218,8 +229,9 @@ class ContractCard extends Component {
   }
 }
 
-export function mapStateToProps(state) {
+export function mapStateToProps(state, ownProps) {
   return {
+    contractInfos: state.contractCard.contractInfos,
     selectedChain: state.chains.selectedChain
   };
 }
@@ -227,6 +239,7 @@ export function mapStateToProps(state) {
 export default withRouter(
   connect(mapStateToProps, {
     selectContractInstance,
+    fetchContractInfoRequest,
     fetchState,
     fetchCirrusInstances,
     fetchAccount

--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.actions.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.actions.js
@@ -1,53 +1,6 @@
-export const METHOD_CALL_OPEN_MODAL = 'METHOD_CALL_OPEN_MODAL';
-export const METHOD_CALL_CLOSE_MODAL = 'METHOD_CALL_CLOSE_MODAL';
-export const METHOD_CALL_FETCH_ARGS_REQUEST = 'METHOD_CALL_FETCH_ARGS_REQUEST';
-export const METHOD_CALL_FETCH_ARGS_SUCCESS = 'METHOD_CALL_FETCH_ARGS_SUCCESS';
-export const METHOD_CALL_FETCH_ARGS_FAILURE = 'METHOD_CALL_FETCH_ARGS_FAILURE';
 export const METHOD_CALL_REQUEST = 'METHOD_CALL_REQUEST';
 export const METHOD_CALL_SUCCESS = 'METHOD_CALL_SUCCESS';
 export const METHOD_CALL_FAILURE = 'METHOD_CALL_FAILURE';
-
-export const methodCallOpenModal = function (key) {
-  return {
-    type: METHOD_CALL_OPEN_MODAL,
-    key: key
-  };
-}
-
-export const methodCallCloseModal = function (key) {
-  return {
-    type: METHOD_CALL_CLOSE_MODAL,
-    key: key
-  };
-}
-
-export const methodCallFetchArgs = function (name, address, symbol, key, chainId) {
-  return {
-    type: METHOD_CALL_FETCH_ARGS_REQUEST,
-    name: name,
-    address: address,
-    symbol: symbol,
-    key: key,
-    chainId: chainId
-  };
-}
-
-export const methodCallFetchArgsSuccess = function (key, args, isPayable) {
-  return {
-    type: METHOD_CALL_FETCH_ARGS_SUCCESS,
-    key: key,
-    args: args,
-    isPayable
-  };
-}
-
-export const methodCallFetchArgsFailure = function (key, error) {
-  return {
-    type: METHOD_CALL_FETCH_ARGS_FAILURE,
-    key: key,
-    error: error
-  };
-}
 
 export const methodCall = function (key, payload) {
   return {

--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.reducer.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.reducer.js
@@ -1,8 +1,4 @@
 import {
-  METHOD_CALL_CLOSE_MODAL,
-  METHOD_CALL_OPEN_MODAL,
-  METHOD_CALL_FETCH_ARGS_SUCCESS,
-  METHOD_CALL_FETCH_ARGS_FAILURE,
   METHOD_CALL_REQUEST,
   METHOD_CALL_SUCCESS,
   METHOD_CALL_FAILURE
@@ -15,55 +11,13 @@ const initialState = {
 
 const reducer = function (state = initialState, action) {
   switch (action.type) {
-    case METHOD_CALL_OPEN_MODAL:
-      return {
-        modals: {
-          ...state.modals,
-          [action.key]: {
-            ...state.modals[action.key],
-            isOpen: true,
-            result: 'Waiting for method to be called...'
-          }
-        }
-      }
-    case METHOD_CALL_CLOSE_MODAL:
-      return {
-        modals: {
-          ...state.modals,
-          [action.key]: {
-            ...state.modals[action.key],
-            isOpen: false
-          }
-        }
-      }
-    case METHOD_CALL_FETCH_ARGS_SUCCESS:
-      return {
-        modals: {
-          ...state.modals,
-          [action.key]: {
-            ...state.modals[action.key],
-            args: action.args,
-            isPayable: action.isPayable
-          }
-        }
-      }
-    case METHOD_CALL_FETCH_ARGS_FAILURE:
-      return {
-        modals: {
-          ...state.modals,
-          [action.key]: {
-            ...state.modals[action.key],
-            error: action.error
-          }
-        }
-      }
     case METHOD_CALL_REQUEST:
       return {
         modals: {
           ...state.modals,
           [action.key]: {
             ...state.modals[action.key],
-            result: 'Sending transaction...'
+            loading: true,
           }
         }
       }
@@ -73,6 +27,7 @@ const reducer = function (state = initialState, action) {
           ...state.modals,
           [action.key]: {
             ...state.modals[action.key],
+            loading: false,
             result: action.result
           }
         }
@@ -83,6 +38,7 @@ const reducer = function (state = initialState, action) {
           ...state.modals,
           [action.key]: {
             ...state.modals[action.key],
+            loading: false,
             result: action.result
           }
         }

--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.saga.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.saga.js
@@ -7,37 +7,12 @@ import {
   METHOD_CALL_REQUEST,
   methodCallSuccess,
   methodCallFailure,
-  METHOD_CALL_FETCH_ARGS_REQUEST,
-  methodCallFetchArgsSuccess,
-  methodCallFetchArgsFailure
 } from './contractMethodCall.actions';
 import { fetchState } from '../ContractCard/contractCard.actions';
 import { env } from '../../../../env.js'
 import { handleErrors } from '../../../../lib/handleErrors';
 import { createUrl } from '../../../../lib/url';
 import { isOauthEnabled } from '../../../../lib/checkMode';
-
-export function getArgs(contractName, contractAddress, symbol, chainid) {
-  const options = { params: { contractName, contractAddress }, query: { chainid } };
-  const url = env.BLOC_URL + createUrl("/contracts/::contractName/::contractAddress", options);
-
-  return fetch(
-    url,
-    {
-      method: 'GET',
-      credentials: "include",
-      headers: {
-        'Accept': 'application/json'
-      },
-    })
-    .then(handleErrors)
-    .then(function (response) {
-      return response.json();
-    })
-    .catch(function (error) {
-      throw error;
-    });
-}
 
 export function postMethodCall(payload) {
   const isModeOauth = isOauthEnabled();
@@ -103,29 +78,13 @@ export function* methodCall(action) {
   try {
     const response = yield call(postMethodCall, action.payload);
     yield put(fetchState(action.payload.contractName, action.payload.contractAddress, action.payload.chainId));
-    yield put(methodCallSuccess(action.key, JSON.stringify(response, null, 2)));
+    yield put(methodCallSuccess(action.key, response));
   }
   catch (err) {
     yield put(methodCallFailure(action.key, err));
   }
 }
 
-export function* fetchArgs(action) {
-  try {
-    const response = yield call(getArgs, action.name, action.address, action.symbol, action.chainId);
-    const args = response.xabi.funcs[action.symbol].args;
-    const isPayable = response.xabi.funcs[action.symbol].payable;
-    yield put(methodCallFetchArgsSuccess(action.key, args, isPayable));
-  }
-  catch (err) {
-    yield put(methodCallFetchArgsFailure(action.key, err));
-  }
-}
-
 export function* watchMethodCall() {
   yield takeEvery(METHOD_CALL_REQUEST, methodCall);
-}
-
-export function* watchFetchArgs() {
-  yield takeEvery(METHOD_CALL_FETCH_ARGS_REQUEST, fetchArgs);
 }

--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
@@ -92,20 +92,20 @@ class ContractMethodCall extends Component {
     </div>)
   }
 
-  renderAddress = (isModeOauth) => {
+  renderAddress = () => {
     const userAddresses = Object.keys(this.props.accounts).length && this.props.modalUsername ?
       Object.getOwnPropertyNames(this.props.accounts[this.props.modalUsername])
       : [];
-    return (<div className={isModeOauth ? "" : "pt-select"}>
+    return (<div className={"pt-select"}>
       <Field
         className="pt-input"
         component="select"
         name="modalAddress"
-        disabled={isModeOauth}
+        disabled={true}
         required
       >
-        <option value={isModeOauth && this.props.userCertificate ? this.props.userCertificate.userAddress : "Verification Pending"}>
-          {isModeOauth && this.props.userCertificate ? this.props.userCertificate.userAddress : "Verification Pending"}
+        <option value={this.props.userCertificate ? this.props.userCertificate.userAddress : "Verification Pending"}>
+          {this.props.userCertificate ? this.props.userCertificate.userAddress : "Verification Pending"}
         </option>
         {
           userAddresses.map((address, i) => {
@@ -221,6 +221,7 @@ class ContractMethodCall extends Component {
         </tr>
       );
     }
+    console.log('HERE')
     return (
       <div>
         <Popover 
@@ -308,13 +309,13 @@ class ContractMethodCall extends Component {
                   >
                     <pre >
                       {/* Render the function signature */}
-                      function {this.props.symbolName}{`(${Object.getOwnPropertyNames(funcInfo.args).length > 0 && Object.entries(funcInfo.args).map(([key, val]) => {
+                      function {this.props.symbolName}{`(${funcInfo && funcInfo.args && Object.getOwnPropertyNames(funcInfo.args).length > 0 && Object.entries(funcInfo.args).map(([key, val]) => {
                         return `${val.tag.toLowerCase()} ${key}`
-                      }).join(',')})`} {Object.getOwnPropertyNames(funcInfo.vals).length > 0 && `returns (${Object.entries(funcInfo.vals).map(([key, val]) => {
+                      }).join(',')})`} {funcInfo && funcInfo.vals && Object.getOwnPropertyNames(funcInfo.vals).length > 0 && `returns (${Object.entries(funcInfo.vals).map(([key, val]) => {
                         return val.tag.toLowerCase()
                       }).join(',')})`} &#123;
                       {/* Render the function body */}
-                        {`\n\t`}{funcInfo.contents}
+                        {`\n\t`}{funcInfo.contents || 'Error loading function body'}
                       {`\n`}&#125;
                     </pre>
                   </Collapse>

--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
@@ -1,15 +1,11 @@
 import React, { Component } from 'react';
-import { Button, Dialog, PopoverInteractionKind, Position, AnchorButton, Popover } from '@blueprintjs/core';
+import { Button, Dialog, PopoverInteractionKind, Position, AnchorButton, Popover, Collapse } from '@blueprintjs/core';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { Link, withRouter } from 'react-router-dom';
 import mixpanelWrapper from '../../../../lib/mixpanelWrapper';
 import { Field, reduxForm, formValueSelector } from 'redux-form';
-import { fetchAccounts, fetchUserAddresses } from '../../../Accounts/accounts.actions';
 import {
   methodCall,
-  methodCallFetchArgs,
-  methodCallOpenModal,
-  methodCallCloseModal
 } from './contractMethodCall.actions';
 import './contractMethodCall.css';
 import ValueInput from "../../../ValueInput";
@@ -19,18 +15,17 @@ import HexText from '../../../HexText';
 
 class ContractMethodCall extends Component {
 
+  constructor() {
+    super()
+    this.state = {
+      isFunctionSourceOpen: false,
+      isOpen: false,
+    }
+  }
+
   handleOpenModal = () => {
     mixpanelWrapper.track("method_call_button_click");
-    this.props.methodCallOpenModal(this.props.lookup);
-    const address = this.props.fromCirrus && this.props.fromBloc === undefined ? this.props.contractName : this.props.contractAddress
-    this.props.methodCallFetchArgs(
-      this.props.contractName,
-      address,
-      this.props.symbolName,
-      this.props.lookup,
-      this.props.chainId
-    );
-    !isOauthEnabled() && this.props.fetchAccounts(false, false);
+    this.setState({isOpen : true})
   }
 
   handleCloseModal = (e) => {
@@ -38,12 +33,12 @@ class ContractMethodCall extends Component {
     e.preventDefault();
     this.props.reset();
     mixpanelWrapper.track("method_call_cancel");
-    this.props.methodCallCloseModal(this.props.lookup);
+    this.setState({isOpen : false})
   }
 
   submit = (values) => {
     try {
-      const parsedArgs = this.props.modal.args ? Object.entries(this.props.modal.args)
+      const parsedArgs = this.props.contractInfo.xabi.funcs[this.props.symbolName] ? Object.entries(this.props.contractInfo.xabi.funcs[this.props.symbolName].args)
         .reduce((args, [arg, info]) => {
           try {
             args[arg] = JSON.parse(values[arg]);
@@ -67,14 +62,10 @@ class ContractMethodCall extends Component {
           chainId: this.props.selectedChain ? this.props.selectedChain : undefined
         }
         mixpanelWrapper.track("method_call_submit");
-        this.props.methodCall(this.props.lookup, payload);
+        this.props.methodCall(this.props.methodKey, payload);
       } catch (e) {
         return
       }
-  }
-
-  handleUsernameChange = (e) => {
-    this.props.fetchUserAddresses(e.target.value, false)
   }
 
   renderUsername = (isModeOauth) => {
@@ -84,7 +75,6 @@ class ContractMethodCall extends Component {
         className="pt-input"
         name="modalUsername"
         component="select"
-        onChange={this.handleUsernameChange}
         disabled={isModeOauth}
         required
       >
@@ -194,13 +184,17 @@ class ContractMethodCall extends Component {
     }
   }
 
+  handleToggleFunctionSource() {
+    this.setState({isFunctionSourceOpen: !this.state.isFunctionSourceOpen})
+  }
+
   render() {
     const params = [];
     const handleSubmit = this.props.handleSubmit;
     const isModeOauth = isOauthEnabled();
-
-    if (this.props.modal.args && Object.getOwnPropertyNames(this.props.modal.args).length > 0) {
-      const args = Object.getOwnPropertyNames(this.props.modal.args);
+    const funcInfo = this.props.contractInfo.xabi && Object.getOwnPropertyNames(this.props.contractInfo.xabi).length > 0 ? this.props.contractInfo.xabi.funcs[this.props.symbolName] : {}
+    if (funcInfo.args && Object.getOwnPropertyNames(funcInfo.args).length > 0) {
+      const args = Object.getOwnPropertyNames(funcInfo.args);
       const self = this;
       args.forEach(function (arg, i) {
         params.push(
@@ -211,7 +205,7 @@ class ContractMethodCall extends Component {
                 name={arg}
                 component="input"
                 type="text"
-                placeholder={self.props.modal.args[arg].type}
+                placeholder={funcInfo.args[arg].type || funcInfo.args[arg].tag}
                 className="pt-input"
                 required
               />
@@ -227,7 +221,6 @@ class ContractMethodCall extends Component {
         </tr>
       );
     }
-
     return (
       <div>
         <Popover 
@@ -255,7 +248,7 @@ class ContractMethodCall extends Component {
         <form>
           <Dialog
             iconName="exchange"
-            isOpen={this.props.modal.isOpen}
+            isOpen={this.state.isOpen}
             onClose={this.handleCloseModal}
             title={"Call '" + this.props.symbolName + "' on " + this.props.contractName}
             className="pt-dark"
@@ -301,24 +294,33 @@ class ContractMethodCall extends Component {
                   {this.renderAddress(isModeOauth)}
                 </div>
               </div>
-              {!isModeOauth && <div className="row">
-                <div className="col-sm-3 text-right">
-                  <label className="pt-label label-margin">
-                    Password
-                  </label>
+              <div className="row">
+                <div className="col-sm-9">
+                  <Button onClick={() => this.handleToggleFunctionSource()}>
+                    Show Function Source Code
+                  </Button>
                 </div>
-                <div className="col-sm-9 smd-pad-4">
-                  <Field
-                    name="modalPassword"
-                    className="pt-input"
-                    placeholder="Password"
-                    component="input"
-                    type="password"
-                    required
-                  />
+              </div>
+              <div className="row smd-margin-4">
+                <div className="col-sm-12">
+                  <Collapse
+                    isOpen={this.state.isFunctionSourceOpen}
+                  >
+                    <pre >
+                      {/* Render the function signature */}
+                      function {this.props.symbolName}{`(${Object.getOwnPropertyNames(funcInfo.args).length > 0 && Object.entries(funcInfo.args).map(([key, val]) => {
+                        return `${val.tag.toLowerCase()} ${key}`
+                      }).join(',')})`} {Object.getOwnPropertyNames(funcInfo.vals).length > 0 && `returns (${Object.entries(funcInfo.vals).map(([key, val]) => {
+                        return val.tag.toLowerCase()
+                      }).join(',')})`} &#123;
+                      {/* Render the function body */}
+                        {`\n\t`}{funcInfo.contents}
+                      {`\n`}&#125;
+                    </pre>
+                  </Collapse>
                 </div>
-              </div>}
-              {this.props.modal.isPayable && <div className="row">
+              </div>
+              {funcInfo.isPayable && <div className="row">
                 <div className="col-sm-3 text-right">
                   <label className="pt-label label-margin">
                     Value
@@ -351,15 +353,92 @@ class ContractMethodCall extends Component {
                   </table>
                 </div>
               </div>
-              <div className="row">
-                <div className="col-sm-12">
-                  <hr />
-                  <h5>Results</h5>
-                  <pre className="smd-scrollable">
-                    {this.props.modal.result} <br />
-                  </pre>
-                </div>
+              {
+                this.props.methodCallModal.result && !this.props.methodCallModal.loading &&
+                <div className="row">
+                  <div className="col-sm-12">
+                    <hr />
+                    <div className={`pt-callout pt-intent-${this.props.methodCallModal.result[0].status == "Success" ? 'success' : this.props.methodCallModal.result[0].status == "Pending" ? 'warning' : 'danger'}`}>
+                    <h5>Transaction Results</h5>
+                        { this.props.methodCallModal.result[0].hash &&
+                    <div className="row">
+                      <div className="col-sm-3 text-right">
+                        <label className="pt-label label-margin">
+                          TX Hash
+                        </label>
+                      </div>
+                      <div className="col-sm-9 smd-pad-4">
+
+                        <HexText value={this.props.methodCallModal.result[0].hash}/>
+                      </div>
+                    </div>                   
+                        }
+                    <div className="row">
+                      <div className="col-sm-3 text-right">
+                        <label className="pt-label label-margin">
+                          Status
+                        </label>
+                      </div>
+                      <div className="col-sm-9 smd-pad-4">
+                        {this.props.methodCallModal.result[0].status == "Success" || this.props.methodCallModal.result[0].status == "Pending" ? this.props.methodCallModal.result[0].status : 'Failed'}
+                      </div>                  
+                    </div>
+                    { typeof(this.props.methodCallModal.result) == "string" &&
+                      <div className="row">
+                        <div className="col-sm-3 text-right">
+                          <label className="pt-label label-margin">
+                            Error:
+                          </label>
+                        </div>
+                        <div className="col-sm-9 smd-pad-4">
+                          {this.props.methodCallModal.result}
+                        </div>                  
+                      </div>
+                    }
+                    {this.props.methodCallModal.result[0].status == "Success" &&
+                      <div>
+                        <div className="row">
+                          <div className="col-sm-3 text-right">
+                            <label className="pt-label label-margin">
+                              Time
+                            </label>
+                          </div>
+                          <div className="col-sm-9 smd-pad-4">
+                            {this.props.methodCallModal.result[0].txResult.time}s
+                          </div>                  
+                        </div>
+                        <div className="row">
+                          <div className="col-sm-3 text-right">
+                            <label className="pt-label label-margin">
+                              Returned Value(s)
+                            </label>
+                          </div>
+                          <div className="col-sm-9 smd-pad-4">
+                            { this.props.methodCallModal.result[0].data.contents.length > 0 ?
+
+                              <pre className='smd-scrollable'>
+                                {JSON.stringify(this.props.methodCallModal.result[0].data.contents, null, 2)}
+                              </pre>
+                              : "No Returned Values"
+                            }
+                          </div>                  
+                        </div>
+                        <div className="row">
+                          <div className="col-sm-3 text-right">
+                            <label className="pt-label label-margin">
+                              Block Hash
+                            </label>
+                          </div>
+                          <div className="col-sm-9 smd-pad-4">
+                            <HexText value={this.props.methodCallModal.result[0].txResult.blockHash} />
+                          </div>                  
+                        </div>
+                      </div>
+                    }
+                  </div>
+                  </div>
               </div>
+              }
             </div>
             <div className="pt-dialog-footer">
               <div className="pt-dialog-footer-actions">
@@ -395,9 +474,12 @@ const selector = formValueSelector('contract-method-call');
 
 export function mapStateToProps(state, ownProps) {
   return {
-    modal: state.methodCall.modals
-      && state.methodCall.modals[ownProps.lookup] ?
-      state.methodCall.modals[ownProps.lookup] : {},
+    contractInfo: state.contractCard.contractInfos
+      && state.contractCard.contractInfos[ownProps.contractKey] ?
+      state.contractCard.contractInfos[ownProps.contractKey] : {},
+    methodCallModal: state.methodCall.modals
+      && state.methodCall.modals[ownProps.methodKey] ?
+      state.methodCall.modals[ownProps.methodKey] : {},
     accounts: state.accounts.accounts,
     modalUsername: selector(state, 'modalUsername'),
     chainLabel: state.chains.listChain,
@@ -413,11 +495,6 @@ const formed = reduxForm({ form: 'contract-method-call', validate })(ContractMet
 const connected = connect(
   mapStateToProps,
   {
-    methodCallFetchArgs,
-    methodCallOpenModal,
-    methodCallCloseModal,
-    fetchAccounts,
-    fetchUserAddresses,
     methodCall,
     fetchChainIds,
     getLabelIds

--- a/smd-ui/src/components/Contracts/contracts.reducer.js
+++ b/smd-ui/src/components/Contracts/contracts.reducer.js
@@ -166,6 +166,7 @@ const reducer = function (state = initialState, action) {
         filter: state.filter,
         error: state.error
       }
+
     default:
       return state;
   }

--- a/smd-ui/src/components/Contracts/index.js
+++ b/smd-ui/src/components/Contracts/index.js
@@ -116,6 +116,9 @@ class Contracts extends Component {
     const filter = this.props.filter;
     const contractNames = Object.getOwnPropertyNames(this.props.contracts);
 
+    const returnedInstances = contracts && contractNames.length > 0 ? Object.values(contracts).reduce((prev, cur) => {
+      return prev + cur.instances.length
+    }, 0) : 0
 
     const cards = contractNames.length === 0 ? [] : contractNames
       .filter(function (contract) {
@@ -288,14 +291,14 @@ class Contracts extends Component {
               />
             </div>
             <div className="col-sm-2 text-center" style={{ marginTop: '22px' }}>
-              {`Rows ${this.state.offset + 1}-${this.state.offset + Math.min(cards.length, this.state.limit)}`}
+              {`Rows ${this.state.offset + 1}-${this.state.offset + Math.min(cards.length, this.state.limit)} (${returnedInstances} Contract Instances)`}
             </div>
             <div className="col-sm-2 smd-pad-16 text-right">
               <Button
                 onClick={this.onNextClick}
                 className="pt-icon-arrow-right"
                 text="Next"
-                disabled={cards.length < this.state.limit}
+                disabled={returnedInstances < this.state.limit}
               />
             </div>
           </div>

--- a/smd-ui/src/components/QueryEngine/queryEngine.reducer.js
+++ b/smd-ui/src/components/QueryEngine/queryEngine.reducer.js
@@ -72,11 +72,13 @@ const reducer = function (state = initialState, action) {
         error: action.error
       };
     case TRANSACTION_RESULT_SUCCESS:
-      const r = action.txResult ? `${action.txResult[0].toUpperCase()}${action.txResult.substring(1)}` : "";
+      console.log(action.txResult)
+      const r = action.txResult && ((typeof action.txResult) == 'string') ? `${action.txResult[0].toUpperCase()}${action.txResult.substring(1)}` : action.txResult.type.tag;
       return {
         ...state,
         error : null,
-        txResult : r
+        txResult : r,
+        txResultMessage: action.txResult.details
       };
     case TRANSACTION_RESULT_FAILURE:
       return {

--- a/smd-ui/src/components/QueryEngine/queryEngine.reducer.js
+++ b/smd-ui/src/components/QueryEngine/queryEngine.reducer.js
@@ -72,7 +72,6 @@ const reducer = function (state = initialState, action) {
         error: action.error
       };
     case TRANSACTION_RESULT_SUCCESS:
-      console.log(action.txResult)
       const r = action.txResult && ((typeof action.txResult) == 'string') ? `${action.txResult[0].toUpperCase()}${action.txResult.substring(1)}` : action.txResult.type.tag;
       return {
         ...state,

--- a/smd-ui/src/components/Transactions/components/TransactionView/index.js
+++ b/smd-ui/src/components/Transactions/components/TransactionView/index.js
@@ -17,9 +17,32 @@ class TransactionView extends Component {
     const history = this.props.history;
     const hash = this.props.match.params.hash;
     const tx = this.props.tx ? this.props.tx : {};
+    console.log(tx)
     if (!Object.keys(tx).length) history.push(`/transactions`);
+
+    let cardIntent = ''
+    switch (this.props.txResult) {
+      case 'Success':
+          cardIntent = 'pt-intent-success'
+          break;
+      case 'Pending':
+          cardIntent = 'pt-intent-warning'
+          break;
+      case 'ExecutionFailure':
+          cardIntent = 'pt-intent-danger'
+          break
+      default:
+          break
+    }
+    const parseArgs = (args) => {
+      const cleaned = args.substring(1, args.length - 1)
+      return cleaned.split(',')
+    }
+    const parsedArgs = tx.metadata && tx.metadata.args ? parseArgs(tx.metadata.args) : [] 
+    console.log(parsedArgs)
     return (
-      <div className="container-fluid pt-dark">
+      <div className="container-fluid pt-dark ">
+        
         <div className="row">
           <div className="col-sm-9">
             <div className="h3">
@@ -36,7 +59,8 @@ class TransactionView extends Component {
         </div>
         <div className="row">
           <div className="col-sm-12">
-            <div className="pt-card">
+            <div className={`pt-card pt-callout ${cardIntent}`}>
+
               <table className="pt-table pt-str">
                 <thead>
                   <tr>
@@ -46,6 +70,25 @@ class TransactionView extends Component {
                 </thead>
                 <tbody>
                   <tr>
+                    <td><strong>Result</strong></td>
+                    <td>{this.props.txResult ? this.props.txResult : ""}</td>
+                  </tr>
+                  {
+                      this.props.txResult === 'ExecutionFailure' &&
+                    <tr>
+                      <td><strong>Error Message</strong></td>
+                      <td>
+                        <pre>
+                        {this.props.txResultMessage || "Unknown Error"}
+                        </pre>
+                        </td>
+                    </tr>
+                  }
+                  <tr>
+                    <td><strong>Type</strong></td>
+                    <td>{tx.transactionType ? tx.transactionType : "Unknown TX Type"}</td>
+                  </tr>
+                  <tr>
                     <td><strong>From</strong></td>
                     <td>{tx.from === undefined ? '' : <HexText value={tx.from} classes="smd-pad-2" />}</td>
                   </tr>
@@ -53,13 +96,47 @@ class TransactionView extends Component {
                     <td><strong>To</strong></td>
                     <td><HexText value={tx.to} classes="smd-pad-2" /></td>
                   </tr>}
+                  {
+                    tx.metadata && tx.metadata.funcName &&
+                    <tr>
+                      <td><strong>Function Name</strong></td>
+                      <td>
+                        {tx.metadata.funcName}
+                      </td>
+                    </tr>
+                  }
+                  {
+                    tx.metadata && tx.metadata.name &&
+                    <tr>
+                      <td><strong>Contract Name</strong></td>
+                      <td>
+                        {tx.metadata.name}
+                      </td>
+                    </tr>
+                  }
+                  {
+                    tx.metadata && tx.metadata.args &&
+                    <tr>
+                      <td><strong>Arguments</strong></td>
+                      <td>
+                        <pre>
+                          {parsedArgs.length > 0 ? parsedArgs.join(',') : 'N/A'}
+                        </pre>
+                      </td>
+                    </tr>
+                  }
+                  {
+                    tx.metadata && tx.metadata.VM &&
+                    <tr>
+                      <td><strong>VM</strong></td>
+                      <td>
+                        {tx.metadata.VM}
+                      </td>
+                    </tr>
+                  }
                   <tr>
                     <td><strong>Value</strong></td>
                     <td>{tx.value === undefined ? '' : tx.value}</td>
-                  </tr>
-                  <tr>
-                    <td><strong>Result</strong></td>
-                    <td>{this.props.txResult ? this.props.txResult : ""}</td>
                   </tr>
                   <tr>
                     <td><strong>Block Number</strong></td>
@@ -101,7 +178,8 @@ export function mapStateToProps(state, ownProps) {
     query: state.queryEngine.query,
     selectedChain: state.chains.selectedChain,
     tx: state.transactions.tx.filter((val) => { return val.hash === hash })[0] || state.queryEngine.queryResult.filter((val) => { return val.hash === hash })[0],
-    txResult : state.queryEngine.txResult
+    txResult : state.queryEngine.txResult,
+    txResultMessage: state.queryEngine.txResultMessage
   };
 }
 

--- a/smd-ui/src/components/Transactions/components/TransactionView/index.js
+++ b/smd-ui/src/components/Transactions/components/TransactionView/index.js
@@ -17,7 +17,6 @@ class TransactionView extends Component {
     const history = this.props.history;
     const hash = this.props.match.params.hash;
     const tx = this.props.tx ? this.props.tx : {};
-    console.log(tx)
     if (!Object.keys(tx).length) history.push(`/transactions`);
 
     let cardIntent = ''
@@ -39,7 +38,6 @@ class TransactionView extends Component {
       return cleaned.split(',')
     }
     const parsedArgs = tx.metadata && tx.metadata.args ? parseArgs(tx.metadata.args) : [] 
-    console.log(parsedArgs)
     return (
       <div className="container-fluid pt-dark ">
         

--- a/smd-ui/src/index.js
+++ b/smd-ui/src/index.js
@@ -37,6 +37,7 @@ import chainsReducer from './components/Chains/chains.reducer'
 import createChainReducer from './components/CreateChain/createChain.reducer';
 import oauthAccountsReducer from './components/Accounts/components/OauthAccounts/oauthAccounts.reducer';
 import searchQueryReducer from './components/SearchResults/searchresults.reducer';
+import contractCardReducer from './components/Contracts/components/ContractCard/contractCard.reducer'
 
 import { watchCommunicateOverSocket } from './sockets/socket.saga'
 import watchFetchBlockData from './components/BlockData/block-data.saga'
@@ -51,11 +52,12 @@ import {watchFetchUser, watchFetchPubKey, watchuserCert} from './components/User
 import {
   watchFetchState,
   watchFetchCirrusContracts,
-  watchAccount
+  watchAccount,
+  watchFetchInfo,
 } from './components/Contracts/components/ContractCard/contractCard.saga';
+
 import {
   watchMethodCall,
-  watchFetchArgs
 } from './components/Contracts/components/ContractMethodCall/contractMethodCall.saga';
 import {watchExecuteQuery, watchTransactionResult} from './components/QueryEngine/queryEngine.saga';
 import { watchQueryCirrus, watchQueryCirrusVars} from './components/ContractQuery/contractQuery.saga';
@@ -87,6 +89,7 @@ const rootReducer = combineReducers({
   chains: chainsReducer,
   contracts: contractsReducer,
   contractQuery: contractQueryReducer,
+  contractCard: contractCardReducer,
   createContract: createContractReducer,
   deployDapp: deployDappReducer,
   methodCall: methodCallReducer,
@@ -121,7 +124,7 @@ const rootSaga = function* startForeman() {
     fork(watchFetchContracts),
     fork(watchCompileContract),
     fork(watchFetchState),
-    fork(watchFetchArgs),
+    fork(watchFetchInfo),
     fork(watchMethodCall),
     fork(watchFetchCirrusContracts),
     fork(watchExecuteQuery),

--- a/smd-ui/src/tests/Contracts/component/ContractCard/__snapshots__/contractCard.actions.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/__snapshots__/contractCard.actions.spec.js.snap
@@ -31,6 +31,38 @@ Object {
 }
 `;
 
+exports[`ContractCard: action fetch contract info snapshots failure 1`] = `
+Object {
+  "error": Object {
+    "message": "some error",
+  },
+  "key": "data-card-1234567-",
+  "type": "FETCH_CONTRACT_INFO_FAILURE",
+}
+`;
+
+exports[`ContractCard: action fetch contract info snapshots request 1`] = `
+Object {
+  "chainId": "123456756789876789876543345678",
+  "contractAddress": "1234567",
+  "contractName": "Foo",
+  "key": "data-card-1234567-",
+  "type": "FETCH_CONTRACT_INFO_REQUEST",
+}
+`;
+
+exports[`ContractCard: action fetch contract info snapshots success 1`] = `
+Object {
+  "data": Object {
+    "address": "1234567",
+    "chainId": "123456756789876789876543345678",
+    "xabi": Object {},
+  },
+  "key": "data-card-1234567-",
+  "type": "FETCH_CONTRACT_INFO_SUCCESS",
+}
+`;
+
 exports[`ContractCard: action fetch instance failure 1`] = `
 Object {
   "error": "ERROR",

--- a/smd-ui/src/tests/Contracts/component/ContractCard/__snapshots__/contractCard.reducer.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/__snapshots__/contractCard.reducer.spec.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContractCard: reducer get contract info on failure 1`] = `
+Object {
+  "contractInfos": Object {
+    "data-card-1234567-": Object {
+      "error": Object {
+        "message": "some error",
+      },
+    },
+  },
+}
+`;
+
+exports[`ContractCard: reducer get contract info on success 1`] = `
+Object {
+  "contractInfos": Object {
+    "data-card-1234567-": Object {
+      "address": "1234567",
+      "chainId": "123456756789876789876543345678",
+      "xabi": Object {},
+    },
+  },
+}
+`;
+
+exports[`ContractCard: reducer set initial state 1`] = `
+Object {
+  "contractInfos": Object {},
+}
+`;

--- a/smd-ui/src/tests/Contracts/component/ContractCard/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/__snapshots__/index.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`ContractCard: index mapStateToProps with default values 1`] = `
 Object {
+  "contractInfos": Object {},
   "selectedChain": "ff7ef45acb7a775018bc765b6fdeea432aaddfcd846cf6dd9442724266b1eac9",
 }
 `;
@@ -28,6 +29,7 @@ ShallowWrapper {
     }
     fetchAccount={[Function]}
     fetchCirrusInstances={[Function]}
+    fetchContractInfoRequest={[Function]}
     fetchState={[Function]}
     selectContractInstance={[Function]}
   />,
@@ -1612,6 +1614,7 @@ ShallowWrapper {
     }
     fetchAccount={[Function]}
     fetchCirrusInstances={[Function]}
+    fetchContractInfoRequest={[Function]}
     fetchState={[Function]}
     selectContractInstance={[Function]}
     selectedChain="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
@@ -1727,7 +1730,14 @@ ShallowWrapper {
               className="row"
             >
               <div
-                className="col-sm-12 text-right"
+                className="col-sm-6"
+              >
+                <ContractSource
+                  contract={Object {}}
+                />
+              </div>
+              <div
+                className="col-sm-6 text-right"
               >
                 <span
                   className="pt-monospace-text"
@@ -1779,10 +1789,11 @@ ShallowWrapper {
                         <withRouter(Connect(ReduxForm))
                           chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                           contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                          contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                           contractName="Greeter"
                           fromBloc={false}
                           fromCirrus={false}
-                          lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                          methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                           symbolName="greet"
                         />
                       </td>
@@ -2509,7 +2520,14 @@ ShallowWrapper {
               className="row"
             >
               <div
-                className="col-sm-12 text-right"
+                className="col-sm-6"
+              >
+                <ContractSource
+                  contract={Object {}}
+                />
+              </div>
+              <div
+                className="col-sm-6 text-right"
               >
                 <span
                   className="pt-monospace-text"
@@ -2561,10 +2579,11 @@ ShallowWrapper {
                         <withRouter(Connect(ReduxForm))
                           chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                           contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                          contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                           contractName="Greeter"
                           fromBloc={false}
                           fromCirrus={false}
-                          lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                          methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                           symbolName="greet"
                         />
                       </td>
@@ -2636,7 +2655,14 @@ ShallowWrapper {
                 className="row"
               >
                 <div
-                  className="col-sm-12 text-right"
+                  className="col-sm-6"
+                >
+                  <ContractSource
+                    contract={Object {}}
+                  />
+                </div>
+                <div
+                  className="col-sm-6 text-right"
                 >
                   <span
                     className="pt-monospace-text"
@@ -2688,10 +2714,11 @@ ShallowWrapper {
                           <withRouter(Connect(ReduxForm))
                             chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractName="Greeter"
                             fromBloc={false}
                             fromCirrus={false}
-                            lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                             symbolName="greet"
                           />
                         </td>
@@ -2759,57 +2786,92 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": <div
-                  className="col-sm-12 text-right"
-                >
-                  <span
-                    className="pt-monospace-text"
+                "children": Array [
+                  <div
+                    className="col-sm-6"
                   >
-                     
-                    
-                     
-                  </span>
-                </div>,
+                    <ContractSource
+                      contract={Object {}}
+                    />
+                  </div>,
+                  <div
+                    className="col-sm-6 text-right"
+                  >
+                    <span
+                      className="pt-monospace-text"
+                    >
+                       
+                      
+                       
+                    </span>
+                  </div>,
+                ],
                 "className": "row",
               },
               "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <span
-                    className="pt-monospace-text"
-                  >
-                     
-                    
-                     
-                  </span>,
-                  "className": "col-sm-12 text-right",
-                },
-                "ref": null,
-                "rendered": Object {
+              "rendered": Array [
+                Object {
                   "instance": null,
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": Array [
+                    "children": <ContractSource
+                      contract={Object {}}
+                    />,
+                    "className": "col-sm-6",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "contract": Object {},
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  "type": "div",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <span
+                      className="pt-monospace-text"
+                    >
+                       
+                      
+                       
+                    </span>,
+                    "className": "col-sm-6 text-right",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        " ",
+                        "",
+                        " ",
+                      ],
+                      "className": "pt-monospace-text",
+                    },
+                    "ref": null,
+                    "rendered": Array [
                       " ",
                       "",
                       " ",
                     ],
-                    "className": "pt-monospace-text",
+                    "type": "span",
                   },
-                  "ref": null,
-                  "rendered": Array [
-                    " ",
-                    "",
-                    " ",
-                  ],
-                  "type": "span",
+                  "type": "div",
                 },
-                "type": "div",
-              },
+              ],
               "type": "div",
             },
             Object {
@@ -2855,10 +2917,11 @@ ShallowWrapper {
                           <withRouter(Connect(ReduxForm))
                             chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractName="Greeter"
                             fromBloc={false}
                             fromCirrus={false}
-                            lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                             symbolName="greet"
                           />
                         </td>
@@ -2958,10 +3021,11 @@ ShallowWrapper {
                           <withRouter(Connect(ReduxForm))
                             chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractName="Greeter"
                             fromBloc={false}
                             fromCirrus={false}
-                            lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                             symbolName="greet"
                           />
                         </td>
@@ -3058,10 +3122,11 @@ ShallowWrapper {
                             <withRouter(Connect(ReduxForm))
                               chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                               contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                              contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                               contractName="Greeter"
                               fromBloc={false}
                               fromCirrus={false}
-                              lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                              methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                               symbolName="greet"
                             />
                           </td>
@@ -3231,10 +3296,11 @@ ShallowWrapper {
                               <withRouter(Connect(ReduxForm))
                                 chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                 contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                 contractName="Greeter"
                                 fromBloc={false}
                                 fromCirrus={false}
-                                lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                                 symbolName="greet"
                               />
                             </td>
@@ -3308,10 +3374,11 @@ ShallowWrapper {
                                 <withRouter(Connect(ReduxForm))
                                   chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                   contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                   contractName="Greeter"
                                   fromBloc={false}
                                   fromCirrus={false}
-                                  lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                                   symbolName="greet"
                                 />
                               </td>,
@@ -3338,10 +3405,11 @@ ShallowWrapper {
                                 "children": <withRouter(Connect(ReduxForm))
                                   chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                   contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                   contractName="Greeter"
                                   fromBloc={false}
                                   fromCirrus={false}
-                                  lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                                   symbolName="greet"
                                 />,
                                 "style": Object {
@@ -3356,10 +3424,11 @@ ShallowWrapper {
                                 "props": Object {
                                   "chainId": "1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14",
                                   "contractAddress": "0293f9b10a4453667db7fcfe74728c9d821add4b",
+                                  "contractKey": "card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14",
                                   "contractName": "Greeter",
                                   "fromBloc": false,
                                   "fromCirrus": false,
-                                  "lookup": "methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b",
+                                  "methodKey": "methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b",
                                   "symbolName": "greet",
                                 },
                                 "ref": null,
@@ -3645,7 +3714,14 @@ ShallowWrapper {
                 className="row"
               >
                 <div
-                  className="col-sm-12 text-right"
+                  className="col-sm-6"
+                >
+                  <ContractSource
+                    contract={Object {}}
+                  />
+                </div>
+                <div
+                  className="col-sm-6 text-right"
                 >
                   <span
                     className="pt-monospace-text"
@@ -3697,10 +3773,11 @@ ShallowWrapper {
                           <withRouter(Connect(ReduxForm))
                             chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractName="Greeter"
                             fromBloc={false}
                             fromCirrus={false}
-                            lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                             symbolName="greet"
                           />
                         </td>
@@ -4427,7 +4504,14 @@ ShallowWrapper {
                 className="row"
               >
                 <div
-                  className="col-sm-12 text-right"
+                  className="col-sm-6"
+                >
+                  <ContractSource
+                    contract={Object {}}
+                  />
+                </div>
+                <div
+                  className="col-sm-6 text-right"
                 >
                   <span
                     className="pt-monospace-text"
@@ -4479,10 +4563,11 @@ ShallowWrapper {
                           <withRouter(Connect(ReduxForm))
                             chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                             contractName="Greeter"
                             fromBloc={false}
                             fromCirrus={false}
-                            lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                            methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                             symbolName="greet"
                           />
                         </td>
@@ -4554,7 +4639,14 @@ ShallowWrapper {
                   className="row"
                 >
                   <div
-                    className="col-sm-12 text-right"
+                    className="col-sm-6"
+                  >
+                    <ContractSource
+                      contract={Object {}}
+                    />
+                  </div>
+                  <div
+                    className="col-sm-6 text-right"
                   >
                     <span
                       className="pt-monospace-text"
@@ -4606,10 +4698,11 @@ ShallowWrapper {
                             <withRouter(Connect(ReduxForm))
                               chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                               contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                              contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                               contractName="Greeter"
                               fromBloc={false}
                               fromCirrus={false}
-                              lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                              methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                               symbolName="greet"
                             />
                           </td>
@@ -4677,57 +4770,92 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": <div
-                    className="col-sm-12 text-right"
-                  >
-                    <span
-                      className="pt-monospace-text"
+                  "children": Array [
+                    <div
+                      className="col-sm-6"
                     >
-                       
-                      
-                       
-                    </span>
-                  </div>,
+                      <ContractSource
+                        contract={Object {}}
+                      />
+                    </div>,
+                    <div
+                      className="col-sm-6 text-right"
+                    >
+                      <span
+                        className="pt-monospace-text"
+                      >
+                         
+                        
+                         
+                      </span>
+                    </div>,
+                  ],
                   "className": "row",
                 },
                 "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <span
-                      className="pt-monospace-text"
-                    >
-                       
-                      
-                       
-                    </span>,
-                    "className": "col-sm-12 text-right",
-                  },
-                  "ref": null,
-                  "rendered": Object {
+                "rendered": Array [
+                  Object {
                     "instance": null,
                     "key": undefined,
                     "nodeType": "host",
                     "props": Object {
-                      "children": Array [
+                      "children": <ContractSource
+                        contract={Object {}}
+                      />,
+                      "className": "col-sm-6",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "contract": Object {},
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <span
+                        className="pt-monospace-text"
+                      >
+                         
+                        
+                         
+                      </span>,
+                      "className": "col-sm-6 text-right",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          " ",
+                          "",
+                          " ",
+                        ],
+                        "className": "pt-monospace-text",
+                      },
+                      "ref": null,
+                      "rendered": Array [
                         " ",
                         "",
                         " ",
                       ],
-                      "className": "pt-monospace-text",
+                      "type": "span",
                     },
-                    "ref": null,
-                    "rendered": Array [
-                      " ",
-                      "",
-                      " ",
-                    ],
-                    "type": "span",
+                    "type": "div",
                   },
-                  "type": "div",
-                },
+                ],
                 "type": "div",
               },
               Object {
@@ -4773,10 +4901,11 @@ ShallowWrapper {
                             <withRouter(Connect(ReduxForm))
                               chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                               contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                              contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                               contractName="Greeter"
                               fromBloc={false}
                               fromCirrus={false}
-                              lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                              methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                               symbolName="greet"
                             />
                           </td>
@@ -4876,10 +5005,11 @@ ShallowWrapper {
                             <withRouter(Connect(ReduxForm))
                               chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                               contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                              contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                               contractName="Greeter"
                               fromBloc={false}
                               fromCirrus={false}
-                              lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                              methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                               symbolName="greet"
                             />
                           </td>
@@ -4976,10 +5106,11 @@ ShallowWrapper {
                               <withRouter(Connect(ReduxForm))
                                 chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                 contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                 contractName="Greeter"
                                 fromBloc={false}
                                 fromCirrus={false}
-                                lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                                 symbolName="greet"
                               />
                             </td>
@@ -5149,10 +5280,11 @@ ShallowWrapper {
                                 <withRouter(Connect(ReduxForm))
                                   chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                   contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                   contractName="Greeter"
                                   fromBloc={false}
                                   fromCirrus={false}
-                                  lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                  methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                                   symbolName="greet"
                                 />
                               </td>
@@ -5226,10 +5358,11 @@ ShallowWrapper {
                                   <withRouter(Connect(ReduxForm))
                                     chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                     contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                    contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                     contractName="Greeter"
                                     fromBloc={false}
                                     fromCirrus={false}
-                                    lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                    methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                                     symbolName="greet"
                                   />
                                 </td>,
@@ -5256,10 +5389,11 @@ ShallowWrapper {
                                   "children": <withRouter(Connect(ReduxForm))
                                     chainId="1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                     contractAddress="0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                    contractKey="card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14"
                                     contractName="Greeter"
                                     fromBloc={false}
                                     fromCirrus={false}
-                                    lookup="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
+                                    methodKey="methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b"
                                     symbolName="greet"
                                   />,
                                   "style": Object {
@@ -5274,10 +5408,11 @@ ShallowWrapper {
                                   "props": Object {
                                     "chainId": "1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14",
                                     "contractAddress": "0293f9b10a4453667db7fcfe74728c9d821add4b",
+                                    "contractKey": "card-data-0293f9b10a4453667db7fcfe74728c9d821add4b-1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14",
                                     "contractName": "Greeter",
                                     "fromBloc": false,
                                     "fromCirrus": false,
-                                    "lookup": "methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b",
+                                    "methodKey": "methodCallgreet0293f9b10a4453667db7fcfe74728c9d821add4b",
                                     "symbolName": "greet",
                                   },
                                   "ref": null,
@@ -6845,6 +6980,7 @@ ShallowWrapper {
     }
     fetchAccount={[Function]}
     fetchCirrusInstances={[Function]}
+    fetchContractInfoRequest={[Function]}
     fetchState={[Function]}
     selectContractInstance={[Function]}
   />,

--- a/smd-ui/src/tests/Contracts/component/ContractCard/contractCard.actions.spec.js
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/contractCard.actions.spec.js
@@ -8,9 +8,12 @@ import {
   fetchCirrusInstancesFailure,
   fetchAccount,
   fetchAccountSuccess,
-  fetchAccountFailure
+  fetchAccountFailure,
+  fetchContractInfoRequest,
+  fetchContractInfoSuccess,
+  fetchContractInfoFailure,
 } from '../../../../components/Contracts/components/ContractCard/contractCard.actions';
-import { contract } from './contractCardMock';
+import { contract, modals } from './contractCardMock';
 
 describe('ContractCard: action', () => {
 
@@ -65,5 +68,19 @@ describe('ContractCard: action', () => {
     });
 
   })
+  describe('fetch contract info snapshots', () => {
 
+    test('request', () => {
+      expect(fetchContractInfoRequest(modals.key, modals.name, modals.address, modals.chainId)).toMatchSnapshot();
+    });
+
+    test('success', () => {
+      expect(fetchContractInfoSuccess(modals.key, {address: modals.address, chainId: modals.chainId, xabi: {}})).toMatchSnapshot();
+    });
+
+    test('failure', () => {
+      expect(fetchContractInfoFailure(modals.key, modals.error)).toMatchSnapshot();
+    });
+
+  })
 });

--- a/smd-ui/src/tests/Contracts/component/ContractCard/contractCard.reducer.spec.js
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/contractCard.reducer.spec.js
@@ -1,0 +1,31 @@
+import reducer from '../../../../components/Contracts/components/ContractCard/contractCard.reducer';
+import {
+  fetchContractInfoRequest,
+  fetchContractInfoSuccess,
+  fetchContractInfoFailure
+} from '../../../../components/Contracts/components/ContractCard/contractCard.actions';
+import { modals, initialState } from './contractCardMock';
+
+describe('ContractCard: reducer', () => {
+
+  // INITIAL_STATE
+  test('set initial state', () => {
+    expect(reducer(undefined, {})).toMatchSnapshot();
+  });
+
+
+  describe('get contract info', () => {
+
+    test('on success', () => {
+      const action = fetchContractInfoSuccess(modals.key, {address: modals.address, chainId: modals.chainId, xabi: {}});
+      expect(reducer(initialState, action)).toMatchSnapshot();
+    });
+
+    test('on failure', () => {
+      const action = fetchContractInfoFailure(modals.key, modals.error);
+      expect(reducer(initialState, action)).toMatchSnapshot();
+    });
+
+  })
+
+})

--- a/smd-ui/src/tests/Contracts/component/ContractCard/contractCard.saga.spec.js
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/contractCard.saga.spec.js
@@ -7,7 +7,10 @@ import {
   fetchState,
   getState,
   fetchAccount,
-  getAccount
+  getAccount,
+  watchFetchInfo,
+  fetchContractInfo,
+  getContract
 } from '../../../../components/Contracts/components/ContractCard/contractCard.saga';
 import {
   takeEvery,
@@ -18,14 +21,16 @@ import {
   FETCH_ACCOUNT_REQUEST,
   FETCH_CIRRUS_INSTANCES_REQUEST,
   fetchAccountSuccess,
-  fetchAccountFailure,
   fetchCirrusInstancesSuccess,
   FETCH_STATE_REQUEST,
   fetchStateSuccess,
-  fetchStateFailure
+  FETCH_CONTRACT_INFO_REQUEST,
+  fetchContractInfoRequest,
+  fetchContractInfoSuccess,
+  fetchContractInfoFailure
 } from '../../../../components/Contracts/components/ContractCard/contractCard.actions';
 import { expectSaga } from 'redux-saga-test-plan';
-import { accounts, cirrus, state } from './contractCardMock'
+import { accounts, cirrus, state, contractInfoResponse } from './contractCardMock'
 
 describe('ContractCard: saga', () => {
 
@@ -39,6 +44,51 @@ describe('ContractCard: saga', () => {
     const gen = fetchAccount({ type: "FETCH_ACCOUNT_REQUEST", address: '3771b31420eda628bf03cd5b119249da0fb4aa6d', name: 'Greeter' });
     expect(gen.next().value).toEqual(call(getAccount, '3771b31420eda628bf03cd5b119249da0fb4aa6d'));
     expect(gen.next().value).toEqual(put(fetchAccountSuccess('Greeter', '3771b31420eda628bf03cd5b119249da0fb4aa6d')))
+  })
+
+  test('watch contract args', () => {
+    const gen = watchFetchInfo();
+    expect(gen.next().value).toEqual(takeEvery(FETCH_CONTRACT_INFO_REQUEST, fetchContractInfo))
+  })
+
+  
+  describe('fetch contract info - sagas', () => {
+
+    test('success', () => {
+      fetch.mockResponse(JSON.stringify(contractInfoResponse))
+      expectSaga(fetchContractInfo, {
+        key: 'key',
+        name: 'abc',
+        address: 'xyz',
+        chainId: '4261aa13'
+      })
+        .call.fn(getContract, 'Cloner', 'eb58f377c7d419e9945b5096cd478b6a7eef9831', 'geneticallyModify').put.like({ action: { type: 'FETCH_CONTRACT_INFO_SUCCESS' } })
+        .run()
+    });
+
+    test('failure', () => {
+      fetch.mockReject(JSON.stringify(contractInfoResponse))
+      expectSaga(fetchContractInfo, {
+        name: 'abc',
+        address: 'xyz',
+        symbol: 'geneticallyModify',
+        key: 'key'
+      })
+        .call.fn(getContract, 'Cloner', 'eb58f377c7d419e9945b5096cd478b6a7eef9831', 'geneticallyModify').put.like({ action: { type: 'FETCH_CONTRACT_INFO_FAILURE' } })
+        .run()
+    });
+
+    test('exception', () => {
+      expectSaga(fetchContractInfo, 'Cloner', 'eb58f377c7d419e9945b5096cd478b6a7eef9831', 'cloneSheep')
+        .provide({
+          call() {
+            throw new Error('Not Found');
+          },
+        })
+        .put.like({ action: { type: 'FETCH_CONTRACT_INFO_FAILURE' } })
+        .run();
+    });
+
   })
 
   describe('fetch accounts', () => {

--- a/smd-ui/src/tests/Contracts/component/ContractCard/contractCardMock.js
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/contractCardMock.js
@@ -37,3 +37,36 @@ export const state = {
   "geneticallyModify": "function (String) returns ()",
   "name": ""
 }
+
+export const modals = {
+  name: 'Foo',
+  key: 'data-card-1234567-',
+  address: '1234567',
+  chainId: '123456756789876789876543345678',
+  error: {
+    message: 'some error'
+  }
+}
+
+export const contractInfoResponse = {
+  address: '1234567',
+  chainId: '123456756789876789876543345678',
+  xabi: {
+    funcs: {
+      geneticallyModify: {
+        args: {
+          _dna: {
+            dynamic: true,
+            type: "String",
+            tag: "String",
+            index: 0
+          }
+        }
+      }
+    }
+  }
+}
+
+export const initialState = {
+  contractInfos: {}
+}

--- a/smd-ui/src/tests/Contracts/component/ContractCard/index.spec.js
+++ b/smd-ui/src/tests/Contracts/component/ContractCard/index.spec.js
@@ -36,7 +36,8 @@ describe('ContractCard: index', () => {
         fetchCirrusInstances: jest.fn(),
         fetchAccount: jest.fn(),
         fetchState: jest.fn(),
-        selectContractInstance: jest.fn()
+        selectContractInstance: jest.fn(),
+        fetchContractInfoRequest: jest.fn(),
       }
       let wrapper = shallow(
         <ContractCard.WrappedComponent {...props} />
@@ -65,7 +66,8 @@ describe('ContractCard: index', () => {
         fetchCirrusInstances: jest.fn(),
         fetchAccount: jest.fn(),
         fetchState: jest.fn(),
-        selectContractInstance: jest.fn()
+        selectContractInstance: jest.fn(),
+        fetchContractInfoRequest: jest.fn(),
       }
       let wrapper = shallow(
         <ContractCard.WrappedComponent {...props} />
@@ -98,7 +100,8 @@ describe('ContractCard: index', () => {
         fetchCirrusInstances: jest.fn(),
         fetchAccount: jest.fn(),
         fetchState: jest.fn(),
-        selectContractInstance: jest.fn()
+        selectContractInstance: jest.fn(),
+        fetchContractInfoRequest: jest.fn(),
       }
       let wrapper = shallow(
         <ContractCard.WrappedComponent {...props} />
@@ -107,6 +110,7 @@ describe('ContractCard: index', () => {
       expect(props.fetchAccount).toHaveBeenCalled();
       expect(props.fetchState).toHaveBeenCalled();
       expect(props.selectContractInstance).toHaveBeenCalled();
+      expect(props.fetchContractInfoRequest).toHaveBeenCalled();
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -118,7 +122,8 @@ describe('ContractCard: index', () => {
       fetchCirrusInstances: jest.fn().mockReturnValue('fetchCirrusInstances'),
       fetchAccount: jest.fn().mockReturnValue('fetchAccount'),
       fetchState: jest.fn().mockReturnValue('fetchState'),
-      selectContractInstance: jest.fn().mockReturnValue('selectContractInstance')
+      selectContractInstance: jest.fn().mockReturnValue('selectContractInstance'),
+      fetchContractInfoRequest: jest.fn().mockReturnValue('fetchContractInfoRequest'),
     }
     const wrapper = shallow(
       <ContractCard.WrappedComponent {...props} />
@@ -127,12 +132,16 @@ describe('ContractCard: index', () => {
     expect(wrapper.instance().props.fetchAccount()).toBe('fetchAccount');
     expect(wrapper.instance().props.fetchState()).toBe('fetchState');
     expect(wrapper.instance().props.selectContractInstance()).toBe('selectContractInstance');
+    expect(wrapper.instance().props.fetchContractInfoRequest()).toBe('fetchContractInfoRequest');
   });
 
   test('mapStateToProps with default values', () => {
     expect(mapStateToProps({
       chains: {
         selectedChain: "ff7ef45acb7a775018bc765b6fdeea432aaddfcd846cf6dd9442724266b1eac9"
+      },
+      contractCard: {
+        contractInfos: {}
       }
     })).toMatchSnapshot();
   });
@@ -143,7 +152,8 @@ describe('ContractCard: index', () => {
       fetchCirrusInstances: jest.fn().mockReturnValue('fetchCirrusInstances'),
       fetchAccount: jest.fn().mockReturnValue('fetchAccount'),
       fetchState: jest.fn().mockReturnValue('fetchState'),
-      selectContractInstance: jest.fn().mockReturnValue('selectContractInstance')
+      selectContractInstance: jest.fn().mockReturnValue('selectContractInstance'),
+      fetchContractInfoRequest: jest.fn().mockReturnValue('fetchContractInfoRequest'),
     }
     const wrapper = shallow(
       <ContractCard.WrappedComponent {...props} />

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/contractMethodCall.actions.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/contractMethodCall.actions.spec.js.snap
@@ -1,46 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ContractMethodCall: action close model with contract key 1`] = `
-Object {
-  "key": "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17",
-  "type": "METHOD_CALL_CLOSE_MODAL",
-}
-`;
-
-exports[`ContractMethodCall: action fetch arguments failure 1`] = `
-Object {
-  "error": "ERROR",
-  "key": "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17",
-  "type": "METHOD_CALL_FETCH_ARGS_FAILURE",
-}
-`;
-
-exports[`ContractMethodCall: action fetch arguments request 1`] = `
-Object {
-  "address": "8070db2390462e2b5748085bde1350590e08bb17",
-  "chainId": "1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14",
-  "key": "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17",
-  "name": "Greeter",
-  "symbol": "greet",
-  "type": "METHOD_CALL_FETCH_ARGS_REQUEST",
-}
-`;
-
-exports[`ContractMethodCall: action fetch arguments success 1`] = `
-Object {
-  "args": Object {
-    "_greeting": Object {
-      "dynamic": true,
-      "index": 0,
-      "type": "String",
-    },
-  },
-  "isPayable": true,
-  "key": "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17",
-  "type": "METHOD_CALL_FETCH_ARGS_SUCCESS",
-}
-`;
-
 exports[`ContractMethodCall: action method call failure 1`] = `
 Object {
   "key": "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17",
@@ -101,12 +60,5 @@ Object {
     },
   ],
   "type": "METHOD_CALL_SUCCESS",
-}
-`;
-
-exports[`ContractMethodCall: action open model with contract key 1`] = `
-Object {
-  "key": "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17",
-  "type": "METHOD_CALL_OPEN_MODAL",
 }
 `;

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/contractMethodCall.actions.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/contractMethodCall.actions.spec.js.snap
@@ -68,10 +68,38 @@ Object {
 exports[`ContractMethodCall: action method call success 1`] = `
 Object {
   "key": "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17",
-  "result": Object {
-    "hash": "8f6fcd037e028f84ec2e9462c4e29444cd3456c8bc8705723f0c36d075c14c5d",
-    "status": "Success",
-  },
+  "result": Array [
+    Object {
+      "data": Object {
+        "contents": Array [
+          "200",
+        ],
+        "tag": "Call",
+      },
+      "hash": "31bcbc86cb6fdd273443406ae27906485fccc8475b269de04878d9b797c0f47e",
+      "status": "Success",
+      "txResult": Object {
+        "appName": "",
+        "blockHash": "36d2629fb5ef27457eb70a87cd886284d0ac7c197f7b3eaf1102edbb8e3518b1",
+        "chainId": null,
+        "contractsCreated": "",
+        "contractsDeleted": "",
+        "deletedStorage": "",
+        "etherUsed": "0000000000000000000000000000000000000000000000000000000005f5e100",
+        "gasUsed": "0000000000000000000000000000000000000000000000000000000005f5e100",
+        "kind": "SolidVM",
+        "message": "Success!",
+        "newStorage": "",
+        "orgName": "Blockapps",
+        "response": "(200)",
+        "stateDiff": "",
+        "status": "success",
+        "time": 0.001361853,
+        "trace": "",
+        "transactionHash": "31bcbc86cb6fdd273443406ae27906485fccc8475b269de04878d9b797c0f47e",
+      },
+    },
+  ],
   "type": "METHOD_CALL_SUCCESS",
 }
 `;

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/contractMethodCall.reducer.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/contractMethodCall.reducer.spec.js.snap
@@ -4,7 +4,6 @@ exports[`ContractMethodCall: reducer method call on failure 1`] = `
 Object {
   "modals": Object {
     "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
-      "isOpen": true,
       "loading": false,
       "result": "ERROR",
     },
@@ -16,7 +15,6 @@ exports[`ContractMethodCall: reducer method call on request 1`] = `
 Object {
   "modals": Object {
     "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
-      "isOpen": true,
       "loading": true,
       "result": undefined,
     },
@@ -28,7 +26,6 @@ exports[`ContractMethodCall: reducer method call on success 1`] = `
 Object {
   "modals": Object {
     "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
-      "isOpen": true,
       "loading": false,
       "result": Object {},
     },
@@ -39,61 +36,5 @@ Object {
 exports[`ContractMethodCall: reducer set initial state 1`] = `
 Object {
   "modals": Object {},
-}
-`;
-
-exports[`ContractMethodCall: reducer update args on failure 1`] = `
-Object {
-  "modals": Object {
-    "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
-      "error": "ERROR",
-      "isOpen": true,
-      "loading": false,
-      "result": undefined,
-    },
-  },
-}
-`;
-
-exports[`ContractMethodCall: reducer update args on success 1`] = `
-Object {
-  "modals": Object {
-    "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
-      "args": Object {
-        "_greeting": Object {
-          "dynamic": true,
-          "index": 0,
-          "type": "String",
-        },
-      },
-      "isOpen": true,
-      "isPayable": true,
-      "loading": false,
-      "result": undefined,
-    },
-  },
-}
-`;
-
-exports[`ContractMethodCall: reducer update close modal 1`] = `
-Object {
-  "modals": Object {
-    "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
-      "isOpen": false,
-      "loading": false,
-      "result": undefined,
-    },
-  },
-}
-`;
-
-exports[`ContractMethodCall: reducer update open modal 1`] = `
-Object {
-  "modals": Object {
-    "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
-      "isOpen": true,
-      "result": undefined,
-    },
-  },
 }
 `;

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/contractMethodCall.reducer.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/contractMethodCall.reducer.spec.js.snap
@@ -5,6 +5,7 @@ Object {
   "modals": Object {
     "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
       "isOpen": true,
+      "loading": false,
       "result": "ERROR",
     },
   },
@@ -16,7 +17,8 @@ Object {
   "modals": Object {
     "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
       "isOpen": true,
-      "result": "Sending transaction...",
+      "loading": true,
+      "result": undefined,
     },
   },
 }
@@ -27,6 +29,7 @@ Object {
   "modals": Object {
     "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
       "isOpen": true,
+      "loading": false,
       "result": Object {},
     },
   },
@@ -45,7 +48,8 @@ Object {
     "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
       "error": "ERROR",
       "isOpen": true,
-      "result": "Waiting for method to be called...",
+      "loading": false,
+      "result": undefined,
     },
   },
 }
@@ -64,7 +68,8 @@ Object {
       },
       "isOpen": true,
       "isPayable": true,
-      "result": "Waiting for method to be called...",
+      "loading": false,
+      "result": undefined,
     },
   },
 }
@@ -75,7 +80,8 @@ Object {
   "modals": Object {
     "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
       "isOpen": false,
-      "result": "Waiting for method to be called...",
+      "loading": false,
+      "result": undefined,
     },
   },
 }
@@ -86,7 +92,7 @@ Object {
   "modals": Object {
     "methodCallgreet8070db2390462e2b5748085bde1350590e08bb17": Object {
       "isOpen": true,
-      "result": "Waiting for method to be called...",
+      "result": undefined,
     },
   },
 }

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/index.spec.js.snap
@@ -183,18 +183,6 @@ exports[`ContractMethodCall: index renders contracts card (Oauth mode) 1`] = `
             </table>
           </div>
         </div>
-        <div className=\\"row\\">
-          <div className=\\"col-sm-12\\">
-            <hr />
-            <h5>
-              Results
-            </h5>
-            <pre className=\\"smd-scrollable\\">
-               
-              <br />
-            </pre>
-          </div>
-        </div>
       </div>
       <div className=\\"pt-dialog-footer\\">
         <div className=\\"pt-dialog-footer-actions\\">
@@ -343,18 +331,6 @@ exports[`ContractMethodCall: index renders contracts card (non Oauth mode) 1`] =
                 </tr>
               </tbody>
             </table>
-          </div>
-        </div>
-        <div className=\\"row\\">
-          <div className=\\"col-sm-12\\">
-            <hr />
-            <h5>
-              Results
-            </h5>
-            <pre className=\\"smd-scrollable\\">
-               
-              <br />
-            </pre>
           </div>
         </div>
       </div>

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/__snapshots__/index.spec.js.snap
@@ -85,7 +85,8 @@ Object {
     "936986d54af89e2fa3c4888563856940d8f80cd5c1d01c386bd98207d29ae1e9": Object {},
     "ab1696d5f6a36836f0bd23d96918cce4f78b3667518d70e721914f391142a5e1": Object {},
   },
-  "modal": Object {},
+  "contractInfo": Object {},
+  "methodCallModal": Object {},
   "modalUsername": undefined,
   "oAuthUser": undefined,
   "selectedChain": undefined,
@@ -96,10 +97,10 @@ Object {
 exports[`ContractMethodCall: index renders contracts card (Oauth mode) 1`] = `
 "<div>
   <Blueprint.Popover isDisabled={false} interactionKind={2} position={10} content={{...}} arrowSize={30} className=\\"\\" defaultIsOpen={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} inline={false} isModal={false} openOnTargetFocus={true} popoverClassName=\\"\\" rootElementTag=\\"span\\" transitionDuration={300} useSmartArrowPositioning={true} useSmartPositioning={false}>
-    <Blueprint.AnchorButton className=\\"pt-intent-primary pt-icon-send-to-graph\\" onClick={[Function: onClick]} disabled={true} text={[undefined]} />
+    <Blueprint.AnchorButton className=\\"pt-intent-primary pt-icon-send-to-graph\\" onClick={[Function: onClick]} disabled={true} text=\\"setX\\" />
   </Blueprint.Popover>
   <form>
-    <Blueprint.Dialog iconName=\\"exchange\\" isOpen={false} onClose={[Function]} title=\\"Call \\\\'undefined\\\\' on undefined\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
+    <Blueprint.Dialog iconName=\\"exchange\\" isOpen={false} onClose={[Function]} title=\\"Call \\\\'setX\\\\' on undefined\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
       <div className=\\"pt-dialog-body\\">
         <div className=\\"row\\">
           <div className=\\"col-sm-3 text-right\\">
@@ -127,7 +128,7 @@ exports[`ContractMethodCall: index renders contracts card (Oauth mode) 1`] = `
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
             <div className=\\"\\">
-              <Field className=\\"pt-input\\" name=\\"modalUsername\\" component=\\"select\\" onChange={[Function]} disabled={true} required={true}>
+              <Field className=\\"pt-input\\" name=\\"modalUsername\\" component=\\"select\\" disabled={true} required={true}>
                 <option value=\\"Verification Pending\\">
                   Verification Pending
                 </option>
@@ -142,7 +143,7 @@ exports[`ContractMethodCall: index renders contracts card (Oauth mode) 1`] = `
             </label>
           </div>
           <div className=\\"col-sm-9 smd-pad-4\\">
-            <div className=\\"\\">
+            <div className=\\"pt-select\\">
               <Field className=\\"pt-input\\" component=\\"select\\" name=\\"modalAddress\\" disabled={true} required={true}>
                 <option value=\\"Verification Pending\\">
                   Verification Pending
@@ -152,6 +153,32 @@ exports[`ContractMethodCall: index renders contracts card (Oauth mode) 1`] = `
           </div>
         </div>
         <div className=\\"row\\">
+          <div className=\\"col-sm-9\\">
+            <Blueprint.Button onClick={[Function: onClick]}>
+              Show Function Source Code
+            </Blueprint.Button>
+          </div>
+        </div>
+        <div className=\\"row smd-margin-4\\">
+          <div className=\\"col-sm-12\\">
+            <Blueprint.Collapse isOpen={false} component=\\"div\\" keepChildrenMounted={false} transitionDuration={200}>
+              <pre>
+                function 
+                setX
+                (int a)
+                 
+                 {
+                
+                	
+                Error loading function body
+                
+                
+                }
+              </pre>
+            </Blueprint.Collapse>
+          </div>
+        </div>
+        <div className=\\"row\\">
           <div className=\\"col-sm-12\\">
             <h5>
               Parameters
@@ -173,160 +200,11 @@ exports[`ContractMethodCall: index renders contracts card (Oauth mode) 1`] = `
               </thead>
               <tbody>
                 <tr>
-                  <td className=\\"text-center\\" colSpan={3}>
-                    <i>
-                      This method has no params
-                    </i>
+                  <td style={{...}}>
+                    a
                   </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-      <div className=\\"pt-dialog-footer\\">
-        <div className=\\"pt-dialog-footer-actions\\">
-          <Blueprint.Button text=\\"Cancel\\" onClick={[Function]} />
-          <button className=\\"pt-button pt-intent-primary\\" type=\\"button\\" onClick={[Function]}>
-            Call Method
-          </button>
-        </div>
-      </div>
-    </Blueprint.Dialog>
-  </form>
-</div>"
-`;
-
-exports[`ContractMethodCall: index renders contracts card (non Oauth mode) 1`] = `
-"<div>
-  <Blueprint.Popover isDisabled={false} interactionKind={2} position={10} content={{...}} arrowSize={30} className=\\"\\" defaultIsOpen={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} inline={false} isModal={false} openOnTargetFocus={true} popoverClassName=\\"\\" rootElementTag=\\"span\\" transitionDuration={300} useSmartArrowPositioning={true} useSmartPositioning={false}>
-    <Blueprint.AnchorButton className=\\"pt-intent-primary pt-icon-send-to-graph\\" onClick={[Function: onClick]} disabled={true} text={[undefined]} />
-  </Blueprint.Popover>
-  <form>
-    <Blueprint.Dialog iconName=\\"exchange\\" isOpen={false} onClose={[Function]} title=\\"Call \\\\'undefined\\\\' on undefined\\" className=\\"pt-dark\\" canOutsideClickClose={true}>
-      <div className=\\"pt-dialog-body\\">
-        <div className=\\"row\\">
-          <div className=\\"col-sm-3 text-right\\">
-            <label className=\\"pt-label smd-pad-4\\">
-              Contract Address
-            </label>
-          </div>
-          <div className=\\"col-sm-9 smd-pad-4\\" />
-        </div>
-        <div className=\\"row\\">
-          <div className=\\"col-sm-3 text-right\\">
-            <label className=\\"pt-label smd-pad-4\\">
-              Shard
-            </label>
-          </div>
-          <div className=\\"col-sm-9 smd-pad-4\\">
-            Main Chain
-          </div>
-        </div>
-        <div className=\\"row\\">
-          <div className=\\"col-sm-3 text-right\\">
-            <label className=\\"pt-label label-margin\\">
-              Name
-            </label>
-          </div>
-          <div className=\\"col-sm-9 smd-pad-4\\">
-            <div className=\\"pt-select\\">
-              <Field className=\\"pt-input\\" name=\\"modalUsername\\" component=\\"select\\" onChange={[Function]} disabled={false} required={true}>
-                <option value=\\"Verification Pending\\">
-                  Verification Pending
-                </option>
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-                <option value={[undefined]} />
-              </Field>
-            </div>
-          </div>
-        </div>
-        <div className=\\"row\\">
-          <div className=\\"col-sm-3 text-right\\">
-            <label className=\\"pt-label label-margin\\">
-              Caller Address
-            </label>
-          </div>
-          <div className=\\"col-sm-9 smd-pad-4\\">
-            <div className=\\"pt-select\\">
-              <Field className=\\"pt-input\\" component=\\"select\\" name=\\"modalAddress\\" disabled={false} required={true}>
-                <option value=\\"Verification Pending\\">
-                  Verification Pending
-                </option>
-                <option value={[undefined]} />
-              </Field>
-            </div>
-          </div>
-        </div>
-        <div className=\\"row\\">
-          <div className=\\"col-sm-3 text-right\\">
-            <label className=\\"pt-label label-margin\\">
-              Password
-            </label>
-          </div>
-          <div className=\\"col-sm-9 smd-pad-4\\">
-            <Field name=\\"modalPassword\\" className=\\"pt-input\\" placeholder=\\"Password\\" component=\\"input\\" type=\\"password\\" required={true} />
-          </div>
-        </div>
-        <div className=\\"row\\">
-          <div className=\\"col-sm-3 text-right\\">
-            <label className=\\"pt-label label-margin\\">
-              Value
-            </label>
-          </div>
-          <div className=\\"col-sm-9 smd-pad-4\\">
-            <Field name=\\"modalValue\\" component={[Function: ValueInput]} />
-          </div>
-        </div>
-        <div className=\\"row\\">
-          <div className=\\"col-sm-12\\">
-            <h5>
-              Parameters
-            </h5>
-          </div>
-        </div>
-        <div className=\\"row\\">
-          <div className=\\"col-sm-12 smd-scrollable\\">
-            <table className=\\"pt-table pt-condensed pt-striped smd-full-width\\">
-              <thead>
-                <tr>
-                  <th>
-                    Name
-                  </th>
-                  <th>
-                    Value
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td className=\\"text-center\\" colSpan={3}>
-                    <i>
-                      This method has no params
-                    </i>
+                  <td>
+                    <Field name=\\"a\\" component=\\"input\\" type=\\"text\\" placeholder=\\"int\\" className=\\"pt-input\\" required={true} />
                   </td>
                 </tr>
               </tbody>

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCall.actions.spec.js
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCall.actions.spec.js
@@ -12,29 +12,6 @@ import { modals } from './contractMethodCallMock';
 
 describe('ContractMethodCall: action', () => {
 
-  test('open model with contract key', () => {
-    expect(methodCallOpenModal(modals.key)).toMatchSnapshot();
-  });
-
-  test('close model with contract key', () => {
-    expect(methodCallCloseModal(modals.key)).toMatchSnapshot();
-  });
-
-  describe('fetch arguments', () => {
-
-    test('request', () => {
-      expect(methodCallFetchArgs(modals.name, modals.address, modals.symbol, modals.key, modals.chainId)).toMatchSnapshot();
-    });
-
-    test('success', () => {
-      expect(methodCallFetchArgsSuccess(modals.key, modals.args, modals.isPayable)).toMatchSnapshot();
-    });
-
-    test('failure', () => {
-      expect(methodCallFetchArgsFailure(modals.key, modals.error)).toMatchSnapshot();
-    });
-
-  })
 
   describe('method call', () => {
 

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCall.reducer.spec.js
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCall.reducer.spec.js
@@ -1,9 +1,5 @@
 import reducer from '../../../../components/Contracts/components/ContractMethodCall/contractMethodCall.reducer';
 import {
-  methodCallOpenModal,
-  methodCallCloseModal,
-  methodCallFetchArgsFailure,
-  methodCallFetchArgsSuccess,
   methodCall,
   methodCallSuccess,
   methodCallFailure
@@ -17,33 +13,6 @@ describe('ContractMethodCall: reducer', () => {
     expect(reducer(undefined, {})).toMatchSnapshot();
   });
 
-  // METHOD_CALL_OPEN_MODAL
-  test('update open modal', () => {
-    const action = methodCallOpenModal(modals.key);
-    expect(reducer({ modals: {} }, action)).toMatchSnapshot();
-  });
-
-  // METHOD_CALL_CLOSE_MODAL
-  test('update close modal', () => {
-    const action = methodCallCloseModal(modals.key);
-    expect(reducer(initialState, action)).toMatchSnapshot();
-  });
-
-  describe('update args', () => {
-
-    // METHOD_CALL_FETCH_ARGS_SUCCESS
-    test('on success', () => {
-      const action = methodCallFetchArgsSuccess(modals.key, modals.args, modals.isPayable);
-      expect(reducer(initialState, action)).toMatchSnapshot();
-    });
-
-    // METHOD_CALL_FETCH_ARGS_FAILURE
-    test('on failure', () => {
-      const action = methodCallFetchArgsFailure(modals.key, modals.error);
-      expect(reducer(initialState, action)).toMatchSnapshot();
-    });
-
-  })
 
   describe('method call', () => {
 

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCall.saga.spec.js
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCall.saga.spec.js
@@ -16,60 +16,13 @@ import {
   methodCallSuccess,
   METHOD_CALL_FETCH_ARGS_REQUEST,
   METHOD_CALL_REQUEST,
-  METHOD_CALL_FETCH_ARGS_SUCCESS,
-  METHOD_CALL_FETCH_ARGS_FAILURE,
-  methodCallFetchArgsSuccess,
-  METHOD_CALL_SUCCESS
-
 } from '../../../../components/Contracts/components/ContractMethodCall/contractMethodCall.actions';
 import { expectSaga } from 'redux-saga-test-plan';
 import { methodCallArgs } from './contractMethodCallMock'
 
-describe('ContractCard: saga', () => {
+describe('ContractMethodCall: saga', () => {
 
-  test('watch contract args', () => {
-    const gen = watchFetchArgs();
-    expect(gen.next().value).toEqual(takeEvery(METHOD_CALL_FETCH_ARGS_REQUEST, fetchArgs))
-  })
-
-  describe('fetch args', () => {
-
-    test('success', () => {
-      fetch.mockResponse(JSON.stringify(methodCallArgs))
-      expectSaga(fetchArgs, {
-        name: 'abc',
-        address: 'xyz',
-        symbol: 'geneticallyModify',
-        key: 'key'
-      })
-        .call.fn(getArgs, 'Cloner', 'eb58f377c7d419e9945b5096cd478b6a7eef9831', 'geneticallyModify').put.like({ action: { type: 'METHOD_CALL_FETCH_ARGS_SUCCESS' } })
-        .run()
-    });
-
-    test('failure', () => {
-      fetch.mockReject(JSON.stringify(methodCallArgs))
-      expectSaga(fetchArgs, {
-        name: 'abc',
-        address: 'xyz',
-        symbol: 'geneticallyModify',
-        key: 'key'
-      })
-        .call.fn(getArgs, 'Cloner', 'eb58f377c7d419e9945b5096cd478b6a7eef9831', 'geneticallyModify').put.like({ action: { type: 'METHOD_CALL_FETCH_ARGS_FAILURE' } })
-        .run()
-    });
-
-    test('exception', () => {
-      expectSaga(fetchArgs, 'Cloner', 'eb58f377c7d419e9945b5096cd478b6a7eef9831', 'cloneSheep')
-        .provide({
-          call() {
-            throw new Error('Not Found');
-          },
-        })
-        .put.like({ action: { type: 'METHOD_CALL_FETCH_ARGS_FAILURE' } })
-        .run();
-    });
-
-  })
+  
 
   test('watch states', () => {
     const gen = watchMethodCall();

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCallMock.js
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCallMock.js
@@ -57,7 +57,6 @@ export const modals = {
 export const initialState = {
   modals: {
     methodCallgreet8070db2390462e2b5748085bde1350590e08bb17: {
-      isOpen: true,
       result: undefined,
       loading: false,
     }
@@ -72,6 +71,7 @@ export const methodCallArgs = {
           _dna: {
             dynamic: true,
             type: "String",
+            tag: "String",
             index: 0
           }
         }

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCallMock.js
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/contractMethodCallMock.js
@@ -20,10 +20,36 @@ export const modals = {
     userAddress: "76a3192ce9aa0531fe7e0e3489a469018c0bff03",
     username: "tanuj"
   },
-  result: {
-    status: "Success",
-    hash: "8f6fcd037e028f84ec2e9462c4e29444cd3456c8bc8705723f0c36d075c14c5d"
-  },
+  result: [{
+    "data": {
+        "contents": [
+            "200"
+        ],
+        "tag": "Call"
+    },
+    "hash": "31bcbc86cb6fdd273443406ae27906485fccc8475b269de04878d9b797c0f47e",
+    "status": "Success",
+    "txResult": {
+        "appName": "",
+        "blockHash": "36d2629fb5ef27457eb70a87cd886284d0ac7c197f7b3eaf1102edbb8e3518b1",
+        "chainId": null,
+        "contractsCreated": "",
+        "contractsDeleted": "",
+        "deletedStorage": "",
+        "etherUsed": "0000000000000000000000000000000000000000000000000000000005f5e100",
+        "gasUsed": "0000000000000000000000000000000000000000000000000000000005f5e100",
+        "kind": "SolidVM",
+        "message": "Success!",
+        "newStorage": "",
+        "orgName": "Blockapps",
+        "response": "(200)",
+        "stateDiff": "",
+        "status": "success",
+        "time": 1.361853e-3,
+        "trace": "",
+        "transactionHash": "31bcbc86cb6fdd273443406ae27906485fccc8475b269de04878d9b797c0f47e"
+    }
+}],
   chainId: '1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14',
   isPayable: true
 }
@@ -32,7 +58,8 @@ export const initialState = {
   modals: {
     methodCallgreet8070db2390462e2b5748085bde1350590e08bb17: {
       isOpen: true,
-      result: 'Waiting for method to be called...'
+      result: undefined,
+      loading: false,
     }
   }
 };

--- a/smd-ui/src/tests/Contracts/component/ContractMethodCall/index.spec.js
+++ b/smd-ui/src/tests/Contracts/component/ContractMethodCall/index.spec.js
@@ -15,43 +15,27 @@ describe('ContractMethodCall: index', () => {
     store = createStore(combineReducers({ form: formReducer }))
   })
 
-  test('renders contracts card (non Oauth mode)', () => {
-    const props = {
-      modal: {
-        isPayable: true
-      },
-      accounts: indexAccountsMock,
-      modalUsername: 'Buyer1',
-      oAuthUser: {
-        "id": '',
-        "username": '',
-        "address": ''
-      },
-      chainLabel: chain,
-      chainLabelIds: chain["airline cartel 9"],
-      fetchChainIds: jest.fn(),
-      getLabelIds: jest.fn(),
-      methodCallFetchArgs: jest.fn(),
-      methodCallOpenModal: jest.fn(),
-      methodCallCloseModal: jest.fn(),
-      fetchAccounts: jest.fn(),
-      methodCall: jest.fn(),
-      store: store
-    }
-
-    checkMode.isOauthEnabled = jest.fn().mockReturnValue(false);
-
-    const wrapper = shallow(
-      <ContractMethodCall.WrappedComponent {...props} />
-    ).dive().dive().dive();
-
-    expect(wrapper.debug()).toMatchSnapshot();
-  });
 
   test('renders contracts card (Oauth mode)', () => {
     const props = {
-      modal: {
+      methodCallModal: {
         isPayable: false
+      },
+      contractInfo: {
+        bin: 'contract Foo {}',
+        xabi: {
+          funcs: {
+            'setX': {
+              args: {
+                a: {
+                  type:'int',
+                  tag: 'Int'
+                }
+              }
+            },
+          }
+        },
+        address: "f114257cb370ad0e0025eedf0a96261b51af23e3",
       },
       accounts: {},
       modalUsername: 'Buyer1',
@@ -62,11 +46,11 @@ describe('ContractMethodCall: index', () => {
         "username": 'Supplier1',
         "address": '370adf114257cb0e0025eedf0a96261b51af23e3'
       },
+      symbolName: 'setX',
+      contractKey: 'card-data-f114257cb370ad0e0025eedf0a96261b51af23e3-',
+      methodKey: 'methodCall-f114257cb370ad0e0025eedf0a96261b51af23e3-',
       fetchChainIds: jest.fn(),
       getLabelIds: jest.fn(),
-      methodCallFetchArgs: jest.fn(),
-      methodCallOpenModal: jest.fn(),
-      methodCallCloseModal: jest.fn(),
       fetchAccounts: jest.fn(),
       methodCall: jest.fn(),
       store: store
@@ -84,8 +68,31 @@ describe('ContractMethodCall: index', () => {
   test('mapStateToProps with default values', () => {
     const state = {
       methodCall: {
-        modals: undefined
+        methodCallModal: {
+          isPayable: false
+        },
       },
+      symbolName: 'setX',
+      contractInfo: {
+        bin: 'contract Foo {}',
+        xabi: {
+          funcs: {
+            'setX': {
+              args: {
+                a: {
+                  type:'int',
+                  tag: 'Int'
+                }
+              }
+            },
+          }
+        },
+        address: "f114257cb370ad0e0025eedf0a96261b51af23e3",
+      },
+      contractCard: {
+        contractInfos: {}
+      },
+      contractKey: 'card-data-f114257cb370ad0e0025eedf0a96261b51af23e3-',
       chains: {
         listChain: chain,
         listLabelIds: chain["airline cartel 9"]
@@ -106,70 +113,30 @@ describe('ContractMethodCall: index', () => {
     expect(mapStateToProps(state, 'methodCallgreetf62c8965f2129d178aa28c043f9b3d0cd52f9e2e')).toMatchSnapshot();
   });
 
-  test('open modal', () => {
-    const props = {
-      modal: modals,
-      accounts: indexAccountsMock,
-      modalUsername: 'Buyer1',
-      oAuthUser: {
-        "id": 6,
-        "username": "tanuj41",
-        "address": "86ee0c9644611495c0a1b1074e40d4e6db2f6b26"
-      },
-      chainLabel: chain,
-      chainLabelIds: chain["airline cartel 9"],
-      fetchChainIds: jest.fn(),
-      getLabelIds: jest.fn(),
-      methodCallFetchArgs: jest.fn(),
-      methodCallOpenModal: jest.fn(),
-      methodCallCloseModal: jest.fn(),
-      fetchAccounts: jest.fn(),
-      methodCall: jest.fn(),
-      userCertificate: { userAddress: "345678"},
-    }
-    const wrapper = mount(
-      <Provider store={store}>
-        <ContractMethodCall.WrappedComponent {...props} />
-      </Provider>
-    );
-    wrapper.find('AnchorButton').simulate('click');
-    expect(props.methodCallOpenModal).toHaveBeenCalled();
-  });
-
-  test('modal close', () => {
-    const props = {
-      modal: modals,
-      accounts: indexAccountsMock,
-      modalUsername: 'Buyer1',
-      oAuthUser: {
-        "id": 6,
-        "username": "tanuj41",
-        "address": "86ee0c9644611495c0a1b1074e40d4e6db2f6b26"
-      },
-      chainLabel: chain,
-      chainLabelIds: chain["airline cartel 9"],
-      fetchChainIds: jest.fn(),
-      getLabelIds: jest.fn(),
-      methodCallFetchArgs: jest.fn(),
-      methodCallOpenModal: jest.fn(),
-      methodCallCloseModal: jest.fn(),
-      fetchAccounts: jest.fn(),
-      methodCall: jest.fn(),
-      store: store,
-      userCertificate: { userAddress: "567890"}
-    }
-    const wrapper = shallow(
-      <Provider store={store}>
-        <ContractMethodCall.WrappedComponent {...props} />
-      </Provider>
-    ).dive().dive().dive().dive();
-    wrapper.find('Button').at(0).simulate('click', { preventDefault() { }, stopPropagation() { } })
-    expect(props.methodCallCloseModal).toHaveBeenCalled();
-  });
-
   test('simulate submit form', () => {
     const props = {
-      modal: modals,
+      methodCallModal: modals,
+      contractInfo: {
+
+      },
+      contractInfo: {
+        bin: 'contract Foo {}',
+        xabi: {
+          funcs: {
+            'setX': {
+              args: {
+                a: {
+                  type:'int',
+                  tag: 'Int'
+                }
+              }
+            },
+          }
+        },
+        address: "f114257cb370ad0e0025eedf0a96261b51af23e3",
+      },
+      symbolName: 'setX',
+      contractKey: 'card-data-f114257cb370ad0e0025eedf0a96261b51af23e3-',
       accounts: indexAccountsMock,
       modalUsername: 'Buyer1',
       oAuthUser: {
@@ -181,9 +148,6 @@ describe('ContractMethodCall: index', () => {
       chainLabelIds: chain["airline cartel 9"],
       fetchChainIds: jest.fn(),
       getLabelIds: jest.fn(),
-      methodCallFetchArgs: jest.fn(),
-      methodCallOpenModal: jest.fn(),
-      methodCallCloseModal: jest.fn(),
       fetchAccounts: jest.fn(),
       methodCall: jest.fn(),
       store: store

--- a/smd-ui/src/tests/Transactions/components/TransactionView/__snapshots__/index.spec.js.snap
+++ b/smd-ui/src/tests/Transactions/components/TransactionView/__snapshots__/index.spec.js.snap
@@ -8,6 +8,7 @@ Object {
   "selectedChain": "1c8792a7e43d132487500936d946f510e7ff51635838060757bf886828403a14",
   "tx": undefined,
   "txResult": undefined,
+  "txResultMessage": undefined,
 }
 `;
 
@@ -35,6 +36,7 @@ Object {
     "value": "0",
   },
   "txResult": undefined,
+  "txResultMessage": undefined,
 }
 `;
 
@@ -129,7 +131,7 @@ ShallowWrapper {
             className="col-sm-12"
           >
             <div
-              className="pt-card"
+              className="pt-card pt-callout "
             >
               <table
                 className="pt-table pt-str"
@@ -145,6 +147,26 @@ ShallowWrapper {
                   </tr>
                 </thead>
                 <tbody>
+                  <tr>
+                    <td>
+                      <strong>
+                        Result
+                      </strong>
+                    </td>
+                    <td>
+                      success
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
+                        Type
+                      </strong>
+                    </td>
+                    <td>
+                      Contract
+                    </td>
+                  </tr>
                   <tr>
                     <td>
                       <strong>
@@ -179,16 +201,6 @@ ShallowWrapper {
                     </td>
                     <td>
                       0
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <strong>
-                        Result
-                      </strong>
-                    </td>
-                    <td>
-                      success
                     </td>
                   </tr>
                   <tr>
@@ -263,7 +275,7 @@ ShallowWrapper {
           </div>
         </div>,
       ],
-      "className": "container-fluid pt-dark",
+      "className": "container-fluid pt-dark ",
     },
     "ref": null,
     "rendered": Array [
@@ -387,7 +399,7 @@ ShallowWrapper {
             className="col-sm-12"
           >
             <div
-              className="pt-card"
+              className="pt-card pt-callout "
             >
               <table
                 className="pt-table pt-str"
@@ -403,6 +415,26 @@ ShallowWrapper {
                   </tr>
                 </thead>
                 <tbody>
+                  <tr>
+                    <td>
+                      <strong>
+                        Result
+                      </strong>
+                    </td>
+                    <td>
+                      success
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
+                        Type
+                      </strong>
+                    </td>
+                    <td>
+                      Contract
+                    </td>
+                  </tr>
                   <tr>
                     <td>
                       <strong>
@@ -437,16 +469,6 @@ ShallowWrapper {
                     </td>
                     <td>
                       0
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <strong>
-                        Result
-                      </strong>
-                    </td>
-                    <td>
-                      success
                     </td>
                   </tr>
                   <tr>
@@ -528,7 +550,7 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": <div
-              className="pt-card"
+              className="pt-card pt-callout "
             >
               <table
                 className="pt-table pt-str"
@@ -544,6 +566,26 @@ ShallowWrapper {
                   </tr>
                 </thead>
                 <tbody>
+                  <tr>
+                    <td>
+                      <strong>
+                        Result
+                      </strong>
+                    </td>
+                    <td>
+                      success
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
+                        Type
+                      </strong>
+                    </td>
+                    <td>
+                      Contract
+                    </td>
+                  </tr>
                   <tr>
                     <td>
                       <strong>
@@ -578,16 +620,6 @@ ShallowWrapper {
                     </td>
                     <td>
                       0
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <strong>
-                        Result
-                      </strong>
-                    </td>
-                    <td>
-                      success
                     </td>
                   </tr>
                   <tr>
@@ -684,6 +716,26 @@ ShallowWrapper {
                   <tr>
                     <td>
                       <strong>
+                        Result
+                      </strong>
+                    </td>
+                    <td>
+                      success
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
+                        Type
+                      </strong>
+                    </td>
+                    <td>
+                      Contract
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
                         From
                       </strong>
                     </td>
@@ -715,16 +767,6 @@ ShallowWrapper {
                     </td>
                     <td>
                       0
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <strong>
-                        Result
-                      </strong>
-                    </td>
-                    <td>
-                      success
                     </td>
                   </tr>
                   <tr>
@@ -795,7 +837,7 @@ ShallowWrapper {
                   </tr>
                 </tbody>
               </table>,
-              "className": "pt-card",
+              "className": "pt-card pt-callout ",
             },
             "ref": null,
             "rendered": Object {
@@ -815,6 +857,26 @@ ShallowWrapper {
                     </tr>
                   </thead>,
                   <tbody>
+                    <tr>
+                      <td>
+                        <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Contract
+                      </td>
+                    </tr>
                     <tr>
                       <td>
                         <strong>
@@ -849,16 +911,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         0
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -1000,6 +1052,27 @@ ShallowWrapper {
                       <tr>
                         <td>
                           <strong>
+                            Result
+                          </strong>
+                        </td>
+                        <td>
+                          success
+                        </td>
+                      </tr>,
+                      false,
+                      <tr>
+                        <td>
+                          <strong>
+                            Type
+                          </strong>
+                        </td>
+                        <td>
+                          Contract
+                        </td>
+                      </tr>,
+                      <tr>
+                        <td>
+                          <strong>
                             From
                           </strong>
                         </td>
@@ -1023,6 +1096,10 @@ ShallowWrapper {
                           />
                         </td>
                       </tr>,
+                      undefined,
+                      undefined,
+                      undefined,
+                      undefined,
                       <tr>
                         <td>
                           <strong>
@@ -1031,16 +1108,6 @@ ShallowWrapper {
                         </td>
                         <td>
                           0
-                        </td>
-                      </tr>,
-                      <tr>
-                        <td>
-                          <strong>
-                            Result
-                          </strong>
-                        </td>
-                        <td>
-                          success
                         </td>
                       </tr>,
                       <tr>
@@ -1113,6 +1180,117 @@ ShallowWrapper {
                   },
                   "ref": null,
                   "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <td>
+                            <strong>
+                              Result
+                            </strong>
+                          </td>,
+                          <td>
+                            success
+                          </td>,
+                        ],
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <strong>
+                              Result
+                            </strong>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Result",
+                            },
+                            "ref": null,
+                            "rendered": "Result",
+                            "type": "strong",
+                          },
+                          "type": "td",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": "success",
+                          },
+                          "ref": null,
+                          "rendered": "success",
+                          "type": "td",
+                        },
+                      ],
+                      "type": "tr",
+                    },
+                    false,
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <td>
+                            <strong>
+                              Type
+                            </strong>
+                          </td>,
+                          <td>
+                            Contract
+                          </td>,
+                        ],
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <strong>
+                              Type
+                            </strong>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Type",
+                            },
+                            "ref": null,
+                            "rendered": "Type",
+                            "type": "strong",
+                          },
+                          "type": "td",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": "Contract",
+                          },
+                          "ref": null,
+                          "rendered": "Contract",
+                          "type": "td",
+                        },
+                      ],
+                      "type": "tr",
+                    },
                     Object {
                       "instance": null,
                       "key": undefined,
@@ -1257,6 +1435,10 @@ ShallowWrapper {
                       ],
                       "type": "tr",
                     },
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
                     Object {
                       "instance": null,
                       "key": undefined,
@@ -1307,61 +1489,6 @@ ShallowWrapper {
                           },
                           "ref": null,
                           "rendered": "0",
-                          "type": "td",
-                        },
-                      ],
-                      "type": "tr",
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": Array [
-                          <td>
-                            <strong>
-                              Result
-                            </strong>
-                          </td>,
-                          <td>
-                            success
-                          </td>,
-                        ],
-                      },
-                      "ref": null,
-                      "rendered": Array [
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": <strong>
-                              Result
-                            </strong>,
-                          },
-                          "ref": null,
-                          "rendered": Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "host",
-                            "props": Object {
-                              "children": "Result",
-                            },
-                            "ref": null,
-                            "rendered": "Result",
-                            "type": "strong",
-                          },
-                          "type": "td",
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": "success",
-                          },
-                          "ref": null,
-                          "rendered": "success",
                           "type": "td",
                         },
                       ],
@@ -1786,7 +1913,7 @@ ShallowWrapper {
               className="col-sm-12"
             >
               <div
-                className="pt-card"
+                className="pt-card pt-callout "
               >
                 <table
                   className="pt-table pt-str"
@@ -1802,6 +1929,26 @@ ShallowWrapper {
                     </tr>
                   </thead>
                   <tbody>
+                    <tr>
+                      <td>
+                        <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Contract
+                      </td>
+                    </tr>
                     <tr>
                       <td>
                         <strong>
@@ -1836,16 +1983,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         0
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -1920,7 +2057,7 @@ ShallowWrapper {
             </div>
           </div>,
         ],
-        "className": "container-fluid pt-dark",
+        "className": "container-fluid pt-dark ",
       },
       "ref": null,
       "rendered": Array [
@@ -2044,7 +2181,7 @@ ShallowWrapper {
               className="col-sm-12"
             >
               <div
-                className="pt-card"
+                className="pt-card pt-callout "
               >
                 <table
                   className="pt-table pt-str"
@@ -2060,6 +2197,26 @@ ShallowWrapper {
                     </tr>
                   </thead>
                   <tbody>
+                    <tr>
+                      <td>
+                        <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Contract
+                      </td>
+                    </tr>
                     <tr>
                       <td>
                         <strong>
@@ -2094,16 +2251,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         0
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -2185,7 +2332,7 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <div
-                className="pt-card"
+                className="pt-card pt-callout "
               >
                 <table
                   className="pt-table pt-str"
@@ -2201,6 +2348,26 @@ ShallowWrapper {
                     </tr>
                   </thead>
                   <tbody>
+                    <tr>
+                      <td>
+                        <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Contract
+                      </td>
+                    </tr>
                     <tr>
                       <td>
                         <strong>
@@ -2235,16 +2402,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         0
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -2341,6 +2498,26 @@ ShallowWrapper {
                     <tr>
                       <td>
                         <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Contract
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
                           From
                         </strong>
                       </td>
@@ -2372,16 +2549,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         0
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -2452,7 +2619,7 @@ ShallowWrapper {
                     </tr>
                   </tbody>
                 </table>,
-                "className": "pt-card",
+                "className": "pt-card pt-callout ",
               },
               "ref": null,
               "rendered": Object {
@@ -2472,6 +2639,26 @@ ShallowWrapper {
                       </tr>
                     </thead>,
                     <tbody>
+                      <tr>
+                        <td>
+                          <strong>
+                            Result
+                          </strong>
+                        </td>
+                        <td>
+                          success
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <strong>
+                            Type
+                          </strong>
+                        </td>
+                        <td>
+                          Contract
+                        </td>
+                      </tr>
                       <tr>
                         <td>
                           <strong>
@@ -2506,16 +2693,6 @@ ShallowWrapper {
                         </td>
                         <td>
                           0
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>
-                          <strong>
-                            Result
-                          </strong>
-                        </td>
-                        <td>
-                          success
                         </td>
                       </tr>
                       <tr>
@@ -2657,6 +2834,27 @@ ShallowWrapper {
                         <tr>
                           <td>
                             <strong>
+                              Result
+                            </strong>
+                          </td>
+                          <td>
+                            success
+                          </td>
+                        </tr>,
+                        false,
+                        <tr>
+                          <td>
+                            <strong>
+                              Type
+                            </strong>
+                          </td>
+                          <td>
+                            Contract
+                          </td>
+                        </tr>,
+                        <tr>
+                          <td>
+                            <strong>
                               From
                             </strong>
                           </td>
@@ -2680,6 +2878,10 @@ ShallowWrapper {
                             />
                           </td>
                         </tr>,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
                         <tr>
                           <td>
                             <strong>
@@ -2688,16 +2890,6 @@ ShallowWrapper {
                           </td>
                           <td>
                             0
-                          </td>
-                        </tr>,
-                        <tr>
-                          <td>
-                            <strong>
-                              Result
-                            </strong>
-                          </td>
-                          <td>
-                            success
                           </td>
                         </tr>,
                         <tr>
@@ -2770,6 +2962,117 @@ ShallowWrapper {
                     },
                     "ref": null,
                     "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": Array [
+                            <td>
+                              <strong>
+                                Result
+                              </strong>
+                            </td>,
+                            <td>
+                              success
+                            </td>,
+                          ],
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <strong>
+                                Result
+                              </strong>,
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "Result",
+                              },
+                              "ref": null,
+                              "rendered": "Result",
+                              "type": "strong",
+                            },
+                            "type": "td",
+                          },
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "success",
+                            },
+                            "ref": null,
+                            "rendered": "success",
+                            "type": "td",
+                          },
+                        ],
+                        "type": "tr",
+                      },
+                      false,
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": Array [
+                            <td>
+                              <strong>
+                                Type
+                              </strong>
+                            </td>,
+                            <td>
+                              Contract
+                            </td>,
+                          ],
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <strong>
+                                Type
+                              </strong>,
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "Type",
+                              },
+                              "ref": null,
+                              "rendered": "Type",
+                              "type": "strong",
+                            },
+                            "type": "td",
+                          },
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Contract",
+                            },
+                            "ref": null,
+                            "rendered": "Contract",
+                            "type": "td",
+                          },
+                        ],
+                        "type": "tr",
+                      },
                       Object {
                         "instance": null,
                         "key": undefined,
@@ -2914,6 +3217,10 @@ ShallowWrapper {
                         ],
                         "type": "tr",
                       },
+                      undefined,
+                      undefined,
+                      undefined,
+                      undefined,
                       Object {
                         "instance": null,
                         "key": undefined,
@@ -2964,61 +3271,6 @@ ShallowWrapper {
                             },
                             "ref": null,
                             "rendered": "0",
-                            "type": "td",
-                          },
-                        ],
-                        "type": "tr",
-                      },
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": Array [
-                            <td>
-                              <strong>
-                                Result
-                              </strong>
-                            </td>,
-                            <td>
-                              success
-                            </td>,
-                          ],
-                        },
-                        "ref": null,
-                        "rendered": Array [
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "host",
-                            "props": Object {
-                              "children": <strong>
-                                Result
-                              </strong>,
-                            },
-                            "ref": null,
-                            "rendered": Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": "Result",
-                              },
-                              "ref": null,
-                              "rendered": "Result",
-                              "type": "strong",
-                            },
-                            "type": "td",
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "host",
-                            "props": Object {
-                              "children": "success",
-                            },
-                            "ref": null,
-                            "rendered": "success",
                             "type": "td",
                           },
                         ],
@@ -3490,7 +3742,7 @@ ShallowWrapper {
             className="col-sm-12"
           >
             <div
-              className="pt-card"
+              className="pt-card pt-callout "
             >
               <table
                 className="pt-table pt-str"
@@ -3509,6 +3761,26 @@ ShallowWrapper {
                   <tr>
                     <td>
                       <strong>
+                        Result
+                      </strong>
+                    </td>
+                    <td>
+                      success
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
+                        Type
+                      </strong>
+                    </td>
+                    <td>
+                      Unknown TX Type
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
                         From
                       </strong>
                     </td>
@@ -3524,16 +3796,6 @@ ShallowWrapper {
                     </td>
                     <td>
                       
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <strong>
-                        Result
-                      </strong>
-                    </td>
-                    <td>
-                      success
                     </td>
                   </tr>
                   <tr>
@@ -3602,7 +3864,7 @@ ShallowWrapper {
           </div>
         </div>,
       ],
-      "className": "container-fluid pt-dark",
+      "className": "container-fluid pt-dark ",
     },
     "ref": null,
     "rendered": Array [
@@ -3726,7 +3988,7 @@ ShallowWrapper {
             className="col-sm-12"
           >
             <div
-              className="pt-card"
+              className="pt-card pt-callout "
             >
               <table
                 className="pt-table pt-str"
@@ -3745,6 +4007,26 @@ ShallowWrapper {
                   <tr>
                     <td>
                       <strong>
+                        Result
+                      </strong>
+                    </td>
+                    <td>
+                      success
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
+                        Type
+                      </strong>
+                    </td>
+                    <td>
+                      Unknown TX Type
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
                         From
                       </strong>
                     </td>
@@ -3760,16 +4042,6 @@ ShallowWrapper {
                     </td>
                     <td>
                       
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <strong>
-                        Result
-                      </strong>
-                    </td>
-                    <td>
-                      success
                     </td>
                   </tr>
                   <tr>
@@ -3845,7 +4117,7 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": <div
-              className="pt-card"
+              className="pt-card pt-callout "
             >
               <table
                 className="pt-table pt-str"
@@ -3864,6 +4136,26 @@ ShallowWrapper {
                   <tr>
                     <td>
                       <strong>
+                        Result
+                      </strong>
+                    </td>
+                    <td>
+                      success
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
+                        Type
+                      </strong>
+                    </td>
+                    <td>
+                      Unknown TX Type
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
                         From
                       </strong>
                     </td>
@@ -3879,16 +4171,6 @@ ShallowWrapper {
                     </td>
                     <td>
                       
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <strong>
-                        Result
-                      </strong>
-                    </td>
-                    <td>
-                      success
                     </td>
                   </tr>
                   <tr>
@@ -3979,6 +4261,26 @@ ShallowWrapper {
                   <tr>
                     <td>
                       <strong>
+                        Result
+                      </strong>
+                    </td>
+                    <td>
+                      success
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
+                        Type
+                      </strong>
+                    </td>
+                    <td>
+                      Unknown TX Type
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>
                         From
                       </strong>
                     </td>
@@ -3994,16 +4296,6 @@ ShallowWrapper {
                     </td>
                     <td>
                       
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <strong>
-                        Result
-                      </strong>
-                    </td>
-                    <td>
-                      success
                     </td>
                   </tr>
                   <tr>
@@ -4068,7 +4360,7 @@ ShallowWrapper {
                   </tr>
                 </tbody>
               </table>,
-              "className": "pt-card",
+              "className": "pt-card pt-callout ",
             },
             "ref": null,
             "rendered": Object {
@@ -4091,6 +4383,26 @@ ShallowWrapper {
                     <tr>
                       <td>
                         <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Unknown TX Type
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
                           From
                         </strong>
                       </td>
@@ -4106,16 +4418,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -4251,6 +4553,27 @@ ShallowWrapper {
                       <tr>
                         <td>
                           <strong>
+                            Result
+                          </strong>
+                        </td>
+                        <td>
+                          success
+                        </td>
+                      </tr>,
+                      false,
+                      <tr>
+                        <td>
+                          <strong>
+                            Type
+                          </strong>
+                        </td>
+                        <td>
+                          Unknown TX Type
+                        </td>
+                      </tr>,
+                      <tr>
+                        <td>
+                          <strong>
                             From
                           </strong>
                         </td>
@@ -4259,6 +4582,10 @@ ShallowWrapper {
                         </td>
                       </tr>,
                       false,
+                      undefined,
+                      undefined,
+                      undefined,
+                      undefined,
                       <tr>
                         <td>
                           <strong>
@@ -4267,16 +4594,6 @@ ShallowWrapper {
                         </td>
                         <td>
                           
-                        </td>
-                      </tr>,
-                      <tr>
-                        <td>
-                          <strong>
-                            Result
-                          </strong>
-                        </td>
-                        <td>
-                          success
                         </td>
                       </tr>,
                       <tr>
@@ -4351,6 +4668,117 @@ ShallowWrapper {
                         "children": Array [
                           <td>
                             <strong>
+                              Result
+                            </strong>
+                          </td>,
+                          <td>
+                            success
+                          </td>,
+                        ],
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <strong>
+                              Result
+                            </strong>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Result",
+                            },
+                            "ref": null,
+                            "rendered": "Result",
+                            "type": "strong",
+                          },
+                          "type": "td",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": "success",
+                          },
+                          "ref": null,
+                          "rendered": "success",
+                          "type": "td",
+                        },
+                      ],
+                      "type": "tr",
+                    },
+                    false,
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <td>
+                            <strong>
+                              Type
+                            </strong>
+                          </td>,
+                          <td>
+                            Unknown TX Type
+                          </td>,
+                        ],
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <strong>
+                              Type
+                            </strong>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Type",
+                            },
+                            "ref": null,
+                            "rendered": "Type",
+                            "type": "strong",
+                          },
+                          "type": "td",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": "Unknown TX Type",
+                          },
+                          "ref": null,
+                          "rendered": "Unknown TX Type",
+                          "type": "td",
+                        },
+                      ],
+                      "type": "tr",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <td>
+                            <strong>
                               From
                             </strong>
                           </td>,
@@ -4399,6 +4827,10 @@ ShallowWrapper {
                       "type": "tr",
                     },
                     false,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
                     Object {
                       "instance": null,
                       "key": undefined,
@@ -4449,61 +4881,6 @@ ShallowWrapper {
                           },
                           "ref": null,
                           "rendered": "",
-                          "type": "td",
-                        },
-                      ],
-                      "type": "tr",
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": Array [
-                          <td>
-                            <strong>
-                              Result
-                            </strong>
-                          </td>,
-                          <td>
-                            success
-                          </td>,
-                        ],
-                      },
-                      "ref": null,
-                      "rendered": Array [
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": <strong>
-                              Result
-                            </strong>,
-                          },
-                          "ref": null,
-                          "rendered": Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "host",
-                            "props": Object {
-                              "children": "Result",
-                            },
-                            "ref": null,
-                            "rendered": "Result",
-                            "type": "strong",
-                          },
-                          "type": "td",
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": "success",
-                          },
-                          "ref": null,
-                          "rendered": "success",
                           "type": "td",
                         },
                       ],
@@ -4922,7 +5299,7 @@ ShallowWrapper {
               className="col-sm-12"
             >
               <div
-                className="pt-card"
+                className="pt-card pt-callout "
               >
                 <table
                   className="pt-table pt-str"
@@ -4941,6 +5318,26 @@ ShallowWrapper {
                     <tr>
                       <td>
                         <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Unknown TX Type
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
                           From
                         </strong>
                       </td>
@@ -4956,16 +5353,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -5034,7 +5421,7 @@ ShallowWrapper {
             </div>
           </div>,
         ],
-        "className": "container-fluid pt-dark",
+        "className": "container-fluid pt-dark ",
       },
       "ref": null,
       "rendered": Array [
@@ -5158,7 +5545,7 @@ ShallowWrapper {
               className="col-sm-12"
             >
               <div
-                className="pt-card"
+                className="pt-card pt-callout "
               >
                 <table
                   className="pt-table pt-str"
@@ -5177,6 +5564,26 @@ ShallowWrapper {
                     <tr>
                       <td>
                         <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Unknown TX Type
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
                           From
                         </strong>
                       </td>
@@ -5192,16 +5599,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -5277,7 +5674,7 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <div
-                className="pt-card"
+                className="pt-card pt-callout "
               >
                 <table
                   className="pt-table pt-str"
@@ -5296,6 +5693,26 @@ ShallowWrapper {
                     <tr>
                       <td>
                         <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Unknown TX Type
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
                           From
                         </strong>
                       </td>
@@ -5311,16 +5728,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -5411,6 +5818,26 @@ ShallowWrapper {
                     <tr>
                       <td>
                         <strong>
+                          Result
+                        </strong>
+                      </td>
+                      <td>
+                        success
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
+                          Type
+                        </strong>
+                      </td>
+                      <td>
+                        Unknown TX Type
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <strong>
                           From
                         </strong>
                       </td>
@@ -5426,16 +5853,6 @@ ShallowWrapper {
                       </td>
                       <td>
                         
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <strong>
-                          Result
-                        </strong>
-                      </td>
-                      <td>
-                        success
                       </td>
                     </tr>
                     <tr>
@@ -5500,7 +5917,7 @@ ShallowWrapper {
                     </tr>
                   </tbody>
                 </table>,
-                "className": "pt-card",
+                "className": "pt-card pt-callout ",
               },
               "ref": null,
               "rendered": Object {
@@ -5523,6 +5940,26 @@ ShallowWrapper {
                       <tr>
                         <td>
                           <strong>
+                            Result
+                          </strong>
+                        </td>
+                        <td>
+                          success
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <strong>
+                            Type
+                          </strong>
+                        </td>
+                        <td>
+                          Unknown TX Type
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <strong>
                             From
                           </strong>
                         </td>
@@ -5538,16 +5975,6 @@ ShallowWrapper {
                         </td>
                         <td>
                           
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>
-                          <strong>
-                            Result
-                          </strong>
-                        </td>
-                        <td>
-                          success
                         </td>
                       </tr>
                       <tr>
@@ -5683,6 +6110,27 @@ ShallowWrapper {
                         <tr>
                           <td>
                             <strong>
+                              Result
+                            </strong>
+                          </td>
+                          <td>
+                            success
+                          </td>
+                        </tr>,
+                        false,
+                        <tr>
+                          <td>
+                            <strong>
+                              Type
+                            </strong>
+                          </td>
+                          <td>
+                            Unknown TX Type
+                          </td>
+                        </tr>,
+                        <tr>
+                          <td>
+                            <strong>
                               From
                             </strong>
                           </td>
@@ -5691,6 +6139,10 @@ ShallowWrapper {
                           </td>
                         </tr>,
                         false,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
                         <tr>
                           <td>
                             <strong>
@@ -5699,16 +6151,6 @@ ShallowWrapper {
                           </td>
                           <td>
                             
-                          </td>
-                        </tr>,
-                        <tr>
-                          <td>
-                            <strong>
-                              Result
-                            </strong>
-                          </td>
-                          <td>
-                            success
                           </td>
                         </tr>,
                         <tr>
@@ -5783,6 +6225,117 @@ ShallowWrapper {
                           "children": Array [
                             <td>
                               <strong>
+                                Result
+                              </strong>
+                            </td>,
+                            <td>
+                              success
+                            </td>,
+                          ],
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <strong>
+                                Result
+                              </strong>,
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "Result",
+                              },
+                              "ref": null,
+                              "rendered": "Result",
+                              "type": "strong",
+                            },
+                            "type": "td",
+                          },
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "success",
+                            },
+                            "ref": null,
+                            "rendered": "success",
+                            "type": "td",
+                          },
+                        ],
+                        "type": "tr",
+                      },
+                      false,
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": Array [
+                            <td>
+                              <strong>
+                                Type
+                              </strong>
+                            </td>,
+                            <td>
+                              Unknown TX Type
+                            </td>,
+                          ],
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <strong>
+                                Type
+                              </strong>,
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "Type",
+                              },
+                              "ref": null,
+                              "rendered": "Type",
+                              "type": "strong",
+                            },
+                            "type": "td",
+                          },
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "Unknown TX Type",
+                            },
+                            "ref": null,
+                            "rendered": "Unknown TX Type",
+                            "type": "td",
+                          },
+                        ],
+                        "type": "tr",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": Array [
+                            <td>
+                              <strong>
                                 From
                               </strong>
                             </td>,
@@ -5831,6 +6384,10 @@ ShallowWrapper {
                         "type": "tr",
                       },
                       false,
+                      undefined,
+                      undefined,
+                      undefined,
+                      undefined,
                       Object {
                         "instance": null,
                         "key": undefined,
@@ -5881,61 +6438,6 @@ ShallowWrapper {
                             },
                             "ref": null,
                             "rendered": "",
-                            "type": "td",
-                          },
-                        ],
-                        "type": "tr",
-                      },
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": Array [
-                            <td>
-                              <strong>
-                                Result
-                              </strong>
-                            </td>,
-                            <td>
-                              success
-                            </td>,
-                          ],
-                        },
-                        "ref": null,
-                        "rendered": Array [
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "host",
-                            "props": Object {
-                              "children": <strong>
-                                Result
-                              </strong>,
-                            },
-                            "ref": null,
-                            "rendered": Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": "Result",
-                              },
-                              "ref": null,
-                              "rendered": "Result",
-                              "type": "strong",
-                            },
-                            "type": "td",
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "host",
-                            "props": Object {
-                              "children": "success",
-                            },
-                            "ref": null,
-                            "rendered": "success",
                             "type": "td",
                           },
                         ],


### PR DESCRIPTION
So to start of with, I want to make note that I am merging into UserX for the sole purpose that that branch was what I initially based mine off of, even though it won't be used anymore. We can merge these into develop when ready.

TODO:
- ~Tests~


What this PR accomplishes:
- Add new "Contract Info" Button/Modal for a selected contract instance
   - Shows contract source code, hash, address, ~chain~ shard ID
   - Allows copy/paste of source code
- Add new "Function Source Code" button when calling a function
   - Shows the signature and source code for the function you are about to call
- Display transaction results in the modal directly in a nicely formatted way
   - Rather than just showing the JSON response, I parse it and show it "richly" with colors matching success/pending/failure
- Transaction detail view 
   - now indicates if the transaction was successful/pending/failure with the displayed color of the card
   - Shows more fields from the transaction like call args, contract name, transaction type, and reason for error if any 

I also found an issue where you can't link to a transaction hash directly because of the way it loads things... but thats not super important to fix

https://user-images.githubusercontent.com/12687494/232854594-f5cd8b8f-d013-4711-b761-db91c1372428.mp4

