### PR TITLE
slipstream: row indexing for grandparent+ inheritance

### DIFF
--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1055,7 +1055,7 @@ insertAbstractTableQuery cs =
     transaction_sender = excluded.transaction_sender,
     contract_name = excluded.contract_name,
     data = excluded.data|],
-                      if null list then "" else ",\n    ",
+                      if null list then "" else "\n    ",
                       tableUpsert $ list',
                       ";"
                     ]

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -383,9 +383,13 @@ getMapNamesFromContract c =
 
 getAbstractParentsFromContract :: Contract -> CodeCollection -> [Contract]
 getAbstractParentsFromContract c cc =
-  let parents' = c ^. parents
-      parentContracts = getContractsForParents parents' (cc ^. contracts)
-   in filter ((== AbstractType) . _contractType) parentContracts
+  -- recursively obtain a grandparent contracts
+  -- ex. B is A, C is B, then C should also be A
+  let go [] = []
+      go xs = xs ++ (go $ getContractsForParents (concatMap (^. parents) xs) ccc)
+      ccc = cc ^. contracts
+      parents' = c ^. parents
+   in filter ((== AbstractType) . _contractType) (go $ getContractsForParents parents' ccc)
 
 processTheMessages ::
   ( MonadLogger m,
@@ -417,10 +421,6 @@ processTheMessages env conn messages = do
       transactionResults = [tr | NewTransactionResult tr <- messages]
       -- Use different functions based on flag value, this way it is only computed once, saving cpu cycles with if statements
       getCC = getCodeCollection
-
-  -- forM :: [a] -> (a -> m b) -> m [b]
-  -- forM :: [a] -> (a -> m (Either b c)) -> m [Either b c]
-  -- m [c]
 
   fkeys' <- forM creates $ \(ccString, cp, o, a, hl, _) -> do
     cc' <- getCC g cp ccString
@@ -537,7 +537,6 @@ processTheMessages env conn messages = do
               $logInfoS "processTheMessages" . T.pack $ "ERROR: Contract not in Code Collection "
               pure . Right $ BatchedInserts indexContract [] hs []
             Just (cc, c) -> do
-              stateDiff <- rowToMappings row
               let mapNames = getMapNamesFromContract c
                   abstracts = getAbstractParentsFromContract c cc
                   appName =
@@ -545,14 +544,17 @@ processTheMessages env conn messages = do
                       then SE.contractName indexContract
                       else SE.application indexContract
               --get columns for abstract table
+              $logDebugLS "abstractColumns" $ T.pack $ "Getting abstract columns from " ++ (show abstracts)
               abstractColumns <- fmap catMaybes . for abstracts $ \ab -> do
                 (o', a', n') <- lift $ resolveNameParts (SE.organization indexContract) appName ab
                 let tableName = AbstractTableName o' a' n'
                     tableNameText = tableNameToDoubleQuoteText tableName
+                $logInfoS "Row will be inserted into abstract table: " tableNameText
                 mCols <- getTableColumns g tableName
                 pure $ (indexContract,tableNameText,) . map extractTextInsideQuotes <$> mCols
               $logDebugLS "Globals: Recorded Map names are: " . T.pack $ show mapNames ++ " contract: " ++ show (contractName indexContract)
               $logDebugLS "History inserts are: " $ show hs
+              stateDiff <- rowToMappings row
               pMappings <- processedContractToProcessedMappingRows stateDiff (mapNames) row abiid --get all mapping rows to insert
               pure . Right $ BatchedInserts indexContract abstractColumns hs pMappings
 

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -383,7 +383,7 @@ getMapNamesFromContract c =
 
 getAbstractParentsFromContract :: Contract -> CodeCollection -> [Contract]
 getAbstractParentsFromContract c cc =
-  -- recursively obtain a grandparent contracts
+  -- recursively obtain parent + grandparent contracts
   -- ex. B is A, C is B, then C should also be A
   let go [] = []
       go xs = xs ++ (go $ getContractsForParents (concatMap (^. parents) xs) ccc)


### PR DESCRIPTION
Fixed the abstract parent search by looking at the grandparents as well - a contract that inherits an abstract contract should also index its rows in the abstract parent contracts