### PR TITLE
Check for error before modifying vm state

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -34,6 +34,7 @@ so that they could be properly moved to their respective version's subsection.
 - Fixed bug in BlockApps.X509.Certificate that filled in empty orgUnit fields with a space, rather than the empty string
 - Fixed bug in Sequencer.hs that prevented nodes from syncing all the way after changes to the validator pool
 - Fixed bug in RedisBlockDB that filled in empty orgUnit fields with the word "Nothing", rather than the empty string
+- Minimal changes to statetree before all tx checks complete to prevent potential stateroot mismatches between when the bagger adds txs vs when the vm does
 
 ### Removed
 - Removed unnecessary stateDiff (and threading) in the vm-runner codebase, fixing numerous sources of persistent memory build-up.

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -368,7 +368,6 @@ addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx {otSigner 
   when (transactionGasLimit bt > min remainingBlockGas maxGas) $ throwE $ TFBlockGasLimitExceeded (transactionGasLimit bt) remainingBlockGas t
   unless nonceValid $ throwE $ TFNonceMismatch (transactionNonce bt) acctNonce t
   when (acctNonce >= flags_accountNonceLimit) $ throwE $ TFNonceLimitExceeded flags_accountNonceLimit acctNonce t
-  when (otHash t `S.member` knownFailedTxs) . throwE $ TFKnownFailedTX t
   let txSize = toInteger $ B.length $ BL.toStrict $ Bin.encode $ otBaseTx t
   when (txSize >= flags_txSizeLimit)
     . throwE
@@ -382,6 +381,8 @@ addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx {otSigner 
   lift $ incrementNonce tAcct
 
   success <- lift $ addToBalance tAcct (-transactionGasLimit bt * transactionGasPrice bt)
+  
+  when (otHash t `S.member` knownFailedTxs) . throwE $ TFKnownFailedTX t
 
   when flags_debug $ $logDebugS "addTx" "running code"
   let txTypeCounter = if isContractCreationTX bt then vmTxsCreation else vmTxsCall

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -357,34 +357,31 @@ addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx {otSigner 
       realIG = fromIntegral intrinsicGas'
       maxGas = fromIntegral (maxBound :: Int)
 
-  unless flags_gasOn $ do
-    $logInfoS "addTx" . T.pack $ "gas is off, so I'm giving the account enough balance for this TX"
-    faucetSuccess <- lift $ addToBalance tAcct txCost
-    unless faucetSuccess $ error "failed to give balance to a gasOff account"
-
   (acctBalance, acctNonce) <-
     lift $
       (addressStateBalance &&& addressStateNonce)
         <$> A.lookupWithDefault (Proxy @AddressState) tAcct
 
   when (chainId /= txChainId bt) $ throwE $ TFChainIdMismatch chainId (txChainId bt) t
-  when (txCost > acctBalance) $ throwE $ TFInsufficientFunds txCost acctBalance t
+  when (flags_gasOn && txCost > acctBalance) $ throwE $ TFInsufficientFunds txCost acctBalance t
   when (realIG > transactionGasLimit bt) $ throwE $ TFIntrinsicGasExceedsTxLimit realIG (transactionGasLimit bt) t
   when (transactionGasLimit bt > min remainingBlockGas maxGas) $ throwE $ TFBlockGasLimitExceeded (transactionGasLimit bt) remainingBlockGas t
   unless nonceValid $ throwE $ TFNonceMismatch (transactionNonce bt) acctNonce t
   when (acctNonce >= flags_accountNonceLimit) $ throwE $ TFNonceLimitExceeded flags_accountNonceLimit acctNonce t
+  when (otHash t `S.member` knownFailedTxs) . throwE $ TFKnownFailedTX t
   let txSize = toInteger $ B.length $ BL.toStrict $ Bin.encode $ otBaseTx t
   when (txSize >= flags_txSizeLimit)
     . throwE
     $ TFTXSizeLimitExceeded txSize flags_txSizeLimit t
 
-  let availableGas = transactionGasLimit bt - fromIntegral intrinsicGas'
+  unless flags_gasOn $ do
+    $logInfoS "addTx" . T.pack $ "gas is off, so I'm giving the account enough balance for this TX"
+    faucetSuccess <- lift $ addToBalance tAcct txCost
+    unless faucetSuccess $ error "failed to give balance to a gasOff account"
 
   lift $ incrementNonce tAcct
 
   success <- lift $ addToBalance tAcct (-transactionGasLimit bt * transactionGasPrice bt)
-
-  when (otHash t `S.member` knownFailedTxs) . throwE $ TFKnownFailedTX t
 
   when flags_debug $ $logDebugS "addTx" "running code"
   let txTypeCounter = if isContractCreationTX bt then vmTxsCreation else vmTxsCall
@@ -418,6 +415,7 @@ addTransaction chainId isRunningTests' b remainingBlockGas t@OutputTx {otSigner 
         lift $
           addressStateBalance
             <$> A.lookupWithDefault (Proxy @AddressState) tAcct
+      let availableGas = transactionGasLimit bt - fromIntegral intrinsicGas'
       $logInfoS "addTransaction/success=false" . T.pack $ "Insufficient funds to run the VM: need " ++ show (availableGas * transactionGasPrice bt) ++ ", have " ++ show balance
       return $
         evmErrorResults (transactionGasLimit bt) Blockchain.VM.VMException.InsufficientFunds

--- a/strato/simulator/strato-lite/tests/Main.hs
+++ b/strato/simulator/strato-lite/tests/Main.hs
@@ -17,5 +17,5 @@ predicate _ = False
 
 main :: IO ()
 main = do
-  void $ $initHFlagsDependentDefaults "debugger spec" (const $ const $ const $ [("requireCerts", "False"), ("minLogLevel", "LevelDebug")])
+  void $ $initHFlagsDependentDefaults "debugger spec" (const $ const $ const $ [("requireCerts", "False"), ("minLogLevel", "LevelDebug"), ("accountNonceLimit", "10"), ("gasOn", "False")])
   hspecWith (configAddFilter predicate defaultConfig) Spec.spec

--- a/strato/simulator/strato-lite/tests/SimulatorSpec.hs
+++ b/strato/simulator/strato-lite/tests/SimulatorSpec.hs
@@ -27,6 +27,7 @@ import Blockchain.Data.AddressStateDB
 import qualified Blockchain.Data.AlternateTransaction as U
 import Blockchain.Data.ArbitraryInstances ()
 import Blockchain.Data.Block hiding (bestBlockNumber)
+import qualified Blockchain.Data.Block as Block (bestBlockNumber)
 import Blockchain.Data.BlockDB ()
 import Blockchain.Data.ChainInfo
 import qualified Blockchain.Data.TXOrigin as Origin
@@ -60,6 +61,7 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Text.Encoding
+import Data.Traversable (for)
 import SolidVM.Model.Storable
 import Strato.Lite
 import Test.Hspec
@@ -867,7 +869,34 @@ spec = do
         void . timeout (3 * 1000 * 1000) $ runConnection connection
         clientExcept <- readTVarIO $ connection ^. clientException
         clientExcept `shouldBe` Just (toException $ HandshakeException "handshake timed out")
+    it "will not get a stateroot mismatch if an exception occurs in the bagger" $ do
+        privKey <- newPrivateKey
+        let validatorAddress = fromPrivateKey privKey
+            validatorInfo = CommonName "BlockApps" "Engineering" "Admin" True
+        cert <- selfSignCert privKey validatorInfo 
+        validator <- createPeer' privKey validatorInfo [(validatorAddress, validatorInfo)] [cert] "node1" "1.1.1.1"
+        ts <- liftIO getCurrentMicrotime
+        let toIetx = IETx ts . IngestTx Origin.API
+            args = "(\"123\")" --dummy address
+            txMd = M.fromList [("funcName", "getUserCert"), ("args", args)]
+            tx n =
+              U.UnsignedTransaction
+                { U.unsignedTransactionNonce = Nonce n,
+                  U.unsignedTransactionGasPrice = Wei 1,
+                  U.unsignedTransactionGasLimit = Gas 1000000000,
+                  U.unsignedTransactionTo = Just $ Address 0x509,
+                  U.unsignedTransactionValue = Wei 0,
+                  U.unsignedTransactionInitOrData = Code "",
+                  U.unsignedTransactionChainId = Nothing
+                }
+            signedTx n = mkSignedTx privKey (tx n) txMd
 
+            reachNonceLim = do
+              for [0..10] (\n -> flip postEvent validator . UnseqEvent . toIetx $ signedTx n) --nonce limit is 10; will trigger
+
+        void . timeout 10000000 $ concurrently_ (runNode validator) reachNonceLim
+        ctx <- atomically $ readTVar . _p2pTestContext $ validator
+        Block.bestBlockNumber (_bestBlock ctx) `shouldNotBe` 0 --create at least 1 block
   describe "X.509 Private Chain exchange" $ do
     it "can add an organization to a private chain" $ do
         privKeys <- traverse (const newPrivateKey) [(1 :: Integer) .. 3]


### PR DESCRIPTION
This PR modifies the order of operations so that most checks occur before any modifications to state (the only exception is checking for `KnownFailedTx` must occur after the nonce is incremented, for backwards compatibility). I also added a strato-lite test to simulate what happens when you send a batch with more transactions than your nonce limit allows to ensure there is no stateroot mismatch. With this change merged in, it will be safe for devs to use the /parallel transaction endpoint

Note: I was hoping to also remove the `gasOn` flag, but that led to many other changes that are quite large, so I will be creating a separate PR for those changes.