### PR TITLE
Sync fetch fix

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -228,20 +228,11 @@ handleEvents peer = awaitForever $ \case
         headersInDB <- fmap M.keysSet . lift $ lookupMany (Proxy @BlockData) hashes
         let neededHeaders = snd <$> filter (not . flip S.member headersInDB . fst) headerHashes
             (neededHeaders', remainingHeaders) = splitNeededHeaders neededHeaders
-        -- blockOffsets <- lift $ fmap (map blockOffsetHash) $ getBlockOffsetsForHashes $ S.toList allNeeded
-        -- let neededHeaders = filter (not . (`elem` blockOffsets) . headerHash) headers
-        --     neededHashes = map headerHash neededHeaders
-        --     neededParents = filter (not . (`elem` blockOffsets)) $ map parentHash neededHeaders
-        --     unfoundParents = S.toList $ S.fromList neededParents S.\\ S.fromList neededHashes
-        -- unless (null unfoundParents) $ do
-        --     $logInfoN "handleEvents/BlockHeaders" $ T.pack $ "neededHashes: " ++ unlines (map format neededHashes)
-        --     $logInfoN "handleEvents/BlockHeaders" $ T.pack $ "incoming blocks don't seem to have existing parents: " ++ unlines (map format unfoundParents)
-        --     $logInfoN "handleEvents/BlockHeaders" $ T.pack $ "### calling syncFetch again" >> syncFetch
-
         lift $ putBlockHeaders neededHeaders'
         lift $ putRemainingBHeaders remainingHeaders
         $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "putBlockHeaders called with length " ++ show (length neededHeaders')
-        yieldR . GetBlockBodies $ blockHeaderHash <$> neededHeaders'
+        unless (null neededHeaders') $ do 
+          yieldR . GetBlockBodies $ blockHeaderHash <$> neededHeaders'
         lift stampActionTimestamp
       else
         $logInfoS "handleEvents/BlockHeaders" $

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -218,12 +218,10 @@ handleEvents peer = awaitForever $ \case
           bestBlock <- lift $ Mod.get (Proxy @BestBlock)
           let fetchNumber = numberFromBestBlock bestBlock + 1
           $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "blockHeaders :: fetchNumber is " ++ show fetchNumber
-          let lastParent =
-                if M.null existingParents
-                  then fetchNumber
-                  else head . sort $ blockHeaderBlockNumber <$> M.elems existingParents
           $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "missing blocks: " ++ (unlines $ format <$> S.toList missingParents)
-          syncFetch Reverse lastParent
+          if M.null existingParents
+            then syncFetch Forward fetchNumber
+            else syncFetch Reverse (minimum $ blockHeaderBlockNumber <$> M.elems existingParents)
 
         let headerHashes = map (blockHeaderHash &&& id) headers
             hashes = map fst headerHashes


### PR DESCRIPTION
Recently, the nightly build experienced a sync stall. Although it was able to recover and continue, this took approximately 7-8 minutes. The culprit was this snippet of code in handling the receipt of a `BlockHeaders` message
```
let lastParent =
      if M.null existingParents
        then fetchNumber
        else head . sort $ blockHeaderBlockNumber <$> M.elems existingParents
$logInfoS "handleEvents/BlockHeaders" $ T.pack $ "missing blocks: " ++ (unlines $ format <$> S.toList missingParents)
syncFetch Reverse lastParent
```
Consider the case where `lastParent` is the `fetchNumber` (next block for the vm to process). However, if we `syncFetch Reverse fetchNumber`, then we will ask for blocks _before_ `fetchNumber` (which by virtue of having been processed by the VM imply we already have them). Such a call to `syncFetch` does nothing to help further along sync and was contributing to why the nightly build could not move forward in sync for so long. 

In addition to remedying this, I also cleaned up a few places where we were making unnecessary network calls