### PR TITLE
mkt-51 Order History Table Bug 

### DIFF
--- a/marketplace/backend/api/middleware/loadDappHandler.js
+++ b/marketplace/backend/api/middleware/loadDappHandler.js
@@ -15,7 +15,7 @@ const loadDapp = async (req, res, next) => {
     username,
     ...accessToken,
   }
-  console.log('req: \n\n\n\n\n', req)
+  console.log('User Credentials: \n\n\n\n\n', userCredentials)
 
   let address
 

--- a/marketplace/ui/src/components/MarketPlace/ProductDetail.js
+++ b/marketplace/ui/src/components/MarketPlace/ProductDetail.js
@@ -134,7 +134,7 @@ const ProductDetails = ({ user, users }) => {
         itemsActions.fetchSerialNumbers(itemDispatch, Id);
       }
     }
-  }, [Id, dispatch, itemDispatch]);
+  }, [Id, dispatch, itemDispatch, user]);
 
   useEffect(() => {
     marketPlaceActions.fetchCartItems(marketplaceDispatch, cartList);
@@ -273,7 +273,8 @@ const ProductDetails = ({ user, users }) => {
     {
       title: <Text className="text-primaryC text-[13px]">SERIAL NUMBER</Text>,
       dataIndex: "serialNumber",
-      key: "serialNumber",
+      // Fixes UI issue of children having the same key
+      key: serialNumbers[0] === "" ? "itemNumber" : "serialNumber",
       align: "center",
       onCell: (record) => {
         return {


### PR DESCRIPTION
Fix on UI side for ownership history table not fetching the serial numbers in some cases. 
- Additionally, fixed a reacts error where children would have the same key if no serial numbers were supplied. 
- Removed the full req from loadDapphandler and console log the user credentials instead. 
  -Originally just the user credentials were console logged. I remember having to log the whole request for a ticket. Must have gotten them mixed up on a PR. EIther way I don't think we need the entire request there. 