### PR TITLE
Don't crash Bagger when txs exceed nonce or size limits

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -39,6 +39,7 @@ so that they could be properly moved to their respective version's subsection.
 - POST `/transaction` calls redirected to the corresponding User contract
 ### Fixed
 - Error handle duplicate key violations in `code_ref` table
+- Bagger no longer crashes the VM upon encountering a transaction that exceeds the nonce or size limit
 ### Removed
 - `bloc22` database removed
 

--- a/strato/core/vm-tools/src/Blockchain/Bagger.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger.hs
@@ -111,8 +111,8 @@ runFromStateRoot mineTransactions remainingGas theBlockHeader txs = do
         Just f@TFNonceMismatch{} -> error $ "mineTransactions' we messed up: " ++ format f
         Just f@TFCodeCollectionNotFound{} -> recoverable f
         Just f@TFInvalidPragma{} -> recoverable f
-        Just f@TFNonceLimitExceeded{} -> error $ "mineTransactions' we messed up: " ++ format f
-        Just f@TFTXSizeLimitExceeded{} -> error $ "mineTransactions' we messed up: " ++ format f
+        Just f@TFNonceLimitExceeded{} -> recoverable f
+        Just f@TFTXSizeLimitExceeded{} -> recoverable f
 
 -- rewardCoinbases :: MonadBagger m => ChainMemberParsedSet -> [DD.BlockData] -> Integer -> m StateRoot -- miner coinbase -> known uncles -> this block number -> stateRoot
 -- rewardCoinbases us uncles ourNumber = do


### PR DESCRIPTION
These exceptions are due to user error, so they should not be treated as internal errors. The case that is an internal error is a nonce mismatch, which is something the Bagger filters on prior to building the block, so if a transaction with a nonce mismatch makes it through the Bagger, that is a bug in the Bagger itself