### PR TITLE
keep strato deployment after the sync test runs

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -305,8 +305,6 @@ pipeline {
                     sh 'sudo ./fetchlogs --as-dir'
                     sh 'mv strato_logs/ strato_logs_testsync/'
                     archiveArtifacts artifacts: 'strato_logs_testsync/**', fingerprint: true, allowEmptyArchive: true
-                    sh 'sudo ./strato --wipe'
-                    sh 'sudo ./vault --wipe'
                   }
                 }
               }

--- a/pipelines/Jenkinsfile.library
+++ b/pipelines/Jenkinsfile.library
@@ -1293,7 +1293,7 @@ def runSyncTester() {
   IS_SYNCED=$(jq -r .isSynced <<< ${METADATA})
   while [ "$IS_SYNCED" != true ]; do
       echo "**************************************"
-      echo "$(date '+%Y-%m-%d %H:%M:%S'):"
+      echo "$(date -u '+%Y-%m-%d %H:%M:%S'):"
       if [[ $(sudo docker ps | grep unhealthy) ]]; then
           echo "Failure: one or more docker containers became unhealthy during sync"
           exit 2

--- a/pipelines/Jenkinsfile.library
+++ b/pipelines/Jenkinsfile.library
@@ -1293,6 +1293,7 @@ def runSyncTester() {
   IS_SYNCED=$(jq -r .isSynced <<< ${METADATA})
   while [ "$IS_SYNCED" != true ]; do
       echo "**************************************"
+      echo "$(date '+%Y-%m-%d %H:%M:%S'):"
       if [[ $(sudo docker ps | grep unhealthy) ]]; then
           echo "Failure: one or more docker containers became unhealthy during sync"
           exit 2


### PR DESCRIPTION
Feels like we need to keep the STRATO node that failed the sync running to be able to debug it properly.

Also, because we are no longer afraid that some random version of STRATO will post the TXs and crash the VM on validators (according to Jim), we can afford these nodes running for debugging.