### PR TITLE
address.derive(salt)

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -28,6 +28,7 @@ so that they could be properly moved to their respective version's subsection.
 - Derived contracts are inserted as rows in abstract tables
 - Support for imports from addresses in SolidVM
 - More lenient P2P disable times to prevent non-validators from being "locked out"
+- `address.derive(salt, args)` function which allows SolidVM to derive salted contracts without creating them
 ### Changed
 - `/compile` and `/transaction` endpoints use SolidVM compiler
 - POST `/transaction` calls redirected to the corresponding User contract

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
@@ -295,6 +295,7 @@ postfix p = Postfix . chainl1 p $ return (flip (.))
 memberName :: SolidityParser SolidString
 memberName = do
   (reserved "call" >> return (stringToLabel "call"))
+  <|> (reserved "derive" >> return (stringToLabel "derive"))
   <|> (reserved "length" >> return (stringToLabel "length"))
   <|> fmap stringToLabel identifier
 

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Types.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Types.hs
@@ -40,9 +40,9 @@ simpleType =
   intSuffixed "uint"  (SVMType.Int (Just False)) <|>
   intSuffixed "int"  (SVMType.Int (Just True)) <|>
   simple "variadic" SVMType.Variadic <|>
-  choice [optionParser, unknownLabelParser, unknownLabelMemberParser]
+  choice [saltParser, unknownLabelParser, unknownLabelMemberParser]
   where
-    optionParser =  try $ do
+    saltParser = try $ do
       name <- identifier
       salt <- braces $ do
         reserved "salt"
@@ -50,9 +50,7 @@ simpleType =
         let myReallyGoodParser = do
               myStr <- stringLiteral
               return ("\"" ++ myStr ++ "\"")
-
-        s <- identifier <|> myReallyGoodParser
-        return s
+        identifier <|> myReallyGoodParser
       return $ SVMType.UnknownLabel name $ Just salt
     unknownLabelParser = try $ do
       name <- identifier

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1454,6 +1454,7 @@ tcExpr (FunctionCall x (MemberAccess _ var "delegatecall" ) args) = do
     (OrderedArgs [], _)    -> pure $ bottom $ ".delegatecall() requires at least one argument" <$ x
     (OrderedArgs (a:_), _) -> (stringType' x)  ~> tcExpr a !> (pure $ topType' x)
     _                      -> pure $ bottom $ ".delegatecall() does not take named arguements" <$ x
+
 tcExpr (FunctionCall x (MemberAccess _ var "call") args) = do
   res <- sumType' (accountType' x) (addressType' x) ~> tcExpr var
   case (args, res) of
@@ -1461,6 +1462,15 @@ tcExpr (FunctionCall x (MemberAccess _ var "call") args) = do
     (OrderedArgs [], _)    -> pure $ bottom $ ".call() requires at least one argument" <$ x
     (OrderedArgs (a:_), _) -> (stringType' x) ~> tcExpr a !> (pure $ topType' x)
     _                      -> pure $ bottom $ ".call() does not take named arguments" <$ x
+
+tcExpr (FunctionCall x (MemberAccess _ var "derive") args) = do
+  res <- sumType' (accountType' x) (addressType' x) ~> tcExpr var
+  case (args, res) of
+    (_, Bottom _)          -> pure $ bottom $ "Can only use derive() as a method on an account or address" <$ x
+    (OrderedArgs [], _)    -> pure $ bottom $ "derive() requires at least one argument" <$ x
+    (OrderedArgs (a:_), _) -> (stringType' x) ~> tcExpr a !> (pure $ topType' x)
+    _                      -> pure $ bottom $ "derive() does not take named arguments" <$ x
+
 tcExpr (FunctionCall x expr args) = do
   e <- tcExpr expr
   a <- case args of

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1952,6 +1952,27 @@ expToVar' theFullExp@(CC.FunctionCall _ e args) = do
             (CC.OrderedArgs a) -> getVar <=< expToVar $ head a
             (CC.NamedArgs _) -> pure $ SNULL
           case (val1, name) of
+            (SAccount addr _, "derive") -> do
+              (hsh, _) <- getCurrentCodeCollection
+              salt <- saltTextToValue $ show convertedFirstArg
+              Account addr'' _ <- getNewAddressWithSalt (Account (_namedAccountAddress addr) Nothing) salt hsh (show args)
+              return . Constant $ SAccount (NamedAccount addr'' UnspecifiedChain) False
+              where
+                saltTextToValue :: MonadSM m => String -> m Value
+                saltTextToValue saltText = do
+                  let stringParser = do
+                        ~(a, str) <- withPosition $ do
+                          s <- stringLiteral
+                          return s
+                        return $ CC.StringLiteral a str
+                  let saltExpression = runParser (stringParser <|> expression) (ParserState "" "" M.empty) "" (saltText)
+                  saltValue <- do
+                    case saltExpression of
+                      Left pe -> invalidArguments "big bad sad" pe
+                      Right e' -> do
+                        s <- getVar =<< expToVar e'
+                        return s
+                  return saltValue
             (SAccount addr _, "delegatecall") -> do
               let  (funcName, args') = (case args of
                     (CC.OrderedArgs []) -> typeError "delegate call needs atleast one arguement, none were given " args

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1917,6 +1917,15 @@ expToVar' (CC.FunctionCall _ (CC.NewExpression _ (SVMType.UnknownLabel contractN
   newAddress <- getNewAddressWithSalt creator salt hsh $ show args'
   $logDebugS "DEBUG" $ T.pack $ (show hsh) ++ "  " ++ show newAddress
   execResults <- create' creator newAddress hsh cc contractName' args
+  onTraced $ do
+    liftIO $ putStrLn $ concat [
+      C.cyan ">> Created salted contract:",
+      "\n   code hash      " ++ C.yellow (show hsh),
+      "\n   salt           " ++ C.yellow (show salt),
+      "\n   creator        " ++ C.yellow (show creator),
+      "\n   arguments      " ++ C.yellow (show args'),
+      "\n   salted address " ++ C.yellow (show newAddress)
+      ]
   return $ Constant $ SContract contractName' $ accountOnUnspecifiedChain
     $ fromMaybe (internalError "a call to create did not create an address" execResults)
     $  erNewContractAccount execResults
@@ -1952,27 +1961,30 @@ expToVar' theFullExp@(CC.FunctionCall _ e args) = do
             (CC.OrderedArgs a) -> getVar <=< expToVar $ head a
             (CC.NamedArgs _) -> pure $ SNULL
           case (val1, name) of
-            (SAccount addr _, "derive") -> do
-              (hsh, _) <- getCurrentCodeCollection
-              salt <- saltTextToValue $ show convertedFirstArg
-              Account addr'' _ <- getNewAddressWithSalt (Account (_namedAccountAddress addr) Nothing) salt hsh (show args)
-              return . Constant $ SAccount (NamedAccount addr'' UnspecifiedChain) False
-              where
-                saltTextToValue :: MonadSM m => String -> m Value
-                saltTextToValue saltText = do
-                  let stringParser = do
-                        ~(a, str) <- withPosition $ do
-                          s <- stringLiteral
-                          return s
-                        return $ CC.StringLiteral a str
-                  let saltExpression = runParser (stringParser <|> expression) (ParserState "" "" M.empty) "" (saltText)
-                  saltValue <- do
-                    case saltExpression of
-                      Left pe -> invalidArguments "big bad sad" pe
-                      Right e' -> do
-                        s <- getVar =<< expToVar e'
-                        return s
-                  return saltValue
+            (SAccount (NamedAccount addr _) _, "derive") -> do
+              (_, hsh, _) <- getCodeAndCollection (Account addr Nothing)
+              args' <- case args of
+                (CC.OrderedArgs []) -> typeError "derive needs at least one argument, none were given " args
+                (CC.OrderedArgs (_ : as)) -> OrderedVals <$> mapM (getVar <=< expToVar) as
+                (CC.NamedArgs _) -> typeError "Cannot provide named args to derive" args
+              let salt = case convertedFirstArg of
+                        SString s -> s
+                        _ -> typeError "first arugment must be a string " args
+                  newAddress = getNewAddressWithSalt_unsafe
+                                addr
+                                salt
+                                (keccak256ToByteString hsh)
+                                (show args')
+              onTraced $ do
+                liftIO $ putStrLn $ concat [
+                  C.cyan ">> Deriving salted contract:",
+                  "\n   code hash      " ++ C.yellow (show hsh),
+                  "\n   salt           " ++ C.yellow (show convertedFirstArg),
+                  "\n   input address  " ++ C.yellow (show addr),
+                  "\n   arguments      " ++ C.yellow (show args'),
+                  "\n   salted address " ++ C.yellow (show newAddress)
+                  ]
+              return . Constant $ SAccount (NamedAccount newAddress UnspecifiedChain) False
             (SAccount addr _, "delegatecall") -> do
               let  (funcName, args') = (case args of
                     (CC.OrderedArgs []) -> typeError "delegate call needs atleast one arguement, none were given " args

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -40,7 +40,7 @@ module Blockchain.SolidVM.SM (
   getCurrentFunctionName,
   getCurrentCodeCollection,
   addFunctionToCurrentContractInCurrentCallInfo,
-  removeFunctionFromCurrentContractInCurrentCallInfo, 
+  removeFunctionFromCurrentContractInCurrentCallInfo,
   getEnv,
   getGasInfo,
   getVariableOfName,
@@ -348,7 +348,7 @@ runSM maybeCode env gi chainId' f = do
         callStack = [],
         _ssMemDBs = csMemDBs,
         _action = startingAction maybeCode env chainId',
-        _gasInfo = gi{_gasLeft=min (_gasLeft gi) gasCap} -- capping the transaction gas limit 
+        _gasInfo = gi{_gasLeft=min (_gasLeft gi) gasCap} -- capping the transaction gas limit
         }
   startingStateRef <- newIORef startingState
   eVal <- try $ runReaderT f startingStateRef
@@ -431,7 +431,7 @@ getVariableOfName name = do
                                                 ,  CC._usings = M.empty
                                                 ,  CC._contractType = currentContract x^.CC.contractType
                                                 ,  CC._contractContext = currentContract x^.CC.contractContext
-                                                } 
+                                                }
                               }
                     else x
       vars = localVariables currentCallInfo
@@ -450,7 +450,7 @@ getVariableOfName name = do
       maybeBuiltinFunction :: Maybe Variable
       maybeBuiltinFunction = toMaybe (name `elem` ["address", "account", "uint", "int", "bool", "byte", "bytes"
                                                   , "string", "keccak256", "ripemd160", "payable"
-                                                  , "require", "revert", "assert", "sha3"  , "delegatecall"
+                                                  , "require", "revert", "assert", "sha3", "delegatecall", "call", "derive"
                                                   , "sha256", "ecrecover", "blockhash","addmod", "mulmod"
                                                   , "selfdestruct", "suicide", "bytes32ToString"
                                                   , "getUserCert", "parseCert", "verifyCert", "verifyCertSignedBy", "verifySignature"]) $
@@ -595,7 +595,7 @@ pushLocalVars = Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
   (curFrame:rest) -> do
     let localVariables' = localVariables curFrame
         variableStack'  = variableStack curFrame
-    {-- We save the local variables available in this scope to the 'stack', 
+    {-- We save the local variables available in this scope to the 'stack',
     which is simply a list of mappings from name to type/values
     --}
     pure $ curFrame{variableStack = (localVariables':variableStack')} : rest
@@ -608,7 +608,7 @@ popLocalVars = Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
     let (varFrame, st) = case variableStack curFrame of
           (varFrame': st') -> (varFrame', st')
           [] -> (M.empty, [])
-    {-- Since all the variables from the previous scope are saved to the most recent stack frame (vars), 
+    {-- Since all the variables from the previous scope are saved to the most recent stack frame (vars),
     we simply reassign the local variables to the top frame of the stack
     and the new stack's value is the rest of the frames
     --}
@@ -692,7 +692,7 @@ addFunctionToCurrentContractInCurrentCallInfo funcName funcObject = do
         (currentCallInfo:_) -> do
             let contract = currentContract currentCallInfo
             -- _functions :: Map SolidString (FuncF a),
-                newContract = contract{CC._functions = M.insert funcName funcObject $ CC._functions contract} 
+                newContract = contract{CC._functions = M.insert funcName funcObject $ CC._functions contract}
             Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
                 [] -> internalError "addFunctionToCurrentContractInCurrentCallInfo called with an empty stack" ()
                 (ci:rest) -> pure $ ci{currentContract=newContract} : rest
@@ -705,7 +705,7 @@ removeFunctionFromCurrentContractInCurrentCallInfo funcName = do
         (currentCallInfo:_) -> do
             let contract = currentContract currentCallInfo
             -- _functions :: Map SolidString (FuncF a),
-                newContract = contract{CC._functions = M.delete funcName $ CC._functions contract} 
+                newContract = contract{CC._functions = M.delete funcName $ CC._functions contract}
             Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
                 [] -> internalError "removeFunctionFromCurrentContractInCurrentCallInfo called with an empty stack" ()
                 (ci:rest) -> pure $ ci{currentContract=newContract} : rest

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -5731,7 +5731,7 @@ contract qq {
   }
 }|]
     runBS src
-    getFields ["x", "y"] `shouldReturn` 
+    getFields ["x", "y"] `shouldReturn`
       [ bContract "X" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just $ BC.pack src) Nothing
       , bContract "Y" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "something" (Just $ BC.pack src) Nothing
       ]
@@ -5766,7 +5766,7 @@ contract qq {
   }
 }|]
     runBS src
-    getFields ["x", "y"] `shouldReturn` 
+    getFields ["x", "y"] `shouldReturn`
       [ bContract "X" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just $ BC.pack src) (Just "OrderedVals [SString \"xNum\"]")
       , bContract "Y" $ deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just $ BC.pack src) (Just "OrderedVals [SInteger 100]")
       ]
@@ -5798,6 +5798,30 @@ contract qq {
     [BContract "User" x] <- getFields["x"]
     getSolidStorageKeyVal' (namedAccountToAccount Nothing x) (singleton "commonName") `shouldReturn` BString "Dustin Norwood"
     getSolidStorageKeyVal' (namedAccountToAccount Nothing x) (singleton "cert") `shouldReturn` BString "Thebestcertyoucangetfor$99.99"
+
+
+  -- todo: 'fit' to 'it'
+  fit "can deterministically derive salted contract addresses with multiple args" . runTest $ do
+    let src = [r|
+contract User {
+  string commonName;
+  string cert;
+  constructor(string _commonName, string _cert) {
+    commonName = _commonName;
+    cert = _cert;
+  }
+}
+
+contract qq {
+  User public x;
+  address y;
+  constructor() public {
+    x = new User{salt: "salt"}("David Moncayo", "MyVeryCoolCert");
+    y = address(x).derive("salt", "David Moncayo", "MyVeryCoolCert");
+  }
+}|]
+    runBS src `shouldReturn` ()
+
 
   it "should fail when trying to create salted contract to the same address" $ runTest (do
     runBS [r|

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -5800,8 +5800,29 @@ contract qq {
     getSolidStorageKeyVal' (namedAccountToAccount Nothing x) (singleton "cert") `shouldReturn` BString "Thebestcertyoucangetfor$99.99"
 
 
-  -- todo: 'fit' to 'it'
-  fit "can deterministically derive salted contract addresses with multiple args" . runTest $ do
+  it "can deterministically derive salted contract addresses with no args" . runTest $ do
+    let src = [r|
+contract VerySimpleStorage {
+  uint x;
+  constructor() {
+    x = 1337;
+  }
+}
+
+contract qq {
+  VerySimpleStorage public x;
+  address y;
+  constructor() public {
+    x = new VerySimpleStorage{salt: "kosher"}();
+    y = address(this).derive("kosher");
+
+    require(address(x) == y, "These salted addresses are not the same");
+  }
+}|]
+    runBS src `shouldReturn` ()
+
+
+  it "can deterministically derive salted contract addresses with multiple args" . runTest $ do
     let src = [r|
 contract User {
   string commonName;
@@ -5816,8 +5837,9 @@ contract qq {
   User public x;
   address y;
   constructor() public {
-    x = new User{salt: "salt"}("David Moncayo", "MyVeryCoolCert");
-    y = address(x).derive("salt", "David Moncayo", "MyVeryCoolCert");
+    x = new User{salt: "himalayan"}("David Moncayo", "Bababadalgharaghtakamminarronnkonnbronntonnerronntuonnthunntrovarrhounawnskawntoohoohoordenenthurnuk");
+    y = address(this).derive("himalayan", "David Moncayo", "Bababadalgharaghtakamminarronnkonnbronntonnerronntuonnthunntrovarrhounawnskawntoohoohoordenenthurnuk");
+    require(address(x) == y, "These salted addresses are not the same");
   }
 }|]
     runBS src `shouldReturn` ()


### PR DESCRIPTION
In the same way that we can create contracts with salted addresses, we should be able to derive those very contract addresses without having to instantiate a new one. `address` type now has a `.derive(salt)` built-in that accepts at least one argument (the salt value) and the argument list that would be used to instantiate the contract. The `address` value should be the contract address so that the code hash can be found in its `CodeCollection`.

```
contract VerySimpleStorage {
  uint x;
  constructor() {
    x = 1337;
  }
}

contract qq {
  VerySimpleStorage public x;
  address y;
  constructor() public {
    x = new VerySimpleStorage{salt: "kosher"}();
    y = address(this).derive("kosher");

    require(address(x) == y, "These salted addresses are not the same");
  }
}
```