### PR TITLE
Fixed ItemStatus after reselling

### DIFF
--- a/marketplace/backend/dapp/products/contracts/ProductManager.sol
+++ b/marketplace/backend/dapp/products/contracts/ProductManager.sol
@@ -267,6 +267,7 @@ contract ProductManager is
             );
             for (int i = 0; i < _quantity; i++) {
                 Item_3 _item = Item_3(_itemsAddress[i]);
+                _item.update(ItemStatus.PUBLISHED, _item.comment(), 1);
                 _item.transferOwnership(
                     tx.origin,
                     address(product),


### PR DESCRIPTION
Previously, the `ItemStatus` of individually serialized items would stay as `SOLD` after reselling them. This PR fixes that so that their status will be set to `PUBLISHED`.