### PR TITLE
Oauth dev mode

### DIFF
--- a/marketplace/backend/api/middleware/authHandler.js
+++ b/marketplace/backend/api/middleware/authHandler.js
@@ -29,8 +29,10 @@ const getTokenFromHeader = async (req) => {
 class AuthHandler {
   static authorizeRequest() {
     return async function (req, res, next) {
-      next();    // for now, this is a hack to just always authorize, this skips the rest of the code in this function
-      return;
+      if(process.env.OAUTH_DEV_MODE !== 'true'){
+        next();    // for now, this is a hack to just always authorize, this skips the rest of the code in this function
+        return;
+      };
 
 	
       try {

--- a/marketplace/backend/api/middleware/loadDappHandler.js
+++ b/marketplace/backend/api/middleware/loadDappHandler.js
@@ -7,8 +7,14 @@ import config from '/load.config'
 const options = { config }
 
 const loadDapp = async (req, res, next) => {
-  const { app, username } = req
-  const accessToken = {token: req.headers['x-user-access-token']};
+  if (process.env.OAUTH_DEV_MODE === 'true') {
+    const { app, accessToken, username } = req;
+  }
+  else{
+    const { app, username } = req
+    const accessToken = {token: req.headers['x-user-access-token']};
+  }
+  
   const userCredentials = {
     username,
     ...accessToken,

--- a/marketplace/backend/index.js
+++ b/marketplace/backend/index.js
@@ -62,7 +62,10 @@ app.use(
   })
 );
 
-//app.oauth = authHandler.initOauth()
+if (process.env.OAUTH_DEV_MODE !== "true") {
+  app.oauth = authHandler.initOauth()
+}
+
 app.set(constants.s3ParamName, {
   bucket: {
     Bucket: process.env.EXT_STORAGE_S3_BUCKET


### PR DESCRIPTION
 Main Premise (From Nikita):
 
 OAuth part of the code in the Markerplace app.
The thing is that we don't need the user authentication through the browser in the app - this is done by STRATO (strato's nginx specifically).
However, if we run in dev mode (remote or local STRATO node + marketplace app (backend + ui) running with npm (without docker) - we need the oauth part in place.
I think this is doable in the app by switch mode based on some env var, e.g. OAUTH_DEV_MODE=true will enable the oauth.