### PR TITLE
converting ByteString to ShortByteString

### DIFF
--- a/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
@@ -22,7 +22,7 @@ import Control.DeepSeq
 import Control.Monad.Extra
 import Data.Bifunctor
 import Data.Bitraversable
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import qualified Data.ByteString.Char8 as C8
 import Data.Char
 import qualified Data.HashMap.Strict as HM
@@ -48,7 +48,7 @@ bimapValue f (name', value') = do
   mValue <- valueToSolidityValue value'
   return $ fmap (name,) mValue
 
-decodeCacheValues :: M.Map B.ByteString B.ByteString -> [(T.Text, Value)] -> [(T.Text, Value)]
+decodeCacheValues :: M.Map B.ShortByteString B.ShortByteString -> [(T.Text, Value)] -> [(T.Text, Value)]
 decodeCacheValues hxs prevState = either (error . (++ ": " ++ show hxs) . printf "SVM.decodeCacheValues: %s" . show) id $ do
   let parseM = bimapM (hexStorageToPath . HexStorage) (hexStorageToBasic . HexStorage)
       isBasic (StoragePath [Field _]) = True
@@ -57,11 +57,11 @@ decodeCacheValues hxs prevState = either (error . (++ ": " ++ show hxs) . printf
   let pathValues' = filter (isBasic . fst) pathValues
   finalState <- bimap show HM.toList $ case prevState of
     [] -> synthesize pathValues'
-    tvs -> replayDeltas pathValues' . HM.fromList . map (first encodeUtf8) $ tvs
+    tvs -> replayDeltas pathValues' . HM.fromList . map (first (B.toShort . encodeUtf8)) $ tvs
 
   mapM (bimapM bsToText return) finalState
 
-decodeCacheValuesForMapping :: M.Map B.ByteString B.ByteString -> [(T.Text, Value)]
+decodeCacheValuesForMapping :: M.Map B.ShortByteString B.ShortByteString -> [(T.Text, Value)]
 decodeCacheValuesForMapping hxs = either (error . (++ ": " ++ show hxs) . printf "SVM.decodeCacheValuesForMapping: %s" . show) id $ do
   let parseM = bimapM (hexStorageToPath . HexStorage) (hexStorageToBasic . HexStorage)
       isBasic (StoragePath [Field _, MapIndex _]) = True
@@ -71,8 +71,8 @@ decodeCacheValuesForMapping hxs = either (error . (++ ": " ++ show hxs) . printf
   finalState <- bimap show HM.toList $ synthesize pathValues'
   mapM (bimapM bsToText return) finalState
 
-bsToText :: B.ByteString -> Either String T.Text
-bsToText = first show . decodeUtf8'
+bsToText :: B.ShortByteString -> Either String T.Text
+bsToText = first show . decodeUtf8' . B.fromShort
 
 -- Why another time?
 --  - original vToSV can't handle sentinels without introducing a monad
@@ -81,7 +81,7 @@ bsToText = first show . decodeUtf8'
 valueToSolidityValue :: V.Value -> Either String (Maybe SolidityValue)
 valueToSolidityValue = \case
   SimpleValue sv -> case sv of
-    ValueBytes _ b -> Just . SolidityValueAsString <$> (first show . decodeUtf8') b
+    ValueBytes _ b -> Just . SolidityValueAsString <$> (first show . decodeUtf8' . B.fromShort) b
     ValueBool b -> Right . Just $ SolidityBool b
     ValueInt _ _ n -> fromShowable n
     ValueAddress a -> fromShowable a
@@ -114,19 +114,19 @@ valueToSolidityValue = \case
       -- we wouldn't want to hex encode user readable strings. Unprintable characters are
       -- escaped, so that the text will maintain readability and data is not lost on encoding
       -- (c.f. T.pack . C8.unpack, which will silently truncate non-UTF8 byte sequences)
-      ValueBytes _ bs -> Right . T.pack . (foldr showLitChar "") . C8.unpack $ bs
+      ValueBytes _ bs -> Right . T.pack . (foldr showLitChar "") . C8.unpack . B.fromShort $ bs
       ValueBool True -> Right "true"
       ValueBool False -> Right "false"
 
-type TotalStorage = HM.HashMap B.ByteString V.Value
+type TotalStorage = HM.HashMap B.ShortByteString V.Value
 
 data ReplayFailure
   = MissingPath StoragePath
   | TypeMismatch StoragePath BasicValue V.Value
-  | MissingStructField B.ByteString
+  | MissingStructField B.ShortByteString
   | FieldRequiredAtTopLevel
   | NoPathsProvided
-  | UnicodeError B.ByteString UnicodeException
+  | UnicodeError B.ShortByteString UnicodeException
   deriving (Show, Eq, Generic, NFData)
 
 replayDeltas :: StorageDelta -> TotalStorage -> Either ReplayFailure TotalStorage
@@ -147,7 +147,7 @@ applyDelta' [] bv (SimpleValue {}) = Right $ fromBasic bv
 applyDelta' [] bv (ValueEnum {}) = Right $ fromBasic bv
 applyDelta' [] bv (ValueContract {}) = Right $ fromBasic bv
 applyDelta' (Field n : sp) bv (ValueStruct ss) = do
-  n' <- first (UnicodeError n) $ decodeUtf8' n
+  n' <- first (UnicodeError n) $ decodeUtf8' $ B.fromShort n
   case M.lookup n' ss of
     Just v -> ValueStruct . (\x -> M.insert n' x ss) <$> applyDelta' sp bv v
     Nothing -> Right . ValueStruct $ M.insert n' (constructFromNothing' sp bv) ss
@@ -177,7 +177,7 @@ constructFromNothing' [] = fromBasic
 constructFromNothing' [Field "length"] = \case
   BInteger n -> ValueArraySentinel $ fromIntegral n
   bv -> ValueStruct . M.singleton "length" $ constructFromNothing' [] bv
-constructFromNothing' (Field n : sp) = ValueStruct . M.singleton (decodeUtf8 n) . constructFromNothing' sp
+constructFromNothing' (Field n : sp) = ValueStruct . M.singleton (decodeUtf8 . B.fromShort $ n) . constructFromNothing' sp
 constructFromNothing' (MapIndex n : sp) =
   ValueMapping . M.singleton (fromIndex n) . constructFromNothing' sp
 constructFromNothing' (ArrayIndex n : sp) =

--- a/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/ArgValue.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/ArgValue.hs
@@ -16,8 +16,8 @@ import qualified Data.Aeson.Key as DAK
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.Bifunctor as BF
 import qualified Data.Bimap as Bimap
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Short as Short
 import qualified Data.ByteString.Base16 as Base16
 import Data.Either
 import qualified Data.Map.Strict as Map
@@ -200,13 +200,13 @@ argValueToSimpleValue theType argVal = case theType of
     ArgString str -> ValueBytes Nothing <$> readBytesDyn str
     o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeBytes to be a string, but got " ++ show o
   where
-    readBytes :: Integer -> Text -> Either Text ByteString
+    readBytes :: Integer -> Text -> Either Text Short.ShortByteString
     readBytes n str =
       case Base16.decode (Text.encodeUtf8 str) of
-        Right bytes' | ByteString.length bytes' == fromInteger n -> return bytes'
+        Right bytes' | ByteString.length bytes' == fromInteger n -> return $ Short.toShort bytes'
         _ -> Left $ "argValueToSimpleValue: could not decode as statically sized bytes: " <> str <> ", expected a Base16 encoded string of length " <> Text.pack (show $ 2 * n) <> ", which represents a bytestring of length " <> Text.pack (show n)
-    readBytesDyn :: Text -> Either Text ByteString
+    readBytesDyn :: Text -> Either Text Short.ShortByteString
     readBytesDyn str =
       case Base16.decode (Text.encodeUtf8 str) of
-        Right bytes' -> return bytes'
+        Right bytes' -> return $ Short.toShort bytes'
         _ -> Left $ "argValueToSimpleValue: could not decode as dynamically sized bytes: " <> str

--- a/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/Parse/Selector.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/Parse/Selector.hs
@@ -10,8 +10,8 @@ module BlockApps.Solidity.Parse.Selector (deriveSelector) where
 import BlockApps.Solidity.Type
 import Crypto.Hash
 import qualified Data.ByteArray as ByteArray
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as ByteString
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as ByteString
 import Data.List
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -25,13 +25,13 @@ import Data.Text.Encoding
 -- respectively 'uintX' and 'address' types, where X is the least number of
 -- bytes (in bits) that can hold all the enum's values.  Structs are not
 -- permitted at all.
-deriveSelector :: [(Text, Int)] -> Text -> [Type] -> ByteString
-deriveSelector enumSizes name args = hash4 $ signature enumSizes name args
+deriveSelector :: [(Text, Int)] -> Text -> [Type] -> ShortByteString
+deriveSelector enumSizes name args = hash4 . ByteString.fromShort $ signature enumSizes name args
   where
-    hash4 bs = ByteString.take 4 . ByteArray.convert $ (hash bs :: Digest Keccak_256)
+    hash4 bs = ByteString.take 4 . ByteString.toShort . ByteArray.convert $ (hash bs :: Digest Keccak_256)
 
-signature :: [(Text, Int)] -> Text -> [Type] -> ByteString
-signature enumSizes name args = encodeUtf8 $ Text.pack $ Text.unpack name ++ prettyArgTypes enumSizes args
+signature :: [(Text, Int)] -> Text -> [Type] -> ShortByteString
+signature enumSizes name args = ByteString.toShort $ encodeUtf8 $ Text.pack $ Text.unpack name ++ prettyArgTypes enumSizes args
 
 prettyArgTypes :: [(Text, Int)] -> [Type] -> String
 prettyArgTypes enumSizes args =

--- a/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/Storage.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/Storage.hs
@@ -7,34 +7,33 @@ import Blockchain.Strato.Model.Account
 import Blockchain.Strato.Model.Address
 import Data.Bits (complement, shiftR, (.&.))
 import Data.Bool
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Short as Short
 import qualified Data.IntMap as I
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Text.Encoding as Text
 import Data.Word (Word8)
 
-toStorage :: Value -> ByteString
+toStorage :: Value -> Short.ShortByteString
 toStorage = \case
   SimpleValue v -> simpleToStorage v
   ValueArrayDynamic vs ->
     toStorage (SimpleValue (valueUInt k))
-      `ByteString.append` toStorage (ValueArrayFixed k $ unsparse vs)
+      `Short.append` toStorage (ValueArrayFixed k $ unsparse vs)
     where
       k :: Num n => n
       k = fromIntegral (I.size vs)
   ValueArrayFixed _ vs ->
     let head' = map (\v -> if isDynamic v then Nothing else Just (toStorage v)) vs
-        tail' = map (\v -> if isDynamic v then toStorage v else ByteString.empty) vs
-        tailLengths = scanl (\b a -> ByteString.length a + b) 0 tail'
-        headLength = sum $ maybe 32 ByteString.length <$> head'
+        tail' = map (\v -> if isDynamic v then toStorage v else Short.empty) vs
+        tailLengths = scanl (\b a -> Short.length a + b) 0 tail'
+        headLength = sum $ maybe 32 Short.length <$> head'
         head'' = zipWith f tailLengths head'
           where
             f t =
               fromMaybe
                 (toStorage $ SimpleValue $ valueUInt $ fromIntegral $ t + headLength)
-     in ByteString.concat head'' `ByteString.append` ByteString.concat tail'
+     in Short.concat head'' `Short.append` Short.concat tail'
   -- byte array of correctly encoded types in vs
   -- head  array contains static size Values
   -- head ends with in order:
@@ -43,31 +42,31 @@ toStorage = \case
   ValueContract {} -> error "toStorage for ValueContract not yet defined"
   ValueFunction {} -> error "toStorage for ValueFunction not yet defined"
   ValueEnum {} -> error "toStorage for ValueEnum not yet defined"
-  ValueStruct {} -> ByteString.empty
+  ValueStruct {} -> Short.empty
   ValueMapping {} -> error "toStorage for ValueMapping not yet defined"
   ValueArraySentinel {} -> error "toStorage for ValueArraySentinel not yet defined"
-  ValueVariadic {} -> ByteString.empty
+  ValueVariadic {} -> Short.empty
 
-simpleToStorage :: SimpleValue -> ByteString
+simpleToStorage :: SimpleValue -> Short.ShortByteString
 simpleToStorage = \case
   ValueBool v -> simpleToStorage $ valueUInt $ bool 0 1 v
-  ValueInt False _ v -> ByteString.pack $ go False v
+  ValueInt False _ v -> Short.pack $ go False v
   ValueInt True _ v ->
-    ByteString.pack $
+    Short.pack $
       if (v < 0)
         then go True ((negate v) - 1)
         else go False v
   ValueAddress v -> simpleToStorage . valueUInt . fromIntegral $ unAddress v
   ValueAccount v -> simpleToStorage . valueUInt . fromIntegral $ _namedAccountAddress v
-  ValueBytes Nothing v -> padRight32 $ ByteString.append (simpleToStorage (valueUInt (toInteger $ ByteString.length v))) v
+  ValueBytes Nothing v -> padRight32 $ Short.append (simpleToStorage (valueUInt (toInteger $ Short.length v))) v
   ValueBytes (Just _) v -> padRight32 v
-  ValueString v -> simpleToStorage . valueBytes $ Text.encodeUtf8 v
+  ValueString v -> simpleToStorage . valueBytes . Short.toShort . Text.encodeUtf8 $ v
   where
     paddingLen bs =
-      let len = ByteString.length bs
+      let len = Short.length bs
           lenMod32 = len `mod` 32
        in (32 - lenMod32) `mod` 32
-    padRight32 bs = bs `ByteString.append` ByteString.replicate (paddingLen bs) 0
+    padRight32 bs = bs `Short.append` Short.replicate (paddingLen bs) 0
     go :: Bool -> Integer -> [Word8]
     go neg val = go' neg (32 :: Integer) val []
     go' _ 0 _ xs = xs

--- a/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/Type.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/Type.hs
@@ -7,7 +7,7 @@ module BlockApps.Solidity.Type where
 
 import Control.DeepSeq
 import Data.Binary
-import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString)
 import Data.List
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -33,7 +33,7 @@ data Type
   | TypeArrayDynamic Type
   | TypeArrayFixed Word Type
   | TypeMapping SimpleType Type
-  | TypeFunction ByteString [(Text, Type)] [(Maybe Text, Type)]
+  | TypeFunction ShortByteString [(Text, Type)] [(Maybe Text, Type)]
   | TypeStruct Text
   | TypeEnum Text
   | TypeContract Text

--- a/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/Value.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/Value.hs
@@ -14,7 +14,8 @@ import Control.DeepSeq
 import qualified Data.Bimap as Bimap
 import qualified Data.Binary as Binary
 import Data.Bits (complement, shiftL, (.|.))
-import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as Short
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as ByteString.Lazy
@@ -44,7 +45,7 @@ valueUInt256 = ValueInt False (Just 32)
 valueInt256 :: Integer -> SimpleValue
 valueInt256 = ValueInt False (Just 32)
 
-valueBytes :: ByteString -> SimpleValue
+valueBytes :: Short.ShortByteString -> SimpleValue
 valueBytes = ValueBytes Nothing
 
 data Value
@@ -53,7 +54,7 @@ data Value
   | ValueArrayFixed Word [Value]
   | ValueContract NamedAccount
   | ValueEnum Text Text Word256
-  | ValueFunction ByteString [(Text, Type)] [(Maybe Text, Type)]
+  | ValueFunction ShortByteString [(Text, Type)] [(Maybe Text, Type)]
   | ValueMapping (Map.Map SimpleValue Value)
   | ValueStruct (Map.Map Text Value)
   | ValueArraySentinel Int
@@ -72,7 +73,7 @@ data SimpleValue
       }
   | ValueBytes
       { bytesSize :: Maybe Integer,
-        bytesVal :: ByteString
+        bytesVal :: ShortByteString
       }
   deriving (Eq, Show, Generic, NFData, Binary.Binary, Ord, Hashable)
 
@@ -95,24 +96,24 @@ zeroOf = \case
   ValueEnum {} -> error "default value of enum"
   ValueVariadic {} -> error "default value of variadic"
 
-bytesToSimpleValue :: ByteString -> SimpleType -> Maybe SimpleValue
+bytesToSimpleValue :: ShortByteString -> SimpleType -> Maybe SimpleValue
 bytesToSimpleValue bs = \case
   TypeBool ->
     if (bytesToNum False (Just 1)) /= 0
       then Just $ ValueBool True
       else Just $ ValueBool False
-  TypeAddress -> ValueAddress <$> stringAddress (Text.unpack . Text.decodeUtf8 $ Base16.encode bs)
-  TypeAccount -> ValueAccount . unspecifiedChain <$> stringAddress (Text.unpack . Text.decodeUtf8 $ Base16.encode bs)
-  TypeString -> Just $ ValueString (Text.decodeUtf8 bs)
+  TypeAddress -> ValueAddress <$> stringAddress (Text.unpack . Text.decodeUtf8 $ Base16.encode $ Short.fromShort bs)
+  TypeAccount -> ValueAccount . unspecifiedChain <$> stringAddress (Text.unpack . Text.decodeUtf8 $ Base16.encode $ Short.fromShort bs)
+  TypeString -> Just $ ValueString (Text.decodeUtf8 . Short.fromShort $ bs)
   TypeInt s b -> Just . ValueInt s b $ bytesToNum s b
   TypeBytes b -> Just $ ValueBytes b bs
   where
     bytesToNum :: Bool -> Maybe Integer -> Integer
     bytesToNum signed' bytes' =
-      if ByteString.null bs
+      if Short.null bs
         then 0
         else
-          let bs' = ByteString.unpack bs
+          let bs' = Short.unpack bs
               h = head bs'
               neg =
                 if signed'
@@ -131,11 +132,11 @@ bytesToSimpleValue bs = \case
               else w
        in go inv ws (x' .|. toInteger w')
 
-bytesToValue :: ByteString -> Type -> Maybe Value
+bytesToValue :: ShortByteString -> Type -> Maybe Value
 bytesToValue b = \case
   SimpleType ty -> SimpleValue <$> bytesToSimpleValue b ty
   TypeArrayDynamic ty ->
-    let rb = ByteString.drop 32 b
+    let rb = Short.drop 32 b
         valArray = splitBytes rb ty
      in ValueArrayDynamic . tosparse <$> sequence valArray
   TypeArrayFixed len ty ->
@@ -149,24 +150,24 @@ bytesToValue b = \case
   TypeVariadic {} -> Nothing -- TODO
   where
     splitBytes b' ty
-      | ByteString.null b' = []
+      | Short.null b' = []
       | otherwise = case getTypeByteLength ty of
         Nothing -> [Nothing]
         Just size ->
-          let (valBytes, rb) = ByteString.splitAt size b'
+          let (valBytes, rb) = Short.splitAt size b'
            in bytesToValue valBytes ty : splitBytes rb ty
 
-bytestringToValues :: ByteString -> [Type] -> Maybe [Value]
+bytestringToValues :: ShortByteString -> [Type] -> Maybe [Value]
 bytestringToValues bs ts =
   case bytesToBytesTypePair bs ts of
     Nothing -> Nothing
     Just byteTypePairs -> for byteTypePairs (uncurry bytesToValue)
 
-bytesToBytesTypePair :: ByteString -> [Type] -> Maybe [(ByteString, Type)]
+bytesToBytesTypePair :: ShortByteString -> [Type] -> Maybe [(ShortByteString, Type)]
 bytesToBytesTypePair totalBytes typesArr = toBytesTypePair totalBytes typesArr
   where
     toBytesTypePair _ [] = Just []
-    toBytesTypePair b (_ : _) | ByteString.null b = Nothing
+    toBytesTypePair b (_ : _) | Short.null b = Nothing
     toBytesTypePair b types =
       let headType = head types
           tailTypes = tail types
@@ -180,44 +181,44 @@ bytesToBytesTypePair totalBytes typesArr = toBytesTypePair totalBytes typesArr
             TypeArrayDynamic ty -> case getTypeByteLength ty of
               Nothing -> Nothing
               Just size -> do
-                let (startingByte, restOfBytes) = ByteString.splitAt 32 b
-                    start = Binary.decode (ByteString.Lazy.fromStrict startingByte)
+                let (startingByte, restOfBytes) = Short.splitAt 32 b
+                    start = Binary.decode (ByteString.Lazy.fromStrict $ Short.fromShort startingByte)
                     (lengthBytes, rb) =
-                      ByteString.splitAt
+                      Short.splitAt
                         32
-                        (ByteString.drop (fromIntegral (start :: Word256)) totalBytes)
-                    len = Binary.decode (ByteString.Lazy.fromStrict lengthBytes)
+                        (Short.drop (fromIntegral (start :: Word256)) totalBytes)
+                    len = Binary.decode (ByteString.Lazy.fromStrict $ Short.fromShort lengthBytes)
                     lenAsInt = fromIntegral (len :: Word256)
-                    vBytes = ByteString.take (size * lenAsInt) rb
-                    arrayBytes = ByteString.append lengthBytes vBytes
+                    vBytes = Short.take (size * lenAsInt) rb
+                    arrayBytes = Short.append lengthBytes vBytes
                 rest <- toBytesTypePair restOfBytes tailTypes
                 return $ (arrayBytes, headType) : rest
             SimpleType (TypeBytes Nothing) -> do
-              let (startingByte, restOfBytes) = ByteString.splitAt 32 b
-                  start = Binary.decode (ByteString.Lazy.fromStrict startingByte)
+              let (startingByte, restOfBytes) = Short.splitAt 32 b
+                  start = Binary.decode (ByteString.Lazy.fromStrict $ Short.fromShort startingByte)
                   (lengthBytes, rb) =
-                    ByteString.splitAt
+                    Short.splitAt
                       32
-                      (ByteString.drop (fromIntegral (start :: Word256)) totalBytes)
-                  len = Binary.decode (ByteString.Lazy.fromStrict lengthBytes)
-                  arrayBytes = ByteString.take (fromIntegral (len :: Word256)) rb
+                      (Short.drop (fromIntegral (start :: Word256)) totalBytes)
+                  len = Binary.decode (ByteString.Lazy.fromStrict $ Short.fromShort lengthBytes)
+                  arrayBytes = Short.take (fromIntegral (len :: Word256)) rb
               rest <- toBytesTypePair restOfBytes tailTypes
               return $ (arrayBytes, headType) : rest
             SimpleType TypeString -> do
-              let (startingByte, restOfBytes) = ByteString.splitAt 32 b
-                  start = Binary.decode (ByteString.Lazy.fromStrict startingByte)
+              let (startingByte, restOfBytes) = Short.splitAt 32 b
+                  start = Binary.decode (ByteString.Lazy.fromStrict $ Short.fromShort startingByte)
                   (lengthBytes, rb) =
-                    ByteString.splitAt
+                    Short.splitAt
                       32
-                      (ByteString.drop (fromIntegral (start :: Word256)) totalBytes)
-                  len = Binary.decode (ByteString.Lazy.fromStrict lengthBytes)
-                  arrayBytes = ByteString.take (fromIntegral (len :: Word256)) rb
+                      (Short.drop (fromIntegral (start :: Word256)) totalBytes)
+                  len = Binary.decode (ByteString.Lazy.fromStrict $ Short.fromShort lengthBytes)
+                  arrayBytes = Short.take (fromIntegral (len :: Word256)) rb
               rest <- toBytesTypePair restOfBytes tailTypes
               return $ (arrayBytes, headType) : rest
             _ -> case getTypeByteLength headType of -- TODO: Figure out wtf
               Nothing -> Nothing
               Just size -> do
-                let (tBytes, restOfBytes) = ByteString.splitAt size b
+                let (tBytes, restOfBytes) = Short.splitAt size b
                 rest <- toBytesTypePair restOfBytes tailTypes
                 return $
                   (tBytes, headType) : rest
@@ -263,7 +264,7 @@ simpleValueToText sv = case sv of
   ValueAccount acct -> Text.pack $ "0x" ++ show acct
   ValueString tx -> '"' `Text.cons` tx `Text.snoc` '"'
   ValueInt _ _ v -> Text.pack $ show v
-  ValueBytes _ b -> Text.pack $ show . Base16.encode $ b
+  ValueBytes _ b -> Text.pack $ show . Base16.encode . Short.fromShort $ b
 
 textToValue :: Maybe TypeDefs -> Text -> Type -> Either Text Value
 textToValue defs str = \case
@@ -319,14 +320,14 @@ textToSimpleValue str = \case
     readNum = case readMaybe (Text.unpack str) of
       Nothing -> Left $ "textToSimpleValue: could not decode as number: " <> str
       Just x -> return x
-    readBytes :: Integer -> Either Text ByteString
+    readBytes :: Integer -> Either Text Short.ShortByteString
     readBytes n =
       case Base16.decode (Text.encodeUtf8 str) of
-        Right bytes' | ByteString.length bytes' == fromInteger n -> return bytes'
+        Right bytes' | ByteString.length bytes' == fromInteger n -> return $ Short.toShort bytes'
         _ -> Left $ "textToSimpleValue: could not decode as statically sized bytes: " <> str <> ", expected a Base16 encoded string of length " <> Text.pack (show $ 2 * n) <> ", which represents a bytestring of length " <> Text.pack (show n)
 
-    readBytesDyn :: Either Text ByteString
+    readBytesDyn :: Either Text Short.ShortByteString
     readBytesDyn =
       case Base16.decode (Text.encodeUtf8 str) of
-        Right val -> return val
+        Right val -> return (Short.toShort val)
         _ -> Left $ "textToSimpleValue: could not decode as dynamically sized bytes: " <> str

--- a/strato/VM/EVM/evm-solidity/src/BlockApps/SolidityVarReader.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/SolidityVarReader.hs
@@ -42,8 +42,8 @@ import Control.Monad.Except
 import Data.Bifunctor (bimap)
 import qualified Data.Bimap as Bimap
 import Data.Bits
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as ByteString
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as Short
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.IntMap as I
@@ -83,7 +83,7 @@ valueToSolidityValue = \case
   ValueArrayFixed _ values -> SolidityArray $ map valueToSolidityValue values
   ValueArrayDynamic values -> SolidityArray $ map valueToSolidityValue $ unsparse values
   SimpleValue (ValueBytes _ bytes) ->
-    SolidityValueAsString $ Text.pack $ BC.unpack $ B16.encode bytes
+    SolidityValueAsString $ Text.pack $ BC.unpack $ B16.encode $ Short.fromShort bytes
   ValueEnum _ _ index -> SolidityValueAsString $ Text.pack $ show index
   -- TODO(tim): What if declaration order is needed here?
   ValueStruct namedItems -> SolidityObject . Map.toList $ fmap valueToSolidityValue namedItems
@@ -99,16 +99,16 @@ valueToSolidityValue = \case
   ValueArraySentinel {} -> error "TODO(tim): ValueArraySentinel"
   ValueVariadic values -> SolidityArray $ map valueToSolidityValue values
 
-word256ToByteString :: Word256 -> ByteString
+word256ToByteString :: Word256 -> ShortByteString
 word256ToByteString = word256ToBytes
 
-byteStringToWord256 :: ByteString -> Word256
+byteStringToWord256 :: ShortByteString -> Word256
 byteStringToWord256 = bytesToWord256
 
 getArrayStartingKey :: Word256 -> Word256
 getArrayStartingKey = getArrayStartingKeyBS . word256ToByteString
 
-getArrayStartingKeyBS :: ByteString -> Word256
+getArrayStartingKeyBS :: ShortByteString -> Word256
 getArrayStartingKeyBS = keccak256ToWord256 . hash
 
 decodeStorageKeySimple :: SimpleType -> Word256 -> Integer -> Integer -> [(Word256, Word256)]
@@ -158,7 +158,7 @@ decodeStorageKey typeDefs'@TypeDefs {..} struct' (varName : _) _ ofs cnt len =
         TypeFunction name _ _ ->
           error $
             "Cannot retrieve "
-              ++ show (ByteString.unpack name)
+              ++ show (Short.unpack name)
               ++ ": Functions are not kept in storage"
         TypeStruct name ->
           case Map.lookup name structDefs of
@@ -217,8 +217,8 @@ decodeCacheValue' typeDefs'@TypeDefs {..} cache position@Storage.Position {..} v
           SimpleValue
             . fromJust
             . flip bytesToSimpleValue t
-            . ByteString.take b
-            . ByteString.drop b'
+            . Short.take b
+            . Short.drop b'
             . word256ToByteString
             <$> cache offset
   SimpleType TypeAddress ->
@@ -246,15 +246,15 @@ decodeCacheValue' typeDefs'@TypeDefs {..} cache position@Storage.Position {..} v
 
         let len' = lastWord64 w `div` 2
             startingKey = getArrayStartingKey offset
-         in SimpleValue $ valueBytes $ ByteString.pack $ take (fromIntegral len') $ concatMap (ByteString.unpack . word256ToByteString . fromMaybe 0 . cache . (startingKey +)) [0 ..] -- if the length is there, so should the data
+         in SimpleValue $ valueBytes $ Short.pack $ take (fromIntegral len') $ concatMap (Short.unpack . word256ToByteString . fromMaybe 0 . cache . (startingKey +)) [0 ..] -- if the length is there, so should the data
       else --small string, less than 32 bytes
 
         let len' = lastWord64 w .&. 0xfe `div` 2
-         in SimpleValue $ valueBytes $ ByteString.take (fromIntegral len') $ word256ToByteString w
+         in SimpleValue $ valueBytes $ Short.take (fromIntegral len') $ word256ToByteString w
   SimpleType TypeString ->
     let v = decodeCacheValue' typeDefs' cache position value $ SimpleType typeBytes
      in case v of
-          Just (SimpleValue (ValueBytes Nothing bytes)) -> Just . SimpleValue . ValueString $ Text.decodeUtf8 bytes
+          Just (SimpleValue (ValueBytes Nothing bytes)) -> Just . SimpleValue . ValueString $ Text.decodeUtf8 $ Short.fromShort bytes
           Just (s@(SimpleValue (ValueString _))) -> Just s
           o -> error $ "decodeCacheValue': Expected ValueBytes or ValueString, but got: " ++ show o
   TypeFunction selector args returns -> Just $ ValueFunction selector args returns
@@ -399,8 +399,8 @@ decodeValue' typeDefs'@TypeDefs {..} storage ofs cnt len position@Storage.Positi
           . SimpleValue
           . fromJust
           . flip bytesToSimpleValue t
-          . ByteString.take b
-          . ByteString.drop b'
+          . Short.take b
+          . Short.drop b'
           . word256ToByteString
           $ storage offset
   SimpleType TypeAddress ->
@@ -423,16 +423,16 @@ decodeValue' typeDefs'@TypeDefs {..} storage ofs cnt len position@Storage.Positi
     | storage offset `testBit` 0 -> --large string, 32+ bytes
       let len' = lastWord64 (storage offset) `div` 2
           startingKey = getArrayStartingKey offset
-       in Just $ SimpleValue $ valueBytes $ ByteString.pack $ take (fromIntegral len') $ concatMap (ByteString.unpack . word256ToByteString . storage . (startingKey +)) [0 ..]
+       in Just $ SimpleValue $ valueBytes $ Short.pack $ take (fromIntegral len') $ concatMap (Short.unpack . word256ToByteString . storage . (startingKey +)) [0 ..]
   SimpleType (TypeBytes Nothing) ->
     --small string, less than 32 bytes
     let len' = lastWord64 (storage offset) .&. 0xfe `div` 2
-     in Just $ SimpleValue $ valueBytes $ ByteString.take (fromIntegral len') $ word256ToByteString $ storage offset
+     in Just $ SimpleValue $ valueBytes $ Short.take (fromIntegral len') $ word256ToByteString $ storage offset
   SimpleType TypeString ->
     let bytes = case decodeValue' typeDefs' storage ofs cnt len position $ SimpleType typeBytes of
           Just (SimpleValue (ValueBytes Nothing bytes')) -> bytes'
           _ -> error "decodeValue': Expected ValueBytes Nothing" -- ++ show v
-     in Just $ SimpleValue $ ValueString $ Text.decodeUtf8 bytes
+     in Just $ SimpleValue $ ValueString $ Text.decodeUtf8 $ Short.fromShort bytes
   TypeFunction selector args returns -> Just $ ValueFunction selector args returns
   TypeArrayFixed _ _ -> Nothing
   {-
@@ -510,7 +510,7 @@ decodeMapValue fetchLimit typeDefs' Struct {..} storage mappingName keyName = do
         return $ word256ToByteString $ fromInteger keyAsInteger
       x -> throwError $ "Sorry, This route doesn't support maps with keys of type: " ++ show x
 
-  let valPositionInt = getArrayStartingKeyBS $ keyByteString `ByteString.append` word256ToByteString (Storage.offset position)
+  let valPositionInt = getArrayStartingKeyBS $ keyByteString `Short.append` word256ToByteString (Storage.offset position)
       getValPosition :: SimpleType -> Text -> Storage.Position -> Storage.Position
       getValPosition _ _ _ = Storage.positionAt valPositionInt --TODO fill in this dummy stub
       valPosition = getValPosition fromType keyName position
@@ -568,7 +568,7 @@ encodeValue' typeDefs'@TypeDefs {} position@Storage.Position {..} ty = \case
   ValueContract (NamedAccount a _) -> encodeValue' typeDefs' position ty . SimpleValue $ ValueInt False (Just 20) $ toInteger a
   SimpleValue (ValueBytes (Just n) v) -> encodeByteString offset byte (fromInteger n) v
   SimpleValue (ValueBytes Nothing v) -> [(offset, byteStringToWord256 v)]
-  SimpleValue (ValueString v) -> encodeValue' typeDefs' position ty . SimpleValue . ValueBytes Nothing $ Text.encodeUtf8 v
+  SimpleValue (ValueString v) -> encodeValue' typeDefs' position ty . SimpleValue . ValueBytes Nothing . Short.toShort $ Text.encodeUtf8 v
   ValueFunction _ _ _ -> error "Cannot convert function to storage"
   ValueArrayFixed _ vs -> case ty of
     TypeArrayFixed _ ty' ->
@@ -595,16 +595,16 @@ orFail :: Maybe a -> String -> Either String a
 orFail Nothing msg = Left msg
 orFail (Just x) _ = Right x
 
-encodeByteString :: Word256 -> Int -> Int -> ByteString -> [(Word256, Word256)]
+encodeByteString :: Word256 -> Int -> Int -> ShortByteString -> [(Word256, Word256)]
 encodeByteString offset byte size bs =
-  let bss = ByteString.concat [ByteString.replicate (32 - byte - size) 0, bs, ByteString.replicate byte 0]
+  let bss = Short.concat [Short.replicate (32 - byte - size) 0, bs, Short.replicate byte 0]
    in [(offset, byteStringToWord256 bss)]
 
 decodeByteString :: Storage -> Word256 -> Int -> Int -> Value
-decodeByteString storage offset byte size = SimpleValue $ ValueBytes Nothing $ ByteString.take size $ ByteString.drop (32 - byte - size) $ word256ToByteString $ storage offset
+decodeByteString storage offset byte size = SimpleValue $ ValueBytes Nothing $ Short.take size $ Short.drop (32 - byte - size) $ word256ToByteString $ storage offset
 
 decodeCacheByteString :: Cache -> Word256 -> Int -> Int -> Value -> Value
-decodeCacheByteString storage offset byte size value = fromMaybe value $ SimpleValue . ValueBytes Nothing . B16.encode . ByteString.take size . ByteString.drop (32 - byte - size) . word256ToByteString <$> storage offset
+decodeCacheByteString storage offset byte size value = fromMaybe value $ SimpleValue . ValueBytes Nothing . Short.take size . Short.drop (32 - byte - size) . word256ToByteString <$> storage offset
 
 encodeInt :: (Integral t, Bits t) => Word256 -> Int -> t -> [(Word256, Word256)]
 encodeInt offset byte val = return $ fmap (fromIntegral . (`shiftL` (byte * 8))) (offset, val)

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
@@ -17,9 +17,9 @@ import Control.Exception
 import Data.Attoparsec.ByteString as Atto
 import Data.Attoparsec.ByteString.Char8 (scientific)
 import Data.Binary
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Internal as BI
+import qualified Data.ByteString.Short as B
 import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.ByteString.Unsafe as BU
 import Data.Char
@@ -35,7 +35,7 @@ import Text.Format
 
 data BasicValue
   = BInteger !Integer
-  | BString !B.ByteString
+  | BString {-# UNPACK #-} !B.ShortByteString
   | BBool !Bool
   | BAccount !NamedAccount
   | BEnumVal !SolidString !SolidString !Word32
@@ -58,7 +58,7 @@ isDefault BDefault = True
 
 instance Format BasicValue where
   format (BInteger i) = show i
-  format (BString s) = ('"' :) . (++ "\"") $ UTF8.toString s
+  format (BString s) = ('"' :) . (++ "\"") $ UTF8.toString $ B.fromShort s
   format (BBool True) = "true"
   format (BBool False) = "false"
   format (BAccount a) = "account(" ++ show a ++ ")"
@@ -69,19 +69,19 @@ instance Format BasicValue where
 
 data IndexType
   = INum Integer
-  | IText B.ByteString
+  | IText {-# UNPACK #-} !B.ShortByteString
   | IBool Bool
   | IAccount NamedAccount
   deriving (Eq, Show, Ord, Generic, Hashable, NFData)
 
 data StoragePathPiece
-  = Field B.ByteString
+  = Field {-# UNPACK #-} !B.ShortByteString
   | MapIndex IndexType
   | ArrayIndex Int
   deriving (Eq, Show, Generic, NFData, Hashable)
 
 instance Format StoragePathPiece where
-  format (Field n) = C8.unpack n
+  format (Field n) = C8.unpack . B.fromShort $ n
   format (MapIndex i) = "[" ++ show i ++ "]"
   format (ArrayIndex i) = "[" ++ show i ++ "]"
 
@@ -99,10 +99,10 @@ instance Format StoragePath where
 empty :: StoragePath
 empty = StoragePath []
 
-singleton :: B.ByteString -> StoragePath
+singleton :: B.ShortByteString -> StoragePath
 singleton bs = StoragePath [Field bs]
 
-getField :: StoragePath -> B.ByteString
+getField :: StoragePath -> B.ShortByteString
 getField (StoragePath (Field f : _)) = f
 getField path = error "StoragePath must begin with field" path
 
@@ -166,12 +166,12 @@ parseMapIndex = do
     'f' -> string "false" >> return (IBool False)
     'a' -> do
       _ <- string "a:"
-      eAddress <- addressFromHex <$> Atto.take 40
+      eAddress <- addressFromHex . B.toShort <$> Atto.take 40
       mColon <- peekWord8
       mChain <- case w82c <$> mColon of
         Just ':' -> do
           _ <- string ":"
-          (MainChain <$ string "main") <|> (ExplicitChain . bytesToWord256 . LabeledError.b16Decode "parseMapIndex" <$> Atto.take 64) <?> "parseMapIndex"
+          (MainChain <$ string "main") <|> (ExplicitChain . bytesToWord256 . B.toShort . LabeledError.b16Decode "parseMapIndex" <$> Atto.take 64) <?> "parseMapIndex"
         _ -> pure UnspecifiedChain
       IAccount <$> either fail (return . flip NamedAccount mChain) eAddress
     '"' -> do
@@ -181,7 +181,7 @@ parseMapIndex = do
           ignoreEscapedQuotes _ _ = Just False
       strContents <- scan False ignoreEscapedQuotes
       skip (== c2w8 '"')
-      return . IText . unescapeKey $ strContents
+      return . IText . unescapeKey . B.toShort $ strContents
     _ -> INum <$> parseInteger
   skip (== c2w8 '>')
   (MapIndex idx :) <$> pathParser
@@ -190,20 +190,20 @@ parseField :: Parser [StoragePathPiece]
 parseField = do
   skip (== c2w8 '.')
   ( do
-      n <- Atto.takeWhile1 (inClass "_a-zA-Z0-9")
+      n <- B.toShort <$> Atto.takeWhile1 (inClass "_a-zA-Z0-9")
       (Field n :) <$> pathParser
     )
     <|> ((string ":creator") *> pathParser)
     <|> ((string ":creatorAddress") *> pathParser)
 
-parsePath :: B.ByteString -> Either String StoragePath
-parsePath = fmap StoragePath . parseOnly pathParser
+parsePath :: B.ShortByteString -> Either String StoragePath
+parsePath = fmap StoragePath . parseOnly pathParser . B.fromShort
 
-escapeKey :: B.ByteString -> B.ByteString
+escapeKey :: B.ShortByteString -> B.ShortByteString
 escapeKey srcBS = unsafePerformIO $ do
   let len = B.length srcBS
-  BI.createAndTrim (2 * len) $ \dst ->
-    BU.unsafeUseAsCString srcBS $ \src' -> do
+  B.toShort <$> (BI.createAndTrim (2 * len) $ \dst ->
+    BU.unsafeUseAsCString (B.fromShort srcBS) $ \src' -> do
       let src = castPtr src'
           copyAndEscape :: Int -> Int -> IO Int
           copyAndEscape !dstOff !srcOff =
@@ -219,13 +219,13 @@ escapeKey srcBS = unsafePerformIO $ do
                     pokeByteOff dst dstOff (0x5c :: Word8)
                     pokeByteOff dst (dstOff + 1) ch
                     copyAndEscape (dstOff + 2) (srcOff + 1)
-      copyAndEscape 0 0
+      copyAndEscape 0 0)
 
-unescapeKey :: B.ByteString -> B.ByteString
+unescapeKey :: B.ShortByteString -> B.ShortByteString
 unescapeKey srcBS = unsafePerformIO $ do
   let len = B.length srcBS
-  BI.createAndTrim len $ \dst ->
-    BU.unsafeUseAsCString srcBS $ \src' -> do
+  B.toShort <$> (BI.createAndTrim len $ \dst ->
+    BU.unsafeUseAsCString (B.fromShort srcBS) $ \src' -> do
       let src = castPtr src'
           copyAndUnescape :: Int -> Int -> IO Int
           copyAndUnescape !dstOff !srcOff =
@@ -247,19 +247,19 @@ unescapeKey srcBS = unsafePerformIO $ do
                     pokeByteOff dst dstOff ch
                     copyAndUnescape (dstOff + 1) (srcOff + 1)
                   else return dstOff
-      copyAndUnescape 0 0
+      copyAndUnescape 0 0)
 
-unparsePath :: StoragePath -> B.ByteString
+unparsePath :: StoragePath -> B.ShortByteString
 unparsePath (StoragePath ps) = B.concat . concatMap go $ ps
   where
-    go :: StoragePathPiece -> [B.ByteString]
+    go :: StoragePathPiece -> [B.ShortByteString]
     go (Field p) = [".", p]
-    go (ArrayIndex n) = ["[", C8.pack $ show n, "]"]
-    go (MapIndex (INum n)) = ["<", C8.pack $ show n, ">"]
+    go (ArrayIndex n) = ["[", B.toShort $ C8.pack $ show n, "]"]
+    go (MapIndex (INum n)) = ["<", B.toShort $ C8.pack $ show n, ">"]
     go (MapIndex (IText t)) = ["<\"", escapeKey t, "\">"]
     go (MapIndex (IBool True)) = ["<true>"]
     go (MapIndex (IBool False)) = ["<false>"]
-    go (MapIndex (IAccount a)) = ["<a:", C8.pack $ show a, ">"]
+    go (MapIndex (IAccount a)) = ["<a:", B.toShort $ C8.pack $ show a, ">"]
 
 instance RLPSerializable BasicValue where
   rlpEncode = \case

--- a/strato/VM/SolidVM/solid-vm-model/test/StorageTest.hs
+++ b/strato/VM/SolidVM/solid-vm-model/test/StorageTest.hs
@@ -1,7 +1,7 @@
 import Blockchain.Data.RLP
 import Blockchain.Strato.Model.Account
 import Control.Monad
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import Data.Either (isLeft)
 import SolidVM.Model.Storable
 import Test.Hspec

--- a/strato/core/blockapps-datadefs/src/Blockchain/Data/PersistTypes.hs
+++ b/strato/core/blockapps-datadefs/src/Blockchain/Data/PersistTypes.hs
@@ -51,9 +51,9 @@ instance PersistFieldSql CodeKind where
   sqlType _ = SqlString
 
 instance PersistField HexStorage where
-  toPersistValue (HexStorage hs) = PersistText . decodeUtf8 . B16.encode $ hs
+  toPersistValue (HexStorage hs) = PersistText . decodeUtf8 . B16.encode . BSS.fromShort $ hs
   fromPersistValue (PersistText t) = case B16.decode (encodeUtf8 t) of
-    Right h -> Right $ HexStorage h
+    Right h -> Right $ HexStorage $ BSS.toShort h
     _ -> Left $ T.pack $ "Invalid hex text: " ++ show t
   fromPersistValue x = Left $ T.pack $ "PersistField HexStorage: expected varchar: " ++ (show x)
 
@@ -77,8 +77,8 @@ instance PersistFieldSql Word512 where
   sqlType _ = SqlOther $ T.pack "varchar(128)"
 
 instance PersistField StateRoot where
-  toPersistValue (StateRoot s) = PersistText . decodeUtf8 . B16.encode $ s
-  fromPersistValue (PersistText s) = Right . StateRoot . LabeledError.b16Decode "PersistField<StateRoot>" . encodeUtf8 $ s
+  toPersistValue (StateRoot s) = PersistText . decodeUtf8 . B16.encode . BSS.fromShort $ s
+  fromPersistValue (PersistText s) = Right . StateRoot . BSS.toShort . LabeledError.b16Decode "PersistField<StateRoot>" . encodeUtf8 $ s
   fromPersistValue _ = Left $ "StateRoot must be persisted as PersistText"
 
 instance PersistFieldSql StateRoot where

--- a/strato/core/merkle-patricia-db/src/Blockchain/Database/MerklePatricia.hs
+++ b/strato/core/merkle-patricia-db/src/Blockchain/Database/MerklePatricia.hs
@@ -54,7 +54,7 @@ import Blockchain.Strato.Model.Util (byteString2NibbleString)
 import Control.Monad.Change.Alter
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Reader
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import Data.Default
 import Data.Maybe (isJust, listToMaybe)
 import qualified Database.LevelDB as DB
@@ -64,7 +64,7 @@ genericLookupDB f (StateRoot sr) = do
   db <- f
   fmap bytes2NodeData <$> DB.get db def sr
   where
-    bytes2NodeData :: B.ByteString -> NodeData
+    bytes2NodeData :: B.ShortByteString -> NodeData
     bytes2NodeData bytes | B.null bytes = EmptyNodeData
     bytes2NodeData bytes = rlpDecode . rlpDeserialize $ bytes
 
@@ -76,7 +76,7 @@ genericInsertDB f (StateRoot sr) nd = do
 genericDeleteDB :: MonadIO m => m DB.DB -> StateRoot -> m ()
 genericDeleteDB f (StateRoot sr) = do
   db <- f
-  DB.delete db def sr
+  DB.delete db def (B.fromShort sr)
 
 instance MonadIO m => (StateRoot `Alters` NodeData) (ReaderT DB.DB m) where
   lookup _ = genericLookupDB ask
@@ -139,5 +139,5 @@ blankStateRoot = emptyTriePtr
 addAllKVs :: (RLPSerializable x, RLPSerializable y, (StateRoot `Alters` NodeData) m) => StateRoot -> [(x, y)] -> m StateRoot
 addAllKVs sr [] = return sr
 addAllKVs sr (x : rest) = do
-  sr' <- unsafePutKeyVal sr (byteString2NibbleString $ rlpSerialize $ rlpEncode $ fst x) (rlpEncode $ rlpSerialize $ rlpEncode $ snd x)
+  sr' <- unsafePutKeyVal sr (byteString2NibbleString $ B.fromShort $ rlpSerialize $ rlpEncode $ fst x) (rlpEncode $ rlpSerialize $ rlpEncode $ snd x)
   addAllKVs sr' rest

--- a/strato/core/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/Internal.hs
+++ b/strato/core/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/Internal.hs
@@ -41,7 +41,7 @@ import Blockchain.Strato.Model.Keccak256 (hash, keccak256ToByteString)
 import Control.Monad.Change.Alter (Alters)
 import qualified Control.Monad.Change.Alter as A
 import Control.Monad.State
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import Data.Function
 import Data.List
 import Data.Maybe
@@ -85,7 +85,7 @@ unsafeDeleteKey sr key = do
 
 keyToSafeKey :: N.NibbleString -> N.NibbleString
 keyToSafeKey key
-  | N.EvenNibbleString keyByteString <- key = N.EvenNibbleString $ keccak256ToByteString $ hash keyByteString
+  | N.EvenNibbleString keyByteString <- key = N.EvenNibbleString $ B.fromShort $ keccak256ToByteString $ hash $ B.toShort keyByteString
   | otherwise = error $ "keyToSafeKey: key is not an EvenNibbleString: " ++ (show key)
 
 -----

--- a/strato/core/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/NodeData.hs
+++ b/strato/core/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/NodeData.hs
@@ -37,7 +37,7 @@ import Control.Monad.State
 import Data.Bifunctor (first)
 import Data.Bitraversable (bitraverse)
 import Data.Bits
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BC
 import Data.Fix
@@ -61,11 +61,11 @@ type Val = RLPObject
 
 -------------------------
 
-type NodeRefF a = Either B.ByteString a
+type NodeRefF a = Either B.ShortByteString a
 
 type NodeRef = NodeRefF StateRoot
 
-smallRef :: B.ByteString -> NodeRefF a
+smallRef :: B.ShortByteString -> NodeRefF a
 smallRef = Left
 
 ptrRef :: a -> NodeRefF a
@@ -116,14 +116,14 @@ formatVal (Just x) = green $ pretty x
 
 instance Pretty a => Pretty (NodeDataF a) where
   pretty EmptyNodeData = text "    <EMPTY>"
-  pretty (ShortcutNodeData s (Left (Left p))) = text $ "    " ++ show (pretty s) ++ " -> " ++ show (green . text . BC.unpack $ B16.encode p)
+  pretty (ShortcutNodeData s (Left (Left p))) = text $ "    " ++ show (pretty s) ++ " -> " ++ show (green . text . BC.unpack $ B16.encode $ B.fromShort p)
   pretty (ShortcutNodeData s (Left (Right v))) = text $ "    " ++ show (pretty s) ++ " -> " ++ show (pretty v)
   pretty (ShortcutNodeData s (Right val)) = text $ "    " ++ show (pretty s) ++ " -> " ++ show (green $ pretty val)
   pretty (FullNodeData cs val) = text "    val: " </> formatVal val </> text "\n        " </> vsep (showChoice <$> zip ([0 ..] :: [Int]) cs)
     where
       showChoice :: Pretty a => (Int, NodeRefF a) -> Doc
       showChoice (v, Left "") = blue (text $ showHex v "") </> text ": " </> red (text "NULL")
-      showChoice (v, Left p) = blue (text $ showHex v "") </> text ": " </> green (text . BC.unpack $ B16.encode p)
+      showChoice (v, Left p) = blue (text $ showHex v "") </> text ": " </> green (text . BC.unpack $ B16.encode $ B.fromShort p)
       showChoice (v, Right p) = blue (text $ showHex v "") </> text ": " </> green (pretty p)
 
 instance RLPSerializable1 NodeDataF where
@@ -178,7 +178,7 @@ instance RLPSerializable a => RLPSerializable (NodeDataF a) where
   rlpEncode = rlpEncode1
   rlpDecode = rlpDecode1
 
-byteString2TermNibbleString :: B.ByteString -> (Bool, N.NibbleString)
+byteString2TermNibbleString :: B.ShortByteString -> (Bool, N.NibbleString)
 byteString2TermNibbleString bs
   | B.null bs = error "string2TermNibbleString called with empty String"
   | otherwise = (terminator, ns)
@@ -188,13 +188,13 @@ byteString2TermNibbleString bs
     (flags, extraNibble) = if w > 0xF then (w `shiftR` 4, 0xF .&. w) else (w, 0)
     terminator = flags `shiftR` 1 == 1
     oddLength = flags .&. 1 == 1
-    ns = if oddLength then N.OddNibbleString extraNibble rest else N.EvenNibbleString rest
+    ns = if oddLength then N.OddNibbleString extraNibble (B.fromShort rest) else N.EvenNibbleString (B.fromShort rest)
 
-termNibbleString2String :: Bool -> N.NibbleString -> B.ByteString
+termNibbleString2String :: Bool -> N.NibbleString -> B.ShortByteString
 termNibbleString2String terminator s =
   case s of
-    (N.EvenNibbleString s') -> B.singleton (extraNibble `shiftL` 4) `B.append` s'
-    (N.OddNibbleString n rest) -> B.singleton (extraNibble `shiftL` 4 + n) `B.append` rest
+    (N.EvenNibbleString s') -> B.singleton (extraNibble `shiftL` 4) `B.append` B.toShort s'
+    (N.OddNibbleString n rest) -> B.singleton (extraNibble `shiftL` 4 + n) `B.append` B.toShort rest
   where
     extraNibble =
       (if terminator then 2 else 0)
@@ -237,7 +237,7 @@ type NodeDataProof = Compose Proof NodeDataF
 type MPProof = Fix NodeDataProof
 
 padKey :: N.NibbleString -> N.NibbleString
-padKey (N.EvenNibbleString n) = N.EvenNibbleString $ B.take 32 $ n `B.append` B.replicate 32 0
+padKey (N.EvenNibbleString n) = N.EvenNibbleString $ B.fromShort $ B.take 32 $ (B.toShort n) `B.append` B.replicate 32 0
 padKey n = N.pack . take 64 . (++ repeat 0) $ N.unpack n
 
 proveNodeData :: (StateRoot `A.Alters` NodeData) m => KeyRange -> (Key, StateRoot) -> m (NodeDataProof (Either MPProof (Key, StateRoot)))

--- a/strato/core/miner-ethash/exec_src/Main.hs
+++ b/strato/core/miner-ethash/exec_src/Main.hs
@@ -9,7 +9,7 @@ import Blockchain.Strato.Mining.Ethash.TimeIt
 import Control.Monad
 import qualified Data.Array.IO as A
 import Data.Binary
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import Data.ByteString.Internal
 import qualified Data.ByteString.Lazy as BL
 import Numeric
@@ -19,12 +19,12 @@ encodeWord8 :: Word8 -> String
 encodeWord8 c | c < 0x20 || c > 0x7e = "\\x" ++ showHex c ""
 encodeWord8 c = [w2c c]
 
-encodeByteString :: B.ByteString -> String
+encodeByteString :: B.ShortByteString -> String
 encodeByteString = (encodeWord8 =<<) . B.unpack
 
-word32Unpack :: B.ByteString -> [Word32]
+word32Unpack :: B.ShortByteString -> [Word32]
 word32Unpack s | B.null s = []
-word32Unpack s | B.length s >= 4 = decode (BL.fromStrict $ B.take 4 s) : word32Unpack (B.drop 4 s)
+word32Unpack s | B.length s >= 4 = decode (BL.fromStrict . B.fromShort $ B.take 4 s) : word32Unpack (B.drop 4 s)
 word32Unpack _ = error "word32Unpack called for ByteString of length not a multiple of 4"
 
 main :: IO ()
@@ -39,7 +39,7 @@ main = do
 
   s <- mmapFileByteString "qqqq" Nothing
 
-  let getItem' i = A.newListArray (0, 15) $ word32Unpack $ B.take 64 $ B.drop (64 * fromIntegral i) s
+  let getItem' i = A.newListArray (0, 15) $ word32Unpack $ B.take 64 $ B.drop (64 * fromIntegral i) (B.toShort s)
 
   timeIt . forM_ [0 .. 15000 :: Integer] $ \_ -> do
     (mixDigest, result) <- hashimoto block nonce fullSize' getItem' -- getItem

--- a/strato/core/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Hashimoto.hs
+++ b/strato/core/miner-ethash/src/Blockchain/Strato/Mining/Ethash/Hashimoto.hs
@@ -12,7 +12,7 @@ import qualified Data.Array.IO as MA
 import Data.Binary.Get
 import Data.Binary.Put
 import Data.Bits
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import qualified Data.ByteString.Lazy as BL
 import Data.Word
 
@@ -46,13 +46,13 @@ import Data.Word
     }
 -}
 
-wordPack :: [Word32] -> B.ByteString
-wordPack = B.concat . fmap (BL.toStrict . runPut . putWord32le)
+wordPack :: [Word32] -> B.ShortByteString
+wordPack = B.concat . fmap (B.toShort . BL.toStrict . runPut . putWord32le)
 
-hashimoto :: B.ByteString -> B.ByteString -> Int -> (Word32 -> IO Slice) -> IO (B.ByteString, B.ByteString)
+hashimoto :: B.ShortByteString -> B.ShortByteString -> Int -> (Word32 -> IO Slice) -> IO (B.ShortByteString, B.ShortByteString)
 hashimoto header nonce fullSize' dataset = do
   let mixhashes = mixBytes `div` hashBytes
-      s = keccak512 $ header `B.append` B.reverse nonce
+      s = keccak512 . B.fromShort $ header `B.append` B.reverse nonce
 
   mix <- MA.newArray (0, 31) 0
 
@@ -60,7 +60,7 @@ hashimoto header nonce fullSize' dataset = do
   sequence_ $ map (uncurry $ MA.writeArray mix) $ zip [16 ..] (shatter s)
 
   forM_ [0 .. 63] $ \j ->
-    f (dataset, fullSize', mixhashes, s) j mix
+    f (dataset, fullSize', mixhashes, B.toShort s) j mix
 
   let f2 i = do
         v1 <- MA.readArray mix i
@@ -70,9 +70,9 @@ hashimoto header nonce fullSize' dataset = do
         return $ v1 `fnv` v2 `fnv` v3 `fnv` v4
 
   cmix <- fmap repair $ sequence $ map f2 [0, 4 .. 31]
-  return (cmix, keccak256ToByteString $ hash (s `B.append` cmix))
+  return (B.toShort cmix, keccak256ToByteString $ hash (B.toShort s `B.append` B.toShort cmix))
 
-f :: (Word32 -> IO Slice, Int, Integer, B.ByteString) -> Word32 -> MA.IOUArray Word32 Word32 -> IO ()
+f :: (Word32 -> IO Slice, Int, Integer, B.ShortByteString) -> Word32 -> MA.IOUArray Word32 Word32 -> IO ()
 f (dataset, fullSize', mixhashes, s) i mix = do
   let n = fullSize' `div` fromInteger hashBytes
       w = mixBytes `div` wordBytes
@@ -81,7 +81,7 @@ f (dataset, fullSize', mixhashes, s) i mix = do
 
   let p =
         ( fnv
-            (i `xor` (runGet getWord32le $ BL.fromStrict $ B.take 4 s))
+            (i `xor` (runGet getWord32le $ BL.fromStrict $ B.fromShort $ B.take 4 s))
             mixVal
         )
           `mod` (fromIntegral n `div` fromInteger mixhashes)

--- a/strato/core/strato-model/src/Blockchain/Blockstanbul/Model/Authentication.hs
+++ b/strato/core/strato-model/src/Blockchain/Blockstanbul/Model/Authentication.hs
@@ -8,9 +8,9 @@ import Blockchain.Data.RLP
 import Blockchain.Strato.Model.ChainMember
 import Blockchain.Strato.Model.Secp256k1
 import Control.Lens
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 
-type RawExtraData = B.ByteString
+type RawExtraData = B.ShortByteString
 
 data IstanbulExtra = IstanbulExtra
   { _validatorList :: ChainMembers,
@@ -22,7 +22,7 @@ data IstanbulExtra = IstanbulExtra
 makeLenses ''IstanbulExtra
 
 data ExtraData = ExtraData
-  { _vanity :: B.ByteString,
+  { _vanity :: B.ShortByteString,
     _istanbul :: Maybe IstanbulExtra
   }
   deriving (Eq, Show)

--- a/strato/core/strato-model/src/Blockchain/SolidVM/Model.hs
+++ b/strato/core/strato-model/src/Blockchain/SolidVM/Model.hs
@@ -12,8 +12,8 @@ import Control.Lens.Operators
 import Data.Aeson
 import Data.Aeson.Types
 import Data.Binary
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Short as BSS
 import Data.Swagger
 import Data.Swagger.Internal.Schema (named)
 import qualified Data.Text as T
@@ -24,7 +24,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Arbitrary.Generic
 import Web.HttpApiData
 
-newtype HexStorage = HexStorage B.ByteString
+newtype HexStorage = HexStorage BSS.ShortByteString
   deriving (Eq, Ord, Show, Read, Generic)
   deriving anyclass (NFData)
 
@@ -35,22 +35,22 @@ word256ToHexStorage :: Word256 -> HexStorage
 word256ToHexStorage = HexStorage . word256ToBytes
 
 instance ToHttpApiData HexStorage where
-  toUrlPiece (HexStorage hs) = decodeUtf8 (B16.encode hs)
+  toUrlPiece (HexStorage hs) = decodeUtf8 . B16.encode . BSS.fromShort $ hs
 
 instance FromHttpApiData HexStorage where
   parseQueryParam t = case B16.decode (encodeUtf8 t) of
-    Right hs -> pure $ HexStorage hs
+    Right hs -> pure $ HexStorage (BSS.toShort hs)
     _ -> Left $ "non-hex string passed off as hex: " `T.append` t
 
 instance ToSchema HexStorage where
   declareNamedSchema _ = return $ named "solidvm hex storage" binarySchema
 
 instance ToJSON HexStorage where
-  toJSON (HexStorage hs) = String . decodeUtf8 . B16.encode $ hs
+  toJSON (HexStorage hs) = String . decodeUtf8 . B16.encode . BSS.fromShort $ hs
 
 instance FromJSON HexStorage where
   parseJSON (String t) = case B16.decode (encodeUtf8 t) of
-    Right hs -> return $ HexStorage hs
+    Right hs -> return $ HexStorage (BSS.toShort hs)
     _ -> fail $ "non-hex string passed off as hex: " ++ show t
   parseJSON x = typeMismatch "HexStorage" x
 

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -41,10 +41,10 @@ import qualified Data.Aeson.Encoding as Enc
 import qualified Data.Aeson.Key as DAK
 import Data.Aeson.Types
 import Data.Binary
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Short as B
 import Data.Data
 import Data.Hashable
 import Data.Maybe (fromMaybe)
@@ -72,8 +72,8 @@ import Web.FormUrlEncoded
 import Web.PathPieces
 
 instance RLPSerializable Address where
-  rlpEncode (Address a) = RLPString $ BL.toStrict $ encode a
-  rlpDecode (RLPString s) = Address $ decode $ BL.fromStrict s
+  rlpEncode (Address a) = RLPString $ B.toShort $ BL.toStrict $ encode a
+  rlpDecode (RLPString s) = Address $ decode $ BL.fromStrict $ B.fromShort s
   rlpDecode x = error ("Malformed rlp object sent to rlp2Address: " ++ show x)
 
 type AddressPayable = Address
@@ -91,10 +91,10 @@ instance PrintfArg Address where
 -- first byte of serialized pubkey is metdata, so we drop it
 fromPrivateKey :: PrivateKey -> Address
 fromPrivateKey =
-  Address . fromIntegral . SHA.keccak256ToWord256 . SHA.hash . B.drop 1 . exportPublicKey False . derivePublicKey
+  Address . fromIntegral . SHA.keccak256ToWord256 . SHA.hash . B.drop 1 . B.toShort . exportPublicKey False . derivePublicKey
 
 fromPublicKey :: PublicKey -> Address
-fromPublicKey = Address . fromIntegral . SHA.keccak256ToWord256 . SHA.hash . B.drop 1 . exportPublicKey False
+fromPublicKey = Address . fromIntegral . SHA.keccak256ToWord256 . SHA.hash . B.drop 1 . B.toShort . exportPublicKey False
 
 {-
  Was necessary to make Address a primary key - which we no longer do (but rather index on the address field).
@@ -143,7 +143,7 @@ instance Binary Address where
   get = do
     bytes <- replicateM 20 get
     let byteString = B.pack bytes
-    return (Address $ fromInteger $ byteString2Integer byteString)
+    return (Address $ fromInteger $ byteString2Integer $ B.fromShort byteString)
 
 maybeToEither :: b -> Maybe a -> Either b a
 maybeToEither err m = maybe (Left err) Right m
@@ -235,7 +235,7 @@ getNewAddress_unsafe a n =
 -- Construct salted contract addresses using a version of the solidity CREATE2 method:
 -- Original -> new_address = hash(0xFF, sender, salt, bytecode)[12::]
 -- Current  -> new_address = hash(0xFF, sender, salt, codecollection_hash, args)[12::]
-getNewAddressWithSalt_unsafe :: Address -> String -> B.ByteString -> String -> Address
+getNewAddressWithSalt_unsafe :: Address -> String -> B.ShortByteString -> String -> Address
 getNewAddressWithSalt_unsafe creator salt codeHash args =
   let theHash = SHA.hash $ rlpSerialize $ RLPArray [rlpEncode (0xFF :: Integer), rlpEncode creator, rlpEncode salt, rlpEncode codeHash, rlpEncode args]
    in decode $ BL.drop 12 $ encode theHash
@@ -251,7 +251,7 @@ deriveAddressWithSalt sender salt srcHash args = do
               [ rlpEncode (0xFF :: Integer),
                 rlpEncode theAddress,
                 rlpEncode salt,
-                rlpEncode $ SHA.keccak256ToByteString $ fromMaybe (SHA.hash $ encodeUtf8 userRegistryContract) srcHash,
+                rlpEncode $ SHA.keccak256ToByteString $ fromMaybe (SHA.hash . B.toShort $ encodeUtf8 userRegistryContract) srcHash,
                 rlpEncode $ fromMaybe "OrderedVals []" args
               ]
   -- trace ((show theAddress) ++ " " ++ salt ++ " " ++ (show $ keccak256ToByteString $ hash src) ++ " " ++ args)
@@ -267,11 +267,11 @@ addressFromNibbleString = Address . decode . BL.fromStrict . nibbleString2ByteSt
 formatAddressWithoutColor :: Address -> String
 formatAddressWithoutColor x = padZeros 40 $ showHex x ""
 
-addressToHex :: Address -> B.ByteString
-addressToHex = B16.encode . BL.toStrict . encode
+addressToHex :: Address -> B.ShortByteString
+addressToHex = B.toShort . B16.encode . BL.toStrict . encode
 
-addressFromHex :: B.ByteString -> Either String Address
-addressFromHex hex = case B16.decode hex of
+addressFromHex :: B.ShortByteString -> Either String Address
+addressFromHex hex = case B16.decode $ B.fromShort hex of
   Right h -> case decodeOrFail (BL.fromStrict h) of
     Right (_, _, a) -> return a
     Left (_, _, mesg) -> Left $ "cannot decode address: " ++ mesg

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Class.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Class.hs
@@ -7,7 +7,7 @@ import Blockchain.Strato.Model.ChainMember
 import Blockchain.Strato.Model.Code
 import Blockchain.Strato.Model.ExtendedWord
 import Blockchain.Strato.Model.Keccak256
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 import Data.Time
@@ -39,21 +39,21 @@ class RLPSerializable h => BlockHeaderLike h where
   blockHeaderParentHash :: h -> Keccak256
   blockHeaderOmmersHash :: h -> Keccak256
   blockHeaderBeneficiary :: h -> ChainMemberParsedSet
-  blockHeaderStateRoot :: h -> B.ByteString -- todo: "StateRoot" thats not the MPDB StateRoot
-  blockHeaderTransactionsRoot :: h -> B.ByteString -- todo: ditto
-  blockHeaderReceiptsRoot :: h -> B.ByteString -- todo: ditto
-  blockHeaderLogsBloom :: h -> B.ByteString -- todo: "Bloom" data?
+  blockHeaderStateRoot :: h -> B.ShortByteString -- todo: "StateRoot" thats not the MPDB StateRoot
+  blockHeaderTransactionsRoot :: h -> B.ShortByteString -- todo: ditto
+  blockHeaderReceiptsRoot :: h -> B.ShortByteString -- todo: ditto
+  blockHeaderLogsBloom :: h -> B.ShortByteString -- todo: "Bloom" data?
   blockHeaderGasLimit :: h -> Integer -- todo: "gas" newtype?
   blockHeaderGasUsed :: h -> Integer -- todo: ditto
   blockHeaderDifficulty :: h -> Integer
   blockHeaderNonce :: h -> Word64 -- todo: nonce newtype
-  blockHeaderExtraData :: h -> B.ByteString -- todo: extradata newtype
+  blockHeaderExtraData :: h -> B.ShortByteString -- todo: extradata newtype
   blockHeaderTimestamp :: h -> UTCTime
   blockHeaderMixHash :: h -> Keccak256
 
   -- This should be Lens' h B.ByteString, except that the RedisHeader cannot
   -- derive it.
-  blockHeaderModifyExtra :: (B.ByteString -> B.ByteString) -> h -> h
+  blockHeaderModifyExtra :: (B.ShortByteString -> B.ShortByteString) -> h -> h
 
   morphBlockHeader :: (BlockHeaderLike h2) => h2 -> h
   {-# MINIMAL
@@ -107,7 +107,7 @@ class (RLPSerializable t) => TransactionLike t where
   txGasPrice :: t -> Integer
   txGasLimit :: t -> Integer
   txCode :: t -> Maybe Code
-  txData :: t -> Maybe B.ByteString -- todo make a `Code` newtype
+  txData :: t -> Maybe B.ShortByteString -- todo make a `Code` newtype
   txChainId :: t -> Maybe Word256
   txMetadata :: t -> Maybe (Map Text Text)
 

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/ExtendedWord.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/ExtendedWord.hs
@@ -36,11 +36,11 @@ import qualified Data.Aeson.Key as DAK
 import Data.Binary
 import Data.Bits
 import qualified Data.ByteArray as BA
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Internal as BI
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Short as B
 import Data.Ix
 import qualified Data.Primitive.ByteArray as PBA
 import Data.Swagger hiding (Format, format)
@@ -91,7 +91,7 @@ bytesToWord160 _ = error "bytesToWord160 was called with the wrong number of byt
 slowWord256ToBytes :: Word256 -> [Word8]
 slowWord256ToBytes word = map (fromIntegral . (word `shiftR`)) [256 - 8, 256 - 16 .. 0]
 
-word256ToBytes :: Word256 -> B.ByteString
+word256ToBytes :: Word256 -> B.ShortByteString
 word256ToBytes ws = unsafePerformIO $ do
   let n = getBigWordInteger ws
   dstFP <- BI.mallocByteString 32 :: IO (ForeignPtr Word8)
@@ -120,7 +120,7 @@ word256ToBytes ws = unsafePerformIO $ do
             FS.pokeElemOff dst 1 (toBE64 (W64# (bigNatIndex# bn 2#)))
             FS.pokeElemOff dst 0 (toBE64 (W64# (bigNatIndex# bn 3#)))
       _ -> error "negative Word256"
-  return $! BI.PS dstFP 0 32
+  return $! B.toShort $ BI.PS dstFP 0 32
 
 slowBytesToWord256 :: [Word8] -> Word256
 slowBytesToWord256 bytes
@@ -130,11 +130,12 @@ slowBytesToWord256 bytes
     error $
       "slowBytesToWord256 was called with the wrong number of bytes: " ++ show bytes
 
-bytesToWord256 :: B.ByteString -> Word256
+bytesToWord256 :: B.ShortByteString -> Word256
 bytesToWord256 bytes
   | B.length bytes /= 32 = error $ "bytesToWord256 called with the wrong number of bytes: " ++ show bytes
   | otherwise = unsafePerformIO $
-    (BA.withByteArray bytes :: (Ptr Word64 -> IO Word256) -> IO Word256) $ \src -> do
+    -- todo: instance ByteArrayAccess ShortByteString
+    (BA.withByteArray (B.fromShort bytes) :: (Ptr Word64 -> IO Word256) -> IO Word256) $ \src -> do
       hh <- fromBE64 <$!> FS.peekElemOff src 0
       hl <- fromBE64 <$!> FS.peekElemOff src 1
       lh <- fromBE64 <$!> FS.peekElemOff src 2
@@ -222,9 +223,9 @@ instance FromHttpApiData Word160 where
       _ -> Left $ T.pack $ "Error parsing Word160: " ++ show v
 
 instance RLPSerializable Word512 where
-  rlpEncode val = RLPString $ BL.toStrict $ encode val
+  rlpEncode val = RLPString $ B.toShort $ BL.toStrict $ encode val
 
-  rlpDecode (RLPString s) | B.length s == 64 = decode $ BL.fromStrict s
+  rlpDecode (RLPString s) | B.length s == 64 = decode . BL.fromStrict . B.fromShort $ s
   rlpDecode x = error ("Missing case in rlp2Word512: " ++ show x)
 
 instance RLPSerializable Word256 where
@@ -232,28 +233,28 @@ instance RLPSerializable Word256 where
   rlpDecode = fromInteger . rlpDecode
 
 instance RLPSerializable Word128 where
-  rlpEncode val = RLPString $ BL.toStrict $ encode val
+  rlpEncode val = RLPString $ B.toShort $ BL.toStrict $ encode val
 
   rlpDecode (RLPString s) | B.null s = 0
-  rlpDecode (RLPString s) | B.length s <= 16 = decode $ BL.fromStrict s
+  rlpDecode (RLPString s) | B.length s <= 16 = decode . BL.fromStrict . B.fromShort $ s
   rlpDecode x = error ("Missing case in rlp2Word128: " ++ show x)
 
 instance RLPSerializable Word32 where
-  rlpEncode val = RLPString $ BL.toStrict $ encode val
+  rlpEncode val = RLPString $ B.toShort $ BL.toStrict $ encode val
 
   rlpDecode (RLPString s) | B.null s = 0
-  rlpDecode (RLPString s) | B.length s <= 4 = decode $ BL.fromStrict s
+  rlpDecode (RLPString s) | B.length s <= 4 = decode . BL.fromStrict . B.fromShort $ s
   rlpDecode x = error ("Missing case in rlp2Word32: " ++ show x)
 
 instance RLPSerializable Word16 where
-  rlpEncode val = RLPString $ BL.toStrict $ encode val
+  rlpEncode val = RLPString $ B.toShort $ BL.toStrict $ encode val
 
   rlpDecode (RLPString s) | B.null s = 0
-  rlpDecode (RLPString s) | B.length s <= 2 = decode $ BL.fromStrict s
+  rlpDecode (RLPString s) | B.length s <= 2 = decode . BL.fromStrict . B.fromShort $ s
   rlpDecode x = error ("Missing case in rlp2Word16: " ++ show x)
 
 instance Format Word256 where
-  format x = BC.unpack $ B16.encode $ B.pack $ slowWord256ToBytes x
+  format x = BC.unpack $ B16.encode $ B.fromShort $ B.pack $ slowWord256ToBytes x
 
 instance Ae.ToJSONKey Word256 where
   toJSONKey = Ae.ToJSONKeyText f (Enc.text . t)

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Keccak256.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Keccak256.hs
@@ -41,12 +41,11 @@ import qualified Data.Aeson.Key as DAK
 import Data.Binary
 import Data.Binary.Get
 import Data.Binary.Put
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as B
 import Data.ByteString.Arbitrary
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy.Char8 as BLC
+import qualified Data.ByteString.Short as BSS
 import Data.Data
 import Data.Hashable (Hashable)
 import qualified Data.RLP as RLP2
@@ -64,11 +63,11 @@ import Text.Format
 import Web.FormUrlEncoded hiding (fieldLabelModifier)
 import Web.PathPieces
 
-newtype Keccak256 = Keccak256 ByteString
+newtype Keccak256 = Keccak256 BSS.ShortByteString
   deriving (Eq, Read, Show, Ord, Generic, Data)
   deriving anyclass (Hashable)
 
-newtype SHA = SHA ByteString
+newtype SHA = SHA BSS.ShortByteString
   deriving (Eq, Read, Show, Ord, Generic, Data)
   deriving anyclass (Hashable)
 
@@ -77,36 +76,36 @@ instance NFData Keccak256
 keccak256ToWord256 :: Keccak256 -> Word256
 keccak256ToWord256 (Keccak256 val) = bytesToWord256 val
 
-keccak256ToByteString :: Keccak256 -> ByteString
+keccak256ToByteString :: Keccak256 -> BSS.ShortByteString
 keccak256ToByteString (Keccak256 val) = val
 
-unsafeCreateKeccak256FromByteString :: ByteString -> Keccak256
+unsafeCreateKeccak256FromByteString :: BSS.ShortByteString -> Keccak256
 unsafeCreateKeccak256FromByteString = Keccak256
 
 unsafeCreateKeccak256FromWord256 :: Word256 -> Keccak256
 unsafeCreateKeccak256FromWord256 = Keccak256 . word256ToBytes
 
 instance Binary Keccak256 where
-  put (Keccak256 x) = putByteString x
-  get = Keccak256 <$> getByteString 32
+  put (Keccak256 x) = putByteString (BSS.fromShort x)
+  get = Keccak256 . BSS.toShort <$> getByteString 32
 
 instance RLPSerializable Keccak256 where
-  rlpDecode (RLPString s) | B.length s == 32 = Keccak256 s
+  rlpDecode (RLPString s) | BSS.length s == 32 = Keccak256 s
   rlpDecode (RLPScalar 0) = unsafeCreateKeccak256FromWord256 0 --special case seems to be allowed, even if length of zeros is wrong
   rlpDecode x = error ("Missing case in rlpDecode for Keccak256: " ++ show x)
 
   --rlpEncode (Keccak256 0) = RLPNumber 0
   rlpEncode (Keccak256 val)
-    | B.length val >= 32 = RLPString $ B.take 32 val
+    | BSS.length val >= 32 = RLPString $ BSS.take 32 val
     | otherwise =
       RLPString $
-        B.replicate (32 - B.length val) 0
-          `B.append` val
+        BSS.replicate (32 - BSS.length val) 0
+          `BSS.append` val
 
 -- Someday we should remove the second RLP library...
 instance RLP2.RLPEncodable Keccak256 where
-  rlpEncode = RLP2.rlpEncode . keccak256ToByteString
-  rlpDecode = Right . Keccak256 <=< RLP2.rlpDecode
+  rlpEncode = RLP2.rlpEncode . BSS.fromShort . keccak256ToByteString
+  rlpDecode = Right . Keccak256 . BSS.toShort <=< RLP2.rlpDecode
 
 instance Ae.ToJSON Keccak256 where
   toJSON = Ae.String . T.pack . keccak256ToHex
@@ -114,7 +113,7 @@ instance Ae.ToJSON Keccak256 where
 instance Ae.FromJSON Keccak256 where
   parseJSON = Ae.withText "Keccak256" $ \t ->
     case B16.decode $ BC.pack $ T.unpack t of
-      Right val -> pure $ Keccak256 val
+      Right val -> pure $ Keccak256 $ BSS.toShort val
       _ -> fail $ "error parsing Keccak256: " ++ show t
 
 instance Ae.ToJSONKey Keccak256 where
@@ -127,10 +126,10 @@ instance Ae.FromJSONKey Keccak256 where
   fromJSONKey = Ae.FromJSONKeyTextParser (Ae.parseJSON . Ae.String)
 
 instance PersistField Keccak256 where
-  toPersistValue (Keccak256 i) = PersistText . T.pack $ BC.unpack $ B16.encode i
+  toPersistValue (Keccak256 i) = PersistText . T.pack $ BC.unpack $ B16.encode $ BSS.fromShort i
   fromPersistValue (PersistText s) =
     case B16.decode $ BC.pack $ T.unpack s of
-      Right val -> Right $ Keccak256 val
+      Right val -> Right $ Keccak256 $ BSS.toShort val
       _ -> Left $ T.pack $ "unable to parse Keccak256: " ++ show s
   fromPersistValue _ = Left $ T.pack $ "PersistField Keccak256 must be persisted as PersistText"
 
@@ -138,16 +137,16 @@ instance PersistFieldSql Keccak256 where
   sqlType _ = SqlOther $ T.pack "varchar(64)"
 
 keccak256ToHex :: Keccak256 -> String
-keccak256ToHex (Keccak256 sha) = BC.unpack $ B16.encode sha
+keccak256ToHex (Keccak256 sha) = BC.unpack $ B16.encode $ BSS.fromShort sha
 
 -- todo: this shouldn't be partial... ever...
 keccak256FromHex :: String -> Keccak256
-keccak256FromHex = Keccak256 . LabeledError.b16Decode "keccak256FromHex" . BC.pack . padZeros 64
+keccak256FromHex = Keccak256 . BSS.toShort . LabeledError.b16Decode "keccak256FromHex" . BC.pack . padZeros 64
 
 stringKeccak256 :: String -> Maybe Keccak256
 stringKeccak256 string =
   case B16.decode $ BC.pack (padZeros 64 string) of
-    Right x -> Just $ Keccak256 x
+    Right x -> Just $ Keccak256 $ BSS.toShort x
     _ -> Nothing
 
 formatKeccak256WithoutColor :: Keccak256 -> String
@@ -158,8 +157,8 @@ formatKeccak256WithoutColor s
 rlpHash :: RLPSerializable a => a -> Keccak256
 rlpHash = hash . rlpSerialize . rlpEncode
 
-hash :: BC.ByteString -> Keccak256
-hash = Keccak256 . fastKeccak256
+hash :: BSS.ShortByteString -> Keccak256
+hash = Keccak256 . BSS.toShort . fastKeccak256 . BSS.fromShort
 
 {-# NOINLINE emptyHash #-}
 emptyHash :: Keccak256
@@ -187,11 +186,11 @@ instance PathPiece Keccak256 where
   toPathPiece = T.pack . show
   fromPathPiece t =
     case B16.decode $ BC.pack $ T.unpack t of
-      Right x -> Just $ Keccak256 x
+      Right x -> Just $ Keccak256 $ BSS.toShort x
       _ -> Nothing
 
 instance ToHttpApiData Keccak256 where
-  toUrlPiece (Keccak256 bytes) = T.pack . BC.unpack . B16.encode $ bytes
+  toUrlPiece (Keccak256 bytes) = T.pack . BC.unpack . B16.encode . BSS.fromShort $ bytes
 
 instance FromHttpApiData Keccak256 where
   parseUrlPiece = unmaybe . fromPathPiece
@@ -203,7 +202,7 @@ instance FromHttpApiData Keccak256 where
 instance MimeUnrender PlainText Keccak256 where
   mimeUnrender _ v =
     case B16.decode $ BLC.toStrict v of
-      Right bytes -> Right $ Keccak256 bytes
+      Right bytes -> Right $ Keccak256 $ BSS.toShort bytes
       _ -> Left "Couldn't read Keccak"
 
 instance MimeRender PlainText Keccak256 where
@@ -225,7 +224,7 @@ instance FromForm Keccak256 where
 instance Arbitrary Keccak256 where
   arbitrary = do
     random256Bit <- fastRandBs 32
-    return $ Keccak256 random256Bit
+    return $ Keccak256 $ BSS.toShort $ random256Bit
 
 instance ToCapture (Capture "hash" Keccak256) where
   toCapture _ = DocCapture "hash" "a transaction hash"
@@ -235,7 +234,7 @@ instance ToParamSchema Keccak256 where
 
 instance ToSample Keccak256 where
   toSamples _ =
-    samples [hash $ BLC.toStrict (encode @Integer n) | n <- [1 .. 10]]
+    samples [hash $ BSS.toShort $ BLC.toStrict (encode @Integer n) | n <- [1 .. 10]]
 
 instance ToSchema Keccak256 where
   declareNamedSchema _ =
@@ -244,7 +243,7 @@ instance ToSchema Keccak256 where
         (Just "Keccak256 hash, 32 byte hex encoded string")
         ( mempty
             & type_ ?~ SwaggerString
-            & example ?~ Ae.toJSON (hash $ BLC.toStrict (encode @Integer 1))
+            & example ?~ Ae.toJSON (hash $ BSS.toShort $ BLC.toStrict (encode @Integer 1))
             & description ?~ "Keccak256 hash, 32 byte hex encoded string"
         )
 

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Secp256k1.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Secp256k1.hs
@@ -225,13 +225,13 @@ instance Arbitrary Signature where
     return $ Signature (S.CompactRecSig r s v)
 
 instance RLPSerializable Signature where
-  rlpEncode = RLPString . exportSignature
+  rlpEncode = RLPString . BSS.toShort . exportSignature
 
-  rlpDecode (RLPString str) = case importSignature str of
+  rlpDecode (RLPString str) = case importSignature (BSS.fromShort str) of
     Left err -> error $ "rlpDecode for RecSig failed for: " ++ show err
     Right sig -> sig
   rlpDecode (RLPArray [RLPString r, RLPString s, RLPScalar v]) =
-    Signature $ S.CompactRecSig (BSS.toShort r) (BSS.toShort s) v
+    Signature $ S.CompactRecSig r s v
   rlpDecode x = error $ "rlpDecode for RecSig failed on " ++ show x
 
 instance ToJSON Signature where

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/StateRoot.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/StateRoot.hs
@@ -19,9 +19,9 @@ import Control.DeepSeq
 import Control.Monad
 import Data.Aeson
 import Data.Binary
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Short as B
 import Data.Data
 import Data.Default
 import Data.String
@@ -36,16 +36,16 @@ import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 -- The stateRoot is of this type,
 -- (ie- the pointer to the full set of key/value pairs at a particular time in history), and
 -- will be of interest if you need to refer to older or parallel version of the data.
-newtype StateRoot = StateRoot B.ByteString
+newtype StateRoot = StateRoot B.ShortByteString
   deriving (Show, Eq, Ord, Read, Generic, Data)
   deriving newtype (IsString)
 
 instance Format StateRoot where
   format x | x == emptyTriePtr = CL.yellow "<empty>"
-  format (StateRoot x) = CL.yellow $ BC.unpack $ B16.encode x
+  format (StateRoot x) = CL.yellow $ BC.unpack $ B16.encode $ B.fromShort x
 
 instance Pretty StateRoot where
-  pretty (StateRoot sr) = green . text . BC.unpack $ B16.encode sr
+  pretty (StateRoot sr) = green . text . BC.unpack . B16.encode . B.fromShort $ sr
 
 instance NFData StateRoot
 
@@ -71,5 +71,5 @@ emptyTriePtr = StateRoot $ keccak256ToByteString $ hash $ rlpSerialize $ rlpEnco
 sha2StateRoot :: Keccak256 -> StateRoot
 sha2StateRoot x = StateRoot $ keccak256ToByteString x
 
-unboxStateRoot :: StateRoot -> B.ByteString
+unboxStateRoot :: StateRoot -> B.ShortByteString
 unboxStateRoot (StateRoot b) = b

--- a/strato/core/strato-model/test/Spec.hs
+++ b/strato/core/strato-model/test/Spec.hs
@@ -19,7 +19,7 @@ import qualified Data.Aeson as Ae
 import Data.Aeson.QQ
 import Data.Binary
 import qualified Data.Bits as Bits
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import qualified Data.ByteString.Char8 as C8
 import Data.Maybe
 import Data.Ranged
@@ -73,7 +73,7 @@ spec = do
     it "works on mid size" $
       replicateM_ 1000 $
         word256ToBytes 0x60646359b0ecaf704caa6f35
-          `shouldBe` ( LabeledError.b16Decode
+          `shouldBe` ( B.toShort $ LabeledError.b16Decode
                          "strato-model/Spec.hs"
                          "000000000000000000000000000000000000000060646359b0ecaf704caa6f35"
                      )
@@ -152,7 +152,7 @@ spec = do
     it "should be fixed width" $ do
       addressToHex 0xdeadbeef
         `shouldBe` "00000000000000000000000000000000deadbeef"
-      addressToHex 0 `shouldBe` C8.replicate 40 '0'
+      addressToHex 0 `shouldBe` (B.toShort $ C8.replicate 40 '0')
       addressToHex 0xca35b7d915458ef540ade6068dfe2f44e8fa733c
         `shouldBe` "ca35b7d915458ef540ade6068dfe2f44e8fa733c"
 
@@ -197,11 +197,11 @@ spec = do
     let mPrv = importPrivateKey $ LabeledError.b16Decode "strato-model/Spec.hs" $ C8.pack $ "09e910621c2e988e9f7f6ffcd7024f54ec1461fa6e86a4b545e9e1fe21c28866"
         prv = fromMaybe (error "could not import private key") mPrv
         pub = derivePublicKey prv
-        mesg = keccak256ToByteString $ hash $ C8.pack "hey guys!"
-        sig = signMsg prv mesg
+        mesg = keccak256ToByteString $ hash $ B.toShort $ C8.pack "hey guys!"
+        sig = signMsg prv $ B.fromShort mesg
 
     it "can export public key as SEC bytestring" $ do
-      B.length (exportPublicKey False pub) `shouldBe` 65
+      B.length (B.toShort $ exportPublicKey False pub) `shouldBe` 65
     it "can convert public key to and from JSON encoding" $ do
       Ae.decode (Ae.encode pub) `shouldBe` Just pub
     it "can convert signature to and from JSON encoding" $ do
@@ -218,17 +218,17 @@ spec = do
     it "arbitrary sigs can be exported/imported" $
       property $ \s -> do
         let sigBS = exportSignature s
-        B.length sigBS `shouldBe` 65
+        B.length (B.toShort sigBS) `shouldBe` 65
         importSignature sigBS `shouldBe` (Right s)
     it "exported sigs can be used for recovery" $ do
       let sigBS = exportSignature sig
           sig' = importSignature sigBS
       case sig' of
         Left err -> error err
-        Right sig'' -> recoverPub sig'' mesg `shouldBe` Just pub
+        Right sig'' -> recoverPub sig'' (B.fromShort mesg) `shouldBe` Just pub
 
     it "can recover public keys from signatures" $ do
-      let mRecPub = recoverPub sig mesg
+      let mRecPub = recoverPub sig $ B.fromShort mesg
       (Just pub) `shouldBe` mRecPub
 
     -- It can verify signatures given a message and key
@@ -243,10 +243,10 @@ spec = do
 
     it "test address derivation, signatures, and signature recovery on arbitrary private keys" $
       property $ \k -> do
-        let sig' = signMsg k mesg
+        let sig' = signMsg k $ B.fromShort mesg
             pub' = derivePublicKey k
             add = fromPublicKey pub'
-            mRecPub = recoverPub sig' mesg
+            mRecPub = recoverPub sig' $ B.fromShort mesg
         Just pub' `shouldBe` mRecPub
         fromPublicKey (fromJust mRecPub) `shouldBe` add
         fromPublicKey (fromJust mRecPub) `shouldBe` fromPrivateKey k

--- a/strato/libs/ethereum-rlp/library/Blockchain/Data/RLP.hs
+++ b/strato/libs/ethereum-rlp/library/Blockchain/Data/RLP.hs
@@ -31,6 +31,7 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BC
 import Data.ByteString.Internal
+import qualified Data.ByteString.Short as BSS
 import Data.Fix
 import Data.Functor.Compose
 import Data.Functor.Identity
@@ -47,7 +48,7 @@ import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 -- End users will not need to directly create objects of this type (an 'RLPObject' can be created using 'rlpEncode'),
 -- however the designer of a new type will need to create conversion code by making their type an instance
 -- of the RLPSerializable class.
-data RLPObject = RLPScalar Word8 | RLPString B.ByteString | RLPArray [RLPObject] deriving (Show, Eq, Ord, Generic)
+data RLPObject = RLPScalar Word8 | RLPString {-# UNPACK #-} !BSS.ShortByteString | RLPArray [RLPObject] deriving (Show, Eq, Ord, Generic)
 
 instance NFData RLPObject
 
@@ -70,51 +71,51 @@ instance Pretty RLPObject where
   pretty (RLPArray objects) =
     encloseSep (text "[") (text "]") (text ", ") $ pretty <$> objects
   pretty (RLPScalar n) = text $ "0x" ++ showHex n ""
-  pretty (RLPString s) = text $ "0x" ++ BC.unpack (B16.encode s)
+  pretty (RLPString s) = text $ "0x" ++ BC.unpack (B16.encode . BSS.fromShort $ s)
 
 formatRLPObject :: RLPObject -> String
 formatRLPObject = show . pretty
 
-splitAtEither :: Int -> B.ByteString -> Either String (B.ByteString, B.ByteString)
-splitAtEither i s | i > B.length s = Left "splitAtEither called with n > length arr"
-splitAtEither i s = Right $ B.splitAt i s
+splitAtEither :: Int -> BSS.ShortByteString -> Either String (BSS.ShortByteString, BSS.ShortByteString)
+splitAtEither i s | i > BSS.length s = Left "splitAtEither called with n > length arr"
+splitAtEither i s = Right $ BSS.splitAt i s
 
-getLength :: Int -> B.ByteString -> (Integer, B.ByteString)
+getLength :: Int -> BSS.ShortByteString -> (Integer, BSS.ShortByteString)
 getLength sizeOfLength bytes =
-  (bytes2Integer $ B.unpack $ B.take sizeOfLength bytes, B.drop sizeOfLength bytes)
+  (bytes2Integer $ BSS.unpack $ BSS.take sizeOfLength bytes, BSS.drop sizeOfLength bytes)
 
-rlpSplit :: B.ByteString -> (RLPObject, B.ByteString)
+rlpSplit :: BSS.ShortByteString -> (RLPObject, BSS.ShortByteString)
 rlpSplit = either error id . rlpSplitEither
 
-rlpSplitMaybe :: B.ByteString -> Maybe (RLPObject, B.ByteString)
+rlpSplitMaybe :: BSS.ShortByteString -> Maybe (RLPObject, BSS.ShortByteString)
 rlpSplitMaybe = either (const Nothing) Just . rlpSplitEither
 
-rlpSplitEither :: B.ByteString -> Either String (RLPObject, B.ByteString)
+rlpSplitEither :: BSS.ShortByteString -> Either String (RLPObject, BSS.ShortByteString)
 rlpSplitEither input =
-  case B.head input of
+  case BSS.head input of
     x
       | x >= 192 && x <= 192 + 55 ->
-        let eResult = splitAtEither (fromIntegral x - 192) $ B.tail input
+        let eResult = splitAtEither (fromIntegral x - 192) $ BSS.tail input
          in (\(arrayData, nextRest) -> (RLPArray $ getRLPObjects arrayData, nextRest)) <$> eResult
     x
       | x >= 0xF8 && x <= 0xFF ->
-        let (arrLength, restAfterLen) = getLength (fromIntegral x - 0xF7) $ B.tail input
+        let (arrLength, restAfterLen) = getLength (fromIntegral x - 0xF7) $ BSS.tail input
             eResult = splitAtEither (fromIntegral arrLength) restAfterLen
          in (\(arrayData, nextRest) -> (RLPArray $ getRLPObjects arrayData, nextRest)) <$> eResult
     x
       | x >= 128 && x <= 128 + 55 ->
-        let eResult = splitAtEither (fromIntegral $ x - 128) $ B.tail input
+        let eResult = splitAtEither (fromIntegral $ x - 128) $ BSS.tail input
          in (\(strList, nextRest) -> (RLPString strList, nextRest)) <$> eResult
     x
       | x >= 0xB8 && x <= 0xBF ->
-        let (strLength, restAfterLen) = getLength (fromIntegral x - 0xB7) $ B.tail input
+        let (strLength, restAfterLen) = getLength (fromIntegral x - 0xB7) $ BSS.tail input
             eResult = splitAtEither (fromIntegral strLength) restAfterLen
          in (\(strList, nextRest) -> (RLPString strList, nextRest)) <$> eResult
-    x | x < 128 -> Right (RLPScalar x, B.tail input)
+    x | x < 128 -> Right (RLPScalar x, BSS.tail input)
     x -> Left ("Missing case in rlpSplit: " ++ show x)
 
-getRLPObjects :: ByteString -> [RLPObject]
-getRLPObjects x | B.null x = []
+getRLPObjects :: BSS.ShortByteString -> [RLPObject]
+getRLPObjects x | BSS.null x = []
 getRLPObjects theData = obj : getRLPObjects rest
   where
     (obj, rest) = rlpSplit theData
@@ -130,54 +131,54 @@ int2Bytes _ = error "int2Bytes not defined for val >= 0x10000000000."
 -- | Converts bytes to 'RLPObject's.
 --
 -- Full deserialization of an object can be obtained using @rlpDecode . rlpDeserialize@.
-rlpDeserialize :: B.ByteString -> RLPObject
+rlpDeserialize :: BSS.ShortByteString -> RLPObject
 rlpDeserialize s =
   case rlpSplit s of
-    (o, x) | B.null x -> o
-    _ -> error ("parse error converting ByteString to an RLP Object: " ++ show (B.unpack s))
+    (o, x) | BSS.null x -> o
+    _ -> error ("parse error converting ByteString to an RLP Object: " ++ show (BSS.unpack s))
 
-rlpDeserializeMaybe :: B.ByteString -> Maybe RLPObject
+rlpDeserializeMaybe :: BSS.ShortByteString -> Maybe RLPObject
 rlpDeserializeMaybe s =
   case rlpSplitMaybe s of
-    Just (o, x) | B.null x -> Just o
+    Just (o, x) | BSS.null x -> Just o
     _ -> Nothing
 
-rlpDeserializeEither :: B.ByteString -> Either String RLPObject
+rlpDeserializeEither :: BSS.ShortByteString -> Either String RLPObject
 rlpDeserializeEither s =
   case rlpSplitEither s of
-    Right (o, x) | B.null x -> Right o
-    Right _ -> Left ("parse error converting ByteString to an RLP Object: " ++ show (B.unpack s))
+    Right (o, x) | BSS.null x -> Right o
+    Right _ -> Left ("parse error converting ByteString to an RLP Object: " ++ show (BSS.unpack s))
     Left e -> Left e
 
 -- | Converts 'RLPObject's to bytes.
 --
 -- Full serialization of an object can be obtained using @rlpSerialize . rlpEncode@.
-rlpSerialize :: RLPObject -> B.ByteString
+rlpSerialize :: RLPObject -> BSS.ShortByteString
 rlpSerialize = \case
-  RLPScalar val -> B.singleton val
+  RLPScalar val -> BSS.singleton val
   RLPString s ->
-    let l = B.length s
+    let l = BSS.length s
      in if l <= 55
-          then B.cons (0x80 + fromIntegral l) s
+          then BSS.cons (0x80 + fromIntegral l) s
           else
             let ibs = int2Bytes l
                 ll = length ibs
-             in (B.pack $ 0xb7 + fromIntegral ll : ibs) <> s
+             in (BSS.pack $ 0xb7 + fromIntegral ll : ibs) <> s
   RLPArray innerObjects -> do
-    let innerBytes = B.concat . map rlpSerialize $ innerObjects
-        l = B.length innerBytes
+    let innerBytes = BSS.concat . map rlpSerialize $ innerObjects
+        l = BSS.length innerBytes
     if l <= 55
-      then B.cons (0xc0 + fromIntegral l) innerBytes
+      then BSS.cons (0xc0 + fromIntegral l) innerBytes
       else
         let ibs = int2Bytes . fromIntegral $ l
             ll = length ibs
-         in (B.pack $ 0xf7 + fromIntegral ll : ibs) <> innerBytes
+         in (BSS.pack $ 0xf7 + fromIntegral ll : ibs) <> innerBytes
 
 instance RLPSerializable Integer where
-  rlpEncode 0 = RLPString B.empty
+  rlpEncode 0 = RLPString BSS.empty
   rlpEncode x | x < 0 = RLPArray [rlpEncode (-x)]
   rlpEncode x | x < 128 = RLPScalar $ fromIntegral x
-  rlpEncode x = RLPString $ B.pack $ integer2Bytes x
+  rlpEncode x = RLPString $ BSS.pack $ integer2Bytes x
   rlpDecode (RLPScalar x) = fromIntegral x
   rlpDecode (RLPString s) = byteString2Integer s
   rlpDecode (RLPArray [x]) = -rlpDecode x
@@ -187,12 +188,20 @@ instance {-# OVERLAPPING #-} RLPSerializable String where
   rlpEncode = rlpEncode . T.pack
   rlpDecode = T.unpack . rlpDecode
 
-instance RLPSerializable B.ByteString where
-  rlpEncode x | B.length x == 1 && B.head x < 128 = RLPScalar $ B.head x
+instance RLPSerializable BSS.ShortByteString where
+  rlpEncode x | BSS.length x == 1 && BSS.head x < 128 = RLPScalar $ BSS.head x
   rlpEncode s = RLPString s
 
-  rlpDecode (RLPScalar x) = B.singleton x
+  rlpDecode (RLPScalar x) = BSS.singleton x
   rlpDecode (RLPString s) = s
+  rlpDecode x = error ("rlpDecode for ByteString not defined for: " ++ show x)
+
+instance RLPSerializable ByteString where
+  rlpEncode x | B.length x == 1 && B.head x < 128 = RLPScalar . BSS.head . BSS.toShort $ x
+  rlpEncode s = RLPString $ BSS.toShort s
+
+  rlpDecode (RLPScalar x) = B.singleton x
+  rlpDecode (RLPString s) = BSS.fromShort s
   rlpDecode x = error ("rlpDecode for ByteString not defined for: " ++ show x)
 
 instance RLPSerializable T.Text where

--- a/strato/libs/ethereum-rlp/library/Blockchain/Data/Util.hs
+++ b/strato/libs/ethereum-rlp/library/Blockchain/Data/Util.hs
@@ -6,14 +6,14 @@ module Blockchain.Data.Util
 where
 
 import Data.Bits
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as BSS
 import Data.Word
 
 --I hate this, it is an ugly way to create an Integer from its component bytes.
 --There should be an easier way....
 --See http://stackoverflow.com/questions/25854311/efficient-packing-bytes-into-integers
-byteString2Integer :: B.ByteString -> Integer
-byteString2Integer x = bytes2Integer $ B.unpack x
+byteString2Integer :: BSS.ShortByteString -> Integer
+byteString2Integer x = bytes2Integer $ BSS.unpack x
 
 bytes2Integer :: [Word8] -> Integer
 bytes2Integer [] = 0

--- a/strato/libs/ethereum-rlp/test/Main.hs
+++ b/strato/libs/ethereum-rlp/test/Main.hs
@@ -3,14 +3,14 @@
 module Main where
 
 import Blockchain.Data.RLP
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as B
 import Data.Word
 import Test.Framework
 import Test.Framework.Providers.HUnit
 import Test.HUnit
 import Test.Hspec
 
-rlpSerialize_list :: RLPObject -> B.ByteString
+rlpSerialize_list :: RLPObject -> B.ShortByteString
 rlpSerialize_list = B.pack . rlp2Bytes
 
 rlp2Bytes :: RLPObject -> [Word8]


### PR DESCRIPTION
Currently converting `ByteString` instances to `ShortByteString` instances. Turns out we use `ByteString` a lot in our code.

`ShortByteString` is ideal for... short bytestrings. Small-sized bytestrings that use normal `ByteString` may cause heap fragmentation over time - having `ShortByteString` would be useful in cases like the parser that generates small string tokens.

**todo**
- Get code to build using the path of least resistance - `instance UTF8Bytes ShortByteString`?
- Review if the changed code would actually have an effect on performance
- Measure performance