### PR TITLE
fix: try single quotes

### DIFF
--- a/pipelines/Jenkinsfile.updateTestnet2
+++ b/pipelines/Jenkinsfile.updateTestnet2
@@ -11,11 +11,11 @@ pipeline {
       steps {
         sh """#!/bin/bash
 
-          echo "Input JSON: {"VersionTag": "${params.VERSION_TAG}"}"
+          echo 'Input JSON: {"VersionTag": "${params.VERSION_TAG}"}'
 
           env.execution_arn=\$(aws stepfunctions start-execution \
             --state-machine-arn arn:aws:states:us-east-1:406773134706:stateMachine:UpgradeTestnet2 \
-            --input "{"VersionTag": "${params.VERSION_TAG}"}" \
+            --input '{"VersionTag": "${params.VERSION_TAG}"}' \
             --query "executionArn" \
             --output text)
 


### PR DESCRIPTION
Running into an issue where Jenkins drops the double quotes in the json input, causing the aws cli call to fail. Tried escaping and not escaping, but doesn't seem to fix the issue.

Trying single quotes around the json string.