### PR TITLE
Top selling image non compression

### DIFF
--- a/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
+++ b/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
@@ -147,7 +147,7 @@ const TopSellingProductCard = () => {
                         className="cursor-pointer"
                         src={topSellingProduct.imageUrl}
                         height={230}
-                        width={230}
+                        style={{ maxWidth: '100%'}}
                         preview={false}
                         onClick={() =>
                           navigate(`${naviroute.replace(":address", topSellingProduct.address)}`, { state: { isCalledFromInventory: false } })


### PR DESCRIPTION
not a good fix but should do the job for us.

Maya wanted the images in the top selling to not be compress like in the prod node right now.

<img width="1774" alt="Screenshot 2023-09-27 at 3 31 58 PM" src="https://github.com/blockapps/strato-platform/assets/61092108/e641bf7c-b3f2-4633-a518-daee302568f8">


