### PR TITLE
[Highway] Add filename character length limit

### DIFF
--- a/strato/highway/server/app/Main.hs
+++ b/strato/highway/server/app/Main.hs
@@ -26,7 +26,9 @@ import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.Wai.Handler.Warp
 import Network.Wai.Middleware.Cors
 import Network.Wai.Middleware.Prometheus
+import Network.Wai.Parse (defaultParseRequestBodyOptions,setMaxRequestKeyLength)
 import Servant
+import Servant.Multipart
 import Servant.Multipart.Client
 import Text.RawString.QQ as TRQQ
 import System.IO
@@ -106,11 +108,13 @@ appHighwayWrapper env =
       }
     . instrumentApp "highway"
     . cors (const $ Just policy)
-    . serve
-      ( Proxy
-          @( HighwayWrapperAPI
-           )
-      )
+    . serveWithContext
+        ( Proxy
+            @( HighwayWrapperAPI
+             )
+        ) ctx
     $ serveHighwayWrapper env
   where
+    --ctx :: Context '[MultipartOptions Mem]
+    ctx    = (MultipartOptions (setMaxRequestKeyLength 100 defaultParseRequestBodyOptions)) :. EmptyContext
     policy = simpleCorsResourcePolicy {corsRequestHeaders = ["Content-Type"]}

--- a/strato/highway/server/package.yaml
+++ b/strato/highway/server/package.yaml
@@ -61,11 +61,13 @@ executables:
       - http-client
       - http-client-tls
       - raw-strings-qq
+      - servant-multipart
       - servant-multipart-client
       - servant-server
       - text
       - unliftio-core
       - wai-cors
+      - wai-extra
       - wai-middleware-prometheus
       - warp
     ghc-options: -threaded 

--- a/strato/highway/server/src/Strato/Monad.hs
+++ b/strato/highway/server/src/Strato/Monad.hs
@@ -63,6 +63,7 @@ data HighwayWrapperEnv = HighwayWrapperEnv
 data HighwayWrapperError
   = BadGetError 
   | BadPutError
+  | BadPutFilenameLengthError
   | UserError Text
   | RuntimeError SomeException
   deriving (Show, Exception)
@@ -94,6 +95,11 @@ handleHighwayError = \case
       "handleHighwayError/BadPutError"
       "Could not push file contents to S3."
     throwIO BadPutError
+  BadPutFilenameLengthError -> do
+    $logErrorS
+      "handleHighwayError/BadPutFilenameLengthError"
+      "Filename length limit of 100 characters exceeded."
+    throwIO BadPutFilenameLengthError
   e@(RuntimeError _) -> do
     $logErrorS "handleHighwayError/RuntimeError" . Text.pack $
       show e ++ "\n  callstack missing for runtime errors"
@@ -122,6 +128,15 @@ enterHighwayWrapper env x = Handler $ do
                     ]
             }
         BadPutError ->
+          err500
+            { errBody =
+                fromString $
+                  unlines
+                    [ "Bad PUT Error!",
+                      "Upload of file was unsuccessful."
+                    ]
+            }
+        BadPutFilenameLengthError ->
           err500
             { errBody =
                 fromString $

--- a/strato/highway/server/src/Strato/Monad.hs
+++ b/strato/highway/server/src/Strato/Monad.hs
@@ -63,7 +63,7 @@ data HighwayWrapperEnv = HighwayWrapperEnv
 data HighwayWrapperError
   = BadGetError 
   | BadPutError
-  | BadPutFilenameLengthError
+  | BadPostFilenameLengthError
   | UserError Text
   | RuntimeError SomeException
   deriving (Show, Exception)
@@ -95,11 +95,11 @@ handleHighwayError = \case
       "handleHighwayError/BadPutError"
       "Could not push file contents to S3."
     throwIO BadPutError
-  BadPutFilenameLengthError -> do
+  BadPostFilenameLengthError -> do
     $logErrorS
       "handleHighwayError/BadPutFilenameLengthError"
       "Filename length limit of 100 characters exceeded."
-    throwIO BadPutFilenameLengthError
+    throwIO BadPostFilenameLengthError
   e@(RuntimeError _) -> do
     $logErrorS "handleHighwayError/RuntimeError" . Text.pack $
       show e ++ "\n  callstack missing for runtime errors"
@@ -136,8 +136,8 @@ enterHighwayWrapper env x = Handler $ do
                       "Upload of file was unsuccessful."
                     ]
             }
-        BadPutFilenameLengthError ->
-          err500
+        BadPostFilenameLengthError ->
+          err400
             { errBody =
                 fromString $
                   unlines

--- a/strato/highway/server/src/Strato/Monad.hs
+++ b/strato/highway/server/src/Strato/Monad.hs
@@ -62,7 +62,7 @@ data HighwayWrapperEnv = HighwayWrapperEnv
 
 data HighwayWrapperError
   = BadGetError 
-  | BadPutError
+  | BadPostError
   | BadPostFilenameLengthError
   | UserError Text
   | RuntimeError SomeException
@@ -90,11 +90,11 @@ handleHighwayError = \case
       "handleHighwayError/BadGetError"
       "Could not retrieve file from S3."
     throwIO BadGetError
-  BadPutError -> do
+  BadPostError -> do
     $logErrorS
-      "handleHighwayError/BadPutError"
+      "handleHighwayError/BadPostError"
       "Could not push file contents to S3."
-    throwIO BadPutError
+    throwIO BadPostError
   BadPostFilenameLengthError -> do
     $logErrorS
       "handleHighwayError/BadPutFilenameLengthError"
@@ -127,12 +127,12 @@ enterHighwayWrapper env x = Handler $ do
                       "Could not find file."
                     ]
             }
-        BadPutError ->
+        BadPostError ->
           err500
             { errBody =
                 fromString $
                   unlines
-                    [ "Bad PUT Error!",
+                    [ "Bad POST Error!",
                       "Upload of file was unsuccessful."
                     ]
             }
@@ -141,7 +141,7 @@ enterHighwayWrapper env x = Handler $ do
             { errBody =
                 fromString $
                   unlines
-                    [ "Bad PUT Error!",
+                    [ "Bad POST Error!",
                       "Upload of file was unsuccessful."
                     ]
             }

--- a/strato/highway/server/src/Strato/Monad.hs
+++ b/strato/highway/server/src/Strato/Monad.hs
@@ -63,7 +63,6 @@ data HighwayWrapperEnv = HighwayWrapperEnv
 data HighwayWrapperError
   = BadGetError 
   | BadPostError
-  | BadPostFilenameLengthError
   | UserError Text
   | RuntimeError SomeException
   deriving (Show, Exception)
@@ -95,11 +94,6 @@ handleHighwayError = \case
       "handleHighwayError/BadPostError"
       "Could not push file contents to S3."
     throwIO BadPostError
-  BadPostFilenameLengthError -> do
-    $logErrorS
-      "handleHighwayError/BadPutFilenameLengthError"
-      "Filename length limit of 100 characters exceeded."
-    throwIO BadPostFilenameLengthError
   e@(RuntimeError _) -> do
     $logErrorS "handleHighwayError/RuntimeError" . Text.pack $
       show e ++ "\n  callstack missing for runtime errors"
@@ -129,15 +123,6 @@ enterHighwayWrapper env x = Handler $ do
             }
         BadPostError ->
           err500
-            { errBody =
-                fromString $
-                  unlines
-                    [ "Bad POST Error!",
-                      "Upload of file was unsuccessful."
-                    ]
-            }
-        BadPostFilenameLengthError ->
-          err400
             { errBody =
                 fromString $
                   unlines

--- a/strato/highway/server/src/Strato/Server/PutS3File.hs
+++ b/strato/highway/server/src/Strato/Server/PutS3File.hs
@@ -64,4 +64,4 @@ putS3File multipartdata =
                    False -> --Filename provided (extension included) exceed 100 characters in length.
                             liftIO $ throwIO BadPostFilenameLengthError
     _ -> --Too many or no files provided via form.
-      liftIO $ throwIO BadPutError
+      liftIO $ throwIO BadPostError

--- a/strato/highway/server/src/Strato/Server/PutS3File.hs
+++ b/strato/highway/server/src/Strato/Server/PutS3File.hs
@@ -31,35 +31,37 @@ putS3File multipartdata =
   --Ensure we have only a single file input via form.
   case files multipartdata of
     [file] -> do --Derive hash (Keccak256?) based on the file contents.
-                $logInfoS "highway/putS3File" $ T.pack $ "Deriving hash based on the file contents."
-                let content     = toStrict     $
-                                  fdPayload    $
-                                  file
-
-                let contentHash = T.pack . keccak256ToHex $ hash content
-                    extension = T.pack . takeExtension . T.unpack $ fdFileName file
-                    uploadFileName = contentHash <> extension
-                --Set up AWS credentials and the default configuration.
-                $logInfoS "highway/putS3File" $ T.pack $ "Setting up AWS credentials and the default AWS configuration."
-                mgr    <- asks httpManager
-                cr     <- asks awsCredentials
-                awss3b <- asks awss3bucket
-                hwUrl  <- asks highwayUrl
-                let cfg = Aws.Configuration { Aws.timeInfo    = Aws.Timestamp
-                                            , Aws.credentials = cr
-                                            , Aws.logger      = Aws.defaultLog Aws.Warning
-                                            , Aws.proxy       = Nothing
-                                            }
-                let s3cfg = Aws.defServiceConfig :: S3.S3Configuration Aws.NormalQuery
-                --Set up a ResourceT region with an available HTTP manager.
-                $logInfoS "highway/putS3File" $ T.pack $ "Setting up a ResourceT region with an available HTTP manager."
-                st  <- askUnliftIO
-                liftIO $ runResourceT $ do
-                  let body = RequestBodyBS content
-                  --Create a request object with S3.getObject and run the request with pureAws.
-                  liftIO $ unliftIO st $ $logInfoS "highway/putS3File" $ T.pack $ "Creating request object with getObject and running request via pureAws."
-                  _ <- Aws.pureAws cfg s3cfg mgr $
-                         S3.putObject awss3b uploadFileName body
-                  return $ hwUrl <> "/highway/" <> uploadFileName
+                 $logInfoS "highway/putS3File" $ T.pack $ "Deriving hash based on the file contents."
+                 let content     = toStrict     $
+                                   fdPayload    $
+                                   file
+                 let contentHash = T.pack . keccak256ToHex $ hash content
+                     extension = T.pack . takeExtension . T.unpack $ fdFileName file
+                     uploadFileName = contentHash <> extension
+                 case (T.length uploadFileName <= 99) of
+                   True -> do --Set up AWS credentials and the default configuration.
+                              $logInfoS "highway/putS3File" $ T.pack $ "Setting up AWS credentials and the default AWS configuration."
+                              mgr    <- asks httpManager
+                              cr     <- asks awsCredentials
+                              awss3b <- asks awss3bucket
+                              hwUrl  <- asks highwayUrl
+                              let cfg = Aws.Configuration { Aws.timeInfo    = Aws.Timestamp
+                                                          , Aws.credentials = cr
+                                                          , Aws.logger      = Aws.defaultLog Aws.Warning
+                                                          , Aws.proxy       = Nothing
+                                                          }
+                              let s3cfg = Aws.defServiceConfig :: S3.S3Configuration Aws.NormalQuery
+                              --Set up a ResourceT region with an available HTTP manager.
+                              $logInfoS "highway/putS3File" $ T.pack $ "Setting up a ResourceT region with an available HTTP manager."
+                              st  <- askUnliftIO
+                              liftIO $ runResourceT $ do
+                                let body = RequestBodyBS content
+                                --Create a request object with S3.getObject and run the request with pureAws.
+                                liftIO $ unliftIO st $ $logInfoS "highway/putS3File" $ T.pack $ "Creating request object with getObject and running request via pureAws."
+                                _ <- Aws.pureAws cfg s3cfg mgr $
+                                       S3.putObject awss3b uploadFileName body
+                                return $ hwUrl <> "/highway/" <> uploadFileName
+                   False -> --Filename provided (extension included) exceed 100 characters in length.
+                            liftIO $ throwIO BadPutFilenameLengthError
     _ -> --Too many or no files provided via form.
       liftIO $ throwIO BadPutError

--- a/strato/highway/server/src/Strato/Server/PutS3File.hs
+++ b/strato/highway/server/src/Strato/Server/PutS3File.hs
@@ -24,7 +24,6 @@ import           System.FilePath (takeExtension)
 import           Strato.Monad
 import           Blockchain.Strato.Model.Keccak256
 
-
 putS3File :: MultipartData Mem 
           -> HighwayM Text
 putS3File multipartdata =
@@ -38,30 +37,27 @@ putS3File multipartdata =
                  let contentHash = T.pack . keccak256ToHex $ hash content
                      extension = T.pack . takeExtension . T.unpack $ fdFileName file
                      uploadFileName = contentHash <> extension
-                 case (T.length uploadFileName <= 99) of
-                   True -> do --Set up AWS credentials and the default configuration.
-                              $logInfoS "highway/putS3File" $ T.pack $ "Setting up AWS credentials and the default AWS configuration."
-                              mgr    <- asks httpManager
-                              cr     <- asks awsCredentials
-                              awss3b <- asks awss3bucket
-                              hwUrl  <- asks highwayUrl
-                              let cfg = Aws.Configuration { Aws.timeInfo    = Aws.Timestamp
-                                                          , Aws.credentials = cr
-                                                          , Aws.logger      = Aws.defaultLog Aws.Warning
-                                                          , Aws.proxy       = Nothing
-                                                          }
-                              let s3cfg = Aws.defServiceConfig :: S3.S3Configuration Aws.NormalQuery
-                              --Set up a ResourceT region with an available HTTP manager.
-                              $logInfoS "highway/putS3File" $ T.pack $ "Setting up a ResourceT region with an available HTTP manager."
-                              st  <- askUnliftIO
-                              liftIO $ runResourceT $ do
-                                let body = RequestBodyBS content
-                                --Create a request object with S3.getObject and run the request with pureAws.
-                                liftIO $ unliftIO st $ $logInfoS "highway/putS3File" $ T.pack $ "Creating request object with getObject and running request via pureAws."
-                                _ <- Aws.pureAws cfg s3cfg mgr $
-                                       S3.putObject awss3b uploadFileName body
-                                return $ hwUrl <> "/highway/" <> uploadFileName
-                   False -> --Filename provided (extension included) exceed 100 characters in length.
-                            liftIO $ throwIO BadPostFilenameLengthError
+                 --Set up AWS credentials and the default configuration.
+                 $logInfoS "highway/putS3File" $ T.pack $ "Setting up AWS credentials and the default AWS configuration."
+                 mgr    <- asks httpManager
+                 cr     <- asks awsCredentials
+                 awss3b <- asks awss3bucket
+                 hwUrl  <- asks highwayUrl
+                 let cfg = Aws.Configuration { Aws.timeInfo    = Aws.Timestamp
+                                             , Aws.credentials = cr
+                                             , Aws.logger      = Aws.defaultLog Aws.Warning
+                                             , Aws.proxy       = Nothing
+                                             }
+                 let s3cfg = Aws.defServiceConfig :: S3.S3Configuration Aws.NormalQuery
+                 --Set up a ResourceT region with an available HTTP manager.
+                 $logInfoS "highway/putS3File" $ T.pack $ "Setting up a ResourceT region with an available HTTP manager."
+                 st  <- askUnliftIO
+                 liftIO $ runResourceT $ do
+                   let body = RequestBodyBS content
+                   --Create a request object with S3.getObject and run the request with pureAws.
+                   liftIO $ unliftIO st $ $logInfoS "highway/putS3File" $ T.pack $ "Creating request object with getObject and running request via pureAws."
+                   _ <- Aws.pureAws cfg s3cfg mgr $
+                          S3.putObject awss3b uploadFileName body
+                   return $ hwUrl <> "/highway/" <> uploadFileName
     _ -> --Too many or no files provided via form.
       liftIO $ throwIO BadPostError

--- a/strato/highway/server/src/Strato/Server/PutS3File.hs
+++ b/strato/highway/server/src/Strato/Server/PutS3File.hs
@@ -62,6 +62,6 @@ putS3File multipartdata =
                                        S3.putObject awss3b uploadFileName body
                                 return $ hwUrl <> "/highway/" <> uploadFileName
                    False -> --Filename provided (extension included) exceed 100 characters in length.
-                            liftIO $ throwIO BadPutFilenameLengthError
+                            liftIO $ throwIO BadPostFilenameLengthError
     _ -> --Too many or no files provided via form.
       liftIO $ throwIO BadPutError


### PR DESCRIPTION
This PR seeks to add a filename length limit within the servant configuration, which ensures a maximum character length of 100.