### PR TITLE
jenkins: put hpc artifacts in zipped folder

### DIFF
--- a/pipelines/Jenkinsfile.nightly
+++ b/pipelines/Jenkinsfile.nightly
@@ -309,9 +309,9 @@ pipeline {
               cd strato-worktree
               ./run_unit_tests.sh --coverage
             '''
-            dir('strato-worktree/strato') {
-              archiveArtifacts artifacts: ".stack-work/**/hpc/**/*.html, .stack-work/**/hpc/index.html", fingerprint: true
-            }
+            dir('strato') {
+              zip dir: 'hpc/', archive: true, zipFile: 'hpc.zip', overwrite: true
+            }   
           }
         }
 

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -51,6 +51,13 @@ stack test $1\
       source-tools \
       strato-lite
 
+if [ $1 = --coverage ]
+then
+      rm -rf hpc
+      mkdir hpc
+      cp -r $(stack path --local-hpc-root) hpc/
+fi
+
 stack bench vm-runner
 
 stack bench solid-vm


### PR DESCRIPTION
To reduce the clutter in artifacts list of Jenkins nightly build