### PR TITLE
Enable address deletion [WIP]

### DIFF
--- a/marketplace/ui/src/components/MarketPlace/ConfirmOrder.js
+++ b/marketplace/ui/src/components/MarketPlace/ConfirmOrder.js
@@ -589,9 +589,26 @@ const ConfirmOrder = () => {
                           <div key={index}>
                             <Card className={index !== selectedAddress ? "w-96 cursor-pointer" : "w-96 border border-primary cursor-pointer"} onClick={() => { setSelectedAddress(index) }}>
                               <AddressComponent userAddress={add} />
+                              <div           
+                              onClick={() => {
+                                let addy = [...userAddresses];
+                                addy.splice(
+                                  index,
+                                  1
+                                );
+                                console.log(userAddresses);
+                                console.log(addy);
+                                console.log("here1");
+                                actions.deleteAddress(marketplaceDispatch, addy);
+                                console.log("here1");
+                              }}
+                              className="hover:text-error cursor-pointer text-xl" >
+                                Delete Address
+                              </div>
                             </Card>
                           </div>
                         )
+                        
                       }
                     </div>
                     :

--- a/marketplace/ui/src/contexts/marketplace/actions.js
+++ b/marketplace/ui/src/contexts/marketplace/actions.js
@@ -25,6 +25,9 @@ const actionDescriptors = {
   addItemToConfirmOrder: "add_item_to_confirm_order",
   addItemToConfirmOrderSuccessful: "add_item_to_confirm_order_successful",
   addItemToConfirmOrderFailed: "add_item_to_confirm_order_failed",
+  deleteAddress: "delete_address",
+  deleteAddressSuccessful: "delete_address_successful",
+  deleteAddressFailed: "delete_address_failed",
   fetchConfirmOrderItems: "fetch_confirm_order_items",
   fetchConfirmOrderItemsSuccessful: "fetch_confirm_order_items_successful",
   fetchConfirmOrderItemsFailed: "fetch_confirm_order_items_failed",
@@ -127,6 +130,24 @@ const actions = {
     } catch (err) {
       dispatch({
         type: actionDescriptors.addItemToConfirmOrderFailed,
+        error: undefined,
+      });
+    }
+  },
+  
+  deleteAddress: (dispatch, addyList) => {
+    console.log("here2");
+    dispatch({ type: actionDescriptors.deleteAddress });
+    try {
+      console.log("here3");
+      dispatch({
+        type: actionDescriptors.deleteAddressSuccessful,
+        payload: addyList,
+      });
+    } catch (err) {
+      console.log("here4");
+      dispatch({
+        type: actionDescriptors.deleteAddressFailed,
         error: undefined,
       });
     }

--- a/marketplace/ui/src/contexts/marketplace/reducer.js
+++ b/marketplace/ui/src/contexts/marketplace/reducer.js
@@ -104,6 +104,21 @@ const reducer = (state, action) => {
         ...state,
         error: action.error,
       };
+    case actionDescriptors.deleteAddress:
+      return {
+        ...state,
+      };
+    case actionDescriptors.deleteAddressSuccessful:
+      console.log("here5");
+      return {
+        ...state,
+        userAddresses: action.payload,
+      };
+    case actionDescriptors.deleteAddressFailed:
+      return {
+        ...state,
+        error: action.error,
+      };
     case actionDescriptors.deleteCartItem:
       return {
         ...state,


### PR DESCRIPTION
We can now delete addresses in the front end BUT our backend enpoints doesn't have anything that allows us to delete an address. The button doesn't look nice but we can fix it later.