### PR TITLE
Updated UserRegistry and User contracts

### DIFF
--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -107,7 +107,7 @@ import Handlers.Transaction
 import SQLM
 import SolidVM.Model.CodeCollection.Contract
 import SolidVM.Model.CodeCollection.Function
-import SolidVM.Model.Value (SString, OrderedVals)
+import qualified SolidVM.Model.Value as SMV
 import Strato.Strato23.API.Types
 import Strato.Strato23.Client
 import System.Clock
@@ -632,7 +632,7 @@ postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTr
                     ]
           userCert <- maybe (throwIO err) pure =<<
             A.select (A.Proxy @Certificate) addr
-          pure $ deriveAddressWithSalt (Just userRegistry) (certificateCommonName userCert) userRegistryHash (Just . show $ OrderedVals [SString $ certificateCommonName userCert])
+          pure $ deriveAddressWithSalt (Just userRegistry) (certificateCommonName userCert) userRegistryHash (Just . show $ SMV.OrderedVals [SMV.SString $ certificateCommonName userCert])
         else pure addr
       nonceMap <- getAccountNonce addr (S.singleton chainId)
       accountNonce <- case Map.lookup chainId nonceMap of

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -107,7 +107,7 @@ import Handlers.Transaction
 import SQLM
 import SolidVM.Model.CodeCollection.Contract
 import SolidVM.Model.CodeCollection.Function
-import SolidVM.Model.Value (ValList(..))
+import SolidVM.Model.Value (SString, OrderedVals)
 import Strato.Strato23.API.Types
 import Strato.Strato23.Client
 import System.Clock

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -107,7 +107,7 @@ import Handlers.Transaction
 import SQLM
 import SolidVM.Model.CodeCollection.Contract
 import SolidVM.Model.CodeCollection.Function
-import SolidVM.Model.Value
+import SolidVM.Model.Value (ValList(..))
 import Strato.Strato23.API.Types
 import Strato.Strato23.Client
 import System.Clock

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -107,6 +107,7 @@ import Handlers.Transaction
 import SQLM
 import SolidVM.Model.CodeCollection.Contract
 import SolidVM.Model.CodeCollection.Function
+import SolidVM.Model.Value
 import Strato.Strato23.API.Types
 import Strato.Strato23.Client
 import System.Clock
@@ -631,7 +632,7 @@ postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTr
                     ]
           userCert <- maybe (throwIO err) pure =<<
             A.select (A.Proxy @Certificate) addr
-          pure $ deriveAddressWithSalt (Just userRegistry) (certificateCommonName userCert) userRegistryHash Nothing
+          pure $ deriveAddressWithSalt (Just userRegistry) (certificateCommonName userCert) userRegistryHash (Just . show $ OrderedVals [SString $ certificateCommonName userCert])
         else pure addr
       nonceMap <- getAccountNonce addr (S.singleton chainId)
       accountNonce <- case Map.lookup chainId nonceMap of

--- a/strato/core/strato-genesis/src/Blockchain/Generation.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Generation.hs
@@ -900,15 +900,12 @@ insertUserRegistryContract certs gi =
       genesisInfoCodeInfo = initialCode ++ [CodeInfo encodedRegistry userRegistryContract (Just "UserRegistry")]
     }
   where
-    addrToCertIdx ad = rlpWrap $ BAccount (NamedAccount (fromJust . stringAddress $ ad) MainChain)
     initialAccounts = genesisInfoAccountInfo gi
     initialCode = genesisInfoCodeInfo gi
 
     rlpWrap = rlpSerialize . rlpEncode
     encodedRegistry = encodeUtf8 userRegistryContract
 
-    rootAddress' = fromPublicKey rootPubKey
-    rootAddress = rlpWrap $ BAccount (NamedAccount rootAddress' UnspecifiedChain)
     rootSub = fromJust $ getCertSubject rootCert
     rootAcct =
       SolidVMContractWithStorage
@@ -925,9 +922,7 @@ insertUserRegistryContract certs gi =
                   case getCertSubject crt of
                     Just s -> s
                     Nothing -> error "Certificate requires a subject"
-                certUserAddress = fromPublicKey . subPub . certSub'
                 certSub = certSub' cert
-                reverseAddr = Address . bytesToWord160 . reverse . word160ToBytes . unAddress . certUserAddress
             SolidVMContractWithStorage
               (deriveAddressWithSalt Nothing (subCommonName certSub) Nothing (Just . show $ OrderedVals [SString $ subCommonName certSub]))
               0

--- a/strato/core/strato-genesis/src/Blockchain/Generation.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Generation.hs
@@ -915,7 +915,7 @@ insertUserRegistryContract certs gi =
         (deriveAddressWithSalt Nothing (subCommonName rootSub) Nothing (Just . show $ OrderedVals [SString $ subCommonName rootSub]))
         123
         (SolidVMCode "User" (KECCAK256.hash encodedRegistry))
-        [ (".commonName", rlpWrap . BString . BC.pack . subCommonName $ rootSub),
+        [ (".commonName", rlpWrap . BString . BC.pack . subCommonName $ rootSub)
         ]
 
     userAccts =
@@ -932,7 +932,7 @@ insertUserRegistryContract certs gi =
               (deriveAddressWithSalt Nothing (subCommonName certSub) Nothing (Just . show $ OrderedVals [SString $ subCommonName certSub]))
               0
               (SolidVMCode "User" (KECCAK256.hash encodedRegistry))
-              [ (".commonName", rlpWrap . BString . BC.pack . subCommonName $ certSub),
+              [ (".commonName", rlpWrap . BString . BC.pack . subCommonName $ certSub)
               ]
         )
         certs

--- a/strato/core/strato-genesis/src/Blockchain/Generation.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Generation.hs
@@ -942,4 +942,4 @@ insertUserRegistryContract certs gi =
         0x720
         720
         (SolidVMCode "UserRegistry" (KECCAK256.hash encodedRegistry))
-        $ [(".owner", rootAddress)]
+        $ []

--- a/strato/core/strato-genesis/src/Blockchain/Generation.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Generation.hs
@@ -55,6 +55,7 @@ import Data.Text.Encoding
 import qualified Data.Vector as V
 import GHC.Generics
 import SolidVM.Model.Storable hiding (size)
+import SolidVM.Model.Value
 import Text.RawString.QQ
 
 data Type
@@ -911,13 +912,10 @@ insertUserRegistryContract certs gi =
     rootSub = fromJust $ getCertSubject rootCert
     rootAcct =
       SolidVMContractWithStorage
-        (deriveAddressWithSalt Nothing (subCommonName rootSub) Nothing Nothing)
+        (deriveAddressWithSalt Nothing (subCommonName rootSub) Nothing (Just . show $ OrderedVals [SString $ subCommonName rootSub]))
         123
         (SolidVMCode "User" (KECCAK256.hash encodedRegistry))
-        [ (".owner", rlpWrap $ BAccount (NamedAccount ((fromJust . stringAddress) "720") UnspecifiedChain)),
-          (".commonName", rlpWrap . BString . BC.pack . subCommonName $ rootSub),
-          (".isActive", rlpWrap $ BBool True),
-          (BC.pack $ ".userCertificates<a:" ++ (show rootAddress') ++ ">", addrToCertIdx "1337")
+        [ (".commonName", rlpWrap . BString . BC.pack . subCommonName $ rootSub),
         ]
 
     userAccts =
@@ -931,13 +929,10 @@ insertUserRegistryContract certs gi =
                 certSub = certSub' cert
                 reverseAddr = Address . bytesToWord160 . reverse . word160ToBytes . unAddress . certUserAddress
             SolidVMContractWithStorage
-              (deriveAddressWithSalt Nothing (subCommonName certSub) Nothing Nothing)
+              (deriveAddressWithSalt Nothing (subCommonName certSub) Nothing (Just . show $ OrderedVals [SString $ subCommonName certSub]))
               0
               (SolidVMCode "User" (KECCAK256.hash encodedRegistry))
-              [ (".owner", rlpWrap $ BAccount (NamedAccount ((fromJust . stringAddress) "720") UnspecifiedChain)),
-                (".commonName", rlpWrap . BString . BC.pack . subCommonName $ certSub),
-                (".isActive", rlpWrap $ BBool True),
-                (BC.pack $ ".userCertificates<a:" ++ (show $ certUserAddress cert) ++ ">", addrToCertIdx . show . reverseAddr $ cert)
+              [ (".commonName", rlpWrap . BString . BC.pack . subCommonName $ certSub),
               ]
         )
         certs

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/UserRegistry.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/UserRegistry.hs
@@ -16,13 +16,6 @@ pragma builtinCreates;
 import { Certificate, CertificateRegistry } from <509>;
 
 contract UserRegistry {
-    // The UserRegistry is responsible for creating User contracts for each user.
-    address public owner;
-
-    constructor() {
-        owner = msg.sender;
-    }
-
     function createUser(string _commonName) public returns (address) {
         User newUser = new User{salt: _commonName}(_commonName);
         return address(newUser);
@@ -30,7 +23,6 @@ contract UserRegistry {
 }
 
 contract User {
-
     string public commonName;
 
     constructor(string _commonName) {

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/UserRegistry.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/UserRegistry.hs
@@ -9,6 +9,12 @@ import Text.RawString.QQ
 userRegistryContract :: Text
 userRegistryContract =
   [r|
+pragma es6;
+pragma strict;
+pragma builtinCreates;
+
+import { Certificate, CertificateRegistry } from <509>;
+
 contract UserRegistry {
     // The UserRegistry is responsible for creating User contracts for each user.
     address public owner;
@@ -17,72 +23,45 @@ contract UserRegistry {
         owner = msg.sender;
     }
 
-    function createUser(string _commonName, string _userAddress, address _certificateAddress) public returns (address) { 
-        require((msg.sender == owner), "You don't have permission to use this function!");
-
-        User newUser = new User{salt: _commonName}();
-        newUser.initializeUser(_commonName, address(_userAddress), _certificateAddress);
+    function createUser(string _commonName) public returns (address) {
+        User newUser = new User{salt: _commonName}(_commonName);
         return address(newUser);
-    }
-
-    function addCertificateToUser(address _userContractAddress, address _certificateAddress) public {
-        require((msg.sender == owner), "You don't have permission to use this function!");
-
-        User targetUser = User(_userContractAddress);
-        targetUser.addCertificate(_userContractAddress, _certificateAddress);
-    }
-
-    function toggleUserActiveStatus(address _userContractAddress) public {
-        require((msg.sender == owner), "You don't have permission to use this function!");
-
-        User targetUser = User(_userContractAddress);
-        targetUser.toggleUserActiveStatus();
     }
 }
 
 contract User {
-    address public owner;
 
-    mapping(address => address) userCertificates;     // Data structure subject to change
     string public commonName;
-    bool isActive;
 
-    constructor() {
-        owner = msg.sender;
-    }
-
-    function initializeUser(string _commonName, address _userAddress, address _certificateAddress) {
-        // Only UserRegistry can add new certificates.
-        require((msg.sender == owner), "You don't have permission to use this function!");
-
+    constructor(string _commonName) {
         commonName = _commonName;
-        userCertificates[_userAddress] = _certificateAddress;
-        isActive = true;
     }
 
-    function addCertificate(address _userAddress, address _certificateAddress) public {
-        // Only UserRegistry can add new certificates.
-        require((msg.sender == owner), "You don't have permission to use this function!");
-        
-        userCertificates[_userAddress] = _certificateAddress;
+    modifier authenticated() {
+        // Only the user that this contract is associated with, can use this function.
+        require(authenticate(), "You don't have permission to use this function!");
+        _;
     }
 
-    function toggleUserActiveStatus() public {
-        require((msg.sender == owner), "You don't have permission to use this function!");
+    function createContract(string contractName, string contractSrc, string args) public authenticated {
+        create(contractName, contractSrc, args);
+    }
 
-        isActive = !isActive;
+    function createSaltedContract(string salt, string contractName, string contractSrc, string args) public authenticated {
+        create2(salt, contractName, contractSrc, args);
+    }
+
+    function callContract(address contractToCall, string functionName, variadic args) public returns (variadic) authenticated {
+        variadic result = address(contractToCall).call(functionName, args);
+        return result;
     }
 
     // Checks if the caller is indeed the user the wallet belongs to.
-    function authenticate() public returns (bool) {
-        return userCertificates[msg.sender] != address(0);
-    }
-
-    function callContract(address contractToCall, string functionName, variadic args) public returns (variadic) {
-        // Only the user that this contract is associated with, can use this function.
-        require((authenticate() && isActive), "You don't have permission to use this function!");
-
-        variadic result = address(contractToCall).call(functionName, args);
-        return result;
+    function authenticate() internal returns (bool) {
+        Certificate cert = CertificateRegistry(address(0x509)).getCertByAddress(msg.sender);
+        if (address(cert) != address(0)) {
+            return cert.commonName() == commonName;
+        }
+        return false;
     }
 }|]


### PR DESCRIPTION
Changes to UserRegistry contract:
- Removed owner, addCertificateToUser, toggleUserActiveStatus: Anyone can create a User contract, because the address will always be the same for the same common name, but using a User contract requires msg.sender to have a cert with the same common name as that of the User contract.
Changes to User contract:
- Added commonName field, createContract and createSaltedContract functions
- Removed owner, userCertificates, isActive, addCertificate, and toggleUserActiveStatus: Ownership/certificates will be determined by looking up the Certificate for `msg.sender`, and comparing the commonName in the cert with the commonName field of the User contract.
- Modified the authenticate function: Now all User functions are guarded by the `authenticated` modifier, which calls `authenticate` to load msg.sender's cert and compare it to the User's common name.