### PR TITLE
P2P handle large msgs

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -324,10 +324,15 @@ maxMessageSize :: Int
 maxMessageSize = 1 `shiftL` 25
 
 messageToBytes :: Monad m => ConduitM Message B.ByteString m ()
-messageToBytes = mapC $ \msg ->
-  let (theWord, o) = wireMessage2Obj msg
-      bs = theWord `B.cons` rlpSerialize o
-  in if B.length bs >= maxMessageSize
-        then error $ printf "messageToBytes: message (%s...) too large for TCP send (%d >= %d)"
-                            (take 50 $ show msg) (B.length bs) maxMessageSize
-        else bs
+messageToBytes = mapC serializeWithRespectToMaxMessageSize
+  where 
+    serializeWithRespectToMaxMessageSize :: Message -> B.ByteString
+    serializeWithRespectToMaxMessageSize msg = 
+      let (theWord, o) = wireMessage2Obj msg 
+          bs = theWord `B.cons` rlpSerialize o 
+      in  if B.length bs >= maxMessageSize
+          then case msg of
+            BlockBodies arr -> serializeWithRespectToMaxMessageSize (BlockBodies $ take (length arr `div` 2) arr)
+            _ -> error $ printf "messageToBytes: message (%s...) too large for TCP send (%d >= %d)"
+              (take 50 $ show msg) (B.length bs) maxMessageSize
+          else bs

--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -321,7 +321,7 @@ bytesToMessages = forever $ do
     yield $ obj2WireMessage word $ rlpDeserialize objBytes
 
 maxMessageSize :: Int
-maxMessageSize = 1 `shiftL` 25
+maxMessageSize = 1 `shiftL` 24
 
 messageToBytes :: Monad m => ConduitM Message B.ByteString m ()
 messageToBytes = mapC serializeWithRespectToMaxMessageSize

--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -332,7 +332,17 @@ messageToBytes = mapC serializeWithRespectToMaxMessageSize
           bs = theWord `B.cons` rlpSerialize o 
       in  if B.length bs >= maxMessageSize
           then case msg of
-            BlockBodies arr -> serializeWithRespectToMaxMessageSize (BlockBodies $ take (length arr `div` 2) arr)
-            _ -> error $ printf "messageToBytes: message (%s...) too large for TCP send (%d >= %d)"
+            NewBlockHashes arr  -> serializeWithRespectToMaxMessageSize . NewBlockHashes  $ firstHalf arr
+            Transactions arr    -> serializeWithRespectToMaxMessageSize . Transactions    $ firstHalf arr
+            BlockHeaders arr    -> serializeWithRespectToMaxMessageSize . BlockHeaders    $ firstHalf arr
+            GetBlockBodies arr  -> serializeWithRespectToMaxMessageSize . GetBlockBodies  $ firstHalf arr
+            BlockBodies arr     -> serializeWithRespectToMaxMessageSize . BlockBodies     $ firstHalf arr
+            GetChainDetails arr -> serializeWithRespectToMaxMessageSize . GetChainDetails $ firstHalf arr 
+            ChainDetails arr    -> serializeWithRespectToMaxMessageSize . ChainDetails    $ firstHalf arr 
+            GetTransactions arr -> serializeWithRespectToMaxMessageSize . GetTransactions $ firstHalf arr
+            _ -> error $ printf "messageToBytes: message (%s...) too large to be sent via RLPx and can't be truncated (%d >= %d)"
               (take 50 $ show msg) (B.length bs) maxMessageSize
           else bs
+    
+    firstHalf :: [a] -> [a]
+    firstHalf arr = take (length arr `div` 2) arr

--- a/strato/core/strato-p2p/src/Blockchain/Options.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Options.hs
@@ -16,7 +16,7 @@ defineFlag "syncBacktrackNumber" (10::Integer) "block number to go back when syn
 defineFlag "debugFail" True "Fail on errors we're not supposed to reach. If false, just log insteand and go on"
 defineFlag "maxConn" (20::Int) "Maximum number of client connections."
 defineFlag "connectionTimeout" (30 :: Int) "Number of seconds to tolerate a useless peer"
-defineFlag "maxReturnedHeaders" (200 :: Int) "Number of headers to return from a GetBlockHeaders request" -- todo: seriously???
+defineFlag "maxReturnedHeaders" (500 :: Int) "Number of headers to return from a GetBlockHeaders request"
 defineFlag "maxHeadersTxsLens" (2500 :: Int) "Number of txs size to return from a BlockHeader request"
 defineFlag "averageTxsPerBlock" (40 :: Int) "Average number of txs per block"
 defineFlag "wireMessageCacheSize" (2000 :: Int) "Number of wire messages to cache for network performance"

--- a/strato/doit.sh
+++ b/strato/doit.sh
@@ -117,7 +117,7 @@ function newnode {
   echo "Starting ethereum-discover"
   runBackgroundProcess ethereum-discover  &>> logs/ethereum-discover
 
-  actualTimeout="${connectionTimeout:-300}"
+  actualTimeout="${connectionTimeout:-30}"
   if [ -n "${blockstanbulRoundPeriodS}" ]; then
     withCushion=$(( 2 * blockstanbulRoundPeriodS ))
     actualTimeout=$(( actualTimeout > withCushion ? actualTimeout : withCushion ))
@@ -138,6 +138,9 @@ function newnode {
   if [ -n "${network}" ]; then
     networkFlag="--network=${network}"
   fi
+  if [ -n "${maxReturnedHeaders}" ]; then
+    maxHeadersFlag="--maxReturnedHeaders=${maxReturnedHeaders}"
+  fi
 
   echo "Starting strato-p2p"
   runBackgroundProcess strato-p2p \
@@ -145,8 +148,8 @@ function newnode {
      --sqlPeers=true \
      --debugFail=${debugFail:-true}  \
      --maxConn=$maxConn \
-     --maxReturnedHeaders=$maxReturnedHeaders \
      --networkID=$networkID \
+     ${maxHeadersFlag} \
      ${txgFlag} \
      ${atbFlag} \
      ${pcamFlag} \
@@ -423,7 +426,6 @@ fi
 setEnv requireCerts true
 setEnv genesisBlock ""
 setEnv bootnode ""
-setEnv maxReturnedHeaders 500
 
 setEnv mineBlocks true
 setEnv verifyBlocks false


### PR DESCRIPTION
Recall there have been several instances in the past where we had to manually decrease the value of `maxReturnedHeaders` in the start script in order to sync all the way. This was the symptom of a bug in the logic for sending out p2p messages. The max message size for an RLPx message is 2^24 bytes, but if a p2p server tried to send out a message larger than that, the RLPx header would be malformed, which would fatally but silently terminate the connection only on the server side. This left the server unable to send out the data and the client waiting indefinitely to receive said data.

To fix this issue, this PR sets the proper limit for an RLPx message and introduces logic for the server to truncate the message if it exceeds that limit. As a result, sync can always continue, even if the `maxReturnedHeaders` is too high (there is no need to ever go in and manually decrease it).

When I tested sync with a server and client who both had `maxReturnedHeaders=500`, the sync would stall indefinitely without the changes (even after several restarts). After the changes, sync completes in ~2 minutes (keep in mind timings will vary subject to network conditions, vm processing speed, and chain length). 
![complete_sync_within_2min](https://github.com/blockapps/strato-platform/assets/31707474/19cc6414-7ec7-4964-8aa2-a485af0a078f)
![complete_sync_inabout_2min](https://github.com/blockapps/strato-platform/assets/31707474/198b0db5-3e4f-47d0-8508-0a67ef6126f1)

