### PR TITLE
Return full URL from highway, and encode response Content-Type header correctly

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -72,7 +72,7 @@ COPY usr/local/bin/blockapps-highway-wrapper-server /usr/local/bin/
 COPY ./highway-wrapper /highway-wrapper
 EXPOSE 8080
 HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
-  CMD curl --silent --output /dev/null --fail localhost:8080/highway/ping || exit 1
+  CMD curl --silent --output /dev/null --fail localhost:8080/ping || exit 1
 ENTRYPOINT ["/highway-wrapper/doit.sh"]
 
 

--- a/docker-compose.highway.tpl.yml
+++ b/docker-compose.highway.tpl.yml
@@ -10,6 +10,8 @@ services:
     - minLogLevel=${minLogLevel}
     build: .
     image: ${HIGHWAYWRAPPER_IMAGE:-<REPO_URL>highway-wrapper:<VERSION>}
+    ports:
+    - 80:8080 #TAG_REMOVE_WHEN_SSL_CUSTOM_HTTPS_PORT
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/strato/highway/api/src/Strato/API.hs
+++ b/strato/highway/api/src/Strato/API.hs
@@ -64,6 +64,6 @@ instance AllCTRender '[Web] ContentTypeAndBody where
 
 type HighwayGetS3File = "highway" :> Capture "filename" T.Text :> Get '[Web] ContentTypeAndBody
 
-type HighwayPutS3File = "highway" :> MultipartForm Mem (MultipartData Mem) :> Put '[Web] T.Text
+type HighwayPutS3File = "highway" :> MultipartForm Mem (MultipartData Mem) :> Post '[Web] T.Text
 
 type HighwayPing      = "ping" :> Get '[JSON] Int

--- a/strato/highway/api/src/Strato/API.hs
+++ b/strato/highway/api/src/Strato/API.hs
@@ -13,12 +13,10 @@ module Strato.API
   )
 where
 
-import qualified Data.ByteString.Char8              as DBC8
 import qualified Data.ByteString.Lazy               as DBL
 import qualified Data.List.NonEmpty                 as NE
 import qualified Data.Text                          as T
 import           Data.Text.Encoding                 (encodeUtf8)
-import           Blockchain.Strato.Model.Keccak256
 import           Network.HTTP.Media ((//), (/:))
 import           Servant.API
 import           Servant.API.ContentTypes
@@ -33,11 +31,13 @@ instance Accept Web where
                    , "text"        // "css" /: ("charset", "utf-8")
                    , "text"        // "javascript"
                    , "text"        // "javascript" /: ("charset", "utf-8")
+                   , "text"        // "plain"
                    , "application" // "json"
                    , "application" // "json" /: ("charset", "utf-8")
                    , "application" // "octet-stream"
                    , "application" // "font-woff"
                    , "application" // "font-woff2"
+                   , "application" // "pdf"
                    , "image"       // "png"
                    , "image"       // "jpeg"
                    , "image"       // "jpg"
@@ -56,19 +56,14 @@ data ContentTypeAndBody = ContentTypeAndBody { contentTypeHeader :: DBL.ByteStri
 instance MimeRender Web ContentTypeAndBody where --Is this correct?
   mimeRender _ (ContentTypeAndBody _ b) = b
 
-instance MimeUnrender Web ContentTypeAndBody where
-  mimeUnrender a bs = Right $ ContentTypeAndBody { contentTypeHeader = DBL.fromStrict $ DBC8.pack $ show a --Need to double check
-                                                 , contentTypeBody   = bs                                  --both of these
-                                                 } 
-
-instance MimeRender Web Keccak256 where
-  mimeRender _ bs = DBL.fromStrict . encodeUtf8 . T.pack $ keccak256ToHex bs
+instance MimeRender Web T.Text where
+  mimeRender _ = DBL.fromStrict . encodeUtf8
 
 instance AllCTRender '[Web] ContentTypeAndBody where
   handleAcceptH _ _ (ContentTypeAndBody h c) = Just (h,c)
 
-type HighwayGetS3File = Capture "hash" Keccak256 :> Get '[Web] ContentTypeAndBody
+type HighwayGetS3File = "highway" :> Capture "filename" T.Text :> Get '[Web] ContentTypeAndBody
 
-type HighwayPutS3File = MultipartForm Mem (MultipartData Mem) :> Put '[Web] Keccak256
+type HighwayPutS3File = "highway" :> MultipartForm Mem (MultipartData Mem) :> Put '[Web] T.Text
 
 type HighwayPing      = "ping" :> Get '[JSON] Int

--- a/strato/highway/server/app/Main.hs
+++ b/strato/highway/server/app/Main.hs
@@ -85,7 +85,13 @@ initHighway = do
                             False -> do $logInfoS "highway/initHighway" $ T.pack $ "Preparing environment for highway."
                                         mgr <- liftIO $ newManager tlsManagerSettings
                                         boundary <- liftIO genBoundary
-                                        let env = HighwayWrapperEnv mgr boundary (DBC8.pack flags_awsaccesskeyid) (DBC8.pack flags_awssecretaccesskey) (T.pack flags_awss3bucket)
+                                        let env = HighwayWrapperEnv
+                                                    mgr
+                                                    boundary
+                                                    (DBC8.pack flags_awsaccesskeyid)
+                                                    (DBC8.pack flags_awssecretaccesskey)
+                                                    (T.pack flags_awss3bucket)
+                                                    (T.pack flags_highwayUrl)
                                         $logInfoS "highway/initHighway" $ T.pack $ "Initialization successful!"
                                         liftIO $ run 8080 $ appHighwayWrapper env
 
@@ -100,7 +106,7 @@ appHighwayWrapper env =
     . cors (const $ Just policy)
     . serve
       ( Proxy
-          @( "highway" :> HighwayWrapperAPI
+          @( HighwayWrapperAPI
            )
       )
     $ serveHighwayWrapper env

--- a/strato/highway/server/app/Options.hs
+++ b/strato/highway/server/app/Options.hs
@@ -8,3 +8,4 @@ import HFlags
 defineFlag "a:awsaccesskeyid"     ("" :: String) "AWS Access Key ID"
 defineFlag "s:awssecretaccesskey" ("" :: String) "AWS Secret Access Key"
 defineFlag "b:awss3bucket"        ("" :: String) "AWS S3 Bucket"
+defineFlag "u:highwayUrl"         ("http://fileserver.mercata-testnet2.blockapps.net" :: String) "Public Highway URL"

--- a/strato/highway/server/package.yaml
+++ b/strato/highway/server/package.yaml
@@ -25,6 +25,7 @@ dependencies:
 - common-log
 - conduit
 - conduit-extra
+- filepath
 - http-client-tls
 - http-conduit
 - monad-logger

--- a/strato/highway/server/src/Strato/Monad.hs
+++ b/strato/highway/server/src/Strato/Monad.hs
@@ -58,6 +58,7 @@ data HighwayWrapperEnv = HighwayWrapperEnv
   , awsaccesskeyid     :: DB.ByteString
   , awssecretaccesskey :: DB.ByteString
   , awss3bucket        :: Text
+  , highwayUrl         :: Text
   }
 
 data HighwayWrapperError

--- a/strato/highway/server/src/Strato/Server/GetS3File.hs
+++ b/strato/highway/server/src/Strato/Server/GetS3File.hs
@@ -18,21 +18,17 @@ import           Control.Monad.Logger
 import           Control.Monad.Reader
 import           Data.ByteString.Lazy as DBL
 import           Data.ByteString.Char8 as DBC8
-import           Data.Either (fromRight)
-import           Data.Proxy
 import           Data.Text as T
 import           Network.HTTP.Conduit (responseBody)
-import           Servant.API.ContentTypes
+import           System.FilePath (takeExtension)
 
 --import           BlockApps.Logging
 import           Strato.API
 import           Strato.Monad
-import           Blockchain.Strato.Model.Keccak256
 
-
-getS3File :: Keccak256
+getS3File :: Text
           -> HighwayM ContentTypeAndBody
-getS3File keccakhash = do
+getS3File filename = do
   --Set up AWS credentials and the default configuration.
   $logInfoS "highway/getS3File" $ T.pack $ "Setting up AWS credentials and the default AWS configuration."
   mgr     <- asks httpManager
@@ -55,13 +51,22 @@ getS3File keccakhash = do
     liftIO $ unliftIO st $ $logInfoS "highway/getS3File" $ T.pack $ "Creating a request object with getObject and running the request via pureAws."
     S3.GetObjectResponse { S3.gorResponse = rsp } <-
       Aws.pureAws cfg s3cfg mgr $
-        S3.getObject awss3b (T.pack $ keccak256ToHex keccakhash)
-    --Save the response to a file.
-    liftIO $ unliftIO st $ $logInfoS "highway/getS3File" $ T.pack $ "Saving the response (file contents) to a file."
+        S3.getObject awss3b filename
     filecontents <- runConduit $ responseBody rsp .| sinkList -- $ DBLC8.unpack $ DBL.fromStrict $ keccak256ToByteString keccakhash
-    let filecontentsf = fromRight (ContentTypeAndBody { contentTypeHeader = DBL.empty
-                                                      , contentTypeBody   = DBL.empty
-                                                      }
-                                  ) 
-                                  (mimeUnrender (Proxy @Web) (DBC8.fromStrict $ DBC8.concat filecontents))
-    return filecontentsf
+    let header = case takeExtension $ T.unpack filename of
+          ".jpg" -> "image/jpg"
+          ".jpeg" -> "image/jpeg"
+          ".png" -> "image/png"
+          ".gif" -> "image/gif"
+          ".svg" -> "image/svg+xml"
+          ".pdf" -> "application/pdf"
+          ".html" -> "text/html"
+          ".css" -> "text/css"
+          ".js" -> "text/javascript"
+          ".json" -> "application/json"
+          ".webp" -> "image/webp"
+          _ -> "text/plain"
+    pure $ ContentTypeAndBody
+      { contentTypeHeader = header
+      , contentTypeBody   = DBL.fromStrict $ DBC8.concat filecontents
+      }

--- a/strato/highway/server/src/Strato/Server/PutS3File.hs
+++ b/strato/highway/server/src/Strato/Server/PutS3File.hs
@@ -19,13 +19,14 @@ import           Data.ByteString as DB
 import           Data.Text as T
 import           Network.HTTP.Conduit (RequestBody(..))
 import           Servant.Multipart
+import           System.FilePath (takeExtension)
 
 import           Strato.Monad
 import           Blockchain.Strato.Model.Keccak256
 
 
 putS3File :: MultipartData Mem 
-          -> HighwayM Keccak256
+          -> HighwayM Text
 putS3File multipartdata =
   --Ensure we have only a single file input via form.
   case files multipartdata of
@@ -35,14 +36,16 @@ putS3File multipartdata =
                                   fdPayload    $
                                   file
 
-                let contentHash = hash content
-                    contentHashText = T.pack $ keccak256ToHex contentHash
+                let contentHash = T.pack . keccak256ToHex $ hash content
+                    extension = T.pack . takeExtension . T.unpack $ fdFileName file
+                    uploadFileName = contentHash <> extension
                 --Set up AWS credentials and the default configuration.
                 $logInfoS "highway/putS3File" $ T.pack $ "Setting up AWS credentials and the default AWS configuration."
                 mgr     <- asks httpManager
                 awsakid <- asks awsaccesskeyid
                 awssak  <- asks awssecretaccesskey
                 awss3b  <- asks awss3bucket
+                hwUrl  <- asks highwayUrl
                 cr      <- liftIO $ Aws.makeCredentials awsakid
                                                         awssak
                 let cfg = Aws.Configuration { Aws.timeInfo    = Aws.Timestamp
@@ -59,7 +62,7 @@ putS3File multipartdata =
                   --Create a request object with S3.getObject and run the request with pureAws.
                   liftIO $ unliftIO st $ $logInfoS "highway/putS3File" $ T.pack $ "Creating request object with getObject and running request via pureAws."
                   _ <- Aws.pureAws cfg s3cfg mgr $
-                         S3.putObject awss3b contentHashText body
-                  return contentHash
+                         S3.putObject awss3b uploadFileName body
+                  return $ hwUrl <> "/highway/" <> uploadFileName
     _ -> --Too many or no files provided via form.
       liftIO $ throwIO BadPutError


### PR DESCRIPTION
Highway now appends the file extension of the incoming file when uploading to S3, and uses the file extension on download to determine the correct `Content-Type` header to use in the response. Some examples are:
http://fileserver.mercata-testnet2.blockapps.net/highway/7995a4cb1d9b3c6e2cc6a14fd6a435d21795973636e67c8fef75b2a3db49868c.jpeg
http://fileserver.mercata-testnet2.blockapps.net/highway/c23a1c5df1bd313f4d96ccdf54a384342e9056c0a2dbfd2fe2c50a9d714b7ee4.jpg
http://fileserver.mercata-testnet2.blockapps.net/highway/8086c2c6a6d054c72336aa7f25498af4caa266716167f75bdeabcf69c3442001.pdf