### PR TITLE
use 1 rlp encoding library

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -51,5 +51,6 @@ so that they could be properly moved to their respective version's subsection.
 - Account not found in call stack errors for returning arrays to another contract
 ### Removed
 - `bloc22` database removed
+- dependency on relapse library for rlp encoding
 
 ## [10.0.0] - TBD

--- a/strato/api/bloc/bloc2/package.yaml
+++ b/strato/api/bloc/bloc2/package.yaml
@@ -39,6 +39,7 @@ library:
     - directory
     - deepseq
     - esqueleto
+    - ethereum-rlp
     - extra
     - filepath
     - format
@@ -55,7 +56,6 @@ library:
     - process
     - product-profunctors
     - profunctors
-    - relapse
     - resource-pool
     - saltine
     - secp256k1-haskell

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -49,6 +49,7 @@ import Blockchain.Data.AlternateTransaction
 import Blockchain.Data.CirrusDefs
 import Blockchain.Data.DataDefs
 import Blockchain.Data.Json hiding (Contract)
+import Blockchain.Data.RLP (rlpSerialize, rlpEncode)
 import Blockchain.Data.TXOrigin
 import Blockchain.Data.Transaction (rawTX2TX, transactionHash)
 import Blockchain.Strato.Model.Account
@@ -90,7 +91,6 @@ import qualified Data.Map as M
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe
-import Data.RLP
 import Data.Semigroup (Max (..))
 import Data.Set (isSubsetOf)
 import qualified Data.Set as S
@@ -1140,7 +1140,7 @@ preparePostTx time from tx =
       kecc
       API
   where
-    kecc = hash (rlpSerialize tx)
+    kecc = hash . rlpSerialize $ rlpEncode tx
     r = transactionR tx
     s = transactionS tx
     v = transactionV tx

--- a/strato/core/blockapps-data/package.yaml
+++ b/strato/core/blockapps-data/package.yaml
@@ -49,7 +49,6 @@ library:
   - persistent-postgresql
   - quickcheck-instances
   - regex-compat
-  - relapse
   - resourcet
   - secp256k1-haskell # remove
   - servant-docs

--- a/strato/core/blockapps-data/src/Blockchain/Data/AlternateTransaction.hs
+++ b/strato/core/blockapps-data/src/Blockchain/Data/AlternateTransaction.hs
@@ -22,10 +22,10 @@ module Blockchain.Data.AlternateTransaction
   )
 where
 
+import Blockchain.Data.RLP
 import Blockchain.Strato.Model.Address
 import Blockchain.Strato.Model.ChainId
 import Blockchain.Strato.Model.Code
-import Blockchain.Strato.Model.CodePtr
 import Blockchain.Strato.Model.ExtendedWord
 import Blockchain.Strato.Model.Gas
 import Blockchain.Strato.Model.Keccak256 hiding (rlpHash)
@@ -34,45 +34,14 @@ import Blockchain.Strato.Model.Wei
 import Control.DeepSeq (NFData)
 import qualified Data.Aeson as A
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as Char8
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
 import Data.Maybe
-import Data.RLP
-import qualified Data.RLP as RLP (RLPObject (..))
 import Data.Text (Text)
-import qualified Data.Text as Text
 import Data.Word
 import GHC.Generics
 import Generic.Random
 import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Instances ()
-
-instance RLPEncodable CodePtr where
-  rlpEncode (EVMCode codeHash) = rlpEncode codeHash
-  rlpEncode (SolidVMCode n ch) =
-    RLP.Array
-      [ RLP.String $ Char8.pack "SolidVM",
-        rlpEncode n,
-        rlpEncode ch
-      ]
-  rlpEncode (CodeAtAccount a n) =
-    RLP.Array
-      [ RLP.String $ Char8.pack "AtAccount",
-        rlpEncode a,
-        rlpEncode n
-      ]
-
-  rlpDecode (RLP.Array [RLP.String "SolidVM", n, ch]) = SolidVMCode <$> rlpDecode n <*> rlpDecode ch
-  rlpDecode (RLP.Array [RLP.String "AtAccount", a, n]) = CodeAtAccount <$> rlpDecode a <*> rlpDecode n
-  rlpDecode ch = EVMCode <$> rlpDecode ch
-
-instance RLPEncodable Code where
-  rlpEncode (Code cb) = rlpEncode cb
-  rlpEncode (PtrToCode cp) = RLP.Array [rlpEncode cp]
-
-  rlpDecode (RLP.Array [x]) = PtrToCode <$> rlpDecode x
-  rlpDecode x = Code <$> rlpDecode x
 
 --------------------------------------------------------------------------------
 
@@ -91,17 +60,9 @@ data Transaction = Transaction
   }
   deriving (Eq, Show, Generic, NFData)
 
-instance RLPEncodable Text where
-  rlpEncode = rlpEncode . Text.unpack
-  rlpDecode = fmap Text.pack . rlpDecode
-
-instance (Ord k, RLPEncodable k, RLPEncodable v) => RLPEncodable (Map k v) where
-  rlpEncode = rlpEncode . M.toList
-  rlpDecode = fmap M.fromList <$> rlpDecode
-
-instance RLPEncodable Transaction where
+instance RLPSerializable Transaction where
   rlpEncode Transaction {..} =
-    Array $
+    RLPArray $
       [ rlpEncode transactionNonce,
         rlpEncode transactionGasPrice,
         rlpEncode transactionGasLimit,
@@ -120,26 +81,26 @@ instance RLPEncodable Transaction where
                Nothing -> []
                Just md -> [rlpEncode md]
            )
-  rlpDecode (Array (n : gp : gl : to' : va : iod : v' : r' : s' : rest)) =
+  rlpDecode (RLPArray (n : gp : gl : to' : va : iod : v' : r' : s' : rest)) =
     let (cid, md) = case rest of
-          [] -> (Right Nothing, Right Nothing)
+          [] -> (Nothing, Nothing)
           [c] -> case c of
-            a@(Array _) -> (Right Nothing, Just <$> rlpDecode a)
-            cid' -> (Just <$> rlpDecode cid', Right Nothing)
-          (c : m : _) -> (Just <$> rlpDecode c, Just <$> rlpDecode m)
+            a@(RLPArray _) -> (Nothing, Just $ rlpDecode a)
+            cid' -> (Just $ rlpDecode cid', Nothing)
+          (c : m : _) -> (Just $ rlpDecode c, Just $ rlpDecode m)
      in Transaction
-          <$> rlpDecode n
-          <*> rlpDecode gp
-          <*> rlpDecode gl
-          <*> rlpDecode to'
-          <*> rlpDecode va
-          <*> rlpDecode iod
-          <*> cid
-          <*> rlpDecode v'
-          <*> rlpDecode r'
-          <*> rlpDecode s'
-          <*> md
-  rlpDecode x = Left $ "rlpDecode Transaction: Got " ++ show x
+          (rlpDecode n)
+          (rlpDecode gp)
+          (rlpDecode gl)
+          (rlpDecode to')
+          (rlpDecode va)
+          (rlpDecode iod)
+          cid
+          (rlpDecode v')
+          (rlpDecode r')
+          (rlpDecode s')
+          md
+  rlpDecode x = error $ "rlpDecode Transaction: Got " ++ show x
 
 data UnsignedTransaction = UnsignedTransaction
   { unsignedTransactionNonce :: Nonce,
@@ -155,35 +116,41 @@ data UnsignedTransaction = UnsignedTransaction
 instance Arbitrary UnsignedTransaction where
   arbitrary = genericArbitrary uniform
 
-instance RLPEncodable UnsignedTransaction where
+instance RLPSerializable UnsignedTransaction where
   rlpEncode UnsignedTransaction {..} =
-    Array $
+    RLPArray $
       [ rlpEncode unsignedTransactionNonce,
         rlpEncode unsignedTransactionGasPrice,
         rlpEncode unsignedTransactionGasLimit,
-        rlpEncode unsignedTransactionTo,
+        (case unsignedTransactionTo of
+          Nothing -> rlpEncode (0 :: Integer) -- arbitrary, but required for backwards compatibility
+          Just a -> rlpEncode a
+        ),
         rlpEncode unsignedTransactionValue,
         rlpEncode unsignedTransactionInitOrData
       ]
         ++ (maybeToList $ fmap rlpEncode unsignedTransactionChainId)
-  rlpDecode (Array (n : gp : gl : to' : va : iod : rest)) =
+  rlpDecode (RLPArray (n : gp : gl : to' : va : iod : rest)) =
     UnsignedTransaction
-      <$> rlpDecode n
-      <*> rlpDecode gp
-      <*> rlpDecode gl
-      <*> rlpDecode to'
-      <*> rlpDecode va
-      <*> rlpDecode iod
-      <*> ( case rest of
-              [] -> pure Nothing
-              [cid] -> Just <$> rlpDecode cid
-              x -> Left $ "rlpDecode UnsignedTransaction: Too many entries, got: " ++ show x
-          )
-  rlpDecode x = Left $ "rlpDecode UnsignedTransaction: Got " ++ show x
+      (rlpDecode n)
+      (rlpDecode gp)
+      (rlpDecode gl)
+      (case to' of 
+        RLPString "" -> Nothing 
+        a -> Just $ rlpDecode a
+      )
+      (rlpDecode va)
+      (rlpDecode iod)
+      (case rest of
+        [] -> Nothing
+        [cid] -> Just $ rlpDecode cid
+        x -> error $ "rlpDecode UnsignedTransaction: Too many entries, got: " ++ show x
+    )
+  rlpDecode x = error $ "rlpDecode UnsignedTransaction: Got " ++ show x
 
-rlpHash :: RLPEncodable x => x -> ByteString
+rlpHash :: RLPSerializable x => x -> ByteString
 rlpHash =
   keccak256ToByteString
     . hash
-    . packRLP
+    . rlpSerialize
     . rlpEncode

--- a/strato/core/strato-model/package.yaml
+++ b/strato/core/strato-model/package.yaml
@@ -58,7 +58,6 @@ library:
     - persistent
     - primitive
     - raw-strings-qq
-    - relapse           # remove this
     - secp256k1-haskell
     - servant
     - servant-docs

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Account.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Account.hs
@@ -39,7 +39,6 @@ import Data.Aeson.Types
 import Data.Binary
 import Data.Data
 import Data.Hashable
-import qualified Data.RLP as RLP2
 import Data.Swagger hiding (Format, format, get, put)
 import qualified Data.Swagger as Sw
 import qualified Data.Text as T
@@ -141,11 +140,6 @@ instance ToCapture (Capture "account" Account) where
 instance ToCapture (Capture "contractAccount" Account) where
   toCapture _ = DocCapture "contractAccount" "a STRATO account"
 
-instance RLP2.RLPEncodable Account where
-  rlpEncode (Account a Nothing) = RLP2.rlpEncode a
-  rlpEncode (Account a (Just cid)) = RLP2.Array [RLP2.rlpEncode a, RLP2.rlpEncode cid]
-  rlpDecode (RLP2.Array [a, cid]) = Account <$> (RLP2.rlpDecode a) <*> (Just <$> RLP2.rlpDecode cid)
-  rlpDecode a = flip Account Nothing <$> RLP2.rlpDecode a
 
 instance ToCapture (Capture "userAccount" Account) where
   toCapture _ = DocCapture "userAccount" "a STRATO account"

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -43,20 +43,17 @@ import Data.Aeson.Types
 import Data.Binary
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy as BL
 import Data.Data
 import Data.Hashable
 import Data.Maybe (fromMaybe)
 import qualified Data.NibbleString as N
-import qualified Data.RLP as RLP2
 import Data.Swagger hiding (Format, format, get, put)
 import qualified Data.Swagger as Sw
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Database.Persist.Sql hiding (get)
 import GHC.Generics
-import qualified LabeledError
 import Numeric
 import Servant.API
 import Servant.Docs
@@ -186,14 +183,6 @@ instance ToCapture (Capture "address" Address) where
 
 instance ToCapture (Capture "contractAddress" Address) where
   toCapture _ = DocCapture "contractAddress" "an Ethereum address"
-
-instance RLP2.RLPEncodable Address where
-  rlpEncode addr = RLP2.rlpEncode . LabeledError.b16Decode "RLPEncodable<Address>" . BC.pack $ formatAddressWithoutColor addr
-  rlpDecode obj = Address . fromInteger <$> RLP2.rlpDecode obj
-
-instance RLP2.RLPEncodable (Maybe Address) where
-  rlpEncode = maybe RLP2.rlp0 RLP2.rlpEncode
-  rlpDecode x = if x == RLP2.rlp0 then return Nothing else Just <$> RLP2.rlpDecode x
 
 instance ToCapture (Capture "userAddress" Address) where
   toCapture _ = DocCapture "userAddress" "an Ethereum address"

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/ChainId.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/ChainId.hs
@@ -12,6 +12,7 @@ module Blockchain.Strato.Model.ChainId
   )
 where
 
+import Blockchain.Data.RLP
 import Blockchain.Strato.Model.ExtendedWord
 import Control.DeepSeq (NFData)
 import Control.Lens.Operators
@@ -21,7 +22,6 @@ import qualified Data.Aeson.Key as DAK
 import qualified Data.Binary as Binary
 import Data.Either.Extra (maybeToEither)
 import Data.Hashable
-import Data.RLP
 import Data.Swagger
 import qualified Data.Text as Text
 import Database.Persist.Sql
@@ -97,9 +97,9 @@ instance ToSample ChainId where
 instance ToCapture (Capture "chainid" ChainId) where
   toCapture _ = DocCapture "chainid" "a private chain Id"
 
-instance RLPEncodable ChainId where
-  rlpEncode (ChainId n) = rlpEncode $ toInteger n
-  rlpDecode obj = ChainId . fromInteger <$> rlpDecode obj
+instance RLPSerializable ChainId where
+  rlpEncode (ChainId n) = rlpEncode n
+  rlpDecode obj = ChainId $ rlpDecode obj
 
 instance ToParam (QueryParam "chainid" ChainId) where
   toParam _ = DocQueryParam "chainid" [] "Blockchain Identifier" Normal

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Gas.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Gas.hs
@@ -5,10 +5,10 @@
 
 module Blockchain.Strato.Model.Gas where
 
+import Blockchain.Data.RLP
 import Control.DeepSeq (NFData)
 import Control.Lens.Operators
 import Data.Aeson hiding (Array, String)
-import Data.RLP
 import Data.Swagger
 import GHC.Generics
 import Test.QuickCheck hiding ((.&.))
@@ -47,6 +47,6 @@ instance ToSchema Gas where
             & description ?~ "Number of Gas units"
         )
 
-instance RLPEncodable Gas where
+instance RLPSerializable Gas where
   rlpEncode (Gas n) = rlpEncode n
-  rlpDecode obj = Gas <$> rlpDecode obj
+  rlpDecode obj = Gas $ rlpDecode obj

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Keccak256.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Keccak256.hs
@@ -34,7 +34,6 @@ import Blockchain.Strato.Model.ExtendedWord
 import Blockchain.Strato.Model.Util
 import Control.DeepSeq
 import Control.Lens.Operators
-import Control.Monad ((<=<))
 import qualified Data.Aeson as Ae
 import qualified Data.Aeson.Encoding as Enc
 import qualified Data.Aeson.Key as DAK
@@ -49,7 +48,6 @@ import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import Data.Data
 import Data.Hashable (Hashable)
-import qualified Data.RLP as RLP2
 import Data.Swagger hiding (Format)
 import qualified Data.Text as T
 import Database.Persist.Sql
@@ -102,11 +100,6 @@ instance RLPSerializable Keccak256 where
       RLPString $
         B.replicate (32 - B.length val) 0
           `B.append` val
-
--- Someday we should remove the second RLP library...
-instance RLP2.RLPEncodable Keccak256 where
-  rlpEncode = RLP2.rlpEncode . keccak256ToByteString
-  rlpDecode = Right . Keccak256 <=< RLP2.rlpDecode
 
 instance Ae.ToJSON Keccak256 where
   toJSON = Ae.String . T.pack . keccak256ToHex

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Nonce.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Nonce.hs
@@ -6,12 +6,12 @@
 
 module Blockchain.Strato.Model.Nonce where
 
+import Blockchain.Data.RLP
 import Blockchain.Strato.Model.ExtendedWord
 import Control.DeepSeq (NFData)
 import Control.Lens.Operators
 import Data.Aeson hiding (Array, String)
 import Data.Proxy
-import Data.RLP
 import Data.Swagger
 import GHC.Generics
 import Test.QuickCheck hiding ((.&.))
@@ -43,9 +43,9 @@ instance ToSchema Nonce where
 
 instance Arbitrary Nonce where arbitrary = Nonce . fromInteger <$> arbitrary
 
-instance RLPEncodable Nonce where
-  rlpEncode (Nonce n) = rlpEncode $ toInteger n
-  rlpDecode obj = Nonce . fromInteger <$> rlpDecode obj
+instance RLPSerializable Nonce where
+  rlpEncode (Nonce n) = rlpEncode n
+  rlpDecode obj = Nonce $ rlpDecode obj
 
 incrNonce :: Nonce -> Nonce
 incrNonce (Nonce n) = Nonce (n + 1)

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Wei.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Wei.hs
@@ -6,12 +6,12 @@
 
 module Blockchain.Strato.Model.Wei where
 
+import Blockchain.Data.RLP
 import Blockchain.Strato.Model.ExtendedWord
 import Control.DeepSeq (NFData)
 import Control.Lens.Operators
 import Data.Aeson hiding (Array, String)
 import Data.Proxy
-import Data.RLP
 import Data.Swagger
 import GHC.Generics
 import Test.QuickCheck hiding ((.&.))
@@ -46,6 +46,6 @@ instance ToJSON Wei where
 instance FromJSON Wei where
   parseJSON = fmap (Wei . fromInteger) . parseJSON
 
-instance RLPEncodable Wei where
-  rlpEncode (Wei n) = rlpEncode $ toInteger n
-  rlpDecode obj = Wei . fromInteger <$> rlpDecode obj
+instance RLPSerializable Wei where
+  rlpEncode (Wei n) = rlpEncode n
+  rlpDecode obj = Wei $ rlpDecode obj

--- a/strato/libs/ethereum-rlp/library/Blockchain/Data/RLP.hs
+++ b/strato/libs/ethereum-rlp/library/Blockchain/Data/RLP.hs
@@ -183,6 +183,11 @@ instance RLPSerializable Integer where
   rlpDecode (RLPArray [x]) = -rlpDecode x
   rlpDecode (RLPArray _) = error "rlpDecode called for Integer for array of wrong size"
 
+instance RLPSerializable Word8 where
+  rlpEncode w = RLPScalar w 
+  rlpDecode (RLPScalar w) = w
+  rlpDecode x = error $ "rlpDecode for Word8 not defined for " ++ show x
+
 instance {-# OVERLAPPING #-} RLPSerializable String where
   rlpEncode = rlpEncode . T.pack
   rlpDecode = T.unpack . rlpDecode


### PR DESCRIPTION
The strato-platform codebase uses 2 different libraries for rlp encoding: relapse and ethereum-rlp. This PR removes all usage of relapse so that we can unify the rlp encoding behavior. In general, this will make it easier to reason about how data is being encoded as it passes between components of strato. In particular, this will make it easier to add network id to the transaction type (since we only have to focus on one encoding library rather than trying to support both).