### PR TITLE
Id server optimization

### DIFF
--- a/docker-compose.identity.tpl.yml
+++ b/docker-compose.identity.tpl.yml
@@ -16,6 +16,7 @@ services:
     - SENDGRID_APIKEY=${SENDGRID_APIKEY}
     - userRegistryAddress=${userRegistryAddress}
     - userTableName=${userTableName}
+    - cacheSize=${cacheSize}
     build: .
     image: ${IDENTTIYPROVIDER_IMAGE:-<REPO_URL>identity-provider:<VERSION>}
     restart: unless-stopped

--- a/docker-compose.identity.tpl.yml
+++ b/docker-compose.identity.tpl.yml
@@ -14,8 +14,6 @@ services:
     - VAULT_PROXY_DEBUG=${VAULT_PROXY_DEBUG}
     - VAULT_URL=${VAULT_URL}
     - SENDGRID_APIKEY=${SENDGRID_APIKEY}
-    - userRegistryAddress=${userRegistryAddress}
-    - userTableName=${userTableName}
     - cacheSize=${cacheSize}
     build: .
     image: ${IDENTTIYPROVIDER_IMAGE:-<REPO_URL>identity-provider:<VERSION>}

--- a/strato/api/bloc/bloc2/src/Bloc/Server.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server.hs
@@ -74,7 +74,7 @@ bloc =
     :<|> postBlocTransactionBody
     :<|> postBlocTransactionUnsigned
     :<|> postBlocTransaction
-    :<|> postBlocTransactionExternal
+    :<|> postBlocTransactionParallelExternal
 
 --serveBloc :: BlocEnv -> Server BlocAPI
 --serveBloc env = hoistServer blocApi (enterBloc env) bloc

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -16,11 +16,11 @@
 
 module Bloc.Server.Transaction
   ( postBlocTransaction,
-    postBlocTransactionExternal,
     postBlocTransactionRaw,
     postBlocTransactionBody,
     postBlocTransactionUnsigned,
     postBlocTransactionParallel,
+    postBlocTransactionParallelExternal,
   )
 where
 
@@ -574,7 +574,7 @@ postBlocTransaction ::
   m [BlocChainOrTransactionResult]
 postBlocTransaction = postBlocTransaction' (Don't CacheNonce)
 
-postBlocTransactionExternal ::
+postBlocTransactionParallelExternal ::
   ( MonadLogger m,
     A.Selectable Account Contract m,
     A.Selectable Account AddressState m,
@@ -588,10 +588,11 @@ postBlocTransactionExternal ::
   Maybe Text ->
   Maybe ChainId ->
   Maybe Bool -> -- use_wallet
-  Bool ->
+  Bool -> -- resolve
+  Bool -> -- queue
   PostBlocTransactionRequest ->
   m [BlocChainOrTransactionResult]
-postBlocTransactionExternal bearerToken = postBlocTransaction' (Don't CacheNonce) (Text.replace "Bearer " "" <$> bearerToken)
+postBlocTransactionParallelExternal bearerToken = postBlocTransactionParallel (Text.replace "Bearer " "" <$> bearerToken)
 
 postBlocTransaction' ::
   ( MonadLogger m,

--- a/strato/api/bloc/bloc2api/src/Bloc/API.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API.hs
@@ -68,7 +68,7 @@ type BlocAPI =
     :<|> PostBlocTransactionBody
     :<|> PostBlocTransactionUnsigned
     :<|> PostBlocTransaction
-    :<|> PostBlocTransactionExternal
+    :<|> PostBlocTransactionParallelExternal
 
 --Unsure what this will break if anything but remove later
 instance ToSample Text where

--- a/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
@@ -67,16 +67,19 @@ instance ToParam (QueryFlag "queue") where
   toParam _ =
     DocQueryParam "queue" ["true", "false", ""] "flag for queueing a transaction request" Flag
 
-type PostBlocTransactionParallel =
+type PostBlocTransactionParallelCommon tokenHeaderName = 
   "transaction"
     :> "parallel"
-    :> S.Header "X-USER-ACCESS-TOKEN" Text
+    :> S.Header tokenHeaderName Text
     :> QueryParam "chainid" ChainId
     :> QueryParam "use_wallet" Bool -- Using QueryParam here to distinguish between Nothing and Just False
     :> QueryFlag "resolve"
     :> QueryFlag "queue"
     :> ReqBody '[JSON] PostBlocTransactionRequest
     :> Post '[JSON] [BlocChainOrTransactionResult]
+
+type PostBlocTransactionParallel = PostBlocTransactionParallelCommon "X-USER-ACCESS-TOKEN"
+type PostBlocTransactionParallelExternal = PostBlocTransactionParallelCommon "Authorization"
 
 type PostBlocTransactionRaw =
   "transaction"
@@ -88,22 +91,15 @@ type PostBlocTransactionRaw =
     :> ReqBody '[JSON] PostBlocTransactionRawRequest
     :> Post '[JSON] BlocChainOrTransactionResult
 
-type PostBlocTransactionCommon =
-  QueryParam "chainid" ChainId
+type PostBlocTransaction =
+  "transaction"
+    :> S.Header "X-USER-ACCESS-TOKEN" Text
+    :> QueryParam "chainid" ChainId
     :> QueryParam "use_wallet" Bool -- Using QueryParam here to distinguish between Nothing and Just False
     :> QueryFlag "resolve"
     :> ReqBody '[JSON] PostBlocTransactionRequest
     :> Post '[JSON] [BlocChainOrTransactionResult]
 
-type PostBlocTransaction =
-  "transaction"
-    :> S.Header "X-USER-ACCESS-TOKEN" Text
-    :> PostBlocTransactionCommon
-
-type PostBlocTransactionExternal =
-  "transaction" -- only to be used for external api client bindings
-    :> S.Header "Authorization" Text
-    :> PostBlocTransactionCommon
 
 -- | PostBlocTransactionBody should return a list of signed transaction hashes,
 -- using the caller's JWT, and their respective raw transaction bodies without

--- a/strato/api/bloc/bloc2client/src/Bloc/Client.hs
+++ b/strato/api/bloc/bloc2client/src/Bloc/Client.hs
@@ -20,7 +20,7 @@ module Bloc.Client
     getBlocTransactionResult,
     postBlocTransactionResults,
     postBlocTransaction,
-    postBlocTransactionExternal,
+    postBlocTransactionParallelExternal,
     postChainInfo,
     getSingleChainInfo,
     postChainInfos,
@@ -168,6 +168,16 @@ postBlocTransactionParallel ::
   ClientM [BlocChainOrTransactionResult]
 postBlocTransactionParallel = client (Proxy @PostBlocTransactionParallel)
 
+postBlocTransactionParallelExternal ::
+  Maybe Text ->
+  Maybe ChainId ->
+  Maybe Bool ->
+  Bool ->
+  Bool ->
+  PostBlocTransactionRequest ->
+  ClientM [BlocChainOrTransactionResult]
+postBlocTransactionParallelExternal = client (Proxy @PostBlocTransactionParallelExternal)
+
 postBlocTransactionRaw ::
   Maybe Text ->
   Maybe ChainId ->
@@ -199,12 +209,3 @@ postBlocTransaction ::
   PostBlocTransactionRequest ->
   ClientM [BlocChainOrTransactionResult]
 postBlocTransaction = client (Proxy @PostBlocTransaction)
-
-postBlocTransactionExternal ::
-  Maybe Text ->
-  Maybe ChainId ->
-  Maybe Bool ->
-  Bool ->
-  PostBlocTransactionRequest ->
-  ClientM [BlocChainOrTransactionResult]
-postBlocTransactionExternal = client (Proxy @PostBlocTransactionExternal)

--- a/strato/identity-provider/README.md
+++ b/strato/identity-provider/README.md
@@ -4,8 +4,9 @@
 This project is meant to help with the registration flow on STRATO. The identity server handles account creation and setup as needed. Specifically, it
 1. creates a user's key in vault for them if they don't already have one
 2. creates, signs, and registers a certificate on-chain for a user if they don't already have one
+3. registers a user wallet on-chain for a user if they don't already have one
 
-To utilize this functionality, you call the PUT /identity endpoint. You must also provide an Authorization header with the user's bearer token, and you can optionally specify the `company` as a query parameter. Whenever possible, the bearer token will be used as the source of truth for information about the user. The common name for the cert will either come from the token's `name` claim, if one exists, or the `preferred_username` claim. Similarly, if there is a `company` claim within the token, that will be used for the cert's organization field. If no claim `company` is found, the identity server will use the `company` query param value instead.
+To utilize this functionality, you call the PUT /identity endpoint. You must also provide an Authorization header with the user's bearer token, and you can optionally specify the `company` as a query parameter. Whenever possible, the bearer token will be used as the source of truth for information about the user. The common name for the cert will either come from the token's `preferred_username` claim, if one exists, or the `name` claim. Similarly, if there is a `company` claim within the token, that will be used for the cert's organization field. If no claim `company` is found, the identity server will use the `company` query param value instead.
 
 ### Notes to the server admin
 
@@ -32,12 +33,12 @@ HTTP_PORT=8080 \
 
 Like all our getting-started scripts, this should be run within the same directory where the identity server's docker-compose, `docker-compose.identity.yml`, is located.
 
-3. Keep in mind that due to the identity server's reliance on `name` and `company` claims in the provided bearer token, we ideally want to have our realms support these claims. The identity server can function without those claims being in the token, but these certs may take a different form than is expected (for example, if a user's JWT has no `name` claim and their `preferred_username` is their email, then the common name in the certificate would be their email instead of their actual name). 
+3. Keep in mind that due to the identity server's reliance on the `company` claim in the provided bearer token, we ideally want to have our realms support this claim. The identity server can function without this claim being in the token, but these certs may take a different form than is expected (for example, if the `company` claim is missing, the cert created may have a suprising value for the `organization` field). 
 
 [!IMPORTANT]
 The information below is important!
 
-4. An important step is setting the URL to you ID-server for your strato node. As of writing this, you can pass the argument in your strato-getting-started script for your node `idServerUrl="https://yourIdServerUrl.com"`, but that is not needed. If that variable is not set in the `sgs` script, it will use `https://identity.blockapps.net` by default.
+4. An important step is setting the URL to you ID-server for your strato node. As of writing this, you can pass the argument in your strato-getting-started script for your node `idServerUrl="https://yourIdServerUrl.com"`, but that is not needed. If that variable is not set in the `sgs` script, it will use `https://identity.blockapps.net` by default on prod and `https://identity.mercata-testnet2.blockapps.net` on testnet
 
 5.  The `strato-getting-started` directory has an `identity-provider` subdirectory from which files will be mounted onto the docker container. These files include `identity-provider/certs/rootPriv.pem`, `identity-provider/certs/rootCert.pem`, and `identity-provider/idconf.yaml`. These files are not included in the docker image for security reasons, as they contain sensitive information. If you do not provide these files within the `identity-provider` subdirectory, the identity docker images will not build.
 
@@ -46,4 +47,4 @@ The information below is important!
 ### Things to consider when updating/restarting an identity server
 1. The main reason for wanting to update the identity server is to update the realms it supports. To do this, add a list element in `identity-provider/idconf.yaml` and specify at minimum a `clientId`, `clientSecret`, and `discoveryUrl` for the realm. You will need to explicitly stop the docker containers and restart them in order to have the identity server read in the new realm information. 
 
-2. The identity server is fairly stateless, so it's quite safe to wipe and restart the server arbitrarily.
+2. The identity server is fairly stateless (with the exception of some caches stored in-memory), so it's quite safe to wipe and restart the server arbitrarily.

--- a/strato/identity-provider/README.md
+++ b/strato/identity-provider/README.md
@@ -42,6 +42,19 @@ The information below is important!
 
 5.  The `strato-getting-started` directory has an `identity-provider` subdirectory from which files will be mounted onto the docker container. These files include `identity-provider/certs/rootPriv.pem`, `identity-provider/certs/rootCert.pem`, and `identity-provider/idconf.yaml`. These files are not included in the docker image for security reasons, as they contain sensitive information. If you do not provide these files within the `identity-provider` subdirectory, the identity docker images will not build.
 
+6. The configuration file `identity-provider/idconf.yaml` contains a list of realm-specific information. Each realm's details is grouped in a single yaml list element. The minimum realm details to provide are 
+  a. `discoveryUrl` for the realm (needed to extract the issuer information and token endpoint)
+  b. `clientId` for the identity server
+  c. `clientSecret` for the identity server
+In addition, you may also choose to specifiy
+  d. `realmName` for readability's sake (does not affect functionality)
+  e. `nodeUrl` of the STRATO node to query and post transactions to. By default this will be `https://node2.<realmName>.blockapps.net`
+  f. `fallbackNodeUrl` of another STRATO node in case the first one is unresponsive. By default this will be `https://node1.<realmName>.blockapps.net`
+  g. `userRegistryAddress` the address of the UserRegistry contract. By default this will be the location hardcoded in new genesis blocks: `0x720`. 
+    *Note:* if using an older genesis block, you will not have this contract and should manually post it to the network, noting the address, code hash, and associated table name in cirrus.
+  h. `userRegistryCodeHash` the code hash of the UserRegistry contract mentioned above. By default this will be the code hash of the hardcoded contract. If using an older genesis block, please see the note under `userRegistryAddress`
+  i. `userTableName` the associated table name in cirrus for `User` contracts. By default this will be `User`. If using an older genesis block, please see the note under `userRegistryAddress`
+
 7. Keep in mind the client credentials you provide use MUST already have keys within the vault specified, and have a cert registered on the associated network.
 
 ### Things to consider when updating/restarting an identity server

--- a/strato/identity-provider/doit.sh
+++ b/strato/identity-provider/doit.sh
@@ -33,12 +33,6 @@ function runIdentityServer {
   fi
   if [ -n "${SENDGRID_APIKEY}" ]; then
       sgFlag="--SENDGRID_APIKEY=${SENDGRID_APIKEY}"
-  fi  
-  if [ -n "${userRegistryAddress}" ]; then
-      urFlag="--userRegistryAddress=${userRegistryAddress}"
-  fi  
-  if [ -n "${userTableName}" ]; then
-      utFlag="--userTableName=${userTableName}"
   fi
   if [ -n "${cacheSize}" ]; then
       csFlag="--cacheSize=${cacheSize}"
@@ -78,7 +72,7 @@ function runIdentityServer {
   echo "Running identity-provider-server..."
   runBackgroundProcess identity-provider-server \
     --minLogLevel=${minLogLevel} --port="${identityProviderPort}" \
-    "${vpFlag}" "${sgFlag}" "${urFlag}" "${utFlag}" "${csFlag}" &>> logs/identity-provider-server
+    "${vpFlag}" "${sgFlag}" "${csFlag}" &>> logs/identity-provider-server
   
   echo "Configuring log rotation..."
   runBackgroundProcess logRotation

--- a/strato/identity-provider/doit.sh
+++ b/strato/identity-provider/doit.sh
@@ -39,6 +39,9 @@ function runIdentityServer {
   fi  
   if [ -n "${userTableName}" ]; then
       utFlag="--userTableName=${userTableName}"
+  fi
+  if [ -n "${cacheSize}" ]; then
+      csFlag="--cacheSize=${cacheSize}"
   fi  
   RED='\033[0;31m'
   NC='\033[0m' # No Color
@@ -75,7 +78,7 @@ function runIdentityServer {
   echo "Running identity-provider-server..."
   runBackgroundProcess identity-provider-server \
     --minLogLevel=${minLogLevel} --port="${identityProviderPort}" \
-    "${vpFlag}" "${sgFlag}" "${urFlag}" "${utFlag}" &>> logs/identity-provider-server
+    "${vpFlag}" "${sgFlag}" "${urFlag}" "${utFlag}" "${csFlag}" &>> logs/identity-provider-server
   
   echo "Configuring log rotation..."
   runBackgroundProcess logRotation

--- a/strato/identity-provider/server/app/Main.hs
+++ b/strato/identity-provider/server/app/Main.hs
@@ -31,7 +31,7 @@ main = do
   crt <- case bsToCert certBS of
     Left err -> error $ "Error parsing issuer cert: " <> err
     Right crt -> do
-      putStrLn $ "Succuessfully parsed issuer cert: " ++ show crt
+      putStrLn "Succuessfully parsed issuer cert"
       return crt
   iss <- case getCertIssuer crt of
     Nothing -> error "Could not deduce issuer from provided cert. Perhaps it is malformed?"
@@ -44,7 +44,7 @@ main = do
   -- read and parse idconf.yaml
   yamlContents <- B.readFile "/identity-provider/idconf.yaml"
   let idconf :: [ProvidedRealmInfo] = either (error . show) id (decodeEither' yamlContents)
-  realmData <- getRealmData idconf
+  realmData <- getRealmMap idconf flags_cacheSize
   if Map.null realmData
     then error "Oh no! We have no realm data. How can we operate on this little info?"
     else putStrLn "Successfully parsed realm data from yaml file"

--- a/strato/identity-provider/server/app/Main.hs
+++ b/strato/identity-provider/server/app/Main.hs
@@ -56,4 +56,4 @@ main = do
         if null flags_SENDGRID_APIKEY
           then Nothing
           else Just (SendgridAPIKey (C8.pack flags_SENDGRID_APIKEY))
-  run p $ identityProviderApp vp iss crt privk realmData mEmailK flags_userRegistryAddress flags_userTableName
+  run p $ identityProviderApp vp iss crt privk realmData mEmailK

--- a/strato/identity-provider/server/app/Options.hs
+++ b/strato/identity-provider/server/app/Options.hs
@@ -6,7 +6,8 @@ module Options
     flags_vaultProxyUrl,
     flags_SENDGRID_APIKEY,
     flags_userRegistryAddress,
-    flags_userTableName
+    flags_userTableName,
+    flags_cacheSize
   )
 where
 
@@ -17,3 +18,4 @@ defineFlag "vaultProxyUrl" ("http://localhost:8013/strato/v2.3" :: String) "URL 
 defineFlag "SENDGRID_APIKEY" ("" :: String) "The api key for sendgrid to automatically send the welcome email"
 defineFlag "userRegistryAddress" ("4ff4fd7c213761718a86d4a2cb3cc334e3f60f31" :: String) "Address of the User Registry contract"
 defineFlag "userTableName" ("BlockApps-UserRegistry-User" :: String) "Name of the User table"
+defineFlag "cacheSize" (200 :: Int) "default size for each network's cache"

--- a/strato/identity-provider/server/app/Options.hs
+++ b/strato/identity-provider/server/app/Options.hs
@@ -5,8 +5,6 @@ module Options
   ( flags_port,
     flags_vaultProxyUrl,
     flags_SENDGRID_APIKEY,
-    flags_userRegistryAddress,
-    flags_userTableName,
     flags_cacheSize
   )
 where
@@ -16,6 +14,4 @@ import HFlags
 defineFlag "port" (8014 :: Int) "Port to run identity server on"
 defineFlag "vaultProxyUrl" ("http://localhost:8013/strato/v2.3" :: String) "URL to Vault"
 defineFlag "SENDGRID_APIKEY" ("" :: String) "The api key for sendgrid to automatically send the welcome email"
-defineFlag "userRegistryAddress" ("4ff4fd7c213761718a86d4a2cb3cc334e3f60f31" :: String) "Address of the User Registry contract"
-defineFlag "userTableName" ("BlockApps-UserRegistry-User" :: String) "Name of the User table"
 defineFlag "cacheSize" (200 :: Int) "default size for each network's cache"

--- a/strato/identity-provider/server/package.yaml
+++ b/strato/identity-provider/server/package.yaml
@@ -43,6 +43,7 @@ library:
   - mtl
   - servant-client
   - servant-server
+  - solid-vm-model
   - split
   - strato-model
   - text

--- a/strato/identity-provider/server/package.yaml
+++ b/strato/identity-provider/server/package.yaml
@@ -39,6 +39,7 @@ library:
   - http-client
   - http-client-tls
   - http-types
+  - lrucache
   - monad-alter
   - mtl
   - servant-client

--- a/strato/identity-provider/server/src/IdentityProvider/OAuth.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/OAuth.hs
@@ -5,7 +5,8 @@
 -- all OAuth-related data types and functions go here
 module IdentityProvider.OAuth where
 
-import Blockchain.Strato.Model.Address (Address)
+import Blockchain.Strato.Model.Address (Address(..))
+import Blockchain.Strato.Model.Keccak256 (Keccak256)
 import Control.Monad.IO.Class
 import Data.Aeson
 import Data.ByteString.Base64
@@ -15,6 +16,7 @@ import Data.IORef
 import Data.List (isSuffixOf)
 import Data.List.Split (splitOn)
 import Data.Map (Map, fromList)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import GHC.Generics
@@ -29,7 +31,10 @@ data ProvidedRealmInfo -- info user provides to support realm
     clientId :: String,
     clientSecret :: String,
     nodeUrl :: Maybe String,
-    fallbackNodeUrl :: Maybe String
+    fallbackNodeUrl :: Maybe String,
+    userRegistryAddress :: Maybe Address,
+    userRegistryCodeHash :: Maybe Keccak256,
+    userTableName :: Maybe String
   }
   deriving (Show, Generic, FromJSON, ToJSON)
 
@@ -45,6 +50,9 @@ data RealmDetails = RealmDetails
     realmClientSecret :: String,
     associatedNodeUrl :: BaseUrl,
     associatedFallback :: BaseUrl,
+    realmUserRegAddr :: Address,
+    realmUserRegCodeHash :: Maybe Keccak256,
+    realmUserTableName :: String,
     cacheRef :: IORef (LRU String Address), -- commonName -> userAddress
     accessTokenRef :: IORef (Maybe AccessToken, UTCTime)
   }
@@ -77,6 +85,9 @@ getRealmMap realmInfos cacheSize = fromList <$> mapM parseRealmMinInfo realmInfo
               realmClientSecret = clientSecret realmInfo,
               associatedNodeUrl = nurl,
               associatedFallback = nurl2,
+              realmUserRegAddr = fromMaybe (Address 0x720) $ userRegistryAddress realmInfo,
+              realmUserRegCodeHash = userRegistryCodeHash realmInfo,
+              realmUserTableName = fromMaybe "User" $ userTableName realmInfo,
               cacheRef = cRef,
               accessTokenRef = tRef
             }

--- a/strato/identity-provider/server/src/IdentityProvider/OAuth.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/OAuth.hs
@@ -5,14 +5,18 @@
 -- all OAuth-related data types and functions go here
 module IdentityProvider.OAuth where
 
+import Blockchain.Strato.Model.Address (Address)
 import Control.Monad.IO.Class
 import Data.Aeson
 import Data.ByteString.Base64
 import qualified Data.ByteString.UTF8 as B (fromString)
+import Data.Cache.LRU hiding (fromList)
+import Data.IORef
 import Data.List (isSuffixOf)
 import Data.List.Split (splitOn)
 import Data.Map (Map, fromList)
 import Data.Text (Text)
+import Data.Time.Clock (UTCTime, getCurrentTime)
 import GHC.Generics
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS
@@ -40,14 +44,15 @@ data RealmDetails = RealmDetails
     realmClientId :: String,
     realmClientSecret :: String,
     associatedNodeUrl :: BaseUrl,
-    associatedFallback :: BaseUrl
+    associatedFallback :: BaseUrl,
+    cacheRef :: IORef (LRU String Address), -- commonName -> userAddress
+    accessTokenRef :: IORef (Maybe AccessToken, UTCTime)
   }
-  deriving (Show)
 
-type RealmData = Map String RealmDetails -- realm name -> realm data
+type RealmMap = Map String RealmDetails -- realm name -> realm dets
 
-getRealmData :: MonadIO m => [ProvidedRealmInfo] -> m RealmData
-getRealmData realmInfos = fromList <$> mapM parseRealmMinInfo realmInfos
+getRealmMap :: MonadIO m => [ProvidedRealmInfo] -> Int -> m RealmMap
+getRealmMap realmInfos cacheSize = fromList <$> mapM parseRealmMinInfo realmInfos
   where
     parseRealmMinInfo :: MonadIO m => ProvidedRealmInfo -> m (String, RealmDetails)
     parseRealmMinInfo realmInfo = do
@@ -61,6 +66,9 @@ getRealmData realmInfos = fromList <$> mapM parseRealmMinInfo realmInfos
         parseBaseUrl $ case fallbackNodeUrl realmInfo of
           Just url -> url
           Nothing -> "https://node1." <> realmName <> ".blockapps.net" -- node1 usually gets more traffic, so preference for node2
+      cRef <- liftIO $ newIORef $ newLRU (Just $ toInteger cacheSize)
+      now <- liftIO getCurrentTime
+      tRef <- liftIO $ newIORef (Nothing, now)
       return
         ( realmName,
           RealmDetails
@@ -68,7 +76,9 @@ getRealmData realmInfos = fromList <$> mapM parseRealmMinInfo realmInfos
               realmClientId = clientId realmInfo,
               realmClientSecret = clientSecret realmInfo,
               associatedNodeUrl = nurl,
-              associatedFallback = nurl2
+              associatedFallback = nurl2,
+              cacheRef = cRef,
+              accessTokenRef = tRef
             }
         )
 
@@ -82,7 +92,10 @@ getEndpointsFromDiscovery url = do
 extractRealmName :: String -> String
 extractRealmName idProv = last $ splitOn "/" (if "/" `isSuffixOf` idProv then init idProv else idProv)
 
-newtype AccessToken = AccessToken {access_token :: Text}
+data AccessToken = AccessToken
+  { access_token :: Text,
+    expires_in :: Integer
+  }
   deriving (Show, Generic, ToJSON, FromJSON)
 
 getAccessToken :: MonadIO m => String -> String -> String -> m (Maybe AccessToken)

--- a/strato/identity-provider/server/src/IdentityProvider/Server.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/Server.hs
@@ -29,7 +29,7 @@ import Bloc.Client
 import BlockApps.Logging
 import BlockApps.Solidity.ArgValue
 import BlockApps.X509 hiding (isValid)
-import Blockchain.Strato.Model.Address (deriveAddressWithSalt, stringAddress)
+import Blockchain.Strato.Model.Address (deriveAddressWithSalt)
 import Blockchain.Strato.Model.Secp256k1 hiding (HasVault)
 import Control.Monad (void, when)
 import qualified Control.Monad.Change.Alter as A
@@ -42,11 +42,11 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.Cache.LRU as LRU
 import Data.List (elemIndex)
 import qualified Data.Map as M
-import Data.Maybe (fromJust)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Time (diffUTCTime, getCurrentTime)
+import Debug.Trace (trace)
 import GHC.Generics
 import qualified IdentityProvider.API as IDAPI
 import IdentityProvider.Email
@@ -66,26 +66,6 @@ import UnliftIO hiding (Handler)
 data IdentityError
   = IdentityError Text
   deriving (Show, Exception)
-
--- getAccessTokenForRealm ::
---   ( MonadIO m,
---     MonadLogger m,
---     Accessible RealmMap m
---   ) =>
---   String ->
---   m (Maybe AccessToken)
--- getAccessTokenForRealm realm = do
---   rd <- access (Proxy @RealmMap)
---   case M.lookup realm rd of
---     Nothing -> do
---       $logErrorS "getAccessTokenForRealm" $ "Recieved PUT /identity request from a realm we don't support: " <> T.pack realm
---       throwIO $ IdentityError "Identity server does not support this realm"
---     Just
---       RealmDetails
---         { realmEndpoints = ep,
---           realmClientId = cid,
---           realmClientSecret = csec
---         } -> getAccessToken cid csec (token_endpoint ep)
 
 getDefaultEmptyOrg :: String -> String -> String
 getDefaultEmptyOrg name uuid = "Mercata Account " ++ getDefaultEmptyOrgOld name uuid
@@ -123,9 +103,7 @@ data IdentityServerData = IdentityServerData
     issuerCert :: X509Certificate, -- the signing cert
     issuerPrivKey :: PrivateKey, -- the signing private key
     realmNameToDetails :: RealmMap,
-    sendgridAPIKey :: Maybe SendgridAPIKey,
-    userRegistryAddress :: Address,
-    userTableName :: String
+    sendgridAPIKey :: Maybe SendgridAPIKey
   }
 
 instance Monad m => Accessible Issuer (ReaderT IdentityServerData m) where
@@ -142,12 +120,6 @@ instance Monad m => Accessible RealmMap (ReaderT IdentityServerData m) where
 
 instance Monad m => Accessible (Maybe SendgridAPIKey) (ReaderT IdentityServerData m) where
   access _ = asks sendgridAPIKey
-
-instance Monad m => Accessible Address (ReaderT IdentityServerData m) where
-  access _ = asks userRegistryAddress
-
-instance Monad m => Accessible String (ReaderT IdentityServerData m) where
-  access _ = asks userTableName
 
 instance MonadIO m => (String `A.Selectable` AccessToken) (ReaderT IdentityServerData m) where
   select _ realm = do
@@ -211,8 +183,6 @@ putIdentity ::
     Accessible PrivateKey m,
     Accessible RealmMap m,
     Accessible (Maybe SendgridAPIKey) m,
-    Accessible Address m,
-    Accessible String m,
     (String `A.Selectable` AccessToken) m,
     ((String, String) `A.Alters` Address) m
   ) =>
@@ -300,8 +270,6 @@ putIdentityExternal ::
     Accessible PrivateKey m,
     Accessible RealmMap m,
     Accessible (Maybe SendgridAPIKey) m,
-    Accessible Address m,
-    Accessible String m,
     (String `A.Selectable` AccessToken) m,
     ((String, String) `A.Alters` Address) m
   ) =>
@@ -376,45 +344,51 @@ certInCirrus token RealmDetails {associatedNodeUrl = nurl1, associatedFallback =
 
 walletInCirrus ::
   ( MonadIO m,
-    MonadLogger m,
-    Accessible String m,
-    Accessible Address m
+    MonadLogger m
   ) =>
   Text ->
   RealmDetails ->
   String ->
   m Bool
-walletInCirrus token RealmDetails {associatedNodeUrl = nurl1, associatedFallback = nurl2} commonName = do
-  userTableName <- access (Proxy @String)
-  userRegistryAddress <- access (Proxy @Address)
-  response1 <- callCirrus userRegistryAddress nurl1 userTableName
-  mWallet :: Maybe [WalletInCirrus] <-
-    if statusCode (responseStatus response1) == 200
-      then return . decode $ responseBody response1
-      else callCirrus userRegistryAddress nurl2 userTableName >>= return . decode . responseBody
-  case mWallet of
-    Just wallet -> do
-      $logInfoS "walletInCirrus" $ T.pack $ "Checked for user's wallet in Cirrus; response was: " <> show wallet
-      return . not $ null wallet -- maybe can also check if cert is valid and matches user attributes
-    Nothing -> do
-      $logErrorS "walletInCirrus" "Unexpected response from cirrus query. This should never happen"
-      throwIO $ IdentityError "Unable to decode cirrus query for user's wallet. Something went very wrong"
-  where
-    cirrusSearchPath :: Address -> String -> String
-    cirrusSearchPath userRegAddr userTableName =
-      let derivedAddr = deriveAddressWithSalt (Just userRegAddr) commonName Nothing (Just . show $ OrderedVals [SString $ commonName])
-       in "/cirrus/search/" <> userTableName <> "?address=eq." <> show derivedAddr
+walletInCirrus
+  token
+  RealmDetails
+    { associatedNodeUrl = nurl1,
+      associatedFallback = nurl2,
+      realmUserTableName = userTableName,
+      realmUserRegAddr = userRegAddr,
+      realmUserRegCodeHash = mHash
+    }
+  commonName = do
+    response1 <- callCirrus nurl1
+    mWallet :: Maybe [WalletInCirrus] <-
+      if statusCode (responseStatus response1) == 200
+        then return . decode $ responseBody response1
+        else callCirrus nurl2 >>= return . decode . responseBody
+    case mWallet of
+      Just wallet -> do
+        $logInfoS "walletInCirrus" $ T.pack $ "Checked for user's wallet in Cirrus; response was: " <> show wallet
+        return . not $ null wallet -- maybe can also check if cert is valid and matches user attributes
+      Nothing -> do
+        $logErrorS "walletInCirrus" "Unexpected response from cirrus query. This should never happen"
+        throwIO $ IdentityError "Unable to decode cirrus query for user's wallet. Something went very wrong"
+    where
+      cirrusSearchPath :: String
+      cirrusSearchPath =
+        let derivedAddr = deriveAddressWithSalt (Just userRegAddr) commonName mHash (Just . show $ OrderedVals [SString $ commonName])
+            derivedAddr' = trace ("DERIVED ADDR IS " <> show derivedAddr) (show derivedAddr)
+         in "/cirrus/search/" <> userTableName <> "?address=eq." <> derivedAddr'
 
-    callCirrus :: MonadIO m => Address -> BaseUrl -> String -> m (HTTP.Response BL.ByteString)
-    callCirrus userRegAddr nurl userTableName = do
-      let cirrusEndpoint = cirrusSearchPath userRegAddr userTableName
-          url = showBaseUrl nurl {baseUrlPath = baseUrlPath nurl <> cirrusEndpoint}
-      mgr <- liftIO $ case baseUrlScheme nurl of
-        Http -> newManager defaultManagerSettings
-        Https -> newManager tlsManagerSettings
-      request <- liftIO $ parseRequest url
-      let rHead = [(hContentType, "application/json"), (hAuthorization, encodeUtf8 $ "Bearer " <> token)]
-      liftIO $ httpLbs request {requestHeaders = rHead} mgr
+      callCirrus :: MonadIO m => BaseUrl -> m (HTTP.Response BL.ByteString)
+      callCirrus nurl = do
+        let cirrusEndpoint = cirrusSearchPath
+            url = showBaseUrl nurl {baseUrlPath = baseUrlPath nurl <> cirrusEndpoint}
+        mgr <- liftIO $ case baseUrlScheme nurl of
+          Http -> newManager defaultManagerSettings
+          Https -> newManager tlsManagerSettings
+        request <- liftIO $ parseRequest url
+        let rHead = [(hContentType, "application/json"), (hAuthorization, encodeUtf8 $ "Bearer " <> token)]
+        liftIO $ httpLbs request {requestHeaders = rHead} mgr
 
 createAndRegisterCert ::
   ( MonadIO m,
@@ -519,7 +493,6 @@ txSuccess _ = False
 registerUserWalletAsync ::
   ( MonadUnliftIO m,
     MonadLogger m,
-    Accessible Address m,
     ((String, String) `A.Alters` Address) m
   ) =>
   AccessToken ->
@@ -534,65 +507,69 @@ registerUserWalletAsync realmToken rd name' realm uuid' a = void . async $ do
   when regSuccess $ A.insert Proxy (realm, uuid') a
 
 registerUserWallet ::
-  (MonadUnliftIO m, MonadLogger m, Accessible Address m) =>
+  (MonadUnliftIO m, MonadLogger m) =>
   AccessToken ->
   RealmDetails ->
   String ->
   m Bool
-registerUserWallet token RealmDetails {associatedNodeUrl = nurl, associatedFallback = nurl2} commonName = do
-  userRegAddr <- access (Proxy @Address)
-  mgr <- liftIO $ case baseUrlScheme nurl of
-    Http -> newManager defaultManagerSettings
-    Https -> newManager tlsManagerSettings
-  let clientEnv = mkClientEnv mgr nurl {baseUrlPath = baseUrlPath nurl <> blocEndpoint}
-      txPayload =
-        BlocFunction
-          FunctionPayload
-            { functionpayloadContractAddress = userRegAddr,
-              functionpayloadMethod = "createUser",
-              functionpayloadArgs = M.singleton "_commonName" (ArgString $ T.pack commonName),
-              functionpayloadValue = Nothing,
-              functionpayloadTxParams = Nothing,
-              functionpayloadChainid = Nothing,
-              functionpayloadMetadata = Nothing
-            }
-      txRequest = PostBlocTransactionRequest Nothing [txPayload] Nothing Nothing
-      postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
-  eresponse <- liftIO $ postBlocTx clientEnv
-  case eresponse of
-    Right response ->
-      if all txSuccess response
-        then do
-          $logInfoS "registerUserWallet"
-            . T.pack
-            $ "Response after registering user wallet was: " ++ show response
-          return True
-        else do
-          $logErrorS "registerUserWallet"
-            . T.pack
-            $ "Failed to register user wallet; response was: " ++ show response
-          return False
-    Left clienterr -> do
-      $logErrorS "registerUserWallet" $
-        T.pack $
-          "Attempting to register on fallback node because recieved the following error when registering user wallet on primary node: "
-            ++ show clienterr
-      mgr2 <- liftIO $ case baseUrlScheme nurl2 of
-        Http -> newManager defaultManagerSettings
-        Https -> newManager tlsManagerSettings
-      let clientEnv2 = mkClientEnv mgr2 nurl2 {baseUrlPath = baseUrlPath nurl2 <> blocEndpoint}
-      eresponse2 <- liftIO $ postBlocTx clientEnv2
-      case eresponse2 of
-        Right response2 | all txSuccess response2 -> do
-          $logInfoS "registerUserWallet" . T.pack $ "Response from fallback node was " ++ show response2
-          return True
-        err -> do
-          $logErrorS "registerUserWallet"
-            . T.pack
-            $ "Failed to register user wallet; response was: " ++ show err
-          return False
-
--- TODO: how to tell if cert successfully added to blockchain?
+registerUserWallet
+  token
+  RealmDetails
+    { associatedNodeUrl = nurl,
+      associatedFallback = nurl2,
+      realmUserRegAddr = userRegAddr
+    }
+  commonName = do
+    mgr <- liftIO $ case baseUrlScheme nurl of
+      Http -> newManager defaultManagerSettings
+      Https -> newManager tlsManagerSettings
+    let clientEnv = mkClientEnv mgr nurl {baseUrlPath = baseUrlPath nurl <> blocEndpoint}
+        txPayload =
+          BlocFunction
+            FunctionPayload
+              { functionpayloadContractAddress = userRegAddr,
+                functionpayloadMethod = "createUser",
+                functionpayloadArgs = M.singleton "_commonName" (ArgString $ T.pack commonName),
+                functionpayloadValue = Nothing,
+                functionpayloadTxParams = Nothing,
+                functionpayloadChainid = Nothing,
+                functionpayloadMetadata = Nothing
+              }
+        txRequest = PostBlocTransactionRequest Nothing [txPayload] Nothing Nothing
+        postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
+    eresponse <- liftIO $ postBlocTx clientEnv
+    case eresponse of
+      Right response ->
+        if all txSuccess response
+          then do
+            $logInfoS "registerUserWallet"
+              . T.pack
+              $ "Response after registering user wallet was: " ++ show response
+            return True
+          else do
+            $logErrorS "registerUserWallet"
+              . T.pack
+              $ "Failed to register user wallet; response was: " ++ show response
+            return False
+      Left clienterr -> do
+        $logErrorS "registerUserWallet" $
+          T.pack $
+            "Attempting to register on fallback node because recieved the following error when registering user wallet on primary node: "
+              ++ show clienterr
+        mgr2 <- liftIO $ case baseUrlScheme nurl2 of
+          Http -> newManager defaultManagerSettings
+          Https -> newManager tlsManagerSettings
+        let clientEnv2 = mkClientEnv mgr2 nurl2 {baseUrlPath = baseUrlPath nurl2 <> blocEndpoint}
+        eresponse2 <- liftIO $ postBlocTx clientEnv2
+        case eresponse2 of
+          Right response2 | all txSuccess response2 -> do
+            $logInfoS "registerUserWallet" . T.pack $ "Response from fallback node was " ++ show response2
+            return True
+          err -> do
+            $logErrorS "registerUserWallet"
+              . T.pack
+              $ "Failed to register user wallet; response was: " ++ show err
+            return False
 
 getVaultKey :: (MonadIO m, MonadLogger m, HasVault m) => Text -> m (Maybe AddressAndKey)
 getVaultKey accessToken = do
@@ -632,8 +609,6 @@ server ::
     Accessible PrivateKey m,
     Accessible RealmMap m,
     Accessible (Maybe SendgridAPIKey) m,
-    Accessible Address m,
-    Accessible String m,
     (String `A.Selectable` AccessToken) m,
     ((String, String) `A.Alters` Address) m
   ) =>
@@ -647,10 +622,8 @@ hoistCoreServer ::
   PrivateKey ->
   RealmMap ->
   Maybe SendgridAPIKey ->
-  String ->
-  String ->
   Server IDAPI.IdentityProviderAPI
-hoistCoreServer vaulturl iss cert privk rd mEmailK userRegAddr userTableName =
+hoistCoreServer vaulturl iss cert privk rd mEmailK =
   hoistServer (Proxy :: Proxy IDAPI.IdentityProviderAPI) (convertErrors runM') server
   where
     convertErrors r x = Handler $ do
@@ -659,7 +632,7 @@ hoistCoreServer vaulturl iss cert privk rd mEmailK userRegAddr userTableName =
         Right a -> return a
         Left e -> throwE $ reThrowError e
     runM' :: ReaderT IdentityServerData (VaultM (LoggingT IO)) x -> IO x
-    runM' x = runLoggingT . runVaultM vaulturl $ runIdentityM iss cert privk rd mEmailK userRegAddr userTableName x
+    runM' x = runLoggingT . runVaultM vaulturl $ runIdentityM iss cert privk rd mEmailK x
     reThrowError :: IdentityError -> ServerError
     reThrowError =
       \case
@@ -671,12 +644,10 @@ runIdentityM ::
   PrivateKey ->
   RealmMap ->
   Maybe SendgridAPIKey ->
-  String ->
-  String ->
   ReaderT IdentityServerData m a ->
   m a
-runIdentityM iss cert privk rd mEmailK userRegAddr userTableName x =
-  runReaderT x $ IdentityServerData iss cert privk rd mEmailK (fromJust $ stringAddress userRegAddr) userTableName
+runIdentityM iss cert privk rd mEmailK x =
+  runReaderT x $ IdentityServerData iss cert privk rd mEmailK
 
 identityProviderApp ::
   String ->
@@ -685,8 +656,6 @@ identityProviderApp ::
   PrivateKey ->
   RealmMap ->
   Maybe SendgridAPIKey ->
-  String ->
-  String ->
   Application
-identityProviderApp vurl iss cert pk rd mEmailK userRegAddr userTableName =
-  serve (Proxy :: Proxy IDAPI.IdentityProviderAPI) $ hoistCoreServer vurl iss cert pk rd mEmailK userRegAddr userTableName
+identityProviderApp vurl iss cert pk rd mEmailK =
+  serve (Proxy :: Proxy IDAPI.IdentityProviderAPI) $ hoistCoreServer vurl iss cert pk rd mEmailK

--- a/strato/identity-provider/server/src/IdentityProvider/Server.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/Server.hs
@@ -216,42 +216,48 @@ putIdentity accessToken uuid idProv name mEmail mCo = do
            , T.pack org
            ]
   $logInfoS "putIdentity/csv" csvLogMsg
-  getVaultKey accessToken >>= \case
-    Just (AddressAndKey a k) -> do
-      -- has vault key, confirm also has cert
-      userCerts <- certInCirrus accessToken realm a
 
-      getAccessTokenForRealm realm >>= \case
-        Nothing -> do
-          $logErrorS "putIdentity" "uh oh! We couldn't retrieve an access token for our realm"
-          throwIO $ IdentityError "Something is wrong with the provided access credentials for the current realm. Have a network administrator look into this."
-        Just realmToken -> do
-          case userCerts of
-            -- User has no cert, create cert and wallet.
-            [] -> do
-              createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken realm k
-              registerUserWallet realmToken realm name'
-            -- User has a cert but no wallet, create wallet using cert's common name. This is for backwards compatibility with existing users.
-            [cert] -> do
-              hasWallet <- walletInCirrus accessToken realm (T.unpack $ certCommonName cert)
-              unless hasWallet $ registerUserWallet realmToken realm (T.unpack $ certCommonName cert)
-            -- Query returned multiple certs even though cirrus query should return only the latest one, fix the logic please.
-            _ -> do
-              $logErrorS "putIdentity" "Yikes! How can we have multiple certs if we're only limiting the search to one?"
-              throwIO $ IdentityError "Something is wrong. Have a network administrator look into this."
-              
-      return a
+  M.lookup realm <$> access (Proxy @RealmData) >>= \case 
     Nothing -> do
-      -- no vault key, so make key and register cert
-      AddressAndKey a k <- postVaultKey accessToken
-      getAccessTokenForRealm realm >>= \case
-        Nothing -> do
-          $logErrorS "putIdentity" "uh oh! We couldn't retrieve an access token for our realm"
-          throwIO $ IdentityError "Something is wrong with the provided access credentials for the current realm. Have a network administrator look into this."
-        Just realmToken -> do  
-          createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken realm k
-          registerUserWallet realmToken realm name'
+      $logErrorS "putIdentity" . T.pack $ "this identity server does not support realm " <> realm
+      throwIO $ IdentityError "Identity server does not support this realm"
+    Just rd -> do
+      getVaultKey accessToken >>= \case
+        Just (AddressAndKey a k) -> do
+          -- has vault key, confirm also has cert
+          userCerts <- certInCirrus accessToken rd a
+
+          getAccessTokenForRealm realm >>= \case
+            Nothing -> do
+              $logErrorS "putIdentity" "uh oh! We couldn't retrieve an access token for our realm"
+              throwIO $ IdentityError "Something is wrong with the provided access credentials for the current realm. Have a network administrator look into this."
+            Just realmToken -> do
+              case userCerts of
+                -- User has no cert, create cert and wallet.
+                [] -> do
+                  createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
+                  registerUserWallet realmToken rd name'
+                -- User has a cert but no wallet, create wallet using cert's common name. This is for backwards compatibility with existing users.
+                [cert] -> do
+                  hasWallet <- walletInCirrus accessToken rd (T.unpack $ certCommonName cert)
+                  unless hasWallet $ registerUserWallet realmToken rd (T.unpack $ certCommonName cert)
+                -- Query returned multiple certs even though cirrus query should return only the latest one, fix the logic please.
+                _ -> do
+                  $logErrorS "putIdentity" "Yikes! How can we have multiple certs if we're only limiting the search to one?"
+                  throwIO $ IdentityError "Something is wrong. Have a network administrator look into this."
+                  
           return a
+        Nothing -> do
+          -- no vault key, so make key and register cert
+          AddressAndKey a k <- postVaultKey accessToken
+          getAccessTokenForRealm realm >>= \case
+            Nothing -> do
+              $logErrorS "putIdentity" "uh oh! We couldn't retrieve an access token for our realm"
+              throwIO $ IdentityError "Something is wrong with the provided access credentials for the current realm. Have a network administrator look into this."
+            Just realmToken -> do  
+              createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
+              registerUserWallet realmToken rd name'
+              return a
 
 -- This is just a dummy function
 -- This never gets called on the sevrvant backend
@@ -308,30 +314,24 @@ instance FromJSON WalletInCirrus where
 instance ToJSON WalletInCirrus
 
 certInCirrus ::
-  (MonadIO m, MonadLogger m, Accessible RealmData m) =>
+  (MonadIO m, MonadLogger m) =>
   Text ->
-  String ->
+  RealmDetails ->
   Address ->
   m [CertificateInCirrus]
-certInCirrus token realm a = do
-  rd <- access (Proxy @RealmData)
-  case M.lookup realm rd of
+certInCirrus token (RealmDetails _ _ _ nurl1 nurl2) a = do
+  response1 <- callCirrus nurl1
+  mCerts :: Maybe [CertificateInCirrus] <-
+    if statusCode (responseStatus response1) == 200
+      then return . decode $ responseBody response1
+      else callCirrus nurl2 >>= return . decode . responseBody
+  case mCerts of
+    Just certs -> do
+      $logInfoS "certInCirrus" $ T.pack $ "Checked for user's cert in Cirrus; response was: " <> show certs
+      return certs -- maybe can also check if cert is valid and matches user attributes
     Nothing -> do
-      $logErrorS "certInCirrus" "Trying to find a cert on a network whose realm we don't support (How?? We should never reach this error)"
-      throwIO $ IdentityError "Identity server does not support this realm. Error should have been thrown sooner"
-    Just (RealmDetails _ _ _ nurl1 nurl2) -> do
-      response1 <- callCirrus nurl1
-      mCerts :: Maybe [CertificateInCirrus] <-
-        if statusCode (responseStatus response1) == 200
-          then return . decode $ responseBody response1
-          else callCirrus nurl2 >>= return . decode . responseBody
-      case mCerts of
-        Just certs -> do
-          $logInfoS "certInCirrus" $ T.pack $ "Checked for user's cert in Cirrus; response was: " <> show certs
-          return certs -- maybe can also check if cert is valid and matches user attributes
-        Nothing -> do
-          $logErrorS "certInCirrus" "Unexpected response from cirrus query. This should never happen"
-          throwIO $ IdentityError "Unable to decode cirrus query for user's cert. Something went very wrong"
+      $logErrorS "certInCirrus" "Unexpected response from cirrus query. This should never happen"
+      throwIO $ IdentityError "Unable to decode cirrus query for user's cert. Something went very wrong"
   where
     cirrusSearchPath :: Address -> String
     cirrusSearchPath address =
@@ -349,31 +349,27 @@ certInCirrus token realm a = do
       liftIO $ httpLbs request {requestHeaders = rHead} mgr
 
 walletInCirrus ::
-  (MonadIO m, MonadLogger m, Accessible RealmData m, Accessible String m) =>
+  ( MonadIO m
+  , MonadLogger m
+  , Accessible String m) =>
   Text ->
-  String ->
+  RealmDetails ->
   String ->
   m Bool
-walletInCirrus token realm commonName = do
-  rd <- access (Proxy @RealmData)
+walletInCirrus token (RealmDetails _ _ _ nurl1 nurl2) commonName = do
   userTableName <- access (Proxy @String)
-  case M.lookup realm rd of
+  response1 <- callCirrus nurl1 userTableName
+  mWallet :: Maybe [WalletInCirrus] <-
+    if statusCode (responseStatus response1) == 200
+      then return . decode $ responseBody response1
+      else callCirrus nurl2 userTableName >>= return . decode . responseBody
+  case mWallet of
+    Just wallet -> do
+      $logInfoS "walletInCirrus" $ T.pack $ "Checked for user's wallet in Cirrus; response was: " <> show wallet
+      return . not $ null wallet -- maybe can also check if cert is valid and matches user attributes
     Nothing -> do
-      $logErrorS "walletInCirrus" "Trying to find a wallet on a network whose realm we don't support (How?? We should never reach this error)"
-      throwIO $ IdentityError "Identity server does not support this realm. Error should have been thrown sooner"
-    Just (RealmDetails _ _ _ nurl1 nurl2) -> do
-      response1 <- callCirrus nurl1 userTableName
-      mWallet :: Maybe [WalletInCirrus] <-
-        if statusCode (responseStatus response1) == 200
-          then return . decode $ responseBody response1
-          else callCirrus nurl2 userTableName >>= return . decode . responseBody
-      case mWallet of
-        Just wallet -> do
-          $logInfoS "walletInCirrus" $ T.pack $ "Checked for user's wallet in Cirrus; response was: " <> show wallet
-          return . not $ null wallet -- maybe can also check if cert is valid and matches user attributes
-        Nothing -> do
-          $logErrorS "walletInCirrus" "Unexpected response from cirrus query. This should never happen"
-          throwIO $ IdentityError "Unable to decode cirrus query for user's wallet. Something went very wrong"
+      $logErrorS "walletInCirrus" "Unexpected response from cirrus query. This should never happen"
+      throwIO $ IdentityError "Unable to decode cirrus query for user's wallet. Something went very wrong"
   where
     cirrusSearchPath :: String -> String
     cirrusSearchPath userTableName = "/cirrus/search/" <> userTableName <> "?commonName=eq." <> commonName
@@ -395,7 +391,6 @@ createAndRegisterCert ::
     Accessible Issuer m,
     Accessible X509Certificate m,
     Accessible PrivateKey m,
-    Accessible RealmData m,
     Accessible (Maybe SendgridAPIKey) m
   ) =>
   String ->
@@ -403,14 +398,14 @@ createAndRegisterCert ::
   String ->
   String ->
   AccessToken ->
-  String ->
+  RealmDetails ->
   PublicKey ->
   m ()
-createAndRegisterCert name mEmail org uuid realmToken realm k = do
+createAndRegisterCert name mEmail org uuid realmToken rd k = do
   sub <- getSubject name org k
   createNewCert sub >>= \case
     Just newCert -> do
-      registerCert newCert realmToken realm
+      registerCert newCert realmToken rd
       mEmailK <- access (Proxy @(Maybe SendgridAPIKey))
       case (mEmail, mEmailK) of
         (Just email, Just emailK) -> sendWelcomeEmail email name uuid emailK
@@ -435,95 +430,83 @@ createNewCert sub = do
   makeSignedCertSigF signWIssuerPrivKey Nothing (Just c) i sub
 
 registerCert ::
-  (MonadIO m, MonadLogger m, Accessible RealmData m) =>
+  (MonadIO m, MonadLogger m) =>
   X509Certificate ->
   AccessToken ->
-  String ->
+  RealmDetails ->
   m ()
-registerCert cert token realm = do
-  rd <- access (Proxy @RealmData)
-  case M.lookup realm rd of
-    Nothing -> do
-      $logErrorS "registerCert" "Trying to register cert for realm we don't support. Error should have been thrown MUCH sooner"
-      throwIO $ IdentityError "Identity server does not support this realm. Error should have been thrown MUCH sooner"
-    Just (RealmDetails _ _ _ nurl nurl2) -> do
-      mgr <- liftIO $ case baseUrlScheme nurl of
+registerCert cert token (RealmDetails _ _ _ nurl nurl2) = do
+  mgr <- liftIO $ case baseUrlScheme nurl of
+    Http -> newManager defaultManagerSettings
+    Https -> newManager tlsManagerSettings
+  let clientEnv = mkClientEnv mgr nurl {baseUrlPath = baseUrlPath nurl <> blocEndpoint}
+      txPayload =
+        BlocFunction
+          FunctionPayload
+            { functionpayloadContractAddress = 0x509,
+              functionpayloadMethod = "registerCertificate",
+              functionpayloadArgs = M.singleton "newCertificateString" (ArgString . decodeUtf8 $ certToBytes cert),
+              functionpayloadValue = Nothing,
+              functionpayloadTxParams = Nothing,
+              functionpayloadChainid = Nothing,
+              functionpayloadMetadata = Nothing
+            }
+      txRequest = PostBlocTransactionRequest Nothing [txPayload] Nothing Nothing
+      postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
+  eresponse <- liftIO $ postBlocTx clientEnv
+  case eresponse of
+    Right response -> $logInfoS "registerCert" $ T.pack $ "Response after registering cert was: " ++ show response
+    Left clienterr -> do
+      $logErrorS "registerCert" $
+        T.pack $
+          "Attempting to register on fallback node because recieved the following error when registering cert on primary node: "
+            ++ show clienterr
+      mgr2 <- liftIO $ case baseUrlScheme nurl2 of
         Http -> newManager defaultManagerSettings
         Https -> newManager tlsManagerSettings
-      let clientEnv = mkClientEnv mgr nurl {baseUrlPath = baseUrlPath nurl <> blocEndpoint}
-          txPayload =
-            BlocFunction
-              FunctionPayload
-                { functionpayloadContractAddress = 0x509,
-                  functionpayloadMethod = "registerCertificate",
-                  functionpayloadArgs = M.singleton "newCertificateString" (ArgString . decodeUtf8 $ certToBytes cert),
-                  functionpayloadValue = Nothing,
-                  functionpayloadTxParams = Nothing,
-                  functionpayloadChainid = Nothing,
-                  functionpayloadMetadata = Nothing
-                }
-          txRequest = PostBlocTransactionRequest Nothing [txPayload] Nothing Nothing
-          postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
-      eresponse <- liftIO $ postBlocTx clientEnv
-      case eresponse of
-        Right response -> $logInfoS "registerCert" $ T.pack $ "Response after registering cert was: " ++ show response
-        Left clienterr -> do
-          $logErrorS "registerCert" $
-            T.pack $
-              "Attempting to register on fallback node because recieved the following error when registering cert on primary node: "
-                ++ show clienterr
-          mgr2 <- liftIO $ case baseUrlScheme nurl2 of
-            Http -> newManager defaultManagerSettings
-            Https -> newManager tlsManagerSettings
-          let clientEnv2 = mkClientEnv mgr2 nurl2 {baseUrlPath = baseUrlPath nurl2 <> blocEndpoint}
-          eresponse2 <- liftIO $ postBlocTx clientEnv2
-          $logInfoS "registerCert" $ T.pack $ "Response from fallback node was " ++ show eresponse2
+      let clientEnv2 = mkClientEnv mgr2 nurl2 {baseUrlPath = baseUrlPath nurl2 <> blocEndpoint}
+      eresponse2 <- liftIO $ postBlocTx clientEnv2
+      $logInfoS "registerCert" $ T.pack $ "Response from fallback node was " ++ show eresponse2
 
 registerUserWallet ::
-  (MonadIO m, MonadLogger m, Accessible RealmData m, Accessible Address m) =>
+  (MonadIO m, MonadLogger m, Accessible Address m) =>
   AccessToken ->
-  String ->
+  RealmDetails ->
   String ->
   m ()
-registerUserWallet token realm commonName = do
-  rd <- access (Proxy @RealmData)
+registerUserWallet token (RealmDetails _ _ _ nurl nurl2) commonName = do
   userRegAddr <- access (Proxy @Address)
-  case M.lookup realm rd of
-    Nothing -> do
-      $logErrorS "registerUserWallet" "Trying to register user wallet for realm we don't support. Error should have been thrown MUCH sooner"
-      throwIO $ IdentityError "Identity server does not support this realm. Error should have been thrown MUCH sooner"
-    Just (RealmDetails _ _ _ nurl nurl2) -> do
-      mgr <- liftIO $ case baseUrlScheme nurl of
+  mgr <- liftIO $ case baseUrlScheme nurl of
+    Http -> newManager defaultManagerSettings
+    Https -> newManager tlsManagerSettings
+  let clientEnv = mkClientEnv mgr nurl {baseUrlPath = baseUrlPath nurl <> blocEndpoint}
+      txPayload =
+        BlocFunction
+          FunctionPayload
+            { functionpayloadContractAddress = userRegAddr,
+              functionpayloadMethod = "createUser",
+              functionpayloadArgs = M.singleton "_commonName" (ArgString $ T.pack commonName),
+              functionpayloadValue = Nothing,
+              functionpayloadTxParams = Nothing,
+              functionpayloadChainid = Nothing,
+              functionpayloadMetadata = Nothing
+            }
+      txRequest = PostBlocTransactionRequest Nothing [txPayload] Nothing Nothing
+      postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
+  eresponse <- liftIO $ postBlocTx clientEnv
+  case eresponse of
+    Right response -> $logInfoS "registerUserWallet" $ T.pack $ "Response after registering user wallet was: " ++ show response
+    Left clienterr -> do
+      $logErrorS "registerUserWallet" $
+        T.pack $
+          "Attempting to register on fallback node because recieved the following error when registering user wallet on primary node: "
+            ++ show clienterr
+      mgr2 <- liftIO $ case baseUrlScheme nurl2 of
         Http -> newManager defaultManagerSettings
         Https -> newManager tlsManagerSettings
-      let clientEnv = mkClientEnv mgr nurl {baseUrlPath = baseUrlPath nurl <> blocEndpoint}
-          txPayload =
-            BlocFunction
-              FunctionPayload
-                { functionpayloadContractAddress = userRegAddr,
-                  functionpayloadMethod = "createUser",
-                  functionpayloadArgs = M.singleton "_commonName" (ArgString $ T.pack commonName),
-                  functionpayloadValue = Nothing,
-                  functionpayloadTxParams = Nothing,
-                  functionpayloadChainid = Nothing,
-                  functionpayloadMetadata = Nothing
-                }
-          txRequest = PostBlocTransactionRequest Nothing [txPayload] Nothing Nothing
-          postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
-      eresponse <- liftIO $ postBlocTx clientEnv
-      case eresponse of
-        Right response -> $logInfoS "registerUserWallet" $ T.pack $ "Response after registering user wallet was: " ++ show response
-        Left clienterr -> do
-          $logErrorS "registerUserWallet" $
-            T.pack $
-              "Attempting to register on fallback node because recieved the following error when registering user wallet on primary node: "
-                ++ show clienterr
-          mgr2 <- liftIO $ case baseUrlScheme nurl2 of
-            Http -> newManager defaultManagerSettings
-            Https -> newManager tlsManagerSettings
-          let clientEnv2 = mkClientEnv mgr2 nurl2 {baseUrlPath = baseUrlPath nurl2 <> blocEndpoint}
-          eresponse2 <- liftIO $ postBlocTx clientEnv2
-          $logInfoS "registerUserWallet" $ T.pack $ "Response from fallback node was " ++ show eresponse2
+      let clientEnv2 = mkClientEnv mgr2 nurl2 {baseUrlPath = baseUrlPath nurl2 <> blocEndpoint}
+      eresponse2 <- liftIO $ postBlocTx clientEnv2
+      $logInfoS "registerUserWallet" $ T.pack $ "Response from fallback node was " ++ show eresponse2
 
 --TODO: how to tell if cert successfully added to blockchain?
 

--- a/strato/identity-provider/server/src/IdentityProvider/Server.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/Server.hs
@@ -25,7 +25,7 @@ module IdentityProvider.Server (identityProviderApp) where
 
 import Bloc.API.Transaction
 import Bloc.API.Users
-import Bloc.Client
+import Bloc.Client (postBlocTransactionParallelExternal)
 import BlockApps.Logging
 import BlockApps.Solidity.ArgValue
 import BlockApps.X509 hiding (isValid)
@@ -459,7 +459,7 @@ registerCert cert token RealmDetails {associatedNodeUrl = nurl, associatedFallba
               functionpayloadMetadata = Nothing
             }
       txRequest = PostBlocTransactionRequest Nothing [txPayload] Nothing Nothing
-      postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
+      postBlocTx = runClientM (postBlocTransactionParallelExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True False txRequest)
   eresponse <- liftIO $ postBlocTx clientEnv
   case eresponse of
     Right response ->
@@ -538,7 +538,7 @@ registerUserWallet
                 functionpayloadMetadata = Nothing
               }
         txRequest = PostBlocTransactionRequest Nothing [txPayload] Nothing Nothing
-        postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
+        postBlocTx = runClientM (postBlocTransactionParallelExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True False txRequest)
     eresponse <- liftIO $ postBlocTx clientEnv
     case eresponse of
       Right response ->

--- a/strato/identity-provider/server/src/IdentityProvider/Server.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/Server.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
@@ -23,26 +24,29 @@
 module IdentityProvider.Server (identityProviderApp) where
 
 import Bloc.API.Transaction
+import Bloc.API.Users
 import Bloc.Client
 import BlockApps.Logging
 import BlockApps.Solidity.ArgValue
 import BlockApps.X509 hiding (isValid)
-import Blockchain.Strato.Model.Address (stringAddress, deriveAddressWithSalt)
+import Blockchain.Strato.Model.Address (deriveAddressWithSalt, stringAddress)
 import Blockchain.Strato.Model.Secp256k1 hiding (HasVault)
-import Control.Monad (unless)
+import Control.Monad (void, when)
+import qualified Control.Monad.Change.Alter as A
 import Control.Monad.Change.Modify
 import Control.Monad.Composable.Vault
 import Control.Monad.Reader
 import Control.Monad.Trans.Except
-import Data.Aeson
+import Data.Aeson hiding (Success)
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.Cache.LRU as LRU
 import Data.List (elemIndex)
 import qualified Data.Map as M
 import Data.Maybe (fromJust)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import Data.Time (getCurrentTime)
+import Data.Time (diffUTCTime, getCurrentTime)
 import GHC.Generics
 import qualified IdentityProvider.API as IDAPI
 import IdentityProvider.Email
@@ -54,7 +58,7 @@ import Network.HTTP.Types.Header (hAuthorization, hContentType)
 import Network.HTTP.Types.Status
 import Servant
 import Servant.Client hiding (manager, responseBody)
-import SolidVM.Model.Value (Value(..), ValList(..))
+import SolidVM.Model.Value (ValList (..), Value (..))
 import Strato.Strato23.API
 import Strato.Strato23.Client
 import UnliftIO hiding (Handler)
@@ -63,35 +67,25 @@ data IdentityError
   = IdentityError Text
   deriving (Show, Exception)
 
-getAccessTokenForRealm ::
-  ( MonadIO m,
-    MonadLogger m,
-    Accessible RealmData m
-  ) =>
-  String ->
-  m (Maybe AccessToken)
-getAccessTokenForRealm realm = do
-  rd <- access (Proxy @RealmData)
-  case M.lookup realm rd of
-    Nothing -> do
-      $logErrorS "getAccessTokenForRealm" $ "Recieved PUT /identity request from a realm we don't support: " <> T.pack realm
-      throwIO $ IdentityError "Identity server does not support this realm"
-    Just (RealmDetails endpoints cid csec _ _) -> getAccessToken cid csec (token_endpoint endpoints)
-
--- oAuthUserToSubject :: OAuthUser -> PublicKey -> Subject
--- oAuthUserToSubject (OAuthUser id' firstN' lastN' attr) pk =
---     let firstN = T.unpack firstN'
---         lastN = T.unpack lastN'
---     in Subject {
---     subCommonName =  firstN <> " " <> lastN,
---     subOrg = case attr of
---         Just (OAuthUserAttributes (Just (org:_))) | not (T.null org) -> T.unpack org
---         _ -> head firstN : lastN ++ T.unpack (T.take 8 id')
---     ,
---     subUnit = Nothing,
---     subCountry = Nothing,
---     subPub = pk
--- }
+-- getAccessTokenForRealm ::
+--   ( MonadIO m,
+--     MonadLogger m,
+--     Accessible RealmMap m
+--   ) =>
+--   String ->
+--   m (Maybe AccessToken)
+-- getAccessTokenForRealm realm = do
+--   rd <- access (Proxy @RealmMap)
+--   case M.lookup realm rd of
+--     Nothing -> do
+--       $logErrorS "getAccessTokenForRealm" $ "Recieved PUT /identity request from a realm we don't support: " <> T.pack realm
+--       throwIO $ IdentityError "Identity server does not support this realm"
+--     Just
+--       RealmDetails
+--         { realmEndpoints = ep,
+--           realmClientId = cid,
+--           realmClientSecret = csec
+--         } -> getAccessToken cid csec (token_endpoint ep)
 
 getDefaultEmptyOrg :: String -> String -> String
 getDefaultEmptyOrg name uuid = "Mercata Account " ++ getDefaultEmptyOrgOld name uuid
@@ -114,37 +108,21 @@ getSubject ::
 getSubject "" _ _ = do
   $logErrorS "getSubject" "Improper query params! Param 'name' is not defined or is empty. Cannot create a cert with so little info"
   throwIO $ IdentityError "Param 'name' cannot be empty"
-getSubject name org pk = pure
-  Subject
-    { subCommonName = name,
-      subOrg = org,
-      subUnit = Nothing,
-      subCountry = Nothing,
-      subPub = pk
-    }
-
--- NOTE TO FUTURE DEVELOPERS: This commented-out code block is from a previous flow where we would call
--- the GET /users endpoint on keycloak to get the user's information. We are trying to be less keycloak
--- dependent, so this flow is not being used, but I'll just leave it in here just in case we ever need it
-
--- getAccessTokenForRealm "master" >>= \case
---     Nothing -> do
---         $logErrorS "createAndRegisterCert" "uh oh! We couldn't get an access token for the master realm"
---         throwIO $ IdentityError "Something is wrong with the provided access credentials for the master realm. Have a network administrator look into this."
---     Just masterToken -> do
---         getUserByUUID masterToken (T.unpack uuid) realm >>= \case
---             Left err -> do
---                 $logErrorS "createAndRegisterCert" $ "Error occurred while querying OAuth server for information on user with uuid " <> uuid <> ": " <> T.pack err
---                 throwIO $ IdentityError "Could not retrieve user's information from OAuth server"
---             Right user -> do
---                 $logInfoS "createAndRegisterCert" $ "The user's info from the OAuth server is " <> T.pack (show user)
---                 return $ oAuthUserToSubject user pk
+getSubject name org pk =
+  pure
+    Subject
+      { subCommonName = name,
+        subOrg = org,
+        subUnit = Nothing,
+        subCountry = Nothing,
+        subPub = pk
+      }
 
 data IdentityServerData = IdentityServerData
   { issuer :: Issuer, -- issuer of signing cert
     issuerCert :: X509Certificate, -- the signing cert
     issuerPrivKey :: PrivateKey, -- the signing private key
-    realmNameToDetails :: RealmData,
+    realmNameToDetails :: RealmMap,
     sendgridAPIKey :: Maybe SendgridAPIKey,
     userRegistryAddress :: Address,
     userTableName :: String
@@ -159,7 +137,7 @@ instance Monad m => Accessible X509Certificate (ReaderT IdentityServerData m) wh
 instance Monad m => Accessible PrivateKey (ReaderT IdentityServerData m) where
   access _ = asks issuerPrivKey
 
-instance Monad m => Accessible RealmData (ReaderT IdentityServerData m) where
+instance Monad m => Accessible RealmMap (ReaderT IdentityServerData m) where
   access _ = asks realmNameToDetails
 
 instance Monad m => Accessible (Maybe SendgridAPIKey) (ReaderT IdentityServerData m) where
@@ -171,6 +149,50 @@ instance Monad m => Accessible Address (ReaderT IdentityServerData m) where
 instance Monad m => Accessible String (ReaderT IdentityServerData m) where
   access _ = asks userTableName
 
+instance MonadIO m => (String `A.Selectable` AccessToken) (ReaderT IdentityServerData m) where
+  select _ realm = do
+    realmMap <- asks realmNameToDetails
+    case M.lookup realm realmMap of
+      Just
+        RealmDetails
+          { realmEndpoints = ep,
+            realmClientId = id',
+            realmClientSecret = s,
+            accessTokenRef = ref
+          } -> do
+          now <- liftIO getCurrentTime
+          readIORef ref >>= \case
+            (Just a@AccessToken {expires_in = ex}, timeRetrieved)
+              | (now `diffUTCTime` timeRetrieved) < (fromIntegral ex) ->
+                  return $ Just a
+            _ -> do
+              token <- getAccessToken id' s (token_endpoint ep)
+              atomicWriteIORef ref (token, now)
+              return token
+      Nothing -> return Nothing
+
+instance MonadIO m => ((String, String) `A.Alters` Address) (ReaderT IdentityServerData m) where
+  lookup _ (realm, k) = do
+    realmMap <- asks realmNameToDetails
+    case M.lookup realm realmMap of
+      Just RealmDetails {cacheRef = ref} -> do
+        cache <- readIORef ref
+        let (!newCache, !mAdd) = LRU.lookup k cache
+        atomicWriteIORef ref newCache
+        return mAdd
+      Nothing -> return Nothing
+
+  insert _ (realm, k) v = do
+    realmMap <- asks realmNameToDetails
+    case M.lookup realm realmMap of
+      Just RealmDetails {cacheRef = ref} -> atomicModifyIORef' ref (\lru -> (LRU.insert k v lru, ()))
+      Nothing -> return ()
+  delete _ (realm, k) = do
+    realmMap <- asks realmNameToDetails
+    case M.lookup realm realmMap of
+      Just RealmDetails {cacheRef = ref} -> void $ atomicModifyIORef' ref (\lru -> LRU.delete k lru)
+      Nothing -> return ()
+
 instance Monad m => Accessible VaultData (VaultM m) where
   access _ = ask
 
@@ -181,16 +203,18 @@ getPingIdentity :: (MonadIO m) => m Int
 getPingIdentity = return 1
 
 putIdentity ::
-  ( MonadIO m,
+  ( MonadUnliftIO m,
     MonadLogger m,
     HasVault m,
     Accessible Issuer m,
     Accessible X509Certificate m,
     Accessible PrivateKey m,
-    Accessible RealmData m,
+    Accessible RealmMap m,
     Accessible (Maybe SendgridAPIKey) m,
     Accessible Address m,
-    Accessible String m
+    Accessible String m,
+    (String `A.Selectable` AccessToken) m,
+    ((String, String) `A.Alters` Address) m
   ) =>
   Text ->
   Text ->
@@ -209,56 +233,57 @@ putIdentity accessToken uuid idProv name mEmail mCo = do
       org = case mCo of
         Just o | o /= "" -> T.unpack o
         _ -> getDefaultEmptyOrg name' uuid'
-      csvLogMsg = T.intercalate ","
-           [ T.pack $ show time'
-           , T.pack realm
-           , uuid
-           , name
-           , T.pack org
-           ]
+      csvLogMsg =
+        T.intercalate
+          ","
+          [ T.pack $ show time',
+            T.pack realm,
+            uuid,
+            name,
+            T.pack org
+          ]
   $logInfoS "putIdentity/csv" csvLogMsg
 
-  M.lookup realm <$> access (Proxy @RealmData) >>= \case 
+  -- check if cached user
+  A.lookup Proxy (realm, uuid') >>= \case
+    Just a -> return a
     Nothing -> do
-      $logErrorS "putIdentity" . T.pack $ "this identity server does not support realm " <> realm
-      throwIO $ IdentityError "Identity server does not support this realm"
-    Just rd -> do
-      getVaultKey accessToken >>= \case
-        Just (AddressAndKey a k) -> do
-          -- has vault key, confirm also has cert
-          userCerts <- certInCirrus accessToken rd a
-
-          getAccessTokenForRealm realm >>= \case
-            Nothing -> do
-              $logErrorS "putIdentity" "uh oh! We couldn't retrieve an access token for our realm"
-              throwIO $ IdentityError "Something is wrong with the provided access credentials for the current realm. Have a network administrator look into this."
-            Just realmToken -> do
-              case userCerts of
+      mRealmDets <- M.lookup realm <$> access (Proxy @RealmMap)
+      mToken <- A.select (Proxy @AccessToken) realm
+      case (mRealmDets, mToken) of
+        (Just rd, Just realmToken) -> do
+          getVaultKey accessToken >>= \case
+            Just (AddressAndKey a k) -> do
+              -- has vault key, confirm also has cert
+              certInCirrus accessToken rd a >>= \case
                 -- User has no cert, create cert and wallet.
                 [] -> do
                   createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
-                  registerUserWallet realmToken rd name'
+                  registerUserWalletAsync realmToken rd name' realm uuid' a
                 -- User has a cert but no wallet, create wallet using cert's common name. This is for backwards compatibility with existing users.
                 [cert] -> do
                   hasWallet <- walletInCirrus accessToken rd (T.unpack $ certCommonName cert)
-                  unless hasWallet $ registerUserWallet realmToken rd (T.unpack $ certCommonName cert)
+                  if hasWallet
+                    then A.insert Proxy (realm, uuid') a
+                    else do
+                      registerUserWalletAsync realmToken rd (T.unpack $ certCommonName cert) realm uuid' a
                 -- Query returned multiple certs even though cirrus query should return only the latest one, fix the logic please.
                 _ -> do
                   $logErrorS "putIdentity" "Yikes! How can we have multiple certs if we're only limiting the search to one?"
                   throwIO $ IdentityError "Something is wrong. Have a network administrator look into this."
-                  
-          return a
-        Nothing -> do
-          -- no vault key, so make key and register cert
-          AddressAndKey a k <- postVaultKey accessToken
-          getAccessTokenForRealm realm >>= \case
-            Nothing -> do
-              $logErrorS "putIdentity" "uh oh! We couldn't retrieve an access token for our realm"
-              throwIO $ IdentityError "Something is wrong with the provided access credentials for the current realm. Have a network administrator look into this."
-            Just realmToken -> do  
-              createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
-              registerUserWallet realmToken rd name'
               return a
+            Nothing -> do
+              -- no vault key, so make key and register cert
+              AddressAndKey a k <- postVaultKey accessToken
+              createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
+              registerUserWalletAsync realmToken rd name' realm uuid' a
+              return a
+        (_, Nothing) -> do
+          $logErrorS "putIdentity" "uh oh! We couldn't retrieve an access token for our realm"
+          throwIO $ IdentityError "Something is wrong with the provided access credentials for the current realm. Have a network administrator look into this."
+        (Nothing, _) -> do
+          $logErrorS "putIdentity" . T.pack $ "this identity server does not support realm " <> realm
+          throwIO $ IdentityError "Identity server does not support this realm"
 
 -- This is just a dummy function
 -- This never gets called on the sevrvant backend
@@ -267,16 +292,18 @@ putIdentity accessToken uuid idProv name mEmail mCo = do
 -- which Identity server's nginx transforms the headers
 -- which patterns matches with putIdentity
 putIdentityExternal ::
-  ( MonadIO m,
+  ( MonadUnliftIO m,
     MonadLogger m,
     HasVault m,
     Accessible Issuer m,
     Accessible X509Certificate m,
     Accessible PrivateKey m,
-    Accessible RealmData m,
+    Accessible RealmMap m,
     Accessible (Maybe SendgridAPIKey) m,
     Accessible Address m,
-    Accessible String m
+    Accessible String m,
+    (String `A.Selectable` AccessToken) m,
+    ((String, String) `A.Alters` Address) m
   ) =>
   Text ->
   m Address
@@ -286,8 +313,7 @@ blocEndpoint :: String
 blocEndpoint = "/bloc/v2.2"
 
 data CertificateInCirrus = CertificateInCirrus
-  { 
-    certCommonName :: Text,
+  { certCommonName :: Text,
     -- organization :: Text,
     isValid :: Bool
   }
@@ -295,22 +321,21 @@ data CertificateInCirrus = CertificateInCirrus
 
 instance FromJSON CertificateInCirrus where
   parseJSON = withObject "CertificateInCirrus" $ \v -> do
-      commonName <- v .: "commonName"
-      isValid <- v .: "isValid"
-      return CertificateInCirrus { certCommonName = commonName, isValid = isValid }
+    commonName <- v .: "commonName"
+    isValid <- v .: "isValid"
+    return CertificateInCirrus {certCommonName = commonName, isValid = isValid}
 
 instance ToJSON CertificateInCirrus
 
 data WalletInCirrus = WalletInCirrus
-  { 
-    walletCommonName :: Text
+  { walletCommonName :: Text
   }
   deriving (Show, Generic)
 
 instance FromJSON WalletInCirrus where
   parseJSON = withObject "WalletInCirrus" $ \v -> do
-      commonName <- v .: "commonName"
-      return WalletInCirrus { walletCommonName = commonName }
+    commonName <- v .: "commonName"
+    return WalletInCirrus {walletCommonName = commonName}
 
 instance ToJSON WalletInCirrus
 
@@ -320,7 +345,7 @@ certInCirrus ::
   RealmDetails ->
   Address ->
   m [CertificateInCirrus]
-certInCirrus token (RealmDetails _ _ _ nurl1 nurl2) a = do
+certInCirrus token RealmDetails {associatedNodeUrl = nurl1, associatedFallback = nurl2} a = do
   response1 <- callCirrus nurl1
   mCerts :: Maybe [CertificateInCirrus] <-
     if statusCode (responseStatus response1) == 200
@@ -350,15 +375,16 @@ certInCirrus token (RealmDetails _ _ _ nurl1 nurl2) a = do
       liftIO $ httpLbs request {requestHeaders = rHead} mgr
 
 walletInCirrus ::
-  ( MonadIO m
-  , MonadLogger m
-  , Accessible String m
-  , Accessible Address m) =>
+  ( MonadIO m,
+    MonadLogger m,
+    Accessible String m,
+    Accessible Address m
+  ) =>
   Text ->
   RealmDetails ->
   String ->
   m Bool
-walletInCirrus token (RealmDetails _ _ _ nurl1 nurl2) commonName = do
+walletInCirrus token RealmDetails {associatedNodeUrl = nurl1, associatedFallback = nurl2} commonName = do
   userTableName <- access (Proxy @String)
   userRegistryAddress <- access (Proxy @Address)
   response1 <- callCirrus userRegistryAddress nurl1 userTableName
@@ -377,7 +403,7 @@ walletInCirrus token (RealmDetails _ _ _ nurl1 nurl2) commonName = do
     cirrusSearchPath :: Address -> String -> String
     cirrusSearchPath userRegAddr userTableName =
       let derivedAddr = deriveAddressWithSalt (Just userRegAddr) commonName Nothing (Just . show $ OrderedVals [SString $ commonName])
-      in "/cirrus/search/" <> userTableName <> "?address=eq." <> show derivedAddr
+       in "/cirrus/search/" <> userTableName <> "?address=eq." <> show derivedAddr
 
     callCirrus :: MonadIO m => Address -> BaseUrl -> String -> m (HTTP.Response BL.ByteString)
     callCirrus userRegAddr nurl userTableName = do
@@ -440,7 +466,7 @@ registerCert ::
   AccessToken ->
   RealmDetails ->
   m ()
-registerCert cert token (RealmDetails _ _ _ nurl nurl2) = do
+registerCert cert token RealmDetails {associatedNodeUrl = nurl, associatedFallback = nurl2} = do
   mgr <- liftIO $ case baseUrlScheme nurl of
     Http -> newManager defaultManagerSettings
     Https -> newManager tlsManagerSettings
@@ -460,7 +486,12 @@ registerCert cert token (RealmDetails _ _ _ nurl nurl2) = do
       postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
   eresponse <- liftIO $ postBlocTx clientEnv
   case eresponse of
-    Right response -> $logInfoS "registerCert" $ T.pack $ "Response after registering cert was: " ++ show response
+    Right response ->
+      if all txSuccess response
+        then $logInfoS "registerCert" $ T.pack $ "Response after registering cert was: " ++ show response
+        else do
+          $logErrorS "registerCert" $ T.pack $ "Failed to register cert for user; response was: " ++ show response
+          throwIO $ IdentityError "Failed to register cert"
     Left clienterr -> do
       $logErrorS "registerCert" $
         T.pack $
@@ -471,15 +502,44 @@ registerCert cert token (RealmDetails _ _ _ nurl nurl2) = do
         Https -> newManager tlsManagerSettings
       let clientEnv2 = mkClientEnv mgr2 nurl2 {baseUrlPath = baseUrlPath nurl2 <> blocEndpoint}
       eresponse2 <- liftIO $ postBlocTx clientEnv2
-      $logInfoS "registerCert" $ T.pack $ "Response from fallback node was " ++ show eresponse2
+      case eresponse2 of
+        Right response2 | all txSuccess response2 -> $logInfoS "registerCert" $ T.pack $ "Response from fallback node was " ++ show response2
+        err -> do
+          $logErrorS "registerCert" $
+            T.pack $
+              "Received following error when trying to register cert on fallback node: " ++ show err
+          throwIO $ IdentityError "Failed to register cert"
 
-registerUserWallet ::
-  (MonadIO m, MonadLogger m, Accessible Address m) =>
+txSuccess :: BlocChainOrTransactionResult -> Bool
+-- txSuccess BlocTxResult (BlocTransactionResult{blocTransactionStatus = stat}) | stat /= Failure = True
+-- instead of this?
+txSuccess (BlocTxResult BlocTransactionResult {blocTransactionStatus = Success}) = True
+txSuccess _ = False
+
+registerUserWalletAsync ::
+  ( MonadUnliftIO m,
+    MonadLogger m,
+    Accessible Address m,
+    ((String, String) `A.Alters` Address) m
+  ) =>
   AccessToken ->
   RealmDetails ->
   String ->
+  String ->
+  String ->
+  Address ->
   m ()
-registerUserWallet token (RealmDetails _ _ _ nurl nurl2) commonName = do
+registerUserWalletAsync realmToken rd name' realm uuid' a = void . async $ do
+  regSuccess <- registerUserWallet realmToken rd name'
+  when regSuccess $ A.insert Proxy (realm, uuid') a
+
+registerUserWallet ::
+  (MonadUnliftIO m, MonadLogger m, Accessible Address m) =>
+  AccessToken ->
+  RealmDetails ->
+  String ->
+  m Bool
+registerUserWallet token RealmDetails {associatedNodeUrl = nurl, associatedFallback = nurl2} commonName = do
   userRegAddr <- access (Proxy @Address)
   mgr <- liftIO $ case baseUrlScheme nurl of
     Http -> newManager defaultManagerSettings
@@ -500,7 +560,18 @@ registerUserWallet token (RealmDetails _ _ _ nurl nurl2) commonName = do
       postBlocTx = runClientM (postBlocTransactionExternal (Just $ "Bearer " <> access_token token) Nothing Nothing True txRequest)
   eresponse <- liftIO $ postBlocTx clientEnv
   case eresponse of
-    Right response -> $logInfoS "registerUserWallet" $ T.pack $ "Response after registering user wallet was: " ++ show response
+    Right response ->
+      if all txSuccess response
+        then do
+          $logInfoS "registerUserWallet"
+            . T.pack
+            $ "Response after registering user wallet was: " ++ show response
+          return True
+        else do
+          $logErrorS "registerUserWallet"
+            . T.pack
+            $ "Failed to register user wallet; response was: " ++ show response
+          return False
     Left clienterr -> do
       $logErrorS "registerUserWallet" $
         T.pack $
@@ -511,9 +582,17 @@ registerUserWallet token (RealmDetails _ _ _ nurl nurl2) commonName = do
         Https -> newManager tlsManagerSettings
       let clientEnv2 = mkClientEnv mgr2 nurl2 {baseUrlPath = baseUrlPath nurl2 <> blocEndpoint}
       eresponse2 <- liftIO $ postBlocTx clientEnv2
-      $logInfoS "registerUserWallet" $ T.pack $ "Response from fallback node was " ++ show eresponse2
+      case eresponse2 of
+        Right response2 | all txSuccess response2 -> do
+          $logInfoS "registerUserWallet" . T.pack $ "Response from fallback node was " ++ show response2
+          return True
+        err -> do
+          $logErrorS "registerUserWallet"
+            . T.pack
+            $ "Failed to register user wallet; response was: " ++ show err
+          return False
 
---TODO: how to tell if cert successfully added to blockchain?
+-- TODO: how to tell if cert successfully added to blockchain?
 
 getVaultKey :: (MonadIO m, MonadLogger m, HasVault m) => Text -> m (Maybe AddressAndKey)
 getVaultKey accessToken = do
@@ -545,16 +624,18 @@ postVaultKey accessToken = do
       throwIO $ IdentityError "Error occurred while trying to create vault key for user"
 
 server ::
-  ( MonadIO m,
+  ( MonadUnliftIO m,
     MonadLogger m,
     HasVault m,
     Accessible Issuer m,
     Accessible X509Certificate m,
     Accessible PrivateKey m,
-    Accessible RealmData m,
+    Accessible RealmMap m,
     Accessible (Maybe SendgridAPIKey) m,
     Accessible Address m,
-    Accessible String m
+    Accessible String m,
+    (String `A.Selectable` AccessToken) m,
+    ((String, String) `A.Alters` Address) m
   ) =>
   ServerT IDAPI.IdentityProviderAPI m
 server = getPingIdentity :<|> putIdentity :<|> putIdentityExternal
@@ -564,12 +645,12 @@ hoistCoreServer ::
   Issuer ->
   X509Certificate ->
   PrivateKey ->
-  RealmData ->
+  RealmMap ->
   Maybe SendgridAPIKey ->
   String ->
   String ->
   Server IDAPI.IdentityProviderAPI
-hoistCoreServer vaulturl iss cert privk rd mEmailK userRegAddr userTableName = 
+hoistCoreServer vaulturl iss cert privk rd mEmailK userRegAddr userTableName =
   hoistServer (Proxy :: Proxy IDAPI.IdentityProviderAPI) (convertErrors runM') server
   where
     convertErrors r x = Handler $ do
@@ -588,13 +669,13 @@ runIdentityM ::
   Issuer ->
   X509Certificate ->
   PrivateKey ->
-  RealmData ->
+  RealmMap ->
   Maybe SendgridAPIKey ->
   String ->
   String ->
   ReaderT IdentityServerData m a ->
   m a
-runIdentityM iss cert privk rd mEmailK userRegAddr userTableName x = 
+runIdentityM iss cert privk rd mEmailK userRegAddr userTableName x =
   runReaderT x $ IdentityServerData iss cert privk rd mEmailK (fromJust $ stringAddress userRegAddr) userTableName
 
 identityProviderApp ::
@@ -602,10 +683,10 @@ identityProviderApp ::
   Issuer ->
   X509Certificate ->
   PrivateKey ->
-  RealmData ->
+  RealmMap ->
   Maybe SendgridAPIKey ->
   String ->
   String ->
   Application
-identityProviderApp vurl iss cert pk rd mEmailK userRegAddr userTableName = 
+identityProviderApp vurl iss cert pk rd mEmailK userRegAddr userTableName =
   serve (Proxy :: Proxy IDAPI.IdentityProviderAPI) $ hoistCoreServer vurl iss cert pk rd mEmailK userRegAddr userTableName

--- a/strato/identity-provider/server/src/IdentityProvider/Server.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/Server.hs
@@ -27,7 +27,7 @@ import Bloc.Client
 import BlockApps.Logging
 import BlockApps.Solidity.ArgValue
 import BlockApps.X509 hiding (isValid)
-import Blockchain.Strato.Model.Address (stringAddress)
+import Blockchain.Strato.Model.Address (stringAddress, deriveAddressWithSalt)
 import Blockchain.Strato.Model.Secp256k1 hiding (HasVault)
 import Control.Monad (unless)
 import Control.Monad.Change.Modify
@@ -54,6 +54,7 @@ import Network.HTTP.Types.Header (hAuthorization, hContentType)
 import Network.HTTP.Types.Status
 import Servant
 import Servant.Client hiding (manager, responseBody)
+import SolidVM.Model.Value (Value(..), ValList(..))
 import Strato.Strato23.API
 import Strato.Strato23.Client
 import UnliftIO hiding (Handler)
@@ -351,18 +352,20 @@ certInCirrus token (RealmDetails _ _ _ nurl1 nurl2) a = do
 walletInCirrus ::
   ( MonadIO m
   , MonadLogger m
-  , Accessible String m) =>
+  , Accessible String m
+  , Accessible Address m) =>
   Text ->
   RealmDetails ->
   String ->
   m Bool
 walletInCirrus token (RealmDetails _ _ _ nurl1 nurl2) commonName = do
   userTableName <- access (Proxy @String)
-  response1 <- callCirrus nurl1 userTableName
+  userRegistryAddress <- access (Proxy @Address)
+  response1 <- callCirrus userRegistryAddress nurl1 userTableName
   mWallet :: Maybe [WalletInCirrus] <-
     if statusCode (responseStatus response1) == 200
       then return . decode $ responseBody response1
-      else callCirrus nurl2 userTableName >>= return . decode . responseBody
+      else callCirrus userRegistryAddress nurl2 userTableName >>= return . decode . responseBody
   case mWallet of
     Just wallet -> do
       $logInfoS "walletInCirrus" $ T.pack $ "Checked for user's wallet in Cirrus; response was: " <> show wallet
@@ -371,12 +374,14 @@ walletInCirrus token (RealmDetails _ _ _ nurl1 nurl2) commonName = do
       $logErrorS "walletInCirrus" "Unexpected response from cirrus query. This should never happen"
       throwIO $ IdentityError "Unable to decode cirrus query for user's wallet. Something went very wrong"
   where
-    cirrusSearchPath :: String -> String
-    cirrusSearchPath userTableName = "/cirrus/search/" <> userTableName <> "?commonName=eq." <> commonName
+    cirrusSearchPath :: Address -> String -> String
+    cirrusSearchPath userRegAddr userTableName =
+      let derivedAddr = deriveAddressWithSalt (Just userRegAddr) commonName Nothing (Just . show $ OrderedVals [SString $ commonName])
+      in "/cirrus/search/" <> userTableName <> "?address=eq." <> show derivedAddr
 
-    callCirrus :: MonadIO m => BaseUrl -> String -> m (HTTP.Response BL.ByteString)
-    callCirrus nurl userTableName = do
-      let cirrusEndpoint = cirrusSearchPath userTableName
+    callCirrus :: MonadIO m => Address -> BaseUrl -> String -> m (HTTP.Response BL.ByteString)
+    callCirrus userRegAddr nurl userTableName = do
+      let cirrusEndpoint = cirrusSearchPath userRegAddr userTableName
           url = showBaseUrl nurl {baseUrlPath = baseUrlPath nurl <> cirrusEndpoint}
       mgr <- liftIO $ case baseUrlScheme nurl of
         Http -> newManager defaultManagerSettings

--- a/strato/identity-provider/server/src/IdentityProvider/Server.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/Server.hs
@@ -46,7 +46,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Time (diffUTCTime, getCurrentTime)
-import Debug.Trace (trace)
 import GHC.Generics
 import qualified IdentityProvider.API as IDAPI
 import IdentityProvider.Email
@@ -373,16 +372,19 @@ walletInCirrus
         $logErrorS "walletInCirrus" "Unexpected response from cirrus query. This should never happen"
         throwIO $ IdentityError "Unable to decode cirrus query for user's wallet. Something went very wrong"
     where
-      cirrusSearchPath :: String
-      cirrusSearchPath =
+      cirrusSearchPath :: (MonadLogger m) => m String
+      cirrusSearchPath = do
         let derivedAddr = deriveAddressWithSalt (Just userRegAddr) commonName mHash (Just . show $ OrderedVals [SString $ commonName])
-            derivedAddr' = trace ("DERIVED ADDR IS " <> show derivedAddr) (show derivedAddr)
-         in "/cirrus/search/" <> userTableName <> "?address=eq." <> derivedAddr'
+            derivedAddr' = show derivedAddr
+            path = "/cirrus/search/" <> userTableName <> "?address=eq." <> derivedAddr' 
+        $logDebugS "walletInCirrus/cirrusSearchPath" $ "Derived address is " <> T.pack derivedAddr'
+        $logDebugS "walletInCirrus/cirrusSearchPath" $ "Cirrus search path is " <> T.pack path
+        return path
 
-      callCirrus :: MonadIO m => BaseUrl -> m (HTTP.Response BL.ByteString)
+      callCirrus :: (MonadIO m, MonadLogger m) => BaseUrl -> m (HTTP.Response BL.ByteString)
       callCirrus nurl = do
-        let cirrusEndpoint = cirrusSearchPath
-            url = showBaseUrl nurl {baseUrlPath = baseUrlPath nurl <> cirrusEndpoint}
+        cirrusEndpoint <- cirrusSearchPath
+        let url = showBaseUrl nurl {baseUrlPath = baseUrlPath nurl <> cirrusEndpoint}
         mgr <- liftIO $ case baseUrlScheme nurl of
           Http -> newManager defaultManagerSettings
           Https -> newManager tlsManagerSettings


### PR DESCRIPTION
This PR includes a couple and some performance changes to the identity server

- functional change 1 is to derive the salted address of the user wallet when querying if a user has one or not. Previously, we queried with the commonName, which occasionally caused issues when they included characters such as `+`. To improve correctness of behavior, we instead derive the address.
- functional change 2 is to use the /parallel transaction endpoint so that when a wave of successive registration occurs, the transactions can all be posted successfully to the network (a new behavior we're seeing with the current marketing campaigns)

- why does the identity server need performance improvements? If we look at the graph below of the testnet identity server's response times from Dec 25-31, we can see that overall we are doing ok (most response times under 2 sec). However, those are when a user calls PUT /identity and already has a cert + wallet. When a user lacks either, the identity server goes ahead and creates them, waiting for a response before returning. Due to issues with increasing transaction processing times, this means the identity server is waiting several seconds _per transaction_. Nginx is configured to wait a max of 15 seconds before returning with a timeout, and we actually hit that! This means when a new user signs in for the first time, they get this weird experience of loading for a long time, the screen flickers strangely as the ui re-requests the data, then they finally see the marketplace populate.
![id-server-response-times](https://github.com/blockapps/strato-platform/assets/31707474/c24fcce0-c3f9-419b-9f1b-8b434a4647f9)

As the main culprit for long response times is waiting for transactions to be processed, we fork a thread any time we need to register a wallet as those are not critical to functionality the same way certs are. We also cache previously seen users and the access token to reduce unnecessary network calls. Below is a graph of the response times from the optimized testnet identity server from Feb 5-9. The average response time is reduced by 80%, but more importantly, we are not seeing response times go over 3 seconds at the moment. This is partially also due to restarting the validators recently, so transaction processing times are down. 
![id-server-response-times-optimized](https://github.com/blockapps/strato-platform/assets/31707474/6bb3d556-6281-4c0d-85a4-4df6640a3ac1)

How does this affect prod? Transaction times on prod are getting concerningly long as well. So far we haven't passed the 15-second nginx max wait time, but we're getting close. The last call to PUT /identity had a *response time of 14.107 seconds*! Since we are pushing to onboard more users, this is something we should address sooner rather than later.
**EDIT**: We actually have passed the 15-second mark at least once so far.

This doesn't fix the core issue of why transaction times are getting longer and longer, but this does ensure that user experience is not adversely affected for new users.