### PR TITLE
automate BASE_CODE_COLLECTION replacement

### DIFF
--- a/marketplace/backend/dapp/dapp/dapp.clean.js
+++ b/marketplace/backend/dapp/dapp/dapp.clean.js
@@ -2,7 +2,7 @@ import { replaceInFiles } from './dapp.helper.js';
 
 describe("dapp.clean.js", function () {
     it('Revert imports back to <BASE_CODE_COLLECTION>', async () => {
-        const pattern = /[0-9a-fA-F]{40}/
+        const pattern = /(import <[0-9a-fA-F]{40}>)/
         replaceInFiles('./dapp/', pattern, 'BASE_CODE_COLLECTION');
     })
 })

--- a/marketplace/backend/dapp/dapp/dapp.clean.js
+++ b/marketplace/backend/dapp/dapp/dapp.clean.js
@@ -3,6 +3,6 @@ import { replaceInFiles } from './dapp.helper.js';
 describe("dapp.clean.js", function () {
     it('Revert imports back to <BASE_CODE_COLLECTION>', async () => {
         const pattern = /(import <[0-9a-fA-F]{40}>)/
-        replaceInFiles('./dapp/', pattern, 'BASE_CODE_COLLECTION');
+        replaceInFiles('./dapp/', pattern, 'import <BASE_CODE_COLLECTION>');
     })
 })

--- a/marketplace/backend/dapp/dapp/dapp.clean.js
+++ b/marketplace/backend/dapp/dapp/dapp.clean.js
@@ -1,0 +1,8 @@
+import { replaceInFiles } from './dapp.helper.js';
+
+describe("dapp.clean.js", function () {
+    it('Revert imports back to <BASE_CODE_COLLECTION>', async () => {
+        const pattern = /[0-9a-fA-F]{40}/
+        replaceInFiles('./dapp/', pattern, 'BASE_CODE_COLLECTION');
+    })
+})

--- a/marketplace/backend/dapp/dapp/dapp.deploy.js
+++ b/marketplace/backend/dapp/dapp/dapp.deploy.js
@@ -8,6 +8,9 @@ import dotenv from 'dotenv'
 
 import dappJs from "./dapp"
 import { ROLE } from "/helpers/constants";
+
+import { replaceInFiles } from './dapp.helper.js';
+
 const options = { config, logger: console }
 const loadEnv = dotenv.config()
 
@@ -42,6 +45,7 @@ describe("Marketplace Dapp - deploy contracts, bootnode organization", function 
       process.env.GLOBAL_ADMIN_PASSWORD,
       "GLOBAL_ADMIN_PASSWORD is missing. Add it to .env file"
     )
+
 
     adminUserName = process.env.GLOBAL_ADMIN_NAME
     adminUserPassword = process.env.GLOBAL_ADMIN_PASSWORD
@@ -88,13 +92,13 @@ describe("Marketplace Dapp - deploy contracts, bootnode organization", function 
     const deployment = dapp.deploy(deployArgs)
     assert.isDefined(deployment)
     assert.equal(deployment.dapp.contract.address, dapp.address)
+
+    const development = process.env.DEVELOP === "true" ? true : false
+    if (development === true) {
+      replaceInFiles('./dapp/', 'BASE_CODE_COLLECTION', dapp.address);
+      console.log(`All instances of <BASE_CODE_COLLECTION> have been replaced with <${dapp.address}>`)
+    }
   })
 
 
 })
-  // it('Should create and assign admin role', async () => {
-  //   await dapp.createUserMembershipAndPermissions({ isAdmin: true, isTradingEntity: false, isCertifier: false, userAddress: adminUser.address })
-  //   if (adminUser.address !== bayer.address) {
-  //     await dapp.createUserMembershipAndPermissions({ isAdmin: true, isTradingEntity: false, isCertifier: false, userAddress: bayer.address })
-  //   }
-  // })

--- a/marketplace/backend/dapp/dapp/dapp.deploy.js
+++ b/marketplace/backend/dapp/dapp/dapp.deploy.js
@@ -93,8 +93,7 @@ describe("Marketplace Dapp - deploy contracts, bootnode organization", function 
     assert.isDefined(deployment)
     assert.equal(deployment.dapp.contract.address, dapp.address)
 
-    const development = process.env.DEVELOP === "true" ? true : false
-    if (development === true) {
+    if (process.env.DEVELOP === "true") {
       replaceInFiles('./dapp/', 'BASE_CODE_COLLECTION', dapp.address);
       console.log(`All instances of <BASE_CODE_COLLECTION> have been replaced with <${dapp.address}>`)
     }

--- a/marketplace/backend/dapp/dapp/dapp.helper.js
+++ b/marketplace/backend/dapp/dapp/dapp.helper.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+function replaceInFiles(directory, searchString, replacement) {
+  fs.readdirSync(directory).forEach(file => {
+    const filePath = path.join(directory, file);
+    const stats = fs.statSync(filePath);
+    if (stats.isDirectory()) {
+      replaceInFiles(filePath, searchString, replacement);
+    } else if (stats.isFile() && file.endsWith('.sol')) {
+      let content = fs.readFileSync(filePath, 'utf8');
+      content = content.replace(new RegExp(searchString, 'g'), replacement);
+      fs.writeFileSync(filePath, content, 'utf8');
+    }
+  });
+}
+
+export { replaceInFiles };

--- a/marketplace/backend/package.json
+++ b/marketplace/backend/package.json
@@ -4,6 +4,8 @@
     "start": "babel-node index",
     "start:prod": "NODE_ENV=production babel-node index",
     "deploy": "cp config/${CONFIG:-localhost}.config.yaml ${CONFIG_DIR_PATH:-.}/config.yaml && yarn mocha-babel dapp/dapp/dapp.deploy.js --config ${CONFIG_DIR_PATH:-.}/config.yaml",
+    "deploy:develop": "yarn deploy:clean && cp config/${CONFIG:-localhost}.config.yaml ${CONFIG_DIR_PATH:-.}/config.yaml && DEVELOP=true yarn mocha-babel dapp/dapp/dapp.deploy.js --config ${CONFIG_DIR_PATH:-.}/config.yaml",
+    "deploy:clean": "yarn mocha-babel dapp/dapp/dapp.clean.js",
     "deploy:secondary-org": "cp config/${CONFIG:-localhost}.config.yaml ${CONFIG_DIR_PATH:-.}/config.yaml && yarn mocha-babel dapp/dapp/dapp.deploy-org.js --config ${CONFIG_DIR_PATH:-.}/config.yaml",
     "test": "PORT=3333 yarn mocha-babel dapp/**/*.test.js && PORT=3334 yarn mocha-babel test/v1 -b",
     "test:dapp": "yarn mocha-babel dapp/dapp/test/dapp.test.js -b",

--- a/marketplace/backend/package.json
+++ b/marketplace/backend/package.json
@@ -4,7 +4,7 @@
     "start": "babel-node index",
     "start:prod": "NODE_ENV=production babel-node index",
     "deploy": "cp config/${CONFIG:-localhost}.config.yaml ${CONFIG_DIR_PATH:-.}/config.yaml && yarn mocha-babel dapp/dapp/dapp.deploy.js --config ${CONFIG_DIR_PATH:-.}/config.yaml",
-    "deploy:develop": "yarn deploy:clean && cp config/${CONFIG:-localhost}.config.yaml ${CONFIG_DIR_PATH:-.}/config.yaml && DEVELOP=true yarn mocha-babel dapp/dapp/dapp.deploy.js --config ${CONFIG_DIR_PATH:-.}/config.yaml",
+    "deploy:develop": "yarn deploy:clean && DEVELOP=true yarn deploy",
     "deploy:clean": "yarn mocha-babel dapp/dapp/dapp.clean.js",
     "deploy:secondary-org": "cp config/${CONFIG:-localhost}.config.yaml ${CONFIG_DIR_PATH:-.}/config.yaml && yarn mocha-babel dapp/dapp/dapp.deploy-org.js --config ${CONFIG_DIR_PATH:-.}/config.yaml",
     "test": "PORT=3333 yarn mocha-babel dapp/**/*.test.js && PORT=3334 yarn mocha-babel test/v1 -b",


### PR DESCRIPTION
This PR adds two scripts to the marketplace/backend package.json:
- `yarn deploy:develop`
- `yarn deploy:clean`

`deploy:develop` calls the dapp deployment script and replace all the instances of `BASE_CODE_COLLECTION` with the new address. Using `yarn deploy` will not update the files.

`deploy:clean` will restore the contract imports to `BASE_CODE_COLLECTION`. This is also used in `deploy:develop` before the actual deployment so the entire flow can be done with `deploy:develop`.

### Expected Flow for Non-Dockerized Marketplace Instances 

1. Pull `strato-platform`
2. Go to `marketplace/backend` and set up environment (`.env`, config files, etc.)
3. `yarn deploy:develop` to upload the BCC and automatically update the `dapps/item/` contracts with this new code collection
4. Start up the marketplace instance as normal
5. Need to make a change to your contract? Save those changes and run `yarn deploy:develop` for an updated contract set