### PR TITLE
Marketplace remove excessive vault cert calls

### DIFF
--- a/marketplace/backend/api/middleware/loadDappHandler.js
+++ b/marketplace/backend/api/middleware/loadDappHandler.js
@@ -9,30 +9,13 @@ import jwtDecode from 'jwt-decode'
 const options = { config }
 
 const loadDapp = async (req, res, next) => {
-  const { app, username, accessToken } = req
+  const { app, username, accessToken, address } = req
 
   const userCredentials = {
     username,
     ...accessToken,
   }
   console.log('User Credentials: \n\n\n\n\n', userCredentials)
-
-  let address
-  
-  try {
-    address = await rest.getKey(userCredentials, options);
-  } catch (e) {
-    // user isn't created in STRATO
-    if (e.response.status === RestStatus.BAD_REQUEST) {
-      rest.response.status(RestStatus.FORBIDDEN, res)
-      return next()
-    }
-    
-    // unexpected error
-    return next(e)
-  }
-    
-  
   const user = {
     ...userCredentials,
     node: config.nodes[0],

--- a/marketplace/backend/api/v1/users/users.controller.js
+++ b/marketplace/backend/api/v1/users/users.controller.js
@@ -2,6 +2,7 @@ import { rest } from 'blockapps-rest'
 import { RestError } from 'blockapps-rest/dist/util/rest.util'
 import RestStatus from 'http-status-codes'
 import config from '../../../load.config'
+import { pollingHelper } from '../../../helpers/utils'
 
 const options = { config, cacheNonce: true }
 
@@ -13,16 +14,11 @@ class UsersController {
       let user = null
       if (Object.hasOwn(dapp, 'hasCert')) user = dapp.hasCert;
       if (user === null || user === undefined) {
-        user = await dapp.getCertificate({ userAddress })
-
-        console.log('me USER ', user)
-        if (user === null || user === undefined) { 
-            console.log('user not found in first attempt')
-            await new Promise(resolve => setTimeout(resolve, 3000));
-            user = await dapp.getCertificate({ userAddress })
-            console.log('user content from second attempt', user)
-        }
+        user = await pollingHelper( dapp.getCertificate, [{ userAddress}]);
+        // user = await dapp.getCertificate({ userAddress })
+        if (user === null || user === undefined) console.log('user not found in after multiple attempts');
       }
+      console.log('me USER ', user);
       if (!user || Object.keys(user).length == 0) {
         rest.response.status400(res, { username }) 
       }

--- a/marketplace/backend/api/v1/users/users.controller.js
+++ b/marketplace/backend/api/v1/users/users.controller.js
@@ -10,17 +10,19 @@ class UsersController {
     try {
       const { dapp, accessToken, decodedToken, address: userAddress } = req
       const username = decodedToken.preferred_username
+      let user = null
+      if (Object.hasOwn(dapp, 'hasCert')) user = dapp.hasCert;
+      if (user === null || user === undefined) {
+        user = await dapp.getCertificate({ userAddress })
 
-      let user = await dapp.getCertificate({ userAddress })
-
-      console.log('me USER ', user)
-      if (user === null || user === undefined) { 
-          console.log('user not found in first attempt')
-          await new Promise(resolve => setTimeout(resolve, 3000));
-          user = await dapp.getCertificate({ userAddress })
-          console.log('user content from second attempt', user)
+        console.log('me USER ', user)
+        if (user === null || user === undefined) { 
+            console.log('user not found in first attempt')
+            await new Promise(resolve => setTimeout(resolve, 3000));
+            user = await dapp.getCertificate({ userAddress })
+            console.log('user content from second attempt', user)
+        }
       }
-
       if (!user || Object.keys(user).length == 0) {
         rest.response.status400(res, { username }) 
       }

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -138,7 +138,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser=false) {
     //We are not guaranteed the user will have a certificate
     //99% chance they do, but if this this their first login
     //the node might not have a certificate in time
-    if (!(userCertificate === null || userCertificate === undefined)) {
+    if (!(userCertificate === null || userCertificate === undefined || userCertificate.organization === null || userCertificate.organization === undefined)) {
       contract.userOrganization = userCertificate.organization
       userOrganization = userCertificate.organization
       userCert    = userCertificate;//Attaching user cert to dapp to save from needing make another call to get it

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -2,6 +2,8 @@ import { rest, util, importer } from "blockapps-rest";
 const { createContract } = rest;
 import constants, { CHARGES, ITEM_STATUS, ORDER_STATUS, SERVICE_PROVIDERS } from "/helpers/constants";
 import { yamlWrite, yamlSafeDumpSync, getYamlFile } from "/helpers/config";
+import { pollingHelper } from "/helpers/utils";
+
 import StripeService from "/payment-service/stripe.service";
 import dayjs from 'dayjs';
 import RestStatus from 'http-status-codes';
@@ -130,15 +132,19 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser=false) {
   let userOrganization
   
   if (!serviceUser) {
-    let userCertificate = await certificateJs.getCertificateMe(rawAdmin);
-    console.log('dapp - userCertificate', userCertificate)
-    if (userCertificate === null || userCertificate === undefined) { 
-      // delay for 6 seconds and check again if cert got created successfully
-      console.log('user not found in first attempt, this may be a brand new registration, recheck in 3 secs')
-      await new Promise(resolve => setTimeout(resolve, 3000));
-      userCertificate = await certificateJs.getCertificateMe(rawAdmin);
-      console.log('user content from second attempt', userCertificate)
-    }
+    
+    let userCertificate = await pollingHelper(certificateJs.getCertificateMe, [rawAdmin]);
+    // let userCertificate = await certificateJs.getCertificateMe(rawAdmin);
+    // console.log('dapp - userCertificate', userCertificate)
+    // if (userCertificate === null || userCertificate === undefined) { 
+    //   // delay for 6 seconds and check again if cert got created successfully
+    //   console.log('user not found in first attempt, this may be a brand new registration, recheck in 3 secs')
+    //   await new Promise(resolve => setTimeout(resolve, 3000));
+    //   userCertificate = await certificateJs.getCertificateMe(rawAdmin);
+    //   console.log('user content from second attempt', userCertificate)
+    // }
+
+
     //We are not guaranteed the user will have a certificate
     //99% chance they do, but if this this their first login
     //the node might not have a certificate in time

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -134,16 +134,6 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser=false) {
   if (!serviceUser) {
     
     let userCertificate = await pollingHelper(certificateJs.getCertificateMe, [rawAdmin]);
-    // let userCertificate = await certificateJs.getCertificateMe(rawAdmin);
-    // console.log('dapp - userCertificate', userCertificate)
-    // if (userCertificate === null || userCertificate === undefined) { 
-    //   // delay for 6 seconds and check again if cert got created successfully
-    //   console.log('user not found in first attempt, this may be a brand new registration, recheck in 3 secs')
-    //   await new Promise(resolve => setTimeout(resolve, 3000));
-    //   userCertificate = await certificateJs.getCertificateMe(rawAdmin);
-    //   console.log('user content from second attempt', userCertificate)
-    // }
-
 
     //We are not guaranteed the user will have a certificate
     //99% chance they do, but if this this their first login

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -32,6 +32,7 @@ const contractName = "Dapp";
 const contractFileName = `dapp/dapp/contracts/Dapp.sol`;
 
 const balance = 100000000000000000000;
+let   userCert = null;
 
 // interface Member {
 //   access?:boolean,
@@ -138,10 +139,15 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser=false) {
       userCertificate = await certificateJs.getCertificateMe(rawAdmin);
       console.log('user content from second attempt', userCertificate)
     }
-    contract.userOrganization = userCertificate.organization
-    userOrganization = userCertificate.organization
-
-    console.log('dapp - userCertificate.organization', userCertificate.organization)
+    //We are not guaranteed the user will have a certificate
+    //99% chance they do, but if this this their first login
+    //the node might not have a certificate in time
+    if (!(userCertificate === null || userCertificate === undefined)) {
+      contract.userOrganization = userCertificate.organization
+      userOrganization = userCertificate.organization
+      userCert    = userCertificate;//Attaching user cert to dapp to save from needing make another call to get it
+      console.log('dapp - userCertificate.organization', userCertificate.organization)
+    }
   }
   
   const managers = await getManagersAndCirrusInfo(rawAdmin, contract, _defaultOptions)
@@ -215,7 +221,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser=false) {
   contract.getCertificate = async function (args) {
     return certificateJs.getCertificate(admin, args);
   };
-  contract.getCertificateMe = async function () {
+  contract.getCertificateMe = (!(userCert === null || userCert === undefined)) ? userCert : async function () {
     return certificateJs.getCertificateMe(admin);
   };
   contract.getCertificates = async function (args) {

--- a/marketplace/backend/helpers/utils.js
+++ b/marketplace/backend/helpers/utils.js
@@ -274,3 +274,11 @@ export function getEnvVariable(name) {
   if (value == '') throw new Error("missing env var for " + name);
   return value
 }
+
+export const  pollingHelper = async ( func, argsToFunc, attemptNumber=0, attemptsAllowed=8, milliseconds=1000  )  => {
+ if (attemptsAllowed  < attemptNumber) return null;
+ let result = await func(...argsToFunc);
+ if (!(result === null || result === undefined)) return result;
+ await new Promise(resolve => setTimeout(resolve, milliseconds));
+ return pollingHelper(func, argsToFunc, attemptNumber+1, attemptsAllowed, milliseconds  );
+}

--- a/marketplace/ui/src/App.js
+++ b/marketplace/ui/src/App.js
@@ -21,7 +21,7 @@ const App = () => {
 
   TagManager.initialize(tagManagerArgs);
 
-  const {user, loginUrl, users } =
+  const {user, loginUrl, users, isAuthenticated } =
     useAuthenticateState();
     
     
@@ -38,7 +38,7 @@ const App = () => {
     <BrowserRouter basename="/marketplace">
       <Layout>
         <UsersProvider>
-          <HeaderComponent user={user} users={users} loginUrl={loginUrl} />
+          <HeaderComponent isOauth={isAuthenticated}  user={user} users={users} loginUrl={loginUrl} />
         </UsersProvider>
         <Content>
           <AuthenticatedRoutes user={user} users={users} />

--- a/marketplace/ui/src/components/Header/Header.js
+++ b/marketplace/ui/src/components/Header/Header.js
@@ -8,6 +8,7 @@ import {
   Badge,
   Avatar,
   Dropdown,
+  Typography,
 } from "antd";
 import { SearchOutlined, ShoppingCartOutlined } from "@ant-design/icons";
 import { Images } from "../../images";
@@ -23,7 +24,7 @@ import { actions as userActions } from "../../contexts/authentication/actions";
 import { useAuthenticateDispatch } from "../../contexts/authentication";
 import TagManager from "react-gtm-module";
 
-
+const { Title } = Typography;
 const { Header } = Layout;
 
 const HeaderComponent = ({ isOauth, user, loginUrl }) => {
@@ -34,9 +35,6 @@ const HeaderComponent = ({ isOauth, user, loginUrl }) => {
   const storedData = useMemo(() => {
     return window.localStorage.getItem("cartList") == null ? [] : JSON.parse(window.localStorage.getItem("cartList"));
   }, []);
-  console.log("oauth", isOauth)
-  console.log("user", user)
-  console.log("loginUrl", loginUrl)
 
   useEffect(() => {
     actions.fetchCartItems(marketplaceDispatch, storedData);
@@ -242,7 +240,7 @@ const HeaderComponent = ({ isOauth, user, loginUrl }) => {
                 })
               } } > 
               Login / Register 
-              </a> : (isOauth  ?  <h1> Something went wrong, try to refresh page</h1> : null)  
+              </a> : (isOauth  ?  <Title  style={{backgroundColor: 'red', border: 3, padding:10,  color: '#FFFFFF'}} level={3} >Something went wrong, try to refresh page</Title> : null)  
           ) :
             <Dropdown menu={{ items }} placement="bottomLeft" trigger={["click"]} overlayStyle={{ marginTop: "40px" }}>
               <a onClick={(e) => e.preventDefault()} className="text-base text-white" id="user-dropdown">

--- a/marketplace/ui/src/components/Header/Header.js
+++ b/marketplace/ui/src/components/Header/Header.js
@@ -26,7 +26,7 @@ import TagManager from "react-gtm-module";
 
 const { Header } = Layout;
 
-const HeaderComponent = ({ user, loginUrl }) => {
+const HeaderComponent = ({ isOauth, user, loginUrl }) => {
   const navigate = useNavigate();
   const marketplaceDispatch = useMarketplaceDispatch();
   const userDispatch = useAuthenticateDispatch();
@@ -34,6 +34,9 @@ const HeaderComponent = ({ user, loginUrl }) => {
   const storedData = useMemo(() => {
     return window.localStorage.getItem("cartList") == null ? [] : JSON.parse(window.localStorage.getItem("cartList"));
   }, []);
+  console.log("oauth", isOauth)
+  console.log("user", user)
+  console.log("loginUrl", loginUrl)
 
   useEffect(() => {
     actions.fetchCartItems(marketplaceDispatch, storedData);
@@ -156,7 +159,7 @@ const HeaderComponent = ({ user, loginUrl }) => {
         >
           <Image src={Images.logo} width={35} preview={false} />
         </div>
-        {roleIndex === undefined || roleIndex === 1 ? null : <div className="ml-7 w-72">
+        {((roleIndex === undefined || roleIndex === 1) && !isOauth)  ? null : <div className="ml-7 w-72">
           <Input
             size="large"
             placeholder="Search"
@@ -230,7 +233,8 @@ const HeaderComponent = ({ user, loginUrl }) => {
         }
         {
           roleIndex === undefined || roleIndex === 1 ? (
-            loginUrl ? <a href={loginUrl} id="Login" className="text-base text-white"> Login / Register </a> : null
+            loginUrl ? <a href={loginUrl} id="Login" className="text-base text-white"> Login / Register </a> : 
+                (isOauth  ?  <h1> Something went wrong, try to refresh page</h1> : null)  
           ) :
             <Dropdown menu={{ items }} placement="bottomLeft" trigger={["click"]} overlayStyle={{ marginTop: "40px" }}>
               <a onClick={(e) => e.preventDefault()} className="text-base text-white" id="user-dropdown">

--- a/strato/api/core/package.yaml
+++ b/strato/api/core/package.yaml
@@ -12,7 +12,6 @@ library:
   dependencies:
   - aeson
   - aeson-casing
-  - async
   - base64-bytestring
   - binary
   - blockapps-data

--- a/strato/api/core/src/Handlers/IdentityServerCallback.hs
+++ b/strato/api/core/src/Handlers/IdentityServerCallback.hs
@@ -11,7 +11,6 @@
 {-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
-{-# OPTIONS -fno-warn-orphans       #-}
 {-# OPTIONS -fno-warn-redundant-constraints       #-}
 
 module Handlers.IdentityServerCallback (API, server) where
@@ -23,7 +22,7 @@ import           GHC.Stack
 import           Servant
 import           Servant.Client
 import           Control.Monad.Reader              (runReaderT)
-import           Control.Concurrent.Async
+import           Control.Exception                 (try, SomeException)
 import           Control.Monad.IO.Class
 
 
@@ -49,9 +48,9 @@ redirect :: ( MonadIO m, MonadLogger m, HasIdentity m)
     => Text ->  m (Headers '[Header "Location" String] Address)
 redirect accessToken = do
   IdentityData url mgr <- access Proxy
-  -- We do not want to wait for the response from the identity server
-  -- so we fork a thread to run the request
-  _ <- liftIO $ async $ runLoggingT $   (flip runReaderT ( IdentityData url mgr)  $ identitytWrapper $ putIdentityExternal ("Bearer " <> accessToken) )
+  --Historical note: we decided to wait for ID serer response, but ignore any bad response
+  --As the fail safe should catch any ID server failure
+  _ <- liftIO $ (try (runLoggingT $ (flip runReaderT ( IdentityData url mgr)  $ identitytWrapper $ putIdentityExternal ("Bearer " <> accessToken) )) :: IO (Either SomeException Address) )
   return $ addHeader "/" (Address 0x0) --At one point we wanted to redirect with an address, but we don't need to do that anymore, maybe we should remove the address from the type signature
 
 identitytWrapper :: (MonadIO m, MonadLogger m, HasIdentity m, HasCallStack) =>

--- a/strato/api/core/src/Handlers/IdentityServerCallback.hs
+++ b/strato/api/core/src/Handlers/IdentityServerCallback.hs
@@ -50,7 +50,12 @@ redirect accessToken = do
   IdentityData url mgr <- access Proxy
   --Historical note: we decided to wait for ID serer response, but ignore any bad response
   --As the fail safe should catch any ID server failure
-  _ <- liftIO $ (try (runLoggingT $ (flip runReaderT ( IdentityData url mgr)  $ identitytWrapper $ putIdentityExternal ("Bearer " <> accessToken) )) :: IO (Either SomeException Address) )
+  idServerResult <- liftIO $ (try (runLoggingT $ (flip runReaderT ( IdentityData url mgr)  $ identitytWrapper $ putIdentityExternal ("Bearer " <> accessToken) )) :: IO (Either SomeException Address) )
+  case idServerResult of 
+    Left e -> do
+      logErrorCS callStack $ "Error calling Identity Server: " <> pack (show e)
+    Right _ -> do
+      logInfoCS callStack "Successfully called Identity Server"
   return $ addHeader "/" (Address 0x0) --At one point we wanted to redirect with an address, but we don't need to do that anymore, maybe we should remove the address from the type signature
 
 identitytWrapper :: (MonadIO m, MonadLogger m, HasIdentity m, HasCallStack) =>


### PR DESCRIPTION
**The objectives:**

- A. dealing with the issue if the marketplace does not attain a cert, what should the user experience be?
- B. Remove the hardcoded delay and add polling.
- C. remove vault/cert calls when possible


**Work  Done/Solutions**

A. Originally we had a thread created for the ID-server originating from the strato node. We did this for the purpose of avoiding handling errors. It turned out, this would cause problems down stream in the marketplace app. As the user was redirected to marketplace instantaneously, which would have the marketplace call vault and the local node for certs. At a higher rate than should be, vault would not have a key generated for the user yet. And at an even higher rate the node would not have received the cert.  **Solution** Add a `try` around the call the to ID-server. The testing I have done, by waiting for the ID response, I have yet to see those problems.
B. I replaced the harded coded delay for certs with a recursive function that polls. I am not a JS master so please suggests improvements. We like learning.
C. Remove vault/cert calls when possible
	i . Vault call removal: I removed an extra vault call located in `loadDappHandler.js` . I was able to remove this call because vault is always called in the prior function call. So I passed it along in the `req`. `loadDappHandler.js` is never called in marketplace prior to `authHandler.authorizeRequest()` .
	ii. Cert removal: I attached a cert to the dapp object. This can save two different function calls down stream. 
		1. The user controller calls for the user's Cert. This is commonly called after `loadDAppHandler.js` where the dapp object is created. Passing the cert from `loadDappHandler.js` can save the future call. I didn't remove the call, but simply check if the cert is already attained, avoiding a possible call.
		2. (This needs your thought and feedback) As noted the `bind`  function in `dapp.js`  may attain the cert of the user. That user does not change inside the `bind` function. If the bind function attains the cert, then why have a function call for it (`contract.getCertificateMe`)?

_(Coming back to A, what should the marketplace show if the cert is not attained)_
A. The rare case that the user cert is not found, but they are authenticated. _What should the user experience be?_ I do not like this solution and I am open to suggestions. In the function  `useAuthenticateState();`,  in `App.js`, returns the user, login, and also has access to `isAuthetnicated` , why not pass that  variable along. Why? Because from what I can tell, that is the case we are dealing with. When they have been authenticated, but their is no cert(and if there is failure to attain the cert, I have seen there be a failure to generate a login/url).  In this case where the `Login` would normally be, there would be a message to the user that there is an error.


Other notes:

1. I was suggested to remove the `createOrGetKey` from marketplace, but in the case that the ID-server fails to do so for whatever reason, I decided to leave it in. (@Dustin ) What do you think?
2. I was suggested to use `setInterval` for polling. Originally I was using a `while` loop, but then a wise engineer commented that is more resource intensive than `setInterval`.  After further consideration, a recursive function seemed appropriate because `setInterval` does not have a `break` or exit if the response is successful.
3. This would be a much larger discussion, but I am wondering why in marketplace we follow the pattern of every backend call to be something like:

` router.get(
  OrderLineItem.get,
  authHandler.authorizeRequest(),
  loadDapp,
  OrderLineItemController.get
);`

In almost all backend calls we have, 

`  authHandler.authorizeRequest(),
  loadDapp,`

I understand we want to verify the user and keep these endpoints secure, but it seems like we are making many duplicate calls to attain the cert on each page load(at the minimum we are making duplicate calls). I am wondering if it would be possible, to have a cache map of cookie to cert to reduce calls to the strato node for the certs. This cache, like the cookie would be time sensitive, expiring at the same time as the cookie expiration.

  