### PR TITLE
lucky orange visitor null 

### DIFF
--- a/marketplace/ui/src/App.js
+++ b/marketplace/ui/src/App.js
@@ -27,11 +27,13 @@ const App = () => {
     "ready",
     async (LO) => {
       await LO.$internal.ready("visitor");
-      LO.visitor.identify({
-        email: user?.email || null,
-        name: user?.commonName || null,
-        username: user?.preferred_username || null
-      });
+      if (user) {
+        LO.visitor.identify({
+          email: user.email,
+          name: user.commonName,
+          username: user.preferred_username
+        });
+      }
     },
   ]);
 


### PR DESCRIPTION
This will fix the issue where visitors are showing as null for lucky orange. The visitor is set then we define it only if the user exists. This way it will take the default setting for lucky orange visitors. 