### PR TITLE
fixes and a cleanup of highway's docker-compose template

### DIFF
--- a/docker-compose.highway.tpl.yml
+++ b/docker-compose.highway.tpl.yml
@@ -1,9 +1,6 @@
 #highway-version:<VERSION>
-#strato-getting-started-min-version:4.0
-version: "1"
-volumes:
-  idpconfig:
-      driver: local
+#strato-getting-started-min-version:4.2.1
+version: "3"
 services:
   highway-wrapper:
     environment:


### PR DESCRIPTION
3 fixes in 6 lines:
1. strato-getting-started minimum version required is 4.2.1
2. version of template must be 3 (this is for docker-compose to know what version this template is)
3. volumes part is redundant (unused leftover from the identity's dc.yml)