### PR TITLE
round the application_fee_amount

### DIFF
--- a/marketplace/backend/payment-service/stripe.service.js
+++ b/marketplace/backend/payment-service/stripe.service.js
@@ -31,7 +31,7 @@ class StripeService {
                 },
                 payment_intent_data: {
                     /* 3% of OrderTotal in Cents */
-                    application_fee_amount: (0.03 * cartData.orderTotal * 100),
+                    application_fee_amount: Math.round(3 * cartData.orderTotal),
                     /* To be used in case of destination charge */
                     // transfer_data: {
                     //     destination: CONNECTED_ACCOUNT_ID


### PR DESCRIPTION
application_fee_amount was resulting in a float on some combinations.. which threw error from Stripe, since it expects this as an int
(e.g) Inventory Price: $15
Order Quantity: 1
Order Total: 1
results in application_fee_amount of 44.9999999999

Solution: Explicity round of the calculated value 