### PR TITLE
buster-based docker images for nodejs services

### DIFF
--- a/apex/api/Dockerfile
+++ b/apex/api/Dockerfile
@@ -1,26 +1,16 @@
-FROM node:8.15-stretch-slim
+FROM node:8.16.2-buster-slim
 RUN apt-get update && \
-    mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
-    apt-get install -y git postgresql-client zip python build-essential && \
+    apt-get install -y git postgresql-client python build-essential && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     mkdir -p /usr/src/app
-
-# /usr/share/man/ required for postgres-client on debian slim
-# postgres-client is required for pgtools module; also used for container health check
-
+    # Layer is shared with SMD. TODO: use shared base
+    # postgres-client is required for pgtools module; also used for container health check
 WORKDIR /usr/src/app
-
 EXPOSE 3009
-
 COPY package*.json  /usr/src/app/
-
 RUN npm install
-
 COPY . /usr/src/app
-
 ARG STRATO_VERSION
-
 ENV STRATO_VERSION=${STRATO_VERSION}
-
 CMD [ "bash", "-c", "/usr/src/app/docker-run.sh" ]

--- a/smd-ui/Dockerfile
+++ b/smd-ui/Dockerfile
@@ -1,20 +1,18 @@
-FROM node:8.15-stretch-slim
-
+FROM node:8.16.2-buster-slim
+RUN apt-get update && \
+    apt-get install -y git postgresql-client python build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    mkdir -p /usr/src/app \
+    # Layer is shared with Apex. TODO: use shared base
 ARG STRATO_VERSION
-
 ENV STRATO_VERSION=${STRATO_VERSION}
-
 RUN mkdir -p /usr/src/app && \
     npm install -g serve@11.3.2
-
 WORKDIR /usr/src/app
-
 COPY . /usr/src/app
-
 RUN npm install && \
     npm run build && \
     rm -rf node_modules public src
-
 EXPOSE 3002
-
 CMD [ "sh", "/usr/src/app/docker-run.sh" ]

--- a/smd-ui/Dockerfile.test
+++ b/smd-ui/Dockerfile.test
@@ -1,12 +1,12 @@
-FROM node:9
-
+FROM node:8.16.2-buster-slim
+RUN apt-get update && \
+    apt-get install -y git postgresql-client python build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    mkdir -p /usr/src/app \
+    # Layer is shared with Apex. TODO: use shared base
 RUN mkdir -p /usr/src/app
-
 WORKDIR /usr/src/app
-
 COPY . /usr/src/app
-
-# Caching npm install
 RUN npm install
-
 RUN npm test


### PR DESCRIPTION
This is to fix the Platform build issue caused by underlying OS in Nodejs docker images.

Update to the newer version of nodejs itself is a part of another ticket (STRATO-3096)

Jenkins build:
https://jenkins.blockapps.net/blue/organizations/jenkins/STRATO_autobuild/detail/STRATO-3097-update_nodejs_base/3/pipeline/90/
The only failure is due to the same issue in strato-api-tests (fix is coming as part of a PR on its repo)

