### PR TITLE
Create contracts by passing a code pointer

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -17,30 +17,13 @@ so that they could be properly moved to their respective version's subsection.
 ## [Unreleased] 
 
 ### Added
-- functionality to enumerate threads and their details in `/threads` endpoint of `P2PAPI`
-- `/peers` endpoint in `P2PAPI` to list peer connections and their health
-- POST `/transaction` contract creation calls will now additionally check for address state ref table entry before resolving
-- Jenkins test to ensure slipstream post sync is consistent with boot node
 - POST `/transaction` allows users to create contracts by providing an address through the `codePtr` field
 
 ### Changed
-- Optimized the byteString2Integer function that lies at the foundation of strato's RLP-related functionality (rlpDecode).
-- Optimized the integer2Bytes function that lies at the foundation of strato's RLP-related functionality (rlpEncode)
-- "DAO Fork" for mercata-hydrogen because buggy block got added to canonical blockchain
 
 ### Fixed
-- `sendOutEvent` inconsistenly encoding code pointer hash
-- simplified p2p conduit code so that all threads handling a peer live or die together using the `async` library
-- Bugfix for slipstream regarding escaping quotes in contract name
-- Fixed bug in BlockApps.X509.Certificate that filled in empty orgUnit fields with a space, rather than the empty string
-- Fixed bug in Sequencer.hs that prevented nodes from syncing all the way after changes to the validator pool
-- Fixed bug in RedisBlockDB that filled in empty orgUnit fields with the word "Nothing", rather than the empty string
-- Minimal changes to statetree before all tx checks complete to prevent potential stateroot mismatches between when the bagger adds txs vs when the vm does
 
 ### Removed
-- Removed unnecessary stateDiff (and threading) in the vm-runner codebase, fixing numerous sources of persistent memory build-up.
-- Removed overcomplicated attempts at solving p2p thread issue (watchdogs, canaries, semaphore, threadmap, etc)
-- `bloc/v2.2/x509/createCert` is no more
 
 
 ## [11.1.0] - 3/7/2023
@@ -51,19 +34,36 @@ so that they could be properly moved to their respective version's subsection.
 - `VM_DEBUGGER=bool` flag added for connecting to the VM debugger + static analysis websocket
 - Derive service provider URLs from node's network ID for testnet and production nodes
 - Update foreign keys for `BlockApps-Mercata-Asset` + `Sale` contracts whenever there is a table expansion
+- functionality to enumerate threads and their details in `/threads` endpoint of `P2PAPI`
+- `/peers` endpoint in `P2PAPI` to list peer connections and their health
+- POST `/transaction` contract creation calls will now additionally check for address state ref table entry before resolving
+- Jenkins test to ensure slipstream post sync is consistent with boot node
 
 ### Changed 
 - When a transaction fails, the `<failed>` message blinks :^)
 - `keccak256` built-in function should return hex-encoded value instead of bytestring
+- Optimized the byteString2Integer function that lies at the foundation of strato's RLP-related functionality (rlpDecode).
+- Optimized the integer2Bytes function that lies at the foundation of strato's RLP-related functionality (rlpEncode)
+- "DAO Fork" for mercata-hydrogen because buggy block got added to canonical blockchain
 
 ### Fixed
 - Mappings within a struct within a `(type => Struct)` mapping can be accessed
 - Constructor arguments are passed by value instead of reference 
 - Escaped quotes for slipstream values
 - Properly escape `"` and `\` string arguments in `strato-api`
+- `sendOutEvent` inconsistenly encoding code pointer hash
+- simplified p2p conduit code so that all threads handling a peer live or die together using the `async` library
+- Bugfix for slipstream regarding escaping quotes in contract name
+- Fixed bug in BlockApps.X509.Certificate that filled in empty orgUnit fields with a space, rather than the empty string
+- Fixed bug in Sequencer.hs that prevented nodes from syncing all the way after changes to the validator pool
+- Fixed bug in RedisBlockDB that filled in empty orgUnit fields with the word "Nothing", rather than the empty string
+- Minimal changes to statetree before all tx checks complete to prevent potential stateroot mismatches between when the bagger adds txs vs when the vm does
 
 ### Removed
 - Removed slipstream's dependency on `eth` database for code collection data
+- Removed unnecessary stateDiff (and threading) in the vm-runner codebase, fixing numerous sources of persistent memory build-up.
+- Removed overcomplicated attempts at solving p2p thread issue (watchdogs, canaries, semaphore, threadmap, etc)
+- `bloc/v2.2/x509/createCert` is no more
 
 ## [11.0.0] - 1/22/2024
 

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -26,7 +26,7 @@ so that they could be properly moved to their respective version's subsection.
 ### Removed
 
 
-## [11.1.0] - 3/7/2023
+## [11.1.0] - 3/28/2023
 
 ### Added
 - Custom `Show` instances for `CodeCollection`, `Function`, `Contract` data types

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -21,6 +21,7 @@ so that they could be properly moved to their respective version's subsection.
 - `/peers` endpoint in `P2PAPI` to list peer connections and their health
 - POST `/transaction` contract creation calls will now additionally check for address state ref table entry before resolving
 - Jenkins test to ensure slipstream post sync is consistent with boot node
+- POST `/transaction` allows users to create contracts by providing an address through the `codePtr` field
 
 ### Changed
 - Optimized the byteString2Integer function that lies at the foundation of strato's RLP-related functionality (rlpDecode).

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Contracts.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Contracts.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Bloc.Server.Contracts where
@@ -420,3 +421,21 @@ completeXabi :: Text -> Xabi -> Either String Xabi
 completeXabi name xabi = do
   c <- xAbiToContract xabi
   return $ contractToXabi name c
+
+getSourceMapFromAddress :: 
+  ( MonadIO m,
+    (Keccak256 `A.Selectable` SourceMap) m, 
+    (Account `A.Selectable` AddressState) m
+  ) => Address -> m SourceMap
+getSourceMapFromAddress cptr = do
+  addressState <- A.select (A.Proxy @AddressState) (Account cptr Nothing)
+  mCodeHash <- case addressState of
+    Nothing -> throwIO $ UserError "Could not find code hash for contract"
+    Just as -> return $ addressStateCodeHash as
+  keccak <- case mCodeHash of
+    SolidVMCode _ k -> pure k
+    _ -> throwIO $ UserError "Could not find code hash for contract"
+  sourcy <- A.select (A.Proxy @SourceMap) keccak
+  case sourcy of
+    Nothing -> throwIO $ UserError "Could not find source map for contract"
+    Just sm -> pure sm

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -32,6 +32,7 @@ import Bloc.API.Utils
 import Bloc.Database.Queries (getContractDetailsForContract)
 import Bloc.Monad
 import Bloc.Server.Chain
+import Bloc.Server.Contracts (getSourceMapFromAddress)
 import Bloc.Server.TransactionResult hiding (constructArgValuesAndSource)
 import Bloc.Server.Utils
 import BlockApps.Logging
@@ -293,7 +294,7 @@ postBlocTransactionBody (Just jwt) cid (PostBlocTransactionRequest mAddr txList 
           getSrc p = fromMaybe mempty $ src' p <|> srcMap p
           mapUploadList =
             map
-              ( \p@(ContractPayload _ c a v x cid' m) -> do
+              ( \p@(ContractPayload _ c a v x cid' _ m) -> do
                   let cn = fromMaybe "unnamed_contract" c
                   UploadListContract
                     (fromJust c)
@@ -438,7 +439,7 @@ postBlocTransactionUnsigned (Just jwt) cid (PostBlocTransactionRequest mAddr txL
               else Just $ contractpayloadSrc p
           getSrc p = fromMaybe mempty $ src' p <|> srcMap p
           upload =
-            ( \p@(ContractPayload _ c a v x cid' m) -> do
+            ( \p@(ContractPayload _ c a v x cid' _ m) -> do
                 let cn = fromMaybe "unnamed_contract" c
                 UploadListContract
                   (fromJust c)
@@ -709,10 +710,13 @@ postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTr
                         resolve
                 fmap ((:[]) . BlocTxResult) $ postUsersContractMethod' cacheNonce bcp jwtToken
               False -> do
+                src'' <- case contractpayloadCodePtr p of 
+                  Nothing -> return $ getSrc p
+                  Just p' -> getSourceMapFromAddress p'
                 let bcp =
                       ContractParameters
                         addr
-                        (getSrc p)
+                        src''
                         (contractpayloadContract p)
                         (contractpayloadArgs p)
                         (contractpayloadValue p)
@@ -731,7 +735,7 @@ postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTr
             ps <- mapM fromContract xs
             case useWallet of
               True -> do
-                methodList <- mapM (\p@(ContractPayload _ c a v x cid m) -> do
+                methodList <- mapM (\p@(ContractPayload _ c a v x cid _ m) -> do
                                   let contractSrc = getSrc p
                                       contractSrcText = sourceBlob $ contractSrc
                                       srcLength = Text.length contractSrcText
@@ -762,26 +766,31 @@ postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTr
                         resolve
                 fmap BlocTxResult <$> postUsersContractMethodList' cacheNonce bcp jwtToken
               False -> do
+                payloadList <-
+                  mapM
+                      ( \p@(ContractPayload _ c a v x cid _ m) -> do
+                          let cn = fromMaybe "unnamed_contract" c
+                          src'' <- case contractpayloadCodePtr p of 
+                            Nothing -> return $ getSrc p
+                            Just p' -> getSourceMapFromAddress p'
+                          return $
+                            UploadListContract
+                              (fromJust c)
+                              src''
+                              (fromMaybe Map.empty a)
+                              (mergeTxParams x txParams)
+                              v
+                              cid
+                              ( case m of
+                                  Nothing -> Just $ Map.singleton "history" cn
+                                  Just h -> Just $ Map.insert "history" cn h
+                              )
+                      )
+                      ps
                 let bclp = 
                       ContractListParameters
                         addr
-                        ( map
-                            ( \p@(ContractPayload _ c a v x cid m) -> do
-                                let cn = fromMaybe "unnamed_contract" c
-                                UploadListContract
-                                  (fromJust c)
-                                  (getSrc p)
-                                  (fromMaybe Map.empty a)
-                                  (mergeTxParams x txParams)
-                                  v
-                                  cid
-                                  ( case m of
-                                      Nothing -> Just $ Map.singleton "history" cn
-                                      Just h -> Just $ Map.insert "history" cn h
-                                  )
-                            )
-                            ps
-                        )
+                        payloadList
                         chainId
                         resolve
                     poster = postUsersUploadListSolidVM'

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -712,6 +712,7 @@ postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTr
               False -> do
                 src'' <- case contractpayloadCodePtr p of 
                   Nothing -> return $ getSrc p
+                  Just _ | getSrc p /= mempty -> throwIO $ UserError "Can only provide one of either `src` or `codePtr`."
                   Just p' -> getSourceMapFromAddress p'
                 let bcp =
                       ContractParameters
@@ -772,6 +773,7 @@ postBlocTransaction' cacheNonce mJwtToken chainId mUseWallet resolve (PostBlocTr
                           let cn = fromMaybe "unnamed_contract" c
                           src'' <- case contractpayloadCodePtr p of 
                             Nothing -> return $ getSrc p
+                            Just _ | getSrc p /= mempty -> throwIO $ UserError "Can only provide one of either `src` or `codePtr`."
                             Just p' -> getSourceMapFromAddress p'
                           return $
                             UploadListContract

--- a/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
+++ b/strato/api/bloc/bloc2api/src/Bloc/API/Transaction.hs
@@ -282,6 +282,7 @@ data ContractPayload = ContractPayload
     contractpayloadValue :: Maybe (Strung Natural),
     contractpayloadTxParams :: Maybe TxParams,
     contractpayloadChainid :: Maybe ChainId,
+    contractpayloadCodePtr :: Maybe Address,
     contractpayloadMetadata :: Maybe (Map Text Text)
   }
   deriving (Eq, Show, Generic)
@@ -324,6 +325,7 @@ instance ToJSON ContractPayload where
         "value" .= contractpayloadValue,
         "txParams" .= contractpayloadTxParams,
         "chainid" .= contractpayloadChainid,
+        "codePtr" .= contractpayloadCodePtr,
         "metadata" .= contractpayloadMetadata
       ]
 
@@ -342,6 +344,7 @@ instance FromJSON ContractPayload where
       <*> (o .:? "value")
       <*> (o .:? "txParams")
       <*> (o .:? "chainid")
+      <*> (o .:? "codePtr")
       <*> (o .:? "metadata")
   parseJSON o = fail $ "parseJSON ContractPayload: Expected Object, got " ++ show o
 
@@ -368,6 +371,7 @@ instance ToSchema BlocTransactionPayload where
               contractpayloadValue = Nothing,
               contractpayloadTxParams = Nothing,
               contractpayloadChainid = Nothing,
+              contractpayloadCodePtr = Nothing,
               contractpayloadMetadata = Nothing
             }
 
@@ -387,6 +391,7 @@ instance ToSchema ContractPayload where
             contractpayloadValue = Nothing,
             contractpayloadTxParams = Nothing,
             contractpayloadChainid = Nothing,
+            contractpayloadCodePtr = Nothing,
             contractpayloadMetadata = Nothing
           }
 


### PR DESCRIPTION
This PR will allow you to upload contracts to the network by specifying a code pointer to existing code. If `codePtr` and `src` are both provided, `codePtr` will take priority. Below is an example of the bare minimum to interact with this feature on the API:

```
    {
      "payload": {
        "contract": "SimpleStorage2",
        "codePtr": "2acbf018851e883b36e3233e428da6865a7aa823",
        "args": {
           "_x": 1
         },
        "metadata": {
          "history": "SimpleStorage",
          "VM": "SolidVM"
        }
      },
      "type": "CONTRACT"
    }
```
If an address contains more than 1 contract then the `contract` field is required.