### PR TITLE
[Strato-P2P] ResourceT Cleanup

### DIFF
--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -60,7 +60,7 @@ runPeer ::
   m ()
 runPeer peer sSource = do
   ender <- toIO . $logInfoS "runPeer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
-  void $ register ender
+  reg   <- register ender
   myPublic <- getPub
   otherPubKey <- case (pPeerPubkey peer) of
     Nothing -> do
@@ -72,6 +72,7 @@ runPeer peer sSource = do
           return pub
         Left e -> do
           $logErrorS "getPubKeyRunPeer" $ T.pack $ "Error, couldn't get public key for peer: " ++ show e
+          release reg
           throwIO NoPeerPubKey
     Just pub -> return pub
 
@@ -91,8 +92,10 @@ runPeer peer sSource = do
             (c ^. seqSource)
             pStr
       case attempt of
-        Nothing  -> $logDebugS "runPeer" "Peer ran successfully!"
+        Nothing  -> do $logDebugS "runPeer" "Peer ran successfully!"
+                       release reg
         Just err -> do $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err
+                       release reg
                        throwIO err
 
 runEthClientConduit ::

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -29,7 +29,6 @@ import Blockchain.Strato.Model.Secp256k1
 import Blockchain.TCPClientWithTimeout
 import Conduit
 import Control.Lens ((^.))
-import Control.Monad
 import qualified Control.Monad.Change.Alter as A
 import Control.Monad.Trans.Resource
 import qualified Data.ByteString as B
@@ -60,7 +59,7 @@ ethServerHandler ::
 ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
   let peerStr = T.unpack i
   ender <- toIO . $logInfoS "runEthServer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow peerStr
-  void $ register ender
+  reg   <- register ender
   getPeerByIP ipAsText >>= \case
     Nothing -> do
       $logErrorS "runEthServer" . T.pack $ "Didn't see peer in discovery at IP " ++ peerStr ++ ". rejecting violently."
@@ -72,7 +71,8 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
             attempt <- withCertifiedPeer p . withActivePeer p . scoped $
                          runEthServerConduit p pSource pSink seqSrc peerStr
             case attempt of
-              Nothing  -> $logDebugS "runEthServer" "Peer ran successfully!"
+              Nothing  -> do _ <- $logDebugS "runEthServer" "Peer ran successfully!"
+                             release reg
               Just err -> do
                 $logErrorS "runEthServer" . T.pack $ "Peer did not run successfully: " ++ show err
                 _ <- case err of
@@ -122,6 +122,7 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
                         lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) p
                       _ -> return $ Right ()
                   _ -> return $ Right ()
+                release reg
                 throwIO err
 
 runEthServerConduit ::


### PR DESCRIPTION
This issue addresses places in both `strato/core/strato-p2p/src/Executable/StratoP2PClient.hs` and `strato/core/strato-p2p/src/Executable/StratoP2PServer.hs` where there was a lack of resource cleanup via `runResourceT` or `release`.