### PR TITLE
fix the apex and smd container healthchecks

### DIFF
--- a/apex/api/Dockerfile
+++ b/apex/api/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18-bookworm-slim
 ARG STRATO_VERSION
 ENV STRATO_VERSION=${STRATO_VERSION}
 RUN apt-get update && \
-    apt-get install -y postgresql-client curl && \
+    apt-get install -y postgresql-client curl lsof && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     mkdir -p /usr/src/app

--- a/smd-ui/Dockerfile
+++ b/smd-ui/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:14-bullseye-slim as base
-RUN mkdir -p /usr/src/app && \
+RUN apt-get update && \
+    apt-get install -y lsof && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    mkdir -p /usr/src/app && \
     npm install -g serve@11.3.2
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Noticed that the apex and smd containers show unhealthy status due to the broken healthcheck (`lsof` is not installed by default in new base image)