### PR TITLE
[STRATO 2505] Add Support for Using Clauses in SolidVM

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Contract.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Contract.hs
@@ -21,6 +21,7 @@ module SolidVM.Model.CodeCollection.Contract (
   events,
   functions,
   modifiers,
+  usings,
   constructor,
   contractContext
   ) where
@@ -58,6 +59,7 @@ data ContractF a =
     _functions :: Map SolidString (FuncF a),
     _constructor :: Maybe (FuncF a),
     _modifiers :: Map SolidString (ModifierF a),
+    _usings :: Map SolidString [UsingF a],
     _contractContext :: a
   } deriving (Show, Generic, NFData, Functor, Foldable, Traversable)
 
@@ -87,6 +89,7 @@ instance Arbitrary Contract  where
     _functions =  empty ,
     _constructor  =  Nothing ,
     _modifiers  =  empty ,
+    _usings  =  empty ,
     _contractContext = a
   }]
 

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Contract.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Contract.hs
@@ -10,6 +10,7 @@
 module SolidVM.Model.CodeCollection.Contract (
   ContractF(..),
   Contract,
+  ContractType(..),
   contractName,
   parents,
   constants,
@@ -23,6 +24,7 @@ module SolidVM.Model.CodeCollection.Contract (
   modifiers,
   usings,
   constructor,
+  contractType,
   contractContext
   ) where
 
@@ -44,6 +46,10 @@ import qualified SolidVM.Model.CodeCollection.VarDef as SolidVM
 import           SolidVM.Model.CodeCollection.VariableDecl
 import           SolidVM.Model.SolidString
 
+
+data ContractType = ContractType | LibraryType | InterfaceType deriving (Show, Generic, NFData, Eq, ToJSON, FromJSON)
+
+
 -- Changes to this structure should also have changes in the Unparser :)
 data ContractF a =
   Contract {     
@@ -60,6 +66,7 @@ data ContractF a =
     _constructor :: Maybe (FuncF a),
     _modifiers :: Map SolidString (ModifierF a),
     _usings :: Map SolidString [UsingF a],
+    _contractType :: ContractType,
     _contractContext :: a
   } deriving (Show, Generic, NFData, Functor, Foldable, Traversable)
 
@@ -90,6 +97,7 @@ instance Arbitrary Contract  where
     _constructor  =  Nothing ,
     _modifiers  =  empty ,
     _usings  =  empty ,
+    _contractType  =  ContractType ,
     _contractContext = a
   }]
 

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Function.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Function.hs
@@ -16,6 +16,8 @@ module SolidVM.Model.CodeCollection.Function (
   Visibility(..),
   ModifierF(..),
   Modifier,
+  UsingF(..),
+  Using,
   tShow,
   tShow',
   tRead,
@@ -166,6 +168,39 @@ instance FromJSON a => FromJSON (ModifierF a) where
 
 instance Arbitrary a => Arbitrary (ModifierF a) where
   arbitrary = GR.genericArbitrary GR.uniform
+
+data UsingF a = Using
+  { _usingContract :: SolidString
+  , _usingType     :: SolidString -- TODO: Use Type here
+  , _usingContext  :: a
+  } deriving (Eq,Show,Generic, Functor, NFData, Traversable, Foldable)
+
+type Using = Positioned UsingF
+
+instance ToJSON a => ToJSON (UsingF a) where
+  toJSON (Using dec typ ctx) = object
+    [ "using" .= dec
+    , "for" .= typ
+    , "context" .= ctx
+    ]
+
+instance FromJSON a => FromJSON (UsingF a) where
+  parseJSON (Object o) = Using
+                     <$> (o .: "using")
+                     <*> (o .: "for")
+                     <*> (o .: "context")
+  parseJSON o = fail $ "SolidVM.Using: Expected Object, got " ++ show o
+
+instance Arbitrary a => Arbitrary (UsingF a) where
+  arbitrary = Using <$> arbitrary <*> arbitrary <*> arbitrary
+
+instance ToSchema Using where
+  declareNamedSchema proxy = genericDeclareNamedSchema soliditySchemaOptions proxy
+     & mapped.name ?~ "Using schema"
+     & mapped.schema.description ?~ "Xabi of a `using` declaration"
+     & mapped.schema.example ?~ toJSON sampleUsing
+     where sampleUsing :: UsingF ()
+           sampleUsing = Using "SafeMath" "uint256" ()
 
 instance Arbitrary a => Arbitrary (FuncF a) where
   arbitrary = GR.genericArbitrary GR.uniform

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Function.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Function.hs
@@ -34,7 +34,10 @@ module SolidVM.Model.CodeCollection.Function (
   modifierArgs,
   modifierSelector,
   modifierContents,
-  modifierContext
+  modifierContext,
+  usingContract,
+  usingType,
+  usingContext
   ) where
 
 import           Control.Lens                 (mapped, (&), (?~), makeLenses)
@@ -174,6 +177,8 @@ data UsingF a = Using
   , _usingType     :: SolidString -- TODO: Use Type here
   , _usingContext  :: a
   } deriving (Eq,Show,Generic, Functor, NFData, Traversable, Foldable)
+
+makeLenses ''UsingF
 
 type Using = Positioned UsingF
 

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -82,7 +82,7 @@ solidityContract = do
   let allFunctions = Map.fromListWith (parseOverloads pragmaVersion') [ (stringToLabel n, f) | (n, FuncDeclaration f) <- declarations ]
   let ctorList = [(stringToLabel n, c) | (n, ConstructorDeclaration c) <- declarations]
   let events = [(stringToLabel n, e) | (n, EventDeclaration e) <- declarations]
-  let using = [(Text.pack n, u) | (n, UsingDeclaration u) <- declarations]
+  let using = [(n, [u]) | (n, UsingDeclaration u) <- declarations]
   allCtors <- if length ctorList > 1
                   then fail "multiple constructors defined"
                   else return . Map.fromList $ ctorList
@@ -101,7 +101,7 @@ solidityContract = do
              , _xabiModifiers = Map.fromList [(stringToLabel name, modifier) | (name, ModifierDeclaration modifier) <- declarations]
              , _xabiEvents = Map.fromList events
              , _xabiKind = kind
-             , _xabiUsing = Map.fromList using
+             , _xabiUsing = Map.fromListWith (++) using
              , _xabiContext = a
            },
         map (Text.pack . fst) baseConstrs
@@ -285,16 +285,17 @@ enumDeclaration = do
 
 usingDeclaration :: SolidityParser (String, Declaration)
 usingDeclaration = do
-  ~(a, (usingContract', rest)) <- withPosition $ do
+  ~(a, (usingContract', usingType')) <- withPosition $ do
     reserved "using"
     usingContract' <- identifier
-    rest <- many1 (noneOf ";")
+    reserved "for"
+    usingType' <- many1 $ noneOf ";"
     semi
-    pure (usingContract', rest)
+    pure (usingContract', usingType')
   return
     (
-      usingContract',
-      UsingDeclaration (Xabi.Using rest a)
+      usingType',
+      UsingDeclaration (Xabi.Using usingContract' usingType' a)
     )
 
 {- Variables -}

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -65,7 +65,7 @@ unparseSourceUnit (NamedXabi name (contract,inherited)) =
   <> concatMap (("\n    " <>) . unparseTypes) (Map.toList $ _xabiTypes contract)
   <> concatMap (("\n    " <>) . unparseModifier) (Map.toList $ _xabiModifiers contract)
   <> concatMap (("\n    " <>) . unparseEvent) (Map.toList $ _xabiEvents contract)
-  <> concatMap (("\n    " <>) . unparseUsing) (Map.toList $ _xabiUsing contract)
+  <> concatMap (("\n    " <>) . unparseUsing) (concat . map snd . Map.toList $ _xabiUsing contract)
   <> concatMap (("\n    " <>) . unparseCtor) (Map.elems $ _xabiConstr contract)
   <> concatMap (("\n    " <>) . unparseFunc) (Map.toList $ _xabiFuncs contract)
   <> "\n}"
@@ -371,8 +371,8 @@ unparseEvent (name, Event{..}) = Text.unpack $
   <> (if _eventAnonymous then "anonymous" else "")
   <> ";"
 
-unparseUsing :: (Text, UsingF a) -> String
-unparseUsing (name, Using body _) = Text.unpack . mconcat $ ["using ", name, " ", Text.pack body, ";\n"]
+unparseUsing :: UsingF a -> String
+unparseUsing (Using lib typ _) = mconcat ["using ", lib, " for ", typ, ";\n"]
 
 unparseTypes :: (SolidString, SolidVM.DefF a) -> String
 unparseTypes (name, SolidVM.Enum {names=names'}) =

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Xabi.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Xabi.hs
@@ -38,11 +38,9 @@ import           Control.DeepSeq
 import           Data.Aeson
 import           Data.Aeson.Casing
 import           Data.Aeson.Casing.Internal   (dropFPrefix)
-import           Data.Aeson.Types
 import           Data.Map.Strict              (Map)
 import           Data.Source
 import           Data.Swagger
-import           Data.Text                    (Text)
 import           GHC.Generics
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances    ()
@@ -79,38 +77,11 @@ data XabiF a = Xabi
   , _xabiModifiers :: Map SolidString (ModifierF a)
   , _xabiEvents    :: Map SolidString (EventF a)
   , _xabiKind      :: XabiKind
-  , _xabiUsing     :: Map Text (UsingF a)
+  , _xabiUsing     :: Map SolidString [UsingF a]
   , _xabiContext   :: a
   } deriving (Eq,Show,Generic, Functor, NFData, Traversable, Foldable)
 
 type Xabi = Positioned XabiF
-
-data UsingF a = Using String a deriving (Eq,Show,Generic, Functor, NFData, Traversable, Foldable)
-
-type Using = Positioned UsingF
-
-instance ToJSON a => ToJSON (UsingF a) where
-  toJSON (Using dec ctx) = object
-    [ "using" .= dec
-    , "context" .= ctx
-    ]
-
-instance FromJSON a => FromJSON (UsingF a) where
-  parseJSON (Object o) = Using
-                     <$> (o .: "using")
-                     <*> (o .: "context")
-  parseJSON o = typeMismatch "SolidVM.Using" o
-
-instance Arbitrary a => Arbitrary (UsingF a) where
-  arbitrary = Using <$> arbitrary <*> arbitrary
-
-instance ToSchema Using where
-  declareNamedSchema proxy = genericDeclareNamedSchema soliditySchemaOptions proxy
-     & mapped.name ?~ "Using schema"
-     & mapped.schema.description ?~ "Xabi of a `using` declaration"
-     & mapped.schema.example ?~ toJSON sampleUsing
-     where sampleUsing :: UsingF ()
-           sampleUsing = Using "for uint[]" ()
 
 --------------------------------------------------------------------------------
 

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -73,13 +73,13 @@ data TypeF' a = Top { topName :: (S.Set SolidString)
 type Type' = Annotated TypeF'
 
 showType :: Type -> Text
-showType (SVMType.Int s b) = (if fromMaybe False s then "u" else "")
+showType (SVMType.Int s b) = (if fromMaybe False s then "" else "u")
                   <> "int"
                   <> (maybe "" (T.pack . show) b)
 showType (SVMType.String _) = "string"
 showType (SVMType.Bytes _ b) = "bytes"
                     <> (maybe "" (T.pack . show) b)
-showType (SVMType.Fixed s b) = (if fromMaybe False s then "u" else "")
+showType (SVMType.Fixed s b) = (if fromMaybe False s then "" else "u")
                   <> "fixed"
                   <> maybe "" (T.pack . show) b
 showType SVMType.Bool = "bool"
@@ -670,6 +670,26 @@ typecheckMember (Static (SVMType.UnknownLabel c _) x) n = do
             t -> pure t
         t -> pure t
     t -> pure t
+typecheckMember t@(Static svmType x) n = do
+  let unknownMember = pure . bottom $ ("Unknown member: " <> showType svmType <> "." <> labelToText n) <$ x
+  c <- asks contract
+  case c ^. usings . at (T.unpack $ showType svmType) of
+    Nothing -> unknownMember
+    Just [] -> unknownMember
+    Just us -> do
+      results <- forM us $ \(Using c' _ _) -> do
+        ~CodeCollection{..} <- asks codeCollection
+        case M.lookup c' _contracts of
+          Nothing -> unknownMember
+          Just c'' -> do
+            r <- ask
+            s <- get
+            let fType' = flip runReader r{contract = c''} . flip evalStateT s $ getVarTypeByName' n x
+            case fType' of
+              Function (Product (a:as) x') rs x'' ovs names ->
+                typecheck a t !> (pure $ Function (Product as x') rs x'' ovs names)
+              _ -> unknownMember
+      pure $ pickType' x results
 typecheckMember x n = pure . bottom $ ("Unknown member: " <> showType' x <> "." <> labelToText n) <$ context' x
 
 getConstructorType' :: MonadReader R m => SourceAnnotation Text -> SolidString -> m Type'

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1407,7 +1407,7 @@ expToPath x = todo "expToPath/unhandled" x
 
 expToVar :: MonadSM m => CC.Expression -> m Variable
 expToVar x = do
-  liftIO $ print $ T.pack $ "expToVar: " ++ show x
+  --liftIO $ print $ T.pack $ "expToVar: " ++ show x
   v <- expToVar' x
   decrementGas 1
   return v
@@ -1826,54 +1826,6 @@ expToVar' (CC.Ternary _ condition expr1 expr2) = do
   c <- getBool =<< expToVar condition
   expToVar $ if c then expr1 else expr2
 
--- case to catch a using statement function like _x.add(3)
-expToVar' (CC.FunctionCall _ (CC.MemberAccess _ (CC.Variable firstPos firstArgVar) usingFuncName) (CC.OrderedArgs xs)) = do
--- firstArgVar == "_x" and usingFuncName == "add" and xs == [NumberLiteral (line 11, column 19) - (line 11, column 20): ()  1 Nothing] 
-    ctrct <- getCurrentContract
-    
-    let usingDeclsInContract = ctrct ^. CC.usings -- Map SolidString [UsingF]
-    (_, cc) <- getCurrentCodeCollection
-    let usingDecls = concat $ M.elems usingDeclsInContract
-    -- iterate through the list of using declartions and find ones that have the someString as a function name
-    -- get the usingContract name
-    let usingContractNames = map (\y -> y ^. CC.usingContract) usingDecls
-    -- search through the contracts in the code collection for the contract with the name usingContractName
-    let contracts = cc ^. CC.contracts
-    let usingContracts = map (\y -> M.lookup y contracts) usingContractNames
-    let usingContracts' = catMaybes usingContracts
-    -- look throught the functions of each contract and find the one with the name usingFuncName
-    let usingFunctions = map (\y -> (^. CC.functions) y) usingContracts'
-    let theFunction = map (\y -> M.lookup usingFuncName y) usingFunctions
-    let theFunction' = catMaybes theFunction
-    let theFunction'' = case theFunction' of
-                          [] -> internalError "No function found" (firstArgVar, usingFuncName)
-                          (x:_) -> x -- big unknown if there are two functions with the same name
-    -- add theFunction' to the current contract's functions
-    addFunctionToCurrentContractInCurrentCallInfo usingFuncName theFunction''
-
-    -- now we need to get the value of the firstArgVar and prepend it to the xs list
-    let x' = (CC.Variable (firstPos) firstArgVar)
-    let dummyAnnotation :: SourceAnnotation ()
-        dummyAnnotation =
-            SourceAnnotation
-            {
-              _sourceAnnotationStart=SourcePosition {
-                _sourcePositionName="",
-                _sourcePositionLine=0,
-                _sourcePositionColumn=0
-                },
-              _sourceAnnotationEnd=SourcePosition {
-                _sourcePositionName="",
-                  _sourcePositionLine=0,
-                  _sourcePositionColumn=0
-                },
-              _sourceAnnotationAnnotation = ()
-            }
-
-    theResult <- expToVar (CC.FunctionCall dummyAnnotation (CC.Variable dummyAnnotation usingFuncName) (CC.OrderedArgs (x' : xs))) 
-    removeFunctionFromCurrentContractInCurrentCallInfo usingFuncName
-    return theResult
-
 expToVar' (CC.FunctionCall _ (CC.NewExpression _ SVMType.Bytes{}) (CC.OrderedArgs args)) = do
   case args of
     [a] -> do
@@ -1930,341 +1882,346 @@ expToVar' (CC.FunctionCall _ (CC.NewExpression _ (SVMType.UnknownLabel contractN
             s <- getVar =<< expToVar expr
             return s
       return saltValue
+-- case to catch a using statement function like _x.add(3)
 
-expToVar' (CC.FunctionCall _ e args) = do
-  case e of -- FunctionCall Special Case when calling a function via Member Access
-    (CC.MemberAccess _ (CC.Variable _ "Util") _) -> regularFunctionCall Nothing --Because of the hardcoded Util functions
-    (CC.MemberAccess _ expr name) -> do
-      var1 <- expToVar expr
-      val1 <- getVar var1
-      case (val1, name) of
-        (SAccount addr _, "delegatecall") -> do
-          let  (funcName, args') = (case args of
-                (CC.OrderedArgs [])  -> typeError "delegate call needs atleast one arguement, none were given " args
-                (CC.OrderedArgs a)  -> case head a of  (CC.StringLiteral _  fname) -> (fname, (CC.OrderedArgs $ tail a)); _ -> typeError "delegate call needs first arguement to be a string" args
-                (CC.NamedArgs _ ) ->  typeError "Cannot provide named args to delegate call" args)
-          fromAddress <- getCurrentAccount
-          let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) addr
-          res <- callWrapper fromAddress toAddress (Just toAddress)  Nothing funcName False args'
-          case res of
-              Just a  -> return $ Constant  a
-              Nothing -> return $ Constant SNULL
-        (SAccount addr _, itemName) -> regularFunctionCall $ Just (return $ Constant $ SContractItem addr itemName)
+expToVar' theFullExp@(CC.FunctionCall _ e args) = do
+  mUsingCase <- specialUsingChecker theFullExp
+  case mUsingCase of
+    Just aResult -> return aResult
+    Nothing -> do
+      case e of -- FunctionCall Special Case when calling a function via Member Access
+        (CC.MemberAccess _ (CC.Variable _ "Util") _) -> regularFunctionCall Nothing --Because of the hardcoded Util functions
+        (CC.MemberAccess _ expr name) -> do
+          var1 <- expToVar expr
+          val1 <- getVar var1
+          case (val1, name) of
+            (SAccount addr _, "delegatecall") -> do
+              let  (funcName, args') = (case args of
+                    (CC.OrderedArgs [])  -> typeError "delegate call needs atleast one arguement, none were given " args
+                    (CC.OrderedArgs a)  -> case head a of  (CC.StringLiteral _  fname) -> (fname, (CC.OrderedArgs $ tail a)); _ -> typeError "delegate call needs first arguement to be a string" args
+                    (CC.NamedArgs _ ) ->  typeError "Cannot provide named args to delegate call" args)
+              fromAddress <- getCurrentAccount
+              let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) addr
+              res <- callWrapper fromAddress toAddress (Just toAddress)  Nothing funcName False args'
+              case res of
+                  Just a  -> return $ Constant  a
+                  Nothing -> return $ Constant SNULL
+            (SAccount addr _, itemName) -> regularFunctionCall $ Just (return $ Constant $ SContractItem addr itemName)
+            _ -> regularFunctionCall Nothing
         _ -> regularFunctionCall Nothing
-    _ -> regularFunctionCall Nothing
-    where
-      regularFunctionCall :: MonadSM m => Maybe (m Variable) -> m Variable
-      regularFunctionCall mSCI = do
-        var <- case mSCI of
-          Just sci -> sci
-          Nothing  -> expToVar' e
-        argVals <- case args of
-                        CC.OrderedArgs as -> OrderedVals <$> mapM (getVar <=< expToVar) as
-                        CC.NamedArgs ns -> NamedVals <$> mapM (mapM $ getVar <=< expToVar) ns
-        let argCount = case args of
-                        CC.OrderedArgs as -> length as
-                        CC.NamedArgs ns -> length ns
-        case var of
-          Constant (SReference (AccountPath address (MS.StoragePath pieces))) -> do
-            val' <- getVar $ Constant $ SReference $ AccountPath address $ MS.StoragePath $ init pieces
-            case (val', last pieces) of
+        where
+          regularFunctionCall :: MonadSM m => Maybe (m Variable) -> m Variable
+          regularFunctionCall mSCI = do
+            var <- case mSCI of
+              Just sci -> sci
+              Nothing  -> expToVar' e
+            argVals <- case args of
+                            CC.OrderedArgs as -> OrderedVals <$> mapM (getVar <=< expToVar) as
+                            CC.NamedArgs ns -> NamedVals <$> mapM (mapM $ getVar <=< expToVar) ns
+            let argCount = case args of
+                            CC.OrderedArgs as -> length as
+                            CC.NamedArgs ns -> length ns
+            case var of
+              Constant (SReference (AccountPath address (MS.StoragePath pieces))) -> do
+                val' <- getVar $ Constant $ SReference $ AccountPath address $ MS.StoragePath $ init pieces
+                case (val', last pieces) of
 
-              (SContract _ toAddress', MS.Field funcName) -> do
-                fromAddress <- getCurrentAccount
-                let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) toAddress'
-                res <- callWrapper fromAddress toAddress Nothing Nothing (stringToLabel $ BC.unpack funcName) False args
-                case res of
-                  Just v -> return $ Constant $ v
-                  Nothing -> return $ Constant SNULL
+                  (SContract _ toAddress', MS.Field funcName) -> do
+                    fromAddress <- getCurrentAccount
+                    let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) toAddress'
+                    res <- callWrapper fromAddress toAddress Nothing Nothing (stringToLabel $ BC.unpack funcName) False args
+                    case res of
+                      Just v -> return $ Constant $ v
+                      Nothing -> return $ Constant SNULL
 
-              (SAccount toAddress' _, MS.Field funcName) -> do
-                fromAddress <- getCurrentAccount
-                let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) toAddress'
-                res <- callWrapper fromAddress toAddress Nothing Nothing (stringToLabel $ BC.unpack funcName) False args
-                case res of
-                  Just v -> return $ Constant $ v
-                  Nothing -> return $ Constant SNULL
-              x -> todo "expToVar'/FunctionCall" x
+                  (SAccount toAddress' _, MS.Field funcName) -> do
+                    fromAddress <- getCurrentAccount
+                    let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) toAddress'
+                    res <- callWrapper fromAddress toAddress Nothing Nothing (stringToLabel $ BC.unpack funcName) False args
+                    case res of
+                      Just v -> return $ Constant $ v
+                      Nothing -> return $ Constant SNULL
+                  x -> todo "expToVar'/FunctionCall" x
 
-          Constant (SBuiltinFunction name o) -> case argVals of
-            OrderedVals vs -> Constant <$> callBuiltin name vs o
-            NamedVals{} -> invalidArguments (printf "expToVar'/builtinfunction: cannot used namedvals with builtin %s" name) argVals
+              Constant (SBuiltinFunction name o) -> case argVals of
+                OrderedVals vs -> Constant <$> callBuiltin name vs o
+                NamedVals{} -> invalidArguments (printf "expToVar'/builtinfunction: cannot used namedvals with builtin %s" name) argVals
 
-          Constant (SFunction funcName func) -> do
-            ro <- readOnly <$> getCurrentCallInfo
-            contract' <- getCurrentContract
-            address <- getCurrentAccount
-            (hsh, cc) <- getCurrentCodeCollection
-            -- when (True) (internalError "IT'S MORBIN TIME" matchingFuncOverload)
-            res <- do
-              if (CC._funcIsFree func)
-                then do
-                  matchingOverload <- findM testMatch $ CC._funcOverload func
-                  doesFunctionMatch <- testMatch func
-                  if (doesFunctionMatch)
-                    then runTheCall address contract' funcName hsh cc func argVals ro True
-                    else case matchingOverload of
-                      Nothing -> runTheCall address contract' funcName hsh cc func argVals ro True
-                      Just mo -> runTheCall address contract' funcName hsh cc mo argVals ro True
-                else do
-                  matchingOverload <- findM testMatch $ CC._funcOverload func
-                  doesFunctionMatch <- testMatch func
-                  if (doesFunctionMatch)
-                    then runTheCall address contract' funcName hsh cc func argVals ro False
-                    else case matchingOverload of
-                            Nothing ->  case M.lookup funcName $ cc^.CC.flFuncs of
-                                          Just ff -> do
-                                            matchingFreeOverload <- findM testMatch $ CC._funcOverload ff
-                                            doesFreeFunctionMatch <- testMatch ff
-                                            if (doesFreeFunctionMatch)
-                                              then runTheCall address contract' funcName hsh cc ff argVals ro True
-                                              else case matchingFreeOverload of
-                                                Nothing -> runTheCall address contract' funcName hsh cc func argVals ro False
-                                                Just mo -> runTheCall address contract' funcName hsh cc mo argVals ro True
-                                          Nothing -> runTheCall address contract' funcName hsh cc func argVals ro False
-                            Just mo -> runTheCall address contract' funcName hsh cc mo argVals ro False
-            return . Constant . fromMaybe SNULL $ res
-            where
-              testMatch :: MonadSM m => CC.Func -> m Bool
-              testMatch tf = do
-                let argMapping = mapArgs tf
-                doArgsMatch <- mapM testNameAndTypes argMapping
-                pure $ ((length argMapping) == (length $ CC._funcArgs tf))
-                       && ((length argMapping) == (argCount))
-                       && (all (== True) doArgsMatch)
-              testNameAndTypes :: MonadSM m => (String, (SVMType.Type, Value)) -> m Bool
-              testNameAndTypes (_, (t, v)) =
-                -- These cases might not be all inclusive of all valid combinations.
-                case (v, t) of
-                  (SInteger _, SVMType.Int _ _) -> pure $ True
-                  (SString _, SVMType.String _) -> pure $ True
-                  (SString _, SVMType.Bytes _ _) -> pure $ True
-                  (SBool _, SVMType.Bool) -> pure $ True
-                  (SAccount _ _, SVMType.Address _) -> pure $ True
-                  (SAccount _ _, SVMType.Account _) -> pure $ True
-                  (SStruct _ _, SVMType.UnknownLabel _ _) -> pure $ True
-                  (SContract x _, SVMType.UnknownLabel y _) -> pure $ x == y
-                  (SArray x _, SVMType.Array y _) -> pure $ x == y
-                  (SReference addressedPath, _) -> do
-                    refType <- getXabiValueType addressedPath
-                    if (refType == t)
-                      then pure $ True
-                      else
-                        case (refType, t) of
-                          (SVMType.UnknownLabel x _, SVMType.UnknownLabel y _) -> pure $ x == y
-                          (SVMType.Array x _, SVMType.Array y _) -> pure $ x == y
-                          _ -> pure $ False
-                  _ -> pure $ False
-              mapArgs :: CC.FuncF a -> [(String, (SVMType.Type, Value))]
-              mapArgs theFunc = case argVals of
-                OrderedVals vs -> let argMeta =
-                                        map (\(n, CC.IndexedType _ t) -> (fromMaybe "" n, t))
-                                        $ CC._funcArgs theFunc
-                                  in zipWith (\(n, t) v -> (n, (t, v))) argMeta vs
-                NamedVals ns ->
-                  let strTypes = M.fromList $ map (\(maybeName, y) -> (fromMaybe "" maybeName, y)) $ CC._funcArgs theFunc
-                      typeAndVal = M.merge (M.dropMissing)
-                                          (M.dropMissing)
-                                          (M.zipWithMatched $ \_k t v -> (t, v))
-                                          strTypes
-                                          $ M.fromList ns
-                      sortedArgs = map snd . sortWith fst
-                                . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
-                                $ M.toList typeAndVal
-                  in sortedArgs
+              Constant (SFunction funcName func) -> do
+                ro <- readOnly <$> getCurrentCallInfo
+                contract' <- getCurrentContract
+                address <- getCurrentAccount
+                (hsh, cc) <- getCurrentCodeCollection
+                -- when (True) (internalError "IT'S MORBIN TIME" matchingFuncOverload)
+                res <- do
+                  if (CC._funcIsFree func)
+                    then do
+                      matchingOverload <- findM testMatch $ CC._funcOverload func
+                      doesFunctionMatch <- testMatch func
+                      if (doesFunctionMatch)
+                        then runTheCall address contract' funcName hsh cc func argVals ro True
+                        else case matchingOverload of
+                          Nothing -> runTheCall address contract' funcName hsh cc func argVals ro True
+                          Just mo -> runTheCall address contract' funcName hsh cc mo argVals ro True
+                    else do
+                      matchingOverload <- findM testMatch $ CC._funcOverload func
+                      doesFunctionMatch <- testMatch func
+                      if (doesFunctionMatch)
+                        then runTheCall address contract' funcName hsh cc func argVals ro False
+                        else case matchingOverload of
+                                Nothing ->  case M.lookup funcName $ cc^.CC.flFuncs of
+                                              Just ff -> do
+                                                matchingFreeOverload <- findM testMatch $ CC._funcOverload ff
+                                                doesFreeFunctionMatch <- testMatch ff
+                                                if (doesFreeFunctionMatch)
+                                                  then runTheCall address contract' funcName hsh cc ff argVals ro True
+                                                  else case matchingFreeOverload of
+                                                    Nothing -> runTheCall address contract' funcName hsh cc func argVals ro False
+                                                    Just mo -> runTheCall address contract' funcName hsh cc mo argVals ro True
+                                              Nothing -> runTheCall address contract' funcName hsh cc func argVals ro False
+                                Just mo -> runTheCall address contract' funcName hsh cc mo argVals ro False
+                return . Constant . fromMaybe SNULL $ res
+                where
+                  testMatch :: MonadSM m => CC.Func -> m Bool
+                  testMatch tf = do
+                    let argMapping = mapArgs tf
+                    doArgsMatch <- mapM testNameAndTypes argMapping
+                    pure $ ((length argMapping) == (length $ CC._funcArgs tf))
+                           && ((length argMapping) == (argCount))
+                           && (all (== True) doArgsMatch)
+                  testNameAndTypes :: MonadSM m => (String, (SVMType.Type, Value)) -> m Bool
+                  testNameAndTypes (_, (t, v)) =
+                    -- These cases might not be all inclusive of all valid combinations.
+                    case (v, t) of
+                      (SInteger _, SVMType.Int _ _) -> pure $ True
+                      (SString _, SVMType.String _) -> pure $ True
+                      (SString _, SVMType.Bytes _ _) -> pure $ True
+                      (SBool _, SVMType.Bool) -> pure $ True
+                      (SAccount _ _, SVMType.Address _) -> pure $ True
+                      (SAccount _ _, SVMType.Account _) -> pure $ True
+                      (SStruct _ _, SVMType.UnknownLabel _ _) -> pure $ True
+                      (SContract x _, SVMType.UnknownLabel y _) -> pure $ x == y
+                      (SArray x _, SVMType.Array y _) -> pure $ x == y
+                      (SReference addressedPath, _) -> do
+                        refType <- getXabiValueType addressedPath
+                        if (refType == t)
+                          then pure $ True
+                          else
+                            case (refType, t) of
+                              (SVMType.UnknownLabel x _, SVMType.UnknownLabel y _) -> pure $ x == y
+                              (SVMType.Array x _, SVMType.Array y _) -> pure $ x == y
+                              _ -> pure $ False
+                      _ -> pure $ False
+                  mapArgs :: CC.FuncF a -> [(String, (SVMType.Type, Value))]
+                  mapArgs theFunc = case argVals of
+                    OrderedVals vs -> let argMeta =
+                                            map (\(n, CC.IndexedType _ t) -> (fromMaybe "" n, t))
+                                            $ CC._funcArgs theFunc
+                                      in zipWith (\(n, t) v -> (n, (t, v))) argMeta vs
+                    NamedVals ns ->
+                      let strTypes = M.fromList $ map (\(maybeName, y) -> (fromMaybe "" maybeName, y)) $ CC._funcArgs theFunc
+                          typeAndVal = M.merge (M.dropMissing)
+                                              (M.dropMissing)
+                                              (M.zipWithMatched $ \_k t v -> (t, v))
+                                              strTypes
+                                              $ M.fromList ns
+                          sortedArgs = map snd . sortWith fst
+                                    . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
+                                    $ M.toList typeAndVal
+                      in sortedArgs
 
-          Constant (SStructDef structName) -> do
-            contract' <- getCurrentContract
-            case M.lookup structName $ contract'^.CC.structs of
-              Just vals -> do
-                return . Constant . SStruct structName . fmap Constant . M.fromList $
-                  case argVals of
-                    OrderedVals as -> zip (map (\(a,_,_) -> a) vals) as
-                    NamedVals ns -> ns
-              Nothing -> do
-                cc <- getCurrentCodeCollection
-                let !vals' = fromMaybe (missingType "struct constructor not found" structName) $ M.lookup structName $ (snd cc) ^. CC.flStructs
-                return . Constant . SStruct structName . fmap Constant . M.fromList $
-                  case argVals of
-                    OrderedVals as -> zip (map (\(a,_,_) -> a) vals') as
-                    NamedVals ns -> ns
-
-          Constant (SContractDef contractName') -> do
-            case argVals of
-              OrderedVals [SInteger address] -> --TODO- clean up this ambiguity between SAddress and SInteger....
-                return $ Constant $ SContract contractName' $ unspecifiedChain $ fromInteger address
-              OrderedVals [SAccount address _] ->
-                return $ Constant $ SContract contractName' address
-              OrderedVals [SContract _ addr] ->
-                return $ Constant $ SContract contractName' $ addr
-              _ -> typeError "contract variable creation" argVals
-
-          -- Transfer wei, throw error on failure no return on success 
-          -- TODO: When gas gets more implemented ensure that this function does not
-          --       consume more than 2300 gas
-          Constant (SContractItem address' "transfer") -> do
-            from <- getCurrentAccount
-            let address = namedAccountToAccount (from ^. accountChainId) address'
-            case argVals of
-              OrderedVals [SInteger amount] -> do
-                res <- pay "built-in transfer function" from address amount
-                case res of
-                  True -> return $ Constant SNULL
-                  _ -> paymentError (show amount) (show address)
-              _ -> paymentError "unknown" (show address)
-
-          -- Send Wei return bool on failure or success
-          -- TODO: When gas gets more implemented ensure that this function does not
-          --       consume more than 2300 gas
-          Constant (SContractItem address' "send") -> do
-            from <- getCurrentAccount
-            let address = namedAccountToAccount (from ^. accountChainId) address'
-            success <- case argVals of
-              OrderedVals [SInteger amount] -> do
-                res <- pay "built-in send function" from address amount
-                case res of
-                  True -> return True
-                  _ -> return False
-              _ -> return False
-            return . Constant $ SBool success
-
-          Constant (SContractItem address' "code") -> do
-            --Only get the items if they are in the same chain as the current contract, this will prevent leaks from private chains
-            from <- getCurrentAccount
-            -- let namedFrom = accountToNamedAccount' from --convert to a namedAccount to verify everything is on the correct chain
-            --If address' chainId is unset then we set to the current chainId
-              -- Get the code at the address
-            cid <- case (address' ^. namedAccountChainId) of
-              UnspecifiedChain -> do
-                --Assume that the chainId is the same as the from chainId when it is unset 
-                cid1 <- view accountChainId <$> getCurrentAccount
-                case cid1 of
-                  Nothing -> return Nothing
-                  Just cid2 -> return $ Just cid2
-              MainChain -> return Nothing
-              ExplicitChain cid -> return $ Just cid
-            let toAccount = namedAccountToAccount cid address'
-            --check that the from and to are on the same chain`
-            isRelated <- (from ^. accountChainId) `isAncestorChainOf` (toAccount ^. accountChainId)
-            unless (isRelated) $ inaccessibleChain (show from) (show toAccount <> " " <> show isRelated)
-            -- Collect a potential item to search
-            searchTerms <- case argVals of
-                -- catch only the SStrings
-                OrderedVals [SString arguments] -> pure $ Just arguments
-                -- Throw an error if too many arguments are passed
-                OrderedVals as | length as > 1 -> tooManyCooks 1 (length as)
-                --If nothing was given or something else, then just return the entire code
-                _ -> pure $ Nothing
-            --get only the contract containing the sweet succulent ContractF definition
-            (!contract, _, _) <- getCodeAndCollection toAccount
-            let codeSnippets :: [String]
-                codeSnippets =
-                  case (fromMaybe "" searchTerms) of
-                    --Unparse just the contract
-                    "" -> [unparseContract contract]
-                    term ->
-                    --Search the full contract for the search term, retrieving the sourceAnnotation location of the part that was found
-                      -- Check for and get the different parts of the contract
-                      let contrString =
-                            case ((contract ^. CC.contractName) == term) of
-                              True -> Just $ unparseContract contract
-                              False -> Nothing
-
-                          constString =
-                            case ((contract ^. CC.constants) M.!? term) of
-                              Just constF -> Just $ unparseConstant (term, constF)
-                              Nothing -> Nothing
-
-                          storjString =
-                            case ((contract ^. CC.storageDefs) M.!? term) of
-                              Just storjF -> Just $ unparseVar (term, storjF)
-                              Nothing -> Nothing
-
-                          enumString =
-                            case ((contract ^. CC.enums) M.!? term) of
-                              Just enumF -> Just $ unparseEnum (term, fst enumF)
-                              Nothing -> Nothing
-
-                          structString =
-                            case ((contract ^. CC.structs) M.!? term) of
-                              Just structF -> Just $ unparseStruct (term, structF)
-                              Nothing -> Nothing
-
-                          eventString =
-                            case ((contract ^. CC.events) M.!? term) of
-                              Just eventF -> Just $ unparseEvent (term, eventF)
-                              Nothing -> Nothing
-
-                          funcString =
-                            case ((contract ^. CC.functions) M.!? term) of
-                              Just funcF -> Just $ unparseFunc (term, funcF)
-                              Nothing -> Nothing
-
-                          modString =
-                            case ((contract ^. CC.modifiers) M.!? term) of
-                              Just modF -> Just $ unparseModifier (term, modF)
-                              Nothing -> Nothing
-
-                      --Remove all of the items that were found to contain nothing, this should leave just the items that we found
-                      in catMaybes [contrString, funcString, constString, storjString, enumString, eventString, structString, modString]
-            pure . Constant $ SString ( unlines codeSnippets)
-
-          Constant (SContractItem address' itemName) -> do
-            from <- getCurrentAccount
-            let address = namedAccountToAccount (from ^. accountChainId) address'
-            result <- callWrapper from address Nothing Nothing itemName False args
-            return . Constant . fromMaybe SNULL $ result
-
-          Constant (SContractFunction name address' functionName) -> do
-            from <- getCurrentAccount
-            let address = namedAccountToAccount (from ^. accountChainId) address'
-            result <- callWrapper from address Nothing name functionName False args
-            return . Constant . fromMaybe SNULL $ result
-
-          Constant (SEnum enumName) -> do
-            case argVals of
-              OrderedVals [SInteger i] -> do
-                c <- getCurrentContract
-                case M.lookup enumName $ c^.CC.enums  of
-                  Just theEnum -> do
-                    case fst theEnum !? fromInteger i of
-                      Nothing -> typeError "enum val out of range" argVals
-                      Just enumVal -> pure . Constant . SEnumVal enumName enumVal $ fromInteger i
+              Constant (SStructDef structName) -> do
+                contract' <- getCurrentContract
+                case M.lookup structName $ contract'^.CC.structs of
+                  Just vals -> do
+                    return . Constant . SStruct structName . fmap Constant . M.fromList $
+                      case argVals of
+                        OrderedVals as -> zip (map (\(a,_,_) -> a) vals) as
+                        NamedVals ns -> ns
                   Nothing -> do
-                    (_, cc) <- getCurrentCodeCollection
-                    let !theEnum' = fromMaybe (missingType "enum constructor" enumName)
-                                $ M.lookup enumName $ cc ^.CC.flEnums
-                    case fst theEnum' !? fromInteger i of
-                      Nothing -> typeError "enum val out of range" argVals
-                      Just enumVal -> pure . Constant . SEnumVal enumName enumVal $ fromInteger i
-              _ -> typeError "called enum constructor with improper args" argVals
+                    cc <- getCurrentCodeCollection
+                    let !vals' = fromMaybe (missingType "struct constructor not found" structName) $ M.lookup structName $ (snd cc) ^. CC.flStructs
+                    return . Constant . SStruct structName . fmap Constant . M.fromList $
+                      case argVals of
+                        OrderedVals as -> zip (map (\(a,_,_) -> a) vals') as
+                        NamedVals ns -> ns
 
-          Constant (SPush theArray mvar) -> Builtins.push theArray mvar argVals
+              Constant (SContractDef contractName') -> do
+                case argVals of
+                  OrderedVals [SInteger address] -> --TODO- clean up this ambiguity between SAddress and SInteger....
+                    return $ Constant $ SContract contractName' $ unspecifiedChain $ fromInteger address
+                  OrderedVals [SAccount address _] ->
+                    return $ Constant $ SContract contractName' address
+                  OrderedVals [SContract _ addr] ->
+                    return $ Constant $ SContract contractName' $ addr
+                  _ -> typeError "contract variable creation" argVals
 
-          Constant SStringConcat -> do
-            case argVals of
-              OrderedVals xs -> do
-                when (any (\x -> case x of
-                                  (SString _) -> False
-                                  _ -> True) xs) $ typeError "string concat" argVals
-                return $ Constant $ SString $ concatMap (\x -> case x of (SString s) -> s; _ -> "") xs
-              _ -> typeError "called string concat with improper args" argVals
+              -- Transfer wei, throw error on failure no return on success 
+              -- TODO: When gas gets more implemented ensure that this function does not
+              --       consume more than 2300 gas
+              Constant (SContractItem address' "transfer") -> do
+                from <- getCurrentAccount
+                let address = namedAccountToAccount (from ^. accountChainId) address'
+                case argVals of
+                  OrderedVals [SInteger amount] -> do
+                    res <- pay "built-in transfer function" from address amount
+                    case res of
+                      True -> return $ Constant SNULL
+                      _ -> paymentError (show amount) (show address)
+                  _ -> paymentError "unknown" (show address)
 
-          Constant SHexDecodeAndTrim ->
-              case argVals of
-                -- bytes should already be hex decoded when appropriate
-                OrderedVals [s@SString{}] -> return $ Constant s
-                _ -> typeError "bytes32ToString with incorrect arguments" argVals
-          Constant SAddressToAscii ->
-            case argVals of
-              OrderedVals [SAccount a _] -> return . Constant . SString $ show a
-              _ -> typeError "addressToAsciiString with incorrect arguments" argVals
+              -- Send Wei return bool on failure or success
+              -- TODO: When gas gets more implemented ensure that this function does not
+              --       consume more than 2300 gas
+              Constant (SContractItem address' "send") -> do
+                from <- getCurrentAccount
+                let address = namedAccountToAccount (from ^. accountChainId) address'
+                success <- case argVals of
+                  OrderedVals [SInteger amount] -> do
+                    res <- pay "built-in send function" from address amount
+                    case res of
+                      True -> return True
+                      _ -> return False
+                  _ -> return False
+                return . Constant $ SBool success
 
-          -- It would be nice to reinterpret two element paths as a function.
-          -- How can we get a to resolve to a local variable instead of a path?
-          -- StorageItem [Field a, Field b] -> todo "reinterpret as a function
+              Constant (SContractItem address' "code") -> do
+                --Only get the items if they are in the same chain as the current contract, this will prevent leaks from private chains
+                from <- getCurrentAccount
+                -- let namedFrom = accountToNamedAccount' from --convert to a namedAccount to verify everything is on the correct chain
+                --If address' chainId is unset then we set to the current chainId
+                  -- Get the code at the address
+                cid <- case (address' ^. namedAccountChainId) of
+                  UnspecifiedChain -> do
+                    --Assume that the chainId is the same as the from chainId when it is unset 
+                    cid1 <- view accountChainId <$> getCurrentAccount
+                    case cid1 of
+                      Nothing -> return Nothing
+                      Just cid2 -> return $ Just cid2
+                  MainChain -> return Nothing
+                  ExplicitChain cid -> return $ Just cid
+                let toAccount = namedAccountToAccount cid address'
+                --check that the from and to are on the same chain`
+                isRelated <- (from ^. accountChainId) `isAncestorChainOf` (toAccount ^. accountChainId)
+                unless (isRelated) $ inaccessibleChain (show from) (show toAccount <> " " <> show isRelated)
+                -- Collect a potential item to search
+                searchTerms <- case argVals of
+                    -- catch only the SStrings
+                    OrderedVals [SString arguments] -> pure $ Just arguments
+                    -- Throw an error if too many arguments are passed
+                    OrderedVals as | length as > 1 -> tooManyCooks 1 (length as)
+                    --If nothing was given or something else, then just return the entire code
+                    _ -> pure $ Nothing
+                --get only the contract containing the sweet succulent ContractF definition
+                (!contract, _, _) <- getCodeAndCollection toAccount
+                let codeSnippets :: [String]
+                    codeSnippets =
+                      case (fromMaybe "" searchTerms) of
+                        --Unparse just the contract
+                        "" -> [unparseContract contract]
+                        term ->
+                        --Search the full contract for the search term, retrieving the sourceAnnotation location of the part that was found
+                          -- Check for and get the different parts of the contract
+                          let contrString =
+                                case ((contract ^. CC.contractName) == term) of
+                                  True -> Just $ unparseContract contract
+                                  False -> Nothing
 
-          _ -> typeError "cannot call non-function" var
+                              constString =
+                                case ((contract ^. CC.constants) M.!? term) of
+                                  Just constF -> Just $ unparseConstant (term, constF)
+                                  Nothing -> Nothing
+
+                              storjString =
+                                case ((contract ^. CC.storageDefs) M.!? term) of
+                                  Just storjF -> Just $ unparseVar (term, storjF)
+                                  Nothing -> Nothing
+
+                              enumString =
+                                case ((contract ^. CC.enums) M.!? term) of
+                                  Just enumF -> Just $ unparseEnum (term, fst enumF)
+                                  Nothing -> Nothing
+
+                              structString =
+                                case ((contract ^. CC.structs) M.!? term) of
+                                  Just structF -> Just $ unparseStruct (term, structF)
+                                  Nothing -> Nothing
+
+                              eventString =
+                                case ((contract ^. CC.events) M.!? term) of
+                                  Just eventF -> Just $ unparseEvent (term, eventF)
+                                  Nothing -> Nothing
+
+                              funcString =
+                                case ((contract ^. CC.functions) M.!? term) of
+                                  Just funcF -> Just $ unparseFunc (term, funcF)
+                                  Nothing -> Nothing
+
+                              modString =
+                                case ((contract ^. CC.modifiers) M.!? term) of
+                                  Just modF -> Just $ unparseModifier (term, modF)
+                                  Nothing -> Nothing
+
+                          --Remove all of the items that were found to contain nothing, this should leave just the items that we found
+                          in catMaybes [contrString, funcString, constString, storjString, enumString, eventString, structString, modString]
+                pure . Constant $ SString ( unlines codeSnippets)
+
+              Constant (SContractItem address' itemName) -> do
+                from <- getCurrentAccount
+                let address = namedAccountToAccount (from ^. accountChainId) address'
+                result <- callWrapper from address Nothing Nothing itemName False args
+                return . Constant . fromMaybe SNULL $ result
+
+              Constant (SContractFunction name address' functionName) -> do
+                from <- getCurrentAccount
+                let address = namedAccountToAccount (from ^. accountChainId) address'
+                result <- callWrapper from address Nothing name functionName False args
+                return . Constant . fromMaybe SNULL $ result
+
+              Constant (SEnum enumName) -> do
+                case argVals of
+                  OrderedVals [SInteger i] -> do
+                    c <- getCurrentContract
+                    case M.lookup enumName $ c^.CC.enums  of
+                      Just theEnum -> do
+                        case fst theEnum !? fromInteger i of
+                          Nothing -> typeError "enum val out of range" argVals
+                          Just enumVal -> pure . Constant . SEnumVal enumName enumVal $ fromInteger i
+                      Nothing -> do
+                        (_, cc) <- getCurrentCodeCollection
+                        let !theEnum' = fromMaybe (missingType "enum constructor" enumName)
+                                    $ M.lookup enumName $ cc ^.CC.flEnums
+                        case fst theEnum' !? fromInteger i of
+                          Nothing -> typeError "enum val out of range" argVals
+                          Just enumVal -> pure . Constant . SEnumVal enumName enumVal $ fromInteger i
+                  _ -> typeError "called enum constructor with improper args" argVals
+
+              Constant (SPush theArray mvar) -> Builtins.push theArray mvar argVals
+
+              Constant SStringConcat -> do
+                case argVals of
+                  OrderedVals xs -> do
+                    when (any (\x -> case x of
+                                      (SString _) -> False
+                                      _ -> True) xs) $ typeError "string concat" argVals
+                    return $ Constant $ SString $ concatMap (\x -> case x of (SString s) -> s; _ -> "") xs
+                  _ -> typeError "called string concat with improper args" argVals
+
+              Constant SHexDecodeAndTrim ->
+                  case argVals of
+                    -- bytes should already be hex decoded when appropriate
+                    OrderedVals [s@SString{}] -> return $ Constant s
+                    _ -> typeError "bytes32ToString with incorrect arguments" argVals
+              Constant SAddressToAscii ->
+                case argVals of
+                  OrderedVals [SAccount a _] -> return . Constant . SString $ show a
+                  _ -> typeError "addressToAsciiString with incorrect arguments" argVals
+
+              -- It would be nice to reinterpret two element paths as a function.
+              -- How can we get a to resolve to a local variable instead of a path?
+              -- StorageItem [Field a, Field b] -> todo "reinterpret as a function
+
+              _ -> typeError "cannot call non-function" var
 
 {-
 SimpleStatement (ExpressionStatement (Binary "=" (Variable "tickets") (FunctionCall (NewExpression (SolidString "Hashmap")) [])))
@@ -3450,6 +3407,61 @@ solidVMExceptionHandler catchBlockMap ex = case ex of
           return res
 
     _ -> error "unhandled solid exception" (show ex)
+
+specialUsingChecker :: MonadSM m => CC.Expression -> m (Maybe Variable)
+specialUsingChecker (CC.FunctionCall _ (CC.MemberAccess _ (CC.Variable firstPos firstArgVar) usingFuncName) (CC.OrderedArgs xs)) = do
+-- firstArgVar == "_x" and usingFuncName == "add" and xs == [NumberLiteral (line 11, column 19) - (line 11, column 20): ()  1 Nothing] 
+    ctrct <- getCurrentContract
+    
+    let usingDeclsInContract = ctrct ^. CC.usings -- Map SolidString [UsingF]
+    (_, cc) <- getCurrentCodeCollection
+    let usingDecls = concat $ M.elems usingDeclsInContract
+    -- iterate through the list of using declartions and find ones that have the someString as a function name
+    -- get the usingContract name
+    let usingContractNames = map (\y -> y ^. CC.usingContract) usingDecls
+    -- search through the contracts in the code collection for the contract with the name usingContractName
+    let contracts = cc ^. CC.contracts
+    let usingContracts = map (\y -> M.lookup y contracts) usingContractNames
+    let usingContracts' = catMaybes usingContracts
+    -- look throught the functions of each contract and find the one with the name usingFuncName
+    let usingFunctions = map (\y -> (^. CC.functions) y) usingContracts'
+    let theFunction = map (\y -> M.lookup usingFuncName y) usingFunctions
+    let theFunction' = catMaybes theFunction
+    let theFunction'' = case theFunction' of
+                          [] -> Nothing 
+                          (x:_) -> Just x -- big unknown if there are two functions with the same name
+    case theFunction'' of
+        Nothing -> return Nothing
+        (Just tf) -> do
+            -- add theFunction' to the current contract's functions
+            addFunctionToCurrentContractInCurrentCallInfo usingFuncName tf 
+
+            -- now we need to get the value of the firstArgVar and prepend it to the xs list
+            let x' = (CC.Variable (firstPos) firstArgVar)
+            let dummyAnnotation :: SourceAnnotation ()
+                dummyAnnotation =
+                    SourceAnnotation
+                    {
+                      _sourceAnnotationStart=SourcePosition {
+                        _sourcePositionName="",
+                        _sourcePositionLine=0,
+                        _sourcePositionColumn=0
+                        },
+                      _sourceAnnotationEnd=SourcePosition {
+                        _sourcePositionName="",
+                          _sourcePositionLine=0,
+                          _sourcePositionColumn=0
+                        },
+                      _sourceAnnotationAnnotation = ()
+                    }
+
+            theResult <- expToVar (CC.FunctionCall dummyAnnotation (CC.Variable dummyAnnotation usingFuncName) (CC.OrderedArgs (x' : xs))) 
+            removeFunctionFromCurrentContractInCurrentCallInfo usingFuncName
+            return $ Just theResult
+specialUsingChecker _ = return $ Nothing 
+
+
+
 
 -- --If given a list, apply a given function to only the first element of the list.
 -- mapOnFirst :: (a -> a) -> [a] -> [a]

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1634,7 +1634,93 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
 
       (SReference p, itemName) -> return . Constant . SReference $ apSnoc p $ MS.Field $ BC.pack $ labelToString itemName
       ((SUserDefined alias notSure actualType), "wrap") -> return . Constant $ (SUserDefined alias notSure actualType) -- return $ Constant . SUserDefined alias val actualType
-      m -> typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m)
+      -- This is for the case where we are using a using declartion such as 
+      {-
+      library SafeMath {
+          function add(uint a, uint b) returns (uint) {
+            return a + b;
+          }
+        }
+        contract qq {
+          using SafeMath for uint;
+          function useUsing(uint _x) returns (uint) {
+            return _x.add(1);
+          }
+          uint x = useUsing(3);
+        }
+    -}
+    -- we should get the using declartions from the current contract and then look through all contracts for the contract with the contratName in the Using
+    -- and the function name given by SomeString
+
+      (_, someString) -> do
+        ctrct <- getCurrentContract
+        let usingDeclsInContract = ctrct ^. CC.usings -- Map SolidString [UsingF]
+        let usingDecls = concat $ M.elems usingDeclsInContract
+        -- iterate through the list of using declartions and find ones that have the someString as a function name
+        (_, cc) <- getCurrentCodeCollection
+        -- get the usingContract name
+        let usingContractNames = map (\y -> y ^. CC.usingContract) usingDecls
+        -- search through the contracts in the code collection for the contract with the name usingContractName
+        let contracts = cc ^. CC.contracts
+        let usingContracts = map (\y -> M.lookup y contracts) usingContractNames
+        let usingContracts' = catMaybes usingContracts
+        -- look throught the functions of each contract and find the one with the name someString
+        let usingFunctions = map (\y -> (^. CC.functions) y) usingContracts'
+        let theFunction = map (\y -> M.lookup someString y) usingFunctions 
+        let theFunction' = catMaybes theFunction
+        if length theFunction' == 0 then
+          typeError ("illegal member access: function you are using, is not in a using claused library ") (x, someString)
+        else do
+            curAccount <- getCurrentAccount
+                        
+            let theFinalFunc = Constant $ SContractFunction (Just $ CC._contractName $ last usingContracts') (accountOnUnspecifiedChain $ curAccount) someString
+           
+        --(SBuiltinVariable "msg", "data") -> do
+        --        contract' <- getCurrentContract
+        --        functionName <- getCurrentFunctionName
+        --        callInfo <- getCurrentCallInfo
+        --        let argList = maybe [] CC._funcArgs $ contract' ^. CC.functions . at functionName
+        --            localVars = localVariables callInfo
+        --        argVals <- forM argList (\(n,_) -> getVar . snd $ localVars M.! (fromMaybe "" n))
+        --        argsToStr <- fmap (intercalate ", ") $ forM argVals showSM
+        --        return . Constant . SString $ "("++argsToStr++")"
+        --      (SBuiltinVariable "msg", "sig") -> do
+        --        functionName <- getCurrentFunctionName
+        --        contract' <- getCurrentContract
+        --        let argList = maybe [] CC._funcArgs $ contract' ^. CC.functions . at functionName
+        --            argTypesList = map (\(_, CC.IndexedType _ t) -> t) argList
+        --            argString = labelToString functionName++"("++intercalate "," (map unparseVarType argTypesList)++")"
+        --            calldataHash = fromMaybe emptyHash $ stringKeccak256 argString
+        --        return . Constant . SString $ take 8 $ keccak256ToHex calldataHash
+
+        --            callData <- getCallData
+        --            let theArgs = callData ^. CC.arguments
+        --            let theArgs' = argString : theArgs
+--            data CallInfo = CallInfo
+--              { currentFunctionName :: SolidString
+--              , currentAccount      :: Account
+--              , currentContract     :: CC.Contract
+--              , codeCollection      :: CC.CodeCollection
+--              , collectionHash      :: Keccak256
+--              , localVariables      :: Map SolidString (SVMType.Type, Variable)
+--              , variableStack       :: [Map SolidString (SVMType.Type, Variable)]
+--              , readOnly            :: Bool
+--              , isUncheckedSection  :: Bool -- TODO: Perform overflow/underflow checks for all arithmetic operations and revert if so, use this flag to disable checks
+--              , currentSourcePos    :: Maybe SourcePosition
+--              , isFreeFunction      :: Bool
+--              } deriving (Show)
+
+
+
+
+            -- now we add the argString to the front of the arguments
+            -- we need to get the arguments from the callInfo
+
+
+            return theFinalFunc
+
+        
+     -- m -> typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m ++ "with full exp" ++ show x)
 {-
     Variable vref -> do
       val' <- liftIO $ readIORef vref

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1498,10 +1498,6 @@ expToVar' (CC.MemberAccess _ (CC.FunctionCall x (CC.Variable _ "type") (CC.Order
   return $ Constant $ SString $ case M.lookup name $ cc ^. CC.contracts of-- (_contracts cc) of 
     Just contract -> unparseContract  contract;
     _ -> getRunTimeCodeError "Failed to get contract runtime code " x
--- case to catch _x.add(3) 
---expToVar' (CC.MemberAccess _ (CC.FunctionCall _ (CC.Variable _ name) (CC.OrderedArgs args)) _) = do
---  let args' = map expToPath args
---  return $ Constant $ SFunctionCall name args'
 expToVar' (CC.MemberAccess _ (CC.Variable _ "Util") "bytes32ToString") = do
   return $ Constant $ SHexDecodeAndTrim
 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1407,6 +1407,7 @@ expToPath x = todo "expToPath/unhandled" x
 
 expToVar :: MonadSM m => CC.Expression -> m Variable
 expToVar x = do
+  liftIO $ print $ T.pack $ "expToVar: " ++ show x
   v <- expToVar' x
   decrementGas 1
   return v
@@ -1451,7 +1452,6 @@ expToVar' (CC.PlusPlus _ e) = do
   value <- getInt var
 
   logAssigningVariable $ SInteger value
-
   setVar var $ SInteger $ value + 1
   return $ Constant $ SInteger value
 
@@ -1498,7 +1498,10 @@ expToVar' (CC.MemberAccess _ (CC.FunctionCall x (CC.Variable _ "type") (CC.Order
   return $ Constant $ SString $ case M.lookup name $ cc ^. CC.contracts of-- (_contracts cc) of 
     Just contract -> unparseContract  contract;
     _ -> getRunTimeCodeError "Failed to get contract runtime code " x
-
+-- case to catch _x.add(3) 
+--expToVar' (CC.MemberAccess _ (CC.FunctionCall _ (CC.Variable _ name) (CC.OrderedArgs args)) _) = do
+--  let args' = map expToPath args
+--  return $ Constant $ SFunctionCall name args'
 expToVar' (CC.MemberAccess _ (CC.Variable _ "Util") "bytes32ToString") = do
   return $ Constant $ SHexDecodeAndTrim
 
@@ -1634,93 +1637,9 @@ expToVar' x@(CC.MemberAccess _ expr name) = do
 
       (SReference p, itemName) -> return . Constant . SReference $ apSnoc p $ MS.Field $ BC.pack $ labelToString itemName
       ((SUserDefined alias notSure actualType), "wrap") -> return . Constant $ (SUserDefined alias notSure actualType) -- return $ Constant . SUserDefined alias val actualType
-      -- This is for the case where we are using a using declartion such as 
-      {-
-      library SafeMath {
-          function add(uint a, uint b) returns (uint) {
-            return a + b;
-          }
-        }
-        contract qq {
-          using SafeMath for uint;
-          function useUsing(uint _x) returns (uint) {
-            return _x.add(1);
-          }
-          uint x = useUsing(3);
-        }
-    -}
-    -- we should get the using declartions from the current contract and then look through all contracts for the contract with the contratName in the Using
-    -- and the function name given by SomeString
-
-      (_, someString) -> do
-        ctrct <- getCurrentContract
-        let usingDeclsInContract = ctrct ^. CC.usings -- Map SolidString [UsingF]
-        let usingDecls = concat $ M.elems usingDeclsInContract
-        -- iterate through the list of using declartions and find ones that have the someString as a function name
-        (_, cc) <- getCurrentCodeCollection
-        -- get the usingContract name
-        let usingContractNames = map (\y -> y ^. CC.usingContract) usingDecls
-        -- search through the contracts in the code collection for the contract with the name usingContractName
-        let contracts = cc ^. CC.contracts
-        let usingContracts = map (\y -> M.lookup y contracts) usingContractNames
-        let usingContracts' = catMaybes usingContracts
-        -- look throught the functions of each contract and find the one with the name someString
-        let usingFunctions = map (\y -> (^. CC.functions) y) usingContracts'
-        let theFunction = map (\y -> M.lookup someString y) usingFunctions 
-        let theFunction' = catMaybes theFunction
-        if length theFunction' == 0 then
-          typeError ("illegal member access: function you are using, is not in a using claused library ") (x, someString)
-        else do
-            curAccount <- getCurrentAccount
-                        
-            let theFinalFunc = Constant $ SContractFunction (Just $ CC._contractName $ last usingContracts') (accountOnUnspecifiedChain $ curAccount) someString
-           
-        --(SBuiltinVariable "msg", "data") -> do
-        --        contract' <- getCurrentContract
-        --        functionName <- getCurrentFunctionName
-        --        callInfo <- getCurrentCallInfo
-        --        let argList = maybe [] CC._funcArgs $ contract' ^. CC.functions . at functionName
-        --            localVars = localVariables callInfo
-        --        argVals <- forM argList (\(n,_) -> getVar . snd $ localVars M.! (fromMaybe "" n))
-        --        argsToStr <- fmap (intercalate ", ") $ forM argVals showSM
-        --        return . Constant . SString $ "("++argsToStr++")"
-        --      (SBuiltinVariable "msg", "sig") -> do
-        --        functionName <- getCurrentFunctionName
-        --        contract' <- getCurrentContract
-        --        let argList = maybe [] CC._funcArgs $ contract' ^. CC.functions . at functionName
-        --            argTypesList = map (\(_, CC.IndexedType _ t) -> t) argList
-        --            argString = labelToString functionName++"("++intercalate "," (map unparseVarType argTypesList)++")"
-        --            calldataHash = fromMaybe emptyHash $ stringKeccak256 argString
-        --        return . Constant . SString $ take 8 $ keccak256ToHex calldataHash
-
-        --            callData <- getCallData
-        --            let theArgs = callData ^. CC.arguments
-        --            let theArgs' = argString : theArgs
---            data CallInfo = CallInfo
---              { currentFunctionName :: SolidString
---              , currentAccount      :: Account
---              , currentContract     :: CC.Contract
---              , codeCollection      :: CC.CodeCollection
---              , collectionHash      :: Keccak256
---              , localVariables      :: Map SolidString (SVMType.Type, Variable)
---              , variableStack       :: [Map SolidString (SVMType.Type, Variable)]
---              , readOnly            :: Bool
---              , isUncheckedSection  :: Bool -- TODO: Perform overflow/underflow checks for all arithmetic operations and revert if so, use this flag to disable checks
---              , currentSourcePos    :: Maybe SourcePosition
---              , isFreeFunction      :: Bool
---              } deriving (Show)
-
-
-
-
-            -- now we add the argString to the front of the arguments
-            -- we need to get the arguments from the callInfo
-
-
-            return theFinalFunc
-
-        
-     -- m -> typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m ++ "with full exp" ++ show x)
+          
+       
+      m -> typeError ("illegal member access: "  ++ (unparseExpression x)) ("parsed as " ++ show m ++ "with full exp" ++ show x)
 {-
     Variable vref -> do
       val' <- liftIO $ readIORef vref
@@ -1906,6 +1825,54 @@ expToVar' (CC.ArrayExpression _ exps) = do
 expToVar' (CC.Ternary _ condition expr1 expr2) = do
   c <- getBool =<< expToVar condition
   expToVar $ if c then expr1 else expr2
+
+-- case to catch a using statement function like _x.add(3)
+expToVar' (CC.FunctionCall _ (CC.MemberAccess _ (CC.Variable firstPos firstArgVar) usingFuncName) (CC.OrderedArgs xs)) = do
+-- firstArgVar == "_x" and usingFuncName == "add" and xs == [NumberLiteral (line 11, column 19) - (line 11, column 20): ()  1 Nothing] 
+    ctrct <- getCurrentContract
+    
+    let usingDeclsInContract = ctrct ^. CC.usings -- Map SolidString [UsingF]
+    (_, cc) <- getCurrentCodeCollection
+    let usingDecls = concat $ M.elems usingDeclsInContract
+    -- iterate through the list of using declartions and find ones that have the someString as a function name
+    -- get the usingContract name
+    let usingContractNames = map (\y -> y ^. CC.usingContract) usingDecls
+    -- search through the contracts in the code collection for the contract with the name usingContractName
+    let contracts = cc ^. CC.contracts
+    let usingContracts = map (\y -> M.lookup y contracts) usingContractNames
+    let usingContracts' = catMaybes usingContracts
+    -- look throught the functions of each contract and find the one with the name usingFuncName
+    let usingFunctions = map (\y -> (^. CC.functions) y) usingContracts'
+    let theFunction = map (\y -> M.lookup usingFuncName y) usingFunctions
+    let theFunction' = catMaybes theFunction
+    let theFunction'' = case theFunction' of
+                          [] -> internalError "No function found" (firstArgVar, usingFuncName)
+                          (x:_) -> x -- big unknown if there are two functions with the same name
+    -- add theFunction' to the current contract's functions
+    addFunctionToCurrentContractInCurrentCallInfo usingFuncName theFunction''
+
+    -- now we need to get the value of the firstArgVar and prepend it to the xs list
+    let x' = (CC.Variable (firstPos) firstArgVar)
+    let dummyAnnotation :: SourceAnnotation ()
+        dummyAnnotation =
+            SourceAnnotation
+            {
+              _sourceAnnotationStart=SourcePosition {
+                _sourcePositionName="",
+                _sourcePositionLine=0,
+                _sourcePositionColumn=0
+                },
+              _sourceAnnotationEnd=SourcePosition {
+                _sourcePositionName="",
+                  _sourcePositionLine=0,
+                  _sourcePositionColumn=0
+                },
+              _sourceAnnotationAnnotation = ()
+            }
+
+    theResult <- expToVar (CC.FunctionCall dummyAnnotation (CC.Variable dummyAnnotation usingFuncName) (CC.OrderedArgs (x' : xs))) 
+    removeFunctionFromCurrentContractInCurrentCallInfo usingFuncName
+    return theResult
 
 expToVar' (CC.FunctionCall _ (CC.NewExpression _ SVMType.Bytes{}) (CC.OrderedArgs args)) = do
   case args of

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -409,6 +409,7 @@ getVariableOfName name = do
                                                 ,  CC._functions = M.empty
                                                 ,  CC._constructor = currentContract x^.CC.constructor
                                                 ,  CC._modifiers = M.empty
+                                                ,  CC._usings = M.empty
                                                 ,  CC._contractContext = currentContract x^.CC.contractContext
                                                 } 
                               }

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -39,6 +39,8 @@ module Blockchain.SolidVM.SM (
   getCurrentChainId,
   getCurrentFunctionName,
   getCurrentCodeCollection,
+  addFunctionToCurrentContractInCurrentCallInfo,
+  removeFunctionFromCurrentContractInCurrentCallInfo, 
   getEnv,
   getGasInfo,
   getVariableOfName,
@@ -666,6 +668,31 @@ setLocal name val = do
       newVariables = M.insert name (theType, val) locals
   Mod.put (Mod.Proxy @[CallInfo]) $ info{localVariables=newVariables} : rest
 
+addFunctionToCurrentContractInCurrentCallInfo :: MonadSM m => SolidString -> CC.Func -> m ()
+addFunctionToCurrentContractInCurrentCallInfo funcName funcObject = do
+    cs <- Mod.get (Mod.Proxy @[CallInfo])
+    case cs of
+        (currentCallInfo:_) -> do
+            let contract = currentContract currentCallInfo
+            -- _functions :: Map SolidString (FuncF a),
+                newContract = contract{CC._functions = M.insert funcName funcObject $ CC._functions contract} 
+            Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
+                [] -> internalError "addFunctionToCurrentContractInCurrentCallInfo called with an empty stack" ()
+                (ci:rest) -> pure $ ci{currentContract=newContract} : rest
+        _ -> internalError "addFunctionToCurrentContractInCurrentCallInfo called with an empty stack" ()
+
+removeFunctionFromCurrentContractInCurrentCallInfo :: MonadSM m => SolidString -> m ()
+removeFunctionFromCurrentContractInCurrentCallInfo funcName = do
+    cs <- Mod.get (Mod.Proxy @[CallInfo])
+    case cs of
+        (currentCallInfo:_) -> do
+            let contract = currentContract currentCallInfo
+            -- _functions :: Map SolidString (FuncF a),
+                newContract = contract{CC._functions = M.delete funcName $ CC._functions contract} 
+            Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
+                [] -> internalError "removeFunctionFromCurrentContractInCurrentCallInfo called with an empty stack" ()
+                (ci:rest) -> pure $ ci{currentContract=newContract} : rest
+        _ -> internalError "removeFunctionFromCurrentContractInCurrentCallInfo called with an empty stack" ()
 
 getCurrentCodeCollection :: MonadSM m => m (Keccak256, CC.CodeCollection)
 getCurrentCodeCollection = do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -410,6 +410,7 @@ getVariableOfName name = do
                                                 ,  CC._constructor = currentContract x^.CC.constructor
                                                 ,  CC._modifiers = M.empty
                                                 ,  CC._usings = M.empty
+                                                ,  CC._contractType = currentContract x^.CC.contractType
                                                 ,  CC._contractContext = currentContract x^.CC.contractContext
                                                 } 
                               }

--- a/strato/VM/SolidVM/solid-vm/src/SolidVM/CodeCollectionTools.hs
+++ b/strato/VM/SolidVM/solid-vm/src/SolidVM/CodeCollectionTools.hs
@@ -48,6 +48,7 @@ xabiToContract contractName' parents' userDefinedTypes xabi = do
   _events = Xabi._xabiEvents xabi,
   _functions = Xabi._xabiFuncs xabi,
   _modifiers = Xabi._xabiModifiers xabi,
+  _usings = Xabi._xabiUsing xabi,
   _constructor = constr,
   _contractContext = Xabi._xabiContext xabi
   }

--- a/strato/VM/SolidVM/solid-vm/src/SolidVM/CodeCollectionTools.hs
+++ b/strato/VM/SolidVM/solid-vm/src/SolidVM/CodeCollectionTools.hs
@@ -50,6 +50,10 @@ xabiToContract contractName' parents' userDefinedTypes xabi = do
   _modifiers = Xabi._xabiModifiers xabi,
   _usings = Xabi._xabiUsing xabi,
   _constructor = constr,
+  _contractType = case (Xabi._xabiKind xabi) of
+    Xabi.ContractKind -> ContractType
+    Xabi.LibraryKind  -> LibraryType
+    Xabi.InterfaceKind -> InterfaceType,
   _contractContext = Xabi._xabiContext xabi
   }
 

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -7077,7 +7077,7 @@ contract A {
 }
 
 contract qq {
-  constructor() public returns () {
+  constructor() public returns () { 
     A a = new A();
     a.f();
     return;
@@ -7096,4 +7096,42 @@ contract qq {
 }
 |] 
     getFields ["x"] `shouldReturn` [BString "0000000000000000000000000000000000000000000000000000000000000000"]
+
+  fit "can use using statement" . runTest $ do
+    runBS [r|
+
+library SafeMath {
+  function add(uint a, uint b) returns (uint) {
+    return a + b;
+  }
+}
+contract qq {
+  using SafeMath for uint;
+  function useUsing(uint _x) returns (uint) {
+    return _x.add(1);
+  }
+  uint x = useUsing(3);
+}
+|] 
+    getFields ["x"] `shouldReturn` [BInteger 4]
+
+
+  fit "can use libraries" . runTest $ do
+    runBS [r|
+
+library SafeMath {
+  function add(uint a, uint b) returns (uint) {
+    return a + b;
+  }
+}
+contract qq is SafeMath {
+  function useUsing(uint _x) returns (uint) {
+    return add(_x,1);
+  }
+  uint x = useUsing(3);
+}
+|] 
+    getFields ["x"] `shouldReturn` [BInteger 4]
+
+
 

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -39,7 +39,7 @@ import Data.Text.Encoding
 import Data.Time.Clock.POSIX
 import HFlags
 import qualified Numeric (readHex, showHex)
-import Test.Hspec (hspec, Spec, describe, xdescribe, it, xit, fit, pendingWith, anyException, shouldThrow, anyErrorCall, Selector)
+import Test.Hspec (hspec, Spec, describe, xdescribe, it, xit, pendingWith, anyException, shouldThrow, anyErrorCall, Selector)
 import Test.Hspec.Expectations.Lifted
 import Text.Printf
 import Text.RawString.QQ
@@ -7097,7 +7097,7 @@ contract qq {
 |] 
     getFields ["x"] `shouldReturn` [BString "0000000000000000000000000000000000000000000000000000000000000000"]
 
-  fit "can use using statement" . runTest $ do
+  it "can use using statement" . runTest $ do
     runBS [r|
 
 library SafeMath {
@@ -7116,7 +7116,7 @@ contract qq {
     getFields ["x"] `shouldReturn` [BInteger 4]
 
 
-  fit "can use libraries" . runTest $ do
+  it "can use libraries" . runTest $ do
     runBS [r|
 
 library SafeMath {

--- a/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
@@ -1362,7 +1362,7 @@ contract A {
     
     fit "Can typecheck `using` expressions" $
       let anns = runTypechecker [r|
-contract SafeMath {
+library SafeMath {
   function add(uint a, uint b) returns (uint) {
     return a + b;
   }

--- a/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
@@ -1359,3 +1359,18 @@ contract A {
   int endofunctor2   = type(A).delegatecall("garbage()");
 }
 |] in length anns `shouldBe` 1
+    
+    fit "Can typecheck `using` expressions" $
+      let anns = runTypechecker [r|
+contract SafeMath {
+  function add(uint a, uint b) returns (uint) {
+    return a + b;
+  }
+}
+contract A {
+  using SafeMath for uint;
+  function useUsing(uint _x) returns (uint) {
+    return _x.add(1);
+  }
+}
+|] in anns `shouldBe` []

--- a/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
@@ -1360,7 +1360,7 @@ contract A {
 }
 |] in length anns `shouldBe` 1
     
-    fit "Can typecheck `using` expressions" $
+    it "Can typecheck `using` expressions" $
       let anns = runTypechecker [r|
 library SafeMath {
   function add(uint a, uint b) returns (uint) {

--- a/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
@@ -9,6 +9,7 @@ module Bloc.XabiHelper
 import           BlockApps.Solidity.Parse.Parser
 
 
+import           Control.Arrow                             ((***))
 import           Data.Int                                  (Int32)
 import qualified Data.Map                                  as M
 import qualified Data.Text                                 as T
@@ -59,7 +60,7 @@ transFormXabi SVMXabi.Xabi{..} =
              , xabiModifiers = M.map tFormModifer $ M.mapKeysMonotonic T.pack _xabiModifiers
              , xabiEvents    = M.map tFormEv      $ M.mapKeysMonotonic T.pack _xabiEvents
              , xabiKind      = case _xabiKind of SVMXabi.ContractKind -> EVMXabi.ContractKind ; SVMXabi.InterfaceKind-> EVMXabi.InterfaceKind; SVMXabi.LibraryKind ->  EVMXabi.LibraryKind;
-             , xabiUsing     = M.map tFormUs _xabiUsing
+             , xabiUsing     = M.fromList . map (T.pack *** tFormUs) $ M.toList _xabiUsing
            }
 
 
@@ -135,8 +136,9 @@ tFormEv SolidEv.Event{..}= EVMXabi.Event {
 }
 
 
-tFormUs:: SVMXabi.Using ->  EVMXabi.Using
-tFormUs (SVMXabi.Using a _) = EVMXabi.Using a
+tFormUs:: [SVMXabi.Using] ->  EVMXabi.Using
+tFormUs [] = EVMXabi.Using $ "for nothing, apparently"
+tFormUs (SVMXabi.Using _ t _ : _) = EVMXabi.Using $ "for " ++ t -- weird legacy code
 
 
 tFormIndexedType :: CCVarfDef.IndexedType -> XabiType.IndexedType

--- a/strato/indexer/slipstream/src/Slipstream/XabiContract.hs
+++ b/strato/indexer/slipstream/src/Slipstream/XabiContract.hs
@@ -38,6 +38,7 @@ xabiToPartialContract xabi =
     _functions=error "_functions undefined",
     _constructor=error "_constructor undefined",
     _modifiers=error "_modifiers undefined",
+    _usings=error "_usings undefined",
     _contractContext=error "_contractContext undefined"
     }
 

--- a/strato/indexer/slipstream/src/Slipstream/XabiContract.hs
+++ b/strato/indexer/slipstream/src/Slipstream/XabiContract.hs
@@ -39,7 +39,8 @@ xabiToPartialContract xabi =
     _constructor=error "_constructor undefined",
     _modifiers=error "_modifiers undefined",
     _usings=error "_usings undefined",
-    _contractContext=error "_contractContext undefined"
+    _contractContext = error "_contractContext undefined",
+    _contractType = error "_contractType undefined"
     }
 
 evmEventToEvent :: OLDXABI.Event -> Event

--- a/strato/indexer/slipstream/tests/OutputDataSpec.hs
+++ b/strato/indexer/slipstream/tests/OutputDataSpec.hs
@@ -650,5 +650,6 @@ createDummyContract v =
       _functions=undefined,
       _constructor=undefined,
       _modifiers=undefined,
+      _usings=undefined,
       _contractContext=undefined
     }

--- a/strato/indexer/slipstream/tests/OutputDataSpec.hs
+++ b/strato/indexer/slipstream/tests/OutputDataSpec.hs
@@ -651,5 +651,6 @@ createDummyContract v =
       _constructor=undefined,
       _modifiers=undefined,
       _usings=undefined,
-      _contractContext=undefined
+      _contractContext=undefined,
+      _contractType=undefined
     }


### PR DESCRIPTION
This is for the case where we are using a using declaration such as 

```
      library SafeMath {
          function add(uint a, uint b) returns (uint) {
            return a + b;
          }
        }
        contract qq {
          using SafeMath for uint;
          function useUsing(uint _x) returns (uint) {
            return _x.add(1);
          }
          uint x = useUsing(3);
        }
```
    we should get the using declarations from the current contract and then look through all contracts for the contract with the contratName in the Using and the function name given by the second string