### PR TITLE
fix: populate env variable with Jenkins scripts

### DIFF
--- a/pipelines/Jenkinsfile.updateTestnet2
+++ b/pipelines/Jenkinsfile.updateTestnet2
@@ -7,10 +7,10 @@ pipeline {
     string(name: 'VERSION_TAG', defaultValue: '', description: 'The STRATO version tag for the version to release to Testnet2. i.e. 9.0.0-753c6527e')
   }
   stages {
-    sstage('Start Step Functions Execution') {
+    stage('Start Step Functions Execution') {
       steps {
         sh """#!/bin/bash
-        
+
           echo 'Input JSON: {"VersionTag": "${params.VERSION_TAG}"}'
 
           env.execution_arn=\$(aws stepfunctions start-execution \

--- a/pipelines/Jenkinsfile.updateTestnet2
+++ b/pipelines/Jenkinsfile.updateTestnet2
@@ -7,20 +7,18 @@ pipeline {
     string(name: 'VERSION_TAG', defaultValue: '', description: 'The STRATO version tag for the version to release to Testnet2. i.e. 9.0.0-753c6527e')
   }
   stages {
-    stage('Start Step Functions Execution') {
+    sstage('Start Step Functions Execution') {
       steps {
-        sh """
+        sh """#!/bin/bash
+        
           echo 'Input JSON: {"VersionTag": "${params.VERSION_TAG}"}'
-        """
-        env.execution_arn = sh(returnStdout: true, script: """
-          \$(aws stepfunctions start-execution \
+
+          env.execution_arn=\$(aws stepfunctions start-execution \
             --state-machine-arn arn:aws:states:us-east-1:406773134706:stateMachine:UpgradeTestnet2 \
             --input '{"VersionTag": "${params.VERSION_TAG}"}' \
             --query "executionArn" \
-            --output text).trim()
-        """)
+            --output text)
 
-        sh """
           echo "Started Step Functions execution with ARN: \$execution_arn" 
         """
       }

--- a/pipelines/Jenkinsfile.updateTestnet2
+++ b/pipelines/Jenkinsfile.updateTestnet2
@@ -9,47 +9,51 @@ pipeline {
   stages {
     stage('Start Step Functions Execution') {
       steps {
-        sh """#!/bin/bash
+        script {
+          def execution_arn = sh(script: """
+            #!/bin/bash
+            echo 'Input JSON: {"VersionTag": "${params.VERSION_TAG}"}'
+            aws stepfunctions start-execution \
+              --state-machine-arn arn:aws:states:us-east-1:406773134706:stateMachine:UpgradeTestnet2 \
+              --input '{"VersionTag": "${params.VERSION_TAG}"}' \
+              --query "executionArn" \
+              --output text
+          """, returnStdout: true).trim()
 
-          echo 'Input JSON: {"VersionTag": "${params.VERSION_TAG}"}'
-
-          env.execution_arn=\$(aws stepfunctions start-execution \
-            --state-machine-arn arn:aws:states:us-east-1:406773134706:stateMachine:UpgradeTestnet2 \
-            --input '{"VersionTag": "${params.VERSION_TAG}"}' \
-            --query "executionArn" \
-            --output text)
-
-          echo "Started Step Functions execution with ARN: \$execution_arn" 
-        """
+          // Set the execution_arn as an environment variable
+          env.EXECUTION_ARN = execution_arn
+        }
       }
+      
     }
     stage('Wait for Step Functions Completion') {
       steps {
-        sh """#!/bin/bash
-          while true; do
-            execution_status=\$(aws stepfunctions describe-execution \
-              --execution-arn "\${execution_arn}" \
-              --query "status" \
-              --output text)
-          
-            if [ "\$execution_status" == "SUCCEEDED" ]; then
+        script {
+          def execution_arn = env.EXECUTION_ARN
+          while (true) {
+            def execution_status = sh(script: """
+              #!/bin/bash
+              aws stepfunctions describe-execution \
+                --execution-arn "${execution_arn}" \
+                --query "status" \
+                --output text
+            """, returnStatus: true, returnStdout: true).trim()
+
+            if (execution_status == "SUCCEEDED") {
               echo "Step Functions execution succeeded."
-              exit 0
-            elif [ "\$execution_status" == "FAILED" ]; then
-              echo "Step Functions execution failed."
-              exit 1 
-            elif [ "\$execution_status" == "TIMED_OUT" ]; then
-              echo "Step Functions execution timed out."
-              exit 1  
-            elif [ "\$execution_status" == "RUNNING" ]; then
+              break
+            } else if (execution_status == "FAILED" || execution_status == "TIMED_OUT") {
+              echo "Step Functions execution failed or timed out."
+              error("Step Functions execution failed or timed out.")
+            } else if (execution_status == "RUNNING") {
               echo "Step Functions execution is still running. Waiting..."
-              sleep 30
-            else
-              echo "Unknown execution status: \$execution_status"
-              exit 1  
-            fi
-          done
-        """
+              sleep(60)
+            } else {
+              echo "Unknown execution status: ${execution_status}"
+              error("Unknown execution status: ${execution_status}")
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Converting stages to use script blocks. This allows me to return the stdout to save it in an env variable to utilize in subsequent steps. Previously wasn't correctly setting the variable, so the describe execution aws cli call failed.