### PR TITLE
add case for single quote state variable names that break slipstream

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -24,6 +24,7 @@ so that they could be properly moved to their respective version's subsection.
 
 ### Fixed
 - Contracts that inherit from abstract contracts at the grandparent+ level are indexed in Cirrus at all levels
+- State variable identifiers should not be allowed to have single quotes
 
 ### Removed
 - NewStatus message type from strato-p2p

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -336,6 +336,7 @@ simpleVariableDeclaration = do
   let isRecord = KRecord `elem` keywords
   -- check to see if the "account" variable is being used
   variableName <- identifier
+  when ('\'' `elem` variableName) $ fail "state variable names cannot contain single quotes" 
   pragmaVersion' <- getPragmaVersion
   when (isReservedWord pragmaVersion' variableName) $ reservedWordError pragmaVersion' variableName
   value <- optionMaybe $ do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1870,7 +1870,7 @@ expToVar' theFullExp@(CC.FunctionCall _ e args) = do
                       _ -> typeError "This should not be possible to reach..." args'
                   salt = case convertedFirstArg of
                     SString s -> s
-                    _ -> typeError "first arugment must be a string " args
+                    _ -> typeError "first argument must be a string " args
                   newAddress =
                     getNewAddressWithSalt_unsafe
                       addr

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -6380,14 +6380,14 @@ contract qq {
           [r|
 
 contract qq {
-  account contract';
+  account contractAddr;
   account payable contractPay;
   account owner;
   account payable ownerPay;
 
   constructor() public {
-    contract' = account(this);
-    contractPay = payable(contract');
+    contractAddr = account(this);
+    contractPay = payable(contractAddr);
     owner = account(0xdeadbeef);
     ownerPay = payable(owner);
   }
@@ -6398,13 +6398,13 @@ contract qq {
 }|]
     runBS contract
     -- Get the contract's accounts
-    [BAccount contract', BAccount owner] <- getFields ["contract'", "owner"]
+    [BAccount contractAddr, BAccount owner] <- getFields ["contractAddr", "owner"]
     -- Adjust the preset balances
-    adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing contract') (\as -> pure $ as {addressStateBalance = 14})
+    adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing contractAddr) (\as -> pure $ as {addressStateBalance = 14})
     adjust_ (Proxy @AddressState) (namedAccountToAccount Nothing owner) (\bs -> pure $ bs {addressStateBalance = 10})
     -- Check return of balance
-    void $ call2 "selfDestructThis" "()" (namedAccountToAccount Nothing contract')
-    getFields ["contract'", "contractPay", "owner", "ownerPay"]
+    void $ call2 "selfDestructThis" "()" (namedAccountToAccount Nothing contractAddr)
+    getFields ["contractAddr", "contractPay", "owner", "ownerPay"]
       `shouldReturn` [ BDefault,
                        BDefault,
                        BDefault,
@@ -6527,10 +6527,10 @@ contract qq {
   X public x;
   Y public y;
   X public z;
-  bytes32 salt';
+  bytes32 saltString;
   constructor() public {
-    salt' = "salt";
-    x = new X{salt: salt'}();
+    saltString = "salt";
+    x = new X{salt: saltString}();
     y = new Y{salt: "something"}();
 
   }
@@ -6563,11 +6563,11 @@ contract qq {
   X public x;
   Y public y;
   X public z;
-  bytes32 salt';
+  bytes32 saltString;
   constructor() public {
-    salt' = "salt";
-    x = new X{salt: salt'}("xNum");
-    y = new Y{salt: salt'}(100);
+    saltString = "salt";
+    x = new X{salt: saltString}("xNum");
+    y = new Y{salt: saltString}(100);
 
   }
 }|]


### PR DESCRIPTION
The parser accepts apostrophes in state variable names like `string hello'world` or `string hello'` which is fine until these state variables are indexed in slipstream and cause a failure in the SolidvVM cache decoder where it tries to decode a state variable called `string` that is probably the result of some query gone wrong