### PR TITLE
remove new env variables

### DIFF
--- a/marketplace/backend/helpers/constants.js
+++ b/marketplace/backend/helpers/constants.js
@@ -3,8 +3,6 @@ import config from '/load.config';
 
 export default {
   baseUrl: `/api/v1`,
-  marketplaceHost: getEnvVariable('MP_SERVER_HOST'),
-  marketplaceSSL: getEnvVariable('MP_SERVER_SSL'),
   deployParamName: "deploy",
   governanceAddress: '0000000000000000000000000000000000000100',
   zeroAddress: '0000000000000000000000000000000000000000',

--- a/marketplace/backend/index.js
+++ b/marketplace/backend/index.js
@@ -29,7 +29,7 @@ let server
     throw new Error(`Deploy file '${config.configDirPath}/${config.deployFilename}' not found`);
   }
 
-  const marketplaceUrl = constants.marketplaceSSL === 'true' ? `https://${constants.marketplaceHost}/marketplace` : `http://${constants.marketplaceHost}/marketplace`;
+  const marketplaceUrl = `${config.serverHost}/marketplace`
   axios.defaults.headers.common['Referer'] = marketplaceUrl;
 
   app.set(deployParamName, deploy);


### PR DESCRIPTION
we don't need this:
MP_SERVER_HOST=localhost
MP_SERVER_SSL=false

instead we can use `serverHost`

```/config # cat config.yaml 
apiDebug: false
timeout: 600000
VM: SolidVM
configDirPath: /config
deployFilename: marketplace.deploy.yaml
orgDeployFilename: org.deploy.yaml
serverHost: https://art.mercata-testnet2.blockapps.net/
orgName: 'BlockApps'
dockerized: true
marketplaceUiUrlPrefix: "/marketplace"```