### PR TITLE
STRATO-3091 - add is_validator, validator_behavior fields to Prometheus & Apex

### DIFF
--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -75,15 +75,15 @@ isAuthorized iev = fmap (either AuthFailure (const AuthSuccess)) . runExceptT $ 
   doAuthn <- use productionAuth
   authenticated <- lift $ authenticate iev    --InEvent (benf is a (ChainMemberParsedSet, Bool,Int))
   let raiseInProd reason = when doAuthn $ do
-        $logWarnS "blockstanbul/auth" . T.pack $ reason 
+        $logWarnS "blockstanbul/auth" . T.pack $ reason
         throwE reason                  --debug statement?
-  unless authenticated $ do               
+  unless authenticated $ do
     raiseInProd $ "Rejecting inevent; message failed authentication: " ++ show iev
   authorize iev
   case iev of                         -- cases of valid and non valid input (for approval of messages and tx's?)
     -- TODO(tim): RoundChange a Preprepare correctly signed by the proposer,
     -- but with incorrect extraData.
-    IMsg _ (Preprepare _ pp) -> do     
+    IMsg _ (Preprepare _ pp) -> do
       vals <- use validators            -- this is _validators from bloctanbul context?
       let valSet = unChainMembers vals
       let payloadVals = getValidatorList pp  -- getvalslsit::Block -> [Address] to word256 x 2
@@ -136,7 +136,7 @@ roundChange = do
   nextView <- uses view (over round (+1))
   pendingRound .= Just (_round nextView)
   rawMsg <- createRoundChangeMessage nextView
-  valB <- use validatorBehavior
+  valB <- use isMirrorNode
   when (valB) $ do
     msg <- signMessage rawMsg
     yieldR msg
@@ -163,10 +163,10 @@ nextRound nt = do
       Nothing -> yieldR MakeBlockCommand
       Just lb -> do
         v <- use view
-        valB <- use validatorBehavior
+        valB <- use isMirrorNode
         when (valB) $ do
-          msg <- signMessage (Preprepare v lb) 
-          yieldR msg 
+          msg <- signMessage (Preprepare v lb)
+          yieldR msg
 
   prepared .= M.empty
   committed .= M.empty
@@ -176,6 +176,8 @@ nextRound nt = do
   hasCommitted .= False
   hasPrepared .= False
   pendingRound .= Nothing
+
+  isValidator .= (self `elem` vals)
 
   yieldR . NewCheckpoint =<< liftA2 Checkpoint (use view)
                                                (uses validators (S.toList . unChainMembers))
@@ -200,8 +202,8 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
    AuthSuccess -> case ev of
     ValidatorBehaviorChange vc -> do
       case vc of
-          ForcedValidator fv -> modify' $ validatorBehavior .~ fv
-      valB <- use validatorBehavior
+          ForcedValidator fv -> modify' $ isMirrorNode .~ fv
+      valB <- use isMirrorNode
       $logInfoLS "blockstanbul/ValidatorBehaviorChange" valB
     ValidatorChange val dir -> do
       modify' $ validators %~ (\(ChainMembers cm) ->
@@ -247,7 +249,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
       when (isNothing ppl && leader == self) $ do
         vs <- use validators
         let blockWithVs = addValidators vs blk
-        pseal <- proposerSeal blockWithVs 
+        pseal <- proposerSeal blockWithVs
         let sealedBlk = addProposerSeal pseal blockWithVs
         mLocked <- use blockLock
         let realSealed = fromMaybe sealedBlk mLocked
@@ -265,7 +267,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
           Right () -> do
             hasPreprepared .= True
             proposal .= Just realSealed
-            valB <- use validatorBehavior
+            valB <- use isMirrorNode
             when (valB) $ do
               msg <- signMessage (Preprepare v realSealed)
               yieldR msg
@@ -302,7 +304,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
                   wasProposed <- isJust <$> use proposal
                   unless wasProposed . yieldL $ OMsg auth ppp
                   proposal .= Just pp
-                  valB <- use validatorBehavior
+                  valB <- use isMirrorNode
                   when (valB) $ do
                     msg <- signMessage (Prepare v (blockHash pp))
                     yieldR msg
@@ -318,7 +320,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
         hasPrepared .= True
         setLock
         seal <- commitmentSeal di
-        valB <- use validatorBehavior
+        valB <- use isMirrorNode
         when (valB) $ do
           msg <- signMessage (Commit v di seal)
           yieldR msg
@@ -355,7 +357,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
           when (3 * sameRNCount > total && Just rn > sentRN) $ do
             pendingRound .= Just rn
             $logInfoS "blockstanbul/roundchange" "agreed change"
-            valB <- use validatorBehavior
+            valB <- use isMirrorNode
             when (valB) $ do
               msg <- signMessage rawMsg
               yieldR msg
@@ -428,7 +430,7 @@ sendMessages = fmap (map fromE) . sendMessages'
 sendAllMessages :: (MonadIO m, MonadLogger m, HasBlockstanbulContext m, HasVault m, A.Selectable Address X509CertInfoState m) => [InEvent] -> m [OutEvent]
 sendAllMessages wms = do
   eout <- sendMessages' wms
-  let out = fromE <$> eout 
+  let out = fromE <$> eout
   $logDebugS "sendAllMessages" . T.pack $ format out
   case mapMaybe loopback eout of
              [] -> return out
@@ -454,7 +456,7 @@ recordInEvent ev = let inc txt = liftIO $ withLabel inEventMetric txt incCounter
    ForcedConfigChange{} -> inc "forced_config_change"
    ValidatorBehaviorChange{} -> inc "validator_behavior_change"
    ValidatorChange{} -> inc "validator_change"
-   
+
 
 recordOutEvent :: (MonadIO m) => EOutEvent -> m ()
 recordOutEvent eev = let inc txt = liftIO $ withLabel outEventMetric txt incCounter

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -178,6 +178,7 @@ nextRound nt = do
   pendingRound .= Nothing
 
   isValidator .= (self `elem` vals)
+  use isValidator >>= recordValidator
 
   yieldR . NewCheckpoint =<< liftA2 Checkpoint (use view)
                                                (uses validators (S.toList . unChainMembers))

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -136,7 +136,7 @@ roundChange = do
   nextView <- uses view (over round (+1))
   pendingRound .= Just (_round nextView)
   rawMsg <- createRoundChangeMessage nextView
-  valB <- use isMirrorNode
+  valB <- use validatorBehavior
   when (valB) $ do
     msg <- signMessage rawMsg
     yieldR msg
@@ -163,7 +163,7 @@ nextRound nt = do
       Nothing -> yieldR MakeBlockCommand
       Just lb -> do
         v <- use view
-        valB <- use isMirrorNode
+        valB <- use validatorBehavior
         when (valB) $ do
           msg <- signMessage (Preprepare v lb)
           yieldR msg
@@ -203,8 +203,8 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
    AuthSuccess -> case ev of
     ValidatorBehaviorChange vc -> do
       case vc of
-          ForcedValidator fv -> modify' $ isMirrorNode .~ fv
-      valB <- use isMirrorNode
+          ForcedValidator fv -> modify' $ validatorBehavior .~ fv
+      valB <- use validatorBehavior
       $logInfoLS "blockstanbul/ValidatorBehaviorChange" valB
     ValidatorChange val dir -> do
       modify' $ validators %~ (\(ChainMembers cm) ->
@@ -268,7 +268,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
           Right () -> do
             hasPreprepared .= True
             proposal .= Just realSealed
-            valB <- use isMirrorNode
+            valB <- use validatorBehavior
             when (valB) $ do
               msg <- signMessage (Preprepare v realSealed)
               yieldR msg
@@ -305,7 +305,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
                   wasProposed <- isJust <$> use proposal
                   unless wasProposed . yieldL $ OMsg auth ppp
                   proposal .= Just pp
-                  valB <- use isMirrorNode
+                  valB <- use validatorBehavior
                   when (valB) $ do
                     msg <- signMessage (Prepare v (blockHash pp))
                     yieldR msg
@@ -321,7 +321,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
         hasPrepared .= True
         setLock
         seal <- commitmentSeal di
-        valB <- use isMirrorNode
+        valB <- use validatorBehavior
         when (valB) $ do
           msg <- signMessage (Commit v di seal)
           yieldR msg
@@ -358,7 +358,7 @@ eventLoop ctx = execStateC ctx $ awaitForever $ \ev -> do
           when (3 * sameRNCount > total && Just rn > sentRN) $ do
             pendingRound .= Just rn
             $logInfoS "blockstanbul/roundchange" "agreed change"
-            valB <- use isMirrorNode
+            valB <- use validatorBehavior
             when (valB) $ do
               msg <- signMessage rawMsg
               yieldR msg

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -178,7 +178,6 @@ nextRound nt = do
   pendingRound .= Nothing
 
   isValidator .= (self `elem` vals)
-  use isValidator >>= recordValidator
 
   yieldR . NewCheckpoint =<< liftA2 Checkpoint (use view)
                                                (uses validators (S.toList . unChainMembers))
@@ -423,6 +422,9 @@ sendMessages' wms = do
                            .| iterMC ($logDebugS "blockstanbul/OutEvent" . T.pack . format . fromE))
       (ctx', evs) <- runConduit $ fuseBoth base sinkList
       putBlockstanbulContext ctx'
+
+      recordValidator (_isValidator ctx') (_validatorBehavior ctx')
+
       return evs
 
 sendMessages :: (MonadIO m, MonadLogger m, HasBlockstanbulContext m, HasVault m, A.Selectable Address X509CertInfoState m) => [InEvent] -> m [OutEvent]

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
@@ -37,7 +37,7 @@ recordView View{..} = liftIO $ do
 {-# NOINLINE validatorView #-}
 validatorView :: Vector Text Gauge
 validatorView = unsafeRegister
-              . vector "validator_view"
+              . vector "view_field"
               . gauge
               $ Info "pbft_current_view" "The validator status of this node (1.0 = validator, 0.0 = non-validator))"
 

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
@@ -41,9 +41,11 @@ validatorView = unsafeRegister
               . gauge
               $ Info "pbft_current_view" "The validator status of this node (1.0 = validator, 0.0 = non-validator))"
 
-recordValidator :: MonadIO m => Bool -> m ()
-recordValidator b = liftIO $ do
-  let b' = if b then 1 else 0 in withLabel validatorView "is_validator" (`setGauge` b')
+recordValidator :: MonadIO m => Bool -> Bool -> m ()
+recordValidator iv vb = liftIO $ do
+  let f b = if b then 1 else 0
+  withLabel validatorView "is_validator" (`setGauge` (f iv))
+  withLabel validatorView "validator_behavior" (`setGauge` (f vb))
 
 {-# NOINLINE authResults #-}
 authResults :: Vector Text Counter

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Metrics.hs
@@ -34,6 +34,17 @@ recordView View{..} = liftIO $ do
   withLabel currentView "round_number" (flip setGauge . fromIntegral $ _round)
   withLabel currentView "sequence_number" (flip setGauge . fromIntegral $ _sequence)
 
+{-# NOINLINE validatorView #-}
+validatorView :: Vector Text Gauge
+validatorView = unsafeRegister
+              . vector "validator_view"
+              . gauge
+              $ Info "pbft_current_view" "The validator status of this node (1.0 = validator, 0.0 = non-validator))"
+
+recordValidator :: MonadIO m => Bool -> m ()
+recordValidator b = liftIO $ do
+  let b' = if b then 1 else 0 in withLabel validatorView "is_validator" (`setGauge` b')
+
 {-# NOINLINE authResults #-}
 authResults :: Vector Text Counter
 authResults = unsafeRegister

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/StateMachine.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/StateMachine.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Blockchain.Blockstanbul.StateMachine where 
+module Blockchain.Blockstanbul.StateMachine where
 
 
 import           Conduit
@@ -76,7 +76,9 @@ data BlockstanbulContext = BlockstanbulContext {
   -- TODO(tim): Initialize _lastParent with the genesis block and
   -- make it required
   , _lastParent :: Maybe Keccak256
-  , _validatorBehavior :: Bool
+  -- Validator characteristics
+  , _isMirrorNode :: Bool
+  , _isValidator :: Bool
 }
 makeLenses ''BlockstanbulContext
 
@@ -93,6 +95,7 @@ debugShowCtx = do
   infoLog "showctx/mBlockNumber" proposal (show . fmap (blockDataNumber . blockBlockData))
   infoLog "showctx/mLockedBlockNo" blockLock (show . fmap (blockDataNumber . blockBlockData))
   infoLog "showctx/mLockedSender" lockSender (show . fmap format)
+  infoLog "showctx/isValidator" isValidator show
   debugLog "showctx/prepared" prepared show
   debugLog "showctx/committed" committed show
   debugLog "showctx/hasPrepared" hasPrepared show
@@ -119,7 +122,8 @@ newContext (Checkpoint v as) chainm valB =
      , _blockLock = Nothing
      , _lockSender = Nothing
      , _lastParent = Nothing
-     , _validatorBehavior = valB
+     , _isMirrorNode = valB
+     , _isValidator = False
      }
 
 generateNonceMap :: [ChainMemberParsedSet] -> M.Map ChainMemberParsedSet Int

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/StateMachine.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/StateMachine.hs
@@ -77,7 +77,7 @@ data BlockstanbulContext = BlockstanbulContext {
   -- make it required
   , _lastParent :: Maybe Keccak256
   -- Validator characteristics
-  , _isMirrorNode :: Bool
+  , _validatorBehavior :: Bool
   , _isValidator :: Bool
 }
 makeLenses ''BlockstanbulContext
@@ -122,7 +122,7 @@ newContext (Checkpoint v as) chainm valB =
      , _blockLock = Nothing
      , _lockSender = Nothing
      , _lastParent = Nothing
-     , _isMirrorNode = valB
+     , _validatorBehavior = valB
      , _isValidator = False
      }
 

--- a/strato/core/strato-sequencer/exec-src/Main.hs
+++ b/strato/core/strato-sequencer/exec-src/Main.hs
@@ -56,7 +56,7 @@ main = do
   putStrLn $ "strato-sequencer network: " ++ show flags_network
   putStrLn $ "strato-sequencer validators: " ++ show validators
   putStrLn $ "strato-sequencer vault-proxy URL: " ++ show flags_vaultWrapperUrl
-  putStrLn $ "strato-sequencer isMirrorNode: " ++ show flags_validatorBehavior
+  putStrLn $ "strato-sequencer validatorBehavior: " ++ show flags_validatorBehavior
   putStrLn $ "strato-sequencer certInfo: " ++ show flags_certInfo
 
   pkg <- atomically newCablePackage

--- a/strato/core/strato-sequencer/exec-src/Main.hs
+++ b/strato/core/strato-sequencer/exec-src/Main.hs
@@ -40,7 +40,7 @@ waitOnVault action = do
   putStrLn "asking vault-proxy for the node address"
   res <- action
   case res of
-    Left err -> do 
+    Left err -> do
       putStrLn $ "failed to get node address from vault-proxy... got this error: " ++ show err
       threadDelay 2000000 -- 2 seconds
       waitOnVault action
@@ -56,7 +56,7 @@ main = do
   putStrLn $ "strato-sequencer network: " ++ show flags_network
   putStrLn $ "strato-sequencer validators: " ++ show validators
   putStrLn $ "strato-sequencer vault-proxy URL: " ++ show flags_vaultWrapperUrl
-  putStrLn $ "strato-sequencer validatorBehavior: " ++ show flags_validatorBehavior
+  putStrLn $ "strato-sequencer isMirrorNode: " ++ show flags_validatorBehavior
   putStrLn $ "strato-sequencer certInfo: " ++ show flags_certInfo
 
   pkg <- atomically newCablePackage
@@ -71,7 +71,7 @@ main = do
         , kafkaConsumerGroup = EC.lookupConsumerGroup kafkaClientId'
         , cablePackage = pkg
         }
-  
+
   -- setup the connection with vault-proxy
   mgr <- newManager defaultManagerSettings
   vaultWrapperUrl <- parseBaseUrl flags_vaultWrapperUrl

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -344,7 +344,7 @@ instance (Word256 `A.Alters` ChainIdEntry) SequencerM where
     sz <- M.size <$> use chainIdRegistry
     liftIO $ withLabel chainIdRegistrySize "chain_id_registry" (flip setGauge (fromIntegral sz))
 
-instance (Address `A.Alters` X509CertInfoState) SequencerM where 
+instance (Address `A.Alters` X509CertInfoState) SequencerM where
   lookup = genericLookupSequencer x509certInfoState
   insert p k v = do
     genericInsertSequencer x509certInfoState p k v
@@ -355,7 +355,7 @@ instance (Address `A.Alters` X509CertInfoState) SequencerM where
     sz <- M.size <$> use x509certInfoState
     liftIO $ withLabel x509CertInfoStateRegistrySize "X509CertInfoState_registry" (flip setGauge (fromIntegral sz))
 
-instance A.Selectable Address X509CertInfoState SequencerM where 
+instance A.Selectable Address X509CertInfoState SequencerM where
   select = A.lookup
 
 instance (Keccak256 `A.Alters` DependentBlockEntry) SequencerM where
@@ -371,11 +371,6 @@ instance (Keccak256 `A.Alters` DependentBlockEntry) SequencerM where
     modify' $ dbeRegistry . at k .~ Nothing
     addLdbBatchOps . (:[]) $ genericBatchDeleteDependentBlockDB k
 
--- instance ((OrgName, OrgUnit) `A.Alters` Word256) SequencerM where
---   -- TODO: Just using this to sneak past the compiler... actually completethese these out
---   lookup _ _ = pure (Just $ bytesToWord256 $ C8.pack "deadbeef" )
---   insert _ _ _ = pure ()
---   delete _ _ = pure ()
 
 instance A.Selectable Word256 ParentChainIds SequencerM where
   select _ cId = join . fmap (fmap (ParentChainIds . parentChains . chainInfo) . _chainIdInfo) <$> A.lookup (A.Proxy @ChainIdEntry) cId
@@ -413,8 +408,8 @@ instance HasBlockstanbulContext SequencerM where
   putBlockstanbulContext = modify' . (.~) (blockstanbulContext . _Just)
 
 
--- If there is no vault client (i.e. in hspec tests), the HasVault instance will use this key, 
--- I know, it's ugly...the SequencerSpec test uses SequencerM itself, so this was a lot 
+-- If there is no vault client (i.e. in hspec tests), the HasVault instance will use this key,
+-- I know, it's ugly...the SequencerSpec test uses SequencerM itself, so this was a lot
 -- easier than making a whole new SequencerM definition just to get a different HasVault instance
 testPriv :: PrivateKey
 testPriv = fromMaybe (error "could not import private key") (importPrivateKey (LabeledError.b16Decode "testPriv" $ C8.pack $ "09e910621c2e988e9f7f6ffcd7024f54ec1461fa6e86a4b545e9e1fe21c28866"))


### PR DESCRIPTION
 To display a node's validator status in CMD, I've added a field in the Prometheus metrics that can keep track if a node is a validator on their network or not. 

For every Sequencer iteration, the node will check if itself is in the list of network validators. For `true` this yields 1, `false` yields 0. This can also be used to keep a timeline of a validator's status. 

The `/apex-api/status` endpoint will return this value in the `pbftData.is_validator` field which the CMD will be able to use to identify a validator in the UI.

(7/6) Added the `validator_behavior` field which indicates if a node is using validator functionality.