### PR TITLE
Alternative kafka middleman implementation using the BroadcastChan

### DIFF
--- a/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
---import           Control.Concurrent.Chan.Unagi
 import           Control.Monad.IO.Class
 import           Control.Concurrent.Async.Lifted.Safe
 import           Blockchain.VMOptions       ()

--- a/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
-import           Control.Concurrent.Chan.Unagi
+--import           Control.Concurrent.Chan.Unagi
 import           Control.Monad.IO.Class
 import           Control.Concurrent.Async.Lifted.Safe
 import           Blockchain.VMOptions       ()
@@ -39,10 +39,9 @@ initP2P = do
   cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   context <- liftIO $ readIORef $ configContext cfg
   let contextkafkastate = contextKafkaState context
-  let contextkafkamiddleman = contextKafkaMiddleman context
-  _ <- async $ runContextM cfg $ seqEventNotificationSourceChanFill contextkafkastate ((\(a,_) -> a) contextkafkamiddleman)
-  let sSource = seqEventNotificationSourceChanPour ((\(a,_) -> a) contextkafkamiddleman)
-                                                   dupChan
+  let contextkafkamiddlemanin = contextKafkaMiddlemanIn context
+  _ <- async $ runContextM cfg $ seqEventNotificationSourceChanFill contextkafkastate contextkafkamiddlemanin
+  let sSource = seqEventNotificationSourceChanPour contextkafkamiddlemanin
       runner f = runContextM cfg $ f sSource
   liftIO $
     race_

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -20,6 +20,7 @@ executables:
     main: StratoP2PMain.hs
     dependencies:
       - blockapps-init
+      - broadcast-chan
       - ethereum-discovery
       - hflags
       - lifted-async
@@ -28,7 +29,7 @@ executables:
       - strato-model
       - strato-p2p
       - thread-hierarchy
-      - unagi-chan
+      - unliftio 
       - wai-middleware-prometheus
       - warp
       
@@ -102,7 +103,6 @@ library:
     - thread-hierarchy
     - time
     - transformers
-      #- unagi-chan
     - unliftio-core
     - unliftio 
     - warp

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -46,6 +46,7 @@ library:
     - blockapps-vault-wrapper-api
     - blockapps-vault-wrapper-client
     - blockstanbul
+    - broadcast-chan
     - bytestring
     - concurrency
     - conduit
@@ -101,7 +102,7 @@ library:
     - thread-hierarchy
     - time
     - transformers
-    - unagi-chan
+      #- unagi-chan
     - unliftio-core
     - unliftio 
     - warp

--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -45,9 +45,10 @@ import Blockchain.Strato.Model.Options (computeNetworkID)
 import Blockchain.Strato.Model.Util
 import Blockchain.TimerSource
 import Blockchain.Watchdog
+import BroadcastChan
 import Conduit
 import Control.Concurrent (ThreadId)
-import Control.Concurrent.Chan.Unagi
+--import Control.Concurrent.Chan.Unagi
 import Control.Concurrent.Hierarchy
 import qualified Control.Monad.Change.Alter as A
 import qualified Control.Monad.Change.Modify as Mod

--- a/strato/core/strato-p2p/src/Blockchain/Context.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Context.hs
@@ -73,10 +73,11 @@ module Blockchain.Context
     ) where
 
 
+import           BroadcastChan
 import           Conduit
 import           Control.Applicative
 import           Control.Concurrent
-import           Control.Concurrent.Chan.Unagi         as CCCU
+--import           Control.Concurrent.Chan.Unagi         as CCCU
 import           Control.Exception                     hiding (bracket)
 import           Control.Lens                          hiding (Context)
 import qualified Control.Monad.Change.Alter            as A
@@ -203,13 +204,14 @@ withPeerAddress :: (Maybe ChainMemberParsedSet -> Maybe ChainMemberParsedSet) ->
 withPeerAddress f = PeerAddress . f . unPeerAddress
 
 data Context = Context
-  { contextKafkaState     :: K.KafkaState
-  , contextKafkaMiddleman :: (InChan (P2pEvent,Int64), OutChan (P2pEvent,Int64))
-  , blockHeaders          :: ([BlockData], UTCTime) -- keep track when last updated global headers cache
-  , remainingBlockHeaders :: (RemainingBlockHeaders, UTCTime) -- keep track when last updated global headers cache
-  , actionTimestamp       :: ActionTimestamp
-  , _blockstanbulPeerAddr :: PeerAddress
-  , _outboundWireMessages :: S.OSet (T.Text, Keccak256)
+  { contextKafkaState        :: K.KafkaState
+  --, contextKafkaMiddleman  :: (InChan (P2pEvent,Int64), OutChan (P2pEvent,Int64))
+  , contextKafkaMiddlemanIn  :: BroadcastChan In (P2pEvent,Int64)
+  , blockHeaders             :: ([BlockData], UTCTime) -- keep track when last updated global headers cache
+  , remainingBlockHeaders    :: (RemainingBlockHeaders, UTCTime) -- keep track when last updated global headers cache
+  , actionTimestamp          :: ActionTimestamp
+  , _blockstanbulPeerAddr    :: PeerAddress
+  , _outboundWireMessages    :: S.OSet (T.Text, Keccak256)
   }
 
 makeLenses ''Context
@@ -709,10 +711,11 @@ initConfig wireMessagesRef maxHeaders = do
 
 initContext :: IO Context
 initContext = do
-  initContextKafkaMiddleman <- CCCU.newChan :: IO (InChan (P2pEvent,Int64), OutChan (P2pEvent,Int64))
+  --initContextKafkaMiddleman <- CCCU.newChan :: IO (InChan (P2pEvent,Int64), OutChan (P2pEvent,Int64))
+  initContextKafkaMiddlemanIn  <- newBroadcastChan :: IO (BroadcastChan In (P2pEvent,Int64))
   return Context { actionTimestamp = emptyActionTimestamp
                  , contextKafkaState = mkConfiguredKafkaState "strato-p2p"
-                 , contextKafkaMiddleman = initContextKafkaMiddleman
+                 , contextKafkaMiddlemanIn = initContextKafkaMiddlemanIn
                  , blockHeaders = ([], jamshidBirth)
                  , remainingBlockHeaders = (RemainingBlockHeaders [], jamshidBirth)
                  , _blockstanbulPeerAddr = PeerAddress Nothing

--- a/strato/core/strato-p2p/src/Blockchain/Context.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Context.hs
@@ -205,7 +205,6 @@ withPeerAddress f = PeerAddress . f . unPeerAddress
 
 data Context = Context
   { contextKafkaState        :: K.KafkaState
-  --, contextKafkaMiddleman  :: (InChan (P2pEvent,Int64), OutChan (P2pEvent,Int64))
   , contextKafkaMiddlemanIn  :: BroadcastChan In (P2pEvent,Int64)
   , blockHeaders             :: ([BlockData], UTCTime) -- keep track when last updated global headers cache
   , remainingBlockHeaders    :: (RemainingBlockHeaders, UTCTime) -- keep track when last updated global headers cache

--- a/strato/core/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/strato/core/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -8,14 +8,14 @@
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 
 module Blockchain.SeqEventNotify (
---  seqEventNotificationSource,
   seqEventNotificationSourceChanFill,
   seqEventNotificationSourceChanPour
   ) where
 
+import           BroadcastChan
 import           Conduit
 --import           Control.Concurrent (myThreadId)
-import           Control.Concurrent.Chan.Unagi
+--import           Control.Concurrent.Chan.Unagi
 import           Control.Monad.Change.Modify (Modifiable(..))
 import           Control.Monad
 import           Control.Monad.Except
@@ -36,7 +36,7 @@ instance Monad m => Modifiable K.KafkaState (State.StateT K.KafkaState m) where
 seqEventNotificationSourceChanFill :: ( MonadIO m
                                       , MonadLogger m
                                       )
-                                   => K.KafkaState -> InChan (P2pEvent,Int64) -> m ()
+                                   => K.KafkaState -> BroadcastChan In (P2pEvent,Int64) -> m ()
 seqEventNotificationSourceChanFill ks p2peventchan = do
   res <- runExceptT $ flip State.evalStateT ks $ do
               ofs' <- K.withKafkaRetry1s $ K.getLastOffset K.LatestTime 0 seqP2pEventsTopicName
@@ -49,35 +49,21 @@ seqEventNotificationSourceChanFill ks p2peventchan = do
                         unless (null events) $ do -- stop bloating the logs
                           $logInfoS "seqEventNotifyChanFill" . T.pack $ "filling kakfa middleman of kafka seqevents @ " ++ show nextOffset
                           forM_ events $ \e -> do
-                            liftIO $ writeChan p2peventchan (e,(\(KP.Offset o) -> o) nextOffset)
+                            liftIO $ writeBChan p2peventchan (e,(\(KP.Offset o) -> o) nextOffset)
                         loop . (nextOffset +) . KP.Offset . fromIntegral $ length events
 
 seqEventNotificationSourceChanPour :: ( MonadIO m
-                                      , MonadLogger m 
+                                      , MonadLogger m
                                       )
-                                   => t -> (t -> IO (OutChan (P2pEvent,Int64))) -> ConduitT () P2pEvent m ()
-seqEventNotificationSourceChanPour p2peventchan dupaction = do
-  dupchan <- liftIO $ dupaction p2peventchan
+                                   => BroadcastChan In (P2pEvent,Int64) -> ConduitT () P2pEvent m ()
+seqEventNotificationSourceChanPour p2peventchanin = do
+  dupchan <- liftIO $ newBChanListener p2peventchanin
   loop dupchan
   where loop chan = do
-            (event,nextOffset) <- liftIO $ readChan chan
-            $logInfoS "seqEventNotifyChanPour" . T.pack $ "pouring from kafka middleman of kafka seqevents @ Offset " ++ show nextOffset
-            _ <- yield event
-            loop chan
-
-{-
-seqEventNotificationSource :: ( MonadIO m
-                              , MonadLogger m
-                              )
-                           => K.KafkaState -> ConduitM () P2pEvent m ()
-seqEventNotificationSource ks = evalStateC ks $ do
-    ofs' <- lift $ K.withKafkaRetry1s $ K.getLastOffset K.LatestTime 0 seqP2pEventsTopicName
-    loop ofs'
-    where loop nextOffset = do
-              events <- lift $ K.withKafkaRetry1s $ readSeqP2pEvents nextOffset
-              unless (null events) $ do -- stop bloating the logs
-                $logInfoS "seqEventNotify" . T.pack $ "reading at kafka seqevents @ " ++ show nextOffset
-                forM_ events $ \e -> do
-                    yield $ e
-              loop . (nextOffset +) . KP.Offset . fromIntegral $ length events
--}
+            newevent <- liftIO $ readBChan chan
+            case newevent of
+              Nothing                 -> do $logInfoS "seqEventNotifyChanPour" . T.pack $ "nothing to pour from kafka middleman."
+                                            loop chan
+              Just (event,nextOffset) -> do $logInfoS "seqEventNotifyChanPour" . T.pack $ "pouring from kafka middleman of kafka seqevents @ Offset " ++ show nextOffset
+                                            _ <- yield event
+                                            loop chan

--- a/strato/core/strato-p2p/src/Blockchain/SeqEventNotify.hs
+++ b/strato/core/strato-p2p/src/Blockchain/SeqEventNotify.hs
@@ -14,8 +14,6 @@ module Blockchain.SeqEventNotify (
 
 import           BroadcastChan
 import           Conduit
---import           Control.Concurrent (myThreadId)
---import           Control.Concurrent.Chan.Unagi
 import           Control.Monad.Change.Modify (Modifiable(..))
 import           Control.Monad
 import           Control.Monad.Except
@@ -62,8 +60,7 @@ seqEventNotificationSourceChanPour p2peventchanin = do
   where loop chan = do
             newevent <- liftIO $ readBChan chan
             case newevent of
-              Nothing                 -> do $logInfoS "seqEventNotifyChanPour" . T.pack $ "nothing to pour from kafka middleman."
-                                            loop chan
+              Nothing                 -> loop chan
               Just (event,nextOffset) -> do $logInfoS "seqEventNotifyChanPour" . T.pack $ "pouring from kafka middleman of kafka seqevents @ Offset " ++ show nextOffset
                                             _ <- yield event
                                             loop chan


### PR DESCRIPTION
This PR seeks to resolve the slow memory build-up (from the kafka middleman) issue seen in strato-p2p by utilizing a `BroadcastChan`, which is optimized to GC messages for which no out channel are reading (so old messages are GC'ed appropriately).

This implementation releases memory from old messages in a more appropriate manner than the bounded unagi-chan variant.

Testing this now on a local node to monitor memory usage of the `strato` docker container.
