### PR TITLE
Truncate large tcp msgs in p2p

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -324,10 +324,15 @@ maxMessageSize :: Int
 maxMessageSize = 1 `shiftL` 25
 
 messageToBytes :: Monad m => ConduitM Message B.ByteString m ()
-messageToBytes = mapC $ \msg ->
-  let (theWord, o) = wireMessage2Obj msg
-      bs = theWord `B.cons` rlpSerialize o
-  in if B.length bs >= maxMessageSize
-        then error $ printf "messageToBytes: message (%s...) too large for TCP send (%d >= %d)"
-                            (take 50 $ show msg) (B.length bs) maxMessageSize
-        else bs
+messageToBytes = mapC serializeWithRespectToMaxMessageSize
+  where 
+    serializeWithRespectToMaxMessageSize :: Message -> B.ByteString
+    serializeWithRespectToMaxMessageSize msg = 
+      let (theWord, o) = wireMessage2Obj msg 
+          bs = theWord `B.cons` rlpSerialize o 
+      in  if B.length bs >= maxMessageSize
+          then case msg of
+            BlockBodies arr -> serializeWithRespectToMaxMessageSize (BlockBodies $ take (length arr `div` 2) arr)
+            _ -> error $ printf "messageToBytes: message (%s...) too large for TCP send (%d >= %d)"
+              (take 50 $ show msg) (B.length bs) maxMessageSize
+          else bs

--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -321,7 +321,7 @@ bytesToMessages = forever $ do
     yield $ obj2WireMessage word $ rlpDeserialize objBytes
 
 maxMessageSize :: Int
-maxMessageSize = 1 `shiftL` 25
+maxMessageSize = 1 `shiftL` 24
 
 messageToBytes :: Monad m => ConduitM Message B.ByteString m ()
 messageToBytes = mapC serializeWithRespectToMaxMessageSize

--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -332,7 +332,17 @@ messageToBytes = mapC serializeWithRespectToMaxMessageSize
           bs = theWord `B.cons` rlpSerialize o 
       in  if B.length bs >= maxMessageSize
           then case msg of
-            BlockBodies arr -> serializeWithRespectToMaxMessageSize (BlockBodies $ take (length arr `div` 2) arr)
-            _ -> error $ printf "messageToBytes: message (%s...) too large for TCP send (%d >= %d)"
+            NewBlockHashes arr  -> serializeWithRespectToMaxMessageSize . NewBlockHashes  $ firstHalf arr
+            Transactions arr    -> serializeWithRespectToMaxMessageSize . Transactions    $ firstHalf arr
+            BlockHeaders arr    -> serializeWithRespectToMaxMessageSize . BlockHeaders    $ firstHalf arr
+            GetBlockBodies arr  -> serializeWithRespectToMaxMessageSize . GetBlockBodies  $ firstHalf arr
+            BlockBodies arr     -> serializeWithRespectToMaxMessageSize . BlockBodies     $ firstHalf arr
+            GetChainDetails arr -> serializeWithRespectToMaxMessageSize . GetChainDetails $ firstHalf arr 
+            ChainDetails arr    -> serializeWithRespectToMaxMessageSize . ChainDetails    $ firstHalf arr 
+            GetTransactions arr -> serializeWithRespectToMaxMessageSize . GetTransactions $ firstHalf arr
+            _ -> error $ printf "messageToBytes: message (%s...) too large to be sent via RLPx and can't be truncated (%d >= %d)"
               (take 50 $ show msg) (B.length bs) maxMessageSize
           else bs
+    
+    firstHalf :: [a] -> [a]
+    firstHalf arr = take (length arr `div` 2) arr

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -316,7 +316,8 @@ handleEvents peer = awaitForever $ \case
         newCount <- lift $ setTitleAndProduceBlocks blocks'
         yieldL . ToUnseq $ IEBlock . blockToIngestBlock (Origin.PeerString $ peerString peer) <$> blocks'
         rHeaders <- lift getRemainingBHeaders
-        let (neededHeaders, remainingHeaders) = splitNeededHeaders rHeaders
+        let unmatchedHeaders = drop (length bodies) headers
+            (neededHeaders, remainingHeaders) = splitNeededHeaders (unmatchedHeaders ++ rHeaders)
         lift $ putBlockHeaders neededHeaders
         lift $ putRemainingBHeaders remainingHeaders
         if null neededHeaders

--- a/strato/doit.sh
+++ b/strato/doit.sh
@@ -117,7 +117,7 @@ function newnode {
   echo "Starting ethereum-discover"
   runBackgroundProcess ethereum-discover  &>> logs/ethereum-discover
 
-  actualTimeout="${connectionTimeout:-300}"
+  actualTimeout="${connectionTimeout:-30}"
   if [ -n "${blockstanbulRoundPeriodS}" ]; then
     withCushion=$(( 2 * blockstanbulRoundPeriodS ))
     actualTimeout=$(( actualTimeout > withCushion ? actualTimeout : withCushion ))
@@ -138,6 +138,9 @@ function newnode {
   if [ -n "${network}" ]; then
     networkFlag="--network=${network}"
   fi
+  if [ -n "${maxReturnedHeaders}" ]; then
+    maxHeadersFlag="--maxReturnedHeaders=${maxReturnedHeaders}"
+  fi
 
   echo "Starting strato-p2p"
   runBackgroundProcess strato-p2p \
@@ -145,8 +148,8 @@ function newnode {
      --sqlPeers=true \
      --debugFail=${debugFail:-true}  \
      --maxConn=$maxConn \
-     --maxReturnedHeaders=$maxReturnedHeaders \
      --networkID=$networkID \
+     ${maxHeadersFlag} \
      ${txgFlag} \
      ${atbFlag} \
      ${pcamFlag} \
@@ -423,7 +426,6 @@ fi
 setEnv requireCerts true
 setEnv genesisBlock ""
 setEnv bootnode ""
-setEnv maxReturnedHeaders 500
 
 setEnv mineBlocks true
 setEnv verifyBlocks false


### PR DESCRIPTION
P2P should shorten a message if it's too long instead of failing (and not even telling the node it is disconnecting)