### PR TITLE
fix: type coerce to string

### DIFF
--- a/pipelines/Jenkinsfile.updateTestnet2
+++ b/pipelines/Jenkinsfile.updateTestnet2
@@ -35,7 +35,7 @@ pipeline {
                 --execution-arn "${execution_arn}" \
                 --query "status" \
                 --output text
-            """, returnStatus: true, returnStdout: true).trim()
+            """, returnStatus: true, returnStdout: true)toString().trim()
 
             if (execution_status == "SUCCEEDED") {
               echo "Step Functions execution succeeded."

--- a/pipelines/Jenkinsfile.updateTestnet2
+++ b/pipelines/Jenkinsfile.updateTestnet2
@@ -35,7 +35,7 @@ pipeline {
                 --execution-arn "${execution_arn}" \
                 --query "status" \
                 --output text
-            """, returnStatus: true, returnStdout: true)toString().trim()
+            """, returnStatus: true, returnStdout: true).toString().trim()
 
             if (execution_status == "SUCCEEDED") {
               echo "Step Functions execution succeeded."


### PR DESCRIPTION
weirdly, Jenkins throws the following error while trimming the output from describe execution:

Hudson.remoting.ProxyException: groovy.lang.MissingMethodException: No signature of method: java.lang.Integer.trim() is applicable for argument types: () values: []
Possible solutions: wait(), grep(), wait(long), or(java.lang.Number), print(java.lang.Object), is(java.lang.Object)


Not sure why it seems to think the response is an integer since AWS returns a string.... let's try type coercing before trimming to drop the newline char.