### PR TITLE
Add code coverage to unit tests

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -51,7 +51,7 @@ pipeline {
           // Copy .pem and .key for SSL
           sh 'cp /home/ubuntu/letsencrypt-ssl/server.pem ssl/certs/'
           sh 'cp /home/ubuntu/letsencrypt-ssl/server.key ssl/private/'
-          
+
           writeFile file: "run-vault.sh", text: """#!/bin/bash
             sudo \\
               ssl=true \\
@@ -63,9 +63,9 @@ pipeline {
               ./vault
           """
           sh 'chmod +x run-vault.sh'
-      
+
           sh './run-vault.sh'
-  
+
           // TODO: run node on https (also update check_availability function)
           withCredentials([
             usernamePassword(credentialsId: 'stripe-key', passwordVariable: 'STRIPE_SECRET_KEY', usernameVariable: 'STRIPE_PUBLISHABLE_KEY'),
@@ -98,11 +98,11 @@ pipeline {
           }
 
           sh 'chmod +x run.sh'
-      
+
           sh './run.sh'
-      
+
           sh 'docker ps'
-      
+
           // Few quick tests
           sh '''#!/bin/bash -le
             check_availability() {
@@ -119,7 +119,7 @@ pipeline {
               done
               echo "STRATO health endpoint is available through nginx - node is running"
             }
-            
+
             check_availability
           '''
         }
@@ -129,7 +129,7 @@ pipeline {
 
         dir("strato-getting-started") {
           sh './strato --wipe'
-  
+
           sh './run.sh'
 
           sh 'docker ps'
@@ -152,15 +152,15 @@ pipeline {
             }
 
             check_availability
-            
+
             echo "Restarting docker containers to simulate computer restart..."
             docker compose -p strato stop
             docker compose -p strato start
-            
+
             check_availability
           '''
         }
-  
+
         script {
           // TODO: replace with jenkins credentials here and in other places in pipelines
           lib.registerTestUserCert(
@@ -209,7 +209,7 @@ pipeline {
             ]) {
               sh '''#!/bin/bash -le
                 set -x
-                version=$(grep -oP "#strato-version:\\K[^#]*" docker-compose.yml)     
+                version=$(grep -oP "#strato-version:\\K[^#]*" docker-compose.yml)
                 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} AWS_DEFAULT_REGION="us-east-1"
                 aws s3 cp docker-compose.yml s3://blockapps-build-artifacts/${version}/
                 aws s3 cp docker-compose.vault.yml s3://blockapps-build-artifacts/${version}/
@@ -221,7 +221,7 @@ pipeline {
               }
           },
 
-/*            
+/*
           'Apex tests': {
             sh '''#!/bin/bash -le
               set -x
@@ -237,6 +237,8 @@ pipeline {
               set -x
               echo "Running unit tests"
               ./run_unit_tests.sh
+              cd strato
+              archiveArtifacts artifacts: "${sh(returnStdout: true, script: 'stack path --local-hpc-root').trim()}", fingerprint: true
             '''
           },
 

--- a/pipelines/Jenkinsfile.nightly
+++ b/pipelines/Jenkinsfile.nightly
@@ -53,7 +53,7 @@ pipeline {
           // Copy .pem and .key for SSL
           sh 'cp /home/ubuntu/letsencrypt-ssl/server.pem ssl/certs/'
           sh 'cp /home/ubuntu/letsencrypt-ssl/server.key ssl/private/'
-      
+
           writeFile file: "run-vault.sh", text: """#!/bin/bash
             sudo \\
               ssl=true \\
@@ -65,9 +65,9 @@ pipeline {
               ./vault
           """
           sh 'chmod +x run-vault.sh'
-      
+
           sh './run-vault.sh'
-  
+
           // TODO: run node on https (also update check_availability function)
           withCredentials([
               usernamePassword(credentialsId: 'stripe-key', passwordVariable: 'STRIPE_SECRET_KEY', usernameVariable: 'STRIPE_PUBLISHABLE_KEY'),
@@ -99,11 +99,11 @@ pipeline {
             """
           }
           sh 'chmod +x run.sh'
-      
+
           sh './run.sh'
-      
+
           sh 'docker ps'
-      
+
           // Few quick tests
           sh '''#!/bin/bash -le
             check_availability() {
@@ -120,11 +120,11 @@ pipeline {
               done
               echo "STRATO health endpoint is available through nginx - node is running"
             }
-            
+
             check_availability
           '''
         }
-  
+
         script {
           lib.generateGenesisBlock('strato-worktree', 'strato-getting-started', null)
         }
@@ -154,15 +154,15 @@ pipeline {
             }
 
             check_availability
-            
+
             echo "Restarting docker containers to simulate computer restart..."
             docker compose -p strato stop
             docker compose -p strato start
-            
+
             check_availability
           '''
         }
-  
+
         script {
           // TODO: replace with jenkins credentials here and in other places in pipelines
           lib.registerTestUserCert(
@@ -212,7 +212,7 @@ pipeline {
               dir ('strato-worktree') {
                 sh '''#!/bin/bash -le
                   set -x
-                  version=$(grep -oP "#strato-version:\\K[^#]*" docker-compose.yml)     
+                  version=$(grep -oP "#strato-version:\\K[^#]*" docker-compose.yml)
                   AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} AWS_DEFAULT_REGION="us-east-1"
                   aws s3 cp docker-compose.yml s3://blockapps-build-artifacts/${version}/
                   aws s3 cp docker-compose.vault.yml s3://blockapps-build-artifacts/${version}/
@@ -224,7 +224,7 @@ pipeline {
               }
             }
           },
-/*            
+/*
           'Apex tests': {
             sh '''#!/bin/bash -le
               set -x
@@ -241,6 +241,8 @@ pipeline {
               echo "Running unit tests"
               cd strato-worktree
               ./run_unit_tests.sh
+              cd strato
+              archiveArtifacts artifacts: "${sh(returnStdout: true, script: 'stack path --local-hpc-root').trim()}", fingerprint: true
             '''
           },
 
@@ -309,7 +311,7 @@ pipeline {
           sh 'git clone https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/docs-website -b develop'
           dir('docs-website/') {
             sh 'npm i'
-            
+
             writeFile file: "test-utility/config.js", text: """
 module.exports = {
   stratoConfig: {
@@ -337,7 +339,7 @@ module.exports = {
                 currentBuild.result = 'UNSTABLE'
               }
             }
-            
+
           }
         }
       }
@@ -372,7 +374,7 @@ module.exports = {
           message: "Nightly develop build failed: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL}"
       )
     }
-    
+
     unstable {
       slackSend (
           color: 'warning',
@@ -384,7 +386,7 @@ module.exports = {
           message: "Nightly develop build is unstable: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL}"
       )
     }
-    
+
     fixed {
       slackSend(
           channel: '#engineering',

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -5,14 +5,14 @@ set -x
 
 declare -i RESULT=0
 
-# There's a good chance that strato-getting-started is also running, so	
-# we change redis's port to avoid a conflict.	
-REDIS=$(docker run -d -p 2023:6379 redis:3.2 redis-server --appendonly yes)	
+# There's a good chance that strato-getting-started is also running, so
+# we change redis's port to avoid a conflict.
+REDIS=$(docker run -d -p 2023:6379 redis:3.2 redis-server --appendonly yes)
 trap "docker rm -f ${REDIS}" EXIT
 
 cd strato
 
-stack test -j1 \
+stack test --coverage -j1 \
       blockapps-data \
       blockapps-mpdbs \
       blockapps-tools \


### PR DESCRIPTION
This PR enables HPC (Haskell Program Coverage) in our unit tests using the stack `--coverage` flag. It generates a `hpc` directory in the top-level `.stack-work` folder that produces an `index.html` which lists each package's test suite.

![image](https://github.com/blockapps/strato-platform/assets/35979292/2a6e0d1c-6eb8-4da0-aee8-0836d3938321)

Clicking a test suite will direct you to the coverage dashboard, showing the modules that make up a package and the code that is covered in its corresponding test suite. I recommend focusing on the _Expressions_ column which provides a more accurate description (shows code coverage by line) and encompasses the other two columns (_Top Level Definitions_ and _Alternatives_ which are redundant and somewhat vague).

![image](https://github.com/blockapps/strato-platform/assets/35979292/37571a0c-026c-4316-ac88-bd07d0e56583)

Clicking each individual module will bring you to the source file but highlighted with three colors:

1. Yellow for uncovered code
2. Green for code that is always true
3. Red for code that is always false

[This article](https://cs-syd.eu/posts/2022-12-16-announcing-dekking) highlights some annoying kinks of HPC and lists some of the bugs that it runs into with certain libraries and language extensions - in these cases, 100% coverage might not be _technically_ possible but that's when we would classify them as _Captured Exclusions_.

![image](https://github.com/blockapps/strato-platform/assets/35979292/95fbfbe6-ad32-4769-a9c9-aa319643c675)

If we're talking numbers, 90-95%+ code coverage is the goal for any large code base. This does not necessarily mean that every single line of code needs to be covered, but rather that we should be covering every line of every package/module that we deem necessary or important. Combine this with the data that we now generate in the Jenkins artifacts, we can slowly work our way up to 100% code coverage.

![image](https://github.com/blockapps/strato-platform/assets/35979292/ea3c1ff7-8abf-4d7e-94ad-62127e413e85)

[Here's some helpful documentation by the HPC authors](https://cs.ox.ac.uk/ralf.hinze/WG2.8/24/slides/john.pdf)