### PR TITLE
Serve STRATO docs on custom Hoogle instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ dryrun.log
 targets.log
 strato/tools/x509-generator/subject.json
 strato/tools/genesis-builder/certs.json
+strato/haddock
 *.cabal
 *~

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,9 @@ pretty: build_buildbase
 hoogle: build_buildbase
 	@echo generating and serving STRATO documentation...
 	cd strato && \
-		stack build --haddock --no-haddock-internal --no-haddock-deps && \
-		stack hoogle generate -- --local=${shell cd strato && stack path --local-doc-root} && \
+		stack build --haddock --no-haddock-internal --no-haddock-deps \
+		--haddock-arguments "-o $(shell pwd)/strato/haddock" && \
+		stack hoogle generate -- --local="$(shell pwd)/strato/haddock" && \
 		stack hoogle -- server --local
 
 strato: build_common

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,13 @@ pretty: build_buildbase
 		gen-hie > hie.yaml && \
 		ormolu --mode inplace `git ls-files '*.hs'`
 
+hoogle: build_buildbase
+	@echo generating and serving STRATO documentation...
+	cd strato && \
+		stack build --haddock --no-haddock-internal --no-haddock-deps && \
+		stack hoogle generate -- --local=${shell cd strato && stack path --local-doc-root} && \
+		stack hoogle -- server --local
+
 strato: build_common
 	@echo Now building core-strato...
 	cp -fr strato/licenses ${STRATODIR}

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -34,6 +34,8 @@ so that they could be properly moved to their respective version's subsection.
 - `address.derive(salt, args)` function which allows SolidVM to derive salted contracts without creating them
 - SolidVM built-in `create` and `create2` functions which allows for the explicit creation of contracts within SolidVM contracts
 - new `solidvmevents` kafka topic for emitted solidvm events
+- `pretty` Makefile command that triggers the `ormolu` code formatter
+- `haddock` Makefile command that generates haddock documentation for STRATO
 
 ### Changed
 - `/compile` and `/transaction` endpoints use SolidVM compiler

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -35,7 +35,7 @@ so that they could be properly moved to their respective version's subsection.
 - SolidVM built-in `create` and `create2` functions which allows for the explicit creation of contracts within SolidVM contracts
 - new `solidvmevents` kafka topic for emitted solidvm events
 - `pretty` Makefile command that triggers the `ormolu` code formatter
-- `haddock` Makefile command that generates haddock documentation for STRATO
+- `hoogle` Makefile command that generates Haddock documentation and serves through local Hoogle instance
 
 ### Changed
 - `/compile` and `/transaction` endpoints use SolidVM compiler

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -11,9 +11,9 @@
 
 module Blockchain.Blockstanbul.EventLoop where
 
+import BlockApps.Crossmon
 import BlockApps.Logging
 import BlockApps.X509.Certificate
-import Blockapps.Crossmon
 import Blockchain.Blockstanbul.Authentication
 import Blockchain.Blockstanbul.Messages
 import Blockchain.Blockstanbul.Metrics

--- a/strato/core/fastMP/src/BatchMerge.hs
+++ b/strato/core/fastMP/src/BatchMerge.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_HADDOCK hide, prune #-}
 
 module BatchMerge
   ( putManyKeyVal,

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -19,9 +19,9 @@ module Blockchain.Event
   )
 where
 
+import BlockApps.Crossmon (recordMaxBlockNumber)
 import BlockApps.Logging
 import BlockApps.X509.Certificate as XC
-import Blockapps.Crossmon (recordMaxBlockNumber)
 import Blockchain.Blockstanbul (WireMessage, blockstanbulSender)
 import Blockchain.Context
 import Blockchain.Data.Block

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -18,8 +18,8 @@ where
 
 --import           Data.List.Split                       (chunksOf)
 
+import BlockApps.Crossmon
 import BlockApps.Logging
-import Blockapps.Crossmon
 import qualified Blockchain.Bagger as Bagger
 import qualified Blockchain.Bagger.BaggerState as B
 import Blockchain.BlockChain

--- a/strato/core/vm-tools/src/Blockchain/Bagger.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger.hs
@@ -11,8 +11,8 @@
 {-# OPTIONS -fprof-auto -fprof-cafs #-}
 module Blockchain.Bagger where
 
+import BlockApps.Crossmon
 import BlockApps.Logging
-import Blockapps.Crossmon
 import qualified Blockchain.Bagger.BaggerState as B
 import Blockchain.Bagger.Transactions
 --import           Blockchain.Data.Block

--- a/strato/indexer/slipstream/src/Slipstream/Metrics.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Metrics.hs
@@ -20,7 +20,7 @@ module Slipstream.Metrics
   )
 where
 
-import Blockapps.Crossmon
+import BlockApps.Crossmon
 import qualified Blockchain.Stream.Action as Action
 import Control.Monad
 import Control.Monad.IO.Class

--- a/strato/libs/prometheus/blockapps-init/src/BlockApps/Init.hs
+++ b/strato/libs/prometheus/blockapps-init/src/BlockApps/Init.hs
@@ -3,8 +3,8 @@
 
 module BlockApps.Init (blockappsInit) where
 
+import BlockApps.Crossmon
 import BlockApps.Logging (LoggingT)
-import Blockapps.Crossmon
 import Control.Concurrent
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)

--- a/strato/libs/prometheus/cross-monitoring/src/BlockApps/Crossmon.hs
+++ b/strato/libs/prometheus/cross-monitoring/src/BlockApps/Crossmon.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Blockapps.Crossmon (recordMaxBlockNumber, initializeHealthChecks) where
+module BlockApps.Crossmon (recordMaxBlockNumber, initializeHealthChecks) where
 
 import Control.Monad
 import Control.Monad.IO.Class

--- a/strato/tools/blockapps-tools/exec_src/Main.hs
+++ b/strato/tools/blockapps-tools/exec_src/Main.hs
@@ -3,42 +3,42 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wall #-}
 
-import Block
-import BlockGO
+import BlockApps.Tools.Block as Block
+import BlockApps.Tools.BlockGO as BlockGO
+import BlockApps.Tools.CanonRedis
+import BlockApps.Tools.ChainHash
+import BlockApps.Tools.Checkpoints
+import BlockApps.Tools.Code as Code
+import BlockApps.Tools.DumpKafkaBlocks
+import BlockApps.Tools.DumpKafkaRaw
+import BlockApps.Tools.DumpKafkaSequencer
+import BlockApps.Tools.DumpKafkaStateDiff
+import BlockApps.Tools.DumpKafkaUnSequencer
+import BlockApps.Tools.DumpKafkaVMEvents
+import BlockApps.Tools.DumpRedis
+import BlockApps.Tools.FRawMP as FRawMP
+import BlockApps.Tools.Hash as Hash
+import BlockApps.Tools.InsertP2P
+import BlockApps.Tools.InsertSeq
+import BlockApps.Tools.InsertTX
+import BlockApps.Tools.Kafka
+import BlockApps.Tools.Privacy
+import BlockApps.Tools.Psql
+import BlockApps.Tools.RLP as RLP
+import BlockApps.Tools.Raw as Raw
+import BlockApps.Tools.RawMP as RawMP
+import BlockApps.Tools.Redis
+import BlockApps.Tools.State as State
 import qualified Blockchain.Database.MerklePatricia as MP
 import Blockchain.Participation
 import Blockchain.Sequencer.Event
 import Blockchain.Strato.Model.ChainMember
 import Blockchain.Strato.Model.Keccak256 hiding (hash)
-import CanonRedis
-import ChainHash
-import Checkpoints
-import Code
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 import Data.Int
 import qualified Data.Text as T
-import DumpKafkaBlocks
-import DumpKafkaRaw
-import DumpKafkaSequencer
-import DumpKafkaStateDiff
-import DumpKafkaUnSequencer
-import DumpKafkaVMEvents
-import DumpRedis
-import FRawMP
-import Hash
-import InsertP2P
-import InsertSeq
-import InsertTX
-import Kafka
 import qualified LabeledError
-import Privacy
-import Psql
-import RLP
-import Raw
-import RawMP
-import Redis
-import State
 import System.Console.CmdArgs
 
 data Options

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Block.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Block.hs
@@ -1,6 +1,6 @@
-module Block where
+module BlockApps.Tools.Block where
 
-import DumpLevelDB
+import BlockApps.Tools.DumpLevelDB
 import Text.Format
 
 doit :: String -> String -> IO ()

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/BlockGO.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/BlockGO.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module BlockGO where
+module BlockApps.Tools.BlockGO where
 
+import BlockApps.Tools.DumpLevelDB ()
 import Blockchain.Constants
 import Control.Monad
 import Control.Monad.IO.Class
@@ -10,7 +11,6 @@ import Control.Monad.Trans.Resource
 import qualified Data.ByteString as B
 import Data.Default
 import qualified Database.LevelDB as DB
-import DumpLevelDB ()
 import System.FilePath
 import Text.Format
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (</>))

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/CanonRedis.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/CanonRedis.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module CanonRedis where
+module BlockApps.Tools.CanonRedis where
 
 -- import           Blockchain.EthConf                    (lookupRedisBlockDBConfig)
 import Blockchain.Data.DataDefs

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/ChainHash.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/ChainHash.hs
@@ -1,4 +1,4 @@
-module ChainHash where
+module BlockApps.Tools.ChainHash where
 
 import Blockchain.Data.ChainInfo
 import Blockchain.Strato.Model.Keccak256

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Checkpoints.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Checkpoints.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Checkpoints
+module BlockApps.Tools.Checkpoints
   ( doCheckpointPut,
     doCheckpointGet,
     doCheckpointUsage,

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Code.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Code.hs
@@ -1,7 +1,7 @@
-module Code where
+module BlockApps.Tools.Code where
 
+import BlockApps.Tools.DumpLevelDB
 import Blockchain.Strato.Model.Code
-import DumpLevelDB
 
 doit :: String -> String -> IO ()
 doit dbtype h = showKeyVal (show . Code) dbtype "code" (if h == "-" then Nothing else Just h)

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaBlocks.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaBlocks.hs
@@ -1,22 +1,22 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module DumpKafkaUnSequencer where
+module BlockApps.Tools.DumpKafkaBlocks where
 
 import Blockchain.EthConf
-import Blockchain.Sequencer.Kafka
+import Blockchain.Stream.VMOutput
 import Control.Monad.IO.Class
 import Network.Kafka.Protocol
 import Text.Format
 
-dumpKafkaUnSequencer :: Offset -> IO ()
-dumpKafkaUnSequencer startingBlock = do
+dumpKafkaBlocks :: Offset -> IO ()
+dumpKafkaBlocks startingBlock = do
   ret <- runKafkaConfigured "queryStrato" $ doConsume' startingBlock
   case ret of
     Left e -> error $ show e
     Right _ -> return ()
   where
     doConsume' offset = do
-      unseqEvents <- readUnseqEvents offset
-      liftIO . putStrLn . unlines $ format <$> unseqEvents
-      doConsume' (offset + fromIntegral (length unseqEvents))
+      vmEvents <- fetchVMOutputs offset
+      liftIO $ putStrLn $ unlines $ map format vmEvents
+      doConsume' (offset + fromIntegral (length vmEvents))

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaRaw.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaRaw.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module DumpKafkaRaw where
+module BlockApps.Tools.DumpKafkaRaw where
 
 import Blockchain.EthConf
 import Blockchain.KafkaTopics

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaSequencer.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaSequencer.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module DumpKafkaSequencer where
+module BlockApps.Tools.DumpKafkaSequencer where
 
 import Blockchain.EthConf
 import Blockchain.Sequencer.Kafka

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaStateDiff.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaStateDiff.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module DumpKafkaStateDiff where
+module BlockApps.Tools.DumpKafkaStateDiff where
 
 --import qualified Data.ByteString.Char8  as BC
 

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaUnSequencer.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaUnSequencer.hs
@@ -1,22 +1,22 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module DumpKafkaVMEvents where
+module BlockApps.Tools.DumpKafkaUnSequencer where
 
 import Blockchain.EthConf
-import Blockchain.Stream.VMEvent
+import Blockchain.Sequencer.Kafka
 import Control.Monad.IO.Class
 import Network.Kafka.Protocol
 import Text.Format
 
-dumpKafkaVMEvents :: Offset -> IO ()
-dumpKafkaVMEvents startingBlock = do
+dumpKafkaUnSequencer :: Offset -> IO ()
+dumpKafkaUnSequencer startingBlock = do
   ret <- runKafkaConfigured "queryStrato" $ doConsume' startingBlock
   case ret of
     Left e -> error $ show e
     Right _ -> return ()
   where
     doConsume' offset = do
-      vmEvents <- fetchVMEvents offset
-      liftIO $ putStrLn $ unlines $ map format vmEvents
-      doConsume' (offset + fromIntegral (length vmEvents))
+      unseqEvents <- readUnseqEvents offset
+      liftIO . putStrLn . unlines $ format <$> unseqEvents
+      doConsume' (offset + fromIntegral (length unseqEvents))

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaVMEvents.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpKafkaVMEvents.hs
@@ -1,22 +1,22 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module DumpKafkaBlocks where
+module BlockApps.Tools.DumpKafkaVMEvents where
 
 import Blockchain.EthConf
-import Blockchain.Stream.VMOutput
+import Blockchain.Stream.VMEvent
 import Control.Monad.IO.Class
 import Network.Kafka.Protocol
 import Text.Format
 
-dumpKafkaBlocks :: Offset -> IO ()
-dumpKafkaBlocks startingBlock = do
+dumpKafkaVMEvents :: Offset -> IO ()
+dumpKafkaVMEvents startingBlock = do
   ret <- runKafkaConfigured "queryStrato" $ doConsume' startingBlock
   case ret of
     Left e -> error $ show e
     Right _ -> return ()
   where
     doConsume' offset = do
-      vmEvents <- fetchVMOutputs offset
+      vmEvents <- fetchVMEvents offset
       liftIO $ putStrLn $ unlines $ map format vmEvents
       doConsume' (offset + fromIntegral (length vmEvents))

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpLevelDB.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpLevelDB.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module DumpLevelDB
+module BlockApps.Tools.DumpLevelDB
   ( showKeyVal,
     typeToDB,
   )

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpRedis.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/DumpRedis.hs
@@ -1,4 +1,4 @@
-module DumpRedis where
+module BlockApps.Tools.DumpRedis where
 
 import Blockchain.EthConf (lookupRedisBlockDBConfig)
 import Blockchain.Strato.Model.Keccak256

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/FRawMP.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/FRawMP.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module FRawMP where
+module BlockApps.Tools.FRawMP where
 
 import Blockchain.Data.RLP
 import qualified Blockchain.Database.MerklePatricia as MP

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Hash.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Hash.hs
@@ -1,6 +1,6 @@
-module Hash where
+module BlockApps.Tools.Hash where
 
-import DumpLevelDB
+import BlockApps.Tools.DumpLevelDB
 import Text.Format
 
 doit :: String -> String -> IO ()

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/InsertP2P.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/InsertP2P.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module InsertP2P where
+module BlockApps.Tools.InsertP2P where
 
 import Blockchain.EthConf
 import Blockchain.Sequencer.Event

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/InsertSeq.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/InsertSeq.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
-module InsertSeq where
+module BlockApps.Tools.InsertSeq where
 
 -- import Control.Monad
 import Blockchain.Blockstanbul

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/InsertTX.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/InsertTX.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module InsertTX where
+module BlockApps.Tools.InsertTX where
 
 import BlockApps.Logging
 import Blockchain.DB.SQLDB (createPostgresqlPool, runSqlPool)

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Kafka.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Kafka.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
-module Kafka (saveKafka, loadKafka, verifyKafkaFile, compressRoundChanges, readMsg, writeMsg) where
+module BlockApps.Tools.Kafka (saveKafka, loadKafka, verifyKafkaFile, compressRoundChanges, readMsg, writeMsg) where
 
 import Blockchain.Blockstanbul.Messages
 import Blockchain.EthConf

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Privacy.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Privacy.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Privacy where
+module BlockApps.Tools.Privacy where
 
 import Blockchain.Constants
 import Blockchain.Privacy.Monad

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Psql.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Psql.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Psql where
+module BlockApps.Tools.Psql where
 
 import BlockApps.Logging
 import qualified Blockchain.Data.Blockchain as DataBlock

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/RLP.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/RLP.hs
@@ -1,8 +1,8 @@
-module RLP where
+module BlockApps.Tools.RLP where
 
+import BlockApps.Tools.Util
 import Blockchain.Data.RLP
 import Text.Format
-import Util
 
 doit :: String -> IO ()
 doit filename = ldbForEach filename $ \key val -> do

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Raw.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Raw.hs
@@ -1,9 +1,9 @@
-module Raw where
+module BlockApps.Tools.Raw where
 
-import DumpLevelDB ()
+import BlockApps.Tools.DumpLevelDB ()
+import BlockApps.Tools.Util
 import Text.Format
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (</>))
-import Util
 
 doit :: String -> IO ()
 doit filename = ldbForEach filename $ \key val ->

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/RawMP.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/RawMP.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module RawMP (doit) where
+module BlockApps.Tools.RawMP (doit) where
 
 import Blockchain.Data.RLP
 import qualified Blockchain.Database.MerklePatricia as MP

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Redis.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Redis.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 
-module Redis where
+module BlockApps.Tools.Redis where
 
 import Blockchain.EthConf
 import Blockchain.Strato.RedisBlockDB

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/State.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/State.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module State (doit) where
+module BlockApps.Tools.State (doit) where
 
+import BlockApps.Tools.Util
 import Blockchain.Constants
 import Blockchain.Data.AddressStateDB
 import Blockchain.Data.RLP
@@ -17,7 +18,6 @@ import qualified Database.LevelDB as DB
 import System.FilePath
 import qualified Text.Colors as CL
 import Text.Format
-import Util
 
 nibbleStringToByteString :: N.NibbleString -> B.ByteString
 nibbleStringToByteString (N.EvenNibbleString x) = x

--- a/strato/tools/blockapps-tools/src/BlockApps/Tools/Util.hs
+++ b/strato/tools/blockapps-tools/src/BlockApps/Tools/Util.hs
@@ -1,4 +1,4 @@
-module Util where
+module BlockApps.Tools.Util where
 
 import Control.Monad.IO.Class
 import Control.Monad.Loops

--- a/strato/tools/blockapps-tools/test/KafkaSpec.hs
+++ b/strato/tools/blockapps-tools/test/KafkaSpec.hs
@@ -3,7 +3,7 @@
 import Control.Monad
 import qualified Data.ByteString as B
 import Data.ByteString.Arbitrary (fastRandBs)
-import Kafka
+import BlockApps.Tools.Kafka
 import System.IO
 import System.IO.Temp
 import Test.Hspec


### PR DESCRIPTION
This PR adds a `make hoogle` command to the Makefile. Now we can build and serve our own documentation for STRATO core. It accomplishes this by:

1. Generating the Haddock documentation from our codebase
2. Creating a local Hoogle database instance (combining the docs from step 1 with what you can already find on Hoogle) 
3. Serving it on `localhost:8080`

With that, we can run a Hoogle instance that also includes our own functions as well. We plan on hosting this to [hoogle.internal.blockapps.net](http://hoogle.internal.blockapps.net/) sometime soon (thanks to @nikitamendelbaum). We can also comment our code [the Haddock way](https://haskell-haddock.readthedocs.io/en/latest/markup.html#documentation-structure-examples) which will actively be reflected in the docs.

https://github.com/blockapps/strato-platform/assets/35979292/b3973c7a-d5f7-437c-b2ef-c4a4b084497f

