### PR TITLE
kafka upgrade to 2.12-2.0.1

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -351,7 +351,7 @@ services:
       KAFKA_OFFSETS_RETENTION_MINUTES: 2147483647
       KAFKA_MAX_REQUEST_SIZE: ${KAFKA_MAX_REQUEST_SIZE:-100663296}
       KAFKA_MESSAGE_MAX_BYTES: ${KAFKA_MESSAGE_MAX_BYTES:-100663296}
-    image: wurstmeister/kafka:1.1.0
+    image: wurstmeister/kafka:2.12-2.0.1
     restart: unless-stopped
     volumes:
     - kafkadata:/kafka


### PR DESCRIPTION
I am not sure how to test the upgraded Kafka properly, but so far everything works well. The Kafka interfaces are backward-compatible. 
- One of the benefits is that this Kafka can run on Apple Silicon.
- Also, I hope this may make some difference with Kafka becoming unavailable for STRATO container on the new Amazon Linux distributions (though there is no certainty that the newer Linux is a cause)