### PR TITLE
Fixed a lot of things with Cirrus event tables

### DIFF
--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -33,7 +33,6 @@ import qualified Data.Map                              as M
 import           Data.Maybe
 import           Data.Proxy
 import qualified Data.Set                              as S
-import qualified Data.Sequence                         as Seq
 import qualified Data.Text                             as T
 import           Data.Traversable                      (for)
 import           Debugger
@@ -548,9 +547,7 @@ logEventSummaries events = do
 
 sendOutEvent :: VmOutEvent ->  ConduitT VmOutEvent TransactionResult ContextM ()
 sendOutEvent (OutAction act) =
-  let filterOutEvents :: Action -> Action
-      filterOutEvents x = x{Action._events=Seq.empty}
-      extractCodeCollectionAddedMessages :: Action -> Maybe VMEvent
+  let extractCodeCollectionAddedMessages :: Action -> Maybe VMEvent
       extractCodeCollectionAddedMessages a =
         case (join $ fmap (M.lookup "src") $ a^.Action.metadata,
               join $ fmap (M.lookup "name") $ a^.Action.metadata,
@@ -573,9 +570,8 @@ sendOutEvent (OutAction act) =
             }
           _ -> Nothing
       ccEvents = maybeToList $ extractCodeCollectionAddedMessages act
-      eventEvents = map EventEmitted . toList $ Action._events act
-      actionEvents = [NewAction $ filterOutEvents act]
-   in void . produceVMEvents $ ccEvents ++ eventEvents ++ actionEvents
+      actionEvents = [NewAction act]
+   in void . produceVMEvents $ ccEvents ++ actionEvents
 sendOutEvent (OutIndexEvent e) = void . K.withKafkaRetry1s $ writeIndexEvents [e]
 sendOutEvent (OutToStateDiff cId cInfo bHash org app) = lift . withCurrentBlockHash bHash $ initializeChainDBs (Just cId) cInfo org app
 sendOutEvent (OutStateDiff diff) = lift $ commitSqlDiffs diff

--- a/strato/core/vm-tools/src/Blockchain/Stream/VMEvent.hs
+++ b/strato/core/vm-tools/src/Blockchain/Stream/VMEvent.hs
@@ -43,7 +43,6 @@ import           BlockApps.Logging
 import           Blockchain.Data.TransactionResult
 import           Blockchain.EthConf
 import           Blockchain.Strato.Model.CodePtr
-import           Blockchain.Strato.Model.Event
 import           Blockchain.Stream.Action (Action)
 import           Blockchain.KafkaTopics
 import           Blockchain.MilenaTools
@@ -54,7 +53,6 @@ import           Text.Tools
 
 data VMEvent =
   NewAction Action |
-  EventEmitted Event |
   CodeCollectionAdded {
     ccString :: Text,
     codePtr :: CodePtr,
@@ -77,7 +75,6 @@ vmType (CodeAtAccount _ _) = "CodeAtAccount"
 
 instance Format VMEvent where
   format (NewAction a) = "NewAction:\n" ++ tab (format a)
-  format (EventEmitted e) = "EventEmitted:\n" ++ tab (format e)
   format (CodeCollectionAdded c cp o a hl rm) =
     "CodeCollectionAdded: (" ++ show o ++ "/" ++ show a ++ ") " ++ vmType cp
     ++ (if (not $ null hl) then " " ++ show hl else "")

--- a/strato/indexer/slipstream/src/Slipstream/Data/Action.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Data/Action.hs
@@ -24,6 +24,7 @@ import           Data.Time
 import           GHC.Generics
 
 import           Blockchain.Strato.Model.Account
+import           Blockchain.Strato.Model.Event
 import           Blockchain.Strato.Model.CodePtr
 import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.Stream.Action (Action)
@@ -43,6 +44,15 @@ data AggregateAction = AggregateAction
   , actionStorage        :: Action.DataDiff
   , actionType           :: Action.CallType
   , actionMetadata       :: Map Text Text
+  } deriving (Show, Generic, NFData)
+
+data AggregateEvent = AggregateEvent
+  { eventBlockHash      :: Keccak256
+  , eventBlockTimestamp :: UTCTime
+  , eventBlockNumber    :: Integer
+  , eventTxHash         :: Keccak256
+  , eventTxSender       :: Account
+  , eventEvent          :: Event
   } deriving (Show, Generic, NFData)
 
 

--- a/strato/indexer/slipstream/src/Slipstream/Events.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Events.hs
@@ -15,7 +15,6 @@ import qualified BlockApps.Solidity.Value as V
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.CodePtr
 import           Blockchain.Strato.Model.Keccak256
-import           Slipstream.Data.Globals
 
 type StateRoot = Text
 
@@ -35,13 +34,3 @@ data ProcessedContract = ProcessedContract
   , transactionSender :: Address
   , contractData      :: Map Text V.Value
   } deriving (Show)
-
-data EventTable = EventTable
-  { eventOrganization :: Text
-  , eventApplication  :: Text
-  , eventContractName :: Text
-  , eventName         :: Text
-  , eventFields       :: TableColumns
-  } deriving (Show)
-
-

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -864,7 +864,7 @@ createEventTable globalsIORef (o, a, n) evName ev = do
 
   eventAlreadyCreated <- isTableCreated globalsIORef eventTable
   unless eventAlreadyCreated $ do
-    setTableCreated globalsIORef eventTable $ fst <$> ev ^. eventLogs
+    setTableCreated globalsIORef eventTable $ fst <$> fillFirstEmptyEntries (ev ^. eventLogs)
     yield $ createEventTableQuery eventTable ev
 
 createEventTableQuery :: TableName -> Event -> Text

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -14,7 +14,7 @@ module Slipstream.OutputData (
   outputData',
   OutputM,
   ProcessedMappingRow(..),
-  insertExpandEventTables,
+  insertEventTables,
   insertIndexTable,
   insertForeignKeys,
   insertMappingTable,
@@ -22,7 +22,7 @@ module Slipstream.OutputData (
   createMappingTable,
   createHistoryTable,
   insertHistoryTable,
-  createEventTables,
+  createExpandEventTables,
   createExpandIndexTable,
   createForeignIndexesForJoins,
   notifyPostgREST,
@@ -36,10 +36,11 @@ import           Conduit
 import           Control.Lens ((^.))
 import           Control.Monad
 import           Data.Aeson                      (encode)
+import           Data.Bifunctor                  (first)
 import qualified Data.ByteString.Char8           as BC
 import qualified Data.ByteString                 as B
 import qualified Data.ByteString.Lazy            as BL
-import qualified Data.Map                        as Map
+import qualified Data.Map.Strict                 as Map
 import           Data.Maybe                      (catMaybes, listToMaybe, mapMaybe)
 import           Data.Text                       (Text)
 import qualified Data.Text                       as T
@@ -51,6 +52,7 @@ import qualified Data.ByteString.Base16          as Base16
 import           Database.PostgreSQL.Typed
 import           Database.PostgreSQL.Typed.Protocol
 import           Database.PostgreSQL.Typed.Query
+import           Text.Format
 import           Text.Printf
 import           Text.RawString.QQ
 import           UnliftIO.IORef
@@ -58,21 +60,28 @@ import           UnliftIO.Exception              (handle, catch, SomeException)
 
 import           Bloc.Server.Utils   (partitionWith)
 import           BlockApps.Logging
+import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import qualified Blockchain.Strato.Model.Event   as Action
 import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.Strato.Model.CodePtr
 import qualified BlockApps.Solidity.Value as V
 
+import           Slipstream.Data.Action
 import qualified Slipstream.Events as E
 import           Slipstream.Globals
 import           Slipstream.Metrics
 import           Slipstream.Options
 import           Slipstream.SolidityValue
 
-import           SolidVM.Model.CodeCollection              hiding (contractName, contracts, events)
+import           SolidVM.Model.CodeCollection              hiding (contractName, contracts)
 import           SolidVM.Model.SolidString
 import qualified SolidVM.Model.Type         as SVMType
+
+newtype First b a = First { unFirst :: (a,b) }
+
+instance Functor (First b) where
+  fmap f (First (a,b)) = First (f a, b)
 
 data ProcessedMappingRow = ProcessedMappingRow
   { address           :: Address
@@ -139,8 +148,15 @@ escapeDoubleQuotes = T.replace "\"" "\\\""
 escapeQuotes :: Text -> Text
 escapeQuotes = escapeSingleQuotes . escapeDoubleQuotes
 
-tableColumns :: [(Text, VariableDeclF a)] -> TableColumns
-tableColumns = mapMaybe go
+fillEmptyEntries :: Functor f => [f Text] -> [f Text]
+fillEmptyEntries = zipWith go [(1 :: Int)..]
+  where go i = fmap (\t -> if T.null t then "val_" <> tshow i else t)
+
+fillFirstEmptyEntries :: [(Text, a)] -> [(Text, a)]
+fillFirstEmptyEntries = map unFirst . fillEmptyEntries . map First 
+
+tableColumns :: [(Text, SVMType.Type)] -> TableColumns
+tableColumns = mapMaybe go . fillFirstEmptyEntries
   where go (x,y) =
           case solidityTypeToSQLType y of
             Nothing -> Nothing
@@ -151,9 +167,9 @@ tableColumns = mapMaybe go
 partialParseTableColumns :: TableColumns -> [Text]
 partialParseTableColumns = concat . mapM (fmap unwrapDoubleQuotes . listToMaybe . T.words)
 
-makeAccount :: E.ProcessedContract -> Text
-makeAccount E.ProcessedContract{chain="", address=addr} = tshow $ addr
-makeAccount E.ProcessedContract{chain=chain, address=addr} = T.concat [
+makeAccount :: Text -> Address -> Text
+makeAccount "" addr = tshow $ addr
+makeAccount chain addr = T.concat [
   tshow $ addr,
   ":",
   chain
@@ -399,7 +415,7 @@ createIndexTable globalsIORef contract (o, a, n) = do
   else do
     incNumTables
     yield $ createIndexTableQuery contract (o, a, n)
-    let list = tableColumns $ map (\(x, y) -> (labelToText x, y)) $ Map.toList $ contract^.storageDefs
+    let list = tableColumns $ map (\(x, y) -> (labelToText x, y ^. varType)) $ Map.toList $ contract^.storageDefs
     setTableCreated globalsIORef tableName list
     return $ getDeferredForeignKeys tableName contract o a
 
@@ -436,7 +452,7 @@ createHistoryTable' globalsIORef contract (o, a, n) = do
     incNumHistoryTables
     yield $ ((createHistoryTableQuery contract (o, a, n)), Nothing)
     yieldMany $ map (\x -> (x, Nothing)) (addHistoryUnique (o, a, n))
-    let list = tableColumns $ map (\(x, y) -> (labelToText x, y)) $ Map.toList $ contract^.storageDefs
+    let list = tableColumns $ map (\(x, y) -> (labelToText x, y ^. varType)) $ Map.toList $ contract^.storageDefs
     setTableCreated globalsIORef tableName list
 
 
@@ -457,7 +473,7 @@ createHistoryTable globalsIORef contract (o, a, n) = do
     incNumHistoryTables
     yield $ createHistoryTableQuery contract (o, a, n)
     yieldMany $ addHistoryUnique (o, a, n)
-    let list = tableColumns $ map (\(x, y) -> (labelToText x, y)) $ Map.toList $ contract^.storageDefs
+    let list = tableColumns $ map (\(x, y) -> (labelToText x, y ^. varType)) $ Map.toList $ contract^.storageDefs
     setTableCreated globalsIORef tableName list
 
 
@@ -497,7 +513,7 @@ expandContractTable' globalsIORef contract tableName = do
           ]
       return []
     Just cols -> do
-      let list = Map.toList $ Map.mapKeys labelToText $ contract^.storageDefs
+      let list = fillFirstEmptyEntries . map (fmap _varType) . Map.toList $ Map.mapKeys labelToText $ contract^.storageDefs
           difference new old = filter ((`notElem` old) . fst) new
           extras = difference list (partialParseTableColumns cols)
           extraTableColumns = tableColumns extras
@@ -515,7 +531,7 @@ expandContractTable' globalsIORef contract tableName = do
         case tableName of
           IndexTableName o a n ->
             flip map
-            [(colName, foreignName) | (colName, VariableDecl{_varType=SVMType.Contract foreignName}) <- extras] $ \(colName, foreignName) ->
+            [(colName, foreignName) | (colName, SVMType.Contract foreignName) <- extras] $ \(colName, foreignName) ->
             ForeignKeyInfo {
               tableName = tableName,
               columnName = colName,
@@ -541,7 +557,7 @@ expandContractTable globalsIORef contract tableName = do
           ]
       return []
     Just cols -> do
-      let list = Map.toList $ Map.mapKeys labelToText $ contract^.storageDefs
+      let list = fillFirstEmptyEntries . map (fmap _varType) . Map.toList $ Map.mapKeys labelToText $ contract^.storageDefs
           difference new old = filter ((`notElem` old) . fst) new
           extras = difference list (partialParseTableColumns cols)
           extraTableColumns = tableColumns extras
@@ -559,7 +575,7 @@ expandContractTable globalsIORef contract tableName = do
         case tableName of
           IndexTableName o a n ->
             flip map
-            [(colName, foreignName) | (colName, VariableDecl{_varType=SVMType.Contract foreignName}) <- extras] $ \(colName, foreignName) ->
+            [(colName, foreignName) | (colName, SVMType.Contract foreignName) <- extras] $ \(colName, foreignName) ->
             ForeignKeyInfo {
               tableName = tableName,
               columnName = colName,
@@ -617,7 +633,7 @@ insertForeignKeys conn contracts = do
             "=" <>
             wrapSingleQuotes (escapeQuotes $ T.pack $ show acct) <>
             " WHERE record_id=" <>
-            wrapSingleQuotes (makeAccount c)  <>
+            wrapSingleQuotes (makeAccount (E.chain c) (E.address c)) <>
             ";"
       `catch` \(e :: SomeException) -> do
             $logInfoS "insertHistoryTable" $ T.pack $ "foreign key update failed, value will be set to null: " ++ show e
@@ -627,7 +643,7 @@ insertForeignKeys conn contracts = do
               " SET " <>
               wrapDoubleQuotes theName <>
               "=null WHERE record_id=" <>
-              wrapSingleQuotes (makeAccount c)
+              wrapSingleQuotes (makeAccount (E.chain c) (E.address c))
 
 insertHistoryTable :: OutputM m
                    => [E.ProcessedContract]
@@ -648,7 +664,7 @@ createIndexTableQuery contract (o, a, n) =
    in T.concat
         [ "CREATE TABLE IF NOT EXISTS " , tableNameToDoubleQuoteText tableName , " ("
         , csv $ ["record_id text", "address text", "\"chainId\" text", "block_hash text", "block_timestamp text",
-               "block_number text", "transaction_hash text", "transaction_sender text"] ++ tableColumns (map (\(x, y) -> (labelToText x, y)) list)
+               "block_number text", "transaction_hash text", "transaction_sender text"] ++ tableColumns (map (\(x, y) -> (labelToText x, y ^. varType)) list)
         , ",\n  PRIMARY KEY (record_id) );"
         ]
 
@@ -670,7 +686,7 @@ createHistoryTableQuery contract (o, a, n) =
         [ "CREATE TABLE IF NOT EXISTS ", tableNameToDoubleQuoteText tableName, " ("
         , csv $ ["record_id text", "address text NOT NULL", "\"chainId\" text NOT NULL", "block_hash text NOT NULL", "block_timestamp text",
                  "block_number text", "transaction_hash text NOT NULL", "transaction_sender text"]
-                 ++ tableColumns (map (\(x, y) -> (labelToText x, y)) list)
+                 ++ tableColumns (map (\(x, y) -> (labelToText x, y ^. varType)) list)
         , ");"
         ]
 
@@ -703,7 +719,7 @@ insertIndexTableQuery cs = concat $
                   (E.application x)
                   (E.contractName x)
               keySt  = wrapAndEscapeDouble . map escapeQuotes $ baseTableColumns ++ map fst list
-              baseVals = [ makeAccount
+              baseVals = [ \c -> makeAccount (E.chain c) (E.address c)
                          , tshow . E.address
                          , E.chain
                          , T.pack . keccak256ToHex . E.blockHash
@@ -749,7 +765,7 @@ insertMappingTableQuery ms = concat $
                   (application x)
                   (contractname x)
                   (mapname x)
-              keySt  = wrapAndEscapeDouble . map escapeQuotes $ baseMappingTableColumns ++ map fst list
+              keySt  = wrapAndEscapeDouble . map escapeQuotes $ baseMappingTableColumns ++ map fst (fillFirstEmptyEntries list)
               baseVals = [ makeAccountM
                          , tshow . address
                          , chain
@@ -798,8 +814,8 @@ insertHistoryTableQuery cs = concat $
                   (E.organization x)
                   (E.application x)
                   (E.contractName x)
-              keySt  = wrapAndEscapeDouble . map escapeQuotes $ baseTableColumns ++ map fst list
-              baseVals = [ makeAccount
+              keySt  = wrapAndEscapeDouble . map escapeQuotes $ baseTableColumns ++ map fst (fillFirstEmptyEntries list)
+              baseVals = [ \c -> makeAccount (E.chain c) (E.address c)
                          , tshow . E.address
                          , E.chain
                          , T.pack . keccak256ToHex . E.blockHash
@@ -825,73 +841,53 @@ insertHistoryTableQuery cs = concat $
 
 -- Creates tables for all event declarations, stores table name in
 -- globals{createdEvents}
-createEventTables :: OutputM m
-                  => IORef Globals
-                  -> [E.EventTable]
-                  -> ConduitM () Text m ()
-createEventTables globalsIORef events = do
-  yieldMany . catMaybes =<< lift (mapM (createEventTable globalsIORef) events)
+createExpandEventTables :: OutputM m
+                        => IORef Globals
+                        -> Contract
+                        -> (Text, Text, Text)
+                        -> ConduitM () Text m ()
+createExpandEventTables globalsIORef c nameParts = mapM_ go . Map.toList $ c ^. events
+  where go (evName, ev) = do
+          createEventTable globalsIORef nameParts evName ev
+          expandEventTable globalsIORef nameParts evName ev
+          
 
 createEventTable :: OutputM m
                  => IORef Globals
-                 -> E.EventTable
-                 -> m (Maybe Text)
-createEventTable globalsIORef ev = do
-  let (org, app, cname) = constructTableNameParameters
-          (E.eventOrganization ev)
-          (E.eventApplication ev)
-          (E.eventContractName ev)
-      eventTable = EventTableName org app cname (escapeQuotes $ E.eventName ev)
+                 -> (Text, Text, Text)
+                 -> SolidString
+                 -> Event
+                 -> ConduitM () Text m ()
+createEventTable globalsIORef (o, a, n) evName ev = do
+  let (org, app, cname) = constructTableNameParameters o a n
+      eventTable = EventTableName org app cname (escapeQuotes $ labelToText evName)
 
   eventAlreadyCreated <- isTableCreated globalsIORef eventTable
-  if eventAlreadyCreated then
-    return Nothing
-  else do
-    setTableCreated globalsIORef eventTable $ E.eventFields ev
-    return (Just $ createEventTableQuery ev)
+  unless eventAlreadyCreated $ do
+    setTableCreated globalsIORef eventTable $ fst <$> ev ^. eventLogs
+    yield $ createEventTableQuery eventTable ev
 
-createEventTableQuery :: E.EventTable -> Text
-createEventTableQuery ev =
-  let (org, app, cname) = constructTableNameParameters
-          (E.eventOrganization ev)
-          (E.eventApplication ev)
-          (E.eventContractName ev)
-      tableName = EventTableName org app cname (escapeQuotes $ E.eventName ev)
-
-      cols = csv $ ["id SERIAL NOT NULL", "address text"] ++
-                (map (\t -> T.concat [wrapDoubleQuotes t, " text"]) $ E.eventFields ev)
+createEventTableQuery :: TableName -> Event -> Text
+createEventTableQuery tableName ev =
+  let cols = ev ^. eventLogs
   in T.concat
       [ "CREATE TABLE IF NOT EXISTS "
       , tableNameToDoubleQuoteText tableName
       ," ("
-      , cols
+      , csv $ ["id SERIAL NOT NULL", "record_id text", "address text", "\"chainId\" text", "block_hash text", "block_timestamp text",
+               "block_number text", "transaction_hash text", "transaction_sender text"] ++ tableColumns (map (\(x, y) -> (x, indexedTypeType y)) cols)
       , ");"
       ]
 
--- Inserts rows for all event emissions into their respective tables, expands tables if necessary
---   Though this function checks that the tables exist before
---   generating the insert query, the VM should prevent undeclared
---   events from being emitted (it should also do an argument check)
-insertExpandEventTables :: OutputM m
-                        => IORef Globals
-                        -> [Action.Event]
-                        -> ConduitM () Text m ()
-insertExpandEventTables _ [] = return ()
-insertExpandEventTables globalsIORef events = do
-  expandEventTables globalsIORef events
-  insertEventTables globalsIORef events
-
-expandEventTables :: OutputM m
-                  => IORef Globals
-                  -> [Action.Event]
-                  -> ConduitM () Text m ()
-expandEventTables _ [] = return ()
-expandEventTables globalsIORef (x:xs) = do
-  let (org, app, cname) = constructTableNameParameters
-          (T.pack $ Action.evContractOrganization x)
-          (T.pack $ Action.evContractApplication x)
-          (T.pack $ Action.evContractName x)
-      tableName = EventTableName org app cname ( escapeQuotes $ T.pack $ Action.evName x)
+expandEventTable :: OutputM m
+                 => IORef Globals
+                 -> (Text, Text, Text)
+                 -> SolidString
+                 -> Event
+                 -> ConduitM () Text m ()
+expandEventTable globalsIORef (o, a, n) evName ev = do
+  let (org, app, cname) = constructTableNameParameters o a n
+      tableName = EventTableName org app cname (escapeQuotes $ labelToText evName)
 
   columns <- getTableColumns globalsIORef tableName
   case columns of
@@ -901,34 +897,34 @@ expandEventTables globalsIORef (x:xs) = do
           , (tableNameToText tableName)
           , " does not exist, but we are trying to expand it?"
           ]
-      expandEventTables globalsIORef xs
+      pure ()
     Just cols -> do
-      let extras = filter (not . flip elem cols) (map (T.pack . fst) $ Action.evArgs x)
+      let extras = filter (not . flip elem cols . fst) . fillFirstEmptyEntries $ ev ^. eventLogs
+          extraNames = fst <$> extras
       unless (null extras) $ do
         $logInfoS "expandEventTable" . T.pack $ "We just got new fields for a contract that already has a table!"
+        setTableCreated globalsIORef tableName $ cols ++ extraNames
+        let extrasWithType = tableColumns $ map (\(x, y) -> (x, indexedTypeType y)) extras
         $logInfoS "expandEventTable" $ T.concat
             [ "Adding columns to "
             , (tableNameToText tableName)
             , " for the following new fields: "
-            , T.intercalate ", " extras
+            , T.intercalate ", " extrasWithType
             ]
-        setTableCreated globalsIORef tableName $ cols ++ extras
-        let extrasWithType = map (\t -> T.concat [wrapDoubleQuotes t, " text"]) extras
         yield $ expandTableQuery tableName extrasWithType
-      expandEventTables globalsIORef xs
 
 insertEventTables :: OutputM m
                   => IORef Globals
-                  -> [Action.Event]
+                  -> [AggregateEvent]
                   -> ConduitM () Text m ()
-insertEventTables globalsIORef events = do
-  yieldMany . catMaybes =<< lift (mapM (insertEventTable globalsIORef) events)
+insertEventTables globalsIORef evs = do
+  yieldMany . catMaybes =<< lift (mapM (insertEventTable globalsIORef) evs)
 
 insertEventTable :: OutputM m
                  => IORef Globals
-                 -> Action.Event
+                 -> AggregateEvent
                  -> m (Maybe Text)
-insertEventTable globalsIORef ev = do
+insertEventTable globalsIORef agEv@AggregateEvent { eventEvent = ev } = do
   let (org, app, cname) = constructTableNameParameters
           (T.pack $ Action.evContractOrganization ev)
           (T.pack $ Action.evContractApplication ev)
@@ -936,56 +932,62 @@ insertEventTable globalsIORef ev = do
       eventTable = EventTableName org app cname (escapeQuotes $ T.pack $ Action.evName ev)
 
   eventExists <- isTableCreated globalsIORef eventTable
-  if eventExists then return (Just $ insertEventTableQuery ev)
+  let q = insertEventTableQuery agEv
+  $logInfoS "insertEventTable" q
+  if eventExists then return (Just q)
   else return Nothing
 
-insertEventTableQuery :: Action.Event -> Text
-insertEventTableQuery ev =
+insertEventTableQuery :: AggregateEvent -> Text
+insertEventTableQuery agEv@AggregateEvent{ eventEvent = ev } =
  let (org, app, cname) = constructTableNameParameters
           (T.pack $ Action.evContractOrganization ev)
           (T.pack $ Action.evContractApplication ev)
           (T.pack $ Action.evContractName ev)
      tableName = EventTableName org app cname (escapeQuotes $ T.pack $ Action.evName ev)
-
-     cols = wrapAndEscapeDouble . map escapeQuotes $ ["id", "address"] ++ (map (T.pack . fst) $ Action.evArgs ev)
-     vals = csv $ map (wrapSingleQuotes . escapeQuotes . T.pack . snd) $ Action.evArgs ev
- in T.concat
-        [ "INSERT INTO "
-        , tableNameToDoubleQuoteText tableName
-        , " "
-        , cols
-        , " VALUES "
-        , "( DEFAULT,\n" -- id, set by Postgres
-        , wrapSingleQuotes $ tshow $ Action.evContractAccount ev
-        , ",\n"
-        , vals
-        ,  " );"
-        , "\n"--  ON CONFLICT DO NOTHING;"
-        ]
-
+     filledArgs = map fst . fillFirstEmptyEntries . map (first T.pack) $ Action.evArgs ev
+     keySt  = wrapAndEscapeDouble . map escapeQuotes $ ("id":baseTableColumns) ++ filledArgs
+     baseVals = [ \e -> makeAccount (T.pack . maybe "" format $ (Action.evContractAccount $ eventEvent e) ^. accountChainId) ((Action.evContractAccount $ eventEvent e) ^. accountAddress)
+                , tshow . _accountAddress . Action.evContractAccount . eventEvent
+                , T.pack . maybe "" format . _accountChainId . Action.evContractAccount . eventEvent
+                , T.pack . keccak256ToHex . eventBlockHash
+                , tshow . eventBlockTimestamp
+                , tshow . eventBlockNumber
+                , T.pack . keccak256ToHex . eventTxHash
+                , tshow . eventTxSender
+                ]
+     vals = csv $ map (wrapSingleQuotes . escapeQuotes . ($ agEv)) baseVals ++ map (wrapSingleQuotes . T.pack . snd) (Action.evArgs ev)
+  in T.concat $
+       [ "INSERT INTO "
+       , tableNameToDoubleQuoteText tableName
+       , " "
+       , keySt
+       , "\n  VALUES ( DEFAULT,\n"
+       , vals
+       , " )\n  ON CONFLICT DO NOTHING;"
+       ]
 
 
 ------------------
 
 
 --This is a temporary function that converts solidity types to a sample value...  I am just using this now to convert table creation from the old way (value based when values come through) to the new way (direct from the types when a CC is registered)
-solidityTypeToSQLType :: VariableDeclF a -> Maybe Text
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Bool} = Just "bool"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Int _ _} = Just "decimal"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.String _} = Just "text"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Bytes _ _} = Just "text"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.UserDefined _ _} = Just "text"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Fixed _ _ } = Just "fixed"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Address _} = Just "text"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Account _} = Just "text"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Array _ _} = Nothing -- Just "jsonb"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Mapping _ _ _} = Nothing -- Just "jsonb"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.UnknownLabel _ _} = Just "text"
---solidityTypeToSQLType VariableDecl{varType=SVMType.UnknownLabel x} = Just $ "text references " <> T.pack x <> "(id)"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Struct _ _} = Just "jsonb"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Enum _ _ _} = Just "text"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Contract _} = Just "text"
-solidityTypeToSQLType VariableDecl{_varType=SVMType.Error _ _} = Just "text"
+solidityTypeToSQLType :: SVMType.Type -> Maybe Text
+solidityTypeToSQLType SVMType.Bool = Just "bool"
+solidityTypeToSQLType (SVMType.Int _ _) = Just "decimal"
+solidityTypeToSQLType (SVMType.String _) = Just "text"
+solidityTypeToSQLType (SVMType.Bytes _ _) = Just "text"
+solidityTypeToSQLType (SVMType.UserDefined _ _) = Just "text"
+solidityTypeToSQLType (SVMType.Fixed _ _) = Just "fixed"
+solidityTypeToSQLType (SVMType.Address _) = Just "text"
+solidityTypeToSQLType (SVMType.Account _) = Just "text"
+solidityTypeToSQLType (SVMType.Array _ _) = Nothing -- Just "jsonb"
+solidityTypeToSQLType (SVMType.Mapping _ _ _) = Nothing -- Just "jsonb"
+solidityTypeToSQLType (SVMType.UnknownLabel _ _) = Just "text"
+--solidityTypeToSQLType (SVMType.UnknownLabel x) = Just $ "text references " <> T.pack x <> "(id)"
+solidityTypeToSQLType (SVMType.Struct _ _) = Just "jsonb"
+solidityTypeToSQLType (SVMType.Enum _ _ _) = Just "text"
+solidityTypeToSQLType (SVMType.Contract _) = Just "text"
+solidityTypeToSQLType (SVMType.Error _ _) = Just "text"
 --solidityTypeToSQLType x = error $ "undefined type in solidityTypeToSQLType: " ++ show (varType x)
 
 

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -34,6 +34,7 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.State.Strict hiding (state)
 import Data.Either (lefts, rights)
+import Data.Foldable (toList)
 import Data.Function
 import Data.IORef
 import qualified Data.Set as S
@@ -66,7 +67,6 @@ import Blockchain.Data.Json
 import Blockchain.SolidVM.CodeCollectionDB
 import Blockchain.Strato.Model.Account
 import Blockchain.Strato.Model.ChainId
-import qualified Blockchain.Strato.Model.Event            as Action
 import Blockchain.Strato.Model.Keccak256
 import qualified Blockchain.Stream.Action as Action
 import Blockchain.Stream.VMEvent
@@ -337,36 +337,6 @@ rowToHistories _ abiId actions cont oldState = do
     newMap <- gets Map.fromList
     return $ processedContract abiId newMap hRow
 
--- Parses xabi event declarations to create a table,
--- ignoring indexes and anonymous flag
--- Only needs xabi events
--- createEvents :: Monad m =>
---                 (Map.Map Text OLD.Event) -> Text -> Text -> m [EventTable]
--- createEvents events' org app = do
---   return $ map makeEvent $ Map.toList events'
---   where
---     makeEvent :: (Text, OLD.Event) -> EventTable
---     makeEvent (name, event) =
---       EventTable
---       { eventOrganization = org
---       , eventApplication  = app
---       , eventContractName = name
---       , eventName = name
---       , eventFields = map fst $ OLD.eventLogs event
---       }
-
-contractToEventTables :: (Text, Text, Text) -> Contract -> [EventTable]
-contractToEventTables (org, app, name) c =
-  flip map (Map.toList $ c ^. events) $
-      \(eName, fields) ->
-        EventTable {
-          eventOrganization = org,
-          eventApplication  = app,
-          eventContractName = name,
-          eventName = labelToText eName,
-          eventFields = map fst $ _eventLogs fields
-        }
-
 processedMappingRow ::  Text -> AggregateAction -> ABIID -> Value -> Value-> ProcessedMappingRow
 processedMappingRow mapping AggregateAction{..} ABIID{..} k v =
    ProcessedMappingRow {
@@ -397,8 +367,18 @@ parseActions events' =
   . filter matters
   . concatMap (flatten) $ [a | NewAction a <- events']
 
-parseEvents :: [VMEvent] -> [Action.Event]
-parseEvents events' = [a | EventEmitted a <- events']
+parseEvents :: [VMEvent] -> [AggregateEvent]
+parseEvents = concatMap parseEvent
+  where parseEvent (NewAction a) = mkAggregateEvent a <$> toList (Action._events a)
+        parseEvent _ = []
+        mkAggregateEvent a e = AggregateEvent
+          { eventBlockHash      = Action._blockHash a
+          , eventBlockTimestamp = Action._blockTimestamp a
+          , eventBlockNumber    = Action._blockNumber a
+          , eventTxHash         = Action._transactionHash a
+          , eventTxSender       = Action._transactionSender a
+          , eventEvent          = e
+          }
 
 getCodeCollection' :: MonadIO m => Bool -> CodePtr -> Text -> m (Either String CodeCollection)
 getCodeCollection' True = getCodeCollection (Map.fromList . map (\(x, y) -> (textToLabel x, xabiToPartialContract y)))
@@ -518,7 +498,7 @@ processTheMessages env sqlEnv conn g messages = do
                 
                 outputData' conn $ createExpandHistoryTable g c nameParts
 
-                outputData conn . createEventTables g $ contractToEventTables nameParts c
+                outputData conn $ createExpandEventTables g c nameParts
 
                 return deferredForeignKeys
 
@@ -590,7 +570,7 @@ processTheMessages env sqlEnv conn g messages = do
     notifyPostgREST conn
 
   when (length events' > 0) $
-    outputData conn $ insertExpandEventTables g events'
+    outputData conn $ insertEventTables g events'
 
   $logInfoS "processTheMessages" . T.pack $ "Inserting " ++ show (length transactionResults) ++ " transaction results"
 


### PR DESCRIPTION
Fixes STRATO-2278, STRATO-2643, and STRATO-2995.

- Adds the regular base columns to Cirrus event tables
- Respects the types of event parameters; doesn't make all columns `text` anymore
- Supports events with no parameters
- Supports events with unnamed parameters

I didn't find a ticket for the last one, but I came across it while testing. Now Slipstream will replace unnamed event parameters with the name `val_i`, where `i` is the index of the parameter, starting with 1.