### PR TITLE
Retire functionality

### DIFF
--- a/docker-compose.identity.tpl.yml
+++ b/docker-compose.identity.tpl.yml
@@ -23,7 +23,7 @@ services:
     image: ${IDENTTIYPROVIDER_IMAGE:-<REPO_URL>identity-provider:<VERSION>}
     restart: unless-stopped
     volumes: 
-      - ./identity-provider-certs:/identity-provider/certs:ro
+      - ./identity-provider/certs:/identity-provider/certs:ro
     logging:
       driver: "json-file"
       options:

--- a/marketplace/backend/api/v1/Item/index.js
+++ b/marketplace/backend/api/v1/Item/index.js
@@ -29,6 +29,13 @@ router.post(
 );
 
 router.post(
+  Item.retire,
+  authHandler.authorizeRequest(),
+  loadDapp,
+  ItemController.retire
+);
+
+router.post(
   Item.transferOwnership,
   authHandler.authorizeRequest(),
   loadDapp,

--- a/marketplace/backend/api/v1/Item/item.controller.js
+++ b/marketplace/backend/api/v1/Item/item.controller.js
@@ -6,29 +6,6 @@ import config from '../../../load.config'
 const options = { config, cacheNonce: true }
 
 class ItemController {
-  //unused route
-  // static async get(req, res, next) {
-  //   try {
-  //     const { dapp, params } = req
-  //     const { address } = params
-
-  //     let args
-  //     let chainOptions = options
-
-  //     if (address) {
-  //       args = { address }
-  //       chainOptions = { ...options, chainIds: [dapp.chainId] }
-  //     }
-
-  //     const result = await dapp.getItem(args, chainOptions)
-  //     rest.response.status200(res, result)
-
-  //     return next()
-  //   } catch (e) {
-  //     return next(e)
-  //   }
-  // }
-
   static async getAll(req, res, next) {
     try {
       const { dapp, query } = req
@@ -64,6 +41,21 @@ class ItemController {
       ItemController.validateCreateItemArgs(body)
 
       const result = await dapp.addItem(body)
+      rest.response.status200(res, result)
+
+      return next()
+    } catch (e) {
+      return next(e)
+    }
+  }
+
+  static async retire(req, res, next) {
+    try {
+      const { dapp, body } = req
+
+      ItemController.validateRetireItemArgs(body)
+
+      const result = await dapp.retireItem(body)
       rest.response.status200(res, result)
 
       return next()
@@ -142,6 +134,25 @@ class ItemController {
 
     if (validation.error) {
       throw new rest.RestError(RestStatus.BAD_REQUEST, 'Create Item Argument Validation Error', {
+        message: `Missing args or bad format: ${validation.error.message}`,
+      })
+    }
+  }
+
+  static validateRetireItemArgs(args) {
+    const retireItemSchema = Joi.object({
+      productId: Joi.string().required(),
+      inventoryId: Joi.string().required(),
+      retiredBy: Joi.string().required(),
+      retiredOnBehalfOf: Joi.string().required(),
+      quantity: Joi.number().integer().min(0).required(),
+      purpose: Joi.string().required()
+    });
+
+    const validation = retireItemSchema.validate(args);
+
+    if (validation.error) {
+      throw new rest.RestError(RestStatus.BAD_REQUEST, 'Retire Item Argument Validation Error', {
         message: `Missing args or bad format: ${validation.error.message}`,
       })
     }

--- a/marketplace/backend/api/v1/endpoints.js
+++ b/marketplace/backend/api/v1/endpoints.js
@@ -50,7 +50,8 @@ export const Item = {
   update: '/update',
   audit: '/:address/:chainId/audit',
   transferOwnership: '/transferOwnership',
-  getRawMaterials: '/rawmaterials'
+  getRawMaterials: '/rawmaterials',
+  retire: '/retire'
 }
 
 export const Order = {

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -584,7 +584,11 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   };
 
   contract.retireItem = async function (args, options = defaultOptions) {
-    return managers.itemManager.retireItem(rawAdmin, contract, args, options);
+    const createOptions = { ...options, org: managers.cirrusOrg, app: contractName };
+    const{ productId, inventoryId, ...newArgs } = args;
+    const items = await managers.itemManager.getItems({ productId: productId, inventoryId: inventoryId }, createOptions);
+    const itemAddress = items[0].address;
+    return managers.itemManager.retireItem({ itemAddress: itemAddress, ...newArgs}, rawAdmin, contract, options);
   }
 
   contract.getRawMaterials = async function (args = {}, options = optionsNoChainIds) {

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -583,6 +583,10 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     return itemJs.update(rawAdmin, contract, updates, chainOptions);
   };
 
+  contract.retireItem = async function (args, options = defaultOptions) {
+    return managers.itemManager.retireItem(rawAdmin, contract, args, options);
+  }
+
   contract.getRawMaterials = async function (args = {}, options = optionsNoChainIds) {
     const getOptions = { ...options, org: managers.cirrusOrg, app: contractName, };
     return managers.itemManager.getRawMaterials({

--- a/marketplace/backend/dapp/items/contracts/Item.sol
+++ b/marketplace/backend/dapp/items/contracts/Item.sol
@@ -1,7 +1,8 @@
 import "/blockapps-sol/lib/rest/contracts/RestStatus.sol";
 import "/dapp/dapp/contracts/Dapp.sol";
 import "/dapp/items/contracts/ItemStatus.sol";
-import "/dapp/items/rawMaterials/contracts/RawMaterial.sol";
+import "./RetiredItem.sol";
+import "/dapp/products/contracts/Inventory.sol";
 
 /// @title A representation of Item assets
 contract Item_4 is ItemStatus {
@@ -74,6 +75,31 @@ contract Item_4 is ItemStatus {
 
     function updateQuantity(int _newQuantity) {
         quantity = _newQuantity;
+    }
+
+    function retireItem(
+        string _retiredBy,
+        string _retiredOnBehalfOf,
+        int _quantity,
+        string _purpose,
+        uint _retirementDate
+    ) public returns (uint256, address) {
+        RetiredItem retiredItem = new RetiredItem(
+            inventoryId,
+            owner,
+            _retiredBy,
+            _retiredOnBehalfOf,
+            _quantity,
+            _purpose,
+            _retirementDate,
+            batchSerializationNumber
+        );
+
+        quantity = quantity - _quantity;
+        Inventory_2 inventory = Inventory_2(inventoryId);
+        inventory.updateQuantity(quantity);
+
+        return (RestStatus.OK, address(retiredItem));
     }
 
     // Get the userOrganization

--- a/marketplace/backend/dapp/items/contracts/Item.sol
+++ b/marketplace/backend/dapp/items/contracts/Item.sol
@@ -5,7 +5,7 @@ import "./RetiredItem.sol";
 import "/dapp/products/contracts/Inventory.sol";
 
 /// @title A representation of Item assets
-contract Item_4 is ItemStatus {
+contract Item_5 is ItemStatus {
     address public owner;
     string public ownerOrganization;
     string public ownerOrganizationalUnit;
@@ -81,8 +81,7 @@ contract Item_4 is ItemStatus {
         string _retiredBy,
         string _retiredOnBehalfOf,
         int _quantity,
-        string _purpose,
-        uint _retirementDate
+        string _purpose
     ) public returns (uint256, address) {
         RetiredItem retiredItem = new RetiredItem(
             inventoryId,
@@ -91,13 +90,13 @@ contract Item_4 is ItemStatus {
             _retiredOnBehalfOf,
             _quantity,
             _purpose,
-            _retirementDate,
+            block.timestamp,
             batchSerializationNumber
         );
 
+        Inventory_3 inventory = Inventory_3(inventoryId);
+        inventory.updateRetiredQuantity(_quantity);
         quantity = quantity - _quantity;
-        Inventory_2 inventory = Inventory_2(inventoryId);
-        inventory.updateQuantity(quantity);
 
         return (RestStatus.OK, address(retiredItem));
     }

--- a/marketplace/backend/dapp/items/contracts/ItemManager.sol
+++ b/marketplace/backend/dapp/items/contracts/ItemManager.sol
@@ -63,6 +63,18 @@ contract ItemManager is ItemStatus, InventoryStatus {
         string _purpose
     ) returns (uint256, address) {
         Item_5 item = Item_5(_itemAddress);
+
+        Inventory_3 inventory = Inventory_3(item.inventoryId());
+        if (_quantity > inventory.availableQuantity()) {
+            return (RestStatus.BAD_REQUEST, address(0));
+        }
+
+        uint256 currentTimestamp = block.timestamp;
+        uint256 currentYear = (currentTimestamp / 31536000) + 1970;
+        if (inventory.vintage() > currentYear) {
+            return (RestStatus.BAD_REQUEST, address(0));
+        }
+
         return
             item.retireItem(
                 _retiredBy,

--- a/marketplace/backend/dapp/items/contracts/ItemManager.sol
+++ b/marketplace/backend/dapp/items/contracts/ItemManager.sol
@@ -55,6 +55,25 @@ contract ItemManager is ItemStatus, InventoryStatus {
         return (RestStatus.OK);
     }
 
+    function retireItem(
+        address _itemAddress,
+        string _retiredBy,
+        string _retiredOnBehalfOf,
+        int _quantity,
+        string _purpose,
+        uint _retirementDate
+    ) returns (uint256, address) {
+        Item_4 item = Item_4(_itemAddress);
+        return
+        item.retireItem(
+            _retiredBy,
+            _retiredOnBehalfOf,
+            _quantity,
+            _purpose,
+            _retirementDate
+        );
+    }
+
     function transferOwnership(
         address[] _itemsAddress,
         address _newOwner,

--- a/marketplace/backend/dapp/items/contracts/ItemManager.sol
+++ b/marketplace/backend/dapp/items/contracts/ItemManager.sol
@@ -20,7 +20,7 @@ contract ItemManager is ItemStatus, InventoryStatus {
     ) public returns (uint, string) {
         string itemAddresses = "";
 
-        Item_4 itemAddr = new Item_4(
+        Item_5 itemAddr = new Item_5(
             _productId,
             _inventoryId,
             _batchSerializationNumber,
@@ -49,7 +49,7 @@ contract ItemManager is ItemStatus, InventoryStatus {
         uint _scheme
     ) public returns (uint) {
         for (uint256 i = 0; i < _itemsAddress.length; i++) {
-            Item_4 item = Item_4(_itemsAddress[i]);
+            Item_5 item = Item_5(_itemsAddress[i]);
             item.update(_status, _scheme);
         }
         return (RestStatus.OK);
@@ -60,18 +60,16 @@ contract ItemManager is ItemStatus, InventoryStatus {
         string _retiredBy,
         string _retiredOnBehalfOf,
         int _quantity,
-        string _purpose,
-        uint _retirementDate
+        string _purpose
     ) returns (uint256, address) {
-        Item_4 item = Item_4(_itemAddress);
+        Item_5 item = Item_5(_itemAddress);
         return
-        item.retireItem(
-            _retiredBy,
-            _retiredOnBehalfOf,
-            _quantity,
-            _purpose,
-            _retirementDate
-        );
+            item.retireItem(
+                _retiredBy,
+                _retiredOnBehalfOf,
+                _quantity,
+                _purpose
+            );
     }
 
     function transferOwnership(
@@ -106,9 +104,9 @@ contract ItemManager is ItemStatus, InventoryStatus {
         address _newOwner,
         int _newQuantity
     ) public returns (address, address) {
-        Item_4 item = Item_4(_itemAddress[0]);
+        Item_5 item = Item_5(_itemAddress[0]);
         Product_4 product;
-        Inventory_2 inventory;
+        Inventory_3 inventory;
 
         Product_4 oldProduct = Product_4(item.productId());
         address productAddress = _productManager.checkForProduct(
@@ -132,7 +130,7 @@ contract ItemManager is ItemStatus, InventoryStatus {
             product = Product_4(productAddress);
         }
 
-        Inventory_2 oldInventory = Inventory_2(item.inventoryId());
+        Inventory_3 oldInventory = Inventory_3(item.inventoryId());
 
         (uint status, address inventory) = product.addInventory(
             _newQuantity,
@@ -144,7 +142,7 @@ contract ItemManager is ItemStatus, InventoryStatus {
         );
 
         for (uint i = 0; i < _itemAddress.length; i++) {
-            Item_4 _item = Item_4(_itemAddress[i]);
+            Item_5 _item = Item_5(_itemAddress[i]);
             if (oldInventory.availableQuantity() == _newQuantity) {
                 _item.transferOwnership(
                     _newOwner,
@@ -152,7 +150,7 @@ contract ItemManager is ItemStatus, InventoryStatus {
                     address(inventory)
                 );
             } else {
-                Item_4 itemAddr = new Item_4(
+                Item_5 itemAddr = new Item_5(
                     _item.productId(),
                     _item.inventoryId(),
                     _item.batchSerializationNumber(),

--- a/marketplace/backend/dapp/items/contracts/RetiredItem.sol
+++ b/marketplace/backend/dapp/items/contracts/RetiredItem.sol
@@ -1,0 +1,44 @@
+import "/dapp/dapp/contracts/Dapp.sol";
+
+contract RetiredItem {
+    address public owner;
+    string public ownerOrganization;
+    string public ownerOrganizationalUnit;
+    string public ownerCommonName;
+
+    address public inventoryId;
+    address public itemId;
+    string public retiredBy;
+    string public retiredOnBehalfOf;
+    int public quantity;
+    string public purpose;
+    uint public retirementDate;
+    string public batchSerializationNumber;
+
+    constructor(
+        address _inventoryId,
+        address _itemId,
+        string _retiredBy,
+        string _retiredOnBehalfOf,
+        int _quantity,
+        string _purpose,
+        uint _retirementDate,
+        string _batchSerializationNumber
+    ) {
+        owner = tx.origin;
+
+        inventoryId = _inventoryId;
+        itemId = _itemId;
+        retiredBy = _retiredBy;
+        retiredOnBehalfOf = _retiredOnBehalfOf;
+        quantity = _quantity;
+        purpose = _purpose;
+        retirementDate = _retirementDate;
+        batchSerializationNumber = _batchSerializationNumber;
+
+        mapping(string => string) ownerCert = getUserCert(owner);
+        ownerOrganization = ownerCert["organization"];
+        ownerOrganizationalUnit = ownerCert["organizationalUnit"];
+        ownerCommonName = ownerCert["commonName"];
+    }
+}

--- a/marketplace/backend/dapp/items/item.js
+++ b/marketplace/backend/dapp/items/item.js
@@ -5,7 +5,7 @@ import { setSearchQueryOptions, searchOne, searchAll, searchAllWithQueryArgs } f
 import dayjs from 'dayjs';
 
 
-const contractName = 'Item_4';
+const contractName = 'Item_5';
 const contractFilename = `${util.cwd}/dapp/items/contracts/Item.sol`;
 const contractEvents = { OWNERSHIP_UPDATE: "OwnershipUpdate" }
 
@@ -173,6 +173,11 @@ async function getAll(admin, args = {}, options) {
     return items.map((item) => marshalOut(item))
 }
 
+async function getAllRetiredItems(admin, args = {}, options) {
+    const retiredItems = await searchAllWithQueryArgs("RetiredItem", args, options, admin)
+    return retiredItems.map((retiredItem) => marshalOut(retiredItem))
+}
+
 /**
  * Get contract state in bloc.
  * @deprecated Use {@link get `get`} instead.
@@ -219,6 +224,7 @@ export default {
     bindAddress,
     get,
     getAll,
+    getAllRetiredItems,
     getAllOwnershipEvents,
     transferOwnership,
     marshalIn,

--- a/marketplace/backend/dapp/items/itemManager.js
+++ b/marketplace/backend/dapp/items/itemManager.js
@@ -121,6 +121,7 @@ function bind(user, _contract, options) {
     contract.addItem = async (args) => addItem(user, contract, args, options);
     contract.transferOwnership = async (args) => transferOwnership(user, contract, args, options);
     contract.updateItem = async (args) => updateItem(user, contract, args, options);
+    contract.retireItem = async (args) => retireItem(user, contract, args, options);
     contract.addEvent = async (args) => addEvent(user, contract, args, options);
     contract.certifyEvent = async (args) => certifyEvent(user, contract, args, options);
     contract.getEvents = async (args, options) => eventJs.getAll(user, args, options);
@@ -203,6 +204,34 @@ async function updateItem(admin, contract, _args, baseOptions) {
     return [restStatus, itemAddress];
 }
 
+/**
+ * Retire an item
+ */
+async function retireItem(admin, contract, _args, baseOptions) {
+    const callArgs = {
+      contract,
+      method: "retireItem",
+      args: util.usc({
+        ..._args,
+      }),
+    };
+    const options = {
+      ...baseOptions,
+      history: [contractName],
+    };
+  
+    const [restStatus, retiredItemAddress] = await rest.call(
+      admin,
+      callArgs,
+      options
+    );
+  
+    if (parseInt(restStatus, 10) !== RestStatus.OK)
+      throw new rest.RestError(restStatus, 0, { callArgs });
+  
+    return [restStatus, retiredItemAddress];
+  }
+
 // * Add the event
 async function addEvent(admin, contract, _args, baseOptions) {
     // const itemArgs = marshalIn(_args);
@@ -278,6 +307,7 @@ export default {
     marshalOut,
     addItem,
     updateItem,
+    retireItem,
     addEvent,
     certifyEvent
 }

--- a/marketplace/backend/dapp/items/itemManager.js
+++ b/marketplace/backend/dapp/items/itemManager.js
@@ -117,6 +117,7 @@ function bind(user, _contract, options) {
     contract.getState = async () => getState(user, contract, options);
     contract.getItem = async (args, options) => itemJs.get(user, args, options);
     contract.getItems = async (args, options) => itemJs.getAll(user, args, options);
+    contract.getRetiredItems = async (args, options) => itemJs.getAllRetiredItems(user, args, options);
     contract.getAllOwnershipEvents = async (args, options) => itemJs.getAllOwnershipEvents(user, args, options);
     contract.addItem = async (args) => addItem(user, contract, args, options);
     contract.transferOwnership = async (args) => transferOwnership(user, contract, args, options);

--- a/marketplace/backend/dapp/orders/contracts/Order.sol
+++ b/marketplace/backend/dapp/orders/contracts/Order.sol
@@ -199,7 +199,7 @@ contract Order_2 is OrderStatus {
         string orderLineQuantities = "";
         for (uint i = 0; i < orderLines.length; i++) {
             OrderLine_3 orderLine = OrderLine_3(address(orderLines[i]));
-            Inventory_2 inventory = Inventory_2(address(orderLine.inventoryId()));
+            Inventory_3 inventory = Inventory_3(address(orderLine.inventoryId()));
             inventories += string(address(orderLine.inventoryId())) + ",";
             orderLineQuantities += string(orderLine.quantity()) + ",";
         }

--- a/marketplace/backend/dapp/products/contracts/Inventory.sol
+++ b/marketplace/backend/dapp/products/contracts/Inventory.sol
@@ -1,37 +1,33 @@
- 
-
 import "/blockapps-sol/lib/rest/contracts/RestStatus.sol";
 import "/dapp/dapp/contracts/Dapp.sol";
 import "/dapp/products/contracts/InventoryStatus.sol";
 
 /// @title A representation of Inventory assets
-contract Inventory_2 is InventoryStatus{
-
+contract Inventory_2 is InventoryStatus {
     address public owner;
     string public ownerOrganization;
     string public ownerOrganizationalUnit;
     string public ownerCommonName;
-                                                           
-    address public productId;                                  
-    string public category;                                  
-    uint public purchasedQuantity;                              
-    int public quantity;                                          
-    int public pricePerUnit;                                   
-    uint public vintage;                                        
-    int public availableQuantity;                               
-    InventoryStatus public status;                              
+
+    address public productId;
+    string public category;
+    uint public purchasedQuantity;
+    int public quantity;
+    int public pricePerUnit;
+    uint public vintage;
+    int public availableQuantity;
+    InventoryStatus public status;
     uint public createdDate;
     uint public retiredQuantity;
-                                                              
-                                                                
+
     constructor(
-            string _category
-        ,   int _quantity
-        ,   int _pricePerUnit
-        ,   uint _vintage
-        ,   InventoryStatus _status
-        ,   uint _createdDate
-        ,   address _owner
+        string _category,
+        int _quantity,
+        int _pricePerUnit,
+        uint _vintage,
+        InventoryStatus _status,
+        uint _createdDate,
+        address _owner
     ) public {
         owner = _owner;
 
@@ -53,41 +49,37 @@ contract Inventory_2 is InventoryStatus{
     }
 
     function update(
-        int _pricePerUnit
-    ,   InventoryStatus _status
-    ,   uint _scheme
+        int _pricePerUnit,
+        InventoryStatus _status,
+        uint _scheme
     ) returns (uint) {
-      if(ownerOrganization != getUserOrganization(tx.origin)){
-        return RestStatus.FORBIDDEN;
-      }
+        if (ownerOrganization != getUserOrganization(tx.origin)) {
+            return RestStatus.FORBIDDEN;
+        }
 
-      if (_scheme == 0) {
+        if (_scheme == 0) {
+            return RestStatus.OK;
+        }
+
+        if ((_scheme & (1 << 0)) == (1 << 0)) {
+            pricePerUnit = _pricePerUnit;
+        }
+        if ((_scheme & (1 << 1)) == (1 << 1)) {
+            status = _status;
+        }
+
         return RestStatus.OK;
-      }
+    }
 
-      if ((_scheme & (1 << 0)) == (1 << 0)) {
-        pricePerUnit = _pricePerUnit;
-      }
-      if ((_scheme & (1 << 1)) == (1 << 1)) {
-        status = _status;
-      }
-
-      return RestStatus.OK;
-    }    
-
-    function updateQuantity(int _quantity) returns(uint){
-      // if (tx.origin != owner) { return RestStatus.FORBIDDEN; }
-      // if(_quantity > quantity){
-      //   return RestStatus.BAD_REQUEST;
-      // }
-      availableQuantity = _quantity;
-      return RestStatus.OK;
+    function updateQuantity(int _quantity) returns (uint) {
+        availableQuantity = _quantity;
+        return RestStatus.OK;
     }
 
     // Get the userOrganization
     function getUserOrganization(address caller) public returns (string) {
-      mapping(string => string) ownerCert = getUserCert(caller);
-      string userOrganization = ownerCert["organization"];
-      return userOrganization;
+        mapping(string => string) ownerCert = getUserCert(caller);
+        string userOrganization = ownerCert["organization"];
+        return userOrganization;
     }
 }

--- a/marketplace/backend/dapp/products/contracts/Inventory.sol
+++ b/marketplace/backend/dapp/products/contracts/Inventory.sol
@@ -3,7 +3,7 @@ import "/dapp/dapp/contracts/Dapp.sol";
 import "/dapp/products/contracts/InventoryStatus.sol";
 
 /// @title A representation of Inventory assets
-contract Inventory_2 is InventoryStatus {
+contract Inventory_3 is InventoryStatus {
     address public owner;
     string public ownerOrganization;
     string public ownerOrganizationalUnit;
@@ -11,14 +11,14 @@ contract Inventory_2 is InventoryStatus {
 
     address public productId;
     string public category;
-    uint public purchasedQuantity;
+    int public purchasedQuantity;
     int public quantity;
     int public pricePerUnit;
     uint public vintage;
     int public availableQuantity;
     InventoryStatus public status;
     uint public createdDate;
-    uint public retiredQuantity;
+    int public retiredQuantity;
 
     constructor(
         string _category,
@@ -73,6 +73,12 @@ contract Inventory_2 is InventoryStatus {
 
     function updateQuantity(int _quantity) returns (uint) {
         availableQuantity = _quantity;
+        return RestStatus.OK;
+    }
+
+    function updateRetiredQuantity(int _quantity) returns (uint) {
+        availableQuantity = availableQuantity - _quantity;
+        retiredQuantity = retiredQuantity + _quantity;
         return RestStatus.OK;
     }
 

--- a/marketplace/backend/dapp/products/contracts/Product.sol
+++ b/marketplace/backend/dapp/products/contracts/Product.sol
@@ -111,7 +111,7 @@ contract Product_4 is InventoryStatus {
         if (!isInventoryAvailable) {
             isInventoryAvailable = true;
         }
-        Inventory_2 inventory = new Inventory_2(
+        Inventory_3 inventory = new Inventory_3(
             category,
             _quantity,
             _pricePerUnit,
@@ -134,7 +134,7 @@ contract Product_4 is InventoryStatus {
             return RestStatus.FORBIDDEN;
         }
 
-        Inventory_2 inventory = Inventory_2(_inventory);
+        Inventory_3 inventory = Inventory_3(_inventory);
         inventory.update(_pricePerUnit, _status, _scheme);
         return (RestStatus.OK);
     }
@@ -144,7 +144,7 @@ contract Product_4 is InventoryStatus {
         address _inventory,
         int _quantity
     ) public returns (uint256) {
-        Inventory_2 inventory = Inventory_2(_inventory);
+        Inventory_3 inventory = Inventory_3(_inventory);
         inventory.updateQuantity(_quantity);
         return (RestStatus.OK);
     }

--- a/marketplace/backend/dapp/products/contracts/ProductManager.sol
+++ b/marketplace/backend/dapp/products/contracts/ProductManager.sol
@@ -151,7 +151,7 @@ contract ProductManager is InventoryStatus, RestStatus {
         bool _isReduce
     ) returns (uint256) {
         for (uint i = 0; i < _inventories.length; i++) {
-            Inventory_2 inventory = Inventory_2(_inventories[i]);
+            Inventory_3 inventory = Inventory_3(_inventories[i]);
 
             if (_isReduce) {
                 if (_quantities[i] > inventory.availableQuantity()) {

--- a/marketplace/backend/dapp/products/inventory.js
+++ b/marketplace/backend/dapp/products/inventory.js
@@ -4,7 +4,7 @@ import RestStatus from 'http-status-codes';
 import { setSearchQueryOptions, searchOne, searchAll, searchAllWithQueryArgs } from '/helpers/utils';
 import dayjs from 'dayjs';
 
-const contractName = 'Inventory_2';
+const contractName = 'Inventory_3';
 const contractFilename = `${util.cwd}/dapp/products/contracts/Inventory.sol`;
 
 /** 

--- a/marketplace/ui/src/components/Header/Header.js
+++ b/marketplace/ui/src/components/Header/Header.js
@@ -230,7 +230,16 @@ const HeaderComponent = ({ user, loginUrl }) => {
         }
         {
           roleIndex === undefined || roleIndex === 1 ? (
-            loginUrl ? <a href={loginUrl} id="Login" className="text-base text-white"> Login / Register </a> : null
+            loginUrl ? <a href={loginUrl} id="Login" className="text-base text-white" 
+              onClick={() => {
+                TagManager.dataLayer({
+                  dataLayer: {
+                    event: 'login_register_click'
+                  }
+                })
+              } } > 
+              Login / Register 
+              </a> : null
           ) :
             <Dropdown menu={{ items }} placement="bottomLeft" trigger={["click"]} overlayStyle={{ marginTop: "40px" }}>
               <a onClick={(e) => e.preventDefault()} className="text-base text-white" id="user-dropdown">

--- a/marketplace/ui/src/components/Inventory/InventoryCard.js
+++ b/marketplace/ui/src/components/Inventory/InventoryCard.js
@@ -6,18 +6,21 @@ import {
   EditOutlined,
   EyeOutlined,
   PlusOutlined,
+  SyncOutlined
 } from "@ant-design/icons";
 import PreviewInventoryModal from "./PreviewInventoryModal";
 import AddEventModal from "./AddEventModal";
 import { useNavigate } from "react-router-dom";
 import { INVENTORY_STATUS } from "../../helpers/constants";
 import UpdateInventoryModal from "./UpdateInventoryModal";
+import RetireModal from "./RetireModal";
 import routes from "../../helpers/routes";
 
 const InventoryCard = ({ inventory, category, debouncedSearchTerm, id }) => {
   const [openPop, setOpenPop] = useState(false);
   const [open, setOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
+  const [retireModalOpen, setRetireModalOpen] = useState(false);
   const [openEdit, setOpenEdit] = useState(false);
   const navigate = useNavigate();
   const naviroute = routes.InventoryDetail.url;
@@ -49,6 +52,15 @@ const InventoryCard = ({ inventory, category, debouncedSearchTerm, id }) => {
 
   const handleEditModalClose = () => {
     setEditModalOpen(false);
+  };
+
+  const showRetireModal = () => {
+    hide();
+    setRetireModalOpen(true);
+  };
+
+  const handleRetireModalClose = () => {
+    setRetireModalOpen(false);
   };
 
   const callDetailPage = () => {
@@ -107,6 +119,13 @@ const InventoryCard = ({ inventory, category, debouncedSearchTerm, id }) => {
                       <EditOutlined />
                       <p className="ml-3">Edit</p>
                     </div>
+                    <div
+                      className="flex items-center mt-2 cursor-pointer"
+                      onClick={showRetireModal}
+                    >
+                      <SyncOutlined />
+                      <p className="ml-3">Retire</p>
+                    </div>
                   </div>
                 }
                 trigger="click"
@@ -131,6 +150,15 @@ const InventoryCard = ({ inventory, category, debouncedSearchTerm, id }) => {
             </p>
             <p className="text-error text-sm ml-3">
               {inventory.availableQuantity}
+            </p>
+          </div>
+          <div className="flex mt-1 items-center">
+            <p className="text-primaryC text-sm w-40">Retired Quantity</p>
+            <p text-secondryB text-sm>
+              :
+            </p>
+            <p className="text-error text-sm ml-3">
+              {inventory.retiredQuantity}
             </p>
           </div>
           <div className="flex mt-1 items-center">
@@ -204,6 +232,13 @@ const InventoryCard = ({ inventory, category, debouncedSearchTerm, id }) => {
             inventory: inventory,
             category: category,
           }}
+        />
+      )}
+      {retireModalOpen && (
+        <RetireModal
+          open={retireModalOpen}
+          handleCancel={handleRetireModalClose}
+          inventory={inventory}
         />
       )}
     </Card>

--- a/marketplace/ui/src/components/Inventory/RetireModal.js
+++ b/marketplace/ui/src/components/Inventory/RetireModal.js
@@ -1,0 +1,96 @@
+import { Button, Input, InputNumber, Modal, Table } from "antd";
+import { useEffect, useState } from "react";
+import { actions } from "../../contexts/item/actions";
+import { useItemDispatch, useItemState } from "../../contexts/item";
+import dayjs from 'dayjs';
+
+
+const RetireModal = ({ open, handleCancel, inventory }) => {
+    const [data, setData] = useState([inventory]);
+    const [quantity, setQuantity] = useState(1);
+    const [retiredOnBehalfOf, setRetiredOnBehalfOf] = useState("");
+    const [purpose, setPurpose] = useState("");
+    const itemsDispatch = useItemDispatch();
+    const [canRetire, setCanRetire] = useState(true);
+    const {
+        isRetiringItem
+    } = useItemState();
+
+    useEffect(() => {
+        if (quantity > inventory.availableQuantity) {
+            setCanRetire(false);
+        }
+        else {
+            setCanRetire(true);
+        };
+        if (inventory.vintage > dayjs().year()) {
+            setCanRetire(false);
+        }
+    }, [quantity])
+    const columns = [
+        {
+            title: "Vintage",
+            dataIndex: "vintage"
+        },
+        {
+            title: "Quantity Available",
+            dataIndex: "availableQuantity"
+        },
+        {
+            title: "Set Quantity",
+            render: () => (
+                <InputNumber value={quantity} controls={false} min={1} onChange={(value) => setQuantity(value)} />
+            )
+        },
+        {
+            title: "Retired on Behalf of",
+            render: () => (
+                <Input value={retiredOnBehalfOf} onChange={(e) => setRetiredOnBehalfOf(e.target.value)} />
+            )
+        },
+        {
+            title: "Retirement Purpose",
+            render: () => (
+                <Input value={purpose} onChange={(e) => setPurpose(e.target.value)} />
+            )
+        }
+    ];
+
+    const handleSubmit = async () => {
+        const body = {
+            productId: inventory.productId,
+            inventoryId: inventory.address,
+            retiredBy: inventory.name,
+            retiredOnBehalfOf: retiredOnBehalfOf,
+            quantity: quantity,
+            purpose: purpose
+        };
+        if (quantity > 0 && quantity <= inventory.availableQuantity && inventory.vintage <= dayjs().year()) {
+            await actions.retireItem(itemsDispatch, body);
+            handleCancel();
+        }
+    }
+
+    return (
+        <Modal
+            open={open}
+            onCancel={handleCancel}
+            title={`Retire - ${decodeURIComponent(inventory.name)}`}
+            width={650}
+            footer={[
+                <Button type="primary" className="w-32 h-9" onClick={handleSubmit} disabled={!canRetire} loading={isRetiringItem}>
+                    Retire
+                </Button>
+            ]}
+        >
+            <Table
+                columns={columns}
+                dataSource={data}
+                pagination={false}
+            />
+        </Modal>
+    )
+}
+
+
+export default RetireModal;

--- a/marketplace/ui/src/contexts/item/actions.js
+++ b/marketplace/ui/src/contexts/item/actions.js
@@ -5,6 +5,9 @@ const actionDescriptors = {
   fetchItem: "fetch_items",
   fetchItemSuccessful: "fetch_item_successful",
   fetchItemFailed: "fetch_item_failed",
+  retireItem: "retire_item",
+  retireItemSuccessful: "retire_item_successful",
+  retireItemFailed: "retire_item_failed",
   resetMessage: "reset_message",
   setMessage: "set_message",
   fetchSerialNumbers: "fetch_serial_numbers",
@@ -32,7 +35,7 @@ const actions = {
     dispatch({
       type: actionDescriptors.setActualRawMaterials,
       payload: payload,
-   });  
+    });
   },
 
   fetchSerialNumbers: async (dispatch, id) => {
@@ -120,19 +123,19 @@ const actions = {
           payload: body.data,
         });
         return;
-      }else if(response.status === RestStatus.INTERNAL_SERVER_ERROR) {
-        dispatch({ 
-          type: actionDescriptors.fetchItemRawMaterialsFailed, 
-          error: "Error while fetching item raw materials" 
+      } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
+        dispatch({
+          type: actionDescriptors.fetchItemRawMaterialsFailed,
+          error: "Error while fetching item raw materials"
         });
         return;
       }
 
       dispatch({ type: actionDescriptors.fetchItemRawMaterialsFailed, error: body.error });
     } catch (err) {
-      dispatch({ 
-        type: actionDescriptors.fetchItemRawMaterialsFailed, 
-        error: "Error while fetching item raw materials" 
+      dispatch({
+        type: actionDescriptors.fetchItemRawMaterialsFailed,
+        error: "Error while fetching item raw materials"
       });
     }
   },
@@ -163,7 +166,53 @@ const actions = {
     } catch (err) {
       dispatch({ type: actionDescriptors.fetchItemFailed, error: undefined });
     }
-  }
+  },
+
+  retireItem: async (dispatch, payload) => {
+    dispatch({ type: actionDescriptors.retireItem });
+    try {
+      const response = await fetch(`${apiUrl}/item/retire`, {
+        method: HTTP_METHODS.POST,
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const body = await response.json();
+
+      if (response.status === RestStatus.OK) {
+        dispatch({
+          type: actionDescriptors.retireItemSuccessful,
+          payload: body.data,
+        });
+        actions.setMessage(dispatch, "Item retired successfully", true);
+        return true;
+      } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
+        dispatch({
+          type: actionDescriptors.retireItemFailed,
+          error: "Error while retiring Item",
+        });
+        actions.setMessage(dispatch, "Error while retiring Item");
+        return false;
+      }
+
+      dispatch({
+        type: actionDescriptors.retireItemFailed,
+        error: body.error,
+      });
+      actions.setMessage(dispatch, body.error);
+      return false;
+    } catch (err) {
+      dispatch({
+        type: actionDescriptors.retireItemFailed,
+        error: "Error while retiring Item",
+      });
+      actions.setMessage(dispatch, "Error while retiring Item");
+    }
+  },
 };
 
 export { actionDescriptors, actions };

--- a/marketplace/ui/src/contexts/item/index.js
+++ b/marketplace/ui/src/contexts/item/index.js
@@ -18,7 +18,9 @@ const ItemsProvider = ({ children }) => {
     isOwnershipHistoryLoading: false,
     rawMaterials:[],
     isRawMaterialsLoading: false,
-    actualRawMaterials: []
+    actualRawMaterials: [],
+    retiredItem: null,
+    isRetiringItem: false
   };
 
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/marketplace/ui/src/contexts/item/reducer.js
+++ b/marketplace/ui/src/contexts/item/reducer.js
@@ -31,62 +31,79 @@ const reducer = (state, action) => {
         error: action.error,
         isItemsLoading: false
       };
-      case actionDescriptors.fetchSerialNumbers:
-        return {
-          ...state,
-          isSerialNumbersLoading: true,
-        };
-      case actionDescriptors.fetchSerialNumbersSuccessful:
-        return {
-          ...state,
-          serialNumbers: action.payload,
-          isSerialNumbersLoading: false,
-        };
-      case actionDescriptors.fetchSerialNumbersFailed:
-        return {
-          ...state,
-          error: action.error,
-          isSerialNumbersLoading: false,
-        };
-      case actionDescriptors.fetchItemOwnershipHistory:
-        return {
-          ...state,
-          isOwnershipHistoryLoading: true,
-        };
-      case actionDescriptors.fetchItemOwnershipHistorySuccessful:
-        return {
-          ...state,
-          ownershipHistory: action.payload,
-          isOwnershipHistoryLoading: false,
-        };
-      case actionDescriptors.fetchItemOwnershipHistoryFailed:
-        return {
-          ...state,
-          error: action.error,
-          isOwnershipHistoryLoading: false,
-        };
-      case actionDescriptors.fetchItemRawMaterials:
-        return {
-          ...state,
-          isRawMaterialsLoading: true,
-        };
-      case actionDescriptors.fetchItemRawMaterialsSuccessful:
-        return {
-          ...state,
-          rawMaterials: action.payload,
-          isRawMaterialsLoading: false,
-        };
-      case actionDescriptors.fetchItemRawMaterialsFailed:
-        return {
-          ...state,
-          error: action.error,
-          isRawMaterialsLoading: false,
-        };
-      case actionDescriptors.setActualRawMaterials:
-        return {
-          ...state,
-          actualRawMaterials: action.payload
-        };
+    case actionDescriptors.retireItem:
+      return {
+        ...state,
+        isRetiringItem: true
+      };
+    case actionDescriptors.retireItemSuccessful:
+      return {
+        ...state,
+        retiredItem: action.payload,
+        isRetiringItem: false
+      };
+    case actionDescriptors.retireItemFailed:
+      return {
+        ...state,
+        error: action.error,
+        isRetiringItem: false
+      };
+    case actionDescriptors.fetchSerialNumbers:
+      return {
+        ...state,
+        isSerialNumbersLoading: true,
+      };
+    case actionDescriptors.fetchSerialNumbersSuccessful:
+      return {
+        ...state,
+        serialNumbers: action.payload,
+        isSerialNumbersLoading: false,
+      };
+    case actionDescriptors.fetchSerialNumbersFailed:
+      return {
+        ...state,
+        error: action.error,
+        isSerialNumbersLoading: false,
+      };
+    case actionDescriptors.fetchItemOwnershipHistory:
+      return {
+        ...state,
+        isOwnershipHistoryLoading: true,
+      };
+    case actionDescriptors.fetchItemOwnershipHistorySuccessful:
+      return {
+        ...state,
+        ownershipHistory: action.payload,
+        isOwnershipHistoryLoading: false,
+      };
+    case actionDescriptors.fetchItemOwnershipHistoryFailed:
+      return {
+        ...state,
+        error: action.error,
+        isOwnershipHistoryLoading: false,
+      };
+    case actionDescriptors.fetchItemRawMaterials:
+      return {
+        ...state,
+        isRawMaterialsLoading: true,
+      };
+    case actionDescriptors.fetchItemRawMaterialsSuccessful:
+      return {
+        ...state,
+        rawMaterials: action.payload,
+        isRawMaterialsLoading: false,
+      };
+    case actionDescriptors.fetchItemRawMaterialsFailed:
+      return {
+        ...state,
+        error: action.error,
+        isRawMaterialsLoading: false,
+      };
+    case actionDescriptors.setActualRawMaterials:
+      return {
+        ...state,
+        actualRawMaterials: action.payload
+      };
     default:
       throw new Error(`Unhandled action: '${action.type}'`);
   }

--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -194,9 +194,11 @@ pipeline {
                 docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
                 docker compose -f docker-compose.push.yml push 2>&1
                 docker compose -f docker-compose.vault.push.yml push 2>&1
+                docker compose -f docker-compose.identity.push.yml push 2>&1
                 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} AWS_DEFAULT_REGION="us-east-1" aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 406773134706.dkr.ecr.us-east-1.amazonaws.com
                 docker compose -f docker-compose.push.ecr.yml push 2>&1
                 docker compose -f docker-compose.vault.push.ecr.yml push 2>&1
+                docker compose -f docker-compose.identity.push.ecr.yml push 2>&1
               '''
             }
           },

--- a/pipelines/Jenkinsfile.nightly
+++ b/pipelines/Jenkinsfile.nightly
@@ -196,9 +196,11 @@ pipeline {
                   docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
                   docker compose -f docker-compose.push.yml push 2>&1
                   docker compose -f docker-compose.vault.push.yml push 2>&1
+                  docker compose -f docker-compose.identity.push.yml push 2>&1
                   AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} AWS_DEFAULT_REGION="us-east-1" aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 406773134706.dkr.ecr.us-east-1.amazonaws.com
                   docker compose -f docker-compose.push.ecr.yml push 2>&1
                   docker compose -f docker-compose.vault.push.ecr.yml push 2>&1
+                  docker compose -f docker-compose.identity.push.ecr.yml push 2>&1
                 '''
               }
             }

--- a/pipelines/Jenkinsfile.release
+++ b/pipelines/Jenkinsfile.release
@@ -235,9 +235,11 @@ pipeline {
               docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
               docker compose -f docker-compose.push.yml push 2>&1
               docker compose -f docker-compose.vault.push.yml push 2>&1
+              docker compose -f docker-compose.identity.push.yml push 2>&1
               AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} AWS_DEFAULT_REGION="us-east-1" aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 406773134706.dkr.ecr.us-east-1.amazonaws.com
               docker compose -f docker-compose.push.ecr.yml push 2>&1
               docker compose -f docker-compose.vault.push.ecr.yml push 2>&1
+              docker compose -f docker-compose.identity.push.ecr.yml push 2>&1
             '''
 
             // Release to blockapps/strato-getting-started


### PR DESCRIPTION
This PR includes:
- Added `RetiredItem.sol`
- Created a modal to retire credits in Inventory Card
- Created API calls and middleware that connect to the `retireItem()` function in `Item.sol` and `ItemManager.sol`
- Updated `Item_4` to `Item_5` and `Inventory_2` to `Inventory_3`

There are 3 cases in which retired items/quantity need to be retrieved:
1. When you need the quantity of retired credits for a certain Inventory regardless of the user that did the retiring. In this case, to retrieve the `RetiredItem` contracts for this, you would run `const retiredItems = await managers.itemManager.getRetiredItems({ batchSerializationNumber: ${batchSerializationNumber} }, getOptions);` in `dapp.js`. All of these contracts share the same `batchSerializationNumber` so you can use this as a filter. Once you have all of these, you can add up all of their quantities and the sum will be the quantity of retired credits for that inventory.
2. When you need the `RetiredItem` contracts for a certain Inventory made by the logged-in user (can be used in the order history page that will be made). To retrieve these contracts, you would run `const retiredItems = await managers.itemManager.getRetiredItems({ inventoryId: ${inventoryId} }, getOptions);` in `dapp.js`. All of these contracts share the same `inventoryId` so you can use this as a filter.
3. When you need the quantity of retired credits for a certain Inventory made by the logged-in user. While you can add up all of the quantities of the contracts from the 2nd case, a more efficient way of doing it is getting the quantity from `retiredQuantity` in the Inventory that you're looking at.