### PR TITLE
Fixed multi loading in membership details page

### DIFF
--- a/marketplace/ui/src/components/MarketPlace/MembershipDetail.js
+++ b/marketplace/ui/src/components/MarketPlace/MembershipDetail.js
@@ -117,7 +117,7 @@ const MembershipDetails = ({ user, users }) => {
         Id
       );
     }
-  }, [limit, offset, debouncedSearchTerm, serviceDispatch, Id, user]);
+  }, [limit, offset, debouncedSearchTerm, serviceDispatch, user]);
 
   useEffect(() => {
     let services = [];


### PR DESCRIPTION
Before fix:

https://github.com/blockapps/strato-platform/assets/79778488/87f37fb4-5cba-4074-98cc-16c15bc05b8f


After fix:

https://github.com/blockapps/strato-platform/assets/79778488/f139a1e6-d6c9-406a-becd-6f2a7a19995c


As you can see in the Network tab, the fetch for the data was being called twice.