### PR TITLE
source code encoding fix

### DIFF
--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Keccak256.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Keccak256.hs
@@ -63,7 +63,7 @@ import Web.FormUrlEncoded hiding (fieldLabelModifier)
 import Web.PathPieces
 
 newtype Keccak256 = Keccak256 ByteString
-  deriving (Eq, Read, Show, Ord, Generic, Data)
+  deriving (Eq, Read, Ord, Generic, Data)
   deriving anyclass (Hashable)
 
 newtype SHA = SHA ByteString
@@ -83,6 +83,9 @@ unsafeCreateKeccak256FromByteString = Keccak256
 
 unsafeCreateKeccak256FromWord256 :: Word256 -> Keccak256
 unsafeCreateKeccak256FromWord256 = Keccak256 . word256ToBytes
+
+instance Show Keccak256 where
+  show = keccak256ToHex
 
 instance Binary Keccak256 where
   put (Keccak256 x) = putByteString x

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Keccak256.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Keccak256.hs
@@ -63,7 +63,7 @@ import Web.FormUrlEncoded hiding (fieldLabelModifier)
 import Web.PathPieces
 
 newtype Keccak256 = Keccak256 ByteString
-  deriving (Eq, Read, Ord, Generic, Data)
+  deriving (Eq, Read, Show, Ord, Generic, Data)
   deriving anyclass (Hashable)
 
 newtype SHA = SHA ByteString
@@ -83,9 +83,6 @@ unsafeCreateKeccak256FromByteString = Keccak256
 
 unsafeCreateKeccak256FromWord256 :: Word256 -> Keccak256
 unsafeCreateKeccak256FromWord256 = Keccak256 . word256ToBytes
-
-instance Show Keccak256 where
-  show = keccak256ToHex
 
 instance Binary Keccak256 where
   put (Keccak256 x) = putByteString x

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -68,6 +68,7 @@ import qualified Data.Map.Ordered as OMap
 import Data.Maybe
 import Data.Proxy
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as UTF8
 import Debugger
 import Executable.EthereumVM2
 import Executable.EVMCheckpoint
@@ -171,7 +172,7 @@ sendOutEvent (OutAction act) = do
              ) of
           (Just c, Just n, actionDatas) ->
             let cp = case join $ fmap (M.lookup "VM") $ a ^. Action.metadata of
-                  Just "SolidVM" -> SolidVMCode (T.unpack n) $ Keccak256.hash $ BC.pack $ T.unpack c
+                  Just "SolidVM" -> SolidVMCode (T.unpack n) $ Keccak256.hash $ UTF8.encodeUtf8 c
                   Just "EVM" -> EVMCode $ Keccak256.hash $ BC.pack $ T.unpack c
                   Just v -> error $ "Unknown VM: " ++ show v
                   Nothing -> EVMCode $ Keccak256.hash $ BC.pack $ T.unpack c


### PR DESCRIPTION
For some reason, posting the `ERC20StablecoinWithMemo` contract would not send the `organization` name down to slipstream to be indexed. Amid our investigation, we simplified the way the source code was being encoded for the hash function which ended up fixing the issue.