### PR TITLE
Do not wrap data objects in quotes in slipstream

### DIFF
--- a/marketplace/backend/config/localhost.deploy.yaml
+++ b/marketplace/backend/config/localhost.deploy.yaml
@@ -2,4 +2,4 @@ url: http://localhost
 dapp:
   contract:
     name: Mercata
-    address: eddd7c9aa884a3b1b8595f0897608c07a8e770b1
+    address: 5a4f9eace9d21c1aae3f8e9c21198649b7b9ab63

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -438,7 +438,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     const sellersCommonName = sales[0].sellersCommonName;
     const saleAddresses = await Promise.all(sales.map(async (sale) => {
       const orderForSale = orderList.find(order => order.assetAddress === sale.assetToBeSold);
-      const saleData = JSON.parse(sale.data);
+      const saleData = sale.data;
       if (saleData.units && orderForSale.quantity < saleData.units) {
         const contract = { name: orderForSale.category, address: orderForSale.assetAddress }
         const splitSaleAddress = await saleJs.createSplitSale(rawAdmin, {

--- a/marketplace/ui/src/components/Inventory/InventoryCard.js
+++ b/marketplace/ui/src/components/Inventory/InventoryCard.js
@@ -35,7 +35,7 @@ const InventoryCard = ({ inventory, category, debouncedSearchTerm, id, paymentPr
   const navigate = useNavigate();
   const naviroute = routes.InventoryDetail.url;
   
-  const itemData = JSON.parse(inventory.data);
+  const itemData = inventory.data;
   const showModalEdit = () => {
     hide();
     setOpenEdit(true);

--- a/marketplace/ui/src/components/Inventory/PreviewInventoryModal.js
+++ b/marketplace/ui/src/components/Inventory/PreviewInventoryModal.js
@@ -29,7 +29,7 @@ const PreviewInventoryModal = ({ open, handleCancel, inventory, category }) => {
   };
 
   const Description = ({ item }) => {
-    const itemData = JSON.parse(item.data);
+    const itemData = item.data;
 
     switch (getCategory()) {
       case "Art":

--- a/marketplace/ui/src/components/Inventory/UpdateInventoryModal.js
+++ b/marketplace/ui/src/components/Inventory/UpdateInventoryModal.js
@@ -70,7 +70,7 @@ const UpdateInventoryModal = ({
 
   useEffect(() => {
     if (inventoryToUpdate) {
-      const data = inventoryToUpdate.inventory.data ? JSON.parse(inventoryToUpdate.inventory.data) : {};
+      const data = inventoryToUpdate.inventory.data ? inventoryToUpdate.inventory.data : {};
       let nextState = {
         category: {
           name: getCategory(),

--- a/marketplace/ui/src/components/MarketPlace/ProductDetail.js
+++ b/marketplace/ui/src/components/MarketPlace/ProductDetail.js
@@ -130,7 +130,7 @@ const ProductDetails = ({ user, users }) => {
         (c) => c.name === details.category
       );
       setCategoryName(prodCategory?.name);
-      const detailsData = JSON.parse(details.data);
+      const detailsData = details.data;
       setItemData(detailsData);
       if (details.saleQuantity) {
         setAvailableQuantity(details.saleQuantity || 1);

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1053,7 +1053,7 @@ insertAbstractTableQuery cs =
                     tshow . E.transactionSender
                   ]
                 vals = flip map contracts $ \((row, contractColumns), _) ->
-                  wrapAndEscape $ map (wrapSingleQuotes . ($ row)) baseVals ++ [wrapSingleQuotes (tableNameToText contractTableName)] ++ [T.pack $ show $ Aeson.encode $ MapWrapper $ aesonHelper $ Map.filterWithKey (\k _ -> k `notElem` abColumns) contractColumns] ++ (map snd $ Map.toList (Map.filterWithKey (\k _ -> k `elem` abColumns) contractColumns))
+                  wrapAndEscape $ map (wrapSingleQuotes . ($ row)) baseVals ++ [wrapSingleQuotes (tableNameToText contractTableName)] ++ [wrapSingleQuotes . decodeUtf8 . BL.toStrict $ Aeson.encode $ MapWrapper $ aesonHelper $ Map.filterWithKey (\k _ -> k `notElem` abColumns) contractColumns] ++ (map snd $ Map.toList (Map.filterWithKey (\k _ -> k `elem` abColumns) contractColumns))
                 inserts = csv vals
             in (: []) $
                   T.concat

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1053,7 +1053,7 @@ insertAbstractTableQuery cs =
                     tshow . E.transactionSender
                   ]
                 vals = flip map contracts $ \((row, contractColumns), _) ->
-                  wrapAndEscape $ map (wrapSingleQuotes . ($ row)) baseVals ++ [wrapSingleQuotes (tableNameToText contractTableName)] ++ [wrapSingleQuotes $ T.pack $ show $ Aeson.encode $ MapWrapper $ aesonHelper $ Map.filterWithKey (\k _ -> k `notElem` abColumns) contractColumns] ++ (map snd $ Map.toList (Map.filterWithKey (\k _ -> k `elem` abColumns) contractColumns))
+                  wrapAndEscape $ map (wrapSingleQuotes . ($ row)) baseVals ++ [wrapSingleQuotes (tableNameToText contractTableName)] ++ [T.pack $ show $ Aeson.encode $ MapWrapper $ aesonHelper $ Map.filterWithKey (\k _ -> k `notElem` abColumns) contractColumns] ++ (map snd $ Map.toList (Map.filterWithKey (\k _ -> k `elem` abColumns) contractColumns))
                 inserts = csv vals
             in (: []) $
                   T.concat


### PR DESCRIPTION
It appears that the `data` objects in abstract tables are being treated as JSON strings, rather than objects, because they are being wrapped in quotes. This prevents us from performing queries filtering on values inside the JSON object