### PR TITLE
Strato 3121 resync mirrors

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/Context.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Context.hs
@@ -199,8 +199,8 @@ withPeerAddress f = PeerAddress . f . unPeerAddress
 
 data Context = Context
   { contextKafkaState     :: K.KafkaState
-  , blockHeaders          :: [BlockData]
-  , remainingBlockHeaders :: RemainingBlockHeaders
+  , blockHeaders          :: ([BlockData], UTCTime) -- keep track when last updated global headers cache
+  , remainingBlockHeaders :: (RemainingBlockHeaders, UTCTime) -- keep track when last updated global headers cache
   , actionTimestamp       :: ActionTimestamp
   , _blockstanbulPeerAddr :: PeerAddress
   , _outboundWireMessages :: S.OSet (T.Text, Keccak256)
@@ -402,15 +402,38 @@ instance MonadIO m => Mod.Accessible ActionTimestamp (ReaderT Config m) where
   access _ = Mod.get (Proxy @ActionTimestamp)
 
 instance MonadIO m => Mod.Modifiable [BlockData] (ReaderT Config m) where
-  get _   = blockHeaders <$> Mod.get (Proxy @Context)
-  put _ k = asks configContext >>= flip atomicModifyIORef' (\c -> (c{blockHeaders = k},()))
+  get _   = do
+    (bHeaders, lastUpdateTS) <- blockHeaders <$> Mod.get (Proxy @Context)
+    now <- liftIO getCurrentTime
+    let diffTime = now `diffUTCTime` lastUpdateTS
+    maxTime <- fromIntegral . unConnectionTimeout <$> Mod.access (Proxy @ConnectionTimeout)
+    if diffTime > maxTime then do -- stale cache; override it
+      Mod.put (Proxy @[BlockData]) []
+      pure []
+    else 
+      pure bHeaders
+  put _ k = do
+    now <- liftIO getCurrentTime
+    asks configContext >>= flip atomicModifyIORef' (\c -> (c{blockHeaders = (k, now)},()))
 
 instance MonadIO m => Mod.Accessible [BlockData] (ReaderT Config m) where
   access _ = Mod.get (Proxy @[BlockData])
 
 instance MonadIO m => Mod.Modifiable RemainingBlockHeaders (ReaderT Config m) where
-  get _   = remainingBlockHeaders <$> Mod.get (Proxy @Context)
-  put _ k = asks configContext >>= flip atomicModifyIORef' (\c -> (c{remainingBlockHeaders = k},()))
+  get _   = do
+    (remBHeaders, lastUpdateTS) <- remainingBlockHeaders <$> Mod.get (Proxy @Context)
+    now <- liftIO getCurrentTime
+    let diffTime = now `diffUTCTime` lastUpdateTS
+    maxTime <- fromIntegral . unConnectionTimeout <$> Mod.access (Proxy @ConnectionTimeout)
+    if diffTime > maxTime then do -- stale cache; override it
+      let emptyRBH = RemainingBlockHeaders []
+      Mod.put (Proxy @RemainingBlockHeaders) emptyRBH
+      pure emptyRBH
+    else 
+      pure remBHeaders
+  put _ k = do
+    now <- liftIO getCurrentTime
+    asks configContext >>= flip atomicModifyIORef' (\c -> (c{remainingBlockHeaders = (k, now)},()))
 
 instance MonadIO m => Mod.Accessible RemainingBlockHeaders (ReaderT Config m) where
   access _ = Mod.get (Proxy @RemainingBlockHeaders)
@@ -637,8 +660,8 @@ initContext :: Context
 initContext = Context
   { actionTimestamp = emptyActionTimestamp
   , contextKafkaState = mkConfiguredKafkaState "strato-p2p"
-  , blockHeaders = []
-  , remainingBlockHeaders = RemainingBlockHeaders []
+  , blockHeaders = ([], jamshidBirth)
+  , remainingBlockHeaders = (RemainingBlockHeaders [], jamshidBirth)
   , _blockstanbulPeerAddr = PeerAddress Nothing
   , _outboundWireMessages = S.empty
   }

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -211,11 +211,7 @@ handleEvents peer = awaitForever $ \case
         let headers = morphBlockHeader <$> bHeaders
         lift stampActionTimestamp
         alreadyRequestedHeaders <- lift getBlockHeaders -- get already requested headers
-        when (null alreadyRequestedHeaders) $ do        -- proceed if we are not already requesting headers
-            -- let headerHashes = S.fromList $ map headerHash headers
-            --     parentHashes = S.fromList $ map parentHash headers
-            --     allNeeded = headerHashes `S.union` parentHashes
-
+        if null alreadyRequestedHeaders then do       -- proceed if we are not already requesting headers
             -- check if blockheaders we recieved have parents.
             let parents = map blockDataParentHash headers
             existingParents <- lift $ lookupMany (Proxy @BlockData) parents
@@ -250,6 +246,11 @@ handleEvents peer = awaitForever $ \case
             $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "putBlockHeaders called with length " ++ show (length neededHeaders')
             yieldR . GetBlockBodies $ blockHeaderHash <$> neededHeaders'
             lift stampActionTimestamp
+          else $logInfoS "handleEvents/BlockHeaders" $ T.unlines [
+            "Tried to request more block headers but it seems the block headers cache is currenlty being used.",
+            "If this message shows up a lot but the node's best block # doesn't increase,",
+            "there might be something wrong with the cache."
+          ]
 
     -- todo: seems like geth and parity will send bodies on a best-effort, skipping shas they doesnt have
     -- todo: e.g. if they have bodies for Keccak256s [1, 2, 4, 7, 8, 9] and you request [1..10] you'll get
@@ -546,6 +547,7 @@ numberFromBestBlock (BestBlock _ n _) = n
 -- todo: we should take blockNumber as argument here instead of just looking for
 -- bestBlock to prevent us from getting stuck
 syncFetch :: ( MonadIO m
+             , MonadLogger m
              , Modifiable ActionTimestamp m
              , Accessible [BlockData] m
              , Accessible MaxReturnedHeaders m
@@ -553,10 +555,15 @@ syncFetch :: ( MonadIO m
           => Direction -> Integer -> ConduitM Event (Either P2PCNC Message) m ()
 syncFetch d num = do
     blockHeaders' <- lift getBlockHeaders -- get blockHeaders from Context
-    when (null blockHeaders') $ do
+    if null blockHeaders' then do
         mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
         yieldR $ GetBlockHeaders (BlockNumber num) mrh 0 d
         lift stampActionTimestamp
+      else $logInfoS "syncFetch" $ T.unlines [
+        "Tried to request more block headers but it seems the block headers cache is currenlty being used.",
+        "If this message shows up a lot but the node's best block # doesn't increase,",
+        "there might be something wrong with the cache."
+      ]
 
 shouldSend :: PPeer -> Origin.TXOrigin -> Bool
 shouldSend peer txo = case txo of

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -16,7 +16,6 @@ module Blockchain.Event (
   handleEvents,
   handleGetChainDetails,
   checkPeerIsMember,
-  cleanUpGlobalHeadersCache
   ) where
 
 import           Control.Arrow                         ((&&&), second)
@@ -488,7 +487,6 @@ handleEvents peer = awaitForever $ \case
                 maxTime <- fromIntegral . unConnectionTimeout <$> lift (access (Proxy @ConnectionTimeout))
                 liftIO $ setTitle $ "timer: " ++ show (maxTime - diffTime)
                 when (diffTime > maxTime) $ do
-                    lift cleanUpGlobalHeadersCache
                     yieldR $ Disconnect UselessPeer
                     liftIO $ setTitle "timer timed out!"
                     error "Peer did not respond"
@@ -501,11 +499,6 @@ handleEvents peer = awaitForever $ \case
       $logInfoS "handleEvents/AbortEvt" . T.pack $ "Received AbortEvt: " ++ reason
       yieldR $ Disconnect AlreadyConnected
     event -> liftIO . error $ "unrecognized event: " ++ show event
-
-cleanUpGlobalHeadersCache :: MonadP2P m => m ()
-cleanUpGlobalHeadersCache = do
-  putBlockHeaders []
-  putRemainingBHeaders [] 
 
 handleGetChainDetails :: ( MonadIO m
                          , MonadLogger m

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -40,7 +40,6 @@ import           UnliftIO
 import           BlockApps.Logging
 import           Blockchain.CommunicationConduit
 import           Blockchain.Context
-import           Blockchain.Event                      (cleanUpGlobalHeadersCache)
 import           Blockchain.Data.PubKey                (secPubKeyToPoint)
 import           Blockchain.EthEncryptionException
 import           Blockchain.EventException
@@ -194,12 +193,10 @@ stratoP2PClient runner = runner $ \_ -> do
                    e' | Just PeerDisconnected <- fromException e' -> do
                     disErr <- storeDisableException thePeer (T.pack "PeerDisconnected")
                     whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-                    cleanUpGlobalHeadersCache -- connection ended, so clean up global cache for other threads
                     lengthenPeerDisable thePeer
                    e' | Just TimeoutException <- fromException e' -> do
                     disErr <- storeDisableException thePeer (T.pack "TimeoutException")
                     whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-                    cleanUpGlobalHeadersCache -- connection ended, so clean up global cache for other threads
                     lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
                    e' | Just NoPeerCertificate <- fromException e' -> do
                     disErr <- storeDisableException thePeer (T.pack "NoPeerCertificate")

--- a/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
+++ b/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
@@ -48,7 +48,7 @@ import           Data.Ranged
 import qualified Data.Set                              as Set
 import qualified Data.Set.Ordered                      as S
 import qualified Data.Sequence                         as Q
-import           Data.Time.Clock                       (getCurrentTime)
+import           Data.Time.Clock                       (UTCTime(..), getCurrentTime, diffUTCTime)
 import           Data.Text (Text)
 import qualified Data.Text                             as T
 import qualified Data.Text.Encoding                    as Text
@@ -149,8 +149,8 @@ preAlGoreInternet :: Internet
 preAlGoreInternet = Internet M.empty M.empty
 
 data P2PContext = P2PContext
-  { _blockHeaders          :: [DataDefs.BlockData]
-  , _remainingBlockHeaders :: RemainingBlockHeaders
+  { _blockHeaders          :: ([DataDefs.BlockData], UTCTime)
+  , _remainingBlockHeaders :: (RemainingBlockHeaders, UTCTime)
   , _actionTimestamp       :: ActionTimestamp
   , _peerAddr              :: PeerAddress
   , _outboundPbftMessages  :: S.OSet (Text, Keccak256)
@@ -159,8 +159,8 @@ data P2PContext = P2PContext
 makeLenses ''P2PContext
 
 instance Default P2PContext where
-  def = P2PContext []
-                   (RemainingBlockHeaders [])
+  def = P2PContext ([], jamshidBirth)
+                   (RemainingBlockHeaders [], jamshidBirth)
                    emptyActionTimestamp
                    (PeerAddress Nothing)
                    S.empty
@@ -291,18 +291,41 @@ instance MonadIO m => Mod.Modifiable ActionTimestamp (MonadP2PTest m) where
 instance MonadIO m => Mod.Accessible ActionTimestamp (MonadP2PTest m) where
   access _ = Mod.get (Mod.Proxy @ActionTimestamp)
 
-instance MonadIO m => Mod.Modifiable [DataDefs.BlockData] (MonadP2PTest m) where
-  get _ = use blockHeaders
-  put _ = assign blockHeaders
+instance (MonadIO m, Mod.Accessible ConnectionTimeout m) => Mod.Modifiable [DataDefs.BlockData] (MonadP2PTest m) where
+  get _ = do
+    (bHeaders, lastUpdateTS) <- use blockHeaders
+    now <- liftIO getCurrentTime
+    let diffTime = now `diffUTCTime` lastUpdateTS
+    maxTime <- fromIntegral . unConnectionTimeout <$> Mod.access (Mod.Proxy @ConnectionTimeout)
+    if diffTime > maxTime then do -- stale cache; override it
+      Mod.put (Mod.Proxy @[DataDefs.BlockData]) []
+      pure []
+    else 
+      pure bHeaders
+  put _ k = do
+    now <- liftIO getCurrentTime
+    assign blockHeaders (k, now)
 
-instance MonadIO m => Mod.Accessible [DataDefs.BlockData] (MonadP2PTest m) where
+instance (MonadIO m, Mod.Accessible ConnectionTimeout m) => Mod.Accessible [DataDefs.BlockData] (MonadP2PTest m) where
   access _ = Mod.get (Mod.Proxy @[DataDefs.BlockData])
 
-instance MonadIO m => Mod.Modifiable RemainingBlockHeaders (MonadP2PTest m) where
-  get _ = use remainingBlockHeaders
-  put _ = assign remainingBlockHeaders
+instance (MonadIO m, Mod.Accessible ConnectionTimeout m) => Mod.Modifiable RemainingBlockHeaders (MonadP2PTest m) where
+  get _ = do
+    (remBHeaders, lastUpdateTS) <- use remainingBlockHeaders
+    now <- liftIO getCurrentTime
+    let diffTime = now `diffUTCTime` lastUpdateTS
+    maxTime <- fromIntegral . unConnectionTimeout <$> Mod.access (Mod.Proxy @ConnectionTimeout)
+    if diffTime > maxTime then do -- stale cache; override it
+      let emptyRBH = RemainingBlockHeaders []
+      Mod.put (Mod.Proxy @RemainingBlockHeaders) emptyRBH
+      pure emptyRBH
+    else 
+      pure remBHeaders
+  put _ k = do 
+    now <- liftIO getCurrentTime
+    assign remainingBlockHeaders (k, now)
 
-instance MonadIO m => Mod.Accessible RemainingBlockHeaders (MonadP2PTest m) where
+instance (MonadIO m, Mod.Accessible ConnectionTimeout m) => Mod.Accessible RemainingBlockHeaders (MonadP2PTest m) where
   access _ = Mod.get (Mod.Proxy @RemainingBlockHeaders)
 
 instance MonadIO m => Mod.Accessible MaxReturnedHeaders (MonadTest m) where
@@ -1142,13 +1165,13 @@ instance (Monad m, A.Replaceable T.Text PPeer m) => A.Replaceable T.Text PPeer (
 startingCheckpoint :: [ChainMemberParsedSet] -> Checkpoint
 startingCheckpoint as = def{checkpointValidators = as}
 
-newBlockstanbulContext :: ChainMemberParsedSet -> [ChainMemberParsedSet] -> BlockstanbulContext
-newBlockstanbulContext paddr as =
+newBlockstanbulContext :: ChainMemberParsedSet -> [ChainMemberParsedSet] -> Bool -> BlockstanbulContext
+newBlockstanbulContext paddr as valBehav =
   let ckpt = startingCheckpoint as
-  in newContext ckpt paddr True
+  in newContext ckpt paddr valBehav
 
 emptyBlockstanbulContext :: BlockstanbulContext
-emptyBlockstanbulContext = newBlockstanbulContext undefined []
+emptyBlockstanbulContext = newBlockstanbulContext undefined [] True
   
 newSequencerContext :: MonadIO m => BlockstanbulContext -> m SequencerContext
 newSequencerContext bc = do
@@ -1283,6 +1306,16 @@ addValidatorsToCertMap vals m =
       insertValidatorInfo (a, b) = M.insert a (Modification (cmpsToXcis a b))
    in foldr insertValidatorInfo m vals
 
+createPeer' :: PrivateKey -> ChainMemberParsedSet -> [(Address, ChainMemberParsedSet)] -> [X509Certificate] -> T.Text -> T.Text -> IO P2PPeer
+createPeer' pk identity as certs n ip = do
+  inet <- newTVarIO preAlGoreInternet
+  createPeer pk identity as certs inet n (IPAsText ip) (TCPPort 30303) (UDPPort 30303) [] True
+
+createNonvalPeer :: PrivateKey -> ChainMemberParsedSet -> [(Address, ChainMemberParsedSet)] -> [X509Certificate] -> T.Text -> T.Text -> IO P2PPeer
+createNonvalPeer pk identity as certs n ip = do
+  inet <- newTVarIO preAlGoreInternet
+  createPeer pk identity as certs inet n (IPAsText ip) (TCPPort 30303) (UDPPort 30303) [] False
+
 createPeer :: PrivateKey
            -> ChainMemberParsedSet
            -> [(Address, ChainMemberParsedSet)]
@@ -1293,8 +1326,9 @@ createPeer :: PrivateKey
            -> TCPPort
            -> UDPPort
            -> [IPAsText]
+           -> Bool
            -> IO P2PPeer
-createPeer privKey selfId initialValidators' extraCerts inet name ipAsText@(IPAsText ipAddr) tcpPort udpPort bootNodes = do
+createPeer privKey selfId initialValidators' extraCerts inet name ipAsText@(IPAsText ipAddr) tcpPort udpPort bootNodes valBehav = do
   unseqSource <- newTQueueIO
   seqP2pSource <- newBroadcastTMChanIO
   seqVmSource <- newTQueueIO
@@ -1307,7 +1341,7 @@ createPeer privKey selfId initialValidators' extraCerts inet name ipAsText@(IPAs
   atomically $ do
     modifyTVar inet $ tcpPorts . at (ipAsText, tcpPort) ?~ tcpVSock
     modifyTVar inet $ udpPorts . at (ipAsText, udpPort) ?~ udpVSock
-  seqCtx' <- newSequencerContext $ newBlockstanbulContext selfId (snd <$> initialValidators')
+  seqCtx' <- newSequencerContext $ newBlockstanbulContext selfId (snd <$> initialValidators') valBehav
   let seqCtx = (x509certInfoState %~ addValidatorsToCertMap initialValidators') seqCtx'
       initialValidators = fst <$> initialValidators'
   cache  <- TRC.new 64
@@ -1704,7 +1738,7 @@ createNode nodeLabel identity ipAddr tcpPort udpPort bootNodes inet = do
   certs <- asks _initialCerts
   vals <- asks _initialValidators
   pKey <- liftIO $ newPrivateKey
-  liftIO $ createPeer pKey identity vals certs inet nodeLabel ipAddr tcpPort udpPort bootNodes
+  liftIO $ createPeer pKey identity vals certs inet nodeLabel ipAddr tcpPort udpPort bootNodes True
 
 addNode :: Text -> ChainMemberParsedSet -> IPAsText -> TCPPort -> UDPPort -> [IPAsText] -> ReaderT NetworkManager IO Bool
 addNode nodeLabel identity ipAddr tcpPort udpPort bootNodes = do
@@ -1781,7 +1815,7 @@ runNetwork nodesList validatorsFilter = do
   certs <- traverse (uncurry selfSignCert) privAndIds
   inet <- newTVarIO preAlGoreInternet
   let bootNodes = (\(_, (_,i,_,_)) -> i) <$> nodesList
-  peers <- traverse (\(p,(n,(c,i,t,u))) -> createPeer p c validators' certs inet n i t u bootNodes) $ zip privKeys nodesList
+  peers <- traverse (\(p,(n,(c,i,t,u))) -> createPeer p c validators' certs inet n i t u bootNodes True) $ zip privKeys nodesList
   let nodesMap = M.fromList $ zip (fst <$> nodesList) peers
       network' = Network nodesMap M.empty inet
   nodeThreads' <- for nodesMap $ async . runNode
@@ -1799,7 +1833,7 @@ runNetworkWithStaticConnections nodesList connectionsList validatorsFilter = do
       validators' = makeValidators validatorsPrivKeys
   certs <- traverse (uncurry selfSignCert) privAndIds
   inet <- newTVarIO preAlGoreInternet
-  peers <- traverse (\(p,(n,i,c)) -> createPeer p c validators' certs inet n i (TCPPort 30303) (UDPPort 30303) []) $ zip privKeys nodesList
+  peers <- traverse (\(p,(n,i,c)) -> createPeer p c validators' certs inet n i (TCPPort 30303) (UDPPort 30303) [] True) $ zip privKeys nodesList
   let nodesMap = M.fromList $ zip ((\(a,_,_) -> a) <$> nodesList) peers
   eConnections <- runExceptT . for connectionsList $ \(server', client') -> do
     serverPeer <- maybeToExceptT ("Couldn't find server " <> server') . MaybeT . pure $ M.lookup server' nodesMap

--- a/strato/simulator/strato-lite/tests/SimulatorSpec.hs
+++ b/strato/simulator/strato-lite/tests/SimulatorSpec.hs
@@ -49,7 +49,6 @@ import           BlockApps.X509.Certificate
 import           Blockchain.Sequencer.Event
 import           Blockchain.Sequencer.Monad
 
-import           Blockchain.Strato.Discovery.Data.Peer hiding (createPeer)
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ChainId
@@ -81,11 +80,6 @@ import           UnliftIO.Concurrent                   (threadDelay)
 
 instance Eq SomeException where
   _ == _ = True -- for the purpose of my test, all exceptions are equal
-
-createPeer' :: PrivateKey -> ChainMemberParsedSet -> [(Address, ChainMemberParsedSet)] -> [X509Certificate] -> T.Text -> T.Text -> IO P2PPeer
-createPeer' pk identity as certs n ip = do
-  inet <- newTVarIO preAlGoreInternet
-  createPeer pk identity as certs inet n (IPAsText ip) (TCPPort 30303) (UDPPort 30303) []
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
This fix introduces more robust handling of the block headers cache in p2p so that no more issues with sync stall should appear (such as those seen recently with the mirror nodes). The cache now keeps track of the last time it was updated and will automatically clear if it is stale so that other threads may use it.

Update: this fix was tested on mirror node 1, which was able to fully sync with the network and remain in sync afterwards. It was also tested on mirror node 2, which is currently still syncing. During its sync, mirror node 2 got stuck on an earlier sequence number than the network was on but was able to resync and catch up with the network, indicating the fix is allowing sync to overcome issues that arise.