### PR TITLE
ensure with Jenkins if the PR merge is allowed for branches

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -30,15 +30,17 @@ pipeline {
             if (env.CHANGE_TARGET == 'master' && env.CHANGE_BRANCH != 'staging') {
               unstable("ERROR: You can only merge to master from 'staging'.")
             }
-            if (env.CHANGE_TARGET == 'staging' && env.CHANGE_BRANCH != 'develop') {
+            else if (env.CHANGE_TARGET == 'staging' && env.CHANGE_BRANCH != 'develop') {
               unstable("ERROR: You can only merge to staging from 'develop'.")
             }
-            if (env.CHANGE_TARGET == 'develop' && env.CHANGE_BRANCH != 'my-non-existent-branch') {
+            else if (env.CHANGE_TARGET == 'develop' && env.CHANGE_BRANCH != 'my-non-existent-branch') {
               unstable("ERROR: You can only merge to develop from 'my-non-existent-branch'.")
             }
-            echo "Allowing the PR merge for branches $env.CHANGE_BRANCH -> $env.CHANGE_TARGET"
+            else {
+              echo "Allowing the PR merge for branches ${env.CHANGE_BRANCH} -> ${env.CHANGE_TARGET}"
+            }
           } else {
-            echo 'Not a PR, skipped git merge flow checks'
+            echo 'Not a PR, skipping the git merge flow checks'
           }
         }
       }

--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -22,7 +22,27 @@ pipeline {
         '''
       }
     }
-
+    
+    stage('Ensure branch merge flow') {
+      steps {
+        script {
+          if (env.BRANCH_NAME.startsWith('PR-')) {
+            if (env.CHANGE_TARGET == 'master' && env.CHANGE_BRANCH != 'staging') {
+              unstable("ERROR: You can only merge to master from 'staging'.")
+            }
+            if (env.CHANGE_TARGET == 'staging' && env.CHANGE_BRANCH != 'develop') {
+              unstable("ERROR: You can only merge to staging from 'develop'.")
+            }
+            if (env.CHANGE_TARGET == 'develop' && env.CHANGE_BRANCH != 'my-non-existent-branch') {
+              unstable("ERROR: You can only merge to develop from 'my-non-existent-branch'.")
+            }
+            echo "Allowing the PR merge for branches $env.CHANGE_BRANCH -> $env.CHANGE_TARGET"
+          } else {
+            echo 'Not a PR, skipped git merge flow checks'
+          }
+        }
+      }
+    }
 
     stage('Build') {
       steps {
@@ -196,9 +216,8 @@ pipeline {
 
       }
     }
-
-//    stage('Test and Push Images') {
-    stage('Push Images & Artifacts') {
+    
+    stage('Test & Push Artifacts') {
       steps {
         parallel (
           'Push Images': {
@@ -221,7 +240,7 @@ pipeline {
               '''
             }
           },
-          'Push Artifacts': {
+          'Test & Push Artifacts': {
             withCredentials([
                 usernamePassword(credentialsId: 'block-apps-jenkins-s3',  passwordVariable: 'AWS_SECRET_ACCESS_KEY', usernameVariable: 'AWS_ACCESS_KEY_ID'),
             ]) {

--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -28,13 +28,10 @@ pipeline {
         script {
           if (env.BRANCH_NAME.startsWith('PR-')) {
             if (env.CHANGE_TARGET == 'master' && env.CHANGE_BRANCH != 'staging') {
-              unstable("ERROR: You can only merge to master from 'staging'.")
+              unstable("ERROR: You can only merge to 'master' from 'staging'.")
             }
             else if (env.CHANGE_TARGET == 'staging' && env.CHANGE_BRANCH != 'develop') {
-              unstable("ERROR: You can only merge to staging from 'develop'.")
-            }
-            else if (env.CHANGE_TARGET == 'develop' && env.CHANGE_BRANCH != 'my-non-existent-branch') {
-              unstable("ERROR: You can only merge to develop from 'my-non-existent-branch'.")
+              unstable("ERROR: You can only merge to 'staging' from 'develop'.")
             }
             else {
               echo "Allowing the PR merge for branches ${env.CHANGE_BRANCH} -> ${env.CHANGE_TARGET}"


### PR DESCRIPTION
Because the GitHub does not provide the way to restrict the source branches for specific target branches for the PRs, that could be done using GitHub Workflow. I tried that in different PR, but our Github plan does not allow GitHub Actions.
So I made a check in Jenkins - it will prevent the merges if trying to merge:
- to 'master' from any branch other than 'staging'
- to 'staging' from any branch other than 'develop'