### PR TITLE
LM-31-orders-page-sort-by-new-orders-first

### DIFF
--- a/marketplace/backend/helpers/utils.js
+++ b/marketplace/backend/helpers/utils.js
@@ -147,6 +147,12 @@ export const setSearchQueryOptions = (args = {}, _queryOptionsArray) => {
   const queryOptionsArray = Array.isArray(_queryOptionsArray) ? _queryOptionsArray : [_queryOptionsArray]
   const queryOptions = queryOptionsArray.reduce((agg, cur) => {
     const { key, value, predicate = 'eq' } = cur
+    if (key === 'order') {
+      return {
+        ...agg,
+        order: value,
+      }
+    }
     if (!value && typeof value != 'boolean') {
       return agg
     }
@@ -223,6 +229,7 @@ export const searchAllWithQueryArgs = async (contractName, args, options, user) 
       const { notEqualsField, notEqualsValue } = args
       result.push({ key: notEqualsField, value: notEqualsValue, predicate: 'neq' })
     }
+    
 
     if (key === 'sort') {
       result.push(args[key])

--- a/marketplace/ui/src/contexts/order/actions.js
+++ b/marketplace/ui/src/contexts/order/actions.js
@@ -233,7 +233,7 @@ const actions = {
 
     try {
       const response = await fetch(
-        `${apiUrl}/order?limit=${limit}&offset=${offset}${query}&buyerOrganization=${organization}`,
+        `${apiUrl}/order?limit=${limit}&offset=${offset}${query}&order=createdDate.desc&buyerOrganization=${organization}`,
         {
           method: HTTP_METHODS.GET,
         }
@@ -261,7 +261,7 @@ const actions = {
 
     try {
       const response = await fetch(
-        `${apiUrl}/order?limit=${limit}&offset=${offset}${query}&sellerOrganization=${organization}`,
+        `${apiUrl}/order?&limit=${limit}&offset=${offset}&order=createdDate.desc${query}&sellerOrganization=${organization}`,
         {
           method: HTTP_METHODS.GET,
         }


### PR DESCRIPTION
Fixed the query options to allow sorting by order in cirrus. 

- Orders are automatically sorted by createdDate when they are fetched. 
- Cirrus Query: https://node1.mercata-testnet2.blockapps.net/cirrus/search/BlockApps-Dapp-Order?limit=10&offset=0&order=createdDate.desc&sellerOrganization=eq.BlockApps

<img width="860" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/aa16e170-c167-4f2e-933c-f9521b597ba3">
<img width="902" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/de09ba05-e9a7-47ff-b3bc-3c4f2a1ea73d">
