### PR TITLE
Assets For Sale, Navigation Fixes

### DIFF
--- a/marketplace/ui/src/components/Inventory/ResellModal.js
+++ b/marketplace/ui/src/components/Inventory/ResellModal.js
@@ -49,7 +49,7 @@ const ResellModal = ({ open, handleCancel, inventory, categoryName, limit, offse
         let isDone = await actions.resellInventory(inventoryDispatch, body);
         if (isDone) {
             await actions.fetchInventory(inventoryDispatch, limit, offset, "", categoryName);
-            await actions.fetchInventoryForUser(inventoryDispatch, limit, offset, user.commonName);
+            await actions.fetchInventoryForUser(inventoryDispatch, user.commonName);
             handleCancel();
         }
     }

--- a/marketplace/ui/src/components/Inventory/TransferModal.js
+++ b/marketplace/ui/src/components/Inventory/TransferModal.js
@@ -114,7 +114,7 @@ const TransferModal = ({ open, handleCancel, inventory, categoryName, limit, off
             let isDone = await actions.transferInventory(inventoryDispatch, body);
             if (isDone) {
                 await actions.fetchInventory(inventoryDispatch, limit, offset, "", categoryName);
-                await actions.fetchInventoryForUser(inventoryDispatch, limit, offset, user.commonName);
+                await actions.fetchInventoryForUser(inventoryDispatch, user.commonName);
                 handleCancel();
             }
         }

--- a/marketplace/ui/src/components/Inventory/UnlistModal.js
+++ b/marketplace/ui/src/components/Inventory/UnlistModal.js
@@ -17,7 +17,7 @@ const UnlistModal = ({ open, handleCancel, inventory, saleAddress, categoryName,
         let isDone = await actions.unlistInventory(inventoryDispatch, body);
         if (isDone) {
             await actions.fetchInventory(inventoryDispatch, limit, offset, "", categoryName);
-            await actions.fetchInventoryForUser(inventoryDispatch, limit, offset, user.commonName);
+            await actions.fetchInventoryForUser(inventoryDispatch, user.commonName);
             handleCancel();
         }
     }

--- a/marketplace/ui/src/components/Inventory/UpdateInventoryModal.js
+++ b/marketplace/ui/src/components/Inventory/UpdateInventoryModal.js
@@ -115,7 +115,7 @@ const UpdateInventoryModal = ({
 
     if (isDone) {
       await actions.fetchInventory(dispatch, limit, offset, debouncedSearchTerm, categoryName);
-      await actions.fetchInventoryForUser(dispatch, limit, offset, user.commonName);
+      await actions.fetchInventoryForUser(dispatch, user.commonName);
 
       handleCancel();
     }

--- a/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
+++ b/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
@@ -170,7 +170,10 @@ const TopSellingProductCard = () => {
             </div>
           ) : 
         <div className="relative md:pl-10">
-          <div onClick={()=>scroll(-300)}  className={`${!prevVisible ? 'hidden' : 'md:flex hidden'} cursor-pointer absolute  justify-center items-center top-48 left-24 h-16 w-16 text-2xl bg-[#6A6A6A] rounded-full text-white`}>{"<"}</div>
+          <div onClick={()=>scroll(-300)} 
+            className={`${!prevVisible ? 'hidden' : 'md:flex hidden'} cursor-pointer absolute z-10 justify-center items-center top-48 left-24 h-16 w-16 text-2xl bg-[#6A6A6A] rounded-full text-white`}>
+            {"<"}
+          </div>
           <div ref={containerRef} className="overflow-x-auto gap-6 px-1 py-2 flex trending_cards">
             {topSellingProducts
               .filter(product => product.saleQuantity > 0)
@@ -183,7 +186,11 @@ const TopSellingProductCard = () => {
                   />)
                 })}
           </div>
-          <div onClick={()=>scroll(300)}  className={`${!nextVisible ? 'hidden' : 'md:flex hidden'} cursor-pointer absolute justify-center items-center top-48 right-24 h-16 w-16 text-2xl bg-[#6A6A6A] rounded-full text-white`}>{">"}</div>
+          <div onClick={()=>scroll(300)} 
+            className={`${!nextVisible ? 'hidden' : 'md:flex hidden'} cursor-pointer absolute z-10 justify-center items-center top-48 right-24 h-16 w-16 text-2xl bg-[#6A6A6A] rounded-full text-white`}>
+            {">"}
+          </div>
+
         </div>}
     </div>
   );

--- a/marketplace/ui/src/components/UserProfile/index.js
+++ b/marketplace/ui/src/components/UserProfile/index.js
@@ -161,7 +161,7 @@ const UserProfile = ({user}) => {
     // Inventories For Sale fetch
     useEffect(() => {
       if(commonName){
-          inventoryActions.fetchInventoryForUser(dispatch, 10, 0, commonName);
+          inventoryActions.fetchInventoryForUser(dispatch, commonName);
         }
       }, [dispatch, hasChecked, isAuthenticated, loginUrl, commonName]);
   

--- a/marketplace/ui/src/contexts/inventory/actions.js
+++ b/marketplace/ui/src/contexts/inventory/actions.js
@@ -224,7 +224,7 @@ const actions = {
 
     try {
       const response = await fetch(
-        `${apiUrl}/inventory/user/inventories?gtField=quantity&gtValue=0&limit=${limit}&offset=${offset}${query}&isMint=true`,
+        `${apiUrl}/inventory/user/inventories?gtField=quantity&gtValue=0${query}&isMint=true`,
         {
           method: HTTP_METHODS.GET,
         }

--- a/marketplace/ui/src/contexts/inventory/actions.js
+++ b/marketplace/ui/src/contexts/inventory/actions.js
@@ -217,7 +217,7 @@ const actions = {
     }
   },
 
-  fetchInventoryForUser: async (dispatch, limit, offset, queryValue) => {
+  fetchInventoryForUser: async (dispatch, queryValue) => {
     const query = queryValue ? `&ownerCommonName=${encodeURIComponent(queryValue)}` : ``;
 
     dispatch({ type: actionDescriptors.fetchInventoryForUser });


### PR DESCRIPTION
This PR addresses the inconsistencies seen in the number of assets for sale fetched for a given profile along with a fix for home page navigation icon styling.

- The filter of `limit` and `offset` has been removed which blocked a few assets from being fetched
- Set the `z-index` for the navigation icon so that it appears on top of the cards when its active

#### The testing can be done on the prod node: https://marketplace-9979732.mercata.blockapps.net/marketplace/

### Notice the difference between number of assets for sale for a given profile:
- https://marketplace-9979732.mercata.blockapps.net/marketplace/profile/blockapps_collectible, https://marketplace.mercata.blockapps.net/marketplace/profile/blockapps_collectibles
- https://marketplace-9979732.mercata.blockapps.net/marketplace/profile/blockapps_clothing, https://marketplace.mercata.blockapps.net/marketplace/profile/blockapps_clothing

### Also validate:
#### Before:
<img width="1440" alt="Screenshot 2024-03-21 at 9 23 05 AM" src="https://github.com/blockapps/strato-platform/assets/35606645/7b339435-9717-415d-9713-7b8b0b0ef653">


#### After:
<img width="1440" alt="Screenshot 2024-03-21 at 9 22 42 AM" src="https://github.com/blockapps/strato-platform/assets/35606645/e52bb7e1-f232-4f78-beff-9b1e60bc74d2">
