### PR TITLE
More lenient P2P disable times

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -22,6 +22,7 @@ so that they could be properly moved to their respective version's subsection.
 - `/transaction/unsigned` endpoint for generating raw transaction inputs
 - Bi-directional sync functionality
 - Mappings in SolidVM receive their own table in Cirrus
+- More lenient P2P disable times to prevent non-validators from being "locked out"
 ### Changed
 - `/compile` and `/transaction` endpoints use SolidVM compiler
 ### Fixed

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -357,9 +357,7 @@ lengthenPeerDisableBy :: (MonadUnliftIO m, A.Replaceable PPeer PeerDisable m)
 lengthenPeerDisableBy secs peer' = try $ do
   currentTime <- liftIO getCurrentTime
   let peer = peer'{pPeerTcpPort=30303}
-      disable = if (currentTime < pPeerDisableExpiration peer)
-                  then ExtendPeerDisableTime (TcpEnableTime $ fromIntegral (pPeerNextDisableWindowSeconds peer) `addUTCTime` currentTime) 2
-                  else SetPeerDisableTime (TcpEnableTime $ 5 `addUTCTime` currentTime) 5 (secs `addUTCTime` currentTime)
+      disable = SetPeerDisableTime (TcpEnableTime $ 5 `addUTCTime` currentTime) 5 (secs `addUTCTime` currentTime)
   A.replace (A.Proxy @PeerDisable) peer disable
 
 -- A variation of 'lengthenPeerDisable' but for UDP instead, currently used for ethereum-discovery.

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -183,7 +183,7 @@ stratoP2PClient runner = runner $ \sSource -> do
                    e' | Just HeadMacIncorrect  <- fromException e' -> do
                     disErr <- storeDisableException thePeer (T.pack "HeadMacIncorrect")
                     whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-                    lengthenPeerDisable thePeer
+                    lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
                    e' | Just NetworkIDMismatch <- fromException e' -> do
                     udpErr <- disableUDPPeerForSeconds thePeer 86400
                     whenLeft udpErr $ \theUDPErr -> do
@@ -195,7 +195,7 @@ stratoP2PClient runner = runner $ \sSource -> do
                    e' | Just PeerDisconnected <- fromException e' -> do
                     disErr <- storeDisableException thePeer (T.pack "PeerDisconnected")
                     whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-                    lengthenPeerDisable thePeer
+                    lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
                    e' | Just TimeoutException <- fromException e' -> do
                     disErr <- storeDisableException thePeer (T.pack "TimeoutException")
                     whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
@@ -215,7 +215,7 @@ stratoP2PClient runner = runner $ \sSource -> do
                           $logErrorLS "stratoP2PClient/handleRunPeerResult" theUDPErr
                         disErr <-storeDisableException thePeer (T.pack "ioErrType: NoSuchThing")
                         whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-                        lengthenPeerDisable thePeer
+                        lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
                       _ -> return $ Right ()
                    _  -> return $ Right ()
           whenLeft eErr $ \err -> do

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -85,7 +85,7 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
                 e' | Just HeadMacIncorrect  <- fromException e' -> do
                   disErr <- storeDisableException p (T.pack "HeadMacIncorrect")
                   whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/runEthServer" . T.pack $ "Unable to store disable exception: " ++ show err2
-                  lengthenPeerDisable p
+                  lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) p
                 e' | Just NetworkIDMismatch <- fromException e' -> do
                  udpErr <- disableUDPPeerForSeconds p 86400
                  whenLeft udpErr $ \theUDPErr -> do
@@ -97,7 +97,7 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
                 e' | Just PeerDisconnected <- fromException e' -> do
                   disErr <- storeDisableException p (T.pack "PeerDisconnected")
                   whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/runEthServer" . T.pack $ "Unable to store disable exception: " ++ show err2
-                  lengthenPeerDisable p
+                  lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) p
                 e' | Just TimeoutException <- fromException e' -> do
                   disErr <- storeDisableException p (T.pack "TimeoutException")
                   whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/runEthServer" . T.pack $ "Unable to store disable exception: " ++ show err2
@@ -117,7 +117,7 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
                       $logErrorLS "stratoP2PServer/runEthServer" theUDPErr
                      disErr <- storeDisableException p (T.pack "TimeoutException")
                      whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/runEthServer" . T.pack $ "Unable to store disable exception: " ++ show err2
-                     lengthenPeerDisable p
+                     lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) p
                    _ -> return $ Right ()
                 _  -> return $ Right ()
               throwIO err


### PR DESCRIPTION
 to prevent non-validators from being "locked out"
Occasionally, non-validators will get blocked from connecting from other nodes due to unclear circumstances, but likely due to network inactivity. Instead of doubling the disable period in these cases, simply extending it for a short period should be enough to allow the node to reconnect without falling too far behind the rest of the network.