### PR TITLE
Import code collection from address

### DIFF
--- a/smd-ui/src/components/CodeEditor/index.js
+++ b/smd-ui/src/components/CodeEditor/index.js
@@ -139,10 +139,10 @@ class CodeEditor extends Component {
         throw new Error("Can't compile. Source is undefined")
       }
       const code = getFileAndReplaceWithImport(this.props.codeEditorData.sourceCode, this.props.codeEditorData.tab)
-      const newFileList = getImportStatements(code)
-      if (newFileList.length > 0) {
-        throw new Error("Can't find the imported file.")
-      }
+      // const newFileList = getImportStatements(code)
+      // if (newFileList.length > 0) {
+      //   throw new Error("Can't find the imported file.")
+      // }
       mixpanelWrapper.track("compile_contract_code_click");
       this.props.compileCodeFromEditor(code, codeType);
     } catch (e) {

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -22,6 +22,7 @@ so that they could be properly moved to their respective version's subsection.
 - `/transaction/unsigned` endpoint for generating raw transaction inputs
 - Bi-directional sync functionality
 - Mappings in SolidVM receive their own table in Cirrus
+- Support for imports from addresses in SolidVM
 ### Changed
 - `/compile` and `/transaction` endpoints use SolidVM compiler
 ### Fixed

--- a/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/SourceTools.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/SourceTools.hs
@@ -61,7 +61,7 @@ defaultSourceTools dSettings =
   let parse = fmap concat
             . traverse (uncurry parseSourceWithAnnotations)
             . unSourceMap
-      compile = compileSourceWithAnnotations True
+      compile = compileSourceWithAnnotationsWithoutImports True
               . M.fromList
               . unSourceMap
       analyze = runDetectors parse compile id

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
@@ -10,6 +10,7 @@
 module SolidVM.Model.CodeCollection (
   CodeCollectionF(..),
   CodeCollection,
+  emptyCodeCollection,
   flFuncs,
   contracts,
   getParents,
@@ -34,6 +35,7 @@ module SolidVM.Model.CodeCollection (
 import           Control.Lens
 import           Control.DeepSeq
 import           Data.Aeson as A
+import           Data.Default
 import           Data.Map (Map)
 import qualified Data.Map as M
 import           Data.Source
@@ -76,6 +78,31 @@ instance FromJSON a => FromJSON (CodeCollectionF a)
 type CodeCollection = Positioned CodeCollectionF
 
 makeLenses ''CodeCollectionF
+
+emptyCodeCollection :: CodeCollectionF a
+emptyCodeCollection = CodeCollection M.empty M.empty M.empty M.empty M.empty M.empty [] []
+
+instance Default (CodeCollectionF a) where
+  def = emptyCodeCollection
+
+mergeCodeCollections :: CodeCollectionF a -> CodeCollectionF a -> CodeCollectionF a
+mergeCodeCollections cc1 cc2 = CodeCollection
+  { _contracts = cc1 ^. contracts <> cc2 ^. contracts
+  , _flFuncs = cc1 ^. flFuncs <> cc2 ^. flFuncs
+  , _flConstants = cc1 ^. flConstants <> cc2 ^. flConstants
+  , _flEnums = cc1 ^. flEnums <> cc2 ^. flEnums
+  , _flStructs = cc1 ^. flStructs <> cc2 ^. flStructs
+  , _flErrors = cc1 ^. flErrors <> cc2 ^. flErrors
+  , _pragmas     = cc1 ^. pragmas <> cc2 ^. pragmas
+  , _imports     = cc1 ^. imports <> cc2 ^. imports
+  }
+
+instance Semigroup (CodeCollectionF a) where
+  (<>) = mergeCodeCollections
+
+instance Monoid (CodeCollectionF a) where
+  mempty = def
+  mappend = (<>)
 
 type SolidEither = Either (Positioned ((,) SolidException))
 

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
@@ -18,9 +18,11 @@ module SolidVM.Model.CodeCollection (
   flEnums,
   flErrors,
   pragmas,  
+  imports,
   module SolidVM.Model.CodeCollection.Contract,
   --module SolidVM.Model.CodeCollection.Def,
   module SolidVM.Model.CodeCollection.Function,
+  module SolidVM.Model.CodeCollection.Import,
   module SolidVM.Model.CodeCollection.Statement,
   module SolidVM.Model.CodeCollection.ConstantDecl,
   --module SolidVM.Model.CodeCollection.Type,
@@ -48,6 +50,7 @@ import           SolidVM.Model.CodeCollection.Contract
 --import qualified SolidVM.Model.CodeCollection.Def as Def
 import           SolidVM.Model.CodeCollection.Event
 import           SolidVM.Model.CodeCollection.Function
+import           SolidVM.Model.CodeCollection.Import
 import           SolidVM.Model.CodeCollection.Statement
 --import           SolidVM.Model.CodeCollection.Type
 import           SolidVM.Model.CodeCollection.VarDef
@@ -63,7 +66,8 @@ data CodeCollectionF a =
     _flEnums :: Map SolidString ([SolidString], a),
     _flStructs :: Map SolidString [(SolidString, FieldType, a)],
     _flErrors :: Map SolidString [(SolidString, IndexedType, a)],
-    _pragmas :: [(String, String)]
+    _pragmas :: [(String, String)],
+    _imports :: [FileImportF a]
   } deriving (Show, Generic, NFData, Functor)
 
 instance ToJSON a => ToJSON (CodeCollectionF a)
@@ -95,4 +99,5 @@ instance Arbitrary CodeCollection where
     , _flEnums     = M.empty
     , _flStructs   = M.empty
     , _flErrors    = M.empty
-    , _pragmas     = []}]
+    , _pragmas     = []
+    , _imports     = []}]

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Import.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Import.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE DeriveFoldable     #-}
+{-# LANGUAGE DeriveTraversable  #-}
+
+module SolidVM.Model.CodeCollection.Import
+  ( ItemImportF(..)
+  , ItemImport
+  , FileImportF(..)
+  , FileImport
+  ) where
+
+import           Control.Lens                 (mapped, (&), (?~), makeLenses)
+import           Control.DeepSeq
+import           Data.Aeson
+import           Data.Aeson.Casing
+import           Data.Aeson.Casing.Internal   (dropFPrefix)
+import           Data.Source
+import           Data.Swagger
+import           Data.Text                    (Text)
+import qualified Generic.Random               as GR
+import           GHC.Generics
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances    ()
+
+import           SolidVM.Model.CodeCollection.Statement
+
+--------------------------------------------------------------------------------
+soliditySchemaOptions :: SchemaOptions
+soliditySchemaOptions = SchemaOptions
+  { fieldLabelModifier = camelCase . dropFPrefix
+  , constructorTagModifier = id
+  , datatypeNameModifier = id
+  , allNullaryToStringTag = True
+  , unwrapUnaryRecords = True
+  }
+--------------------------------------------------------------------------------
+
+data ItemImportF a = Named Text a
+                   | Aliased Text Text a
+                   deriving (Eq, Show, Generic, Functor, NFData, Foldable, Traversable)
+
+makeLenses ''ItemImportF
+
+instance ToJSON a => ToJSON (ItemImportF a)
+instance FromJSON a => FromJSON (ItemImportF a)
+
+instance Arbitrary a => Arbitrary (ItemImportF a) where
+  arbitrary = GR.genericArbitrary GR.uniform
+
+type ItemImport = Positioned ItemImportF
+
+instance ToSchema ItemImport where
+  declareNamedSchema proxy = genericDeclareNamedSchema soliditySchemaOptions proxy
+     & mapped.name ?~ "ItemImport schema"
+     & mapped.schema.description ?~ "Xabi of an item import declaration"
+     & mapped.schema.example ?~ toJSON sampleItemImport
+     where sampleItemImport :: ItemImportF ()
+           sampleItemImport = Aliased "add" "func" ()
+
+-- Changes to this structure should also have changes in the Unparser :)
+data FileImportF a = Simple (ExpressionF a) a
+                   | Qualified (ExpressionF a) Text a
+                   | Braced [ItemImportF a] (ExpressionF a) a
+                   deriving (Eq, Show, Generic, Functor, NFData, Foldable, Traversable)
+
+makeLenses ''FileImportF
+
+instance ToJSON a => ToJSON (FileImportF a)
+instance FromJSON a => FromJSON (FileImportF a)
+
+instance Arbitrary a => Arbitrary (FileImportF a) where
+  arbitrary = GR.genericArbitrary GR.uniform
+
+type FileImport = Positioned FileImportF
+
+-- instance ToSchema FileImport where
+--   declareNamedSchema proxy = genericDeclareNamedSchema soliditySchemaOptions proxy
+--      & mapped.name ?~ "FileImport schema"
+--      & mapped.schema.description ?~ "Xabi of an file import declaration"
+--      & mapped.schema.example ?~ toJSON sampleFileImport
+--      where sampleFileImport :: FileImportF ()
+--            sampleFileImport = Qualified (StringLiteral () "./Foo.sol") "F" ()

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Statement.hs
@@ -28,7 +28,7 @@ module SolidVM.Model.CodeCollection.Statement
   , numLitGen
   ) where
 
-import Blockchain.Model.Strato.Account
+import Blockchain.Strato.Model.Account
 import Data.Aeson
 import Data.Source
 --import Data.Swagger

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Statement.hs
@@ -28,6 +28,7 @@ module SolidVM.Model.CodeCollection.Statement
   , numLitGen
   ) where
 
+import Blockchain.Model.Strato.Account
 import Data.Aeson
 import Data.Source
 --import Data.Swagger
@@ -153,6 +154,7 @@ data ExpressionF a =
   | BoolLiteral a Bool
   | NumberLiteral a Integer (Maybe NumberUnit)
   | StringLiteral a String
+  | AccountLiteral a NamedAccount
   | TupleExpression a [Maybe (ExpressionF a)]
   | ArrayExpression a [(ExpressionF a)]
   | Variable a SolidString 
@@ -174,6 +176,7 @@ extractExpression (Ternary a _ _ _) = a
 extractExpression (BoolLiteral a _) = a
 extractExpression (NumberLiteral a _ _) = a
 extractExpression (StringLiteral a _) = a
+extractExpression (AccountLiteral a _) = a
 extractExpression (TupleExpression a _) = a
 extractExpression (ArrayExpression a _) = a
 extractExpression (Variable a _) = a

--- a/strato/VM/SolidVM/solid-vm-parser/package.yaml
+++ b/strato/VM/SolidVM/solid-vm-parser/package.yaml
@@ -30,6 +30,7 @@ library:
   - semver-range
   - solid-vm-model
   - source-tools
+  - strato-model
   - swagger2
   - text
   - deepseq

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -44,7 +44,7 @@ import qualified SolidVM.Solidity.Xabi              as Xabi
 import           Blockchain.VM.SolidException
 
 data SourceUnitF a = Pragma a Identifier String
-                   | Import a Text.Text
+                   | Import a (SolidVM.FileImportF a)
                    | Alias a String String
                    | NamedXabi Text.Text (XabiF a, [Text.Text])
                    | FLFunc String SolidVM.Func

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Imports.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Imports.hs
@@ -9,14 +9,61 @@ module SolidVM.Solidity.Parse.Imports (solidityImport) where
 import           Data.Source
 import qualified Data.Text   as T
 
+import           SolidVM.Model.CodeCollection.Import
 import           SolidVM.Solidity.Parse.Declarations
 import           SolidVM.Solidity.Parse.Lexer
 import           SolidVM.Solidity.Parse.ParserTypes
+import           SolidVM.Solidity.Parse.Statement
+
+import           Text.Parsec
 
 solidityImport :: SolidityParser SourceUnit
 solidityImport = do
-  ~(a, path) <- withPosition $ do
+  ~(a, imp) <- withPosition $ do
     reserved "import"
-    T.pack <$> stringLiteral
+    fileImport
   semi
-  return $ Import a path
+  pure $ Import a imp
+
+fileImport :: SolidityParser FileImport
+fileImport = bracedImport <|> try qualifiedImport <|> simpleImport
+
+simpleImport :: SolidityParser FileImport
+simpleImport = do
+  ~(a, expr) <- withPosition expression
+  pure $ Simple expr a
+
+qualifiedImport :: SolidityParser FileImport
+qualifiedImport = do
+  ~(a, (expr, qualifier)) <- withPosition $ do
+    expr <- expression
+    reserved "as"
+    qualifier <- T.pack <$> stringLiteral
+    pure (expr, qualifier)
+  pure $ Qualified expr qualifier a
+
+bracedImport :: SolidityParser FileImport
+bracedImport = do
+  ~(a, (items, expr)) <- withPosition $ do
+    items <- braces $ commaSep1 itemImport
+    reserved "from"
+    expr <- expression
+    pure (items, expr)
+  pure $ Braced items expr a
+
+itemImport :: SolidityParser ItemImport
+itemImport = try aliasedImport <|> namedImport
+
+namedImport :: SolidityParser ItemImport
+namedImport = do
+  ~(a, path) <- withPosition $ T.pack <$> identifier
+  pure $ Named path a
+
+aliasedImport :: SolidityParser ItemImport
+aliasedImport = do
+  ~(a, (item, alias)) <- withPosition $ do
+    item <- T.pack <$> identifier
+    reserved "as"
+    alias <- T.pack <$> identifier
+    pure (item, alias)
+  pure $ Aliased item alias a

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
@@ -11,7 +11,9 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import           Text.Parsec
 import           Text.Parsec.Expr
+import           Text.Read (readMaybe)
 
+import           Blockchain.Strato.Model.Account
 import           SolidVM.Model.CodeCollection.Statement
 import           SolidVM.Model.SolidString
 import           SolidVM.Model.Type
@@ -374,6 +376,7 @@ primaryExpression = do
               pure (val, nu)
             pure $ NumberLiteral a val nu)
     <|> (uncurry StringLiteral <$> withPosition stringLiteral)
+    <|> (uncurry AccountLiteral <$> withPosition accountLiteral)
 
 myHexParser :: SolidityParser Expression
 myHexParser = try $ do
@@ -413,12 +416,27 @@ parseExternalCallArgs = do
       return (name, args)
   return (fname, args)
 
+accountLiteral :: SolidityParser NamedAccount
+accountLiteral = do
+  void $ char '<'
+  addr <- many1 hexDigit
+  cId <- optionMaybe $ do
+    void $ char ':'
+    (reserved "main" >> pure "main") <|> many1 hexDigit
+  let acctStr = addr ++ maybe "" (':':) cId
+  acct <- case readMaybe acctStr of
+    Nothing -> fail $ "accountLiteral: Could not parse account from " ++ acctStr
+    Just acct -> pure acct
+  void $ char '>'
+  pure acct
+
 literal :: SolidityParser Expression
 literal = asum
         [ do
             ~(a, (n, u)) <- withPosition $ (,) <$> integer <*> optionMaybe numberUnit
             pure $ NumberLiteral a n u
         , uncurry StringLiteral <$> withPosition stringLiteral
+        , uncurry AccountLiteral <$> withPosition accountLiteral
         , uncurry BoolLiteral <$> withPosition (False <$ reserved "false")
         , uncurry BoolLiteral <$> withPosition (True <$ reserved "true")
         , uncurry ArrayExpression <$> withPosition (brackets $ commaSep literal)

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -336,6 +336,7 @@ unparseExpression (NumberLiteral _ x _) = show x
 unparseExpression (BoolLiteral _ False) = "false"
 unparseExpression (BoolLiteral _ True) = "true"
 unparseExpression (StringLiteral _ s) = ('"':) . (++"\"") $ s
+unparseExpression (AccountLiteral _ a) = ('<':) . (++">") $ show a
 unparseExpression (HexaLiteral _ a) = "hex\"" ++ (labelToString a) ++ "\"" 
 unparseExpression (TupleExpression _ vals) = "(" ++ List.intercalate ", " (map (maybe "" unparseExpression) vals) ++ ")"
 unparseExpression (IndexAccess _ e maybeVal) = unparseExpression e ++ "[" ++ fromMaybe "" (fmap unparseExpression maybeVal) ++ "]"

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -40,7 +40,7 @@ unparse (File units) = List.concat $ List.map unparseSourceUnit units
 
 unparseSourceUnit :: SourceUnit -> String
 unparseSourceUnit (Pragma _ ident contents) = "pragma " ++ ident ++ " " ++ contents ++ ";\n"
-unparseSourceUnit (Import _ path) = "import \"" ++ Text.unpack path ++ "\";\n"
+unparseSourceUnit (Import _ imp) = "import \"" ++ unparseFileImport imp ++ "\";\n"
 unparseSourceUnit (FLConstant name conDecl) = (("\n    " <>) . unparseConstant) (Text.unpack name, conDecl)
 unparseSourceUnit (FLStruct name decl) = (("\n    " <>) . unparseTypes) (Text.unpack name, decl)
 unparseSourceUnit (FLEnum name decl) = (("\n    " <>) . unparseTypes) (Text.unpack name, decl)
@@ -419,3 +419,12 @@ unparseVals (name, theType) =
 
 unparseIndexedType :: IndexedType -> Text
 unparseIndexedType = Text.pack . unparseVarType . indexedTypeType
+
+unparseFileImport :: Show a => FileImportF a -> String
+unparseFileImport (Simple e _) = unparseExpression e
+unparseFileImport (Qualified e q _) = unparseExpression e ++ " as " ++ Text.unpack q
+unparseFileImport (Braced i e _) = "{ " ++ (List.intercalate ", " $ unparseItemImport <$> i) ++ " } from " ++ unparseExpression e
+
+unparseItemImport :: ItemImportF a -> String
+unparseItemImport (Named n _) = Text.unpack n
+unparseItemImport (Aliased n a _) = Text.unpack $ n <> " as " <> a

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/BooleanLiterals.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/BooleanLiterals.hs
@@ -109,6 +109,7 @@ expressionHelper (BoolLiteral a _) =
   ["Misuse of boolean literal. Consider removing." <$ a]
 expressionHelper (NumberLiteral _ _ _) = []
 expressionHelper (StringLiteral _ _) = []
+expressionHelper (AccountLiteral _ _) = []
 expressionHelper (TupleExpression _ es) =
   concat $ maybe [] expressionHelper <$> es
 expressionHelper (ArrayExpression _ es) = concat $ expressionHelper <$> es

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/DivideBeforeMultiply.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/DivideBeforeMultiply.hs
@@ -105,6 +105,7 @@ expressionHelper (Ternary _ a b c) =
 expressionHelper (BoolLiteral _ _) = []
 expressionHelper (NumberLiteral _ _ _) = []
 expressionHelper (StringLiteral _ _) = []
+expressionHelper (AccountLiteral _ _) = []
 expressionHelper (TupleExpression _ es) =
   concat $ maybe [] expressionHelper <$> es
 expressionHelper (ArrayExpression _ es) = concat $ expressionHelper <$> es

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Functions/ConstantFunctions.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Functions/ConstantFunctions.hs
@@ -353,6 +353,7 @@ expressionHelper (Ternary _ a b c) = concat <$> traverse expressionHelper [a, b,
 expressionHelper (BoolLiteral _ _) = pure []
 expressionHelper (NumberLiteral _ _ _) = pure []
 expressionHelper (StringLiteral _ _) = pure []
+expressionHelper (AccountLiteral _ _) = pure []
 expressionHelper (TupleExpression _ es) =
   concat <$> traverse (maybe (pure []) expressionHelper) es
 expressionHelper (ArrayExpression _ es) = concat <$> traverse expressionHelper es

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/WriteAfterWrite.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/WriteAfterWrite.hs
@@ -191,6 +191,7 @@ expressionHelper (Ternary _ a b c) = concat <$> traverse expressionHelper [a, b,
 expressionHelper (BoolLiteral _ _) = pure []
 expressionHelper (NumberLiteral _ _ _) = pure []
 expressionHelper (StringLiteral _ _) = pure []
+expressionHelper (AccountLiteral _ _) = pure []
 expressionHelper (HexaLiteral _ _) = pure []
 expressionHelper (TupleExpression _ es) =
   concat <$> traverse (maybe (pure []) expressionHelper) es

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1475,6 +1475,7 @@ tcExpr (Ternary x a b c) =
 tcExpr (BoolLiteral x _) = pure $ boolType' x
 tcExpr (NumberLiteral x _ _) = pure $ intType' x
 tcExpr (StringLiteral x _) = pure $ stringType' x
+tcExpr (AccountLiteral x _) = pure $ accountType' x
 tcExpr (HexaLiteral x _) = pure $ stringType' x
 tcExpr (TupleExpression x es) =
   productType' x <$> traverse (maybe (pure $ topType' x) tcExpr) es

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Variables/StateVariables.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Variables/StateVariables.hs
@@ -217,6 +217,7 @@ expressionHelper (Ternary _ a b c) = concat <$> traverse expressionHelper [a, b,
 expressionHelper (BoolLiteral _ _) = pure []
 expressionHelper (NumberLiteral _ _ _) = pure []
 expressionHelper (StringLiteral _ _) = pure []
+expressionHelper (AccountLiteral _ _) = pure []
 expressionHelper (TupleExpression _ es) =
   concat <$> traverse (maybe (pure []) expressionHelper) es
 expressionHelper (ArrayExpression _ es) = concat <$> traverse expressionHelper es

--- a/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
+++ b/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
@@ -116,7 +116,7 @@ main = do
   contents <- readFile filename
   File parsedFile <- either (die . show) return $ runParser solidityFile (ParserState "" "" M.empty) "" contents
   let namedContracts = [(textToLabel name, either (throw . fst) id $ xabiToContract (textToLabel name) (map textToLabel parents') M.empty xabi) | NamedXabi name (xabi, parents') <- parsedFile]
-      cc = CodeCollection (M.fromList namedContracts) (M.empty) (M.empty) (M.empty) (M.empty) (M.empty) []
+      cc = CodeCollection (M.fromList namedContracts) (M.empty) (M.empty) (M.empty) (M.empty) (M.empty) [] []
       typecheck = TC.detector cc
       nodes = codeCollectionCrawler cc
   putStrLn (show typecheck) --when (not null typecheck)

--- a/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
+++ b/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
@@ -80,6 +80,7 @@ expressionCrawler = \case
   HexaLiteral{} -> ["HexaLiteral"]
   NumberLiteral{} -> ["NumberLiteral"]
   StringLiteral{} -> ["StringLiteral"]
+  AccountLiteral{} -> ["AccountLiteral"]
   TupleExpression _ subexprs -> "TupleExpression" : do
     expr <- catMaybes subexprs
     expressionCrawler expr

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -758,6 +758,7 @@ argsToValsModifiers ctract md args =
                                                 CC.Ether -> return . coerceType ctract t $ SInteger (n * (10 ^ (18 :: Integer)))
             CC.BoolLiteral _ b             -> return . coerceType ctract t $ SBool b
             CC.StringLiteral _ s           -> return . coerceType ctract t $ SString s
+            CC.AccountLiteral _ a          -> return . coerceType ctract t $ SAccount a False
             CC.ArrayExpression _ as        -> case t of
               SVMType.Array{SVMType.entry=t'} ->
                 SArray t . V.fromList <$> mapM (fmap Constant . eval32 t') as
@@ -817,6 +818,7 @@ argsToVals ctract fn args = case args of
                                                   CC.Ether -> return . coerceType ctract t $ SInteger (n * (10 ^ (18 :: Integer)))
             CC.BoolLiteral _ b             -> return . coerceType ctract t $ SBool b
             CC.StringLiteral _ s           -> return . coerceType ctract t $ SString s
+            CC.AccountLiteral _ a          -> return . coerceType ctract t $ SAccount a False
             CC.ArrayExpression _ as        -> case t of
               SVMType.Array{SVMType.entry=t'} ->
                 SArray t . V.fromList <$> mapM (fmap Constant . eval32 t') as
@@ -853,6 +855,7 @@ expressionType :: CC.Expression -> SVMType.Type
 expressionType (CC.BoolLiteral _ _ ) = SVMType.Bool
 expressionType (CC.NumberLiteral _ _ _) = SVMType.Int (Just True) Nothing
 expressionType (CC.StringLiteral _ _) = SVMType.String $ Just True
+expressionType (CC.AccountLiteral _ _) = SVMType.Account False
 expressionType (CC.ArrayExpression _ xs) = SVMType.Array (expressionType (head xs)) Nothing
 
 expressionType ex = typeError "Cannot deduce a type from" (ex, ex)
@@ -1451,6 +1454,7 @@ expToVar' (CC.NumberLiteral _ v (Just nu)) =
     CC.Finney -> return . Constant $ SInteger (v * (10 ^ (15 :: Integer)))
     CC.Ether -> return . Constant $ SInteger (v * (10 ^ (18 :: Integer)))
 expToVar' (CC.StringLiteral _ s) = return $ Constant $ SString s
+expToVar' (CC.AccountLiteral _ a) = return $ Constant $ SAccount a False
 expToVar' (CC.BoolLiteral _ b) = return $ Constant $ SBool b
 expToVar' (CC.HexaLiteral _ a) = return $ Constant $ SString $ BC.unpack . either (parseError "Couldn't parse hexadecimal literal: ") id . B16.decode $ BC.pack a
 expToVar' (CC.Variable _ "bytes32ToString") = return $ Constant $ SHexDecodeAndTrim

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -1,27 +1,40 @@
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeOperators #-}
+
 module Blockchain.SolidVM.CodeCollectionDB
-  ( ParseTypeCheckOrSolidVMError(..)
+  ( CompilationError(..)
+  , MemCompilerT(..)
+  , runMemCompilerT
   , parseSource
   , parseSourceWithAnnotations
   , compileSourceNoInheritance
   , compileSource
   , compileSourceWithAnnotations
+  , compileSourceWithAnnotationsWithoutImports
   , codeCollectionFromSource
   , codeCollectionFromHash
   ) where
 
 import           Control.Exception
-import           Control.Monad                        ((<=<))
+import qualified Control.Monad.Change.Alter           as A
 import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Except
 import           Control.Lens                         hiding (assign, from, to, bimap, Context)
 import qualified Data.Aeson                           as Aeson
 import           Data.Bifunctor                       (bimap, first)
 import qualified Data.ByteString                      as B
 import qualified Data.ByteString.Lazy                 as BL
+import           Data.Default
 import           Data.Foldable                        (foldrM)
 import           Data.IORef
 import           Data.Map                             (Map)
@@ -30,14 +43,19 @@ import           Data.Maybe                           (catMaybes)
 import           Data.Source
 import qualified Data.Text                            as T
 import           Data.Text.Encoding                   (decodeUtf8, encodeUtf8)
-import           Data.Traversable                     (for)
 import           System.IO.Unsafe
 import           Text.Parsec                          (runParser)
 import           Text.Parsec.Error
 
+import           Blockchain.Data.AddressStateDB
+import           Blockchain.Data.ChainInfo
 import           Blockchain.DB.CodeDB
+import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.SolidVM.Exception         hiding (assert)
+import           Blockchain.SolidVM.ImportResolver
 import           Blockchain.SolidVM.Metrics
+import           Blockchain.Strato.Model.Account
+import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Strato.Model.Keccak256
 
 import           Control.DeepSeq                      (force)
@@ -57,27 +75,35 @@ import qualified SolidVM.Solidity.StaticAnalysis.Functions.ConstantFunctions    
 import           SolidVM.Solidity.StaticAnalysis.Optimizer                              as O
 import qualified        SolidVM.Solidity.StaticAnalysis.Statements.MultipleDeclarations as MultipleDeclarations
 
-data ParseTypeCheckOrSolidVMError = PEx ParseError
-                         | TCEx [SourceAnnotation T.Text]
-                         | SVMEx (Positioned ((,) SolidException)) deriving (Show)
+data CompilationError = PEx ParseError
+                      | IEx T.Text
+                      | TCEx [SourceAnnotation T.Text]
+                      | SVMEx (Positioned ((,) SolidException)) deriving (Show)
 
-data SUnitIntermediary = Con Contract
-                       | FLC ConstantDecl
-                       | FLS Def.Def
-                       | FLE Def.Def
-                       | FLF Func
-                       | FLER Def.Def
-                       | Prag (String, String)
-                       | Imp  FileImport
+newtype MemCompilerT m a = MemCompilerT { unMemCompilerT :: MainChainT (MemAddressStateDB (MemCodeDB m)) a }
+  deriving (Functor, Applicative, Monad, MonadIO)
 
--- | OTHER CACHE OPTIONS
--- {-# NOINLINE unsafeCodeMapIORef #-}
--- unsafeCodeMapIORef :: IORef (Map Keccak256 CodeCollection)
--- unsafeCodeMapIORef = unsafePerformIO $ newIORef M.empty
+instance MonadTrans MemCompilerT where
+  lift = MemCompilerT . MainChainT . MemAddressStateDB . lift . MemCodeDB . lift
 
--- {-# NOINLINE unsafeCodeCahcheIO #-}
--- unsafeCodeCahcheIORef :: IORef (DC.Cache Keccak256 CodeCollection)
--- unsafeCodeCahcheIORef = unsafePerformIO $ newIORef $ newCache timeLife
+instance Monad m => (Account `A.Alters` AddressState) (MemCompilerT m) where
+  lookup p   = MemCompilerT . MainChainT . A.lookup p
+  insert p k = MemCompilerT . MainChainT . A.insert p k
+  delete p   = MemCompilerT . MainChainT . A.delete p
+
+instance Monad m => A.Selectable Account AddressState (MemCompilerT m) where
+  select = A.lookup
+
+instance Monad m => (Keccak256 `A.Alters` DBCode) (MemCompilerT m) where
+  lookup p   = MemCompilerT . MainChainT . MemAddressStateDB . lift . A.lookup p
+  insert p k = MemCompilerT . MainChainT . MemAddressStateDB . lift . A.insert p k
+  delete p   = MemCompilerT . MainChainT . MemAddressStateDB . lift . A.delete p
+
+instance Monad m => A.Selectable Word256 ParentChainIds (MemCompilerT m) where
+  select p   = MemCompilerT . A.select p
+
+runMemCompilerT :: Monad m => MemCompilerT m a -> m a
+runMemCompilerT = runNewMemCodeDB . runNewMemAddressStateDB . runMainChainT . unMemCompilerT
 
 maxCacheSize :: Integer
 maxCacheSize = 10
@@ -88,92 +114,66 @@ unsafeCodeCahcheLRUIORef = unsafePerformIO $ newIORef $ LRU.newLRU (Just maxCach
 
 
 
-withAnnotations :: (a -> Either ParseTypeCheckOrSolidVMError b) -> a -> Either [SourceAnnotation T.Text] b
-withAnnotations f = first unwind . f
+withAnnotations :: Monad m => (a -> m (Either CompilationError b)) -> a -> m (Either [SourceAnnotation T.Text] b)
+withAnnotations f = fmap (first unwind) . f
   where unwind (PEx pe) = [parseErrorToAnnotation pe]
+        unwind (IEx t)  = [t <$ emptySourceAnnotation]
         unwind (SVMEx (e,x)) = [T.pack (show e) <$ x]
         unwind (TCEx errs) = errs
 
-parseSource :: T.Text -> T.Text -> Either ParseTypeCheckOrSolidVMError [SourceUnit]
+parseSource :: T.Text -> T.Text -> Either CompilationError [SourceUnit]
 parseSource fileName src = bimap PEx unsourceUnits $ runParser solidityFile (ParserState "" "" M.empty) (T.unpack fileName) (T.unpack src)
 
 parseSourceWithAnnotations :: T.Text -> T.Text -> Either [SourceAnnotation T.Text] [SourceUnit]
-parseSourceWithAnnotations = withAnnotations . parseSource
+parseSourceWithAnnotations fileName = runIdentity . withAnnotations (Identity . parseSource fileName)
 
-compileSourceNoInheritance :: Map T.Text T.Text -> Either ParseTypeCheckOrSolidVMError CodeCollection
-compileSourceNoInheritance initCodeMap = do
-  let getNamedSUnits :: T.Text -> T.Text -> Either ParseTypeCheckOrSolidVMError [(SolidString, SUnitIntermediary)]
+compileSourceNoInheritance :: ( HasCodeDB m
+                              , A.Selectable Account AddressState m
+                              )
+                           => Bool -> Map T.Text T.Text -> m (Either CompilationError CodeCollection)
+compileSourceNoInheritance typeCheck initCodeMap = runExceptT $ do
+  let getNamedSUnits :: T.Text -> T.Text -> Either CompilationError (Positioned UnresolvedFileUnitsF)
       getNamedSUnits fileName src = do
         sourceUnits <- parseSource fileName src
+        foldrM (\u ufu -> maybe (pure ufu) (first IEx . mergeUnresolvedFileUnits ufu) =<< getNameAndUnit sourceUnits u) def sourceUnits
 
-        let userDefinedFromFile = M.fromList $ map (\case (Alias _ alias typ) -> (alias, typ); _ -> ("", "")) $ filter (\case (Alias _ _ _) -> True; _ -> False;) sourceUnits
-        fmap catMaybes . for sourceUnits $ \case
-          NamedXabi name (xabi, parents') -> do
-            ctrct <- first SVMEx
-                   $ xabiToContract (textToLabel name) (map textToLabel parents') userDefinedFromFile xabi
-            pure $ Just $ (textToLabel name, Con ctrct)
-          FLFunc name fdec -> do
-            pure $ Just $ (name, FLF fdec)
-          FLConstant name cnst -> do
-            pure $ Just $ (textToLabel name, FLC cnst)
-          FLStruct name fls -> do
-            pure $ Just $ (textToLabel name, FLS fls)
-          FLEnum name fle -> do
-            pure $ Just $ (textToLabel name, FLE fle)
-          FLError name args -> do
-            pure $ Just $ (textToLabel name, FLER args)
-          Pragma _ n v -> do 
-            pure $ Just $ (" ", Prag (n,v))
-          Import _ i -> pure . Just $ ("", Imp i)
-          _ -> pure Nothing
-
-      throwDuplicate' :: (SolidString, a) -> Map SolidString a -> (a -> SourceAnnotation b) -> Either ParseTypeCheckOrSolidVMError (Map SolidString a)
-      throwDuplicate' (sName, unit) m contextFunc = case M.lookup sName m of
-        Nothing -> pure $ M.insert sName unit m
-
-        Just _ ->  Left . PEx
-                  $ newErrorMessage (Message $ "Duplicate unit found: " ++ labelToString sName)
-                                    (fromSourcePosition $ _sourceAnnotationStart $ contextFunc unit)
-
-      throwDuplicate :: (SolidString, SUnitIntermediary) ->  CodeCollection -> Either ParseTypeCheckOrSolidVMError CodeCollection
-      throwDuplicate (name, sUnit) cc = case sUnit of 
-        Con ctrct                 -> fmap (\cMap -> cc & contracts   .~ cMap) $ throwDuplicate' (name, ctrct) (cc ^. contracts)  _contractContext
-        FLC cnst                  -> fmap (\cMap -> cc & flConstants .~ cMap) $ throwDuplicate' (name, cnst) (cc ^. flConstants) _constContext
-        FLE (Def.Enum vals _ a)   -> fmap (\cMap -> cc & flEnums     .~ cMap) $ throwDuplicate' (name, (vals, a)) (cc ^. flEnums) (const a)
-        FLS (Def.Struct vals _ a) -> fmap (\cMap -> cc & flStructs   .~ cMap) $ throwDuplicate' (name, (\(k,v) -> (k,v,a)) <$> vals) (cc ^. flStructs) (\_ -> a)
-        FLF func                  -> fmap (\cMap -> cc & flFuncs     .~ cMap) $ throwDuplicateFunction (name, func) (cc ^. flFuncs) -- Thanks Jin!
-        FLER (Def.Error vals _ a) -> fmap (\cMap -> cc & flErrors    .~ cMap) $ throwDuplicate' (name, (\(k,v) -> (k,v,a)) <$> vals) (cc ^. flErrors) (\_ -> a)
-        --not map type
-        Prag a                -> fmap (\cList -> cc & pragmas .~ cList) $ pure (a : (cc ^. pragmas))
-        Imp  i                -> fmap (\cList -> cc & imports .~ cList) $ pure (i : (cc ^. imports))
-        FLE y  -> parseError  "FLE non Enum should be impossible  "  (show y)
-        FLS x  -> parseError  "FLS non Struct should be impossible"  (show x)
-        FLER z -> parseError  "FLER non Error should be impossible"  (show z)
-      sUnitSorter = foldrM throwDuplicate $ CodeCollection M.empty M.empty M.empty M.empty M.empty M.empty [] [] -- the list of all the sUnits goes here
-
-      throwDuplicateFunction :: (SolidString, Func) -> Map SolidString Func -> Either ParseTypeCheckOrSolidVMError (Map SolidString Func)
-      throwDuplicateFunction (fname, func) m = case M.lookup fname m of
-        Nothing -> pure $ M.insert fname func m 
-        Just fdec -> do
-          let oldParamTypes = fmap snd $ _funcArgs fdec
-              newParamTypes = fmap snd $ _funcArgs func
-              overloadParamTypes = concatMap (\x -> [fmap snd $ _funcArgs x]) $ _funcOverload fdec
-          if ((oldParamTypes == newParamTypes) || (newParamTypes `elem` overloadParamTypes))
-            then Left . PEx $ newErrorMessage (Message $ "Free function could not be overloaded: " ++ labelToString fname)
-                                              (fromSourcePosition $ _sourceAnnotationStart $ _funcContext func)
-            else do
-              pure $ M.insert fname (fdec{_funcOverload = _funcOverload fdec ++ [func]}) m
-                                           
-  allSUnits <- fmap concat . traverse (uncurry getNamedSUnits) $ M.toList initCodeMap
-  theCC <- sUnitSorter allSUnits
+      userDefinedFromFile ss = M.fromList . catMaybes $ (\case (Alias _ alias typ) -> Just (alias, typ); _ -> Nothing) <$> ss
+      getNameAndUnit ss = \case
+        NamedXabi name (xabi, parents') -> do
+          ctrct <- first SVMEx
+                 $ xabiToContract (textToLabel name) (map textToLabel parents') (userDefinedFromFile ss) xabi
+          pure . Just $ def & ufuUnits . at (textToLabel name) ?~ FUContract ctrct
+        FLFunc name fdec ->
+          pure . Just $ def & ufuUnits . at name ?~ FUFunction fdec
+        FLConstant name cnst ->
+          pure . Just $ def & ufuUnits . at (textToLabel name) ?~ FUConstant cnst
+        FLStruct name (Def.Struct fs _ a) ->
+          let fls = (\(n,t) -> (n,t,a)) <$> fs
+           in pure . Just $ def & ufuUnits . at (textToLabel name) ?~ FUStruct fls
+        FLEnum name (Def.Enum ns _ a) ->
+          let fle = (ns, a)
+           in pure . Just $ def & ufuUnits . at (textToLabel name) ?~ FUEnum fle
+        FLError name (Def.Error ps _ a) ->
+          let fler = (\(n,t) -> (n,t,a)) <$> ps
+           in pure . Just $ def & ufuUnits . at (textToLabel name) ?~ FUError fler
+        Pragma _ n v ->
+          pure . Just $ def & ufuPragmas . at n ?~ v
+        Import _ i -> pure . Just $ def & ufuImports .~ [i]
+        _ -> pure Nothing
+  ufuMap <- except . fmap M.fromList . traverse (\(n,s) -> (n,) <$> getNamedSUnits n s) $ M.toList initCodeMap
+  theCC <- withExceptT IEx $ resolveImports (codeCollectionFromHashNoCache typeCheck) ufuMap
   pure $ force theCC
 
     
 --- Don't typecheck in Slipstream!!!
-compileSource :: Bool -> Map T.Text T.Text-> Either ParseTypeCheckOrSolidVMError CodeCollection
+compileSource :: ( HasCodeDB m
+                 , A.Selectable Account AddressState m
+                 )
+              => Bool -> Map T.Text T.Text-> m (Either CompilationError CodeCollection)
 compileSource typeCheck mTT = do
   let applyInheritanceE = first SVMEx . applyInheritance
-  case (applyInheritanceE <=< compileSourceNoInheritance) mTT of
+  eCC <- compileSourceNoInheritance typeCheck mTT
+  pure $ case applyInheritanceE =<< eCC of
     Right cc | typeCheck -> O.detector <$> typeCheckDetector cc
              | otherwise                 -> Right cc
     Left x -> Left x
@@ -182,11 +182,19 @@ compileSource typeCheck mTT = do
         [] -> Right ecc
         xs -> Left $ TCEx xs
 
-compileSourceWithAnnotations :: Bool -> Map T.Text T.Text -> Either [SourceAnnotation T.Text] CodeCollection
+compileSourceWithAnnotations :: ( HasCodeDB m
+                                , A.Selectable Account AddressState m
+                                )
+                             => Bool -> Map T.Text T.Text -> m (Either [SourceAnnotation T.Text] CodeCollection)
 compileSourceWithAnnotations typeCheck = withAnnotations (compileSource typeCheck)
+
+compileSourceWithAnnotationsWithoutImports
+  :: Bool -> Map T.Text T.Text -> Either [SourceAnnotation T.Text] CodeCollection
+compileSourceWithAnnotationsWithoutImports typeCheck = runIdentity . runMemCompilerT . withAnnotations (compileSource typeCheck)
 
 codeCollectionFromSource :: ( MonadIO m
                             , HasCodeDB m
+                            , A.Selectable Account AddressState m
                             -- , HasCodeCollectionDB m
                             )
                          => Bool
@@ -212,10 +220,11 @@ codeCollectionFromSource typeCheck initCode = do
     (_, Nothing) -> do
       recordCacheEvent StorageWrite
       hsh' <- addCode SolidVM canonicalInitCode
-      let ecc = compileSource typeCheck initMap
-          cc = case ecc of
+      ecc <- compileSource typeCheck initMap
+      let cc = case ecc of
                  Right a -> a
                  Left (PEx p) -> parseError "codeCollectionFromSource" p
+                 Left (IEx p) -> typeError "codeCollectionFromSource" p
                  Left (SVMEx (s, _)) -> throw s
                  Left (TCEx xs) -> typeError "Typechecker" (typeErrorToAnnotation xs)
       liftIO $ modifyIORef' unsafeCodeCahcheLRUIORef (LRU.insert hsh cc) 
@@ -223,6 +232,7 @@ codeCollectionFromSource typeCheck initCode = do
 
 codeCollectionFromHash :: ( MonadIO m
                           , HasCodeDB m
+                          , A.Selectable Account AddressState m
                           -- , HasCodeCollectionDB m
                           )
                        => Bool
@@ -237,20 +247,26 @@ codeCollectionFromHash typeCheck hsh = do
       return cc
     (_, Nothing) -> do
       recordCacheEvent CacheMiss
-      mCode <- getCode hsh
-      case mCode of
-        Just (_, initCode) -> do
-          let initMap = case Aeson.decode $ BL.fromStrict initCode of
-                  Just l -> M.fromList l
-                  Nothing -> M.singleton T.empty (decodeUtf8 initCode)
-          let ecc = compileSource typeCheck initMap
-              cc = case ecc of
-                     Right a -> a
-                     Left (PEx p) -> parseError "codeCollectionFromHash" p
-                     Left (SVMEx (s, _)) -> throw s
-                     Left (TCEx xs) -> typeError "codeCollectionFromSource" (show xs)
-          --     codeMap' = M.insert hsh cc codeMap
-          -- recordCacheSize $ M.size codeMap'
-          liftIO $ modifyIORef' unsafeCodeCahcheLRUIORef (LRU.insert hsh cc)
-          return cc
-        Nothing -> internalError "unknown code hash" hsh
+      cc <- codeCollectionFromHashNoCache typeCheck hsh
+      liftIO $ modifyIORef' unsafeCodeCahcheLRUIORef (LRU.insert hsh cc)
+      return cc
+
+codeCollectionFromHashNoCache :: ( HasCodeDB m
+                                 , A.Selectable Account AddressState m
+                                 )
+                              => Bool
+                              -> Keccak256
+                              -> m CodeCollection
+codeCollectionFromHashNoCache typeCheck hsh = getCode hsh >>= \case
+  Nothing -> internalError "unknown code hash" hsh
+  Just (_, initCode) -> do
+    let initMap = case Aeson.decode $ BL.fromStrict initCode of
+            Just l -> M.fromList l
+            Nothing -> M.singleton T.empty (decodeUtf8 initCode)
+    ecc <- compileSource typeCheck initMap
+    case ecc of
+      Right a -> pure a
+      Left (PEx p) -> parseError "codeCollectionFromHash" p
+      Left (IEx p) -> typeError "codeCollectionFromHash" p
+      Left (SVMEx (s, _)) -> throw s
+      Left (TCEx xs) -> typeError "codeCollectionFromHash" (show xs)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -61,7 +61,14 @@ data ParseTypeCheckOrSolidVMError = PEx ParseError
                          | TCEx [SourceAnnotation T.Text]
                          | SVMEx (Positioned ((,) SolidException)) deriving (Show)
 
-data SUnitIntermediary = Con Contract | FLC ConstantDecl | FLS Def.Def | FLE Def.Def | FLF Func | FLER Def.Def | Prag (String, String)
+data SUnitIntermediary = Con Contract
+                       | FLC ConstantDecl
+                       | FLS Def.Def
+                       | FLE Def.Def
+                       | FLF Func
+                       | FLER Def.Def
+                       | Prag (String, String)
+                       | Imp  FileImport
 
 -- | OTHER CACHE OPTIONS
 -- {-# NOINLINE unsafeCodeMapIORef #-}
@@ -117,6 +124,7 @@ compileSourceNoInheritance initCodeMap = do
             pure $ Just $ (textToLabel name, FLER args)
           Pragma _ n v -> do 
             pure $ Just $ (" ", Prag (n,v))
+          Import _ i -> pure . Just $ ("", Imp i)
           _ -> pure Nothing
 
       throwDuplicate' :: (SolidString, a) -> Map SolidString a -> (a -> SourceAnnotation b) -> Either ParseTypeCheckOrSolidVMError (Map SolidString a)
@@ -137,10 +145,11 @@ compileSourceNoInheritance initCodeMap = do
         FLER (Def.Error vals _ a) -> fmap (\cMap -> cc & flErrors    .~ cMap) $ throwDuplicate' (name, (\(k,v) -> (k,v,a)) <$> vals) (cc ^. flErrors) (\_ -> a)
         --not map type
         Prag a                -> fmap (\cList -> cc & pragmas .~ cList) $ pure (a : (cc ^. pragmas))
+        Imp  i                -> fmap (\cList -> cc & imports .~ cList) $ pure (i : (cc ^. imports))
         FLE y  -> parseError  "FLE non Enum should be impossible  "  (show y)
         FLS x  -> parseError  "FLS non Struct should be impossible"  (show x)
         FLER z -> parseError  "FLER non Error should be impossible"  (show z)
-      sUnitSorter = foldrM throwDuplicate $ CodeCollection M.empty M.empty M.empty M.empty M.empty M.empty [] -- the list of all the sUnits goes here
+      sUnitSorter = foldrM throwDuplicate $ CodeCollection M.empty M.empty M.empty M.empty M.empty M.empty [] [] -- the list of all the sUnits goes here
 
       throwDuplicateFunction :: (SolidString, Func) -> Map SolidString Func -> Either ParseTypeCheckOrSolidVMError (Map SolidString Func)
       throwDuplicateFunction (fname, func) m = case M.lookup fname m of

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/ImportResolver.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/ImportResolver.hs
@@ -12,9 +12,18 @@
 module Blockchain.SolidVM.ImportResolver
   ( FileUnitF(..)
   , FileUnitMapF
+  , UnresolvedFileUnitsF(..)
+  , ufuImports
+  , ufuPragmas
+  , ufuUnits
+  , emptyUnresolvedFileUnits
+  , mergeUnresolvedFileUnitsIgnoreDuplicates
+  , mergeUnresolvedFileUnits
   , FileUnitsF(..)
   , fuPragmas
   , fuUnits
+  , emptyFileUnits
+  , mergeFileUnits
   , resolveImports
   ) where
 
@@ -32,9 +41,7 @@ import           Data.Text                            (Text)
 import qualified Data.Text                            as T
 
 import           Blockchain.Data.AddressStateDB
-import           Blockchain.Data.ChainInfo
 import           Blockchain.Strato.Model.Account
-import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Strato.Model.Keccak256
 
 import           SolidVM.Model.CodeCollection
@@ -60,31 +67,69 @@ data UnresolvedFileUnitsF a = UFU
   }
 makeLenses ''UnresolvedFileUnitsF
 
+emptyUnresolvedFileUnits :: UnresolvedFileUnitsF a
+emptyUnresolvedFileUnits = UFU [] M.empty M.empty
+
+instance Default (UnresolvedFileUnitsF a) where
+  def = emptyUnresolvedFileUnits
+
+mergeUnresolvedFileUnitsIgnoreDuplicates :: UnresolvedFileUnitsF a -> UnresolvedFileUnitsF a -> UnresolvedFileUnitsF a
+mergeUnresolvedFileUnitsIgnoreDuplicates (UFU i p u) (UFU j q v) = UFU (i <> j) (p <> q) (u <> v)
+
+mergeUnresolvedFileUnits :: Show a => UnresolvedFileUnitsF a -> UnresolvedFileUnitsF a -> Either Text (UnresolvedFileUnitsF a)
+mergeUnresolvedFileUnits (UFU i p u) (UFU j q v) =
+  let n = M.intersection u v
+   in if null n
+        then Right $ UFU (i <> j) (p <> q) (u <> v)
+        else Left . T.pack $ "Duplicate values: " ++ show n
+
+instance Semigroup (UnresolvedFileUnitsF a) where
+  (<>) = mergeUnresolvedFileUnitsIgnoreDuplicates
+
+instance Monoid (UnresolvedFileUnitsF a) where
+  mempty = def
+  mappend = (<>)
+
 data FileUnitsF a = FileUnits
   { _fuPragmas :: Map String String
   , _fuUnits   :: Map (Maybe Text) (FileUnitMapF a)
   }
 makeLenses ''FileUnitsF
 
+emptyFileUnits :: FileUnitsF a
+emptyFileUnits = FileUnits M.empty M.empty
+
+instance Default (FileUnitsF a) where
+  def = emptyFileUnits
+
+mergeFileUnits :: FileUnitsF a -> FileUnitsF a -> FileUnitsF a
+mergeFileUnits (FileUnits p u) (FileUnits q v) = FileUnits (p <> q) (u <> v)
+
+instance Semigroup (FileUnitsF a) where
+  (<>) = mergeFileUnits
+
+instance Monoid (FileUnitsF a) where
+  mempty = def
+  mappend = (<>)
+
 type ImportMapF a = Map Text (Either (UnresolvedFileUnitsF a) (FileUnitsF a))
 
-resolveImports :: ( (Account `A.Alters` AddressState) m
-                  , A.Selectable Word256 ParentChainIds m
+resolveImports :: ( A.Selectable Account AddressState m
                   , Show a
                   , Ord a
                   , Default a
                   )
                => (Keccak256 -> m (CodeCollectionF a))
                -> Map Text (UnresolvedFileUnitsF a)
-               -> m (Either Text (Map Text (FileUnitsF a)))
-resolveImports getCCFromHash m = runExceptT $ do
+               -> ExceptT Text m (CodeCollectionF a)
+resolveImports getCCFromHash m = do
   m' <- fmap snd . foldrM (resolveFile getCCFromHash) (S.empty, Left <$> m) . map lit $ M.keys m
-  flip M.traverseWithKey m' $ \k v -> case v of
+  m'' <- flip M.traverseWithKey m' $ \k v -> case v of
     Left _ -> throwE $ "Failed to resolve imports for file: " <> k
     Right r -> pure r
+  pure . foldMap fileUnitsToCodeCollection $ M.elems m''
 
-resolveFile :: ( (Account `A.Alters` AddressState) m
-               , A.Selectable Word256 ParentChainIds m
+resolveFile :: ( A.Selectable Account AddressState m
                , Show a
                , Ord a
                , Default a
@@ -99,9 +144,9 @@ resolveFile getCCFromHash expr (seen, resolved) = if tShowExpr expr `S.member` s
       if namedAcct ^. namedAccountChainId == MainChain || namedAcct ^. namedAccountChainId == UnspecifiedChain
         then do
           let acct = namedAccountToAccount Nothing namedAcct
-          lift (A.lookup (A.Proxy @AddressState) acct) >>= \case
+          lift (A.select (A.Proxy @AddressState) acct) >>= \case
             Nothing -> pure (seen, resolved)
-            Just AddressState{..} -> lift (resolveCodePtr Nothing addressStateCodeHash) >>= \case
+            Just AddressState{..} -> lift (runMainChainT $ resolveCodePtr Nothing addressStateCodeHash) >>= \case
               Just (SolidVMCode _ ch) -> do
                 rfu <- lift $ codeCollectionToFileUnits <$> getCCFromHash ch
                 pure (seen, M.insert (tShowExpr expr) (Right rfu) resolved)
@@ -130,8 +175,17 @@ codeCollectionToFileUnits CodeCollection{..} =
            <> (FUError    <$> _flErrors)
    in FileUnits (M.fromList _pragmas) $ M.singleton Nothing units
 
-doResolve :: ( (Account `A.Alters` AddressState) m
-             , A.Selectable Word256 ParentChainIds m
+fileUnitsToCodeCollection :: FileUnitsF a -> CodeCollectionF a
+fileUnitsToCodeCollection (FileUnits ps us) =
+  foldr addUnit (def & pragmas .~ M.toList ps) . concat $ M.toList <$> M.elems us
+  where addUnit (n, (FUContract c)) = contracts . at n ?~ c 
+        addUnit (n, (FUConstant c)) = flConstants . at n ?~ c
+        addUnit (n, (FUStruct s))   = flStructs . at n ?~ s
+        addUnit (n, (FUEnum e))     = flEnums . at n ?~ e
+        addUnit (n, (FUFunction f)) = flFuncs . at n ?~ f
+        addUnit (n, (FUError e))    = flErrors . at n ?~ e
+
+doResolve :: ( A.Selectable Account AddressState m
              , Show a
              , Ord a
              , Default a

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/ImportResolver.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/ImportResolver.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Blockchain.SolidVM.ImportResolver
+  ( FileUnitF(..)
+  , FileUnitMapF
+  , FileUnitsF(..)
+  , fuPragmas
+  , fuUnits
+  , resolveImports
+  ) where
+
+import qualified Control.Monad.Change.Alter           as A
+import           Control.Monad.Trans.Class            (lift)
+import           Control.Monad.Trans.Except
+import           Control.Lens                         hiding (assign, from, to, bimap, Context)
+import           Data.Default
+import           Data.Foldable                        (foldrM)
+import           Data.Map                             (Map)
+import qualified Data.Map                             as M
+import           Data.Maybe                           (fromMaybe)
+import qualified Data.Set                             as S
+import           Data.Text                            (Text)
+import qualified Data.Text                            as T
+
+import           Blockchain.Data.AddressStateDB
+import           Blockchain.Data.ChainInfo
+import           Blockchain.Strato.Model.Account
+import           Blockchain.Strato.Model.ExtendedWord
+import           Blockchain.Strato.Model.Keccak256
+
+import           SolidVM.Model.CodeCollection
+import           SolidVM.Model.SolidString
+import           SolidVM.Solidity.Parse.UnParser (unparseExpression)
+
+type EndoM m a = a -> m a
+
+data FileUnitF a = FUContract (ContractF a)
+                 | FUConstant (ConstantDeclF a)
+                 | FUStruct   [(SolidString, FieldType, a)]
+                 | FUEnum     ([SolidString], a)
+                 | FUFunction (FuncF a)
+                 | FUError    [(SolidString, IndexedType, a)]
+                 deriving (Show)
+
+type FileUnitMapF a = Map SolidString (FileUnitF a)
+
+data UnresolvedFileUnitsF a = UFU
+  { _ufuImports :: [FileImportF a]
+  , _ufuPragmas :: Map String String
+  , _ufuUnits   :: FileUnitMapF a
+  }
+makeLenses ''UnresolvedFileUnitsF
+
+data FileUnitsF a = FileUnits
+  { _fuPragmas :: Map String String
+  , _fuUnits   :: Map (Maybe Text) (FileUnitMapF a)
+  }
+makeLenses ''FileUnitsF
+
+type ImportMapF a = Map Text (Either (UnresolvedFileUnitsF a) (FileUnitsF a))
+
+resolveImports :: ( (Account `A.Alters` AddressState) m
+                  , A.Selectable Word256 ParentChainIds m
+                  , Show a
+                  , Ord a
+                  , Default a
+                  )
+               => (Keccak256 -> m (CodeCollectionF a))
+               -> Map Text (UnresolvedFileUnitsF a)
+               -> m (Either Text (Map Text (FileUnitsF a)))
+resolveImports getCCFromHash m = runExceptT $ do
+  m' <- fmap snd . foldrM (resolveFile getCCFromHash) (S.empty, Left <$> m) . map lit $ M.keys m
+  flip M.traverseWithKey m' $ \k v -> case v of
+    Left _ -> throwE $ "Failed to resolve imports for file: " <> k
+    Right r -> pure r
+
+resolveFile :: ( (Account `A.Alters` AddressState) m
+               , A.Selectable Word256 ParentChainIds m
+               , Show a
+               , Ord a
+               , Default a
+               )
+  => (Keccak256 -> m (CodeCollectionF a))
+  -> ExpressionF a
+  -> EndoM (ExceptT Text m) (S.Set Text, ImportMapF a)
+resolveFile getCCFromHash expr (seen, resolved) = if tShowExpr expr `S.member` seen
+  then throwE . T.concat $ "Circular reference identified: " : S.toList seen
+  else case expr of
+    AccountLiteral _ namedAcct ->
+      if namedAcct ^. namedAccountChainId == MainChain || namedAcct ^. namedAccountChainId == UnspecifiedChain
+        then do
+          let acct = namedAccountToAccount Nothing namedAcct
+          lift (A.lookup (A.Proxy @AddressState) acct) >>= \case
+            Nothing -> pure (seen, resolved)
+            Just AddressState{..} -> lift (resolveCodePtr Nothing addressStateCodeHash) >>= \case
+              Just (SolidVMCode _ ch) -> do
+                rfu <- lift $ codeCollectionToFileUnits <$> getCCFromHash ch
+                pure (seen, M.insert (tShowExpr expr) (Right rfu) resolved)
+              Just (EVMCode _) -> throwE . T.pack $ "Account referenced in import contains EVM code: " ++ show acct
+              _ -> throwE . T.pack $ "Account referenced in import could not be resolved: " ++ show acct
+        else throwE "Account imports can only come from the main chain"
+    StringLiteral _ fileName' ->
+      let fileName = T.pack fileName'
+       in case M.lookup fileName resolved of
+            Nothing -> throwE $ "Could not find file by name of " <> fileName
+            Just (Right _) -> pure (seen, resolved)
+            Just (Left l)  ->
+              let eResolved' = snd <$> foldrM (doResolve getCCFromHash fileName) (S.insert fileName seen, resolved) (l ^. ufuImports)
+               in fmap (seen,) . flip fmap eResolved' . flip M.adjust fileName $ \case
+                    Left u -> Right . FileUnits (u ^. ufuPragmas) $ M.singleton Nothing (u ^. ufuUnits)
+                    Right r -> Right . FileUnits (r ^. fuPragmas) $ M.singleton Nothing (l ^. ufuUnits) <> (r ^. fuUnits)
+    _ -> throwE . T.pack $ "Unsupported expression in import: " ++ unparseExpression expr 
+
+codeCollectionToFileUnits :: CodeCollectionF a -> FileUnitsF a
+codeCollectionToFileUnits CodeCollection{..} =
+  let units = (FUContract <$> _contracts)
+           <> (FUConstant <$> _flConstants)
+           <> (FUStruct   <$> _flStructs)
+           <> (FUEnum     <$> _flEnums)
+           <> (FUFunction <$> _flFuncs)
+           <> (FUError    <$> _flErrors)
+   in FileUnits (M.fromList _pragmas) $ M.singleton Nothing units
+
+doResolve :: ( (Account `A.Alters` AddressState) m
+             , A.Selectable Word256 ParentChainIds m
+             , Show a
+             , Ord a
+             , Default a
+             )
+          => (Keccak256 -> m (CodeCollectionF a))
+          -> Text
+          -> FileImportF a
+          -> EndoM (ExceptT Text m) (S.Set Text, ImportMapF a)
+doResolve f fileName imp (seen, resolved) = case imp of
+  Simple path _ -> resolvePath fileName path >>= \p -> resolveFile f p (seen, resolved) >>= \(_,r') -> (seen,) <$> updateResolved fileName (tShowExpr p) "" r'
+  Qualified path alias _ -> resolvePath fileName path >>= \p -> resolveFile f p (seen, resolved) >>= \(_,r') -> (seen,) <$> updateResolved fileName (tShowExpr p) alias r'
+  Braced items path _ -> resolvePath fileName path >>= \p -> resolveFile f p (seen, resolved) >>= \(_,r') -> (seen,) <$> foldrM (updateSingleItem fileName $ tShowExpr p) r' items
+
+resolvePath :: Monad m => Text -> EndoM (ExceptT Text m) (ExpressionF a)
+resolvePath fileName (StringLiteral a path') =
+  let path = T.pack path'
+      fileDir = tail . reverse $ T.splitOn "/" fileName
+      pathDir = T.splitOn "/" path
+   in maybe (throwE $ "Could not resolve path: " <> path) (pure . lit' a) $ resolvePath' fileDir pathDir
+resolvePath _ expr = pure expr
+
+resolvePath' :: [Text] -> [Text] -> Maybe Text
+resolvePath' fileDir pathDir = case pathDir of
+        ("":_) -> Just $ T.intercalate "/" pathDir -- root directory
+        ("..":pathRest) -> case fileDir of
+                             [] -> Nothing
+                             (_:fileRest) -> resolvePath' fileRest pathRest
+        (".":pathRest)  -> resolvePath' fileDir pathRest
+        [] -> Nothing
+        pathRest -> Just . T.intercalate "/" $ reverse fileDir ++ pathRest
+
+updateResolved :: (Monad m, Show a) => Text -> Text -> Text -> EndoM (ExceptT Text m) (ImportMapF a)
+updateResolved fileName path qualifier resolved = case M.lookup path resolved of
+  Just (Right (FileUnits _ us)) -> do
+    let natives = fromMaybe M.empty $ M.lookup Nothing us
+        fUnits = M.lookup fileName resolved
+    fUnits' <- case fUnits of
+      Just (Left (UFU _ ps us')) -> pure . Right . FileUnits ps $ M.singleton Nothing us' <> M.singleton (Just qualifier) natives
+      Just (Right (FileUnits ps us')) -> Right . FileUnits ps <$> unionUnits (Just qualifier) natives us'
+      Nothing -> pure . Right . FileUnits M.empty $ M.singleton (Just qualifier) natives
+    pure $ M.insert fileName fUnits' resolved
+  _ -> pure resolved
+
+updateSingleItem :: (Monad m, Show a) => Text -> Text -> ItemImportF a -> EndoM (ExceptT Text m) (ImportMapF a)
+updateSingleItem f p i m = do
+  fileUnits' <- maybe (throwE $ "Could not find file " <> f) pure $ M.lookup f m
+  pathUnits <- maybe (throwE $ "Could not find file " <> p) pure $ M.lookup p m
+  let resolveUnits u = case fileUnits' of
+        Left (UFU _ ps _) -> Right (FileUnits ps u)
+        Right (FileUnits ps _) -> Right (FileUnits ps u)
+      fileUnits = case fileUnits' of
+        Left (UFU _ _ u) -> M.singleton Nothing u
+        Right (FileUnits _ u) -> u
+      natives = case pathUnits of
+        Left (UFU _ _ u) -> u
+        Right (FileUnits _ u) -> fromMaybe M.empty $ M.lookup Nothing u
+  (n,i') <- case i of
+    Named n _ -> let nStr = textToLabel n
+                  in fmap (nStr,) . maybe (throwE $ "Could not find item " <> n <> " in file " <> p) pure $ M.lookup nStr natives
+    Aliased n a _ -> fmap (textToLabel a,) . maybe (throwE $ "Could not find item " <> n <> " in file " <> p) pure $ M.lookup (textToLabel n) natives
+  flip (M.insert f) m . resolveUnits <$> unionUnits (Just "") (M.singleton n i') fileUnits
+
+unionUnits :: (Monad m, Show a, Show b, Ord a, Ord k) => k -> Map a b -> EndoM (ExceptT Text m) (Map k (Map a b))
+unionUnits k v' m = do
+  let v = fromMaybe M.empty $ M.lookup k m
+      n = M.intersection v v'
+  if null n then pure $ M.insert k (v <> v') m else throwE . T.pack $ "Duplicate values: " ++ show n
+
+lit :: Default a => Text -> ExpressionF a
+lit = lit' def
+
+lit' :: a -> Text -> ExpressionF a
+lit' a = StringLiteral a . T.unpack
+
+tShowExpr :: Show a => ExpressionF a -> Text
+tShowExpr (StringLiteral _ str) = T.pack str
+tShowExpr (AccountLiteral _ acct) = "<" <> T.pack (show acct) <> ">"
+tShowExpr expr = T.pack $ show expr

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -168,6 +168,7 @@ makeLenses ''SState
 type SM m = ReaderT (IORef SState) m
 
 type MonadSM m = ( (Account `A.Alters` AddressState) m
+                 , A.Selectable Account AddressState m
                  , HasStateDB m
                  , (Keccak256 `A.Alters` DBCode) m
                  , (Keccak256 `A.Alters` BlockSummary) m
@@ -234,6 +235,14 @@ instance ( MonadUnliftIO m
   lookup _ = getAddressStateMaybe
   insert _ = putAddressState
   delete _ = deleteAddressState
+
+instance ( MonadUnliftIO m
+         , (Maybe Word256 `A.Alters` MP.StateRoot) m
+         , MonadLogger m
+         , (MP.StateRoot `A.Alters` MP.NodeData) m
+         , (N.NibbleString `A.Alters` N.NibbleString) m
+         ) => A.Selectable Account AddressState (SM m) where
+  select _ = getAddressStateMaybe
 
 instance (MonadUnliftIO m, (Maybe Word256 `A.Alters` MP.StateRoot) m)
          => (Maybe Word256 `A.Alters` MP.StateRoot) (SM m) where

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -518,7 +518,7 @@ getVariableOfName name = do
       ]
 
 getTypeOfName' :: SolidString -> CC.CodeCollection -> Typo
-getTypeOfName' s (CC.CodeCollection ccs _ _ enms strcts _ _) =
+getTypeOfName' s (CC.CodeCollection ccs _ _ enms strcts _ _ _) =
   let lookInContract :: CC.Contract -> [Typo]
       lookInContract (CC.Contract{..}) = catMaybes
         [ fmap StructTypo (fmap (\(a,b,_) -> (a,b)) <$> M.lookup s _structs)

--- a/strato/VM/SolidVM/solid-vm/tests/OptimizerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/OptimizerSpec.hs
@@ -1,11 +1,19 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, FlexibleContexts #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module OptimizerSpec where
 
 import           Control.Lens
-import qualified Data.Map as M
+import qualified Control.Monad.Change.Alter as A
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import qualified Data.Map.Strict as M
 import           Data.Maybe            (catMaybes) 
 import qualified Data.Text as T
 import           Data.Source.Annotation
@@ -16,6 +24,9 @@ import           Text.RawString.QQ
 
 import           BlockApps.Logging
 
+import           Blockchain.Data.AddressStateDB
+import           Blockchain.DB.MemAddressStateDB
+import           Blockchain.DB.CodeDB
 import           Blockchain.DB.SolidStorageDB
 import           Blockchain.SolidVM.Exception
 import           Blockchain.SolidVM.CodeCollectionDB
@@ -35,10 +46,17 @@ import           SolidVMSpec
 --Helper Functions
 --------------------
 
-runOptimizer :: String -> CodeCollection
-runOptimizer c = case compileSourceWithAnnotations True (M.fromList [("",T.pack c)]) of
-            Left _ -> internalError "Compilation Error" ()
-            Right cc -> cc
+instance (Keccak256 `A.Alters` DBCode) m => (Keccak256 `A.Alters` DBCode) (MainChainT (MemAddressStateDB m)) where 
+  lookup p   = lift . lift . A.lookup p
+  insert p k = lift . lift . A.insert p k
+  delete p   = lift . lift . A.delete p
+
+runOptimizer :: String -> IO CodeCollection
+runOptimizer c = runNewMemCodeDB . runNewMemAddressStateDB . runMainChainT $ do
+  eCC <- compileSourceWithAnnotations True (M.fromList [("",T.pack c)])
+  case eCC of
+    Left _ -> internalError "Compilation Error" ()
+    Right cc -> pure cc
 
 runTestOptimizer :: CodeCollection -> IO ()
 runTestOptimizer f = case f of
@@ -160,21 +178,23 @@ prop_example = monadicIO $ do
 ---------------------
 spec :: Spec
 spec = describe "Optimizer tests" $ do
-    it "can replace binary expression with number literal for state variables" $
-        let anns = (runOptimizer [r|
+    it "can replace binary expression with number literal for state variables" $ do
+        anns <- liftIO (runOptimizer [r|
             contract A {
                 int b = 2 + 2 + 2;
-            }|])  in case (varDeclHelper'' $ varDeclHelper' anns) of
+            }|])
+        (case (varDeclHelper'' $ varDeclHelper' anns) of
                 [(NumberLiteral _ 6 _) ] -> True
-                _ -> False
-    it "Variable  wrap --- then takes the wrap and turns it to." $
-        let anns = runOptimizer [r|
+                _ -> False) `shouldBe` True
+    it "Variable  wrap --- then takes the wrap and turns it to." $ do
+        anns <- liftIO $ runOptimizer [r|
             type Mytype is int;
             contract A {
                 Mytype a = Mytype.wrap(2);
-            }|]  in case (varDeclHelper'' $ varDeclHelper' anns) of
+            }|]
+        (case (varDeclHelper'' $ varDeclHelper' anns) of
                 [NumberLiteral _ 2 _] -> True
-                _ -> False
+                _ -> False) `shouldBe` True
 
     -- Temporarly removed untill further tests/research is done on optimizing variables by name
     -- it "Unwrap Variable by name of Variable " $
@@ -186,17 +206,16 @@ spec = describe "Optimizer tests" $ do
     --         }|]  in case varDeclHelper'' $ varDeclHelper' anns of
     --             [NumberLiteral _ 2 _, (NumberLiteral _ 2 _) ] -> True
     --             _ -> False
-    it "can turn func arguements and values to user defined" $
-        let anns = runOptimizer [r|
+    it "can turn func arguements and values to user defined" $ do
+        anns <- liftIO $ runOptimizer [r|
             type Mytype is int;
             contract A {
                 Mytype a = Mytype.wrap(2);
                 function f(Mytype y) returns (Mytype) { return (y);}
-            }|] in case
-             concat $ (_funcArgs <$> getFuncByName"f" anns) ++ (_funcArgs <$> getFuncByName"f" anns)
-             of
+            }|]
+        (case concat $ (_funcArgs <$> getFuncByName"f" anns) ++ (_funcArgs <$> getFuncByName"f" anns) of
                 [(Just _, (IndexedType  0  ( SVMType.Int (Just True)  Nothing) ) ), (Just _, (IndexedType  0  ( SVMType.Int (Just True)  Nothing) ) )] -> True
-                _ -> False
+                _ -> False) `shouldBe` True
     it "Should be the same after one optimization as two optimizes" $ --Cannot optimize an already optimized CodeCollection
             quickCheck propIdempotence
     it "Should have evaluated expressions between optimized and non-optimized CodeCollections equal" $

--- a/strato/VM/SolidVM/solid-vm/tests/OptimizerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/OptimizerSpec.hs
@@ -42,7 +42,7 @@ runOptimizer c = case compileSourceWithAnnotations True (M.fromList [("",T.pack 
 
 runTestOptimizer :: CodeCollection -> IO ()
 runTestOptimizer f = case f of
-    (CodeCollection _ _ _ _ _ _ _) -> return ()
+    (CodeCollection _ _ _ _ _ _ _ _) -> return ()
 
 varDeclHelper' :: CodeCollection -> [VariableDeclF (SourceAnnotation ())]
 varDeclHelper' cc = cc  ^.. contracts . folded . storageDefs .folded

--- a/strato/VM/SolidVM/solid-vm/tests/StaticAnalysisSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/StaticAnalysisSpec.hs
@@ -1,10 +1,22 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module StaticAnalysisSpec where
 
+import           Blockchain.Data.AddressStateDB
+import           Blockchain.DB.CodeDB
+import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.SolidVM.CodeCollectionDB
-import qualified Data.Map as M
+import           Blockchain.Strato.Model.Keccak256
+import qualified Control.Monad.Change.Alter as A
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import qualified Data.Map.Strict as M
 import           Data.Source
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -23,15 +35,22 @@ import qualified SolidVM.Solidity.StaticAnalysis.Statements.MultipleDeclarations
 import           Test.Hspec
 import           Text.RawString.QQ
 
+instance (Keccak256 `A.Alters` DBCode) m => (Keccak256 `A.Alters` DBCode) (MainChainT (MemAddressStateDB m)) where 
+  lookup p   = lift . lift . A.lookup p
+  insert p k = lift . lift . A.insert p k
+  delete p   = lift . lift . A.delete p
+
 forSource :: ParserDetector -> String -> [SourceAnnotation Text]
 forSource detector c = case parseSourceWithAnnotations "" $ T.pack c of
   Left anns -> anns
   Right cc -> detector cc
 
-forContract :: CompilerDetector -> String -> [SourceAnnotation Text]
-forContract detector c = case compileSourceWithAnnotations True (M.fromList [("",T.pack c)]) of
-  Left anns -> anns
-  Right cc -> detector cc
+forContract :: CompilerDetector -> String -> IO [SourceAnnotation Text]
+forContract detector c = runNewMemCodeDB . runNewMemAddressStateDB . runMainChainT $ do
+  eCC <- compileSourceWithAnnotations True (M.fromList [("",T.pack c)])
+  pure $ case eCC of
+    Left anns -> anns
+    Right cc -> detector cc
 
 spec :: Spec
 spec = describe "Static analysis detectors" $ do
@@ -50,8 +69,8 @@ contract B {
        in length anns `shouldBe` 1
 
   describe "Parent constructor detectors" $ do
-    it "can call parent constructors correctly" $
-      let anns = ParentConstructors.detector `forContract` [r|
+    it "can call parent constructors correctly" $ do
+      anns <- liftIO $ ParentConstructors.detector `forContract` [r|
 contract A {
   constructor() {
   }
@@ -61,9 +80,9 @@ contract B is A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can detect when a contract calls a constructor it does not inherit from" $
-      let anns = ParentConstructors.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "can detect when a contract calls a constructor it does notherit from" $ do
+      anns <- liftIO $ ParentConstructors.detector `forContract` [r|
 contract A {
 }
 contract B {
@@ -71,17 +90,17 @@ contract B {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "can detect when a contract calls a constructor that is not in scope" $
-      let anns = ParentConstructors.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "can detect when a contract calls a constructor that is not scope" $ do
+      anns <- liftIO $ ParentConstructors.detector `forContract` [r|
 contract B is A {
   constructor() A() {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "can detect when a contract calls a constructor that is not defined by its parent" $
-      let anns = ParentConstructors.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "can detect when a contract calls a constructor that is not defined by its parent" $ do
+      anns <- liftIO $ ParentConstructors.detector `forContract` [r|
 contract A {
 }
 contract B is A {
@@ -89,9 +108,9 @@ contract B is A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "can detect when a contract calls a constructor using the wrong number of arguments" $
-      let anns = ParentConstructors.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "can detect when a contract calls a constructor using the wrong number of arguments" $ do
+      anns <- liftIO $ ParentConstructors.detector `forContract` [r|
 contract A {
   constructor() {
   }
@@ -101,29 +120,29 @@ contract B is A {
   }
 }
 |]
-       in length anns `shouldBe` 1
+      length anns `shouldBe` 1
 
   describe "Boolean literal detectors" $ do
-    it "can assign a boolean literal to a variable" $
-      let anns = BooleanLiterals.detector `forContract` [r|
+    it "can assign a boolean literal to a variable" $ do
+      anns <- liftIO $ BooleanLiterals.detector `forContract` [r|
 contract A {
   function f() {
     bool b = true;
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can return a boolean literal from a function" $
-      let anns = BooleanLiterals.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "can return a boolean literal from a function" $ do
+      anns <- liftIO $ BooleanLiterals.detector `forContract` [r|
 contract A {
   function f() returns (bool) {
     return true;
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "warns when using a boolean literal on the left side of an equality condition" $
-      let anns = BooleanLiterals.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "warns when using a boolean literal on the left side of an equality condition" $ do
+      anns <- liftIO $ BooleanLiterals.detector `forContract` [r|
 contract A {
   function f(bool b) {
     if (false == b) {
@@ -132,9 +151,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "warns when using a boolean literal on the right side of an equality condition" $
-      let anns = BooleanLiterals.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "warns when using a boolean literal on the right side of an equality condition" $ do
+      anns <- liftIO $ BooleanLiterals.detector `forContract` [r|
 contract A {
   function f(bool b) {
     if (b == false) {
@@ -143,9 +162,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "warns when using a boolean literal outside of an assignment expression" $
-      let anns = BooleanLiterals.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "warns when using a boolean literal outside of an assignment expression" $ do
+      anns <- liftIO $ BooleanLiterals.detector `forContract` [r|
 contract A {
   mapping (bool => bool) bools;
   function f(bool b) returns (bool) {
@@ -161,31 +180,31 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 4
+      length anns `shouldBe` 4
 
   describe "Divide before multiply detector" $ do
-    it "can multiply before divide" $
-      let anns = DivideBeforeMultiply.detector `forContract` [r|
+    it "can multiply before divide" $ do
+      anns <- liftIO $ DivideBeforeMultiply.detector `forContract` [r|
 contract A {
   function f() {
     uint x = (7 * 8) / 6;
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can divide before multiply when another operation happens between the two" $
-      let anns = DivideBeforeMultiply.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "can divide before multiply when another operation happens between the two" $ do
+      anns <- liftIO $ DivideBeforeMultiply.detector `forContract` [r|
 contract A {
   function f() returns (bool) {
     uint x = ((7 / 6) + 3) * 9;
   }
 }
 |]
-       in length anns `shouldBe` 0
+      length anns `shouldBe` 0
        
   describe "Constant function detectors" $ do
-    it "can write pure and view functions" $
-      let anns = ConstantFunctions.detector `forContract` [r|
+    it "can write pure and view functions" $ do
+      anns <- liftIO $ ConstantFunctions.detector `forContract` [r|
 contract A {
   uint x = 5;
   function f(uint y) pure returns (uint) {
@@ -196,9 +215,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "warns when reading from contract state in a pure function" $
-      let anns = ConstantFunctions.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "warns when reading from contract state a pure function" $ do
+      anns <- liftIO $ ConstantFunctions.detector `forContract` [r|
 contract A {
   uint x = 5;
   function f(uint y) pure returns (uint) {
@@ -206,9 +225,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "warns when writing to contract state from a pure or view function" $
-      let anns = ConstantFunctions.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "warns when writing to contract state from a pure or view function" $ do
+      anns <- liftIO $ ConstantFunctions.detector `forContract` [r|
 contract A {
   uint x = 5;
   function f(uint y) pure returns (uint) {
@@ -221,9 +240,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 2
-    it "warns when using assembly code from a pure or view function" $
-      let anns = ConstantFunctions.detector `forContract` [r|
+      length anns `shouldBe` 2
+    it "warns when using assembly code from a pure or view function" $ do
+      anns <- liftIO $ ConstantFunctions.detector `forContract` [r|
 contract A {
   uint x = 5;
   function f(uint y) pure returns (uint) {
@@ -238,11 +257,11 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 2
+      length anns `shouldBe` 2
 
-  describe "Missing inheritance detectors" $ do
-    it "can resolve state variables inherited from a contract" $
-      let anns = ConstantFunctions.detector `forContract` [r|
+  describe "Missingheritance detectors" $ do
+    it "can resolve state variablesherited from a contract" $ do
+      anns <- liftIO $ ConstantFunctions.detector `forContract` [r|
 contract A {
   uint x = 7;
 }
@@ -252,9 +271,9 @@ contract B is A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can resolve state variables from multiple layers of inheritance" $
-      let anns = ConstantFunctions.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "can resolve state variables from multiple layers ofheritance" $ do
+      anns <- liftIO $ ConstantFunctions.detector `forContract` [r|
 contract A {
   uint x = 7;
 }
@@ -266,9 +285,9 @@ contract C is B {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can inherit from multiple contracts" $
-      let anns = ConstantFunctions.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "canherit from multiple contracts" $ do
+      anns <- liftIO $ ConstantFunctions.detector `forContract` [r|
 contract A {
   uint x = 7;
 }
@@ -282,9 +301,9 @@ contract C is A, B {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can detect when referencing a state variable from a non-inherited contract" $
-      let anns = ConstantFunctions.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "can detect when referencing a state variable from a non-inherited contract" $ do
+      anns <- liftIO $ ConstantFunctions.detector `forContract` [r|
 contract A {
   uint x = 7;
 }
@@ -294,11 +313,11 @@ contract B {
   }
 }
 |]
-       in length anns `shouldBe` 2
+      length anns `shouldBe` 2
 
   describe "State variable shadowing" $ do
-    it "can create local variables that don't shadow state variable names" $
-      let anns = StateVariableShadowing.detector `forContract` [r|
+    it "can create local variables that don't shadow state variable names" $ do
+      anns <- liftIO $ StateVariableShadowing.detector `forContract` [r|
 contract A {
   uint x;
   function f() {
@@ -306,9 +325,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can create local variables that don't shadow state variable names from inherited contracts" $
-      let anns = StateVariableShadowing.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "can create local variables that don't shadow state variable names fromherited contracts" $ do
+      anns <- liftIO $ StateVariableShadowing.detector `forContract` [r|
 contract A {
   uint x;
 }
@@ -318,9 +337,9 @@ contract B is A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "warns when a local variable shadows a state variable" $
-      let anns = StateVariableShadowing.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "warns when a local variable shadows a state variable" $ do
+      anns <- liftIO $ StateVariableShadowing.detector `forContract` [r|
 contract A {
   uint x;
   function f() {
@@ -328,9 +347,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "warns when a local variable shadows a state variable from an inherited contract" $
-      let anns = StateVariableShadowing.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "warns when a local variable shadows a state variable from anherited contract" $ do
+      anns <- liftIO $ StateVariableShadowing.detector `forContract` [r|
 contract A {
   uint x;
 }
@@ -340,40 +359,40 @@ contract B is A {
   }
 }
 |]
-       in length anns `shouldBe` 1
+      length anns `shouldBe` 1
 
   describe "Uninitialized local variables" $ do
-    it "can initialize local variables" $
-      let anns = UninitializedLocalVariables.detector `forContract` [r|
+    it "canitialize local variables" $ do
+      anns <- liftIO $ UninitializedLocalVariables.detector `forContract` [r|
 contract A {
   function f() {
     uint x = 7;
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "warns when local variables are uninitialized" $
-      let anns = UninitializedLocalVariables.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "warns when local variables are uninitialized" $ do
+      anns <- liftIO $ UninitializedLocalVariables.detector `forContract` [r|
 contract A {
   function f() {
     uint x;
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "warns when local variables defined in a tuple are uninitialized" $
-      let anns = UninitializedLocalVariables.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "warns when local variables defined a tuple are uninitialized" $ do
+      anns <- liftIO $ UninitializedLocalVariables.detector `forContract` [r|
 contract A {
   function f() {
     (uint x, string y);
   }
 }
 |]
-       in length anns `shouldBe` 1
+      length anns `shouldBe` 1
 
   describe "Redundant writes" $ do
-    it "can write to variables" $
-      let anns = WriteAfterWrite.detector `forContract` [r|
+    it "can write to variables" $ do
+      anns <- liftIO $ WriteAfterWrite.detector `forContract` [r|
 contract A {
   function f() {
     uint x = 7;
@@ -381,9 +400,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can write to variable again after reading from it" $
-      let anns = WriteAfterWrite.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "can write to variable again after reading from it" $ do
+      anns <- liftIO $ WriteAfterWrite.detector `forContract` [r|
 contract A {
   function f() {
     uint x = 7;
@@ -392,9 +411,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can apply multiple consecutive binary operations on a variable" $
-      let anns = WriteAfterWrite.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "can apply multiple consecutive binary operations on a variable" $ do
+      anns <- liftIO $ WriteAfterWrite.detector `forContract` [r|
 contract A {
   function f() {
     uint x = 7;
@@ -409,9 +428,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "warns when a variable is written to multiple times without being read" $
-      let anns = WriteAfterWrite.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "warns when a variable is written to multiple times without being read" $ do
+      anns <- liftIO $ WriteAfterWrite.detector `forContract` [r|
 contract A {
   function f() {
     uint x = 7;
@@ -419,9 +438,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "warns when making consecutive writes, even after passing through a branching statement" $
-      let anns = WriteAfterWrite.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "warns when making consecutive writes, even after passing through a branching statement" $ do
+      anns <- liftIO $ WriteAfterWrite.detector `forContract` [r|
 contract A {
   function f() {
     uint x = 7;
@@ -438,9 +457,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 3
-    it "can make a subsequent write if variable is read in a conditional block" $
-      let anns = WriteAfterWrite.detector `forContract` [r|
+      length anns `shouldBe` 3
+    it "can make a subsequent write if variable is read a conditional block" $ do
+      anns <- liftIO $ WriteAfterWrite.detector `forContract` [r|
 contract A {
   function f() {
     uint x = 7;
@@ -461,11 +480,11 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
+      length anns `shouldBe` 0
 
   describe "State variable detectors" $ do
-    it "can use a state variable without warning" $
-      let anns = StateVariables.detector `forContract` [r|
+    it "can use a state variable without warning" $ do
+      anns <- liftIO $ StateVariables.detector `forContract` [r|
 contract A {
   uint x = 7;
   function f(uint _x) {
@@ -473,18 +492,18 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "warns if a state variable is unused" $
-      let anns = StateVariables.detector `forContract` [r|
+      length anns `shouldBe` 0
+    it "warns if a state variable is unused" $ do
+      anns <- liftIO $ StateVariables.detector `forContract` [r|
 contract A {
   uint x = 7;
   function f() {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "warns if a state variable is read but uninitialized" $
-      let anns = StateVariables.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "warns if a state variable is read but uninitialized" $ do
+      anns <- liftIO $ StateVariables.detector `forContract` [r|
 contract A {
   uint x;
   function f() returns (uint) {
@@ -492,9 +511,9 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "recommends making unmodified state variables constants" $
-      let anns = StateVariables.detector `forContract` [r|
+      length anns `shouldBe` 1
+    it "recommends making unmodified state variables constants" $ do
+      anns <- liftIO $ StateVariables.detector `forContract` [r|
 contract A {
   uint x = 7;
   function f() returns (uint) {
@@ -502,11 +521,11 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
+      length anns `shouldBe` 1
 
 
-    it "can detect duplicate declarations" $
-      let anns = MultipleDeclarations.detector `forContract` [r|
+    it "can detect duplicate declarations" $ do
+      anns <- liftIO $ MultipleDeclarations.detector `forContract` [r|
 contract A {
   function hey(){
     y = 0;
@@ -517,4 +536,4 @@ contract A {
   }
 }
 |]
-      in length anns `shouldBe` 3
+      length anns `shouldBe` 3

--- a/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
@@ -1,27 +1,45 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module TypecheckerSpec where
 
+import           Blockchain.Data.AddressStateDB
+import           Blockchain.DB.CodeDB
+import           Blockchain.DB.MemAddressStateDB
 import           Blockchain.SolidVM.CodeCollectionDB
-import qualified Data.Map as M
+import           Blockchain.Strato.Model.Keccak256
+import qualified Control.Monad.Change.Alter as A
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import qualified Data.Map.Strict as M
 import           Data.Source
 import           Data.Text (Text)
 import qualified Data.Text as T
-import qualified SolidVM.Solidity.StaticAnalysis.Typechecker                            as Typechecker
+import qualified SolidVM.Solidity.StaticAnalysis.Typechecker as Typechecker
 import           Test.Hspec
 import           Text.RawString.QQ
 
+instance (Keccak256 `A.Alters` DBCode) m => (Keccak256 `A.Alters` DBCode) (MainChainT (MemAddressStateDB m)) where 
+  lookup p   = lift . lift . A.lookup p
+  insert p k = lift . lift . A.insert p k
+  delete p   = lift . lift . A.delete p
 
-runTypechecker :: String -> [SourceAnnotation Text]
-runTypechecker c = case compileSourceWithAnnotations True (M.fromList [("",T.pack c)]) of
-  Left anns -> anns
-  Right cc -> Typechecker.detector cc
+runTypechecker :: String -> IO [SourceAnnotation Text]
+runTypechecker c = runNewMemCodeDB . runNewMemAddressStateDB . runMainChainT $ do
+  eCC <- compileSourceWithAnnotations True (M.fromList [("",T.pack c)])
+  pure $ case eCC of
+    Left anns -> anns
+    Right cc -> Typechecker.detector cc
 
 spec :: Spec
 spec = describe "Typechecker tests" $ do
-  it "can declare state variables with the correct type" $
-    let anns = runTypechecker [r|
+  it "can declare state variables with the correct type" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   uint x = 8;
   string y = "string";
@@ -37,9 +55,10 @@ contract A {
   Complex i = Complex(0, 1);
 }
 |]
-     in length anns `shouldBe` 0
-  it "can detect type errors in state variable declarations" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "can detect type errors in state variable declarations" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   uint x = "hello";
   string y = true;
@@ -55,9 +74,10 @@ contract A {
   Complex i = RestStatus.Z;
 }
 |]
-     in length anns `shouldBe` 7
-  it "can declare constants with the correct type" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 7
+  it "can declare constants with the correct type" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   uint constant x = 8;
   string constant y = "string";
@@ -73,9 +93,10 @@ contract A {
   Complex i = Complex(0, 1);
 }
 |]
-     in length anns `shouldBe` 0
-  it "can detect type errors in constant declarations" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "can detect type errors in constant declarations" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   uint constant x = "hello";
   string constant y = true;
@@ -91,9 +112,10 @@ contract A {
   Complex i = RestStatus.Z;
 }
 |]
-     in length anns `shouldBe` 7
-  it "can call contract functions" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 7
+  it "can call contract functions" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function realFunction() {
   }
@@ -105,9 +127,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "can call public contract functions" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "can call public contract functions" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function realFunction() public {
   }
@@ -119,9 +142,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "can call external contract functions" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "can call external contract functions" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function realFunction() external {
   }
@@ -133,9 +157,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "cannot call private contract functions" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "cannot call private contract functions" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function realFunction() private {
   }
@@ -147,9 +172,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "cannot call internal contract functions" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "cannot call internal contract functions" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function realFunction() internal {
   }
@@ -161,9 +187,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can detect missing contract functions" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can detect missing contract functions" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
 }
 contract B {
@@ -173,9 +200,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can access public contract state variables" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can access public contract state variables" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   uint public x = 75;
 }
@@ -187,9 +215,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "cannot access non-public state variables" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "cannot access non-public state variables" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   uint x = 75;
 }
@@ -201,9 +230,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "cannot access private state variables" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "cannot access private state variables" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   uint private x = 75;
 }
@@ -215,9 +245,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "cannot access internal state variables" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "cannot access internal state variables" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   uint internal x = 75;
 }
@@ -229,9 +260,10 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can detect missing contract state variables" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can detect missing contract state variables" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
 }
 contract B {
@@ -242,27 +274,30 @@ contract B {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can detect treating a non-function type as a function" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can detect treating a non-function type as a function" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract B {
   constructor(uint y) {
     y();
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can detect treating a non-function type as a function" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can detect treating a non-function type as a function" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract B {
   constructor(uint y) {
     y();
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can declare local variables of the correct type" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can declare local variables of the correct type" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   enum RestStatus { W, X, Y, Z }
   struct Complex {
@@ -280,9 +315,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "can detect type errors in local variable declarations" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "can detect type errors in local variable declarations" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   enum RestStatus { W, X, Y, Z }
   struct Complex {
@@ -300,9 +336,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 7
-  it "can declare tuple types" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 7
+  it "can declare tuple types" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   struct Complex {
     uint re;
@@ -314,9 +351,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "can detect arity mismatches in tuple type declarations from the left side" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "can detect arity mismatches in tuple type declarations from the left side" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   struct Complex {
     uint re;
@@ -328,9 +366,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can detect arity mismatches in tuple type declarations from the right side" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can detect arity mismatches in tuple type declarations from the right side" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   struct Complex {
     uint re;
@@ -342,9 +381,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can detect signedness mismatch between int types" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can detect signedness mismatch between int types" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     uint x = 7;
@@ -353,9 +393,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can lookup integer index of array" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can lookup integer index of array" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   string[] myArray = ["one", "two", "three"];
   function f(uint i) returns (string) {
@@ -363,9 +404,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "cannot lookup string index of array" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "cannot lookup string index of array" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   string[] myArray = ["one", "two", "three"];
   function f(string i) {
@@ -373,9 +415,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can lookup value of mapping using correct key type" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can lookup value of mapping using correct key type" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   mapping (string => uint) myMapping;
   function f(string i) returns (uint) {
@@ -383,9 +426,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "cannot lookup value of mapping using incorrect key type" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "cannot lookup value of mapping using incorrect key type" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   mapping (string => uint) myMapping;
   function f(uint i) {
@@ -393,9 +437,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can get array length" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can get array length" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   string[] myArray;
   function f() returns (uint) {
@@ -403,9 +448,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "can push to an array" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "can push to an array" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   string[] myArray;
   function f(string s) {
@@ -413,9 +459,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "cannot get mapping length" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "cannot get mapping length" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   mapping (string => uint) myMapping;
   function f() {
@@ -423,9 +470,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "cannot push to a mapping" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "cannot push to a mapping" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   mapping (string => uint) myMapping;
   function f(string s, uint i) {
@@ -435,9 +483,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 3
-  it "can access builtins" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 3
+  it "can access builtins" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     address a = msg.sender;
@@ -451,9 +500,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "cannot change the type of builtins" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "cannot change the type of builtins" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     string a = msg.sender;
@@ -467,9 +517,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 8
-  it "can call super on parent contract functions" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 8
+  it "can call super on parent contract functions" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function realFunction() {
   }
@@ -480,18 +531,20 @@ contract B is A {
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "cannot call super without a parent contract" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "cannot call super without a parent contract" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     super.fakeFunction();
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "cannot call super on missing parent contract functions" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "cannot call super on missing parent contract functions" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function realFunction() {
   }
@@ -502,9 +555,10 @@ contract B is A {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "cannot access missing enum elements" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "cannot access missing enum elements" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   enum E { W, X, Y, Z }
   function f() {
@@ -512,9 +566,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 4 -- TODO: this should be 1
-  it "cannot access missing struct elements" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 4 -- TODO: this should be 1
+  it "cannot access missing struct elements" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   struct Complex {
     uint re;
@@ -526,44 +581,49 @@ contract A {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "cannot resolve unknown contracts" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "cannot resolve unknown contracts" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A is B {
   constructor() B() {
   }
 }
 |]
-     in length anns `shouldBe` 1
-  it "can use 'this' keyword" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 1
+  it "can use 'this' keyword" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() returns (address) {
     return this;
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "can use require" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "can use require" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     require(true, "require");
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "can use assert" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "can use assert" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     assert(true);
   }
 }
 |]
-     in length anns `shouldBe` 0
-  it "cannot use require with incorrect arguments" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldBe` 0
+  it "cannot use require with incorrect arguments" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     require(7, "require");
@@ -573,9 +633,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldSatisfy` (>=4) -- TODO: should be exactly 4
-  it "cannot use assert with incorrect arguments" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldSatisfy` (>=4) -- TODO: should be exactly 4
+  it "cannot use assert with incorrect arguments" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     assert(true, "assert");
@@ -584,9 +645,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldSatisfy` (>=3) -- TODO: should be exactly 3
+    
+    length anns `shouldSatisfy` (>=3) -- TODO: should be exactly 3
   it "can cast to account" $ do
-    let anns = runTypechecker [r|
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     account a = account(0xdeadbeef);
@@ -604,8 +666,8 @@ contract A {
 |]
     putStrLn $ show anns
     length anns `shouldBe` 0
-  it "can cast to account with incorrect types" $
-    let anns = runTypechecker [r|
+  it "can cast to account with incorrect types" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     account a = account("1234");
@@ -614,9 +676,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldSatisfy` (>=3) -- TODO: should be exactly 3
-  it "can cast to account with incorrect types" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldSatisfy` (>=3) -- TODO: should be exactly 3
+  it "can cast to account with incorrect types" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   function f() {
     account a = account("1234");
@@ -625,9 +688,10 @@ contract A {
   }
 }
 |]
-     in length anns `shouldSatisfy` (>=3) -- TODO: should be exactly 3
-  it "can throw exception when the types are different from contructor and call" $
-    let anns = runTypechecker [r|
+    
+    length anns `shouldSatisfy` (>=3) -- TODO: should be exactly 3
+  it "can throw exception when the types are different from contructor and call" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract qq {
   uint x = 0;
 
@@ -639,10 +703,11 @@ contract qq {
   }
 
 }|]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "can typecheck account(this, \"self\").chainId" $
-    let anns = runTypechecker [r|
+  it "can typecheck account(this, \"self\").chainId" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract qq {
   uint a1;
@@ -658,10 +723,11 @@ contract qq {
     a5 = account(this, "self").chainId;
   }
 }|]
-    in length anns `shouldBe` 0
+   
+    length anns `shouldBe` 0
 
-  it "can use the string.concat(x,y) function and succeeds when the types are strings" $
-    let anns = runTypechecker [r|
+  it "can use the string.concat(x,y) function and succeeds when the types are strings" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   function f() {
@@ -671,10 +737,11 @@ contract A {
   }
 }
 |]
-    in length anns `shouldBe` 0
+   
+    length anns `shouldBe` 0
 
-  it "can use the string.concat(x,y) function and fails when the types are not strings" $
-    let anns = runTypechecker [r|
+  it "can use the string.concat(x,y) function and fails when the types are not strings" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   function f() {
@@ -683,10 +750,11 @@ contract A {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "cannot assign an immutable a new value inside a function" $
-    let anns = runTypechecker [r|
+  it "cannot assign an immutable a new value inside a function" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   unint immutable g =2;
@@ -696,9 +764,10 @@ contract A {
   } 
 }
 |]
-    in length anns `shouldBe` 2
-  it "cannot incrument an immutable already assigned within the constructor" $
-    let anns = runTypechecker [r|
+   
+    length anns `shouldBe` 2
+  it "cannot incrument an immutable already assigned within the constructor" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract qq {
   uint g = 2022;
@@ -708,18 +777,20 @@ contract qq {
   }
 }
 |]
-    in length anns `shouldBe` 1
-  it "can have the receive() function and succeeds when there are no arguments, no return values, and is Payable and External" $
-    let anns = runTypechecker [r|
+   
+    length anns `shouldBe` 1
+  it "can have the receive() function and succeeds when there are no arguments, no return values, and is Payable and External" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   receive() external payable {
   }
 }
 |]
-    in length anns `shouldBe` 0
-  it "can throw exception when receive() function has arguments" $
-    let anns = runTypechecker [r|
+   
+    length anns `shouldBe` 0
+  it "can throw exception when receive() function has arguments" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   receive(uint i) external payable {
@@ -727,10 +798,11 @@ contract A {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
   
-  it "can assign a value to a declared unassigned immutable within the constructor" $
-    let anns = runTypechecker [r|
+  it "can assign a value to a declared unassigned immutable within the constructor" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract qq {
   uint g = 2022;
@@ -740,9 +812,10 @@ contract qq {
   }
 }
 |]
-    in length anns `shouldBe` 0
-  it "cannot assign an immutable a value after already assinged on contract level" $
-    let anns = runTypechecker [r|
+   
+    length anns `shouldBe` 0
+  it "cannot assign an immutable a value after already assinged on contract level" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract qq {
   uint g = 2022;
@@ -751,9 +824,10 @@ contract qq {
     d = g;
   } 
 }|]
-    in length anns `shouldBe` 1
-  it "can throw exception when receive() function has return values" $
-    let anns = runTypechecker [r|
+   
+    length anns `shouldBe` 1
+  it "can throw exception when receive() function has return values" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   receive() external payable returns (uint) {
@@ -762,30 +836,33 @@ contract A {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "can throw exception when receive() function is not external" $
-    let anns = runTypechecker [r|
+  it "can throw exception when receive() function is not external" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   receive() internal payable {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "can throw exception when receive() function is not payable" $
-    let anns = runTypechecker [r|
+  it "can throw exception when receive() function is not payable" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   receive() external {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "cannot assign an immutable after already assinged within a function" $
-    let anns = runTypechecker [r|
+  it "cannot assign an immutable after already assinged within a function" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract qq {
   uint c = 2022;
@@ -797,29 +874,32 @@ contract qq {
     x = 13;
   }
 }|]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "can throw exception when receive() function is decalred with function keyword" $
-    let anns = runTypechecker [r|
+  it "can throw exception when receive() function is decalred with function keyword" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   function receive() external payable {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "can have the fallback() function and succeeds when there are no arguments, no return values, and is External" $
-    let anns = runTypechecker [r|
+  it "can have the fallback() function and succeeds when there are no arguments, no return values, and is External" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
   fallback() external payable {
   }
 }
 |]
-    in length anns `shouldBe` 0
+   
+    length anns `shouldBe` 0
 
-  it "can throw exception when fallback() function has arguments" $
-    let anns = runTypechecker [r|
+  it "can throw exception when fallback() function has arguments" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   fallback(uint i) external payable {
@@ -827,10 +907,11 @@ contract A {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "can use an immutable within a function" $
-    let anns = runTypechecker [r|
+  it "can use an immutable within a function" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract qq {
   uint c = 2022;
@@ -844,9 +925,10 @@ contract qq {
   }
 }
 |]
-    in length anns `shouldBe` 0
-  it "can throw exception when fallback() function has return values" $
-    let anns = runTypechecker [r|
+   
+    length anns `shouldBe` 0
+  it "can throw exception when fallback() function has return values" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
   fallback() external payable returns (uint) {
@@ -855,42 +937,46 @@ contract A {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "can throw exception when fallback() function is not external" $
-    let anns = runTypechecker [r|
+  it "can throw exception when fallback() function is not external" $ do
+    anns <- liftIO $ runTypechecker [r|
 
 contract A {
    fallback() internal payable {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
-  it "can throw exception when fallback() function is declared with function keyword" $
-    let anns = runTypechecker [r|
+  it "can throw exception when fallback() function is declared with function keyword" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract A {
    function fallback() external payable {
   }
 }
 |]
-    in length anns `shouldBe` 1
+   
+    length anns `shouldBe` 1
 
 
-  it "Supports pure functions in 3.3" $
-      let anns = runTypechecker [r|
+  it "Supports pure functions in 3.3" $ do
+    anns <- liftIO $ runTypechecker [r|
 contract C {
     function f(uint a, uint b) public pure returns (uint) {
         return a * (b + 42);
     }
 }
 |]
-      in length anns `shouldBe` 0
+     
+    length anns `shouldBe` 0
 
 
   describe "pure and view modifier for solidvm 3.4" $ do
-    it "can write pure and view functions" $
-      let anns = runTypechecker [r|
+    it "can write pure and view functions" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -902,9 +988,10 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "error when reading from contract state in a pure function" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "error when reading from contract state in a pure function" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -913,9 +1000,10 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "error when writing to contract state from a pure or view function" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 1
+    it "error when writing to contract state from a pure or view function" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -929,9 +1017,10 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 2
-    it "error when using assembly code from a pure or view function" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 2
+    it "error when using assembly code from a pure or view function" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -947,11 +1036,12 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 2
+      
+      length anns `shouldBe` 2
 
   describe "Check contract inheritance solidvm 3.3" $ do
-    it "can resolve state variables inherited from a contract" $
-      let anns = runTypechecker [r|
+    it "can resolve state variables inherited from a contract" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -962,9 +1052,10 @@ contract B is A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can resolve state variables from multiple layers of inheritance" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "can resolve state variables from multiple layers of inheritance" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -977,9 +1068,10 @@ contract C is B {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can inherit from multiple contracts" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "can inherit from multiple contracts" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -994,9 +1086,10 @@ contract C is A, B {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "error when referencing a state variable from a non-inherited contract" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "error when referencing a state variable from a non-inherited contract" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -1007,12 +1100,13 @@ contract B {
   }
 }
 |]
-       in length anns `shouldBe` 2
+      
+      length anns `shouldBe` 2
 
 -- start of 3.2 tests
   describe "pure and view modifier for solidvm 3.2" $ do
-    it "can write pure and view functions" $
-      let anns = runTypechecker [r|
+    it "can write pure and view functions" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -1024,9 +1118,10 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "Warns when reading from contract state in a pure function" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "Warns when reading from contract state in a pure function" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -1035,9 +1130,10 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "Warns when writing to contract state from a pure or view function" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 1
+    it "Warns when writing to contract state from a pure or view function" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -1051,9 +1147,10 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 2
-    it "Warns when using assembly code from a pure or view function" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 2
+    it "Warns when using assembly code from a pure or view function" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -1069,11 +1166,12 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 2
+      
+      length anns `shouldBe` 2
 
   describe "Check contract inheritance" $ do
-    it "can resolve state variables inherited from a contract" $
-      let anns = runTypechecker [r|
+    it "can resolve state variables inherited from a contract" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -1084,9 +1182,10 @@ contract B is A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can resolve state variables from multiple layers of inheritance" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "can resolve state variables from multiple layers of inheritance" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -1099,9 +1198,10 @@ contract C is B {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can inherit from multiple contracts" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "can inherit from multiple contracts" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -1116,9 +1216,10 @@ contract C is A, B {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can detect when referencing a state variable from a non-inherited contract" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "can detect when referencing a state variable from a non-inherited contract" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -1129,12 +1230,13 @@ contract B {
   }
 }
 |]
-       in length anns `shouldBe` 2
+      
+      length anns `shouldBe` 2
 
 
   describe "Constant function detectors" $ do
-    it "can write pure and view functions" $
-      let anns = runTypechecker [r|
+    it "can write pure and view functions" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -1146,9 +1248,10 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "Warns when reading from contract state in a pure function" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "Warns when reading from contract state in a pure function" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -1157,9 +1260,10 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 1
-    it "Warns when writing to contract state from a pure or view function" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 1
+    it "Warns when writing to contract state from a pure or view function" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -1173,9 +1277,10 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 2
-    it "Warns when using assembly code from a pure or view function" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 2
+    it "Warns when using assembly code from a pure or view function" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 5;
@@ -1191,11 +1296,12 @@ contract A {
   }
 }
 |]
-       in length anns `shouldBe` 2
+      
+      length anns `shouldBe` 2
 
   describe "Missing inheritance detectors" $ do
-    it "can resolve state variables inherited from a contract" $
-      let anns = runTypechecker [r|
+    it "can resolve state variables inherited from a contract" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -1206,9 +1312,10 @@ contract B is A {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can resolve state variables from multiple layers of inheritance" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "can resolve state variables from multiple layers of inheritance" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -1221,9 +1328,10 @@ contract C is B {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can inherit from multiple contracts" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "can inherit from multiple contracts" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -1238,9 +1346,10 @@ contract C is A, B {
   }
 }
 |]
-       in length anns `shouldBe` 0
-    it "can detect when referencing a state variable from a non-inherited contract" $
-      let anns = runTypechecker [r|
+      
+      length anns `shouldBe` 0
+    it "can detect when referencing a state variable from a non-inherited contract" $ do
+      anns <- liftIO $ runTypechecker [r|
 
 contract A {
   uint x = 7;
@@ -1251,12 +1360,13 @@ contract B {
   }
 }
 |]
-       in length anns `shouldBe` 2
+      
+      length anns `shouldBe` 2
 
 
   describe "User Defined Value Types" $ do
-    it "must pass the associated type within the wrap function " $ 
-        let anns = runTypechecker [r|
+    it "must pass the associated type within the wrap function " $ do
+      anns <- liftIO $ runTypechecker [r|
   
   type MagicInt is int;
   type MysticalString is string;
@@ -1274,10 +1384,11 @@ contract B {
     MagicInt mrBool         = UBool.wrap(true);          //Error          -- passing wrong type to alias wrap function
     bool shouldThrowError   = UBool.wrap(true);         //Error           -- assigning user defined to bool variable
 }
-|] in length anns `shouldBe` 7
+|]
+      length anns `shouldBe` 7
 
-    it "can use user defined unwrap and unwrap" $
-      let anns = runTypechecker [r|
+    it "can use user defined unwrap and unwrap" $ do
+      anns <- liftIO $ runTypechecker [r|
   
   
   type MagicInt       is int;
@@ -1302,10 +1413,11 @@ contract B {
     string         banach   = MysticalString.unwrap(hilbert);
     string krull            = MysticalString.unwrap(MysticalString.wrap(string.concat("33",  banach)));
 }
-|] in length anns `shouldBe` 0
+|]
+      length anns `shouldBe` 0
 
-    it "can use user-defined-types wrap and unwrap within fuctions" $
-      let anns = runTypechecker [r|
+    it "can use user-defined-types wrap and unwrap within fuctions" $ do
+      anns <- liftIO $ runTypechecker [r|
   
   type UBool is bool;
   type MagicInt is int;
@@ -1320,11 +1432,12 @@ contract B {
       bool  felixKlein   =  UBool.unwrap(UBool.wrap(mrBool));
     }
 
-}|] in length anns `shouldBe` 0
+}|]
+      length anns `shouldBe` 0
 
   describe "function tests calling other contracts" $ do
-    it "can call type(C).name, type(C).creationCode, type(C).runtimeCode" $
-      let anns = runTypechecker [r|
+    it "can call type(C).name, type(C).creationCode, type(C).runtimeCode" $ do
+      anns <- liftIO $ runTypechecker [r|
 contract A {
   string endofunctor1 = type(A).name;
   string endofunctor2 = type(A).creationCode;
@@ -1341,27 +1454,30 @@ contract C {
   string endofunctor1 = type(A).name;
   string endofunctor2 = type(A).creationCode;
   string endofunctor3 = type(A).runtimeCode;
-} |]  in length anns `shouldBe` 0
+} |] 
+      length anns `shouldBe` 0
   
-    it "type(C).name, type(C).creationCode, type(C).runtimeCode only produce strings" $
-      let anns = runTypechecker [r|
+    it "type(C).name, type(C).creationCode, type(C).runtimeCode only produce strings" $ do
+      anns <- liftIO $ runTypechecker [r|
 contract A {
   int endofunctor1   = type(A).name;
   int endofunctor2   = type(A).creationCode;
   int groupoid       = type(A).runtimeCode;
 }
-|] in length anns `shouldBe` 3
+|]
+      length anns `shouldBe` 3
     
-    it "Can only call accounts and addresses with delegate call" $
-      let anns = runTypechecker [r|
+    it "Can only call accounts and addresses with delegate call" $ do
+      anns <- liftIO $ runTypechecker [r|
 contract A {
   int endofunctor1   = address(0xdeadbeef).delegatecall("garbage()");
   int endofunctor2   = type(A).delegatecall("garbage()");
 }
-|] in length anns `shouldBe` 1
+|]
+      length anns `shouldBe` 1
     
-    it "Can typecheck `using` expressions" $
-      let anns = runTypechecker [r|
+    it "Can typecheck `using` expressions" $ do
+      anns <- liftIO $ runTypechecker [r|
 library SafeMath {
   function add(uint a, uint b) returns (uint) {
     return a + b;
@@ -1373,4 +1489,5 @@ contract A {
     return _x.add(1);
   }
 }
-|] in anns `shouldBe` []
+|]
+      anns `shouldBe` []

--- a/strato/VM/SolidVM/source-tools/src/Data/Source/Annotation.hs
+++ b/strato/VM/SolidVM/source-tools/src/Data/Source/Annotation.hs
@@ -43,7 +43,7 @@ data SourceAnnotation a = SourceAnnotation
   { _sourceAnnotationStart      :: SourcePosition
   , _sourceAnnotationEnd        :: SourcePosition
   , _sourceAnnotationAnnotation :: a
-  } deriving (Eq, Generic, Functor, Data, NFData)
+  } deriving (Eq, Ord, Generic, Functor, Data, NFData)
 
 makeLenses ''SourceAnnotation
 

--- a/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
@@ -32,6 +32,7 @@ import qualified Data.Text.Encoding              as Text
 import           Text.Format
 import           UnliftIO
 
+import           Blockchain.DB.CodeDB
 import           Blockchain.SolidVM.CodeCollectionDB
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.CodePtr
@@ -44,7 +45,9 @@ import           SQLM
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
 
-getContractDetailsByCodeHash :: ( A.Selectable Account AddressState m
+getContractDetailsByCodeHash :: ( MonadIO m
+                                , HasCodeDB m
+                                , A.Selectable Account AddressState m
                                 , (Keccak256 `A.Selectable` SourceMap) m
                                 )
                              => CodePtr -> m (Either Text (CodePtr, Contract))
@@ -59,7 +62,7 @@ getContractDetailsByCodeHash codePtr = do
         Nothing -> throwE $ "Could not find source code for code hash " <> Text.pack (format ch)
         Just s -> pure s
       let nameStr = Text.unpack name
-      ~(cHash, cc) <- either (throwE . Text.pack . show) pure $ sourceToContractDetails srcMap
+      ~(cHash, cc) <- either (throwE . Text.pack . show) pure =<< lift (sourceToContractDetails srcMap)
       case Map.lookup nameStr $ _contracts cc of
           Nothing -> throwE $ "Could not find contract " <> name <> " in code collection " <> Text.pack (format ch)
           Just d -> pure (SolidVMCode nameStr cHash, d)
@@ -75,11 +78,14 @@ evmContractSolidVMError = Text.concat
   , "If you are intending to use EVM, please modify your contracts and try again."
   ]
 
-getContractDetailsForContract :: MonadIO m
+getContractDetailsForContract :: ( MonadIO m
+                                 , HasCodeDB m
+                                 , A.Selectable Account AddressState m
+                                 )
                               => SourceMap -> Maybe Text -> m (Maybe (CodePtr, Contract))
 getContractDetailsForContract src mContract = do
   eCodeCollection <- if hasAnyNonEmptySources src
-                       then pure $ sourceToContractDetails src
+                       then sourceToContractDetails src
                        else throwIO . UserError $ "No source code given for contract"
   case eCodeCollection of
     Left annotations -> throwIO . UserError . Text.pack $ "Detected errors during compilation: " ++ show annotations
@@ -90,12 +96,20 @@ getContractDetailsForContract src mContract = do
         _ -> throwIO $ UserError "When you upload multiple contracts, you need to specify which contract should be uploaded to the chain in the 'contract' key of the given data"
       Just c -> pure . fmap (SolidVMCode (Text.unpack c) ch,) $ Map.lookup (Text.unpack c) _contracts
 
-sourceToContractDetails :: SourceMap -> Either [SourceAnnotation Text] (Keccak256, CodeCollection)
+sourceToContractDetails :: ( MonadIO m
+                           , HasCodeDB m
+                           , A.Selectable Account AddressState m
+                           )
+                        => SourceMap -> m (Either [SourceAnnotation Text] (Keccak256, CodeCollection))
 sourceToContractDetails = createMetadataNoCompile
 
 -- SolidVM only
-createMetadataNoCompile :: SourceMap -> Either [SourceAnnotation Text] (Keccak256, CodeCollection)
-createMetadataNoCompile sourceList =
-  let compiledSource = compileSourceWithAnnotations True (Map.fromList $ unSourceMap sourceList)
-      srcHash = hash . Text.encodeUtf8 $ serializeSourceMap sourceList
-   in (srcHash,) <$> compiledSource
+createMetadataNoCompile :: ( MonadIO m
+                           , HasCodeDB m
+                           , A.Selectable Account AddressState m
+                           )
+                        => SourceMap -> m (Either [SourceAnnotation Text] (Keccak256, CodeCollection))
+createMetadataNoCompile sourceList = do
+  compiledSource <- compileSourceWithAnnotations True (Map.fromList $ unSourceMap sourceList)
+  let srcHash = hash . Text.encodeUtf8 $ serializeSourceMap sourceList
+  pure $ (srcHash,) <$> compiledSource

--- a/strato/api/bloc/bloc2/src/Bloc/Server.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server.hs
@@ -31,6 +31,7 @@ import Bloc.Monad
 import Blockchain.Strato.Model.Account
 import Blockchain.Strato.Model.Keccak256
 import Blockchain.Data.AddressStateDB
+import Blockchain.DB.CodeDB
 
 import Control.Monad.Composable.SQL
 import Control.Monad.Composable.Vault
@@ -43,6 +44,7 @@ bloc :: ( MonadLogger m
         , HasSQL m
         , Selectable Account Contract m
         , Selectable Account AddressState m
+        , HasCodeDB m
         , (Keccak256 `Selectable` SourceMap) m
         )
      => ServerT BlocAPI m

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Chain.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Chain.hs
@@ -40,6 +40,7 @@ import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.ChainInfo
 import           Blockchain.Data.DataDefs
 import           Blockchain.Data.TransactionResultStatus
+import           Blockchain.DB.CodeDB
 import           Blockchain.DB.SQLDB
 import           Blockchain.TypeLits
 import           Blockchain.Strato.Model.Account
@@ -81,6 +82,7 @@ governanceAddress = Address 0x100
 --           _ -> m
 
 createChainInfo :: ( A.Selectable Account AddressState m
+                   , HasCodeDB m
                    , (Keccak256 `A.Selectable` SourceMap) m
                    , MonadLogger m
                    , HasVault m
@@ -156,6 +158,7 @@ getLastBlockHash = do
 
 
 postChainInfo :: ( A.Selectable Account AddressState m
+                 , HasCodeDB m
                  , (Keccak256 `A.Selectable` SourceMap) m
                  , MonadLogger m
                  , HasBlocEnv m
@@ -184,6 +187,7 @@ postChainInfo mJwtToken chainInput = case mJwtToken of
         pure chainId
 
 postChainInfos :: ( A.Selectable Account AddressState m
+                  , HasCodeDB m
                   , (Keccak256 `A.Selectable` SourceMap) m
                   , MonadLogger m
                   , HasSQL m

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Contracts.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Contracts.hs
@@ -41,6 +41,7 @@ import           Blockchain.Data.AddressStateRef
 import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.DataDefs
 import           Blockchain.Data.Json hiding (Contract)
+import           Blockchain.DB.CodeDB
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ChainId
@@ -94,6 +95,7 @@ getContractsData (ContractName cName) = do
   return $ (\(AddressStateRef' r _)-> addressStateRefAddress r) <$> svmRefs
 
 getContractsContract :: ( A.Selectable Account AddressState m
+                        , HasCodeDB m
                         , (Keccak256 `A.Selectable` SourceMap) m
                         , HasSQL m
                         )
@@ -131,6 +133,7 @@ translateStorageMap storage' =
 
 getContractsState :: ( MonadLogger m
                      , A.Selectable Account AddressState m
+                     , HasCodeDB m
                      , (Keccak256 `A.Selectable` SourceMap) m
                      , HasSQL m
                      )
@@ -195,6 +198,7 @@ getContractsState _ address chainId mName mCount mOffset _ = do
 
 postContractsBatchStates :: ( MonadLogger m
                             , A.Selectable Account AddressState m
+                            , HasCodeDB m
                             , (Keccak256 `A.Selectable` SourceMap) m
                             , HasSQL m
                             )
@@ -211,6 +215,7 @@ postContractsBatchStates = traverse flattenRequest
                             (fromMaybe False postcontractsbatchstatesrequestLength)
 
 getContractsDetails' :: ( A.Selectable Account AddressState m
+                        , HasCodeDB m
                         , (Keccak256 `A.Selectable` SourceMap) m
                         , HasSQL m
                         )
@@ -237,6 +242,7 @@ getContractsDetails' contractAddress chainId = do
         Right contract -> pure $ snd contract
 
 getContractsDetails :: ( A.Selectable Account AddressState m
+                       , HasCodeDB m
                        , (Keccak256 `A.Selectable` SourceMap) m
                        , HasSQL m
                        )
@@ -244,6 +250,7 @@ getContractsDetails :: ( A.Selectable Account AddressState m
 getContractsDetails = getContractsDetails'
 
 getContractsFunctions :: ( A.Selectable Account AddressState m
+                         , HasCodeDB m
                          , (Keccak256 `A.Selectable` SourceMap) m
                          , HasSQL m
                          )
@@ -253,6 +260,7 @@ getContractsFunctions _ contractId chainId = do
   pure . map (FunctionName . Text.pack) . Map.keys $ _functions contract
 
 getContractsSymbols :: ( A.Selectable Account AddressState m
+                       , HasCodeDB m
                        , (Keccak256 `A.Selectable` SourceMap) m
                        , HasSQL m
                        )
@@ -262,6 +270,7 @@ getContractsSymbols _ contractId chainId = do
   pure . map (SymbolName . Text.pack) . Map.keys $ _storageDefs contract
 
 getContractsEnum :: ( A.Selectable Account AddressState m
+                    , HasCodeDB m
                     , (Keccak256 `A.Selectable` SourceMap) m
                     , HasSQL m
                     )
@@ -313,12 +322,15 @@ getContractsStates :: MonadIO m =>
                       ContractName -> m [GetContractsStatesResponse] -- state-translation
 getContractsStates _ = throwIO $ Unimplemented "getContractsStates"
 
-postContractsCompile :: MonadIO m
+postContractsCompile :: ( MonadIO m
+                        , HasCodeDB m
+                        , A.Selectable Account AddressState m
+                        )
                      => [PostCompileRequest] -> m [PostCompileResponse]
 postContractsCompile = traverse compileOneContract
   where
     compileOneContract PostCompileRequest{..} = do
-      let eContract = sourceToContractDetails postcompilerequestSource
+      eContract <- sourceToContractDetails postcompilerequestSource
       case eContract of
         Left anns -> throwIO . UserError . Text.pack $ show anns
         Right (srcHash, _) -> pure $ PostCompileResponse (fromMaybe "" postcompilerequestContractName) srcHash

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -86,6 +86,7 @@ import           Blockchain.Data.DataDefs
 import           Blockchain.Data.Json             hiding (Contract)
 import           Blockchain.Data.TXOrigin
 import           Blockchain.Data.Transaction      (rawTX2TX, transactionHash)
+import           Blockchain.DB.CodeDB
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address  hiding (unAddress)
 import           Blockchain.Strato.Model.ChainId
@@ -123,6 +124,7 @@ mergeTxParams inner outer = inner <|> outer
 txWorker :: ( MonadLogger m
             , A.Selectable Account Contract m
             , A.Selectable Account AddressState m
+            , HasCodeDB m
             , (Keccak256 `A.Selectable` SourceMap) m
             , HasBlocEnv m
             , HasVault m
@@ -225,6 +227,8 @@ postBlocTransactionRaw _ _ h resolve PostBlocTransactionRawRequest{..} = do
 -- | postBlocTransactionBody(jwt, chain ID, [Transactions])
 postBlocTransactionBody :: ( MonadLogger m
                            , A.Selectable Account Contract m
+                           , A.Selectable Account AddressState m
+                           , HasCodeDB m
                            , HasBlocEnv m
                            , HasSQL m
                            , HasVault m
@@ -348,6 +352,8 @@ postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList 
 -- | postBlocTransactionUnsigned
 postBlocTransactionUnsigned :: ( MonadLogger m
                                , A.Selectable Account Contract m
+                               , A.Selectable Account AddressState m
+                               , HasCodeDB m
                                , HasBlocEnv m
                                , HasSQL m
                                , HasVault m
@@ -471,6 +477,7 @@ postBlocTransactionUnsigned (Just jwt) cid (PostBlocTransactionRequest mAddr txL
 postBlocTransactionParallel :: ( MonadLogger m
                                , A.Selectable Account Contract m
                                , A.Selectable Account AddressState m
+                               , HasCodeDB m
                                , (Keccak256 `A.Selectable` SourceMap) m
                                , HasBlocEnv m
                                , HasVault m
@@ -495,6 +502,7 @@ postBlocTransactionParallel jwtToken b resolve queue c =
 postBlocTransaction :: ( MonadLogger m
                        , A.Selectable Account Contract m
                        , A.Selectable Account AddressState m
+                       , HasCodeDB m
                        , (Keccak256 `A.Selectable` SourceMap) m
                        , HasBlocEnv m
                        , HasVault m
@@ -510,6 +518,7 @@ postBlocTransaction = postBlocTransaction' (Don't CacheNonce)
 postBlocTransactionExternal :: ( MonadLogger m
                               , A.Selectable Account Contract m
                               , A.Selectable Account AddressState m
+                              , HasCodeDB m
                               , (Keccak256 `A.Selectable` SourceMap) m
                               , HasBlocEnv m
                               , HasVault m
@@ -526,6 +535,7 @@ postBlocTransactionExternal bearerToken = postBlocTransaction' (Don't CacheNonce
 postBlocTransaction' :: ( MonadLogger m
                         , A.Selectable Account Contract m
                         , A.Selectable Account AddressState m
+                        , HasCodeDB m
                         , (Keccak256 `A.Selectable` SourceMap) m
                         , HasBlocEnv m
                         , HasVault m
@@ -707,6 +717,7 @@ data TransactionHeader = TransactionHeader
 
 postUsersSend' :: ( A.Selectable Account AddressState m
                   , (Keccak256 `A.Selectable` SourceMap) m
+                  , HasCodeDB m
                   , MonadLogger m
                   , HasBlocEnv m
                   , HasVault m
@@ -730,6 +741,7 @@ postUsersSend' cacheNonce TransferParameters{..} jwtToken = do
 postUsersContractSolidVM' :: ( MonadLogger m
                              , A.Selectable Account AddressState m
                              , (Keccak256 `A.Selectable` SourceMap) m
+                             , HasCodeDB m
                              , HasBlocEnv m
                              , HasVault m
                              , HasSQL m
@@ -767,6 +779,7 @@ postUsersContractSolidVM' cacheNonce ContractParameters{..} jwtToken = do
 postUsersUploadListSolidVM' :: ( MonadLogger m
                                , A.Selectable Account AddressState m
                                , (Keccak256 `A.Selectable` SourceMap) m
+                               , HasCodeDB m
                                , HasBlocEnv m
                                , HasVault m
                                , HasSQL m
@@ -805,6 +818,7 @@ postUsersUploadListSolidVM' cacheNonce ContractListParameters{..} jwtToken = do
 
 postUsersSendList' :: ( MonadLogger m
                       , A.Selectable Account AddressState m
+                      , HasCodeDB m
                       , (Keccak256 `A.Selectable` SourceMap) m
                       , HasBlocEnv m
                       , HasVault m
@@ -832,6 +846,7 @@ postUsersSendList' cacheNonce TransferListParameters{..} jwtToken = do
 postUsersContractMethodList' :: ( MonadLogger m
                                 , A.Selectable Account Contract m
                                 , A.Selectable Account AddressState m
+                                , HasCodeDB m
                                 , (Keccak256 `A.Selectable` SourceMap) m
                                 , HasBlocEnv m
                                 , HasVault m
@@ -883,6 +898,7 @@ postUsersContractMethodList' cacheNonce FunctionListParameters{..} jwtToken = do
 postUsersContractMethod' :: ( MonadLogger m
                             , A.Selectable Account Contract m
                             , A.Selectable Account AddressState m
+                            , HasCodeDB m
                             , (Keccak256 `A.Selectable` SourceMap) m
                             , HasBlocEnv m
                             , HasVault m
@@ -1217,6 +1233,7 @@ getSolidityType av Xabi.Mapping{}            = Left $ Text.pack $ "Expected Obje
 
 
 getResultAndRespond :: ( A.Selectable Account AddressState m
+                       , HasCodeDB m
                        , (Keccak256 `A.Selectable` SourceMap) m
                        , MonadLogger m
                        , HasSQL m

--- a/strato/api/bloc/bloc2/src/Bloc/Server/TransactionResult.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/TransactionResult.hs
@@ -73,10 +73,10 @@ import           BlockApps.SolidityVarReader
 import           BlockApps.XAbiConverter
 import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.DataDefs
+import           Blockchain.DB.CodeDB
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.ChainId
 import           Blockchain.Strato.Model.Code
-import           Blockchain.Strato.Model.CodePtr   (CodeKind(..))
 import           Blockchain.Strato.Model.Keccak256
 import qualified Bloc.API.DeprecatedPostTransaction as Deprecated
 import           Bloc.API.TypeWrappers
@@ -107,6 +107,7 @@ emptyBatchState = BatchState Map.empty
 -- when multiple hashes are provided. This is a glass-half-full
 -- function, and if one TX succeeds then the result is a success.
 getBlocTransactionResult' :: ( (Keccak256 `A.Selectable` SourceMap) m
+                             , HasCodeDB m
                              , A.Selectable Account AddressState m
                              , MonadLogger m
                              , HasSQL m
@@ -127,6 +128,7 @@ getBlocTransactionResult' hashes@(txh:_) resolve =
     else return $ BlocTransactionResult Pending txh Nothing Nothing
 
 getBlocTransactionResult :: ( (Keccak256 `A.Selectable` SourceMap) m
+                            , HasCodeDB m
                             , A.Selectable Account AddressState m
                             , MonadLogger m
                             , HasSQL m
@@ -136,6 +138,7 @@ getBlocTransactionResult txHash resolve = fmap head $ postBlocTransactionResults
 
 
 getBatchBlocTransactionResult' :: ( (Keccak256 `A.Selectable` SourceMap) m
+                                  , HasCodeDB m
                                   , A.Selectable Account AddressState m
                                   , MonadLogger m
                                   , HasSQL m
@@ -147,6 +150,7 @@ getBatchBlocTransactionResult' hashes resolve =
     else return $ map (\h -> BlocTransactionResult Pending h Nothing Nothing) hashes
 
 postBlocTransactionResults :: ( (Keccak256 `A.Selectable` SourceMap) m
+                              , HasCodeDB m
                               , A.Selectable Account AddressState m
                               , MonadLogger m
                               , HasSQL m
@@ -214,6 +218,7 @@ rawTx2PostTx RawTransaction{..} = Deprecated.PostTransaction
   }
 
 evalAndReturn :: ( (Keccak256 `A.Selectable` SourceMap) m
+                 , HasCodeDB m
                  , A.Selectable Account AddressState m
                  , MonadLogger m
                  , HasSQL m
@@ -267,6 +272,7 @@ contractResult i txHash txResult@TransactionResult{..} mmd = do
       return $ BlocTransactionResult Success txHash (Just txResult) (Just $ Upload details)
 
 functionResult :: ( A.Selectable Account AddressState m
+                  , HasCodeDB m
                   , (Keccak256 `A.Selectable` SourceMap) m
                   , MonadLogger m
                   , HasSQL m

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Users.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Users.hs
@@ -22,6 +22,7 @@ import           Bloc.Server.Utils
 import           BlockApps.Logging
 import           BlockApps.Solidity.Contract()
 import           Blockchain.Data.AddressStateDB
+import           Blockchain.DB.CodeDB
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.Keccak256
@@ -33,6 +34,7 @@ import           SQLM
 
 
 postUsersFill :: ( A.Selectable Account AddressState m
+                 , HasCodeDB m
                  , (Keccak256 `A.Selectable` SourceMap) m
                  , MonadLogger m
                  , HasSQL m

--- a/strato/api/core/src/Handlers/AccountInfo.hs
+++ b/strato/api/core/src/Handlers/AccountInfo.hs
@@ -16,6 +16,7 @@ module Handlers.AccountInfo where
 
 import           Control.Monad.Change.Alter
 import           Control.Lens
+import qualified Data.ByteString             as B
 import           Data.List
 import           Data.Maybe
 import           Data.Source.Map
@@ -243,8 +244,13 @@ codeServer cHash = select (Proxy @SourceMap) cHash >>= \case
 
 getCodeFromPostgres :: HasSQL m => Keccak256 -> m (Maybe SourceMap)
 getCodeFromPostgres cHash =
-  let getSourceMap = deserializeSourceMap . decodeUtf8 . codeRefCode . E.entityVal
-   in fmap (listToMaybe . map getSourceMap) . sqlQuery . E.select $
+  let getSourceMap = deserializeSourceMap . decodeUtf8
+   in fmap getSourceMap <$> getCodeByteStringFromPostgres cHash
+
+getCodeByteStringFromPostgres :: HasSQL m => Keccak256 -> m (Maybe B.ByteString)
+getCodeByteStringFromPostgres cHash =
+  let getBS = codeRefCode . E.entityVal
+   in fmap (listToMaybe . map getBS) . sqlQuery . E.select $
         E.from $ \(codeRef) -> do
         E.where_ (codeRef E.^. CodeRefCodeHash E.==. E.val cHash)
         return codeRef

--- a/strato/api/strato-api/exec_src/Main.hs
+++ b/strato/api/strato-api/exec_src/Main.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE TypeOperators     #-}
 
 
@@ -13,6 +15,7 @@
 
 module Main where
 
+import           Prelude                         hiding (lookup)
 import           Control.Lens.Operators
 import           Control.Monad.Change.Modify  (Accessible)
 import           Control.Monad.Change.Alter
@@ -59,6 +62,7 @@ import           Blockchain.Data.AddressStateDB
 import           Blockchain.Data.AddressStateRef
 import           Blockchain.Data.DataDefs
 import           Blockchain.Data.Json
+import           Blockchain.DB.CodeDB
 
 import           Control.Monad.Composable.SQL
 import           Control.Monad.Composable.Identity
@@ -117,6 +121,11 @@ instance Selectable Account Contract m => Selectable Account Contract (IdentityM
 instance MonadUnliftIO m => (Keccak256 `Selectable` SourceMap) (SQLM m) where
   select _ = Account.getCodeFromPostgres
 
+instance MonadUnliftIO m => (Keccak256 `Alters` DBCode) (SQLM m) where
+  lookup _ k   = fmap (SolidVM,) <$> Account.getCodeByteStringFromPostgres k
+  insert _ _ _ = error "API: Keccak256 `Alters` DBCode insert"
+  delete _ _   = error "API: Keccak256 `Alters` DBCode delete"
+
 instance (Keccak256 `Selectable` SourceMap) m => (Keccak256 `Selectable` SourceMap) (VaultM m) where
   select p = lift . select p
 
@@ -126,6 +135,21 @@ instance (Keccak256 `Selectable` SourceMap) m => (Keccak256 `Selectable` SourceM
 
 instance Selectable Keccak256 SourceMap m => Selectable Keccak256 SourceMap (ReaderT BlocEnv m) where
   select p = lift . select p
+
+instance (Keccak256 `Alters` DBCode) m => (Keccak256 `Alters` DBCode) (VaultM m) where
+  lookup p   = lift . lookup p
+  insert p k = lift . insert p k
+  delete p   = lift . delete p
+
+instance (Keccak256 `Alters` DBCode) m => (Keccak256 `Alters` DBCode) (IdentityM m) where
+  lookup p   = lift . lookup p
+  insert p k = lift . insert p k
+  delete p   = lift . delete p
+
+instance (Keccak256 `Alters` DBCode) m => (Keccak256 `Alters` DBCode) (ReaderT BlocEnv m) where
+  lookup p   = lift . lookup p
+  insert p k = lift . insert p k
+  delete p   = lift . delete p
 
 instance MonadUnliftIO m => Selectable Account AddressState (SQLM m) where
   select _ a = runMaybeT $ do
@@ -214,6 +238,7 @@ fullServer :: ( MonadLogger m
               , HasVault m
               , Selectable Account Contract m
               , Selectable Account AddressState m
+              , HasCodeDB m
               , Selectable Keccak256 SourceMap m
               )
            => ServerT FullAPI m

--- a/strato/core/blockapps-mpdbs/src/Blockchain/DB/CodeDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/DB/CodeDB.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
@@ -11,6 +13,9 @@ module Blockchain.DB.CodeDB (
   CodeKind(..),
   HasCodeDB,
   DBCode,
+  MemCodeDB(..),
+  runMemCodeDB,
+  runNewMemCodeDB,
   shaToKey,
   dbCodeToValue,
   genericLookupCodeDB,
@@ -27,14 +32,17 @@ module Blockchain.DB.CodeDB (
 
 
 import           Control.DeepSeq
-import           Control.Monad.Change.Alter
+import qualified Control.Monad.Change.Alter         as A
 import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Reader
+import           Control.Monad.Trans.State.Strict
 import           Data.Bifunctor                     (first)
 import           Data.Binary
 import qualified Data.ByteString                    as B
 import qualified Data.ByteString.Lazy               as BL
 import           Data.Default
+import qualified Data.Map.Strict                    as M
 import qualified Database.LevelDB                   as DB
 import           Prelude                            hiding (lookup)
 
@@ -47,9 +55,26 @@ newtype CodeDB = CodeDB { unCodeDB :: DB.DB }
 instance NFData CodeDB where
   rnf (CodeDB a) = a `seq` ()
 
-type HasCodeDB m = (Keccak256 `Alters` DBCode) m
+type HasCodeDB m = (Keccak256 `A.Alters` DBCode) m
 
 type DBCode = (CodeKind, B.ByteString)
+
+newtype MemCodeDB m a = MemCodeDB { unMemCodeDB :: StateT (M.Map Keccak256 DBCode) m a }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance MonadTrans MemCodeDB where
+  lift = MemCodeDB . lift
+
+instance Monad m => (Keccak256 `A.Alters` DBCode) (MemCodeDB m) where
+  lookup _   = MemCodeDB . gets . M.lookup
+  insert _ k = MemCodeDB . modify' . M.insert k
+  delete _   = MemCodeDB . modify' . M.delete
+
+runMemCodeDB :: Monad m => MemCodeDB m a -> M.Map Keccak256 DBCode -> m a
+runMemCodeDB f m = evalStateT (unMemCodeDB f) m
+
+runNewMemCodeDB :: Monad m => MemCodeDB m a -> m a
+runNewMemCodeDB f = runMemCodeDB f M.empty
 
 shaToKey :: Keccak256 -> B.ByteString
 shaToKey = BL.toStrict . encode . sha2StateRoot
@@ -76,7 +101,7 @@ genericDeleteCodeDB f codeHash = do
   db <- unCodeDB <$> f
   DB.delete db def (shaToKey codeHash)
 
-instance MonadIO m => (Keccak256 `Alters` DBCode) (ReaderT CodeDB m) where
+instance MonadIO m => (Keccak256 `A.Alters` DBCode) (ReaderT CodeDB m) where
   lookup _ = genericLookupCodeDB ask
   insert _ = genericInsertCodeDB ask
   delete _ = genericDeleteCodeDB ask
@@ -102,8 +127,8 @@ getCodeKind hsh = maybe (error $ "no codekind found for " ++ show hsh) fst <$> g
 codeDBPut :: HasCodeDB m => CodeKind -> B.ByteString -> m Keccak256
 codeDBPut kind code = do
   let hsh = hash code
-  insert Proxy hsh (kind,code)
+  A.insert A.Proxy hsh (kind,code)
   return hsh
 
 codeDBGet :: HasCodeDB m => Keccak256 -> m (Maybe DBCode)
-codeDBGet = lookup Proxy
+codeDBGet = A.lookup A.Proxy

--- a/strato/core/blockapps-mpdbs/src/Blockchain/DB/MemAddressStateDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/DB/MemAddressStateDB.hs
@@ -1,8 +1,14 @@
 {-# OPTIONS -fno-warn-redundant-constraints #-} -- todo fixme
+{-# LANGUAGE DeriveFunctor    #-}
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators    #-}
 module Blockchain.DB.MemAddressStateDB (
+  MemAddressStateDB(..),
+  runMemAddressStateDB,
+  runNewMemAddressStateDB,
   HasMemAddressStateDB(..),
   AddressStateModification(..),
   formatAddressStateDBMap,
@@ -18,6 +24,9 @@ module Blockchain.DB.MemAddressStateDB (
 
 import           Control.Monad
 import qualified Control.Monad.Change.Alter     as A
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.State.Strict
 import           Control.DeepSeq
 import           Data.Maybe
 import qualified Data.Map                       as M
@@ -31,6 +40,26 @@ import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ExtendedWord
 import           Text.Format
+
+newtype MemAddressStateDB m a = MemAddressStateDB { unMemAddressStateDB :: StateT (M.Map Account AddressState) m a }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance MonadTrans MemAddressStateDB where
+  lift = MemAddressStateDB . lift
+
+instance Monad m => (Account `A.Alters` AddressState) (MemAddressStateDB m) where
+  lookup _   = MemAddressStateDB . gets . M.lookup
+  insert _ k = MemAddressStateDB . modify' . M.insert k
+  delete _   = MemAddressStateDB . modify' . M.delete
+
+instance Monad m => A.Selectable Account AddressState (MemAddressStateDB m) where
+  select = A.lookup
+
+runMemAddressStateDB :: Monad m => MemAddressStateDB m a -> M.Map Account AddressState -> m a
+runMemAddressStateDB f m = evalStateT (unMemAddressStateDB f) m
+
+runNewMemAddressStateDB :: Monad m => MemAddressStateDB m a -> m a
+runNewMemAddressStateDB f = runMemAddressStateDB f M.empty
 
 data AddressStateModification = ASModification AddressState | ASDeleted deriving (Show, Eq, Generic)
 

--- a/strato/core/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
@@ -1,15 +1,22 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 --TODO : Take this next line out
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Blockchain.Data.AddressStateDB (
   AddressState(..),
+  MainChainT(..),
   CodePtr(..),
   blankAddressState,
   resolveCodePtr,
@@ -27,6 +34,8 @@ import           Prelude hiding (lookup)
 import           Control.Lens                       ((^.))
 import           Control.Monad
 import           Control.Monad.Change.Alter
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
 import           Data.Default
 import           Data.Maybe                         (maybeToList)
 import qualified Data.Set                           as Set
@@ -57,6 +66,23 @@ data AddressState =
     } deriving (Eq, Generic, Read, Show)
 
 instance NFData AddressState
+
+newtype MainChainT m a = MainChainT { runMainChainT :: m a }
+  deriving (Eq, Show, Functor, Applicative, Monad, MonadIO)
+
+instance MonadTrans MainChainT where
+  lift = MainChainT
+
+instance (Account `Alters` AddressState) m => (Account `Alters` AddressState) (MainChainT m) where
+  lookup p   = lift . lookup p
+  insert p k = lift . insert p k
+  delete p   = lift . delete p
+
+instance Selectable Account AddressState m => Selectable Account AddressState (MainChainT m) where
+  select p = lift . select p
+
+instance Monad m => Selectable Word256 ParentChainIds (MainChainT m) where
+  select _ _ = pure Nothing 
 
 blankAddressState:: AddressState
 blankAddressState = AddressState { addressStateNonce=0, addressStateBalance=0, addressStateContractRoot=MP.emptyTriePtr, addressStateCodeHash=EVMCode $ hash "" , addressStateChainId = Nothing}
@@ -104,11 +130,11 @@ instance RLPSerializable AddressState where
     possible solution is to have a helper function that keeps track of all previously visited codepointers and termiantes if it visits the same one twice (aka cycle detection)
 --}
 resolveCodePtr' :: ( Selectable Word256 ParentChainIds m
-                  , (Account `Alters` AddressState) m
-                  )
+                   , Selectable Account AddressState m
+                   )
                => Set.Set CodePtr -> Maybe Word256 -> CodePtr -> m (Maybe CodePtr)
 resolveCodePtr' visited chainId (CodeAtAccount acct name) = do
-  lookup Proxy acct >>= \case
+  select Proxy acct >>= \case
     Nothing -> pure Nothing
     Just AddressState{..} -> do
       let codeAccountChainId = (acct ^. accountChainId)
@@ -122,7 +148,7 @@ resolveCodePtr' visited chainId (CodeAtAccount acct name) = do
 resolveCodePtr' _ cid cp = resolveCodePtr cid cp
    
 resolveCodePtr :: ( Selectable Word256 ParentChainIds m
-                  , (Account `Alters` AddressState) m
+                  , Selectable Account AddressState m
                   )
                => Maybe Word256 -> CodePtr -> m (Maybe CodePtr)
 resolveCodePtr chainId coa@(CodeAtAccount _ _) = resolveCodePtr' Set.empty chainId coa
@@ -130,8 +156,8 @@ resolveCodePtr chainId coa@(CodeAtAccount _ _) = resolveCodePtr' Set.empty chain
 -- for solidVM/EVM code
 resolveCodePtr _ cp = pure $ Just cp
 
-unsafeResolveCodePtr :: (Account `Alters` AddressState) m => CodePtr -> m (Maybe CodePtr)
-unsafeResolveCodePtr (CodeAtAccount acct name) = lookup Proxy acct >>= \case
+unsafeResolveCodePtr :: Selectable Account AddressState m => CodePtr -> m (Maybe CodePtr)
+unsafeResolveCodePtr (CodeAtAccount acct name) = select Proxy acct >>= \case
   Nothing -> pure Nothing
   Just AddressState{..} -> unsafeResolveCodePtr addressStateCodeHash >>= \case
     Just e@(EVMCode _) -> pure $ Just e
@@ -150,7 +176,7 @@ unsafeResolveCodePtrSelect (CodeAtAccount acct name) = select Proxy acct >>= \ca
 unsafeResolveCodePtrSelect codePtr = pure $ Just codePtr
 
 resolveCodePtrParent :: ( Selectable Word256 ParentChainIds m
-                        , (Account `Alters` AddressState) m
+                        , Selectable Account AddressState m
                         )
                         => Maybe Word256 -> CodePtr -> m (Maybe CodePtr)
 resolveCodePtrParent chainId cp@(CodeAtAccount acct _) = do
@@ -160,8 +186,8 @@ resolveCodePtrParent chainId cp@(CodeAtAccount acct _) = do
     else pure Nothing
 resolveCodePtrParent _ cp = unsafeResolveCodePtrParent cp
 
-unsafeResolveCodePtrParent :: (Account `Alters` AddressState) m => CodePtr -> m (Maybe CodePtr)
-unsafeResolveCodePtrParent (CodeAtAccount acct _) = lookup Proxy acct >>= \case
+unsafeResolveCodePtrParent :: Selectable Account AddressState m => CodePtr -> m (Maybe CodePtr)
+unsafeResolveCodePtrParent (CodeAtAccount acct _) = select Proxy acct >>= \case
   Nothing -> pure Nothing
   Just AddressState{..} -> unsafeResolveCodePtrParent addressStateCodeHash >>= \case
     Just e@(EVMCode _) -> pure $ Just e
@@ -170,7 +196,7 @@ unsafeResolveCodePtrParent (CodeAtAccount acct _) = lookup Proxy acct >>= \case
 unsafeResolveCodePtrParent codePtr = pure $ Just codePtr
 
 codePtrToSHA :: ( Selectable Word256 ParentChainIds m
-                , (Account `Alters` AddressState) m
+                , Selectable Account AddressState m
                 )
              => Maybe Word256 -> CodePtr -> m (Maybe Keccak256)
 codePtrToSHA chainId = resolveCodePtr chainId >=> \case
@@ -184,25 +210,25 @@ resolvedCodePtrToSHA (SolidVMCode _ hsh) = hsh
 resolvedCodePtrToSHA _ = emptyHash
 
 codePtrToCodeKind :: ( Selectable Word256 ParentChainIds m
-                     , (Account `Alters` AddressState) m
+                     , Selectable Account AddressState m
                      )
                   => Maybe Word256 -> CodePtr -> m CodeKind
 codePtrToCodeKind chainId = resolveCodePtr chainId >=> \case
   Just (SolidVMCode _ _) -> pure SolidVM
   _ -> pure EVM -- TODO: should this return (Maybe CodeKind)?
 
-unsafeCodePtrToCodeKind :: (Account `Alters` AddressState) m => CodePtr -> m CodeKind
+unsafeCodePtrToCodeKind :: Selectable Account AddressState m => CodePtr -> m CodeKind
 unsafeCodePtrToCodeKind = unsafeResolveCodePtr >=> \case
   Just (SolidVMCode _ _) -> pure SolidVM
   _ -> pure EVM -- TODO: should this return (Maybe CodeKind)?
 
 
 getAppAccount :: ( Selectable Word256 ParentChainIds m
-                 , (Account `Alters` AddressState) m
+                 , Selectable Account AddressState m
                  )
               => Maybe Word256 -> Account -> m (Maybe Account)
 getAppAccount chainId acct = do
-  lookup Proxy acct >>= \case
+  select Proxy acct >>= \case
     Nothing -> pure Nothing
     Just AddressState{..} -> do
       let codeAccountChainId = (acct ^. accountChainId)

--- a/strato/core/blockapps-mpdbs/test/StorageSpec.hs
+++ b/strato/core/blockapps-mpdbs/test/StorageSpec.hs
@@ -88,6 +88,9 @@ instance (Account `Alters` AddressState) StorM where
   insert _ = putAddressState
   delete _ = deleteAddressState
 
+instance Selectable Account AddressState StorM where
+  select _ = getAddressStateMaybe
+
 instance (MP.StateRoot `Alters` MP.NodeData) StorM where
   lookup _ = MP.genericLookupDB $ use sdb
   insert _ = MP.genericInsertDB $ use sdb

--- a/strato/core/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
@@ -285,7 +285,7 @@ initializeChainDBs :: ( MonadLogger m
                       , HasHashDB m
                       , HasSQLDB m
                       , HasStateDB m
-                      , (Account `A.Alters` AddressState) m
+                      , A.Selectable Account AddressState m
                       , A.Selectable Word256 ParentChainIds m
                       )
                    => Maybe Word256

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -12,7 +12,7 @@ module Blockchain.GenesisBlock (
 ) where
 
 import           Control.Monad
-import           Control.Monad.Change.Alter                   (Alters)
+import           Control.Monad.Change.Alter                   (Alters, Selectable)
 import           Control.Monad.Change.Modify                  (Accessible)
 import           Control.Monad.IO.Class
 import qualified Data.ByteString.Base16                       as B16
@@ -163,6 +163,7 @@ initializeGenesisBlock :: ( HasCodeDB m
                           , HasMemStorageDB m
                           , MonadLogger m
                           , (Ac.Account `Alters` AddressState) m
+                          , Selectable Ac.Account AddressState m
                           )
                        => String
                        -> m ()
@@ -204,7 +205,7 @@ populateStorageDBs :: ( MonadLogger m
                       , HasCodeDB m
                       , HasStateDB m
                       , HasHashDB m
-                      , (Ac.Account `Alters` AddressState) m
+                      , Selectable Ac.Account AddressState m
                       )
                    => (Keccak256 -> Maybe (Map Text Text))
                    -> Block 

--- a/strato/core/strato-init/src/Blockchain/Init/Monad.hs
+++ b/strato/core/strato-init/src/Blockchain/Init/Monad.hs
@@ -133,6 +133,9 @@ instance (Account `A.Alters` AddressState) SetupDBM where
   insert _ = putAddressState
   delete _ = deleteAddressState
 
+instance (Account `A.Selectable` AddressState) SetupDBM where
+  select _ = getAddressStateMaybe
+
 instance (Keccak256 `A.Alters` DBCode) SetupDBM where
   lookup _ = genericLookupCodeDB $ asks codeDB
   insert _ = genericInsertCodeDB $ asks codeDB

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -698,6 +698,9 @@ instance (MonadIO m, MonadLogger m) => (Account `A.Alters` AddressState) (MonadT
   insert _ = putAddressState
   delete _ = deleteAddressState
 
+instance (MonadIO m, MonadLogger m) => A.Selectable Account AddressState (MonadTest m) where
+  select _ = getAddressStateMaybe
+
 instance (MonadIO m, MonadLogger m) => (Maybe Word256 `A.Alters` MP.StateRoot) (MonadTest m) where
   lookup _ chainId = do
     mBH <- gets $ Lens.view $ memDBs . currentBlock

--- a/strato/core/strato-statediff/src/Blockchain/Strato/StateDiff.hs
+++ b/strato/core/strato-statediff/src/Blockchain/Strato/StateDiff.hs
@@ -36,7 +36,7 @@ import           Blockchain.Strato.Model.ExtendedWord
 import           Conduit
 import           Control.Applicative
 import           Control.Monad                               (when, unless)
-import           Control.Monad.Change                        (Alters, Modifiable)
+import           Control.Monad.Change                        (Alters, Modifiable, Selectable)
 import qualified Control.Monad.Change                        as A
 import           Data.ByteString                             (ByteString)
 import qualified Data.ByteString                             as B
@@ -174,7 +174,7 @@ chainDiff :: ( MonadLogger m
              , Modifiable BlockHashRoot m
              , Modifiable GenesisRoot m
              , Modifiable BestBlockRoot m
-             , (Account `Alters` AddressState) m
+             , Selectable Account AddressState m
              )
           => Maybe Word256 -> Integer -> Keccak256 -> ConduitT i StateDiff m ()
 chainDiff chainId newBlockNum newBlockHash = do
@@ -190,7 +190,7 @@ stateDiff :: ( MonadLogger m
              , HasHashDB m
              , HasStateDB m
              , Modifiable BestBlockRoot m
-             , (Account `Alters` AddressState) m
+             , Selectable Account AddressState m
              ) 
           => Maybe Word256 -> Integer -> Keccak256 -> StateRoot -> StateRoot -> ConduitT i StateDiff m ()
 stateDiff chainId blockNumber blockHash oldRoot newRoot = do
@@ -232,7 +232,7 @@ accountEnd :: ( MonadLogger m
               , HasHashDB m
               , HasCodeDB m
               , (MP.StateRoot `Alters` MP.NodeData) m
-              , (Account `Alters` AddressState) m
+              , Selectable Account AddressState m
               )
            => Maybe Word256 -> [N.Nibble] -> Val -> m (Account, AccountDiff 'Eventual)
 accountEnd chainId k v = do
@@ -246,7 +246,7 @@ accountUpdate :: ( MonadLogger m
                  , HasHashDB m
                  , HasCodeDB m
                  , (MP.StateRoot `Alters` MP.NodeData) m
-                 , (Account `Alters` AddressState) m
+                 , Selectable Account AddressState m
                  ) 
               => Maybe Word256 -> [N.Nibble] -> Val -> Val -> m (Account, AccountDiff 'Incremental)
 accountUpdate chainId k vOld vNew = do
@@ -262,7 +262,7 @@ eventualAccountState :: ( MonadLogger m
                         , HasHashDB m
                         , HasCodeDB m
                         , (MP.StateRoot `Alters` MP.NodeData) m
-                        , (Account `Alters` AddressState) m
+                        , Selectable Account AddressState m
                         )
                      => AddressState -> m (AccountDiff 'Eventual)
 eventualAccountState
@@ -290,7 +290,7 @@ incrementalAccountState :: ( MonadLogger m
                            , HasHashDB m
                            , HasCodeDB m
                            , (MP.StateRoot `Alters` MP.NodeData) m
-                           , (Account `Alters` AddressState) m
+                           , Selectable Account AddressState m
                            ) 
                         => AddressState -> AddressState -> m (AccountDiff 'Incremental)
 incrementalAccountState oldState newState = do
@@ -372,7 +372,7 @@ decodeStorageKV k v = do
 lookupAddress :: (MonadLogger m, HasHashDB m) => [N.Nibble] -> m Address
 lookupAddress (N.pack -> addrHash) = fromMaybe (Address 0) <$> lookupInMPDB "address" getAddressFromHash addrHash
 
-lookupCode :: (MonadLogger m, HasHashDB m, HasCodeDB m, (Account `Alters` AddressState) m) => CodePtr -> m (CodeKind, ByteString)
+lookupCode :: (MonadLogger m, HasHashDB m, HasCodeDB m, Selectable Account AddressState m) => CodePtr -> m (CodeKind, ByteString)
 lookupCode (EVMCode ch) = fromMaybe (EVM, "") <$> lookupInMPDB "contract code" getCode ch
 lookupCode (SolidVMCode _ ch) = fromMaybe (SolidVM, "") <$> lookupInMPDB "contract code" getCode ch
 lookupCode cp@(CodeAtAccount _ _) = maybe (pure (EVM, "")) lookupCode =<< unsafeResolveCodePtr cp

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -746,6 +746,7 @@ completeDiff :: ( MonadLogger m
                 , HasMemAddressStateDB m
                 , (MP.StateRoot `A.Alters` MP.NodeData) m
                 , (Account `A.Alters` AddressState) m
+                , A.Selectable Account AddressState m
                 , (Maybe Word256 `A.Alters` MP.StateRoot) m
                 , HasMemRawStorageDB m
                 , (RawStorageKey `A.Alters` RawStorageValue) m

--- a/strato/core/vm-tools/src/Blockchain/MemVMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/MemVMContext.hs
@@ -267,6 +267,9 @@ instance (Account `A.Alters` AddressState) MemContextM where
   insert _ = putAddressState
   delete _ = deleteAddressState
 
+instance A.Selectable Account AddressState MemContextM where
+  select _ = getAddressStateMaybe
+
 instance (Maybe Word256 `A.Alters` MP.StateRoot) MemContextM where
   lookup _ chainId = do
     mBH <- gets $ view $ memDBs . currentBlock

--- a/strato/core/vm-tools/src/Blockchain/VMContext.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMContext.hs
@@ -244,6 +244,7 @@ type VMBase m = ( MonadIO m
                 , Mod.Modifiable GasCap m
                 , HasMemAddressStateDB m
                 , A.Selectable Word256 ParentChainIds m
+                , A.Selectable Account AddressState m
                 , (Maybe Word256 `A.Alters` MP.StateRoot) m
                 , (MP.StateRoot `A.Alters` MP.NodeData) m
                 , (Account `A.Alters` AddressState) m
@@ -426,6 +427,9 @@ instance (Account `A.Alters` AddressState) ContextM where
   lookup _ = getAddressStateMaybe
   insert _ = putAddressState
   delete _ = deleteAddressState
+
+instance A.Selectable Account AddressState ContextM where
+  select _ = getAddressStateMaybe
 
 instance (Maybe Word256 `A.Alters` MP.StateRoot) ContextM where
   lookup _ chainId = do

--- a/strato/indexer/slipstream/src/Slipstream/MessageConsumer.hs
+++ b/strato/indexer/slipstream/src/Slipstream/MessageConsumer.hs
@@ -10,6 +10,8 @@ module Slipstream.MessageConsumer (
   getAndProcessMessages
   ) where
 
+import Prelude hiding (lookup)
+import Control.Monad.Change.Alter
 import Control.Monad.IO.Unlift
 import Data.IORef
 import Data.String
@@ -19,8 +21,11 @@ import qualified Network.Kafka.Protocol as K hiding (Message)
 
 import Bloc.Monad (BlocEnv)
 import BlockApps.Logging
+import Blockchain.Data.AddressStateDB
+import Blockchain.DB.CodeDB
 import Blockchain.MilenaTools
 import Blockchain.Stream.VMEvent
+import Blockchain.Strato.Model.Account
 
 import Control.Monad.Composable.Kafka
 import Control.Monad.Composable.SQL
@@ -64,15 +69,25 @@ putStatediffOffset off = do
         error $ show err
       Right () -> return ()
 
-getAndProcessMessages :: (MonadLogger m, HasKafka m, HasSQL m) =>
-                         BlocEnv -> PGConnection -> IORef Globals -> m ()
+getAndProcessMessages :: ( MonadLogger m
+                         , HasKafka m
+                         , HasSQL m
+                         , Selectable Account AddressState m
+                         , HasCodeDB m
+                         )
+                      => BlocEnv -> PGConnection -> IORef Globals -> m ()
 getAndProcessMessages env conn cache = do
   let errorCount = 0
   offset <- getStatediffOffset
   getAndProcessMessages' env conn cache offset errorCount
 
-getAndProcessMessages' :: (MonadLogger m, HasKafka m, HasSQL m) =>
-                          BlocEnv -> PGConnection -> IORef Globals -> K.Offset -> Int -> m ()
+getAndProcessMessages' :: ( MonadLogger m
+                          , HasKafka m
+                          , HasSQL m
+                          , Selectable Account AddressState m
+                          , HasCodeDB m
+                          )
+                       => BlocEnv -> PGConnection -> IORef Globals -> K.Offset -> Int -> m ()
 getAndProcessMessages' env conn cache offset errorCounter = do
   $logInfoS "getAndProcessMessages'" $ T.pack $ "#### fetching VMEvents: Offset=" ++ show offset
   recordOffset offset

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -13,6 +13,7 @@
     , ScopedTypeVariables
     , TemplateHaskell
     , TupleSections
+    , TypeApplications
     , TypeOperators
 #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -61,6 +62,7 @@ import Blockchain.Data.AddressStateDB
 import Blockchain.Data.TransactionResult
 import Blockchain.Data.DataDefs
 import Blockchain.Data.Json
+import Blockchain.DB.CodeDB
 import Blockchain.SolidVM.CodeCollectionDB
 import Blockchain.Strato.Model.Account
 import Blockchain.Strato.Model.ChainId
@@ -105,6 +107,11 @@ instance Selectable Account Contract m => Selectable Account Contract (ReaderT B
 
 instance MonadUnliftIO m => (Keccak256 `Selectable` SourceMap) (SQLM m) where
   select _ = Account.getCodeFromPostgres
+
+instance MonadUnliftIO m => (Keccak256 `Alters` DBCode) (SQLM m) where
+  lookup _ k   = fmap (SolidVM,) <$> Account.getCodeByteStringFromPostgres k
+  insert _ _ _ = error "Slipstream: Keccak256 `Alters` DBCode insert"
+  delete _ _   = error "Slipstream: Keccak256 `Alters` DBCode delete"
 
 instance (Keccak256 `Selectable` SourceMap) m => (Keccak256 `Selectable` SourceMap) (ReaderT BlocEnv m) where
   select p = lift . select p
@@ -274,7 +281,11 @@ parseEvents = concatMap parseEvent
           , eventEvent          = e
           }
 
-getCodeCollection :: MonadIO m => CodePtr -> Text -> m (Either String CodeCollection)
+getCodeCollection :: ( MonadIO m
+                     , HasCodeDB m
+                     , Selectable Account AddressState m
+                     )
+                  => CodePtr -> Text -> m (Either String CodeCollection)
 getCodeCollection cp ccString = do
   let initList =
         case Aeson.decodeStrict $ encodeUtf8 ccString of
@@ -287,8 +298,7 @@ getCodeCollection cp ccString = do
   --bad contract into the blockchain (the API shouldn't allow this)
 
   case cp of
-    SolidVMCode _ _ ->
-      case fmap resolveLabels $ compileSource False $ Map.fromList initList of
+    SolidVMCode _ _ -> (fmap resolveLabels <$> compileSource False (Map.fromList initList)) >>= \case
         Left e -> return $ Left $ "failed parse: "  ++ show e --- return $ CodeCollection Map.empty
         Right v -> return $ Right v
     EVMCode _ -> return $ Left "EVM contracts are not indexed by Slipstream"
@@ -299,8 +309,12 @@ getContractsForParents parents' cc =
   let getContractForParent parent = Map.lookup parent cc
   in mapMaybe getContractForParent parents'
 
-processTheMessages :: (MonadLogger m, HasSQL m) =>
-                      BlocEnv -> PGConnection -> IORef Globals -> [VMEvent] -> m ()
+processTheMessages :: ( MonadLogger m
+                      , HasSQL m
+                      , Selectable Account AddressState m
+                      , HasCodeDB m
+                      )
+                   => BlocEnv -> PGConnection -> IORef Globals -> [VMEvent] -> m ()
 processTheMessages env conn g messages = do
 
   case length messages of

--- a/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
+++ b/strato/simulator/strato-lite/src/Strato/Lite/Monad.hs
@@ -741,6 +741,9 @@ instance (MonadIO m, MonadLogger m) => (Account `A.Alters` AddressState) (MonadT
   insert _ = putAddressState
   delete _ = deleteAddressState
 
+instance (MonadIO m, MonadLogger m) => A.Selectable Account AddressState (MonadTest m) where
+  select _ = getAddressStateMaybe
+
 instance (MonadIO m, MonadLogger m) => (Maybe Word256 `A.Alters` MP.StateRoot) (MonadTest m) where
   lookup _ chainId = do
     mBH <- gets $ Lens.view $ memDBs . currentBlock


### PR DESCRIPTION
This PR allows you to import definitions from a deployed code collection into your own, eliminating the need to deploy multiple copies of the same contract code.
More immediately, this change will allow us to discriminate between official BlockApps contracts, such as the abstract Asset and Sale contracts for the asset model, and third-party contracts. This means every row in the Asset Cirrus table will be guaranteed to inherit from the official contracts.

To use, add an import statement to your .sol file with the desired address, wrapped in chevrons (e.g. `<509>`). A new layer in the SolidVM compiler, the import resolver, connects to the state db and code db to retrieve the desired code.
Example usage:
```sol
import { CertificateRegistry, Certificate } from <509>;

contract MyContract {
    string name = Certificate(account(0x1337, "main")).commonName();
    CertificateRegistry cr;

    constructor() {
        cr = new CertificateRegistry();
    }
}
```
After creating an instance of `MyContract`, you should see both the `MyContract` instance, and the `CertificateRegistry` instance in SMD. Additionally, the `name` field in `MyContract` is correctly filled in with the value from the root cert (address `0x1337`):
![Screenshot from 2023-08-15 17-51-40](https://github.com/blockapps/strato-platform/assets/26780905/9a05f253-7793-4d37-8b68-e97774d8966b)

Only imports from main chain addresses are supported by this PR. 