### PR TITLE
Change Marketplace Inventory API to use the asset table (customizable)

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -92,6 +92,7 @@ services:
     - GLOBAL_ADMIN_PASSWORD=${GLOBAL_ADMIN_PASSWORD}
     - ORG_NAME='BlockApps' # TODO: can be removed?
     - SENDGRID_API_KEY=${SENDGRID_API_KEY}
+    - ASSET_TABLE_NAME=${ASSET_TABLE_NAME}
     build: .
     image: ${MARKETPLACEBACKEND_IMAGE:-<REPO_URL>marketplace-backend:<VERSION>}
     restart: unless-stopped

--- a/marketplacev2/backend/dapp/products/inventory.js
+++ b/marketplacev2/backend/dapp/products/inventory.js
@@ -143,7 +143,6 @@ function bindAddress(user, address, options) {
  */
 
 async function get(user, args, options) {
-    console.log(contractName);
     const { org, ...modifiedOptions } = options;
     const { uniqueInventoryID, address, ownerOrganization, ...restArgs } = args;
     let inventory;
@@ -166,7 +165,6 @@ async function get(user, args, options) {
 }
 
 async function getAll(admin, args = {}, options) {
-    console.log(contractName);
     const { org, ...modifiedOptions } = options;
     const {ownerOrganization, ...modifiedArgs} = args
     const inventories = await searchAllWithQueryArgs(contractName, modifiedArgs, modifiedOptions, admin)

--- a/marketplacev2/backend/dapp/products/inventory.js
+++ b/marketplacev2/backend/dapp/products/inventory.js
@@ -3,8 +3,9 @@ import config from '/load.config';
 import RestStatus from 'http-status-codes';
 import { setSearchQueryOptions, searchOne, searchAll, searchAllWithQueryArgs } from '/helpers/utils';
 import dayjs from 'dayjs';
+import { ASSET_TABLE_NAME } from '../../helpers/constants';
 
-const contractName = 'Inventory';
+const contractName = ASSET_TABLE_NAME;
 const contractFilename = `${util.cwd}/dapp/products/contracts/Inventory.sol`;
 
 /** 
@@ -142,15 +143,17 @@ function bindAddress(user, address, options) {
  */
 
 async function get(user, args, options) {
-    const { uniqueInventoryID, address, ...restArgs } = args;
+    console.log(contractName);
+    const { org, ...modifiedOptions } = options;
+    const { uniqueInventoryID, address, ownerOrganization, ...restArgs } = args;
     let inventory;
 
     if (address) {
         const searchArgs = setSearchQueryOptions(restArgs, { key: 'address', value: address });
-        inventory = await searchOne(contractName, searchArgs, options, user);
+        inventory = await searchOne(contractName, searchArgs, modifiedOptions, user);
     } else {
         const searchArgs = setSearchQueryOptions(restArgs, { key: 'uniqueInventoryID', value: uniqueInventoryID });
-        inventory = await searchOne(contractName, searchArgs, options, user);
+        inventory = await searchOne(contractName, searchArgs, modifiedOptions, user);
     }
     if (!inventory) {
         return undefined;
@@ -163,7 +166,10 @@ async function get(user, args, options) {
 }
 
 async function getAll(admin, args = {}, options) {
-    const inventories = await searchAllWithQueryArgs(contractName, args, options, admin)
+    console.log(contractName);
+    const { org, ...modifiedOptions } = options;
+    const {ownerOrganization, ...modifiedArgs} = args
+    const inventories = await searchAllWithQueryArgs(contractName, modifiedArgs, modifiedOptions, admin)
     return inventories.map((inventory) => marshalOut(inventory))
 }
 

--- a/marketplacev2/backend/helpers/constants.js
+++ b/marketplacev2/backend/helpers/constants.js
@@ -82,3 +82,13 @@ SERVICE_PROVIDERS[SERVICE_PROVIDERS['STRIPE'] = 1] = 'STRIPE';
 SERVICE_PROVIDERS[SERVICE_PROVIDERS['PAYPAL'] = 2] = 'PAYPAL';
 Object.freeze(SERVICE_PROVIDERS)
 
+export const ASSET_TABLE_NAME = (() => {
+  try { 
+    return getEnvVariable("ASSET_TABLE_NAME");
+  } catch (err) {
+     return "BlockApps-Dapp-Inventory";
+  }
+})();
+Object.freeze(ASSET_TABLE_NAME)
+
+

--- a/marketplacev2/ui/docker-run.sh
+++ b/marketplacev2/ui/docker-run.sh
@@ -1,20 +1,5 @@
 #!/usr/bin/env sh
 
-# Creating .env file if using the relevant flags
-if [ -n "${ASSET_TABLE_NAME}" ] || [ -n "${SALE_TABLE_NAME}" ]; then
-  if [ ! -f .env ]; then
-    # If it doesn't exist, create the .env file and insert environment variables.
-    touch .env
-
-    echo "REACT_APP_ASSET_TABLE_NAME=${ASSET_TABLE_NAME}" >> .env
-    echo "REACT_APP_SALE_TABLE_NAME=${SALE_TABLE_NAME}" >> .env
-  else
-    # If the .env file exists, replace the environment variables.
-    sed -i `s/REACT_APP_ASSET_TABLE_NAME=.*/REACT_APP_ASSET_TABLE_NAME=${ASSET_TABLE_NAME}/` .env
-    sed -i `s/REACT_APP_SALE_TABLE_NAME=.*/REACT_APP_SALE_TABLE_NAME=${SALE_TABLE_NAME}/` .env
-  fi
-fi
-
 echo 'Starting ui server...'
 
-npx react-inject-env set && serve --single -l 3003 build
+serve --single -l 3003 build

--- a/marketplacev2/ui/package.json
+++ b/marketplacev2/ui/package.json
@@ -61,7 +61,6 @@
     "autoprefixer": "^10.4.13",
     "cypress": "12.16.0",
     "postcss": "^8.4.20",
-    "react-inject-env": "2.1.0",
     "react-scripts": "^5.0.1",
     "tailwindcss": "^3.2.4"
   }

--- a/marketplacev2/ui/public/index.html
+++ b/marketplacev2/ui/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <script src='%PUBLIC_URL%/env.js'></script>
     <link rel="icon" href="%PUBLIC_URL%/favicon_large.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/marketplacev2/ui/src/contexts/inventory/actions.js
+++ b/marketplacev2/ui/src/contexts/inventory/actions.js
@@ -102,7 +102,7 @@ const actions = {
       if (response.status === RestStatus.OK) {
         dispatch({
           type: actionDescriptors.fetchInventorySuccessful,
-          payload: body,
+          payload: body.data,
         });
         return;
       } else if (response.status === RestStatus.INTERNAL_SERVER_ERROR) {

--- a/marketplacev2/ui/src/contexts/inventory/actions.js
+++ b/marketplacev2/ui/src/contexts/inventory/actions.js
@@ -91,7 +91,7 @@ const actions = {
 
     try {
       const response = await fetch(
-        `${cirrusUrl}/${assetTableName}?limit=${limit}&offset=${offset}${query}`,
+        `${apiUrl}/inventory?limit=${limit}&offset=${offset}${query}`,
         {
           method: HTTP_METHODS.GET,
         }

--- a/marketplacev2/ui/src/env.js
+++ b/marketplacev2/ui/src/env.js
@@ -1,1 +1,0 @@
-export const env = { ...process.env, ...window.env }

--- a/marketplacev2/ui/src/helpers/constants.js
+++ b/marketplacev2/ui/src/helpers/constants.js
@@ -1,20 +1,6 @@
-import { env } from "../env";
-
 export const apiUrl = process.env.REACT_APP_URL
   ? process.env.REACT_APP_URL + "/api/v1"
   : "/api/v1";
-
-export const cirrusUrl = process.env.REACT_APP_URL
-  ? process.env.REACT_APP_URL + "/cirrus/search"
-  : "/cirrus/search"
-
-export const assetTableName = env.REACT_APP_ASSET_TABLE_NAME
-  ? env.REACT_APP_ASSET_TABLE_NAME
-  : "BlockApps-Mercata-Asset"
-
-export const saleTableName = env.REACT_APP_SALE_TABLE_NAME
-  ? env.REACT_APP_SALE_TABLE_NAME
-  : "BlockApps-Mercata-Sale"
 
 export const HTTP_METHODS = {
   GET: "GET",


### PR DESCRIPTION
This PR changes the behavior of the Inventory API in the marketplace. This PR allows the use of a custom table name in the Inventory API that is set by including the flag `ASSET_TABLE_NAME` in your `strato-getting-started` run script. If the environment variable is not set, the table will default to the old `BlockApps-Dapp-Inventory` table.

Note: The table name should be the full name including the org and app. Ex. "BlockApps-Mercata-Asset"
Note 2: Things might be broken (almost definitely broken) especially when it comes to `order`ing (aka descending or ascending). This should be customized to the needs of the contracts we're deploying.