### PR TITLE
offline tx test gets user's nonce before starting

### DIFF
--- a/tests/e2e/offline-txs.test.ts
+++ b/tests/e2e/offline-txs.test.ts
@@ -18,7 +18,9 @@ describe('Test Offline Transactions', async function () {
 
   const getNonce = async function(){
     const n = await exec(dockerPrefix + `docker exec strato-strato-1 curl "localhost:3000/eth/v1.2/account?address=74f014fef932d2728c6c7e2b4d3b88ac37a7e1d0" -s`)
-    return parseInt(JSON.parse(n.stdout)[0]['nonce'])
+    const accountInfo = JSON.parse(n.stdout)
+    const nonce = accountInfo.length === 0 ? 0 : parseInt(accountInfo[0]['nonce'])
+    return nonce
   }
 
   before(async function () {

--- a/tests/e2e/offline-txs.test.ts
+++ b/tests/e2e/offline-txs.test.ts
@@ -9,11 +9,17 @@ describe('Test Offline Transactions', async function () {
   
   let dockerPrefix
   let x509UserData
-  let nonceCounter = 0
+  let nonceCounter
 
   const getSimpleStorageCountFromCirrus = async function () {
     const cirrusResp = await exec(dockerPrefix + 'docker exec strato-postgrest-1 curl localhost:3001/BlockApps-SimpleStorageTest')
     return cirrusResp.stdout.split('transaction_hash').length - 1
+  }
+
+  const getNonce = async function(){
+    const eth_db_name = await exec(dockerPrefix + `docker exec strato-postgres-1 psql -U postgres -t -c "select datname from pg_database where datname like '%eth_%';" | tr -d "[:space:]"`)
+    const n = await exec(dockerPrefix + `docker exec strato-postgres-1 psql -U postgres -d ` + eth_db_name.stdout + ` -t -c "select nonce from address_state_ref where address='74f014fef932d2728c6c7e2b4d3b88ac37a7e1d0';" | tr -d "[:space:]"`)
+    return parseInt(n.stdout)
   }
 
   before(async function () {
@@ -41,6 +47,7 @@ describe('Test Offline Transactions', async function () {
   it ('should create contract using offline tx', async function () {
     const ssCount1 = await getSimpleStorageCountFromCirrus()
     let ssCount2
+    nonceCounter = await getNonce()
     const ss1Resp = await exec(dockerPrefix + `docker exec strato-strato-1 post-raw-transaction --contract=SimpleStorageTest --source=SimpleStorage1.sol --key=rootPriv.pem --nonce=${nonceCounter}`)
     nonceCounter+=1
     const startTimestamp = +new Date()

--- a/tests/e2e/offline-txs.test.ts
+++ b/tests/e2e/offline-txs.test.ts
@@ -17,9 +17,8 @@ describe('Test Offline Transactions', async function () {
   }
 
   const getNonce = async function(){
-    const eth_db_name = await exec(dockerPrefix + `docker exec strato-postgres-1 psql -U postgres -t -c "select datname from pg_database where datname like '%eth_%';" | tr -d "[:space:]"`)
-    const n = await exec(dockerPrefix + `docker exec strato-postgres-1 psql -U postgres -d ` + eth_db_name.stdout + ` -t -c "select nonce from address_state_ref where address='74f014fef932d2728c6c7e2b4d3b88ac37a7e1d0';" | tr -d "[:space:]"`)
-    return parseInt(n.stdout)
+    const n = await exec(dockerPrefix + `docker exec strato-strato-1 curl "localhost:3000/eth/v1.2/account?address=74f014fef932d2728c6c7e2b4d3b88ac37a7e1d0" -s`)
+    return parseInt(JSON.parse(n.stdout)[0]['nonce'])
   }
 
   before(async function () {


### PR DESCRIPTION
The offline tx integration test assumes the user's nonce is 0 when it runs. This causes issues sometimes when the test is re-run in jenkins as the nonce has been incremented since then and none of the offline txs go through. This change allows the test to query for the user's nonce and always successfully run