### PR TITLE
Fixing semaphore leaking caused from improper handling of non-responsive peers in strato-p2p.

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -518,7 +518,7 @@ handleEvents peer = awaitForever $ \case
         when (diffTime > maxTime) $ do
           yieldR $ Disconnect UselessPeer
           liftIO $ setTitle "timer timed out!"
-          error "Peer did not respond"
+          throwIO PeerNonResponsive
       Nothing -> do
         $logInfoS "TimerEvt" $ T.pack "Timestamp is not set"
         return ()

--- a/strato/core/strato-p2p/src/Blockchain/EventException.hs
+++ b/strato/core/strato-p2p/src/Blockchain/EventException.hs
@@ -8,6 +8,7 @@ import Control.Exception.Lifted
 
 data EventException
   = PeerDisconnected
+  | PeerNonResponsive
   | EventBeforeHandshake Message
   | WrongGenesisBlock
   | NetworkIDMismatch

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -170,7 +170,8 @@ stratoP2PClient runner = runner $ \sSource -> do
             liftIO (SSem.signal sem)
     handleRunPeerResult :: MonadP2P m => PPeer -> Either SomeException a -> m ()
     handleRunPeerResult thePeer = \case
-      Left e | Just (ErrorCall x) <- fromException e -> error x
+      Left e | Just (ErrorCall x) <- fromException e -> do _  <- liftIO $ print ("handleRunPeerResult Left!" :: String)
+                                                           error x
       Left e -> do
         $logInfoS "stratoP2PClient/handleRunPeerResult" $ T.pack $ "Connection ended: " ++ show (e :: SomeException)
         recordException thePeer e
@@ -197,6 +198,10 @@ stratoP2PClient runner = runner $ \sSource -> do
             lengthenPeerDisable thePeer
           e' | Just PeerDisconnected <- fromException e' -> do
             disErr <- storeDisableException thePeer (T.pack "PeerDisconnected")
+            whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
+            lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
+          e' | Just PeerNonResponsive <- fromException e' -> do
+            disErr <- storeDisableException thePeer (T.pack "PeerNonResponsive")
             whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
             lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
           e' | Just TimeoutException <- fromException e' -> do

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -170,8 +170,7 @@ stratoP2PClient runner = runner $ \sSource -> do
             liftIO (SSem.signal sem)
     handleRunPeerResult :: MonadP2P m => PPeer -> Either SomeException a -> m ()
     handleRunPeerResult thePeer = \case
-      Left e | Just (ErrorCall x) <- fromException e -> do _  <- liftIO $ print ("handleRunPeerResult Left!" :: String)
-                                                           error x
+      Left e | Just (ErrorCall x) <- fromException e -> error x
       Left e -> do
         $logInfoS "stratoP2PClient/handleRunPeerResult" $ T.pack $ "Connection ended: " ++ show (e :: SomeException)
         recordException thePeer e


### PR DESCRIPTION
An erroneous handling of non-responsive peers was detected in the `stratoP2PClient` function within `strato/core/strato-p2p/src/Executable/StratoP2PClient.hs`.

By adding verbose logging to the `multiThreadedClient` function, a leaky semaphore was detected.

Currently, there is an expectation of around ~10-15 peer connections (max).  Prior to this fix, the semaphore would show a slow emission all the way to 0 quantity, indicating 1000 concurrent peer connections (the set current maximum).

This fix works by fixing the improper error handling within `strato/core/strato-p2p/src/Blockchain/Event.hs`,

```
TimerEvt -> do
    maybeOldTS <- unActionTimestamp <$> lift getActionTimestamp
    case maybeOldTS of
      Just oldTS -> do
        ts <- liftIO getCurrentTime
        let diffTime = ts `diffUTCTime` oldTS
        maxTime <- fromIntegral . unConnectionTimeout <$> lift (access (Proxy @ConnectionTimeout))
        liftIO $ setTitle $ "timer: " ++ show (maxTime - diffTime)
        when (diffTime > maxTime) $ do
          yieldR $ Disconnect UselessPeer
          liftIO $ setTitle "timer timed out!"
          error "Peer did not respond"
```

The problem line here is `error "Peer did not respond"`.

An addition of the `PeerNonResponsive` constructor to `EventException`:

```
data EventException
  = PeerDisconnected
  | PeerNonResponsive
  | EventBeforeHandshake Message
  | WrongGenesisBlock
  | NetworkIDMismatch
  | RootCertificateMismatch
  | NoPeerPubKey
  | NoPeerCertificate
  deriving (Show)
```

along with swapping in `throwIO PeerNonResponsive` for `error: "Peer did not respond"` solved this issue.

The following alternative within the `handleRunPeerResult` function was added to handle `PeerNonResponsive`:

```
e' | Just PeerNonResponsive <- fromException e' -> do
  disErr <- storeDisableException thePeer (T.pack "PeerNonResponsive")
  whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
  lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
```