### PR TITLE
Update quantity (and other stuff) in slipstream

### DIFF
--- a/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
@@ -136,7 +136,7 @@ replayDeltas ((StoragePath (Field f : sp), bv) : rs) ts =
     Just sv -> do
       ts' <- (\v' -> HM.insert f v' ts) <$> applyDelta (StoragePath sp) bv sv
       replayDeltas rs ts'
-    Nothing -> return $ HM.insert f (constructFromNothing' sp bv) ts
+    Nothing -> replayDeltas rs $ HM.insert f (constructFromNothing' sp bv) ts
 replayDeltas ((p, _) : _) _ = Left $ MissingPath p
 
 applyDelta :: StoragePath -> BasicValue -> V.Value -> Either ReplayFailure V.Value


### PR DESCRIPTION
This PR fixes a bug in slipstream that was affecting the marketplace because the sale `quantity` would not be updated. This flow exposed a long-dormant bug in slipstream where not all the diffs are applied (in the line changed, we `return` too early and should instead recursively apply `replayDeltas` to the rest of the diffs first). 

To test that this change works properly, we created a sale (at address `e304c2b73a8544270ca83b17ec242483a911e1cf`) on a UTXOAsset and bought a portion of it. In slipstream, both the `quantity` and `totalLockedQuantity` updated (previously wouldn't). In the marketplace ui, the "Quantity For Sale" automatically updated on the buyer's side (previously wouldn't update). If another buyer tries to purchase this asset, the ui would not let them buy more than the new quantity (previously would let you buy up to the old quantity).

![image](https://github.com/blockapps/strato-platform/assets/31707474/c5e515cf-6978-4ca3-a59a-a6badf00b8ef)
In the image above, we see Goldv6 was purchased from after the testing change was implemented, so the UI shows the quantity for sale is less than the total quantity. In contrast, Goldv5 shows the old functionality, where after a purchase is made, the quantity for sale it still the same as the original quantity.