### PR TITLE
[Strato-P2P] - Move Config/Context Initialization to Peer Threads

### DIFF
--- a/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
@@ -35,6 +35,11 @@ initP2P = do
   liftIO $ resetPeers
   _ <- liftIO $ $initHFlags "Strato P2P"
   setParticipationMode flags_participationMode
+  liftIO $
+    race_
+      (run 10248 $ prometheus def p2pApp)
+      (runLoggingT stratoP2P)
+  {-
   wireMessagesRef <- liftIO $ newIORef empty
   cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   let sSource  = seqEventNotificationSource $ contextKafkaState initContext
@@ -43,3 +48,4 @@ initP2P = do
     race_
       (run 10248 $ prometheus def p2pApp)
       (runLoggingT $ stratoP2P runner)
+  -}

--- a/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE OverloadedStrings     #-}
 
 import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Resource
+--import           Control.Monad.IO.Unlift
 import           Control.Concurrent.Async.Lifted.Safe
 import           Blockchain.VMOptions       ()
 
@@ -28,17 +30,28 @@ import           Data.Set.Ordered (empty)
 
 main :: IO ()
 main = runLoggingT initP2P
+--main = initP2P
 
 initP2P :: LoggingT IO ()
+--initP2P :: ( MonadIO m
+--           )
+--        => LoggingT m ()
 initP2P = do
   liftIO $ blockappsInit "strato_p2p"
   liftIO $ resetPeers
   _ <- liftIO $ $initHFlags "Strato P2P"
   setParticipationMode flags_participationMode
+  wireMessagesRef <- liftIO $ newIORef empty
+  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   liftIO $
     race_
       (run 10248 $ prometheus def p2pApp)
-      (runLoggingT stratoP2P)
+      (runLoggingT $ stratoP2P cfg)
+    --(runResourceT $ runLoggingT stratoP2P)
+      --(runLoggingT stratoP2P)
+      --(runResourceT $ runLoggingT stratoP2P)
+      --( withRunInIO (\run -> run $ runResourceT $ runLoggingT stratoP2P)
+      --)
   {-
   wireMessagesRef <- liftIO $ newIORef empty
   cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -72,6 +72,7 @@ library:
     - milena
     - milena-tools
     - monad-alter
+    - monad-control
     - monad-logger
     - monadIO
     - mtl

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -22,6 +22,7 @@ executables:
       - hflags
       - lifted-async
       - ordered-containers
+      - resourcet
       - strato-model
       - strato-p2p
       - wai-middleware-prometheus

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -37,6 +37,7 @@ library:
     - base16-bytestring
     - blockapps-data
     - blockapps-datadefs
+    - blockapps-haskoin
     - blockapps-vault-wrapper-api
     - blockapps-vault-wrapper-client
     - blockstanbul

--- a/strato/core/strato-p2p/src/Blockchain/Context.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Context.hs
@@ -30,6 +30,7 @@ module Blockchain.Context
     , Outbound(..)
     , IsValidator(..)
     , Context(..)
+    , ContextIOR(..)
     , Config(..)
     , ContextM
     , P2pConduits(..)
@@ -52,6 +53,7 @@ module Blockchain.Context
     , PeerRunner
     , initConfig
     , initContext
+    , initContextIOR
     , runContextM
     , blockstanbulPeerAddr
     , getBlockHeaders
@@ -96,6 +98,7 @@ import qualified Data.Set.Ordered                      as S
 import qualified Data.Text                             as T
 import           Data.Time.Clock
 import           GHC.Exts                              (Constraint)
+--import           Ki.Unlifted                           as KIU
 
 import           BlockApps.Logging
 import           BlockApps.X509.Certificate
@@ -114,6 +117,7 @@ import           Blockchain.Options
 import           Blockchain.P2PUtil
 import           Blockchain.Sequencer.Event
 import qualified Blockchain.Sequencer.Kafka            as SK
+--import           Blockchain.SeqEventNotify
 
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Strato.Discovery.ContextLite ()
@@ -181,7 +185,7 @@ data Config = Config
     configConnectionTimeout :: ConnectionTimeout,
     configMaxReturnedHeaders :: MaxReturnedHeaders,
     configVaultClient :: ClientEnv,
-    configContext :: IORef Context,
+    --configContext :: IORef Context,
     configBlockstanbulWireMessages :: IORef (S.OSet Keccak256),
     configPubKey :: PublicKey
   }
@@ -213,11 +217,20 @@ data Context = Context
 
 makeLenses ''Context
 
+data ContextIOR = ContextIOR
+  { contextiorConfig  :: Config
+  , contextiorContext :: IORef Context
+  }
+
+makeLenses ''ContextIOR
+
 newtype GenesisBlockHash = GenesisBlockHash {unGenesisBlockHash :: Keccak256}
 
 newtype BestBlockNumber = BestBlockNumber {unBestBlockNumber :: Integer}
 
 type ContextM = ReaderT Config (ResourceT (LoggingT IO))
+
+type ContextIORM = ReaderT ContextIOR (ResourceT (LoggingT IO))
 
 data P2pConduits m = P2pConduits
   { _peerSource :: ConduitM () B.ByteString m (),
@@ -246,6 +259,53 @@ instance RunsClient ContextM where
           pSink = appSink app
           conduits = P2pConduits pSource pSink sSource
       handler conduits
+
+instance RunsClient ContextIORM where
+  runClientConnection (IPAsText ip) (TCPPort p) sSource handler = do
+    let peerAddress = BC.pack $ T.unpack ip
+    runTCPClientWithConnectTimeout (clientSettings p peerAddress) 5 $ \app -> do
+      let pSource = appSource app
+          pSink = appSink app
+          conduits = P2pConduits pSource pSink sSource
+      handler conduits
+
+{-
+class RunsClientKI m where
+  runClientConnectionKI ::
+    IPAsText ->
+    TCPPort ->
+    (P2pConduits m -> m ()) ->
+    m ()
+
+instance RunsClientKI ContextM where
+  runClientConnectionKI (IPAsText ip) (TCPPort p) handler =
+    KIU.scoped $ \scope -> do
+      peerthread <- KIU.fork scope
+                             (do wireMessagesRef <- liftIO $ newIORef empty
+                                 cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+                                 let sSource  = seqEventNotificationSource $ contextKafkaState initContext
+                                     runner f = runContextM cfg $ f sSource
+                                 runner $ \sSource' -> do
+                                   let peerAddress = BC.pack $ T.unpack ip
+                                   runTCPClientWithConnectTimeout (clientSettings p peerAddress) 5 $ \app -> do
+                                     let pSource = appSource app
+                                         pSink = appSink app
+                                         conduits = P2pConduits pSource pSink sSource'
+                                     handler conduits
+                             )
+      atomically $ KIU.await peerthread
+-}
+
+{-
+instance (MonadIO m,MonadUnliftIO m) => RunsClient (ReaderT Config (ResourceT (LoggingT m))) where
+  runClientConnection (IPAsText ip) (TCPPort p) sSource handler = do
+    let peerAddress = BC.pack $ T.unpack ip
+    runTCPClientWithConnectTimeout (clientSettings p peerAddress) 5 $ \app -> do
+      let pSource = appSource app
+          pSink = appSink app
+          conduits = P2pConduits pSource pSink sSource
+      handler conduits    
+-}
 
 instance RunsServer ContextM (LoggingT IO) where
   runServer (TCPPort listenPort) runner handler = do
@@ -388,7 +448,24 @@ instance MonadIO m => (Keccak256 `A.Alters` (Proxy (Inbound WireMessage))) (Read
              in (wms', ())
         )
 
+{-
 instance MonadIO m => ((T.Text, Keccak256) `A.Alters` (Proxy (Outbound WireMessage))) (ReaderT Config m) where
+  lookup _ k = do
+    wms <- _outboundWireMessages <$> Mod.get (Mod.Proxy @Context)
+    let b = S.member k wms
+    pure $ if b then Just (Proxy @(Outbound WireMessage)) else Nothing
+  insert _ k _ = Mod.modifyStatefully_ (Mod.Proxy @Context) $ do
+    wms <- use outboundWireMessages
+    let s = S.size wms
+        wms' = if s >= flags_wireMessageCacheSize then S.delete (head $ toList wms) wms else wms
+        !wms'' = wms' S.>| k
+    assign outboundWireMessages wms''
+  delete _ k =
+    Mod.modifyStatefully_ (Mod.Proxy @Context) $
+      outboundWireMessages %= S.delete k
+-}
+
+instance MonadIO m => ((T.Text,Keccak256) `A.Alters` (Proxy (Outbound WireMessage))) (ReaderT ContextIOR m) where
   lookup _ k = do
     wms <- _outboundWireMessages <$> Mod.get (Mod.Proxy @Context)
     let b = S.member k wms
@@ -413,21 +490,37 @@ instance
 instance MonadIO m => Mod.Accessible BestBlockNumber (ReaderT Config m) where
   access _ = BestBlockNumber <$> liftIO getBestKafkaBlockNumber
 
-instance MonadIO m => Mod.Modifiable Context (ReaderT Config m) where
-  get _ = readIORef =<< asks configContext
-  put _ c = asks configContext >>= flip atomicModifyIORef' (const (c, ()))
+--instance MonadIO m => Mod.Modifiable Context (ReaderT Config m) where
+--  get _ = readIORef =<< asks configContext
+--  put _ c = asks configContext >>= flip atomicModifyIORef' (const (c, ()))
 
-instance MonadIO m => Mod.Modifiable K.KafkaState (ReaderT Config m) where
-  get _ = contextKafkaState <$> Mod.get (Proxy @Context)
-  put _ k = asks configContext >>= flip atomicModifyIORef' (\c -> (c {contextKafkaState = k}, ()))
+instance MonadIO m => Mod.Modifiable Context (ReaderT ContextIOR m) where
+  get _   = readIORef =<< asks contextiorContext
+  put _ c = asks contextiorContext >>= flip atomicModifyIORef' (const (c,()))
 
-instance MonadIO m => Mod.Modifiable ActionTimestamp (ReaderT Config m) where
-  get _ = actionTimestamp <$> Mod.get (Proxy @Context)
-  put _ k = asks configContext >>= flip atomicModifyIORef' (\c -> (c {actionTimestamp = k}, ()))
+--instance MonadIO m => Mod.Modifiable K.KafkaState (ReaderT Config m) where
+--  get _ = contextKafkaState <$> Mod.get (Proxy @Context)
+--  put _ k = asks configContext >>= flip atomicModifyIORef' (\c -> (c {contextKafkaState = k}, ()))
 
-instance MonadIO m => Mod.Accessible ActionTimestamp (ReaderT Config m) where
+instance MonadIO m => Mod.Modifiable K.KafkaState (ReaderT ContextIOR m) where
+  get _   = contextKafkaState <$> Mod.get (Proxy @Context)
+  put _ k = asks contextiorContext >>= flip atomicModifyIORef' (\c -> (c {contextKafkaState = k},()))
+
+--instance MonadIO m => Mod.Modifiable ActionTimestamp (ReaderT Config m) where
+--  get _ = actionTimestamp <$> Mod.get (Proxy @Context)
+--  put _ k = asks configContext >>= flip atomicModifyIORef' (\c -> (c {actionTimestamp = k}, ()))
+
+instance MonadIO m => Mod.Modifiable ActionTimestamp (ReaderT ContextIOR m) where
+  get _   = actionTimestamp <$> Mod.get (Proxy @Context)
+  put _ k = asks contextiorContext >>= flip atomicModifyIORef' (\c -> (c {actionTimestamp = k},()))
+
+--instance MonadIO m => Mod.Accessible ActionTimestamp (ReaderT Config m) where
+--  access _ = Mod.get (Proxy @ActionTimestamp)
+
+instance MonadIO m => Mod.Accessible ActionTimestamp (ReaderT ContextIOR m) where
   access _ = Mod.get (Proxy @ActionTimestamp)
 
+{-
 instance MonadIO m => Mod.Modifiable [BlockData] (ReaderT Config m) where
   get _ = do
     (bHeaders, lastUpdateTS) <- blockHeaders <$> Mod.get (Proxy @Context)
@@ -443,10 +536,33 @@ instance MonadIO m => Mod.Modifiable [BlockData] (ReaderT Config m) where
   put _ k = do
     now <- liftIO getCurrentTime
     asks configContext >>= flip atomicModifyIORef' (\c -> (c {blockHeaders = (k, now)}, ()))
+-}
 
-instance MonadIO m => Mod.Accessible [BlockData] (ReaderT Config m) where
+instance MonadIO m => Mod.Modifiable [BlockData] (ReaderT ContextIOR m) where
+  get _ = do
+    (bHeaders, lastUpdateTS) <- blockHeaders <$> Mod.get (Proxy @Context)
+    now <- liftIO getCurrentTime
+    let diffTime = now `diffUTCTime` lastUpdateTS
+    env <- ask
+    --maxTime <- fromIntegral . unConnectionTimeout <$> Mod.access (Proxy @ConnectionTimeout)
+    let maxTime = fromIntegral $ unConnectionTimeout $ configConnectionTimeout $ contextiorConfig env
+    if diffTime > maxTime
+      then do
+        -- stale cache; override it
+        Mod.put (Proxy @[BlockData]) []
+        pure []
+      else pure bHeaders
+  put _ k = do
+    now <- liftIO getCurrentTime
+    asks contextiorContext >>= flip atomicModifyIORef' (\c -> (c {blockHeaders = (k, now)},()))
+
+--instance MonadIO m => Mod.Accessible [BlockData] (ReaderT Config m) where
+--  access _ = Mod.get (Proxy @[BlockData])
+
+instance MonadIO m => Mod.Accessible [BlockData] (ReaderT ContextIOR m) where
   access _ = Mod.get (Proxy @[BlockData])
 
+{-
 instance MonadIO m => Mod.Modifiable RemainingBlockHeaders (ReaderT Config m) where
   get _ = do
     (remBHeaders, lastUpdateTS) <- remainingBlockHeaders <$> Mod.get (Proxy @Context)
@@ -463,18 +579,48 @@ instance MonadIO m => Mod.Modifiable RemainingBlockHeaders (ReaderT Config m) wh
   put _ k = do
     now <- liftIO getCurrentTime
     asks configContext >>= flip atomicModifyIORef' (\c -> (c {remainingBlockHeaders = (k, now)}, ()))
+-}
 
-instance MonadIO m => Mod.Accessible RemainingBlockHeaders (ReaderT Config m) where
+instance MonadIO m => Mod.Modifiable RemainingBlockHeaders (ReaderT ContextIOR m) where
+  get _ = do
+    (remBHeaders,lastUpdateTS) <- remainingBlockHeaders <$> Mod.get (Proxy @Context)
+    now <- liftIO getCurrentTime
+    let diffTime = now `diffUTCTime` lastUpdateTS
+    env <- ask
+    --maxTime <- fromIntegral . unConnectionTimeout <$> Mod.access (Proxy @ConnectionTimeout)
+    let maxTime = fromIntegral $ unConnectionTimeout $ configConnectionTimeout $ contextiorConfig env
+    if diffTime > maxTime
+      then do
+        -- stale cache; override it
+        let emptyRBH = RemainingBlockHeaders []
+        Mod.put (Proxy @RemainingBlockHeaders) emptyRBH
+        pure emptyRBH
+      else pure remBHeaders
+  put _ k = do
+    now <- liftIO getCurrentTime
+    asks contextiorContext >>= flip atomicModifyIORef' (\c -> (c {remainingBlockHeaders = (k,now)},()))
+
+--instance MonadIO m => Mod.Accessible RemainingBlockHeaders (ReaderT Config m) where
+--  access _ = Mod.get (Proxy @RemainingBlockHeaders)
+
+instance MonadIO m => Mod.Accessible RemainingBlockHeaders (ReaderT ContextIOR m) where
   access _ = Mod.get (Proxy @RemainingBlockHeaders)
 
 instance MonadIO m => Mod.Accessible MaxReturnedHeaders (ReaderT Config m) where
   access _ = asks configMaxReturnedHeaders
 
-instance MonadIO m => Mod.Modifiable PeerAddress (ReaderT Config m) where
-  get _ = _blockstanbulPeerAddr <$> Mod.get (Proxy @Context)
-  put _ k = asks configContext >>= flip atomicModifyIORef' (\c -> (c {_blockstanbulPeerAddr = k}, ()))
+--instance MonadIO m => Mod.Modifiable PeerAddress (ReaderT Config m) where
+--  get _ = _blockstanbulPeerAddr <$> Mod.get (Proxy @Context)
+--  put _ k = asks configContext >>= flip atomicModifyIORef' (\c -> (c {_blockstanbulPeerAddr = k}, ()))
 
-instance MonadIO m => Mod.Accessible PeerAddress (ReaderT Config m) where
+instance MonadIO m => Mod.Modifiable PeerAddress (ReaderT ContextIOR m) where
+  get _   = _blockstanbulPeerAddr <$> Mod.get (Proxy @Context)
+  put _ k = asks contextiorContext >>= flip atomicModifyIORef' (\c -> (c {_blockstanbulPeerAddr = k},()))
+
+--instance MonadIO m => Mod.Accessible PeerAddress (ReaderT Config m) where
+--  access _ = Mod.get (Proxy @PeerAddress)
+
+instance MonadIO m => Mod.Accessible PeerAddress (ReaderT ContextIOR m) where
   access _ = Mod.get (Proxy @PeerAddress)
 
 instance MonadIO m => Mod.Accessible ConnectionTimeout (ReaderT Config m) where
@@ -489,7 +635,15 @@ instance MonadIO m => Mod.Accessible SQLDB (ReaderT Config m) where
 instance {-# OVERLAPPING #-} MonadIO m => AccessibleEnv SQLDB (ReaderT Config m) where
   accessEnv = asks configSQLDB
 
+{-
 instance (MonadIO m, MonadLogger m) => Stacks Block (ReaderT Config m) where
+  takeStack _ n = do
+    vmEvents <- liftIO . fetchLastVMOutputs $ fromIntegral n
+    pure [b | ChainBlock b <- vmEvents]
+  pushStack b = void . produceVMOutputsM $ ChainBlock <$> b
+-}
+
+instance (MonadIO m,MonadLogger m) => Stacks Block (ReaderT ContextIOR m) where
   takeStack _ n = do
     vmEvents <- liftIO . fetchLastVMOutputs $ fromIntegral n
     pure [b | ChainBlock b <- vmEvents]
@@ -511,8 +665,11 @@ instance MonadUnliftIO m => A.Selectable Point PPeer (ReaderT Config m) where
     where
       actions = SQL.selectList [PPeerPubkey SQL.==. (Just pk)] []
 
-instance (MonadIO m, MonadLogger m) => Mod.Outputs (ReaderT Config m) [IngestEvent] where
-  output = void . K.withKafkaRetry1s . SK.writeUnseqEvents
+--instance (MonadIO m, MonadLogger m) => Mod.Outputs (ReaderT Config m) [IngestEvent] where
+--  output = void . K.withKafkaRetry1s . SK.writeUnseqEvents
+
+instance (MonadIO m,MonadLogger m) => Mod.Outputs (ReaderT ContextIOR m) [IngestEvent] where
+  output = void . K.withKafkaRetry1s . SK.writeUnseqEvents 
 
 instance (MonadIO m, MonadLogger m) => HasVault (ReaderT Config m) where
   sign bs = do
@@ -655,15 +812,15 @@ initConfig wireMessagesRef maxHeaders = do
     $logInfoS "HasVault" "Calling vault-wrapper to get the node's public key"
     fmap VC.unPubKey $ waitOnVault $ liftIO $ runClientM (VC.getKey Nothing Nothing) vaultClient
 
-  let initState  = initContext
-  initStateF <- newIORef initState
+  --let initState  = initContext
+  --initStateF <- newIORef initState
   return $ Config
     { configSQLDB = sqlDB' dbs
     , configRedisBlockDB = RBDB.RedisConnection redisBDBPool
     , configConnectionTimeout = ConnectionTimeout flags_connectionTimeout
     , configMaxReturnedHeaders = MaxReturnedHeaders maxHeaders
     , configVaultClient = vaultClient
-    , configContext = initStateF
+    --, configContext = initStateF
     , configBlockstanbulWireMessages = wireMessagesRef
     , configPubKey = nodePubKey
     }
@@ -677,6 +834,17 @@ initContext =
           , _blockstanbulPeerAddr = PeerAddress Nothing
           , _outboundWireMessages = S.empty
           }
+
+initContextIOR :: MonadIO m
+               => Config
+               -> m ContextIOR
+initContextIOR config = do
+  let initState = initContext
+  initStateF    <- newIORef initState
+  return $ ContextIOR
+    { contextiorConfig  = config
+    , contextiorContext = initStateF
+    }
 
 getPeerByIP ::
   A.Selectable IPAsText PPeer m =>

--- a/strato/core/strato-p2p/src/Executable/StratoP2P.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2P.hs
@@ -5,21 +5,46 @@
 
 module Executable.StratoP2P where
 
-import           Control.Concurrent.Async.Lifted.Safe(Concurrently(..),runConcurrently)
+--import           Control.Concurrent.Async.Lifted.Safe(Concurrently(..),runConcurrently)
 import           Control.Exception hiding (catch)
 import           Control.Exception.Lifted (catch)
+import           Control.Monad.Change.Alter
+import           Control.Monad.Change.Modify
+--import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Resource
+import           Control.Monad.Trans.Control
+import           Control.Monad.Trans.Reader
 import           Control.Monad.Logger
-import           Data.Foldable            (asum)
+import           Crypto.Types.PubKey.ECC
+import           Data.ByteString
+--import           Data.Foldable            (asum)
 import qualified Data.Text as T
+import           UnliftIO.Async (race_)
 import           BlockApps.Logging as BL
+import           BlockApps.X509.Certificate
+import           Blockchain.Blockstanbul.Messages
 import           Blockchain.Context
+import           Blockchain.Data.Block
+import           Blockchain.Data.DataDefs
+import           Blockchain.Data.Enode
+import           Blockchain.Sequencer.Event
+import           Blockchain.Strato.Discovery.Data.Peer
+import           Blockchain.Strato.Model.Address
+import           Blockchain.Strato.Model.ChainMember
+import           Blockchain.Strato.Model.Keccak256
+import           Blockchain.Strato.Model.Secp256k1
+import           Network.Haskoin.Crypto.BigWord
 import           Executable.StratoP2PClient
 import           Executable.StratoP2PLoopback
 import           Executable.StratoP2PServer
 
-raceAll :: [BL.LoggingT IO a]
-        -> BL.LoggingT IO a
-raceAll = runConcurrently . asum . map Concurrently
+--raceAll :: [BL.LoggingT IO a]
+--        -> BL.LoggingT IO a
+--raceAll :: ( MonadBaseControl IO m
+--           )
+--        => [BL.LoggingT m a]
+--        -> BL.LoggingT m a
+--raceAll = runConcurrently . asum . map Concurrently
 
 {-
 stratoP2P :: ( MonadP2P n
@@ -40,8 +65,73 @@ stratoP2P runner =
 --             )
 --          => PeerRunner n (BL.LoggingT IO) () -> BL.LoggingT IO ()
 --stratoP2P runner =
+stratoP2P :: ( MonadBaseControl IO m
+             , MonadResource m
+             , MonadLogger m
+             , MonadUnliftIO m
+             , HasVault (BL.LoggingT m)
+             , Accessible [BlockData] (BL.LoggingT m)
+             , Accessible ActionTimestamp (BL.LoggingT m)
+             , Accessible RemainingBlockHeaders (BL.LoggingT m)
+             , Accessible PeerAddress (BL.LoggingT m)
+             , Accessible MaxReturnedHeaders (BL.LoggingT m)
+             , Accessible ConnectionTimeout (BL.LoggingT m)
+             , Accessible GenesisBlockHash (BL.LoggingT m)
+             , Accessible BestBlockNumber (BL.LoggingT m)
+             , Accessible PublicKey (BL.LoggingT m)
+             , Accessible BondedPeers (ReaderT Config (ResourceT (BL.LoggingT m)))
+             , Accessible BondedPeers (BL.LoggingT m)
+             , Accessible AvailablePeers (ReaderT Config (ResourceT (BL.LoggingT m)))
+             , Accessible AvailablePeers (BL.LoggingT m)
+             , Alters (T.Text,Keccak256) (Proxy (Outbound Blockchain.Blockstanbul.Messages.WireMessage)) (BL.LoggingT m)
+             , Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT (BL.LoggingT m)))
+             , Alters (IPAsText,TCPPort) ActivityState (BL.LoggingT m)
+             , Alters Keccak256 (Proxy (Inbound WireMessage)) (BL.LoggingT m)
+             , Alters Keccak256 BlockData (BL.LoggingT m)
+             , Alters Keccak256 OutputBlock (BL.LoggingT m)
+             , Modifiable ActionTimestamp (BL.LoggingT m)
+             , Modifiable RemainingBlockHeaders (BL.LoggingT m)
+             , Modifiable [BlockData] (BL.LoggingT m)
+             , Modifiable PeerAddress (BL.LoggingT m)
+             , Modifiable BestBlock (BL.LoggingT m)
+             , Modifiable WorldBestBlock (BL.LoggingT m)
+             , Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT (BL.LoggingT m)))
+             , Replaceable (IPAsText,Point) PeerBondingState (BL.LoggingT m)
+             , Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT (BL.LoggingT m)))
+             , Replaceable PPeer TcpEnableTime (BL.LoggingT m)
+             , Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT (BL.LoggingT m)))
+             , Replaceable PPeer UdpEnableTime (BL.LoggingT m)
+             , Replaceable PPeer PeerDisable (ReaderT Config (ResourceT (BL.LoggingT m)))
+             , Replaceable PPeer PeerDisable (BL.LoggingT m)
+             , Replaceable PPeer T.Text (ReaderT Config (ResourceT (BL.LoggingT m)))
+             , Replaceable PPeer T.Text (BL.LoggingT m)
+             , Selectable (IPAsText,UDPPort,ByteString) Point (BL.LoggingT m)
+             , Selectable Word256 ChainMemberRSet (BL.LoggingT m)
+             , Selectable Word256 ChainInfo (BL.LoggingT m)
+             , Selectable Integer (Canonical BlockData) (BL.LoggingT m)
+             , Selectable Keccak256 (Private (Word256,OutputTx)) (BL.LoggingT m)
+             , Selectable Keccak256 ChainTxsInBlock (BL.LoggingT m)
+             , Selectable Address X509CertInfoState (BL.LoggingT m)
+             , Selectable IPAsText PPeer (BL.LoggingT m)
+             , Selectable Point PPeer (BL.LoggingT m)
+             , Selectable ChainMemberParsedSet [ChainMemberParsedSet] (BL.LoggingT m)
+             , Selectable ChainMemberParsedSet TrueOrgNameChains (BL.LoggingT m)
+             , Selectable ChainMemberParsedSet FalseOrgNameChains (BL.LoggingT m)
+             , Selectable ChainMemberParsedSet X509CertInfoState (BL.LoggingT m)
+             , Selectable ChainMemberParsedSet IsValidator (BL.LoggingT m)
+             , Stacks Block (BL.LoggingT m)
+             , Outputs (BL.LoggingT m) [IngestEvent]
+             , RunsClient (ReaderT Config (ResourceT (BL.LoggingT m)))
+             , RunsServer (ReaderT Config (ResourceT (BL.LoggingT m))) (BL.LoggingT m)
+             )
+          => BL.LoggingT m ()
 stratoP2P =
-  raceAll [ stratoP2PLoopback `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e)
-          , stratoP2PClient   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e)
-          , stratoP2PServer   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e)
-          ]
+  race_ (stratoP2PLoopback `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e))
+        ( race_ (stratoP2PClient   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e))
+                (stratoP2PServer   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e))
+        )   
+     
+  --raceAll [ stratoP2PLoopback `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e)
+  --        , stratoP2PClient   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e)
+  --        , stratoP2PServer   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e)
+  --        ]

--- a/strato/core/strato-p2p/src/Executable/StratoP2P.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2P.hs
@@ -5,19 +5,16 @@
 
 module Executable.StratoP2P where
 
---import           Control.Concurrent.Async.Lifted.Safe(Concurrently(..),runConcurrently)
 import           Control.Exception hiding (catch)
 import           Control.Exception.Lifted (catch)
 import           Control.Monad.Change.Alter
 import           Control.Monad.Change.Modify
---import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource
 import           Control.Monad.Trans.Control
 import           Control.Monad.Trans.Reader
 import           Control.Monad.Logger
 import           Crypto.Types.PubKey.ECC
 import           Data.ByteString
---import           Data.Foldable            (asum)
 import qualified Data.Text as T
 import           UnliftIO.Async (race_)
 import           BlockApps.Logging as BL
@@ -38,33 +35,6 @@ import           Executable.StratoP2PClient
 import           Executable.StratoP2PLoopback
 import           Executable.StratoP2PServer
 
---raceAll :: [BL.LoggingT IO a]
---        -> BL.LoggingT IO a
---raceAll :: ( MonadBaseControl IO m
---           )
---        => [BL.LoggingT m a]
---        -> BL.LoggingT m a
---raceAll = runConcurrently . asum . map Concurrently
-
-{-
-stratoP2P :: ( MonadP2P n
-             , RunsClient n
-             , RunsServer n (BL.LoggingT IO)
-             )
-          => PeerRunner n (BL.LoggingT IO) () -> BL.LoggingT IO ()
-stratoP2P runner =
-  raceAll [ stratoP2PLoopback runner `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e)
-          , stratoP2PClient   runner `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e)
-          , stratoP2PServer   runner `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e)
-          ]
--}
-
---stratoP2P :: ( MonadP2P n
---             , RunsClient n
---             , RunsServer n (BL.LoggingT IO)
---             )
---          => PeerRunner n (BL.LoggingT IO) () -> BL.LoggingT IO ()
---stratoP2P runner =
 stratoP2P :: ( MonadBaseControl IO m
              , MonadResource m
              , MonadLogger m
@@ -127,11 +97,6 @@ stratoP2P :: ( MonadBaseControl IO m
           => BL.LoggingT m ()
 stratoP2P =
   race_ (stratoP2PLoopback `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e))
-        ( race_ (stratoP2PClient   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e))
-                (stratoP2PServer   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e))
-        )   
-     
-  --raceAll [ stratoP2PLoopback `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e)
-  --        , stratoP2PClient   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e)
-  --        , stratoP2PServer   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e)
-  --        ]
+        ( race_ (stratoP2PClient `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e))
+                (stratoP2PServer `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e))
+        )

--- a/strato/core/strato-p2p/src/Executable/StratoP2P.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2P.hs
@@ -21,6 +21,7 @@ raceAll :: [BL.LoggingT IO a]
         -> BL.LoggingT IO a
 raceAll = runConcurrently . asum . map Concurrently
 
+{-
 stratoP2P :: ( MonadP2P n
              , RunsClient n
              , RunsServer n (BL.LoggingT IO)
@@ -30,4 +31,17 @@ stratoP2P runner =
   raceAll [ stratoP2PLoopback runner `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e)
           , stratoP2PClient   runner `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e)
           , stratoP2PServer   runner `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e)
+          ]
+-}
+
+--stratoP2P :: ( MonadP2P n
+--             , RunsClient n
+--             , RunsServer n (BL.LoggingT IO)
+--             )
+--          => PeerRunner n (BL.LoggingT IO) () -> BL.LoggingT IO ()
+--stratoP2P runner =
+stratoP2P =
+  raceAll [ stratoP2PLoopback `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e)
+          , stratoP2PClient          `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e)
+          , stratoP2PServer   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e)
           ]

--- a/strato/core/strato-p2p/src/Executable/StratoP2P.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2P.hs
@@ -17,7 +17,7 @@ import           Crypto.Types.PubKey.ECC
 import           Data.ByteString
 import qualified Data.Text as T
 import           UnliftIO.Async (race_)
-import           BlockApps.Logging as BL
+--import           BlockApps.Logging as BL
 import           BlockApps.X509.Certificate
 import           Blockchain.Blockstanbul.Messages
 import           Blockchain.Context
@@ -35,6 +35,7 @@ import           Executable.StratoP2PClient
 import           Executable.StratoP2PLoopback
 import           Executable.StratoP2PServer
 
+{-
 stratoP2P :: ( MonadBaseControl IO m
              , MonadResource m
              , MonadLogger m
@@ -94,9 +95,78 @@ stratoP2P :: ( MonadBaseControl IO m
              , RunsClient (ReaderT Config (ResourceT (BL.LoggingT m)))
              , RunsServer (ReaderT Config (ResourceT (BL.LoggingT m))) (BL.LoggingT m)
              )
-          => BL.LoggingT m ()
-stratoP2P =
-  race_ (stratoP2PLoopback `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e))
-        ( race_ (stratoP2PClient `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e))
-                (stratoP2PServer `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e))
+          => BL.LoggingT m () 
+          -- => BL.LoggingT IO ()
+          -- => BL.LoggingT (ResourceT IO) ()
+-}
+stratoP2P :: ( MonadUnliftIO m
+             , MonadBaseControl IO m
+             , MonadLogger m
+             , MonadResource m
+             , HasVault m
+             , RunsClient (ReaderT Config (ResourceT m))
+             , Stacks Block m
+             , Stacks Block (ReaderT Config (ResourceT m))
+             , Outputs m [IngestEvent]
+             , Outputs (ReaderT Config (ResourceT m)) [IngestEvent]
+             , Accessible [BlockData] m
+             , Accessible [BlockData] (ReaderT Config (ResourceT m))
+             , Accessible ActionTimestamp m
+             , Accessible ActionTimestamp (ReaderT Config (ResourceT m))
+             , Accessible RemainingBlockHeaders m
+             , Accessible RemainingBlockHeaders (ReaderT Config (ResourceT m))
+             , Accessible PeerAddress m
+             , Accessible PeerAddress (ReaderT Config (ResourceT m))
+             , Accessible MaxReturnedHeaders m, Accessible ConnectionTimeout m
+             , Accessible GenesisBlockHash m, Accessible BestBlockNumber m
+             , Accessible AvailablePeers m
+             , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+             , Accessible BondedPeers m
+             , Accessible BondedPeers (ReaderT Config (ResourceT m))
+             , Accessible PublicKey m, Modifiable [BlockData] m
+             , Modifiable [BlockData] (ReaderT Config (ResourceT m))
+             , Modifiable ActionTimestamp m
+             , Modifiable ActionTimestamp (ReaderT Config (ResourceT m))
+             , Modifiable RemainingBlockHeaders m
+             , Modifiable RemainingBlockHeaders (ReaderT Config (ResourceT m))
+             , Modifiable PeerAddress m
+             , Modifiable PeerAddress (ReaderT Config (ResourceT m))
+             , Modifiable BestBlock m, Modifiable WorldBestBlock m
+             , Selectable (IPAsText, UDPPort, ByteString) Point m
+             , Selectable Word256 ChainMemberRSet m
+             , Selectable Word256 ChainInfo m
+             , Selectable Integer (Canonical BlockData) m
+             , Selectable Keccak256 (Private (Word256, OutputTx)) m
+             , Selectable Keccak256 ChainTxsInBlock m
+             , Selectable Address X509CertInfoState m
+             , Selectable IPAsText PPeer m, Selectable Point PPeer m
+             , Selectable ChainMemberParsedSet [ChainMemberParsedSet] m
+             , Selectable ChainMemberParsedSet TrueOrgNameChains m
+             , Selectable ChainMemberParsedSet FalseOrgNameChains m
+             , Selectable ChainMemberParsedSet X509CertInfoState m
+             , Selectable ChainMemberParsedSet IsValidator m
+             , Replaceable (IPAsText, Point) PeerBondingState m
+             , Replaceable (IPAsText, Point) PeerBondingState (ReaderT Config (ResourceT m))
+             , Replaceable PPeer TcpEnableTime m
+             , Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+             , Replaceable PPeer UdpEnableTime m
+             , Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+             , Replaceable PPeer PeerDisable m
+             , Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+             , Replaceable PPeer T.Text m
+             , Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
+             , Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) m
+             , Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) (ReaderT Config (ResourceT m))
+             , Alters (IPAsText, TCPPort) ActivityState m
+             , Alters (IPAsText, TCPPort) ActivityState (ReaderT Config (ResourceT m))
+             , Alters Keccak256 (Proxy (Inbound WireMessage)) m
+             , Alters Keccak256 BlockData m, Alters Keccak256 OutputBlock m
+             , RunsServer (ReaderT Config (ResourceT m)) m
+             )
+          => Config
+          -> m ()
+stratoP2P cfg =
+  race_ (stratoP2PLoopback       cfg `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e))
+        ( race_ (stratoP2PClient cfg `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e))
+                (stratoP2PServer cfg `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e))
         )

--- a/strato/core/strato-p2p/src/Executable/StratoP2P.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2P.hs
@@ -42,6 +42,6 @@ stratoP2P runner =
 --stratoP2P runner =
 stratoP2P =
   raceAll [ stratoP2PLoopback `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PLoopback ERROR" . T.pack $ show e)
-          , stratoP2PClient          `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e)
+          , stratoP2PClient   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PClient ERROR" . T.pack $ show e)
           , stratoP2PServer   `catch` (\(e :: SomeException) -> $logErrorS "stratoP2PServer ERROR" . T.pack $ show e)
           ]

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -52,6 +52,7 @@ import qualified Control.Monad.Change.Alter as A
 import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
 import           Control.Monad.Trans.Resource
+import           Control.Monad.Trans.Reader
 import           Crypto.Types.PubKey.ECC
 import qualified Data.ByteString as B
 import           Data.Conduit
@@ -64,7 +65,7 @@ import           Network.Haskoin.Crypto.BigWord
 import qualified Text.Colors as C
 import           Text.Format
 import           UnliftIO
---import           Data.Set.Ordered (empty)
+import           Data.Set.Ordered (empty)
 
 --runPeer ::
 --  (RunsClient m, MonadP2P m) =>
@@ -72,10 +73,12 @@ import           UnliftIO
 --  ConduitM () P2pEvent m () ->
 --  m ()
 --runPeer peer sSource = do
-runPeer :: ( MonadUnliftIO m
+runPeer :: ( 
+             MonadUnliftIO m
            , MonadLogger m
            , MonadResource m
            , HasVault m
+           {-
            , RunsClient m
            , Stacks Block m
            , Outputs m [IngestEvent]
@@ -120,6 +123,17 @@ runPeer :: ( MonadUnliftIO m
            , A.Alters Keccak256 (Proxy (Inbound WireMessage)) m
            , A.Alters Keccak256 BlockData m
            , A.Alters Keccak256 OutputBlock m
+           -}
+           , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
+           , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+           , RunsClient (ReaderT Config (ResourceT m))
+           , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
+           , Accessible BondedPeers (ReaderT Config (ResourceT m))
+           , A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT m))
+           , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+           , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+           , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+           , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
            )
         => PPeer
         -> m ()
@@ -147,6 +161,28 @@ runPeer peer = do
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "server pubkey is: " ++ format otherPubKey 
   --runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource $ \c -> do
   scoped $ \scope -> do
+    peerthread <- fork scope (do wireMessagesRef <- liftIO $ newIORef empty
+                                 cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+                                 let sSource  = seqEventNotificationSource $ contextKafkaState initContext
+                                     runner f = runContextM cfg $ f sSource
+                                 runner $ \sSource' ->  
+                                   runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource' $ \c -> do
+                                       let pStr = pPeerString peer -- display string will show up as dns name
+                                       attempt :: (Maybe SomeException) <- 
+                                         withCertifiedPeer peer . withActivePeer peer . scoped $
+                                           runEthClientConduit
+                                             peer {pPeerPubkey = Just otherPubKey}
+                                             (c ^. peerSource)
+                                             (c ^. peerSink)
+                                             (c ^. seqSource)
+                                             pStr
+                                       case attempt of
+                                         Nothing  -> $logDebugS "runPeer" "Peer ran successfully!"
+                                         Just err -> do $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err
+                                                        throwIO err
+                             )
+    atomically $ KIU.await peerthread
+    {-
     peerthread <- fork scope (do --wireMessagesRef <- liftIO $ newIORef empty
                                  --cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
                                  let sSource  = seqEventNotificationSource $ contextKafkaState initContext
@@ -167,6 +203,7 @@ runPeer peer = do
                                                       throwIO err
                              )
     atomically $ KIU.await peerthread
+    -}
 
 runEthClientConduit ::
   MonadP2P m =>
@@ -206,6 +243,7 @@ runPeerInList :: ( MonadUnliftIO m
                  --, Exception e
                  , MonadResource m
                  , HasVault m
+                 {-
                  , RunsClient m
                  , Stacks Block m
                  , Outputs m [IngestEvent]
@@ -250,6 +288,18 @@ runPeerInList :: ( MonadUnliftIO m
                  , A.Alters Keccak256 (Proxy (Inbound WireMessage)) m
                  , A.Alters Keccak256 BlockData m
                  , A.Alters Keccak256 OutputBlock m
+                 -}
+                 , A.Replaceable PPeer TcpEnableTime m
+                 , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
+                 , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+                 , RunsClient (ReaderT Config (ResourceT m))
+                 , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
+                 , Accessible BondedPeers (ReaderT Config (ResourceT m))
+                 , A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT m))
+                 , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+                 , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+                 , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+                 , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
                  )
               => PPeer
               -> m (Either SomeException ())
@@ -266,7 +316,8 @@ runPeerInList thePeer = do
 
 --stratoP2PClient :: (MonadP2P m, RunsClient m) => PeerRunner m (LoggingT IO) () -> LoggingT IO ()
 --stratoP2PClient runner = runner $ \sSource -> do
-stratoP2PClient :: ( MonadP2P m
+stratoP2PClient :: ( {-
+                     MonadP2P m
                    , Stacks Block (LoggingT m)
                    , Accessible BondedPeers (LoggingT m)
                    , HasVault (LoggingT m)
@@ -311,7 +362,74 @@ stratoP2PClient :: ( MonadP2P m
                    , A.Alters Keccak256 (Proxy (Inbound WireMessage)) (LoggingT m)
                    , A.Alters Keccak256 BlockData (LoggingT m)
                    , A.Alters Keccak256 OutputBlock (LoggingT m)
+                   , Accessible AvailablePeers (ReaderT Config (ResourceT m))
                    , RunsClient (LoggingT m)
+                   , RunsClient (ReaderT Config (ResourceT m))
+                   , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
+                   , Accessible BondedPeers (ReaderT Config (ResourceT m))
+                   , A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
+                   -}
+                     MonadUnliftIO m
+                   --, MonadLogger m
+                   , MonadResource m
+                   --, HasVault m
+                   , HasVault (LoggingT m)
+                   , Accessible BondedPeers (LoggingT m)
+                   , Stacks Block (LoggingT m)
+                   , Outputs (LoggingT m) [IngestEvent]
+                   , Accessible [BlockData] (LoggingT m)
+                   , Accessible ActionTimestamp (LoggingT m)
+                   , Accessible RemainingBlockHeaders (LoggingT m)
+                   , Accessible PeerAddress (LoggingT m)
+                   , Accessible MaxReturnedHeaders (LoggingT m)
+                   , Accessible ConnectionTimeout (LoggingT m)
+                   , Accessible GenesisBlockHash (LoggingT m)
+                   , Accessible BestBlockNumber (LoggingT m)
+                   , Accessible AvailablePeers (LoggingT m)
+                   , Accessible PublicKey (LoggingT m)
+                   , Modifiable [BlockData] (LoggingT m)
+                   , Modifiable ActionTimestamp (LoggingT m)
+                   , Modifiable RemainingBlockHeaders (LoggingT m)
+                   , Modifiable PeerAddress (LoggingT m)
+                   , Modifiable BestBlock (LoggingT m)
+                   , Modifiable WorldBestBlock (LoggingT m)
+                   , A.Selectable (IPAsText, UDPPort, B.ByteString) Point (LoggingT m)
+                   , A.Selectable Word256 ChainMemberRSet (LoggingT m)
+                   , A.Selectable Word256 ChainInfo (LoggingT m)
+                   , A.Selectable Integer (Canonical BlockData) (LoggingT m)
+                   , A.Selectable Keccak256 (Private (Word256,OutputTx)) (LoggingT m)
+                   , A.Selectable Keccak256 ChainTxsInBlock (LoggingT m)
+                   , A.Selectable Address X509CertInfoState (LoggingT m)
+                   , A.Selectable IPAsText PPeer (LoggingT m)
+                   , A.Selectable Point PPeer (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet TrueOrgNameChains (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet FalseOrgNameChains (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet X509CertInfoState (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet IsValidator (LoggingT m)
+                   , A.Replaceable (IPAsText,Point) PeerBondingState (LoggingT m)
+                   , A.Replaceable PPeer TcpEnableTime (LoggingT m)
+                   , A.Replaceable PPeer UdpEnableTime (LoggingT m)
+                   , A.Replaceable PPeer PeerDisable (LoggingT m)
+                   , A.Replaceable PPeer T.Text (LoggingT m)
+                   , A.Alters (T.Text,Keccak256) (Proxy (Outbound WireMessage)) (LoggingT m)
+                   , A.Alters (IPAsText,TCPPort) ActivityState (LoggingT m)
+                   , A.Alters Keccak256 (Proxy (Inbound WireMessage)) (LoggingT m)
+                   , A.Alters Keccak256 BlockData (LoggingT m)
+                   , A.Alters Keccak256 OutputBlock (LoggingT m)
+                   , RunsClient (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT (LoggingT m)))
+                   , Accessible BondedPeers (ReaderT Config (ResourceT (LoggingT m)))
+                   , Accessible AvailablePeers (ReaderT Config (ResourceT (LoggingT m)))
                    )
                 => LoggingT m ()
 stratoP2PClient = do
@@ -332,7 +450,21 @@ stratoP2PClient = do
   where
     --multiThreadedClient :: (MonadP2P m, RunsClient m) => [PPeer] -> SSem -> ConduitM () P2pEvent m () -> m ()
     --multiThreadedClient [] _ _ = do
-    multiThreadedClient :: (MonadP2P m, RunsClient m) => [PPeer] -> SSem -> m ()
+    multiThreadedClient :: ( MonadP2P m
+                           --, RunsClient m
+                           , RunsClient (ReaderT Config (ResourceT m))
+                           , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
+                           , Accessible BondedPeers (ReaderT Config (ResourceT m))
+                           , A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT m))
+                           , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+                           , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+                           , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+                           , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
+                           , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+                           )
+                        => [PPeer]
+                        -> SSem
+                        -> m ()
     multiThreadedClient [] _ = do
       $logInfoS "stratoP2PClient/multiThreadedClient" "No available peers, will try again in 10 seconds"
       liftIO $ threadDelay 10000000

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -42,7 +42,7 @@ import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.TCPClientWithTimeout
 import           Control.Concurrent hiding (yield)
-import           Control.Concurrent.SSem (SSem)
+--import           Control.Concurrent.SSem (SSem)
 import qualified Control.Concurrent.SSem as SSem
 import           Control.Exception.Base (ErrorCall (..))
 import           Control.Lens ((^.))
@@ -65,12 +65,24 @@ import           Network.Haskoin.Crypto.BigWord
 import qualified Text.Colors as C
 import           Text.Format
 import           UnliftIO
-import           Data.Set.Ordered (empty)
+--import           Data.Set.Ordered (empty)
+
 
 runPeer :: ( MonadUnliftIO m
            , MonadLogger m
            , MonadResource m
            , HasVault m
+           , Stacks Block (ReaderT Config (ResourceT m))
+           , Outputs (ReaderT Config (ResourceT m)) [IngestEvent]
+           , Accessible [BlockData] (ReaderT Config (ResourceT m))
+           , Accessible ActionTimestamp (ReaderT Config (ResourceT m))
+           , Accessible RemainingBlockHeaders (ReaderT Config (ResourceT m))
+           , Accessible PeerAddress (ReaderT Config (ResourceT m))
+           , Modifiable [BlockData] (ReaderT Config (ResourceT m))
+           , Modifiable ActionTimestamp (ReaderT Config (ResourceT m))
+           , Modifiable RemainingBlockHeaders (ReaderT Config (ResourceT m))
+           , Modifiable PeerAddress (ReaderT Config (ResourceT m))
+           , A.Alters (T.Text,Keccak256) (Proxy (Outbound WireMessage)) (ReaderT Config (ResourceT m))
            , A.Selectable (IPAsText,UDPPort,B.ByteString) Point m
            , Accessible AvailablePeers (ReaderT Config (ResourceT m))
            , RunsClient (ReaderT Config (ResourceT m))
@@ -83,10 +95,16 @@ runPeer :: ( MonadUnliftIO m
            , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
            )
         => PPeer
+        -> Config
         -> m ()
-runPeer peer = do
+--runPeer :: ( MonadP2P m
+--           , RunsClient m
+--           )
+--        => PPeer -> Config -> m ()
+runPeer peer cfg = do
   ender <- toIO . $logInfoS "runPeer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
-  void $ register ender
+  reg <- register ender
+  --void $ register ender
   myPublic <- getPub
   otherPubKey <- case (pPeerPubkey peer) of
     Nothing -> do
@@ -98,58 +116,60 @@ runPeer peer = do
           return pub
         Left e -> do
           $logErrorS "getPubKeyRunPeer" $ T.pack $ "Error, couldn't get public key for peer: " ++ show e
+          release reg
           throwIO NoPeerPubKey
     Just pub -> return pub
-
   $logInfoS "runPeer" . T.pack . C.blue $ "Welcome to strato-p2p-client"
   $logInfoS "runPeer" . T.pack . C.blue $ "============================"
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "Attempting to connect to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "my pubkey is: " ++ format myPublic
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "server pubkey is: " ++ format otherPubKey
-  scoped $ \scope -> do
-    peerthread <- fork scope (do wireMessagesRef <- liftIO $ newIORef empty
-                                 cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
-                                 let sSource  = seqEventNotificationSource $ contextKafkaState initContext
-                                     runner f = runContextM cfg $ f sSource
-                                 runner $ \sSource' ->  
-                                   runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource' $ \c -> do
-                                       let pStr = pPeerString peer -- display string will show up as dns name
-                                       attempt :: (Maybe SomeException) <- 
-                                         withCertifiedPeer peer . withActivePeer peer . scoped $
-                                           runEthClientConduit
-                                             peer {pPeerPubkey = Just otherPubKey}
-                                             (c ^. peerSource)
-                                             (c ^. peerSink)
-                                             (c ^. seqSource)
-                                             pStr
-                                       case attempt of
-                                         Nothing  -> $logDebugS "runPeer" "Peer ran successfully!"
-                                         Just err -> do $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err
-                                                        throwIO err
-                             )
-    atomically $ KIU.await peerthread
-    {-
-    peerthread <- fork scope (do --wireMessagesRef <- liftIO $ newIORef empty
-                                 --cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
-                                 let sSource  = seqEventNotificationSource $ contextKafkaState initContext
-                                 --    runner f = runContextM cfg $ f sSource
-                                 runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource $ \c -> do
+  let sSource  = seqEventNotificationSource $ contextKafkaState initContext
+      runner f = runContextM cfg $ f sSource 
+  runner $ \sSource' ->
+    runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource' $ \c -> do
+        let pStr = pPeerString peer -- display string will show up as dns name
+        attempt :: (Maybe SomeException) <- 
+          withCertifiedPeer peer . withActivePeer peer . scoped $
+            runEthClientConduit
+              peer {pPeerPubkey = Just otherPubKey}
+              (c ^. peerSource)
+              (c ^. peerSink)
+              (c ^. seqSource)
+              pStr
+        case attempt of
+          Nothing  -> $logDebugS "runPeer" "Peer ran successfully!"
+          Just err -> do $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err
+                         throwIO err
+
+  {-
+  KIU.scoped $ \scope -> do
+    peerthread <- KIU.fork scope
+                           (do wireMessagesRef <- liftIO $ newIORef empty
+                               cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+                               let sSource  = seqEventNotificationSource $ contextKafkaState initContext
+                                   runner f = runContextM cfg $ f sSource 
+                               runner $ \sSource' -> 
+                                 runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource' $ \c -> do
                                      let pStr = pPeerString peer -- display string will show up as dns name
                                      attempt :: (Maybe SomeException) <- 
-                                       withCertifiedPeer peer . withActivePeer peer . scoped $
+                                       withCertifiedPeer peer . withActivePeer peer $
                                          runEthClientConduit
                                            peer {pPeerPubkey = Just otherPubKey}
                                            (c ^. peerSource)
                                            (c ^. peerSink)
                                            (c ^. seqSource)
                                            pStr
+                                           scope
                                      case attempt of
-                                       Nothing  -> $logDebugS "runPeer" "Peer ran successfully!"
+                                       Nothing  -> do $logDebugS "runPeer" "Peer ran successfully!" 
+                                                      release reg
                                        Just err -> do $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err
+                                                      release reg
                                                       throwIO err
-                             )
+                           )
     atomically $ KIU.await peerthread
-    -}
+  -}
 
 runEthClientConduit ::
   MonadP2P m =>
@@ -176,6 +196,7 @@ runEthClientConduit peer pSource pSink seqSrc peerStr scp = do
            .| eventSink
            .| pSink
 
+{-
 runPeerInList :: ( MonadUnliftIO m
                  , MonadLogger m
                  , MonadResource m
@@ -194,7 +215,38 @@ runPeerInList :: ( MonadUnliftIO m
                  )
               => PPeer
               -> m (Either SomeException ())
-runPeerInList thePeer = do
+-}
+runPeerInList :: ( MonadUnliftIO m
+                 , MonadLogger m
+                 , MonadResource m
+                 , HasVault m
+                 , Stacks Block (ReaderT Config (ResourceT m))
+                 , Outputs (ReaderT Config (ResourceT m)) [IngestEvent]
+                 , Modifiable [BlockData] (ReaderT Config (ResourceT m))
+                 , Modifiable ActionTimestamp (ReaderT Config (ResourceT m))
+                 , Modifiable RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                 , Modifiable PeerAddress (ReaderT Config (ResourceT m))
+                 , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
+                 , RunsClient (ReaderT Config (ResourceT m))
+                 , A.Alters (T.Text,Keccak256) (Proxy (Outbound WireMessage)) (ReaderT Config (ResourceT m))
+                 , A.Alters (IPAsText, TCPPort) ActivityState (ReaderT Config (ResourceT m))
+                 , Accessible [BlockData] (ReaderT Config (ResourceT m))
+                 , Accessible ActionTimestamp (ReaderT Config (ResourceT m))
+                 , Accessible RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                 , Accessible PeerAddress (ReaderT Config (ResourceT m))
+                 , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+                 , Accessible BondedPeers (ReaderT Config (ResourceT m))
+                 , A.Replaceable (IPAsText, Point) PeerBondingState (ReaderT Config (ResourceT m))
+                 , A.Replaceable PPeer TcpEnableTime m
+                 , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+                 , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+                 , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+                 , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
+                 )
+              => PPeer
+              -> Config
+              -> m (Either SomeException ())
+runPeerInList thePeer cfg = do
   eErr <- nonviolentDisable thePeer --don't connect to a peer too frequently, out of politeness
   case eErr of
     Left err -> do
@@ -202,8 +254,9 @@ runPeerInList thePeer = do
       $logErrorS "runPeerInList" "Simulating disable..."
       liftIO $ threadDelay $ 10 * 1000 * 1000
     Right () -> pure ()
-  try $ runPeer thePeer
+  try $ runPeer thePeer cfg
 
+{-
 stratoP2PClient :: ( MonadUnliftIO m
                    , MonadResource m
                    , HasVault (LoggingT m)
@@ -261,7 +314,77 @@ stratoP2PClient :: ( MonadUnliftIO m
                    , Accessible AvailablePeers (ReaderT Config (ResourceT (LoggingT m)))
                    )
                 => LoggingT m ()
-stratoP2PClient = do
+-}
+stratoP2PClient :: ( MonadLogger m
+                   , MonadUnliftIO m
+                   , MonadResource m
+                   , HasVault m
+                   , RunsClient (ReaderT Config (ResourceT m)), Stacks Block m
+                   , Stacks Block (ReaderT Config (ResourceT m))
+                   , Outputs m [IngestEvent]
+                   , Outputs (ReaderT Config (ResourceT m)) [IngestEvent]
+                   , Accessible [BlockData] m
+                   , Accessible [BlockData] (ReaderT Config (ResourceT m))
+                   , Accessible ActionTimestamp m
+                   , Accessible ActionTimestamp (ReaderT Config (ResourceT m))
+                   , Accessible RemainingBlockHeaders m
+                   , Accessible RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                   , Accessible PeerAddress m
+                   , Accessible PeerAddress (ReaderT Config (ResourceT m))
+                   , Accessible MaxReturnedHeaders m
+                   , Accessible ConnectionTimeout m
+                   , Accessible GenesisBlockHash m
+                   , Accessible BestBlockNumber m
+                   , Accessible AvailablePeers m
+                   , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+                   , Accessible BondedPeers m
+                   , Accessible BondedPeers (ReaderT Config (ResourceT m))
+                   , Accessible PublicKey m
+                   , Modifiable [BlockData] m
+                   , Modifiable [BlockData] (ReaderT Config (ResourceT m))
+                   , Modifiable ActionTimestamp m
+                   , Modifiable ActionTimestamp (ReaderT Config (ResourceT m))
+                   , Modifiable RemainingBlockHeaders m
+                   , Modifiable RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                   , Modifiable PeerAddress m
+                   , Modifiable PeerAddress (ReaderT Config (ResourceT m))
+                   , Modifiable BestBlock m
+                   , Modifiable WorldBestBlock m
+                   , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
+                   , A.Selectable Word256 ChainMemberRSet m
+                   , A.Selectable Word256 ChainInfo m
+                   , A.Selectable Integer (Canonical BlockData) m
+                   , A.Selectable Keccak256 (Private (Word256, OutputTx)) m
+                   , A.Selectable Keccak256 ChainTxsInBlock m
+                   , A.Selectable Address X509CertInfoState m
+                   , A.Selectable IPAsText PPeer m
+                   , A.Selectable Point PPeer m
+                   , A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] m
+                   , A.Selectable ChainMemberParsedSet TrueOrgNameChains m
+                   , A.Selectable ChainMemberParsedSet FalseOrgNameChains m
+                   , A.Selectable ChainMemberParsedSet X509CertInfoState m
+                   , A.Selectable ChainMemberParsedSet IsValidator m
+                   , A.Replaceable (IPAsText, Point) PeerBondingState m
+                   , A.Replaceable (IPAsText, Point) PeerBondingState (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer TcpEnableTime m
+                   , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer UdpEnableTime m
+                   , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer PeerDisable m
+                   , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer T.Text m
+                   , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
+                   , A.Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) m
+                   , A.Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) (ReaderT Config (ResourceT m))
+                   , A.Alters (IPAsText, TCPPort) ActivityState m
+                   , A.Alters (IPAsText, TCPPort) ActivityState (ReaderT Config (ResourceT m))
+                   , A.Alters Keccak256 (Proxy (Inbound WireMessage)) m
+                   , A.Alters Keccak256 BlockData m
+                   , A.Alters Keccak256 OutputBlock m
+                   )
+                => Config
+                -> m ()
+stratoP2PClient cfg = do
   $logInfoS "stratoP2PClient" $ T.pack $ "maxConn: " ++ show flags_maxConn
   activePeersSem <- liftIO (SSem.new flags_maxConn)
   forever $ do
@@ -272,10 +395,11 @@ stratoP2PClient = do
         $logErrorS "stratoP2PClient" . T.pack $ "Could not fetch peers: " ++ show err
         liftIO $ threadDelay 1000000
       Right peers -> do
-        _ <- async (multiThreadedClient peers activePeersSem)
+        _ <- async (multiThreadedClient peers activePeersSem cfg)
         $logInfoS "stratoP2PClient" "Waiting 5 seconds before looping over peers again"
         liftIO $ threadDelay 5000000
   where
+    {-
     multiThreadedClient :: ( MonadP2P m
                            , RunsClient (ReaderT Config (ResourceT m))
                            , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
@@ -290,16 +414,17 @@ stratoP2PClient = do
                         => [PPeer]
                         -> SSem
                         -> m ()
-    multiThreadedClient [] _ = do
+    -}
+    multiThreadedClient [] _ _ = do
       $logInfoS "stratoP2PClient/multiThreadedClient" "No available peers, will try again in 10 seconds"
       liftIO $ threadDelay 10000000
-    multiThreadedClient peers sem = do
+    multiThreadedClient peers sem cfg' = do
       let notRunningPeers = filter ((== 0) . pPeerActiveState) peers
       unless (null notRunningPeers) . void . forConcurrently notRunningPeers $ \p -> do
         liftIO (SSem.tryWait sem) >>= \case
           Nothing -> return ()
           Just _ -> do
-            result <- runPeerInList p
+            result <- runPeerInList p cfg'
             _ <- handleRunPeerResult p result
             liftIO $ SSem.signal sem
     handleRunPeerResult :: MonadP2P m => PPeer -> Either SomeException () -> m ()

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -67,64 +67,11 @@ import           Text.Format
 import           UnliftIO
 import           Data.Set.Ordered (empty)
 
---runPeer ::
---  (RunsClient m, MonadP2P m) =>
---  PPeer ->
---  ConduitM () P2pEvent m () ->
---  m ()
---runPeer peer sSource = do
-runPeer :: ( 
-             MonadUnliftIO m
+runPeer :: ( MonadUnliftIO m
            , MonadLogger m
            , MonadResource m
            , HasVault m
-           {-
-           , RunsClient m
-           , Stacks Block m
-           , Outputs m [IngestEvent]
-           , Accessible [BlockData] m
-           , Accessible ActionTimestamp m
-           , Accessible RemainingBlockHeaders m
-           , Accessible PeerAddress m
-           , Accessible MaxReturnedHeaders m
-           , Accessible ConnectionTimeout m
-           , Accessible GenesisBlockHash m
-           , Accessible BestBlockNumber m
-           , Accessible AvailablePeers m
-           , Accessible BondedPeers m
-           , Accessible PublicKey m
-           , Modifiable [BlockData] m
-           , Modifiable ActionTimestamp m
-           , Modifiable RemainingBlockHeaders m
-           , Modifiable PeerAddress m
-           , Modifiable BestBlock m
-           , Modifiable WorldBestBlock m
-           , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
-           , A.Selectable Word256 ChainMemberRSet m
-           , A.Selectable Word256 ChainInfo m
-           , A.Selectable Integer (Canonical BlockData) m
-           , A.Selectable Keccak256 (Private (Word256, OutputTx)) m
-           , A.Selectable Keccak256 ChainTxsInBlock m
-           , A.Selectable Address X509CertInfoState m
-           , A.Selectable IPAsText PPeer m
-           , A.Selectable Point PPeer m
-           , A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] m
-           , A.Selectable ChainMemberParsedSet TrueOrgNameChains m
-           , A.Selectable ChainMemberParsedSet FalseOrgNameChains m
-           , A.Selectable ChainMemberParsedSet X509CertInfoState m
-           , A.Selectable ChainMemberParsedSet IsValidator m
-           , A.Replaceable (IPAsText, Point) PeerBondingState m
-           , A.Replaceable PPeer TcpEnableTime m
-           , A.Replaceable PPeer UdpEnableTime m
-           , A.Replaceable PPeer PeerDisable m
-           , A.Replaceable PPeer T.Text m
-           , A.Alters (IPAsText, TCPPort) ActivityState m
-           , A.Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) m
-           , A.Alters Keccak256 (Proxy (Inbound WireMessage)) m
-           , A.Alters Keccak256 BlockData m
-           , A.Alters Keccak256 OutputBlock m
-           -}
-           , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
+           , A.Selectable (IPAsText,UDPPort,B.ByteString) Point m
            , Accessible AvailablePeers (ReaderT Config (ResourceT m))
            , RunsClient (ReaderT Config (ResourceT m))
            , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
@@ -158,8 +105,7 @@ runPeer peer = do
   $logInfoS "runPeer" . T.pack . C.blue $ "============================"
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "Attempting to connect to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "my pubkey is: " ++ format myPublic
-  $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "server pubkey is: " ++ format otherPubKey 
-  --runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource $ \c -> do
+  $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "server pubkey is: " ++ format otherPubKey
   scoped $ \scope -> do
     peerthread <- fork scope (do wireMessagesRef <- liftIO $ newIORef empty
                                  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
@@ -230,67 +176,12 @@ runEthClientConduit peer pSource pSink seqSrc peerStr scp = do
            .| eventSink
            .| pSink
 
---runPeerInList ::
---  ( MonadP2P m,
---    RunsClient m
---  ) =>
---  PPeer ->
---  ConduitM () P2pEvent m () ->
---  m (Either SomeException ())
---runPeerInList thePeer sSource = do
 runPeerInList :: ( MonadUnliftIO m
                  , MonadLogger m
-                 --, Exception e
                  , MonadResource m
                  , HasVault m
-                 {-
-                 , RunsClient m
-                 , Stacks Block m
-                 , Outputs m [IngestEvent]
-                 , Accessible [BlockData] m
-                 , Accessible ActionTimestamp m
-                 , Accessible RemainingBlockHeaders m
-                 , Accessible PeerAddress m
-                 , Accessible MaxReturnedHeaders m
-                 , Accessible ConnectionTimeout m
-                 , Accessible GenesisBlockHash m
-                 , Accessible BestBlockNumber m
-                 , Accessible AvailablePeers m
-                 , Accessible BondedPeers m
-                 , Accessible PublicKey m
-                 , Modifiable [BlockData] m
-                 , Modifiable ActionTimestamp m
-                 , Modifiable RemainingBlockHeaders m
-                 , Modifiable PeerAddress m
-                 , Modifiable BestBlock m
-                 , Modifiable WorldBestBlock m
-                 , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
-                 , A.Selectable Word256 ChainMemberRSet m
-                 , A.Selectable Word256 ChainInfo m
-                 , A.Selectable Integer (Canonical BlockData) m
-                 , A.Selectable Keccak256 (Private (Word256, OutputTx)) m
-                 , A.Selectable Keccak256 ChainTxsInBlock m
-                 , A.Selectable Address X509CertInfoState m
-                 , A.Selectable IPAsText PPeer m
-                 , A.Selectable Point PPeer m
-                 , A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] m
-                 , A.Selectable ChainMemberParsedSet TrueOrgNameChains m
-                 , A.Selectable ChainMemberParsedSet FalseOrgNameChains m
-                 , A.Selectable ChainMemberParsedSet X509CertInfoState m
-                 , A.Selectable ChainMemberParsedSet IsValidator m
-                 , A.Replaceable (IPAsText, Point) PeerBondingState m
                  , A.Replaceable PPeer TcpEnableTime m
-                 , A.Replaceable PPeer UdpEnableTime m
-                 , A.Replaceable PPeer PeerDisable m
-                 , A.Replaceable PPeer T.Text m
-                 , A.Alters (IPAsText, TCPPort) ActivityState m
-                 , A.Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) m
-                 , A.Alters Keccak256 (Proxy (Inbound WireMessage)) m
-                 , A.Alters Keccak256 BlockData m
-                 , A.Alters Keccak256 OutputBlock m
-                 -}
-                 , A.Replaceable PPeer TcpEnableTime m
-                 , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
+                 , A.Selectable (IPAsText,UDPPort,B.ByteString) Point m
                  , Accessible AvailablePeers (ReaderT Config (ResourceT m))
                  , RunsClient (ReaderT Config (ResourceT m))
                  , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
@@ -311,72 +202,10 @@ runPeerInList thePeer = do
       $logErrorS "runPeerInList" "Simulating disable..."
       liftIO $ threadDelay $ 10 * 1000 * 1000
     Right () -> pure ()
-  --try $ runPeer thePeer sSource
   try $ runPeer thePeer
 
---stratoP2PClient :: (MonadP2P m, RunsClient m) => PeerRunner m (LoggingT IO) () -> LoggingT IO ()
---stratoP2PClient runner = runner $ \sSource -> do
-stratoP2PClient :: ( {-
-                     MonadP2P m
-                   , Stacks Block (LoggingT m)
-                   , Accessible BondedPeers (LoggingT m)
-                   , HasVault (LoggingT m)
-                   , Outputs (LoggingT m) [IngestEvent]
-                   , Accessible [BlockData] (LoggingT m)
-                   , Accessible ActionTimestamp (LoggingT m)
-                   , Accessible RemainingBlockHeaders (LoggingT m)
-                   , Accessible PeerAddress (LoggingT m)
-                   , Accessible MaxReturnedHeaders (LoggingT m)
-                   , Accessible ConnectionTimeout (LoggingT m)
-                   , Accessible GenesisBlockHash (LoggingT m)
-                   , Accessible BestBlockNumber (LoggingT m)
-                   , Accessible AvailablePeers (LoggingT m)
-                   , Accessible PublicKey (LoggingT m)
-                   , Modifiable [BlockData] (LoggingT m)
-                   , Modifiable ActionTimestamp (LoggingT m)
-                   , Modifiable RemainingBlockHeaders (LoggingT m)
-                   , Modifiable PeerAddress (LoggingT m)
-                   , Modifiable BestBlock (LoggingT m)
-                   , Modifiable WorldBestBlock (LoggingT m)
-                   , A.Selectable (IPAsText, UDPPort, B.ByteString) Point (LoggingT m)
-                   , A.Selectable Word256 ChainMemberRSet (LoggingT m)
-                   , A.Selectable Word256 ChainInfo (LoggingT m)
-                   , A.Selectable Integer (Canonical BlockData) (LoggingT m)
-                   , A.Selectable Keccak256 (Private (Word256,OutputTx)) (LoggingT m)
-                   , A.Selectable Keccak256 ChainTxsInBlock (LoggingT m)
-                   , A.Selectable Address X509CertInfoState (LoggingT m)
-                   , A.Selectable IPAsText PPeer (LoggingT m)
-                   , A.Selectable Point PPeer (LoggingT m)
-                   , A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] (LoggingT m)
-                   , A.Selectable ChainMemberParsedSet TrueOrgNameChains (LoggingT m)
-                   , A.Selectable ChainMemberParsedSet FalseOrgNameChains (LoggingT m)
-                   , A.Selectable ChainMemberParsedSet X509CertInfoState (LoggingT m)
-                   , A.Selectable ChainMemberParsedSet IsValidator (LoggingT m)
-                   , A.Replaceable (IPAsText,Point) PeerBondingState (LoggingT m)
-                   , A.Replaceable PPeer TcpEnableTime (LoggingT m)
-                   , A.Replaceable PPeer UdpEnableTime (LoggingT m)
-                   , A.Replaceable PPeer PeerDisable (LoggingT m)
-                   , A.Replaceable PPeer T.Text (LoggingT m)
-                   , A.Alters (T.Text,Keccak256) (Proxy (Outbound WireMessage)) (LoggingT m)
-                   , A.Alters (IPAsText,TCPPort) ActivityState (LoggingT m)
-                   , A.Alters Keccak256 (Proxy (Inbound WireMessage)) (LoggingT m)
-                   , A.Alters Keccak256 BlockData (LoggingT m)
-                   , A.Alters Keccak256 OutputBlock (LoggingT m)
-                   , Accessible AvailablePeers (ReaderT Config (ResourceT m))
-                   , RunsClient (LoggingT m)
-                   , RunsClient (ReaderT Config (ResourceT m))
-                   , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
-                   , Accessible BondedPeers (ReaderT Config (ResourceT m))
-                   , A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT m))
-                   , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
-                   , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
-                   , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
-                   , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
-                   -}
-                     MonadUnliftIO m
-                   --, MonadLogger m
+stratoP2PClient :: ( MonadUnliftIO m
                    , MonadResource m
-                   --, HasVault m
                    , HasVault (LoggingT m)
                    , Accessible BondedPeers (LoggingT m)
                    , Stacks Block (LoggingT m)
@@ -443,15 +272,11 @@ stratoP2PClient = do
         $logErrorS "stratoP2PClient" . T.pack $ "Could not fetch peers: " ++ show err
         liftIO $ threadDelay 1000000
       Right peers -> do
-        --_ <- async (multiThreadedClient peers activePeersSem sSource)
         _ <- async (multiThreadedClient peers activePeersSem)
         $logInfoS "stratoP2PClient" "Waiting 5 seconds before looping over peers again"
         liftIO $ threadDelay 5000000
   where
-    --multiThreadedClient :: (MonadP2P m, RunsClient m) => [PPeer] -> SSem -> ConduitM () P2pEvent m () -> m ()
-    --multiThreadedClient [] _ _ = do
     multiThreadedClient :: ( MonadP2P m
-                           --, RunsClient m
                            , RunsClient (ReaderT Config (ResourceT m))
                            , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
                            , Accessible BondedPeers (ReaderT Config (ResourceT m))
@@ -468,14 +293,12 @@ stratoP2PClient = do
     multiThreadedClient [] _ = do
       $logInfoS "stratoP2PClient/multiThreadedClient" "No available peers, will try again in 10 seconds"
       liftIO $ threadDelay 10000000
-    --multiThreadedClient peers sem sSource = do
     multiThreadedClient peers sem = do
       let notRunningPeers = filter ((== 0) . pPeerActiveState) peers
       unless (null notRunningPeers) . void . forConcurrently notRunningPeers $ \p -> do
         liftIO (SSem.tryWait sem) >>= \case
           Nothing -> return ()
           Just _ -> do
-            --result <- runPeerInList p sSource
             result <- runPeerInList p
             _ <- handleRunPeerResult p result
             liftIO $ SSem.signal sem

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -19,8 +19,13 @@ module Executable.StratoP2PClient
 where
 
 import           BlockApps.Logging
+import           BlockApps.X509.Certificate
+import           Blockchain.Blockstanbul.Messages
 import           Blockchain.CommunicationConduit
 import           Blockchain.Context
+import           Blockchain.Data.Block
+import           Blockchain.Data.DataDefs
+import           Blockchain.Data.Enode
 import           Blockchain.Data.PubKey (secPubKeyToPoint)
 import           Blockchain.EthEncryptionException
 import           Blockchain.EventException
@@ -28,8 +33,12 @@ import           Blockchain.Metrics
 import           Blockchain.Options
 import           Blockchain.RLPx
 import           Blockchain.Sequencer.Event
+import           Blockchain.SeqEventNotify
 import           Blockchain.Strato.Discovery.Data.Peer
 import           Blockchain.Strato.Discovery.UDP
+import           Blockchain.Strato.Model.Address
+import           Blockchain.Strato.Model.ChainMember
+import           Blockchain.Strato.Model.Keccak256
 import           Blockchain.Strato.Model.Secp256k1
 import           Blockchain.TCPClientWithTimeout
 import           Control.Concurrent hiding (yield)
@@ -38,10 +47,12 @@ import qualified Control.Concurrent.SSem as SSem
 import           Control.Exception.Base (ErrorCall (..))
 import           Control.Lens ((^.))
 import           Control.Monad (forever, unless, void)
+import           Control.Monad.Change.Modify
 import qualified Control.Monad.Change.Alter as A
 import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
 import           Control.Monad.Trans.Resource
+import           Crypto.Types.PubKey.ECC
 import qualified Data.ByteString as B
 import           Data.Conduit
 import           Data.Either.Combinators
@@ -49,16 +60,70 @@ import           Data.Maybe
 import qualified Data.Text as T
 import           GHC.IO.Exception
 import           Ki.Unlifted as KIU
+import           Network.Haskoin.Crypto.BigWord
 import qualified Text.Colors as C
 import           Text.Format
 import           UnliftIO
+--import           Data.Set.Ordered (empty)
 
-runPeer ::
-  (RunsClient m, MonadP2P m) =>
-  PPeer ->
-  ConduitM () P2pEvent m () ->
-  m ()
-runPeer peer sSource = do
+--runPeer ::
+--  (RunsClient m, MonadP2P m) =>
+--  PPeer ->
+--  ConduitM () P2pEvent m () ->
+--  m ()
+--runPeer peer sSource = do
+runPeer :: ( MonadUnliftIO m
+           , MonadLogger m
+           , MonadResource m
+           , HasVault m
+           , RunsClient m
+           , Stacks Block m
+           , Outputs m [IngestEvent]
+           , Accessible [BlockData] m
+           , Accessible ActionTimestamp m
+           , Accessible RemainingBlockHeaders m
+           , Accessible PeerAddress m
+           , Accessible MaxReturnedHeaders m
+           , Accessible ConnectionTimeout m
+           , Accessible GenesisBlockHash m
+           , Accessible BestBlockNumber m
+           , Accessible AvailablePeers m
+           , Accessible BondedPeers m
+           , Accessible PublicKey m
+           , Modifiable [BlockData] m
+           , Modifiable ActionTimestamp m
+           , Modifiable RemainingBlockHeaders m
+           , Modifiable PeerAddress m
+           , Modifiable BestBlock m
+           , Modifiable WorldBestBlock m
+           , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
+           , A.Selectable Word256 ChainMemberRSet m
+           , A.Selectable Word256 ChainInfo m
+           , A.Selectable Integer (Canonical BlockData) m
+           , A.Selectable Keccak256 (Private (Word256, OutputTx)) m
+           , A.Selectable Keccak256 ChainTxsInBlock m
+           , A.Selectable Address X509CertInfoState m
+           , A.Selectable IPAsText PPeer m
+           , A.Selectable Point PPeer m
+           , A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] m
+           , A.Selectable ChainMemberParsedSet TrueOrgNameChains m
+           , A.Selectable ChainMemberParsedSet FalseOrgNameChains m
+           , A.Selectable ChainMemberParsedSet X509CertInfoState m
+           , A.Selectable ChainMemberParsedSet IsValidator m
+           , A.Replaceable (IPAsText, Point) PeerBondingState m
+           , A.Replaceable PPeer TcpEnableTime m
+           , A.Replaceable PPeer UdpEnableTime m
+           , A.Replaceable PPeer PeerDisable m
+           , A.Replaceable PPeer T.Text m
+           , A.Alters (IPAsText, TCPPort) ActivityState m
+           , A.Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) m
+           , A.Alters Keccak256 (Proxy (Inbound WireMessage)) m
+           , A.Alters Keccak256 BlockData m
+           , A.Alters Keccak256 OutputBlock m
+           )
+        => PPeer
+        -> m ()
+runPeer peer = do
   ender <- toIO . $logInfoS "runPeer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
   void $ register ender
   myPublic <- getPub
@@ -80,20 +145,28 @@ runPeer peer sSource = do
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "Attempting to connect to " ++ C.yellow (T.unpack (pPeerIp peer) ++ ":" ++ show (pPeerTcpPort peer))
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "my pubkey is: " ++ format myPublic
   $logInfoS "runPeer" . T.pack . C.green $ " * " ++ "server pubkey is: " ++ format otherPubKey 
-  runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource $ \c -> do
-      let pStr = pPeerString peer -- display string will show up as dns name
-      attempt :: (Maybe SomeException) <- 
-        withCertifiedPeer peer . withActivePeer peer . scoped $
-          runEthClientConduit
-            peer {pPeerPubkey = Just otherPubKey}
-            (c ^. peerSource)
-            (c ^. peerSink)
-            (c ^. seqSource)
-            pStr
-      case attempt of
-        Nothing  -> $logDebugS "runPeer" "Peer ran successfully!"
-        Just err -> do $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err
-                       throwIO err
+  --runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource $ \c -> do
+  scoped $ \scope -> do
+    peerthread <- fork scope (do --wireMessagesRef <- liftIO $ newIORef empty
+                                 --cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+                                 let sSource  = seqEventNotificationSource $ contextKafkaState initContext
+                                 --    runner f = runContextM cfg $ f sSource
+                                 runClientConnection (IPAsText $ pPeerIp peer) (TCPPort . fromIntegral $ pPeerTcpPort peer) sSource $ \c -> do
+                                     let pStr = pPeerString peer -- display string will show up as dns name
+                                     attempt :: (Maybe SomeException) <- 
+                                       withCertifiedPeer peer . withActivePeer peer . scoped $
+                                         runEthClientConduit
+                                           peer {pPeerPubkey = Just otherPubKey}
+                                           (c ^. peerSource)
+                                           (c ^. peerSink)
+                                           (c ^. seqSource)
+                                           pStr
+                                     case attempt of
+                                       Nothing  -> $logDebugS "runPeer" "Peer ran successfully!"
+                                       Just err -> do $logErrorS "runPeer" . T.pack $ "Peer did not run successfully: " ++ show err
+                                                      throwIO err
+                             )
+    atomically $ KIU.await peerthread
 
 runEthClientConduit ::
   MonadP2P m =>
@@ -120,14 +193,67 @@ runEthClientConduit peer pSource pSink seqSrc peerStr scp = do
            .| eventSink
            .| pSink
 
-runPeerInList ::
-  ( MonadP2P m,
-    RunsClient m
-  ) =>
-  PPeer ->
-  ConduitM () P2pEvent m () ->
-  m (Either SomeException ())
-runPeerInList thePeer sSource = do 
+--runPeerInList ::
+--  ( MonadP2P m,
+--    RunsClient m
+--  ) =>
+--  PPeer ->
+--  ConduitM () P2pEvent m () ->
+--  m (Either SomeException ())
+--runPeerInList thePeer sSource = do
+runPeerInList :: ( MonadUnliftIO m
+                 , MonadLogger m
+                 --, Exception e
+                 , MonadResource m
+                 , HasVault m
+                 , RunsClient m
+                 , Stacks Block m
+                 , Outputs m [IngestEvent]
+                 , Accessible [BlockData] m
+                 , Accessible ActionTimestamp m
+                 , Accessible RemainingBlockHeaders m
+                 , Accessible PeerAddress m
+                 , Accessible MaxReturnedHeaders m
+                 , Accessible ConnectionTimeout m
+                 , Accessible GenesisBlockHash m
+                 , Accessible BestBlockNumber m
+                 , Accessible AvailablePeers m
+                 , Accessible BondedPeers m
+                 , Accessible PublicKey m
+                 , Modifiable [BlockData] m
+                 , Modifiable ActionTimestamp m
+                 , Modifiable RemainingBlockHeaders m
+                 , Modifiable PeerAddress m
+                 , Modifiable BestBlock m
+                 , Modifiable WorldBestBlock m
+                 , A.Selectable (IPAsText, UDPPort, B.ByteString) Point m
+                 , A.Selectable Word256 ChainMemberRSet m
+                 , A.Selectable Word256 ChainInfo m
+                 , A.Selectable Integer (Canonical BlockData) m
+                 , A.Selectable Keccak256 (Private (Word256, OutputTx)) m
+                 , A.Selectable Keccak256 ChainTxsInBlock m
+                 , A.Selectable Address X509CertInfoState m
+                 , A.Selectable IPAsText PPeer m
+                 , A.Selectable Point PPeer m
+                 , A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] m
+                 , A.Selectable ChainMemberParsedSet TrueOrgNameChains m
+                 , A.Selectable ChainMemberParsedSet FalseOrgNameChains m
+                 , A.Selectable ChainMemberParsedSet X509CertInfoState m
+                 , A.Selectable ChainMemberParsedSet IsValidator m
+                 , A.Replaceable (IPAsText, Point) PeerBondingState m
+                 , A.Replaceable PPeer TcpEnableTime m
+                 , A.Replaceable PPeer UdpEnableTime m
+                 , A.Replaceable PPeer PeerDisable m
+                 , A.Replaceable PPeer T.Text m
+                 , A.Alters (IPAsText, TCPPort) ActivityState m
+                 , A.Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) m
+                 , A.Alters Keccak256 (Proxy (Inbound WireMessage)) m
+                 , A.Alters Keccak256 BlockData m
+                 , A.Alters Keccak256 OutputBlock m
+                 )
+              => PPeer
+              -> m (Either SomeException ())
+runPeerInList thePeer = do
   eErr <- nonviolentDisable thePeer --don't connect to a peer too frequently, out of politeness
   case eErr of
     Left err -> do
@@ -135,10 +261,60 @@ runPeerInList thePeer sSource = do
       $logErrorS "runPeerInList" "Simulating disable..."
       liftIO $ threadDelay $ 10 * 1000 * 1000
     Right () -> pure ()
-  try $ runPeer thePeer sSource
+  --try $ runPeer thePeer sSource
+  try $ runPeer thePeer
 
-stratoP2PClient :: (MonadP2P m, RunsClient m) => PeerRunner m (LoggingT IO) () -> LoggingT IO ()
-stratoP2PClient runner = runner $ \sSource -> do
+--stratoP2PClient :: (MonadP2P m, RunsClient m) => PeerRunner m (LoggingT IO) () -> LoggingT IO ()
+--stratoP2PClient runner = runner $ \sSource -> do
+stratoP2PClient :: ( MonadP2P m
+                   , Stacks Block (LoggingT m)
+                   , Accessible BondedPeers (LoggingT m)
+                   , HasVault (LoggingT m)
+                   , Outputs (LoggingT m) [IngestEvent]
+                   , Accessible [BlockData] (LoggingT m)
+                   , Accessible ActionTimestamp (LoggingT m)
+                   , Accessible RemainingBlockHeaders (LoggingT m)
+                   , Accessible PeerAddress (LoggingT m)
+                   , Accessible MaxReturnedHeaders (LoggingT m)
+                   , Accessible ConnectionTimeout (LoggingT m)
+                   , Accessible GenesisBlockHash (LoggingT m)
+                   , Accessible BestBlockNumber (LoggingT m)
+                   , Accessible AvailablePeers (LoggingT m)
+                   , Accessible PublicKey (LoggingT m)
+                   , Modifiable [BlockData] (LoggingT m)
+                   , Modifiable ActionTimestamp (LoggingT m)
+                   , Modifiable RemainingBlockHeaders (LoggingT m)
+                   , Modifiable PeerAddress (LoggingT m)
+                   , Modifiable BestBlock (LoggingT m)
+                   , Modifiable WorldBestBlock (LoggingT m)
+                   , A.Selectable (IPAsText, UDPPort, B.ByteString) Point (LoggingT m)
+                   , A.Selectable Word256 ChainMemberRSet (LoggingT m)
+                   , A.Selectable Word256 ChainInfo (LoggingT m)
+                   , A.Selectable Integer (Canonical BlockData) (LoggingT m)
+                   , A.Selectable Keccak256 (Private (Word256,OutputTx)) (LoggingT m)
+                   , A.Selectable Keccak256 ChainTxsInBlock (LoggingT m)
+                   , A.Selectable Address X509CertInfoState (LoggingT m)
+                   , A.Selectable IPAsText PPeer (LoggingT m)
+                   , A.Selectable Point PPeer (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet TrueOrgNameChains (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet FalseOrgNameChains (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet X509CertInfoState (LoggingT m)
+                   , A.Selectable ChainMemberParsedSet IsValidator (LoggingT m)
+                   , A.Replaceable (IPAsText,Point) PeerBondingState (LoggingT m)
+                   , A.Replaceable PPeer TcpEnableTime (LoggingT m)
+                   , A.Replaceable PPeer UdpEnableTime (LoggingT m)
+                   , A.Replaceable PPeer PeerDisable (LoggingT m)
+                   , A.Replaceable PPeer T.Text (LoggingT m)
+                   , A.Alters (T.Text,Keccak256) (Proxy (Outbound WireMessage)) (LoggingT m)
+                   , A.Alters (IPAsText,TCPPort) ActivityState (LoggingT m)
+                   , A.Alters Keccak256 (Proxy (Inbound WireMessage)) (LoggingT m)
+                   , A.Alters Keccak256 BlockData (LoggingT m)
+                   , A.Alters Keccak256 OutputBlock (LoggingT m)
+                   , RunsClient (LoggingT m)
+                   )
+                => LoggingT m ()
+stratoP2PClient = do
   $logInfoS "stratoP2PClient" $ T.pack $ "maxConn: " ++ show flags_maxConn
   activePeersSem <- liftIO (SSem.new flags_maxConn)
   forever $ do
@@ -149,21 +325,26 @@ stratoP2PClient runner = runner $ \sSource -> do
         $logErrorS "stratoP2PClient" . T.pack $ "Could not fetch peers: " ++ show err
         liftIO $ threadDelay 1000000
       Right peers -> do
-        _ <- async (multiThreadedClient peers activePeersSem sSource)
+        --_ <- async (multiThreadedClient peers activePeersSem sSource)
+        _ <- async (multiThreadedClient peers activePeersSem)
         $logInfoS "stratoP2PClient" "Waiting 5 seconds before looping over peers again"
         liftIO $ threadDelay 5000000
   where
-    multiThreadedClient :: (MonadP2P m, RunsClient m) => [PPeer] -> SSem -> ConduitM () P2pEvent m () -> m ()
-    multiThreadedClient [] _ _ = do
+    --multiThreadedClient :: (MonadP2P m, RunsClient m) => [PPeer] -> SSem -> ConduitM () P2pEvent m () -> m ()
+    --multiThreadedClient [] _ _ = do
+    multiThreadedClient :: (MonadP2P m, RunsClient m) => [PPeer] -> SSem -> m ()
+    multiThreadedClient [] _ = do
       $logInfoS "stratoP2PClient/multiThreadedClient" "No available peers, will try again in 10 seconds"
       liftIO $ threadDelay 10000000
-    multiThreadedClient peers sem sSource = do
+    --multiThreadedClient peers sem sSource = do
+    multiThreadedClient peers sem = do
       let notRunningPeers = filter ((== 0) . pPeerActiveState) peers
       unless (null notRunningPeers) . void . forConcurrently notRunningPeers $ \p -> do
         liftIO (SSem.tryWait sem) >>= \case
           Nothing -> return ()
           Just _ -> do
-            result <- runPeerInList p sSource
+            --result <- runPeerInList p sSource
+            result <- runPeerInList p
             _ <- handleRunPeerResult p result
             liftIO $ SSem.signal sem
     handleRunPeerResult :: MonadP2P m => PPeer -> Either SomeException () -> m ()

--- a/strato/core/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -9,22 +9,22 @@ module Executable.StratoP2PLoopback (stratoP2PLoopback) where
 import BlockApps.Logging
 import Blockchain.Blockstanbul (WireMessage)
 import Blockchain.Context
-import Blockchain.Options
+--import Blockchain.Options
 import Blockchain.Sequencer.Event
 import Blockchain.Sequencer.Kafka
 import Blockchain.SeqEventNotify
 --import Blockchain.Strato.Discovery.Data.Peer
 import Blockchain.Strato.Model.Keccak256
 import Conduit
---import Control.Monad.Trans.Reader
+import Control.Monad.Trans.Reader
 import qualified Control.Monad.Change.Alter as A
---import Control.Monad.Change.Modify
+import Control.Monad.Change.Modify
 --import Crypto.Types.PubKey.ECC
 import qualified Data.Text as T
 import Prometheus
 import Text.Format
-import Data.IORef
-import Data.Set.Ordered (empty)
+--import Data.IORef
+--import Data.Set.Ordered (empty)
 
 {-# NOINLINE loopbackEvents #-}
 loopbackEvents :: Vector T.Text Counter
@@ -39,8 +39,8 @@ recordEvent lab = liftIO $ withLabel loopbackEvents lab incCounter
 
 --stratoP2PLoopback :: MonadP2P n => PeerRunner n (LoggingT IO) () -> LoggingT IO ()
 --stratoP2PLoopback runner = do
-stratoP2PLoopback :: ( MonadLogger m
-                     , MonadUnliftIO m
+--stratoP2PLoopback :: ( MonadLogger m
+--                     , MonadUnliftIO m
                      --, Accessible AvailablePeers (ReaderT Config (ResourceT (LoggingT m)))
                      --, Accessible BondedPeers (ReaderT Config (ResourceT (LoggingT m)))
                      --, A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT (LoggingT m)))
@@ -50,11 +50,18 @@ stratoP2PLoopback :: ( MonadLogger m
                      --, A.Replaceable PPeer T.Text (ReaderT Config (ResourceT (LoggingT m)))
                      --, A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT (LoggingT m)))
                      --, RunsServer (ReaderT Config (ResourceT (LoggingT m))) (LoggingT m)
+--                     )
+--                  => LoggingT m ()
+stratoP2PLoopback :: ( MonadLogger m
+                     , MonadUnliftIO m
+                     , Outputs (ReaderT Config (ResourceT m)) [IngestEvent]
+                     --, A.Alters Keccak256 (Proxy (Inbound WireMessage)) (ReaderT Config (ResourceT m))
                      )
-                  => LoggingT m ()
-stratoP2PLoopback = do
-  wireMessagesRef <- liftIO $ newIORef empty
-  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+                  => Config
+                  -> m ()
+stratoP2PLoopback cfg = do
+  --wireMessagesRef <- liftIO $ newIORef empty
+  --cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   let sSource  = seqEventNotificationSource $ contextKafkaState initContext
       runner f = runContextM cfg $ f sSource
   $logInfoS "stratoP2PLoopback" "Reflecting PBFT back to unseq since 2019"

--- a/strato/core/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -9,14 +9,22 @@ module Executable.StratoP2PLoopback (stratoP2PLoopback) where
 import BlockApps.Logging
 import Blockchain.Blockstanbul (WireMessage)
 import Blockchain.Context
+import Blockchain.Options
 import Blockchain.Sequencer.Event
 import Blockchain.Sequencer.Kafka
+import Blockchain.SeqEventNotify
+--import Blockchain.Strato.Discovery.Data.Peer
 import Blockchain.Strato.Model.Keccak256
 import Conduit
+--import Control.Monad.Trans.Reader
 import qualified Control.Monad.Change.Alter as A
+--import Control.Monad.Change.Modify
+--import Crypto.Types.PubKey.ECC
 import qualified Data.Text as T
 import Prometheus
 import Text.Format
+import Data.IORef
+import Data.Set.Ordered (empty)
 
 {-# NOINLINE loopbackEvents #-}
 loopbackEvents :: Vector T.Text Counter
@@ -29,10 +37,28 @@ loopbackEvents =
 recordEvent :: MonadIO m => T.Text -> m ()
 recordEvent lab = liftIO $ withLabel loopbackEvents lab incCounter
 
-stratoP2PLoopback :: MonadP2P n => PeerRunner n (LoggingT IO) () -> LoggingT IO ()
-stratoP2PLoopback runner = do
+--stratoP2PLoopback :: MonadP2P n => PeerRunner n (LoggingT IO) () -> LoggingT IO ()
+--stratoP2PLoopback runner = do
+stratoP2PLoopback :: ( MonadLogger m
+                     , MonadUnliftIO m
+                     --, Accessible AvailablePeers (ReaderT Config (ResourceT (LoggingT m)))
+                     --, Accessible BondedPeers (ReaderT Config (ResourceT (LoggingT m)))
+                     --, A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT (LoggingT m)))
+                     --, A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT (LoggingT m)))
+                     --, A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT (LoggingT m)))
+                     --, A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT (LoggingT m)))
+                     --, A.Replaceable PPeer T.Text (ReaderT Config (ResourceT (LoggingT m)))
+                     --, A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT (LoggingT m)))
+                     --, RunsServer (ReaderT Config (ResourceT (LoggingT m))) (LoggingT m)
+                     )
+                  => LoggingT m ()
+stratoP2PLoopback = do
+  wireMessagesRef <- liftIO $ newIORef empty
+  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+  let sSource  = seqEventNotificationSource $ contextKafkaState initContext
+      runner f = runContextM cfg $ f sSource
   $logInfoS "stratoP2PLoopback" "Reflecting PBFT back to unseq since 2019"
-  runner $ \sSource -> do
+  runner $ \sSource' -> do
     let toWireMessage = \case
           P2pBlockstanbul wm -> do
             let msgHash = rlpHash wm
@@ -48,7 +74,7 @@ stratoP2PLoopback runner = do
           _ -> pure Nothing
 
     runConduit $
-      sSource
+      sSource'
         .| iterMC (const $ recordEvent "in")
         .| concatMapMC toWireMessage
         .| iterMC (const $ recordEvent "out")

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -24,14 +24,18 @@ import Blockchain.EventException
 import Blockchain.Options
 import Blockchain.RLPx
 import Blockchain.Sequencer.Event
+import Blockchain.SeqEventNotify
 import Blockchain.Strato.Discovery.Data.Peer
 import Blockchain.Strato.Model.Secp256k1
 import Blockchain.TCPClientWithTimeout
 import Conduit
 import Control.Lens ((^.))
 import Control.Monad
+import Control.Monad.Change.Modify
 import qualified Control.Monad.Change.Alter as A
+import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Resource
+import Crypto.Types.PubKey.ECC
 import qualified Data.ByteString as B
 import Data.Either.Combinators
 import Data.Maybe (fromMaybe)
@@ -40,13 +44,27 @@ import GHC.IO.Exception
 import Ki.Unlifted as KIU
 import qualified Text.Colors as C
 import UnliftIO
+import Data.Set.Ordered (empty)
 
-runEthServer ::
-  (RunsServer n m, MonadP2P n) =>
-  Int ->
-  PeerRunner n m () ->
-  m ()
-runEthServer listenPort runner =
+runEthServer :: ( MonadLogger m
+                , MonadUnliftIO m
+                , RunsServer (ReaderT Config (ResourceT m)) m
+                , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+                , Accessible BondedPeers (ReaderT Config (ResourceT m))
+                , A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
+                , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT m))
+                )
+             => Int
+             -> m ()
+runEthServer listenPort = do
+  wireMessagesRef <- liftIO $ newIORef empty
+  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+  let sSource  = seqEventNotificationSource $ contextKafkaState initContext
+      runner f = runContextM cfg $ f sSource 
   runServer (TCPPort listenPort) runner $ \c a ->
     ethServerHandler (c ^. peerSource) (c ^. peerSink) (c ^. seqSource) a
 
@@ -149,11 +167,20 @@ runEthServerConduit p pSource pSink seqSrc peerStr scp = do
           .| eventSink
           .| pSink
 
-stratoP2PServer ::
-  (MonadP2P n, RunsServer n (LoggingT IO)) =>
-  PeerRunner n (LoggingT IO) () ->
-  LoggingT IO ()
-stratoP2PServer runner = do
+stratoP2PServer :: ( MonadLogger m
+                   , MonadUnliftIO m
+                   , Accessible AvailablePeers (ReaderT Config (ResourceT (LoggingT m)))
+                   , Accessible BondedPeers (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable (IPAsText,Point) PeerBondingState (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT (LoggingT m)))
+                   , A.Alters (IPAsText,TCPPort) ActivityState (ReaderT Config (ResourceT (LoggingT m)))
+                   , RunsServer (ReaderT Config (ResourceT (LoggingT m))) (LoggingT m)
+                   )
+                => LoggingT m ()
+stratoP2PServer = do
   $logInfoS "stratoP2PServer" $ T.pack $ "connect address: " ++ flags_address
   $logInfoS "stratoP2PServer" $ T.pack $ "listen port:     " ++ show flags_listen
-  runEthServer flags_listen runner
+  runEthServer flags_listen

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -16,8 +16,13 @@ module Executable.StratoP2PServer
 where
 
 import BlockApps.Logging
+--import BlockApps.X509.Certificate
+import Blockchain.Blockstanbul.Messages
 import Blockchain.CommunicationConduit
 import Blockchain.Context
+import Blockchain.Data.Block
+import Blockchain.Data.DataDefs
+--import Blockchain.Data.Enode
 import Blockchain.Data.PubKey (secPubKeyToPoint)
 import Blockchain.EthEncryptionException
 import Blockchain.EventException
@@ -26,11 +31,15 @@ import Blockchain.RLPx
 import Blockchain.Sequencer.Event
 import Blockchain.SeqEventNotify
 import Blockchain.Strato.Discovery.Data.Peer
+--import Blockchain.Strato.Model.Address
+--import Blockchain.Strato.Model.ChainMember
+import Blockchain.Strato.Model.Keccak256
 import Blockchain.Strato.Model.Secp256k1
 import Blockchain.TCPClientWithTimeout
+--import Network.Haskoin.Crypto.BigWord
 import Conduit
 import Control.Lens ((^.))
-import Control.Monad
+--import Control.Monad
 import Control.Monad.Change.Modify
 import qualified Control.Monad.Change.Alter as A
 import Control.Monad.Trans.Reader
@@ -44,8 +53,9 @@ import GHC.IO.Exception
 import Ki.Unlifted as KIU
 import qualified Text.Colors as C
 import UnliftIO
-import Data.Set.Ordered (empty)
+--import Data.Set.Ordered (empty)
 
+{-
 runEthServer :: ( MonadLogger m
                 , MonadUnliftIO m
                 , RunsServer (ReaderT Config (ResourceT m)) m
@@ -60,9 +70,89 @@ runEthServer :: ( MonadLogger m
                 )
              => Int
              -> m ()
-runEthServer listenPort = do
-  wireMessagesRef <- liftIO $ newIORef empty
-  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
+-}
+{-
+runEthServer :: ( RunsServer (ReaderT Config (ResourceT m)) m
+                , MonadUnliftIO m
+                , MonadLogger m
+                , Stacks Block (ReaderT Config (ResourceT m))
+                , HasVault (ReaderT Config (ResourceT m))
+                , Outputs (ReaderT Config (ResourceT m)) [IngestEvent]
+                , Accessible [BlockData] (ReaderT Config (ResourceT m))
+                , Accessible ActionTimestamp (ReaderT Config (ResourceT m))
+                , Accessible RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                , Accessible PeerAddress (ReaderT Config (ResourceT m))
+                , Accessible MaxReturnedHeaders (ReaderT Config (ResourceT m))
+                , Accessible ConnectionTimeout (ReaderT Config (ResourceT m))
+                , Accessible GenesisBlockHash (ReaderT Config (ResourceT m))
+                , Accessible BestBlockNumber (ReaderT Config (ResourceT m))
+                , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+                , Accessible BondedPeers (ReaderT Config (ResourceT m))
+                , Accessible PublicKey (ReaderT Config (ResourceT m))
+                , Modifiable [BlockData] (ReaderT Config (ResourceT m))
+                , Modifiable ActionTimestamp (ReaderT Config (ResourceT m))
+                , Modifiable RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                , Modifiable PeerAddress (ReaderT Config (ResourceT m))
+                , Modifiable BestBlock (ReaderT Config (ResourceT m))
+                , Modifiable WorldBestBlock (ReaderT Config (ResourceT m))
+                , A.Selectable (IPAsText, UDPPort, B.ByteString) Point (ReaderT Config (ResourceT m))
+                , A.Selectable Word256 ChainMemberRSet (ReaderT Config (ResourceT m))
+                , A.Selectable Word256 ChainInfo (ReaderT Config (ResourceT m))
+                , A.Selectable Integer (Canonical BlockData) (ReaderT Config (ResourceT m))
+                , A.Selectable Keccak256 (Private (Word256, OutputTx)) (ReaderT Config (ResourceT m))
+                , A.Selectable Keccak256 ChainTxsInBlock (ReaderT Config (ResourceT m))
+                , A.Selectable Address X509CertInfoState (ReaderT Config (ResourceT m))
+                , A.Selectable IPAsText PPeer (ReaderT Config (ResourceT m))
+                , A.Selectable Point PPeer (ReaderT Config (ResourceT m))
+                , A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] (ReaderT Config (ResourceT m))
+                , A.Selectable ChainMemberParsedSet TrueOrgNameChains (ReaderT Config (ResourceT m))
+                , A.Selectable ChainMemberParsedSet FalseOrgNameChains (ReaderT Config (ResourceT m))
+                , A.Selectable ChainMemberParsedSet X509CertInfoState (ReaderT Config (ResourceT m))
+                , A.Selectable ChainMemberParsedSet IsValidator (ReaderT Config (ResourceT m))
+                , A.Replaceable (IPAsText, Point) PeerBondingState (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
+                , A.Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) (ReaderT Config (ResourceT m))
+                , A.Alters (IPAsText, TCPPort) ActivityState (ReaderT Config (ResourceT m))
+                , A.Alters Keccak256 (Proxy (Inbound WireMessage)) (ReaderT Config (ResourceT m))
+                , A.Alters Keccak256 BlockData (ReaderT Config (ResourceT m))
+                , A.Alters Keccak256 OutputBlock (ReaderT Config (ResourceT m))
+                )
+             => Int
+             -> Config
+             -> m ()
+-}
+runEthServer :: ( MonadLogger m
+                , MonadUnliftIO m
+                , RunsServer (ReaderT Config (ResourceT m)) m
+                , Stacks Block (ReaderT Config (ResourceT m))
+                , Outputs (ReaderT Config (ResourceT m)) [IngestEvent]
+                , Accessible [BlockData] (ReaderT Config (ResourceT m))
+                , Accessible ActionTimestamp (ReaderT Config (ResourceT m))
+                , Accessible RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                , Accessible PeerAddress (ReaderT Config (ResourceT m))
+                , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+                , Accessible BondedPeers (ReaderT Config (ResourceT m))
+                , Modifiable [BlockData] (ReaderT Config (ResourceT m))
+                , Modifiable ActionTimestamp (ReaderT Config (ResourceT m))
+                , Modifiable RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                , Modifiable PeerAddress (ReaderT Config (ResourceT m))
+                , A.Replaceable (IPAsText, Point) PeerBondingState (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+                , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
+                , A.Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) (ReaderT Config (ResourceT m))
+                , A.Alters (IPAsText, TCPPort) ActivityState (ReaderT Config (ResourceT m))
+                )
+             => Int
+             -> Config
+             -> m ()
+runEthServer listenPort cfg = do
+  --wireMessagesRef <- liftIO $ newIORef empty
+  --cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   let sSource  = seqEventNotificationSource $ contextKafkaState initContext
       runner f = runContextM cfg $ f sSource 
   runServer (TCPPort listenPort) runner $ \c a ->
@@ -78,7 +168,8 @@ ethServerHandler ::
 ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
   let peerStr = T.unpack i
   ender <- toIO . $logInfoS "runEthServer/exit" . T.pack . C.green $ " * Connection ended to " ++ C.yellow peerStr
-  void $ register ender
+  --void $ register ender
+  reg <- register ender
   getPeerByIP ipAsText >>= \case
     Nothing -> do
       $logErrorS "runEthServer" . T.pack $ "Didn't see peer in discovery at IP " ++ peerStr ++ ". rejecting violently."
@@ -90,7 +181,8 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
             attempt <- withCertifiedPeer p . withActivePeer p . scoped $
                          runEthServerConduit p pSource pSink seqSrc peerStr
             case attempt of
-              Nothing  -> $logDebugS "runEthServer" "Peer ran successfully!"
+              Nothing  -> do $logDebugS "runEthServer" "Peer ran successfully!"
+                             release reg
               Just err -> do
                 $logErrorS "runEthServer" . T.pack $ "Peer did not run successfully: " ++ show err
                 _ <- case err of
@@ -140,6 +232,7 @@ ethServerHandler pSource pSink seqSrc ipAsText@(IPAsText i) = do
                         lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) p
                       _ -> return $ Right ()
                   _ -> return $ Right ()
+                release reg
                 throwIO err
 
 runEthServerConduit ::
@@ -167,6 +260,7 @@ runEthServerConduit p pSource pSink seqSrc peerStr scp = do
           .| eventSink
           .| pSink
 
+{-
 stratoP2PServer :: ( MonadLogger m
                    , MonadUnliftIO m
                    , Accessible AvailablePeers (ReaderT Config (ResourceT (LoggingT m)))
@@ -180,7 +274,33 @@ stratoP2PServer :: ( MonadLogger m
                    , RunsServer (ReaderT Config (ResourceT (LoggingT m))) (LoggingT m)
                    )
                 => LoggingT m ()
-stratoP2PServer = do
+-}
+stratoP2PServer :: ( MonadLogger m
+                   , MonadUnliftIO m
+                   , RunsServer (ReaderT Config (ResourceT m)) m
+                   , Stacks Block (ReaderT Config (ResourceT m))
+                   , Outputs (ReaderT Config (ResourceT m)) [IngestEvent]
+                   , Accessible [BlockData] (ReaderT Config (ResourceT m))
+                   , Accessible ActionTimestamp (ReaderT Config (ResourceT m))
+                   , Accessible RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                   , Accessible PeerAddress (ReaderT Config (ResourceT m))
+                   , Accessible AvailablePeers (ReaderT Config (ResourceT m))
+                   , Accessible BondedPeers (ReaderT Config (ResourceT m))
+                   , Modifiable [BlockData] (ReaderT Config (ResourceT m))
+                   , Modifiable ActionTimestamp (ReaderT Config (ResourceT m))
+                   , Modifiable RemainingBlockHeaders (ReaderT Config (ResourceT m))
+                   , Modifiable PeerAddress (ReaderT Config (ResourceT m))
+                   , A.Replaceable (IPAsText, Point) PeerBondingState (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer TcpEnableTime (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer UdpEnableTime (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer PeerDisable (ReaderT Config (ResourceT m))
+                   , A.Replaceable PPeer T.Text (ReaderT Config (ResourceT m))
+                   , A.Alters (T.Text, Keccak256) (Proxy (Outbound WireMessage)) (ReaderT Config (ResourceT m))
+                   , A.Alters (IPAsText, TCPPort) ActivityState (ReaderT Config (ResourceT m))
+                   )
+                => Config
+                -> m ()
+stratoP2PServer cfg = do
   $logInfoS "stratoP2PServer" $ T.pack $ "connect address: " ++ flags_address
   $logInfoS "stratoP2PServer" $ T.pack $ "listen port:     " ++ show flags_listen
-  runEthServer flags_listen
+  runEthServer flags_listen cfg

--- a/strato/core/strato-p2p/test/EventSpec.hs
+++ b/strato/core/strato-p2p/test/EventSpec.hs
@@ -109,9 +109,9 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as Text
 import Data.Traversable (for)
 import Debugger (DebugSettings)
-import Executable.EthereumDiscovery
+--import Executable.EthereumDiscovery
 import Executable.EthereumVM2
-import Executable.StratoP2P
+--import Executable.StratoP2P
 import Executable.StratoP2PClient
 import Executable.StratoP2PServer
 import Ki.Unlifted as KIU
@@ -119,6 +119,7 @@ import Network.Socket
 import Test.Hspec
 import Text.Read (readMaybe)
 import UnliftIO
+--import qualified UnliftIO.Async as UIOA
 import Prelude hiding (round)
 
 data VSocket = VSocket
@@ -1165,6 +1166,7 @@ runMonad :: MonadUnliftIO m =>
             P2PPeer -> ReaderT P2PPeer (ReaderT MemPeerDBEnv (ResourceT (LoggingT m))) a -> m a
 runMonad p = runNoLoggingT . runResourceT . runMemPeerDBMUsingEnv (p^.p2pPeerDB) . flip runReaderT p
 
+{-
 runNodeWithoutP2P :: P2PPeer -> IO ()
 runNodeWithoutP2P p = do
   concurrently_
@@ -1194,6 +1196,7 @@ runNode p = do
         (runNoLoggingT $ stratoP2P (\f -> runResourceT . runMemPeerDBMUsingEnv (p^.p2pPeerDB) . flip runReaderT p $ runReaderT (f s) ctx))
         (runNoLoggingT $ ethereumDiscovery (\f -> runResourceT . runMemPeerDBMUsingEnv (p^.p2pPeerDB) . flip runReaderT p $ runReaderT (f 100) ctx))
     )
+-}
 
 postEvent :: SeqLoopEvent -> P2PPeer -> IO ()
 postEvent e p = atomically $ writeTQueue (_p2pPeerUnseqSource p) [e]
@@ -1541,11 +1544,13 @@ runConnection connection = do
         atomically $ writeTVar (connection ^. clientException) mEx
   concurrently_ rServer rClient
 
+{-
 runNetwork :: [P2PPeer] -> [P2PConnection] -> IO ()
 runNetwork nodes connections =
   concurrently_
     (mapConcurrently runNode nodes)
     (mapConcurrently runConnection connections)
+-}
 
 makeValidators :: [PrivateKey] -> [Address]
 makeValidators = map fromPrivateKey


### PR DESCRIPTION
This PR seeks to move the initialization of the Config/Context datatypes once inside of forked peer threads.  This should allow for GC'ing of Kafka-related state/connects (as well as DB connections, etc.) when peer threads are closed.