### PR TITLE
20240322 hotfixes

### DIFF
--- a/marketplace/backend/api/middleware/authHandler.js
+++ b/marketplace/backend/api/middleware/authHandler.js
@@ -64,11 +64,8 @@ class AuthHandler {
           try {
             address = await rest.createOrGetKey({ username: decodedToken.preferred_username, token }, { config })
           } catch (e) {
-            // user isn't created in STRATO
-            if (e.response && e.response.status === RestStatus.BAD_REQUEST) {
-              console.log('User not created in STRATO!')
-              return next(e)
-            }
+            console.error('STRATO API is unreachable or unhealthy. Error: ', e)
+            return rest.response.status(RestStatus.INTERNAL_SERVER_ERROR, res, "Internal Server Error 101")
           }
           req.address = address
           req.accessToken = { token }
@@ -78,7 +75,6 @@ class AuthHandler {
           return next()
         }
       } catch (err) {
-        rest.response.status(RestStatus.INTERNAL_SERVER_ERROR, res, "Internal Server Error")
         return next(err)
       }
       

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -402,12 +402,11 @@ http {
         proxy_pass http://__MARKETPLACE_UI_HOST__/;
       }
 
+      # Redirecting with access_by_lua_block to make sure the rewrite_by_lua_file is executed for proper OpenID authentication handling (see https://openresty-reference.readthedocs.io/en/latest/Directives/)
       location /marketplace/login {
         set $is_ui "true";
         rewrite_by_lua_file  lua/openid.lua;
-        proxy_set_header Accept-Encoding "";
-        proxy_read_timeout 300;
-        proxy_pass http://__STRATO_HOSTNAME__:__STRATO_PORT_API__/eth/v1.2/identity;
+        access_by_lua_block {return ngx.redirect('/marketplace/', 302)}
       }
 
       # TODO: prefix api path with marketplace (requires marketplace app changes)

--- a/prometheus-packager/Dockerfile
+++ b/prometheus-packager/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/prometheus:latest
+FROM prom/prometheus:v2.49.1
 
 COPY strato_prometheus.yml /etc/prometheus/strato_prometheus.yml
 


### PR DESCRIPTION
1. Bad Gateway error that Kieren and others started getting on Login when the strato container is down (the login was changed for some reason to call strato api but it was completely unnecessary).

2. Wrong email appearing in the UI (Vijay's)- the authHandler in marketplace backend was not handling the exception correctly when the call to strato api to get user's key was failed, and used the admin token in the authorized mode (which should only be used in unathorized mode) - changing the error handling prevented this. The reason it was the Vijay's email is that the x509 cert issued for the node's client credentials has Vijay's name on it in the Testnet2.

3. Issue with Monitor not showing the nodes' health correctly - was in fact the problem with latest Prometheus version not executing the checks for some reason. Had to peg to one of the versions that previously worked 100% (in 11.0 release) (THIS FIX IS YET TO BE FULLY TESTED)