### PR TITLE
[Performance] Optimizing Integer to ByteString creation

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -29,7 +29,8 @@ so that they could be properly moved to their respective version's subsection.
 ### Changed 
 - When a transaction fails, the `<failed>` message blinks :^)
 - `keccak256` built-in function should return hex-encoded value instead of bytestring
-- Optimized the byteString2Integer function that lies at the foundation of strato's RLP-related functionality.
+- Optimized the byteString2Integer function that lies at the foundation of strato's RLP-related functionality (rlpDecode).
+- Optimized the integer2Bytes function that lies at the foundation of strato's RLP-related functionality (rlpEncode)
 - Removed unnecessary stateDiff (and threading) in the vm-runner codebase, fixing numerous sources of persistent memory build-up.
 
 ### Fixed

--- a/strato/libs/ethereum-rlp/library/Blockchain/Data/RLP.hs
+++ b/strato/libs/ethereum-rlp/library/Blockchain/Data/RLP.hs
@@ -177,7 +177,7 @@ instance RLPSerializable Integer where
   rlpEncode 0 = RLPString B.empty
   rlpEncode x | x < 0 = RLPArray [rlpEncode (-x)]
   rlpEncode x | x < 128 = RLPScalar $ fromIntegral x
-  rlpEncode x = RLPString $ B.pack $ integer2Bytes x
+  rlpEncode x = RLPString $ integer2Bytes x
   rlpDecode (RLPScalar x) = fromIntegral x
   rlpDecode (RLPString s) = byteString2Integer s
   rlpDecode (RLPArray [x]) = -rlpDecode x

--- a/strato/libs/ethereum-rlp/library/Blockchain/Data/Util.hs
+++ b/strato/libs/ethereum-rlp/library/Blockchain/Data/Util.hs
@@ -6,7 +6,6 @@ where
 
 import Data.Bits
 import qualified Data.ByteString as B
-import Data.Word
 
 byteString2Integer :: B.ByteString
                    -> Integer
@@ -20,6 +19,10 @@ byteString2Integer bs =
                                  (shiftamount + 8)
                                  (n - 1)
 
-integer2Bytes :: Integer -> [Word8]
-integer2Bytes 0 = []
-integer2Bytes x = integer2Bytes (x `shiftR` 8) ++ [fromInteger (x .&. 255)]
+integer2Bytes :: Integer
+              -> B.ByteString
+integer2Bytes = B.pack . go []
+  where
+    go acc 0 = acc
+    go acc x = go (fromInteger (x .&. 255) : acc)
+                  (x `shiftR` 8)


### PR DESCRIPTION
This PR seeks to replaced existing functionality surrounding essential and low-level functions related to `ByteString` creation from an `Integer` (foundation for `rlpEncode`).

Benchmarking via `criterion` shows this methodology of `ByteString` creation from an `Integer` is about twice as fast as the previous implementation:

```
module Main (main) where

import Criterion.Main
import Data.Bits
import qualified Data.ByteString as BS
import Data.Word

functionA :: Integer -> [Word8]
functionA 0 = []
functionA x = functionA (x `shiftR` 8) ++ [fromInteger (x .&. 255)]

functionB :: Integer -> BS.ByteString
functionB = BS.pack . go []
  where
    go acc 0 = acc
    go acc x = go (fromInteger (x .&. 255) : acc)
                  (x `shiftR` 8)

main :: IO ()
main = defaultMain
  [ bench "functionA" $ nf functionA 12345678901234567
  , bench "functionB" $ nf functionB 12345678901234567
  ]
```

Results:

```
benchmarking functionA
time                 217.0 ns   (216.2 ns .. 218.0 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 217.9 ns   (216.8 ns .. 219.5 ns)
std dev              4.352 ns   (3.697 ns .. 5.482 ns)
variance introduced by outliers: 26% (moderately inflated)

benchmarking functionB
time                 115.8 ns   (115.1 ns .. 116.8 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 116.8 ns   (116.1 ns .. 117.6 ns)
std dev              2.629 ns   (2.189 ns .. 3.023 ns)
variance introduced by outliers: 32% (moderately inflated)
```

A more apples-to-apples comparison (`functionB :: Integer -> [Word8]`) illustrates an even more stark performance difference:

```
module Main (main) where

import Criterion.Main
import Data.Bits
import qualified Data.ByteString as BS
import Data.Word

functionA :: Integer -> [Word8]
functionA 0 = []
functionA x = functionA (x `shiftR` 8) ++ [fromInteger (x .&. 255)]

functionB :: Integer -> [Word8]
functionB = go []
  where
    go acc 0 = acc
    go acc x = go (fromInteger (x .&. 255) : acc)
                  (x `shiftR` 8)

main :: IO ()
main = defaultMain
  [ bench "functionA" $ nf functionA 12345678901234567
  , bench "functionB" $ nf functionB 12345678901234567
  ]
```

Results:

```
benchmarking functionA
time                 229.0 ns   (227.7 ns .. 230.8 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 228.8 ns   (228.0 ns .. 229.9 ns)
std dev              3.114 ns   (2.380 ns .. 4.247 ns)
variance introduced by outliers: 14% (moderately inflated)

benchmarking functionB
time                 106.0 ns   (105.6 ns .. 106.5 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 105.6 ns   (105.1 ns .. 106.2 ns)
std dev              1.975 ns   (1.622 ns .. 2.364 ns)
variance introduced by outliers: 25% (moderately inflated)
```

The most likely reason of the more performant nature of the updated implementation of `integer2Bytes` is due to the accumulator-based construction.

In the new implementation, the byte list (`[Word8]`) is constructed using an accumulator (acc) which is passed along through recursive calls. This accumulator-based approach eliminates the need for list concatenation (via `++`), which can be inefficient (and create a large-overhead) due to the need to copy the entire list on each concatenation operation.