### PR TITLE
fix returnUrl fired in UI, TODO: check backend logs for cookie issue

### DIFF
--- a/marketplace/backend/api/v1/authentication/authentication.controller.js
+++ b/marketplace/backend/api/v1/authentication/authentication.controller.js
@@ -133,15 +133,20 @@ class AuthenticationController {
       return next(e)
     }
 
+    // This might be coming up undefined in Carbon Node. Logging to check in backend logs.
     returnUrl = req.cookies.returnUrl
+    console.log("returnUrl======>", returnUrl);
+    console.log("req.cookies======>", req.cookies);
+    console.log("full req======>", req)
 
-    if (returnUrl) {
-      res.redirect(returnUrl)
-    }
-    else {
-      res.redirect('/')
-    }
+    // if (returnUrl) {
+    //   res.redirect(returnUrl)
+    // }
+    // else {
+    //   res.redirect('/')
+    // }
 
+    res.redirect("/")
     return true
   }
 

--- a/marketplace/backend/api/v1/authentication/authentication.controller.js
+++ b/marketplace/backend/api/v1/authentication/authentication.controller.js
@@ -135,9 +135,6 @@ class AuthenticationController {
 
     // This might be coming up undefined in Carbon Node. Logging to check in backend logs.
     returnUrl = req.cookies.returnUrl
-    console.log("returnUrl======>", returnUrl);
-    console.log("req.cookies======>", req.cookies);
-    console.log("full req======>", req)
 
     // if (returnUrl) {
     //   res.redirect(returnUrl)

--- a/marketplace/ui/src/App.js
+++ b/marketplace/ui/src/App.js
@@ -26,6 +26,7 @@ const App = () => {
   
     // Using this to delete our returnUrl cookie after login
     if (getCookie('returnUrl') && isAuthenticated) {
+      window.location.href = getCookie('returnUrl');
       delete_cookie('returnUrl');
     }
   


### PR DESCRIPTION
See console logs added to check reason we aren't getting the returnUrl in the authentication controller. 
- This fix allows you to return where you left off, but returnUrl is fired in the front end in App.js. 
- TODO: investigate backend logs to see why const returnUrl isn't being seen. 


Redirecting from the backend is faster than in the UI.
- Redirecting from UI first loads "/" (called in authentication controller) then returnUrl is picked up and loaded (called in App.js). Difference is by a couple seconds, but noticeably faster when compared side by side. 