### PR TITLE
Sync cache optimization

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -41,6 +41,7 @@ so that they could be properly moved to their respective version's subsection.
 ### Changed
 - `/compile` and `/transaction` endpoints use SolidVM compiler
 - POST `/transaction` calls redirected to the corresponding User contract
+- optimized logic flow in p2p to prevent sync stalls
 ### Fixed
 - Error handle duplicate key violations in `code_ref` table
 - Bagger no longer crashes the VM upon encountering a transaction that exceeds the nonce or size limit

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -220,24 +220,28 @@ handleEvents peer = awaitForever $ \case
         else syncFetch Reverse (minimum $ blockHeaderBlockNumber <$> M.elems existingParents)
     
     alreadyRequestedHeaders <- lift getBlockHeaders -- check what already requested
-    if null alreadyRequestedHeaders
-      then do
+    alreadyRequestedRemainingHeaders <- lift getRemainingBHeaders
+    let headerHashes = map (blockHeaderHash &&& id) headers
+        hashes = map fst headerHashes
+    headersInDB <- fmap M.keysSet . lift $ lookupMany (Proxy @BlockData) hashes
+    let neededHeaders = snd <$> filter (not . flip S.member headersInDB . fst) headerHashes
+        (neededHeaders', remainingHeaders) = splitNeededHeaders neededHeaders
+    case (alreadyRequestedHeaders, alreadyRequestedRemainingHeaders) of
+      ([], _) -> do
         -- proceed if we are not already requesting bodies
-        let headerHashes = map (blockHeaderHash &&& id) headers
-            hashes = map fst headerHashes
-        headersInDB <- fmap M.keysSet . lift $ lookupMany (Proxy @BlockData) hashes
-        let neededHeaders = snd <$> filter (not . flip S.member headersInDB . fst) headerHashes
-            (neededHeaders', remainingHeaders) = splitNeededHeaders neededHeaders
         lift $ putBlockHeaders neededHeaders'
         lift $ putRemainingBHeaders remainingHeaders
         $logInfoS "handleEvents/BlockHeaders" $ T.pack $ "putBlockHeaders called with length " ++ show (length neededHeaders')
         unless (null neededHeaders') $ do 
           yieldR . GetBlockBodies $ blockHeaderHash <$> neededHeaders'
         lift stampActionTimestamp
-      else
-        $logInfoS "handleEvents/BlockHeaders" $
+      (_, []) -> do
+        lift $ putRemainingBHeaders neededHeaders -- save it to handle later
+        $logInfoS "handleEvents/BlockHeaders" $ 
+          "Not requesting BlockBodies because cache is currently in use, but will request after next batch of BlockBodies arrives."
+      (_, _) -> $logInfoS "handleEvents/BlockHeaders" $
           T.unlines
-            [ "Tried to request more block headers but it seems the block headers cache is currenlty being used.",
+            [ "Tried to request more block bodies but it seems the block headers cache is currenlty being used.",
               "If this message shows up a lot but the node's best block # doesn't increase,",
               "there might be something wrong with the cache."
             ]

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -568,29 +568,18 @@ handleGetChainDetails peer cids' = do
 numberFromBestBlock :: BestBlock -> Integer
 numberFromBestBlock (BestBlock _ n _) = n
 
--- todo: we should take blockNumber as argument here instead of just looking for
--- bestBlock to prevent us from getting stuck
 syncFetch ::
   ( MonadIO m,
-    MonadLogger m,
     Modifiable ActionTimestamp m,
-    Accessible [BlockData] m,
     Accessible MaxReturnedHeaders m
   ) =>
   Direction ->
   Integer ->
   ConduitM Event (Either P2PCNC Message) m ()
 syncFetch d num = do
-    blockHeaders' <- lift getBlockHeaders -- get blockHeaders from Context
-    if null blockHeaders' then do
-        mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
-        yieldR $ GetBlockHeaders (BlockNumber num) mrh 0 d
-        lift stampActionTimestamp
-      else $logInfoS "syncFetch" $ T.unlines [
-        "Tried to request more block headers but it seems the block headers cache is currently being used.",
-        "If this message shows up a lot but the node's best block # doesn't increase,",
-        "there might be something wrong with the cache."
-      ]
+  mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
+  yieldR $ GetBlockHeaders (BlockNumber num) mrh 0 d
+  lift stampActionTimestamp
 
 shouldSend :: PPeer -> Origin.TXOrigin -> Bool
 shouldSend peer txo = case txo of


### PR DESCRIPTION
This PR seeks to optimize the way we utilize the block header caches in p2p during sync. There are two block caches shared among threads in p2p: the "blockHeaders" and the "remainingBlockHeaders," and they keep track of the headers of blocks whose bodies we requested. We heavily underutilize the "remainingBlockHeaders" (it's only used when requesting a large number of blocks and we need to break up the request into smaller chunks) when it could be a greater asset during sync. This PR allows us to utilize the "remainingBlockHeaders" cache to note the next batch of block bodies to request. This will help keep sync constantly progressing because what can happen is that due to the timing of requests and responses, we may get some headers but be unable to request bodies because the cache is in use. Rather than just abandoning those headers and hoping we will request them again at a later point, we can store them in the "remainingBlockHeaders" cache so that the node will automatically move on to them once it's done processing the block bodies associated with "blockHeaders".