### PR TITLE
[SolidVM] Fix SolidVMSpec tests

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -39,6 +39,7 @@ so that they could be properly moved to their respective version's subsection.
 - POST `/transaction` calls redirected to the corresponding User contract
 ### Fixed
 - Error handle duplicate key violations in `code_ref` table
+- Bagger no longer crashes the VM upon encountering a transaction that exceeds the nonce or size limit
 ### Removed
 - `bloc22` database removed
 

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -38,6 +38,10 @@ so that they could be properly moved to their respective version's subsection.
 - POST `/transaction` calls redirected to the corresponding User contract
 ### Fixed
 - Error handle duplicate key violations in `code_ref` table
+- String formatting related errors in `.code` SolidVM tests
+- Typechecker test errors that were missing `pragma strict` and failing
+- The out-of-scope errors of storage variables for Solidity try/catch statements
+- Free function overloading conflict with the import resolver 
 ### Removed
 - `bloc22` database removed
 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1175,7 +1175,8 @@ runStatement (CC.SolidityTryCatchStatement tryExpression returnsDecl statementsF
     expResultVal <- getVar =<< expToVar tryExpression
     return expResultVal
   case mRes of
-    Left ex -> do
+    Left (ex :: SolidException) -> do
+      $logInfoS "DEBUG" $ T.pack $ show ex
       res1 <- solidityExceptionHandler catchBlockMap ex
       return res1
     Right aRealVal -> do
@@ -3162,20 +3163,24 @@ encodeForReturn' x = todo "Cannot encode this return type: " x
 {- BEN WILL REFACTOR THIS SOMEDAY -}
 solidityExceptionHandler :: MonadSM m => (M.Map String (Maybe (String, SVMType.Type), [CC.Statement])) -> SolidException -> m (Maybe Value)
 solidityExceptionHandler catchBlockMap ex = do
+  $logInfoS "DEBUG2" $ T.pack $ show catchBlockMap
   let solidityExceptionHandlerHelper cbm s1 s2 errCode errFunc = do
         case M.lookup "Panic" cbm of
           Nothing -> do
             case M.lookup "Nill" cbm of
               Nothing -> errFunc s1 s2
               Just (_, stmts) -> do
+                popCallInfo
                 res' <-  runStatementBlock stmts
                 return res'
           Just (mVar, block) -> do
             case mVar of
               Nothing -> do
+                popCallInfo
                 res' <-  runStatementBlock block
                 return res'
               Just (varName, varType) -> do
+                popCallInfo
                 addLocalVariable varType varName (SInteger errCode)
                 res <- runStatementBlock block
                 return res
@@ -3211,14 +3216,17 @@ solidityExceptionHandler catchBlockMap ex = do
           case M.lookup "Nill" catchBlockMap of
             Nothing -> arityMismatch s1 i1 i2
             Just (_, stmts) -> do
+              popCallInfo
               res' <-  runStatementBlock stmts
               return res'
         Just (mVar, block) -> do
           case mVar of
             Nothing -> do
+              popCallInfo
               res' <-  runStatementBlock block
               return res'
             Just (varName, varType) -> do
+              popCallInfo
               addLocalVariable varType varName (SInteger 9)
               res <- runStatementBlock block
               return res
@@ -3234,14 +3242,17 @@ solidityExceptionHandler catchBlockMap ex = do
           case M.lookup "Nill" catchBlockMap of
             Nothing -> divideByZero s1
             Just (_, stmts) -> do
+              popCallInfo
               res' <-  runStatementBlock stmts
               return res'
         Just (mVar, block) -> do
           case mVar of
             Nothing -> do
+              popCallInfo
               res' <-  runStatementBlock block
               return res'
             Just (varName, varType) -> do
+              popCallInfo
               addLocalVariable varType varName (SInteger 12)
               res <- runStatementBlock block
               return res
@@ -3253,14 +3264,17 @@ solidityExceptionHandler catchBlockMap ex = do
               _ <- require False s1
               return Nothing
             Just (_, stmts) -> do
+              popCallInfo
               res' <-  runStatementBlock stmts
               return res'
         Just (mVar, block) -> do
           case mVar of
             Nothing -> do
+              popCallInfo
               res' <-  runStatementBlock block
               return res'
             Just (varName, varType) -> do
+              popCallInfo
               addLocalVariable varType varName (SString (fromMaybe "Require Error" s1))
               res <- runStatementBlock block
               return res
@@ -3272,14 +3286,17 @@ solidityExceptionHandler catchBlockMap ex = do
               _ <- assert False
               return Nothing
             Just (_, stmts) -> do
+              popCallInfo
               res' <-  runStatementBlock stmts
               return res'
         Just (mVar, block) -> do
           case mVar of
             Nothing -> do
+              popCallInfo
               res' <-  runStatementBlock block
               return res'
             Just (varName, varType) -> do
+              popCallInfo
               addLocalVariable varType varName (SString "Assertion Error")
               res <- runStatementBlock block
               return res

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1176,7 +1176,6 @@ runStatement (CC.SolidityTryCatchStatement tryExpression returnsDecl statementsF
     return expResultVal
   case mRes of
     Left (ex :: SolidException) -> do
-      $logInfoS "DEBUG" $ T.pack $ show ex
       res1 <- solidityExceptionHandler catchBlockMap ex
       return res1
     Right aRealVal -> do
@@ -3163,7 +3162,6 @@ encodeForReturn' x = todo "Cannot encode this return type: " x
 {- BEN WILL REFACTOR THIS SOMEDAY -}
 solidityExceptionHandler :: MonadSM m => (M.Map String (Maybe (String, SVMType.Type), [CC.Statement])) -> SolidException -> m (Maybe Value)
 solidityExceptionHandler catchBlockMap ex = do
-  $logInfoS "DEBUG2" $ T.pack $ show catchBlockMap
   let solidityExceptionHandlerHelper cbm s1 s2 errCode errFunc = do
         case M.lookup "Panic" cbm of
           Nothing -> do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/ImportResolver.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/ImportResolver.hs
@@ -32,10 +32,10 @@ import           Control.Monad.Trans.Class            (lift)
 import           Control.Monad.Trans.Except
 import           Control.Lens                         hiding (assign, from, to, bimap, Context)
 import           Data.Default
-import           Data.Foldable                        (foldrM)
+import           Data.Foldable                        (foldl', foldrM)
 import           Data.Map                             (Map)
 import qualified Data.Map                             as M
-import           Data.Maybe                           (fromMaybe)
+import           Data.Maybe                           (fromJust, fromMaybe)
 import qualified Data.Set                             as S
 import           Data.Text                            (Text)
 import qualified Data.Text                            as T
@@ -77,11 +77,25 @@ mergeUnresolvedFileUnitsIgnoreDuplicates :: UnresolvedFileUnitsF a -> Unresolved
 mergeUnresolvedFileUnitsIgnoreDuplicates (UFU i p u) (UFU j q v) = UFU (i <> j) (p <> q) (u <> v)
 
 mergeUnresolvedFileUnits :: Show a => UnresolvedFileUnitsF a -> UnresolvedFileUnitsF a -> Either Text (UnresolvedFileUnitsF a)
-mergeUnresolvedFileUnits (UFU i p u) (UFU j q v) =
-  let n = M.intersection u v
-   in if null n
-        then Right $ UFU (i <> j) (p <> q) (u <> v)
-        else Left . T.pack $ "Duplicate values: " ++ show n
+mergeUnresolvedFileUnits (UFU i p u) (UFU j q v) = do
+  -- Checking if there are duplicates and if there are,
+  -- determine if they are functions that are overloadable.
+  let duplicates = M.toList $ M.intersection u v
+      overloads = map (\(k, val) -> do
+                        let otherVal = fromJust $ M.lookup k v
+                          in case (val, otherVal) of
+                               (FUFunction v1, FUFunction v2) -> if (_funcArgs v1) == (_funcArgs v2)
+                                                                   then (False, k, FUFunction v1)
+                                                                   else (True, k, FUFunction v1{_funcOverload = (_funcOverload v1) ++ [v2]})
+                               _ -> (False, k, val)
+                          ) duplicates
+      mergeAsOverloads = all (\(b, _, _) -> b) overloads
+      newFileUnits = foldl' (\accumMap (_, k, newVal) -> M.insert k newVal accumMap) u overloads
+  if null duplicates
+    then Right $ UFU (i <> j) (p <> q) (u <> v)
+    else if mergeAsOverloads
+           then Right $ UFU (i <> j) (p <> q) (newFileUnits)
+           else Left . T.pack $ "Duplicate values: " ++ show duplicates
 
 instance Semigroup (UnresolvedFileUnitsF a) where
   (<>) = mergeUnresolvedFileUnitsIgnoreDuplicates

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -4197,7 +4197,7 @@ contract qq{
   it "can get the code for a contract if supplied an empty string" . runTest $ do
     let codeSnippet :: String
         codeSnippet = [r|contract Test {
-
+  
   constructor () public {
     }
 }
@@ -4530,7 +4530,7 @@ contract qq {
   it "Can get just the contract if empty string is fed to the code function. using .code" . runTest $ do
     let codeSnippet :: String
         codeSnippet = [r|contract Test {
-
+  
   constructor () public {
     }
 }

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -6356,7 +6356,7 @@ contract qq{
   constructor() public {
     myNum = sum(myArr);
   }
-}|]) `shouldThrow` anyParseError
+}|]) `shouldThrow` anyTypeError
 
 
   it "can declare a constant at the file level and use it" . runTest $ do

--- a/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
@@ -161,6 +161,8 @@ contract B {
     length anns `shouldBe` 0
   it "cannot call private contract functions" $ do
     anns <- liftIO $ runTypechecker [r|
+pragma strict;
+
 contract A {
   function realFunction() private {
   }
@@ -176,6 +178,8 @@ contract B {
     length anns `shouldBe` 1
   it "cannot call internal contract functions" $ do
     anns <- liftIO $ runTypechecker [r|
+pragma strict;
+
 contract A {
   function realFunction() internal {
   }
@@ -1513,6 +1517,7 @@ contract qq {
 
     it "can't call own external function" $ do
       anns <- liftIO $ runTypechecker [r|
+pragma strict;
 
 contract qq {
   uint x = 7;
@@ -1570,6 +1575,7 @@ contract qq {
 
     it "can't call an inherited private function" $ do
       anns <- liftIO $ runTypechecker [r|
+pragma strict;
 
 contract Parent {
   uint x = 7;
@@ -1592,6 +1598,7 @@ contract qq is Parent {
 
     it "can't call an inherited external function" $ do
       anns <- liftIO $ runTypechecker [r|
+pragma strict;
 
 contract Parent {
   uint x = 7;
@@ -1658,6 +1665,7 @@ contract qq is Parent {
 
     it "can't call a private function in another contract" $ do
       anns <- liftIO $ runTypechecker [r|
+pragma strict;
 
 contract Parent {
   uint x = 7;
@@ -1696,6 +1704,7 @@ contract qq {
 
     it "can't call an internal function from another contract" $ do
       anns <- liftIO $ runTypechecker [r|
+pragma strict;
 
 contract Parent {
   uint x = 7;

--- a/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
@@ -162,4 +162,4 @@ tFormTypeToType = \case
   (SolidType.Account _)                   ->  (XabiType.Account)
   (SolidType.Fixed _ _)                   ->  (XabiType.Bool) --Questionable at best
   (SolidType.Error _ ss)                  ->  (XabiType.UnknownLabel ss)          --Questionable at best
-  SolidType.Variadic                      ->  error "type (variadic) is not an indexable type"
+  SolidType.Variadic                      ->  XabiType.Variadic

--- a/strato/core/vm-tools/src/Blockchain/Bagger.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger.hs
@@ -111,8 +111,8 @@ runFromStateRoot mineTransactions remainingGas theBlockHeader txs = do
         Just f@TFNonceMismatch{} -> error $ "mineTransactions' we messed up: " ++ format f
         Just f@TFCodeCollectionNotFound{} -> recoverable f
         Just f@TFInvalidPragma{} -> recoverable f
-        Just f@TFNonceLimitExceeded{} -> error $ "mineTransactions' we messed up: " ++ format f
-        Just f@TFTXSizeLimitExceeded{} -> error $ "mineTransactions' we messed up: " ++ format f
+        Just f@TFNonceLimitExceeded{} -> recoverable f
+        Just f@TFTXSizeLimitExceeded{} -> recoverable f
 
 -- rewardCoinbases :: MonadBagger m => ChainMemberParsedSet -> [DD.BlockData] -> Integer -> m StateRoot -- miner coinbase -> known uncles -> this block number -> stateRoot
 -- rewardCoinbases us uncles ourNumber = do

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -999,7 +999,7 @@ solidityTypeToSQLType (SVMType.Struct _ _) = Just "jsonb"
 solidityTypeToSQLType (SVMType.Enum _ _ _) = Just "text"
 solidityTypeToSQLType (SVMType.Contract _) = Just "text"
 solidityTypeToSQLType (SVMType.Error _ _) = Just "text"
-solidityTypeToSQLType SVMType.Variadic = error "type (variadic) is not an indexable type"
+solidityTypeToSQLType SVMType.Variadic = Nothing
 --solidityTypeToSQLType x = error $ "undefined type in solidityTypeToSQLType: " ++ show (varType x)
 
 


### PR DESCRIPTION
This PR fixes all the current outstanding errors for SolidVM tests contained within the `SolidVMSpec.hs` file.

Briefly, the fixes include:
- String formatting related errors in `.code` SolidVM tests
- Typechecker test errors that were missing `pragma strict` and failing
- The out-of-scope errors of storage variables for Solidity try/catch statements
- Free function overloading conflict with the import resolver
