### PR TITLE
More Asset Model Fixes

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -201,6 +201,10 @@ services:
     - svmDev=${svmDev}
     - txSizeLimit=${txSizeLimit}
     - useSyncMode=${useSyncMode}
+    - userRegistryAddress=${userRegistryAddress}
+    - userRegistryCodeHash=${userRegistryCodeHash}
+    - useBuiltinUserRegistry=${useBuiltinUserRegistry}
+    - useWalletsByDefault=${useWalletsByDefault}
     - VAULT_URL=${VAULT_URL}
     - VAULT_PROXY_DEBUG=${VAULT_PROXY_DEBUG}
     - vmDebug=${vmDebug}

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -385,4 +385,5 @@ showSM (SContractFunction maybeContractName address functionName ) = do
       contract <- getCurrentContract
       return $ CC._contractName contract
   return $ "Contract function: " ++ labelToString contractName ++ "/" ++ format address ++ "." ++ labelToString functionName
+showSM (SVariadic xs) = ('[':) . (++"]") . intercalate ", " <$> traverse showSM xs
 showSM x = todo "showSM called for unsupported value: " x

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -5732,8 +5732,8 @@ contract qq {
 }|]
     runBS src
     getFields ["x", "y"] `shouldReturn` 
-      [ bContract "X" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just $ BC.pack src) Nothing
-      , bContract "Y" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "something" (Just $ BC.pack src) Nothing
+      [ bContract "X" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just . hash $ BC.pack src) Nothing
+      , bContract "Y" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "something" (Just . hash $ BC.pack src) Nothing
       ]
 
   it "can deterministically create multiple salted contract with args" . runTest $ do
@@ -5767,8 +5767,8 @@ contract qq {
 }|]
     runBS src
     getFields ["x", "y"] `shouldReturn` 
-      [ bContract "X" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just $ BC.pack src) (Just "OrderedVals [SString \"xNum\"]")
-      , bContract "Y" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just $ BC.pack src) (Just "OrderedVals [SInteger 100]")
+      [ bContract "X" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just . hash $ BC.pack src) (Just "OrderedVals [SString \"xNum\"]")
+      , bContract "Y" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just . hash $ BC.pack src) (Just "OrderedVals [SInteger 100]")
       ]
     [BContract "X" x] <- getFields ["x"]
     [BContract "Y" y] <- getFields ["y"]
@@ -5794,7 +5794,7 @@ contract qq {
   }
 }|]
     runBS src
-    getFields ["x"] `shouldReturn` [bContract "User" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "Dustin Norwood" (Just $ BC.pack src) (Just "OrderedVals [SString \"Dustin Norwood\",SString \"Thebestcertyoucangetfor$99.99\"]")]
+    getFields ["x"] `shouldReturn` [bContract "User" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "Dustin Norwood" (Just . hash $ BC.pack src) (Just "OrderedVals [SString \"Dustin Norwood\",SString \"Thebestcertyoucangetfor$99.99\"]")]
     [BContract "User" x] <- getFields["x"]
     getSolidStorageKeyVal' (namedAccountToAccount Nothing x) (singleton "commonName") `shouldReturn` BString "Dustin Norwood"
     getSolidStorageKeyVal' (namedAccountToAccount Nothing x) (singleton "cert") `shouldReturn` BString "Thebestcertyoucangetfor$99.99"

--- a/strato/api/bloc/bloc2/src/Bloc/Monad.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Monad.hs
@@ -41,6 +41,7 @@ import           BlockApps.Logging
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
 import           Blockchain.Strato.Model.ChainId
+import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.Strato.Model.Nonce
 
 import           Control.Monad.Change.Modify        hiding (modify)
@@ -64,6 +65,7 @@ data BlocEnv = BlocEnv
   , globalNonceCounter  :: Cache Account Nonce
   , txTBQueue           :: TBQueue (Maybe Text, Maybe ChainId, Maybe Bool, Bool, PostBlocTransactionRequest)
   , userRegistryAddress :: Address
+  , userRegistryCodeHash :: Maybe Keccak256
   , useWalletsByDefault :: Bool
   }
 

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -564,6 +564,7 @@ postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTr
   checkIsSynced
   accountNonceLimit <- fmap accountNonceLimit getBlocEnv
   userRegistry <- fmap userRegistryAddress getBlocEnv
+  userRegistryHash <- fmap userRegistryCodeHash getBlocEnv
   case mJwtToken of
     Nothing -> throwIO $ UserError $ Text.pack "Did not find X-USER-ACCESS-TOKEN in the header"
     Just jwtToken -> do
@@ -576,7 +577,7 @@ postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTr
                 ]
       userCert <- maybe (throwIO err) pure =<<
         A.select (A.Proxy @Certificate) addr
-      let userContractAddr = deriveAddressWithSalt (Just userRegistry) (certificateCommonName userCert) Nothing Nothing
+      let userContractAddr = deriveAddressWithSalt (Just userRegistry) (certificateCommonName userCert) userRegistryHash Nothing
       nonceMap <- getAccountNonce addr (S.singleton chainId)
       accountNonce <- case Map.lookup chainId nonceMap of
         Nothing -> pure $ 0

--- a/strato/api/strato-api/exec_src/Main.hs
+++ b/strato/api/strato-api/exec_src/Main.hs
@@ -338,6 +338,7 @@ main = do
           globalNonceCounter = nonceCache,
           txTBQueue = tbqueue,
           userRegistryAddress = fromJust $ stringAddress flags_userRegistryAddress,
+          userRegistryCodeHash = if flags_useBuiltinUserRegistry then Nothing else stringKeccak256 flags_userRegistryCodeHash,
           useWalletsByDefault = flags_useWalletsByDefault
           }
   run 3000 $ app env theDoc

--- a/strato/api/strato-api/exec_src/Options.hs
+++ b/strato/api/strato-api/exec_src/Options.hs
@@ -24,5 +24,7 @@ defineFlag "accountNonceLimit" (1000 :: Integer) "The maximum number of transact
 defineFlag "gasLimit" (1000000 :: Integer) "The maximum amount of gas a transaction can use"
 defineFlag "identityServerUrl" ("https://identity.blockapps.net" :: String) "The URL of the identity server" -- This could be used during the strato-getting started or default use with network flag
 defineFlag "vaultProxyPort" ("8013" :: String) "URL to Vault"
-defineFlag "userRegistryAddress" ("0000000000000000000000000000000000000720" :: String) "Address of the User Registry contract"
+defineFlag "userRegistryAddress" ("4be508b4b59039cbacf5f18ccd9b67ab48e86e6d" :: String) "Address of the User Registry contract" -- TODO: Change back to 720 once we start deploying networks with UserRegistry in the genesis block
+defineFlag "userRegistryCodeHash" ("02946aa18081cd1c540f931e600d58e1c1e21a447620fb318ddf57b29126720b" :: String) "Code hash of UserRegistry contract code collection"
+defineFlag "useBuiltinUserRegistry" (True :: Bool) "Whether to use the code hash for the standard UserRegistry contracts"
 defineFlag "useWalletsByDefault" (False :: Bool) "Whether to redirect transactions to user wallet contracts by default"

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -37,7 +37,7 @@ import qualified Data.ByteString.Char8                as BC
 import qualified Data.ByteString.Lazy                 as BL
 import           Data.Data
 import           Data.Hashable
-import           Data.Maybe                           (fromJust, fromMaybe)
+import           Data.Maybe                           (fromMaybe)
 import           Data.Swagger                         hiding (Format, format, get, put)
 import qualified Data.Swagger                         as Sw
 import qualified Data.Text                            as T
@@ -58,7 +58,7 @@ import           Web.PathPieces
 
 import           Blockchain.Data.RLP
 import           Blockchain.Strato.Model.ExtendedWord (Word160, word160ToBytes)
-import qualified Blockchain.Strato.Model.Keccak256    as SHA (hash, keccak256ToWord256, keccak256ToByteString)
+import qualified Blockchain.Strato.Model.Keccak256    as SHA (Keccak256, hash, keccak256ToWord256, keccak256ToByteString)
 import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.Strato.Model.Util
 import           Blockchain.Strato.Model.UserRegistry
@@ -252,13 +252,13 @@ getNewAddressWithSalt_unsafe creator salt codeHash args =
   in decode $ BL.drop 12 $ encode theHash
 
 -- Default values are for the UserRegistry/User contract. Salt should be the userAddress.
-deriveAddressWithSalt :: Maybe Address -> String -> Maybe BC.ByteString -> Maybe String -> Address
-deriveAddressWithSalt sender salt src args = do
-  let theAddress = fromMaybe (fromJust $ stringAddress "0000000000000000000000000000000000000720") sender -- UserRegistry address
+deriveAddressWithSalt :: Maybe Address -> String -> Maybe SHA.Keccak256 -> Maybe String -> Address
+deriveAddressWithSalt sender salt srcHash args = do
+  let theAddress = fromMaybe (Address 0x720) sender -- UserRegistry address
       theHash = SHA.hash $ rlpSerialize $ RLPArray [ rlpEncode (0xFF :: Integer)
                                                    , rlpEncode theAddress
                                                    , rlpEncode salt
-                                                   , rlpEncode $ SHA.keccak256ToByteString $ maybe (SHA.hash $ encodeUtf8 userRegistryContract) (SHA.hash) src 
+                                                   , rlpEncode $ SHA.keccak256ToByteString $ fromMaybe (SHA.hash $ encodeUtf8 userRegistryContract) srcHash 
                                                    , rlpEncode $ fromMaybe "OrderedVals []" args
                                                    ]
   -- trace ((show theAddress) ++ " " ++ salt ++ " " ++ (show $ keccak256ToByteString $ hash src) ++ " " ++ args)

--- a/strato/doit.sh
+++ b/strato/doit.sh
@@ -229,6 +229,18 @@ function newnode {
   if [ -n "${idServerUrl}" ]; then
       idServer="--identityServerUrl=${idServerUrl}"
   fi
+  if [ -n "${userRegistryAddress}" ]; then
+      urFlag="--userRegistryAddress=${userRegistryAddress}"
+  fi
+  if [ -n "${userRegistryCodeHash}" ]; then
+      ucFlag="--userRegistryCodeHash=${userRegistryCodeHash}"
+  fi
+  if [ -n "${useBuiltinUserRegistry}" ]; then
+      ubFlag="--useBuiltinUserRegistry=${useBuiltinUserRegistry}"
+  fi
+  if [ -n "${useWalletsByDefault}" ]; then
+      udFlag="--useWalletsByDefault=${useWalletsByDefault}"
+  fi
 
   echo "Starting vm-runner"
   runBackgroundProcess vm-runner --useSyncMode=$useSyncMode --maxTxsPerBlock=$maxTxsPerBlock \
@@ -242,7 +254,7 @@ function newnode {
 
   echo "Starting strato-api"
   # Leave the +RTS -N1, it is important
-  runBackgroundProcess strato-api --minLogLevel=$evmMinLogLevel --gasOn=$gasOn --evmCompatible=$evmCompatible "${aclFlag}" "${txsFlag}" "${gasFlag}" "${idServer}" +RTS -N1 >> logs/strato-api 2>&1
+  runBackgroundProcess strato-api --minLogLevel=$evmMinLogLevel --gasOn=$gasOn --evmCompatible=$evmCompatible "${aclFlag}" "${txsFlag}" "${gasFlag}" "${idServer}" "${urFlag}" "${ucFlag}" "${ubFlag}" "${udFlag}" +RTS -N1 >> logs/strato-api 2>&1
 
   if [ "${evmCompatible}" = true ]; then
       echo "EVM Compatibility mode is on, so Slipstream EVM contract indexing is being turned on."

--- a/strato/indexer/slipstream/exec_src/Main.hs
+++ b/strato/indexer/slipstream/exec_src/Main.hs
@@ -59,6 +59,7 @@ createBlocEnv = liftIO $ do
                  , globalNonceCounter=error("globalNonceCounter shouldn't be needed in slipstream, it is undefined")
                  , txTBQueue=error("txTBQueue shouldn't be needed in slipstream, it is undefined")
                  , userRegistryAddress=0x0
+                 , userRegistryCodeHash = Nothing
                  , useWalletsByDefault = error "useWalletsByDefault shouldn't be needed in slipstream"
     }
 


### PR DESCRIPTION
Added flags for using different UserRegistry code hashes, and a showSM case for SVariadic

I'm now able to use the "Use Wallet" feature in SMD when setting userRegistryAddress=4be508b4b59039cbacf5f18ccd9b67ab48e86e6d, useBuiltinUserRegistry=false, and userRegistryCodeHash= 02946aa18081cd1c540f931e600d58e1c1e21a447620fb318ddf57b29126720b.