### PR TITLE
remove access tokens from marketplace logs output

### DIFF
--- a/marketplace/backend/api/middleware/loadDappHandler.js
+++ b/marketplace/backend/api/middleware/loadDappHandler.js
@@ -15,7 +15,7 @@ const loadDapp = async (req, res, next) => {
     username,
     ...accessToken,
   }
-  console.log('User Credentials: \n\n\n\n\n', userCredentials)
+  console.log(`Requester username/uuid: ${username}`)
   const user = {
     ...userCredentials,
     node: config.nodes[0],


### PR DESCRIPTION
This removes the security vulnerability when the real user tokens are exposed in the output of marketplace backend logs like this:
```
{
  username: 'chase_denecke@blockapps.net',
  token: 'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlZHFmUmhlM0pydldhaER3enhvWV85YXFiVDVSNkNwMHotZy1TamxGQWxnIn0.eyJqdGkiOiI3YWZjNmZmMi0yYTIzLTQ1NmQtYTllNi1lNDA4YWUzODZhMWMiLCJleHAiOjE2OTYzNDgxNjQsIm5iZiI6MCwiaWF0IjoxNjk2MzQ3ODY0LCJpc3MiOiJo(removed the rest of token here but in the output it's all there //Nikita)'
}
{
  name: 'Dapp',
  address: 'c93f9a422a4508a6501a63537291128122f7bcf2',
  managers: {
    cirrusOrg: 'BlockApps',
    productManager: {
      name: 'ProductManager',
      address: '4966042cf9a42e973541cecea8296834434324e4',
      getState: [AsyncFunction (anonymous)],
      getProduct: [AsyncFunction (anonymous)],
      getProducts: [AsyncFunction (anonymous)],
      getInventory: [AsyncFunction (anonymous)],
      ...........
```