### PR TITLE
Remove the redundant steps from buildbase Dockerfile, some refactoring

### DIFF
--- a/Dockerfile.buildbase
+++ b/Dockerfile.buildbase
@@ -2,16 +2,12 @@ ARG STACK_RESOLVER
 
 FROM fpco/stack-build:${STACK_RESOLVER}
 
-# First apt-key adv line is the fix for `The repository 'https://packages.confluent.io/deb/5.2 stable InRelease' is not signed.` error (started happening 05/06/2021)
-# Second apt-key adv line along with apt-key del is the fix for `W: GPG error: http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC` (see https://forums.developer.nvidia.com/t/invalid-public-key-for-cuda-apt-repository/212901/18)
-# Disabling nodesource.list to resolve the problem with expired nodesource certificate on Sep 30th 2021 (see https://github.com/nodesource/distributions/issues/1266)
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 8B1DA6120C2BF624 && \
-    apt-key del 7fa2af80 && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
-    apt-get update && \
-    # touch /etc/apt/sources.list.d/nodesource.list && \
-    # mv /etc/apt/sources.list.d/nodesource.list /etc/apt/sources.list.d/nodesource.list.disabled && \
-    # check if libsodium version 1.0.18 is already installed if it is skip this
-    # if not install it
+RUN apt-get update && \
+    apt-get -y --allow-unauthenticated install autoconf libtool libblas-dev liblapack-dev libsodium-dev jq vim liblzma-dev libleveldb-dev libpq-dev pkg-config && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && \
+    # TODO: check if the libsodium installed with apt is ver 1.0.18 (for ubuntu 20.04+) and if not - make from source. Remove the touch command
     if [ ! -f /usr/local/lib/libsodium.so.23 ]; then \
         wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz && \
         tar -xvzf libsodium-1.0.18-stable.tar.gz && \
@@ -24,15 +20,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 8B1DA6120C2BF
         rm -rf libsodium-stable && \
         rm -rf libsodium-1.0.18-stable.tar.gz; \
         touch /usr/local/lib/libsodium.so.23; \
-    fi && \
-    apt-get -y --allow-unauthenticated install autoconf libtool libblas-dev liblapack-dev libsodium-dev jq vim liblzma-dev libleveldb-dev libpq-dev && \
-    apt-get autoremove && \
-    # apt-get -y install libpq-dev && \
-    apt-get -y install pkg-config && \
-    stack install ormolu implicit-hie && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean && \
-    git clone https://github.com/blockapps/secp256k1 && \
+    fi
+RUN stack install ormolu implicit-hie
+RUN git clone https://github.com/blockapps/secp256k1 && \
     cd secp256k1/ && \
     ./autogen.sh && \
     ./configure --enable-module-recovery --enable-experimental --enable-module-ecdh && \
@@ -40,4 +30,3 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 8B1DA6120C2BF
     make install && \
     cd .. && \
     rm -rf secp256k1
-


### PR DESCRIPTION
This will prevent the intermittent issues with ubuntu keyserver for Buildbase image, as we don't really need to call it since we use stack resolver 20.