### PR TITLE
Fixed CodeCollectionAdded bug in EthereumVM.hs

### DIFF
--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -557,22 +557,27 @@ sendOutEvent (OutAction act) =
         case (join $ fmap (M.lookup "src") $ a^.Action.metadata,
               join $ fmap (M.lookup "name") $ a^.Action.metadata,
               M.toList $ a^.Action.actionData) of
-          (Just c, Just n, first:_) -> Just $ CodeCollectionAdded {
-              ccString = c,
-              codePtr =
-                  case join $ fmap (M.lookup "VM") $ a^.Action.metadata of
+          (Just c, Just n, actionDatas) ->
+            let cp = case join $ fmap (M.lookup "VM") $ a^.Action.metadata of
                     Just "SolidVM" -> SolidVMCode (T.unpack n) $ Keccak256.hash $ BC.pack $ T.unpack c
                     Just "EVM" -> EVMCode $ Keccak256.hash $ BC.pack $ T.unpack c
                     Just v -> error $ "Unknown VM: " ++ show v
-                    Nothing -> EVMCode $ Keccak256.hash $ BC.pack $ T.unpack c,
-              organization = first^._2.Action.actionDataOrganization,
-              application = n,
-              historyList=
-                  case join $ fmap (M.lookup "history") (a^.Action.metadata) of
-                    Nothing -> []
-                    Just v -> T.splitOn "," v,
-              recordMappings = []
-            }
+                    Nothing -> EVMCode $ Keccak256.hash $ BC.pack $ T.unpack c
+                org = fromMaybe "" . listToMaybe . catMaybes . flip map actionDatas $ \(_,Action.ActionData{..}) ->
+                  if _actionDataCodeHash == cp
+                    then Just _actionDataOrganization
+                    else Nothing
+             in Just $ CodeCollectionAdded {
+                  ccString = c,
+                  codePtr = cp,
+                  organization = org,
+                  application = n,
+                  historyList=
+                      case join $ fmap (M.lookup "history") (a^.Action.metadata) of
+                        Nothing -> []
+                        Just v -> T.splitOn "," v,
+                  recordMappings = []
+                }
           _ -> Nothing
       ccEvents = maybeToList $ extractCodeCollectionAddedMessages act
       actionEvents = [NewAction act]


### PR DESCRIPTION
There was a bug in EthereumVM.hs that occurred when creating a new contract that referenced a contract with a lower address. For example:
```sol
contract A {
  string ownerCommonName;
  constructor() {
    Certificate c = Certificate(account(0x1337, "main"));
    ownerCommonName = c.commonName();
  }
}
```
would result in the `CodeCollectionAdded` event written to Slipstream to take the organization name from `Certificate`, because the address 0x1337 would be lower than than the address of `A`. This would cause the Cirrus table for `A` to just be `A` (or `<Certificate's org name>-A` if `Certificate` had an org name), but it should really be `<org of tx.origin>-A`.