### PR TITLE
Removed unnecessary text from inventories page

### DIFF
--- a/marketplace/ui/src/components/Inventory/index.js
+++ b/marketplace/ui/src/components/Inventory/index.js
@@ -189,7 +189,6 @@ const Inventory = ({ user }) => {
               <Title level={3} className="mt-2">
                 No inventory found
               </Title>
-              <Text className="text-sm">Start adding your inventory</Text>
               <div className="flex items-center">
                 <Button
                   type="primary"


### PR DESCRIPTION
Removed text from empty inventories page.

<img width="1412" alt="Screenshot 2023-12-01 at 4 54 52 PM" src="https://github.com/blockapps/strato-platform/assets/79778488/82f122ea-3270-447f-9d85-4e2af41c8124">
