### PR TITLE
fix: escape non sub dollar signs

### DIFF
--- a/pipelines/Jenkinsfile.updateTestnet2
+++ b/pipelines/Jenkinsfile.updateTestnet2
@@ -13,13 +13,13 @@ pipeline {
 
           echo "Input JSON: {\"VersionTag\": \"${params.VERSION_TAG}\"}"
 
-          env.execution_arn=$(aws stepfunctions start-execution \
+          env.execution_arn=\$(aws stepfunctions start-execution \
             --state-machine-arn arn:aws:states:us-east-1:406773134706:stateMachine:UpgradeTestnet2 \
             --input "{\"VersionTag\": \"${params.VERSION_TAG}\"}" \
             --query "executionArn" \
             --output text)
 
-          echo "Started Step Functions execution with ARN: $execution_arn" 
+          echo "Started Step Functions execution with ARN: \$execution_arn" 
         """
       }
     }
@@ -27,25 +27,25 @@ pipeline {
       steps {
         sh """#!/bin/bash
           while true; do
-            execution_status=$(aws stepfunctions describe-execution \
-              --execution-arn "${execution_arn}" \
+            execution_status=\$(aws stepfunctions describe-execution \
+              --execution-arn "\${execution_arn}" \
               --query "status" \
               --output text)
           
-            if [ "$execution_status" == "SUCCEEDED" ]; then
+            if [ "\$execution_status" == "SUCCEEDED" ]; then
               echo "Step Functions execution succeeded."
               exit 0
-            elif [ "$execution_status" == "FAILED" ]; then
+            elif [ "\$execution_status" == "FAILED" ]; then
               echo "Step Functions execution failed."
               exit 1 
-            elif [ "$execution_status" == "TIMED_OUT" ]; then
+            elif [ "\$execution_status" == "TIMED_OUT" ]; then
               echo "Step Functions execution timed out."
               exit 1  
-            elif [ "$execution_status" == "RUNNING" ]; then
+            elif [ "\$execution_status" == "RUNNING" ]; then
               echo "Step Functions execution is still running. Waiting..."
               sleep 30
             else
-              echo "Unknown execution status: $execution_status"
+              echo "Unknown execution status: \$execution_status"
               exit 1  
             fi
           done


### PR DESCRIPTION
job fails with WorkflowScript: 14: illegal string body character after dollar sign.

Escaping all non-sub $s
Hopefully the last pr.... 