### PR TITLE
list mult inventories

### DIFF
--- a/marketplace/ui/src/components/Inventory/index.js
+++ b/marketplace/ui/src/components/Inventory/index.js
@@ -193,7 +193,7 @@ const Inventory = ({ user }) => {
               <div className="flex items-center">
                 <Button
                   type="primary"
-                  className="w-44 h-9 bg-primary !hover:bg-primaryHover mt-6 mr-3"
+                  className="w-48 bg-primary !hover:bg-primaryHover mr-3"
                   onClick={() => {
                     if (hasChecked && !isAuthenticated && loginUrl !== undefined) {
                       window.location.href = loginUrl;
@@ -205,20 +205,32 @@ const Inventory = ({ user }) => {
                 >
                   {"Connect Stripe"}
                 </Button>
-                <Button
-                  id="add-inventory-button"
-                  type="primary"
-                  className="w-44 h-9 bg-primary !hover:bg-primaryHover mt-6 ml-3"
-                  onClick={() => {
-                    if (hasChecked && !isAuthenticated && loginUrl !== undefined) {
-                      window.location.href = loginUrl;
-                    } else {
-                      showModal()
-                    }
-                  }}
-                >
-                  Add Item
-                </Button>
+                <Tooltip
+                  title={
+                    stripeStatus.chargesEnabled && stripeStatus.detailsSubmitted && stripeStatus.payoutsEnabled
+                      ? ""
+                      : "Please connect to Stripe first"
+                  }
+                  placement="bottom"
+                  >
+                  <div>
+                    <Button
+                      id="add-inventory-button"
+                      type="primary"
+                      className="w-48 bg-primary !hover:bg-primaryHover"
+                      onClick={() => {
+                        if (hasChecked && !isAuthenticated && loginUrl !== undefined) {
+                          window.location.href = loginUrl;
+                        } else {
+                          showModal()
+                        }
+                      }}
+                      disabled={!stripeStatus.chargesEnabled || !stripeStatus.detailsSubmitted || !stripeStatus.payoutsEnabled}
+                    >
+                      Add Item
+                    </Button>
+                  </div>
+                </Tooltip>
               </div>
             </div>
           ) : (
@@ -262,7 +274,22 @@ const Inventory = ({ user }) => {
                         : "Please connect to Stripe first"
                     }
                     placement="bottom"
-                  />
+                  >
+                    <div>
+                      <Button id="add-inventory-button" type="primary" className="w-48"
+                        onClick={() => {
+                          if (hasChecked && !isAuthenticated && loginUrl !== undefined) {
+                            window.location.href = loginUrl;
+                          } else {
+                            showModal()
+                          }
+                        }}
+                        disabled={!stripeStatus.chargesEnabled || !stripeStatus.detailsSubmitted || !stripeStatus.payoutsEnabled}
+                      >
+                        Add Item
+                      </Button>
+                    </div>
+                  </Tooltip>
                 </div>
               </div>
               <>


### PR DESCRIPTION
Addresses blocker on testing the new marketplace where you could only list 1 item before the "add item" button disappeared. Also adjusts styling so the buttons are not weirdly misaligned with the search bar. 
EDIT: also forces users to onboard on stripe first before adding items

Before (note no "add item" button):
![inventory-page-before](https://github.com/blockapps/strato-platform/assets/31707474/68782092-b626-4f34-bebd-d9e9118df6da)

After, when user has at least 1 item in inventory:
![inventory-page-after-has-items](https://github.com/blockapps/strato-platform/assets/31707474/35cd7d0d-78b6-4e18-89c5-69dfc03621d5)


After, when user has no inventory (not yet onboarded to stripe):
![inventory-page-after-no-items](https://github.com/blockapps/strato-platform/assets/31707474/eb7de1be-b8a4-4a95-882d-e42bb45e4ada)

After, when user has no inventory (onboarded to stripe):
![inventory-page-after-stripe-onboarding](https://github.com/blockapps/strato-platform/assets/31707474/4aa2a034-4183-4756-aa70-c42abb0e8887)


