### PR TITLE
limit the number of slipstream sync test attempts

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -401,7 +401,7 @@ pipeline {
                                 ]) {
                         // Now CLIENT_ID1, CLIENT_SECRET1, and CLIENT_SECRET2 are available as environment variables
                         sh "pip3 install -r requirements.txt"
-                        sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2' 2 30"
+                        sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2' 5 30"
                       }
                     } 
                 

--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -401,7 +401,7 @@ pipeline {
                                 ]) {
                         // Now CLIENT_ID1, CLIENT_SECRET1, and CLIENT_SECRET2 are available as environment variables
                         sh "pip3 install -r requirements.txt"
-                        sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2'"
+                        sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2' '2' '30'"
                       }
                     } 
                 

--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -401,7 +401,7 @@ pipeline {
                                 ]) {
                         // Now CLIENT_ID1, CLIENT_SECRET1, and CLIENT_SECRET2 are available as environment variables
                         sh "pip3 install -r requirements.txt"
-                        sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2' '2' '30'"
+                        sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2' 2 30"
                       }
                     } 
                 

--- a/strato/indexer/slipstream/integrity_tests/slipstream_sync.py
+++ b/strato/indexer/slipstream/integrity_tests/slipstream_sync.py
@@ -5,12 +5,13 @@ import base64
 import time
 import sys
 
-def wait_for_nodes_to_sync(node1_url, node2_url, headers1, headers2):
+def wait_for_slipstream_to_sync(node1_url, node2_url, headers1, headers2, attempts, sleep_time):
+    attempt = 0
     while True:
+        attempt += 1
         try:
             response1 = requests.get(node1_url + "/cirrus/search/BlockApps-Mercata-Asset", headers=headers1, params={'order':'block_timestamp.desc', 'limit':1})
             response2 = requests.get(node2_url + "/cirrus/search/BlockApps-Mercata-Asset", headers=headers2, params={'order':'block_timestamp.desc', 'limit':1})
-
             if response1.ok and response2.ok:
                 block_number1 = response1.json()[0]["block_number"]
                 block_number2 = response2.json()[0]["block_number"]
@@ -18,13 +19,18 @@ def wait_for_nodes_to_sync(node1_url, node2_url, headers1, headers2):
                     print(f"Nodes are in sync with block number: {block_number1}")
                     break
                 else:
-                    print(f"jenkins is at block {block_number1}, but Node1 is at block {block_number2}. Retrying in 30 seconds...")
+                    print(f"Slipstream of node1 is at block {block_number1}, but Node2 is at block {block_number2} (attempt #{attempt})")
             else:
-                print(f"Failed to fetch data for one of the nodes. Retrying in 30 seconds...")
+                print(f"Failed to fetch data for one of the nodes (attempt #{attempt})")
         except Exception as e:
-            print(f"Exception occurred: {e}")
-
-        time.sleep(30)
+            print(f"Slipstream sync test exception occurred: {e}")
+            sys.exit(1)
+        if attempts != 0 and attempt == attempts:
+            print(f"Failed to find the slipstream being in sync for the nodes. Made {attempts} attempts with sleep time {sleep_time}sec")
+            sys.exit(1) 
+        else:
+          print(f"Retrying in {sleep_time} seconds...")
+          time.sleep(sleep_time)
 
 def get_auth_token(client_id, client_secret, realm_name):
     basic_token = base64.b64encode(bytes('%s:%s' % (client_id, client_secret), 'utf-8')).decode('utf-8')
@@ -87,9 +93,12 @@ def check_table(table):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 7:
-        print('Incorrect number of arguments supplied. Expected 4 arguments.')
+    if len(sys.argv) < 7 or len(sys.argv) > 9:
+        print('Incorrect number of arguments supplied. Expected 6-8 arguments.')
         sys.exit(1)
+
+    DEFAULT_ATTEMPTS = 0  # 0 for infinite
+    DEFAULT_SLEEP_TIME = 30
 
     client_id1 = sys.argv[1]
     client_id2 = sys.argv[2]
@@ -97,6 +106,8 @@ if __name__ == "__main__":
     client_secret2 = sys.argv[4]
     realm_1 = sys.argv[5]
     realm_2 = sys.argv[6]
+    attempts = sys.argv[7] if len(sys.argv) > 7 else DEFAULT_ATTEMPTS
+    sleep_time = sys.argv[8] if len(sys.argv) > 8 else DEFAULT_SLEEP_TIME
 
     node1_url = "http://localhost"
     node2_url = "https://node1.mercata-testnet2.blockapps.net"
@@ -106,8 +117,8 @@ if __name__ == "__main__":
     headers1 = {'Authorization': f'Bearer {token1}'}
     headers2 = {'Authorization': f'Bearer {token2}'}
 
-    # Wait until both nodes have the same latest block number
-    wait_for_nodes_to_sync(node1_url, node2_url, headers1, headers2)
+    # Wait until both nodes have the same latest block indexed in Slipstream
+    wait_for_slipstream_to_sync(node1_url, node2_url, headers1, headers2, attempts, sleep_time)
 
     discrepancies_asset, count_asset_discrepancy = check_table("BlockApps-Mercata-Asset")
     discrepancies_sale, count_sale_discrepancy = check_table("BlockApps-Mercata-Order")

--- a/strato/indexer/slipstream/integrity_tests/slipstream_sync.py
+++ b/strato/indexer/slipstream/integrity_tests/slipstream_sync.py
@@ -6,31 +6,40 @@ import time
 import sys
 
 def wait_for_slipstream_to_sync(node1_url, node2_url, headers1, headers2, attempts, sleep_time):
+    attempts = int(attempts)
+    sleep_time = int(sleep_time)
     attempt = 0
     while True:
         attempt += 1
         try:
             response1 = requests.get(node1_url + "/cirrus/search/BlockApps-Mercata-Asset", headers=headers1, params={'order':'block_timestamp.desc', 'limit':1})
             response2 = requests.get(node2_url + "/cirrus/search/BlockApps-Mercata-Asset", headers=headers2, params={'order':'block_timestamp.desc', 'limit':1})
-            if response1.ok and response2.ok:
-                block_number1 = response1.json()[0]["block_number"]
-                block_number2 = response2.json()[0]["block_number"]
-                if block_number1 == block_number2:
-                    print(f"Nodes are in sync with block number: {block_number1}")
-                    break
+            if response1.ok and response2.ok and response1:
+                response1_json = response1.json()
+                response2_json = response2.json()
+                if len(response1_json) < 1:
+                    print(f"Cirrus response from Node1 is empty: `{response1_json}` (attempt #{attempt} of {attempts})")
+                elif len(response2_json) < 1:
+                    print(f"Cirrus response from Node2 is empty: `{response2_json}` (attempt #{attempt} of {attempts})")
                 else:
-                    print(f"Slipstream of node1 is at block {block_number1}, but Node2 is at block {block_number2} (attempt #{attempt})")
+                    block_number1 = response1.json()[0]["block_number"]
+                    block_number2 = response2.json()[0]["block_number"]
+                    if block_number1 == block_number2:
+                        print(f"Nodes are in sync with block number: {block_number1}")
+                        break
+                    else:
+                        print(f"Slipstream of node1 is at block {block_number1}, but Node2 is at block {block_number2} (attempt #{attempt} of {attempts})")
             else:
-                print(f"Failed to fetch data for one of the nodes (attempt #{attempt})")
+                print(f"Failed to fetch data for one of the nodes (attempt #{attempt} of {attempts})")
         except Exception as e:
             print(f"Slipstream sync test exception occurred: {e}")
             sys.exit(1)
         if attempts != 0 and attempt == attempts:
-            print(f"Failed to find the slipstream being in sync for the nodes. Made {attempts} attempts with sleep time {sleep_time}sec")
-            sys.exit(1) 
+            print(f"Failed to find the cirrus data to be in sync for the nodes. Made {attempts} attempts with sleep time {sleep_time} seconds.")
+            sys.exit(1)
         else:
-          print(f"Retrying in {sleep_time} seconds...")
-          time.sleep(sleep_time)
+            print(f"Retrying in {sleep_time} seconds...")
+            time.sleep(sleep_time)
 
 def get_auth_token(client_id, client_secret, realm_name):
     basic_token = base64.b64encode(bytes('%s:%s' % (client_id, client_secret), 'utf-8')).decode('utf-8')
@@ -123,8 +132,8 @@ if __name__ == "__main__":
     discrepancies_asset, count_asset_discrepancy = check_table("BlockApps-Mercata-Asset")
     discrepancies_sale, count_sale_discrepancy = check_table("BlockApps-Mercata-Order")
     discrepancies_order, count_order_discrepancy = check_table("BlockApps-Mercata-Sale")
-    
-        # Print the results
+
+    # Print the results
     print("\nFinal check summary:")
     print(f"Asset Discrepancies: {'Yes' if discrepancies_asset else 'No'}")
     print(f"Order Discrepancies: {'Yes' if discrepancies_order else 'No'}")
@@ -132,6 +141,6 @@ if __name__ == "__main__":
     print(f"Asset Count Match Discrepancies: {'Yes' if count_asset_discrepancy else 'No'}")
     print(f"Order Count Match Discrepancies: {'Yes' if count_order_discrepancy else 'No'}")
     print(f"Sale Count Match Discrepancies: {'Yes' if  count_sale_discrepancy else 'No'}")
-        
+
     if discrepancies_asset or discrepancies_sale or discrepancies_order or count_asset_discrepancy or count_sale_discrepancy or count_order_discrepancy:
         sys.exit(1)


### PR DESCRIPTION
This limits the number of slipstream sync test attempts to break the infinite loop.
Because we run the slipstream test **after** we confirm the node is in sync, we only allow 2 attempts to slipstream test with one 30sec sleep which should be enough.