### PR TITLE
[Performance] Optimizing Integer creation from component bytes by Vector conversion

### DIFF
--- a/strato/libs/ethereum-rlp/library/Blockchain/Data/Util.hs
+++ b/strato/libs/ethereum-rlp/library/Blockchain/Data/Util.hs
@@ -6,18 +6,15 @@ where
 
 import Data.Bits
 import qualified Data.ByteString as B
+import qualified Data.Vector.Storable as V
 
 byteString2Integer :: B.ByteString
                    -> Integer
-byteString2Integer bs =
-  go 0
-     0
-     (B.length bs - 1)
-  where
-    go acc _           (-1) = acc
-    go acc shiftamount n    = go (acc + (fromIntegral (bs `B.index` n) `shiftL` shiftamount))
-                                 (shiftamount + 8)
-                                 (n - 1)
+byteString2Integer bs = do
+  let bsv = V.fromList $ B.unpack bs
+  V.foldl' (\acc byte -> acc * 256 + fromIntegral byte)
+           0
+           bsv
 
 integer2Bytes :: Integer
               -> B.ByteString

--- a/strato/libs/ethereum-rlp/package.yaml
+++ b/strato/libs/ethereum-rlp/package.yaml
@@ -46,6 +46,7 @@ default-extensions:
 dependencies:
   - base
   - bytestring
+  - vector
 
 library:
   source-dirs: library/


### PR DESCRIPTION
This PR seeks to replace existing functionality surrounding essential and low-level functions related to `Integer` creation via component bytes.

This implementation further optimizes runtime perfomance by means of converting the input `ByteString` into a `Vector Word8`.

Benchmarking via `criterion` shows this methodology of `Integer` creation (starting from a `ByteString`) is about ~80% faster than the previous non-[Vector](https://hackage.haskell.org/package/vector-0.13.1.0/docs/Data-Vector-Storable.html) implementation:

`functionA` represents the previous implementation of `bytes2Integer` (see PR [2989](https://github.com/blockapps/strato-platform/pull/2989)).
`functionB` represents the implementation of `bytes2Integer` provided in this PR.

```
module Main (main) where

import Criterion.Main
import qualified Data.ByteString as BS
import qualified Data.ByteString.Char8 as BSC8
import Data.Word
import Data.Bits
import qualified Data.Vector.Storable as V

functionA :: BS.ByteString
          -> Integer
functionA bs =
  go 0 0 (BS.length bs - 1)
  where
    go acc _           (-1) = acc
    go acc shiftAmount n    = go (acc + (fromIntegral (bs `BS.index` n) `shiftL` shiftAmount))
                                 (shiftAmount + 8)
                                 (n - 1)

functionB :: BS.ByteString
          -> Integer
functionB bs = do
  let bsv = V.fromList $ BS.unpack bs
  V.foldl' (\acc byte -> acc * 256 + fromIntegral byte)
           0
           bsv

exampleinput :: [Word8]
exampleinput = [0x12, 0x34, 0x56, 0x78, 0xAB, 0xCD, 0xEF, 0x12, 0x34, 0x56, 0x78, 0xAB, 0xCD, 0xEF, 0x12]

main :: IO ()
main = defaultMain
  [ bench "functionA" $ nf functionA (BS.pack exampleinput)
  , bench "functionB" $ nf functionB (BS.pack exampleinput)
  ]
  ```
  
  Results:
  
  ```
  benchmarking functionA
time                 438.5 ns   (436.9 ns .. 439.5 ns)
                       1.000 R²   (1.000 R² .. 1.000 R²)
mean                 436.2 ns   (434.1 ns .. 437.7 ns)
std dev              5.690 ns   (4.320 ns .. 7.184 ns)
variance introduced by outliers: 12% (moderately inflated)

benchmarking functionB
time                 346.6 ns   (345.0 ns .. 348.2 ns)
                       1.000 R²   (1.000 R² .. 1.000 R²)
mean                 348.0 ns   (346.8 ns .. 349.3 ns)
std dev              4.489 ns   (3.789 ns .. 5.199 ns)
variance introduced by outliers: 12% (moderately inflated)
  ```
  
  The `strato/CHANGELOG.md` should already be updated (see PR [2989](https://github.com/blockapps/strato-platform/pull/2989)).