### PR TITLE
Change SolidVM storage types from ByteString to ShortByteString

### DIFF
--- a/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
@@ -19,6 +19,7 @@ import Data.Char
 import Data.Bifunctor
 import Data.Bitraversable
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as BSS
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.HashMap.Strict as HM
 import qualified Data.IntMap as I
@@ -39,7 +40,7 @@ decodeSolidVMValues :: [(HexStorage, HexStorage)] -> [(T.Text, SolidityValue)]
 decodeSolidVMValues hxs = either (error . printf "decodeSolidVMValues: %s" . show) id $ do
   pathValues <- mapM (bimapM hexStorageToPath hexStorageToBasic) hxs
   totalStorage <- bimap show HM.toList $ synthesize pathValues
-  mapMaybeM (bimapValue bsToText) totalStorage
+  mapMaybeM (bimapValue (bsToText . BSS.fromShort)) totalStorage
 
 bimapValue:: (t1 -> Either String t2) -> (t1, V.Value) -> Either String (Maybe (t2, SolidityValue))
 bimapValue f (name', value') = do
@@ -57,8 +58,8 @@ decodeCacheValues hxs prevState = either (error . (++ ": " ++ show hxs) . printf
   let pathValues' = filter (isBasic . fst) pathValues
   finalState <- bimap show HM.toList $ case prevState of
     [] -> synthesize pathValues'
-    tvs -> replayDeltas pathValues' . HM.fromList . map (first encodeUtf8) $ tvs
-  mapM (bimapM bsToText return) finalState
+    tvs -> replayDeltas pathValues' . HM.fromList . map (first (BSS.toShort . encodeUtf8)) $ tvs
+  mapM (bimapM (bsToText . BSS.fromShort) return) finalState
 
 bsToText :: B.ByteString -> Either String T.Text
 bsToText = first show . decodeUtf8'
@@ -108,7 +109,7 @@ valueToSolidityValue = \case
           ValueBool True -> Right "true"
           ValueBool False -> Right "false"
 
-type TotalStorage = HM.HashMap B.ByteString V.Value
+type TotalStorage = HM.HashMap BSS.ShortByteString V.Value
 
 data ReplayFailure = MissingPath StoragePath
                    | TypeMismatch StoragePath BasicValue V.Value
@@ -136,7 +137,7 @@ applyDelta' [] bv (SimpleValue{}) = Right $ fromBasic bv
 applyDelta' [] bv (ValueEnum{}) = Right $ fromBasic bv
 applyDelta' [] bv (ValueContract{}) = Right $ fromBasic bv
 applyDelta' (Field n:sp) bv (ValueStruct ss) = do
-  n' <- first (UnicodeError n) $ decodeUtf8' n
+  n' <- first (UnicodeError $ BSS.fromShort n) $ decodeUtf8' $ BSS.fromShort n
   case M.lookup n' ss of
     Just v -> ValueStruct . (\x -> M.insert n' x ss) <$> applyDelta' sp bv v
     Nothing -> Right . ValueStruct $ M.insert n' (constructFromNothing' sp bv) ss
@@ -166,7 +167,7 @@ constructFromNothing' [] = fromBasic
 constructFromNothing' [Field "length"] = \case
   BInteger n -> ValueArraySentinel $ fromIntegral n
   bv -> ValueStruct . M.singleton "length" $ constructFromNothing' [] bv
-constructFromNothing' (Field n:sp) = ValueStruct . M.singleton (decodeUtf8 n) . constructFromNothing' sp
+constructFromNothing' (Field n:sp) = ValueStruct . M.singleton (decodeUtf8 $ BSS.fromShort n) . constructFromNothing' sp
 constructFromNothing' (MapIndex n:sp) =
   ValueMapping . M.singleton (fromIndex n) . constructFromNothing' sp
 constructFromNothing' (ArrayIndex n:sp) =
@@ -196,7 +197,7 @@ fromBasic :: BasicValue -> V.Value
 fromBasic = \case
   BBool b -> SimpleValue $ ValueBool b
   BInteger n -> SimpleValue $! valueInt n
-  BString bs -> SimpleValue $! valueBytes bs
+  BString bs -> SimpleValue $! valueBytes (BSS.fromShort bs)
   BAccount a -> SimpleValue $! ValueAccount a
   BContract _ c -> ValueContract c
   BEnumVal tipe name num -> ValueEnum (labelToText tipe) (labelToText name) (fromIntegral num)
@@ -208,5 +209,5 @@ fromIndex :: IndexType -> V.SimpleValue
 fromIndex = \case
   IBool b -> ValueBool b
   INum n -> valueInt n
-  IText bs -> valueBytes bs
+  IText bs -> valueBytes (BSS.fromShort bs)
   IAccount a -> ValueAccount a

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
@@ -10,7 +10,7 @@ import           Control.Exception
 import           Data.Attoparsec.ByteString as Atto
 import           Data.Attoparsec.ByteString.Char8 (scientific)
 import           Data.Binary
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as BSS
 import qualified Data.ByteString.Internal as BI
 import qualified Data.ByteString.Unsafe as BU
 import qualified Data.ByteString.Char8 as C8
@@ -33,9 +33,9 @@ import           SolidVM.Model.SolidString
 import           Text.Format
 
 data BasicValue = BInteger !Integer
-                | BString !B.ByteString
+                | BString {-# UNPACK #-} !BSS.ShortByteString
                 | BBool !Bool
-                | BAccount !NamedAccount 
+                | BAccount !NamedAccount
                 | BEnumVal !SolidString !SolidString !Word32
                 | BContract !SolidString !NamedAccount
                   -- The sole purpose of this sentinel is to make slipstream reserve
@@ -46,9 +46,9 @@ data BasicValue = BInteger !Integer
 
 isDefault :: BasicValue -> Bool
 isDefault (BInteger i)     = i == 0
-isDefault (BString bs)     = B.null bs
+isDefault (BString bs)     = BSS.null bs
 isDefault (BBool b)        = not b
-isDefault (BAccount a)     = a == unspecifiedChain 0x0 
+isDefault (BAccount a)     = a == unspecifiedChain 0x0
 isDefault (BEnumVal _ _ w) = w == 0
 isDefault (BContract _ a)  = a == unspecifiedChain 0x0
 isDefault BMappingSentinel = False
@@ -56,7 +56,7 @@ isDefault BDefault         = True
 
 instance Format BasicValue where
   format (BInteger i) = show i
-  format (BString s) = ('"':) . (++"\"") $ UTF8.toString s
+  format (BString s) = ('"':) . (++"\"") $ UTF8.toString (BSS.fromShort s)
   format (BBool True) = "true"
   format (BBool False) = "false"
   format (BAccount a) = "account(" ++ show a ++ ")"
@@ -66,18 +66,18 @@ instance Format BasicValue where
   format BDefault = "<unknown>"
 
 data IndexType = INum Integer
-               | IText B.ByteString
+               | IText {-# UNPACK #-} !BSS.ShortByteString
                | IBool Bool
                | IAccount NamedAccount
                deriving (Eq, Show, Ord, Generic, Hashable, NFData)
 
-data StoragePathPiece = Field B.ByteString
+data StoragePathPiece = Field {-# UNPACK #-} !BSS.ShortByteString
                       | MapIndex IndexType
                       | ArrayIndex Int
                       deriving (Eq, Show, Generic, NFData, Hashable)
 
 instance Format StoragePathPiece where
-  format (Field n) = C8.unpack n
+  format (Field n) = C8.unpack . BSS.fromShort $ n
   format (MapIndex i) = "[" ++ show i ++ "]"
   format (ArrayIndex i) = "[" ++ show i ++ "]"
 
@@ -96,10 +96,10 @@ instance Format StoragePath where
 empty :: StoragePath
 empty = StoragePath []
 
-singleton :: B.ByteString -> StoragePath
+singleton :: BSS.ShortByteString -> StoragePath
 singleton bs = StoragePath [Field bs]
 
-getField :: StoragePath -> B.ByteString
+getField :: StoragePath -> BSS.ShortByteString
 getField (StoragePath (Field f:_)) = f
 getField path = error "StoragePath must begin with field" path
 
@@ -178,7 +178,7 @@ parseMapIndex = do
            ignoreEscapedQuotes _ _ = Just False
        strContents <- scan False ignoreEscapedQuotes
        skip (== c2w8 '"')
-       return . IText . unescapeKey $ strContents
+       return . IText . unescapeKey . BSS.toShort $ strContents
     _ -> INum <$> parseInteger
   skip (== c2w8 '>')
   (MapIndex idx:) <$> pathParser
@@ -187,18 +187,18 @@ parseField :: Parser [StoragePathPiece]
 parseField = do
   skip (== c2w8 '.')
   (do n <- Atto.takeWhile1 (inClass "_a-zA-Z0-9")
-      (Field n:) <$> pathParser)
+      (Field (BSS.toShort n):) <$> pathParser)
     <|> ((string ":creator") *> pathParser)
     <|> ((string ":creatorAddress") *> pathParser)
 
-parsePath :: B.ByteString-> Either String StoragePath
-parsePath = fmap StoragePath . parseOnly pathParser
+parsePath :: BSS.ShortByteString-> Either String StoragePath
+parsePath = fmap StoragePath . parseOnly pathParser . BSS.fromShort
 
-escapeKey :: B.ByteString -> B.ByteString
-escapeKey srcBS = unsafePerformIO $ do
-  let len = B.length srcBS
-  BI.createAndTrim (2 * len) $ \dst ->
-    BU.unsafeUseAsCString srcBS $ \src' -> do
+escapeKey :: BSS.ShortByteString -> BSS.ShortByteString
+escapeKey srcBS = do
+  let len = BSS.length srcBS
+  BSS.toShort . unsafePerformIO $ BI.createAndTrim (2 * len) $ \dst ->
+    BU.unsafeUseAsCString (BSS.fromShort srcBS) $ \src' -> do
       let src = castPtr src'
           copyAndEscape :: Int -> Int -> IO Int
           copyAndEscape !dstOff !srcOff =
@@ -216,11 +216,11 @@ escapeKey srcBS = unsafePerformIO $ do
                    copyAndEscape (dstOff+2) (srcOff+1)
       copyAndEscape 0 0
 
-unescapeKey :: B.ByteString -> B.ByteString
-unescapeKey srcBS = unsafePerformIO $ do
-  let len = B.length srcBS
-  BI.createAndTrim len $ \dst ->
-    BU.unsafeUseAsCString srcBS $ \src' -> do
+unescapeKey :: BSS.ShortByteString -> BSS.ShortByteString
+unescapeKey srcBS = do
+  let len = BSS.length srcBS
+  BSS.toShort . unsafePerformIO $ BI.createAndTrim len $ \dst ->
+    BU.unsafeUseAsCString (BSS.fromShort srcBS) $ \src' -> do
       let src = castPtr src'
           copyAndUnescape :: Int -> Int -> IO Int
           copyAndUnescape !dstOff !srcOff =
@@ -242,22 +242,22 @@ unescapeKey srcBS = unsafePerformIO $ do
               else return dstOff
       copyAndUnescape 0 0
 
-unparsePath :: StoragePath -> B.ByteString
-unparsePath (StoragePath ps) = B.concat . concatMap go $ ps
-  where go :: StoragePathPiece -> [B.ByteString]
+unparsePath :: StoragePath -> BSS.ShortByteString
+unparsePath (StoragePath ps) = BSS.concat . concatMap go $ ps
+  where go :: StoragePathPiece -> [BSS.ShortByteString]
         go (Field p) = [".", p]
-        go (ArrayIndex n) = ["[", C8.pack $ show n, "]"]
-        go (MapIndex (INum n)) = ["<", C8.pack $ show n, ">"]
+        go (ArrayIndex n) = ["[", BSS.toShort . C8.pack $ show n, "]"]
+        go (MapIndex (INum n)) = ["<", BSS.toShort . C8.pack $ show n, ">"]
         go (MapIndex (IText t)) = ["<\"", escapeKey t, "\">"]
         go (MapIndex (IBool True)) = ["<true>"]
         go (MapIndex (IBool False)) = ["<false>"]
-        go (MapIndex (IAccount a)) = ["<a:", C8.pack $ show a, ">"]
+        go (MapIndex (IAccount a)) = ["<a:", BSS.toShort . C8.pack $ show a, ">"]
 
 instance RLPSerializable BasicValue where
   rlpEncode = \case
     BDefault -> RLPString ""
     BInteger n -> RLPArray [RLPScalar 0, rlpEncode n]
-    BString t -> RLPArray [RLPScalar 1, rlpEncode t]
+    BString t -> RLPArray [RLPScalar 1, rlpEncode (BSS.fromShort t)]
     BBool b -> RLPArray [RLPScalar 2, rlpEncode b]
     BAccount a -> RLPArray [RLPScalar 3, rlpEncode a]
     BContract n a -> RLPArray [RLPScalar 4, rlpEncode n, rlpEncode a]
@@ -266,7 +266,7 @@ instance RLPSerializable BasicValue where
   rlpDecode x@(RLPArray ((RLPScalar t):s)) =
     case (t, s) of
       (0, [f]) -> BInteger $ rlpDecode f
-      (1, [f]) -> BString $ rlpDecode f
+      (1, [f]) -> BString . BSS.toShort $ rlpDecode f
       (2, [f]) -> BBool $ rlpDecode f
       (3, [f]) -> BAccount $ rlpDecode f
       (4, [f, a']) -> BContract (rlpDecode f) (rlpDecode a')
@@ -277,13 +277,13 @@ instance RLPSerializable BasicValue where
   rlpDecode x = error $ "invalid shape for BasicValue: " ++ show x
 
 pathToHexStorage :: StoragePath -> HexStorage
-pathToHexStorage = HexStorage . unparsePath
+pathToHexStorage = HexStorage . BSS.fromShort . unparsePath
 
 basicToHexStorage :: BasicValue -> HexStorage
 basicToHexStorage = HexStorage . rlpSerialize . rlpEncode
 
 hexStorageToPath :: HexStorage -> Either String StoragePath
-hexStorageToPath (HexStorage hs) = parsePath hs
+hexStorageToPath (HexStorage hs) = parsePath (BSS.toShort hs)
 
 hexStorageToBasic :: HexStorage -> Either String BasicValue
 hexStorageToBasic (HexStorage hs) = unsafeDupablePerformIO . handle handler

--- a/strato/VM/SolidVM/solid-vm-model/test/StorageTest.hs
+++ b/strato/VM/SolidVM/solid-vm-model/test/StorageTest.hs
@@ -1,4 +1,4 @@
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as BSS
 import Control.Monad
 import Data.Either (isLeft)
 import Test.Hspec
@@ -20,12 +20,12 @@ spec = do
 
     it "should be able to escape quotes" $ do
       escapeKey "" `shouldBe` ""
-      escapeKey (B.singleton 0x22) `shouldBe` B.pack [0x5c, 0x22]
+      escapeKey (BSS.singleton 0x22) `shouldBe` BSS.pack [0x5c, 0x22]
       escapeKey "ok\"fail\"ok\"" `shouldBe` "ok\\\"fail\\\"ok\\\""
 
     it "should be able to unescape quotes" $ do
       unescapeKey "" `shouldBe` ""
-      unescapeKey (B.pack [0x5c, 0x22]) `shouldBe` B.singleton 0x22
+      unescapeKey (BSS.pack [0x5c, 0x22]) `shouldBe` BSS.singleton 0x22
       unescapeKey "ok\\\"fail\\\"ok\\\"" `shouldBe` "ok\"fail\"ok\""
 
   describe "StoragePath" $ do
@@ -77,11 +77,11 @@ spec = do
         "<a:ca35b7d915458ef540ade6068dfe2f44e8fa733c:ca35b7d915458ef540ade6068dfe2f44e8fa733cca35b7d915458ef540ade606>"
 
     it "should allow unbounded map indices" $ do
-      parsePath (B.concat ["<1", B.replicate 100 0x30, ">"])
+      parsePath (BSS.concat ["<1", BSS.replicate 100 0x30, ">"])
         `shouldBe` toAns [MapIndex (INum (product (replicate 100 10)))]
 
     it "should not allow unbounded array indices" $ do
-      parsePath (B.concat ["[1", B.replicate 100 0x30, "]"])
+      parsePath (BSS.concat ["[1", BSS.replicate 100 0x30, "]"])
         `shouldSatisfy` isLeft
 
     it "should unescape paths" $ do
@@ -95,9 +95,9 @@ spec = do
       let examples = [ BInteger 3399293429
                      , BString "This is text"
                      , BBool True
-                     , BAccount (unspecifiedChain 0x23421421421341232341bbbb) 
-                     , BAccount (mainChain 0x23421421421341232341bbbb) 
-                     , BAccount (explicitChain 0x23421421421341232341bbbb 0xdeadbeefd00d) 
+                     , BAccount (unspecifiedChain 0x23421421421341232341bbbb)
+                     , BAccount (mainChain 0x23421421421341232341bbbb)
+                     , BAccount (explicitChain 0x23421421421341232341bbbb 0xdeadbeefd00d)
                      , BContract "Wings!" (unspecifiedChain 0xdeadbeef)
                      , BContract "Wings!" (mainChain 0xdeadbeef)
                      , BContract "Wings!" (explicitChain 0xdeadbeef 0x1234567890)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -38,6 +38,7 @@ import           Data.Bits
 import           Data.Typeable
 import           Data.Bool                            (bool)
 import qualified Data.ByteString                      as B
+import qualified Data.ByteString.Short                as BSS
 import qualified Data.ByteString.Base16               as B16
 import qualified Data.ByteString.Char8                as BC
 import qualified Data.ByteString.UTF8                 as UTF8
@@ -144,9 +145,9 @@ onTraced = when flags_svmTrace
 -- TL;DR Use onTracedSM whenever you have a showSM in a trace over onTraced
 -- Full: In some onTraced logging statements we called showSM. Through a series
 -- of function calls (showSM -> getVar -> getSolidStorageKeyVal'
--- -> getRawStorageKeyVal' -> getRawStorageKeyValMC -> lookupWithDefault 
+-- -> getRawStorageKeyVal' -> getRawStorageKeyValMC -> lookupWithDefault
 -- -> genericLookupRawStorageDB) we end up calling genericLookupRawStorageDB.
--- This adds default values to the MP Trie whenever we lookup a nonexistant 
+-- This adds default values to the MP Trie whenever we lookup a nonexistant
 -- value in our DB. THIS IS PROBLOMATIC, we are adding somthing to the MP Trie
 -- (and therefore changing the stateroot) for just having a logging statement!
 -- TODO: Do not add default values to RawStorageDBs for SolidVM > 3.
@@ -192,7 +193,7 @@ instance MonadSM m => Mod.Accessible [SourcePosition] m where
 
 -- instance (MonadIO m, MonadLogger m) => ((Address,T.Text) `A.Selectable` X509.X509CertificateField) (MonadTest m) where
 --   select _ (k,t) = do
---     let certKey addr = ((Account addr Nothing),) . TE.encodeUtf8 
+--     let certKey addr = ((Account addr Nothing),) . TE.encodeUtf8
 --     mCertAddress <- lookupX509AddrFromCBHash k
 --     fmap join . for mCertAddress $ \certAddress ->
 --       maybe Nothing (readMaybe . T.unpack . TE.decodeUtf8) <$> A.lookup (A.Proxy) (certKey certAddress t)
@@ -472,7 +473,7 @@ setCreator creator contract _ _ = do
   putSolidStorageKeyVal' contract (MS.StoragePath [MS.Field ":creatorAddress"]) (MS.BAccount (accountToNamedAccount' creator))
   let putCreatorField org = do
         $logDebugS "setCreator/versioning" . T.pack $ "setting the org as " ++ (show org)
-        putSolidStorageKeyVal' contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString $ BC.pack org)
+        putSolidStorageKeyVal' contract (MS.StoragePath [MS.Field ":creator"]) (MS.BString . BSS.toShort $ BC.pack org)
 
   if _org /= "" then putCreatorField _org else do
       $logDebugS "setCreator/versioning" . T.pack . C.red $ "Ignoring creator field for empty org field"
@@ -503,7 +504,7 @@ getOrg caller = do
           case appCreator of
             MS.BString org' -> do
               $logDebugS "getOrg/versioning" . T.pack $ "Its org is " ++ show org'
-              return $ BC.unpack org'
+              return . BC.unpack . BSS.fromShort $ org'
             _ -> do
               $logDebugS "getOrg/versioning" . T.pack $ "Its org is unset. Returning empty string"
               return ""
@@ -739,7 +740,7 @@ callWrapper' from to' mLogicAddress mContract functionName isRCC argExps  = do
 
   let functionsIncludingConstructor =
         case contract^.CC.constructor of
-          Nothing -> M.insert "<constructor>" emptyFunction $ contract^.CC.functions                  --contract^. M.empty $ CC.functions 
+          Nothing -> M.insert "<constructor>" emptyFunction $ contract^.CC.functions                  --contract^. M.empty $ CC.functions
           Just c -> M.insert "<constructor>" c $ contract^.CC.functions
         where
           emptyFunction = CC.Func [] [] Nothing (Just []) Nothing M.empty [] dummyAnnotation False []
@@ -808,9 +809,9 @@ callWrapper' from to' mLogicAddress mContract functionName isRCC argExps  = do
               Just _ -> do
                   $logDebugS "callWrapper/getter" . T.pack $ labelToString functionName
                   addCallInfo to contract functionName hsh cc M.empty True False
-                --TODO- this should only exist if the storage variable is declared "public", 
+                --TODO- this should only exist if the storage variable is declared "public",
                 -- right now I just ignore this and allow anything to be called as a getter
-                  val <- fmap Just $ getVar $ Constant $ SReference $ AccountPath to . MS.singleton $ BC.pack $ labelToString functionName
+                  val <- fmap Just $ getVar $ Constant $ SReference $ AccountPath to . MS.singleton . BSS.toShort . BC.pack $ labelToString functionName
                   popCallInfo
                   return (pure val, OrderedVals [])
               Nothing -> (case M.lookup "fallback" functionsIncludingConstructor of
@@ -828,7 +829,7 @@ callWrapper' from to' mLogicAddress mContract functionName isRCC argExps  = do
               Just _ -> do
                 liftIO $ putStrLn ("callWrapper/getter " ++ functionName)
                 addCallInfo to contract functionName hsh cc M.empty True
-                --TODO- this should only exist if the storage variable is declared "public", 
+                --TODO- this should only exist if the storage variable is declared "public",
                 -- right now I just ignore this and allow anything to be called as a getter
                 val <- fmap Just $ getVar $ Constant $ SReference $ AccountPath to . MS.singleton $ BC.pack functionName
                 popCallInfo
@@ -839,12 +840,12 @@ callWrapper' from to' mLogicAddress mContract functionName isRCC argExps  = do
                 addCallInfo to contract' (stringToLabel $ labelToString (contract'^.CC.contractName) ++ " constructor") hsh cc M.empty False False
                 forM_ [(n, e) | (n, CC.VariableDecl _ _ (Just e) _ _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, e) -> do
                   v <- expToVar e
-                  setVar (Constant (SReference (AccountPath to $ MS.StoragePath [MS.Field $ BC.pack $ labelToString n]))) =<< getVar v
+                  setVar (Constant (SReference (AccountPath to $ MS.StoragePath [MS.Field . BSS.toShort . BC.pack $ labelToString n]))) =<< getVar v
                 forM_ [(n, theType) | (n, CC.VariableDecl theType _ Nothing _ _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, theType) -> do
                   case theType of
                     SVMType.Mapping _ _ _-> return ()
                     SVMType.Array _ _-> return ()
-                    _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n]) MS.BDefault
+                    _ -> markDiffForAction to (MS.StoragePath [MS.Field . BSS.toShort . BC.pack $ labelToString n]) MS.BDefault
                 popCallInfo)
   ((org, parentName'),) <$> logFunctionCall args to contract functionName f
 
@@ -915,12 +916,12 @@ runStatement (CC.SimpleStatement (CC.ExpressionStatement (CC.PlusPlus e))) = do
 --    revert();
 
 --    revert(args);
-    --    revert("error message") i.e. OrderedArgs 
+    --    revert("error message") i.e. OrderedArgs
     --    revert({x:"Message"}) i.e. NamedArgs
 
 --    revert customError(args);
-    --    revert customError("error message") i.e. OrderedArgs 
-    --    revert customError({x:"Message"}) i.e. NamedArgs 
+    --    revert customError("error message") i.e. OrderedArgs
+    --    revert customError({x:"Message"}) i.e. NamedArgs
 runStatement (CC.RevertStatement mString theArgs _) = do
   g <- getCurrentContract
   case mString of
@@ -1004,7 +1005,7 @@ runStatement (CC.SimpleStatement (CC.ExpressionStatement (CC.Binary _ "=" dst sr
   return Nothing
 
 
-{-  
+{-
   case e1 of
     CC.TupleExpression es -> do
       vs <- mapM (mapM expToVar) es
@@ -1333,7 +1334,7 @@ doWhile condition code = do
 getIndexType :: MonadSM m => AccountPath -> m IndexType
 getIndexType (AccountPath addr p) = do
   let field = MS.getField p
-  mType <- getXabiType addr field
+  mType <- getXabiType addr (BSS.fromShort field)
   let n = MS.size p - 1
   case mType of
     Nothing -> todo "getIndexType/unknown storage reference" field
@@ -1358,7 +1359,7 @@ getIndexType (AccountPath addr p) = do
 expToPath :: MonadSM m => CC.Expression -> m AccountPath
 expToPath (CC.Variable _ x) = do
   callInfo <- getCurrentCallInfo
-  let path = MS.singleton $ BC.pack $ labelToString x
+  let path = MS.singleton . BSS.toShort . BC.pack $ labelToString x
   case x `M.lookup` localVariables callInfo of
     Just (_, var) -> do
       val <- weakGetVar var
@@ -1391,7 +1392,7 @@ expToPath x@(CC.IndexAccess _ parent mIndex) = do
     MapStringIndex -> do
       idx <- getString idxVar
       return $ case idx of
-        SString s -> MS.MapIndex $ MS.IText $ UTF8.fromString s
+        SString s -> MS.MapIndex . MS.IText . BSS.toShort $ UTF8.fromString s
         _ -> typeError "invalid map of strings index" idx
     ArrayIndex -> do
       n <- getInt idxVar
@@ -1401,7 +1402,7 @@ expToPath (CC.MemberAccess _ parent field) = do
     parvar <- expToVar parent
     case parvar of
       _ -> expToPath parent
-  return . apSnoc apt . MS.Field $ BC.pack $ labelToString field
+  return . apSnoc apt . MS.Field . BSS.toShort . BC.pack $ labelToString field
 
 expToPath x = todo "expToPath/unhandled" x
 
@@ -1416,7 +1417,7 @@ decrementGas gas = do
   gasInfo' <- Mod.modifyStatefully (Mod.Proxy @GasInfo) $ gasLeft -= gas
   Mod.modifyStatefully_ (Mod.Proxy @GasInfo) $ gasUsed += gas
   let !gasLeft' = gasInfo' ^. gasLeft
-  if (gasLeft') < (Gas 0) 
+  if (gasLeft') < (Gas 0)
     then do
       let msg = "out of gas: " ++ show gasLeft' ++ " < " ++ show gas
       liftIO $ putStrLn $ C.red $ msg
@@ -1495,7 +1496,7 @@ expToVar' (CC.Binary _ ">>>=" lhs rhs)= do
   binopAssign (\x i -> fromInteger ( toInteger ( (fromInteger x) ::Word256) ) `shiftR` fromInteger i ) lhs rhs
 expToVar' (CC.MemberAccess _ (CC.FunctionCall x (CC.Variable _ "type") (CC.OrderedArgs [CC.Variable _ name])) "runTimeCode") = do
   (_, cc) <- getCurrentCodeCollection
-  return $ Constant $ SString $ case M.lookup name $ cc ^. CC.contracts of-- (_contracts cc) of 
+  return $ Constant $ SString $ case M.lookup name $ cc ^. CC.contracts of-- (_contracts cc) of
     Just contract -> unparseContract  contract;
     _ -> getRunTimeCodeError "Failed to get contract runtime code " x
 
@@ -1632,7 +1633,7 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
             return . Constant . SInteger . fromIntegral $ length $ getInnerString val
           _ -> return . Constant . SReference . apSnoc apt $ MS.Field "length"
 
-      (SReference p, itemName) -> return . Constant . SReference $ apSnoc p $ MS.Field $ BC.pack $ labelToString itemName
+      (SReference p, itemName) -> return . Constant . SReference . apSnoc p . MS.Field . BSS.toShort . BC.pack $ labelToString itemName
       ((SUserDefined alias notSure actualType), "wrap") -> return . Constant $ (SUserDefined alias notSure actualType) -- return $ Constant . SUserDefined alias val actualType
       m -> typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m)
 {-
@@ -1919,7 +1920,7 @@ expToVar' (CC.FunctionCall _ e args) = do
               (SContract _ toAddress', MS.Field funcName) -> do
                 fromAddress <- getCurrentAccount
                 let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) toAddress'
-                res <- callWrapper fromAddress toAddress Nothing Nothing (stringToLabel $ BC.unpack funcName) False args
+                res <- callWrapper fromAddress toAddress Nothing Nothing (stringToLabel . BC.unpack . BSS.fromShort $ funcName) False args
                 case res of
                   Just v -> return $ Constant $ v
                   Nothing -> return $ Constant SNULL
@@ -1927,7 +1928,7 @@ expToVar' (CC.FunctionCall _ e args) = do
               (SAccount toAddress' _, MS.Field funcName) -> do
                 fromAddress <- getCurrentAccount
                 let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) toAddress'
-                res <- callWrapper fromAddress toAddress Nothing Nothing (stringToLabel $ BC.unpack funcName) False args
+                res <- callWrapper fromAddress toAddress Nothing Nothing (stringToLabel . BC.unpack . BSS.fromShort $ funcName) False args
                 case res of
                   Just v -> return $ Constant $ v
                   Nothing -> return $ Constant SNULL
@@ -2046,7 +2047,7 @@ expToVar' (CC.FunctionCall _ e args) = do
                 return $ Constant $ SContract contractName' $ addr
               _ -> typeError "contract variable creation" argVals
 
-          -- Transfer wei, throw error on failure no return on success 
+          -- Transfer wei, throw error on failure no return on success
           -- TODO: When gas gets more implemented ensure that this function does not
           --       consume more than 2300 gas
           Constant (SContractItem address' "transfer") -> do
@@ -2083,7 +2084,7 @@ expToVar' (CC.FunctionCall _ e args) = do
               -- Get the code at the address
             cid <- case (address' ^. namedAccountChainId) of
               UnspecifiedChain -> do
-                --Assume that the chainId is the same as the from chainId when it is unset 
+                --Assume that the chainId is the same as the from chainId when it is unset
                 cid1 <- view accountChainId <$> getCurrentAccount
                 case cid1 of
                   Nothing -> return Nothing
@@ -2314,7 +2315,7 @@ evaluateAccountMember a _ "code" = do
               Just (_,bs) -> bs
               Nothing -> missingCodeCollection "Could not locate SolidVM code collection at account" (format realAccount)
   let decodeCD = DT.decodeUtf8 cd'
-  -- Format the result  
+  -- Format the result
   return $ Constant $ SString $ T.unpack decodeCD
 evaluateAccountMember a _ "balance" = do
   cid <- case (a ^. namedAccountChainId) of
@@ -2775,15 +2776,15 @@ runTheConstructors from to hsh cc contractName' argExps = do
 
   forM_ [(n, e) | (n, CC.VariableDecl _ _ (Just e) _ _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, e) -> do
     v <- expToVar e
-    setVar (Constant (SReference (AccountPath to $ MS.StoragePath [MS.Field $ BC.pack $ labelToString n]))) =<< getVar v
+    setVar (Constant (SReference (AccountPath to $ MS.StoragePath [MS.Field . BSS.toShort . BC.pack $ labelToString n]))) =<< getVar v
 
   forM_ [(n, theType) | (n, CC.VariableDecl theType _ Nothing _ _) <- M.toList $ contract'^.CC.storageDefs] $ \(n, theType) -> do
     case theType of
       SVMType.Mapping _ _ _-> return ()
       SVMType.Array _ _-> return ()
-      t -> do 
+      t -> do
         defVal <- createDefaultValue cc contract' t
-        markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n]) $ toBasic defVal
+        markDiffForAction to (MS.StoragePath [MS.Field . BSS.toShort . BC.pack $ labelToString n]) $ toBasic defVal
       -- SVMType.Bool -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n]) $ MS.BBool False
 
   forM_ (reverse $ contract'^.CC.parents) $ \parent -> do
@@ -2995,25 +2996,25 @@ encodeForReturn' (SAccount a _) = return $  "\"" ++ (show $ a ^. namedAccountAdd
 encodeForReturn' (SContract _ a) = return $ "\"" ++ (show $ a ^. namedAccountAddress) ++ "\""
 encodeForReturn' (SBool b) = return $ if b then "true" else "false"
 encodeForReturn' (SString s) = return $ show s
-{- The following comments are just for previous encodeForReturn function to return ByteString type. 
+{- The following comments are just for previous encodeForReturn function to return ByteString type.
 -- in the case of tuples, we need to follow the EVM/Solidity encoding convention:
 --   1) starting at the first value to encode, check if it is fixed length type (32), or
---      dynamic (right now, this group is only strings since we don't return arrays). 
+--      dynamic (right now, this group is only strings since we don't return arrays).
 --   2) if a fixed type, encode it directly into the next 32 characters in the bytestring
 --   3) if dynamic:
 --      a) encode an offset value into the next 32 characters.
---      b) at that offset, put the encoded string's length in the first 32 characters, 
+--      b) at that offset, put the encoded string's length in the first 32 characters,
 --         followed by the encoded string
 --   4) repeat for the remaining values
---   
+--
 --   The headers of the bytestring are the initial (tuple_length * 32) characters.
 --   They are either encoded simple values, or offsets. If some are offsets (to
 --   encoded strings), then they point to characters beyond the (tuple_length * 32)
 --   In other words, the final bytestring is headers `B.append` encodedStrings
---  
+--
 --
 --   As an example, return type (string, uint, string) would have the following encoding:
---                                                                            
+--
 --                                            (offsetStr1)            (offsetStr2)
 -- Size:  |     32    |     32    |     32    |    32    | str1EncLen |    32    | str2EncLen |
 -- Value: |offset_str1|encoded_int|offset_str2|str1EncLen|   str1Enc  |str2EncLen|   str2Enc  |
@@ -3422,19 +3423,19 @@ solidVMExceptionHandler catchBlockMap ex = case ex of
 -- trimCodeCollection cc sa = final
 --   where (startLine, startColumn, endLine, endColumn) = sa
 --         bandwidth = drop (startLine - 1) (take endLine (lines cc))
---         trimBack = mapOnLast (take endColumn) bandwidth 
+--         trimBack = mapOnLast (take endColumn) bandwidth
 --         trimmedUp = mapOnFirst (drop $ startColumn - 1) trimBack
 --         body = unlines trimmedUp
 --         numOpen = countElem '{' body
 --         numClosed = countElem '}' body
---         enclosed = if (numOpen > numClosed) then 
+--         enclosed = if (numOpen > numClosed) then
 --           body ++ replicate (numOpen - numClosed) '}'
 --           else body
 --         final = if (numOpen == 0) then
 --           enclosed
---           else 
---             finalCut 
---             where 
+--           else
+--             finalCut
+--             where
 --               goodCut = fst $ splitLast '}' enclosed
 --               numClosedFinal = countElem '}' goodCut
 --               finalCut = if (numClosedFinal == numOpen) then
@@ -3456,7 +3457,7 @@ solidVMExceptionHandler catchBlockMap ex = case ex of
 -- makeSourceAnnotation :: (Int, Int, Int, Int) -> SourceAnnotation a
 -- makeSourceAnnotation (startLine, startColumn, endLine, endColumn) =
 --   let start = SourcePosition startLine startColumn
---       end = SourcePosition endLine endColumn 
+--       end = SourcePosition endLine endColumn
 --   in SourceAnnotation
 --     {
 --       start,

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -75,6 +75,7 @@ import qualified Prelude                            as Ordering (Ordering (..))
 
 
 --import           Data.IORef
+import qualified Data.ByteString.Short as BSS
 import           Data.Map (Map)
 import qualified Data.Map as M
 import           Data.Maybe
@@ -293,7 +294,7 @@ instance Monad m => Mod.Modifiable MemDBs (SM m) where
 
 instance Monad m => Mod.Modifiable GasInfo (SM m) where
   get _ = use gasInfo
-  put _ = assign gasInfo 
+  put _ = assign gasInfo
 
 instance Monad m => Mod.Modifiable Action (SM m) where
   get _ = use action
@@ -330,7 +331,7 @@ runSM maybeCode env gi chainId' f = do
         ssEvents = Q.empty,
         _ssMemDBs = csMemDBs,
         _action = startingAction maybeCode env chainId',
-        _gasInfo = gi{_gasLeft=min (_gasLeft gi) gasCap} -- capping the transaction gas limit 
+        _gasInfo = gi{_gasLeft=min (_gasLeft gi) gasCap} -- capping the transaction gas limit
         }
 
   eValState <- try $ runStateT f startingState
@@ -410,7 +411,7 @@ getVariableOfName name = do
                                                 ,  CC._constructor = currentContract x^.CC.constructor
                                                 ,  CC._modifiers = M.empty
                                                 ,  CC._contractContext = currentContract x^.CC.contractContext
-                                                } 
+                                                }
                               }
                     else x
       vars = localVariables currentCallInfo
@@ -467,7 +468,7 @@ getVariableOfName name = do
         if name `elem` M.keys (currentContract currentCallInfo^.CC.storageDefs)
         then Just . Constant . SReference $ AccountPath
                 (currentAccount currentCallInfo)
-                (MS.singleton $ BC.pack $ labelToString name)
+                (MS.singleton . BSS.toShort . BC.pack $ labelToString name)
         else Nothing
 
       maybeThis :: Maybe Variable
@@ -574,7 +575,7 @@ pushLocalVars = Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
   (curFrame:rest) -> do
     let localVariables' = localVariables curFrame
         variableStack'  = variableStack curFrame
-    {-- We save the local variables available in this scope to the 'stack', 
+    {-- We save the local variables available in this scope to the 'stack',
     which is simply a list of mappings from name to type/values
     --}
     pure $ curFrame{variableStack = (localVariables':variableStack')} : rest
@@ -587,7 +588,7 @@ popLocalVars = Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
     let (varFrame, st) = case variableStack curFrame of
           (varFrame': st') -> (varFrame', st')
           [] -> (M.empty, [])
-    {-- Since all the variables from the previous scope are saved to the most recent stack frame (vars), 
+    {-- Since all the variables from the previous scope are saved to the most recent stack frame (vars),
     we simply reassign the local variables to the top frame of the stack
     and the new stack's value is the rest of the frames
     --}
@@ -718,7 +719,7 @@ getXabiValueType :: MonadSM m => AccountPath -> m SVMType.Type
 getXabiValueType (AccountPath loc path) = do
   ccs' <- codeCollection <$> getCurrentCallInfo
   let field = MS.getField path
-  mType <- getXabiType loc field
+  mType <- getXabiType loc (BSS.fromShort field)
   case mType of
     Nothing -> todo "getXabiValueType/unknown storage reference" field
     Just v -> return $!! loop ccs' (tail $ MS.toList path) v
@@ -739,7 +740,7 @@ getXabiValueType (AccountPath loc path) = do
            let t' = getTypeOfName' s ccs
             in case (x, t') of
                  (MS.Field n, StructTypo fs) ->
-                   let mt'' = lookup (textToLabel $ decodeUtf8 n) fs
+                   let mt'' = lookup (textToLabel . decodeUtf8 . BSS.fromShort $ n) fs
                     in case mt'' of
                         Just t'' -> CC.fieldTypeType t''
                         Nothing -> missingField "field not present in struct definition" $ show (n, fs)
@@ -766,7 +767,7 @@ initializeAction acct name appName hsh = do
 
 markDiffForAction :: Mod.Modifiable Action m => Account -> MS.StoragePath -> MS.BasicValue -> m ()
 markDiffForAction owner key' val' = do
-  let key = MS.unparsePath key'
+  let key = (BSS.fromShort . MS.unparsePath) key'
       val = rlpSerialize $ rlpEncode val'
       ins = \case
               Action.SolidVMDiff m -> Action.SolidVMDiff $ M.insert key val m

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -26,12 +26,13 @@ module Blockchain.SolidVM.SetGet (
 
   toBasic,
   fromBasic,
-    
+
   showSM
   ) where
 
 import           Control.Monad
 import           Control.Monad.IO.Class
+import qualified Data.ByteString.Short as BSS
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.UTF8  as UTF8
 import           Data.Foldable (for_)
@@ -75,7 +76,7 @@ getSolid loc key = case loc of
 fromBasic :: MS.BasicValue -> Value
 fromBasic = \case
   MS.BInteger i -> SInteger i
-  MS.BString s -> SString . BC.unpack $ s
+  MS.BString s -> SString . BC.unpack . BSS.fromShort $ s
   MS.BBool b -> SBool b
   MS.BAccount a -> SAccount a False
   MS.BContract n a -> SContract n a
@@ -98,7 +99,7 @@ findDefault = \case
 toBasic :: Value -> MS.BasicValue
 toBasic = \case
   SInteger i -> MS.BInteger i
-  SString s -> MS.BString (BC.pack s)
+  SString s -> MS.BString (BSS.toShort . BC.pack $ s)
   SBool b -> MS.BBool b
   SAccount a _ -> MS.BAccount a
   SContract n a -> MS.BContract n a
@@ -115,7 +116,7 @@ setVal :: MonadSM m => Value -> Value -> m ()
 -- If val is a simple value, assign it. If it
 -- is deeper, read the subfields and assign to their adjustment
 
-setVal (SUserDefined a _ _) (SUserDefined _ _ _) = 
+setVal (SUserDefined a _ _) (SUserDefined _ _ _) =
   when (True) (internalError "Unimplemented feature user defined types" (a ))
 
 setVal (SReference dst) (SReference src) = do
@@ -133,7 +134,7 @@ setVal (SReference dst) (SReference src) = do
 
 setVal (SReference dst) (SStruct _ fs) = do
   forM_ (M.toList fs) $ \(f, var) -> do
-    setVal (SReference $ dst `apSnoc` MS.Field (BC.pack $ labelToString f)) =<< weakGetVar var
+    setVal (SReference $ dst `apSnoc` MS.Field (BSS.toShort . BC.pack $ labelToString f)) =<< weakGetVar var
 
 setVal (SReference dst) (SArray _ fs) = do
   let len = length fs
@@ -145,7 +146,7 @@ setVal (SReference dst) (SArray _ fs) = do
 
 
 
-setVal (STuple dstVector) (STuple srcVector) = 
+setVal (STuple dstVector) (STuple srcVector) =
   if V.length dstVector /= V.length srcVector
   then typeError "you are trying to set the value of a tuple to another tuple of the wrong length:\n" (show dstVector ++ "\n" ++ show srcVector)
   else do
@@ -156,7 +157,7 @@ setVal (STuple dstVector) (STuple srcVector) =
       return (dstItem, srcItemVal)
     forM_ zipped' $ \(dstItem, srcItemVal) -> do
       setVar dstItem srcItemVal
-   
+
 setVal dst@(SReference addressedPath@(AccountPath addr path)) src = do
   ro <- readOnly <$> getCurrentCallInfo
   when ro $ invalidWrite "Invalid write during read-only access" $ "src: " ++ show src ++ ", dst: " ++ show dst
@@ -166,7 +167,7 @@ setVal dst@(SReference addressedPath@(AccountPath addr path)) src = do
                             case t of   -- t is evaluated here because Haskell is lazy
                                         -- We ONLY want to evaluate it if we know src is a SString because
                                         -- in some non-SString cases getXabiValueType will throw an exception
-                                SVMType.String{} -> MS.BString . UTF8.fromString $ s 
+                                SVMType.String{} -> MS.BString . BSS.toShort . UTF8.fromString $ s
                                 _             -> toBasic src
                         _         -> toBasic src
   markDiffForAction addr path basicSrc
@@ -181,7 +182,7 @@ setVal (SNULL) _ = return ()
 
 setVal dst src = typeError "unknown case called in setVal (Probably tried to change the value of a constant):" ("src = " ++ show src ++ ", dst = " ++ show dst)
 
-  
+
 {-
 
 
@@ -236,7 +237,7 @@ getVar (Constant (SReference addressedPath@(AccountPath addr key))) = do
     MS.BString bs -> do
         t <- getXabiValueType addressedPath
         case t of
-                SVMType.String{} -> return . SString $ UTF8.toString bs
+                SVMType.String{} -> return . SString . UTF8.toString . BSS.fromShort $ bs
                 _             -> return $ fromBasic theValue
     _ -> return $ fromBasic theValue
 
@@ -260,7 +261,7 @@ getVar (Constant (STuple vct)) = do
       return $ Constant v
     ) vct
   return $ STuple resolved
-  
+
 getVar (Constant (SMap ty mp)) = do
   resolved <- mapM (\var -> do
       v <- getVar var

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -49,7 +49,7 @@ import Blockchain.Data.GenesisBlock as GB
 import Blockchain.GenesisBlock
 import  Blockchain.Data.GenesisInfo
 import Blockchain.Data.Block
-import qualified Handlers.AccountInfo 
+import qualified Handlers.AccountInfo
 import Blockchain.DB.CodeDB
 import qualified Control.Monad.Change.Alter           as A
 import Blockchain.Strato.Model.Keccak256  hiding (rlpHash)
@@ -220,10 +220,10 @@ failedAssertion _ = False
 sender :: Account
 sender = Account 0xdeadbeef Nothing
 
-privateChainAcc :: Account 
+privateChainAcc :: Account
 privateChainAcc = Account 0xdeadbeef (Just 0x776622233444)
 
-rootAcc :: Account 
+rootAcc :: Account
 rootAcc = Account (fromPublicKey X509.rootPubKey) Nothing
 
 getCert :: X509Certificate
@@ -268,8 +268,8 @@ recursiveAddr :: Account
 recursiveAddr = Account (getNewAddress_unsafe (uploadAddress ^. accountAddress) 0) Nothing
 
 -- makeStrArgs :: [T.Text] -> T.Text
--- makeStrArgs xs = 
---   let 
+-- makeStrArgs xs =
+--   let
 --     escp :: T.Text -> T.Text
 --     escp s = "\"" <> s <> "\""
 --     repl = map escp
@@ -306,7 +306,7 @@ generateGBlock gi = do
             blockReceiptTransactions = [],
             blockBlockUncles         = []
           },
-          OutputBlock { 
+          OutputBlock {
             obOrigin = TXO.Direct
           , obTotalDifficulty     = 0
           , obBlockData           = bData
@@ -333,10 +333,10 @@ runTestWithTimeout timeout f = do
         !vals   = either error id eVals
         gi      = "{ \"logBloom\":\"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\", \"accountInfo\":[ [\"e1fd0d4a52b75a694de8b55528ad48e2e2cf7859\",1809251394333065553493296640760748560207343510400633813116524750123642650624] ], \"transactionRoot\":\"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\", \"extraData\":0, \"gasUsed\":0, \"gasLimit\":22517998136852480000000000000000, \"unclesHash\":\"1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\", \"mixHash\":\"0000000000000000000000000000000000000000000000000000000000000000\", \"receiptsRoot\":\"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\", \"number\":0, \"difficulty\":8192, \"timestamp\":\"1970-01-01T00:00:00.000Z\", \"coinbase\":\"00000000000000000000\", \"parentHash\":\"0000000000000000000000000000000000000000000000000000000000000000\", \"nonce\":42 }"
         eInput  = Ae.eitherDecodeStrict (BC.pack gi)
-        !input  = either error id eInput 
+        !input  = either error id eInput
         cert = getCert
         gi'  = buildGenesisInfo [] [cert] vals admins input
-    
+
     (blockCreated,outputBlock) <- generateGBlock gi'
     MP.initializeBlank
     setStateDBStateRoot Nothing $ blockDataStateRoot $ blockBlockData $ blockCreated
@@ -345,23 +345,23 @@ runTestWithTimeout timeout f = do
     bhr <- bootstrapChainDB  genHash [(Nothing, (blockDataStateRoot $ blockBlockData $ blockCreated))]
     putContextBestBlockInfo $ ContextBestBlockInfo genHash (blockBlockData $ blockCreated) 0 0 0
     Mod.put (Mod.Proxy @BlockHashRoot) $ bhr
-    processNewBestBlock genHash (blockBlockData $ blockCreated) [] -- bootstrap Bagger with genesis block   
+    processNewBestBlock genHash (blockBlockData $ blockCreated) [] -- bootstrap Bagger with genesis block
     withCurrentBlockHash genHash $ do
-      let certKey addr    = ((Account addr Nothing),) . encodeUtf8 
+      let certKey addr    = ((Account addr Nothing),) . encodeUtf8
           certRegistryKey = certKey (Address 0x509)
           rlpWrap         = rlpSerialize . rlpEncode
           ua              = userAddress $ x509CertToCertInfoState getCert
           certsub         = fromJust $ getCertSubject cert
       insert (Proxy @RawStorageValue) (certRegistryKey . T.pack $ ".addressToCertMap<a:" <> formatAddressWithoutColor ua <> ">") ((rlpWrap $ BAccount $ NamedAccount (Address 0xdeadbeef) MainChain)) --(encodeUtf8 $ T.pack (formatAddressWithoutColor (Address 0xdeadbeef)))
-      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".certificateString") (rlpWrap $ BString $ BC.pack myCertString)
+      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".certificateString") (rlpWrap . BString . SB.toShort $ BC.pack myCertString)
       insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".userAddress") ((rlpWrap $ BAccount $ NamedAccount ua MainChain))
       insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".owner") (rlpWrap $ BAccount (NamedAccount ((fromJust . stringAddress) "509") UnspecifiedChain))
-      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".commonName") (rlpWrap . BString . BC.pack . subCommonName $ certsub)
-      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".country") (rlpWrap . BString . BC.pack . fromJust . subCountry $ certsub)
-      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".organization") (rlpWrap . BString . BC.pack . subOrg $ certsub)
-      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".organizationalUnit") (rlpWrap . BString . BC.pack . fromJust . subUnit $ certsub)
-      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".group") (rlpWrap . BString . BC.pack . fromJust . subUnit $ certsub)
-      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".publicKey") (rlpWrap . BString . pubToBytes . subPub $ certsub)
+      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".commonName") (rlpWrap . BString . SB.toShort . BC.pack . subCommonName $ certsub)
+      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".country") (rlpWrap . BString . SB.toShort . BC.pack . fromJust . subCountry $ certsub)
+      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".organization") (rlpWrap . BString . SB.toShort . BC.pack . subOrg $ certsub)
+      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".organizationalUnit") (rlpWrap . BString . SB.toShort . BC.pack . fromJust . subUnit $ certsub)
+      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".group") (rlpWrap . BString . SB.toShort . BC.pack . fromJust . subUnit $ certsub)
+      insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".publicKey") (rlpWrap . BString . SB.toShort . pubToBytes . subPub $ certsub)
       insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".isValid") (rlpWrap (BBool True))
       insert (Proxy @RawStorageValue) (certKey (Address 0xdeadbeef) ".parent") ((rlpWrap $ BAccount $ NamedAccount (fromMaybe (Address 0x0) $ getParentUserAddress cert) MainChain))
       f
@@ -524,30 +524,30 @@ contract CertificateRegistry {
     }
 
     function initializeCertificateRegistry(string _rootCert) returns () {
-        require(!initialized, "The CertificateRegistry has already been initialized!");        
-        
+        require(!initialized, "The CertificateRegistry has already been initialized!");
+
         // Create the Certificate record
         Certificate c = new Certificate(_rootCert);
 
         // Register the root certificates and emit event
         addressToCertMap[c.userAddress()] = address(c);
         emit CertificateRegistered(_rootCert);
-        
+
 
         initialized = true;
-        emit CertificateRegistryInitialized(); 
+        emit CertificateRegistryInitialized();
 
-        
-        
+
+
     }
-    
+
     function registerCertificate(string newCertificateString) returns (address) {
         // Create the new Certificate record
         Certificate c = new Certificate(newCertificateString);
         addressToCertMap[c.userAddress()] = address(c);
         emit CertificateRegistered(newCertificateString);
         return c.userAddress();
-        
+
     }
 
     function getUserCert(address _address) returns (Certificate) {
@@ -707,10 +707,10 @@ getAll2 :: [[StoragePathPiece]] -> ContextM [BasicValue]
 getAll2 = mapM (getSolidStorageKeyVal' secondAddress . MS.fromList)
 
 getFields :: [BC.ByteString] -> ContextM [BasicValue]
-getFields = getAll . map (\t -> [Field t])
+getFields = getAll . map (\t -> [Field (SB.toShort t)])
 
 getFields2 :: [BC.ByteString] -> ContextM [BasicValue]
-getFields2 = getAll2 . map (\t -> [Field t])
+getFields2 = getAll2 . map (\t -> [Field (SB.toShort t)])
 
 bAddress :: Address -> BasicValue
 bAddress = BAccount . unspecifiedChain
@@ -863,10 +863,10 @@ spec = do
     it "can hash correctly" . runTest $ do
       runFile "testdata/Keccak256.sol"
       getFields ["buf1", "buf2", "hash1", "hash2"] `shouldReturn`
-        [ BString (B.replicate 32 0xfe)
-        , BString (BC.replicate 32 'x')
-        , BString (LabeledError.b16Decode "SolidVMSpec.hs" "59c3290d81fbdfe9ce1ffd3df2b61185e3089df0e3c49e0918e82a60acbed75a")
-        , BString (LabeledError.b16Decode "SolidVMSpec.hs" "5601c4475f2f6aa73d6a70a56f9c756f24d211a914cc7aff3fb80d2d8741c868")
+        [ BString (SB.replicate 32 0xfe)
+        , BString (SB.replicate 32 (c2w8 'x'))
+        , BString (SB.toShort $ LabeledError.b16Decode "SolidVMSpec.hs" "59c3290d81fbdfe9ce1ffd3df2b61185e3089df0e3c49e0918e82a60acbed75a")
+        , BString (SB.toShort $ LabeledError.b16Decode "SolidVMSpec.hs" "5601c4475f2f6aa73d6a70a56f9c756f24d211a914cc7aff3fb80d2d8741c868")
         ]
 
     it "can hash multiple arguments" . runTest $ do
@@ -881,7 +881,7 @@ contract qq {
   }
 }
 |]
-      getFields ["hsh"] `shouldReturn` [BString $ word256ToBytes 0x4ebc701886e9562cf7998b9ab563c6d3ca5ad243b547f11f31ae1ae156b2ff97]
+      getFields ["hsh"] `shouldReturn` [BString . SB.toShort $ word256ToBytes 0x4ebc701886e9562cf7998b9ab563c6d3ca5ad243b547f11f31ae1ae156b2ff97]
 
 
     it "can create a struct" . runTest $ do
@@ -1429,14 +1429,14 @@ contract qq {
   }
 }|]
     getFields ["x"] `shouldReturn` [BInteger 12345]
-  
+
   it "can throw exception if omitted parameter name and types are different" $ runTest (do
     runBS [r|
 contract qq {
   uint x = 0;
 
   constructor() {
-    x = f(6,5);   
+    x = f(6,5);
   }
   function f(string, uint) public returns (uint) {
     return 7;
@@ -1449,12 +1449,12 @@ contract qq {
   uint x = 0;
 
   constructor() {
-    x = f(6,5);   
+    x = f(6,5);
   }
   function f(uint, uint) public returns (uint) {
     return 7;
   }
-}|] 
+}|]
     getFields ["x"] `shouldReturn` [BInteger 7]
 
   it "can unpack tuples" . runTest $ do
@@ -1735,7 +1735,7 @@ contract qq {
     myS = new S();
     local_s = myS.s();
   }
-}|] 
+}|]
     getFields ["local_s"] `shouldReturn` [BString "Blockapps"]
 
   it "can cast address to contract" . runTest $ do
@@ -1757,7 +1757,7 @@ contract qq {
   account y;
   account payable x;
   bool z;
-  
+
   constructor() public {
     y = msg.sender;
     x = payable(y);
@@ -1874,10 +1874,10 @@ contract qq {
   uint x;
   function pushMem(uint[] memory ts) public {
     ts.push(7);
-    uint[] cpy = ts; 
+    uint[] cpy = ts;
     x = cpy[2];
   }
-}|] `shouldReturn` Just "()" 
+}|] `shouldReturn` Just "()"
     getFields ["x"] `shouldReturn` [BInteger 7]
 
   it "can store array literals" . runTest $ do
@@ -2061,7 +2061,7 @@ contract qq {
   }
 }|]
     --let dec =  show $ Numeric.readHex "0123456789abcdef0123456789abcdef"
-    
+
     let dec = case Numeric.readHex "0123456789abcdef0123456789abcdef" of
           [(n, "")] -> show (n :: Integer)
           _ -> error "Error parsing Hex: 0123456789abcdef0123456789abcdef"
@@ -2250,7 +2250,7 @@ contract qq {
   }
 }|]
     getFields ["x"] `shouldReturn` [BString "\194\175\&2"]
-  
+
   it "can use hexadecimal string literals double quotes" . runTest $ do
     runBS [r|
 contract qq {
@@ -2323,7 +2323,7 @@ contract string_test {
 }
 contract qq {
   bool test;
-  constructor(){ 
+  constructor(){
     test = it_getsTrueAndThisDotV();
   }
   function it_getsTrueAndThisDotV() external returns (bool) { // fails
@@ -2331,7 +2331,7 @@ contract qq {
     (bool b, string v) = y.getTrueAndThisDotV();
     return b && v == "test string" && (false == (v != "test string"));
   }
-}|] 
+}|]
     getFields ["test"] `shouldReturn` [BBool True]
 
   it "can initialize from constants" . runTest $ do
@@ -2625,14 +2625,14 @@ contract qq {
     st = _st;
   }
 }|] `shouldReturn` Just "()"
-    getFields ["st"] `shouldReturn` [BString (UTF8.fromString "4.11 g CO₂ / t · nm")]
+    getFields ["st"] `shouldReturn` [BString (SB.toShort $ UTF8.fromString "4.11 g CO₂ / t · nm")]
 
   it "can encode Unicode strings in Solidtiy source" . runTest $ do
     runBS [r|
 contract qq {
   string st = "4.11 g CO₂ / t · nm";
 }|]
-    getFields ["st"] `shouldReturn` [BString (UTF8.fromString "4.11 g CO₂ / t · nm")]
+    getFields ["st"] `shouldReturn` [BString (SB.toShort $ UTF8.fromString "4.11 g CO₂ / t · nm")]
 
   it "can accept bytes32 arguments" . runTest $ do
     runCall "set" "(\"deadbeef00000000000000000000000000000000000000000000000000000000\")" [r|
@@ -2769,11 +2769,11 @@ contract qq {
     getFields ["i"] `shouldReturn` [BInteger 8]
 
   it "can accept modifiers" $ runTest (do
-      runBS [r| 
-  contract qq { 
+      runBS [r|
+  contract qq {
     modifier m() {
-       _; 
-      } 
+       _;
+      }
 }|]) `shouldReturn` ()
 
   it "catches parse errors" $ (runTest $ runBS [r| contract { |]) `shouldThrow` anyParseError
@@ -3148,14 +3148,14 @@ contract Bite_Test {
 contract qq {
   Bite_Test bContract;
   bytes c;
-  bytes d;  
+  bytes d;
   int  e;
   constructor (){
     bContract = new Bite_Test();
     d = 'ab';
     bContract.set(d);
     c = bContract.b();
-    e = int(c) + int(d);  
+    e = int(c) + int(d);
     }
 } |]
     getFields ["e"] `shouldReturn` [BInteger 342]
@@ -3225,7 +3225,7 @@ contract qq {
   it "throws array index out of bounds exception" $ (runTest (runBS [r|
 contract qq {
    uint x;
-    
+
    constructor()
    {
       uint[] arr = [42, 2020];
@@ -3243,7 +3243,7 @@ contract qq {
       x = arr[true];
    }
 }|])) `shouldThrow` anyTypeError
- 
+
   it "type checks the index value in array index assignment" $ (runTest (runBS [r|
 contract qq {
    uint x;
@@ -3254,7 +3254,7 @@ contract qq {
       arr[true] = 2112;
    }
 }|])) `shouldThrow` anyTypeError
- 
+
   it "rejects empty index value on array index access" $ (runTest (runBS [r|
 contract qq {
    uint x;
@@ -3265,7 +3265,7 @@ contract qq {
       x = arr[];
    }
 }|])) `shouldThrow` anyTypeError
- 
+
   it "rejects empty index value on mapping index access" $ (runTest (runBS [r|
 contract qq {
    mapping(bool => uint) bs;
@@ -3276,7 +3276,7 @@ contract qq {
       x = bs[];
    }
 }|])) `shouldThrow` anyTypeError
- 
+
   it "rejects empty index value on array index assignment" $ (runTest (runBS [r|
 contract qq {
    uint x;
@@ -3406,7 +3406,7 @@ contract qq {
   it "rejects declared but undefined function" $ (runTest (runBS [r|
 contract qq {
    function f();
-   
+
    constructor()
    {
       f();
@@ -3432,7 +3432,7 @@ contract qq {
 
   it "catches division by zero error" $ (runTest (runBS [r|
 contract qq {
-  
+
    uint x = 42;
    uint y = 0;
    uint z;
@@ -3441,19 +3441,19 @@ contract qq {
    {
       z = 42/0;
    }
-}|])) `shouldThrow` anyDivideByZeroError 
+}|])) `shouldThrow` anyDivideByZeroError
 
   it "supports ternary operations" . runTest $ do
     runBS [r|
 contract qq {
-  
+
   uint x;
   uint y;
 
   constructor() {
     x = true == true ? 100 : 42;
     y = true == false ? 100 : 42;
-  
+
   }
 }|]
     getFields ["x", "y"] `shouldReturn` [BInteger 100, BInteger 42]
@@ -3461,7 +3461,7 @@ contract qq {
 
   it "rejects illegal enum access" $ (runTest (runBS [r|
 contract qq {
-  
+
   enum Role { ADMIN, USER }
   uint[] perms;
 
@@ -3558,21 +3558,21 @@ contract qq {
   }
 }|]
     getFields ["sce", "scm", "scu", "sde", "sdm", "sdu"] `shouldReturn`
-      [ BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedbeef)) 
-      , BAccount (NamedAccount 0xdeadbeef MainChain) 
-      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) 
-      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) 
-      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) 
-      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain) 
+      [ BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedbeef))
+      , BAccount (NamedAccount 0xdeadbeef MainChain)
+      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain)
+      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain)
+      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain)
+      , BAccount (NamedAccount 0xdeadbeef UnspecifiedChain)
       ]
-  
+
   it "can cast strings to chainIds" . runTest $ do
     runBS [r|
 contract qq {
   account sce;
   account scm;
   account scu;
-  
+
   constructor() public {
     sce = account("deadbeef:feedbeef");
     scm = account(address("deadbeef"), "0xfeedb33f");
@@ -3580,9 +3580,9 @@ contract qq {
   }
 }|]
     getFields ["sce", "scm", "scu"] `shouldReturn`
-      [ BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedbeef)) 
-      , BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedb33f)) 
-      , BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xf33dbeef)) 
+      [ BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedbeef))
+      , BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xfeedb33f))
+      , BAccount (NamedAccount 0xdeadbeef (ExplicitChain 0xf33dbeef))
       ]
 
   it "can cast strings to bool" . runTest $ do
@@ -3625,7 +3625,7 @@ contract qq{
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 13 })
     -- Check return of balance
-    void $ call2 "myTransfer" "()" (namedAccountToAccount Nothing a) 
+    void $ call2 "myTransfer" "()" (namedAccountToAccount Nothing a)
     getFields ["bal"] `shouldReturn` [ BInteger 13 ]
 
   it "will not over send (send when there is not enough gas)" . runTest $ do
@@ -3651,7 +3651,7 @@ contract qq{
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 7 })
     -- Check return of balance
-    void $ call2 "mySend" "()" (namedAccountToAccount Nothing a) 
+    void $ call2 "mySend" "()" (namedAccountToAccount Nothing a)
     getFields ["success", "bal"] `shouldReturn` [ BDefault, BInteger 7 ]
 
   it "will allow for sending to self" . runTest $ do
@@ -3677,7 +3677,7 @@ contract qq{
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 13 })
     -- Check return of balance
-    void $ call2 "mySend" "()" (namedAccountToAccount Nothing a) 
+    void $ call2 "mySend" "()" (namedAccountToAccount Nothing a)
     getFields ["success", "bal"] `shouldReturn` [ BBool True, BInteger 13 ]
 
   it "will not send when there is not anything to send between account" . runTest $ do
@@ -3703,7 +3703,7 @@ contract qq{
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 0 })
     -- Check return of balance
-    void $ call2 "mySend" "()" (namedAccountToAccount Nothing a) 
+    void $ call2 "mySend" "()" (namedAccountToAccount Nothing a)
     getFields ["success", "bal"] `shouldReturn` [ BDefault, BDefault ]
 
   it "cannot send to a non account payable type" $ runTest (do
@@ -3727,7 +3727,7 @@ contract qq{
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 26 })
     -- Check return of balance
-    (void $ call2 "mySend" "()" (namedAccountToAccount Nothing a))) `shouldThrow` anyTypeError 
+    (void $ call2 "mySend" "()" (namedAccountToAccount Nothing a))) `shouldThrow` anyTypeError
 
   it "cannot transfer for non account payable types" $ runTest (do
     runBS [r|
@@ -3792,8 +3792,8 @@ contract qq{
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing c) (\cs -> pure $ cs { addressStateBalance = 13 })
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing b) (\bs -> pure $ bs { addressStateBalance = 13 })
     -- Check return of balance
-    void $ call2 "myTransfer" "()" (namedAccountToAccount Nothing a) 
-    getFields ["bala", "balb", "balc"] `shouldReturn` 
+    void $ call2 "myTransfer" "()" (namedAccountToAccount Nothing a)
+    getFields ["bala", "balb", "balc"] `shouldReturn`
       [ BInteger 1,
         BInteger 26,
         BInteger 13 ]
@@ -3839,7 +3839,7 @@ contract qq{
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing c) (\cs -> pure $ cs { addressStateBalance = 13 })
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing b) (\bs -> pure $ bs { addressStateBalance = 13 })
     -- Check return of balance
-    void $ call2 "mySend" "()" (namedAccountToAccount Nothing a) 
+    void $ call2 "mySend" "()" (namedAccountToAccount Nothing a)
     getFields ["success", "bala", "balb", "balc"] `shouldReturn` [ BBool True, BInteger 1, BInteger 26, BInteger 13 ]
 
   it "cannot over transfer from an account." $ runTest (do
@@ -3926,9 +3926,9 @@ contract qq{
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing b) (\bs -> pure $ bs { addressStateBalance = 13 })
     -- Check return of balance
     void $ call2 "mySend" "()" (namedAccountToAccount Nothing a)
-    getFields [ "success", "bala", "balb", "balc"] `shouldReturn` 
+    getFields [ "success", "bala", "balb", "balc"] `shouldReturn`
       [ BDefault,
-        BInteger 14, 
+        BInteger 14,
         BInteger 13,
         BInteger 13 ]
 
@@ -3945,7 +3945,7 @@ contract qq {
   uint cid4;
   constructor() public {
     a1 = account(0xdeadbeef, 0xfeedbeef);
-    a2 = account(0x123, "main");    
+    a2 = account(0x123, "main");
     a3 = account(0x124);
     a4 = account(0xdeadbeef, "0xdeadbeef");
     cid1 = a1.chainId;
@@ -3997,7 +3997,7 @@ contract qq{
     -- Set the balance
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing a) (\as -> pure $ as { addressStateBalance = 13 })
     -- Check return of balance
-    void $ call2 "myBalance" "()" (namedAccountToAccount Nothing a) 
+    void $ call2 "myBalance" "()" (namedAccountToAccount Nothing a)
     getFields ["bal"] `shouldReturn` [ BInteger 13 ]
   it "can get the codehash from an address" . runTest $ do
     let contract = [r|
@@ -4014,7 +4014,7 @@ contract qq{
 }|]
     runBS contract
     getFields ["codeHashTest", "codeHashTest"] `shouldReturn`
-      [ BString $ BC.pack $ keccak256ToHex $ hash $ UTF8.fromString contract
+      [ BString . SB.toShort . BC.pack . keccak256ToHex . hash $ UTF8.fromString contract
       , BString "75dde029db795d07c2fed3b5d14443cf540520397ffc250b19567c80ff8e17fc" ]
 
   it "can the codehash from this an address" . runTest $ do
@@ -4027,7 +4027,7 @@ contract qq{
 }|]
     runBS contract
     getFields ["codeHashTest", "codeHashTest"] `shouldReturn`
-      [ BString $ BC.pack $  keccak256ToHex $ hash $ UTF8.fromString contract 
+      [ BString . SB.toShort . BC.pack .  keccak256ToHex . hash $ UTF8.fromString contract
       , BString "bd03e87420032a4d4ac1653f8af8f4c42ae85bf8d07d02ff2433c7052d6d4fbb" ]
 
   it "can get structs from the '.code' function" . runTest $ do
@@ -4061,7 +4061,7 @@ contract qq {
 }|]
     runBS codeSnippet
     getFields [ "codePiece" ] `shouldReturn`
-      [ BString $ UTF8.fromString testCode]
+      [ BString . SB.toShort $ UTF8.fromString testCode]
 
   it "can get overloaded function using the .code parameter" . runTest $ do
     let testCode :: String
@@ -4115,7 +4115,7 @@ contract qq{
 }|]
     runBS codeSnippet
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString testCode]
+      [ BString . SB.toShort $ UTF8.fromString testCode]
 
   it "can get events from the '.code' function" . runTest $ do
     let codeSnippet :: String
@@ -4142,7 +4142,7 @@ contract qq{
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString codeSnippet]
+      [ BString . SB.toShort $ UTF8.fromString codeSnippet]
 
   it "can get external modifiers using the '.code' function" . runTest $ do
     let codeSnippet :: String
@@ -4157,7 +4157,7 @@ contract qq{
 
 contract anotherThing {
   uint x = 3;
-  modifier myModifier() {  
+  modifier myModifier() {
     require(x == 3 , string.concat('x is not 3 : ', string(x)));
     x = 4;
     _;
@@ -4186,12 +4186,12 @@ contract qq{
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString codeSnippet]
+      [ BString . SB.toShort $ UTF8.fromString codeSnippet]
 
   it "can get the code for a contract if supplied an empty string" . runTest $ do
     let codeSnippet :: String
         codeSnippet = [r|contract Test {
-  
+
   constructor () public {
     }
 }
@@ -4213,7 +4213,7 @@ contract qq{
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString codeSnippet]
+      [ BString . SB.toShort $ UTF8.fromString codeSnippet]
 
   it "can search for an enum body within a codeCollection using .code" . runTest $ do
     let codeSnippet :: String
@@ -4240,7 +4240,7 @@ contract qq {
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString codeSnippet]
+      [ BString . SB.toShort $ UTF8.fromString codeSnippet]
 
   it "can search for any public variable in a contract initialized value using .code" . runTest $ do
     let codeSnippet :: String
@@ -4264,7 +4264,7 @@ contract qq{
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString codeSnippet]
+      [ BString . SB.toShort $ UTF8.fromString codeSnippet]
 
   it "can search for a constant and get its initial code. using .code" . runTest $ do
     let codeSnippet :: String
@@ -4289,7 +4289,7 @@ contract qq{
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString codeSnippet]
+      [ BString . SB.toShort $ UTF8.fromString codeSnippet]
 
   it "can get the current contract code without supplying anything to the code using .code" . runTest $ do
     let codeSnippet :: String
@@ -4324,7 +4324,7 @@ contract qq{
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString codeSnippet]
+      [ BString . SB.toShort $ UTF8.fromString codeSnippet]
 
   it "Code won't return anything if the thing is not in the file, using .code" . runTest $ do
     let contract :: String
@@ -4373,7 +4373,7 @@ contract qq{
 }|]
     runBS collection
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString contractqq]
+      [ BString . SB.toShort $ UTF8.fromString contractqq]
 
   it "can properly add the final } to a contract without a constructor using the code member function using .code" . runTest $ do
     let myContract :: String
@@ -4399,7 +4399,7 @@ contract qq {
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString myContract]
+      [ BString . SB.toShort $ UTF8.fromString myContract]
 
   it "can properly add the final } to a contract with a constructor but information after the constructor using the code member function using .code" . runTest $ do
     let myContract :: String
@@ -4434,7 +4434,7 @@ contract qq {
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString myContract]
+      [ BString . SB.toShort $ UTF8.fromString myContract]
 
   it "Can find a function within a codeCollection using .code" . runTest $ do
     let myFunxion :: String
@@ -4472,7 +4472,7 @@ contract qq {
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString myFunxion]
+      [ BString . SB.toShort $ UTF8.fromString myFunxion]
 
   it "Can avoid getting confused if two functions with the same name are in the same codeCollection using .code" . runTest $ do
     let myFunxion :: String
@@ -4519,12 +4519,12 @@ contract qq {
 |]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString myFunxion]
+      [ BString . SB.toShort $ UTF8.fromString myFunxion]
 
   it "Can get just the contract if empty string is fed to the code function. using .code" . runTest $ do
     let codeSnippet :: String
         codeSnippet = [r|contract Test {
-  
+
   constructor () public {
     }
 }
@@ -4550,7 +4550,7 @@ contract qq{
 }|]
     runBS contract
     getFields ["codeTest"] `shouldReturn`
-      [ BString $ UTF8.fromString codeSnippet]
+      [ BString . SB.toShort $ UTF8.fromString codeSnippet]
 
   it "Can throw an error if more than one item is given to the code member function, using .code" $ (runTest (runBS [r|
 
@@ -4624,7 +4624,7 @@ contract qq{
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing b) (\bs -> pure $ bs { addressStateBalance = 0 })
 
     -- Check return of balance
-    void $ call2 "myBalance" "()" (namedAccountToAccount Nothing a) 
+    void $ call2 "myBalance" "()" (namedAccountToAccount Nothing a)
     getFields ["bala", "balb"] `shouldReturn` [ BInteger 1, BInteger 13  ]
 
   it "can't assign a value to an unallocated index in an array" $ (runTest (runBS [r|
@@ -4706,7 +4706,7 @@ contract qq {
 
 --   it "only a contract posted by the root user can call registerCert" $ (runTest $ do
 --     runBS [r|
--- 
+--
 -- contract qq {
 --     string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBjjCCATKgAwIBAgIRANJH2FERGO/3JvoPHo52I3IwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyNTE0NTIwMloXDTIzMDQy\nNTE0NTIwMlowSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANIADBFAiEA\n9sjaARt+VEUCjZv3NAuEENoD744fZIuuUTt6qwM7fKQCIDLp02y/lSHtLfOOgCW5\n40qEIDYu2UO1JqSuyGvIUOoc\n-----END CERTIFICATE-----";
 --     constructor() {
@@ -4719,7 +4719,7 @@ contract qq {
 
 contract Certificate {
     address public userAddress;
-    
+
     // Store all the fields of a certificate in a Cirrus record
     string public commonName;
     string public organization;
@@ -4756,7 +4756,7 @@ contract qq is CertificateRegistry{
 
 --   it "cannot post X509 certificates not signed by the BlockApps private key" $ (runTest $ do
 --     void $ runArgsWithOrigin rootAcc sender "()" [r|
--- 
+--
 -- contract qq {
 --     account public certAddr = account(0xe79beda3078bcb66524f91f74de982d2fcc89287);
 --     string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBjjCCATKgAwIBAgIRANJH2FERGO/3JvoPHo52I3IwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyNTE0NTIwMloXDTIzMDQy\nNTE0NTIwMlowSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANIADBFAiEA\n9sjaARt+VEUCjZv3NAuEENoD744fZIuuUTt6qwM7fKQCIDLp02y/lSHtLfOOgCW5\n40qEIDYu2UO1JqSuyGvIUOoc\n-----END CERTIFICATE-----";
@@ -4771,20 +4771,20 @@ contract qq is CertificateRegistry{
 
 --   it "cannot register a x509 certificate on a private chain" $ (runTest $ do
 --     void $ runArgsWithOrigin rootAcc privateChainAcc "()" [r|
--- 
+--
 -- contract qq {
 --     account myAccount = account("deadbeef:feedbeef");
-    
+
 --     string myNewCertificate = "-----BEGIN CERTIFICATE-----\nMIIBiDCCAS2gAwIBAgIQCgO76hC29iXEFXJNco5ekjAMBggqhkjOPQQDAgUAMEYx\nDDAKBgNVBAMMA2RhbjEMMAoGA1UEBgwDVVNBMRIwEAYDVQQKDAlibG9ja2FwcHMx\nFDASBgNVBAsMC2VuZ2luZWVyaW5nMB4XDTIxMDMxODE1NDgwN1oXDTIyMDMxODE1\nNDgwN1owRjEMMAoGA1UEAwwDZGFuMQwwCgYDVQQGDANVU0ExEjAQBgNVBAoMCWJs\nb2NrYXBwczEUMBIGA1UECwwLZW5naW5lZXJpbmcwVjAQBgcqhkjOPQIBBgUrgQQA\nCgNCAAQY4p67l1IIEUdVC7L+rUDwF5Nv30bze0NV5y8ced7qwp+YFk3UAiOGkcYo\n7ba8F92rd0yf9AGpvZN1H3Dda8xdMAwGCCqGSM49BAMCBQADRwAwRAIgbKXO8tZ5\noPhBusPQFkNEQDnLO/MRru4KjtCpPnVb5sACIE0TwBJ7yeIGuPc/8G50/858Pf3a\n0t1hHbhYnJarPkNA\n-----END CERTIFICATE-----";
 
 --     constructor() {
---         registerCert(myNewCertificate); 
+--         registerCert(myNewCertificate);
 --     }
 -- }|]) `shouldThrow` anyInvalidWriteError
 
   -- it "cannot use old registerCert on solidvm 3.2" $ (runTest $ do
   --     (runBS [r|
-  -- 
+  --
   -- contract qq {
   --     account public certAddr = account(0x622EB3792DaA3d3770E3D27D02e53755408aE00b);
   --     string public myCertificate = "-----BEGIN CERTIFICATE-----\nMIIBizCCAS+gAwIBAgIQejfmUC0VeygSTQ0htwpDbzAMBggqhkjOPQQDAgUAMEcx\nDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIGA1UECwwLRW5n\naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTAeFw0yMjA0MTQyMTI4NDdaFw0yMzA0MTQy\nMTI4NDdaMEcxDTALBgNVBAMMBFRyb3kxEjAQBgNVBAoMCUJsb2NrYXBwczEUMBIG\nA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEGBSuB\nBAAKA0IABCSwiVfrLj1MCa+1bcBXOnGhnLxS5DYo3/1udE/LYFi2hFgDCPQxKYqP\n7LmHV2W35B3ZZw5SQVf1FxjWE0tZqswwDAYIKoZIzj0EAwIFAANIADBFAiEAvbGZ\nqma5fKnHnzpGCI5lc4VYdHBfgqfG7CwqJ5ii66YCIFUT+eXA1fS9q4/jJ+eULQwH\neXbEHHtO6nBOorRsoG3H\n-----END CERTIFICATE-----";
@@ -4806,7 +4806,7 @@ contract qq is CertificateRegistry{
   --         certPubKey = getUserCert(certAddr)["publicKey"];
   --     }
   -- }|])) `shouldThrow` anyUnknownFunc
-  
+
   -- it "cannot use new registerCert(string _cert, Certificate c) on solidvm < 3.2" $ (runTest $ do
   --     (runBS [r|
   -- contract Certificate {
@@ -4825,13 +4825,13 @@ contract qq is CertificateRegistry{
   --         certPubKey = getUserCert(certAddr)["publicKey"];
   --     }
   -- }|])) `shouldThrow` anyInvalidWriteError
-  
+
   xit "can only post X509 certificates to the address of the public key" . runTest $ do
     void $ runArgsWithCertificateRegistry [r|
 
 contract Certificate {
     address public userAddress;
-    
+
     // Store all the fields of a certificate in a Cirrus record
     string public commonName;
     string public organization;
@@ -4871,7 +4871,7 @@ contract qq is CertificateRegistry{
 
 -- contract Certificate {
 --     address public userAddress;
-    
+
 --     // Store all the fields of a certificate in a Cirrus record
 --     string public commonName;
 --     string public organization;
@@ -4897,7 +4897,7 @@ contract qq is CertificateRegistry{
 -- }
 -- contract qq is CertificateRegistry{
 --     account myAccount = account(0x74f014FEF932D2728c6c7E2B4d3B88ac37A7E1d0);
-    
+
 --     string myNewCertificate = "-----BEGIN CERTIFICATE-----\nMIIBjTCCATKgAwIBAgIRAOPPkVoBp/GnwZGR32jcIjwwDAYIKoZIzj0EAwIFADBI\nMQ4wDAYDVQQDDAVBZG1pbjESMBAGA1UECgwJQmxvY2tBcHBzMRQwEgYDVQQLDAtF\nbmdpbmVlcmluZzEMMAoGA1UEBgwDVVNBMB4XDTIyMDQyMDE3NTcxM1oXDTIzMDQy\nMDE3NTcxM1owSDEOMAwGA1UEAwwFQWRtaW4xEjAQBgNVBAoMCUJsb2NrQXBwczEU\nMBIGA1UECwwLRW5naW5lZXJpbmcxDDAKBgNVBAYMA1VTQTBWMBAGByqGSM49AgEG\nBSuBBAAKA0IABFISUeMfsGYl/sWStpv6cDeNHLwktFAO2dAwe7J8uWZzS8ONyYCs\n9FEQ2NsmDj5IaCAKcRSvVFNwXOAUQDQ1pnUwDAYIKoZIzj0EAwIFAANHADBEAiA8\nR0UERQZbF3qJUt5A0ZFf2ZmB0l/ZPjIvM383gOF3xwIgbxbQ8NLkDEe2mWJ/qa4n\nN8txKc8G9R27ZYAUuz15zF0=\n-----END CERTIFICATE-----";
 
 --     address public certRegAddr;
@@ -4920,13 +4920,13 @@ contract qq is CertificateRegistry{
 --     constructor() {
 --         certReg = new CertificateRegistry();
 --         certRegAddr = certReg.registerCertificate(myNewCertificate);
---         userCert = certReg.getUserCert(certRegAddr); 
+--         userCert = certReg.getUserCert(certRegAddr);
 
 --         myUsername     = tx.username;
 --         myOrganization = tx.organization;
 --         myGroup        = tx.group;
 --         myOrganizationalUnit = tx.organizationalUnit;
- 
+
 --         certificate    = tx.certificate;
 --         myCommonName   = userCert.commonName();
 --         myCountry      = userCert.country();
@@ -4974,7 +4974,7 @@ contract qq {
       string pubkey = "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUhJR4x+wZiX+xZK2m/pwN40cvCS0UA7Z\n0DB7sny5ZnNLw43JgKz0URDY2yYOPkhoIApxFK9UU3Bc4BRANDWmdQ==\n-----END PUBLIC KEY-----";
       isValid = verifyCert(cert, pubkey);
     }
-}|] 
+}|]
     getFields ["isValid"] `shouldReturn` [ BBool True ]
 
   it "verifyCert fails for hex-encoded public keys" $ (runTest $ do
@@ -5015,7 +5015,7 @@ contract qq {
       string pubkey = "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUhJR4x+wZiX+xZK2m/pwN40cvCS0UA7Z\n0DB7sny5ZnNLw43JgKz0URDY2yYOPkhoIApxFK9UU3Bc4BRANDWmdQ==\n-----END PUBLIC KEY-----";
       isValid = verifyCert(cert, pubkey);
     }
-}|] 
+}|]
     runBS contract
     getFields ["isValid"] `shouldReturn` [ BBool True ]
 
@@ -5045,11 +5045,11 @@ contract qq {
       string pubkey = "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAlGfMOmhI+AjQlfxve8YoEXhZErFdkCx\nc8OkTB1TP6giwof4fWG+Fua8b2W0YjOQkrQojwnKbBDt3CQeqU+bPA==\n-----END PUBLIC KEY-----";
       isValid = verifyCert(cert, pubkey);
     }
-}|] 
+}|]
     runBS contract
     getFields ["isValid"] `shouldReturn` [ BDefault ]
-      
-    
+
+
   it "can call builtin function verifyCertSignedBy" . runTest $ do
     runBS [r|
 
@@ -5060,9 +5060,9 @@ contract qq {
       string pubkey = "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUhJR4x+wZiX+xZK2m/pwN40cvCS0UA7Z\n0DB7sny5ZnNLw43JgKz0URDY2yYOPkhoIApxFK9UU3Bc4BRANDWmdQ==\n-----END PUBLIC KEY-----";
       isValid = verifyCertSignedBy(cert, pubkey);
     }
-}|] 
+}|]
     getFields ["isValid"] `shouldReturn` [ BBool True ]
-    
+
   it "verifyCertSignedBy fails for hex-encoded public keys" $ (runTest $ do
     (runBS [r|
 
@@ -5103,11 +5103,11 @@ contract qq {
     string pubkey = "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEWgaGAD+EzRzA+zZILPDzRzDJiURfTYYZ\n/PYjx26acOAKKHjX6HkNUlVgJ0N/1oeMPYRhXm2tDGgZt6VbS1if8w==\n-----END PUBLIC KEY-----";
     isValid = verifyCertSignedBy(cert, pubkey);
   }
-}|] 
+}|]
     runBS contract
     getFields ["isValid"] `shouldReturn` [ BBool True ]
-  
-  
+
+
   it "verifyCertSignedBy fails with a chained cert and the wrong public key" . runTest $ do
     let cert = T.pack $ filter (\c -> not (isSpace c) || c == ' ') [r|-----BEGIN CERTIFICATE-----\nMIIBgzCCASegAwIBAgIQ
 JN1cZoLJ4yhjGrEHRxzPNDAMBggqhkjOPQQDAgUAMEMx\nDjAMBgNVBAMMBUNOT25lMREwDwYDVQQKDAhDTk9uZU9yZzEQMA4GA1UECwwHT25l\nVW5pdDE
@@ -5134,7 +5134,7 @@ contract qq {
       string pubkey = "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAlGfMOmhI+AjQlfxve8YoEXhZErFdkCx\nc8OkTB1TP6giwof4fWG+Fua8b2W0YjOQkrQojwnKbBDt3CQeqU+bPA==\n-----END PUBLIC KEY-----";
       isValid = verifyCertSignedBy(cert, pubkey);
     }
-}|] 
+}|]
     runBS contract
     getFields ["isValid"] `shouldReturn` [ BDefault ]
 
@@ -5149,9 +5149,9 @@ contract qq {
     string pubkey = "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUhJR4x+wZiX+xZK2m/pwN40cvCS0UA7Z\n0DB7sny5ZnNLw43JgKz0URDY2yYOPkhoIApxFK9UU3Bc4BRANDWmdQ==\n-----END PUBLIC KEY-----";
     isValid = verifySignature(msgHash, signature, pubkey);
   }
-}|]  
+}|]
     getFields ["isValid"] `shouldReturn` [ BBool True ]
-  
+
   it "verifySignature fails for an incorrect message hash" $ (runTest $ do
     runBS [r|
 
@@ -5177,7 +5177,7 @@ contract qq {
     isValid = verifySignature(msgHash, signature, pubkey);
   }
 }|]) `shouldThrow` anyMalformedDataError
-  
+
   it "verifySignature fails for a hex-encoded public key" $ (runTest $ do
     runBS [r|
 
@@ -5231,7 +5231,7 @@ contract qq{
     timestamp = block.timestamp;
     gaslimit = block.gaslimit;
     diff = block.difficulty;
-    return;        
+    return;
   }
 }|]
     getFields ["blockNumber", "a1", "timestamp", "gaslimit", "diff"] `shouldReturn` [BInteger 8033, BDefault, BInteger 16384, BInteger 1000000, BInteger 900]
@@ -5307,14 +5307,14 @@ contract qq {
     assert(s == "helloworld");
     assert(w == "helloworld and friends");
   }
-}|] 
+}|]
 
   it "can use the builtin keccak256 function with any amount of string arguments" . runTest $ do
     runCall' "a" "()" [r|
 
 contract qq {
   function a() public returns (bytes32) {
-    return keccak256("hello", "world"); 
+    return keccak256("hello", "world");
   }
 }|] `shouldReturn` Just ("(\"\\250&\\219|\\168^\\173\\&9\\146\\SYN\\231\\198\\&1k\\197\\SO\\210C\\147\\195\\DC2+X'5\\231\\243\\176\\249\\ESC\\147\\240\")")
 --keccak256ToByteString function implementation wrong
@@ -5420,7 +5420,7 @@ contract qq {
 
 contract qq {
   uint x = 3;
-  modifier myModifier() {  
+  modifier myModifier() {
     require(x == 3 , string.concat('x is not 3 : ', string(x)));
     x = 4;
     _;
@@ -5439,7 +5439,7 @@ contract qq {
 
 contract qq {
   uint x = 3;
-  modifier myModifier() {  
+  modifier myModifier() {
     require(x == 3 , string.concat('x is not 3 : ', string(x)));
     x = 4;
     _;
@@ -5465,7 +5465,7 @@ contract qq {
 
 contract qq {
   uint x = 3;
-  modifier myModifier(uint _x) {  
+  modifier myModifier(uint _x) {
     require(_x == 3 , string.concat('x is not 3 : ', string(_x)));
     x = 4;
     _;
@@ -5540,7 +5540,7 @@ contract qq {
     runBS [r|
 
 contract qq {
-  
+
   address addr;
   constructor() {
   addr = ecrecover("ca678fcee68aa0b4b1e0bf01b24a0beff75133284f0ad84f1e8cc70d5a9959bc",27,"c99b861c7a2d47bcf5a8423b94cc962b585f340a53e88c91b86a53effd10dc58","3dfd7acaf4625c69df55a2f4cf4f7d63da25bb495abd8dfcc9bd53481c0ccaeb");
@@ -5550,9 +5550,9 @@ contract qq {
 
 --   it "returns 0  for invalid ecrecover call" . runTest $ do
 --     runBS [r|
--- 
+--
 -- contract qq {
-  
+
 --   address addr;
 --   constructor() {
 --   addr = ecrecover("ca678fcee68aa0b4b1e0bf01b24a0beff75133284f0ad84f1e8cc70d5a9959bc",27,"efd16e46ceb4851861b89aa5fddb18e18a70bdaf029d77482bdd9b2242854b59","3dfd7acaf4625c69df55a2f4cf4f7d63da25bb495abd8dfcc9bd53481c0ccaeb");
@@ -5571,7 +5571,7 @@ contract qq {
   }
 }
 |]
-    getFields ["hsh"] `shouldReturn` [BString $ word256ToBytes 0x5C0BE87ED7434D69005F8BBD84CAD8AE6ABFD49121B4AAEEB4C1F4A2E2987711]
+    getFields ["hsh"] `shouldReturn` [BString . SB.toShort $ word256ToBytes 0x5C0BE87ED7434D69005F8BBD84CAD8AE6ABFD49121B4AAEEB4C1F4A2E2987711]
 
   it "can use the builtin ripemd160 function" . runTest $ do
     runBS [r|
@@ -5583,7 +5583,7 @@ contract qq {
     hsh = ripemd160(username);
   }
 }|]
-    getFields ["hsh"] `shouldReturn` [BString $ B.pack $ word160ToBytes 0x63f4a6f6005b0ded8c5fc7e62ddf2550e9320410]
+    getFields ["hsh"] `shouldReturn` [BString . SB.toShort . B.pack $ word160ToBytes 0x63f4a6f6005b0ded8c5fc7e62ddf2550e9320410]
 
   it "can use the selfdestruct function" . runTest $ do
     let contract = [r|
@@ -5603,7 +5603,7 @@ contract qq {
 
   function selfDestructThis() internal {
     selfdestruct(ownerPay);
-  } 
+  }
 }|]
     runBS contract
     -- Get the contract's accounts
@@ -5612,14 +5612,14 @@ contract qq {
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing contract') (\as -> pure $ as { addressStateBalance = 14 })
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing owner) (\bs -> pure $ bs { addressStateBalance = 10 })
     -- Check return of balance
-    void $ call2 "selfDestructThis" "()" (namedAccountToAccount Nothing contract') 
-    getFields ["contract'", "contractPay", "owner", "ownerPay"] `shouldReturn` 
+    void $ call2 "selfDestructThis" "()" (namedAccountToAccount Nothing contract')
+    getFields ["contract'", "contractPay", "owner", "ownerPay"] `shouldReturn`
       [ BDefault
       , BDefault
       , BDefault
       , BDefault
       ]
-  
+
   it "throw an error when the 'account' reserved word is for a variable name." $ runTest (do
       runBS [r|
 
@@ -5675,7 +5675,7 @@ contract qq {
   uint constant c = 2022;
   constructor() public {
   }
-}|] 
+}|]
     getFields ["c"] `shouldReturn` [BDefault] --- Wait does this return BDefault or Int?
 
   it "an assign an immutable" . runTest $ do
@@ -5725,12 +5725,12 @@ contract qq {
 
   }
 }|]
-    getFields ["x", "y", "z"] `shouldReturn` 
+    getFields ["x", "y", "z"] `shouldReturn`
       [ bContract "X" 0x6532c90691674287ccc10aeb251e0a0f7439073e
       , bContract "Y" 0xfa29c1031db9942202c710ed85879c3d3e9f7110
       , bContract "X" 0x898eabafbe40a722b6393ff16c9166e75e519b8f
       ]
-      
+
   it "can use a try catch statment to catch a divide by zero error the SolidVM Way (trademark pending)" . runTest $ do
     runBS [r|
 
@@ -5762,7 +5762,7 @@ contract qq{
     getFields ["mynum"] `shouldReturn` [BInteger 3]
 
   it "can use a try catch statment to catch a divide by zero error the Solidity Way (trademark very much in effect)" . runTest $ do
-    runBS [r| 
+    runBS [r|
 
 contract Divisor {
   function doTheDivide() public returns (uint) {
@@ -5778,7 +5778,7 @@ contract qq {
     Divisor d =  new Divisor();
     try d.doTheDivide() returns (uint v) {
           return (v, true);
-        } catch Error(string memory amsg) { 
+        } catch Error(string memory amsg) {
             // This is executed in case
             // revert was called inside getData
             // and a reason string was provided.
@@ -5820,7 +5820,7 @@ contract qq {
   function tryTheDivide() returns (uint, bool) {
     try d.doTheDivide() returns (uint v) {
         return (v, true);
-    } catch Error(string memory itsamessage) { 
+    } catch Error(string memory itsamessage) {
         // This is executed in case
         // revert was called inside doTheDivide()
         // and a reason string was provided.
@@ -5842,7 +5842,7 @@ contract qq {
   }
 }|] `shouldReturn` (Just "(12,false)")
 
-    getFields ["errCount", "theError"] `shouldReturn` [BInteger 1, BInteger 12] 
+    getFields ["errCount", "theError"] `shouldReturn` [BInteger 1, BInteger 12]
 
 
   it "allows overloading functions with different number of parameters" . runTest $ do
@@ -5920,7 +5920,7 @@ contract qq{
   }
 }|]
     getFields ["myNum", "myStatus"] `shouldReturn` [BInteger 3, BBool True]
-    
+
 
   it "can use randomly ordered named argument function calls with overloading" . runTest $ do
     runBS [r|
@@ -5946,8 +5946,8 @@ contract qq{
   }
 }|]
     getFields ["myNum", "myStatus", "myString"] `shouldReturn` [BInteger 9, BBool True, BString "hi world"]
-    
-    
+
+
   it "should catch invalid function overloads" $ runTest (do
     runBS [r|
 
@@ -6074,7 +6074,7 @@ contract qq {
   }
 }|]
     let calldataHash = fromMaybe emptyHash $ stringKeccak256 "func2(uint,string,bool)"
-    getFields ["ss"] `shouldReturn` [BString $ BC.pack $ L.take 8 $ keccak256ToHex calldataHash ]
+    getFields ["ss"] `shouldReturn` [BString . SB.toShort . BC.pack . L.take 8 $ keccak256ToHex calldataHash ]
 
   it "can use free functions, free functions can access this" . runTest $ do
     runBS [r|
@@ -6227,8 +6227,8 @@ contract qq{
     myNum = sum(myArr);
   }
 }|]) `shouldThrow` anyParseError
-    
-  
+
+
   it "can declare a constant at the file level and use it" . runTest $ do
     runBS [r|
 
@@ -6309,12 +6309,12 @@ contract qq {
   int result1 = 0;
   int result2 = 0;
   int result3 = -2;
-  int result4 = 24; 
+  int result4 = 24;
   constructor() {
     result1 += -2 >>> 254;
     result2 += 12 >>> 1;
     result3 >>>= 255;
-    result4 >>>= 1; 
+    result4 >>>= 1;
   }
 }|]
     getFields ["result1", "result2", "result3", "result4"] `shouldReturn` [BInteger 3, BInteger 6, BInteger 1, BInteger 12]
@@ -6356,7 +6356,7 @@ contract qq {
   constructor() {
     throwsError();
   }
-  
+
   function throwsError() {
     throw myError("lmao pranked");
   }
@@ -6379,7 +6379,7 @@ contract qq {
 
   function checkTen(int _val) returns (int) {
      if (_val == 10) {
-        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen"); 
+        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen");
      }
      return _val;
   }
@@ -6391,7 +6391,7 @@ contract qq {
   function setVal(int _val) returns (int) {
      try {
         val = checkTen(_val);
-     } catch IsTen(vall, mes) { 
+     } catch IsTen(vall, mes) {
         val = vall + 1;
         errorMsg = mes;
      }
@@ -6413,7 +6413,7 @@ contract qq {
 
   function checkTen(int _val) returns (int) {
      if (_val == 10) {
-        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen"); 
+        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen");
      }
      return _val;
   }
@@ -6421,7 +6421,7 @@ contract qq {
   function setVal(int _val) returns (int) {
      try {
         val = checkTen(_val);
-     } catch IsTen(vall) { 
+     } catch IsTen(vall) {
         val = vall + 1;
      }
   }
@@ -6444,7 +6444,7 @@ contract qq {
 
   function checkTen(int _val) returns (int) {
      if (_val == 10) {
-        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen"); 
+        throw IsTen(_val, "Stop trying to make ten happen, its not going to happen");
      }
      return _val;
   }
@@ -6456,7 +6456,7 @@ contract qq {
   function setVal(int _val) returns (int) {
      try {
         val = checkTen(_val);
-     } catch IsTen(vall, mes, bad) { 
+     } catch IsTen(vall, mes, bad) {
         val = vall + 1;
         myString = bad;
      }
@@ -6467,9 +6467,9 @@ contract qq {
     runBS [r|
 
 contract qq {
-  
+
   uint a;
-  
+
   constructor()
   {
     a=1;
@@ -6479,17 +6479,17 @@ contract qq {
   function randomFunction(uint checker)
   {
     if(a==checker)
-      revert(); 
-  } 
+      revert();
+  }
 }|]) `shouldThrow` anyRevertError
 
   it "revert sucessfully when invoked with arguments" $ runTest (do
     runBS [r|
 
 contract qq {
-  
+
   uint a;
-  
+
   constructor()
   {
     a=1;
@@ -6499,17 +6499,17 @@ contract qq {
   function randomFunction(uint checker)
   {
     if(a==checker)
-      revert("logic flag"); 
-  } 
+      revert("logic flag");
+  }
 }|]) `shouldThrow` anyRevertError
 
   it "revert sucessfully when invoked with namedargs" $ runTest (do
     runBS [r|
 
 contract qq {
-  
+
   uint a;
-  
+
   constructor()
   {
     a=1;
@@ -6519,15 +6519,15 @@ contract qq {
   function randomFunction(uint checker)
   {
     if(a==checker)
-      revert({x:"logic flag"}); 
-  } 
+      revert({x:"logic flag"});
+  }
 }|]) `shouldThrow` anyRevertError
 
   it "Revert customError" $ runTest (do
     runBS [r|
 
 contract qq {
-  
+
   uint a;
   error f (string message);
   constructor()
@@ -6539,15 +6539,15 @@ contract qq {
   function randomFunction(uint checker)
   {
     if(a==checker)
-      revert f("ERROR"); 
-  } 
+      revert f("ERROR");
+  }
 }|]) `shouldThrow` anyCustomError
 
   it "Revert customError  namedargs" $ runTest (do
     runBS [r|
 
 contract qq {
-  
+
   uint a;
   error f(string x,string y);
   constructor()
@@ -6559,8 +6559,8 @@ contract qq {
   function randomFunction(uint checker)
   {
     if(a==checker)
-      revert f({x:'a',y:'b'}); 
-  } 
+      revert f({x:'a',y:'b'});
+  }
 }|]) `shouldThrow` anyCustomError
 
   it "Supports pure functions in 3.3" . runTest $ do
@@ -6572,7 +6572,7 @@ contract qq {
     }
 }
 |]
-    getAll [[Field "a"], [Field "b"]] `shouldReturn` [BDefault,BDefault] 
+    getAll [[Field "a"], [Field "b"]] `shouldReturn` [BDefault,BDefault]
 
 
 
@@ -6585,7 +6585,7 @@ contract qq {
     }
 }
 |]
-    getAll [[Field "a"], [Field "b"]] `shouldReturn` [BDefault,BDefault] 
+    getAll [[Field "a"], [Field "b"]] `shouldReturn` [BDefault,BDefault]
 
 
   it "can write pure and view functions" .runTest $ do
@@ -6601,7 +6601,7 @@ contract qq {
   }
 }
 |]
-    getAll [[Field "a"], [Field "b"]] `shouldReturn` [BDefault,BDefault] 
+    getAll [[Field "a"], [Field "b"]] `shouldReturn` [BDefault,BDefault]
 
   it "error when reading from contract state in a pure function" $ (runTest $
     runBS [r|
@@ -6612,7 +6612,7 @@ contract qq {
     return (x * y) / 6;
   }
 }
-|]) `shouldThrow` anyTypeError 
+|]) `shouldThrow` anyTypeError
 
   it "error when writing to contract state from a pure or view function" $ (runTest $
     runBS [r|
@@ -6661,7 +6661,7 @@ contract qq is A {
   }
 }
 |]
-    getAll [[Field "x"]]`shouldReturn` [BInteger 7] 
+    getAll [[Field "x"]]`shouldReturn` [BInteger 7]
 
   it "can resolve state variables from multiple layers of inheritance" . runTest $ do
     runBS [r|
@@ -6677,7 +6677,7 @@ contract qq is B {
   }
 }
 |]
-    getAll [[Field "x"]] `shouldReturn` [BInteger 7] 
+    getAll [[Field "x"]] `shouldReturn` [BInteger 7]
 
   it "can inherit from multiple contracts" . runTest $ do
     runBS [r|
@@ -6725,7 +6725,7 @@ contract qq {
   }
 }
 |]
-    getAll [[Field "x"], [Field "y"]] `shouldReturn` [BInteger 5,BDefault] 
+    getAll [[Field "x"], [Field "y"]] `shouldReturn` [BInteger 5,BDefault]
 
   it "Warns when reading from contract state in a pure function" $ (runTest $ do
     runBS [r|
@@ -6788,7 +6788,7 @@ contract qq is A {
   }
 }
 |]
-    getAll [[Field "x"]] `shouldReturn` [BInteger 7] 
+    getAll [[Field "x"]] `shouldReturn` [BInteger 7]
 
   it "can resolve state variables from multiple layers of inheritance" . runTest $ do
     runBS [r|
@@ -6804,7 +6804,7 @@ contract qq is B {
   }
 }
 |]
-    getAll [[Field "x"]] `shouldReturn` [BInteger 7] 
+    getAll [[Field "x"]] `shouldReturn` [BInteger 7]
 
   it "can inherit from multiple contracts" . runTest $ do
     runBS [r|
@@ -6822,7 +6822,7 @@ contract qq is A, B {
   }
 }
 |]
-    getAll [[Field "x"], [Field "y"]] `shouldReturn` [BInteger 7,BInteger 9] 
+    getAll [[Field "x"], [Field "y"]] `shouldReturn` [BInteger 7,BInteger 9]
 
   it "can detect when referencing a state variable from a non-inherited contract" $ (runTest $
     runBS [r|
@@ -6835,7 +6835,7 @@ contract B {
     x = 8;
   }
 }
-|]) `shouldThrow` anyTypeError  
+|]) `shouldThrow` anyTypeError
 
 
   it "can't write pure and view functions in solidvm 3.2" . runTest $ do
@@ -6851,7 +6851,7 @@ contract qq {
   }
 }
 |]
-    getAll [[Field "x"], [Field "y"]] `shouldReturn` [BInteger 5,BDefault] 
+    getAll [[Field "x"], [Field "y"]] `shouldReturn` [BInteger 5,BDefault]
 
   it "Warns when reading from contract state in a pure function" $ (runTest $ do
     runBS [r|
@@ -6914,7 +6914,7 @@ contract qq is A {
   }
 }
 |]
-    getAll [[Field "x"]] `shouldReturn` [BInteger 7] 
+    getAll [[Field "x"]] `shouldReturn` [BInteger 7]
 
   it "Can't resolve state variables from multiple layers of inheritance" . runTest $ do
     runBS [r|
@@ -6930,7 +6930,7 @@ contract qq is B {
   }
 }
 |]
-    getAll [[Field "x"]] `shouldReturn` [BInteger 7] 
+    getAll [[Field "x"]] `shouldReturn` [BInteger 7]
 
   it "Can't inherit from multiple contracts" . runTest $ do
     runBS [r|
@@ -6948,7 +6948,7 @@ contract qq is A, B {
   }
 }
 |]
-    getAll [[Field "x"], [Field "y"]] `shouldReturn` [BInteger 7,BInteger 9] 
+    getAll [[Field "x"], [Field "y"]] `shouldReturn` [BInteger 7,BInteger 9]
 
   it "can detect when referencing a state variable from a non-inherited contract" $ (runTest $
     runBS [r|
@@ -6986,7 +6986,7 @@ contract qq {
     }
 }
 |]
-    getAll [[Field "a"], [Field "b"]] `shouldReturn` [BDefault,BDefault]  
+    getAll [[Field "a"], [Field "b"]] `shouldReturn` [BDefault,BDefault]
 
   it "can return chainIdString in a simple manner" . runTest $ do
     runBS [r|
@@ -6996,7 +6996,7 @@ contract qq {
     x = this.chainIdString;
   }
 }
-|] 
+|]
     getFields ["x"] `shouldReturn` [BString "0000000000000000000000000000000000000000000000000000000000000000"]
 
   it "View functions enforced in 3.4" $ (runTest $
@@ -7024,7 +7024,7 @@ contract qq {
         uint ggg =  NagicIn.unwrap(NagicIn.wrap(3));
         MagicInt myInt;
         int public regularInt;
-        
+
         constructor() {
             myInt = MagicInt.wrap( 1+ 1+ 1); //creates defined type using wrap function
             regularInt = MagicInt.unwrap(myInt); // turn userDefined type back into underlying type
@@ -7044,7 +7044,7 @@ contract qq {
         a = b.regularInt();
         funcB = MagicInt.unwrap(b.foo()) + MagicInt.unwrap(b.foo());
         temp = b.foo();
-        temp2 =  MagicInt.unwrap( MagicInt.wrap( MagicInt.unwrap(b.foo()) + MagicInt.unwrap(b.foo())  ));   
+        temp2 =  MagicInt.unwrap( MagicInt.wrap( MagicInt.unwrap(b.foo()) + MagicInt.unwrap(b.foo())  ));
     }
   }
 

--- a/strato/core/blockapps-mpdbs/src/Blockchain/DB/SolidStorageDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/DB/SolidStorageDB.hs
@@ -17,6 +17,7 @@ module Blockchain.DB.SolidStorageDB (
 
 import           Control.Monad.Change.Alter                  (Alters)
 import           Data.Bifunctor                              (second)
+import qualified Data.ByteString.Short                       as BSS
 import           BlockApps.Logging
 import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.RLP
@@ -41,7 +42,7 @@ type FullSolidStorage m = ( HasMemAddressStateDB m
                           )
 
 toKey :: Account -> StoragePath -> RawStorageKey
-toKey =  curry $ fmap unparsePath
+toKey =  curry $ fmap (BSS.fromShort . unparsePath)
 
 toVal :: BasicValue -> RawStorageValue
 toVal bv =

--- a/strato/core/strato-genesis/src/Blockchain/Generation.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Generation.hs
@@ -23,39 +23,40 @@ module Blockchain.Generation (
   TypeHashMap(..)
 ) where
 
-import qualified Data.Aeson as Ae
-import qualified Data.Aeson.KeyMap as KM
-import qualified Data.Aeson.Key as DAK
-import qualified Data.JsonStream.Parser as JS
-import Data.Bits
-import Data.Maybe
-import qualified Data.Bifunctor as BF
-import qualified Data.ByteString.Lazy as L
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Char8 as BC
-import qualified Data.List as List
-import qualified Data.Map.Strict as M
-import Data.Scientific (floatingOrInteger)
-import           Data.Text (Text)
-import qualified Data.Vector as V
-import Data.Text.Encoding
-import GHC.Generics
-import Text.RawString.QQ
+import qualified Data.Aeson                             as Ae
+import qualified Data.Aeson.KeyMap                      as KM
+import qualified Data.Aeson.Key                         as DAK
+import qualified Data.JsonStream.Parser                 as JS
+import           Data.Bits
+import           Data.Maybe
+import qualified Data.Bifunctor                         as BF
+import qualified Data.ByteString.Lazy                   as L
+import qualified Data.ByteString                        as BS
+import qualified Data.ByteString.Short                  as BSS
+import qualified Data.ByteString.Base16                 as B16
+import qualified Data.ByteString.Char8                  as BC
+import qualified Data.List                              as List
+import qualified Data.Map.Strict                        as M
+import           Data.Scientific                        (floatingOrInteger)
+import           Data.Text                              (Text)
+import qualified Data.Vector                            as V
+import           Data.Text.Encoding
+import           GHC.Generics
+import           Text.RawString.QQ
 
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ChainMember
 import           Blockchain.Strato.Model.CodePtr
-import qualified Blockchain.Strato.Model.Keccak256              as KECCAK256
+import qualified Blockchain.Strato.Model.Keccak256      as KECCAK256
 import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Data.GenesisInfo
 import           Blockchain.Data.RLP
 import           Blockchain.Data.ChainInfo
 
-import           SolidVM.Model.Storable         hiding (size)
+import           SolidVM.Model.Storable                hiding (size)
 import           BlockApps.X509.Certificate
-import           BlockApps.X509.Keys             (pubToBytes, rootPubKey)
+import           BlockApps.X509.Keys                   (pubToBytes, rootPubKey)
 
 data Type = Number Integer
           | Stryng Text
@@ -202,7 +203,7 @@ readCertsFromGenesisInfo gi = catMaybes . flip map (genesisInfoAccountInfo gi) $
         rlpUnwrap = rlpDecode . rlpDeserialize
     certStr <- rlpUnwrap <$> M.lookup ".certificateString" storageMap
     case certStr of
-      BString certStr' -> either (const Nothing) Just $ bsToCert certStr'
+      BString certStr' -> either (const Nothing) Just $ bsToCert $ BSS.fromShort certStr'
       _ -> Nothing
   _ -> Nothing
 
@@ -216,9 +217,9 @@ readValidatorsFromGenesisInfo gi = catMaybes . flip map (genesisInfoAccountInfo 
     c <- rlpUnwrap <$> M.lookup ".commonName" storageMap
     case (o,u,c) of
       (BString o', BString u', BString c') -> do
-        let o'' = decodeUtf8 o'
-            u'' = decodeUtf8 u'
-            c'' = decodeUtf8 c'
+        let o'' = decodeUtf8 . BSS.fromShort $ o'
+            u'' = decodeUtf8 . BSS.fromShort $ u'
+            c'' = decodeUtf8 . BSS.fromShort $ c'
         pure $ CommonName o'' u'' c'' True
       _ -> Nothing
   _ -> Nothing
@@ -229,7 +230,7 @@ insertCertRegistryContract :: [X509Certificate] -> GenesisInfo -> GenesisInfo
 insertCertRegistryContract certs gi =
     gi {genesisInfoAccountInfo = initialAccounts ++ registryAcct:rootAcct:certAccts,
         genesisInfoCodeInfo    = initialCode ++ [CodeInfo encodedRegistry certificateRegistryContract (Just "CertificateRegistry")]}
-    where 
+    where
         initialAccounts = genesisInfoAccountInfo gi
         initialCode     = genesisInfoCodeInfo gi
 
@@ -250,13 +251,13 @@ insertCertRegistryContract certs gi =
             (SolidVMCode "Certificate" (KECCAK256.hash encodedRegistry)) [
                 (".owner", rlpWrap $ BAccount (NamedAccount ((fromJust . stringAddress) "509") UnspecifiedChain)),
                 (".userAddress", rlpWrap $ BAccount (NamedAccount (fromPublicKey . subPub $ rootSub) UnspecifiedChain)),
-                (".commonName", rlpWrap . BString . BC.pack . subCommonName $ rootSub),
-                (".country", rlpWrap . BString . BC.pack . fromJust . subCountry $ rootSub),
-                (".organization", rlpWrap . BString . BC.pack . subOrg $ rootSub),
-                (".group", rlpWrap . BString . BC.pack . fromJust . subUnit $ rootSub),
-                (".organizationalUnit", rlpWrap . BString . BC.pack . fromJust . subUnit $ rootSub),
-                (".publicKey", rlpWrap . BString . pubToBytes . subPub $ rootSub),
-                (".certificateString", rlpWrap . BString $ certToBytes rootCert),
+                (".commonName", rlpWrap . BString . BSS.toShort . BC.pack . subCommonName $ rootSub),
+                (".country", rlpWrap . BString . BSS.toShort . BC.pack . fromJust . subCountry $ rootSub),
+                (".organization", rlpWrap . BString . BSS.toShort . BC.pack . subOrg $ rootSub),
+                (".group", rlpWrap . BString . BSS.toShort . BC.pack . fromJust . subUnit $ rootSub),
+                (".organizationalUnit", rlpWrap . BString . BSS.toShort . BC.pack . fromJust . subUnit $ rootSub),
+                (".publicKey", rlpWrap . BString . BSS.toShort . pubToBytes . subPub $ rootSub),
+                (".certificateString", rlpWrap . BString . BSS.toShort $ certToBytes rootCert),
                 (".isValid", rlpWrap (BBool True)),
                 (".parent", rlpWrap $ BAccount (NamedAccount (Address 0x0) UnspecifiedChain))
             ]
@@ -276,13 +277,13 @@ insertCertRegistryContract certs gi =
             SolidVMContractWithStorage (reverseAddr cert) 0 (SolidVMCode "Certificate" (KECCAK256.hash encodedRegistry)) [
                 (".owner", rlpWrap $ BAccount (NamedAccount ((fromJust . stringAddress) "509") UnspecifiedChain)),
                 (".userAddress", rlpWrap $ BAccount (NamedAccount (fromPublicKey . subPub $ certSub) UnspecifiedChain)),
-                (".commonName", rlpWrap . BString . BC.pack . subCommonName $ certSub),
-                (".country", rlpWrap . BString . BC.pack . maybeCertField . subCountry $ certSub),
-                (".organization", rlpWrap . BString . BC.pack . subOrg $ certSub),
-                (".group", rlpWrap . BString . BC.pack . maybeCertField . subUnit $ certSub),
-                (".organizationalUnit", rlpWrap . BString . BC.pack . maybeCertField . subUnit $ certSub),
-                (".publicKey", rlpWrap . BString . pubToBytes . subPub $ certSub),
-                (".certificateString", rlpWrap . BString $ certToBytes cert),
+                (".commonName", rlpWrap . BString . BSS.toShort . BC.pack . subCommonName $ certSub),
+                (".country", rlpWrap . BString . BSS.toShort . BC.pack . maybeCertField . subCountry $ certSub),
+                (".organization", rlpWrap . BString . BSS.toShort . BC.pack . subOrg $ certSub),
+                (".group", rlpWrap . BString . BSS.toShort . BC.pack . maybeCertField . subUnit $ certSub),
+                (".organizationalUnit", rlpWrap . BString . BSS.toShort . BC.pack . maybeCertField . subUnit $ certSub),
+                (".publicKey", rlpWrap . BString . BSS.toShort . pubToBytes . subPub $ certSub),
+                (".certificateString", rlpWrap . BString . BSS.toShort $ certToBytes cert),
                 (".isValid", rlpWrap (BBool True)),
                 (".parent", rlpWrap $ BAccount (NamedAccount (fromMaybe (Address 0x0) $ getParentUserAddress cert) UnspecifiedChain))]
             ) certs
@@ -296,7 +297,7 @@ contract Certificate {
     address public parent;
     address[] public children;
 
-    
+
     // Store all the fields of a certificate in a Cirrus record
     string public commonName;
     string public country;
@@ -324,23 +325,23 @@ contract Certificate {
         parent = address(parsedCert["parent"]);
         children = [];
     }
-    
+
     function addChild(address _child) public {
         require((msg.sender == owner || msg.sender == parent),"You don't have permission to CALL addChild!");
-        
+
         children.push(_child);
     }
-    
+
     function revoke() public returns (int){
         require(msg.sender == owner,"You don't have permission to CALL revoke!");
 
         isValid = false;
         return children.length;
     }
-    
+
     function getChild(int index) public returns (address){
         require(msg.sender == owner,"You don't have permission to get children!");
-        
+
         return children[index];
     }
 }
@@ -354,18 +355,18 @@ contract CertificateRegistry {
 
     event CertificateRegistered(string certificate);
     event CertificateRevoked(address userAddress);
-    
+
     function registerCertificate(string newCertificateString) returns (int) {
         mapping(string => string) parsedCert = parseCert(newCertificateString);
         address parentUserAddress = address(parsedCert["parent"]);
         Certificate parentContract = Certificate(addressToCertMap[account(parentUserAddress)]);
-        
+
         if (address(parentContract) != address(0) && parentContract.isValid() && verifyCertSignedBy(newCertificateString, parentContract.publicKey())) {
             // Create the new Certificate record
             Certificate c = new Certificate(newCertificateString);
 
             if (parentUserAddress != address(0x0)){
-                parentContract.addChild(c.userAddress());    
+                parentContract.addChild(c.userAddress());
             }
 
             addressToCertMap[c.userAddress()] = address(c);
@@ -378,15 +379,15 @@ contract CertificateRegistry {
     function getUserCert(address _address) returns (Certificate) {
         return Certificate(addressToCertMap[account(_address)]);
     }
-    
+
     function getCertByAddress(address _address) returns (Certificate) {
         return Certificate(getCertByAccount(account(_address)));
     }
-    
+
     function getCertByAccount(address _account) returns (Certificate) {
         return Certificate(addressToCertMap[account(_account)]);
     }
-    
+
     function revokeCert(address userAddress){
         Certificate myCert = Certificate(addressToCertMap[account(userAddress)]);
         require(isChild(tx.certificate, myCert.userAddress()), "You don't have permission to revoke!");
@@ -395,21 +396,21 @@ contract CertificateRegistry {
         for (int i = 0; i < childrenLength; i += 1) {
             revokeCert(myCert.getChild(i));
         }
-        
+
         emit CertificateRevoked(userAddress);
     }
-    
+
     function isChild(string pCert, address certUserAddress) returns (bool) {
         Certificate myCert = Certificate(addressToCertMap[account(certUserAddress)]);
         address parentUserAddress = myCert.parent();
         if(myCert.parent() != address(0x0) && pCert ==  Certificate(addressToCertMap[account(parentUserAddress)]).certificateString()){
             return true;
         }
-        
+
         if(myCert.parent() != address(0x0)){
             return isChild(pCert, parentUserAddress);
         }
-        
+
         return false;
     }
 }|]
@@ -419,7 +420,7 @@ insertMercataGovernanceContract :: [ChainMemberParsedSet] -> [ChainMemberParsedS
 insertMercataGovernanceContract validators admins gi =
     gi {genesisInfoAccountInfo = initialAccounts ++ govAcct:(validatorAccts ++ adminAccts),
         genesisInfoCodeInfo    = initialCode ++ [CodeInfo encodedGovernance governanceSrc (Just "MercataGovernance")]}
-    where 
+    where
         initialAccounts = genesisInfoAccountInfo gi
         initialCode     = genesisInfoCodeInfo gi
 
@@ -441,7 +442,7 @@ insertMercataGovernanceContract validators admins gi =
           [ (".owner", rootAddress),
             (".validatorCount", rlpWrap . BInteger . toInteger $ length validators),
             (".adminCount", rlpWrap . BInteger . toInteger $ length admins)
-          ] 
+          ]
             -- ++ map (\(i, CommonName o u c True) ->
             --          ( encodeUtf8 $ ".validatorMap<\"" <> o <> "\"><\"" <> u <> "\"><\"" <> c <> "\">"
             --          , addrToCertIdx . show $ validatorAddr i)) valIx
@@ -456,20 +457,20 @@ insertMercataGovernanceContract validators admins gi =
                         (i, CommonName o u c True) -> ( encodeUtf8 $ ".adminMap<\"" <> o <> "\"><\"" <> u <> "\"><\"" <> c <> "\">"
                                                     , addrToCertIdx . show $ adminAddr i)
                         _ -> error "Invalid admin cert") adminIx
-        validatorAccts = map (\case 
+        validatorAccts = map (\case
                                 (i, CommonName o u c True) -> SolidVMContractWithStorage (validatorAddr i) 0 (SolidVMCode "MercataValidator" (KECCAK256.hash encodedGovernance)) [
                                     (".owner", rlpWrap $ BAccount (NamedAccount ((fromJust . stringAddress) "100") MainChain)),
-                                    (".org", rlpWrap . BString $ encodeUtf8 o),
-                                    (".orgUnit", rlpWrap . BString $ encodeUtf8 u),
-                                    (".commonName", rlpWrap . BString $ encodeUtf8 c),
+                                    (".org", rlpWrap . BString . BSS.toShort $ encodeUtf8 o),
+                                    (".orgUnit", rlpWrap . BString . BSS.toShort $ encodeUtf8 u),
+                                    (".commonName", rlpWrap . BString . BSS.toShort $ encodeUtf8 c),
                                     (".isActive", rlpWrap $ BBool True)]
                                 _ -> error "Invalid validator cert") valIx
         adminAccts = map (\case
                                 (i, CommonName o u c True) -> SolidVMContractWithStorage (adminAddr i) 0 (SolidVMCode "MercataAdmin" (KECCAK256.hash encodedGovernance)) [
                                     (".owner", rlpWrap $ BAccount (NamedAccount ((fromJust . stringAddress) "100") MainChain)),
-                                    (".org", rlpWrap . BString $ encodeUtf8 o),
-                                    (".orgUnit", rlpWrap . BString $ encodeUtf8 u),
-                                    (".commonName", rlpWrap . BString $ encodeUtf8 c),
+                                    (".org", rlpWrap . BString . BSS.toShort $ encodeUtf8 o),
+                                    (".orgUnit", rlpWrap . BString . BSS.toShort $ encodeUtf8 u),
+                                    (".commonName", rlpWrap . BString . BSS.toShort $ encodeUtf8 c),
                                     (".isActive", rlpWrap $ BBool True)]
                                 _ -> error "Invalid admin cert") adminIx
 
@@ -658,7 +659,7 @@ contract MercataGovernance {
 
     event ValidatorAdded(string org, string orgUnit, string commonName);
     event ValidatorRemoved(string org, string orgUnit, string commonName);
-    
+
     function voteToAddValidator(string _org, string _orgUnit, string _commonName) {
         Certificate c = CertificateRegistry(address(0x509)).getUserCert(tx.origin);
         require(address(c) != address(0), "Voting to add a validator requires having a valid X.509 certificate");
@@ -670,10 +671,10 @@ contract MercataGovernance {
         MercataAdmin a = adminMap[originOrg][originUnit][originName];
         require(address(a) != address(0), "Only registered network admins can vote for validators");
         require(a.isActive(), "Only registered network admins can vote for validators");
-        
+
         MercataValidator v = validatorMap[_org][_orgUnit][_commonName];
         require(address(v) == address(0), "Votes to add cannot be counted for current validators");
-        
+
         uint voteIndex = validatorVoteMap[_org][_orgUnit][_commonName][originOrg][originUnit][originName];
         require(voteIndex == 0, "Vote to add already cast for " + _org + " " + _orgUnit + " " + _commonName);
         MercataValidatorVote newVote = new MercataValidatorVote(originOrg, originUnit, originName, _org, _orgUnit, _commonName, true);
@@ -701,7 +702,7 @@ contract MercataGovernance {
             emit ValidatorAdded(_org, _orgUnit, _commonName);
         }
     }
-    
+
     function voteToRemoveValidator(string _org, string _orgUnit, string _commonName) {
         Certificate c = CertificateRegistry(address(0x509)).getUserCert(tx.origin);
         require(address(c) != address(0), "Voting to add a validator requires having a valid X.509 certificate");
@@ -713,10 +714,10 @@ contract MercataGovernance {
         MercataAdmin a = adminMap[originOrg][originUnit][originName];
         require(address(a) != address(0), "Only registered network admins can vote for validators");
         require(a.isActive(), "Only registered network admins can vote for validators");
-        
+
         MercataValidator v = validatorMap[_org][_orgUnit][_commonName];
         require(address(v) != address(0), "Votes to remove can only be counted for current validators");
-        
+
         uint voteIndex = validatorVoteMap[_org][_orgUnit][_commonName][originOrg][originUnit][originName];
         require(voteIndex == 0, "Vote to add already cast for " + _org + " " + _orgUnit + " " + _commonName);
         MercataValidatorVote newVote = new MercataValidatorVote(originOrg, originUnit, originName, _org, _orgUnit, _commonName, false);
@@ -744,7 +745,7 @@ contract MercataGovernance {
             emit ValidatorRemoved(_org, _orgUnit, _commonName);
         }
     }
-    
+
     function voteToAddAdmin(string _org, string _orgUnit, string _commonName) {
         Certificate c = CertificateRegistry(address(0x509)).getUserCert(tx.origin);
         require(address(c) != address(0), "Voting to add a network admin requires having a valid X.509 certificate");
@@ -756,10 +757,10 @@ contract MercataGovernance {
         MercataAdmin a = adminMap[originOrg][originUnit][originName];
         require(address(a) != address(0), "Only registered network admins can vote for admins");
         require(a.isActive(), "Only registered network admins can vote for admins");
-        
+
         MercataAdmin v = adminMap[_org][_orgUnit][_commonName];
         require(address(v) == address(0), "Votes to add cannot be counted for current admins");
-        
+
         uint voteIndex = adminVoteMap[_org][_orgUnit][_commonName][originOrg][originUnit][originName];
         require(voteIndex == 0, "Vote to add already cast for " + _org + " " + _orgUnit + " " + _commonName);
         MercataAdminVote newVote = new MercataAdminVote(originOrg, originUnit, originName, _org, _orgUnit, _commonName, true);
@@ -786,7 +787,7 @@ contract MercataGovernance {
             adminCount++;
         }
     }
-    
+
     function voteToRemoveAdmin(string _org, string _orgUnit, string _commonName) {
         Certificate c = CertificateRegistry(address(0x509)).getUserCert(tx.origin);
         require(address(c) != address(0), "Voting to add an admin requires having a valid X.509 certificate");
@@ -798,10 +799,10 @@ contract MercataGovernance {
         MercataAdmin a = adminMap[originOrg][originUnit][originName];
         require(address(a) != address(0), "Only registered network admins can vote for admins");
         require(a.isActive(), "Only registered network admins can vote for admins");
-        
+
         MercataAdmin v = adminMap[_org][_orgUnit][_commonName];
         require(address(v) != address(0), "Votes to remove can only be counted for current admins");
-        
+
         uint voteIndex = adminVoteMap[_org][_orgUnit][_commonName][originOrg][originUnit][originName];
         require(voteIndex == 0, "Vote to add already cast for " + _org + " " + _orgUnit + " " + _commonName);
         MercataAdminVote newVote = new MercataAdminVote(originOrg, originUnit, originName, _org, _orgUnit, _commonName, false);

--- a/strato/core/vm-tools/src/Blockchain/MemVMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/MemVMContext.hs
@@ -40,10 +40,11 @@ import qualified Control.Monad.Change.Modify        as Mod
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import qualified Data.ByteString                    as B
+import qualified Data.ByteString.Short              as BSS
 import           Data.Default
 import qualified Data.Map                           as M
 import qualified Data.Text                          as T
-import qualified Data.Text.Encoding                 as Text            
+import qualified Data.Text.Encoding                 as Text
 import           Data.Maybe                         (fromMaybe)
 import qualified Data.NibbleString                  as N
 import           Data.Traversable                   (for)
@@ -300,19 +301,19 @@ instance (Keccak256 `A.Alters` DBCode) MemContextM where
 
 instance ((Address,T.Text) `A.Selectable` X509CertificateField ) MemContextM where
   select _ (k,t) = do
-    let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8 
+    let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8
     mCertAddress <- lookupX509AddrFromCBHash k
     fmap join . for mCertAddress $ \certAddress ->
       maybe Nothing (readMaybe . T.unpack . Text.decodeUtf8) <$> A.lookup (A.Proxy) (certKey certAddress t)
 
 instance (Address `A.Selectable` X509Certificate) MemContextM where
   select _ k = do
-      let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8 
+      let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8
       mCertAddress <- lookupX509AddrFromCBHash k
       fmap join . for mCertAddress $ \certAddress -> do
         mBString <- fmap (rlpDecode . rlpDeserialize) <$> A.lookup (A.Proxy) (certKey certAddress ".certificateString")
         case mBString of
-            Just (BString bs) -> pure . eitherToMaybe $ bsToCert bs
+            Just (BString bs) -> pure . eitherToMaybe . bsToCert . BSS.fromShort $ bs
             _ -> pure Nothing
 
 instance (N.NibbleString `A.Alters` N.NibbleString) MemContextM where

--- a/strato/core/vm-tools/src/Blockchain/VMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMContext.hs
@@ -79,6 +79,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import           Control.Monad.Trans.Resource
 import qualified Data.ByteString                    as B
+import qualified Data.ByteString.Short              as BSS
 import           Data.Default
 import qualified Data.Map                           as M
 import           Data.Maybe                         (fromMaybe)
@@ -450,19 +451,19 @@ instance (Keccak256 `A.Alters` DBCode) ContextM where
 
 instance ((Address,T.Text) `A.Selectable` X509CertificateField ) ContextM where
   select _ (k,t) = do
-    let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8 
+    let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8
     mCertAddress <- lookupX509AddrFromCBHash k
     fmap join . for mCertAddress $ \certAddress -> do
       maybe Nothing (readMaybe . T.unpack . Text.decodeUtf8) <$> A.lookup (A.Proxy) (certKey certAddress t)
 
 instance (Address `A.Selectable` X509Certificate) ContextM where
   select _ k = do
-      let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8 
+      let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8
       mCertAddress <- lookupX509AddrFromCBHash k
       fmap join . for mCertAddress $ \certAddress -> do
         mBString <- fmap (rlpDecode . rlpDeserialize) <$> A.lookup (A.Proxy) (certKey certAddress ".certificateString")
         case mBString of
-            Just (BString bs) -> pure . eitherToMaybe $ bsToCert bs
+            Just (BString bs) -> pure . eitherToMaybe . bsToCert . BSS.fromShort $ bs
             _ -> pure Nothing
 
 lookupX509AddrFromCBHash ::(
@@ -471,7 +472,7 @@ lookupX509AddrFromCBHash ::(
                       )
       => Address -> m (Maybe Address)
 lookupX509AddrFromCBHash k = do
-    let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8 
+    let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8
         certRegistryKey = certKey (Address 0x509)
     mAccount <- fmap (rlpDecode . rlpDeserialize) <$> A.lookup (A.Proxy) (certRegistryKey . T.pack $ ".addressToCertMap<a:" <> show k <> ">")
     $logDebugS "lookupX509AddrFromCBHash" $ T.pack $ "Looking up certificate for address: " ++ (show mAccount)
@@ -516,7 +517,7 @@ instance Mod.Accessible (Maybe WorldBestBlock) ContextM where
 instance Mod.Modifiable GasCap ContextM where
   get _ = contextGets (GasCap . _vmGasCap)
 
-  put _ (GasCap g) = do 
+  put _ (GasCap g) = do
     contextModify (vmGasCap .~ g)
     $logDebugS "#### Mod.put @vmGasCap" . T.pack $ "VM Gas Cap updated to: " ++ show g
 


### PR DESCRIPTION
In previous profiling attempts, `OTHER` was a serious offender in the memory leaks that the VM was suffering from, especially during idle times. We think that this is the result of heap fragmentation from `ByteString` usage in the interpreter, so syncing a large amount of data would result in a large amount of _pinned memory_ that never gets freed and consumes unnecessary resources. `ShortByteString` uses less memory overhead and tackles the heap fragging problem, so hopefully these changes will address some of these issues.

https://hackage.haskell.org/package/bytestring-0.11.4.0/docs/Data-ByteString-Short.html#g:2