### PR TITLE
Fix for function matching and abstract away UserRegistry source

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -821,13 +821,13 @@ argsToValsModifiers ctract md args =
 argsToVals :: MonadSM m => CC.Contract -> CC.Func -> CC.ArgList -> m ValList
 argsToVals ctract fn args = case args of
   CC.OrderedArgs xs -> do
-    when (length xs /= length orderedTypes && not (validVariadicSignature orderedTypes)) $
-      invalidArguments "arity mismatch" (xs, orderedTypes)
     valList <- zipWithM eval32 orderedTypes xs
     let maybeVariadic = Data.List.uncons valList
         unpackedList = case maybeVariadic of
           Just (SVariadic x, _) -> init valList ++ x
           _ -> valList
+    when (length unpackedList /= length orderedTypes && not (validVariadicSignature orderedTypes)) $
+      invalidArguments "arity mismatch" (unpackedList, orderedTypes)
     pure $ OrderedVals unpackedList
 
   CC.NamedArgs xs -> NamedVals . M.toList <$> do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -565,6 +565,8 @@ call' from to' fnCalltype mContract functionName isRCC argExps  = do
                               (SInteger _, SVMType.Int _ _) -> True
                               (SString _, SVMType.String _) -> True
                               (SString _, SVMType.Bytes _ _) -> True
+                              (SString _, SVMType.Address _) -> True
+                              (SString _, SVMType.Account _) -> True
                               (SBool _, SVMType.Bool) -> True
                               (SAccount _ _, SVMType.Address _) -> True
                               (SAccount _ _, SVMType.Account _) -> True
@@ -2067,6 +2069,8 @@ expToVar' theFullExp@(CC.FunctionCall _ e args) = do
                       (SInteger _, SVMType.Int _ _) -> pure True
                       (SString _, SVMType.String _) -> pure True
                       (SString _, SVMType.Bytes _ _) -> pure True
+                      (SString _, SVMType.Address _) -> pure True
+                      (SString _, SVMType.Account _) -> pure True
                       (SBool _, SVMType.Bool) -> pure True
                       (SAccount _ _, SVMType.Address _) -> pure True
                       (SAccount _ _, SVMType.Account _) -> pure True

--- a/strato/core/strato-genesis/src/Blockchain/Generation.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Generation.hs
@@ -951,14 +951,6 @@ insertUserRegistryContract certs gi =
                         (BC.pack $ ".userCertificates<a:" ++ (show $ certUserAddress cert) ++ ">", addrToCertIdx . show . reverseAddr $ cert)]
             ) certs
 
-        -- testAcct = SolidVMContractWithStorage (deriveAddressWithSalt Nothing "Jin Huai Xuan" Nothing Nothing) 0
-        --     (SolidVMCode "User" (KECCAK256.hash encodedRegistry)) [
-        --         (".owner", rlpWrap $ BAccount (NamedAccount ((fromJust . stringAddress) "720") UnspecifiedChain)),
-        --         (".commonName", rlpWrap $ BString $ BC.pack $ "Jin Huai Xuan"),
-        --         (".isActive", rlpWrap $ BBool True),
-        --         (BC.pack $ ".userCertificates<a:a13bf5afbd9e23e92568b546880b55d8ee0d54a5>", addrToCertIdx "a5540deed8550b8846b56825e9239ebdaff53ba1")
-        --     ]
-
         registryAcct = SolidVMContractWithStorage 0x720 720
             (SolidVMCode "UserRegistry" (KECCAK256.hash encodedRegistry)) $
             [(".owner", rootAddress)]

--- a/strato/core/strato-genesis/src/Blockchain/Generation.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Generation.hs
@@ -909,22 +909,20 @@ contract User {
         variadic result = address(contractToCall).call(functionName, args);
         return result;
     }
-} 
-|]
+}|]
 
 -- | Inserts a User Registry contract into the genesis block with the BlockApps root cert as owner
 insertUserRegistryContract :: [X509Certificate] -> GenesisInfo -> GenesisInfo
 insertUserRegistryContract certs gi =
     gi {genesisInfoAccountInfo = initialAccounts ++ [registryAcct, rootAcct] ++ userAccts,
-        genesisInfoCodeInfo    = initialCode ++ [CodeInfo encodedRegistry contractSrc (Just "UserRegistry")]}
+        genesisInfoCodeInfo    = initialCode ++ [CodeInfo encodedRegistry userRegistryContract (Just "UserRegistry")]}
     where 
         addrToCertIdx ad = rlpWrap $ BAccount (NamedAccount (fromJust . stringAddress $ ad) MainChain)
         initialAccounts = genesisInfoAccountInfo gi
         initialCode     = genesisInfoCodeInfo gi
 
         rlpWrap         = rlpSerialize . rlpEncode
-        contractSrc     = certificateRegistryContract <> "\n\n" <> userRegistryContract
-        encodedRegistry = encodeUtf8 contractSrc
+        encodedRegistry = encodeUtf8 userRegistryContract
 
         rootAddress'    = fromPublicKey rootPubKey
         rootAddress     = rlpWrap $ BAccount (NamedAccount rootAddress' UnspecifiedChain)

--- a/strato/core/strato-genesis/src/Blockchain/Generation.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Generation.hs
@@ -50,6 +50,7 @@ import           Blockchain.Strato.Model.CodePtr
 import qualified Blockchain.Strato.Model.Keccak256              as KECCAK256
 import           Blockchain.Strato.Model.ExtendedWord
 import           Blockchain.Strato.Model.Account
+import           Blockchain.Strato.Model.UserRegistry
 import           Blockchain.Data.GenesisInfo
 import           Blockchain.Data.RLP
 import           Blockchain.Data.ChainInfo
@@ -828,86 +829,6 @@ contract MercataGovernance {
             adminMap[_org][_orgUnit][_commonName] = MercataAdmin(address(0));
             adminCount--;
         }
-    }
-}|]
-
-userRegistryContract :: Text
-userRegistryContract = [r|
-contract UserRegistry {
-    // The UserRegistry is responsible for creating User contracts for each user.
-    address public owner;
-
-    constructor() {
-        owner = msg.sender;
-    }
-
-    function createUser(string _commonName, string _userAddress, address _certificateAddress) public returns (address) { 
-        require((msg.sender == owner), "You don't have permission to use this function!");
-
-        User newUser = new User{salt: _commonName}();
-        newUser.initializeUser(_commonName, address(_userAddress), _certificateAddress);
-        return address(newUser);
-    }
-
-    function addCertificateToUser(address _userContractAddress, address _certificateAddress) public {
-        require((msg.sender == owner), "You don't have permission to use this function!");
-
-        User targetUser = User(_userContractAddress);
-        targetUser.addCertificate(_userContractAddress, _certificateAddress);
-    }
-
-    function toggleUserActiveStatus(address _userContractAddress) public {
-        require((msg.sender == owner), "You don't have permission to use this function!");
-
-        User targetUser = User(_userContractAddress);
-        targetUser.toggleUserActiveStatus();
-    }
-}
-
-contract User {
-    address public owner;
-
-    mapping(address => address) userCertificates;     // Data structure subject to change
-    string public commonName;
-    bool isActive;
-
-    constructor() {
-        owner = msg.sender;
-    }
-
-    function initializeUser(string _commonName, address _userAddress, address _certificateAddress) {
-        // Only UserRegistry can add new certificates.
-        require((msg.sender == owner), "You don't have permission to use this function!");
-
-        commonName = _commonName;
-        userCertificates[_userAddress] = _certificateAddress;
-        isActive = true;
-    }
-
-    function addCertificate(address _userAddress, address _certificateAddress) public {
-        // Only UserRegistry can add new certificates.
-        require((msg.sender == owner), "You don't have permission to use this function!");
-        
-        userCertificates[_userAddress] = _certificateAddress;
-    }
-
-    function toggleUserActiveStatus() public {
-        require((msg.sender == owner), "You don't have permission to use this function!");
-
-        isActive = !isActive;
-    }
-
-    // Checks if the caller is indeed the user the wallet belongs to.
-    function authenticate() public returns (bool) {
-        return userCertificates[msg.sender] != address(0);
-    }
-
-    function callContract(address contractToCall, string functionName, variadic args) public returns (variadic) {
-        // Only the user that this contract is associated with, can use this function.
-        require((authenticate() && isActive), "You don't have permission to use this function!");
-
-        variadic result = address(contractToCall).call(functionName, args);
-        return result;
     }
 }|]
 

--- a/strato/core/strato-model/package.yaml
+++ b/strato/core/strato-model/package.yaml
@@ -57,6 +57,7 @@ library:
     - path-pieces
     - persistent
     - primitive
+    - raw-strings-qq
     - relapse           # remove this
     - secp256k1-haskell
     - servant

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -256,7 +256,7 @@ deriveAddressWithSalt sender salt src args = do
       theHash = SHA.hash $ rlpSerialize $ RLPArray [ rlpEncode (0xFF :: Integer)
                                                    , rlpEncode theAddress
                                                    , rlpEncode salt
-                                                   , rlpEncode $ maybe ("Y\207#0 \253\186Gp\221\191\145\183\203D\183q\STX\a\158~\174\226t\178d\233\DLEC6\STXt" :: BC.ByteString) (SHA.keccak256ToByteString . SHA.hash) src 
+                                                   , rlpEncode $ maybe ("\130\234\RS\133\184\&4\198O\151\232\&1\RS\213\132\196\&8\n'\161\177\&5\247\200\157\&8\135\139\SYN\GS<\148\GS" :: BC.ByteString) (SHA.keccak256ToByteString . SHA.hash) src 
                                                    , rlpEncode $ fromMaybe "OrderedVals []" args
                                                    ]
   -- trace ((show theAddress) ++ " " ++ salt ++ " " ++ (show $ keccak256ToByteString $ hash src) ++ " " ++ args)

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -258,7 +258,7 @@ deriveAddressWithSalt sender salt src args = do
       theHash = SHA.hash $ rlpSerialize $ RLPArray [ rlpEncode (0xFF :: Integer)
                                                    , rlpEncode theAddress
                                                    , rlpEncode salt
-                                                   , rlpEncode $ maybe (encodeUtf8 userRegistryContract) (SHA.keccak256ToByteString . SHA.hash) src 
+                                                   , rlpEncode $ SHA.keccak256ToByteString $ maybe (SHA.hash $ encodeUtf8 userRegistryContract) (SHA.hash) src 
                                                    , rlpEncode $ fromMaybe "OrderedVals []" args
                                                    ]
   -- trace ((show theAddress) ++ " " ++ salt ++ " " ++ (show $ keccak256ToByteString $ hash src) ++ " " ++ args)

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -41,6 +41,7 @@ import           Data.Maybe                           (fromJust, fromMaybe)
 import           Data.Swagger                         hiding (Format, format, get, put)
 import qualified Data.Swagger                         as Sw
 import qualified Data.Text                            as T
+import           Data.Text.Encoding                   (encodeUtf8)
 import           Database.Persist.Sql                 hiding (get)
 import           GHC.Generics
 import           Numeric
@@ -60,6 +61,7 @@ import           Blockchain.Strato.Model.ExtendedWord (Word160, word160ToBytes)
 import qualified Blockchain.Strato.Model.Keccak256    as SHA (hash, keccak256ToWord256, keccak256ToByteString)
 import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Strato.Model.Util
+import           Blockchain.Strato.Model.UserRegistry
 import qualified Data.NibbleString                    as N
 import qualified Data.RLP                             as RLP2
 import qualified LabeledError
@@ -256,7 +258,7 @@ deriveAddressWithSalt sender salt src args = do
       theHash = SHA.hash $ rlpSerialize $ RLPArray [ rlpEncode (0xFF :: Integer)
                                                    , rlpEncode theAddress
                                                    , rlpEncode salt
-                                                   , rlpEncode $ maybe ("\130\234\RS\133\184\&4\198O\151\232\&1\RS\213\132\196\&8\n'\161\177\&5\247\200\157\&8\135\139\SYN\GS<\148\GS" :: BC.ByteString) (SHA.keccak256ToByteString . SHA.hash) src 
+                                                   , rlpEncode $ maybe (encodeUtf8 userRegistryContract) (SHA.keccak256ToByteString . SHA.hash) src 
                                                    , rlpEncode $ fromMaybe "OrderedVals []" args
                                                    ]
   -- trace ((show theAddress) ++ " " ++ salt ++ " " ++ (show $ keccak256ToByteString $ hash src) ++ " " ++ args)

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -256,7 +256,7 @@ deriveAddressWithSalt sender salt src args = do
       theHash = SHA.hash $ rlpSerialize $ RLPArray [ rlpEncode (0xFF :: Integer)
                                                    , rlpEncode theAddress
                                                    , rlpEncode salt
-                                                   , rlpEncode $ maybe ("2_\156\246X\192\246\237<\n\142FF\244\SI\132\&6Q^=\DC1z#\159O?n\DEL\"\nF*" :: BC.ByteString) (SHA.keccak256ToByteString . SHA.hash) src 
+                                                   , rlpEncode $ maybe ("Y\207#0 \253\186Gp\221\191\145\183\203D\183q\STX\a\158~\174\226t\178d\233\DLEC6\STXt" :: BC.ByteString) (SHA.keccak256ToByteString . SHA.hash) src 
                                                    , rlpEncode $ fromMaybe "OrderedVals []" args
                                                    ]
   -- trace ((show theAddress) ++ " " ++ salt ++ " " ++ (show $ keccak256ToByteString $ hash src) ++ " " ++ args)

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/UserRegistry.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/UserRegistry.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module Blockchain.Strato.Model.UserRegistry 
+    (userRegistryContract) where
+
+import                      Data.Text
+import                      Text.RawString.QQ
+
+userRegistryContract :: Text
+userRegistryContract = [r|
+contract UserRegistry {
+    // The UserRegistry is responsible for creating User contracts for each user.
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function createUser(string _commonName, string _userAddress, address _certificateAddress) public returns (address) { 
+        require((msg.sender == owner), "You don't have permission to use this function!");
+
+        User newUser = new User{salt: _commonName}();
+        newUser.initializeUser(_commonName, address(_userAddress), _certificateAddress);
+        return address(newUser);
+    }
+
+    function addCertificateToUser(address _userContractAddress, address _certificateAddress) public {
+        require((msg.sender == owner), "You don't have permission to use this function!");
+
+        User targetUser = User(_userContractAddress);
+        targetUser.addCertificate(_userContractAddress, _certificateAddress);
+    }
+
+    function toggleUserActiveStatus(address _userContractAddress) public {
+        require((msg.sender == owner), "You don't have permission to use this function!");
+
+        User targetUser = User(_userContractAddress);
+        targetUser.toggleUserActiveStatus();
+    }
+}
+
+contract User {
+    address public owner;
+
+    mapping(address => address) userCertificates;     // Data structure subject to change
+    string public commonName;
+    bool isActive;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function initializeUser(string _commonName, address _userAddress, address _certificateAddress) {
+        // Only UserRegistry can add new certificates.
+        require((msg.sender == owner), "You don't have permission to use this function!");
+
+        commonName = _commonName;
+        userCertificates[_userAddress] = _certificateAddress;
+        isActive = true;
+    }
+
+    function addCertificate(address _userAddress, address _certificateAddress) public {
+        // Only UserRegistry can add new certificates.
+        require((msg.sender == owner), "You don't have permission to use this function!");
+        
+        userCertificates[_userAddress] = _certificateAddress;
+    }
+
+    function toggleUserActiveStatus() public {
+        require((msg.sender == owner), "You don't have permission to use this function!");
+
+        isActive = !isActive;
+    }
+
+    // Checks if the caller is indeed the user the wallet belongs to.
+    function authenticate() public returns (bool) {
+        return userCertificates[msg.sender] != address(0);
+    }
+
+    function callContract(address contractToCall, string functionName, variadic args) public returns (variadic) {
+        // Only the user that this contract is associated with, can use this function.
+        require((authenticate() && isActive), "You don't have permission to use this function!");
+
+        variadic result = address(contractToCall).call(functionName, args);
+        return result;
+    }
+}|]


### PR DESCRIPTION
This PR will fix the pattern matching when calling functions with address parameters using the `.call` functionality. This PR also abstracts away the UserRegistry contract source so we don't have to change the code hash of the `deriveAddressWithSalt` every time. (Also removed some whitespaces because of quasiquoter interaction.)