### PR TITLE
fix: move country input after zipcde

### DIFF
--- a/marketplace/ui/src/components/MarketPlace/ProductDetail.js
+++ b/marketplace/ui/src/components/MarketPlace/ProductDetail.js
@@ -504,7 +504,7 @@ const ProductDetails = ({ user, users }) => {
             </Text>
             </Space> */}
 
-            <Space className="flex justify-between py-[15px] px-[14px]  border border-[#E9E9E9] rounded-md">
+            <Space className="flex justify-between">
               <DescTitle text="Purity" />
               <Text className="text-[13px] text-[#202020] font-medium">{itemData?.purity}</Text>
             </Space>

--- a/marketplace/ui/src/components/MarketPlace/ResponsiveAddAddress.js
+++ b/marketplace/ui/src/components/MarketPlace/ResponsiveAddAddress.js
@@ -190,7 +190,7 @@ const ResponsiveAddAddress = ({ back }) => {
               Country
             </p>
             <Input
-              label="state"
+              label="country"
               className="h-[42px] w-full  "
               name="country"
               placeholder="Enter Country"

--- a/marketplace/ui/src/components/MarketPlace/ResponsiveAddAddress.js
+++ b/marketplace/ui/src/components/MarketPlace/ResponsiveAddAddress.js
@@ -166,25 +166,6 @@ const ResponsiveAddAddress = ({ back }) => {
               </p>
             )}
           </Form.Item>
-          <Form.Item label="" name="country" className="">
-            <p className="text-[#202020]  text-sm font-medium text-left">
-              Country
-            </p>
-            <Input
-              label="state"
-              className="h-[42px] w-full  "
-              name="country"
-              placeholder="Enter Country"
-              value={formik.values.country}
-              onChange={formik.handleChange}
-            />
-            {formik.touched.country && formik.errors.country && (
-              <p className="text-error text-xs text-left">
-                {formik.errors.country}
-              </p>
-            )}
-          </Form.Item>
-
           <Form.Item label="" name="zipcode" className="">
             <p className="text-[#202020]  text-sm font-medium text-left">
               Zipcode
@@ -201,6 +182,24 @@ const ResponsiveAddAddress = ({ back }) => {
             {formik.touched.zipcode && formik.errors.zipcode && (
               <p className="text-error text-xs text-left">
                 {formik.errors.zipcode}
+              </p>
+            )}
+          </Form.Item>
+          <Form.Item label="" name="country" className="">
+            <p className="text-[#202020]  text-sm font-medium text-left">
+              Country
+            </p>
+            <Input
+              label="state"
+              className="h-[42px] w-full  "
+              name="country"
+              placeholder="Enter Country"
+              value={formik.values.country}
+              onChange={formik.handleChange}
+            />
+            {formik.touched.country && formik.errors.country && (
+              <p className="text-error text-xs text-left">
+                {formik.errors.country}
               </p>
             )}
           </Form.Item>


### PR DESCRIPTION
Moving the country input to be after the zipcode in the responsive form. 

Also includes an update to the formatting for the metals products in the description tab. See below: 

<img width="518" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/088f32be-ec21-441c-922b-d7e187626891">
