### PR TITLE
Sync stall fix

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/Context.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Context.hs
@@ -540,6 +540,7 @@ type MonadP2P m = ( MonadIO m
                        , GenesisBlockHash
                        , BestBlockNumber
                        , AvailablePeers
+                       , BondedPeers
                        , PublicKey
                        ] m
                   , All '[Mod.Modifiable]

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -15,7 +15,8 @@ module Blockchain.Event (
   module Blockchain.EventModel,
   handleEvents,
   handleGetChainDetails,
-  checkPeerIsMember
+  checkPeerIsMember,
+  cleanUpGlobalHeadersCache
   ) where
 
 import           Control.Arrow                         ((&&&), second)
@@ -487,6 +488,7 @@ handleEvents peer = awaitForever $ \case
                 maxTime <- fromIntegral . unConnectionTimeout <$> lift (access (Proxy @ConnectionTimeout))
                 liftIO $ setTitle $ "timer: " ++ show (maxTime - diffTime)
                 when (diffTime > maxTime) $ do
+                    lift cleanUpGlobalHeadersCache
                     yieldR $ Disconnect UselessPeer
                     liftIO $ setTitle "timer timed out!"
                     error "Peer did not respond"
@@ -499,6 +501,11 @@ handleEvents peer = awaitForever $ \case
       $logInfoS "handleEvents/AbortEvt" . T.pack $ "Received AbortEvt: " ++ reason
       yieldR $ Disconnect AlreadyConnected
     event -> liftIO . error $ "unrecognized event: " ++ show event
+
+cleanUpGlobalHeadersCache :: MonadP2P m => m ()
+cleanUpGlobalHeadersCache = do
+  putBlockHeaders []
+  putRemainingBHeaders [] 
 
 handleGetChainDetails :: ( MonadIO m
                          , MonadLogger m

--- a/strato/core/strato-p2p/src/Blockchain/Options.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Options.hs
@@ -18,7 +18,7 @@ defineFlag "sqlPeers" False "Choose peers from the SQL DB, not the config file"
 defineFlag "syncBacktrackNumber" (10::Integer) "block number to go back when syncing"
 defineFlag "debugFail" True "Fail on errors we're not supposed to reach. If false, just log insteand and go on"
 defineFlag "maxConn" (20::Int) "Maximum number of client connections."
-defineFlag "connectionTimeout" (300 :: Int) "Number of seconds to tolerate a useless peer"
+defineFlag "connectionTimeout" (30 :: Int) "Number of seconds to tolerate a useless peer"
 defineFlag "maxReturnedHeaders" (200 :: Int) "Number of headers to return from a GetBlockHeaders request" -- todo: seriously???
 defineFlag "maxHeadersTxsLens" (2500 :: Int) "Number of txs size to return from a BlockHeader request"
 defineFlag "averageTxsPerBlock" (40 :: Int) "Average number of txs per block"

--- a/strato/core/strato-p2p/src/Executable/StratoP2P.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2P.hs
@@ -6,7 +6,7 @@ import           Control.Concurrent.Async.Lifted.Safe
 import           BlockApps.Logging
 import           Blockchain.Context
 import           Executable.StratoP2PClient
-import           Executable.StratoP2PClientDirect
+-- import           Executable.StratoP2PClientDirect
 import           Executable.StratoP2PServer
 import           Executable.StratoP2PLoopback
 
@@ -16,8 +16,8 @@ stratoP2P :: ( MonadP2P n
              )
           => PeerRunner n (LoggingT IO) () -> LoggingT IO ()
 stratoP2P runner =
-  concurrently_
-  (race_ (stratoP2PLoopback runner)
+  -- concurrently_ (
+  race_ (stratoP2PLoopback runner)
     (race_ (stratoP2PClient runner)
-           (stratoP2PServer runner)))
-  (stratoP2PClientDirect runner)
+           (stratoP2PServer runner))
+  -- )(stratoP2PClientDirect runner)

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -139,7 +139,7 @@ stratoP2PClient runner = runner $ \_ -> do
   activePeersSem <- liftIO (SSem.new flags_maxConn)
   forever $ do
     $logDebugS "stratoP2PClient" "About to fetch available peers and loop over them"
-    ePeers <- getAvailablePeers
+    ePeers <- getBondedPeers
     case ePeers of
       Left err -> do
         $logErrorS "stratoP2PClient" . T.pack $ "Could not fetch peers: " ++ show err

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -111,7 +111,7 @@ runEthClientConduit peer pSource pSink seqSrc peerStr = do
       otherPubKey = fromMaybe (error "programmer error: runEthClientConduit was called without a pubkey") $ pPeerPubkey peer
   mConnectionResult <- timeout 2000000 $ pSource $$+ ethCryptConnect otherPubKey `fuseUpstream` pSink
   case mConnectionResult of
-    Nothing -> throwIO $ HandshakeException "handshake timed out"
+    Nothing -> pure $ Just $ toException $ HandshakeException "handshake timed out"
     Just (_, (outCtx, inCtx)) -> do
       !eventSource <- mkEthP2PEventSource pSource seqSrc peerStr inCtx
       !eventSink <- mkEthP2PEventConduit peerStr outCtx 

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -40,6 +40,7 @@ import           UnliftIO
 import           BlockApps.Logging
 import           Blockchain.CommunicationConduit
 import           Blockchain.Context
+import           Blockchain.Event                      (cleanUpGlobalHeadersCache)
 import           Blockchain.Data.PubKey                (secPubKeyToPoint)
 import           Blockchain.EthEncryptionException
 import           Blockchain.EventException
@@ -193,10 +194,12 @@ stratoP2PClient runner = runner $ \_ -> do
                    e' | Just PeerDisconnected <- fromException e' -> do
                     disErr <- storeDisableException thePeer (T.pack "PeerDisconnected")
                     whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
+                    cleanUpGlobalHeadersCache -- connection ended, so clean up global cache for other threads
                     lengthenPeerDisable thePeer
                    e' | Just TimeoutException <- fromException e' -> do
                     disErr <- storeDisableException thePeer (T.pack "TimeoutException")
                     whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
+                    cleanUpGlobalHeadersCache -- connection ended, so clean up global cache for other threads
                     lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
                    e' | Just NoPeerCertificate <- fromException e' -> do
                     disErr <- storeDisableException thePeer (T.pack "NoPeerCertificate")

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -108,14 +108,16 @@ runEthClientConduit peer pSource pSink seqSrc peerStr = do
 
   let myPublic = secPubKeyToPoint myPublic'
       otherPubKey = fromMaybe (error "programmer error: runEthClientConduit was called without a pubkey") $ pPeerPubkey peer
-  (_, (outCtx, inCtx)) <- pSource $$+ ethCryptConnect otherPubKey `fuseUpstream` pSink
-
-  !eventSource <- mkEthP2PEventSource pSource seqSrc peerStr inCtx
-  !eventSink <- mkEthP2PEventConduit peerStr outCtx 
-  fmap (either Just (const Nothing)) . try . runConduit $ eventSource
-                  .| handleMsgClientConduit myPublic peer
-                  .| eventSink
-                  .| pSink
+  mConnectionResult <- timeout 2000000 $ pSource $$+ ethCryptConnect otherPubKey `fuseUpstream` pSink
+  case mConnectionResult of
+    Nothing -> throwIO $ HandshakeException "handshake timed out"
+    Just (_, (outCtx, inCtx)) -> do
+      !eventSource <- mkEthP2PEventSource pSource seqSrc peerStr inCtx
+      !eventSink <- mkEthP2PEventConduit peerStr outCtx 
+      fmap (either Just (const Nothing)) . try . runConduit $ eventSource
+                      .| handleMsgClientConduit myPublic peer
+                      .| eventSink
+                      .| pSink
 
 
 runPeerInList :: ( MonadP2P m

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -131,14 +131,16 @@ runEthServerConduit p pSource pSink seqSrc peerStr = do
   
   let myPubkey = secPubKeyToPoint myPubKey'
       otherPubKey = fromMaybe (error "programmer error: runEthServerConduit was called without a pubkey") $ pPeerPubkey p
-  (_, (outCtx, inCtx)) <- pSource $$+ ethCryptAccept otherPubKey `fuseUpstream` pSink
-  
-  !eventSource <- mkEthP2PEventSource pSource seqSrc peerStr inCtx
-  !eventSink <- mkEthP2PEventConduit peerStr outCtx
-  fmap (either Just (const Nothing)) . try . runConduit $ eventSource
-                  .| handleMsgServerConduit myPubkey p
-                  .| eventSink
-                  .| pSink
+  mConnectionResult <- timeout 2000000 $ pSource $$+ ethCryptAccept otherPubKey `fuseUpstream` pSink
+  case mConnectionResult of 
+    Nothing -> throwIO $ HandshakeException "handshake timed out"
+    Just (_, (outCtx, inCtx)) -> do     
+      !eventSource <- mkEthP2PEventSource pSource seqSrc peerStr inCtx
+      !eventSink <- mkEthP2PEventConduit peerStr outCtx
+      fmap (either Just (const Nothing)) . try . runConduit $ eventSource
+                      .| handleMsgServerConduit myPubkey p
+                      .| eventSink
+                      .| pSink
 
 stratoP2PServer :: (MonadP2P n, RunsServer n (LoggingT IO))
                 => PeerRunner n (LoggingT IO) () -> LoggingT IO ()

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -133,7 +133,7 @@ runEthServerConduit p pSource pSink seqSrc peerStr = do
       otherPubKey = fromMaybe (error "programmer error: runEthServerConduit was called without a pubkey") $ pPeerPubkey p
   mConnectionResult <- timeout 2000000 $ pSource $$+ ethCryptAccept otherPubKey `fuseUpstream` pSink
   case mConnectionResult of 
-    Nothing -> throwIO $ HandshakeException "handshake timed out"
+    Nothing -> pure $ Just $ toException $ HandshakeException "handshake timed out"
     Just (_, (outCtx, inCtx)) -> do     
       !eventSource <- mkEthP2PEventSource pSource seqSrc peerStr inCtx
       !eventSink <- mkEthP2PEventConduit peerStr outCtx

--- a/strato/simulator/strato-lite/package.yaml
+++ b/strato/simulator/strato-lite/package.yaml
@@ -116,6 +116,7 @@ tests:
       - containers
       - crypto-pubkey-types
       - deepseq
+      - ethereum-encryption
       - monad-alter
       - parsec
       - QuickCheck

--- a/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
+++ b/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
@@ -1590,6 +1590,35 @@ createConnection server' client' = do
     serverExceptionTVar
     clientExceptionTVar
 
+createGermophobicConnection :: P2PPeer
+                            -> P2PPeer
+                            -> IO P2PConnection
+createGermophobicConnection server' client' = do
+  serverToClientTQueue <- newTQueueIO
+  clientToServerTQueue <- newTQueueIO
+  clientSeqSource <- atomically . dupTMChan $ _p2pPeerSeqP2pSource client'
+  serverCtx <- newIORef $ def & unseqSink .~ _p2pPeerUnseqSource server'
+  clientCtx <- newIORef $ def & unseqSink .~ _p2pPeerUnseqSource client'
+  serverExceptionTVar <- newTVarIO Nothing
+  clientExceptionTVar <- newTVarIO Nothing
+  let rServer :: MonadP2PTest TestContextM (Maybe SomeException)
+      rServer = pure Nothing -- server is germophobic; will not conduct handshake
+      rClient :: MonadP2PTest TestContextM (Maybe SomeException)
+      rClient = runEthClientConduit (_p2pPeerPPeer server')
+                                    (sourceTQueue serverToClientTQueue)
+                                    (sinkTQueue clientToServerTQueue)
+                                    (sourceTMChan clientSeqSource .| (awaitForever $ either (const $ pure ()) yield))
+                                    ("Me: " ++ _p2pPeerName client' ++ ", Them: " ++ _p2pPeerName server')
+  pure $ P2PConnection
+    serverToClientTQueue
+    clientToServerTQueue
+    server'
+    client'
+    (runReaderT rServer serverCtx)
+    (runReaderT rClient clientCtx)
+    serverExceptionTVar
+    clientExceptionTVar
+
 makeValidators :: [(PrivateKey, a)] -> [(Address, a)]
 makeValidators = map (first fromPrivateKey)
 

--- a/strato/simulator/strato-lite/tests/SimulatorSpec.hs
+++ b/strato/simulator/strato-lite/tests/SimulatorSpec.hs
@@ -43,6 +43,7 @@ import           Blockchain.Data.TransactionDef
 import qualified Blockchain.Data.TXOrigin              as Origin
 import           Blockchain.DB.RawStorageDB
 import           Blockchain.DB.SolidStorageDB
+import           Blockchain.EthEncryptionException     (EthEncryptionException(..))
 import           BlockApps.X509.Certificate           
 
 import           Blockchain.Sequencer.Event
@@ -77,6 +78,9 @@ import           Text.RawString.QQ
 
 import           UnliftIO
 import           UnliftIO.Concurrent                   (threadDelay)
+
+instance Eq SomeException where
+  _ == _ = True -- for the purpose of my test, all exceptions are equal
 
 createPeer' :: PrivateKey -> ChainMemberParsedSet -> [(Address, ChainMemberParsedSet)] -> [X509Certificate] -> T.Text -> T.Text -> IO P2PPeer
 createPeer' pk identity as certs n ip = do
@@ -767,6 +771,21 @@ contract B {
         void . timeout 20000000 $ concurrently_ (runNetworkOld (take 3 peers) (take 3 connections')) (concurrently_ (void . timeout 4000000 $ mainChainRoutine 0) routine)
         ctxs <- atomically $ traverse (readTVar . _p2pTestContext) peers
         ifor_ ctxs $ \i ctx -> (i, Set.size . unChainMembers . _validators <$> _blockstanbulContext (_sequencerContext ctx)) `shouldBe` (i, Just 3)
+    it "will throw an exception if the handshake times out" $ do
+      serverPKey <- newPrivateKey
+      clientPKey <- newPrivateKey
+      let validatorAddresses = fromPrivateKey <$> [serverPKey, clientPKey]
+          validatorInfos = [ CommonName "GrumpyCat, Inc" "" "GrumpyCat" True
+                           , CommonName "BlockApps" "" "Aya" True
+                           ]
+          zippedValidators = zip validatorAddresses validatorInfos
+      certs <- traverse (uncurry selfSignCert) $ zip [serverPKey, clientPKey] validatorInfos
+      server' <- createPeer' serverPKey (validatorInfos !! 0) zippedValidators certs "server" "1.1.1.1"
+      client' <- createPeer' clientPKey (validatorInfos !! 1) zippedValidators certs "client" "2.2.2.2"
+      connection <- createGermophobicConnection server' client'
+      void . timeout (3 * 1000 * 1000) $ runConnection connection
+      clientExcept <- readTVarIO $ connection ^. clientException
+      clientExcept `shouldBe` Just (toException $ HandshakeException "handshake timed out")
 
   describe "X.509 Private Chain exchange" $ do
     it "can add an organization to a private chain" $ do


### PR DESCRIPTION
This branch addresses two issues that were occurring during sync that would cause it to stall indefinitely 

1. If the connection failed during the handshake, the thread would hang instead of timing out the connection (test for the fix added to strato-lite due to the difficulty of replicating this issue)
2. There is a global cache being used by all threads to keep track of requested headers. Sometimes when a connection would fail, this cache would not be cleaned up properly, which prevented all subsequent threads from being able to make any forward progress in sync (fix for this has been tested several times locally and just this weekend on the marketplace node)

Other minor changes include

- removing usage of stratop2pclientdirect
- setting the default timeout for a useless peer to 30 seconds instead of five whole whopping minutes
- only trying to connect to BondedPeers in p2p rather than AvailablePeers 