### PR TITLE
temporary disable the git flow check until the flow is settled

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -22,7 +22,9 @@ pipeline {
         '''
       }
     }
-    
+
+    /*
+    # Commented out until we settle on the release flow
     stage('Ensure branch merge flow') {
       steps {
         script {
@@ -42,7 +44,8 @@ pipeline {
         }
       }
     }
-
+    */
+    
     stage('Build') {
       steps {
         sh 'rm -rf .docker-work'


### PR DESCRIPTION
Because we are removing the staging and testnet2 branches, the check should be updated to reflect the new flow. Once we settle on the new flow, we'll re-enable it with new rules.