### PR TITLE
Correcting implementation of kafka middleman in Strato P2P

### DIFF
--- a/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
-import           Control.Concurrent.Chan.Unagi
+import           Control.Concurrent.Chan.Unagi.Bounded
 import           Control.Monad.IO.Class
 import           Control.Concurrent.Async.Lifted.Safe
 import           Blockchain.VMOptions       ()

--- a/strato/core/strato-p2p/src/Blockchain/Context.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Context.hs
@@ -76,7 +76,7 @@ module Blockchain.Context
 import           Conduit
 import           Control.Applicative
 import           Control.Concurrent
-import           Control.Concurrent.Chan.Unagi         as CCCU
+import           Control.Concurrent.Chan.Unagi.Bounded as CCCUB
 import           Control.Exception                     hiding (bracket)
 import           Control.Lens                          hiding (Context)
 import qualified Control.Monad.Change.Alter            as A
@@ -709,7 +709,7 @@ initConfig wireMessagesRef maxHeaders = do
 
 initContext :: IO Context
 initContext = do
-  initContextKafkaMiddleman <- CCCU.newChan :: IO (InChan (P2pEvent,Int64), OutChan (P2pEvent,Int64))
+  initContextKafkaMiddleman <- CCCUB.newChan 1000 :: IO (InChan (P2pEvent,Int64), OutChan (P2pEvent,Int64))
   return Context { actionTimestamp = emptyActionTimestamp
                  , contextKafkaState = mkConfiguredKafkaState "strato-p2p"
                  , contextKafkaMiddleman = initContextKafkaMiddleman

--- a/strato/core/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/strato/core/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -15,7 +15,7 @@ module Blockchain.SeqEventNotify (
 
 import           Conduit
 --import           Control.Concurrent (myThreadId)
-import           Control.Concurrent.Chan.Unagi
+import           Control.Concurrent.Chan.Unagi.Bounded
 import           Control.Monad.Change.Modify (Modifiable(..))
 import           Control.Monad
 import           Control.Monad.Except


### PR DESCRIPTION
This PR seeks to resolve the slow memory build-up issue seen in strato-p2p by utilizing the bounded unagi-chan variant instead of the unbounded unagi-chan variant (kafka middleman).