### PR TITLE
P2p validator fix

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -30,6 +30,7 @@ so that they could be properly moved to their respective version's subsection.
 - `sendOutEvent` inconsistenly encoding code pointer hash
 - simplified p2p conduit code so that all threads handling a peer live or die together using the `async` library
 - Removed overcomplicated attempts at solving p2p thread issue (watchdogs, canaries, semaphore, threadmap, etc)
+- Fixed bug in BlockApps.X509.Certificate that filled in empty orgUnit fields with a space, rather than the empty string
 
 ### Removed
 - `bloc/v2.2/x509/createCert` is no more

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -28,7 +28,6 @@ so that they could be properly moved to their respective version's subsection.
 ### Fixed
 - `sendOutEvent` inconsistenly encoding code pointer hash
 - simplified p2p conduit code so that all threads handling a peer live or die together using the `async` library
-- Removed overcomplicated attempts at solving p2p thread issue (watchdogs, canaries, semaphore, threadmap, etc)
 - Fixed bug in BlockApps.X509.Certificate that filled in empty orgUnit fields with a space, rather than the empty string
 - Bugfix for slipstream regarding escaping quotes in contract name
 

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -424,6 +424,15 @@ handleEvents peer = awaitForever $ \case
         when (isJust cInfo) $ do
           yieldR $ ChainDetails [(cId, fromJust cInfo)]
     P2pBlockstanbul msg ->
+      peerCert <- lift $ getPeerX509 peer
+      let peerCMPS = getChainMemberFromX509 <$> peer
+      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer IP: " ++ show (pPeerIp peer)
+      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer Pubkey: " ++ pointToString (pPeerPubkey peer)
+      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer Cert: " ++ show peerCert
+      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer Org: " ++ fmap orgName peerCert
+      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer OrgUnit: " ++ fmap (fromMaybe "Nothing" . orgUnit) peerCert
+      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer CommonName: " ++ fmap commonName peerCert
+      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer ChainMemberParsedSet: " ++ show peerCMPS
       lift (fmap getChainMemberFromX509 <$> getPeerX509 peer) >>= \case
         Nothing ->
           $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $
@@ -435,7 +444,7 @@ handleEvents peer = awaitForever $ \case
         Just cm ->
           maybe False unIsValidator <$> lift (select (Proxy @IsValidator) cm) >>= \case
             False ->
-              $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $
+              $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $
                 concat
                   [ "Peer ",
                     show (pPeerIp peer),

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -424,15 +424,6 @@ handleEvents peer = awaitForever $ \case
         when (isJust cInfo) $ do
           yieldR $ ChainDetails [(cId, fromJust cInfo)]
     P2pBlockstanbul msg ->
-      peerCert <- lift $ getPeerX509 peer
-      let peerCMPS = getChainMemberFromX509 <$> peer
-      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer IP: " ++ show (pPeerIp peer)
-      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer Pubkey: " ++ pointToString (pPeerPubkey peer)
-      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer Cert: " ++ show peerCert
-      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer Org: " ++ fmap orgName peerCert
-      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer OrgUnit: " ++ fmap (fromMaybe "Nothing" . orgUnit) peerCert
-      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer CommonName: " ++ fmap commonName peerCert
-      $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $ "Peer ChainMemberParsedSet: " ++ show peerCMPS
       lift (fmap getChainMemberFromX509 <$> getPeerX509 peer) >>= \case
         Nothing ->
           $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -435,7 +435,7 @@ handleEvents peer = awaitForever $ \case
         Just cm ->
           maybe False unIsValidator <$> lift (select (Proxy @IsValidator) cm) >>= \case
             False ->
-              $logInfoS "handleEvents/P2pBlockstanbul" . T.pack $
+              $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $
                 concat
                   [ "Peer ",
                     show (pPeerIp peer),

--- a/strato/libs/x509-certs/src/BlockApps/X509/Certificate.hs
+++ b/strato/libs/x509-certs/src/BlockApps/X509/Certificate.hs
@@ -191,12 +191,12 @@ getAddressFromCM (Everyone _) (X509CertInfoState ua _ _ _ _ _ _) = Just ua
 getAddressFromCM (Org on _) (X509CertInfoState ua _ _ _ onx _ _) =
   if on == T.pack onx then Just ua else Nothing
 getAddressFromCM (OrgUnit on ou _) (X509CertInfoState ua _ _ _ onx oux _) =
-  if on == T.pack onx && ou == T.pack (fromMaybe " " oux) then Just ua else Nothing
+  if on == T.pack onx && ou == T.pack (fromMaybe "" oux) then Just ua else Nothing
 getAddressFromCM (CommonName on ou cmn _) (X509CertInfoState ua _ _ _ onx oux cnmx) =
-  if on == T.pack onx && ou == T.pack (fromMaybe " " oux) && cmn == T.pack cnmx then Just ua else Nothing
+  if on == T.pack onx && ou == T.pack (fromMaybe "" oux) && cmn == T.pack cnmx then Just ua else Nothing
 
 getChainMemberFromX509 :: X509CertInfoState -> ChainMemberParsedSet
-getChainMemberFromX509 (X509CertInfoState _ _ _ _ on ou cname) = (CommonName (T.pack $ on) (T.pack (fromMaybe " " ou)) (T.pack $ cname) True)
+getChainMemberFromX509 (X509CertInfoState _ _ _ _ on ou cname) = (CommonName (T.pack $ on) (T.pack (fromMaybe "" ou)) (T.pack $ cname) True)
 
 getX509FromAddress ::
   A.Selectable Address X509CertInfoState m =>


### PR DESCRIPTION
The new validators don't have orgUnits in their certs, which prevented p2p from recognizing them as validators, since the `getChainMemberFromX509` function in `BlockApps.X509.Certificate` filled in empty orgUnit fields with a space (`" "`) rather than the empty string (`""`)