### PR TITLE
Mkt Order API tests (pay now/later)

### DIFF
--- a/marketplace/backend/api/v1/Order/order.controller.js
+++ b/marketplace/backend/api/v1/Order/order.controller.js
@@ -100,8 +100,8 @@ class OrderController {
   static async payment(req, res, next) {
     try {
       const { dapp, body, accessToken } = req
-
-      OrderController.validateCreateOrderArgs(body)
+      console.log("body payment======", body)
+      OrderController.validatePaymentArgs(body)
 
       const result = await dapp.paymentCheckout(body, options, accessToken)
       rest.response.status200(res, result)
@@ -184,6 +184,7 @@ class OrderController {
         inventoryId: Joi.string().required(),
         quantity: Joi.number().required()
       })).required(),
+      shippingAddress: Joi.string().required(),
       orderTotal: Joi.number().required()
     }).required();
 

--- a/marketplace/backend/api/v1/Order/order.controller.js
+++ b/marketplace/backend/api/v1/Order/order.controller.js
@@ -100,7 +100,6 @@ class OrderController {
   static async payment(req, res, next) {
     try {
       const { dapp, body, accessToken } = req
-      console.log("body payment======", body)
       OrderController.validatePaymentArgs(body)
 
       const result = await dapp.paymentCheckout(body, options, accessToken)

--- a/marketplace/backend/test/v1/factories/order.js
+++ b/marketplace/backend/test/v1/factories/order.js
@@ -1,3 +1,5 @@
+import { use } from "chai"
+
 const zeroAddress=''.padStart(40,'0')
 const factory={
   getCreateOrderArgs(uid,buyerOrganization="",inventories=[]){
@@ -9,6 +11,39 @@ const factory={
       })),
       orderTotal:40,
       shippingAddress: '0000000000000000000000000000000000000000'
+    }
+    return args
+  },
+
+  getCreatePaymentArgs(uid, buyerOrganization="", inventories=[], userAddress){
+    const args = {
+      buyerOrganization,
+      orderList: 
+        inventories.map(inventory=>({
+          inventoryId:inventory,
+          quantity:2
+        }))
+      ,
+      orderTotal: 40,
+      shippingAddress: userAddress,
+    }
+    return args
+  },
+
+  getUserAddressArgs(uid){
+    const args = {
+      shippingName: `name_${uid}`,
+      shippingZipcode: `${uid}`,
+      shippingState: `state_${uid}`,
+      shippingCity: `city_${uid}`,
+      shippingAddressLine1: `addressLine1_${uid}`,
+      shippingAddressLine2: `addressLine2_${uid}`,
+      billingName: `name_${uid}`,
+      billingZipcode: `${uid}`,
+      billingState: `state_${uid}`,
+      billingCity: `city_${uid}`,
+      billingAddressLine1: `addressLine1_${uid}`,
+      billingAddressLine2: `addressLine2_${uid}`,
     }
     return args
   },

--- a/marketplace/backend/test/v1/factories/order.js
+++ b/marketplace/backend/test/v1/factories/order.js
@@ -1,4 +1,3 @@
-import { use } from "chai"
 
 const zeroAddress=''.padStart(40,'0')
 const factory={

--- a/marketplace/backend/test/v1/order.test.js
+++ b/marketplace/backend/test/v1/order.test.js
@@ -7,7 +7,12 @@ import certificateJs from '/dapp/certificates/certificate'
 import { get, post } from '/helpers/rest'
 import RestStatus from 'http-status-codes';
 import factory from './factories/order'
-import { Order } from '../../api/v1/endpoints'
+
+import { Product, Inventory, Order } from '../../api/v1/endpoints'
+import { productArgs } from './factories/product'
+import { inventoryArgs } from './factories/inventory'
+
+
 
 
 const loadEnv = dotenv.config()
@@ -62,113 +67,208 @@ describe('Order End-To-End Tests', function () {
     buyerOrganization = buyerCert.organization;
   })
 
-  // it('Create an Order', async () => {
-  //   const createProductArgs = {
-  //     ...productArgs(util.uid()),
-  //   }
+  it('Create an Order Pay Later', async () => {
+    // In this case the seller must have gone through the connect stripe flow
+    const createProductArgs = {
+      ...productArgs(util.uid()),
+    }
 
-  //   const createProductResponse = await post(
-  //     Product.prefix,
-  //     Product.create,
-  //     createProductArgs,
-  //     seller.token,
-  //   )
-  //   const [,productAddress]=createProductResponse.body.data;
-    
-  //   assert.equal(createProductResponse.status, RestStatus.OK, 'should be 200');
-  //   assert.isDefined(createProductResponse.body, 'body should be defined')
-    
-  //   const createInventoryArgs={
-  //     ...inventoryArgs(productAddress, util.uid()),
-  //   }
 
-  //   const createInventoryResponse=await post(
-  //     Inventory.prefix,
-  //     Inventory.create,
-  //     createInventoryArgs,
-  //     seller.token,
-  //   )
-  //   const [,inventoryAddress,serialNumbers]=createInventoryResponse.body.data
+    const createProductResponse = await post(
+      Product.prefix,
+      Product.create,
+      createProductArgs,
+      seller.token,
+    )
+    const [,productAddress]=createProductResponse.body.data;
+    
+    assert.equal(createProductResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(createProductResponse.body, 'body should be defined')
+    
+    const createInventoryArgs={
+      ...inventoryArgs(productAddress, util.uid()),
+    }
+
+    const createInventoryResponse=await post(
+      Inventory.prefix,
+      Inventory.create,
+      createInventoryArgs,
+      seller.token,
+    )
+    const [,inventoryAddress,serialNumbers]=createInventoryResponse.body.data
  
-  //   assert.equal(createInventoryResponse.status, RestStatus.OK, 'should be 200');
-  //   assert.isDefined(createInventoryResponse.body, 'body should be defined')
+    assert.equal(createInventoryResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(createInventoryResponse.body, 'body should be defined')
 
-  //   const inventories=[inventoryAddress]
-  //   const createOrderArgs=factory.getCreateOrderArgs(util.uid(),buyerOrganization,inventories)
+    const inventories=[inventoryAddress]
+    const createOrderArgs=factory.getCreateOrderArgs(util.uid(),buyerOrganization,inventories)
     
-  //   const createOrderResponse = await post(
-  //     Order.prefix,
-  //     Order.create,
-  //     createOrderArgs,
-  //     globalAdmin.token
-  //   )
+    const createOrderResponse = await post(
+      Order.prefix,
+      Order.create,
+      createOrderArgs,
+      globalAdmin.token
+    )
 
-  //   assert.equal(createOrderResponse.status, RestStatus.OK, 'should be 200');
-  //   assert.isDefined(createOrderResponse.body, 'body should be defined')
-  // })
+    assert.equal(createOrderResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(createOrderResponse.body, 'body should be defined')
+  })
 
-  // it('Get an Order', async () => {
-  //   const createProductArgs = {
-  //     ...productArgs(util.uid()),
-  //   }
+  it('Create an Order Pay Now', async () => {
+    const createProductArgs = {
+      ...productArgs(util.uid()),
+    }
 
-  //   const createProductResponse = await post(
-  //     Product.prefix,
-  //     Product.create,
-  //     createProductArgs,
-  //     seller.token,
-  //   )
-  //   const [,productAddress]=createProductResponse.body.data;
+    const createProductResponse = await post(
+      Product.prefix,
+      Product.create,
+      createProductArgs,
+      seller.token,
+    )
+    const [,productAddress]=createProductResponse.body.data;
     
-  //   assert.equal(createProductResponse.status, RestStatus.OK, 'should be 200');
-  //   assert.isDefined(createProductResponse.body, 'body should be defined')
+    assert.equal(createProductResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(createProductResponse.body, 'body should be defined')
     
-  //   const createInventoryArgs={
-  //     ...inventoryArgs(productAddress, util.uid()),
-  //   }
+    const createInventoryArgs={
+      ...inventoryArgs(productAddress, util.uid()),
+    }
 
-  //   const createInventoryResponse=await post(
-  //     Inventory.prefix,
-  //     Inventory.create,
-  //     createInventoryArgs,
-  //     seller.token,
-  //   )
-  //   const [,inventoryAddress,serialNumbers]=createInventoryResponse.body.data
+    const createInventoryResponse=await post(
+      Inventory.prefix,
+      Inventory.create,
+      createInventoryArgs,
+      seller.token,
+    )
+    const [,inventoryAddress,serialNumbers]=createInventoryResponse.body.data
  
-  //   assert.equal(createInventoryResponse.status, RestStatus.OK, 'should be 200');
-  //   assert.isDefined(createInventoryResponse.body, 'body should be defined')
+    assert.equal(createInventoryResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(createInventoryResponse.body, 'body should be defined')
 
-  //   const inventories=[inventoryAddress]
-  //   const createOrderArgs=factory.getCreateOrderArgs(util.uid(),buyerOrganization,inventories)
+    // An array of inventory addresses created by the seller
+    const inventories=[inventoryAddress]
+
+    // Create a user address if one does not exist already
+    const buyerAddressArgs = factory.getUserAddressArgs(util.uid())
+    const createUserAddressResponse = await post(
+      Order.prefix,
+      Order.userAddress,
+      buyerAddressArgs,
+      globalAdmin.token
+    )
+
+    const [,userAddress]=createUserAddressResponse.body.data
+
+    const getBuyerAddressResponse = await get(
+      Order.prefix,
+      Order.getAllUserAddress.replace(':address',userAddress),
+      {},
+      globalAdmin.token
+    )
+
+    const buyerAddress = getBuyerAddressResponse.body.data.filter(address=>address.address === userAddress)
+
+    assert.deepInclude(buyerAddress[0], buyerAddressArgs, 'should include the buyer address args')
     
-  //   const createOrderResponse = await post(
-  //     Order.prefix,
-  //     Order.create,
-  //     createOrderArgs,
-  //     globalAdmin.token
-  //   )
+    // The pay now functionality opens this endpoint to make a payment before posting the order
+    const createPaymentArgs = factory.getCreatePaymentArgs(util.uid(),buyerOrganization, inventories, userAddress)
 
-  //   const orderAddress = createOrderResponse.body.data[0][1]
-  //   // const orderAddress = createOrderResponse.body.data[0].address
-  //   // const orderChainId = createOrderResponse.body.data[0].chainIds[0]
+    const createPaymentSession = await post(
+      Order.prefix,
+      Order.payment,
+      createPaymentArgs,
+      globalAdmin.token
+    )
 
-  //   assert.equal(createOrderResponse.status, RestStatus.OK, 'should be 200');
-  //   assert.isDefined(createOrderResponse.body, 'body should be defined')
-  //   console.log("createOrderResponse", orderAddress);
+    assert.equal(createPaymentSession.status, RestStatus.OK, 'should be 200');
 
-  //   // get
-  //   const getOrderResponse = await get(
-  //     Order.prefix,
-  //     // Order.get.replace(':address',orderAddress).replace(':chainId', orderChainId),
-  //     Order.get.replace(':address',orderAddress),
-  //     {},
-  //     globalAdmin.token,
-  //   )
+    const createOrderArgs=factory.getCreateOrderArgs(util.uid(), buyerOrganization, inventories)
+    
+    const createOrderResponse = await post(
+      Order.prefix,
+      Order.create,
+      createOrderArgs,
+      globalAdmin.token
+    )
 
-  //   assert.equal(getOrderResponse.status, RestStatus.OK, 'should be 200');
-  //   assert.isDefined(getOrderResponse.body, 'body should be defined');
+    const orderAddress = createOrderResponse.body.data[0][1]
 
-  // })
+    assert.equal(createOrderResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(createOrderResponse.body, 'body should be defined')
+
+    // get
+    const getOrderResponse = await get(
+      Order.prefix,
+      // Order.get.replace(':address',orderAddress).replace(':chainId', orderChainId),
+      Order.get.replace(':address',orderAddress),
+      {},
+      globalAdmin.token,
+    )
+
+    assert.equal(getOrderResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(getOrderResponse.body, 'body should be defined');
+
+  })
+
+  it('Get an Order', async () => {
+    const createProductArgs = {
+      ...productArgs(util.uid()),
+    }
+
+    const createProductResponse = await post(
+      Product.prefix,
+      Product.create,
+      createProductArgs,
+      seller.token,
+    )
+    const [,productAddress]=createProductResponse.body.data;
+
+    assert.equal(createProductResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(createProductResponse.body, 'body should be defined')
+
+    const createInventoryArgs={
+      ...inventoryArgs(productAddress, util.uid()),
+    }
+
+    const createInventoryResponse=await post(
+      Inventory.prefix,
+      Inventory.create,
+      createInventoryArgs,
+      seller.token,
+    )
+
+    const [,inventoryAddress,serialNumbers]=createInventoryResponse.body.data
+
+    assert.equal(createInventoryResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(createInventoryResponse.body, 'body should be defined')
+
+    const inventories=[inventoryAddress]
+    const createOrderArgs=factory.getCreateOrderArgs(util.uid(),buyerOrganization,inventories)
+
+    const createOrderResponse = await post(
+      Order.prefix,
+      Order.create,
+      createOrderArgs,
+      globalAdmin.token
+    )
+
+    const orderAddress = createOrderResponse.body.data[0][1]
+
+    assert.equal(createOrderResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(createOrderResponse.body, 'body should be defined')
+
+    // get
+    const getOrderResponse = await get(
+      Order.prefix,
+      Order.get.replace(':address',orderAddress),
+      {},
+      globalAdmin.token,
+    )
+
+    assert.equal(getOrderResponse.status, RestStatus.OK, 'should be 200');
+    assert.isDefined(getOrderResponse.body, 'body should be defined');
+  })
+
 
   it('Get all Order', async () => {
     // get

--- a/marketplace/backend/test/v1/order.test.js
+++ b/marketplace/backend/test/v1/order.test.js
@@ -95,7 +95,7 @@ describe('Order End-To-End Tests', function () {
       createInventoryArgs,
       seller.token,
     )
-    const [,inventoryAddress,serialNumbers]=createInventoryResponse.body.data
+    const [,inventoryAddress]=createInventoryResponse.body.data
  
     assert.equal(createInventoryResponse.status, RestStatus.OK, 'should be 200');
     assert.isDefined(createInventoryResponse.body, 'body should be defined')
@@ -141,7 +141,7 @@ describe('Order End-To-End Tests', function () {
       createInventoryArgs,
       seller.token,
     )
-    const [,inventoryAddress,serialNumbers]=createInventoryResponse.body.data
+    const [,inventoryAddress]=createInventoryResponse.body.data
  
     assert.equal(createInventoryResponse.status, RestStatus.OK, 'should be 200');
     assert.isDefined(createInventoryResponse.body, 'body should be defined')
@@ -237,7 +237,7 @@ describe('Order End-To-End Tests', function () {
       seller.token,
     )
 
-    const [,inventoryAddress,serialNumbers]=createInventoryResponse.body.data
+    const [,inventoryAddress]=createInventoryResponse.body.data
 
     assert.equal(createInventoryResponse.status, RestStatus.OK, 'should be 200');
     assert.isDefined(createInventoryResponse.body, 'body should be defined')

--- a/marketplace/backend/test/v1/order.test.js
+++ b/marketplace/backend/test/v1/order.test.js
@@ -28,6 +28,7 @@ describe('Order End-To-End Tests', function () {
     let globalAdminToken
     let sellerToken
     try {
+      // Seller and buyer tokens musst be of different orgs.
       globalAdminToken = await oauthHelper.getUserToken(
         `${process.env.TEST_BUYER_ORG}`,
         `${process.env.TEST_BUYER_PASSWORD}`,
@@ -68,7 +69,6 @@ describe('Order End-To-End Tests', function () {
   })
 
   it('Create an Order Pay Later', async () => {
-    // In this case the seller must have gone through the connect stripe flow
     const createProductArgs = {
       ...productArgs(util.uid()),
     }
@@ -115,6 +115,7 @@ describe('Order End-To-End Tests', function () {
   })
 
   it('Create an Order Pay Now', async () => {
+    // In this case the seller must have gone through the connect stripe flow
     const createProductArgs = {
       ...productArgs(util.uid()),
     }
@@ -148,7 +149,7 @@ describe('Order End-To-End Tests', function () {
     // An array of inventory addresses created by the seller
     const inventories=[inventoryAddress]
 
-    // Create a user address if one does not exist already
+    // Create a user address for the buyer's shipping information
     const buyerAddressArgs = factory.getUserAddressArgs(util.uid())
     const createUserAddressResponse = await post(
       Order.prefix,
@@ -199,7 +200,6 @@ describe('Order End-To-End Tests', function () {
     // get
     const getOrderResponse = await get(
       Order.prefix,
-      // Order.get.replace(':address',orderAddress).replace(':chainId', orderChainId),
       Order.get.replace(':address',orderAddress),
       {},
       globalAdmin.token,


### PR DESCRIPTION
Added tests for order flow. Pay now and pay later flows both included. 
- Pay now includes user address creation and order.payment
- Pay later goes straight through to order creation after inventory is created. 