### PR TITLE
Strato 3176 create a standard inventory page in the marketplace which queries the asset and sale tables from cirrus

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -106,6 +106,8 @@ services:
       - marketplace-backend
     environment:
       - NODE_ENV=${NODE_ENV:-production}
+      - ASSET_TABLE_NAME=${ASSET_TABLE_NAME}
+      - SALE_TABLE_NAME=${SALE_TABLE_NAME}
     build: .
     image: ${MARKETPLACEUI_IMAGE:-<REPO_URL>marketplace-ui:<VERSION>}
     restart: unless-stopped

--- a/marketplace/ui/Dockerfile
+++ b/marketplace/ui/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /usr/src/ui/
 
 RUN yarn install && \
   yarn global add serve@13.0.2 && \
+  yarn global add react-inject-env@2.1.0 && \
   REACT_APP_IN_DOCKER=true REACT_APP_UI_VERSION=$(node -e "console.log(require('./package.json').version);") yarn build && \
   rm -rf node_modules
 

--- a/marketplace/ui/docker-run.sh
+++ b/marketplace/ui/docker-run.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 
+# Creating .env file if using the relevant flags
+if [ -n "${ASSET_TABLE_NAME}" ] || [ -n "${SALE_TABLE_NAME}" ]; then
+  if [ ! -f .env ]; then
+    # If it doesn't exist, create the .env file and insert environment variables.
+    touch .env
+
+    echo "REACT_APP_ASSET_TABLE_NAME=${ASSET_TABLE_NAME}" >> .env
+    echo "REACT_APP_SALE_TABLE_NAME=${SALE_TABLE_NAME}" >> .env
+  else
+    # If the .env file exists, replace the environment variables.
+    sed -i `s/REACT_APP_ASSET_TABLE_NAME=.*/REACT_APP_ASSET_TABLE_NAME=${ASSET_TABLE_NAME}/` .env
+    sed -i `s/REACT_APP_SALE_TABLE_NAME=.*/REACT_APP_SALE_TABLE_NAME=${SALE_TABLE_NAME}/` .env
+  fi
+fi
+
 echo 'Starting ui server...'
 
-serve --single -l 3003 build
+npx react-inject-env set && serve --single -l 3003 build

--- a/marketplace/ui/public/index.html
+++ b/marketplace/ui/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <script src='%PUBLIC_URL%/env.js'></script>
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/marketplace/ui/src/AuthenticatedRoutes.js
+++ b/marketplace/ui/src/AuthenticatedRoutes.js
@@ -33,6 +33,8 @@ import EventSerialNumberList from "./components/Event/EventSerialNumberList";
 import ProcessingOrder from "./components/MarketPlace/ProcessingOrder";
 import Invoice from "./components/Order/Invoice";
 import { CertifiersProvider } from "./contexts/certifier";
+import { StorageProvider } from "./contexts/storage";
+import Storage from "./components/Storage";
 import LoginRedirect from "./components/LoginRedirect";
 
 const AuthenticatedRoutes = ({ user, users }) => {
@@ -384,6 +386,16 @@ const AuthenticatedRoutes = ({ user, users }) => {
             </EventsProvider>
           </UsersProvider>
         }
+      />
+      <Route
+        exact
+        path={routes.Storage.url}
+        element={
+          <UsersProvider>
+            <StorageProvider>
+              <Storage user={user} users={users} />
+            </StorageProvider>
+          </UsersProvider>}
       />
       <Route
         path="/"

--- a/marketplace/ui/src/components/Header/Header.js
+++ b/marketplace/ui/src/components/Header/Header.js
@@ -43,6 +43,7 @@ const HeaderComponent = ({ user, loginUrl }) => {
   const [initials, setInitials] = useState("");
   const [roleIndex, setRoleIndex] = useState();
 
+  const showStorage = user && user.organization && user.organization == "BlockApps" ? true : false 
 
   const navItems = [
     {
@@ -53,6 +54,7 @@ const HeaderComponent = ({ user, loginUrl }) => {
         { label: <div id="Inventory">Inventory</div>, key: '2' },
         { label: <div id="Products">Products</div>, key: '3' },
         { label: <div id="Events">Events</div>, key: '4' },
+        showStorage && { label: <div id="Storage">Storage</div>, key: '5' },
       ]
     },
     {
@@ -69,6 +71,7 @@ const HeaderComponent = ({ user, loginUrl }) => {
     routes.Inventories.url,
     routes.Products.url,
     routes.Events.url,
+    routes.Storage.url,
   ];
 
   const logout = () => {
@@ -93,6 +96,8 @@ const HeaderComponent = ({ user, loginUrl }) => {
       setSelectedTab("3");
     } else if (pathName.includes("/events") || pathName === "/certifier") {
       setSelectedTab("4");
+    } else if (pathName.includes("/storage")) {
+      setSelectedTab("5");
     }
     else{
       setSelectedTab("0");
@@ -203,6 +208,13 @@ const HeaderComponent = ({ user, loginUrl }) => {
               },
             });
             navigate(navUrls[item.key], { state: { tab: "EventType" } })}
+          if (item.key === "5") {
+            TagManager.dataLayer({
+              dataLayer: {
+                event: 'view_storage_page',
+              }
+            });
+          }
           else navigate(navUrls[item.key]);
         }}
         items={navItems[roleIndex]?.items}

--- a/marketplace/ui/src/components/Header/Header.js
+++ b/marketplace/ui/src/components/Header/Header.js
@@ -43,7 +43,7 @@ const HeaderComponent = ({ user, loginUrl }) => {
   const [initials, setInitials] = useState("");
   const [roleIndex, setRoleIndex] = useState();
 
-  const showStorage = user && user.organization && user.organization == "BlockApps" ? true : false 
+  const showStorage = user && user.organization && user.organization === "BlockApps" ? true : false 
 
   const navItems = [
     {
@@ -208,6 +208,7 @@ const HeaderComponent = ({ user, loginUrl }) => {
               },
             });
             navigate(navUrls[item.key], { state: { tab: "EventType" } })}
+          else navigate(navUrls[item.key]);
           if (item.key === "5") {
             TagManager.dataLayer({
               dataLayer: {
@@ -215,7 +216,6 @@ const HeaderComponent = ({ user, loginUrl }) => {
               }
             });
           }
-          else navigate(navUrls[item.key]);
         }}
         items={navItems[roleIndex]?.items}
       />

--- a/marketplace/ui/src/components/Storage/AssetsTable.js
+++ b/marketplace/ui/src/components/Storage/AssetsTable.js
@@ -1,37 +1,37 @@
 import React, { useEffect, useState } from "react";
 import { useStorageDispatch, useStorageState } from "../../contexts/storage";
 import { actions } from "../../contexts/storage/actions";
-import useDebounce from "../UseDebounce";
 import DataTableComponent from "../DataTableComponent";
 import { Pagination } from "antd";
 
-const AssetsTable = ({ user }) => {
+const AssetsTable = ({ user, searchQuery }) => {
   const dispatch = useStorageDispatch();
-  const debouncedSearchTerm = useDebounce("", 1000);
   const limit = 10;
   const [offset, setOffset] = useState(0);
   const [total, setTotal] = useState(10);
   const [page, setPage] = useState(1);
 
-  const { assets, isAssetsLoading } = useStorageState();
+  const { data, isStorageLoading } = useStorageState();
 
   useEffect(() => {
-    actions.fetchAssets(
+    actions.fetchStorage(
       dispatch,
       limit,
       offset,
-      debouncedSearchTerm
+      "Asset",
+      searchQuery
     );
-  }, [dispatch, limit, offset, debouncedSearchTerm]);
+  }, [dispatch, limit, offset, searchQuery]);
 
-  const [data, setData ] = useState([]);
+  const [assets, setAssets] = useState([]);
+
   useEffect(() => {
     let items = [];
-    assets && assets.forEach((asset) => {
+    data && data.forEach((asset) => {
       items.push(asset);
     });
-    setData(items);
-  }, [assets]);
+    setAssets(items);
+  }, [data]);
 
   const column = [
     {
@@ -50,19 +50,19 @@ const AssetsTable = ({ user }) => {
   }
 
   useEffect(() => {
-    let len = data.length;
+    let len = assets.length;
     let total;
     if (len === limit) total = page * 10 + limit;
     else total = (page - 1) * 10 + limit;
     setTotal(total);
-  }, [data]);
+  }, [assets]);
 
   return (
     <div>
       <DataTableComponent
         columns = {column}
-        data={data}
-        isLoading={isAssetsLoading}
+        data={assets}
+        isLoading={isStorageLoading}
         pagination={false}
         scrollX="100%"
       />

--- a/marketplace/ui/src/components/Storage/AssetsTable.js
+++ b/marketplace/ui/src/components/Storage/AssetsTable.js
@@ -11,35 +11,46 @@ const AssetsTable = ({ user, searchQuery }) => {
   const [total, setTotal] = useState(10);
   const [page, setPage] = useState(1);
 
-  const { data, isStorageLoading } = useStorageState();
+  const { assets, isAssetsLoading } = useStorageState();
 
   useEffect(() => {
-    actions.fetchStorage(
+    actions.fetchAssets(
       dispatch,
       limit,
       offset,
-      "Asset",
       searchQuery
     );
   }, [dispatch, limit, offset, searchQuery]);
 
-  const [assets, setAssets] = useState([]);
+  const [data, setData] = useState([]);
 
   useEffect(() => {
     let items = [];
-    data && data.forEach((asset) => {
-      items.push(asset);
+    assets.forEach((asset) => {
+      const { ["record_id"]: omittedKey, ...rest } = asset;
+      items.push({
+        recordId: asset.record_id,
+        recordData: rest,
+      });
     });
-    setAssets(items);
-  }, [data]);
+    setData(items);
+  }, [assets]);
 
   const column = [
     {
-      title: "Something".toUpperCase(),
-      dataIndex: "something",
-      key: "something",
-      render: (something) => (
-        <p>something</p>
+      title: "Record ID".toUpperCase(),
+      dataIndex: "recordId",
+      key: "recordId",
+      render: (recordId) => (
+        <p>{recordId}</p>
+      )
+    },
+    {
+      title: "Record Data".toUpperCase(),
+      dataIndex: "recordData",
+      key: "recordData",
+      render: (recordData) => (
+        <p><pre>{JSON.stringify(recordData, null, 2)}</pre></p>
       )
     }
   ]
@@ -50,19 +61,19 @@ const AssetsTable = ({ user, searchQuery }) => {
   }
 
   useEffect(() => {
-    let len = assets.length;
+    let len = data.length;
     let total;
     if (len === limit) total = page * 10 + limit;
     else total = (page - 1) * 10 + limit;
     setTotal(total);
-  }, [assets]);
+  }, [data]);
 
   return (
     <div>
       <DataTableComponent
         columns = {column}
-        data={assets}
-        isLoading={isStorageLoading}
+        data={data}
+        isLoading={isAssetsLoading}
         pagination={false}
         scrollX="100%"
       />

--- a/marketplace/ui/src/components/Storage/AssetsTable.js
+++ b/marketplace/ui/src/components/Storage/AssetsTable.js
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from "react";
+import { useStorageDispatch, useStorageState } from "../../contexts/storage";
+import { actions } from "../../contexts/storage/actions";
+import useDebounce from "../UseDebounce";
+import DataTableComponent from "../DataTableComponent";
+import { Pagination } from "antd";
+
+const AssetsTable = ({ user }) => {
+  const dispatch = useStorageDispatch();
+  const debouncedSearchTerm = useDebounce("", 1000);
+  const limit = 10;
+  const [offset, setOffset] = useState(0);
+  const [total, setTotal] = useState(10);
+  const [page, setPage] = useState(1);
+
+  const { assets, isAssetsLoading } = useStorageState();
+
+  useEffect(() => {
+    actions.fetchAssets(
+      dispatch,
+      limit,
+      offset,
+      debouncedSearchTerm
+    );
+  }, [dispatch, limit, offset, debouncedSearchTerm]);
+
+  const [data, setData ] = useState([]);
+  useEffect(() => {
+    let items = [];
+    assets && assets.forEach((asset) => {
+      items.push(asset);
+    });
+    setData(items);
+  }, [assets]);
+
+  const column = [
+    {
+      title: "Something".toUpperCase(),
+      dataIndex: "something",
+      key: "something",
+      render: (something) => (
+        <p>something</p>
+      )
+    }
+  ]
+
+  const onPageChange = (page) => {
+    setOffset((page - 1) * limit);
+    setPage(page);
+  }
+
+  useEffect(() => {
+    let len = data.length;
+    let total;
+    if (len === limit) total = page * 10 + limit;
+    else total = (page - 1) * 10 + limit;
+    setTotal(total);
+  }, [data]);
+
+  return (
+    <div>
+      <DataTableComponent
+        columns = {column}
+        data={data}
+        isLoading={isAssetsLoading}
+        pagination={false}
+        scrollX="100%"
+      />
+      <Pagination
+        current={page}
+        onChange={onPageChange}
+        total={total}
+        showSizeChanger={false}
+        className="flex justify-center my-5"
+      />
+    </div>
+  )
+};
+
+export default AssetsTable;

--- a/marketplace/ui/src/components/Storage/SalesTable.js
+++ b/marketplace/ui/src/components/Storage/SalesTable.js
@@ -11,34 +11,46 @@ const SalesTable = ({ user, searchQuery }) => {
   const [total, setTotal] = useState(10);
   const [page, setPage] = useState(1);
 
-  const { data, isStorageLoading } = useStorageState();
+  const { sales, isSalesLoading } = useStorageState();
 
   useEffect(() => {
-    actions.fetchStorage(
+    actions.fetchSales(
       dispatch,
       limit,
       offset,
-      "Sale",
       searchQuery
     );
   }, [dispatch, limit, offset, searchQuery]);
 
-  const [sales, setSales] = useState([]);
+  const [data, setData] = useState([]);
+
   useEffect(() => {
     let items = [];
-    data && data.forEach((sale) => {
-      items.push(sale);
+    sales.forEach((sale) => {
+      const { ["record_id"]: omittedKey, ...rest } = sale;
+      items.push({
+        recordId: sale.record_id,
+        recordData: rest,
+      });
     });
-    setSales(items);
-  }, [data]);
+    setData(items);
+  }, [sales]);
 
   const column = [
     {
-      title: "Something".toUpperCase(),
-      dataIndex: "something",
-      key: "something",
-      render: (something) => (
-        <p>something</p>
+      title: "Record ID".toUpperCase(),
+      dataIndex: "recordId",
+      key: "recordId",
+      render: (recordId) => (
+        <p>{recordId}</p>
+      )
+    },
+    {
+      title: "Record Data".toUpperCase(),
+      dataIndex: "recordData",
+      key: "recordData",
+      render: (recordData) => (
+        <p><pre>{JSON.stringify(recordData, null, 2)}</pre></p>
       )
     }
   ]
@@ -49,19 +61,19 @@ const SalesTable = ({ user, searchQuery }) => {
   }
 
   useEffect(() => {
-    let len = sales.length;
+    let len = data.length;
     let total;
     if (len === limit) total = page * 10 + limit;
     else total = (page - 1) * 10 + limit;
     setTotal(total);
-  }, [sales]);
+  }, [data]);
 
   return (
     <div>
       <DataTableComponent
         columns = {column}
-        data={sales}
-        isLoading={isStorageLoading}
+        data={data}
+        isLoading={isSalesLoading}
         pagination={false}
         scrollX="100%"
       />

--- a/marketplace/ui/src/components/Storage/SalesTable.js
+++ b/marketplace/ui/src/components/Storage/SalesTable.js
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from "react";
+import { useStorageDispatch, useStorageState } from "../../contexts/storage";
+import { actions } from "../../contexts/storage/actions";
+import useDebounce from "../UseDebounce";
+import DataTableComponent from "../DataTableComponent";
+import { Pagination } from "antd";
+
+const SalesTable = ({ user }) => {
+  const dispatch = useStorageDispatch();
+  const debouncedSearchTerm = useDebounce("", 1000);
+  const limit = 10;
+  const [offset, setOffset] = useState(0);
+  const [total, setTotal] = useState(10);
+  const [page, setPage] = useState(1);
+
+  const { sales, isSalesLoading } = useStorageState();
+
+  useEffect(() => {
+    actions.fetchSales(
+      dispatch,
+      limit,
+      offset,
+      debouncedSearchTerm
+    );
+  }, [dispatch, limit, offset, debouncedSearchTerm]);
+
+  const [data, setData ] = useState([]);
+  useEffect(() => {
+    let items = [];
+    sales && sales.forEach((sale) => {
+      items.push(sale);
+    });
+    setData(items);
+  }, [sales]);
+
+  const column = [
+    {
+      title: "Something".toUpperCase(),
+      dataIndex: "something",
+      key: "something",
+      render: (something) => (
+        <p>something</p>
+      )
+    }
+  ]
+
+  const onPageChange = (page) => {
+    setOffset((page - 1) * limit);
+    setPage(page);
+  }
+
+  useEffect(() => {
+    let len = data.length;
+    let total;
+    if (len === limit) total = page * 10 + limit;
+    else total = (page - 1) * 10 + limit;
+    setTotal(total);
+  }, [data]);
+
+  return (
+    <div>
+      <DataTableComponent
+        columns = {column}
+        data={data}
+        isLoading={isSalesLoading}
+        pagination={false}
+        scrollX="100%"
+      />
+      <Pagination
+        current={page}
+        onChange={onPageChange}
+        total={total}
+        showSizeChanger={false}
+        className="flex justify-center my-5"
+      />
+    </div>
+  )
+};
+
+export default SalesTable;

--- a/marketplace/ui/src/components/Storage/SalesTable.js
+++ b/marketplace/ui/src/components/Storage/SalesTable.js
@@ -1,37 +1,36 @@
 import React, { useEffect, useState } from "react";
 import { useStorageDispatch, useStorageState } from "../../contexts/storage";
 import { actions } from "../../contexts/storage/actions";
-import useDebounce from "../UseDebounce";
 import DataTableComponent from "../DataTableComponent";
 import { Pagination } from "antd";
 
-const SalesTable = ({ user }) => {
+const SalesTable = ({ user, searchQuery }) => {
   const dispatch = useStorageDispatch();
-  const debouncedSearchTerm = useDebounce("", 1000);
   const limit = 10;
   const [offset, setOffset] = useState(0);
   const [total, setTotal] = useState(10);
   const [page, setPage] = useState(1);
 
-  const { sales, isSalesLoading } = useStorageState();
+  const { data, isStorageLoading } = useStorageState();
 
   useEffect(() => {
-    actions.fetchSales(
+    actions.fetchStorage(
       dispatch,
       limit,
       offset,
-      debouncedSearchTerm
+      "Sale",
+      searchQuery
     );
-  }, [dispatch, limit, offset, debouncedSearchTerm]);
+  }, [dispatch, limit, offset, searchQuery]);
 
-  const [data, setData ] = useState([]);
+  const [sales, setSales] = useState([]);
   useEffect(() => {
     let items = [];
-    sales && sales.forEach((sale) => {
+    data && data.forEach((sale) => {
       items.push(sale);
     });
-    setData(items);
-  }, [sales]);
+    setSales(items);
+  }, [data]);
 
   const column = [
     {
@@ -50,19 +49,19 @@ const SalesTable = ({ user }) => {
   }
 
   useEffect(() => {
-    let len = data.length;
+    let len = sales.length;
     let total;
     if (len === limit) total = page * 10 + limit;
     else total = (page - 1) * 10 + limit;
     setTotal(total);
-  }, [data]);
+  }, [sales]);
 
   return (
     <div>
       <DataTableComponent
         columns = {column}
-        data={data}
-        isLoading={isSalesLoading}
+        data={sales}
+        isLoading={isStorageLoading}
         pagination={false}
         scrollX="100%"
       />

--- a/marketplace/ui/src/components/Storage/index.js
+++ b/marketplace/ui/src/components/Storage/index.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Input, Tabs } from "antd";
+import AssetsTable from "./AssetsTable";
+import SalesTable from "./SalesTable";
+
+const { Search } = Input; 
+
+const Storage = ({ user }) => {
+  const onChange = (key) => {
+
+  };
+
+  return (
+    <div>
+      <Tabs 
+        className="mx-16 mt-14"
+        defaultActiveKey={"Assets"}
+        onChange={onChange}
+        tabBarExtraContent={<Search placeholder="Search" className="w-80" />}
+        items={[
+          {
+            label: <p id="assets-tab" className="font-medium text-base">Assets</p>,
+            key: "Assets",
+            children: <AssetsTable user={user} />,
+          },
+          {
+            label: <p id="sales-tab" className="font-medium text-base">Sales</p>,
+            key: "Sales",
+            children: <SalesTable user={user} />,
+          }
+        ]}
+      />
+    </div>
+  );
+};
+
+export default Storage;

--- a/marketplace/ui/src/components/Storage/index.js
+++ b/marketplace/ui/src/components/Storage/index.js
@@ -1,12 +1,14 @@
 import React, { useState } from "react";
 import { Input, Tabs } from "antd";
 import AssetsTable from "./AssetsTable";
+import routes from "../../helpers/routes";
 import SalesTable from "./SalesTable";
 
 const { Search } = Input; 
 
 const Storage = ({ user }) => {
   const [searchValue, setSearchValue] = useState("");
+  const showStorage = user && user.organization && user.organization === "BlockApps" ? true : false
 
   const onChange = (key) => {
 
@@ -17,7 +19,9 @@ const Storage = ({ user }) => {
   }
 
   return (
-    <div>
+    <>
+    {showStorage ?
+    (<div>
       <Tabs 
         className="mx-16 mt-14"
         defaultActiveKey={"Asset"}
@@ -36,7 +40,9 @@ const Storage = ({ user }) => {
           }
         ]}
       />
-    </div>
+    </div>) : <p>It appears that you do not have access to this page. Click <a className="font-bold text-blue" href={routes.Marketplace.url}>here</a> to go back to the homepage.</p>
+    }
+    </>
   );
 };
 

--- a/marketplace/ui/src/components/Storage/index.js
+++ b/marketplace/ui/src/components/Storage/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Input, Tabs } from "antd";
 import AssetsTable from "./AssetsTable";
 import SalesTable from "./SalesTable";
@@ -6,27 +6,33 @@ import SalesTable from "./SalesTable";
 const { Search } = Input; 
 
 const Storage = ({ user }) => {
+  const [searchValue, setSearchValue] = useState("");
+
   const onChange = (key) => {
 
   };
+
+  const onSearch = (value, event) => {
+    setSearchValue(value);
+  }
 
   return (
     <div>
       <Tabs 
         className="mx-16 mt-14"
-        defaultActiveKey={"Assets"}
+        defaultActiveKey={"Asset"}
         onChange={onChange}
-        tabBarExtraContent={<Search placeholder="Search" className="w-80" />}
+        tabBarExtraContent={<Search placeholder="Search" className="w-80" onSearch={onSearch}/>}
         items={[
           {
             label: <p id="assets-tab" className="font-medium text-base">Assets</p>,
-            key: "Assets",
-            children: <AssetsTable user={user} />,
+            key: "Asset",
+            children: <AssetsTable user={user} searchQuery={searchValue} />,
           },
           {
             label: <p id="sales-tab" className="font-medium text-base">Sales</p>,
-            key: "Sales",
-            children: <SalesTable user={user} />,
+            key: "Sale",
+            children: <SalesTable user={user} searchQuery={searchValue} />,
           }
         ]}
       />

--- a/marketplace/ui/src/contexts/storage/actions.js
+++ b/marketplace/ui/src/contexts/storage/actions.js
@@ -4,9 +4,12 @@ import { cirrusUrl, HTTP_METHODS } from "../../helpers/constants";
 const actionDescriptors = {
   resetMessage: "reset_message",
   setMessage: "set_message",
-  fetchStorage: "fetch_storage",
-  fetchStorageSuccessful: "fetch_storage_successful",
-  fetchStorageFailed: "fetch_storage_failed"
+  fetchAssets: "fetch_assets",
+  fetchAssetsSuccessful: "fetch_assets_successful",
+  fetchAssetsFailed: "fetch_assets_failed",
+  fetchSales: "fetch_sales",
+  fetchSalesSuccessful: "fetch_sales_successful",
+  fetchSalesFailed: "fetch_sales_failed",
 };
 
 const actions = {
@@ -18,10 +21,10 @@ const actions = {
     dispatch({ type: actionDescriptors.setMessage, message, success });
   },
 
-  fetchStorage: async (dispatch, limit, offset, queryValue) => {
+  fetchAssets: async (dispatch, limit, offset, queryValue) => {
     const query = queryValue ? `&contractName=${queryValue}` : "";
 
-    dispatch({ type: actionDescriptors.fetchStorage });
+    dispatch({ type: actionDescriptors.fetchAssets });
 
     try {
       const response = await fetch(
@@ -35,24 +38,63 @@ const actions = {
 
       if (response.status === RestStatus.OK) {
         dispatch({
-          type: actionDescriptors.fetchStorageSuccessful,
+          type: actionDescriptors.fetchAssetsSuccessful,
           payload: body.data,
         });
         return;
       } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
         dispatch({
-          type: actionDescriptors.fetchStorageFailed,
-          error: "Error while fetching Storage",
+          type: actionDescriptors.fetchAssetsFailed,
+          error: "Error while fetching from the Asset table",
         });
       }
       dispatch({
-        type: actionDescriptors.fetchStorageFailed,
+        type: actionDescriptors.fetchAssetsFailed,
         error: body.error,
       });
     } catch (err) {
       dispatch({
-        type: actionDescriptors.fetchStorageFailed,
-        error: "Error while fetching Storage",
+        type: actionDescriptors.fetchAssetsFailed,
+        error: "Error while fetching from the Asset table",
+      });
+    }
+  },
+
+  fetchSales: async (dispatch, limit, offset, queryValue) => {
+    const query = queryValue ? `&contractName=${queryValue}` : "";
+
+    dispatch({ type: actionDescriptors.fetchSales });
+
+    try {
+      const response = await fetch(
+        `${cirrusUrl}/Sale?limit=${limit}&offset=${offset}${query}`,
+        {
+          method: HTTP_METHODS.GET,
+        }
+      );
+
+      const body = await response.json();
+
+      if (response.status === RestStatus.OK) {
+        dispatch({
+          type: actionDescriptors.fetchSalesSuccessful,
+          payload: body.data,
+        });
+        return;
+      } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
+        dispatch({
+          type: actionDescriptors.fetchSalesFailed,
+          error: "Error while fetching from the Sale table",
+        });
+      }
+      dispatch({
+        type: actionDescriptors.fetchSalesFailed,
+        error: body.error,
+      });
+    } catch (err) {
+      dispatch({
+        type: actionDescriptors.fetchSalesFailed,
+        error: "Error while fetching from the Sale table",
       });
     }
   },

--- a/marketplace/ui/src/contexts/storage/actions.js
+++ b/marketplace/ui/src/contexts/storage/actions.js
@@ -1,5 +1,5 @@
 import RestStatus from "http-status-codes";
-import { cirrusUrl, HTTP_METHODS } from "../../helpers/constants";
+import { cirrusUrl, assetTableName, saleTableName, HTTP_METHODS } from "../../helpers/constants";
 
 const actionDescriptors = {
   resetMessage: "reset_message",
@@ -28,7 +28,7 @@ const actions = {
 
     try {
       const response = await fetch(
-        `${cirrusUrl}/Asset?limit=${limit}&offset=${offset}${query}`,
+        `${cirrusUrl}/${assetTableName}?limit=${limit}&offset=${offset}${query}`,
         {
           method: HTTP_METHODS.GET,
         }
@@ -67,7 +67,7 @@ const actions = {
 
     try {
       const response = await fetch(
-        `${cirrusUrl}/Sale?limit=${limit}&offset=${offset}${query}`,
+        `${cirrusUrl}/${saleTableName}?limit=${limit}&offset=${offset}${query}`,
         {
           method: HTTP_METHODS.GET,
         }

--- a/marketplace/ui/src/contexts/storage/actions.js
+++ b/marketplace/ui/src/contexts/storage/actions.js
@@ -4,12 +4,9 @@ import { cirrusUrl, HTTP_METHODS } from "../../helpers/constants";
 const actionDescriptors = {
   resetMessage: "reset_message",
   setMessage: "set_message",
-  fetchAssets: "fetch_assets",
-  fetchAssetsSuccessful: "fetch_assets_successful",
-  fetchAssetsFailed: "fetch_assets_failed",
-  fetchSales: "fetch_sales",
-  fetchSalesSuccessful: "fetch_sales_successful",
-  fetchSalesFailed: "fetch_sales_failed",
+  fetchStorage: "fetch_storage",
+  fetchStorageSuccessful: "fetch_storage_successful",
+  fetchStorageFailed: "fetch_storage_failed",
 };
 
 const actions = {
@@ -21,14 +18,14 @@ const actions = {
     dispatch({ type: actionDescriptors.setMessage, message, success });
   },
 
-  fetchAssets: async (dispatch, limit, offset, queryValue) => {
+  fetchStorage: async (dispatch, limit, offset, table, queryValue) => {
     const query = queryValue ? `&contractName=${queryValue}` : "";
 
-    dispatch({ type: actionDescriptors.fetchAssets });
+    dispatch({ type: actionDescriptors.fetchStorage });
 
     try {
       const response = await fetch(
-        `${cirrusUrl}/Asset?limit=${limit}&offset=${offset}${query}`,
+        `${cirrusUrl}/${table}?limit=${limit}&offset=${offset}${query}`,
         {
           method: HTTP_METHODS.GET,
         }
@@ -38,63 +35,24 @@ const actions = {
 
       if (response.status === RestStatus.OK) {
         dispatch({
-          type: actionDescriptors.fetchAssetsSuccessful,
+          type: actionDescriptors.fetchStorageSuccessful,
           payload: body.data,
         });
         return;
       } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
         dispatch({
-          type: actionDescriptors.fetchAssetsFailed,
-          error: "Error while fetching from the Asset table",
+          type: actionDescriptors.fetchStorageFailed,
+          error: `Error while fetching from the ${table} table`,
         });
       }
       dispatch({
-        type: actionDescriptors.fetchAssetsFailed,
+        type: actionDescriptors.fetchStorageFailed,
         error: body.error,
       });
     } catch (err) {
       dispatch({
-        type: actionDescriptors.fetchAssetsFailed,
-        error: "Error while fetching from the Asset table",
-      });
-    }
-  },
-
-  fetchSales: async (dispatch, limit, offset, queryValue) => {
-    const query = queryValue ? `&contractName=${queryValue}` : "";
-
-    dispatch({ type: actionDescriptors.fetchSales });
-
-    try {
-      const response = await fetch(
-        `${cirrusUrl}/Sale?limit=${limit}&offset=${offset}${query}`,
-        {
-          method: HTTP_METHODS.GET,
-        }
-      );
-
-      const body = await response.json();
-
-      if (response.status === RestStatus.OK) {
-        dispatch({
-          type: actionDescriptors.fetchSalesSuccessful,
-          payload: body.data,
-        });
-        return;
-      } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
-        dispatch({
-          type: actionDescriptors.fetchSalesFailed,
-          error: "Error while fetching from the Sale table",
-        });
-      }
-      dispatch({
-        type: actionDescriptors.fetchSalesFailed,
-        error: body.error,
-      });
-    } catch (err) {
-      dispatch({
-        type: actionDescriptors.fetchSalesFailed,
-        error: "Error while fetching from the Sale table",
+        type: actionDescriptors.fetchStorageFailed,
+        error: `Error while fetching from the ${table} table`,
       });
     }
   },

--- a/marketplace/ui/src/contexts/storage/actions.js
+++ b/marketplace/ui/src/contexts/storage/actions.js
@@ -4,9 +4,12 @@ import { cirrusUrl, HTTP_METHODS } from "../../helpers/constants";
 const actionDescriptors = {
   resetMessage: "reset_message",
   setMessage: "set_message",
-  fetchStorage: "fetch_storage",
-  fetchStorageSuccessful: "fetch_storage_successful",
-  fetchStorageFailed: "fetch_storage_failed",
+  fetchAssets: "fetch_assets",
+  fetchAssetsSuccessful: "fetch_assets_successful",
+  fetchAssetsFailed: "fetch_assets_failed",
+  fetchSales: "fetch_sales",
+  fetchSalesSuccessful: "fetch_sales_successful",
+  fetchSalesFailed: "fetch_sales_failed",
 };
 
 const actions = {
@@ -18,14 +21,14 @@ const actions = {
     dispatch({ type: actionDescriptors.setMessage, message, success });
   },
 
-  fetchStorage: async (dispatch, limit, offset, table, queryValue) => {
-    const query = queryValue ? `&contractName=${queryValue}` : "";
+  fetchAssets: async (dispatch, limit, offset, queryValue) => {
+    const query = queryValue ? `&${queryValue}` : "";
 
-    dispatch({ type: actionDescriptors.fetchStorage });
+    dispatch({ type: actionDescriptors.fetchAssets });
 
     try {
       const response = await fetch(
-        `${cirrusUrl}/${table}?limit=${limit}&offset=${offset}${query}`,
+        `${cirrusUrl}/Asset?limit=${limit}&offset=${offset}${query}`,
         {
           method: HTTP_METHODS.GET,
         }
@@ -35,24 +38,63 @@ const actions = {
 
       if (response.status === RestStatus.OK) {
         dispatch({
-          type: actionDescriptors.fetchStorageSuccessful,
-          payload: body.data,
+          type: actionDescriptors.fetchAssetsSuccessful,
+          payload: body,
         });
         return;
       } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
         dispatch({
-          type: actionDescriptors.fetchStorageFailed,
-          error: `Error while fetching from the ${table} table`,
+          type: actionDescriptors.fetchAssetsFailed,
+          error: `Error while fetching from the Asset table`,
         });
       }
       dispatch({
-        type: actionDescriptors.fetchStorageFailed,
+        type: actionDescriptors.fetchAssetsFailed,
         error: body.error,
       });
     } catch (err) {
       dispatch({
-        type: actionDescriptors.fetchStorageFailed,
-        error: `Error while fetching from the ${table} table`,
+        type: actionDescriptors.fetchAssetsFailed,
+        error: `Error while fetching from the Asset table`,
+      });
+    }
+  },
+
+  fetchSales: async (dispatch, limit, offset, queryValue) => {
+    const query = queryValue ? `&${queryValue}` : "";
+
+    dispatch({ type: actionDescriptors.fetchSales });
+
+    try {
+      const response = await fetch(
+        `${cirrusUrl}/Sale?limit=${limit}&offset=${offset}${query}`,
+        {
+          method: HTTP_METHODS.GET,
+        }
+      );
+
+      const body = await response.json();
+
+      if (response.status === RestStatus.OK) {
+        dispatch({
+          type: actionDescriptors.fetchSalesSuccessful,
+          payload: body,
+        });
+        return;
+      } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
+        dispatch({
+          type: actionDescriptors.fetchSalesFailed,
+          error: `Error while fetching from the Asset table`,
+        });
+      }
+      dispatch({
+        type: actionDescriptors.fetchSalesFailed,
+        error: body.error,
+      });
+    } catch (err) {
+      dispatch({
+        type: actionDescriptors.fetchSalesFailed,
+        error: `Error while fetching from the Asset table`,
       });
     }
   },

--- a/marketplace/ui/src/contexts/storage/actions.js
+++ b/marketplace/ui/src/contexts/storage/actions.js
@@ -1,0 +1,62 @@
+import RestStatus from "http-status-codes";
+import { cirrusUrl, HTTP_METHODS } from "../../helpers/constants";
+
+const actionDescriptors = {
+  resetMessage: "reset_message",
+  setMessage: "set_message",
+  fetchStorage: "fetch_storage",
+  fetchStorageSuccessful: "fetch_storage_successful",
+  fetchStorageFailed: "fetch_storage_failed"
+};
+
+const actions = {
+  resetMessage: (dispatch) => {
+    dispatch({ type: actionDescriptors.resetMessage });
+  },
+
+  setMessage: (dispatch, message, success = false) => {
+    dispatch({ type: actionDescriptors.setMessage, message, success });
+  },
+
+  fetchStorage: async (dispatch, limit, offset, queryValue) => {
+    const query = queryValue ? `&contractName=${queryValue}` : "";
+
+    dispatch({ type: actionDescriptors.fetchStorage });
+
+    try {
+      const response = await fetch(
+        `${cirrusUrl}/Asset?limit=${limit}&offset=${offset}${query}`,
+        {
+          method: HTTP_METHODS.GET,
+        }
+      );
+
+      const body = await response.json();
+
+      if (response.status === RestStatus.OK) {
+        dispatch({
+          type: actionDescriptors.fetchStorageSuccessful,
+          payload: body.data,
+        });
+        return;
+      } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {
+        dispatch({
+          type: actionDescriptors.fetchStorageFailed,
+          error: "Error while fetching Storage",
+        });
+      }
+      dispatch({
+        type: actionDescriptors.fetchStorageFailed,
+        error: body.error,
+      });
+    } catch (err) {
+      dispatch({
+        type: actionDescriptors.fetchStorageFailed,
+        error: "Error while fetching Storage",
+      });
+    }
+  },
+
+};
+
+export { actionDescriptors, actions };

--- a/marketplace/ui/src/contexts/storage/index.js
+++ b/marketplace/ui/src/contexts/storage/index.js
@@ -5,8 +5,7 @@ const StorageStateContext = createContext();
 const StorageDispatchContext = createContext();
 
 const initialState = {
-  assets: [],
-  sales: [],
+  data: [],
   error: undefined,
   isAssetsLoading: false,
   isSalesLoading: false,
@@ -36,7 +35,7 @@ const useStorageState = () => {
   return context;
 };
 
-const useStorageDispatch =() => {
+const useStorageDispatch = () => {
   const context = useContext(StorageDispatchContext);
   if (context === undefined) {
     throw new Error(

--- a/marketplace/ui/src/contexts/storage/index.js
+++ b/marketplace/ui/src/contexts/storage/index.js
@@ -4,16 +4,17 @@ import reducer from "./reducer";
 const StorageStateContext = createContext();
 const StorageDispatchContext = createContext();
 
-const initialState = {
-  data: [],
-  error: undefined,
-  isAssetsLoading: false,
-  isSalesLoading: false,
-  success: false,
-  message: null,
-};
-
 const StorageProvider = ({ children }) => {
+  const initialState = {
+    error: undefined,
+    assets: [],
+    sales: [],
+    isAssetsLoading: false,
+    isSalesLoading: false,
+    success: false,
+    message: null,
+  };
+
   const [state, dispatch] = useReducer(reducer, initialState);
 
   return (
@@ -54,5 +55,4 @@ export {
   useStorageState,
   useStorageUnit,
   StorageProvider,
-  initialState
 };

--- a/marketplace/ui/src/contexts/storage/index.js
+++ b/marketplace/ui/src/contexts/storage/index.js
@@ -4,15 +4,17 @@ import reducer from "./reducer";
 const StorageStateContext = createContext();
 const StorageDispatchContext = createContext();
 
-const StorageProvider = ({ children }) => {
-  const initialState = {
-    data: [],
-    error: undefined,
-    isStorageLoading: false,
-    success: false,
-    message: null,
-  };
+const initialState = {
+  assets: [],
+  sales: [],
+  error: undefined,
+  isAssetsLoading: false,
+  isSalesLoading: false,
+  success: false,
+  message: null,
+};
 
+const StorageProvider = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   return (
@@ -53,4 +55,5 @@ export {
   useStorageState,
   useStorageUnit,
   StorageProvider,
+  initialState
 };

--- a/marketplace/ui/src/contexts/storage/index.js
+++ b/marketplace/ui/src/contexts/storage/index.js
@@ -1,0 +1,56 @@
+import React, { createContext, useContext, useReducer } from "react";
+import reducer from "./reducer";
+
+const StorageStateContext = createContext();
+const StorageDispatchContext = createContext();
+
+const StorageProvider = ({ children }) => {
+  const initialState = {
+    data: [],
+    error: undefined,
+    isStorageLoading: false,
+    success: false,
+    message: null,
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <StorageStateContext.Provider value={state}>
+      <StorageDispatchContext.Provider value={dispatch}>
+        {children}
+      </StorageDispatchContext.Provider>
+    </StorageStateContext.Provider>
+  );
+};
+
+const useStorageState = () => {
+  const context = useContext(StorageStateContext);
+  if (context === undefined) {
+    throw new Error(
+      `'useStorageState' must be used within a StorageProvider`
+    );
+  }
+  return context;
+};
+
+const useStorageDispatch =() => {
+  const context = useContext(StorageDispatchContext);
+  if (context === undefined) {
+    throw new Error(
+      `'useStorageDispatch' must be used within a StorageProvider`
+    );
+  }
+  return context;
+};
+
+const useStorageUnit = () => {
+  return [useStorageState(), useStorageDispatch()];
+};
+
+export {
+  useStorageDispatch,
+  useStorageState,
+  useStorageUnit,
+  StorageProvider,
+};

--- a/marketplace/ui/src/contexts/storage/reducer.js
+++ b/marketplace/ui/src/contexts/storage/reducer.js
@@ -15,39 +15,22 @@ const reducer = (state = initialState, action) => {
         success: action.success,
         message: action.message
       };
-    case actionDescriptors.fetchAssets:
+    case actionDescriptors.fetchStorage:
       return {
         ...state,
-        isAssetsLoading: true
+        isStorageLoading: true
       };
-    case actionDescriptors.fetchAssetsSuccessful:
+    case actionDescriptors.fetchStorageSuccessful:
       return {
         ...state,
-        assets: action.payload,
-        isAssetsLoading: false
+        data: action.payload,
+        isStorageLoading: false
       };
-    case actionDescriptors.fetchAssetsFailed:
+    case actionDescriptors.fetchStorageFailed:
       return {
         ...state,
         error: action.error,
-        isAssetsLoading: false
-      };
-    case actionDescriptors.fetchSales:
-      return {
-        ...state,
-        isSalesLoading: true
-      };
-    case actionDescriptors.fetchSalesSuccessful:
-      return {
-        ...state,
-        sales: action.payload,
-        isSalesLoading: false
-      };
-    case actionDescriptors.fetchSalesFailed:
-      return {
-        ...state,
-        error: action.error,
-        isSalesLoading: false
+        isStorageLoading: false
       };
     default:
       throw new Error (`Unhandled action: '${action.type}'`);

--- a/marketplace/ui/src/contexts/storage/reducer.js
+++ b/marketplace/ui/src/contexts/storage/reducer.js
@@ -1,0 +1,39 @@
+import { actionDescriptors } from "./actions";
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case actionDescriptors.resetMessage:
+      return {
+        ...state,
+        success: false,
+        message: null
+      };
+    case actionDescriptors.setMessage:
+      return {
+        ...state,
+        success: action.success,
+        message: action.message
+      };
+    case actionDescriptors.fetchStorage:
+      return {
+        ...state,
+        isStorageLoading: true
+      };
+    case actionDescriptors.fetchStorageSuccessful:
+      return {
+        ...state,
+        data: action.payload,
+        isStorageLoading: false
+      };
+    case actionDescriptors.fetchStorageFailed:
+      return {
+        ...state,
+        error: action.error,
+        isStorageLoading: false
+      };
+    default:
+      throw new Error (`Unhandled action: '${action.type}'`);
+  }
+}
+
+export default reducer;

--- a/marketplace/ui/src/contexts/storage/reducer.js
+++ b/marketplace/ui/src/contexts/storage/reducer.js
@@ -1,6 +1,7 @@
 import { actionDescriptors } from "./actions";
+import { initialState } from ".";
 
-const reducer = (state, action) => {
+const reducer = (state = initialState, action) => {
   switch (action.type) {
     case actionDescriptors.resetMessage:
       return {
@@ -14,22 +15,39 @@ const reducer = (state, action) => {
         success: action.success,
         message: action.message
       };
-    case actionDescriptors.fetchStorage:
+    case actionDescriptors.fetchAssets:
       return {
         ...state,
-        isStorageLoading: true
+        isAssetsLoading: true
       };
-    case actionDescriptors.fetchStorageSuccessful:
+    case actionDescriptors.fetchAssetsSuccessful:
       return {
         ...state,
-        data: action.payload,
-        isStorageLoading: false
+        assets: action.payload,
+        isAssetsLoading: false
       };
-    case actionDescriptors.fetchStorageFailed:
+    case actionDescriptors.fetchAssetsFailed:
       return {
         ...state,
         error: action.error,
-        isStorageLoading: false
+        isAssetsLoading: false
+      };
+    case actionDescriptors.fetchSales:
+      return {
+        ...state,
+        isSalesLoading: true
+      };
+    case actionDescriptors.fetchSalesSuccessful:
+      return {
+        ...state,
+        sales: action.payload,
+        isSalesLoading: false
+      };
+    case actionDescriptors.fetchSalesFailed:
+      return {
+        ...state,
+        error: action.error,
+        isSalesLoading: false
       };
     default:
       throw new Error (`Unhandled action: '${action.type}'`);

--- a/marketplace/ui/src/contexts/storage/reducer.js
+++ b/marketplace/ui/src/contexts/storage/reducer.js
@@ -1,7 +1,6 @@
 import { actionDescriptors } from "./actions";
-import { initialState } from ".";
 
-const reducer = (state = initialState, action) => {
+const reducer = (state, action) => {
   switch (action.type) {
     case actionDescriptors.resetMessage:
       return {
@@ -15,22 +14,39 @@ const reducer = (state = initialState, action) => {
         success: action.success,
         message: action.message
       };
-    case actionDescriptors.fetchStorage:
+    case actionDescriptors.fetchAssets:
       return {
         ...state,
-        isStorageLoading: true
+        isAssetsLoading: true
       };
-    case actionDescriptors.fetchStorageSuccessful:
+    case actionDescriptors.fetchAssetsSuccessful:
       return {
         ...state,
-        data: action.payload,
-        isStorageLoading: false
+        assets: action.payload,
+        isAssetsLoading: false
       };
-    case actionDescriptors.fetchStorageFailed:
+    case actionDescriptors.fetchAssetsFailed:
       return {
         ...state,
         error: action.error,
-        isStorageLoading: false
+        isAssetsLoading: false
+      };
+    case actionDescriptors.fetchSales:
+      return {
+        ...state,
+        isSalesLoading: true
+      };
+    case actionDescriptors.fetchSalesSuccessful:
+      return {
+        ...state,
+        sales: action.payload,
+        isSalesLoading: false
+      };
+    case actionDescriptors.fetchSalesFailed:
+      return {
+        ...state,
+        error: action.error,
+        isSalesLoading: false
       };
     default:
       throw new Error (`Unhandled action: '${action.type}'`);

--- a/marketplace/ui/src/env.js
+++ b/marketplace/ui/src/env.js
@@ -1,0 +1,1 @@
+export const env = { ...process.env, ...window.env }

--- a/marketplace/ui/src/helpers/constants.js
+++ b/marketplace/ui/src/helpers/constants.js
@@ -2,6 +2,10 @@ export const apiUrl = process.env.REACT_APP_URL
   ? process.env.REACT_APP_URL + "/api/v1"
   : "/api/v1";
 
+export const cirrusUrl = process.env.REACT_APP_URL
+  ? process.env.REACT_APP_URL + "/cirrus/search"
+  : "/cirrus/search"
+
 export const HTTP_METHODS = {
   GET: "GET",
   POST: "POST",

--- a/marketplace/ui/src/helpers/constants.js
+++ b/marketplace/ui/src/helpers/constants.js
@@ -1,3 +1,5 @@
+import { env } from "../env";
+
 export const apiUrl = process.env.REACT_APP_URL
   ? process.env.REACT_APP_URL + "/api/v1"
   : "/api/v1";
@@ -5,6 +7,14 @@ export const apiUrl = process.env.REACT_APP_URL
 export const cirrusUrl = process.env.REACT_APP_URL
   ? process.env.REACT_APP_URL + "/cirrus/search"
   : "/cirrus/search"
+
+export const assetTableName = env.REACT_APP_ASSET_TABLE_NAME
+  ? env.REACT_APP_ASSET_TABLE_NAME
+  : "Asset"
+
+export const saleTableName = env.REACT_APP_SALE_TABLE_NAME
+  ? env.REACT_APP_SALE_TABLE_NAME
+  : "Sale"
 
 export const HTTP_METHODS = {
   GET: "GET",

--- a/marketplace/ui/src/helpers/routes.js
+++ b/marketplace/ui/src/helpers/routes.js
@@ -51,4 +51,5 @@ export default {
   ProcessingOrder: { label: "Processing Order", url: "/order/status" },
   Invoice: { label: "Invoice", url: "/orders/invoice/:id" },
   OnboardingSellerToStripe: { label: "Onboarding Seller to Stripe", url: "/inventories/stripe/onboarding" },
+  Storage: { label: "Storage", url: "/storage" },
 };


### PR DESCRIPTION
This PR creates a new page in the marketplace that can be used to query the asset and sale tables from the Cirrus database. 

### Features:

- **This new "Storage" page can only be accessed/seen by users whose X509 certificate organization is registered to exactly `BlockApps`. The button to access this page on the header will not be visible to any users outside of BlockApps. If someone outside BlockApps does try to access the page, it'll display an error message directing users back to the homepage.**
- The table displayed on the page features two columns:
   1. the `record_id` of the asset/sale
   2. the data associated with the `record_id` displayed in a JSON file text format.

- The search bar can be used to query the current opened table using Cirrus queries such as `address=eq.12345`.

Edit: Added new configurable flag for the asset/sale table names. To use, add the `ASSET_TABLE_NAME` and/or `SALE_TABLE_NAME` flag to your `strato-getting-started` run script.

### Example table using the Certificate contract data
![image](https://github.com/blockapps/strato-platform/assets/35944722/617e44d2-5d4b-48b3-899b-ac1064d635a1)


 