### PR TITLE
[SolidVM] Strato 2772 - Contracts created using new not being found in call stack

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -45,6 +45,7 @@ so that they could be properly moved to their respective version's subsection.
 - Typechecker test errors that were missing `pragma strict` and failing
 - The out-of-scope errors of storage variables for Solidity try/catch statements
 - Free function overloading conflict with the import resolver 
+- Multilayer contract creation using `new` not able to be found in call stack
 ### Removed
 - `bloc22` database removed
 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1900,6 +1900,8 @@ expToVar' (CC.FunctionCall _ (CC.NewExpression _ (SVMType.UnknownLabel contractN
   (hsh, cc) <- getCurrentCodeCollection
   newAddress <- getNewAddress creator
   execResults <- create' creator newAddress hsh cc contractName' args False
+  let !contract' = fromMaybe (missingType "create'/contract" contractName') (cc ^. CC.contracts . at contractName')
+  addCallInfoToEnd newAddress contract' (stringToLabel $ labelToString contractName') hsh cc M.empty False False
   return $
     Constant $
       SContract contractName' $
@@ -1918,6 +1920,8 @@ expToVar' (CC.FunctionCall _ (CC.NewExpression _ (SVMType.UnknownLabel contractN
   newAddress <- getNewAddressWithSalt creator salt hsh $ show args'
   $logDebugS "DEBUG" $ T.pack $ (show hsh) ++ "  " ++ show newAddress
   execResults <- create' creator newAddress hsh cc contractName' args False
+  let !contract' = fromMaybe (missingType "create'/contract" contractName') (cc ^. CC.contracts . at contractName')
+  addCallInfoToEnd newAddress contract' (stringToLabel $ labelToString contractName') hsh cc M.empty False False
   onTraced $ do
     liftIO $
       putStrLn $

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -23,6 +23,7 @@ module Blockchain.SolidVM.SM
     runSM,
     getCurrentAccount,
     addCallInfo,
+    addCallInfoToEnd,
     dupCallInfo,
     uncheckedCallInfo,
     popCallInfo,
@@ -632,6 +633,37 @@ addCallInfo a c fn hsh cc initialLocalVariables ro ff = do
           }
 
   Mod.modify_ (Mod.Proxy @[CallInfo]) $ pure . (newCallInfo :)
+
+addCallInfoToEnd ::
+  MonadSM m =>
+  Account ->
+  CC.Contract ->
+  SolidString ->
+  Keccak256 ->
+  CC.CodeCollection ->
+  Map SolidString (SVMType.Type, Variable) ->
+  Bool ->
+  Bool ->
+  m ()
+addCallInfoToEnd a c fn hsh cc initialLocalVariables ro ff = do
+  let newCallInfo =
+        CallInfo
+          { currentFunctionName = fn,
+            currentAccount = a,
+            currentContract = c,
+            codeCollection = cc,
+            collectionHash = hsh,
+            localVariables = initialLocalVariables,
+            variableStack = [initialLocalVariables],
+            readOnly = ro,
+            isUncheckedSection = False, -- The rationale here is that unchecked sections only apply to the current stack frame
+            currentSourcePos = Nothing,
+            isFreeFunction = ff
+          }
+
+  Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
+    [] -> internalError "probably shouldn't happen?" ()
+    rest -> pure $ rest ++ [newCallInfo]
 
 dupCallInfo :: MonadSM m => Bool -> m ()
 dupCallInfo ro = Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -8417,3 +8417,45 @@ contract qq {
 }|]
       )
       `shouldThrow` anyMissingTypeError
+  it "can test whether embedded contracts created using new can be found in call stack" . runTest $ do
+      runBS [r|
+
+contract Node {
+  address orgAddress;
+
+  constructor (address _orgAddress){
+    orgAddress = _orgAddress;
+  }
+}
+
+contract Organization {
+
+  Node[] public nodes;
+
+  constructor(address _dappAddress) {
+
+    Node node = new Node(_dappAddress);
+    nodes.push(node);
+  }
+
+}
+
+contract qq {
+
+  Organization[] orgs;
+  address test;
+
+  constructor() {
+    test = createOrganization(address(0xdeadbeef));
+  }
+
+  function createOrganization(address _x) returns (address) {
+
+    Organization org = new Organization(_x);
+    orgs.push(org);
+    Node node = Node(org.nodes()[0]);
+    return (address(node));
+  }
+}
+|]
+      getFields ["test"] `shouldReturn` [BAccount $ NamedAccount ((fromJust . stringAddress) "af11a56deca85ea206c89766e250fa5668050568") UnspecifiedChain]


### PR DESCRIPTION
This PR fixes a bug in SolidVM where if a contract creates embedded `new` contracts, the subsequent created contracts will not exist in the call stack anymore and is thus inaccessible. The solution proposed is to append the created contracts resulting from the use of the `new` keyword (salted/not salted) at the end of the call info stack. 