### PR TITLE
Order Closing Automation fix for Credit Card Payments

### DIFF
--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Orders/Order.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Orders/Order.sol
@@ -133,7 +133,7 @@ abstract contract Order is Utils {
 
     function onCancel(string _comments) internal virtual {}
 
-    function cancelOrder(string _comments) external returns (uint) {
+    function cancelOrder(string _comments)  returns (uint) {
         require(status != OrderStatus.CLOSED && status != OrderStatus.CANCELED, "Order already closed.");
         require((tx.origin == purchasersAddress || getCommonName(tx.origin) == sellersCommonName), "Only the purchaser/seller can cancel the order");
         onCancel(_comments);

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Orders/Order.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Orders/Order.sol
@@ -13,6 +13,7 @@ abstract contract Order is Utils {
         CLOSED,
         CANCELED,
         PAYMENT_PENDING,
+        PAID,
         MAX
     }
 
@@ -69,9 +70,14 @@ abstract contract Order is Utils {
         status = _status;
         shippingAddressId = _shippingAddressId;
         paymentSessionId = _paymentSessionId;
+        
+        if(status == OrderStatus.PAID)
+        {
+            completeOrder(_createdDate,"Thank you for your payment.");
+        }
     }
 
-    function completeOrder(uint _fulfillmentDate, string _comments) external returns (uint) {
+    function completeOrder(uint _fulfillmentDate, string _comments) returns (uint) {
         require(status != OrderStatus.CLOSED && status != OrderStatus.CANCELED, "Order already closed.");
         for (uint i = 0; i < saleAddresses.length; i++) {
             if (!completedSales[i]) {

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
@@ -48,17 +48,17 @@ abstract contract Sale is Utils {
     modifier requireSellerOrBuyer(string action) {
         string sellersCommonName = assetToBeSold.ownerCommonName();
         Order order = Order(msg.sender);
-        string purchasersAddress = order.purchasersAddress();
+        address purchasersCommonName = order.purchasersCommonName();
         string err = "Only "
                    + sellersCommonName
-                   + ","
-                   + purchasersAddress
+                   + ", "
+                   + purchasersCommonName
                    + " can perform "
                    + action
                    + ".";
         string commonName = getCommonName(tx.origin);
 
-        require((tx.origin == purchasersAddress || commonName == sellersCommonName), err);
+        require((commonName == purchasersCommonName || commonName == sellersCommonName), err);
 
     }    
 

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
@@ -48,7 +48,7 @@ abstract contract Sale is Utils {
     modifier requireSellerOrBuyer(string action) {
         string sellersCommonName = assetToBeSold.ownerCommonName();
         Order order = Order(msg.sender);
-        address purchasersCommonName = order.purchasersCommonName();
+        string purchasersCommonName = order.purchasersCommonName();
         string err = "Only "
                    + sellersCommonName
                    + ", "

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
@@ -45,6 +45,23 @@ abstract contract Sale is Utils {
         require(commonName == sellersCommonName, err);
     }
 
+    modifier requireSellerOrBuyer(string action) {
+        string sellersCommonName = assetToBeSold.ownerCommonName();
+        Order order = Order(msg.sender);
+        string purchasersAddress = order.purchasersAddress();
+        string err = "Only "
+                   + sellersCommonName
+                   + ","
+                   + purchasersAddress
+                   + " can perform "
+                   + action
+                   + ".";
+        string commonName = getCommonName(tx.origin);
+
+        require((tx.origin == purchasersAddress || commonName == sellersCommonName), err);
+
+    }    
+
     function changePrice(uint _price) public requireSeller("change price"){
         price=_price;
     }
@@ -81,7 +98,7 @@ abstract contract Sale is Utils {
     }
 
     function completeSale(
-    ) public requireSeller("complete sale") returns (uint) {
+    ) public requireSellerOrBuyer("complete sale") returns (uint) {
         Order order = Order(msg.sender);
         address purchaser = order.purchasersAddress();
         uint orderQuantity = takeLockedQuantity(msg.sender);

--- a/marketplace/backend/docker-run.sh
+++ b/marketplace/backend/docker-run.sh
@@ -5,7 +5,7 @@ export CONFIG_DIR_PATH=/config
 export DEPLOY_FILE_NAME=marketplace.deploy.yaml
 export STRATO_NODE_PROTOCOL=${STRATO_NODE_PROTOCOL:-http}
 export STRATO_NODE_HOST=${STRATO_NODE_HOST:-nginx}
-export BASE_CODE_COLLECTION=${BASE_CODE_COLLECTION:-8f8d4cef7232db7001bae657db85eb4325ee2f3d} # Current deployment address on testnet2
+export BASE_CODE_COLLECTION=${BASE_CODE_COLLECTION:-d736617f2bf25b636949623420ed16cc44ef665a} # Current deployment address on testnet2
 export STRATO_HOSTNAME=${STRATO_HOSTNAME:-strato}
 export STRATO_PORT_API=${STRATO_PORT_API:-3000}
 

--- a/marketplace/backend/docker-run.sh
+++ b/marketplace/backend/docker-run.sh
@@ -5,7 +5,7 @@ export CONFIG_DIR_PATH=/config
 export DEPLOY_FILE_NAME=marketplace.deploy.yaml
 export STRATO_NODE_PROTOCOL=${STRATO_NODE_PROTOCOL:-http}
 export STRATO_NODE_HOST=${STRATO_NODE_HOST:-nginx}
-export BASE_CODE_COLLECTION=${BASE_CODE_COLLECTION:-8ee24403fbd1f24537a2b96e9022c42eb4b4d79c} # Current deployment address on testnet2
+export BASE_CODE_COLLECTION=${BASE_CODE_COLLECTION:-0e09491503d78b1ada7e846c43aaa3ae4d133506} # Current deployment address on testnet2
 export STRATO_HOSTNAME=${STRATO_HOSTNAME:-strato}
 export STRATO_PORT_API=${STRATO_PORT_API:-3000}
 

--- a/marketplace/backend/docker-run.sh
+++ b/marketplace/backend/docker-run.sh
@@ -5,7 +5,7 @@ export CONFIG_DIR_PATH=/config
 export DEPLOY_FILE_NAME=marketplace.deploy.yaml
 export STRATO_NODE_PROTOCOL=${STRATO_NODE_PROTOCOL:-http}
 export STRATO_NODE_HOST=${STRATO_NODE_HOST:-nginx}
-export BASE_CODE_COLLECTION=${BASE_CODE_COLLECTION:-d736617f2bf25b636949623420ed16cc44ef665a} # Current deployment address on testnet2
+export BASE_CODE_COLLECTION=${BASE_CODE_COLLECTION:-8ee24403fbd1f24537a2b96e9022c42eb4b4d79c} # Current deployment address on testnet2
 export STRATO_HOSTNAME=${STRATO_HOSTNAME:-strato}
 export STRATO_PORT_API=${STRATO_PORT_API:-3000}
 

--- a/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
+++ b/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
@@ -27,7 +27,7 @@ const ProcessingOrder = ({user}) => {
   // const { cartList } = useMarketplaceState();
   const marketplaceDispatch = useMarketplaceDispatch();
   const [error, seterror] = useState(null)
-  const { message, success } = useOrderState();
+  const { order, message, success } = useOrderState();
   const [api, contextHolder] = notification.useNotification();
 
 
@@ -81,7 +81,7 @@ const ProcessingOrder = ({user}) => {
             if (body.data["payment_status"] === "paid") {
               const customerEmail = user.email;
               const cart = JSON.parse(body.data.metadata.cart);
-              let object = { paymentSessionId: sessionId, status:ORDER_STATUS.AWAITING_FULFILLMENT, paymentMethod: body.data.payment_method, ...cart };
+              let object = { paymentSessionId: sessionId, status:ORDER_STATUS.PAID, paymentMethod: body.data.payment_method, ...cart };
               handleOrderConfirm(object, customerEmail);
             }
             else if (body.data["payment_method_options"].hasOwnProperty("us_bank_account")) {
@@ -232,6 +232,7 @@ const ProcessingOrder = ({user}) => {
 
   return <div>
     {contextHolder}
+    {console.log(order)}
     <div className="h-96 flex flex-col justify-center items-center">
       <Spin spinning={true} size="large" />
       <p className="mt-4">Please wait while your order is being processed</p>

--- a/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
+++ b/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
@@ -27,7 +27,7 @@ const ProcessingOrder = ({user}) => {
   // const { cartList } = useMarketplaceState();
   const marketplaceDispatch = useMarketplaceDispatch();
   const [error, seterror] = useState(null)
-  const { order, message, success } = useOrderState();
+  const { message, success } = useOrderState();
   const [api, contextHolder] = notification.useNotification();
 
 
@@ -232,7 +232,6 @@ const ProcessingOrder = ({user}) => {
 
   return <div>
     {contextHolder}
-    {console.log(order)}
     <div className="h-96 flex flex-col justify-center items-center">
       <Spin spinning={true} size="large" />
       <p className="mt-4">Please wait while your order is being processed</p>

--- a/marketplace/ui/src/components/Order/BoughtOrderDetails.js
+++ b/marketplace/ui/src/components/Order/BoughtOrderDetails.js
@@ -268,7 +268,7 @@ const BoughtOrderDetails = ({ user, users }) => {
     } else if (status === "Closed") {
       bgClass = "bg-[#119B2D]";
     } else if (status === "Paid") {
-      textClass = "bg-[#119B2D33]";
+      textClass = "bg-[#119B2D]";
     } else if (status === "Canceled") {
       bgClass = "bg-[#FF0000]";
     }

--- a/marketplace/ui/src/components/Order/BoughtOrderDetails.js
+++ b/marketplace/ui/src/components/Order/BoughtOrderDetails.js
@@ -267,6 +267,8 @@ const BoughtOrderDetails = ({ user, users }) => {
       bgClass = "bg-[#FF8C00]"
     } else if (status === "Closed") {
       bgClass = "bg-[#119B2D]";
+    } else if (status === "Paid") {
+      textClass = "bg-[#119B2D33]";
     } else if (status === "Canceled") {
       bgClass = "bg-[#FF0000]";
     }

--- a/marketplace/ui/src/components/Order/BoughtOrdersTable.js
+++ b/marketplace/ui/src/components/Order/BoughtOrdersTable.js
@@ -303,6 +303,8 @@ const BoughtOrdersTable = ({ user, selectedDate, onDateChange, download, isAllOr
       textClass = "bg-[#FF8C0033]"
     } else if (status === "Closed") {
       textClass = "bg-[#119B2D33]";
+    } else if (status === "Paid") {
+      textClass = "bg-[#119B2D33]";
     } else if (status === "Canceled") {
       textClass = "bg-[#FFF0F0]";
     }

--- a/marketplace/ui/src/components/Order/SoldOrderDetails.js
+++ b/marketplace/ui/src/components/Order/SoldOrderDetails.js
@@ -258,6 +258,8 @@ const SoldOrderDetails = ({ user, users }) => {
       textClass = "bg-[#FF8C0033]"
     } else if (status === "Closed") {
       textClass = "bg-[#119B2D33]";
+    } else if (status === "Paid") {
+      textClass = "bg-[#119B2D33]";
     } else if (status === "Canceled") {
       textClass = "bg-[#FFF0F0]";
     }
@@ -270,6 +272,8 @@ const SoldOrderDetails = ({ user, users }) => {
       bgClass = "bg-[#FF8C00]"
     } else if (status === "Closed") {
       bgClass = "bg-[#119B2D]";
+    } else if (status === "Paid") {
+      textClass = "bg-[#119B2D33]";
     } else if (status === "Canceled") {
       bgClass = "bg-[#FF0000]";
     }

--- a/marketplace/ui/src/components/Order/SoldOrderDetails.js
+++ b/marketplace/ui/src/components/Order/SoldOrderDetails.js
@@ -273,7 +273,7 @@ const SoldOrderDetails = ({ user, users }) => {
     } else if (status === "Closed") {
       bgClass = "bg-[#119B2D]";
     } else if (status === "Paid") {
-      textClass = "bg-[#119B2D33]";
+      textClass = "bg-[#119B2D]";
     } else if (status === "Canceled") {
       bgClass = "bg-[#FF0000]";
     }

--- a/marketplace/ui/src/components/Order/SoldOrdersTable.js
+++ b/marketplace/ui/src/components/Order/SoldOrdersTable.js
@@ -313,7 +313,7 @@ const SoldOrdersTable = ({ user, selectedDate, onDateChange, download, isAllOrde
     } else if (status === "Closed") {
       bgClass = "bg-[#119B2D]";
     } else if (status === "Paid") {
-      textClass = "bg-[#119B2D33]";
+      textClass = "bg-[#119B2D]";
     } else if (status === "Canceled") {
       bgClass = "bg-[#FF0000]";
     }

--- a/marketplace/ui/src/components/Order/SoldOrdersTable.js
+++ b/marketplace/ui/src/components/Order/SoldOrdersTable.js
@@ -298,6 +298,8 @@ const SoldOrdersTable = ({ user, selectedDate, onDateChange, download, isAllOrde
       textClass = "bg-[#FF8C0033]"
     } else if (status === "Closed") {
       textClass = "bg-[#119B2D33]";
+    } else if (status === "Paid") {
+      textClass = "bg-[#119B2D33]";
     } else if (status === "Canceled") {
       textClass = "bg-[#FFF0F0]";
     }
@@ -310,6 +312,8 @@ const SoldOrdersTable = ({ user, selectedDate, onDateChange, download, isAllOrde
       bgClass = "bg-[#FF8C00]"
     } else if (status === "Closed") {
       bgClass = "bg-[#119B2D]";
+    } else if (status === "Paid") {
+      textClass = "bg-[#119B2D33]";
     } else if (status === "Canceled") {
       bgClass = "bg-[#FF0000]";
     }

--- a/marketplace/ui/src/components/Order/constant.js
+++ b/marketplace/ui/src/components/Order/constant.js
@@ -3,7 +3,8 @@ export const status = {
   2: "Awaiting Shipment",
   3: "Closed",
   4: "Canceled",
-  5: "Payment Pending"
+  5: "Payment Pending",
+  6: "Paid"
 };
 
 export const statusByName = {
@@ -11,7 +12,8 @@ export const statusByName = {
   "Awaiting Shipment": "Awaiting Shipment",
   "Closed": "Closed",
   "Canceled": "Canceled",
-  "Payment Pending": "Payment Pending"
+  "Payment Pending": "Payment Pending",
+  "Paid": "Paid",
 };
 
 export const getStatusByName = (name) => {

--- a/marketplace/ui/src/helpers/constants.js
+++ b/marketplace/ui/src/helpers/constants.js
@@ -142,7 +142,8 @@ export const ORDER_STATUS = {
   "AWAITING_SHIPMENT": 2,
   "CLOSED": 3,
   "CANCELED": 4,
-  "PAYMENT_PENDING": 5
+  "PAYMENT_PENDING": 5,
+  "PAID": 6
 }
 
 export const PAYMENT_LIST = ['card','us_bank_account']


### PR DESCRIPTION
This PR automates order closing for credit cards. 
Rest of the app features are intact.

- Order Closing automation for credit card payment orders.

- ACH flow requires seller intervention to close orders (from Awaiting Fulfillment to Closed status)

#### Before the fix is deployed to prod:

- Prod seller accounts should close the orders(which say Awaiting Fulfillment)

#### Once the fix is deployed:

- Prod accounts should unlist existing assets which are listed for sale and re-list for sale with the same price & corresponding quantity for sale

- Testing can be done at: (https://workspace-vijay-0exm82f.blockapps.net/marketplace/)