### PR TITLE
add make develop, profile, build_common_fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ eks:
 	cd devops/eks/strato && sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' strato-platform-manifest.tpl.yaml > strato-platform-manifest.yaml
 	cd devops/eks/vault && sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' eks-vault-deployment.tpl.yaml > eks-vault-deployment.yaml
 	#TODO: create eks manifest for identity server
-    #cd devops/eks/identity && sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' eks-identity-deployment.tpl.yaml > eks-identity-deployment.yaml
+	#cd devops/eks/identity && sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' eks-identity-deployment.tpl.yaml > eks-identity-deployment.yaml
 
 build_buildbase:
 	@echo building buildbase...
@@ -91,6 +91,15 @@ build_common_profiled: build_buildbase
 		--profile --work-dir .stack-work-profile \
 		--copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin
 
+build_common_fast: build_buildbase
+	@echo building haskell libraries and creating directories
+	mkdir -p ${STRATODIR}
+	mkdir -p ${VAULTDIR}
+	mkdir -p ${IDENTITYDIR}
+	cd strato && stack build \
+		--fast --no-run-tests \
+		--copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin
+
 pretty: build_buildbase
 	@echo formatting STRATO Haskell code...
 	cd strato && \
@@ -106,6 +115,20 @@ hoogle: build_buildbase
 
 strato: build_common
 	@echo Now building core-strato...
+	cp -fr strato/licenses ${STRATODIR}
+	cp strato/doit.sh ${STRATODIR}
+	docker build --target strato --tag ${REPO_URL}strato:${VERSION} --file Dockerfile.multi ${FAKEROOT}
+	docker tag ${REPO_URL}strato:${VERSION} ${REPO_AWS_ECR_URL}strato:${VERSION}
+
+develop: build_common_fast
+	@echo Now building core-strato using --fast...
+	cp -fr strato/licenses ${STRATODIR}
+	cp strato/doit.sh ${STRATODIR}
+	docker build --target strato --tag ${REPO_URL}strato:${VERSION} --file Dockerfile.multi ${FAKEROOT}
+	docker tag ${REPO_URL}strato:${VERSION} ${REPO_AWS_ECR_URL}strato:${VERSION}
+
+profile: build_common_profiled
+	@echo Now building core-strato using --profile...
 	cp -fr strato/licenses ${STRATODIR}
 	cp strato/doit.sh ${STRATODIR}
 	docker build --target strato --tag ${REPO_URL}strato:${VERSION} --file Dockerfile.multi ${FAKEROOT}


### PR DESCRIPTION
Added three commands to the Makefile:

- `develop` + `build_common_fast` to build STRATO core quickly. Good for quick iteration, syncs to testnet just fine.
- `profile` for a profile build. Still requires profiling arguments to be passed in `doit.sh.`

### Normal build:
`make strato  1.28s user 1.52s system 0% cpu 12:59.47 total`

### Using `--fast` and not building test suites:
`make develop  2.35s user 2.50s system 2% cpu 3:34.89 total`
