### PR TITLE
Handle duplicate key violations on code_ref table

### DIFF
--- a/strato/core/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
+++ b/strato/core/strato-statediff/src/Blockchain/Strato/StateDiff/Database.hs
@@ -87,7 +87,8 @@ createAccount blockNumber accountDiffs =
 
       $logDebugS "commitSqlDiffs/createAccount" . T.pack $ "Inserting storage: " ++ (unlines $ map show (concat newStorage))
       SQL.insertMany_ (concat newStorage)
-      traverse_ (`SQL.upsert` []) $ uncurry codeRef <$> accountDiffs
+      traverse_ (`SQL.upsert` []) (uncurry codeRef <$> accountDiffs) `catch` (\(e :: SomeException) -> do
+        $logWarnS "commitSqlDiffs/createAccount" . T.pack $ "Error inserting code: " ++ show e)
     code' account diff = getField (theError account "code") $ code diff
     codeRef account diff = CodeRef {
       codeRefCodeHash = hash $ code' account diff,


### PR DESCRIPTION
This should prevent the crashes seen when syncing to testnet1