### PR TITLE
fix websocket uptime calculation

### DIFF
--- a/apex/api/controllers/health.js
+++ b/apex/api/controllers/health.js
@@ -107,12 +107,12 @@ module.exports = {
 
   healthStatus: async function (req, res, next) {
     try {
-      let health = null;
+      let health = null, uptime = null;
       const [healthInfo, stallInfo, systemInfo, syncInfo] =
         await getLatestHealth();
 
       if (healthInfo && stallInfo && systemInfo && syncInfo) {
-        ({ health } = utils.consolidateHealthData(
+        ({ health, uptime } = utils.consolidateHealthData(
           healthInfo,
           stallInfo,
           systemInfo,
@@ -129,6 +129,7 @@ module.exports = {
         version: process.env.STRATO_VERSION,
         timestamp: new Date().toISOString(),
         health: health,
+        uptime: uptime,
       });
     } catch (error) {
       console.error(error);

--- a/apex/api/lib/utils.js
+++ b/apex/api/lib/utils.js
@@ -46,7 +46,7 @@ function consolidateHealthData(healthInfo, stallInfo, systemInfo, syncInfo) {
     healthStatus,
     healthIssues,
     uptime: healthStatHealth
-      ? currentTime - healthInfo.lastFailureTimestamp
+      ? (currentTime - healthInfo.lastFailureTimestamp) / 1000
       : 0,
     healthData: {
       healthChecks: {


### PR DESCRIPTION
The uptime was being divided by 1000 twice for SMD. Once in the consolidateHealth utils function and then once again for the websocket push.