### PR TITLE
generate a tx hash without posting to the network

### DIFF
--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -87,6 +87,7 @@ import           Blockchain.Data.AlternateTransaction
 import           Blockchain.Data.DataDefs
 import           Blockchain.Data.Json
 import           Blockchain.Data.TXOrigin
+import           Blockchain.Data.Transaction      (rawTX2TX, transactionHash)
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address  hiding (unAddress)
 import           Blockchain.Strato.Model.ChainId
@@ -147,10 +148,11 @@ txWorker = forever $ do
 postBlocTransactionRaw :: (MonadLogger m, HasSQL m) =>
                           Maybe Text     -- username (unused)
                        -> Maybe ChainId
+                       -> Bool           -- hash
                        -> Bool           -- resolve
                        -> PostBlocTransactionRawRequest
                        -> m BlocChainOrTransactionResult
-postBlocTransactionRaw _ _ resolve PostBlocTransactionRawRequest{..} = do
+postBlocTransactionRaw _ _ h resolve PostBlocTransactionRawRequest{..} = do
   checkIsSynced
   -- as a requirement for Pepsi, we have to be able to accept non-rec sigs
   -- so, if 'v' is not provided, we have to figure out what 'v' is here
@@ -200,22 +202,27 @@ postBlocTransactionRaw _ _ resolve PostBlocTransactionRawRequest{..} = do
                postbloctransactionrawrequestR
                postbloctransactionrawrequestS
                postbloctransactionrawrequestMetadata
-      rawTx = preparePostTx time postbloctransactionrawrequestAddress tx
+      rawTx@(RawTransaction' raw _) = preparePostTx time postbloctransactionrawrequestAddress tx
 
-  txHash <- postTransaction rawTx
-
-
-
-  trds <- recurseTRDs resolve [txHash]
-  case trds of
-    [] -> throwIO $ AnError $ Text.pack "empty TRD response, which shouldn't happen"
-    [x] -> return $ BlocTxResult $ BlocTransactionResult
-              { blocTransactionStatus   = trdStatus x
-              , blocTransactionHash     = txHash
-              , blocTransactionTxResult = snd <$> trdResult x
-              , blocTransactionData     = Nothing   -- can we get this without the txHash table query?
-              }
-    _ -> throwIO $ UserError $ Text.pack "found multiple tx results for a single tx"
+  if h
+    then return . BlocTxResult $ BlocTransactionResult
+      { blocTransactionStatus = Success
+      , blocTransactionHash = transactionHash . rawTX2TX $ raw
+      , blocTransactionTxResult = Nothing
+      , blocTransactionData = Nothing
+      }
+    else do
+      txHash <- postTransaction rawTx
+      trds <- recurseTRDs resolve [txHash]
+      case trds of
+        [] -> throwIO $ AnError $ Text.pack "empty TRD response, which shouldn't happen"
+        [x] -> return $ BlocTxResult $ BlocTransactionResult
+                  { blocTransactionStatus   = trdStatus x
+                  , blocTransactionHash     = txHash
+                  , blocTransactionTxResult = snd <$> trdResult x
+                  , blocTransactionData     = Nothing   -- can we get this without the txHash table query?
+                  }
+        _ -> throwIO $ UserError $ Text.pack "found multiple tx results for a single tx"
 
 
 

--- a/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
@@ -404,4 +404,4 @@ instance ToSchema BlocChainOrTransactionResult where
 
 instance ToParam (QueryFlag "hash") where
   toParam _ =
-    DocQueryParam "hash" ["0","1",""] "flag for generating a tx hash without posting it to the network" Flag
+    DocQueryParam "hash" ["true", "false", ""] "flag for generating a tx hash without posting it to the network" Flag

--- a/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
@@ -81,6 +81,7 @@ type PostBlocTransactionRaw = "transaction"
   :> "raw"
   :> S.Header "X-USER-ACCESS-TOKEN" Text
   :> QueryParam "chainid" ChainId
+  :> QueryFlag "hash"
   :> QueryFlag "resolve"
   :> ReqBody '[JSON] PostBlocTransactionRawRequest
   :> Post '[JSON] BlocChainOrTransactionResult
@@ -400,3 +401,7 @@ instance ToSchema BlocChainOrTransactionResult where
         , blocTransactionTxResult = Nothing
         , blocTransactionData = Nothing
         }
+
+instance ToParam (QueryFlag "hash") where
+  toParam _ =
+    DocQueryParam "hash" ["0","1",""] "flag for generating a tx hash without posting it to the network" Flag

--- a/strato/api/strato-api/exec_src/PostRawTransaction.hs
+++ b/strato/api/strato-api/exec_src/PostRawTransaction.hs
@@ -229,7 +229,7 @@ parseArgs = do
 
 
 -- servant client for the endpoint
-postRawTransaction :: Maybe T.Text -> Maybe ChainId -> Bool -> PostBlocTransactionRawRequest
+postRawTransaction :: Maybe T.Text -> Maybe ChainId -> Bool -> Bool -> PostBlocTransactionRawRequest
                    -> ClientM BlocChainOrTransactionResult
 postRawTransaction = client (Proxy @PostBlocTransactionRaw)
 
@@ -327,7 +327,7 @@ main = do
     let clientEnv = mkClientEnv mgr stratoURL
 
     -- post it
-    result <- runClientM (postRawTransaction Nothing Nothing True request) clientEnv
+    result <- runClientM (postRawTransaction Nothing Nothing False True request) clientEnv
     putStrLn $ "\n\nTransaction result: " ++ show result
 
 

--- a/strato/tools/x509-tools/exec_src/X509CertRegistry.hs
+++ b/strato/tools/x509-tools/exec_src/X509CertRegistry.hs
@@ -94,7 +94,7 @@ entryPoint (Options privPath certPaths nonce) = do
             let clientEnv = mkClientEnv mgr stratoURL
 
             -- post it
-            result <- runClientM (postRawTransaction Nothing Nothing True request) clientEnv
+            result <- runClientM (postRawTransaction Nothing Nothing False True request) clientEnv
             putStrLn $ "\n\nTransaction result: " <> show result
 
             let oops = error "We did not successfully post the CertificateRegistry!"
@@ -108,11 +108,11 @@ entryPoint (Options privPath certPaths nonce) = do
             BL.putStr $ Ae.encode request'
 
             -- post initializeCertificateRegistry
-            result' <- runClientM (postRawTransaction Nothing Nothing True request') clientEnv
+            result' <- runClientM (postRawTransaction Nothing Nothing False True request') clientEnv
             putStrLn $ "\n\nTransaction result: " <> show result'
 
 -- servant client for the endpoint
-postRawTransaction :: Maybe T.Text -> Maybe ChainId -> Bool -> PostBlocTransactionRawRequest
+postRawTransaction :: Maybe T.Text -> Maybe ChainId -> Bool -> Bool -> PostBlocTransactionRawRequest
                    -> ClientM BlocChainOrTransactionResult
 postRawTransaction = client (Proxy @PostBlocTransactionRaw)
 


### PR DESCRIPTION
Stably requested for an endpoint that could return a transaction hash without posting it to the network. 

The `/transaction/raw?hash[=true]` returns the hash in the usual `PostBlocTransactionResponse` record:

![image](https://user-images.githubusercontent.com/35979292/234087116-25a81206-cac5-49f1-9e2a-d872d8f6d376.png)

The response will indicate `status: Success` for the successful operation and `hash` will contain the resulting TX hash. Rest of the fields will always be empty.