### PR TITLE
Expand index tables when delegatecall is made

### DIFF
--- a/strato/VM/EVM/ethereum-vm/src/Blockchain/EVM/VMState.hs
+++ b/strato/VM/EVM/ethereum-vm/src/Blockchain/EVM/VMState.hs
@@ -121,6 +121,7 @@ startingAction Environment{..} = Action.Action
   , _actionData               = M.empty
   , _metadata                 = envMetadata
   , _events                   = Seq.empty
+  , _delegatecalls            = Seq.empty
   }
 
 startingState :: Bool -> Bool -> Environment -> MemDBs -> IO VMState

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Function.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Function.hs
@@ -57,7 +57,6 @@ import           GHC.Generics
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances    ()
 
-import           Blockchain.Strato.Model.Account (Account)
 import           SolidVM.Model.CodeCollection.Statement
 import qualified SolidVM.Model.CodeCollection.VarDef  as SolidVM
 import           SolidVM.Model.SolidString
@@ -220,4 +219,5 @@ instance Arbitrary a => Arbitrary (FuncF a) where
 
 data FunctionCallType = DefaultCall
                       | RawCall
-                      | DelegateCall Account
+                      | DelegateCall
+                      deriving (Eq, Show)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -468,9 +468,9 @@ call' :: MonadSM m
       -> m ((SolidString, SolidString), Maybe Value)
 call' from to' fnCalltype mContract functionName isRCC argExps  = do
   let (to, ccToGet) = case fnCalltype of
-        CC.DefaultCall        -> (to', to')
-        CC.RawCall            -> (to', to')
-        CC.DelegateCall proxy -> (from, proxy)
+        CC.DefaultCall  -> (to', to')
+        CC.RawCall      -> (to', to')
+        CC.DelegateCall -> (from, to')
       fromChain = from ^. accountChainId
       toChain   = to ^. accountChainId
   isAccessibleChain <- toChain `isAncestorChainOf` fromChain
@@ -641,6 +641,7 @@ call' from to' fnCalltype mContract functionName isRCC argExps  = do
                     SVMType.Array _ _ -> return ()
                     _ -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n]) MS.BDefault
                 popCallInfo)
+  when (fnCalltype == CC.DelegateCall) $ addDelegatecall from to' (T.pack org) (T.pack parentName')
   ((org, parentName'),) <$> logFunctionCall args to contract functionName f
   where
     flattenVals (x:xs) = [x] ++ flattenVals xs
@@ -2003,7 +2004,7 @@ expToVar' theFullExp@(CC.FunctionCall _ e args) = do
                     (CC.NamedArgs _ ) ->  typeError "Cannot provide named args to delegate call" args)
               fromAddress <- getCurrentAccount
               let toAddress = namedAccountToAccount (fromAddress ^. accountChainId) addr
-              res <- callWithResult fromAddress toAddress (CC.DelegateCall toAddress) Nothing funcName False args'
+              res <- callWithResult fromAddress toAddress CC.DelegateCall Nothing funcName False args'
               case res of
                   Just a  -> return $ Constant  a
                   Nothing -> return $ Constant SNULL

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -54,7 +54,8 @@ module Blockchain.SolidVM.SM (
   markDiffForAction,
   getBlockHashWithNumber,
   getBSum,
-  addEvent
+  addEvent,
+  addDelegatecall
   ) where
 
 import           Control.Monad
@@ -186,6 +187,7 @@ type MonadSM m = ( (Account `A.Alters` AddressState) m
                  , Mod.Modifiable [CallInfo] m
                  , Mod.Modifiable Action m
                  , Mod.Modifiable (Q.Seq Event) m
+                 , Mod.Modifiable (Q.Seq Action.Delegatecall) m
                  , Mod.Modifiable (Maybe DebugSettings) m
                  , MonadUnliftIO m --todo: remove
                  , MonadCatch m
@@ -327,6 +329,10 @@ instance MonadUnliftIO m => Mod.Modifiable (Q.Seq Event) (SM m) where
   get _   = gets (Action._events . _action)
   put _ q = modify $ action . Action.events .~ q
 
+instance MonadUnliftIO m => Mod.Modifiable (Q.Seq Action.Delegatecall) (SM m) where
+  get _   = gets (Action._delegatecalls . _action)
+  put _ q = modify $ action . Action.delegatecalls .~ q
+
 runSM :: ( MonadUnliftIO m
          , MonadLogger m
          , Mod.Modifiable ContextState m
@@ -395,6 +401,7 @@ startingAction maybeCode env' chainId' = Action.Action
           Just $ M.insert "src" (T.pack $ UTF8.toString theCode) $ fromMaybe M.empty $ Env.metadata env'
         Nothing -> Env.metadata env'
   , _events             = Q.empty
+  , _delegatecalls      = Q.empty
   }
 
 
@@ -823,6 +830,9 @@ markDiffForAction owner key' val' = do
 
 addEvent :: Mod.Modifiable (Q.Seq Event) m => Event -> m ()
 addEvent newEvent = Mod.modify_ (Mod.Proxy @(Q.Seq Event)) $ pure . (Q.|> newEvent)
+
+addDelegatecall :: Mod.Modifiable (Q.Seq Action.Delegatecall) m => Account -> Account -> T.Text -> T.Text -> m ()
+addDelegatecall s c o a = Mod.modify_ (Mod.Proxy @(Q.Seq Action.Delegatecall)) $ pure . (Q.|> Action.Delegatecall s c o a)
 
 getBlockHashWithNumber :: MonadSM m => Integer -> Keccak256 -> m (Maybe Keccak256)
 getBlockHashWithNumber num h = do

--- a/strato/core/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Data/GenesisBlock.hs
@@ -348,6 +348,7 @@ initializeChainDBs chainId (ChainInfo UnsignedChainInfo{..} _) org app = do
                                [A.Create]
           , A._metadata = getMetadata ch
           , A._events = S.empty
+          , A._delegatecalls = S.empty
           }
         where
              ch =

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -264,6 +264,7 @@ populateStorageDBs getMetadata genesisBlock genesisChainId = do
                   SolidVMCode _ ch' -> ch'
                   CodeAtAccount _ _ -> error "TODO: Encountered CodeAtAccount in genesis block")
             , A._events = S.empty
+            , A._delegatecalls = S.empty
             }
           fromDiff :: Diff a 'Eventual -> a
           fromDiff (Value v) = v

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -580,8 +580,9 @@ sendOutEvent (OutAction act) =
                 }
           _ -> Nothing
       ccEvents = maybeToList $ extractCodeCollectionAddedMessages act
+      dcEvents = DelegatecallMade <$> toList (act ^. Action.delegatecalls)
       actionEvents = [NewAction act]
-   in void . produceVMEvents $ ccEvents ++ actionEvents
+   in void . produceVMEvents $ ccEvents ++ dcEvents ++ actionEvents
 sendOutEvent (OutIndexEvent e) = void . K.withKafkaRetry1s $ writeIndexEvents [e]
 sendOutEvent (OutToStateDiff cId cInfo bHash org app) = withCurrentBlockHash bHash $ initializeChainDBs (Just cId) cInfo org app
 sendOutEvent (OutStateDiff diff) = do

--- a/strato/core/vm-tools/src/Blockchain/Stream/Action.hs
+++ b/strato/core/vm-tools/src/Blockchain/Stream/Action.hs
@@ -98,7 +98,7 @@ instance FromJSON CallData where
     <*> (o .: "value")
     <*> (o .: "input")
     <*> (o .:? "output")
-  parseJSON o = error $ "parseJSON CallData: Expected object, got: " ++ show o
+  parseJSON o = fail $ "parseJSON CallData: Expected object, got: " ++ show o
 
 emptyCallData :: CallData
 emptyCallData = CallData
@@ -199,7 +199,39 @@ instance FromJSON ActionData where
       SolidVM -> explicitParseField parseDiffSolidVM) o "diff"
     dt <- o .: "types"
     return $ ActionData ch og ap ck df dt
-  parseJSON o = error $ "parseJSON ActionData: Expected object, got: " ++ show o
+  parseJSON o = fail $ "parseJSON ActionData: Expected object, got: " ++ show o
+
+data Delegatecall = Delegatecall
+  { _delegatecallStorageAccount :: Account
+  , _delegatecallCodeAccount    :: Account
+  , _delegatecallOrganization   :: Text
+  , _delegatecallApplication    :: Text
+  } deriving (Eq, Show, Generic, NFData)
+makeLenses ''Delegatecall
+
+instance Format Delegatecall where
+  format Delegatecall{..} =
+    "delegatecallStorageAccount: " ++ format _delegatecallStorageAccount ++ "\n"
+    ++ "delegatecallCodeAccount: " ++ format _delegatecallCodeAccount ++ "\n"
+    ++ "delegatecallOrganization: " ++ T.unpack _delegatecallOrganization ++ "\n"
+    ++ "delegatecallApplication: " ++ T.unpack _delegatecallApplication
+
+instance ToJSON Delegatecall where
+  toJSON Delegatecall{..} = object
+    [ "storageAccount" .= _delegatecallStorageAccount
+    , "codeAccount"    .= _delegatecallCodeAccount
+    , "organization"   .= _delegatecallOrganization
+    , "application"    .= _delegatecallApplication
+    ]
+
+instance FromJSON Delegatecall where
+  parseJSON (Object o) = do
+    s <- o .: "storageAccount"
+    c <- o .: "codeAccount"
+    r <- o .: "organization"
+    a <- o .: "application"
+    pure $ Delegatecall s c r a
+  parseJSON o = fail $ "parseJSON Delegatecall: Expected object, got: " ++ show o
 
 data Action = Action
   { _blockHash          :: Keccak256
@@ -211,6 +243,7 @@ data Action = Action
   , _actionData         :: Map Account ActionData
   , _metadata           :: Maybe (Map Text Text)
   , _events             :: S.Seq Event
+  , _delegatecalls      :: S.Seq Delegatecall
   } deriving (Eq, Show, Generic, NFData)
 makeLenses ''Action
 
@@ -225,6 +258,7 @@ instance Format Action where
     ++ "actionData:\n" ++ unlines (map (\(k, v) -> tab $ format k ++ ":\n" ++ (tab $ format v)) $ M.toList _actionData) ++ "\n"
     ++ "actionMetadata: " ++ unwords (map (\(k, v) -> "(" ++ CL.blue (show k) ++ ": " ++ show (shorten 30 $ T.unpack v) ++ ")") $ M.toList $ fromMaybe M.empty $ _metadata) ++ "\n"
     ++ "actionEvents: " ++ unlines (map show $ toList _events) ++ "\n"
+    ++ "actionDelegatecalls: " ++ unlines (map show $ toList _delegatecalls) ++ "\n"
 
 instance ToJSON Action where
   toJSON Action{..} = object
@@ -237,6 +271,7 @@ instance ToJSON Action where
     , "data"            .= _actionData
     , "metadata"        .= _metadata
     , "events"          .= _events
+    , "delegatecalls"   .= _delegatecalls
     ]
 
 instance FromJSON Action where
@@ -250,7 +285,8 @@ instance FromJSON Action where
     <*> (o .: "data")
     <*> (o .: "metadata")
     <*> (o .: "events")
-  parseJSON o = error $ "parseJSON Action: Expected object, got: " ++ show o
+    <*> (fromMaybe S.empty <$> (o .:? "delegatecalls"))
+  parseJSON o = fail $ "parseJSON Action: Expected object, got: " ++ show o
 
 instance Arbitrary CallType where
   arbitrary = genericArbitrary
@@ -262,6 +298,9 @@ instance Arbitrary DataDiff where
   arbitrary = genericArbitrary
 
 instance Arbitrary ActionData where
+  arbitrary = genericArbitrary
+
+instance Arbitrary Delegatecall where
   arbitrary = genericArbitrary
 
 instance Arbitrary Action where

--- a/strato/core/vm-tools/src/Blockchain/Stream/VMEvent.hs
+++ b/strato/core/vm-tools/src/Blockchain/Stream/VMEvent.hs
@@ -43,7 +43,7 @@ import           BlockApps.Logging
 import           Blockchain.Data.TransactionResult
 import           Blockchain.EthConf
 import           Blockchain.Strato.Model.CodePtr
-import           Blockchain.Stream.Action (Action)
+import           Blockchain.Stream.Action (Action, Delegatecall)
 import           Blockchain.KafkaTopics
 import           Blockchain.MilenaTools
 import           Blockchain.Stream.Raw
@@ -61,6 +61,7 @@ data VMEvent =
     historyList :: [Text],
     recordMappings :: [Text]
     } |
+  DelegatecallMade Delegatecall |
   NewTransactionResult TransactionResult deriving (Show, Generic)
 
 instance JSON.ToJSON VMEvent where
@@ -81,6 +82,8 @@ instance Format VMEvent where
     ++ (if (not $ null rm) then " " ++ show rm else "")
     ++ "\n    "
     ++ show (shorten 120 (T.unpack c))
+  format (DelegatecallMade d) =
+    "DelegatecallMade: " ++ format d
   format (NewTransactionResult tr) = "NewTransactionResult:\n" ++ tab (format tr)
 
 class HasVMEventsSink k where

--- a/strato/indexer/slipstream/src/Slipstream/MessageConsumer.hs
+++ b/strato/indexer/slipstream/src/Slipstream/MessageConsumer.hs
@@ -80,6 +80,7 @@ getAndProcessMessages :: ( MonadLogger m
                          , Accessible (IORef Globals) m
                          , Selectable Account AddressState m
                          , Selectable Account CodeCollection m
+                         , Selectable Account Contract m
                          , Selectable Word256 ParentChainIds m
                          , HasCodeDB m
                          )
@@ -95,6 +96,7 @@ getAndProcessMessages' :: ( MonadLogger m
                           , Accessible (IORef Globals) m
                           , Selectable Account AddressState m
                           , Selectable Account CodeCollection m
+                          , Selectable Account Contract m
                           , Selectable Word256 ParentChainIds m
                           , HasCodeDB m
                           )

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -402,6 +402,7 @@ processTheMessages :: ( MonadLogger m
                       , HasSQL m
                       , Selectable Account AddressState m
                       , Selectable Account CodeCollection m
+                      , Selectable Account Contract m
                       , Selectable Word256 ParentChainIds m
                       , HasCodeDB m
                       , Mod.Accessible (IORef Globals) m
@@ -419,6 +420,7 @@ processTheMessages env conn messages = do
       events' = parseEvents messages
       -- TODO (Dan) : would be nice if we didn't just rip events out at the top level like this
       creates = [(c, cp, o, a, hl, rm) | CodeCollectionAdded c cp o a hl rm <- messages]
+      delegates = [d | DelegatecallMade d <- messages]
       transactionResults = [tr | NewTransactionResult tr <- messages]
       -- Use different functions based on flag value, this way it is only computed once, saving cpu cycles with if statements
       getCC = getCodeCollection
@@ -481,7 +483,25 @@ processTheMessages env conn messages = do
         $logInfoS "processTheMessages" $ T.pack cc
         pure $ Left cc -- Either String String
 
-  let fkeys = rights fkeys'
+  dfkeys' <- forM delegates $ \d@(Action.Delegatecall s c' o a) -> do
+    $logInfoS "processTheMessages" $ "Delegatecall made: " <> T.pack (format d)
+    mStorageContract <- select (Proxy @Contract) s
+    mCodeContract <- select (Proxy @Contract) c'
+    deferredForeignKeys <- case (,) <$> mStorageContract <*> mCodeContract of
+      Nothing -> pure []
+      Just (sc, cc) -> do
+        let c = cc{_contractName = _contractName sc}
+            mapNames = getMapNamesFromContract c
+        nameParts <- resolveNameParts o a c
+        forM_ mapNames $ outputData conn . createMappingTable g nameParts
+        deferredForeignKeys <- outputData conn $ createExpandIndexTable g c nameParts
+        outputData' conn $ createExpandHistoryTable g c nameParts
+        outputData conn $ createExpandEventTables g c nameParts
+        pure deferredForeignKeys
+    forM_ deferredForeignKeys $ outputData conn . createForeignIndexesForJoins
+    pure $ Right deferredForeignKeys
+
+  let fkeys = rights $ fkeys' ++ dfkeys'
 
   inserts <- enterBloc2 env $ do
     forM changes $ \(acct,actions) -> do

--- a/strato/indexer/slipstream/tests/ActionFidelitySpec.hs
+++ b/strato/indexer/slipstream/tests/ActionFidelitySpec.hs
@@ -31,7 +31,7 @@ emptySolidVMData :: Action.ActionData
 emptySolidVMData = Action.ActionData (SolidVMCode "ContractName" $ unsafeCreateKeccak256FromWord256 0) "LambdaCorp2" "Clozure2" SolidVM (Action.SolidVMDiff M.empty) []
 
 emptyAction :: Action
-emptyAction = Action.Action (unsafeCreateKeccak256FromWord256 0) (posixSecondsToUTCTime 0) 0 (unsafeCreateKeccak256FromWord256 0) Nothing (Account 0x0 Nothing) M.empty Nothing S.empty
+emptyAction = Action.Action (unsafeCreateKeccak256FromWord256 0) (posixSecondsToUTCTime 0) 0 (unsafeCreateKeccak256FromWord256 0) Nothing (Account 0x0 Nothing) M.empty Nothing S.empty S.empty
 
 spec :: Spec
 spec = describe "Action conversions" $ do
@@ -133,5 +133,5 @@ spec = describe "Action conversions" $ do
           }
         , Action._metadata = Just . M.fromList $ [("name", "Vehicle"), ("src", "contract Vehicle {}")]
         , Action._events = S.singleton $ Event zeroHash "BlockApps2" "LogisticsEngine2" "Vehicle" (Account 0x2e385b6a3aea46d4172df98617b5385c13b7100d Nothing) "Vehicle Event" [("field", "value"), ("anotherField", "anotherValue")]
-         
+        , Action._delegatecalls = S.empty
       })


### PR DESCRIPTION
This allows fields from logic contracts in the Proxy contract pattern to show up in Cirrus.
For example, creating a normal Proxy contract:
```js
abstract contract ProxyBase {}

contract Proxy is ProxyBase {
    address public codeAddress;
    address public owner;

    constructor(address _codeAddress) {
        owner = msg.sender;
        codeAddress = _codeAddress;
    }

    modifier onlyOwner(string _func) {
        require(msg.sender == owner, "You must be the owner to call " + _func);
        _;
    }

    function upgrade(address _newCodeAddress) public onlyOwner("upgrade") {
        codeAddress = _newCodeAddress;
    }

    function callFunction(string _funcName, variadic _args) public onlyOwner("callFunction") returns (variadic) {
        return codeAddress.delegatecall(_funcName, _args);
    }
}
```
pointing to a logic contract:
```js
contract Logic {
    uint x;
    string y;
    bool z;
    address alpha;

    function setY(string _y) {
      y = _y;
    }
}
```

Creates the Proxy table as so:
```json
[{"record_id":"aa63a1c1280ea92f665e06b753f09bdd7ed3dd6b","address":"aa63a1c1280ea92f665e06b753f09bdd7ed3dd6b","chainId":"","block_hash":"dea63618bf275f3f21ab92a2d68f95d91c67945f426b4a27a4092a566ace6e85","block_timestamp":"2023-09-10 15:59:02 UTC","block_number":"9799","transaction_hash":"c02d62d3db14107a2e59c1edc5325acead42250ed7d04ab59d420040c4463e64","transaction_sender":"16ba814ac7b1ad6ab119fd53c760822c01643cc5","codeAddress":"82f8bf55213ab9847e42969f15e5491b1a6c4bca","owner":"16ba814ac7b1ad6ab119fd53c760822c01643cc5"}]
```
and the ProxyBase table:
```js
[{"record_id":"aa63a1c1280ea92f665e06b753f09bdd7ed3dd6b","address":"aa63a1c1280ea92f665e06b753f09bdd7ed3dd6b","chainId":"","block_hash":"dea63618bf275f3f21ab92a2d68f95d91c67945f426b4a27a4092a566ace6e85","block_timestamp":"2023-09-10 15:59:02 UTC","block_number":"9799","transaction_hash":"c02d62d3db14107a2e59c1edc5325acead42250ed7d04ab59d420040c4463e64","transaction_sender":"16ba814ac7b1ad6ab119fd53c760822c01643cc5","contract_name":"BlockApps-ProxyTest2","data":"{\"codeAddress\":\"82f8bf55213ab9847e42969f15e5491b1a6c4bca\",\"owner\":\"16ba814ac7b1ad6ab119fd53c760822c01643cc5\"}"}]
```

But after making a call to `callFunction`, with the arguments `{_funcName: "setY", _args: ["Hello World!"]}`, the Proxy table is expanded to include the fields from `Logic`:
```js
[{"record_id":"aa63a1c1280ea92f665e06b753f09bdd7ed3dd6b","address":"aa63a1c1280ea92f665e06b753f09bdd7ed3dd6b","chainId":"","block_hash":"dea63618bf275f3f21ab92a2d68f95d91c67945f426b4a27a4092a566ace6e85","block_timestamp":"2023-09-10 15:59:02 UTC","block_number":"9799","transaction_hash":"c02d62d3db14107a2e59c1edc5325acead42250ed7d04ab59d420040c4463e64","transaction_sender":"16ba814ac7b1ad6ab119fd53c760822c01643cc5","codeAddress":"82f8bf55213ab9847e42969f15e5491b1a6c4bca","owner":"16ba814ac7b1ad6ab119fd53c760822c01643cc5","alpha":null,"x":null,"y":"Hello World!","z":null}]
```
and the row in the ProxyBase table is updated to include `y`:
```js
[{"record_id":"aa63a1c1280ea92f665e06b753f09bdd7ed3dd6b","address":"aa63a1c1280ea92f665e06b753f09bdd7ed3dd6b","chainId":"","block_hash":"dea63618bf275f3f21ab92a2d68f95d91c67945f426b4a27a4092a566ace6e85","block_timestamp":"2023-09-10 15:59:02 UTC","block_number":"9799","transaction_hash":"c02d62d3db14107a2e59c1edc5325acead42250ed7d04ab59d420040c4463e64","transaction_sender":"16ba814ac7b1ad6ab119fd53c760822c01643cc5","contract_name":"BlockApps-ProxyTest2","data":"{\"codeAddress\":\"82f8bf55213ab9847e42969f15e5491b1a6c4bca\",\"owner\":\"16ba814ac7b1ad6ab119fd53c760822c01643cc5\",\"y\":\"Hello World!\"}"}]
```