### PR TITLE
/transaction/body endpoint

### DIFF
--- a/strato/api/bloc/bloc2/src/Bloc/Server.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server.hs
@@ -73,6 +73,7 @@ bloc = return gitInfo
   :<|> getChainInfo
   :<|> postBlocTransactionParallel
   :<|> postBlocTransactionRaw
+  :<|> postBlocTransactionBody
   :<|> postBlocTransaction
 
 --serveBloc :: BlocEnv -> Server BlocAPI

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -236,33 +236,28 @@ postBlocTransactionBody :: ( MonadLogger m
                              -> m [BlocTransactionBodyResult]  -- ^ Signed tx hash & raw tx data
 postBlocTransactionBody Nothing _ _ = throwIO $ UserError $ Text.pack "Did not find X-USER-ACCESS-TOKEN in the header"
 postBlocTransactionBody _ _ (PostBlocTransactionRequest _ [] _ _) = return []
-postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr ttxs txParams _) = do
+postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList txParams _) = do
   addr <- case mAddr of
-    Nothing -> fmap unAddress . blocVaultWrapper $  getKey (Just jwt) Nothing
+    Nothing -> fmap unAddress . blocVaultWrapper $ getKey (Just jwt) Nothing
     Just addr' -> return addr'
-  fmap join . forM (partitionWith transactionType ttxs) $ \(ttype, txs) -> case ttype of
+  fmap join . forM (partitionWith transactionType txList) $ \(ttype, txs) -> case ttype of
       TRANSFER -> do
         txs' <- mapM fromTransfer txs
-        let TransferListParameters fromAddr ts _ _ = TransferListParameters
-                    addr
-                    (map (\(TransferPayload t v x c m) -> SendTransaction t v (mergeTxParams x txParams) c m) txs')
-                    cid
-                    False
+        let ts = map (\(TransferPayload t v x c m) -> SendTransaction t v (mergeTxParams x txParams) c m) txs'
             txsWithChainids = map (sendtransactionChainid %~ (<|> cid)) ts
-        txsWithParams <- genNonces (Don't CacheNonce) fromAddr sendtransactionChainid sendtransactionTxParams txsWithChainids
+        txsWithParams <- genNonces (Don't CacheNonce) addr sendtransactionChainid sendtransactionTxParams txsWithChainids
         txs'' <- mapM
           (\(SendTransaction toAddr (Strung value) params cid' md) -> do
               let header = TransactionHeader
                     (Just toAddr)
-                    fromAddr
+                    addr
                     (fromMaybe emptyTxParams params)
                     (Wei $ fromIntegral value)
                     (Code ByteString.empty)
                     cid'
-              signAndPrepare jwt fromAddr md header
-          ) txsWithParams
-        forM txs'' (\r -> return $ BlocTransactionBodyResult (txHash' r) (Just r))
-          where txHash' = transactionHash . rawTX2TX . rtPrimeToRt
+              signAndPrepare jwt addr md header) txsWithParams
+        forM txs'' (\r -> return $ BlocTransactionBodyResult (hash' r) (Just r))
+          where hash' = transactionHash . rawTX2TX . rtPrimeToRt
       CONTRACT -> return []
                   -- let cp@ContractParameters{..} = handleContractParameters txs' txParams cid
                   -- params <- getAccountTxParams (Don't CacheNonce) fromAddr cid cp

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -227,16 +227,20 @@ postBlocTransactionRaw _ _ h resolve PostBlocTransactionRawRequest{..} = do
 
 -- | postBlocTransactionBody(jwt, chain ID, [Transactions])
 postBlocTransactionBody :: ( MonadLogger m
+                           -- , A.Selectable Account ContractDetails m
+                           , A.Selectable Account AddressState m
+                           , (Keccak256 `A.Alters` SourceMap) m
                            , HasBlocEnv m
+                           , HasBlocSQL m
                            , HasSQL m
                            , HasVault m
                            ) => Maybe Text                     -- ^ jwt
                              -> Maybe ChainId                  -- ^ shard id
                              -> PostBlocTransactionRequest     -- ^ SolidVM transactions
-                             -> m [BlocTransactionBodyResult]  -- ^ Signed tx hash & raw tx data
+                             -> m [BlocTransactionBodyResult]  -- ^ tx hash & raw tx data
 postBlocTransactionBody Nothing _ _ = throwIO $ UserError $ Text.pack "Did not find X-USER-ACCESS-TOKEN in the header"
 postBlocTransactionBody _ _ (PostBlocTransactionRequest _ [] _ _) = return []
-postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList txParams _) = do
+postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList txParams msrcs) = do
   addr <- case mAddr of
     Nothing -> fmap unAddress . blocVaultWrapper $ getKey (Just jwt) Nothing
     Just addr' -> return addr'
@@ -258,38 +262,67 @@ postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList 
               signAndPrepare jwt addr md header) txsWithParams
         forM txs'' (\r -> return $ BlocTransactionBodyResult (hash' r) (Just r))
           where hash' = transactionHash . rawTX2TX . rtPrimeToRt
-      CONTRACT -> return []
-                  -- let cp@ContractParameters{..} = handleContractParameters txs' txParams cid
-                  -- params <- getAccountTxParams (Don't CacheNonce) fromAddr cid cp
-                  -- signAndPrepare jwt fromAddress metadata $
-                      -- TransactionHeader
-                        -- (Just toAddress)
-                        -- fromAddress
-                        -- params
-                        -- (Wei (fromIntegral $ unStrung value))
-                        -- (Code ByteString.empty)
-                        -- chainId
+      CONTRACT -> do
+        ps <- mapM fromContract txs
+        let srcMap :: ContractPayload -> Maybe SourceMap
+            srcMap p = join $ liftA2 Map.lookup (contractpayloadContract p) msrcs
+            src' :: ContractPayload -> Maybe SourceMap
+            src' p = if contractpayloadSrc p == mempty
+                        then Nothing
+                        else Just $ contractpayloadSrc p
+            getSrc p = fromMaybe mempty $ src' p <|> srcMap p
+            mapUploadList = map (\p@(ContractPayload _ c a v x cid' m) -> do
+                            let cn = fromMaybe "unnamed_contract" c
+                            UploadListContract (fromJust c)
+                                                (getSrc p)
+                                                (fromMaybe Map.empty a)
+                                                (mergeTxParams x txParams)
+                                                v
+                                                cid'
+                                                (case m of
+                                                  Nothing -> Just $ Map.singleton "history" cn
+                                                  Just h -> Just $ Map.insert "history" cn h))
+                                                ps
+            bclp = ContractListParameters addr mapUploadList cid False
+            contracts' = map (uploadlistcontractChainid %~ (<|> cid)) (contracts bclp)
+        txsWithParams <- genNonces (Don't CacheNonce) addr uploadlistcontractChainid uploadlistcontractTxParams contracts'
+        forStateT Map.empty txsWithParams $
+          \(UploadListContract name srcs args params value cid' md) -> do
+            (src, xabi) <- do
+              cd <- fmap snd . lift $ getContractDetailsForContract "SolidVM" srcs (Just name) >>= \case
+                Nothing -> throwIO $ UserError "You need to supply at least one contract in the source" --remove
+                Just x -> pure x
+              at name <?= (contractdetailsSrc cd, contractdetailsXabi cd)
+
+            let xabiArgs = maybe Map.empty funcArgs $ xabiConstr xabi
+            (_, argsAsSource) <- lift $ constructArgValuesAndSource (Just args) xabiArgs
+
+            let metadata' = Just $ fromMaybe Map.empty md `Map.union` Map.fromList [("name", name), ("args", argsAsSource)]
+            tx <- lift . signAndPrepare jwt addr metadata' $
+                TransactionHeader
+                  Nothing
+                  addr
+                  (fromMaybe emptyTxParams params)
+                  (Wei (maybe 0 fromIntegral $ fmap unStrung value))
+                  (Code $ Text.encodeUtf8 $ serializeSourceMap src)
+                  cid'
+            return $ BlocTransactionBodyResult (hash' tx) (Just tx)
+              where hash' = transactionHash . rawTX2TX . rtPrimeToRt
       FUNCTION -> return []
       GENESIS  -> return []
   where fromTransfer = \case
           BlocTransfer t -> return t
           _ -> throwIO $ UserError "Could not decode transfer arguments from body"
-{-        fromContract = \case
+        fromContract = \case
           BlocContract c -> return c
           _ -> throwIO $ UserError "Could not decode contract arguments from body"
-        fromFunction = \case
+{-      fromFunction = \case
           BlocFunction f -> return f
           _ -> throwIO $ UserError "Could not decode function arguments from body"
         fromGenesis = \case
           BlocGenesis f -> return f
           _ -> throwIO $ UserError "Could not decode function arguments from body"
-        src' :: ContractPayload -> Maybe SourceMap
-        src' p = if contractpayloadSrc p == mempty
-                    then Nothing
-                    else Just $ contractpayloadSrc p
-        srcMap :: ContractPayload -> Maybe SourceMap
-        srcMap p = join $ liftA2 Map.lookup (contractpayloadContract p) msrcs
-        getSrc p = fromMaybe mempty $ src' p <|> srcMap p
+       hash' = transactionHash . rawTX2TX . rtPrimeToRt
 -}
 
 ---------------------------------- REGULAR TRANSACTIONS ---------------------------------------

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -261,7 +261,6 @@ postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList 
                     cid'
               signAndPrepare jwt addr md header) txsWithParams
         forM txs'' (\r -> return $ BlocTransactionBodyResult (hash' r) (Just r))
-          where hash' = transactionHash . rawTX2TX . rtPrimeToRt
       CONTRACT -> do
         ps <- mapM fromContract txs
         let srcMap :: ContractPayload -> Maybe SourceMap
@@ -306,7 +305,6 @@ postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList 
                   (Code $ Text.encodeUtf8 $ serializeSourceMap src)
                   cid'
             return $ BlocTransactionBodyResult (hash' tx) (Just tx)
-              where hash' = transactionHash . rawTX2TX . rtPrimeToRt
       FUNCTION -> do
         p <- mapM fromFunction txs
         let mapMethodCalls = map (\(FunctionPayload a m r v x c md) -> MethodCall a m r (fromMaybe (Strung 0) v) (mergeTxParams x txParams) c md) p
@@ -348,9 +346,9 @@ postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList 
                 (Code $ sel <> argsBin)
                 _methodcallChainid
             return $ BlocTransactionBodyResult (hash' tx) (Just tx)
-              where hash' = transactionHash . rawTX2TX . rtPrimeToRt
-      GENESIS -> return []
-  where fromTransfer = \case
+      GENESIS -> throwIO . UserError . Text.pack $ "ERROR! Only TRANSFER, CONTRACT, and FUNCTION calls are allowed."
+  where hash' = transactionHash . rawTX2TX . rtPrimeToRt
+        fromTransfer = \case
           BlocTransfer t -> return t
           _ -> throwIO $ UserError "Could not decode transfer arguments from body"
         fromContract = \case
@@ -359,11 +357,6 @@ postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList 
         fromFunction = \case
           BlocFunction f -> return f
           _ -> throwIO $ UserError "Could not decode function arguments from body"
-{-        fromGenesis = \case
-          BlocGenesis f -> return f
-          _ -> throwIO $ UserError "Could not decode function arguments from body"
-       hash' = transactionHash . rawTX2TX . rtPrimeToRt
--}
 
 ---------------------------------- REGULAR TRANSACTIONS ---------------------------------------
 

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -234,50 +234,48 @@ postBlocTransactionBody :: ( MonadLogger m
                              -> Maybe ChainId                  -- ^ shard id
                              -> PostBlocTransactionRequest     -- ^ SolidVM transactions
                              -> m [BlocTransactionBodyResult]  -- ^ Signed tx hash & raw tx data
+postBlocTransactionBody Nothing _ _ = throwIO $ UserError $ Text.pack "Did not find X-USER-ACCESS-TOKEN in the header"
 postBlocTransactionBody _ _ (PostBlocTransactionRequest _ [] _ _) = return []
-postBlocTransactionBody jwt' cid (PostBlocTransactionRequest mAddr ttxs txParams _) =
-  case jwt' of
-    Nothing -> throwIO $ UserError $ Text.pack "Did not find X-USER-ACCESS-TOKEN in the header"
-    Just jwt -> do
-      addr <- case mAddr of
-        Nothing -> fmap unAddress . blocVaultWrapper $  getKey (Just jwt) Nothing
-        Just addr' -> return addr'
-      fmap join . forM (partitionWith transactionType ttxs) $ \(ttype, txs) -> case ttype of
-          TRANSFER -> do
-            txs' <- mapM fromTransfer txs
-            let TransferListParameters fromAddr ts _ _ = TransferListParameters
-                        addr
-                        (map (\(TransferPayload t v x c m) -> SendTransaction t v (mergeTxParams x txParams) c m) txs')
-                        cid
-                        False
-                txsWithChainids = map (sendtransactionChainid %~ (<|> cid)) ts
-            txsWithParams <- genNonces (Don't CacheNonce) fromAddr sendtransactionChainid sendtransactionTxParams txsWithChainids
-            txs'' <- mapM
-              (\(SendTransaction toAddr (Strung value) params cid' md) -> do
-                  let header = TransactionHeader
-                        (Just toAddr)
-                        fromAddr
-                        (fromMaybe emptyTxParams params)
-                        (Wei $ fromIntegral value)
-                        (Code ByteString.empty)
-                        cid'
-                  signAndPrepare jwt fromAddr md header
-              ) txsWithParams
-            forM txs'' (\r -> return $ BlocTransactionBodyResult (txHash' r) (Just r))
-              where txHash' = transactionHash . rawTX2TX . rtPrimeToRt
-          CONTRACT -> return []
-                      -- let cp@ContractParameters{..} = handleContractParameters txs' txParams cid
-                      -- params <- getAccountTxParams (Don't CacheNonce) fromAddr cid cp
-                      -- signAndPrepare jwt fromAddress metadata $
-                          -- TransactionHeader
-                            -- (Just toAddress)
-                            -- fromAddress
-                            -- params
-                            -- (Wei (fromIntegral $ unStrung value))
-                            -- (Code ByteString.empty)
-                            -- chainId
-          FUNCTION -> return []
-          GENESIS  -> return []
+postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr ttxs txParams _) = do
+  addr <- case mAddr of
+    Nothing -> fmap unAddress . blocVaultWrapper $  getKey (Just jwt) Nothing
+    Just addr' -> return addr'
+  fmap join . forM (partitionWith transactionType ttxs) $ \(ttype, txs) -> case ttype of
+      TRANSFER -> do
+        txs' <- mapM fromTransfer txs
+        let TransferListParameters fromAddr ts _ _ = TransferListParameters
+                    addr
+                    (map (\(TransferPayload t v x c m) -> SendTransaction t v (mergeTxParams x txParams) c m) txs')
+                    cid
+                    False
+            txsWithChainids = map (sendtransactionChainid %~ (<|> cid)) ts
+        txsWithParams <- genNonces (Don't CacheNonce) fromAddr sendtransactionChainid sendtransactionTxParams txsWithChainids
+        txs'' <- mapM
+          (\(SendTransaction toAddr (Strung value) params cid' md) -> do
+              let header = TransactionHeader
+                    (Just toAddr)
+                    fromAddr
+                    (fromMaybe emptyTxParams params)
+                    (Wei $ fromIntegral value)
+                    (Code ByteString.empty)
+                    cid'
+              signAndPrepare jwt fromAddr md header
+          ) txsWithParams
+        forM txs'' (\r -> return $ BlocTransactionBodyResult (txHash' r) (Just r))
+          where txHash' = transactionHash . rawTX2TX . rtPrimeToRt
+      CONTRACT -> return []
+                  -- let cp@ContractParameters{..} = handleContractParameters txs' txParams cid
+                  -- params <- getAccountTxParams (Don't CacheNonce) fromAddr cid cp
+                  -- signAndPrepare jwt fromAddress metadata $
+                      -- TransactionHeader
+                        -- (Just toAddress)
+                        -- fromAddress
+                        -- params
+                        -- (Wei (fromIntegral $ unStrung value))
+                        -- (Code ByteString.empty)
+                        -- chainId
+      FUNCTION -> return []
+      GENESIS  -> return []
   where fromTransfer = \case
           BlocTransfer t -> return t
           _ -> throwIO $ UserError "Could not decode transfer arguments from body"

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -15,6 +15,7 @@
 module Bloc.Server.Transaction (
   postBlocTransaction,
   postBlocTransactionRaw,
+  postBlocTransactionBody,
   postBlocTransactionParallel,
   ) where
 
@@ -224,8 +225,79 @@ postBlocTransactionRaw _ _ h resolve PostBlocTransactionRawRequest{..} = do
                   }
         _ -> throwIO $ UserError $ Text.pack "found multiple tx results for a single tx"
 
-
-
+-- | postBlocTransactionBody(jwt, chain ID, [Transactions])
+postBlocTransactionBody :: ( MonadLogger m
+                           , HasBlocEnv m
+                           , HasSQL m
+                           , HasVault m
+                           ) => Maybe Text                     -- ^ jwt
+                             -> Maybe ChainId                  -- ^ shard id
+                             -> PostBlocTransactionRequest     -- ^ SolidVM transactions
+                             -> m [BlocTransactionBodyResult]  -- ^ Signed tx hash & raw tx data
+postBlocTransactionBody _ _ (PostBlocTransactionRequest _ [] _ _) = return []
+postBlocTransactionBody jwt' cid (PostBlocTransactionRequest mAddr ttxs txParams _) =
+  case jwt' of
+    Nothing -> throwIO $ UserError $ Text.pack "Did not find X-USER-ACCESS-TOKEN in the header"
+    Just jwt -> do
+      addr <- case mAddr of
+        Nothing -> fmap unAddress . blocVaultWrapper $  getKey (Just jwt) Nothing
+        Just addr' -> return addr'
+      fmap join . forM (partitionWith transactionType ttxs) $ \(ttype, txs) -> case ttype of
+          TRANSFER -> do
+            txs' <- mapM fromTransfer txs
+            let TransferListParameters fromAddr ts _ _ = TransferListParameters
+                        addr
+                        (map (\(TransferPayload t v x c m) -> SendTransaction t v (mergeTxParams x txParams) c m) txs')
+                        cid
+                        False
+                txsWithChainids = map (sendtransactionChainid %~ (<|> cid)) ts
+            txsWithParams <- genNonces (Don't CacheNonce) fromAddr sendtransactionChainid sendtransactionTxParams txsWithChainids
+            txs'' <- mapM
+              (\(SendTransaction toAddr (Strung value) params cid' md) -> do
+                  let header = TransactionHeader
+                        (Just toAddr)
+                        fromAddr
+                        (fromMaybe emptyTxParams params)
+                        (Wei $ fromIntegral value)
+                        (Code ByteString.empty)
+                        cid'
+                  signAndPrepare jwt fromAddr md header
+              ) txsWithParams
+            forM txs'' (\r -> return $ BlocTransactionBodyResult (txHash' r) (Just r))
+              where txHash' = transactionHash . rawTX2TX . rtPrimeToRt
+          CONTRACT -> return []
+                      -- let cp@ContractParameters{..} = handleContractParameters txs' txParams cid
+                      -- params <- getAccountTxParams (Don't CacheNonce) fromAddr cid cp
+                      -- signAndPrepare jwt fromAddress metadata $
+                          -- TransactionHeader
+                            -- (Just toAddress)
+                            -- fromAddress
+                            -- params
+                            -- (Wei (fromIntegral $ unStrung value))
+                            -- (Code ByteString.empty)
+                            -- chainId
+          FUNCTION -> return []
+          GENESIS  -> return []
+  where fromTransfer = \case
+          BlocTransfer t -> return t
+          _ -> throwIO $ UserError "Could not decode transfer arguments from body"
+{-        fromContract = \case
+          BlocContract c -> return c
+          _ -> throwIO $ UserError "Could not decode contract arguments from body"
+        fromFunction = \case
+          BlocFunction f -> return f
+          _ -> throwIO $ UserError "Could not decode function arguments from body"
+        fromGenesis = \case
+          BlocGenesis f -> return f
+          _ -> throwIO $ UserError "Could not decode function arguments from body"
+        src' :: ContractPayload -> Maybe SourceMap
+        src' p = if contractpayloadSrc p == mempty
+                    then Nothing
+                    else Just $ contractpayloadSrc p
+        srcMap :: ContractPayload -> Maybe SourceMap
+        srcMap p = join $ liftA2 Map.lookup (contractpayloadContract p) msrcs
+        getSrc p = fromMaybe mempty $ src' p <|> srcMap p
+-}
 
 ---------------------------------- REGULAR TRANSACTIONS ---------------------------------------
 
@@ -339,11 +411,10 @@ postBlocTransaction' cacheNonce mJwtToken chainId resolve (PostBlocTransactionRe
                         (contractpayloadArgs p)
                         (contractpayloadValue p)
                         (mergeTxParams (contractpayloadTxParams p) txParams)
-                        {-
-                          History tables are always enabled
-                          'contractpayloadContract p' should always return a name but in the case that it doesn't
-                            it will go in the history table unnamed
-                        -}
+
+                        -- | History tables are always enabled. 'contractpayloadContract p' should
+                        -- always return a name but in the case that it doesn't it will go in the
+                        -- history table unnamed.
                         (case md of
                           Nothing -> Just $ Map.singleton "history" cn
                           Just m -> Just $ Map.insert "history" cn m)

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -227,7 +227,7 @@ postBlocTransactionRaw _ _ h resolve PostBlocTransactionRawRequest{..} = do
 
 -- | postBlocTransactionBody(jwt, chain ID, [Transactions])
 postBlocTransactionBody :: ( MonadLogger m
-                           -- , A.Selectable Account ContractDetails m
+                           , A.Selectable Account ContractDetails m
                            , A.Selectable Account AddressState m
                            , (Keccak256 `A.Alters` SourceMap) m
                            , HasBlocEnv m
@@ -283,8 +283,7 @@ postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList 
                                                   Nothing -> Just $ Map.singleton "history" cn
                                                   Just h -> Just $ Map.insert "history" cn h))
                                                 ps
-            bclp = ContractListParameters addr mapUploadList cid False
-            contracts' = map (uploadlistcontractChainid %~ (<|> cid)) (contracts bclp)
+            contracts' = map (uploadlistcontractChainid %~ (<|> cid)) mapUploadList
         txsWithParams <- genNonces (Don't CacheNonce) addr uploadlistcontractChainid uploadlistcontractTxParams contracts'
         forStateT Map.empty txsWithParams $
           \(UploadListContract name srcs args params value cid' md) -> do
@@ -308,18 +307,59 @@ postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList 
                   cid'
             return $ BlocTransactionBodyResult (hash' tx) (Just tx)
               where hash' = transactionHash . rawTX2TX . rtPrimeToRt
-      FUNCTION -> return []
-      GENESIS  -> return []
+      FUNCTION -> do
+        p <- mapM fromFunction txs
+        let mapMethodCalls = map (\(FunctionPayload a m r v x c md) -> MethodCall a m r (fromMaybe (Strung 0) v) (mergeTxParams x txParams) c md) p
+            txsWithChainids = map (methodcallChainid %~ (<|> cid)) mapMethodCalls
+        txsWithParams <- genNonces (Don't CacheNonce) addr methodcallChainid methodcallTxParams txsWithChainids
+        forStateT Map.empty txsWithParams $
+          \MethodCall{..} -> do
+            let theAccount = Account methodcallContractAddress $ fmap unChainId _methodcallChainid
+            mXabi <- use $ at theAccount
+            xabi <- case mXabi of
+              Just x -> pure x
+              Nothing -> do
+                mXabi' <- lift $ fmap contractdetailsXabi <$> A.select (A.Proxy @ContractDetails) theAccount
+                x <- case mXabi' of
+                  Nothing -> lift $ throwIO . UserError $ "Could not find contract " <> Text.pack (show theAccount)
+                  Just x -> pure x
+                at theAccount <?= x
+            contract' <- case xAbiToContract xabi of
+              Left err -> throwIO . AnError $ Text.pack err
+              Right c -> return c
+            let maybeFunc = OMap.lookup methodcallMethodName (fields $ C.mainStruct contract')
+            sel <-
+              case maybeFunc of
+              Just (_, TypeFunction selector _ _) -> return selector
+              _ -> lift $ throwIO . UserError $ "Contract doesn't have a method named '" <> methodcallMethodName <> "'"
+            let xabiArgs = maybe Map.empty funcArgs . Map.lookup methodcallMethodName $ xabiFuncs xabi
+            (argsBin, argsAsSource) <-
+              lift $ constructArgValuesAndSource (Just methodcallArgs) xabiArgs
+            let methodcallMetadataWithCallInfo = Just $
+                  Map.insert "funcName" methodcallMethodName
+                  $ Map.insert "args" argsAsSource
+                  $ fromMaybe Map.empty methodcallMetadata
+            tx <- lift . signAndPrepare jwt addr methodcallMetadataWithCallInfo $
+              TransactionHeader
+                (Just methodcallContractAddress)
+                addr
+                (fromMaybe emptyTxParams _methodcallTxParams)
+                (Wei (fromIntegral $ unStrung methodcallValue))
+                (Code $ sel <> argsBin)
+                _methodcallChainid
+            return $ BlocTransactionBodyResult (hash' tx) (Just tx)
+              where hash' = transactionHash . rawTX2TX . rtPrimeToRt
+      GENESIS -> return []
   where fromTransfer = \case
           BlocTransfer t -> return t
           _ -> throwIO $ UserError "Could not decode transfer arguments from body"
         fromContract = \case
           BlocContract c -> return c
           _ -> throwIO $ UserError "Could not decode contract arguments from body"
-{-      fromFunction = \case
+        fromFunction = \case
           BlocFunction f -> return f
           _ -> throwIO $ UserError "Could not decode function arguments from body"
-        fromGenesis = \case
+{-        fromGenesis = \case
           BlocGenesis f -> return f
           _ -> throwIO $ UserError "Could not decode function arguments from body"
        hash' = transactionHash . rawTX2TX . rtPrimeToRt

--- a/strato/api/bloc/bloc2api/src/Bloc/API.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API.hs
@@ -62,6 +62,7 @@ type BlocAPI =
   -- /transaction endpoints
   :<|> PostBlocTransactionParallel
   :<|> PostBlocTransactionRaw
+  :<|> PostBlocTransactionBody
   :<|> PostBlocTransaction
 
 --Unsure what this will break if anything but remove later

--- a/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
@@ -93,6 +93,17 @@ type PostBlocTransaction = "transaction"
   :> ReqBody '[JSON] PostBlocTransactionRequest
   :> Post '[JSON] [BlocChainOrTransactionResult]
 
+-- | PostBlocTransactionBody should return a list of signed transaction hashes,
+-- using the caller's JWT, and their respective raw transaction bodies without
+-- posting the transactions to the VM
+--
+-- This was made at the request of Stably for their API integration
+type PostBlocTransactionBody = "transaction"
+  :> "body"                                      -- ^ /transaction/body
+  :> S.Header "X-USER-ACCESS-TOKEN" Text         -- ^ jwt
+  :> QueryParam "chainid" ChainId                -- ^ shard ID (optional)
+  :> ReqBody '[JSON] PostBlocTransactionRequest  -- ^ SolidVM transaction
+  :> Post '[JSON] [BlocTransactionBodyResult]    -- ^ Transaction results
 
 data PostBlocTransactionRawRequest = PostBlocTransactionRawRequest
   { postbloctransactionrawrequestAddress    :: Address

--- a/strato/api/bloc/bloc2api/src/Bloc/API/Users.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API/Users.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE TypeOperators              #-}
 
 module Bloc.API.Users (
+    BlocTransactionBodyResult(..),
     BlocTransactionResult(..),
     BlocTransactionStatus(..),
     PostUsersFill,
@@ -64,6 +65,7 @@ import           BlockApps.Solidity.SolidityValue
 import           BlockApps.Solidity.Xabi
 
 import           Blockchain.Data.TransactionResult
+import           Blockchain.Data.Json              (RawTransaction')
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ChainId
@@ -161,6 +163,11 @@ instance ToSchema BlocTransactionData where
         ex :: BlocTransactionData
         ex = Call [] -- probably make a better ToSchema example
 
+data BlocTransactionBodyResult = BlocTransactionBodyResult
+  { blocTransactionHash :: Keccak256
+  , blocTransactionRaw  :: Maybe RawTransaction'
+  } deriving (Eq, Show, Generic)
+
 data BlocTransactionResult = BlocTransactionResult
   { blocTransactionStatus   :: BlocTransactionStatus
   , blocTransactionHash     :: Keccak256
@@ -177,12 +184,23 @@ instance ToJSON BlocTransactionResult where
 instance FromJSON BlocTransactionResult where
   parseJSON = genericParseJSON (aesonDrop 15 camelCase)
 
+instance ToJSON BlocTransactionBodyResult where
+  toJSON = genericToJSON (aesonDrop 15 camelCase)
+
+instance FromJSON BlocTransactionBodyResult where
+  parseJSON = genericParseJSON (aesonDrop 15 camelCase)
 instance ToSample BlocTransactionResult where
   toSamples _ = singleSample BlocTransactionResult
     { blocTransactionStatus = Success
     , blocTransactionHash = hash "foo"
     , blocTransactionTxResult = Nothing
     , blocTransactionData = Nothing
+    }
+
+instance ToSample BlocTransactionBodyResult where
+  toSamples _ = singleSample BlocTransactionBodyResult
+    { blocTransactionHash = hash "foobarbaz"
+    , blocTransactionRaw = Nothing
     }
 
 instance ToSchema BlocTransactionResult where
@@ -197,6 +215,14 @@ instance ToSchema BlocTransactionResult where
         , blocTransactionTxResult = Nothing
         , blocTransactionData = Nothing
         }
+
+instance ToSchema BlocTransactionBodyResult where
+  declareNamedSchema proxy = genericDeclareNamedSchema blocSchemaOptions proxy
+    & mapped.schema.description ?~ "Bloc Transaction body result"
+    & mapped.schema.example ?~ toJSON ex
+    where
+      ex :: BlocTransactionBodyResult
+      ex = BlocTransactionBodyResult (hash "foobarbaz") Nothing -- ^ TODO: replace Nothing with Something
 
 type GetBlocTransactionResult = "transactions"
   :> Capture "hash" Keccak256


### PR DESCRIPTION
[As per Stably's request,](https://docs.google.com/document/d/18Gr_AviT8cfrxYXPMrpVm2ttxT2kKESyCmXz2UakGzQ/edit#heading=h.jkwvbm2uqs0d) the `/transaction/body` endpoint accepts the same requests as `/transaction` except it doesn't send the transaction to the VM, it signs transactions and returns a list of transaction hashes and their respective raw transaction bodies:
```
POST /transaction/body result
[
  {
    hash: Keccak256,
    raw: RawTransaction
  },
  ...
]
```
`hash` is already included in `raw` but someone calling this endpoint may just want the hash and not care about the raw tx, so a little redundancy should be ok.

In the following screenshots, the `/transaction/body` endpoint is called first to get the transaction hash then the `/transaction` endpoint is called with the same transaction payload. The transaction results in a matching transaction hash:

### POST Contract
![image](https://github.com/blockapps/strato-platform/assets/35979292/beadf50f-c554-429f-b232-c516be4f0532)

### POST Function
![image](https://github.com/blockapps/strato-platform/assets/35979292/15062208-d186-40ee-94d1-381bf9dfc2bf)
