### PR TITLE
Smd health status

### DIFF
--- a/apex/api/lib/utils.js
+++ b/apex/api/lib/utils.js
@@ -11,8 +11,7 @@ function consolidateHealthData(healthInfo, stallInfo, systemInfo, syncInfo) {
   const isSyncStalled = JSON.parse(syncInfo.additionalInfo)?.isStalled;
   const systemWarnings = JSON.parse(systemInfo.additionalInfo).Alerts;
 
-  const health =
-    healthStatHealth && stallStatHealth && !isSyncStalled && systemStatHealth;
+  const health = healthStatHealth && stallStatHealth && !isSyncStalled;
   const healthStatus = isSyncStalled
     ? "SYNC STALLED"
     : !health

--- a/smd-ui/src/components/Dashboard/dashboard.reducer.js
+++ b/smd-ui/src/components/Dashboard/dashboard.reducer.js
@@ -172,7 +172,7 @@ const reducer = function (state = initialState, action) {
       return {
         ...state,
         systemStatus: action.data.status,
-        warnings: action.data.warnings,
+        systemWarnings: action.data.warnings,
         systemInfo: action.data.systemInfo,
       };
 
@@ -180,7 +180,7 @@ const reducer = function (state = initialState, action) {
       return {
         ...state,
         systemStatus: action.data.status,
-        warnings: action.data.warnings,
+        systemWarnings: action.data.warnings,
         systemInfo: action.data.systemInfo,
       };
 

--- a/smd-ui/src/components/Dashboard/index.js
+++ b/smd-ui/src/components/Dashboard/index.js
@@ -232,7 +232,7 @@ class Dashboard extends Component {
         <div className="row">
           <div className="col-sm-4">
             <Popover
-              isDisabled={synced && health}
+              isDisabled={synced && health && systemHealth}
               interactionKind={PopoverInteractionKind.HOVER}
               position={Position.BOTTOM}
               className={"full-width"}
@@ -241,7 +241,7 @@ class Dashboard extends Component {
                   className={`pt-dark pt-callout smd-pad-8 pt-icon-info-sign pt-intent-${
                     !metadata
                       ? "danger"
-                      : !health || !synced
+                      : !health || !systemHealth || !synced
                       ? "warning"
                       : "success"
                   }`}
@@ -251,7 +251,7 @@ class Dashboard extends Component {
                   </h5>
                   {!metadata
                     ? "Cannot connect to the Node's API"
-                    : !health
+                    : !health || !systemHealth
                     ? `Health issues: ${
                         healthIssues.length > 0
                           ? healthIssues.join(". ")
@@ -267,14 +267,14 @@ class Dashboard extends Component {
                 mode={
                   !metadata
                     ? "danger"
-                    : !health || !synced
+                    : !health || !systemWarnings || !synced
                     ? "warning"
                     : "success"
                 }
                 iconClass={
                   !metadata
                     ? "fa-triangle-exclamation"
-                    : !health
+                    : !health || !systemHealth
                     ? "fa-exclamation-circle"
                     : !synced
                     ? "fa-rotate"

--- a/smd-ui/src/components/Dashboard/index.js
+++ b/smd-ui/src/components/Dashboard/index.js
@@ -267,7 +267,7 @@ class Dashboard extends Component {
                 mode={
                   !metadata
                     ? "danger"
-                    : !health || !systemWarnings || !synced
+                    : !health || !systemHealth || !synced
                     ? "warning"
                     : "success"
                 }


### PR DESCRIPTION
Changes SMD logic so system warnings do not trigger an 'UNHEALTHY' node status:

<img width="616" alt="image" src="https://github.com/blockapps/strato-platform/assets/77761312/5bbc8147-8960-4024-9773-03d51cc31b55">
