### PR TITLE
Strato 3169 verify that using salted contract creations leads to deterministic addresses

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
@@ -14,6 +14,7 @@ module Blockchain.VM.SolidException
   , customError
   , missingType
   , duplicateDefinition
+  , duplicateContract
   , parseError
   , require
   , assert
@@ -61,6 +62,7 @@ data SolidException = TypeError String String
                     | CustomError String String [B.BasicValue]
                     | MissingType String String
                     | DuplicateDefinition String String
+                    | DuplicateContract String
                     | ArityMismatch String Int Int
                     | ParseError String String
                     | Require (Maybe String)
@@ -102,6 +104,7 @@ showSolidException (MissingField m v) = printf "missing field: %s: %s" m v
 showSolidException (MissingType m v) = printf "missing type: %s: %s" m v
 showSolidException (RevertError m v) = printf "revert: %s %s:" m v
 showSolidException (DuplicateDefinition m v) = printf "duplicate definition: %s: %s" m v
+showSolidException (DuplicateContract a) = printf "duplicate salted contract address: %s" a
 showSolidException (ParseError m v) = printf "parse error: %s: %s" m v
 showSolidException (ModifierError m v) = printf "modifier error: %s: %s" m v
 showSolidException (Require Nothing) = printf "solidity require failed"
@@ -165,6 +168,9 @@ missingType = toThrower MissingType
 
 duplicateDefinition :: (Show v) => String -> v -> a
 duplicateDefinition = toThrower DuplicateDefinition
+
+duplicateContract :: (Show v) => v -> a 
+duplicateContract x = throw $ DuplicateContract (show x)
 
 checkArity :: (MonadIO m) => String -> Int -> Int -> m ()
 checkArity msg got want = when (got /= want) . liftIO . throwIO $ ArityMismatch msg got want

--- a/strato/VM/SolidVM/solid-vm/package.yaml
+++ b/strato/VM/SolidVM/solid-vm/package.yaml
@@ -85,6 +85,7 @@ tests:
       - seqevents
       - mtl
       - crypto-api
+      - binary
       - blockapps-data
       - core-api2
       - strato-genesis

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1856,9 +1856,12 @@ expToVar' (CC.FunctionCall _ (CC.NewExpression _ (SVMType.UnknownLabel contractN
   when ro $ invalidWrite "Invalid contract creation during read-only access" $ "contractName: " ++ show contractName' ++ ", args: " ++ show args
   creator <- getCurrentAccount
   (hsh, cc) <- getCurrentCodeCollection
-  let contractNameString = labelToString contractName'
   salt <- saltTextToValue saltExpressionText
-  newAddress <- getNewAddressWithSalt creator salt contractNameString hsh
+  args' <- do
+        case args of
+                (CC.OrderedArgs oa) -> mapM (expToVar') oa
+                (CC.NamedArgs na) -> mapM (\(_, expr) -> (expToVar' expr)) na
+  newAddress <- getNewAddressWithSalt creator salt hsh $ show args'
   execResults <- create' creator newAddress hsh cc contractName' args
   return $ Constant $ SContract contractName' $ accountOnUnspecifiedChain
     $ fromMaybe (internalError "a call to create did not create an address" execResults)

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -21,11 +21,13 @@ import Control.Exception
 import Control.Lens ((^.))
 import Control.Monad
 import Control.Monad.IO.Class
+import Data.Binary (encode, decode)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Short as SB
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.UTF8   as UTF8
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as Char8
 import Data.Coerce
 import qualified Data.Map as M
@@ -39,7 +41,7 @@ import Data.Text.Encoding
 import Data.Time.Clock.POSIX
 import HFlags
 import qualified Numeric (readHex, showHex)
-import Test.Hspec (hspec, Spec, describe, xdescribe, it, xit, pendingWith, anyException, shouldThrow, anyErrorCall, Selector)
+import Test.Hspec (hspec, Spec, describe, xdescribe, it, xit, fit, pendingWith, anyException, shouldThrow, anyErrorCall, Selector)
 import Test.Hspec.Expectations.Lifted
 import Text.Printf
 import Text.RawString.QQ
@@ -104,6 +106,7 @@ import qualified Control.Monad.State                   as State
 import Data.Map.Strict (Map)
 import qualified Blockchain.Data.TXOrigin as TXO
 import Data.Either                     (fromRight)
+import Debug.Trace
 
 -- The newtype distinguishes uncaught SolidExceptions and
 -- those that are returned in ExecResults
@@ -196,6 +199,10 @@ anyModifierError _ = False
 anyReservedWordError :: Selector HandledException
 anyReservedWordError (HE Blockchain.SolidVM.Exception.ReservedWordError{}) = True
 anyReservedWordError _ = False
+
+anyDuplicateContractError :: Selector HandledException
+anyDuplicateContractError (HE Blockchain.SolidVM.Exception.DuplicateContract{}) = True
+anyDuplicateContractError _ = False
 
 anyImmutableError :: Selector HandledException
 anyImmutableError (HE Blockchain.SolidVM.Exception.ImmutableError{}) = True
@@ -738,6 +745,19 @@ bAccount a =
 
 iAddress :: Address -> IndexType
 iAddress = IAccount . unspecifiedChain
+
+-- hash(0xFF, sender, salt, code_hash, args)[12::]
+deriveAddressWithSalt :: String -> BC.ByteString -> String -> Address
+deriveAddressWithSalt salt src args = do
+  let theAddress = fromJust $ stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe"
+      theHash = hash $ rlpSerialize $ RLPArray [ rlpEncode (0xFF :: Integer)
+                                               , rlpEncode theAddress
+                                               , rlpEncode salt
+                                               , rlpEncode $ keccak256ToByteString $ hash src
+                                               , rlpEncode args
+                                               ]
+  -- trace ((show theAddress) ++ " " ++ salt ++ " " ++ (show $ keccak256ToByteString $ hash src) ++ " " ++ args)
+  (decode $ BL.drop 12 $ encode theHash)
 
 spec :: Spec
 spec = do
@@ -5701,8 +5721,8 @@ contract qq {
 }|]
     getFields ["t2a", "t2x"] `shouldReturn` [BInteger 2022, BInteger 2022]
 
-  it "can create salted contract" . runTest $ do
-    runBS [r|
+  it "can deterministically create multiple salted contracts with no args" . runTest $ do
+    let src = [r|
 
 contract X {
   string public xNum;
@@ -5720,16 +5740,98 @@ contract qq {
   constructor() public {
     salt' = "salt";
     x = new X{salt: salt'}();
-    y = new Y{salt: salt'}();
-    z = new X{salt: "something"}();
+    y = new Y{salt: "something"}();
 
   }
 }|]
-    getFields ["x", "y", "z"] `shouldReturn` 
-      [ bContract "X" 0x6532c90691674287ccc10aeb251e0a0f7439073e
-      , bContract "Y" 0xfa29c1031db9942202c710ed85879c3d3e9f7110
-      , bContract "X" 0x898eabafbe40a722b6393ff16c9166e75e519b8f
+    runBS src
+    getFields ["x", "y"] `shouldReturn` 
+      [ bContract "X" $ deriveAddressWithSalt "salt" (BC.pack src) "[]"
+      , bContract "Y" $ deriveAddressWithSalt "something" (BC.pack src) "[]"
       ]
+
+  it "can deterministically create multiple salted contract with args" . runTest $ do
+    let src = [r|
+
+contract X {
+  string public xNum;
+  constructor(string _xNum) public {
+    xNum = _xNum;
+  }
+}
+
+contract Y {
+  uint public yNum;
+  constructor(uint _yNum) public {
+    yNum = _yNum;
+  }
+}
+
+contract qq {
+  X public x;
+  Y public y;
+  X public z;
+  bytes32 salt';
+  constructor() public {
+    salt' = "salt";
+    x = new X{salt: salt'}("xNum");
+    y = new Y{salt: salt'}(100);
+
+  }
+}|]
+    runBS src
+    getFields ["x", "y"] `shouldReturn` 
+      [ bContract "X" $ deriveAddressWithSalt "salt" (BC.pack src) "[Constant: SString \"xNum\"]"
+      , bContract "Y" $ deriveAddressWithSalt "salt" (BC.pack src) "[Constant: SInteger 100]"
+      ]
+    [BContract "X" x] <- getFields ["x"]
+    [BContract "Y" y] <- getFields ["y"]
+    getSolidStorageKeyVal' (namedAccountToAccount Nothing x) (singleton "xNum") `shouldReturn` BString "xNum"
+    getSolidStorageKeyVal' (namedAccountToAccount Nothing y) (singleton "yNum") `shouldReturn` BInteger 100
+  
+
+  it "can deterministically create salted contract with multiple args" . runTest $ do
+    let src = [r|
+contract User {
+  string commonName;
+  string cert;
+  constructor(string _commonName, string _cert) {
+    commonName = _commonName;
+    cert = _cert;
+  }
+}
+
+contract qq {
+  User public x;
+  constructor() public {
+    x = new User{salt: "Dustin Norwood"}("Dustin Norwood", "Thebestcertyoucangetfor$99.99");
+  }
+}|] 
+    runBS src
+    getFields ["x"] `shouldReturn` [bContract "User" $ deriveAddressWithSalt "Dustin Norwood" (BC.pack src) "[Constant: SString \"Dustin Norwood\",Constant: SString \"Thebestcertyoucangetfor$99.99\"]"]
+    [BContract "User" x] <- getFields["x"]
+    getSolidStorageKeyVal' (namedAccountToAccount Nothing x) (singleton "commonName") `shouldReturn` BString "Dustin Norwood"
+    getSolidStorageKeyVal' (namedAccountToAccount Nothing x) (singleton "cert") `shouldReturn` BString "Thebestcertyoucangetfor$99.99"
+
+  it "should fail when trying to create salted contract to the same address" $ runTest (do
+    runBS [r|
+contract User {
+  string commonName;
+  string cert;
+  constructor(string _commonName, string _cert) {
+    commonName = _commonName;
+    cert = _cert;
+  }
+}
+
+contract qq {
+  User public x;
+  User public y;
+  constructor() public {
+    x = new User{salt: "Dustin Norwood"}("Dustin Norwood", "Thebestcertyoucangetfor$99.99");
+    y = new User{salt: "Dustin Norwood"}("Dustin Norwood", "Thebestcertyoucangetfor$99.99");
+  }
+}|]) `shouldThrow` anyDuplicateContractError
       
   it "can use a try catch statment to catch a divide by zero error the SolidVM Way (trademark pending)" . runTest $ do
     runBS [r|

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -240,11 +240,11 @@ getNewAddress_unsafe a n =
     in decode $ BL.drop 12 $ encode theHash
 
 -- Construct salted contract addresses using a version of the solidity CREATE2 method:
--- Original -> new_address = hash(0xFF, sender, salt, bytecode) 
--- Current  -> new_address = hash(0xFF, sender, salt, contract_name, codecollection_hash)
-getNewAddressWithSalt_unsafe :: Address -> RLPObject -> String -> B.ByteString -> Address
-getNewAddressWithSalt_unsafe a s c h =
-  let theHash = SHA.hash $ rlpSerialize $ RLPArray [rlpEncode (255 :: Integer), rlpEncode a, s, rlpEncode c, rlpEncode h]
+-- Original -> new_address = hash(0xFF, sender, salt, bytecode)[12::]
+-- Current  -> new_address = hash(0xFF, sender, salt, codecollection_hash, args)[12::]
+getNewAddressWithSalt_unsafe :: Address -> String -> B.ByteString -> String -> Address
+getNewAddressWithSalt_unsafe creator salt codeHash args =
+  let theHash = SHA.hash $ rlpSerialize $ RLPArray [rlpEncode (0xFF :: Integer), rlpEncode creator, rlpEncode salt, rlpEncode codeHash, rlpEncode args]
   in decode $ BL.drop 12 $ encode theHash
 
 addressAsNibbleString::Address->N.NibbleString

--- a/strato/core/vm-tools/src/Blockchain/VMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMContext.hs
@@ -659,17 +659,21 @@ getNewAddress account = do
   incrementNonce account
   return $ (accountAddress .~ newAddress) account
 
-getNewAddressWithSalt :: (MonadIO m, (Account `A.Alters` AddressState) m) => Account -> Value -> String -> Keccak256 -> m Account
-getNewAddressWithSalt account salt cname hsh = do
+getNewAddressWithSalt :: (MonadIO m, MonadLogger m, (Account `A.Alters` AddressState) m) => Account -> Value -> Keccak256 -> String -> m Account
+getNewAddressWithSalt account salt hsh args = do
   nonce <- addressStateNonce <$> A.lookupWithDefault Mod.Proxy account
   when flags_debug $ liftIO $ putStrLn $ "Creating new account: owner=" ++ show (pretty account) ++ ", nonce=" ++ show nonce
-  let rlpEncodedSalt = case salt of
-          (SInteger i) -> rlpEncode i
-          (SString s) -> rlpEncode s
+  let saltAsString = case salt of
+          (SString s) -> s
           _ -> invalidArguments "big major bad" salt
-  let newAddress = getNewAddressWithSalt_unsafe (account ^. accountAddress) rlpEncodedSalt cname $ keccak256ToByteString hsh
-  incrementNonce account
-  return $ (accountAddress .~ newAddress) account
+  let newAddress = getNewAddressWithSalt_unsafe (account ^. accountAddress) saltAsString (keccak256ToByteString hsh) args
+  $logDebugS "getNewAddressWithSalt" $ T.pack $ (show $ account ^. accountAddress) ++ " " ++ saltAsString ++ " " ++ (show $ keccak256ToByteString hsh) ++ " " ++ args
+  doesAddressAlreadyExist <- A.lookup (Mod.Proxy @AddressState) $ Account newAddress (_accountChainId account)
+  case doesAddressAlreadyExist of
+    Just _ -> duplicateContract $ "The address " ++ (show newAddress) ++ " already exists. Try using a different salt or constructor arguments."
+    Nothing ->  do
+      incrementNonce account
+      return $ (accountAddress .~ newAddress) account
 
 purgeStorageMap :: HasMemStorageDB m => Account -> m ()
 purgeStorageMap account = do


### PR DESCRIPTION
This PR finalizes the CREATE2 logic for salted contract creation and verifies that we can deterministically create addresses using the hashing formula: `hash(0xFF, sender, salt, code_hash, args)[12::]`