### PR TITLE
Keep active peer logic outside of thread scoping

### DIFF
--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -80,7 +80,7 @@ runPeer peer sSource = do
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "Attempting to connect to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "my pubkey is: " ++ format myPublic
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "server pubkey is: " ++ format otherPubKey 
-  runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource $ \c ->
+  runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource $ \c -> do
       let pStr = pPeerString peer -- display string will show up as dns name
       attempt :: (Maybe SomeException) <- 
         withCertifiedPeer peer . withActivePeer peer . scoped $

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -81,17 +81,15 @@ runPeer peer sSource = do
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "my pubkey is: " ++ format myPublic
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "server pubkey is: " ++ format otherPubKey 
   runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource $ \c ->
-    scoped $ \scope -> do
       let pStr = pPeerString peer -- display string will show up as dns name
       attempt :: (Maybe SomeException) <- 
-        withCertifiedPeer peer . withActivePeer peer $
+        withCertifiedPeer peer . withActivePeer peer . scoped $
           runEthClientConduit
             peer {pPeerPubkey = Just otherPubKey}
             (c ^. peerSource)
             (c ^. peerSink)
             (c ^. seqSource)
             pStr
-            scope
       case attempt of
         Nothing  -> $logDebugS "runPeer" "Peer ran successfully!"
         Just err -> do $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -69,9 +69,8 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
         Nothing -> do
           $logErrorS "runEthServer" . T.pack $ "Didn't get pubkey during discovery for peer " ++ peerStr ++ ". rejecting violently."
         Just pubkey ->
-          scoped $ \scope -> do
-            attempt <- withCertifiedPeer p . withActivePeer p $
-                         runEthServerConduit p pSource pSink seqSrc peerStr scope
+            attempt <- withCertifiedPeer p . withActivePeer p . scoped $
+                         runEthServerConduit p pSource pSink seqSrc peerStr
             case attempt of
               Nothing  -> $logDebugS "runEthServer" "Peer ran successfully!"
               Just err -> do

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -68,7 +68,7 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
       case pPeerPubkey p of
         Nothing -> do
           $logErrorS "runEthServer" . T.pack $ "Didn't get pubkey during discovery for peer " ++ peerStr ++ ". rejecting violently."
-        Just pubkey ->
+        Just pubkey -> do
             attempt <- withCertifiedPeer p . withActivePeer p . scoped $
                          runEthServerConduit p pSource pSink seqSrc peerStr
             case attempt of


### PR DESCRIPTION
I think that by putting the `withActivePeer` call inside the `scoped` call, the thread is exiting before it can update the peer's active status to 0. I have a suspicion that this is causing sync to be slow, since peers are being ignored if their active status isn't being reset.