### PR TITLE
Order Details Page fix & other misc. changes for Metals

### DIFF
--- a/marketplace/ui/src/components/Inventory/CreateInventoryModal.js
+++ b/marketplace/ui/src/components/Inventory/CreateInventoryModal.js
@@ -531,7 +531,7 @@ const CreateInventoryModal = ({
             >
               <Input
                 label="purity"
-                placeholder="Enter Purity"
+                placeholder="Enter Purity (Ex: 999/1000)"
                 name="purity"
                 value={formik.values.purity}
                 onChange={formik.handleChange}

--- a/marketplace/ui/src/components/Inventory/InventorySchema.js
+++ b/marketplace/ui/src/components/Inventory/InventorySchema.js
@@ -6,7 +6,12 @@ const getSchema = () => {
     name: yup.string().required("Name is required"),
     description: yup.string().required("Description is required"),
     artist: yup.string(),
-    source: yup.string(),
+    source: yup.string().required("Enter Source"),
+    unitOfMeasurement: yup.object().shape({
+      name: yup.string().required("Measurement Name is required"),
+      value: yup.number().positive("Measurement Value must be a positive number").required("Measurement Value is required"),
+    }).required("Measurement Unit Required"),
+    purity: yup.string().required("Enter Purity"),
     // clothingType: yup.string().nullable().required("The clothing type is required"),
     // size: yup.string().nullable().required("A size is required"),
     // skuNumber: yup.string().nullable().required("An SKU is required"),

--- a/marketplace/ui/src/components/Inventory/ListForSaleModal.js
+++ b/marketplace/ui/src/components/Inventory/ListForSaleModal.js
@@ -112,13 +112,6 @@ const ListForSaleModal = ({ open, handleCancel, inventory, paymentProviderAddres
                 finalColumns = finalColumns.concat(
                     [
                         {
-                            title: "Quantity",
-                            align: "center",
-                            render: () => (
-                                <InputNumber value={quantity} controls={false} min={1} onChange={(value) => setQuantity(value)} />
-                            )
-                        },
-                        {
                             title: "Set Price Per Unit",
                             align: "center",
                             render: () => (

--- a/marketplace/ui/src/components/Order/BoughtOrderDetails.js
+++ b/marketplace/ui/src/components/Order/BoughtOrderDetails.js
@@ -131,7 +131,7 @@ const BoughtOrderDetails = ({ user, users }) => {
       setcomment(orderDetails.order.comments);
 
       let items = [];
-      orderDetails.assets.forEach((prod) => {
+      orderDetails.assets.forEach((prod, index) => {
         items.push({
           address: prod.address,
           chainId: prod.chainId,
@@ -139,9 +139,9 @@ const BoughtOrderDetails = ({ user, users }) => {
           productImage: prod.images && prod.images.length > 0 ? prod.images[0] : image_placeholder,
           productName: prod,
           unitPrice: prod.price,
-          quantity: prod.quantity,
+          quantity: parseInt(orderDetails.order.quantities[index]),
           shippingCharges: prod.shippingCharges ? prod.shippingCharges : 0,
-          amount: prod.amount,
+          amount: prod.price * parseInt(orderDetails.order.quantities[index]),
           serialNumber: prod,
           tax: prod.tax ? prod.tax : 0,
         });

--- a/marketplace/ui/src/components/Order/SoldOrderDetails.js
+++ b/marketplace/ui/src/components/Order/SoldOrderDetails.js
@@ -94,7 +94,7 @@ const SoldOrderDetails = ({ user, users }) => {
       }
 
       let items = [];
-      orderDetails.assets.forEach((prod) => {
+      orderDetails.assets.forEach((prod, index) => {
         items.push({
           address: prod.address,
           chainId: prod.chainId,
@@ -102,9 +102,9 @@ const SoldOrderDetails = ({ user, users }) => {
           productImage: prod.images && prod.images.length > 0 ? prod.images[0] : image_placeholder,
           productName: prod,
           unitPrice: prod.price,
-          quantity: prod.quantity,
+          quantity: parseInt(orderDetails.order.quantities[index]),
           shippingCharges: prod.shippingCharges ? prod.shippingCharges : 0,
-          amount: prod.amount,
+          amount: prod.price * parseInt(orderDetails.order.quantities[index]),
           serialNumber: prod,
           tax: prod.tax ? prod.tax : 0,
         });


### PR DESCRIPTION
This PR corrects Order Details information.

<img width="1438" alt="Screenshot 2023-12-15 at 9 46 08 AM" src="https://github.com/blockapps/strato-platform/assets/35606645/11e49a8c-c194-46f4-b370-e35a7d972af7">

- Additionally a few validations and modal changes are done for listing Metals(had double input for quantity).
<img width="668" alt="Screenshot 2023-12-15 at 10 12 08 AM" src="https://github.com/blockapps/strato-platform/assets/35606645/1803d748-87c7-4c32-9141-2f1160cbdb15">
