### PR TITLE
Consistent network default

### DIFF
--- a/strato/core/strato-init/exec_src/TabulaRasa.hs
+++ b/strato/core/strato-init/exec_src/TabulaRasa.hs
@@ -3,6 +3,7 @@
 
 import Blockchain.Init.Generator
 import Blockchain.Init.Options
+import Blockchain.Strato.Model.Options ()
 import Data.String
 import HFlags
 

--- a/strato/core/strato-init/package.yaml
+++ b/strato/core/strato-init/package.yaml
@@ -91,6 +91,7 @@ executables:
     dependencies:
       - hflags
       - strato-init
+      - strato-model
 
     other-modules: []
 

--- a/strato/core/strato-init/src/Blockchain/Init/Generator.hs
+++ b/strato/core/strato-init/src/Blockchain/Init/Generator.hs
@@ -7,6 +7,7 @@ import Blockchain.Init.EthConf
 import Blockchain.Init.Options
 import Blockchain.Init.Protocol
 import qualified Blockchain.Network as Net
+import Blockchain.Strato.Model.Options (flags_network)
 import Control.Concurrent
 import Control.Lens.Combinators (use)
 import Control.Monad

--- a/strato/core/strato-init/src/Blockchain/Init/Options.hs
+++ b/strato/core/strato-init/src/Blockchain/Init/Options.hs
@@ -17,7 +17,6 @@ defineFlag "K:kafkahost" ("" :: String) "Kafka hostname"
 defineFlag "vaultWrapperUrl" ("http://localhost:8013/strato/v2.3" :: String) "Vault-Wrapper URL"
 defineFlag "z:zkhost" ("localhost" :: String) "Zookeeper hostname"
 defineFlag "z:lazyblocks" (False :: Bool) "Don't mine empty blocks"
-defineFlag "network" ("" :: String) "The network that strato will join"
 defineFlag "addBootnodes" True "Adds bootnodes to the peer DB at setup time.  If set to false, the peer will not be able to initiate a connection to the network by itself (this option is useful if you want to set up a peer to itself be a bootnode in a private network)"
 defineCustomFlag
   "stratoBootnode"

--- a/strato/core/strato-init/src/Blockchain/Setup.hs
+++ b/strato/core/strato-init/src/Blockchain/Setup.hs
@@ -20,6 +20,7 @@ import Blockchain.Init.Monad
 import Blockchain.Init.Options
 import Blockchain.KafkaTopics
 import qualified Blockchain.Network as Net
+import Blockchain.Strato.Model.Options (flags_network)
 import Control.Concurrent
 import Control.Monad
 import Control.Monad.Composable.Redis

--- a/strato/core/strato-sequencer/exec-src/Flags.hs
+++ b/strato/core/strato-sequencer/exec-src/Flags.hs
@@ -26,7 +26,6 @@ defineFlag "kafkaaddress" ("" :: String) "Alternate kafka instance to connect to
 -- blockstanbul related flags
 -- TODO(tim): We may need to specify a starting view, or catch up from the network
 defineFlag "blockstanbul" (False :: Bool) "Whether to run blockstanbul"
-defineFlag "network" ("" :: String) "The network that strato will join"
 defineFlag "certInfo" ("{\"access\":false}" :: String) "JSON encoded ChainMemberParsedSet representing this node's identity"
 defineFlag "genesisBlockName" ("livenet" :: String) "use the alternate stablenet genesis block"
 defineFlag "blockstanbul_block_period_ms" (1000 :: Int) "Minimum delay between block creations"

--- a/strato/core/strato-sequencer/exec-src/Main.hs
+++ b/strato/core/strato-sequencer/exec-src/Main.hs
@@ -16,6 +16,7 @@ import Blockchain.Sequencer.CablePackage
 import Blockchain.Sequencer.Gregor
 import Blockchain.Sequencer.Monad
 import Blockchain.Strato.Model.ChainMember
+import Blockchain.Strato.Model.Options (flags_network)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async as Async
 import Control.Concurrent.STM

--- a/strato/doit.sh
+++ b/strato/doit.sh
@@ -416,7 +416,7 @@ function setEnv {
 }
 
 echo "Processed environment variables:"
-setEnv addBootnodes false
+setEnv addBootnodes true
 setEnv bootnode ""
 setEnv genesisBlock ""
 setEnv kafkaHost ${kafkaHost}


### PR DESCRIPTION
This PR removes redundant `network` flags so that there are never conflicting definitions of the `network`. It also fixes a bug where tabula-rasa doesn't try to add the bootnode unless the `network` or `bootnode` flag is explicitly defined. This PR is required if we want to sync to prodnet without explicitly providing either var in the start script.