### PR TITLE
Removed Organization from Orders Screen

### DIFF
--- a/marketplace/ui/src/components/Order/BoughtOrderDetails.js
+++ b/marketplace/ui/src/components/Order/BoughtOrderDetails.js
@@ -347,12 +347,12 @@ const BoughtOrderDetails = ({ user, users }) => {
               <OrderData title="NUMBER" value={`#${details.orderId}`} />
               <Divider type="vertical" className="h-14 bg-secondryD" />
               <OrderData
-                title="BUYER ORGANIZATION"
+                title="BUYER"
                 value={details.buyerOrganization}
               />
               <Divider type="vertical" className="h-14 bg-secondryD" />
               <OrderData
-                title="SELLER ORGANIZATION"
+                title="SELLER"
                 value={details.sellerOrganization}
               />
               <Divider type="vertical" className="h-14 bg-secondryD" />

--- a/marketplace/ui/src/components/Order/BoughtOrdersTable.js
+++ b/marketplace/ui/src/components/Order/BoughtOrdersTable.js
@@ -77,7 +77,7 @@ const BoughtOrdersTable = ({ user }) => {
       ),
     },
     {
-      title: "seller organization".toUpperCase(),
+      title: "seller".toUpperCase(),
       dataIndex: "sellerOrganization",
       key: "sellerOrganization",
       render: (text) => <p>{text}</p>,

--- a/marketplace/ui/src/components/Order/InvoiceComponent.js
+++ b/marketplace/ui/src/components/Order/InvoiceComponent.js
@@ -154,8 +154,8 @@ const InvoiceComponent = ({ invoice }) => {
           <View>
             <Text style={styles.label}>Order Number: <Text style={styles.value}>{invoice.orderId}</Text></Text>
             <Text style={styles.label}>Order Date: <Text style={styles.value}>{getStringDate(invoice.orderDate, US_DATE_FORMAT)}</Text></Text>
-            <Text style={styles.label}>Buyer Organization: <Text style={styles.value}>{invoice.buyerOrganization}</Text></Text>
-            <Text style={styles.label}>Seller Organization: <Text style={styles.value}>{invoice.sellerOrganization}</Text></Text>
+            <Text style={styles.label}>Buyer: <Text style={styles.value}>{invoice.buyerOrganization}</Text></Text>
+            <Text style={styles.label}>Seller: <Text style={styles.value}>{invoice.sellerOrganization}</Text></Text>
           </View>
           <View style={styles.topSection}>
             <View style={styles.addressSection}>

--- a/marketplace/ui/src/components/Order/SoldOrderDetails.js
+++ b/marketplace/ui/src/components/Order/SoldOrderDetails.js
@@ -494,12 +494,12 @@ const SoldOrderDetails = ({ user, users }) => {
               <OrderData title="NUMBER" value={`#${details.orderId}`} />
               <Divider type="vertical" className="h-14 bg-secondryD" />
               <OrderData
-                title="BUYER ORGANIZATION"
+                title="BUYER"
                 value={details.buyerOrganization}
               />
               <Divider type="vertical" className="h-14 bg-secondryD" />
               <OrderData
-                title="SELLER ORGANIZATION"
+                title="SELLER"
                 value={details.sellerOrganization}
               />
               <Divider type="vertical" className="h-14 bg-secondryD" />

--- a/marketplace/ui/src/components/Order/SoldOrdersTable.js
+++ b/marketplace/ui/src/components/Order/SoldOrdersTable.js
@@ -80,7 +80,7 @@ const SoldOrdersTable = ({ user }) => {
       ),
     },
     {
-      title: "buyer organization".toUpperCase(),
+      title: "buyer".toUpperCase(),
       dataIndex: "buyerOrganization",
       key: "buyerOrganization",
       render: (text) => <p>{text}</p>,


### PR DESCRIPTION
Refer: Ticket [MKT-44](https://blockapps.atlassian.net/browse/MKT-44)

Removed the word `Organization` from the `Orders` screen.
- Additionally, removed its occurences in invoices under the `Orders`.
<video src='https://github.com/blockapps/strato-platform/assets/35606645/881e8c8d-46b6-4ebd-977f-74820536d050' width=180/>

[MKT-44]: https://blockapps.atlassian.net/browse/MKT-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ