### PR TITLE
add node sync/stall checks to apex

### DIFF
--- a/apex/api/config/app.config.js
+++ b/apex/api/config/app.config.js
@@ -17,8 +17,8 @@ module.exports = {
     stallCheckProgressWindow: 10 * 60 * 1000,
     memoryUsedAlertLevel: 80, // Alert when used memory (RAM) >= N%
     diskspaceUsedAlertLevel: 80, // Alert when used diskspace >= N%
-    cpuAvgLoadAlertLevel: 1.2, // Alert when cpu avg load > N
-    cpuCurrentLoadAlertLevel: 97, // Alert when cpu current load > N%,
+    cpuAvgLoadAlertLevel: 97, // Alert when cpu avg load > N%
+    cpuCurrentLoadAlertLevel: 99, // Alert when cpu current load > N%,
     maxStalledIntervals: 20 , //max number of failed stall checks before reporting stalled: 300 seconds / poll freq (15) = 20 
   },
   // Unused code notice. Node stats disabled, to be deprecated  #node-stats-deprecation

--- a/apex/api/config/app.config.js
+++ b/apex/api/config/app.config.js
@@ -18,7 +18,8 @@ module.exports = {
     memoryUsedAlertLevel: 80, // Alert when used memory (RAM) >= N%
     diskspaceUsedAlertLevel: 80, // Alert when used diskspace >= N%
     cpuAvgLoadAlertLevel: 1.2, // Alert when cpu avg load > N
-    cpuCurrentLoadAlertLevel: 97, // Alert when cpu current load > N%
+    cpuCurrentLoadAlertLevel: 97, // Alert when cpu current load > N%,
+    maxStalledIntervals: 20 , //max number of failed stall checks before reporting stalled: 300 seconds / poll freq (15) = 20 
   },
   // Unused code notice. Node stats disabled, to be deprecated  #node-stats-deprecation
   // statistics: {

--- a/apex/api/controllers/health.js
+++ b/apex/api/controllers/health.js
@@ -8,7 +8,8 @@ module.exports = {
   ping: async function (req, res) {
     res.status(200).send('pong');
   },
-
+  getPbftData,
+  findView,
   nodeStatus: async function (req, res, next) {
     try {
       //get node's block number, best block hash, best block parent hash, total difficulty
@@ -28,15 +29,15 @@ module.exports = {
         raw: true,
       });
 
-      let healthStatus, stallStatus, uptime, isInc, isPending, healthAI, systemInfoAI, systemInfoStatus, warningMessages, systemInfoBody;
+      let healthStatus, stallStatus, uptime, isInc, isPending, healthAI, systemInfoAI, systemInfoStatus, warningMessages, systemInfoBody, syncStallStatus, syncStatus;
 
       const currentTime = Date.now();
 
       const responses = await Promise.all([getLatestHealth(), getPbftData()]);
 
-      const [[healthInfo, stallInfo, systemInfo], pbftData] = responses;
+      const [[healthInfo, stallInfo, systemInfo, syncInfo], pbftData] = responses;
 
-      if (healthInfo && stallInfo) {
+      if (healthInfo && stallInfo && syncInfo) {
         healthStatus = healthInfo.latestHealthStatus;
         stallStatus = stallInfo.latestHealthStatus;
         uptime = (healthStatus) ? currentTime - healthInfo.lastFailureTimestamp : 0;
@@ -46,13 +47,16 @@ module.exports = {
         systemInfoAI = JSON.parse(systemInfo.additionalInfo);
         systemInfoStatus = systemInfo.latestHealthStatus;
         warningMessages = systemInfoStatus ? "" : systemInfoAI.Alerts;
-        systemInfoBody = systemInfoAI
+        systemInfoBody = systemInfoAI;
+        syncStallStatus = JSON.parse(syncInfo.additionalInfo)?.isStalled;
+        syncStatus = syncInfo.latestHealthStatus;
         if (systemInfoStatus) {
           delete systemInfoBody.Alerts
         }
       } else {
         winston.warn(`Health table has no entries; Health endpoint is called too soon`)
       }
+
 
       res.status(200).json(
         {
@@ -72,7 +76,9 @@ module.exports = {
             isNotStalled: stallStatus,
             isValidBlocksInc: isInc,
             isLastPending: isPending,
-            unhealthyProcess: healthAI
+            unhealthyProcess: healthAI,
+            isSynced: syncStatus,
+            isSyncStalled: syncStallStatus
           },
           warnings: {
             warningsActive: !systemInfoStatus,
@@ -89,18 +95,20 @@ module.exports = {
 
   healthStatus: async function (req, res, next) {
     try {
-      let healthStatus, stallStatus, uptime, isInc, isPending;
+      let healthStatus, stallStatus, uptime, isInc, isPending, syncStallStatus, syncStatus;
 
       const currentTime = Date.now();
 
-      const [healthInfo, stallInfo, _ignored_systemInfo] = await getLatestHealth();
+      const [healthInfo, stallInfo, _ignored_systemInfo, syncInfo] = await getLatestHealth();
 
-      if (healthInfo && stallInfo) {
+      if (healthInfo && stallInfo && syncInfo) {
         healthStatus = healthInfo.latestHealthStatus;
         stallStatus = stallInfo.latestHealthStatus;
         uptime = (healthStatus) ? currentTime - healthInfo.lastFailureTimestamp : 0;
         isInc = stallInfo.isBlocksValidInc;
         isPending = stallInfo.isLastPending;
+        syncStallStatus = JSON.parse(syncInfo.additionalInfo)?.isStalled;
+        syncStatus = syncInfo.latestHealthStatus;
       } else {
         winston.warn(`Health table has no entires; Health endpoint is called too soon`)
       }
@@ -114,7 +122,9 @@ module.exports = {
               isHealthy: healthStatus,
               isNotStalled: stallStatus,
               isValidBlocksInc: isInc,
-              isLastPending: isPending
+              isLastPending: isPending,
+              isSynced: syncStatus,
+              isSyncStalled: syncStallStatus
             },
           }
       )
@@ -127,7 +137,7 @@ module.exports = {
 };
 
 async function getLatestHealth() {
-  const [healthInfo, stallInfo, systemInfo] = await Promise.all([
+  const [healthInfo, stallInfo, systemInfo, syncInfo] = await Promise.all([
     
     models.CurrentHealth.findOne({
       where: {
@@ -171,9 +181,21 @@ async function getLatestHealth() {
       raw:true,
     }),
     
+    models.CurrentHealth.findOne({
+      where: {
+        processName: "SyncStat"
+      },
+      attributes: [
+        'latestHealthStatus',
+        'latestCheckTimestamp',
+        'lastFailureTimestamp',
+        'additionalInfo'
+      ],
+      raw:true,
+    }),
   ])
   
-  return [healthInfo, stallInfo, systemInfo]
+  return [healthInfo, stallInfo, systemInfo, syncInfo];
 }
 
 function getPbftData() {

--- a/apex/api/daemons/node-health-check-utils.js
+++ b/apex/api/daemons/node-health-check-utils.js
@@ -1,10 +1,13 @@
 const winston = require('winston-color');
 const models = require('../models');
+const BlockDataRef = require('../models/strato/eth/blockDataRef');
 const Promise = require('bluebird');
 const rp = require('request-promise');
 const moment = require('moment');
 const si = require('systeminformation');
 const config = require('../config/app.config');
+const getPbftData = require('../controllers/health')['getPbftData'];
+const findView = require('../controllers/health')['findView'];
 
 // TODO: do the mass-refactoring of the daemon. Use the OOP! Really, don't even try refactoring this without the main Object (SingleCheck object with methods and shared params). Don't change any db data formats.
 
@@ -16,6 +19,8 @@ const neededJobs = {
   // TODO: add vault-proxy in prometheus
   "core-api": "core-api"
 }
+
+const maxStalledIntervals = config.healthCheck.maxStalledIntervals;
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
@@ -67,6 +72,86 @@ async function checkIfGlobalPasswordSet() {
   const options = {
     method: 'GET',
     url: `${process.env.vaultProxyUrl}/strato/v2.3/verify-password`,
+    followRedirects: false,
+    timeout: config.healthCheck.requestTimeout - 100,
+    json: true,
+  };
+
+  return await rp(options);
+}
+
+async function checkNodeSyncStallStatus(syncStat) {
+  let currentTime = Date.now();
+
+  let {lastVmBlockNum = 0, 
+    lastSeqBlockNum = 0,
+    stalledIntervalCount = 0
+  } = (syncStat?.additionalInfo) ? JSON.parse(syncStat?.additionalInfo) : {};
+
+  let isStalled = false;
+
+  const {number: currVmBlockNum = 0} = await BlockDataRef.findOne({
+    where: {
+      pow_verified: true,
+      is_confirmed: true
+    },
+    order: [['number', 'DESC']],
+    attributes: [
+      'number',
+    ],
+    raw: true,
+  });
+
+  const pbftInfo = await getPbftData()
+  const {sequence_number: currSeqBlockNum = 0} = findView(pbftInfo);
+
+  const {isSynced} = await getStratoMetadata();
+  
+  try {
+    if (isSynced) {
+      return [isSynced, {
+        stalledIntervalCount: 0,
+        lastVmBlockNum: 0,
+        lastSeqBlockNum: 0,
+        isStalled
+      }];
+    } else {
+      if (currVmBlockNum === lastVmBlockNum && currSeqBlockNum === lastSeqBlockNum) {
+        if (stalledIntervalCount < maxStalledIntervals) {
+          stalledIntervalCount++;
+        } else {
+          winston.error(`Node stalled during sync at ${currentTime}; went ${maxStalledIntervals * (config.healthCheck.pollFrequency / 1000)} seconds without increasing block number`);
+          isStalled = true;
+        }
+      } else {
+        stalledIntervalCount = 0;
+      }
+      winston.debug(`sync check: prev vm block #: ${lastVmBlockNum}, cur vm block #: ${currVmBlockNum}`);
+      winston.debug(`sync check: prev seq block #: ${lastSeqBlockNum}, cur seq block #: ${currSeqBlockNum}`);
+      winston.debug(`sync check: inverval ${stalledIntervalCount} of ${maxStalledIntervals}`);
+
+      lastVmBlockNum = currVmBlockNum;
+      lastSeqBlockNum = currSeqBlockNum;
+    }
+  } catch (e) {
+    winston.warn(`Error ${e.message ? e.message : ''} occurred while checking node's stall status`);
+  }
+
+  const additionalSyncInfo = {
+    stalledIntervalCount,
+    lastVmBlockNum,
+    lastSeqBlockNum,
+    isStalled
+  }
+
+  return [isSynced, additionalSyncInfo];
+}
+
+
+async function getStratoMetadata() {
+  const options = {
+    method: 'GET',
+    url: `http://strato:3000/eth/v1.2/metadata`,
     followRedirects: false,
     timeout: config.healthCheck.requestTimeout - 100,
     json: true,
@@ -190,6 +275,32 @@ async function updateNodeHealthStatus(nodeHealthData, isGlobalPasswordSet) {
         where: { processName: 'SystemInfoStat' }
       })
   }
+
+  let [syncStat, _] = await models.CurrentHealth.findOrCreate({
+    where: { processName: 'SyncStat' }, defaults: {
+      latestHealthStatus: false,
+      latestCheckTimestamp: currentTime,
+      additionalInfo:  JSON.stringify({
+        stalledIntervalCount: 0,
+        lastVmBlockNum: 0,
+        lastSeqBlockNum: 0
+      }),
+      lastFailureTimestamp: currentTime  // default first time marked as failure
+    }
+  });
+
+  const [isSynced, additionalSyncInfo] = await checkNodeSyncStallStatus(syncStat);
+  await syncStat.update(
+    {
+      latestCheckTimestamp: currentTime,
+      latestHealthStatus: isSynced,
+      additionalInfo: JSON.stringify(additionalSyncInfo),
+      lastFailureTimestamp: isSynced ? syncStat.lastFailureTimestamp : currentTime
+    },
+    {
+      where: { processName: 'SyncStat' }
+    })
+
   return
 }
 
@@ -260,10 +371,10 @@ async function checkSystemInfo(isGlobalPasswordSet) {
       'currentLoad': metadataLoad.currentLoad,
       'avgLoad': metadataLoad.avgLoad,
     };
-    if (metadataLoad.avgLoad >= config.healthCheck.cpuAvgLoadAlertLevel) {
-      isHealthy = false;
-      additional_info.push(`Average CPU load is high (${metadataLoad.avgLoad})`)
-    }
+    // if (metadataLoad.avgLoad >= config.healthCheck.cpuAvgLoadAlertLevel) {
+    //   isHealthy = false;
+    //   additional_info.push(`Average CPU load is high (${metadataLoad.avgLoad})`)
+    // }
     if (metadataLoad.currentLoad >= config.healthCheck.cpuCurrentLoadAlertLevel) {
       isHealthy = false;
       additional_info.push(`Current CPU load is high (${metadataLoad.currentLoad})`)

--- a/apex/api/daemons/node-health-check-utils.js
+++ b/apex/api/daemons/node-health-check-utils.js
@@ -371,10 +371,10 @@ async function checkSystemInfo(isGlobalPasswordSet) {
       'currentLoad': metadataLoad.currentLoad,
       'avgLoad': metadataLoad.avgLoad,
     };
-    // if (metadataLoad.avgLoad >= config.healthCheck.cpuAvgLoadAlertLevel) {
-    //   isHealthy = false;
-    //   additional_info.push(`Average CPU load is high (${metadataLoad.avgLoad})`)
-    // }
+     if (metadataLoad.avgLoad >= cpudata.cores * config.healthCheck.cpuAvgLoadAlertLevel/100) {
+       isHealthy = false;
+       additional_info.push(`Average CPU load is high (${metadataLoad.avgLoad})`)
+     }
     if (metadataLoad.currentLoad >= config.healthCheck.cpuCurrentLoadAlertLevel) {
       isHealthy = false;
       additional_info.push(`Current CPU load is high (${metadataLoad.currentLoad})`)


### PR DESCRIPTION
This PR adds two new fields to the apex nodeStatus/healthStatus endpoints:

- `isSynced`: is the node synced
-  `isSyncStalled`: did the node stall during the sync