### PR TITLE
keccak256 built-in returns hex value instead of bytes

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2532,12 +2532,13 @@ callBuiltin "keccak256" args Nothing = do
   let allStrings [] = True
       allStrings ((SString _) : xs) = True && (allStrings xs)
       allStrings _ = False
+      customConcat :: [Value] -> String 
       customConcat [] = ""
       customConcat ((SString str) : ys) = str ++ customConcat ys
       customConcat _ = invalidArguments "cannot use a non string arguments in keccak256" args
   case allStrings args of
     False -> invalidArguments "cannot use a non string arguments in keccak256" args
-    True -> return . SString . BC.unpack . keccak256ToByteString . hash . BC.pack $ customConcat args
+    True -> return . SString . keccak256ToHex . hash . BC.pack $ customConcat args
 callBuiltin ("ecrecover") [SString h, SInteger v, SString r, SString s] _ = case B16.decode (BC.pack h) of
   Left err -> invalidArguments err ("" :: String)
   Right bytestringHash -> do

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -6079,8 +6079,8 @@ contract qq {
     return keccak256("hello", "world");
   }
 }|]
-      `shouldReturn` Just ("(\"\\250&\\219|\\168^\\173\\&9\\146\\SYN\\231\\198\\&1k\\197\\SO\\210C\\147\\195\\DC2+X'5\\231\\243\\176\\249\\ESC\\147\\240\")")
-  --keccak256ToByteString function implementation wrong
+      `shouldReturn` Just "(\"fa26db7ca85ead399216e7c6316bc50ed24393c3122b582735e7f3b0f91b93f0\")"
+
   it "cant use  a commented pragma" . runTest $ do
     runCall'
       "a"


### PR DESCRIPTION
Resolves an issue posed by the Stably coin where `keccak256` values were being returned as pure byte values instead of a hex values