### PR TITLE
Product Duplication on Purchasing an item twice(or more)

### DIFF
--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -584,9 +584,8 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   };
   contract.resellInventory = async function (args, options = defaultOptions) {
     const { inventoryId, quantity, price, itemsAddress } = args;
-    const newBatchId = util.uid();
     const newItemNumber = parseInt(util.uid());
-    return await managers.productManager.resellInventory({ existingInventory: inventoryId, quantity, price, batchId: newBatchId, itemNumber: newItemNumber, itemsAddress: itemsAddress });
+    return await managers.productManager.resellInventory({ existingInventory: inventoryId, quantity, price, itemNumber: newItemNumber, itemsAddress: itemsAddress });
   };
   contract.getProduct = async function (args, options = optionsNoChainIds) {
     const getOptions = { ...options, org: managers.cirrusOrg, app: contractName, };

--- a/marketplace/backend/dapp/items/contracts/ItemManager.sol
+++ b/marketplace/backend/dapp/items/contracts/ItemManager.sol
@@ -196,28 +196,30 @@ contract ItemManager is ItemStatus, InventoryStatus {
 
         Product_3 oldProduct = Product_3(item.productId());
         address productAddress = productManager.checkForProduct(
-            address(oldProduct),
             oldProduct.uniqueProductCode(),
             _newOwner
         );
 
-        product = (productAddress == address(0))
-            ? new Product_3(
-                oldProduct.name(),
-                oldProduct.description(),
-                oldProduct.manufacturer(),
-                oldProduct.unitOfMeasurement(),
-                oldProduct.userUniqueProductCode(),
-                oldProduct.uniqueProductCode(),
-                oldProduct.leastSellableUnit(),
-                oldProduct.imageKey(),
-                oldProduct.isActive(),
-                oldProduct.category(),
-                oldProduct.subCategory(),
-                block.timestamp,
-                _newOwner
-            )
-            : Product_3(productAddress);
+        if (productAddress == address(0)) {
+                    address addr = productManager.addProductForBuyer(
+                        oldProduct.name(),
+                        oldProduct.description(),
+                        oldProduct.manufacturer(),
+                        oldProduct.unitOfMeasurement(),
+                        oldProduct.userUniqueProductCode(),
+                        oldProduct.uniqueProductCode(),
+                        oldProduct.leastSellableUnit(),
+                        oldProduct.imageKey(),
+                        oldProduct.isActive(),
+                        oldProduct.category(),
+                        oldProduct.subCategory(),
+                        block.timestamp,
+                        _newOwner
+                    );
+                    product = Product_3(addr);
+                } else {
+                    product = Product_3(productAddress);
+                }
 
         Inventory oldInventory = Inventory(item.inventoryId());
 
@@ -245,6 +247,9 @@ contract ItemManager is ItemStatus, InventoryStatus {
                 block.timestamp,
                 _newOwner
             );
+            address itemContractAddress = address(itemAddr);
+            itemProductIdMapping[itemContractAddress] = address(product);
+            itemInventoryIdMapping[itemContractAddress] = address(inventory);
         } else {
             (uint status, address inventory) = product.addInventory(
                 _itemsAddress.length,

--- a/marketplace/backend/dapp/products/contracts/ProductManager.sol
+++ b/marketplace/backend/dapp/products/contracts/ProductManager.sol
@@ -54,6 +54,43 @@ contract ProductManager is
         return (RestStatus.OK, address(product));
     }
 
+    function addProductForBuyer(
+        string _name,
+        string _description,
+        string _manufacturer,
+        UnitOfMeasurement _unitOfMeasurement,
+        string _userUniqueProductCode,
+        uint _uniqueProductCode,
+        int _leastSellableUnit,
+        string _imageKey,
+        bool _isActive,
+        string _category,
+        string _subCategory,
+        uint _createdDate,
+        address _newOwner
+    ) returns (address) {
+        Product_3 product = new Product_3(
+            _name,
+            _description,
+            _manufacturer,
+            _unitOfMeasurement,
+            _userUniqueProductCode,
+            _uniqueProductCode,
+            _leastSellableUnit,
+            _imageKey,
+            _isActive,
+            _category,
+            _subCategory,
+            _createdDate,
+            _newOwner
+        );
+
+        string _organization = getOrganization(_newOwner);
+        orgToUPCToProduct[_organization][_uniqueProductCode] = address(product);
+
+        return (address(product));
+    }
+
     function updateProduct(
         address _productAddress,
         string _description,
@@ -251,18 +288,13 @@ contract ProductManager is
     }
 
     function checkForProduct(
-        address _productAddress,
         uint _uniqueProductCode,
         address _owner
     ) public returns (address) {
         string _organization = getOrganization(_owner);
 
-        if (
-            orgToUPCToProduct[_organization][_uniqueProductCode] !=
-            address(0) &&
-            orgToUPCToProduct[_organization][_uniqueProductCode] ==
-            address(_productAddress)
-        ) {
+        if (orgToUPCToProduct[_organization][_uniqueProductCode] != address(0)) 
+        {
             return orgToUPCToProduct[_organization][_uniqueProductCode];
         }
         return address(0);

--- a/marketplace/backend/dapp/products/contracts/ProductManager.sol
+++ b/marketplace/backend/dapp/products/contracts/ProductManager.sol
@@ -14,7 +14,7 @@ contract ProductManager is
     RestStatus
 {
     // constructor() public {}
-    mapping(string => mapping(uint => address)) orgToUPCToProduct;
+    mapping(string => mapping(uint => address)) record orgToUPCToProduct;
     mapping(address => mapping(string => bool))
         private uniqueSerialNumberByProductAddress;
 

--- a/marketplace/backend/dapp/products/contracts/ProductManager.sol
+++ b/marketplace/backend/dapp/products/contracts/ProductManager.sol
@@ -217,7 +217,6 @@ contract ProductManager is
         address _existingInventory,
         int _quantity,
         int _price,
-        string _batchId,
         uint _itemNumber,
         address[] _itemsAddress
     ) returns (uint256, address) {
@@ -235,7 +234,7 @@ contract ProductManager is
             (uint256 status, address inventoryAddress) = product.addInventory(
                 _quantity,
                 _price,
-                _batchId,
+                existingInventory.batchId(),
                 existingInventory.inventoryType(),
                 InventoryStatus.PUBLISHED,
                 block.timestamp,
@@ -260,7 +259,7 @@ contract ProductManager is
             (uint256 status, address inventoryAddress) = product.addInventory(
                 _quantity,
                 _price,
-                _batchId,
+                existingInventory.batchId(),
                 existingInventory.inventoryType(),
                 InventoryStatus.PUBLISHED,
                 block.timestamp,


### PR DESCRIPTION
Hi,

This PR fixes the issue on product duplication on purchasing same product more than once.

To test this out:
- Create a new product
(We track product when its created or when its purchased)
- As a buyer, purchase the new product created.
- As a seller, close the order for the above.
- Repeat it again.
- You would see that the products are not replicated for every purchase that is closed.

**Preventing Product Duplication**
For more information on the methodology followed, here's the [documentation](https://docs.google.com/document/d/1t_7GlDQwadclt5c0JC9ow86EXfnpStim3Y8LFRruCwg/edit?usp=sharing).


