### PR TITLE
Error happing in Docker build stage as error indicated the need to add leading slashes

### DIFF
--- a/marketplace/ui/Dockerfile
+++ b/marketplace/ui/Dockerfile
@@ -2,21 +2,21 @@ FROM node:14.21.3-alpine3.17 as base
 RUN apk add --no-cache curl yarn git lsof && \
     yarn global add serve@13.0.2 && \
     mkdir -p /usr/src/ui
-WORKDIR /usr/src/ui
+WORKDIR /usr/src/ui/
 
 FROM base as yarninstaller
-COPY package*.json /usr/src/ui
-COPY yarn.lock /usr/src/ui
+COPY package*.json /usr/src/ui/
+COPY yarn.lock /usr/src/ui/
 RUN yarn install
 
 ### Builder
 FROM yarninstaller as builder
-COPY . /usr/src/ui
+COPY . /usr/src/ui/
 RUN REACT_APP_IN_DOCKER=true REACT_APP_UI_VERSION=$(node -e "console.log(require('./package.json').version);") yarn build
 
 ### Prod
 FROM base as prod
-COPY docker-run.sh /usr/src/ui
+COPY docker-run.sh /usr/src/ui/
 COPY --from=builder /usr/src/ui/build build/
 EXPOSE 3003
 HEALTHCHECK --interval=3s --timeout=2s --start-period=300s \
@@ -26,7 +26,7 @@ CMD [ "sh", "/usr/src/ui/docker-run.sh" ]
 
 ### Test
 FROM base as test
-COPY . /usr/src/ui
+COPY . /usr/src/ui/
 COPY --from=yarninstaller /usr/src/ui/node_modules /usr/src/ui/node_modules/
 RUN yarn install
 RUN yarn test

--- a/smd-ui/Dockerfile
+++ b/smd-ui/Dockerfile
@@ -5,19 +5,19 @@ RUN apk add --no-cache lsof && \
 WORKDIR /usr/src/app
 
 FROM base as npminstaller
-COPY package*.json /usr/src/app
+COPY package*.json /usr/src/app/
 RUN npm install
 
 ### Builder
 FROM npminstaller as builder
-COPY . /usr/src/app
+COPY . /usr/src/app/
 RUN npm run build
 
 ### Prod
 FROM base as prod
 ARG STRATO_VERSION
 ENV STRATO_VERSION=${STRATO_VERSION}
-COPY docker-run.sh /usr/src/app
+COPY docker-run.sh /usr/src/app/
 COPY --from=builder /usr/src/app/build build/
 EXPOSE 3002
 HEALTHCHECK --interval=5s --timeout=2s --start-period=180s \


### PR DESCRIPTION
Unsure if this was effecting anyone else but I was unable to build on develop due to a series of similar docker errors that looked like this,

```
Step 5/17 : COPY package*.json /usr/src/app
When using COPY with more than one source file, the destination must be a directory and end with a /
make[1]: *** [Makefile:16: build] Error 1
make[1]: Leaving directory '/home/ben/blockapps/strato-platform/smd-ui'
make: *** [Makefile:61: smd] Error 2
```

Thus I have fixed the error in this PR

