### PR TITLE
STRATO-3143 Amendment to the P2P mem leak fix

### DIFF
--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -146,7 +146,7 @@ stratoP2PClient runner = runner $ \sSource -> do
         $logErrorS "stratoP2PClient" . T.pack $ "Could not fetch peers: " ++ show err
         liftIO $ threadDelay 1000000
       Right peers -> do
-        multiThreadedClient peers activePeersSem sSource
+        _ <- withAsync (multiThreadedClient peers activePeersSem sSource) (\a -> waitCatch a)
         $logInfoS "stratoP2PClient" "Waiting 5 seconds before looping over peers again"
         liftIO $ threadDelay 5000000
     where

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -146,7 +146,7 @@ stratoP2PClient runner = runner $ \sSource -> do
         $logErrorS "stratoP2PClient" . T.pack $ "Could not fetch peers: " ++ show err
         liftIO $ threadDelay 1000000
       Right peers -> do
-        _ <- withAsync (multiThreadedClient peers activePeersSem sSource) (\a -> waitCatch a)
+        _ <- async (multiThreadedClient peers activePeersSem sSource)
         $logInfoS "stratoP2PClient" "Waiting 5 seconds before looping over peers again"
         liftIO $ threadDelay 5000000
     where


### PR DESCRIPTION
This PR hopefully fixes some bugs with the fix.

1. Multi-peer connection should now be consistent. :heavy_check_mark:
2. P2P `error`s should no longer crash the whole thing. :heavy_check_mark:

Memory Usage of this change:
![image](https://github.com/blockapps/strato-platform/assets/35944722/e8c1fa4b-cc95-4bc9-b6e6-8645991dfa90)
