### PR TITLE
[Performance]  Optimizing Integer creation from ByteString sans unpacking

### DIFF
--- a/strato/libs/ethereum-rlp/library/Blockchain/Data/RLP.hs
+++ b/strato/libs/ethereum-rlp/library/Blockchain/Data/RLP.hs
@@ -82,6 +82,7 @@ getLength sizeOfLength bytes =
   where
     (lengthbytes,remainingbytes) = B.splitAt sizeOfLength bytes
     result = byteString2Integer lengthbytes
+                                0
 
 rlpSplit :: B.ByteString -> (RLPObject, B.ByteString)
 rlpSplit = either error id . rlpSplitEither
@@ -179,7 +180,7 @@ instance RLPSerializable Integer where
   rlpEncode x | x < 128 = RLPScalar $ fromIntegral x
   rlpEncode x = RLPString $ integer2Bytes x
   rlpDecode (RLPScalar x) = fromIntegral x
-  rlpDecode (RLPString s) = byteString2Integer s
+  rlpDecode (RLPString s) = byteString2Integer s 0
   rlpDecode (RLPArray [x]) = -rlpDecode x
   rlpDecode (RLPArray _) = error "rlpDecode called for Integer for array of wrong size"
 

--- a/strato/libs/ethereum-rlp/library/Blockchain/Data/Util.hs
+++ b/strato/libs/ethereum-rlp/library/Blockchain/Data/Util.hs
@@ -4,17 +4,21 @@ module Blockchain.Data.Util
   )
 where
 
-import Data.Bits
+import           Data.Bits
 import qualified Data.ByteString as B
-import qualified Data.Vector.Storable as V
 
 byteString2Integer :: B.ByteString
                    -> Integer
-byteString2Integer bs = do
-  let bsv = V.fromList $ B.unpack bs
-  V.foldl' (\acc byte -> acc * 256 + fromIntegral byte)
-           0
-           bsv
+                   -> Integer
+byteString2Integer bs
+                   acc = do
+  case B.uncons bs of
+    Nothing                 ->
+      acc
+    Just (byte,restofbytes) ->
+      let newacc = acc * 256 + fromIntegral byte
+        in byteString2Integer restofbytes
+                              newacc
 
 integer2Bytes :: Integer
               -> B.ByteString

--- a/strato/libs/ethereum-rlp/package.yaml
+++ b/strato/libs/ethereum-rlp/package.yaml
@@ -46,7 +46,6 @@ default-extensions:
 dependencies:
   - base
   - bytestring
-  - vector
 
 library:
   source-dirs: library/


### PR DESCRIPTION
This PR seeks to replace existing functionality surrounding essential and low-level functions related to Integer creation via component bytes.

This implementation further optimizes runtime perfomance by means of recursing through the input `ByteString` without unpacking to a `[Word]` (prior to PR [2989](https://github.com/blockapps/strato-platform/pull/2989)) or a `Vector [Word8]` (PR [3002](https://github.com/blockapps/strato-platform/pull/3002)).

Benchmarking via criterion shows this methodology of `Integer` creation (starting from a `ByteString`) is about ~97% faster than the previous [Vector](https://hackage.haskell.org/package/vector-0.13.1.0/docs/Data-Vector-Storable.html) implementation, and about ~98% faster than the original implementation (pre-PR [2989](https://github.com/blockapps/strato-platform/pull/2989)).

`functionA` represents the implementation of `bytes2Integer` prior to PR [2898](https://github.com/blockapps/strato-platform/pull/2989).
`functionB` represents the implementation of `byteString2Integer` provided in PR [2898](https://github.com/blockapps/strato-platform/pull/2989).
`functionC` represents the implementation of `byteString2Integer` provided in PR [3002](https://github.com/blockapps/strato-platform/pull/3002).
`functionD` respresents the implementation of `byteString2Integer` provided in this PR.

```
module Main (main) where

import Criterion.Main
import qualified Data.ByteString as BS
import Data.Word
import Data.Bits
import Data.Foldable
import qualified Data.Vector.Storable as V

functionA :: [Word8] 
          -> Integer
functionA []            = 0
functionA (byte : rest) = fromIntegral byte `shift` (8 * length rest) + functionA rest

functionB :: BS.ByteString
          -> Integer
functionB bs =
  go 0 0 (BS.length bs - 1)
  where
    go acc _           (-1) = acc
    go acc shiftAmount n    = go (acc + (fromIntegral (bs `BS.index` n) `shiftL` shiftAmount))
                                 (shiftAmount + 8)
                                 (n - 1)

functionC :: BS.ByteString
          -> Integer
functionC bs = do
  let bsv = V.fromList $ BS.unpack bs
  V.foldl' (\acc byte -> acc * 256 + fromIntegral byte)
           0
           bsv

functionD :: BS.ByteString
          -> Integer
          -> Integer
functionD bs acc =
  case BS.uncons bs of
    Nothing          ->
      acc
    Just (byte,rest) ->
      let newAcc = acc * 256 + fromIntegral byte
        in functionD rest newAcc

exampleInput :: [Word8]
exampleInput = [0x12, 0x34, 0x56, 0x78, 0xAB, 0xCD, 0xEF, 0x12, 0x34, 0x56, 0x78, 0xAB, 0xCD, 0xEF, 0x12]

main :: IO ()
main = defaultMain
  [ bench "functionA" $ nf functionA exampleInput
  , bench "functionB" $ nf functionB (BS.pack exampleInput)
  , bench "functionC" $ nf functionC (BS.pack exampleInput)
  , bench "functionD" $ nf functionD (BS.pack exampleInput)
  ]
```

Results:

```
benchmarking functionA
time                 510.2 ns   (508.1 ns .. 512.5 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 509.6 ns   (507.9 ns .. 510.8 ns)
std dev              4.887 ns   (4.155 ns .. 6.229 ns)

benchmarking functionB
time                 432.9 ns   (431.4 ns .. 434.7 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 435.7 ns   (433.3 ns .. 443.1 ns)
std dev              13.92 ns   (5.892 ns .. 24.85 ns)
variance introduced by outliers: 46% (moderately inflated)

benchmarking functionC
time                 330.3 ns   (328.8 ns .. 331.4 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 330.1 ns   (329.0 ns .. 331.2 ns)
std dev              3.835 ns   (3.152 ns .. 4.892 ns)
variance introduced by outliers: 11% (moderately inflated)

benchmarking functionD
time                 10.32 ns   (10.16 ns .. 10.54 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 10.46 ns   (10.33 ns .. 10.61 ns)
std dev              479.8 ps   (408.3 ps .. 574.9 ps)
variance introduced by outliers: 71% (severely inflated)
```

The strato/CHANGELOG.md should already be updated (see PR https://github.com/blockapps/strato-platform/pull/2989).