### PR TITLE
prevent node from getting stuck during sync

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -216,7 +216,9 @@ handleMsgClientConduit myId peer = do
       when (S.difference rcs rootCerts' /= S.empty) $ throwIO RootCertificateMismatch
       -- we set to 0 cause we dont necessarily know the number yet
       lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
-      (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
+      (BestBlockNumber num) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
+      (BestBlock _ num' _ ) <- lift $ Mod.get (Mod.Proxy @BestBlock)
+      let lastBlockNumber = max num num' -- BestBlockNumber not guaranteed to be > BestBlock (nor vice versa)
       mrh <- lift $ unMaxReturnedHeaders <$> Mod.access (Mod.Proxy @MaxReturnedHeaders)
       yield . Right $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) 0)) mrh 0 Forward
       yield . Right $ GetChainDetails []
@@ -228,7 +230,9 @@ handleMsgClientConduit myId peer = do
       when (networkID' /= computeNetworkID) $ throwIO $ NetworkIDMismatch
       -- we set to 0 cause we dont necessarily know the number yet
       lift . Mod.put (Mod.Proxy @WorldBestBlock) . WorldBestBlock $ BestBlock peerBestHash 0 peerTD
-      (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
+      (BestBlockNumber num) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
+      (BestBlock _ num' _ ) <- lift $ Mod.get (Mod.Proxy @BestBlock)
+      let lastBlockNumber = max num num' -- BestBlockNumber not guaranteed to be > BestBlock (nor vice versa)
       mrh <- lift $ unMaxReturnedHeaders <$> Mod.access (Mod.Proxy @MaxReturnedHeaders)
       yield . Right $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) 0)) mrh 0 Forward
       yield . Right $ GetChainDetails []
@@ -278,7 +282,9 @@ handleMsgServerConduit myPubkey peer = do
                 genesisHash = genHash,
                 rootCerts = rootCerts'
               }
-        (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
+        (BestBlockNumber num) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
+        (BestBlock _ num' _ ) <- lift $ Mod.get (Mod.Proxy @BestBlock)
+        let lastBlockNumber = max num num' -- BestBlockNumber not guaranteed to be > BestBlock (nor vice versa)
         mrh <- lift $ unMaxReturnedHeaders <$> Mod.access (Mod.Proxy @MaxReturnedHeaders)
         yield . Right $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) 0)) mrh 0 Forward
         yield . Right $ GetChainDetails []
@@ -302,7 +308,9 @@ handleMsgServerConduit myPubkey peer = do
                       genesisHash = genHash
                     }
           )
-      (BestBlockNumber lastBlockNumber) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
+      (BestBlockNumber num) <- lift $ Mod.access (Mod.Proxy @BestBlockNumber)
+      (BestBlock _ num' _ ) <- lift $ Mod.get (Mod.Proxy @BestBlock)
+      let lastBlockNumber = max num num' -- BestBlockNumber not guaranteed to be > BestBlock (nor vice versa)
       mrh <- lift $ unMaxReturnedHeaders <$> Mod.access (Mod.Proxy @MaxReturnedHeaders)
       yield . Right $ GetBlockHeaders (BlockNumber (max (lastBlockNumber - flags_syncBacktrackNumber) 0)) mrh 0 Forward
       yield . Right $ GetChainDetails []

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -206,23 +206,23 @@ handleEvents peer = awaitForever $ \case
   MsgEvt (BlockHeaders bHeaders) -> do
     let headers = morphBlockHeader <$> bHeaders
     lift stampActionTimestamp
-    alreadyRequestedHeaders <- lift getBlockHeaders -- get already requested headers
+    -- check if blockheaders we recieved have parents.
+    let parents = map blockDataParentHash headers
+    existingParents <- lift $ lookupMany (Proxy @BlockData) parents
+    let missingParents = S.fromList parents S.\\ M.keysSet existingParents
+    unless (S.null missingParents) $ do
+      bestBlock <- lift $ Mod.get (Proxy @BestBlock)
+      let fetchNumber = numberFromBestBlock bestBlock + 1
+      $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "blockHeaders :: fetchNumber is " ++ show fetchNumber
+      $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "missing blocks: " ++ (unlines $ format <$> S.toList missingParents)
+      if M.null existingParents
+        then syncFetch Forward fetchNumber
+        else syncFetch Reverse (minimum $ blockHeaderBlockNumber <$> M.elems existingParents)
+    
+    alreadyRequestedHeaders <- lift getBlockHeaders -- check what already requested
     if null alreadyRequestedHeaders
       then do
-        -- proceed if we are not already requesting headers
-        -- check if blockheaders we recieved have parents.
-        let parents = map blockDataParentHash headers
-        existingParents <- lift $ lookupMany (Proxy @BlockData) parents
-        let missingParents = S.fromList parents S.\\ M.keysSet existingParents
-        unless (S.null missingParents) $ do
-          bestBlock <- lift $ Mod.get (Proxy @BestBlock)
-          let fetchNumber = numberFromBestBlock bestBlock + 1
-          $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "blockHeaders :: fetchNumber is " ++ show fetchNumber
-          $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "missing blocks: " ++ (unlines $ format <$> S.toList missingParents)
-          if M.null existingParents
-            then syncFetch Forward fetchNumber
-            else syncFetch Reverse (minimum $ blockHeaderBlockNumber <$> M.elems existingParents)
-
+        -- proceed if we are not already requesting bodies
         let headerHashes = map (blockHeaderHash &&& id) headers
             hashes = map fst headerHashes
         headersInDB <- fmap M.keysSet . lift $ lookupMany (Proxy @BlockData) hashes
@@ -303,7 +303,10 @@ handleEvents peer = awaitForever $ \case
 
   -- todo: support the "best effort" behavior that everyone uses for bodies they dont have (mentioned above
   -- todo:
-  MsgEvt (BlockBodies []) -> return () --clearActionTimestamp
+  MsgEvt (BlockBodies []) -> do 
+    lift stampActionTimestamp
+    lift $ putBlockHeaders [] -- clear cache for other threads
+    lift $ putRemainingBHeaders []
   MsgEvt (BlockBodies bodies) -> do
     lift stampActionTimestamp
     headers <- lift getBlockHeaders


### PR DESCRIPTION
This PR aims to prevent nodes from getting stuck during sync by fixing the following issues

- there is a discrepancy between `BestBlock` and `BestBlockNumber` that prevents any guarantee of ordering between them (i.e. we cannot assume `BestBlockNumber` will be at or ahead of `BestBlock`, nor vice versa. However, we were making the former assumption). One case that was coming up was `BestBlockNumber` would be less than `BestBlock`, and since we would always use `BestBlockNumber`, the node would request blocks it had already processed in the vm (a useless endeavor that prevented any forward progress in sync). To remedy this, we now look at both values and use whichever is greater.
- explicitly clearing the cache when we get an empty `BlockBodies` message, allowing other threads to continue sync instead of having to wait for the cache to get stale