### PR TITLE
MKT-70: filter error fix

### DIFF
--- a/marketplace/ui/src/components/MarketPlace/CategoryProductList.js
+++ b/marketplace/ui/src/components/MarketPlace/CategoryProductList.js
@@ -126,7 +126,7 @@ const CategoryProductList = ({ user }) => {
           debouncedMinPrice,
           debouncedMaxPrice
         );
-    } else {
+    } else if (category !== "") {
         actions.fetchMarketplaceLoggedIn(
           marketplaceDispatch,
           arrayToStr(selectedCategories),


### PR DESCRIPTION
https://blockapps.atlassian.net/browse/MKT-70

First the regular fetch is going.
then it sees a category is selected and fetches the category info
the category info loads first
then the unfiltered search finally finishes and overrides the marketplace list because it was so much bigger it finished last.