### PR TITLE
[Strato P2P] Fixing Leaky Canary Count

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -126,11 +126,11 @@ mkEthP2PEventSource peerSourceConduit seqEventSource peerStr inCtx scp = do
     merged
       .| CL.iterM recordEvent
 
---mkCanarySource :: (MonadLogger m, MonadUnliftIO m, MonadResource m) => m (ConduitM () Void m ())
-mkCanarySource :: (MonadLogger m, MonadUnliftIO m) => m (ConduitM () Void m ())
+mkCanarySource :: ( MonadLogger m
+                  , MonadUnliftIO m
+                  )
+               => m (ConduitM () Void m ())
 mkCanarySource = do
-  --ender <- toIO $ $logInfoS "canary/exit" "" >> killCanary
-  --void . register $ ender
   q <- atomically newTQueue
   $logInfoS "canary/enter" ""
   addCanary

--- a/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
+++ b/strato/core/strato-p2p/src/Blockchain/CommunicationConduit.hs
@@ -83,9 +83,9 @@ blockstanbulVersion :: Int
 blockstanbulVersion = 1
 
 mkEthP2PEventSource ::
-  ( MonadResource m,
-    MonadLogger m,
-    MonadUnliftIO m
+  ( MonadResource m
+  ,  MonadLogger m
+  ,  MonadUnliftIO m
   ) =>
   ConduitM () B.ByteString m () ->
   ConduitM () P2pEvent m () ->
@@ -98,17 +98,26 @@ mkEthP2PEventSource peerSourceConduit seqEventSource peerStr inCtx scp = do
   eventsourcethreadid <- myThreadId
   recvWatchdog <- mkWatchdog eventsourcethreadid $ fromIntegral flags_connectionTimeout
   merged <- mergeSourcesByForce
-              ( [ peerSourceConduit
+              ( [ ( ("peerSourceConduit" :: String)
+                  , peerSourceConduit
                     .| ethDecrypt inCtx
                     .| CL.iterM (recordTraffic Inbound)
                     .| bytesToMessages
                     .| CL.iterM (displayMessage Inbound peerStr)
                     .| CL.map MsgEvt
-                    .| CL.iterM (const $ petWatchdog recvWatchdog),
-                  seqEventSource
-                    .| CL.map NewSeqEvent,
-                  canarySource .| CL.map absurd,
-                  timerSource
+                    .| CL.iterM (const $ petWatchdog recvWatchdog)
+                  )
+                , ( ("seqEventSource" :: String)
+                  , seqEventSource
+                    .| CL.map NewSeqEvent
+                  )
+                , ( ("canarySource" :: String)
+                  , canarySource
+                    .| CL.map absurd
+                  )
+                , ( ("timerSource" :: String)
+                  , timerSource
+                  )
                 ]
               )
               4096 -- 🙏
@@ -117,10 +126,11 @@ mkEthP2PEventSource peerSourceConduit seqEventSource peerStr inCtx scp = do
     merged
       .| CL.iterM recordEvent
 
-mkCanarySource :: (MonadLogger m, MonadUnliftIO m, MonadResource m) => m (ConduitM () Void m ())
+--mkCanarySource :: (MonadLogger m, MonadUnliftIO m, MonadResource m) => m (ConduitM () Void m ())
+mkCanarySource :: (MonadLogger m, MonadUnliftIO m) => m (ConduitM () Void m ())
 mkCanarySource = do
-  ender <- toIO $ $logInfoS "canary/exit" "" >> killCanary
-  void . register $ ender
+  --ender <- toIO $ $logInfoS "canary/exit" "" >> killCanary
+  --void . register $ ender
   q <- atomically newTQueue
   $logInfoS "canary/enter" ""
   addCanary

--- a/strato/core/strato-p2p/src/Blockchain/ExtMergeSources.hs
+++ b/strato/core/strato-p2p/src/Blockchain/ExtMergeSources.hs
@@ -13,6 +13,8 @@ module Blockchain.ExtMergeSources
   )
 where
 
+import           BlockApps.Logging
+import           Blockchain.Metrics
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
@@ -22,6 +24,7 @@ import           Data.Conduit                 as DC
 import           Data.Conduit.TMChan          hiding (mergeSources)
 import qualified Data.Conduit.List            as CL
 import           Data.Kind
+import           Data.String
 import           Ki.Unlifted as KIU
 import           UnliftIO.Exception
 import           UnliftIO.STM
@@ -76,22 +79,39 @@ chanSink :: MonadIO m
 chanSink ch writer = CL.mapM_ $ liftIO . atomically . writer ch
 {-# INLINE chanSink #-}
 
-mergeSourcesByForce :: (MonadResource mi, Monad mo, MonadUnliftIO mi)
-                    => [ConduitM () a mi ()]
+--mergeSourcesByForce :: (MonadResource mi, Monad mo, MonadUnliftIO mi)
+--                    => [(a1,ConduitM () a mi ())]
+--                    -> Int
+--                    -> Scope
+--                    -> mo (ConduitM () a mi ())
+mergeSourcesByForce :: ( MonadResource m1
+                       , Monad m2
+                       , MonadUnliftIO m1
+                       , Eq a1
+                       , Data.String.IsString a1
+                       , MonadLogger m1
+                       )
+                    => [(a1,ConduitT () a2 m1 ())]
                     -> Int
                     -> Scope
-                    -> mo (ConduitM () a mi ())
+                    -> m2 (ConduitT z a2 m1 ())
 mergeSourcesByForce sx bound scp =
   return $ do
     (chkey,c) <- allocate (liftSTM $ newTBMChan bound)
                           (liftSTM . closeTBMChan)
     refcount <- liftSTM . newTVar $ length sx
     st <- lift $ askUnliftIO
-    _  <- forM sx $ \s ->
+    _  <- forM sx $ \(tag,s) ->
             liftIO $ fork scp 
                  ( (unliftIO st $
                       runConduit $ s .| chanSink c writeTBMChan)
-                        `finally` (liftSTM $ decRefcount refcount c)
+                        `finally` ( case tag of
+                                      "canarySource" -> do
+                                        _ <- unliftIO st $ $logInfoS "canary/exit" "" >> killCanary
+                                        liftSTM $ decRefcount refcount c
+                                      _              ->
+                                        liftSTM $ decRefcount refcount c
+                                  )
                  )
     chanSource c readTBMChan
     release chkey

--- a/strato/core/strato-p2p/src/Blockchain/ExtMergeSources.hs
+++ b/strato/core/strato-p2p/src/Blockchain/ExtMergeSources.hs
@@ -79,11 +79,7 @@ chanSink :: MonadIO m
 chanSink ch writer = CL.mapM_ $ liftIO . atomically . writer ch
 {-# INLINE chanSink #-}
 
---mergeSourcesByForce :: (MonadResource mi, Monad mo, MonadUnliftIO mi)
---                    => [(a1,ConduitM () a mi ())]
---                    -> Int
---                    -> Scope
---                    -> mo (ConduitM () a mi ())
+-- | Custom mergeSourcesByForce function.
 mergeSourcesByForce :: ( MonadResource m1
                        , Monad m2
                        , MonadUnliftIO m1


### PR DESCRIPTION
The PR seeks to resolve the leaky p2p_canary_count observed by monitoring via logging/prometheus.

When running a local node on testnet, this fix also appears to help alleviate the ever-increasing slow memory build-up (its possible that the root cause/one of the root causes of the slow memory build-up stemmed from a ever-increasing p2p canary counter).

---

Visual comparisons before and after this PR:

- Both of the graphics are taken from `prometheus`.
- Both of the graphics are generated from local nodes connected to the testnet.

Before this PR:

This graphic displays the clear trend of an ever increasing amount of `p2p_canary_count`s, indicating an issue with the way the counter is decremented.

![Screenshot 2024-01-11 at 13-19-40 Prometheus Time Series Collection and Processing Server](https://github.com/blockapps/strato-platform/assets/31868392/5e92c8ca-a04c-4802-9b35-7e774eb6410d)

With this PR:

This graphic illustrates that handling the decrementing of the `p2p_canary_count` at the time the thread is terminated ensures that the counter is in line with reality.

![Screenshot 2024-01-11 at 11-26-17 Prometheus Time Series Collection and Processing Server](https://github.com/blockapps/strato-platform/assets/31868392/c7585b0a-de1d-4d73-bde3-89eeeccc6ac0)
