### PR TITLE
removing unsightly error message about oauth

### DIFF
--- a/marketplace/ui/src/components/Header/Header.js
+++ b/marketplace/ui/src/components/Header/Header.js
@@ -7,8 +7,7 @@ import {
   Space,
   Badge,
   Avatar,
-  Dropdown,
-  Typography,
+  Dropdown
 } from "antd";
 import { SearchOutlined, ShoppingCartOutlined } from "@ant-design/icons";
 import { Images } from "../../images";
@@ -24,7 +23,6 @@ import { actions as userActions } from "../../contexts/authentication/actions";
 import { useAuthenticateDispatch } from "../../contexts/authentication";
 import TagManager from "react-gtm-module";
 
-const { Title } = Typography;
 const { Header } = Layout;
 
 const HeaderComponent = ({ isOauth, user, loginUrl }) => {
@@ -251,7 +249,7 @@ const HeaderComponent = ({ isOauth, user, loginUrl }) => {
                 })
               }} >
               Login / Register
-            </a> : (isOauth ? <Title style={{ backgroundColor: 'red', border: 3, padding: 10, color: '#FFFFFF' }} level={3} >Something went wrong, try to refresh page</Title> : null)
+            </a> : null
           ) :
             <Dropdown menu={{ items }} placement="bottomLeft" trigger={["click"]} overlayStyle={{ marginTop: "40px" }}>
               <a onClick={(e) => e.preventDefault()} className="text-base text-white" id="user-dropdown">


### PR DESCRIPTION
This PR removes the bright red error message that appears when a user is not yet authenticated. This was added in a long time ago back when we first introduced the identity server and wanted a way to signify if the registration process had failed. However, now this error message is triggering too early and causing a brief red flash every time the page is reloaded before it realizes the registration was actually successful. Since the identity server is now stable and we don't rely on the polling method anymore, this error message is obsolete and can be removed.


Note no red glitching on the header bar anymore:

[no_red_glitch.webm](https://github.com/blockapps/strato-platform/assets/31707474/354fbbd1-fc8d-4999-9de8-ff01fb81df91)
