### PR TITLE
Strato 3105 - Determine and implement platform nonce limit

### DIFF
--- a/strato/api/bloc/bloc2/src/Bloc/Monad.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Monad.hs
@@ -78,6 +78,7 @@ data BlocEnv = BlocEnv
   { stateFetchLimit    :: Integer
   , gasOn              :: Bool
   , evmCompatible      :: Bool
+  , accountNonceLimit         :: Integer
   , globalNonceCounter :: Cache Account Nonce
   , globalSourceCache  :: Cache (Text, SourceMap) (Map Text ContractDetails)
   , globalCodePtrCache :: Cache CodePtr ContractDetails

--- a/strato/api/bloc/bloc2/src/Bloc/Monad.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Monad.hs
@@ -78,7 +78,7 @@ data BlocEnv = BlocEnv
   { stateFetchLimit    :: Integer
   , gasOn              :: Bool
   , evmCompatible      :: Bool
-  , accountNonceLimit         :: Integer
+  , accountNonceLimit  :: Integer
   , globalNonceCounter :: Cache Account Nonce
   , globalSourceCache  :: Cache (Text, SourceMap) (Map Text ContractDetails)
   , globalCodePtrCache :: Cache CodePtr ContractDetails

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -291,12 +291,18 @@ postBlocTransaction' :: ( MonadLogger m
 postBlocTransaction' cacheNonce mJwtToken chainId resolve (PostBlocTransactionRequest mAddr txs' txParams msrcs) = do
   checkIsSynced
   evmCompatibleOn <- fmap evmCompatible getBlocEnv
+  accountNonceLimit <- fmap accountNonceLimit getBlocEnv
   case mJwtToken of
     Nothing -> throwIO $ UserError $ Text.pack "Did not find X-USER-ACCESS-TOKEN in the header"
     Just jwtToken -> do
       addr <- case mAddr of
         Nothing -> fmap unAddress . blocVaultWrapper $  getKey (Just jwtToken) Nothing
         Just addr' -> return addr'
+      nonceMap <- getAccountNonce addr (S.singleton chainId)
+      accountNonce <- case Map.lookup chainId nonceMap of
+        Nothing -> pure $ 0
+        Just (Nonce n) -> pure $ toInteger n
+      when (accountNonce >= accountNonceLimit) $ throwIO NonceLimitExceededError
       let src' :: ContractPayload -> Maybe SourceMap
           src' p = if contractpayloadSrc p == mempty
                      then Nothing

--- a/strato/api/core/src/SQLM.hs
+++ b/strato/api/core/src/SQLM.hs
@@ -41,6 +41,7 @@ data ApiError
   | VaultWrapperError ClientError
   | DBError Text
   | UserError Text
+  | NonceLimitExceededError
   | CouldNotFind Text
   | AnError Text
   | Unimplemented Text
@@ -125,6 +126,7 @@ apiErrorToServantErr = \case
                    ]}
   CirrusError err -> err500{errBody = JSON.encode (show err)}
   UserError err -> err400{errBody = JSON.encode err}
+  NonceLimitExceededError -> err400{errBody = JSON.encode $ unlines ["You have reached your transaction limit."]}
   AlreadyExists err -> err409{errBody = JSON.encode err}
   CouldNotFind err -> err400{errBody = JSON.encode err}
   UnavailableError err -> err503{errBody = JSON.encode err}

--- a/strato/api/strato-api/exec_src/Main.hs
+++ b/strato/api/strato-api/exec_src/Main.hs
@@ -250,6 +250,7 @@ main = do
         BlocEnv{
           gasOn = flags_gasOn,
           evmCompatible= flags_evmCompatible,
+          accountNonceLimit = flags_accountNonceLimit,
           stateFetchLimit = stateFetchLimit',
           globalNonceCounter = nonceCache,
           globalCodePtrCache = codePtrCache,

--- a/strato/api/strato-api/exec_src/Options.hs
+++ b/strato/api/strato-api/exec_src/Options.hs
@@ -19,4 +19,4 @@ import           HFlags
 --defineFlag "txQueueSize" (4096::Integer) "The maximum number of requests to queue"
 defineFlag "gasOn" (True :: Bool) "Whether or not to throw an error if an account sending a TX has no balance - used in conjunction with the VM gasOn flag"
 defineFlag "evmCompatible" (False :: Bool) "Whether to turn off STRATO enhancements or not"
-defineFlag "accountNonceLimit" (1::Integer) "The maximum number of transactions an account can make"
+defineFlag "accountNonceLimit" (500::Integer) "The maximum number of transactions an account can make"

--- a/strato/api/strato-api/exec_src/Options.hs
+++ b/strato/api/strato-api/exec_src/Options.hs
@@ -19,3 +19,4 @@ import           HFlags
 --defineFlag "txQueueSize" (4096::Integer) "The maximum number of requests to queue"
 defineFlag "gasOn" (True :: Bool) "Whether or not to throw an error if an account sending a TX has no balance - used in conjunction with the VM gasOn flag"
 defineFlag "evmCompatible" (False :: Bool) "Whether to turn off STRATO enhancements or not"
+defineFlag "accountNonceLimit" (1::Integer) "The maximum number of transactions an account can make"

--- a/strato/indexer/slipstream/exec_src/Main.hs
+++ b/strato/indexer/slipstream/exec_src/Main.hs
@@ -58,6 +58,7 @@ createBlocEnv = liftIO $ do
   return BlocEnv { stateFetchLimit = 0
                  , gasOn=error("gasOn shouldn't be needed in slipstream, it is undefined")
                  , evmCompatible=False
+                 , accountNonceLimit=0
                  , globalNonceCounter=error("globalNonceCounter shouldn't be needed in slipstream, it is undefined")
                  , globalSourceCache=error("globalSourceCache shouldn't be needed in slipstream, it is undefined")
                  , globalCodePtrCache=error("globalCodePtrCache shouldn't be needed in slipstream, it is undefined")


### PR DESCRIPTION
This PR will add a new `accountNonceLimit` flag to the API which it will use to check whether an account is able to post a transaction or not. Currently set to 500 but subject to change. The check will be before any computation takes place to avoid doing any substantial work if the account had already hit its limit.

TODO: Add logic to grant more transactions to an account