### PR TITLE
[Strato-P2P] Memory Leak Fix

### DIFF
--- a/strato/core/strato-conf/src/Blockchain/EthConf.hs
+++ b/strato/core/strato-conf/src/Blockchain/EthConf.hs
@@ -9,7 +9,8 @@ where
 
 import Blockchain.EthConf.Model
 import Control.Monad.Except (ExceptT (..))
-import Control.Monad.Trans.State
+import Control.Monad.State.Strict as CMSS
+--import Control.Monad.Trans.State
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
 import Data.String
@@ -37,7 +38,7 @@ connStr = postgreSQLConnectionString . sqlConfig $ ethConf
 cirrusConnStr :: B.ByteString
 cirrusConnStr = postgreSQLConnectionString . cirrusConfig $ ethConf
 
-runKafkaConfigured :: KafkaClientId -> StateT KafkaState (ExceptT KafkaClientError IO) a -> IO (Either KafkaClientError a)
+runKafkaConfigured :: KafkaClientId -> CMSS.StateT KafkaState (ExceptT KafkaClientError IO) a -> IO (Either KafkaClientError a)
 runKafkaConfigured name = runKafka (mkConfiguredKafkaState name)
 
 mkConfiguredKafkaState :: KafkaClientId -> KafkaState

--- a/strato/core/strato-init/package.yaml
+++ b/strato/core/strato-init/package.yaml
@@ -48,6 +48,7 @@ library:
   - milena
   - milena-tools
   - monad-alter
+  - mtl
   - nibblestring
   - persistent-postgresql
   - resourcet

--- a/strato/core/strato-init/src/Blockchain/Init/Generator.hs
+++ b/strato/core/strato-init/src/Blockchain/Init/Generator.hs
@@ -12,7 +12,8 @@ import Control.Lens.Combinators (use)
 import Control.Monad
 import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Except
-import Control.Monad.Trans.State
+import Control.Monad.State.Strict as CMSS
+--import Control.Monad.Trans.State
 import qualified Data.Aeson as Ae
 import qualified Data.ByteString.Char8 as C8
 import Data.FileEmbed
@@ -26,7 +27,7 @@ import System.Exit
 import UnliftIO.Directory
 import UnliftIO.IO
 
-type GenM = StateT KafkaState (ExceptT KafkaClientError IO)
+type GenM = CMSS.StateT KafkaState (ExceptT KafkaClientError IO)
 
 runGenM :: KafkaAddress -> GenM a -> IO a
 runGenM kaddr mv = do
@@ -106,7 +107,7 @@ sendAccountInfo accountInfoFileName = do
             unless (T.null chk) $ do
               addEvent $ GenesisAccounts chk
               sendChunks h
-      s <- get
+      s <- CMSS.get
       liftIO . withFile accountInfoFileName ReadMode $ \h -> do
         hSetBuffering h (BlockBuffering (Just (1024 * 1024)))
         mErr <- runKafka s $ sendChunks h

--- a/strato/libs/kafka/milena/Network/Kafka.hs
+++ b/strato/libs/kafka/milena/Network/Kafka.hs
@@ -11,10 +11,11 @@ import Control.Exception (Exception, IOException)
 import Control.Exception.Lifted (catch)
 import Control.Lens
 import Control.Monad.Except (ExceptT (..), MonadError (..), runExceptT)
-import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.State.Class (MonadState)
+--import Control.Monad.IO.Class (MonadIO, liftIO)
+--import Control.Monad.State.Class (MonadState)
+import Control.Monad.State.Strict as CMSS
 import Control.Monad.Trans.Control 
-import Control.Monad.Trans.State
+--import Control.Monad.Trans.State
 import Data.ByteString.Char8 (ByteString)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
@@ -199,8 +200,8 @@ addKafkaAddress = over stateAddresses . NE.nub .: NE.cons
     (.:) = (.) . (.)
 
 -- | Run the underlying Kafka monad.
-runKafka :: KafkaState -> StateT KafkaState (ExceptT KafkaClientError IO) a -> IO (Either KafkaClientError a)
-runKafka s k = runExceptT $ evalStateT k s
+runKafka :: KafkaState -> CMSS.StateT KafkaState (ExceptT KafkaClientError IO) a -> IO (Either KafkaClientError a)
+runKafka s k = runExceptT $ CMSS.evalStateT k s
 
 -- | Catch 'IOException's and wrap them in 'KafkaIOException's.
 tryKafka :: Kafka m => m a -> m a


### PR DESCRIPTION
This PR seeks to resolve the slow memory leak issue seen in `strato-p2p` by altering `milena` and `milena-tools` to use a strict StateT monad instead of the default lazy StateT monad in hopes of resolving the observed slow memory leak present in strato-p2p.