### PR TITLE
Prefer newer transactions when updating bagger

### DIFF
--- a/strato/core/vm-tools/src/Blockchain/Bagger/TransactionList.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger/TransactionList.hs
@@ -38,7 +38,7 @@ insertTransaction t tl =
    in case oldTx of
         Nothing -> (Nothing, t, M.insert nonce' t tl)
         Just existing ->
-          if gasPrice existing < gasPrice t
+          if gasPrice existing > gasPrice t
             then (oldTx, t, M.insert nonce' t tl)
             else (Just t, existing, tl)
 

--- a/strato/core/vm-tools/src/Executable/EVMFlags.hs
+++ b/strato/core/vm-tools/src/Executable/EVMFlags.hs
@@ -5,7 +5,7 @@ module Executable.EVMFlags where
 import HFlags
 
 defineFlag "maxTxsPerBlock" (500 :: Integer) "max number of transactions that may be put into a block"
-defineFlag "mempoolLivenessCutoff" (240 :: Integer) "max age of a transaction in seconds that is valid for the mempool"
+defineFlag "mempoolLivenessCutoff" (60 :: Integer) "max age of a transaction in seconds that is valid for the mempool"
 defineFlag "useTestnet" False "Change difficulty computation for ethdev testnet"
 defineFlag "newRBIBBehavior" True "Use new replaceBestIfBetter behavior"
 defineFlag "useSyncMode" False "Whether or not to wait for P2P world state to get filled before buffering transactions"


### PR DESCRIPTION
We occasionally see 422 errors appear where a transaction is dropped in favor of a previously posted transaction with the same sender and nonce. However, often this creates more confusion to the end user, since they may be attempting to retry their last transaction, or are posting a completely new transaction. Instead, if the newer transaction has the sender, nonce, and gas price, we should favor it over the older transaction.

Note: This will not affect the stateroot or break backwards compatibiliy in any way. This will only affect which transaction a particular node chooses to keep in its own bagger mempool when faced with two otherwise equal-priority transactions.