### PR TITLE
derive parts of setup just from network name

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/Options.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Options.hs
@@ -40,5 +40,10 @@ computeNetworkID =
       if flags_testnet
       then 0
       else 1
-    (network, -1) -> toInteger (fromInteger . bytes2Integer $ map c2w network :: Int)
-    (_, _) -> toInteger (fromInteger flags_networkID :: Int)
+    (network, -1) -> newtorkToID network
+    (_, networkID) -> networkID -- providing a networkID will ignore network name
+
+    where newtorkToID :: String -> Integer
+          newtorkToID network = case network of 
+            "mercata-hydrogen" -> 7596898649924658542 -- mercata-hydrogen networkID was manually changed
+            n -> bytes2Integer $ map c2w n


### PR DESCRIPTION
Most of the work for this actually happened in [an earlier pr](https://github.com/blockapps/strato-platform/pull/2127) but this addresses the manual change of `mercata-hydrogen`'s newtork id. It also fixes the overflow bug. The following consequences now apply:

- explicitly specifying the `networkID` will cause strato to ignore the network name and use the network id instead. Note that ALL PREVIOUS NETWORK IDS OVERFLOWED, so when trying to sync to old testnets (or if restarting any validators), you CANNOT USE THE OLD NETWORK IDS IN YOUR START SCRIPTS. For example, a script to sync to `mercata-testnet` uses `networkID=568017943717623020294451674200565108` but with the overflow, `computeNetworkID` would actually output `3275354375554229620`. Thus, start scripts will need to be modified to use the old network id mod 2^64. 
- if you want to connect to `mercata-hydrogen`, you no longer need to specify the `network`, `networkID`, or `BOOT_NODE_IP` flags