### PR TITLE
Fixed rich text editor styling in all browsers

### DIFF
--- a/marketplace/ui/src/components/RichEditor/MenuBar.js
+++ b/marketplace/ui/src/components/RichEditor/MenuBar.js
@@ -63,13 +63,19 @@ const MenuBar = ({ editor, addLink }) => {
     label: family,
   }));
 
+  const buttonStyling = (type) => {
+    return `py-[2.5px] px-[5px] m-1 border border-gray rounded cursor-pointer font-arial font-extralight text-sm transition duration-300 ease-in-out hover:bg-tertiary ${editor.isActive(type) ? "bg-primaryB text-white" : "bg-white text-[#616161]"}`
+  }
+
+  const nonActiveButtonStyling = "py-[2.5px] px-[5px] mx-1 border border-gray rounded cursor-pointer font-arial font-extralight bg-white text-[#616161] text-sm transition duration-300 ease-in-out hover:bg-tertiary";
+
   return (
     <>
       {/* Bold */}
       <button
         onClick={() => editor.chain().focus().toggleBold().run()}
         disabled={!editor.can().chain().focus().toggleBold().run()}
-        className={editor.isActive("bold") ? "is-active" : ""}
+        className={buttonStyling("bold")}
       >
         Bold
       </button>
@@ -78,7 +84,7 @@ const MenuBar = ({ editor, addLink }) => {
       <button
         onClick={() => editor.chain().focus().toggleItalic().run()}
         disabled={!editor.can().chain().focus().toggleItalic().run()}
-        className={editor.isActive("italic") ? "is-active" : ""}
+        className={buttonStyling("italic")}
       >
         Italic
       </button>
@@ -86,7 +92,7 @@ const MenuBar = ({ editor, addLink }) => {
       {/* Underline Button */}
       <button
         onClick={() => editor.chain().focus().toggleUnderline().run()}
-        className={editor.isActive("underline") ? "is-active" : ""}
+        className={buttonStyling("underline")}
       >
         Underline
       </button>
@@ -94,7 +100,7 @@ const MenuBar = ({ editor, addLink }) => {
       <button
         onClick={() => editor.chain().focus().toggleStrike().run()}
         disabled={!editor.can().chain().focus().toggleStrike().run()}
-        className={editor.isActive("strike") ? "is-active" : ""}
+        className={buttonStyling("strike")}
       >
         Strike
       </button>
@@ -102,54 +108,58 @@ const MenuBar = ({ editor, addLink }) => {
       {/* Text Alignment */}
       <button
         onClick={() => editor.chain().focus().setTextAlign("left").run()}
-        className={editor.isActive({ textAlign: "left" }) ? "is-active" : ""}
+        className={buttonStyling({ textAlign: "left" })}
       >
         Left
       </button>
       <button
         onClick={() => editor.chain().focus().setTextAlign("center").run()}
-        className={editor.isActive({ textAlign: "center" }) ? "is-active" : ""}
+        className={buttonStyling({ textAlign: "center" })}
       >
         Center
       </button>
       <button
         onClick={() => editor.chain().focus().setTextAlign("right").run()}
-        className={editor.isActive({ textAlign: "right" }) ? "is-active" : ""}
+        className={buttonStyling({ textAlign: "right" })}
       >
         Right
       </button>
 
       <Dropdown
-          className="ant-dropdown-link"
-          menu={{
-            items: fontSizeMenuItems,
-            onClick: ({ key }) => handleFontSizeClick(key),
-          }}
-          trigger={["click"]}
+        menu={{
+          items: fontSizeMenuItems,
+          onClick: ({ key }) => handleFontSizeClick(key),
+        }}
+        trigger={["click"]}
+      >
+        <button
+          onClick={(e) => e.preventDefault()}
+          className={nonActiveButtonStyling}
         >
-          <button onClick={(e) => e.preventDefault()}>
-            {selectedFontSize || "12px"} <DownOutlined />
-          </button>
-        </Dropdown>
+          {selectedFontSize || "12px"} <DownOutlined />
+        </button>
+      </Dropdown>
 
-        <Dropdown
-          className="ant-dropdown-link"
-          menu={{
-            items: fontFamilyMenuItems,
-            onClick: ({ key }) => handleFontFamilyClick(key),
-          }}
-          trigger={["click"]}
+      <Dropdown
+        menu={{
+          items: fontFamilyMenuItems,
+          onClick: ({ key }) => handleFontFamilyClick(key),
+        }}
+        trigger={["click"]}
+      >
+        <button
+          onClick={(e) => e.preventDefault()}
+          className={nonActiveButtonStyling}
         >
-          <button onClick={(e) => e.preventDefault()}>
-            {selectedFontFamily ? selectedFontFamily.split(",")[0] : "Arial"}{" "}
-            <DownOutlined />
-          </button>
-        </Dropdown>
+          {selectedFontFamily ? selectedFontFamily.split(",")[0] : "Arial"}{" "}
+          <DownOutlined />
+        </button>
+      </Dropdown>
 
       {/* Bullet List */}
       <button
         onClick={() => editor.chain().focus().toggleBulletList().run()}
-        className={editor.isActive("bulletList") ? "is-active" : ""}
+        className={buttonStyling("bulletList")}
       >
         Bullet List
       </button>
@@ -157,7 +167,7 @@ const MenuBar = ({ editor, addLink }) => {
       {/* Ordered List */}
       <button
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
-        className={editor.isActive("orderedList") ? "is-active" : ""}
+        className={buttonStyling("orderedList")}
       >
         Ordered List
       </button>
@@ -165,21 +175,32 @@ const MenuBar = ({ editor, addLink }) => {
       {/* Blockquote */}
       <button
         onClick={() => editor.chain().focus().toggleBlockquote().run()}
-        className={editor.isActive("blockquote") ? "is-active" : ""}
+        className={buttonStyling("blockquote")}
       >
         Blockquote
       </button>
 
       {/* Button for inserting links */}
-      <button onClick={addLink}>Insert Link</button>
+      <button
+        onClick={addLink}
+        className={nonActiveButtonStyling}
+      >
+        Insert Link
+      </button>
 
       {/* Horizontal Rule */}
-      <button onClick={() => editor.chain().focus().setHorizontalRule().run()}>
+      <button
+        onClick={() => editor.chain().focus().setHorizontalRule().run()}
+        className={nonActiveButtonStyling}
+      >
         Divider
       </button>
 
       {/* Hard Break */}
-      <button onClick={() => editor.chain().focus().setHardBreak().run()}>
+      <button
+        onClick={() => editor.chain().focus().setHardBreak().run()}
+        className={nonActiveButtonStyling}
+      >
         New Line
       </button>
 
@@ -187,6 +208,7 @@ const MenuBar = ({ editor, addLink }) => {
       <button
         onClick={() => editor.chain().focus().undo().run()}
         disabled={!editor.can().chain().focus().undo().run()}
+        className={nonActiveButtonStyling}
       >
         Undo
       </button>
@@ -195,21 +217,28 @@ const MenuBar = ({ editor, addLink }) => {
       <button
         onClick={() => editor.chain().focus().redo().run()}
         disabled={!editor.can().chain().focus().redo().run()}
+        className={nonActiveButtonStyling}
       >
         Redo
       </button>
       {/* Clear Marks */}
-      <button onClick={() => editor.chain().focus().unsetAllMarks().run()}>
+      <button
+        onClick={() => editor.chain().focus().unsetAllMarks().run()}
+        className={nonActiveButtonStyling}
+      >
         Clear Marks
       </button>
 
       {/* Clear Nodes */}
-      <button onClick={() => editor.chain().focus().clearNodes().run()}>
+      <button
+        onClick={() => editor.chain().focus().clearNodes().run()}
+        className={nonActiveButtonStyling}
+      >
         Clear Formatting
       </button>
 
       {/* Custom color picker */}
-      <button>
+      <button className={nonActiveButtonStyling}>
         <input
           type="color"
           onInput={event => editor.chain().focus().setColor(event.target.value).run()}

--- a/marketplace/ui/src/components/RichEditor/customExtensions.js
+++ b/marketplace/ui/src/components/RichEditor/customExtensions.js
@@ -1,4 +1,50 @@
 import { Extension } from "@tiptap/react";
+import { Node } from '@tiptap/core';
+
+export class BlockquoteNode extends Node {
+  get name() {
+    return 'blockquote';
+  }
+
+  get schema() {
+    return {
+      content: 'block+',
+      defining: true,
+      parseDOM: [{ tag: 'blockquote' }],
+      toDOM: () => ['blockquote', 0],
+    };
+  }
+}
+
+export class UnorderedListNode extends Node {
+  get name() {
+    return 'bulletList';
+  }
+
+  get schema() {
+    return {
+      content: 'listItem+',
+      group: 'block',
+      parseDOM: [{ tag: 'ul' }],
+      toDOM: () => ['ul', 0],
+    };
+  }
+}
+
+export class OrderedListNode extends Node {
+  get name() {
+    return 'orderedList';
+  }
+
+  get schema() {
+    return {
+      content: 'listItem+',
+      group: 'block',
+      parseDOM: [{ tag: 'ol' }],
+      toDOM: () => ['ol', 0],
+    };
+  }
+}
 
 export const FontSize = Extension.create({
     name: "fontSize",

--- a/marketplace/ui/src/components/RichEditor/index.css
+++ b/marketplace/ui/src/components/RichEditor/index.css
@@ -1,18 +1,5 @@
 
 .tiptap {
-    > * + * {
-      margin-top: 0.75em;
-    }
-  
-    ul {
-      padding: 0 1rem;
-      list-style: disc;
-    }
-    ol {
-      padding: 0 1rem;
-      list-style: decimal;
-    }
-
     /* This helps the links appear as they should. They are being overwritten in the editor without this */
     a {
         color: #1677ff !important;
@@ -53,37 +40,12 @@
       height: auto;
     }
   
-    blockquote {
-      padding-left: 1rem;
-      border-left: 2px solid rgba(13, 13, 13, 0.1);
-    }
-  
     hr {
       border: none;
       border-top: 2px solid rgba(13, 13, 13, 0.1);
       margin: 2rem 0;
     }
   
-    button {
-      padding: 2.5px 5px;
-      margin: 0.25rem;
-      background-color: white;
-      color: #616161;
-      border: 1px solid rgba(97, 97, 97, 0.5);
-      border-radius: 4px;
-      cursor: pointer;
-      font-family: 'Arial', sans-serif;
-      font-size: 0.875rem;
-  
-      &:hover {
-        background-color: rgba(97, 97, 97, 0.1);
-      }
-  
-      &.is-active {
-        background-color: #0D0D0D;
-        color: white;
-      }
-    }
   }
   
   .editor-container {

--- a/marketplace/ui/src/components/RichEditor/index.js
+++ b/marketplace/ui/src/components/RichEditor/index.js
@@ -11,7 +11,7 @@ import Underline from "@tiptap/extension-underline";
 import Paragraph from "@tiptap/extension-paragraph";
 import Document from "@tiptap/extension-document";
 import Text from "@tiptap/extension-text";
-import { FontFamily, FontSize } from "./customExtensions.js";
+import { FontFamily, FontSize, BlockquoteNode, UnorderedListNode, OrderedListNode } from "./customExtensions.js";
 
 import "./index.css";
 import {
@@ -43,6 +43,9 @@ const RichEditor = ({ onChange, initialValue }) => {
       Color,
       Underline,
       Paragraph,
+      BlockquoteNode,
+      UnorderedListNode,
+      OrderedListNode,
       Document,
       Text,
     ],
@@ -53,6 +56,54 @@ const RichEditor = ({ onChange, initialValue }) => {
       onChange(htmlContent);
     },
   });
+
+  // allows tiptap blockquote to work properly
+  useEffect(() => {
+    const styleElement = document.createElement('style');
+    styleElement.innerHTML = `
+      .ProseMirror blockquote {
+        padding-left: 1rem;
+        border-left: 2px solid rgba(13, 13, 13, 0.1);
+      }
+    `;
+    document.head.appendChild(styleElement);
+
+    return () => {
+      document.head.removeChild(styleElement);
+    };
+  }, []);
+
+  // allows tiptap bullet list to work properly
+  useEffect(() => {
+    const styleElement = document.createElement('style');
+    styleElement.innerHTML = `
+      .ProseMirror ul {
+        padding: 0 1rem;
+        list-style: disc;
+      }
+    `;
+    document.head.appendChild(styleElement);
+
+    return () => {
+      document.head.removeChild(styleElement);
+    };
+  }, []);
+
+  // allows tiptap ordered list to work properly
+  useEffect(() => {
+    const styleElement = document.createElement('style');
+    styleElement.innerHTML = `
+      .ProseMirror ol {
+        padding: 0 1rem;
+        list-style: decimal;
+      }
+    `;
+    document.head.appendChild(styleElement);
+
+    return () => {
+      document.head.removeChild(styleElement);
+    };
+  }, []);
 
   useEffect(() => {
     if (initialValue && editor) {
@@ -159,7 +210,7 @@ const RichEditor = ({ onChange, initialValue }) => {
       </BubbleMenu>
       <MenuBar editor={editor} addLink={addLink} />
 
-      <EditorContent editor={editor} />
+      <EditorContent className="mt-2" editor={editor} />
     </div>
   );
 };

--- a/marketplace/ui/tailwind.config.js
+++ b/marketplace/ui/tailwind.config.js
@@ -43,6 +43,7 @@ module.exports = {
     fontFamily: {
       sans: ["Montserrat", "sans-serif"],
       serif: ["Montserrat", "serif"],
+      arial: ["Arial", "sans-serif"],
     },
 
     extend: {


### PR DESCRIPTION
Previously, there was an issue with css styling of the rich text editor in certain browsers such as Safari desktop version 16. It seems that some browsers have trouble reading from .css files. The solution is to use in-line css styling using Tailwindcss. 



https://github.com/blockapps/strato-platform/assets/79778488/cca7d805-c77b-4906-9a71-572360ccafe8

