### PR TITLE
[SolidVM] Bandaging the stateroot mismatch caused by create/create2 state changes 

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2773,12 +2773,14 @@ callBuiltin "create" args@[SString contractName', SString contractSrc, SString a
   when (contractName' == "" || contractSrc == "") 
     $ invalidArguments "The contract name and src arguments for the create function should not be empty" args
   creator <- getCurrentAccount
+  (_, parentCC) <- getCurrentCodeCollection
+  let pragmaCheck = isJust $ find ((== "builtinCreates") . fst) $ CC._pragmas parentCC
   (hsh, cc) <- codeCollectionFromSource True $ BC.pack contractSrc
   newAddress <- getNewAddress creator
   let constructorArgs = case runParser parseArgs initialParserState "" argString of
                           Right parsedArgs -> parsedArgs
                           _ -> internalError "Failed to parse constructor args in a create builtin call" argString
-  execResults <- create' creator newAddress hsh cc contractName' (CC.OrderedArgs constructorArgs) True
+  execResults <- create' creator newAddress hsh cc contractName' (CC.OrderedArgs constructorArgs) pragmaCheck
   return $ ((flip SAccount) False) . accountOnUnspecifiedChain
     $ fromMaybe (internalError "a call to create did not create an address" execResults)
     $ erNewContractAccount execResults
@@ -2787,13 +2789,21 @@ callBuiltin "create2" args@[salt, SString contractName', SString contractSrc, SS
   when (contractName' == "" || contractSrc == "") 
     $ invalidArguments "The contract name and src arguments for the create2 function should not be empty" args
   creator <- getCurrentAccount
+  (_, parentCC) <- getCurrentCodeCollection
+  -- Because of the current testnet stateroot problem with contracts using an older version of
+  -- create/create2 with incomplete codeptrs, this pragma will allow new contract using the
+  -- create/create2 features to work correctly but unfortunately, even without the pragma, the contracts
+  -- will still work but will have incorrect codeptrs. 
+  -- Thus, when the testnet wipes, this pragma can largely be removed because the old contracts on the
+  -- testnet won't exist anymore and the stateroot mismatches will be corrected.
+  let pragmaCheck = isJust $ find ((== "builtinCreates") . fst) $ CC._pragmas parentCC
   (hsh, cc) <- codeCollectionFromSource True $ BC.pack contractSrc
   let constructorArgs = case runParser parseArgs initialParserState "" argString of
                           Right parsedArgs -> parsedArgs
                           _ -> internalError "Failed to parse constructor args in a create builtin call" argString
   constructorArgVals <- OrderedVals <$> mapM (getVar <=< expToVar) constructorArgs
   newAddress <- getNewAddressWithSalt creator salt hsh $ show constructorArgVals
-  execResults <- create' creator newAddress hsh cc contractName' (CC.OrderedArgs constructorArgs) True
+  execResults <- create' creator newAddress hsh cc contractName' (CC.OrderedArgs constructorArgs) pragmaCheck
   return $ ((flip SAccount) False) . accountOnUnspecifiedChain
     $ fromMaybe (internalError "a call to create did not create an address" execResults)
     $ erNewContractAccount execResults

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -304,7 +304,7 @@ mineTransactions' header remGas ran unran@(tx:txs) = do
     trr <- setNewAddresses $ TxRunResult tx result time' beforeMap afterMap []
     case result of
         Right execResult ->
-          let supportedPragmas = [("es6",""), ("strict","")]
+          let supportedPragmas = [("es6",""), ("strict",""), ("builtinCreates","")]
               findInvalidPragmas pragma = if fst pragma == "solidity" || pragma `elem` supportedPragmas then id else (pragma:) -- include solidity pragma for backwards compatibility
               invalidPragmasUsed = foldr findInvalidPragmas [] (erPragmas execResult) 
            in if not $ null invalidPragmasUsed


### PR DESCRIPTION
This PR is meant as a temporary fix for the sync to the testnet and allows the create/create2 codeptrs to work correctly (for contracts not already existent on the testnet AND is using `pragma builtinCreates`) through `pragma builtinCreates`. 

The downside is that until the testnet wipes, the old test contracts that uses the create/create2 function that have incorrect codeptrs will still work albeit not correctly. Similarly this also means that new contracts using the create/create2 functions without the pragma will also still work. 

If and when the testnet wipes for whatever reason, the pragma can be removed entirely or expanded to cover the entire feature and not just the codePtr fix.