### PR TITLE
Order Flow Fix

### DIFF
--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -607,21 +607,8 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
       }
       let stripePaymentSession;
       try {
-        const { orderList, ...rest } = args;
 
-        // Convert orderList into an object with keys like 'orderList_0', 'orderList_1', ...
-        const orderListObject = orderList.reduce((acc, item, index) => {
-          acc[`orderList_${index}`] = JSON.stringify(item);
-          return acc;
-        }, {});
-
-        // Merge the orderListObject with the rest of the properties
-        const cartData = { ...rest, ...orderListObject };
-        Object.keys(cartData).forEach(key => {
-          cartData[key] = String(cartData[key]);
-        });
-
-        stripePaymentSession = await StripeService.initiatePayment(cartData, invoices, sellerStripeDetails.accountId);
+        stripePaymentSession = await StripeService.initiatePayment(args, invoices, sellerStripeDetails.accountId);
       } catch (err) {
         throw new rest.RestError(err.statusCode, err.message)
       }

--- a/marketplace/backend/payment-service/stripe.service.js
+++ b/marketplace/backend/payment-service/stripe.service.js
@@ -27,7 +27,7 @@ class StripeService {
                     }
                 }),
                 metadata: {
-                    ...cartData
+                    cart: JSON.stringify(cartData)
                 },
                 payment_intent_data: {
                     /* 3% of OrderTotal in Cents */

--- a/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
+++ b/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
@@ -62,24 +62,6 @@ const ProcessingOrder = () => {
 
   }, [sessionId])
 
-  const restructureData = (cartData) =>{
-    // Convert the orderList items to an array of objects
-    const orderList = Object.keys(cartData)
-    .filter(key => key.startsWith('orderList'))
-    .map(key => JSON.parse(cartData[key]));
-    
-    //Prepare Cart Details
-    const cart = {
-      buyerOrganization: cartData.buyerOrganization,
-      orderList: orderList,
-      orderTotal: parseInt(cartData.orderTotal),
-      shippingAddress: cartData.shippingAddress,
-      tax: parseInt(cartData.tax),
-      user: cartData.user,
-      email: cartData.email
-    };
-    return cart;
-  }
 
   const getCartData = async () => {
     try {
@@ -192,7 +174,7 @@ const ProcessingOrder = () => {
       htmlContents: htmlContents,
     }
 
-    let isDone = await orderActions.createSale(orderDispatch, body);
+    let isDone = await orderActions.createSaleOrder(orderDispatch, body);
     if (isDone) {
       let updatedCart = [];
       storedData.forEach(cart => {

--- a/marketplace/ui/src/contexts/order/actions.js
+++ b/marketplace/ui/src/contexts/order/actions.js
@@ -31,9 +31,9 @@ const actionDescriptors = {
   updateSellerDetailsFailed: "update_seller_details_failed",
   resetMessage: "reset_message",
   setMessage: "set_message",
-  createSale: "create_sale",
-  createSaleSuccessful: "create_sale_successful",
-  createSaleFailed: "create_sale_failed",
+  createSaleOrder: "create_sale",
+  createSaleOrderSuccessful: "create_sale_successful",
+  createSaleOrderFailed: "create_sale_failed",
   cancelSale: "cancel_sale",
   cancelSaleSuccessful: "cancel_sale_successful",
   cancelSaleFailed: "cancel_sale_failed",
@@ -471,8 +471,8 @@ const actions = {
     }
   },
 
-  createSale: async (dispatch, payload) => {
-    dispatch ({ type: actionDescriptors.createSale });
+  createSaleOrder: async (dispatch, payload) => {
+    dispatch ({ type: actionDescriptors.createSaleOrder });
     
     try {
       const response = await fetch(`${apiUrl}/order/sale`, {
@@ -489,7 +489,7 @@ const actions = {
 
       if (response.status === RestStatus.OK) {
         dispatch({
-          type: actionDescriptors.createSaleSuccessful,
+          type: actionDescriptors.createSaleOrderSuccessful,
           payload: body.data,
         });
         actions.setMessage(dispatch, "Sale created successfully", true);
@@ -497,14 +497,14 @@ const actions = {
       }
 
       dispatch({
-        type: actionDescriptors.createSaleFailed,
+        type: actionDescriptors.createSaleOrderFailed,
         error: "Error while executing sale",
       });
       actions.setMessage(dispatch, "Error while creating sale");
       return false;
     } catch (err) {
       dispatch({
-        type: actionDescriptors.createSaleFailed,
+        type: actionDescriptors.createSaleOrderFailed,
         error: "Error while creating Sale",
       });
       actions.setMessage(dispatch, "Error while creating sale");

--- a/marketplace/ui/src/contexts/order/reducer.js
+++ b/marketplace/ui/src/contexts/order/reducer.js
@@ -185,17 +185,17 @@ const reducer = (state, action) => {
         error: action.error,
         isCreateOrderSubmitting: false,
       }
-    case actionDescriptors.createSale:
+    case actionDescriptors.createSaleOrder:
       return {
         ...state,
         isCreateOrderSubmitting: true,
       }
-    case actionDescriptors.createSaleSuccessful:
+    case actionDescriptors.createSaleOrderSuccessful:
       return {
         ...state,
         isCreateOrderSubmitting: false,
       }
-    case actionDescriptors.createSaleFailed:
+    case actionDescriptors.createSaleOrderFailed:
       return {
         ...state,
         error: action.error,


### PR DESCRIPTION
This PR fixes the order flow on the buyer side.
- Action descriptor correction
- Payment Meta Data correction on Stripe

![image](https://github.com/blockapps/strato-platform/assets/35606645/2b8bd7d9-9ed0-4396-875e-795c53250d77)
![Screenshot from 2023-11-30 11-11-56](https://github.com/blockapps/strato-platform/assets/35606645/d00e817a-d6ac-4731-8935-16de4acacbd5)

#### Things to look at:
- Currently the sale contracts created are fetched based on the payment type & asset. So in a scenario that the seller chooses to accept '`X`' payment type for the asset, corresponding sale contract is created.
- Next if the buyer chooses to do the payment (using '`Y`' method), the payment goes through. But at the next step, before Order gets created we are trying to fetch the sale contracts for '`Y`' method. Since sale contracts weren't created for it, we get an empty result set failing to create the payload for order creation.