### PR TITLE
Fixed users of the same org not being able to update inventories/products

### DIFF
--- a/marketplace/backend/api/v1/Image/image.controller.js
+++ b/marketplace/backend/api/v1/Image/image.controller.js
@@ -50,11 +50,11 @@ class ImageController {
       rest.response.status400(res, "Missing file key");
     }
     try {
-      const oldFileKey=req.params.fileKey;
-      const isDeleted=await deleteFileFromS3(oldFileKey,req.app.get(constants.s3ParamName))
-      if(!isDeleted){
-        rest.response.status400(res,"Image is failed to update")
-      }
+      // const oldFileKey=req.params.fileKey;
+      // const isDeleted=await deleteFileFromS3(oldFileKey,req.app.get(constants.s3ParamName))
+      // if(!isDeleted){
+      //   rest.response.status400(res,"Image is failed to update")
+      // }
       
       const fileKey = `${moment()
         .utc()

--- a/marketplace/backend/api/v1/Image/image.controller.js
+++ b/marketplace/backend/api/v1/Image/image.controller.js
@@ -4,7 +4,7 @@ import RestStatus from 'http-status-codes'
 import config from '../../../load.config'
 import moment from "moment";
 import crypto from "crypto";
-import { uploadFileToS3, getFileStreamFromS3, getFileFromS3, deleteFileFromS3 } from "../../../helpers/s3";
+import { uploadFileToS3, deleteFileFromS3 } from "../../../helpers/s3";
 import constants from '../../../helpers/constants';
 const options = { config, cacheNonce: true }
 import aws from 'aws-sdk'
@@ -50,11 +50,6 @@ class ImageController {
       rest.response.status400(res, "Missing file key");
     }
     try {
-      // const oldFileKey=req.params.fileKey;
-      // const isDeleted=await deleteFileFromS3(oldFileKey,req.app.get(constants.s3ParamName))
-      // if(!isDeleted){
-      //   rest.response.status400(res,"Image is failed to update")
-      // }
       
       const fileKey = `${moment()
         .utc()
@@ -77,8 +72,24 @@ class ImageController {
     }
   }
 
+  static async deleteImage(req, res, next) {
 
+    if(!req.params.fileKey){
+      rest.response.status400(res, "Missing file key");
+    }
+    try {
+      const fileKey=req.params.fileKey; 
 
+      const isDeleted=await deleteFileFromS3(fileKey,req.app.get(constants.s3ParamName))
+      if(!isDeleted){
+        rest.response.status400(res,"Image is failed to delete")
+      }      
+      
+      rest.response.status200(res, true);
+    } catch (e) {
+      return next(e);
+    }
+  }
 
 }
 

--- a/marketplace/backend/api/v1/Image/image.controller.js
+++ b/marketplace/backend/api/v1/Image/image.controller.js
@@ -72,25 +72,6 @@ class ImageController {
     }
   }
 
-  static async deleteImage(req, res, next) {
-
-    if(!req.params.fileKey){
-      rest.response.status400(res, "Missing file key");
-    }
-    try {
-      const fileKey=req.params.fileKey; 
-
-      const isDeleted=await deleteFileFromS3(fileKey,req.app.get(constants.s3ParamName))
-      if(!isDeleted){
-        rest.response.status400(res,"Image is failed to delete")
-      }      
-      
-      rest.response.status200(res, true);
-    } catch (e) {
-      return next(e);
-    }
-  }
-
 }
 
 export default ImageController

--- a/marketplace/backend/api/v1/Image/index.js
+++ b/marketplace/backend/api/v1/Image/index.js
@@ -24,6 +24,13 @@ router.put(
   ImageController.updateImage
 );
 
+router.put(
+  Image.delete,
+  fileUploader.single(constants.fileUploadFieldName),
+  authHandler.authorizeRequest(),
+  loadDapp,
+  ImageController.deleteImage
+);
 
 
 

--- a/marketplace/backend/api/v1/Image/index.js
+++ b/marketplace/backend/api/v1/Image/index.js
@@ -24,15 +24,4 @@ router.put(
   ImageController.updateImage
 );
 
-router.put(
-  Image.delete,
-  fileUploader.single(constants.fileUploadFieldName),
-  authHandler.authorizeRequest(),
-  loadDapp,
-  ImageController.deleteImage
-);
-
-
-
-
 export default router;

--- a/marketplace/backend/api/v1/Product/product.controller.js
+++ b/marketplace/backend/api/v1/Product/product.controller.js
@@ -2,7 +2,7 @@ import { rest } from 'blockapps-rest'
 import Joi from '@hapi/joi'
 import RestStatus from 'http-status-codes'
 import config from '../../../load.config'
-import { getSignedUrlFromS3 } from '../../../helpers/s3'
+import { getSignedUrlFromS3, deleteFileFromS3} from '../../../helpers/s3'
 import constants from '../../../helpers/constants'
 
 const options = { config, cacheNonce: true }
@@ -88,8 +88,20 @@ class ProductController {
 
       ProductController.validateUpdateProductArgs(body)
 
-      const result = await dapp.updateProduct(body, options)
+      let result
+      if (req.body.updates.oldImageKey) {
 
+        result = await dapp.updateProduct(body, options)
+        const fileKey = req.body.updates.oldImageKey
+
+        const isDeleted = await deleteFileFromS3(fileKey, req.app.get(constants.s3ParamName))
+        if (!isDeleted) {
+          rest.response.status400(res, "Image is failed to delete")
+        }
+
+      } else {
+        result = await dapp.updateProduct(body, options)
+      }
       rest.response.status200(res, result)
       return next()
     } catch (e) {
@@ -171,7 +183,8 @@ class ProductController {
         description: Joi.string(),
         imageKey: Joi.string(),
         isActive: Joi.boolean(),
-        userUniqueProductCode: Joi.string().allow("")
+        userUniqueProductCode: Joi.string().allow(""),
+        oldImageKey: Joi.string().optional()
       }).required()
     });
 

--- a/marketplace/backend/api/v1/Product/product.controller.js
+++ b/marketplace/backend/api/v1/Product/product.controller.js
@@ -89,6 +89,8 @@ class ProductController {
       ProductController.validateUpdateProductArgs(body)
 
       // If the old image key is present, delete the old image from S3. Keys are sent from UpdateProductModal.js
+      const result = await dapp.updateProduct(body, options)
+      
       if (req.body.updates.oldImageKey) {
 
         const fileKey = req.body.updates.oldImageKey
@@ -99,7 +101,6 @@ class ProductController {
         }
       } 
 
-      const result = await dapp.updateProduct(body, options)
       rest.response.status200(res, result)
       return next()
     } catch (e) {

--- a/marketplace/backend/api/v1/Product/product.controller.js
+++ b/marketplace/backend/api/v1/Product/product.controller.js
@@ -88,20 +88,18 @@ class ProductController {
 
       ProductController.validateUpdateProductArgs(body)
 
-      let result
+      // If the old image key is present, delete the old image from S3. Keys are sent from UpdateProductModal.js
       if (req.body.updates.oldImageKey) {
 
-        result = await dapp.updateProduct(body, options)
         const fileKey = req.body.updates.oldImageKey
 
         const isDeleted = await deleteFileFromS3(fileKey, req.app.get(constants.s3ParamName))
         if (!isDeleted) {
           rest.response.status400(res, "Image is failed to delete")
         }
+      } 
 
-      } else {
-        result = await dapp.updateProduct(body, options)
-      }
+      const result = await dapp.updateProduct(body, options)
       rest.response.status200(res, result)
       return next()
     } catch (e) {

--- a/marketplace/backend/api/v1/endpoints.js
+++ b/marketplace/backend/api/v1/endpoints.js
@@ -113,7 +113,6 @@ export const Image = {
   prefix: '/image',
   upload: '/',
   update: '/:fileKey',
-  delete: '/delete/:fileKey',
 }
 
 export const Marketplace = {

--- a/marketplace/backend/api/v1/endpoints.js
+++ b/marketplace/backend/api/v1/endpoints.js
@@ -112,7 +112,8 @@ export const Event = {
 export const Image = {
   prefix: '/image',
   upload: '/',
-  update: '/:fileKey'
+  update: '/:fileKey',
+  delete: '/delete/:fileKey',
 }
 
 export const Marketplace = {

--- a/marketplace/backend/dapp/items/contracts/Item.sol
+++ b/marketplace/backend/dapp/items/contracts/Item.sol
@@ -77,7 +77,7 @@ contract Item_3 is ItemStatus {
         string _comment,
         uint _scheme
     ) returns (uint) {
-        if (tx.origin != owner) {
+        if(ownerOrganization != getUserOrganization(tx.origin)){
             return RestStatus.FORBIDDEN;
         }
 
@@ -95,13 +95,20 @@ contract Item_3 is ItemStatus {
         return RestStatus.OK;
     }
 
+    // Get the userOrganization
+    function getUserOrganization(address caller) public returns (string) {
+      mapping(string => string) ownerCert = getUserCert(caller);
+      string userOrganization = ownerCert["organization"];
+      return userOrganization;
+    }
+
     function generateOwnershipHistory(
         string _seller,
         string _newOwner,
         uint _ownershipStartDate,
         address _itemAddress
     ) returns (uint) {
-        if (tx.origin != owner) {
+        if(ownerOrganization != getUserOrganization(tx.origin)){
             return RestStatus.FORBIDDEN;
         }
         emit OwnershipUpdate(

--- a/marketplace/backend/dapp/products/contracts/Inventory.sol
+++ b/marketplace/backend/dapp/products/contracts/Inventory.sol
@@ -56,7 +56,9 @@ contract Inventory is InventoryStatus{
     ,   InventoryStatus _status
     ,   uint _scheme
     ) returns (uint) {
-      if (tx.origin != owner) { return RestStatus.FORBIDDEN; }
+      if(ownerOrganization != getUserOrganization(tx.origin)){
+        return RestStatus.FORBIDDEN;
+      }
 
       if (_scheme == 0) {
         return RestStatus.OK;
@@ -79,5 +81,12 @@ contract Inventory is InventoryStatus{
       // }
       availableQuantity = _quantity;
       return RestStatus.OK;
+    }
+
+    // Get the userOrganization
+    function getUserOrganization(address caller) public returns (string) {
+      mapping(string => string) ownerCert = getUserCert(caller);
+      string userOrganization = ownerCert["organization"];
+      return userOrganization;
     }
 }

--- a/marketplace/backend/dapp/products/contracts/Product.sol
+++ b/marketplace/backend/dapp/products/contracts/Product.sol
@@ -76,7 +76,9 @@ contract Product_3 is UnitOfMeasurement, InventoryStatus {
     ,   string _userUniqueProductCode
     ,   uint _scheme
     ) returns (uint) {
-      if (tx.origin != owner) { return RestStatus.FORBIDDEN; }
+      if(ownerOrganization != getUserOrganization(tx.origin)){
+        return RestStatus.FORBIDDEN;
+      }
 
       if (_scheme == 0) {
         return RestStatus.OK;

--- a/marketplace/backend/dapp/products/productManager.js
+++ b/marketplace/backend/dapp/products/productManager.js
@@ -180,7 +180,7 @@ async function updateProduct(admin, contract, _args, baseOptions) {
     history: [contractName],
   };
 
-  const [restStatus, ProductAddress] = await rest.call(
+  const [restStatus] = await rest.call(
     admin,
     callArgs,
     options
@@ -189,7 +189,7 @@ async function updateProduct(admin, contract, _args, baseOptions) {
   if (parseInt(restStatus, 10) !== RestStatus.OK)
     throw new rest.RestError(restStatus, 0, { callArgs });
 
-  return [restStatus, ProductAddress];
+  return [restStatus];
 }
 
 /**

--- a/marketplace/ui/src/components/Product/UpdateProductModal.js
+++ b/marketplace/ui/src/components/Product/UpdateProductModal.js
@@ -104,23 +104,37 @@ const UpdateProductModal = ({
         imageKey: productToUpdate.imageKey,
       };
     }
+    let body = {};
 
     if (imageData) {
-      const body = {
-        productAddress: productToUpdate.address,
-        updates: {
-          description: encodeURIComponent(values.description),
-          imageKey: imageData.imageKey,
-          isActive: values.active,
-          userUniqueProductCode: values.userUniqueProductCode
-        },
-      };
+      // If the image is changed we send the old image to be deleted.
+      if (isImgChanged) {
+
+        body = {
+          productAddress: productToUpdate.address,
+          updates: {
+            description: encodeURIComponent(values.description),
+            imageKey: imageData.imageKey,
+            isActive: values.active,
+            userUniqueProductCode: values.userUniqueProductCode,
+            oldImageKey: productToUpdate.imageKey,
+          },
+        }
+      } else {
+        body = {
+          productAddress: productToUpdate.address,
+          updates: {
+            description: encodeURIComponent(values.description),
+            imageKey: imageData.imageKey,
+            isActive: values.active,
+            userUniqueProductCode: values.userUniqueProductCode,
+          },
+        }
+      }
 
       let isDone = await actions.updateProduct(dispatch, body);
 
       if (isDone) {
-        // Deletes the previous image if the image was changed successfully
-        const deleteImage = await actions.deleteImage(dispatch, productToUpdate.imageKey);
         actions.fetchProduct(dispatch, 10, 0, debouncedSearchTerm);
         handleCancel();
       }

--- a/marketplace/ui/src/components/Product/UpdateProductModal.js
+++ b/marketplace/ui/src/components/Product/UpdateProductModal.js
@@ -98,7 +98,7 @@ const UpdateProductModal = ({
       formData.append("fileUpload", formik.values.image);
 
       imageData = await actions.updateImage(dispatch, formData, productToUpdate.imageKey);
-      setIsImgChanged(false);
+
     } else {
       imageData = {
         imageKey: productToUpdate.imageKey,
@@ -131,10 +131,10 @@ const UpdateProductModal = ({
           },
         }
       }
-
       let isDone = await actions.updateProduct(dispatch, body);
 
       if (isDone) {
+        setIsImgChanged(false);
         actions.fetchProduct(dispatch, 10, 0, debouncedSearchTerm);
         handleCancel();
       }

--- a/marketplace/ui/src/components/Product/UpdateProductModal.js
+++ b/marketplace/ui/src/components/Product/UpdateProductModal.js
@@ -119,6 +119,8 @@ const UpdateProductModal = ({
       let isDone = await actions.updateProduct(dispatch, body);
 
       if (isDone) {
+        // Deletes the previous image if the image was changed successfully
+        const deleteImage = await actions.deleteImage(dispatch, productToUpdate.imageKey);
         actions.fetchProduct(dispatch, 10, 0, debouncedSearchTerm);
         handleCancel();
       }

--- a/marketplace/ui/src/contexts/inventory/actions.js
+++ b/marketplace/ui/src/contexts/inventory/actions.js
@@ -156,7 +156,7 @@ const actions = {
         type: actionDescriptors.updateInventoryFailed,
         error: body.error
       });
-      actions.setMessage(dispatch, body.error);
+      actions.setMessage(dispatch, "Error while updating Inventory");
       return false;
     } catch (err) {
       dispatch({

--- a/marketplace/ui/src/contexts/product/actions.js
+++ b/marketplace/ui/src/contexts/product/actions.js
@@ -27,9 +27,6 @@ const actionDescriptors = {
   updateProduct: "update_product",
   updateProductSuccessful: "update_product_successful",
   updateProductFailed: "update_product_failed",
-  deleteImage: "delete_image",
-  deleteImageSuccessful: "delete_image_successful",
-  deleteImageFailed: "delete_image_failed",
   deleteProduct: "delete_product",
   deleteProductSuccessful: "delete_product_successful",
   deleteProductFailed: "delete_product_failed",
@@ -395,45 +392,6 @@ const actions = {
         error: "Image update failed",
       });
       actions.setMessage(dispatch, "Error while updating Image");
-    }
-  },
-
-  deleteImage: async (dispatch, fileKey) => {
-    dispatch({ type: actionDescriptors.deleteImage });
-  
-    try {
-      const response = await fetch(`${apiUrl}/Image/delete/${fileKey}`, {
-        method: HTTP_METHODS.PUT,
-        body: '',
-      });
-  
-      const body = await response.json();
-  
-      if (response.status === RestStatus.OK) {
-        dispatch({
-          type: actionDescriptors.deleteImageSuccessful,
-          payload: body.data,
-        });
-        // actions.setMessage(dispatch, "Image deleted successfully", true);
-        return true;
-      } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
-        dispatch({
-          type: actionDescriptors.deleteImageFailed,
-          error: "Image delete failed",
-        });
-        return false;
-      }
-  
-      dispatch({
-        type: actionDescriptors.deleteImageFailed,
-        error: body.error,
-      });
-      return false;
-    } catch (err) {
-      dispatch({
-        type: actionDescriptors.deleteImageFailed,
-        error: "Image delete failed",
-      });
     }
   },
   

--- a/marketplace/ui/src/contexts/product/actions.js
+++ b/marketplace/ui/src/contexts/product/actions.js
@@ -27,6 +27,9 @@ const actionDescriptors = {
   updateProduct: "update_product",
   updateProductSuccessful: "update_product_successful",
   updateProductFailed: "update_product_failed",
+  deleteImage: "delete_image",
+  deleteImageSuccessful: "delete_image_successful",
+  deleteImageFailed: "delete_image_failed",
   deleteProduct: "delete_product",
   deleteProductSuccessful: "delete_product_successful",
   deleteProductFailed: "delete_product_failed",
@@ -395,6 +398,45 @@ const actions = {
     }
   },
 
+  deleteImage: async (dispatch, fileKey) => {
+    dispatch({ type: actionDescriptors.deleteImage });
+  
+    try {
+      const response = await fetch(`${apiUrl}/Image/delete/${fileKey}`, {
+        method: HTTP_METHODS.PUT,
+        body: '',
+      });
+  
+      const body = await response.json();
+  
+      if (response.status === RestStatus.OK) {
+        dispatch({
+          type: actionDescriptors.deleteImageSuccessful,
+          payload: body.data,
+        });
+        // actions.setMessage(dispatch, "Image deleted successfully", true);
+        return true;
+      } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
+        dispatch({
+          type: actionDescriptors.deleteImageFailed,
+          error: "Image delete failed",
+        });
+        return false;
+      }
+  
+      dispatch({
+        type: actionDescriptors.deleteImageFailed,
+        error: body.error,
+      });
+      return false;
+    } catch (err) {
+      dispatch({
+        type: actionDescriptors.deleteImageFailed,
+        error: "Image delete failed",
+      });
+    }
+  },
+  
   fetchProductsForFilter: async (dispatch, categorys, subCategorys) => {
     dispatch({ type: actionDescriptors.fetchProductsForFilter });
 

--- a/marketplace/ui/src/contexts/product/actions.js
+++ b/marketplace/ui/src/contexts/product/actions.js
@@ -247,7 +247,7 @@ const actions = {
         type: actionDescriptors.updateProductFailed,
         error: body.error,
       });
-      actions.setMessage(dispatch, body.error);
+      actions.setMessage(dispatch, "Error while updating Product");
       return false;
     } catch (err) {
       dispatch({

--- a/marketplace/ui/src/contexts/product/index.js
+++ b/marketplace/ui/src/contexts/product/index.js
@@ -20,6 +20,8 @@ const ProductsProvider = ({ children }) => {
     productDeleteObject: null,
     uploadedImg : null,
     isuploadImageSubmitting: false,
+    deletedImg: null,
+    isdeletedImageSubmitting: false,
     isupdateImageSubmitting: false,
     updatedImg: null,
     productUpdateObject: null,

--- a/marketplace/ui/src/contexts/product/reducer.js
+++ b/marketplace/ui/src/contexts/product/reducer.js
@@ -120,22 +120,6 @@ const reducer = (state, action) => {
         error: action.error,
         isupdateImageSubmitting: false,
       };
-    case actionDescriptors.deleteImage:
-      return {
-        ...state,
-        isdeletedImageSubmitting: true,
-      };
-    case actionDescriptors.deleteImageSuccessful:
-      return {
-        ...state,
-        deletedImg: action.payload,
-      };
-    case actionDescriptors.deleteImageFailed:
-      return {
-        ...state,
-        error: action.error,
-        isdeletedImageSubmitting: false,
-      };
     case actionDescriptors.updateProduct:
       return {
         ...state,

--- a/marketplace/ui/src/contexts/product/reducer.js
+++ b/marketplace/ui/src/contexts/product/reducer.js
@@ -120,7 +120,22 @@ const reducer = (state, action) => {
         error: action.error,
         isupdateImageSubmitting: false,
       };
-
+    case actionDescriptors.deleteImage:
+      return {
+        ...state,
+        isdeletedImageSubmitting: true,
+      };
+    case actionDescriptors.deleteImageSuccessful:
+      return {
+        ...state,
+        deletedImg: action.payload,
+      };
+    case actionDescriptors.deleteImageFailed:
+      return {
+        ...state,
+        error: action.error,
+        isdeletedImageSubmitting: false,
+      };
     case actionDescriptors.updateProduct:
       return {
         ...state,


### PR DESCRIPTION
- Fixed users of the same org not being able to update inventories/products
- Fixed error pop-up not showing up when updating inventories/products fails
- Temporarily commented out function that deletes old images from updated products. This fixes a product's image breaking after a failed update. However, this means images will pile up in the S3 bucket so this is a temporary solution.