### PR TITLE
Revert disabled optimizations

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -53,7 +53,7 @@ pipeline {
     stage('Build') {
       steps {
         sh 'rm -rf .docker-work'
-        sh 'REPO=private make all_develop'
+        sh 'REPO=private make all'
         dir ('blockapps-rest') {
           sh 'yarn install --pure-lockfile'
           sh 'yarn build'

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -12,7 +12,7 @@ trap "docker rm -f ${REDIS}" EXIT
 
 cd strato
 
-stack test --fast $1\
+stack test $1\
       blockapps-data \
       blockapps-init \
       blockapps-mpdbs \


### PR DESCRIPTION
will help stop the marketplace test nodes from exploding