### PR TITLE
remove older images in testsync stage

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -303,6 +303,7 @@ pipeline {
               }
               post {
                 always {
+                  sh 'sudo docker system prune -fa' // remove older unused images to save diskspace
                   dir('strato-getting-started') {
                     sh 'sudo rm -rf strato_logs*'
                     sh 'sudo ./fetchlogs --as-dir'


### PR DESCRIPTION
This should prevent the testsync machines from out of diskspace issue