### PR TITLE
Transfer feature

### DIFF
--- a/marketplace/backend/api/v1/Inventory/index.js
+++ b/marketplace/backend/api/v1/Inventory/index.js
@@ -62,6 +62,13 @@ router.post(
   InventoryController.transfer
 );
 
+router.get(
+  Inventory.transferredItems,
+  authHandler.authorizeRequest(),
+  loadDapp,
+  InventoryController.getAllItemTransferEvents
+);
+
 router.put(
   Inventory.update,
   authHandler.authorizeRequest(),

--- a/marketplace/backend/api/v1/Inventory/inventory.controller.js
+++ b/marketplace/backend/api/v1/Inventory/inventory.controller.js
@@ -134,6 +134,19 @@ class InventoryController {
     }
   }
 
+  static async getAllItemTransferEvents(req, res, next) {
+    try {
+      const { dapp, query } = req
+      const itemTransfers = await dapp.getAllItemTransferEvents(query)
+
+      rest.response.status200(res, itemTransfers)
+
+      return next()
+    } catch (e) {
+      return next(e)
+    }
+  }
+
   static async updateSale(req, res, next) {
     try {
       const { dapp, body } = req

--- a/marketplace/backend/api/v1/endpoints.js
+++ b/marketplace/backend/api/v1/endpoints.js
@@ -43,6 +43,7 @@ export const Product = {
 
 export const Inventory = {
   prefix: '/inventory',
+  transferredItems: '/transfers/items/',
   getOwnershipHistory: '/ownership/history',
   get: '/:address',
   getAll: '/',

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -238,9 +238,16 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
 
   contract.transferItem = async function (args, options = defaultOptions) {
     const { assetAddress, ...restArgs } = args;
+    const transferNumber = parseInt(util.uid())
+    const finalArgs = {transferNumber:transferNumber, ...restArgs};
     const contract = { address: assetAddress };
-    return await inventoryJs.transferItem(rawAdmin, contract, restArgs, options);
+    return inventoryJs.transferItem(rawAdmin, contract, finalArgs, options);
   }
+
+  contract.getAllItemTransferEvents = function (args, options = defaultOptions) {
+    const getOptions = { ...options, app: contractName, };
+    return inventoryJs.getAllItemTransferEvents(rawAdmin, args, getOptions);
+  };
 
   contract.updateSale = async function (args, options = defaultOptions) {
     const { saleAddress, ...restArgs } = args;

--- a/marketplace/backend/dapp/items/contracts/Art.sol
+++ b/marketplace/backend/dapp/items/contracts/Art.sol
@@ -1,7 +1,7 @@
 pragma es6;
 pragma strict;
 
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 /// @title A representation of Art assets
 contract Art is UTXO {

--- a/marketplace/backend/dapp/items/contracts/CarbonDAO.sol
+++ b/marketplace/backend/dapp/items/contracts/CarbonDAO.sol
@@ -1,7 +1,7 @@
 pragma es6;
 pragma strict;
 
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 /// @title A representation of CarbonDAO assets
 contract CarbonDAO is SemiFungible {

--- a/marketplace/backend/dapp/items/contracts/CarbonOffset.sol
+++ b/marketplace/backend/dapp/items/contracts/CarbonOffset.sol
@@ -1,7 +1,7 @@
 pragma es6;
 pragma strict;
 
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 /// @title A representation of CarbonOffset assets
 contract CarbonOffset is Mintable {

--- a/marketplace/backend/dapp/items/contracts/Clothing.sol
+++ b/marketplace/backend/dapp/items/contracts/Clothing.sol
@@ -1,7 +1,7 @@
 pragma es6;
 pragma strict;
 
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 /// @title A representation of Clothing assets
 contract Clothing is Mintable {

--- a/marketplace/backend/dapp/items/contracts/Collectibles.sol
+++ b/marketplace/backend/dapp/items/contracts/Collectibles.sol
@@ -1,7 +1,7 @@
 pragma es6;
 pragma strict;
 
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 /// @title A representation of Collectible assets
 contract Collectibles is Mintable {

--- a/marketplace/backend/dapp/items/contracts/Membership.sol
+++ b/marketplace/backend/dapp/items/contracts/Membership.sol
@@ -1,7 +1,7 @@
 pragma es6;
 pragma strict;
 
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 /// @title A representation of Membership assets
 contract Membership is SemiFungible {

--- a/marketplace/backend/dapp/items/contracts/Metals.sol
+++ b/marketplace/backend/dapp/items/contracts/Metals.sol
@@ -1,7 +1,7 @@
 pragma es6;
 pragma strict;
 
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 contract UnitOfMeasurement {
 enum UnitOfMeasurement {

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Asset.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Asset.sol
@@ -30,6 +30,20 @@ abstract contract Asset is Utils {
         uint maxItemNumber
     );
 
+    event ItemTransfers(
+        address indexed assetAddress,
+        address indexed oldOwner,
+        string oldOwnerCommonName,
+        address indexed newOwner,
+        string newOwnerCommonName,
+        string assetName,
+        uint minItemNumber,
+        uint maxItemNumber,
+        uint quantity,
+        uint transferNumber,
+        uint transferDate
+    );
+
     constructor(
         string _name,
         string _description,
@@ -112,8 +126,27 @@ abstract contract Asset is Utils {
         sale = address(0);
     }
 
-    function _transfer(address _newOwner, uint _quantity) internal virtual {
+    function _transfer(address _newOwner, uint _quantity, bool _isUserTransfer, uint _transferNumber) internal virtual {
         string newOwnerCommonName = getCommonName(_newOwner);
+
+        if(_isUserTransfer && _transferNumber>0){
+
+            emit ItemTransfers(
+                originAddress,
+                owner,
+                ownerCommonName,
+                _newOwner,
+                newOwnerCommonName,
+                name,
+                itemNumber,
+                itemNumber + _quantity - 1,
+                _quantity,
+                _transferNumber,
+                block.timestamp
+                );
+
+            }
+
         emit OwnershipTransfer(
             originAddress,
             owner,
@@ -130,13 +163,13 @@ abstract contract Asset is Utils {
     
     function transferOwnership(address _newOwner, uint _quantity) public fromSale("transfer ownership") {
         require(_quantity <= quantity, "Cannot transfer more than available quantity.");
-        _transfer(_newOwner, _quantity);
+        _transfer(_newOwner, _quantity, false, 0);
     }
 
-    function automaticTransfer(address _newOwner, uint _quantity) public requireOwner("automatic transfer") returns (uint) {
+    function automaticTransfer(address _newOwner, uint _quantity, uint _transferNumber) public requireOwner("automatic transfer") returns (uint) {
         require(_quantity <= quantity, "Cannot transfer more than available quantity.");
         if (sale == address(0)) {
-            _transfer(_newOwner, _quantity);
+            _transfer(_newOwner, _quantity, true, _transferNumber);
             return RestStatus.OK;
         } else {
             return Sale(sale).automaticTransfer(_newOwner, _quantity);

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/UTXO.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/UTXO.sol
@@ -25,7 +25,7 @@ abstract contract UTXO is Asset {
     }
 
     // Quantity is already checked by transferOwnership function
-    function _transfer(address _newOwner, uint _quantity) internal override {
+    function _transfer(address _newOwner, uint _quantity, bool _isUserTransfer, uint _transferNumber) internal override {
         require(checkCondition(), "Condition is not met");
         // Create a new UTXO with a portion of the units
         try {
@@ -34,6 +34,24 @@ abstract contract UTXO is Asset {
             owner = _newOwner;
             ownerCommonName = getCommonName(_newOwner);
         } catch {
+            
+            if(_isUserTransfer && _transferNumber>0){
+            // Emit ItemTransfers Event
+                emit ItemTransfers(
+                    originAddress,
+                    owner,
+                    ownerCommonName,
+                    _newOwner,
+                    getCommonName(_newOwner),
+                    name,
+                    itemNumber,
+                    itemNumber + _quantity - 1,
+                    _quantity,
+                    _transferNumber,
+                    block.timestamp
+                    );
+            }
+
             emit OwnershipTransfer(
                 originAddress,
                 owner,

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Orders/SimpleOrder.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Orders/SimpleOrder.sol
@@ -1,6 +1,6 @@
 pragma es6;
 pragma strict;
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 contract SimpleOrder is Order {
     constructor(

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Payments/StripePaymentProvider.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Payments/StripePaymentProvider.sol
@@ -1,7 +1,7 @@
 pragma es6;
 pragma strict;
 
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 /// @title A representation of Carbon assets
 contract StripePaymentProvider is BasePaymentProvider {

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/SimpleSale.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/SimpleSale.sol
@@ -1,6 +1,6 @@
 pragma es6;
 pragma strict;
-import <d6cdd554a0503fb0e33cbaee329afeab5b0a26b2>;
+import <9cd03ab3290710caa85563a82a1c745772901650>;
 
 /// @title A representation of asset sale contract
 contract SimpleSale is Sale {

--- a/marketplace/backend/dapp/products/inventory.js
+++ b/marketplace/backend/dapp/products/inventory.js
@@ -11,6 +11,7 @@ const contractFilename = `${util.cwd}/dapp/products/contracts/Inventory.sol`;
 const saleContractName = 'SimpleSale';
 const saleContract = constants.saleTableName;
 const saleContractFilename = `${util.cwd}/dapp/mercata-base-contracts/Templates/Sales/SimpleSale.sol`;
+const contractEvents = { ITEM_TRANSFER: "ItemTransfers" }
 
 /** 
  * Upload a new Inventory 
@@ -332,6 +333,7 @@ async function getAll(admin, args = {}, defaultOptions) {
     let inventories;
     let sales;
     let finalInventory = [];
+    console.log("GetALL call")
     const options = { ...defaultOptions, org: 'BlockApps', app: 'Mercata' }
 
     if (ownerCommonName) {
@@ -377,6 +379,13 @@ async function getAll(admin, args = {}, defaultOptions) {
     }
 
     return finalInventory ? finalInventory.map((inventory) => marshalOut(inventory)) : undefined;
+}
+
+async function getAllItemTransferEvents(admin, args = {}, defaultOptions) {
+    const options = { ...defaultOptions, org: 'BlockApps', app: 'Mercata' }
+    const itemTransferEvents = await searchAllWithQueryArgs(`${contractName}.${contractEvents.ITEM_TRANSFER}`, args, options, admin);
+    const total  = await searchAllWithQueryArgs( `${contractName}.${contractEvents.ITEM_TRANSFER}`, { ...args, limit: undefined, offset: 0, order: undefined, queryOptions: { select: "count", } }, options, admin );
+    return { transfers: itemTransferEvents.map((item) => marshalOut(item)), total: total[0].count };
 }
 
 async function getOwnershipHistory(user, args, options) {
@@ -445,6 +454,7 @@ export default {
     get,
     getAll,
     getOwnershipHistory,
+    getAllItemTransferEvents,
     inventoryCount,
     marshalIn,
     marshalOut,

--- a/marketplace/backend/helpers/utils.js
+++ b/marketplace/backend/helpers/utils.js
@@ -153,6 +153,12 @@ export const setSearchQueryOptions = (args = {}, _queryOptionsArray) => {
         order: value,
       }
     }
+    if (key === 'or') {
+      return {
+        ...agg,
+        or: value,
+      }
+    }
     if (key === 'category') {
       const categoryQueries = value.map(category => 'contract_name.like.' + category);
       return {

--- a/marketplace/ui/src/AuthenticatedRoutes.js
+++ b/marketplace/ui/src/AuthenticatedRoutes.js
@@ -270,7 +270,9 @@ const AuthenticatedRoutes = ({ user, users }) => {
           <UsersProvider>
             <OrdersProvider>
               <ItemsProvider>
+                <InventoriesProvider>
                 <Order user={user} users={users} />
+                </InventoriesProvider>
               </ItemsProvider>
             </OrdersProvider>
           </UsersProvider>

--- a/marketplace/ui/src/components/Order/ResponsiveTransferOrdersCard.js
+++ b/marketplace/ui/src/components/Order/ResponsiveTransferOrdersCard.js
@@ -14,19 +14,19 @@ export const ResponsiveTransferOrderCard = ({ data, isLoading}) => {
                         </div>
                         <div className={`p-2 px-4 w-full flex justify-between`}>
                             <Typography>From</Typography>
-                            <Typography>{item?.oldOwnerOrganization || 'N/A'}</Typography>
+                            <Typography>{item?.oldOwnerCommonName || 'N/A'}</Typography>
                         </div>
                         <div className={`p-2 px-4 w-full flex justify-between`}>
                             <Typography>To</Typography>
-                            <Typography className={`text-[#202020]`}>{item?.newOwnerOrganization || 'N/A'}</Typography>
+                            <Typography className={`text-[#202020]`}>{item?.newOwnerCommonName || 'N/A'}</Typography>
                         </div>
                         <div className={`p-2 px-4 w-full flex justify-between`}>
                             <Typography>Date</Typography>
-                            <Typography className={`text-[#202020]`}>{item?.date || 'N/A'}</Typography>
+                            <Typography className={`text-[#202020]`}>{item?.transferDate || 'N/A'}</Typography>
                         </div>
                         <div className={`p-2 px-4 w-full flex justify-between`}>
-                            <Typography>Product Name</Typography>
-                            <Typography className={`text-[#202020]`}>{item?.productName || 'N/A'}</Typography>
+                            <Typography>Asset Name</Typography>
+                            <Typography className={`text-[#202020]`}>{item?.assetName || 'N/A'}</Typography>
                         </div>
                         <div className={`p-2 px-4 w-full flex justify-between`}>
                             <Typography>Quantity</Typography>

--- a/marketplace/ui/src/components/Order/TransfersTable.js
+++ b/marketplace/ui/src/components/Order/TransfersTable.js
@@ -1,27 +1,27 @@
 import React, { useEffect, useState } from "react";
 import DataTableComponent from "../DataTableComponent";
 import { getStringDate } from "../../helpers/utils";
-import { actions } from "../../contexts/item/actions";
-import { useItemDispatch, useItemState } from "../../contexts/item";
+import { actions } from "../../contexts/inventory/actions";
 import { US_DATE_FORMAT } from "../../helpers/constants";
 import { Input, Pagination } from "antd";
 import "./ordersTable.css"
 import { DownOutlined, SearchOutlined, UpOutlined } from "@ant-design/icons";
 import { ResponsiveOrderCard } from "./ResponsiveOrdersCard";
 import { ResponsiveTransferOrderCard } from "./ResponsiveTransferOrdersCard";
+import { useInventoryDispatch, useInventoryState } from "../../contexts/inventory";
 
 
 const TransfersTable = ({ user, selectedDate }) => {
-  const dispatch = useItemDispatch();
+  const dispatch = useInventoryDispatch();
   const limit = 10;
   const [offset, setOffset] = useState(0);
   const [page, setPage] = useState(1);
-  const { itemTransfers, totalItemsTransfered, isFetchingItemTransfers } = useItemState();
+  const { itemTransfers, totalItemsTransfered, isFetchingItemTransfers } = useInventoryState();
   const [order, setOrder] = useState("desc")
 
   console.log("selectedDate", selectedDate)
   useEffect(() => {
-    actions.fetchItemTransfers(dispatch, limit, offset, user.organization, order, selectedDate);
+    actions.fetchItemTransfers(dispatch, limit, offset, user.commonName, order, selectedDate);
   }, [dispatch, limit, offset, user, order, selectedDate]);
 
   useEffect(() => {
@@ -32,25 +32,27 @@ const TransfersTable = ({ user, selectedDate }) => {
   const [data, setdata] = useState([]);
   useEffect(() => {
     let items = [];
+    if(itemTransfers)
+    {
     itemTransfers.forEach((transfer) => {
       items.push({
         address: transfer.address,
         key: transfer.address,
-        inventoryId: transfer.inventoryId,
-        productName: decodeURIComponent(transfer.productName),
+        assetAddress: transfer.assetAddress,
+        assetName: decodeURIComponent(transfer.assetName),
         newOwner: transfer.newOwner,
         newOwnerCommonName: transfer.newOwnerCommonName,
-        newOwnerOrganization: transfer.newOwnerOrganization,
         oldOwner: transfer.oldOwner,
         oldOwnerCommonName: transfer.oldOwnerCommonName,
-        oldOwnerOrganization: transfer.oldOwnerOrganization,
         quantity: transfer.quantity,
         transferDate: getStringDate(transfer.transferDate, US_DATE_FORMAT),
         transferNumber: transfer.transferNumber,
       });
     });
+  }
     setdata(items);
   }, [itemTransfers]);
+
   
   const column = [
     {
@@ -62,12 +64,12 @@ const TransfersTable = ({ user, selectedDate }) => {
     {
       title: "From",
       key: "oldOwnerCommonName",
-      render: (text, record) => <p>{record.oldOwnerOrganization.startsWith("Mercata Account") ? record.oldOwnerCommonName : record.oldOwnerOrganization}</p>,
+      render: (text, record) => <p>{record.oldOwnerCommonName}</p>,
     },
     {
       title: "To",
       key: "newOwnerCommonName",
-      render: (text, record) => <p>{record.newOwnerOrganization.startsWith("Mercata Account") ? record.newOwnerCommonName : record.newOwnerOrganization}</p>,
+      render: (text, record) => <p>{record.newOwnerCommonName}</p>,
     },
     {
       dataIndex: "transferDate",
@@ -87,9 +89,9 @@ const TransfersTable = ({ user, selectedDate }) => {
       ),
     },
     {
-      title: "Product Name",
-      dataIndex: "productName",
-      key: "productName",
+      title: "Asset Name",
+      dataIndex: "assetName",
+      key: "assetName",
       render: (text) => <p>{text}</p>,
     },
     {

--- a/marketplace/ui/src/contexts/inventory/actions.js
+++ b/marketplace/ui/src/contexts/inventory/actions.js
@@ -35,6 +35,9 @@ const actionDescriptors = {
   transferInventory: "transfer_inventory",
   transferInventorySuccessful: "transfer_inventory_successful",
   transferInventoryFailed: "transfer_inventory_failed",
+  fetchItemTransfers: "fetch_item_transfers",
+  fetchItemTransfersSuccessful: "fetch_item_transfers_successful",
+  fetchItemTransfersFailed: "fetch_item_transfers_failed",
   resetMessage: "reset_message",
   setMessage: "set_message",
   onboardSellerToStripe: "onboard_seller_to_stripe",
@@ -529,6 +532,54 @@ const actions = {
       actions.setMessage(dispatch, "Error while transferring Item");
     }
   },
+
+
+ 
+  fetchItemTransfers: async (dispatch, limit, offset, ownerCommonName, order, date) => {
+    dispatch({ type: actionDescriptors.fetchItemTransfers });
+
+    let range;
+    const end = date + 86400; // This is the end of the same day, needed for the range filter. 
+    if (date) {
+      range = `&range[]=transferDate,${date},${end}`
+    }
+    
+    try {
+      const response = await fetch(`${apiUrl}/inventory/transfers/items?limit=${limit}&order=transferDate.${order}&offset=${offset}&or=(oldOwnerCommonName.eq.${ownerCommonName},newOwnerCommonName.eq.${ownerCommonName})${range}`, {
+        method: HTTP_METHODS.GET,
+
+      });
+
+      const body = await response.json();
+
+      if (response.status === RestStatus.OK) {
+        dispatch({
+          type: actionDescriptors.fetchItemTransfersSuccessful,
+          payload: body.data,
+        });
+
+        return true;
+      } else if(response.status === RestStatus.UNAUTHORIZED) {
+        dispatch({ 
+          type: actionDescriptors.fetchItemTransfersFailed, 
+          error: "Unauthorized while fetching item transfers" 
+        });
+        window.location.href = body.error.loginUrl;
+      }
+
+      dispatch({
+        type: actionDescriptors.fetchItemTransfersFailed,
+        error: "Error while fetching item transfers",
+      });
+      return false;
+    } catch (err) {
+      dispatch({
+        type: actionDescriptors.fetchItemTransfersFailed,
+        error: "Error while fetching item transfers",
+      });
+      return false;
+    }
+  }, 
 
   fetchInventoryDetail: async (dispatch, address) => {
     dispatch({ type: actionDescriptors.fetchInventoryDetail });

--- a/marketplace/ui/src/contexts/inventory/index.js
+++ b/marketplace/ui/src/contexts/inventory/index.js
@@ -30,6 +30,10 @@ const InventoriesProvider = ({ children }) => {
     isLoadingStripeStatus: false,
     uploadedImg : null,
     isUploadImageSubmitting: false,
+    isTransferringItems: false,
+    itemTransfers: [],
+    totalItemsTransfered: 0,
+    isFetchingItemTransfers: false    
   };
 
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/marketplace/ui/src/contexts/inventory/reducer.js
+++ b/marketplace/ui/src/contexts/inventory/reducer.js
@@ -169,6 +169,24 @@ const reducer = (state, action) => {
         error: action.error,
         isTransferring: false
       };
+    case actionDescriptors.fetchItemTransfers:
+      return {
+        ...state,
+        isFetchingItemTransfers: true,
+      };
+    case actionDescriptors.fetchItemTransfersSuccessful:
+      return {
+        ...state,
+        itemTransfers: action.payload.transfers,
+        totalItemsTransfered: action.payload.total,
+        isFetchingItemTransfers: false,
+      };
+    case actionDescriptors.fetchItemTransfersFailed:
+      return {
+        ...state,
+        error: action.error,
+        isFetchingItemTransfers: false,
+      };
     case actionDescriptors.fetchInventoryOwnershipHistory:
       return {
         ...state,


### PR DESCRIPTION
This PR deals with transfer feature on marketplace. Whenever a user transfers an asset to another user, `ItemTransfers` event is emitted, the details of which are now dispalyed on the `Orders` -> `Transfers` Tab.

Contract Level Changes: 
 - Introduced `Itemtransfers` event in the Asset.sol
 - Handled transfer method arguments to accept additional args required for Transfer Feature
 - `isUserTransfer` is a boolean flag which needs to be `false` for regular transfers and `true` for `Transfer Feature` related transfers
 - `automaticTransfer` accepts additional argument `transferNumber`
 - `transferNumber` is defaulted to `0` for regular transfers, and `>0` for `Transfer Feature` related transfers


This can only be visible for **newly created assets**.


<img width="388" alt="Screenshot 2024-01-02 at 3 27 52 PM" src="https://github.com/blockapps/strato-platform/assets/35606645/97f3be39-b9d7-4b4e-9a17-ee41c7229d87">
<img width="1440" alt="Screenshot 2024-01-02 at 3 27 35 PM" src="https://github.com/blockapps/strato-platform/assets/35606645/8101a203-1acc-45df-8ff4-2a4b73ff76a6">
