### PR TITLE
don't fail if docker compose fails to wipe

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -283,8 +283,8 @@ pipeline {
                 dir("strato-getting-started"){
                   sh 'sudo cp /datadrive/letsencrypt-ssl/server.pem ssl/certs/'
                   sh 'sudo cp /datadrive/letsencrypt-ssl/server.key ssl/private/'
-                  sh 'sudo ./strato --wipe'
-                  sh 'sudo ./vault --wipe'
+                  sh 'sudo ./strato --wipe || true'
+                  sh 'sudo ./vault --wipe || true'
                   sh 'mv genesis-block-official.json genesis-block.json'
                   sh './run-vault.sh'
                   // run again but connecting to mercata-hydrogen this time

--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -283,8 +283,9 @@ pipeline {
                 dir("strato-getting-started"){
                   sh 'sudo cp /datadrive/letsencrypt-ssl/server.pem ssl/certs/'
                   sh 'sudo cp /datadrive/letsencrypt-ssl/server.key ssl/private/'
-                  sh 'sudo ./strato --wipe || true'
-                  sh 'sudo ./vault --wipe || true'
+                  // Double-wiping to prevent situation when docker compose throws erroneous failure on first attempt (possibly a bug in dc)
+                  sh 'sudo ./strato --wipe || sudo ./strato --wipe'
+                  sh 'sudo ./vault --wipe || sudo ./vault --wipe'
                   sh 'mv genesis-block-official.json genesis-block.json'
                   sh './run-vault.sh'
                   // run again but connecting to mercata-hydrogen this time


### PR DESCRIPTION
re-attempt the wipe if the first one failed with "containeer not found" which is presumably a docker compose bug