### PR TITLE
Order-Closing-ACH/Credit Cards (includes prod version changes)

### DIFF
--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Orders/Order.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Orders/Order.sol
@@ -71,14 +71,15 @@ abstract contract Order is Utils {
         shippingAddressId = _shippingAddressId;
         paymentSessionId = _paymentSessionId;
         
-        if(status == OrderStatus.PAID)
+        //Credit Card Payment Orders go in this block
+        if(status == OrderStatus.AWAITING_FULFILLMENT)
         {
             completeOrder(_createdDate,"Thank you for your payment.");
         }
     }
 
-    function completeOrder(uint _fulfillmentDate, string _comments) returns (uint) {
-        require(status != OrderStatus.CLOSED && status != OrderStatus.CANCELED, "Order already closed.");
+    function completeOrder(uint _fulfillmentDate, string _comments) public returns (uint) {
+        require(status == OrderStatus.AWAITING_FULFILLMENT, "Order is not in AWAITING FULFILLMENT state.");
         for (uint i = 0; i < saleAddresses.length; i++) {
             if (!completedSales[i]) {
                 Sale(saleAddresses[i]).completeSale();
@@ -126,6 +127,8 @@ abstract contract Order is Utils {
         }else if(status == OrderStatus.PAYMENT_PENDING){
             if (_status == OrderStatus.AWAITING_FULFILLMENT) {
                 status = _status;
+                completeOrder(block.timestamp, "Thank you for your payment.");
+
             } 
         }
         return RestStatus.OK;
@@ -133,7 +136,7 @@ abstract contract Order is Utils {
 
     function onCancel(string _comments) internal virtual {}
 
-    function cancelOrder(string _comments)  returns (uint) {
+    function cancelOrder(string _comments) external  returns (uint) {
         require(status != OrderStatus.CLOSED && status != OrderStatus.CANCELED, "Order already closed.");
         require((tx.origin == purchasersAddress || getCommonName(tx.origin) == sellersCommonName), "Only the purchaser/seller can cancel the order");
         onCancel(_comments);

--- a/marketplace/backend/docker-run.sh
+++ b/marketplace/backend/docker-run.sh
@@ -5,7 +5,7 @@ export CONFIG_DIR_PATH=/config
 export DEPLOY_FILE_NAME=marketplace.deploy.yaml
 export STRATO_NODE_PROTOCOL=${STRATO_NODE_PROTOCOL:-http}
 export STRATO_NODE_HOST=${STRATO_NODE_HOST:-nginx}
-export BASE_CODE_COLLECTION=${BASE_CODE_COLLECTION:-0e09491503d78b1ada7e846c43aaa3ae4d133506} # Current deployment address on testnet2
+export BASE_CODE_COLLECTION=${BASE_CODE_COLLECTION:-9ed8a49bbd72fc4ca3ee7dcce9bc25be23014a7f} # Current deployment address on testnet2
 export STRATO_HOSTNAME=${STRATO_HOSTNAME:-strato}
 export STRATO_PORT_API=${STRATO_PORT_API:-3000}
 

--- a/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
+++ b/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
@@ -81,7 +81,7 @@ const ProcessingOrder = ({user}) => {
             if (body.data["payment_status"] === "paid") {
               const customerEmail = user.email;
               const cart = JSON.parse(body.data.metadata.cart);
-              let object = { paymentSessionId: sessionId, status:ORDER_STATUS.PAID, paymentMethod: body.data.payment_method, ...cart };
+              let object = { paymentSessionId: sessionId, status:ORDER_STATUS.AWAITING_FULFILLMENT, paymentMethod: body.data.payment_method, ...cart };
               handleOrderConfirm(object, customerEmail);
             }
             else if (body.data["payment_method_options"].hasOwnProperty("us_bank_account")) {

--- a/marketplace/ui/src/components/Order/BoughtOrderDetails.js
+++ b/marketplace/ui/src/components/Order/BoughtOrderDetails.js
@@ -267,8 +267,6 @@ const BoughtOrderDetails = ({ user, users }) => {
       bgClass = "bg-[#FF8C00]"
     } else if (status === "Closed") {
       bgClass = "bg-[#119B2D]";
-    } else if (status === "Paid") {
-      textClass = "bg-[#119B2D]";
     } else if (status === "Canceled") {
       bgClass = "bg-[#FF0000]";
     }

--- a/marketplace/ui/src/components/Order/BoughtOrdersTable.js
+++ b/marketplace/ui/src/components/Order/BoughtOrdersTable.js
@@ -303,8 +303,6 @@ const BoughtOrdersTable = ({ user, selectedDate, onDateChange, download, isAllOr
       textClass = "bg-[#FF8C0033]"
     } else if (status === "Closed") {
       textClass = "bg-[#119B2D33]";
-    } else if (status === "Paid") {
-      textClass = "bg-[#119B2D33]";
     } else if (status === "Canceled") {
       textClass = "bg-[#FFF0F0]";
     }

--- a/marketplace/ui/src/components/Order/SoldOrderDetails.js
+++ b/marketplace/ui/src/components/Order/SoldOrderDetails.js
@@ -258,8 +258,6 @@ const SoldOrderDetails = ({ user, users }) => {
       textClass = "bg-[#FF8C0033]"
     } else if (status === "Closed") {
       textClass = "bg-[#119B2D33]";
-    } else if (status === "Paid") {
-      textClass = "bg-[#119B2D33]";
     } else if (status === "Canceled") {
       textClass = "bg-[#FFF0F0]";
     }

--- a/marketplace/ui/src/components/Order/SoldOrdersTable.js
+++ b/marketplace/ui/src/components/Order/SoldOrdersTable.js
@@ -298,8 +298,6 @@ const SoldOrdersTable = ({ user, selectedDate, onDateChange, download, isAllOrde
       textClass = "bg-[#FF8C0033]"
     } else if (status === "Closed") {
       textClass = "bg-[#119B2D33]";
-    } else if (status === "Paid") {
-      textClass = "bg-[#119B2D33]";
     } else if (status === "Canceled") {
       textClass = "bg-[#FFF0F0]";
     }
@@ -312,8 +310,6 @@ const SoldOrdersTable = ({ user, selectedDate, onDateChange, download, isAllOrde
       bgClass = "bg-[#FF8C00]"
     } else if (status === "Closed") {
       bgClass = "bg-[#119B2D]";
-    } else if (status === "Paid") {
-      textClass = "bg-[#119B2D]";
     } else if (status === "Canceled") {
       bgClass = "bg-[#FF0000]";
     }

--- a/marketplace/ui/src/components/Order/constant.js
+++ b/marketplace/ui/src/components/Order/constant.js
@@ -3,8 +3,7 @@ export const status = {
   2: "Awaiting Shipment",
   3: "Closed",
   4: "Canceled",
-  5: "Payment Pending",
-  6: "Paid"
+  5: "Payment Pending"
 };
 
 export const statusByName = {
@@ -12,8 +11,7 @@ export const statusByName = {
   "Awaiting Shipment": "Awaiting Shipment",
   "Closed": "Closed",
   "Canceled": "Canceled",
-  "Payment Pending": "Payment Pending",
-  "Paid": "Paid",
+  "Payment Pending": "Payment Pending"
 };
 
 export const getStatusByName = (name) => {

--- a/marketplace/ui/src/helpers/constants.js
+++ b/marketplace/ui/src/helpers/constants.js
@@ -142,8 +142,7 @@ export const ORDER_STATUS = {
   "AWAITING_SHIPMENT": 2,
   "CLOSED": 3,
   "CANCELED": 4,
-  "PAYMENT_PENDING": 5,
-  "PAID": 6
+  "PAYMENT_PENDING": 5
 }
 
 export const PAYMENT_LIST = ['card','us_bank_account']


### PR DESCRIPTION
This PR deals with clean up on Order Closing and additionally also includes ACH order automation.

Testing can be done [here](https://workspace-neel2-0exm82f.blockapps.net/marketplace/):

- Invoking 1 API call to update order status from Payment Pending to Awaiting Fulfillment >> will invoke completeOrder from contract side on successful payment (https://github.com/blockapps/strato-platform/compare/develop...order-closing-for-card/ach-option-1) which is deployed [here](https://workspace-neel2-0exm82f.blockapps.net/marketplace/). This has all the changes that were deployed on prod node and additionally, we invoke completeOrder to close it when we update the order status from Payment Pending to Awaiting Fulfillment.