### PR TITLE
Strato network update

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -166,7 +166,7 @@ services:
     - mineBlocks=${mineBlocks:-true}
     - miningAlgorithm=${miningAlgorithm}
     - miningThreads=${miningThreads}
-    - network=${network:-blockappsnet}
+    - network=${network:-mercata-hydrogen}
     - networkID=${networkID}
     - numMinPeers=${numMinPeers}
     - OAUTH_DISCOVERY_URL=${OAUTH_DISCOVERY_URL}

--- a/strato/core/strato-networks/src/Blockchain/Network.hs
+++ b/strato/core/strato-networks/src/Blockchain/Network.hs
@@ -44,4 +44,12 @@ getParams "mercata-testnet" = return $ Just
 --      webAddress = "engineering.stratoid.blockapps.net"
       }
   ]
+getParams "mercata-hydrogen" = return $ Just -- to make network id: mercata-hydrogen -> ascii to hex -> convert # to base10
+  [
+    NetworkParams {
+      ethAddress = Address 0x100, -- not important
+      webAddress = "52.4.166.179", -- testnet2 node 1
+      identity = blockAppsIdentity
+    }
+  ]
 getParams _ = return Nothing

--- a/strato/core/vm-tools/src/Blockchain/VMOptions.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMOptions.hs
@@ -60,5 +60,5 @@ defineFlag "accountNonceLimit" (1000::Integer) "The maximum number of transactio
 defineFlag "gasLimit" (1000000::Integer) "The maximum amount of gas a transaction can use"
 
 defineFlag "network" (""::String) "Choose a network to join"
-defineFlag "networkID" (-1::Int) "set a custom network ID for the client"
+defineFlag "networkID" (-1::Integer) "set a custom network ID for the client"
 defineFlag "testnet" False "connect to testnet"


### PR DESCRIPTION
This change allows you to start up a strato node that connects to mercata-hydrogen (testnet2) by default without having to specify any flags for the network, network id, or boot node. However, it appears the network ids have been overflowing this whole time, so this change would have to be introduced delicately as it can be potentially disastrous. We can't wipe the validator node or else it won't be able to sync to the network. If a new block comes in while some validators are updated and other aren't, this will cause a split network.

One option may be to hold off on using this change until we spin up another network so everyone is on the same page there. However, this change is not backwards compatible, so you wouldn't be able to spin up a new node and connect it to the old testnet or testnet2.

Another option is to just force the overflow to always happen, which would be ugly but backwards compatible (and also avoid issues of having to very delicately re-spin up networks). It's the quickest and easiest solution, but perhaps not best for the long term.