### PR TITLE
Proper indexing of imported abstract contracts

### DIFF
--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.saga.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/contractMethodCall.saga.js
@@ -16,7 +16,7 @@ import { isOauthEnabled } from '../../../../lib/checkMode';
 
 export function postMethodCall(payload) {
   const isModeOauth = isOauthEnabled();
-  const options = isModeOauth ? { query: { resolve: true, chainid: payload.chainId } } :
+  const options = isModeOauth ? { query: { resolve: true, chainid: payload.chainId, use_wallet: payload.useWallet } } :
     {
       params: {
         username: payload.username,

--- a/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
+++ b/smd-ui/src/components/Contracts/components/ContractMethodCall/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Dialog, PopoverInteractionKind, Position, AnchorButton, Popover, Collapse } from '@blueprintjs/core';
+import { Button, Dialog, PopoverInteractionKind, Position, AnchorButton, Popover, Collapse, Switch } from '@blueprintjs/core';
 import { connect } from 'react-redux';
 import { Link, withRouter } from 'react-router-dom';
 import mixpanelWrapper from '../../../../lib/mixpanelWrapper';
@@ -20,6 +20,7 @@ class ContractMethodCall extends Component {
     this.state = {
       isFunctionSourceOpen: false,
       isOpen: false,
+      useWallet: false,
     }
   }
 
@@ -34,6 +35,10 @@ class ContractMethodCall extends Component {
     this.props.reset();
     mixpanelWrapper.track("method_call_cancel");
     this.setState({isOpen : false})
+  }
+
+  toggleWalletUsage = (e) => {
+    this.setState({ useWallet : !this.state.useWallet }, () => {})
   }
 
   submit = (values) => {
@@ -62,7 +67,8 @@ class ContractMethodCall extends Component {
           password: isOauthEnabled() ? '' : values.modalPassword,
           value: values.modalValue,
           args: parsedArgs,
-          chainId: this.props.selectedChain ? this.props.selectedChain : undefined
+          chainId: this.props.selectedChain ? this.props.selectedChain : undefined,
+          useWallet: this.state.useWallet
         }
         mixpanelWrapper.track("method_call_submit");
         this.props.methodCall(this.props.methodKey, payload);
@@ -298,6 +304,15 @@ class ContractMethodCall extends Component {
                 </div>
                 <div className="col-sm-9 smd-pad-4">
                   {this.renderAddress(isModeOauth)}
+                </div>
+              </div>
+              <div className="row">
+                <div className="col-sm-9 smd-pad-4">
+                  <Switch
+                    checked={this.state.useWallet}
+                    onChange={this.toggleWalletUsage}
+                    label="Use Wallet"
+                  />
                 </div>
               </div>
               <div className="row">

--- a/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/XabiContract.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/XabiContract.hs
@@ -2,15 +2,10 @@
 
 --this module is used to convert an EVM XABI to a partial Contract type (defined in SolidVM).  Since the XABI is missing a lot of the stuff in Contract, this conversion will always be incomplete, but the resulting type can be used anywhere that doesn't need the missing stuff.  This will allow us to unify some code that works with both solidvm and EVM
 module BlockApps.Solidity.XabiContract (
-  xabiToPartialContract,
   indexedTypeToEvmIndexedType
   ) where
 
 
-import qualified Data.Map as M
-import Data.Source.Annotation
-import Data.Source.Position
-import qualified BlockApps.Solidity.Xabi      as OLDXABI
 import qualified BlockApps.Solidity.Xabi.Type as OLDXABI
 
 import SolidVM.Model.SolidString
@@ -21,42 +16,6 @@ import SolidVM.Model.CodeCollection hiding (contractName, events)
 
 import qualified SolidVM.Model.Type               as SVMType
 
---I am leaving a lot of this undefined....  Partly because the values don't exist in a XABI,
---and partly just because we don't need some of these values yet.  If a dev uses one of these
---undefined values, the error messages will let them know something needs to be filled in.
-xabiToPartialContract :: OLDXABI.Xabi -> Contract
-xabiToPartialContract xabi =
-  Contract {
-    _contractName=error "_contractName undefined",
-    _parents=error "_parents undefined",
-    _constants=error "_constants undefined",
-    _storageDefs=M.mapKeys textToLabel $ fmap varTypeToVariableDecl $ OLDXABI.xabiVars xabi,
-    _userDefined = error "_userDefined undefined", 
-    _enums=error "_enums undefined",
-    _structs=error "_structs undefined",
-    _errors=error "_errors undefined",
-    _events=M.mapKeys textToLabel $ fmap evmEventToEvent $ OLDXABI.xabiEvents xabi,
-    _functions=error "_functions undefined",
-    _constructor=error "_constructor undefined",
-    _modifiers=error "_modifiers undefined",
-    _usings=error "_usings undefined",
-    _contractContext = error "_contractContext undefined",
-    _contractType = error "_contractType undefined"
-    }
-
-evmEventToEvent :: OLDXABI.Event -> Event
-evmEventToEvent e = Event {
-  _eventAnonymous = OLDXABI.eventAnonymous e,
-  _eventLogs = map (fmap evmIndexedTypeToIndexedType) $ OLDXABI.eventLogs e,
-  _eventContext = dummyAnnotation
-  }
-
-evmIndexedTypeToIndexedType :: OLDXABI.IndexedType -> IndexedType
-evmIndexedTypeToIndexedType x = IndexedType {
-  indexedTypeIndex = OLDXABI.indexedTypeIndex x,
-  indexedTypeType = evmTypeToType $ OLDXABI.indexedTypeType x
-  }
-
 indexedTypeToEvmIndexedType :: IndexedType -> Maybe OLDXABI.IndexedType
 indexedTypeToEvmIndexedType x =
   let mType = typeToEvmType $ indexedTypeType x
@@ -64,21 +23,6 @@ indexedTypeToEvmIndexedType x =
         OLDXABI.indexedTypeIndex = indexedTypeIndex x,
         OLDXABI.indexedTypeType = t
         }) mType
-
-evmTypeToType :: OLDXABI.Type -> SVMType.Type
-evmTypeToType (OLDXABI.Int x y) = SVMType.Int x y
-evmTypeToType (OLDXABI.String x) = SVMType.String x
-evmTypeToType (OLDXABI.Bytes x y) = SVMType.Bytes x y
-evmTypeToType OLDXABI.Bool = SVMType.Bool
-evmTypeToType OLDXABI.Address = SVMType.Address False
-evmTypeToType OLDXABI.Account = SVMType.Account False
-evmTypeToType (OLDXABI.UnknownLabel x) = SVMType.UnknownLabel (stringToLabel x) Nothing
-evmTypeToType (OLDXABI.Struct x y) = SVMType.Struct x $ textToLabel y
-evmTypeToType (OLDXABI.Enum x y z) = SVMType.Enum x (textToLabel y) $ fmap (map textToLabel) z
-evmTypeToType (OLDXABI.Array x y) = SVMType.Array (evmTypeToType x) y
-evmTypeToType (OLDXABI.Contract x) = SVMType.Contract $ textToLabel x
-evmTypeToType (OLDXABI.Mapping x y z) = SVMType.Mapping x (evmTypeToType y) (evmTypeToType z)
-evmTypeToType OLDXABI.Variadic = SVMType.Variadic
 
 typeToEvmType :: SVMType.Type -> Maybe OLDXABI.Type
 typeToEvmType (SVMType.Int x y) = Just $ OLDXABI.Int x y
@@ -95,33 +39,3 @@ typeToEvmType (SVMType.Contract x) = Just $ OLDXABI.Contract (labelToText x)
 typeToEvmType (SVMType.Mapping x y z) = OLDXABI.Mapping x <$> typeToEvmType y <*> typeToEvmType z
 typeToEvmType (SVMType.Variadic) = Just $ OLDXABI.Variadic
 typeToEvmType _ = Nothing
-
-varTypeToVariableDecl :: OLDXABI.VarType -> VariableDeclF (SourceAnnotation ())
-varTypeToVariableDecl x =
-  VariableDecl {
-  _varType=evmTypeToType $ OLDXABI.varTypeType x,
-  _varIsPublic=False,
-  _varInitialVal=Nothing,
-  _varContext=dummyAnnotation,
-  _isImmutable=False,
-  _isRecord=False
-  }
-
-dummyAnnotation :: SourceAnnotation ()
-dummyAnnotation =
-  SourceAnnotation
-  {
-    _sourceAnnotationStart=SourcePosition {
-      _sourcePositionName="",
-      _sourcePositionLine=0,
-      _sourcePositionColumn=0
-      },
-    _sourceAnnotationEnd=SourcePosition {
-      _sourcePositionName="",
-        _sourcePositionLine=0,
-        _sourcePositionColumn=0
-      },
-    _sourceAnnotationAnnotation = ()
-  }
-
-

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Contract.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Contract.hs
@@ -25,6 +25,7 @@ module SolidVM.Model.CodeCollection.Contract (
   usings,
   constructor,
   contractType,
+  importedFrom,
   contractContext
   ) where
 
@@ -41,6 +42,7 @@ import GHC.Generics
 import           Test.QuickCheck.Instances    ()
 import           Test.QuickCheck
 
+import           Blockchain.Strato.Model.Account
 import           SolidVM.Model.CodeCollection.ConstantDecl
 import qualified SolidVM.Model.CodeCollection.Event as SolidVM
 import           SolidVM.Model.CodeCollection.Function

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Contract.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Contract.hs
@@ -69,6 +69,7 @@ data ContractF a =
     _modifiers :: Map SolidString (ModifierF a),
     _usings :: Map SolidString [UsingF a],
     _contractType :: ContractType,
+    _importedFrom :: Maybe Account,
     _contractContext :: a
   } deriving (Show, Generic, NFData, Functor, Foldable, Traversable)
 
@@ -89,9 +90,10 @@ instance Default a => Default (ContractF a) where
     _functions = empty,
     _constructor = Nothing,
     _modifiers = empty,
-    _contractContext = def,
     _usings = empty,
-    _contractType = ContractType
+    _contractType = ContractType,
+    _importedFrom = Nothing,
+    _contractContext = def
   }
 
 type Contract = Positioned ContractF
@@ -118,6 +120,7 @@ instance Arbitrary Contract where
     _modifiers  =  empty ,
     _usings  =  empty ,
     _contractType  =  ContractType ,
+    _importedFrom = Nothing,
     _contractContext = a
   }]
 

--- a/strato/VM/SolidVM/solid-vm-parser/exec_src/Parse.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/exec_src/Parse.hs
@@ -7,5 +7,5 @@ import qualified Data.Map as M
 main :: IO ()
 main = do
   contents <- getContents
-  let maybeFile = runParser solidityFile (ParserState "qq" "" M.empty) "qq" contents
+  let maybeFile = runParser solidityFile (ParserState "qq" "" M.empty M.empty) "qq" contents
   putStrLn $ show maybeFile

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Imports.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Imports.hs
@@ -6,6 +6,8 @@
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 module SolidVM.Solidity.Parse.Imports (solidityImport) where
 
+import           Data.Maybe (isJust)
+import qualified Data.Map.Strict as M
 import           Data.Source
 import qualified Data.Text   as T
 
@@ -19,14 +21,18 @@ import           Text.Parsec
 
 solidityImport :: SolidityParser SourceUnit
 solidityImport = do
+  es6 <- isJust . M.lookup "es6" . pragmas <$> getState
   ~(a, imp) <- withPosition $ do
     reserved "import"
-    fileImport
+    fileImport es6
   semi
   pure $ Import a imp
 
-fileImport :: SolidityParser FileImport
-fileImport = bracedImport <|> try qualifiedImport <|> simpleImport
+fileImport :: Bool -> SolidityParser FileImport
+fileImport es6 =
+  if es6
+    then bracedImport <|> try qualifiedImport <|> simpleImport
+    else simpleImport
 
 simpleImport :: SolidityParser FileImport
 simpleImport = do

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Imports.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Imports.hs
@@ -29,10 +29,14 @@ solidityImport = do
   pure $ Import a imp
 
 fileImport :: Bool -> SolidityParser FileImport
-fileImport es6 =
+fileImport es6 = do
+  i <- bracedImport <|> try qualifiedImport <|> simpleImport
   if es6
-    then bracedImport <|> try qualifiedImport <|> simpleImport
-    else simpleImport
+    then pure i
+    else case i of
+      Simple{} -> pure i
+      Qualified{} -> fail "Please add `pragma es6;` to the top of the file to enable support for qualified imports."
+      Braced{} -> fail "Please add `pragma es6;` to the top of the file to enable support for braced imports."
 
 simpleImport :: SolidityParser FileImport
 simpleImport = do

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/ParserTypes.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/ParserTypes.hs
@@ -37,38 +37,43 @@ type SourceCode = String
 data ParserState = ParserState 
     { contractName :: ContractName
     , pragmaVersion :: PragmaVersion
+    , pragmas       :: M.Map String String
     , userDefinedTypes :: (M.Map String String)
     }
 -- TODO: add lenses to make the referencing and changing of the parser state faster
 
 type SolidityParser = Parsec SourceCode ParserState
 
+initialParserState :: ParserState
+initialParserState = ParserState "" "" M.empty M.empty
+
 --given inputs set the parser state
 setParserState :: ParserState -> SolidityParser ()
-setParserState ParserState{..} = putState $ ParserState {
-      contractName     = contractName
-    , pragmaVersion    = pragmaVersion
-    , userDefinedTypes = userDefinedTypes
-    }
+setParserState = putState
 
 --Change the Pragma Version of the ParserState with a given input
 setPragmaVersion :: PragmaVersion -> SolidityParser ()
 -- Given a new pragma version replace the old parser State with a new one with an updated pragma version.
 setPragmaVersion p = 
     do ParserState{..} <- getState
-       putState (ParserState contractName p userDefinedTypes)
+       putState (ParserState contractName p pragmas userDefinedTypes)
 
 --Change the contract name of the ParserState with a given input
 setContractName :: ContractName -> SolidityParser ()
 -- Given a new contract name replace the old parser State with a new one with an updated contract name.
 setContractName cn = 
     do ParserState{..} <- getState
-       putState (ParserState cn pragmaVersion userDefinedTypes)
+       putState (ParserState cn pragmaVersion pragmas userDefinedTypes)
+
+addPragma :: String -> String -> SolidityParser ()
+addPragma k v = do
+  ParserState{..} <- getState
+  putState $ ParserState contractName pragmaVersion (M.insert k v pragmas) userDefinedTypes 
 
 addUserDefinedType :: String -> String -> SolidityParser ()
 addUserDefinedType k v =  --putState (ParserState contractName pragmaVersion (M.insert k v userDefinedTypes )) =<< ParserState{..} =<< getState
     do ParserState{..} <- getState
-       putState (ParserState contractName pragmaVersion (M.insert k v userDefinedTypes )) 
+       putState (ParserState contractName pragmaVersion pragmas (M.insert k v userDefinedTypes )) 
 
 -- Get the contract name from the parser state
 getContractName :: SolidityParser ContractName

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Pragmas.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Pragmas.hs
@@ -6,6 +6,7 @@
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 module SolidVM.Solidity.Parse.Pragmas (solidityPragma) where
 
+import           Control.Monad (when)
 import           Data.Source
 import           Text.Parsec
 
@@ -20,9 +21,10 @@ solidityPragma = do
     -- this is the word immediately following the pragma keyword (typically it is 'solidvm')
     pragmaName <- identifier
     -- The follow is anything else after the pragmaName.
-    rest <- many1 (noneOf ";")
+    rest <- many (noneOf ";")
     -- Modify the state of the parser to change the pragma version if a new version is found
-    modifyState(\s -> s { pragmaVersion = rest })
+    when (pragmaName == "solidvm") $ modifyState(\s -> s { pragmaVersion = rest })
+    addPragma pragmaName rest
     semi
     pure (pragmaName, rest)
   return $ Pragma a pragmaName rest

--- a/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
@@ -13,11 +13,6 @@ import SolidVM.Model.CodeCollection.Statement
 import SolidVM.Model.Type
 import SolidVM.Solidity.Parse.Lexer
 import SolidVM.Solidity.Parse.Statement
-import qualified Data.Map as M
--- import SolidVM.Solidity.Parse.Declarations
--- import SolidVM.Model.CodeCollection.Def as Def
-
--- import SolidVM.Solidity.Parse.UnParser
 import SolidVM.Solidity.Parse.ParserTypes 
 
 import           Data.Source.Annotation as SA 
@@ -50,7 +45,7 @@ dummyAnnotation =
 spec :: Spec
 spec = do
   describe "String lexing" $ do
-    let parseStr = runParser (stringLiteral <* eof) (ParserState "" "" M.empty) ""
+    let parseStr = runParser (stringLiteral <* eof) initialParserState ""
         cases = [ ([r|"ok"|], "ok")
                 , ([r|"ok" |], "ok")
                 ]
@@ -58,7 +53,7 @@ spec = do
       it ("can parse " ++ show input) $ parseStr input `shouldBe` Right want
 
   describe "Expression parsing" $ do
-    let parseExpr = fmap (fmap (const ())) . runParser expression (ParserState "" "" M.empty) ""
+    let parseExpr = fmap (fmap (const ())) . runParser expression initialParserState ""
         cases = [ ("x++", PlusPlus () (Variable () "x"))
                 , ("++x", Unitary () "++" (Variable () "x"))
                 , ("--x", Unitary () "--" (Variable () "x"))
@@ -142,7 +137,7 @@ spec = do
 -}
 
   describe "Statement parsing" $ do
-    let parseStatement = fmap (fmap (const ())) . runParser statement (ParserState "" "" M.empty) ""
+    let parseStatement = fmap (fmap (const ())) . runParser statement initialParserState ""
         scases = [ ("x++;", SimpleStatement $ ExpressionStatement $ PlusPlus () $ Variable () "x")
                  , ("assembly { dst := mload(add(src, 32)) }",
                       AssemblyStatement $ MloadAdd32 "dst" "src")

--- a/strato/VM/SolidVM/solid-vm-parser/tests/PragmaSpec.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/tests/PragmaSpec.hs
@@ -12,7 +12,6 @@ import           SolidVM.Solidity.Parse.Declarations
 import           SolidVM.Solidity.Parse.File
 import           Data.Source.Annotation as SA 
 import           Data.Source.Position as SP
-import qualified Data.Map as M
 
 dummyAnnotation :: SA.SourceAnnotation ()
 dummyAnnotation =
@@ -34,12 +33,12 @@ dummyAnnotation =
 
 spec :: Spec
 spec = do
-  let pragmaParse = runParser solidityPragma (ParserState "" "" M.empty) ""
+  let pragmaParse = runParser solidityPragma initialParserState ""
   describe "Pragma" $ do
     it "should fail without an identifier" $
       pragmaParse "pragma;" `shouldSatisfy` isLeft
-    it "should fail without contents for version number" $
-      pragmaParse "pragma typecheck;" `shouldSatisfy` isLeft
+    it "should succeed without contents for version number" $
+      pragmaParse "pragma typecheck;" `shouldSatisfy` isRight
     it "shoudl fail without a ;" $
       pragmaParse "pragma solc 0.4.8" `shouldSatisfy` isLeft
 

--- a/strato/VM/SolidVM/solid-vm/bench/CodeBench.hs
+++ b/strato/VM/SolidVM/solid-vm/bench/CodeBench.hs
@@ -96,7 +96,7 @@ strSipBench = bench "time spent on (siphash) hashing the wings contract"
 
 parseBench :: Benchmark
 parseBench = bench "time required to parse the contract"
-           $ nf (runParser solidityFile (ParserState "" "" M.empty) "") wingsContract
+           $ nf (runParser solidityFile initialParserState "") wingsContract
 
 showCCBench :: Benchmark
 showCCBench = bench "time to show the wingsCC"

--- a/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
+++ b/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
@@ -115,7 +115,7 @@ main = do
     [] -> die $ printf "usage: %s <filename>" progName
     (fn:_) -> return fn
   contents <- readFile filename
-  File parsedFile <- either (die . show) return $ runParser solidityFile (ParserState "" "" M.empty) "" contents
+  File parsedFile <- either (die . show) return $ runParser solidityFile initialParserState "" contents
   let namedContracts = [(textToLabel name, either (throw . fst) id $ xabiToContract (textToLabel name) (map textToLabel parents') M.empty xabi) | NamedXabi name (xabi, parents') <- parsedFile]
       cc = CodeCollection (M.fromList namedContracts) (M.empty) (M.empty) (M.empty) (M.empty) (M.empty) [] []
       typecheck = TC.detector cc

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -199,7 +199,7 @@ instance MonadSM m => Mod.Accessible [SourcePosition] m where
 
 runExpr :: MonadSM m => EvaluationRequest -> m EvaluationResponse
 runExpr exprText = withoutDebugging . withTempCallInfo True $ do -- TODO: allow write access once we figure out how to discard changes
-  let eExpr = runParser expression (ParserState "" "" M.empty) "" (T.unpack exprText)
+  let eExpr = runParser expression initialParserState "" (T.unpack exprText)
   case eExpr of
     Left pe -> pure . Left . T.pack $ show pe
     Right expr -> do
@@ -275,7 +275,7 @@ create _ _ _ blockData _ sender' origin' _ _ availableGas newAddress code txHash
 
     let maybeArgString = M.lookup "args" =<< metadata
         argString = maybe "()" T.unpack maybeArgString
-        maybeArgs = runParser parseArgs (ParserState "" "" M.empty) "" argString
+        maybeArgs = runParser parseArgs initialParserState "" argString
         !args = either (parseError "create arguments") CC.OrderedArgs maybeArgs
 
     (hsh, cc) <- codeCollectionFromSource True initCode
@@ -428,7 +428,7 @@ call _ _ _ isRCC _ blockData _ _ codeAddress sender' _ _ _ availableGas origin' 
         !funcName = textToLabel $ fromMaybe (missingField "TX is missing a metadata parameter called 'funcName'" $ show metadata) maybeFuncName
         maybeArgString = M.lookup "args" =<< metadata
         !argString = T.unpack $ fromMaybe (missingField "TX is missing metadata parameter called 'args'" $ show metadata) maybeArgString
-        maybeArgs = runParser parseArgs (ParserState "" "" M.empty) "" argString
+        maybeArgs = runParser parseArgs initialParserState "" argString
         !args = either (parseError "call arguments") CC.OrderedArgs maybeArgs
 
     ((orgName, appName), returnVal) <- traverse (fmap Just . maybe (return "()") encodeForReturn)
@@ -530,7 +530,7 @@ call' from to' fnCalltype mContract functionName isRCC argExps  = do
         case fnCalltype of
           CC.DefaultCall -> functionName
           -- Handles RawCall and DelegateCall function signature parsing
-          _ -> (case runParser parseExternalCallArgs (ParserState "" "" M.empty) "" functionName of
+          _ -> (case runParser parseExternalCallArgs initialParserState "" functionName of
             Right (funcTocall, _) -> funcTocall
             _ -> functionName)
 
@@ -806,7 +806,7 @@ argsToValsModifiers ctract md args =
                 return $ SMap valueType $ M.fromList m
                 where
                       go (k, v) = do
-                                let !maybeExp = runParser literal (ParserState "" "" M.empty) "" (labelToString k)
+                                let !maybeExp = runParser literal initialParserState "" (labelToString k)
                                 case maybeExp of
                                   Right ex -> do
                                     k' <- eval32 keyType ex
@@ -873,7 +873,7 @@ argsToVals ctract fn args = case args of
                 return $ SMap valueType $ M.fromList m
                 where --go :: (SolidString, CC.Expression) -> (SolidString, (Value, Variable))
                       go (k, v) = do
-                                let !maybeExp = runParser literal (ParserState "" "" M.empty) "" (labelToString k)
+                                let !maybeExp = runParser literal initialParserState "" (labelToString k)
                                 case maybeExp of
                                   Right ex -> do
                                     k' <- eval32 keyType ex
@@ -1927,7 +1927,7 @@ expToVar' (CC.FunctionCall _ (CC.NewExpression _ (SVMType.UnknownLabel contractN
               s <- stringLiteral
               return s
             return $ CC.StringLiteral a str
-      let saltExpression = runParser (stringParser <|> expression) (ParserState "" "" M.empty) "" (saltText)
+      let saltExpression = runParser (stringParser <|> expression) initialParserState "" (saltText)
       saltValue <- do
         case saltExpression of
           Left pe -> invalidArguments "big bad sad" pe

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -122,7 +122,7 @@ withAnnotations f = fmap (first unwind) . f
         unwind (TCEx errs) = errs
 
 parseSource :: T.Text -> T.Text -> Either CompilationError [SourceUnit]
-parseSource fileName src = bimap PEx unsourceUnits $ runParser solidityFile (ParserState "" "" M.empty) (T.unpack fileName) (T.unpack src)
+parseSource fileName src = bimap PEx unsourceUnits $ runParser solidityFile initialParserState (T.unpack fileName) (T.unpack src)
 
 parseSourceWithAnnotations :: T.Text -> T.Text -> Either [SourceAnnotation T.Text] [SourceUnit]
 parseSourceWithAnnotations fileName = runIdentity . withAnnotations (Identity . parseSource fileName)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/ImportResolver.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/ImportResolver.hs
@@ -148,7 +148,7 @@ resolveFile getCCFromHash expr (seen, resolved) = if tShowExpr expr `S.member` s
             Nothing -> pure (seen, resolved)
             Just AddressState{..} -> lift (runMainChainT $ resolveCodePtr Nothing addressStateCodeHash) >>= \case
               Just (SolidVMCode _ ch) -> do
-                rfu <- lift $ codeCollectionToFileUnits <$> getCCFromHash ch
+                rfu <- lift $ codeCollectionToFileUnits (Just acct) <$> getCCFromHash ch
                 pure (seen, M.insert (tShowExpr expr) (Right rfu) resolved)
               Just (EVMCode _) -> throwE . T.pack $ "Account referenced in import contains EVM code: " ++ show acct
               _ -> throwE . T.pack $ "Account referenced in import could not be resolved: " ++ show acct
@@ -165,9 +165,9 @@ resolveFile getCCFromHash expr (seen, resolved) = if tShowExpr expr `S.member` s
                     Right r -> Right . FileUnits (r ^. fuPragmas) $ M.singleton Nothing (l ^. ufuUnits) <> (r ^. fuUnits)
     _ -> throwE . T.pack $ "Unsupported expression in import: " ++ unparseExpression expr 
 
-codeCollectionToFileUnits :: CodeCollectionF a -> FileUnitsF a
-codeCollectionToFileUnits CodeCollection{..} =
-  let units = (FUContract <$> _contracts)
+codeCollectionToFileUnits :: Maybe Account -> CodeCollectionF a -> FileUnitsF a
+codeCollectionToFileUnits from CodeCollection{..} =
+  let units = (FUContract . (importedFrom %~ maybe from Just) <$> _contracts)
            <> (FUConstant <$> _flConstants)
            <> (FUStruct   <$> _flStructs)
            <> (FUEnum     <$> _flEnums)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -430,6 +430,7 @@ getVariableOfName name = do
                                                 ,  CC._modifiers = M.empty
                                                 ,  CC._usings = M.empty
                                                 ,  CC._contractType = currentContract x^.CC.contractType
+                                                ,  CC._importedFrom = Nothing
                                                 ,  CC._contractContext = currentContract x^.CC.contractContext
                                                 } 
                               }

--- a/strato/VM/SolidVM/solid-vm/src/SolidVM/CodeCollectionTools.hs
+++ b/strato/VM/SolidVM/solid-vm/src/SolidVM/CodeCollectionTools.hs
@@ -55,6 +55,7 @@ xabiToContract contractName' parents' userDefinedTypes xabi = do
     Xabi.LibraryKind  -> LibraryType
     Xabi.AbstractKind  -> AbstractType
     Xabi.InterfaceKind -> InterfaceType,
+  _importedFrom = Nothing,
   _contractContext = Xabi._xabiContext xabi
   }
 

--- a/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
@@ -17,6 +17,7 @@ module Bloc.Database.Queries
   ( sourceToContractDetails
   , getContractDetailsForContract
   , getContractDetailsByCodeHash
+  , getCodeCollectionByCodePtr
   , evmContractSolidVMError
   ) where
 
@@ -29,7 +30,6 @@ import qualified Data.Map.Strict                 as Map
 import           Data.Text                       (Text)
 import qualified Data.Text                       as Text
 import qualified Data.Text.Encoding              as Text
-import           Data.Traversable                (for)
 import           Text.Format
 import           UnliftIO
 
@@ -53,18 +53,15 @@ getContractDetailsByCodeHash :: ( MonadIO m
                                 )
                              => CodePtr -> m (Either Text (CodePtr, Contract))
 getContractDetailsByCodeHash codePtr = runExceptT $ do
-  nameStr <- fmap Text.unpack $ case codePtr of
+  nameStr <- case codePtr of
     SolidVMCode n _ -> pure n
     CodeAtAccount _ n -> pure n
     _ -> throwE "EVM contracts no longer supported"
   (cHash, cc) <- getCodeHashAndCollection codePtr
-  mDetails <- case Map.lookup nameStr $ _contracts cc of
-    Nothing -> throwE $ "Could not find contract " <> name <> " in code collection " <> Text.pack (format ch)
+  details <- case Map.lookup nameStr $ _contracts cc of
+    Nothing -> throwE $ "Could not find contract " <> (Text.pack nameStr) <> " in code collection " <> Text.pack (format codePtr)
     Just d -> pure (SolidVMCode nameStr cHash, d)
-  let !mDetails' = force mDetails
-  case mDetails' of
-    Nothing -> throwE $ "Could not resolve code pointer " <> Text.pack (format codePtr)
-    Just details -> pure details
+  pure $ force details
 
 getCodeCollectionByCodePtr :: ( MonadIO m
                               , HasCodeDB m
@@ -80,17 +77,16 @@ getCodeHashAndCollection :: ( MonadIO m
                             , (Keccak256 `A.Selectable` SourceMap) m
                             )
                          => CodePtr -> ExceptT Text m (Keccak256, CodeCollection)
-getCodeHashAndCollection codePtr = do
-  mcp <- lift $ unsafeResolveCodePtr codePtr
-  for mcp $ \codeHash -> do
-    (name, ch) <- case codeHash of
+getCodeHashAndCollection codePtr = lift (unsafeResolveCodePtr codePtr) >>= \case
+  Nothing -> throwE . Text.pack $ "Could not resolve code pointer: " ++ show codePtr
+  Just codeHash -> do
+    ch <- case codeHash of
       EVMCode _ -> throwE $ "EVM contracts no longer supported"
-      SolidVMCode name ch -> pure (Text.pack name, ch)
+      SolidVMCode _ ch -> pure ch
       CodeAtAccount acct _ -> throwE $ "Could not resolve code at account " <> Text.pack (show acct)
     srcMap <- lift (A.select (A.Proxy @SourceMap) ch) >>= \case
       Nothing -> throwE $ "Could not find source code for code hash " <> Text.pack (format ch)
       Just s -> pure s
-    let nameStr = Text.unpack name
     either (throwE . Text.pack . show) pure =<< lift (sourceToContractDetails srcMap)
 
 evmContractSolidVMError :: Text

--- a/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
@@ -20,7 +20,7 @@ module Bloc.Database.Queries
   , evmContractSolidVMError
   ) where
 
-import           Blockchain.Data.AddressStateDB  (AddressState, unsafeResolveCodePtrSelect)
+import           Blockchain.Data.AddressStateDB  (AddressState, unsafeResolveCodePtr)
 import           Control.DeepSeq
 import qualified Control.Monad.Change.Alter      as A
 import           Control.Monad.Trans.Class       (lift)
@@ -29,6 +29,7 @@ import qualified Data.Map.Strict                 as Map
 import           Data.Text                       (Text)
 import qualified Data.Text                       as Text
 import qualified Data.Text.Encoding              as Text
+import           Data.Traversable                (for)
 import           Text.Format
 import           UnliftIO
 
@@ -51,25 +52,46 @@ getContractDetailsByCodeHash :: ( MonadIO m
                                 , (Keccak256 `A.Selectable` SourceMap) m
                                 )
                              => CodePtr -> m (Either Text (CodePtr, Contract))
-getContractDetailsByCodeHash codePtr = do
-  runExceptT $ do
-    mDetails <- lift (unsafeResolveCodePtrSelect codePtr) >>= \mcp -> flip traverse mcp $ \codeHash -> do
-      (name, ch) <- case codeHash of
-        EVMCode _ -> throwE $ "EVM contracts no longer supported"
-        SolidVMCode name ch -> pure (Text.pack name, ch)
-        CodeAtAccount acct _ -> throwE $ "Could not resolve code at account " <> Text.pack (show acct)
-      srcMap <- lift (A.select (A.Proxy @SourceMap) ch) >>= \case
-        Nothing -> throwE $ "Could not find source code for code hash " <> Text.pack (format ch)
-        Just s -> pure s
-      let nameStr = Text.unpack name
-      ~(cHash, cc) <- either (throwE . Text.pack . show) pure =<< lift (sourceToContractDetails srcMap)
-      case Map.lookup nameStr $ _contracts cc of
-          Nothing -> throwE $ "Could not find contract " <> name <> " in code collection " <> Text.pack (format ch)
-          Just d -> pure (SolidVMCode nameStr cHash, d)
-    let !mDetails' = force mDetails
-    case mDetails' of
-      Nothing -> throwE $ "Could not resolve code pointer " <> Text.pack (format codePtr)
-      Just details -> pure details
+getContractDetailsByCodeHash codePtr = runExceptT $ do
+  nameStr <- fmap Text.unpack $ case codePtr of
+    SolidVMCode n _ -> pure n
+    CodeAtAccount _ n -> pure n
+    _ -> throwE "EVM contracts no longer supported"
+  (cHash, cc) <- getCodeHashAndCollection codePtr
+  mDetails <- case Map.lookup nameStr $ _contracts cc of
+    Nothing -> throwE $ "Could not find contract " <> name <> " in code collection " <> Text.pack (format ch)
+    Just d -> pure (SolidVMCode nameStr cHash, d)
+  let !mDetails' = force mDetails
+  case mDetails' of
+    Nothing -> throwE $ "Could not resolve code pointer " <> Text.pack (format codePtr)
+    Just details -> pure details
+
+getCodeCollectionByCodePtr :: ( MonadIO m
+                              , HasCodeDB m
+                              , A.Selectable Account AddressState m
+                              , (Keccak256 `A.Selectable` SourceMap) m
+                              )
+                           => CodePtr -> m (Either Text CodeCollection)
+getCodeCollectionByCodePtr = runExceptT . fmap snd . getCodeHashAndCollection
+
+getCodeHashAndCollection :: ( MonadIO m
+                            , HasCodeDB m
+                            , A.Selectable Account AddressState m
+                            , (Keccak256 `A.Selectable` SourceMap) m
+                            )
+                         => CodePtr -> ExceptT Text m (Keccak256, CodeCollection)
+getCodeHashAndCollection codePtr = do
+  mcp <- lift $ unsafeResolveCodePtr codePtr
+  for mcp $ \codeHash -> do
+    (name, ch) <- case codeHash of
+      EVMCode _ -> throwE $ "EVM contracts no longer supported"
+      SolidVMCode name ch -> pure (Text.pack name, ch)
+      CodeAtAccount acct _ -> throwE $ "Could not resolve code at account " <> Text.pack (show acct)
+    srcMap <- lift (A.select (A.Proxy @SourceMap) ch) >>= \case
+      Nothing -> throwE $ "Could not find source code for code hash " <> Text.pack (format ch)
+      Just s -> pure s
+    let nameStr = Text.unpack name
+    either (throwE . Text.pack . show) pure =<< lift (sourceToContractDetails srcMap)
 
 evmContractSolidVMError :: Text
 evmContractSolidVMError = Text.concat

--- a/strato/api/bloc/bloc2/src/Bloc/Monad.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Monad.hs
@@ -62,8 +62,9 @@ data BlocEnv = BlocEnv
   , accountNonceLimit   :: Integer
   , gasLimit            :: Integer
   , globalNonceCounter  :: Cache Account Nonce
-  , txTBQueue           :: TBQueue (Maybe Text, Maybe ChainId, Bool, PostBlocTransactionRequest)
+  , txTBQueue           :: TBQueue (Maybe Text, Maybe ChainId, Maybe Bool, Bool, PostBlocTransactionRequest)
   , userRegistryAddress :: Address
+  , useWalletsByDefault :: Bool
   }
 
 --------------------------------------------------------------------------------

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -32,6 +32,7 @@ import           Control.Monad.Extra
 import           Control.Monad.Reader
 import           Control.Monad.Trans.State.Lazy
 import qualified Crypto.Secp256k1                  as S
+import           Data.Bool
 import           Data.ByteString                   (ByteString)
 import qualified Data.ByteString                   as ByteString
 import qualified Data.ByteString.Short             as BSS
@@ -141,8 +142,8 @@ txWorker = forever $ do
   case e of
     Left (ex :: SomeException) -> $logErrorS "txWorker/error" . Text.pack $ show ex
     Right () -> error "txWorker returned a Right (). This should never happen. Please contact Simon Peyton Jones."
-  where processTxs = awaitForever $ \(a,b,r,c) ->
-          lift . void $ postBlocTransaction' (Do CacheNonce) a b r c
+  where processTxs = awaitForever $ \(a,b,w,r,c) ->
+          lift . void $ postBlocTransaction' (Do CacheNonce) a b w r c
 
 
 
@@ -490,18 +491,19 @@ postBlocTransactionParallel :: ( MonadLogger m
                                )
                             => Maybe Text
                             -> Maybe ChainId
+                            -> Maybe Bool -- use_wallet
                             -> Bool -- resolve
                             -> Bool -- queue
                             -> PostBlocTransactionRequest
                             -> m [BlocChainOrTransactionResult]
-postBlocTransactionParallel jwtToken b resolve queue c =
+postBlocTransactionParallel jwtToken b mUseWallet resolve queue c =
   if queue && not resolve
     then do
       checkIsSynced
       tbqueue <- fmap txTBQueue getBlocEnv
-      atomically $ writeTBQueue tbqueue (jwtToken,b,resolve,c)
+      atomically $ writeTBQueue tbqueue (jwtToken,b,mUseWallet,resolve,c)
       pure []
-    else postBlocTransaction' (Do CacheNonce) jwtToken b resolve c
+    else postBlocTransaction' (Do CacheNonce) jwtToken b mUseWallet resolve c
 
 
 postBlocTransaction :: ( MonadLogger m
@@ -516,6 +518,7 @@ postBlocTransaction :: ( MonadLogger m
                        )
                     => Maybe Text
                     -> Maybe ChainId
+                    -> Maybe Bool -- use_wallet
                     -> Bool
                     -> PostBlocTransactionRequest
                     -> m [BlocChainOrTransactionResult]
@@ -533,6 +536,7 @@ postBlocTransactionExternal :: ( MonadLogger m
                               )
                             => Maybe Text
                             -> Maybe ChainId
+                            -> Maybe Bool -- use_wallet
                             -> Bool
                             -> PostBlocTransactionRequest
                             -> m [BlocChainOrTransactionResult]
@@ -552,10 +556,11 @@ postBlocTransaction' :: ( MonadLogger m
                      => Should CacheNonce
                      -> Maybe Text
                      -> Maybe ChainId
+                     -> Maybe Bool -- use_wallet
                      -> Bool
                      -> PostBlocTransactionRequest
                      -> m [BlocChainOrTransactionResult]
-postBlocTransaction' cacheNonce mJwtToken chainId resolve (PostBlocTransactionRequest mAddr txs' txParams msrcs) = do
+postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTransactionRequest mAddr txs' txParams msrcs) = do
   checkIsSynced
   accountNonceLimit <- fmap accountNonceLimit getBlocEnv
   userRegistry <- fmap userRegistryAddress getBlocEnv
@@ -656,6 +661,16 @@ postBlocTransaction' cacheNonce mJwtToken chainId resolve (PostBlocTransactionRe
             p <- fromFunction x
             let bfp = FunctionParameters
                         addr
+                        (functionpayloadContractAddress p)
+                        (functionpayloadMethod p)
+                        (functionpayloadArgs p)
+                        (functionpayloadValue p)
+                        (mergeTxParams (functionpayloadTxParams p) txParams)
+                        (functionpayloadMetadata p)
+                        (functionpayloadChainid p <|> chainId)
+                        resolve
+            let bfpWallet = FunctionParameters
+                        addr
                         userContractAddr
                         "callContract"
                         (M.fromList $ [("contractToCall",ArgString $ Text.pack $ show $ functionpayloadContractAddress p), ("functionName",ArgString $ functionpayloadMethod p), ("args", ArgArray $ V.fromList $ M.elems $ functionpayloadArgs p)])
@@ -664,10 +679,18 @@ postBlocTransaction' cacheNonce mJwtToken chainId resolve (PostBlocTransactionRe
                         (functionpayloadMetadata p)
                         (functionpayloadChainid p <|> chainId)
                         resolve
-            fmap ((:[]) . BlocTxResult) $ postUsersContractMethod' cacheNonce bfp jwtToken
+            walletFlag <- useWalletsByDefault <$> getBlocEnv
+            let bfp' = bool bfp bfpWallet $ fromMaybe walletFlag mUseWallet
+            fmap ((:[]) . BlocTxResult) $ postUsersContractMethod' cacheNonce bfp' jwtToken
           xs -> do
             p <- mapM fromFunction xs
             let bflp = FunctionListParameters
+                        addr
+                        (map (\(FunctionPayload a m r v x c md) ->
+                          MethodCall a m r (fromMaybe (Strung 0) v) (mergeTxParams x txParams) c md) p)
+                        chainId
+                        resolve
+            let bflpWallet = FunctionListParameters
                         addr
                         (map (\(FunctionPayload a m r v x c md) ->
                                 MethodCall 
@@ -681,7 +704,9 @@ postBlocTransaction' cacheNonce mJwtToken chainId resolve (PostBlocTransactionRe
                               ) p)
                         chainId
                         resolve
-            fmap BlocTxResult <$> postUsersContractMethodList' cacheNonce bflp jwtToken
+            walletFlag <- useWalletsByDefault <$> getBlocEnv
+            let bflp' = bool bflp bflpWallet $ fromMaybe walletFlag mUseWallet
+            fmap BlocTxResult <$> postUsersContractMethodList' cacheNonce bflp' jwtToken
         GENESIS -> case txs of
           [] -> return []
           xs -> do

--- a/strato/api/bloc/bloc2/src/Bloc/Server/TransactionResult.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/TransactionResult.hs
@@ -53,7 +53,7 @@ import           UnliftIO
 import           Text.Parsec                          (runParser)
 import           SolidVM.Solidity.Parse.Statement
 
-import           SolidVM.Solidity.Parse.ParserTypes   (ParserState(..))
+import           SolidVM.Solidity.Parse.ParserTypes   (initialParserState)
 
 
 import           Bloc.API.Users
@@ -343,7 +343,7 @@ convertResultResToVals byteResp responseTypes =
 convertSvmResultResToVals :: MonadLogger m => String ->  m (Maybe [SolidityValue])
 convertSvmResultResToVals resp = do
   $logDebugS "convertSvmResultResToVals" . Text.pack $ "response: " ++ resp
-  let args = runParser parseArgs (ParserState "" "" Map.empty) "" resp
+  let args = runParser parseArgs initialParserState "" resp
   $logDebugS "convertSvmResultResToVals" . Text.pack $ "args: " ++ show args
   case args of
     Left _ -> pure Nothing

--- a/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
@@ -40,7 +40,7 @@ import qualified SolidVM.Solidity.Parse.UnParser           as SolidUnparse
 
 parseSolidXabi :: SourceName -> SourceCode ->  Either String (EVMParseT.SolcVersion,  [(T.Text, EVMXabi.Xabi)] )
 parseSolidXabi sName sCode = do
-  fi@(File parsedFile) <-  showError $ runParser solidityFile (ParserState "" "" M.empty) sName sCode
+  fi@(File parsedFile) <-  showError $ runParser solidityFile initialParserState sName sCode
   let nameXabi = [(name, transFormXabi xabi) |  NamedXabi name (xabi, _) <- parsedFile]
   let associatedEVMVersion = case decideVersion fi of
             SolidParseT.ZeroPointFour -> EVMParseT.ZeroPointFour

--- a/strato/api/bloc/bloc2api/src/Bloc/API/Contracts.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API/Contracts.hs
@@ -141,9 +141,10 @@ instance ToSample Contract where
     _functions = Map.empty,
     _constructor = Nothing,
     _modifiers = Map.empty,
-    _contractContext = SourceAnnotation (SourcePosition "SimpleStorage.sol" 1 1) (SourcePosition "SimpleStorage.sol" 1 2) (),
     _usings = Map.empty,
-    _contractType = ContractType
+    _contractType = ContractType,
+    _importedFrom = Nothing,
+    _contractContext = SourceAnnotation (SourcePosition "SimpleStorage.sol" 1 1) (SourcePosition "SimpleStorage.sol" 1 2) ()
   }
 --------------------------------------------------------------------------------
 type GetContractsState = "contracts"

--- a/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
@@ -72,6 +72,7 @@ type PostBlocTransactionParallel = "transaction"
   :> "parallel"
   :> S.Header "X-USER-ACCESS-TOKEN" Text
   :> QueryParam "chainid" ChainId
+  :> QueryParam "use_wallet" Bool -- Using QueryParam here to distinguish between Nothing and Just False
   :> QueryFlag "resolve"
   :> QueryFlag "queue"
   :> ReqBody '[JSON] PostBlocTransactionRequest
@@ -87,6 +88,7 @@ type PostBlocTransactionRaw = "transaction"
   :> Post '[JSON] BlocChainOrTransactionResult
 
 type PostBlocTransactionCommon = QueryParam "chainid" ChainId
+  :> QueryParam "use_wallet" Bool -- Using QueryParam here to distinguish between Nothing and Just False
   :> QueryFlag "resolve"
   :> ReqBody '[JSON] PostBlocTransactionRequest
   :> Post '[JSON] [BlocChainOrTransactionResult]

--- a/strato/api/bloc/bloc2api/src/Bloc/API/Users.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API/Users.hs
@@ -297,6 +297,10 @@ instance ToParam (QueryFlag "resolve") where
   toParam _ =
     DocQueryParam "resolve" ["0","1",""] "flag for resolving a transaction result" Flag
 
+instance ToParam (QueryParam "use_wallet" Bool) where
+  toParam _ =
+    DocQueryParam "use_wallet" [] "flag for overriding default user wallet behavior" Normal
+
 --------------------------------------------------------------------------------
 
 type PostUsersFill = "users"

--- a/strato/api/bloc/bloc2client/src/Bloc/Client.hs
+++ b/strato/api/bloc/bloc2client/src/Bloc/Client.hs
@@ -153,6 +153,7 @@ getChainInfo = client (Proxy @GetChainInfo)
 ------------- /transaction endpoints -------------
 postBlocTransactionParallel :: Maybe Text
                             -> Maybe ChainId 
+                            -> Maybe Bool 
                             -> Bool 
                             -> Bool 
                             -> PostBlocTransactionRequest
@@ -181,6 +182,7 @@ postBlocTransactionUnsigned = client (Proxy @PostBlocTransactionUnsigned)
 
 postBlocTransaction :: Maybe Text 
                     -> Maybe ChainId 
+                    -> Maybe Bool 
                     -> Bool 
                     -> PostBlocTransactionRequest
                     -> ClientM [BlocChainOrTransactionResult]
@@ -188,6 +190,7 @@ postBlocTransaction = client (Proxy @PostBlocTransaction)
 
 postBlocTransactionExternal :: Maybe Text 
                             -> Maybe ChainId 
+                            -> Maybe Bool 
                             -> Bool 
                             -> PostBlocTransactionRequest
                             -> ClientM [BlocChainOrTransactionResult]

--- a/strato/api/strato-api/exec_src/Main.hs
+++ b/strato/api/strato-api/exec_src/Main.hs
@@ -337,7 +337,8 @@ main = do
           stateFetchLimit = stateFetchLimit',
           globalNonceCounter = nonceCache,
           txTBQueue = tbqueue,
-          userRegistryAddress = fromJust $ stringAddress flags_userRegistryAddress
+          userRegistryAddress = fromJust $ stringAddress flags_userRegistryAddress,
+          useWalletsByDefault = flags_useWalletsByDefault
           }
   run 3000 $ app env theDoc
 

--- a/strato/api/strato-api/exec_src/Options.hs
+++ b/strato/api/strato-api/exec_src/Options.hs
@@ -26,6 +26,7 @@ defineFlag "gasLimit" (1000000 :: Integer) "The maximum amount of gas a transact
 defineFlag "identityServerUrl" ("" :: String) "The URL of the identity server" -- This could be used during the strato-getting started or default use with network flag
 defineFlag "vaultProxyPort" ("8013" :: String) "URL to Vault"
 defineFlag "userRegistryAddress" ("0000000000000000000000000000000000000720" :: String) "Address of the User Registry contract"
+defineFlag "useWalletsByDefault" (False :: Bool) "Whether to redirect transactions to user wallet contracts by default"
 
 --Simple helper functions
 getIdServerUrl ::  String

--- a/strato/core/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/Data/AddressStateDB.hs
@@ -21,7 +21,6 @@ module Blockchain.Data.AddressStateDB (
   blankAddressState,
   resolveCodePtr,
   unsafeResolveCodePtr,
-  unsafeResolveCodePtrSelect,
   resolveCodePtrParent,
   codePtrToSHA,
   resolvedCodePtrToSHA,
@@ -164,16 +163,6 @@ unsafeResolveCodePtr (CodeAtAccount acct name) = select Proxy acct >>= \case
     Just (SolidVMCode _ d) -> pure . Just $ SolidVMCode name d
     _ -> pure Nothing
 unsafeResolveCodePtr codePtr = pure $ Just codePtr
-
--- TODO: Remove this when Selectable is a superclass of Alters
-unsafeResolveCodePtrSelect :: Selectable Account AddressState m => CodePtr -> m (Maybe CodePtr)
-unsafeResolveCodePtrSelect (CodeAtAccount acct name) = select Proxy acct >>= \case
-  Nothing -> pure Nothing
-  Just AddressState{..} -> unsafeResolveCodePtrSelect addressStateCodeHash >>= \case
-    Just e@(EVMCode _) -> pure $ Just e
-    Just (SolidVMCode _ d) -> pure . Just $ SolidVMCode name d
-    _ -> pure Nothing
-unsafeResolveCodePtrSelect codePtr = pure $ Just codePtr
 
 resolveCodePtrParent :: ( Selectable Word256 ParentChainIds m
                         , Selectable Account AddressState m

--- a/strato/identity-provider/server/src/IdentityProvider/Server.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/Server.hs
@@ -311,7 +311,7 @@ registerCert cert token = do
             functionpayloadMetadata = Nothing
         }
         txRequest = PostBlocTransactionRequest Nothing [txPayload] Nothing Nothing
-    eresponse <- liftIO $ runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing True txRequest) clientEnv
+    eresponse <- liftIO $ runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest) clientEnv
     $logInfoS "registerCert" $ T.pack $ "Response after registering cert was: " ++ show eresponse
     --TODO: how to tell if cert successfully added to blockchain?
 

--- a/strato/indexer/slipstream/exec_src/Main.hs
+++ b/strato/indexer/slipstream/exec_src/Main.hs
@@ -59,6 +59,7 @@ createBlocEnv = liftIO $ do
                  , globalNonceCounter=error("globalNonceCounter shouldn't be needed in slipstream, it is undefined")
                  , txTBQueue=error("txTBQueue shouldn't be needed in slipstream, it is undefined")
                  , userRegistryAddress=0x0
+                 , useWalletsByDefault = error "useWalletsByDefault shouldn't be needed in slipstream"
     }
 
 

--- a/strato/indexer/slipstream/exec_src/Main.hs
+++ b/strato/indexer/slipstream/exec_src/Main.hs
@@ -13,6 +13,7 @@ import Control.Concurrent
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
+import Control.Monad.Trans.Reader
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 import Data.String
@@ -72,7 +73,6 @@ main = do
   runLoggingT
     . runResourceT
     . runKafkaM ("slipstream" :: KafkaClientId) (fromString flags_kafkahost, fromIntegral flags_kafkaport)
-    . runSQLM
     . withPostgresqlConn workerConnStr $ \workerConn -> do
 
     $logInfoS "main" "Welcome to Slipstream!!!!"
@@ -94,10 +94,6 @@ main = do
 
     handle <- runSqlConn initStorage workerConn
     gref <- newGlobals handle (CirrusHandle conn S.empty)
-
-    --Create Mercata Abstract tables
-    -- generateAssetTable conn gref
-    -- generateSaleTable conn gref
-    -- generateUserTable conn gref
     
-    getAndProcessMessages env conn gref
+    flip runReaderT gref . runSQLM $
+      getAndProcessMessages env conn

--- a/strato/indexer/slipstream/package.yaml
+++ b/strato/indexer/slipstream/package.yaml
@@ -74,6 +74,7 @@ executables:
       - base
       - bloc2
       - blockapps-init
+      - blockapps-mpdbs
       - cache
       - clock
       - hflags
@@ -81,6 +82,7 @@ executables:
       - persistent-postgresql
       - postgresql-typed
       - slipstream
+      - transformers
       - wai-middleware-prometheus
       - warp
 

--- a/strato/indexer/slipstream/package.yaml
+++ b/strato/indexer/slipstream/package.yaml
@@ -41,6 +41,7 @@ library:
     - core-api2
     - cross-monitoring
     - deepseq
+    - ethereum-rlp
     - extra
     - format
     - lens

--- a/strato/indexer/slipstream/src/Slipstream/Data/Globals.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Data/Globals.hs
@@ -21,6 +21,7 @@ import           Database.PostgreSQL.Typed (PGConnection)
 import           BlockApps.Solidity.Value
 import           Blockchain.Strato.Model.Account
 import           Slipstream.Data.GlobalsColdStorage (Handle)
+import           SolidVM.Model.CodeCollection
 
 
 instance NFData (LRU key val) where
@@ -37,6 +38,7 @@ data CirrusHandle = CirrusHandle {cirrusConn :: PGConnection, queriedMaps ::S.Se
 
 data Globals = Globals { createdTables :: M.Map TableName TableColumns
                        , contractStates :: LRU Account [(T.Text, Value)]
+                       , ccMap :: LRU Account CodeCollection
                        , coldStorageHandle :: Handle
                        , cirrusHandle :: CirrusHandle
                        } deriving (Generic, NFData)

--- a/strato/indexer/slipstream/src/Slipstream/Data/Globals.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Data/Globals.hs
@@ -20,6 +20,7 @@ import           Database.PostgreSQL.Typed (PGConnection)
 
 import           BlockApps.Solidity.Value
 import           Blockchain.Strato.Model.Account
+import           Blockchain.Strato.Model.Keccak256
 import           Slipstream.Data.GlobalsColdStorage (Handle)
 import           SolidVM.Model.CodeCollection
 
@@ -38,7 +39,7 @@ data CirrusHandle = CirrusHandle {cirrusConn :: PGConnection, queriedMaps ::S.Se
 
 data Globals = Globals { createdTables :: M.Map TableName TableColumns
                        , contractStates :: LRU Account [(T.Text, Value)]
-                       , ccMap :: LRU Account CodeCollection
+                       , ccMap :: LRU Keccak256 CodeCollection
                        , coldStorageHandle :: Handle
                        , cirrusHandle :: CirrusHandle
                        } deriving (Generic, NFData)
@@ -70,12 +71,6 @@ data TableName =
       { atOrganization :: T.Text
       , atApplication  :: T.Text
       , atContractName :: T.Text
-      }
-  | AbstractTableRowName
-      { atrOrganization :: T.Text
-      , atrApplication  :: T.Text
-      , atrContractName :: T.Text
-      , atrAbstractName :: T.Text
       } deriving (Show, Eq, Ord)
 
 type TableColumns = [T.Text]

--- a/strato/indexer/slipstream/src/Slipstream/Globals.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Globals.hs
@@ -16,6 +16,8 @@ module Slipstream.Globals
     setContractState,
     flushPendingWrites,
     getContractState,
+    getCCFromGlobals,
+    putCCIntoGlobals,
     forceGlobalEval,
     newGlobals,
     getAbstractTableRow,
@@ -48,7 +50,7 @@ import           Slipstream.Metrics
 import           Slipstream.QueryFormatHelper
 
 newGlobals :: MonadIO m => Handle -> CirrusHandle -> m (IORef Globals)
-newGlobals h ch = newIORef $ Globals M.empty (LRU.newLRU (Just 1024)) h ch
+newGlobals h ch = newIORef $ Globals M.empty (LRU.newLRU (Just 1024)) (LRU.newLRU (Just 1024)) h ch
 
 updateGlobals :: MonadIO m => IORef Globals -> Globals -> m ()
 updateGlobals gref g = do
@@ -168,6 +170,24 @@ setContractState gref account values = do
   globals@Globals{..} <- readIORef gref
   updateGlobals gref globals{contractStates = LRU.insert account values contractStates}
   asyncWriteToStorage coldStorageHandle account values
+
+getCCFromGlobals :: MonadIO m => IORef Globals -> Account -> m (Maybe CodeCollection)
+getCCFromGlobals globalsIORef account = do
+  g@Globals{..} <- readIORef globalsIORef
+  case LRU.lookup account ccMap of
+    (newCache, jv@Just{}) -> do
+      recordCacheHit
+      writeIORef globalsIORef g{ ccMap = newCache }
+      return jv
+    (newCache, Nothing) -> do
+      recordCacheMiss
+      writeIORef globalsIORef g{ ccMap = newCache }
+      return Nothing
+
+putCCIntoGlobals :: MonadIO m => IORef Globals -> Account -> CodeCollection -> m ()
+putCCIntoGlobals gref account cc = do
+  globals@Globals{..} <- readIORef gref
+  updateGlobals gref globals{ccMap = LRU.insert account cc ccMap}
 
 forceGlobalEval :: (MonadIO m) => IORef Globals -> m ()
 forceGlobalEval gref = liftIO $ modifyIORef' gref force

--- a/strato/indexer/slipstream/src/Slipstream/Globals.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Globals.hs
@@ -20,7 +20,6 @@ module Slipstream.Globals
     putCCIntoGlobals,
     forceGlobalEval,
     newGlobals,
-    getAbstractTableRow,
     module Slipstream.Data.Globals
   ) where
 
@@ -43,11 +42,13 @@ import           UnliftIO.IORef
 
 import           BlockApps.Solidity.Value
 import           Blockchain.Strato.Model.Account
+import           Blockchain.Strato.Model.Keccak256
 
 import           Slipstream.Data.Globals
 import           Slipstream.GlobalsColdStorage
 import           Slipstream.Metrics
 import           Slipstream.QueryFormatHelper
+import           SolidVM.Model.CodeCollection
 
 newGlobals :: MonadIO m => Handle -> CirrusHandle -> m (IORef Globals)
 newGlobals h ch = newIORef $ Globals M.empty (LRU.newLRU (Just 1024)) (LRU.newLRU (Just 1024)) h ch
@@ -85,18 +86,6 @@ getMappingTables globalsIORef org app contract = do
   let mapNames = map mtMappingName (M.keys mappingTables)
   return mapNames
 
-getAbstractTableRow :: MonadIO m => IORef Globals -> T.Text -> T.Text -> T.Text -> m ([T.Text])
-getAbstractTableRow globalsIORef org app contract = do
-  Globals{..} <- readIORef globalsIORef
-  let abstractTables = M.filterWithKey isAbstractTableName (createdTables)
-                        where
-                          isAbstractTableName :: TableName -> TableColumns -> Bool
-                          isAbstractTableName (AbstractTableRowName o a n _) _ = 
-                            o == org && a == app && n == contract
-                          isAbstractTableName _ _ = False
-  let result = map atrAbstractName (M.keys abstractTables)
-  return result
-
 getTableColumns :: MonadIO m => IORef Globals -> TableName -> m (Maybe TableColumns)
 getTableColumns globalsIORef tableName = do
   Globals{..} <- readIORef globalsIORef
@@ -125,7 +114,7 @@ scrapeFor globalsIORef tableName = do
               setTableCreated globalsIORef (MappingTableName org app contract mapName) cols
             _ -> return ()
           ) 
-        g@(Globals createdTables' _ _ _) <- readIORef globalsIORef -- need to read again so have current ver of createdTables
+        g@Globals{createdTables=createdTables'} <- readIORef globalsIORef -- need to read again so have current ver of createdTables
         updateGlobals globalsIORef g{cirrusHandle = cirrusHandle{queriedMaps = (org, app, contract) `S.insert` queriedMaps}}
         return createdTables'
       _ -> do
@@ -134,7 +123,7 @@ scrapeFor globalsIORef tableName = do
           then return createdTables
           else do
             setTableCreated globalsIORef tableName cols
-            Globals createdTables' _ _ _ <- readIORef globalsIORef
+            Globals{createdTables=createdTables'} <- readIORef globalsIORef
             return createdTables'
 
   where scrapeForCols :: MonadIO m => T.Text -> PGConnection -> m TableColumns
@@ -171,10 +160,10 @@ setContractState gref account values = do
   updateGlobals gref globals{contractStates = LRU.insert account values contractStates}
   asyncWriteToStorage coldStorageHandle account values
 
-getCCFromGlobals :: MonadIO m => IORef Globals -> Account -> m (Maybe CodeCollection)
-getCCFromGlobals globalsIORef account = do
+getCCFromGlobals :: MonadIO m => IORef Globals -> Keccak256 -> m (Maybe CodeCollection)
+getCCFromGlobals globalsIORef codeHash = do
   g@Globals{..} <- readIORef globalsIORef
-  case LRU.lookup account ccMap of
+  case LRU.lookup codeHash ccMap of
     (newCache, jv@Just{}) -> do
       recordCacheHit
       writeIORef globalsIORef g{ ccMap = newCache }
@@ -184,10 +173,10 @@ getCCFromGlobals globalsIORef account = do
       writeIORef globalsIORef g{ ccMap = newCache }
       return Nothing
 
-putCCIntoGlobals :: MonadIO m => IORef Globals -> Account -> CodeCollection -> m ()
-putCCIntoGlobals gref account cc = do
+putCCIntoGlobals :: MonadIO m => IORef Globals -> Keccak256 -> CodeCollection -> m ()
+putCCIntoGlobals gref codeHash cc = do
   globals@Globals{..} <- readIORef gref
-  updateGlobals gref globals{ccMap = LRU.insert account cc ccMap}
+  updateGlobals gref globals{ccMap = LRU.insert codeHash cc ccMap}
 
 forceGlobalEval :: (MonadIO m) => IORef Globals -> m ()
 forceGlobalEval gref = liftIO $ modifyIORef' gref force

--- a/strato/indexer/slipstream/src/Slipstream/MessageConsumer.hs
+++ b/strato/indexer/slipstream/src/Slipstream/MessageConsumer.hs
@@ -4,6 +4,7 @@
     , OverloadedStrings
     , FlexibleContexts
     , TemplateHaskell
+    , TypeApplications
 #-}
 
 module Slipstream.MessageConsumer (
@@ -12,6 +13,7 @@ module Slipstream.MessageConsumer (
 
 import Prelude hiding (lookup)
 import Control.Monad.Change.Alter
+import Control.Monad.Change.Modify
 import Control.Monad.IO.Unlift
 import Data.IORef
 import Data.String
@@ -22,10 +24,12 @@ import qualified Network.Kafka.Protocol as K hiding (Message)
 import Bloc.Monad (BlocEnv)
 import BlockApps.Logging
 import Blockchain.Data.AddressStateDB
+import Blockchain.Data.ChainInfo
 import Blockchain.DB.CodeDB
 import Blockchain.MilenaTools
 import Blockchain.Stream.VMEvent
 import Blockchain.Strato.Model.Account
+import Blockchain.Strato.Model.ExtendedWord
 
 import Control.Monad.Composable.Kafka
 import Control.Monad.Composable.SQL
@@ -33,6 +37,7 @@ import Control.Monad.Composable.SQL
 import Slipstream.Globals
 import Slipstream.Metrics
 import Slipstream.Processor
+import SolidVM.Model.CodeCollection
 
 lookupTopic :: K.TopicName
 lookupTopic = fromString "statediff"
@@ -72,29 +77,36 @@ putStatediffOffset off = do
 getAndProcessMessages :: ( MonadLogger m
                          , HasKafka m
                          , HasSQL m
+                         , Accessible (IORef Globals) m
                          , Selectable Account AddressState m
+                         , Selectable Account CodeCollection m
+                         , Selectable Word256 ParentChainIds m
                          , HasCodeDB m
                          )
-                      => BlocEnv -> PGConnection -> IORef Globals -> m ()
-getAndProcessMessages env conn cache = do
+                      => BlocEnv -> PGConnection -> m ()
+getAndProcessMessages env conn = do
   let errorCount = 0
   offset <- getStatediffOffset
-  getAndProcessMessages' env conn cache offset errorCount
+  getAndProcessMessages' env conn offset errorCount
 
 getAndProcessMessages' :: ( MonadLogger m
                           , HasKafka m
                           , HasSQL m
+                          , Accessible (IORef Globals) m
                           , Selectable Account AddressState m
+                          , Selectable Account CodeCollection m
+                          , Selectable Word256 ParentChainIds m
                           , HasCodeDB m
                           )
-                       => BlocEnv -> PGConnection -> IORef Globals -> K.Offset -> Int -> m ()
-getAndProcessMessages' env conn cache offset errorCounter = do
+                       => BlocEnv -> PGConnection -> K.Offset -> Int -> m ()
+getAndProcessMessages' env conn offset errorCounter = do
   $logInfoS "getAndProcessMessages'" $ T.pack $ "#### fetching VMEvents: Offset=" ++ show offset
   recordOffset offset
   messages <- execKafka $ fetchVMEvents offset
   recordKafkaMessages messages
+  cache <- access (Proxy @(IORef Globals))
   forceGlobalEval cache
-  processTheMessages env conn cache messages
+  processTheMessages env conn messages
   let newOffset = offset + fromIntegral (length messages)
   currentOffset <- getStatediffOffset
   offset' <- if currentOffset /= offset
@@ -106,4 +118,4 @@ getAndProcessMessages' env conn cache offset errorCounter = do
                putStatediffOffset newOffset
                return newOffset
 
-  getAndProcessMessages' env conn cache offset' errorCounter
+  getAndProcessMessages' env conn offset' errorCounter

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -264,15 +264,6 @@ constructTableNameParameters org app contract =
          then (org, "", contract)
          else (org, app, contract)
 
-constructMappingOrAbstractTableNameParameters :: Text -> Text -> Text -> Text -> (Text, Text, Text, Text)
-constructMappingOrAbstractTableNameParameters org app contract m_or_a=
-  if T.null org
-    then ("", "", contract, m_or_a)
-    else if app == contract
-         then (org, "", contract, m_or_a)
-         else (org, app, contract, m_or_a)
-
-
 uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
 uncurry3 f (x, y, z) = f x y z
 
@@ -289,10 +280,14 @@ abstractTableName :: Text -> Text -> Text -> TableName
 abstractTableName o a n = uncurry3 AbstractTableName $ constructTableNameParameters o a n
 
 abstractTableRowName :: Text -> Text -> Text -> Text -> TableName
-abstractTableRowName o a n ab = uncurry4 AbstractTableRowName $ constructMappingOrAbstractTableNameParameters o a n ab
+abstractTableRowName o a n ab =
+  let (o', a', n') = constructTableNameParameters o a n
+   in AbstractTableRowName o' a' n' ab
 
 mappingTableName :: Text -> Text -> Text -> Text -> TableName
-mappingTableName o a n m = uncurry4 MappingTableName $ constructMappingOrAbstractTableNameParameters o a n m
+mappingTableName o a n m =
+  let (o', a', n') = constructTableNameParameters o a n
+   in MappingTableRowName o' a' n' m
 
 createExpandIndexTable
   :: OutputM m

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -20,15 +20,10 @@ module Slipstream.OutputData (
   insertMappingTable,
   insertAbstractTable,
   insertAbstractTableQuery,
-  -- insertContractInAbstractTableQuery,
   createIndexTable,
   createMappingTable,
   createHistoryTable,
   createAbstractTable,
-  createAbstractTableRow,
-  createAssetTable,
-  createSaleTable,
-  createUserTable,
   insertHistoryTable,
   createExpandEventTables,
   createExpandIndexTable,
@@ -41,6 +36,7 @@ module Slipstream.OutputData (
 
 import           BlockApps.Solidity.Value
 import           Conduit
+import           Control.Arrow                   ((***))
 import           Control.Lens ((^.))
 import           Control.Monad
 import qualified Data.Aeson                      as Aeson
@@ -229,20 +225,8 @@ baseMappingColumns = [ "record_id"
               , "block_number"
               , "transaction_hash"
               , "transaction_sender"
-              , "contractname"
+              , "contract_name"
               , "mapname"
-              ]
-
-baseAbstractColumns :: TableColumns
-baseAbstractColumns = [ "record_id"
-              , "address"
-              , "chainId"
-              , "block_hash"
-              , "block_timestamp"
-              , "block_number"
-              , "transaction_hash"
-              , "transaction_sender"
-              , "contractname"
               ]
 
 baseTableColumns :: TableColumns
@@ -250,10 +234,6 @@ baseTableColumns = baseColumns
 
 baseMappingTableColumns :: TableColumns
 baseMappingTableColumns = baseMappingColumns
-
-baseAbstractTableColumns :: TableColumns
-baseAbstractTableColumns = baseAbstractColumns
-
 
 -- discard app if org is null
 constructTableNameParameters :: Text -> Text -> Text -> (Text, Text, Text)
@@ -267,9 +247,6 @@ constructTableNameParameters org app contract =
 uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
 uncurry3 f (x, y, z) = f x y z
 
-uncurry4 :: (a -> b -> c -> d -> e) -> (a, b, c, d) -> e
-uncurry4 f (v, x, y, z) = f v x y z
-
 historyTableName :: Text -> Text -> Text -> TableName
 historyTableName o a n = uncurry3 HistoryTableName $ constructTableNameParameters o a n
 
@@ -279,15 +256,10 @@ indexTableName o a n = uncurry3 IndexTableName $ constructTableNameParameters o 
 abstractTableName :: Text -> Text -> Text -> TableName
 abstractTableName o a n = uncurry3 AbstractTableName $ constructTableNameParameters o a n
 
-abstractTableRowName :: Text -> Text -> Text -> Text -> TableName
-abstractTableRowName o a n ab =
-  let (o', a', n') = constructTableNameParameters o a n
-   in AbstractTableRowName o' a' n' ab
-
 mappingTableName :: Text -> Text -> Text -> Text -> TableName
 mappingTableName o a n m =
   let (o', a', n') = constructTableNameParameters o a n
-   in MappingTableRowName o' a' n' m
+   in MappingTableName o' a' n' m
 
 createExpandIndexTable
   :: OutputM m
@@ -366,36 +338,6 @@ createIndexTable globalsIORef contract (o, a, n) = do
     setTableCreated globalsIORef tableName list
     return $ getDeferredForeignKeys tableName contract o a
 
-createAssetTableQuery :: Text
-createAssetTableQuery =
-  let tableName = indexTableName "" "" "Asset"
-   in T.concat
-        [ "CREATE TABLE IF NOT EXISTS " , tableNameToDoubleQuoteText tableName , " ("
-        , csv $ ["record_id text", "address text", "\"chainId\" text", "block_hash text", "block_timestamp text",
-               "block_number text", "transaction_hash text", "transaction_sender text", "contractname text", "data jsonb"]
-        , ",\n  PRIMARY KEY (contractname));"
-        ]
-
-createSaleTableQuery :: Text
-createSaleTableQuery =
-  let tableName = indexTableName "" "" "Sale"
-   in T.concat
-        [ "CREATE TABLE IF NOT EXISTS " , tableNameToDoubleQuoteText tableName , " ("
-        , csv $ ["record_id text", "address text", "\"chainId\" text", "block_hash text", "block_timestamp text",
-               "block_number text", "transaction_hash text", "transaction_sender text", "contractname text", "data jsonb"]
-        , ",\n  PRIMARY KEY (contractname));"
-        ]
-
-createUserTableQuery :: Text
-createUserTableQuery =
-  let tableName = indexTableName "" "" "User"
-   in T.concat
-        [ "CREATE TABLE IF NOT EXISTS " , tableNameToDoubleQuoteText tableName , " ("
-        , csv $ ["record_id text", "address text", "\"chainId\" text", "block_hash text", "block_timestamp text",
-               "block_number text", "transaction_hash text", "transaction_sender text", "contractname text", "data jsonb"]
-        , ",\n  PRIMARY KEY (contractname));"
-        ]
-
 createAbstractTable :: OutputM m
                  => IORef Globals
                  -> Contract
@@ -408,53 +350,6 @@ createAbstractTable globalsIORef contract (o, a, n) = do
     let list = tableColumns $ map (\(x, y) -> (labelToText x, y ^. varType)) $ Map.toList $ contract^.storageDefs
     yield $ createAbstractTableQuery contract (o,a,n)
     setTableCreated globalsIORef tableName (list++ ["\"data\" jsonb"])
-
-createAbstractTableRow :: OutputM m
-                 => IORef Globals
-                 -> Contract
-                 -> (Text, Text, Text)
-                 -> Text
-                 -> ConduitM () Text m ()
-createAbstractTableRow globalsIORef contract (o, a, n) ab = do
-  let tableName = abstractTableRowName o a n ab
-  tableExists <- isTableCreated globalsIORef tableName
-  when (not tableExists) $ do
-    let list = tableColumns $ map (\(x, y) -> (labelToText x, y ^. varType)) $ Map.toList $ contract^.storageDefs
-    setTableCreated globalsIORef tableName list
-
-createAssetTable :: OutputM m
-                 => IORef Globals
-                 -> ConduitM () Text m ()
-createAssetTable globalsIORef = do
-  let tableName = indexTableName "" "" "Asset"
-  tableExists <- isTableCreated globalsIORef tableName
-  when (not tableExists) $ do
-    yield $ createAssetTableQuery
-    let list = ["data"]
-    setTableCreated globalsIORef tableName list
-
-createSaleTable :: OutputM m
-                 => IORef Globals
-                 -> ConduitM () Text m ()
-createSaleTable globalsIORef = do
-  let tableName = indexTableName "" "" "Sale"
-  tableExists <- isTableCreated globalsIORef tableName
-  when (not tableExists) $ do
-    yield $ createSaleTableQuery
-    let list = ["data"]
-    setTableCreated globalsIORef tableName list
-
-createUserTable :: OutputM m
-                 => IORef Globals
-                 -> ConduitM () Text m ()
-createUserTable globalsIORef = do
-  let tableName = indexTableName "" "" "User"
-  tableExists <- isTableCreated globalsIORef tableName
-  when (not tableExists) $ do
-    yield $ createUserTableQuery
-    let list = ["data"]
-    setTableCreated globalsIORef tableName list
-
 
 -- if flag from solidvm that it is a record, vmevent
 createMappingTable :: OutputM m
@@ -695,17 +590,13 @@ insertHistoryTable contracts@(E.ProcessedContract { organization = org, applicat
   yieldMany $ insertHistoryTableQuery contracts
 
 insertAbstractTable :: OutputM m
-                 => [Maybe (E.ProcessedContract, T.Text, TableColumns)]
+                 => [(E.ProcessedContract, T.Text, TableColumns)]
                  -> ConduitM () Text m ()
-insertAbstractTable [] = return () -- no data, do nothing
-insertAbstractTable contracts = do
-    let validContracts = catMaybes contracts
-    case validContracts of
-        [] -> return () -- no valid contracts, do nothing
-        ((E.ProcessedContract { organization = org, application = app, contractName = cName },_,_) : _) -> do
-            let tableName = indexTableName org app cName
-            $logInfoS "insertAbstractTable" $ T.pack $ "Inserting row in abstract table for: " ++ show tableName
-            yieldMany $ insertAbstractTableQuery validContracts
+insertAbstractTable [] = pure ()
+insertAbstractTable cs@((E.ProcessedContract { organization = org, application = app, contractName = cName }, _, _):_) = do
+  let tableName = indexTableName org app cName
+  $logInfoS "insertAbstractTable" $ T.pack $ "Inserting row in abstract table for: " ++ show tableName ++ " (and potentially others)"
+  yieldMany $ insertAbstractTableQuery cs
 
 
 createIndexTableQuery :: Contract -> (Text, Text, Text) -> Text
@@ -725,8 +616,8 @@ createMappingTableQuery (o, a, n, m) =
    in T.concat
         [ "CREATE TABLE IF NOT EXISTS " , tableNameToDoubleQuoteText tableName , " ("
         , csv $ ["record_id text", "address text", "\"chainId\" text", "block_hash text", "block_timestamp text",
-               "block_number text", "transaction_hash text", "transaction_sender text", "contractname text", "mapname text","key text", "value text"]
-        , ",\n  PRIMARY KEY (address, key));"
+               "block_number text", "transaction_hash text", "transaction_sender text", "contract_name text", "mapname text","key text", "value text"]
+        , ",\n  PRIMARY KEY (record_id));"
         ]
 
 createAbstractTableQuery ::  Contract -> (Text, Text, Text) -> Text
@@ -736,8 +627,8 @@ createAbstractTableQuery contract (o, a, n) =
    in T.concat
         [ "CREATE TABLE IF NOT EXISTS " , tableNameToDoubleQuoteText tableName , " ("
         , csv $ ["record_id text", "address text", "\"chainId\" text", "block_hash text", "block_timestamp text",
-               "block_number text", "transaction_hash text", "transaction_sender text", "contractname text", "data jsonb"] ++ tableColumns (map (\(x, y) -> (labelToText x, y ^. varType)) list)
-        , ",\n  PRIMARY KEY (contractname));"
+               "block_number text", "transaction_hash text", "transaction_sender text", "contract_name text"] ++ tableColumns (map (\(x, y) -> (labelToText x, y ^. varType)) list) ++ ["data jsonb"]
+        , ",\n  PRIMARY KEY (record_id));"
         ]
 
 createHistoryTableQuery :: Contract -> (Text, Text, Text) -> Text
@@ -860,43 +751,24 @@ insertMappingTableQuery ms = concat $
     block_number = excluded.block_number,
     transaction_hash = excluded.transaction_hash,
     transaction_sender = excluded.transaction_sender,
-    contractname = excluded.contractname,
+    contract_name = excluded.contract_name,
     mapname = excluded.mapname,
     value = excluded.value|]
                 , ";"
                 ]
 
--- insertContractInAbstractTableQuery :: OutputM m => IORef Globals -> (Text, Text) -> Text -> ConduitM () Text m ()
--- insertContractInAbstractTableQuery globalsIORef (o,a) ab = do
---   let abstractTableName = abstractTableRowName o a ab
---       contractTableName = indexTableName o a 
---   tableExists <- isTableCreated globalsIORef abstractTableName
---   $logInfoLS "insertContractInAbstractTableQuery/abstractTableRowExists" (abstractTableName, tableExists)
-
---   when (not tableExists) $ do
---     incNumAbstractRowTables
---     yield $ T.concat [ "INSERT INTO ",tableNameToDoubleQuoteText abstractTableName," (contractname) VALUES ('", tableNameToDoubleQuoteText contractTableName, "');" ]
---     let list = ["data"]
---     setTableCreated globalsIORef abstractTableName list
-
 insertAbstractTableQuery :: [(E.ProcessedContract, T.Text, TableColumns)] -> [Text]
 insertAbstractTableQuery [] = error "insertAbstractTableQuery: unhandled empty list"
 insertAbstractTableQuery cs = concat $
   let cs' = (\(c@E.ProcessedContract{contractData = contractData}, ab, abColumns) -> ((c, Map.mapMaybe valueToSQLTextFilterContract $ contractData), (ab, abColumns))) <$> cs
-   in flip map (map snd $ partitionWith (length . snd . fst) cs') $ \case
+   in flip map (map snd $ partitionWith ((length . snd) *** fst) cs') $ \case
         [] -> []
-        contracts@(((x, _), (ab, abColumns)):_) ->
+        contracts@(((x, _), (abTableName, abColumns)):_) ->
           let contractTableName = indexTableName
                   (E.organization x)
                   (E.application x)
                   (E.contractName x)  
-              abTableName = case ab of
-                "Asset" -> abstractTableName "" "" "Asset"
-                "Sale"  -> abstractTableName "" "" "Sale"
-                "User"  -> abstractTableName "" "" "User"
-                _ -> abstractTableName (E.organization x) (E.contractName x) (ab)
-              abTableName' = tableNameToDoubleQuoteText abTableName 
-              keySt  = wrapAndEscapeDouble . map escapeQuotes $ (baseAbstractTableColumns ++ abColumns)
+              keySt  = wrapAndEscapeDouble $ escapeQuotes <$> abColumns
               baseVals = [ \c -> makeAccount (E.chain c) (E.address c)
                          , tshow . E.address
                          , E.chain
@@ -911,14 +783,13 @@ insertAbstractTableQuery cs = concat $
               inserts = csv vals
            in (:[]) $ T.concat
                 [ "INSERT INTO "
-                , abTableName'
+                , abTableName
                 , " "
                 , keySt
                 , "\n  VALUES "
                 , inserts
                 , [r|
-  ON CONFLICT (contractname) DO UPDATE SET
-    record_id = excluded.record_id,
+  ON CONFLICT (record_id) DO UPDATE SET
     address = excluded.address,
     "chainId" = excluded."chainId",
     block_hash = excluded.block_hash,
@@ -926,6 +797,7 @@ insertAbstractTableQuery cs = concat $
     block_number = excluded.block_number,
     transaction_hash = excluded.transaction_hash,
     transaction_sender = excluded.transaction_sender,
+    contract_name = excluded.contract_name,
     data = excluded.data|]
                 , ";"
                 ]

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -229,6 +229,18 @@ baseMappingColumns = [ "record_id"
               , "mapname"
               ]
 
+baseAbstractColumns :: TableColumns
+baseAbstractColumns = [ "record_id"
+              , "address"
+              , "chainId"
+              , "block_hash"
+              , "block_timestamp"
+              , "block_number"
+              , "transaction_hash"
+              , "transaction_sender"
+              , "contract_name"
+              ]
+
 baseTableColumns :: TableColumns
 baseTableColumns = baseColumns
 
@@ -768,7 +780,7 @@ insertAbstractTableQuery cs = concat $
                   (E.organization x)
                   (E.application x)
                   (E.contractName x)  
-              keySt  = wrapAndEscapeDouble $ escapeQuotes <$> abColumns
+              keySt  = wrapAndEscapeDouble $ escapeQuotes <$> (baseAbstractColumns ++ filter (`notElem` baseAbstractColumns) abColumns)
               baseVals = [ \c -> makeAccount (E.chain c) (E.address c)
                          , tshow . E.address
                          , E.chain

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -6,6 +6,7 @@
     , FlexibleInstances
     , LambdaCase
     , GeneralizedNewtypeDeriving
+    , MonoLocalBinds
     , MultiParamTypeClasses
     , OverloadedStrings
     , QuasiQuotes
@@ -64,6 +65,7 @@ import Blockchain.Data.ChainInfo
 import Blockchain.Data.TransactionResult
 import Blockchain.Data.DataDefs
 import Blockchain.Data.Json
+import Blockchain.Data.RLP
 import Blockchain.DB.CodeDB
 import Blockchain.SolidVM.CodeCollectionDB
 import Blockchain.Strato.Model.Account
@@ -75,6 +77,8 @@ import Blockchain.Stream.VMEvent
 
 import Control.Monad.Composable.SQL
 import qualified Handlers.AccountInfo            as Account
+import           Handlers.Storage
+import           MaybeNamed
 
 import Data.Source.Map
 
@@ -91,6 +95,7 @@ import Slipstream.QueryFormatHelper
 import SolidVM.CodeCollectionTools
 import SolidVM.Model.CodeCollection hiding (contractName)
 import SolidVM.Model.SolidString
+import qualified SolidVM.Model.Storable as MS
 import qualified SolidVM.Model.Type as SVMType
 
 import Text.Format
@@ -352,6 +357,47 @@ getAbstractParentsFromContract c cc =
       parentContracts = getContractsForParents parents' (cc ^. contracts)
    in filter ((== AbstractType) . _contractType) parentContracts
 
+resolveNameParts :: ( MonadLogger m
+                    , Selectable Account AddressState m
+                    , Selectable Word256 ParentChainIds m
+                    , Selectable StorageFilterParams [StorageAddress] m
+                    )
+                 => Text -> Text -> Contract -> m (Text, Text, Text)
+resolveNameParts o a c = do
+  let tName = T.pack . _contractName
+  case c ^. importedFrom of
+    Nothing -> pure (o, a, tName c)
+    Just acct -> select (Proxy @AddressState) acct >>= \case
+      Nothing -> do
+        $logWarnS "processTheMessages/resolveNameParts" . T.pack $
+          "Could not find address state for account " ++ show acct
+        pure (o, a, tName c)
+      Just s -> resolveCodePtr (acct ^. accountChainId) (addressStateCodeHash s) >>= \case
+        Just (SolidVMCode appName _) -> do
+          let qs = storageFilterParams
+                 { qsKey = Just $ HexStorage ".:creator"
+                 , qsAddress = Just $ acct ^. accountAddress
+                 , qsChainId = Unnamed . ChainId <$> acct ^. accountChainId
+                 }
+          select (Proxy @[StorageAddress]) qs >>= \case
+            Just (sa : _) -> case value sa of
+              HexStorage orgHex -> case rlpDecode <$> rlpDeserializeMaybe orgHex of
+                Just (MS.BString orgBS) -> case decodeUtf8' orgBS of
+                  Right o' -> pure (o', T.pack appName, tName c)
+                  Left _ -> do
+                    $logWarnS "resolveNameParts" . T.pack $
+                      ":creator field is not valid UTF8 for account " ++ show acct ++ ": " ++ show orgBS
+                    pure (o, T.pack appName, tName c)
+                _ -> do
+                  $logWarnS "resolveNameParts" . T.pack $
+                    "Could not RLP decode :creator field for account " ++ show acct ++ ": " ++ show orgHex
+                  pure (o, T.pack appName, tName c)
+            _ -> pure ("", T.pack appName, tName c)
+        _ -> do
+          $logWarnS "resolveNameParts" . T.pack $
+            "Could not resolve code for account " ++ show acct
+          pure (o, a, tName c)
+
 processTheMessages :: ( MonadLogger m
                       , HasSQL m
                       , Selectable Account AddressState m
@@ -381,18 +427,6 @@ processTheMessages env conn messages = do
   -- forM :: [a] -> (a -> m (Either b c)) -> m [Either b c]
   -- m [c]
   
-  let tName = T.pack . _contractName
-      resolveNameParts (o, a) c = case c ^. importedFrom of
-        Nothing -> pure (o, a, tName c)
-        Just acct -> select (Proxy @AddressState) acct >>= \case
-          Nothing -> do
-            $logWarnS "processTheMessages/resolveNameParts" . T.pack $ "Could not find address state for account " ++ show acct
-            pure (o, a, tName c)
-          Just s -> resolveCodePtr (acct ^. accountChainId) (addressStateCodeHash s) >>= \case
-            Just (SolidVMCode appName _) -> pure (o, T.pack appName, tName c) -- TODO: Get org from :creator field
-            _ -> do
-              $logWarnS "processTheMessages/resolveNameParts" . T.pack $ "Could not resolve code for account " ++ show acct
-              pure (o, a, tName c)
 
   fkeys' <- forM creates $ \(ccString, cp, o, a, hl, _) -> do
     cc' <- getCC g cp ccString
@@ -402,8 +436,7 @@ processTheMessages env conn messages = do
 
 
               deferredForeignKeys <- fmap concat $ forM (Map.toList $ cc^.contracts) $ \(nameString, c) -> do
-                let n = labelToText nameString
-                    a' = if a /= ""
+                let a' = if a /= ""
                            then a
                            else case cp of
                             SolidVMCode n' _ | nameString /= n' -> T.pack n'
@@ -418,8 +451,8 @@ processTheMessages env conn messages = do
                 let historyTableNames = map (historyTableName o a') hl
                 $logInfoS "processTheMessages/historyTableNames" $ T.pack $ show historyTableNames
 
-                $logInfoS "processTheMessages" $ "New Contract Added: org=" <> o <> ", app=" <> a' <> ", name=" <> n <> " (fields: " <> T.pack (show $ Map.toList $ fmap _varType $ c ^. storageDefs) <> ")"
-                nameParts <- resolveNameParts (o, a') c
+                nameParts@(o'', a'', n'') <- resolveNameParts o a' c
+                $logInfoS "processTheMessages" $ "New Contract Added: org=" <> o'' <> ", app=" <> a'' <> ", name=" <> n'' <> " (fields: " <> T.pack (show $ Map.toList $ fmap _varType $ c ^. storageDefs) <> ")"
 
                 --Create mapping tables
                 forM_ mapNames $ \m -> do 
@@ -488,7 +521,7 @@ processTheMessages env conn messages = do
                               else SE.application indexContract
               --get columns for abstract table
               abstractColumns <- fmap catMaybes . for abstracts $ \ab -> do
-                (o',a',n') <- lift $ resolveNameParts (SE.organization indexContract, appName) ab
+                (o',a',n') <- lift $ resolveNameParts (SE.organization indexContract) appName ab
                 let tableName = AbstractTableName o' a' n'
                     tableNameText = tableNameToDoubleQuoteText tableName
                 mCols <- getTableColumns g tableName

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -31,13 +31,14 @@ import qualified Data.Aeson                           as Aeson
 import Control.Arrow ((&&&))
 import Control.Lens ((^.), (.~), (?~))
 import Control.Monad.Change.Alter
+import qualified Control.Monad.Change.Modify as Mod
 import Control.Monad.Except
 import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.State.Strict hiding (state)
 import Data.Either (lefts, rights)
-import Data.Foldable (toList)
+import Data.Foldable (for_, toList)
 import Data.Function
 import Data.IORef
 import qualified Data.Set as S
@@ -104,6 +105,24 @@ instance MonadUnliftIO m => Selectable Account Contract (SQLM m) where
     codePtr <- MaybeT . pure $ addressStateRefCodePtr r
     MaybeT $ either (const Nothing) (Just . snd) <$> getContractDetailsByCodeHash codePtr
 
+instance (MonadUnliftIO m, Mod.Accessible (IORef Globals) m) => Selectable Account CodeCollection (SQLM m) where
+  select _ a = do
+    g <- lift $ Mod.access (Mod.Proxy @(IORef Globals))
+    mCC <- getCCFromGlobals g a
+    case mCC of
+      Just cc -> pure $ Just cc
+      Nothing -> runMaybeT $ do
+        (AddressStateRef' r _) <- MaybeT
+                                . fmap listToMaybe
+                                . Account.getAccount'
+                                $ Account.accountsFilterParams
+                                & Account.qaAddress ?~ (a ^. accountAddress)
+                                & Account.qaChainId .~ (fmap ChainId . maybeToList $ a ^. accountChainId)
+        codePtr <- MaybeT . pure $ addressStateRefCodePtr r
+        cc <- MaybeT $ either (const Nothing) Just <$> getCodeCollectionByCodePtr codePtr
+        for_ cc $ putCCIntoGlobals g
+        pure cc
+
 instance Selectable Account Contract m => Selectable Account Contract (ReaderT BlocEnv m) where
   select p = lift . select p
 
@@ -148,7 +167,7 @@ mergeDiffs lhs rhs = error $ "Invalid diff combination: " ++ show (lhs, rhs)
 
 data BatchedInserts = BatchedInserts
   { indexInsert     :: ProcessedContract
-  , abstractInsert     :: Maybe (ProcessedContract, T.Text, TableColumns)
+  , abstractInsert  :: [(ProcessedContract, T.Text, TableColumns)]
   , historyInserts  :: [ProcessedContract]
   , mappingInserts  :: [ProcessedMappingRow]
   } deriving (Show)
@@ -311,13 +330,29 @@ getContractsForParents parents' cc =
   let getContractForParent parent = Map.lookup parent cc
   in mapMaybe getContractForParent parents'
 
+getMapNamesFromContract :: Contract -> [String]
+getMapNamesFromContract c =
+  let storageDefs' = c ^. storageDefs
+      storageDefsList = Map.toList storageDefs'
+      listOfMappings = filter (\(_, vd) -> case (_varType vd) of SVMType.Mapping _ _ _ -> True ; _ -> False;) storageDefsList
+      listOfMappingsWithRecords = filter (\(_, vd) -> _isRecord vd) listOfMappings
+   in fst <$> listOfMappingsWithRecords
+
+getAbstractParentsFromContract :: Contract -> [Contract]
+getAbstractParentsFromContract c =
+  let parents' = c ^. parents
+      parentContracts = getContractsForParents parents' (cc^.contracts)
+   in filter ((== AbstractType) . _contractType) parentContracts
+
 processTheMessages :: ( MonadLogger m
                       , HasSQL m
                       , Selectable Account AddressState m
                       , HasCodeDB m
+                      , Mod.Accessible (IORef Globals) m
                       )
-                   => BlocEnv -> PGConnection -> IORef Globals -> [VMEvent] -> m ()
-processTheMessages env conn g messages = do
+                   => BlocEnv -> PGConnection -> [VMEvent] -> m ()
+processTheMessages env conn messages = do
+  g <- Mod.access (Mod.Proxy @(IORef Globals))
 
   case length messages of
    0 -> return ()
@@ -335,8 +370,18 @@ processTheMessages env conn g messages = do
   -- forM :: [a] -> (a -> m b) -> m [b]
   -- forM :: [a] -> (a -> m (Either b c)) -> m [Either b c]
   -- m [c]
-  let hardCodeAbstracts (o,a,n) | n `elem` ["Asset", "Sale", "User"] = ("", "", n)
-                                | otherwise                          = (o, a, n)
+  
+  let resolveNameParts (o, a) c = case c ^. importedFrom of
+        Nothing -> pure (o, a, c ^. contractName)
+        Just acct -> A.select (A.Proxy @AddressState) acct >>= \case
+          Nothing -> do
+            $logWarnS "processTheMessages/resolveNameParts" . T.pack $ "Could not find address state for account " ++ show acct
+            pure (o, a, c ^. contractName)
+          Just s -> resolveCodePtr (acct ^. accountChainId) (addressStateCodeHash s) >>= \case
+            Just (SolidVMCode appName _) -> pure (o, appName, c ^. contractName) -- TODO: Get org from :creator field
+            _ -> do
+              $logWarnS "processTheMessages/resolveNameParts" . T.pack $ "Could not resolve code for account " ++ show acct
+              pure (o, a, c ^. contractName)
 
   fkeys' <- forM creates $ \(ccString, cp, o, a, hl, _) -> do
     cc' <- getCC cp ccString
@@ -357,22 +402,13 @@ processTheMessages env conn g messages = do
                 -- Here we will get the storageDefs attribute of the contract (c) and iterate through the Map of (Text, VariableDecl) and look for VariableDecls that have the last attribute (isRecord) true and thetype are mappings
                 -- We will then create a table for each of these mappings and add a foreign key to the main table
 
-                let storageDefs' = c ^. storageDefs
-                    storageDefsList = Map.toList storageDefs'
-                    listOfMappings = filter (\(_, vd) -> case (_varType vd) of SVMType.Mapping _ _ _ -> True ; _ -> False;) storageDefsList
-                    listOfMappingsWithRecords = filter (\(_, vd) -> _isRecord vd) listOfMappings
-                    mapNames = map fst listOfMappingsWithRecords
-                    parents' = c ^. parents
-                    parentContracts = getContractsForParents parents' (cc^.contracts)
-                    parentAbstractContracts = filter (\contract -> _contractType contract == AbstractType) parentContracts
-                    parentAbstractContractsName = map (labelToText ._contractName) parentAbstractContracts
-              
+                let mapNames = getMapNamesFromContract c
 
                 let historyTableNames = map (historyTableName o a') hl
                 $logInfoS "processTheMessages/historyTableNames" $ T.pack $ show historyTableNames
 
                 $logInfoS "processTheMessages" $ "New Contract Added: org=" <> o <> ", app=" <> a' <> ", name=" <> n <> " (fields: " <> T.pack (show $ Map.toList $ fmap _varType $ c ^. storageDefs) <> ")"
-                let nameParts = hardCodeAbstracts (o, a', n)
+                nameParts <- resolveNameParts (o, a') c
 
                 --Create mapping tables
                 forM_ mapNames $ \m -> do 
@@ -382,7 +418,7 @@ processTheMessages env conn g messages = do
 
                 deferredForeignKeys <- case (_contractType c ) of
                   AbstractType -> do
-                    outputData conn $ createAbstractTable g c $ hardCodeAbstracts (o, a', n)
+                    outputData conn $ createAbstractTable g c nameParts
                     return []
                   _ -> do
                     outputData conn $ createExpandIndexTable g c nameParts
@@ -391,8 +427,10 @@ processTheMessages env conn g messages = do
 
                 outputData conn $ createExpandEventTables g c nameParts
                 
-                when(length parentAbstractContractsName >=1 ) $ do outputData conn $ createAbstractTableRow g c (hardCodeAbstracts (o, a', n)) (head parentAbstractContractsName)
-
+                -- I suspect these lines aren't needed
+                -- for_ parentAbstractContracts $ \p -> do
+                --   parentNameParts <- resolveNameParts (o, a') p
+                --   outputData conn $ createAbstractTable g c parentNameParts
   
                 return deferredForeignKeys
 
@@ -430,31 +468,27 @@ processTheMessages env conn g messages = do
           $logDebugLS "Contract name is: " $ show name
           oldState <- readPreviousSolidVMState g acct
           indexContract <- rowToInsert g abiid row cont oldState
-          stateDiff <- rowToMappings row
-          mapNames <- getMappingTables g (SE.organization indexContract) (SE.application indexContract) (SE.contractName indexContract)
-          abstracts <- getAbstractTableRow g (SE.organization indexContract) (SE.application indexContract) (SE.contractName indexContract)
-          --get columns for abstract table
-          abstractColumns <- case abstracts of
-                              [] -> return Nothing
-                              (firstAbstract:_) -> do
-                                case  (SE.application indexContract) of
-                                  "" -> let (o',a',n') = hardCodeAbstracts (SE.organization indexContract, SE.contractName indexContract, firstAbstract)
-                                         in getTableColumns g $ AbstractTableName o' a' n'
-                                  _ -> let (o',a',n') = hardCodeAbstracts (SE.organization indexContract, SE.application indexContract, firstAbstract)
-                                        in getTableColumns g $ AbstractTableName o' a' n'
-          
-          $logDebugLS "Globals: Recorded Map names are: " . T.pack $ show mapNames ++ " contract: " ++ show (contractName indexContract)
           hs <- rowToHistories g abiid actions cont oldState
-          $logDebugLS "History inserts are: " $ show hs
-          pMappings <- processedContractToProcessedMappingRows stateDiff (mapNames) row abiid--get all mapping rows to insert
-          case abstracts of
-            [] -> pure . Right $ BatchedInserts indexContract Nothing hs pMappings
-            (firstAbstract:_) -> case abstractColumns of 
-              Just abC -> do
-                let finalColumns = map extractTextInsideQuotes abC
-                pure . Right $ BatchedInserts indexContract (Just (indexContract, firstAbstract, finalColumns)) hs pMappings
-              Nothing -> pure . Right $ BatchedInserts indexContract Nothing hs pMappings
-            
+          let cName = SE.contractName indexContract
+          mContract <- do
+            mCC <- select (Proxy @CodeCollection) (actionAccount row)
+            pure $ M.lookup cName . _contracts =<< mCC
+          case mContract of
+            Nothing -> pure . Right $ BatchedInserts indexContract [] hs []
+            Just c -> do
+              stateDiff <- rowToMappings row
+              let mapNames = getMapNamesFromContract c
+                  abstracts = getAbstractParentsFromContract c
+              --get columns for abstract table
+              abstractColumns <- for abstracts $ \ab -> do
+                (o',a',n') <- resolveNameParts (SE.organization indexContract, SE.application indexContract) ab
+                cols <- getTableColumns g $ AbstractTableName o' a' n'
+                pure $ extractTextInsideQuotes <$> cols
+          
+              $logDebugLS "Globals: Recorded Map names are: " . T.pack $ show mapNames ++ " contract: " ++ show (contractName indexContract)
+              $logDebugLS "History inserts are: " $ show hs
+              pMappings <- processedContractToProcessedMappingRows stateDiff (mapNames) row abiid--get all mapping rows to insert
+              pure . Right $ BatchedInserts indexContract abstractColumns hs pMappings
 
   forM_ (lefts inserts) $ $logErrorS "processTheMessages"
 

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -21,9 +21,6 @@
 module Slipstream.Processor
   ( processTheMessages
   , parseActions
-  , generateAssetTable
-  , generateSaleTable
-  , generateUserTable
   ) where
 
 import Prelude hiding (lookup)
@@ -49,6 +46,7 @@ import Data.Ord (Down(..))
 import qualified Data.Text as T
 import Data.Text (Text)
 import Data.Text.Encoding
+import Data.Traversable (for)
 import Database.PostgreSQL.Typed (PGConnection)
 
 import Bloc.Database.Queries
@@ -62,6 +60,7 @@ import qualified BlockApps.SolidVMStorageDecoder as SolidVM
 
 import Blockchain.Data.AddressStateRef
 import Blockchain.Data.AddressStateDB
+import Blockchain.Data.ChainInfo
 import Blockchain.Data.TransactionResult
 import Blockchain.Data.DataDefs
 import Blockchain.Data.Json
@@ -69,6 +68,7 @@ import Blockchain.DB.CodeDB
 import Blockchain.SolidVM.CodeCollectionDB
 import Blockchain.Strato.Model.Account
 import Blockchain.Strato.Model.ChainId
+import Blockchain.Strato.Model.ExtendedWord
 import Blockchain.Strato.Model.Keccak256
 import qualified Blockchain.Stream.Action as Action
 import Blockchain.Stream.VMEvent
@@ -86,6 +86,7 @@ import qualified Slipstream.Events as SE
 import Slipstream.Globals
 import Slipstream.Metrics
 import Slipstream.OutputData
+import Slipstream.QueryFormatHelper
 
 import SolidVM.CodeCollectionTools
 import SolidVM.Model.CodeCollection hiding (contractName)
@@ -108,20 +109,23 @@ instance MonadUnliftIO m => Selectable Account Contract (SQLM m) where
 instance (MonadUnliftIO m, Mod.Accessible (IORef Globals) m) => Selectable Account CodeCollection (SQLM m) where
   select _ a = do
     g <- lift $ Mod.access (Mod.Proxy @(IORef Globals))
-    mCC <- getCCFromGlobals g a
-    case mCC of
-      Just cc -> pure $ Just cc
-      Nothing -> runMaybeT $ do
-        (AddressStateRef' r _) <- MaybeT
-                                . fmap listToMaybe
-                                . Account.getAccount'
-                                $ Account.accountsFilterParams
-                                & Account.qaAddress ?~ (a ^. accountAddress)
-                                & Account.qaChainId .~ (fmap ChainId . maybeToList $ a ^. accountChainId)
-        codePtr <- MaybeT . pure $ addressStateRefCodePtr r
-        cc <- MaybeT $ either (const Nothing) Just <$> getCodeCollectionByCodePtr codePtr
-        for_ cc $ putCCIntoGlobals g
-        pure cc
+    mASR <- fmap listToMaybe
+          . Account.getAccount'
+          $ Account.accountsFilterParams
+          & Account.qaAddress ?~ (a ^. accountAddress)
+          & Account.qaChainId .~ (fmap ChainId . maybeToList $ a ^. accountChainId)
+    let codePtr = fromMaybe (EVMCode emptyHash) $ (\(AddressStateRef' r _) -> addressStateRefCodePtr r) =<< mASR
+    unsafeResolveCodePtr codePtr >>= \case
+      Just (SolidVMCode _ ch) -> getCCFromGlobals g ch >>= \case
+        Just cc -> pure $ Just cc
+        Nothing -> do
+          mCC <- either (const Nothing) Just <$> getCodeCollectionByCodePtr codePtr
+          for_ mCC $ putCCIntoGlobals g ch
+          pure mCC
+      _ -> pure Nothing
+
+instance Monad m => Selectable Word256 ParentChainIds (SQLM m) where
+  select _ _ = pure Nothing
 
 instance Selectable Account Contract m => Selectable Account Contract (ReaderT BlocEnv m) where
   select p = lift . select p
@@ -306,8 +310,8 @@ getCodeCollection :: ( MonadIO m
                      , HasCodeDB m
                      , Selectable Account AddressState m
                      )
-                  => CodePtr -> Text -> m (Either String CodeCollection)
-getCodeCollection cp ccString = do
+                  => IORef Globals -> CodePtr -> Text -> m (Either String CodeCollection)
+getCodeCollection g cp ccString = do
   let initList =
         case Aeson.decodeStrict $ encodeUtf8 ccString of
           Just l -> l
@@ -319,9 +323,13 @@ getCodeCollection cp ccString = do
   --bad contract into the blockchain (the API shouldn't allow this)
 
   case cp of
-    SolidVMCode _ _ -> (fmap resolveLabels <$> compileSource False (Map.fromList initList)) >>= \case
+    SolidVMCode _ ch -> getCCFromGlobals g ch >>= \case
+      Just cc -> pure $ Right cc
+      Nothing -> (fmap resolveLabels <$> compileSource False (Map.fromList initList)) >>= \case
         Left e -> return $ Left $ "failed parse: "  ++ show e --- return $ CodeCollection Map.empty
-        Right v -> return $ Right v
+        Right v -> do
+          putCCIntoGlobals g ch v
+          return $ Right v
     EVMCode _ -> return $ Left "EVM contracts are not indexed by Slipstream"
     CodeAtAccount _ _ -> return $ Left "Cannot compile or parse code at account"
 
@@ -330,23 +338,25 @@ getContractsForParents parents' cc =
   let getContractForParent parent = Map.lookup parent cc
   in mapMaybe getContractForParent parents'
 
-getMapNamesFromContract :: Contract -> [String]
+getMapNamesFromContract :: Contract -> [Text]
 getMapNamesFromContract c =
   let storageDefs' = c ^. storageDefs
       storageDefsList = Map.toList storageDefs'
       listOfMappings = filter (\(_, vd) -> case (_varType vd) of SVMType.Mapping _ _ _ -> True ; _ -> False;) storageDefsList
       listOfMappingsWithRecords = filter (\(_, vd) -> _isRecord vd) listOfMappings
-   in fst <$> listOfMappingsWithRecords
+   in T.pack . fst <$> listOfMappingsWithRecords
 
-getAbstractParentsFromContract :: Contract -> [Contract]
-getAbstractParentsFromContract c =
+getAbstractParentsFromContract :: Contract -> CodeCollection -> [Contract]
+getAbstractParentsFromContract c cc =
   let parents' = c ^. parents
-      parentContracts = getContractsForParents parents' (cc^.contracts)
+      parentContracts = getContractsForParents parents' (cc ^. contracts)
    in filter ((== AbstractType) . _contractType) parentContracts
 
 processTheMessages :: ( MonadLogger m
                       , HasSQL m
                       , Selectable Account AddressState m
+                      , Selectable Account CodeCollection m
+                      , Selectable Word256 ParentChainIds m
                       , HasCodeDB m
                       , Mod.Accessible (IORef Globals) m
                       )
@@ -371,20 +381,21 @@ processTheMessages env conn messages = do
   -- forM :: [a] -> (a -> m (Either b c)) -> m [Either b c]
   -- m [c]
   
-  let resolveNameParts (o, a) c = case c ^. importedFrom of
-        Nothing -> pure (o, a, c ^. contractName)
-        Just acct -> A.select (A.Proxy @AddressState) acct >>= \case
+  let tName = T.pack . _contractName
+      resolveNameParts (o, a) c = case c ^. importedFrom of
+        Nothing -> pure (o, a, tName c)
+        Just acct -> select (Proxy @AddressState) acct >>= \case
           Nothing -> do
             $logWarnS "processTheMessages/resolveNameParts" . T.pack $ "Could not find address state for account " ++ show acct
-            pure (o, a, c ^. contractName)
+            pure (o, a, tName c)
           Just s -> resolveCodePtr (acct ^. accountChainId) (addressStateCodeHash s) >>= \case
-            Just (SolidVMCode appName _) -> pure (o, appName, c ^. contractName) -- TODO: Get org from :creator field
+            Just (SolidVMCode appName _) -> pure (o, T.pack appName, tName c) -- TODO: Get org from :creator field
             _ -> do
               $logWarnS "processTheMessages/resolveNameParts" . T.pack $ "Could not resolve code for account " ++ show acct
-              pure (o, a, c ^. contractName)
+              pure (o, a, tName c)
 
   fkeys' <- forM creates $ \(ccString, cp, o, a, hl, _) -> do
-    cc' <- getCC cp ccString
+    cc' <- getCC g cp ccString
     case cc' of
       Right cc -> do
               $logInfoS "processTheMessages" $ "CodeCollection Added: " <> T.pack (format cp) <> ", contracts = " <> T.pack (show $ Map.keys $ cc^.contracts)
@@ -412,7 +423,7 @@ processTheMessages env conn messages = do
 
                 --Create mapping tables
                 forM_ mapNames $ \m -> do 
-                  outputData conn $ createMappingTable g nameParts (T.pack m) --Tables are created
+                  outputData conn $ createMappingTable g nameParts m --Tables are created
 
 -- mark        
 
@@ -426,11 +437,6 @@ processTheMessages env conn messages = do
                 outputData' conn $ createExpandHistoryTable g c nameParts
 
                 outputData conn $ createExpandEventTables g c nameParts
-                
-                -- I suspect these lines aren't needed
-                -- for_ parentAbstractContracts $ \p -> do
-                --   parentNameParts <- resolveNameParts (o, a') p
-                --   outputData conn $ createAbstractTable g c parentNameParts
   
                 return deferredForeignKeys
 
@@ -469,21 +475,24 @@ processTheMessages env conn messages = do
           oldState <- readPreviousSolidVMState g acct
           indexContract <- rowToInsert g abiid row cont oldState
           hs <- rowToHistories g abiid actions cont oldState
-          let cName = SE.contractName indexContract
-          mContract <- do
-            mCC <- select (Proxy @CodeCollection) (actionAccount row)
-            pure $ M.lookup cName . _contracts =<< mCC
-          case mContract of
+          let cName = T.unpack $ SE.contractName indexContract
+          mCC <- lift $ select (Proxy @CodeCollection) (actionAccount row)
+          case (,) <$> mCC <*> (Map.lookup cName . _contracts =<< mCC) of
             Nothing -> pure . Right $ BatchedInserts indexContract [] hs []
-            Just c -> do
+            Just (cc, c) -> do
               stateDiff <- rowToMappings row
               let mapNames = getMapNamesFromContract c
-                  abstracts = getAbstractParentsFromContract c
+                  abstracts = getAbstractParentsFromContract c cc
+                  appName = if T.null $ SE.application indexContract
+                              then SE.contractName indexContract
+                              else SE.application indexContract
               --get columns for abstract table
-              abstractColumns <- for abstracts $ \ab -> do
-                (o',a',n') <- resolveNameParts (SE.organization indexContract, SE.application indexContract) ab
-                cols <- getTableColumns g $ AbstractTableName o' a' n'
-                pure $ extractTextInsideQuotes <$> cols
+              abstractColumns <- fmap catMaybes . for abstracts $ \ab -> do
+                (o',a',n') <- lift $ resolveNameParts (SE.organization indexContract, appName) ab
+                let tableName = AbstractTableName o' a' n'
+                    tableNameText = tableNameToDoubleQuoteText tableName
+                mCols <- getTableColumns g tableName
+                pure $ (indexContract, tableNameText,) . map extractTextInsideQuotes <$> mCols
           
               $logDebugLS "Globals: Recorded Map names are: " . T.pack $ show mapNames ++ " contract: " ++ show (contractName indexContract)
               $logDebugLS "History inserts are: " $ show hs
@@ -503,7 +512,7 @@ processTheMessages env conn messages = do
     unless (null ins) $ outputData conn . insertIndexTable $ map indexInsert ins
     outputData conn . insertHistoryTable $ concatMap historyInserts ins
     unless ((length (concatMap mappingInserts ins) < 1) ) $ outputData conn . insertMappingTable $ concatMap mappingInserts ins
-    unless (null ins) $ outputData conn . insertAbstractTable $ map abstractInsert ins
+    unless (null ins) $ outputData conn . insertAbstractTable $ concatMap abstractInsert ins
 
   forM_ insertsByCodeHash $ \ins -> do
     unless (null ins) $ insertForeignKeys conn $ map indexInsert ins
@@ -520,21 +529,6 @@ processTheMessages env conn messages = do
   forM_ transactionResults $ putTransactionResult
 
   flushPendingWrites g
-
-generateAssetTable :: (MonadLogger m, HasSQL m) =>
-                      PGConnection -> IORef Globals -> m ()
-generateAssetTable conn g = do
-  outputData conn $ createAssetTable g
-
-generateSaleTable :: (MonadLogger m, HasSQL m) =>
-                      PGConnection -> IORef Globals -> m ()
-generateSaleTable conn g = do
-  outputData conn $ createSaleTable g
-
-generateUserTable :: (MonadLogger m, HasSQL m) =>
-                      PGConnection -> IORef Globals -> m ()
-generateUserTable conn g = do
-  outputData conn $ createUserTable g
 
 extractTextInsideQuotes :: T.Text -> T.Text
 extractTextInsideQuotes input =

--- a/strato/indexer/slipstream/src/Slipstream/QueryFormatHelper.hs
+++ b/strato/indexer/slipstream/src/Slipstream/QueryFormatHelper.hs
@@ -66,7 +66,7 @@ tableNameToText (MappingTableName o a c m ) =
         | T.null a = o <> tableSeparator
         | otherwise = o <> tableSeparator <> a <> tableSeparator
       contractAndMapping = c <> "." <> m
-  in "mapping@" <> prefix <> contractAndMapping
+  in prefix <> contractAndMapping
 tableNameToText (HistoryTableName o a c) =
   let prefix
         | T.null o = ""
@@ -85,15 +85,7 @@ tableNameToText (AbstractTableName o a c) =
         | T.null o = ""
         | T.null a = o <> tableSeparator
         | otherwise = o <> tableSeparator <> a <> tableSeparator
-  in "abstract@" <> prefix <> c
-tableNameToText (AbstractTableRowName o a c ab) =
-  let prefix
-        | T.null o = ""
-        | T.null a = o <> tableSeparator
-        | otherwise = o <> tableSeparator <> a <> tableSeparator
-      contractAndAbstract =  c <> "." <> ab
-  in "abstract@" <> prefix <> contractAndAbstract
-
+  in prefix <> c
 
 tableNameToTextPostgres :: TableName -> T.Text
 tableNameToTextPostgres = T.take 63 . tableNameToText -- max table name len in psql is 63 char

--- a/strato/indexer/slipstream/tests/OutputDataSpec.hs
+++ b/strato/indexer/slipstream/tests/OutputDataSpec.hs
@@ -617,6 +617,7 @@ createDummyContract v =
       _constructor=undefined,
       _modifiers=undefined,
       _usings=undefined,
-      _contractContext=undefined,
-      _contractType=undefined
+      _contractType=undefined,
+      _importedFrom=undefined,
+      _contractContext=undefined
     }


### PR DESCRIPTION
This PR changes the behavior of indexing abstract contract tables in Cirrus to do the following:
- Preserve the org and app name of the abstract contract by resolving the abstract contract's original code collection
- Allow multiple abstract contract tables to be populated per contract update
Additionally, some housekeeping items:
- I messed up and tried to use address imports before they were deployed to the testnet2 validators. This means I broke backwards compatibility and had to figure out a way to fix it. The result is I added the `es6` pragma to SolidVM to signal support for braced and address imports.
- Mapping tables no longer have the `mapping@` prefix, to match with the event table naming convention.
- Abstract tables no longer have the `abstract@` prefix, to match with the index table naming convention.
- The `contractname` column in mapping and abstract tables is now `contract_name`, to match with the snake case convention used in other base columns.
- I added a new Keccak256 -> CodeCollection map in the Slipstream Globals, which resulted in great performance improvements for both CodeCollectionAdded and Action event processing.