### PR TITLE
mkt Top Selling Products Bug

### DIFF
--- a/marketplace/backend/dapp/marketplace/marketplace.js
+++ b/marketplace/backend/dapp/marketplace/marketplace.js
@@ -81,6 +81,9 @@ async function getTopSellingProducts(admin, args = {}, options) {
     const inventory = await inventoryJs.getAll(admin, { appChainId: args.appChainId, status: inventoryStatus.PUBLISHED, range, gteField: 'availableQuantity', gteValue: 1, sort: '-createdDate', offset: args.offset, limit: constants.TOP_SELLING_GET_LIMIT }, options);
     const inventoryIds = inventory.map(inventory => inventory.productId)
 
+    // We don't need to pass the offset here to the productJs.getAll function
+    delete restArgs.offset
+
     const products = await productJs.getAll(admin, {
         isActive: true,
         isDeleted: false,
@@ -88,7 +91,7 @@ async function getTopSellingProducts(admin, args = {}, options) {
         address: inventoryIds,
         ...restArgs
     }, options);
-
+    
     const productIds = products.map(product => product.address);
 
     let inventoriesWithProductInfo = inventory.filter(inventory => productIds.includes(inventory.productId)).map(inventory => ({

--- a/marketplace/backend/dapp/marketplace/marketplace.js
+++ b/marketplace/backend/dapp/marketplace/marketplace.js
@@ -77,16 +77,19 @@ async function getAll(admin, args = {}, options) {
 
 async function getTopSellingProducts(admin, args = {}, options) {
     const { quantity, pricePerUnit, range = [], ...restArgs } = args
+    
+    const inventory = await inventoryJs.getAll(admin, { appChainId: args.appChainId, status: inventoryStatus.PUBLISHED, range, gteField: 'availableQuantity', gteValue: 1, sort: '-createdDate', offset: args.offset, limit: constants.TOP_SELLING_GET_LIMIT }, options);
+    const inventoryIds = inventory.map(inventory => inventory.productId)
 
     const products = await productJs.getAll(admin, {
         isActive: true,
         isDeleted: false,
         isInventoryAvailable: true,
+        address: inventoryIds,
         ...restArgs
     }, options);
 
     const productIds = products.map(product => product.address);
-    const inventory = await inventoryJs.getAll(admin, { appChainId: args.appChainId, status: inventoryStatus.PUBLISHED, productId: productIds, range, gteField: 'availableQuantity', gteValue: 1, sort: '-createdDate', offset: args.offset, limit: constants.TOP_SELLING_GET_LIMIT }, options);
 
     let inventoriesWithProductInfo = inventory.filter(inventory => productIds.includes(inventory.productId)).map(inventory => ({
         ...products.find(product => product.address == inventory.productId), ...inventory

--- a/marketplace/backend/dapp/marketplace/marketplace.js
+++ b/marketplace/backend/dapp/marketplace/marketplace.js
@@ -55,7 +55,7 @@ function marshalOut(_args) {
 }
 
 async function getAll(admin, args = {}, options) {
-    const { quantity, pricePerUnit, productId, range = [], ...restArgs } = args
+    const { quantity, pricePerUnit, productId, range = [], ...restArgs } = args;
     const products = await productJs.getAll(admin, {
         isActive: true,
         isDeleted: false,
@@ -63,16 +63,42 @@ async function getAll(admin, args = {}, options) {
         ...restArgs
     }, options);
 
-    let productIds
-    productIds = products.map(product => product.address)
+    const productIds = products.map(product => product.address);
+    const batchSize = 200; // Set the desired batch size. Can adjust to optimize performance.
+    const inventoryPromises = [];
 
-    const inventory = await inventoryJs.getAll(admin, { appChainId: args.appChainId, status: inventoryStatus.PUBLISHED, productId: productIds, range, gteField: 'availableQuantity', gteValue: 1 }, options);
+    // Break up the productIds into batches, and get the inventory for each batch
+    for (let i = 0; i < productIds.length; i += batchSize) {
+        const batchProductIds = productIds.slice(i, i + batchSize);
 
-    let inventoriesWithProductInfo = inventory.filter(inventory => productIds.includes(inventory.productId)).map(inventory => ({
-        ...products.find(product => product.address == inventory.productId), ...inventory
-    }));
+        const inventoryPromise = inventoryJs.getAll(admin, {
+            appChainId: args.appChainId,
+            status: inventoryStatus.PUBLISHED,
+            productId: batchProductIds,
+            range,
+            gteField: 'availableQuantity',
+            gteValue: 1
+        }, options);
 
-    return inventoriesWithProductInfo.map((inventory) => marshalOut(inventory))
+        inventoryPromises.push(inventoryPromise);
+    }
+
+    // Wait for all inventory promises to resolve
+    const inventoryResults = await Promise.all(inventoryPromises);
+    const inventoriesWithProductInfo = [];
+
+    // Loop through each inventory result and add the product info to the inventory
+    inventoryResults.forEach(inventory => {
+        inventory.forEach(item => {
+            const product = products.find(p => p.address === item.productId);
+            if (product) {
+                const inventoryWithProductInfo = { ...product, ...item };
+                inventoriesWithProductInfo.push(inventoryWithProductInfo);
+            }
+        });
+    });
+
+    return inventoriesWithProductInfo.map(inventory => marshalOut(inventory));
 }
 
 async function getTopSellingProducts(admin, args = {}, options) {

--- a/marketplace/backend/dapp/marketplace/marketplace.js
+++ b/marketplace/backend/dapp/marketplace/marketplace.js
@@ -112,7 +112,7 @@ async function getTopSellingProducts(admin, args = {}, options) {
     }, options);
 
     const productIds = products.map(product => product.address);
-    const batchSize = 100; // Set the desired batch size
+    const batchSize = 200; // Set the desired batch size
     const inventoryPromises = [];
 
     for (let i = 0; i < productIds.length; i += batchSize) {

--- a/marketplace/backend/dapp/marketplace/marketplace.js
+++ b/marketplace/backend/dapp/marketplace/marketplace.js
@@ -64,7 +64,7 @@ async function getAll(admin, args = {}, options) {
     }, options);
 
     const productIds = products.map(product => product.address);
-    const batchSize = 200; // Set the desired batch size. Can adjust to optimize performance.
+    const batchSize = 200; // Set the desired batch size. Can adjust to optimize performance (max 374)
     const inventoryPromises = [];
 
     // Break up the productIds into batches, and get the inventory for each batch
@@ -102,30 +102,53 @@ async function getAll(admin, args = {}, options) {
 }
 
 async function getTopSellingProducts(admin, args = {}, options) {
-    const { quantity, pricePerUnit, range = [], ...restArgs } = args
-    
-    const inventory = await inventoryJs.getAll(admin, { appChainId: args.appChainId, status: inventoryStatus.PUBLISHED, range, gteField: 'availableQuantity', gteValue: 1, sort: '-createdDate', offset: args.offset, limit: constants.TOP_SELLING_GET_LIMIT }, options);
-    const inventoryIds = inventory.map(inventory => inventory.productId)
-
-    // We don't need to pass the offset here to the productJs.getAll function
-    delete restArgs.offset
+    const { quantity, pricePerUnit, range = [], ...restArgs } = args;
 
     const products = await productJs.getAll(admin, {
         isActive: true,
         isDeleted: false,
         isInventoryAvailable: true,
-        address: inventoryIds,
         ...restArgs
     }, options);
-    
+
     const productIds = products.map(product => product.address);
+    const batchSize = 100; // Set the desired batch size
+    const inventoryPromises = [];
 
-    let inventoriesWithProductInfo = inventory.filter(inventory => productIds.includes(inventory.productId)).map(inventory => ({
-        ...products.find(product => product.address == inventory.productId), ...inventory
-    }));
+    for (let i = 0; i < productIds.length; i += batchSize) {
+        const batchProductIds = productIds.slice(i, i + batchSize);
 
-    return inventoriesWithProductInfo.map((inventory) => marshalOut(inventory))
+        const inventoryPromise = inventoryJs.getAll(admin, {
+            appChainId: args.appChainId,
+            status: inventoryStatus.PUBLISHED,
+            productId: batchProductIds,
+            range,
+            gteField: 'availableQuantity',
+            gteValue: 1,
+            sort: '-createdDate',
+            offset: args.offset,
+            limit: constants.TOP_SELLING_GET_LIMIT
+        }, options);
+
+        inventoryPromises.push(inventoryPromise);
+    }
+
+    const inventoryResults = await Promise.all(inventoryPromises);
+    const inventoriesWithProductInfo = [];
+
+    inventoryResults.forEach(inventory => {
+        inventory.forEach(item => {
+            const product = products.find(p => p.address === item.productId);
+            if (product) {
+                const inventoryWithProductInfo = { ...product, ...item };
+                inventoriesWithProductInfo.push(inventoryWithProductInfo);
+            }
+        });
+    });
+
+    return inventoriesWithProductInfo.map(inventory => marshalOut(inventory));
 }
+
 
 export default {
     getAll,

--- a/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
+++ b/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
@@ -40,14 +40,15 @@ const TopSellingProductCard = () => {
 
   const naviroute = routes.MarketplaceProductDetail.url;
 
+  const limit = 3;
+
   const getPrevProds = () => {
-    if (offset > 0) setOffset(0);
-    // setOffset(offset-limit);
+    if (offset > 0) setOffset(offset-limit);
   };
 
   const getNextProds = () => {
-    setOffset(3);
-    // setOffset(offset+limit);
+    // setOffset(3);
+    setOffset(offset+limit);
   };
 
   const navigate = useNavigate();


### PR DESCRIPTION
- Server error seen where top selling products fetch would be too large after too many products are created. 
-  Previously we would get all products, map their addresses, find inventory of each product address and return the 3 most recent. 
- Now we get 3 most recent inventory, map addresses, get products with those inventory addresses. 
- Will always return 3 inventory and 3 products regardless of how many have been created preventing the server error from being triggered. 
- Test by running `yarn test:api:marketplace` or trigger the call in the UI. 