### PR TITLE
add: object-fit property to prevent image skewing

### DIFF
--- a/marketplace/ui/src/components/MarketPlace/CategoryProductCard.js
+++ b/marketplace/ui/src/components/MarketPlace/CategoryProductCard.js
@@ -124,6 +124,7 @@ const CategoryProductCard = ({ product, category }) => {
               src={product.imageUrl}
               width={200}
               height={180}
+              style={{ objectFit: "contain" }}
               preview={false}
               onClick={() =>
                 navigate(`${naviroute.replace(":address", product.address)}`, { state: { isCalledFromInventory: false } })

--- a/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
+++ b/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
@@ -147,7 +147,8 @@ const TopSellingProductCard = () => {
                         className="cursor-pointer"
                         src={topSellingProduct.imageUrl}
                         height={230}
-                        style={{ maxWidth: '100%'}}
+                        width={230}
+                        style={{ objectFit: "contain" }}
                         preview={false}
                         onClick={() =>
                           navigate(`${naviroute.replace(":address", topSellingProduct.address)}`, { state: { isCalledFromInventory: false } })


### PR DESCRIPTION
See before and after pictures. I am unable to see most of the top selling products to see the fix there. Only one image is loading for me in. my locally deployed version. This property fits the image into its container without changing the image w/h ratio. 

Before: 
<img width="432" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/32350cc7-64b0-4626-9042-9933860cc7e4">
<img width="405" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/276fbf13-4ded-4a67-9ef2-5dafa3759a8b">
<img width="447" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/e41a574f-4ff1-4320-a633-35c5341fbdda">


After: 
<img width="396" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/b5041b36-7f46-455c-9a07-6292ad849711">
<img width="463" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/a4b917c5-73cb-4971-b3d3-8543d8c7a9e4">
<img width="460" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/36900cf0-2af6-4508-812c-18feb4b6dbf0">


