### PR TITLE
Allow calls to identity server from /login endpoint

### DIFF
--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -402,11 +402,12 @@ http {
         proxy_pass http://__MARKETPLACE_UI_HOST__/;
       }
 
-      # Redirecting with access_by_lua_block to make sure the rewrite_by_lua_file is executed for proper OpenID authentication handling (see https://openresty-reference.readthedocs.io/en/latest/Directives/)
       location /marketplace/login {
         set $is_ui "true";
         rewrite_by_lua_file  lua/openid.lua;
-        access_by_lua_block {return ngx.redirect('/marketplace/', 302)}
+        proxy_set_header Accept-Encoding "";
+        proxy_read_timeout 300;
+        proxy_pass http://__STRATO_HOSTNAME__:__STRATO_PORT_API__/eth/v1.2/identity;
       }
 
       # TODO: prefix api path with marketplace (requires marketplace app changes)


### PR DESCRIPTION
The reverted commit accidentally prevented new users from getting certs registered for them. Until a permanent fix is in, it's best to just revert this