### PR TITLE
Mkt 239 stripe redirect

### DIFF
--- a/marketplace/backend/api/v1/Order/order.controller.js
+++ b/marketplace/backend/api/v1/Order/order.controller.js
@@ -107,11 +107,10 @@ class OrderController {
   static async payment(req, res, next) {
     try {
       const { dapp, body, accessToken } = req
-      
-      const origin_url = req.headers.origin
+      const originUrl = req.headers.origin
       OrderController.validatePaymentArgs(body)
 
-      const result = await dapp.paymentCheckout(origin_url, body, options, accessToken)
+      const result = await dapp.paymentCheckout(originUrl, body, options, accessToken)
       rest.response.status200(res, result)
     } catch (e) {
       return next(e)

--- a/marketplace/backend/api/v1/Order/order.controller.js
+++ b/marketplace/backend/api/v1/Order/order.controller.js
@@ -107,9 +107,11 @@ class OrderController {
   static async payment(req, res, next) {
     try {
       const { dapp, body, accessToken } = req
+      
+      const origin_url = req.headers.origin
       OrderController.validatePaymentArgs(body)
 
-      const result = await dapp.paymentCheckout(req.headers.origin,body, options, accessToken)
+      const result = await dapp.paymentCheckout(origin_url, body, options, accessToken)
       rest.response.status200(res, result)
     } catch (e) {
       return next(e)

--- a/marketplace/backend/api/v1/Order/order.controller.js
+++ b/marketplace/backend/api/v1/Order/order.controller.js
@@ -109,7 +109,7 @@ class OrderController {
       const { dapp, body, accessToken } = req
       OrderController.validatePaymentArgs(body)
 
-      const result = await dapp.paymentCheckout(body, options, accessToken)
+      const result = await dapp.paymentCheckout(req.headers.origin,body, options, accessToken)
       rest.response.status200(res, result)
     } catch (e) {
       return next(e)

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -665,7 +665,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   }
   // //-----------------------------PAYMENT starts here -------------------------------
 
-  contract.paymentCheckout = async function (args, options = defaultOptions) {
+  contract.paymentCheckout = async function (url,args, options = defaultOptions) {
     try {
 
       const { orderList, orderTotal: recievedOrderTotal } = args;
@@ -729,7 +729,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
         }
         stripePaymentSession = await axios.post(new URL('/stripe/checkout', STRIPE_PAYMENT_SERVER_URL).href, checkoutBody, {
           headers: {
-            'referer': `${options.config.serverHost}${options.config.marketplaceUiUrlPrefix}`
+            'referer': `${url}${options.config.marketplaceUiUrlPrefix}`
           }
         })
           .then(function (res) {

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -665,7 +665,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   }
   // //-----------------------------PAYMENT starts here -------------------------------
 
-  contract.paymentCheckout = async function (url,args, options = defaultOptions) {
+  contract.paymentCheckout = async function (origin_url, args, options = defaultOptions) {
     try {
 
       const { orderList, orderTotal: recievedOrderTotal } = args;
@@ -729,7 +729,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
         }
         stripePaymentSession = await axios.post(new URL('/stripe/checkout', STRIPE_PAYMENT_SERVER_URL).href, checkoutBody, {
           headers: {
-            'referer': `${url}${options.config.marketplaceUiUrlPrefix}`
+            'referer': `${origin_url}${options.config.marketplaceUiUrlPrefix}`
           }
         })
           .then(function (res) {

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -727,7 +727,11 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
           orderDetail: invoices,
           accountId: sellerStripeDetails[0].accountId,
         }
-        stripePaymentSession = await axios.post(new URL('/stripe/checkout', STRIPE_PAYMENT_SERVER_URL).href, checkoutBody)
+        stripePaymentSession = await axios.post(new URL('/stripe/checkout', STRIPE_PAYMENT_SERVER_URL).href, checkoutBody, {
+          headers: {
+            'referer': `${options.config.serverHost}${options.config.marketplaceUiUrlPrefix}`
+          }
+        })
           .then(function (res) {
             if (res.status === 200) {
               return res.data;

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -665,7 +665,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   }
   // //-----------------------------PAYMENT starts here -------------------------------
 
-  contract.paymentCheckout = async function (origin_url, args, options = defaultOptions) {
+  contract.paymentCheckout = async function (originUrl, args, options = defaultOptions) {
     try {
 
       const { orderList, orderTotal: recievedOrderTotal } = args;
@@ -729,7 +729,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
         }
         stripePaymentSession = await axios.post(new URL('/stripe/checkout', STRIPE_PAYMENT_SERVER_URL).href, checkoutBody, {
           headers: {
-            'referer': `${origin_url}${options.config.marketplaceUiUrlPrefix}`
+            'referer': `${originUrl}${options.config.marketplaceUiUrlPrefix}`
           }
         })
           .then(function (res) {


### PR DESCRIPTION
- Added 'referer' in the header for the '/stripe/checkout' API call (passing req.headers.origin URL).

Here is the video:-
[payment_redirect.webm](https://github.com/blockapps/strato-platform/assets/30270881/20c2df93-abc0-49bf-b07c-c68a49c7c817)

Test case
we have two URL's:-
https://workspace-tanuj-a03kf75.mercata-testnet2.blockapps.net/ (Linked to the node config)
https://workspace-tanuj2-a03kf75.mercata-testnet2.blockapps.net/

[Before:-]
(https://workspace-tanuj2-a03kf75.mercata-testnet2.blockapps.net/)
when making payment through this url:-
https://workspace-tanuj2-a03kf75.mercata-testnet2.blockapps.net/ 
it was redirecting the user to this url:-
https://workspace-tanuj-a03kf75.mercata-testnet2.blockapps.net/
Due to this, we were not able to create order.

Now:-
After making payment with the url:-
https://workspace-tanuj2-a03kf75.mercata-testnet2.blockapps.net/
it is redirecting to the same Url through which we are making payment. 
so now we are able to create order.
