### PR TITLE
MKT-325 Removed user's own inventories from displaying in trending section

### DIFF
--- a/marketplace/backend/api/v1/Marketplace/marketplace.controller.js
+++ b/marketplace/backend/api/v1/Marketplace/marketplace.controller.js
@@ -8,10 +8,7 @@ class MarketplaceController {
     try {
       const { dapp, query } = req
       const {soldOut, forSale , ...restQuery} =  query  
-      if (query.manufacturer) {
-        const encodedManufacturers = query.manufacturer.map(product => { return encodeURIComponent(product) })
-        query.manufacturer = encodedManufacturers
-      }
+
       const inventories = await dapp.getMarketplaceInventories({ ...restQuery })
       let finalInventory = MarketplaceController.getFinalInventory(inventories, forSale, soldOut)
 
@@ -27,13 +24,10 @@ class MarketplaceController {
     try {
       const { dapp, query } = req
       const {soldOut, forSale , ...restQuery} =  query  
-      if (query.manufacturer) {
-        const encodedManufacturers = query.manufacturer.map(product => { return encodeURIComponent(product) })
-        query.manufacturer = encodedManufacturers
-      }
-      const inventories = await dapp.getMarketplaceInventoriesLoggedIn({ ...restQuery })
 
+      const inventories = await dapp.getMarketplaceInventoriesLoggedIn({ ...restQuery })
       let finalInventory = MarketplaceController.getFinalInventory(inventories, forSale, soldOut)
+      
       rest.response.status200(res, { productsWithImageUrl: finalInventory, inventoryCount: finalInventory?.length })
 
       return next()

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -306,7 +306,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     const getOptions = { ...options, app: contractName }
     const newArgs = {
       ...args, notEqualsField: ['sale', 'ownerCommonName'],
-      notEqualsValue: [constants.zeroAddress, userCert.commonName] , ownerCommonName: [constants.baUserNames, userCert.commonName]
+      notEqualsValue: [constants.zeroAddress, userCert.commonName] , ownerCommonName: [userCert.commonName]
     }
     return marketplaceJs.getTopSellingProducts(rawAdmin, newArgs, getOptions)
   }

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -287,11 +287,11 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
 
   contract.getMarketplaceInventoriesLoggedIn = async function (args = {}, options = optionsNoChainIds) {
     const getOptions = { ...options, app: contractName };
-    let usersArr = constants.baUserNames.filter(user => user !== userCommonName)
+    let usersArr = constants.baUserNames.filter(user => user !== userCert.commonName)
     const newArgs = { ...args, ownerCommonName: usersArr }
     const all = await marketplaceJs.getAll(rawAdmin, newArgs, getOptions);
 
-    const newArgs1 = { ...args, notEqualsField: ['ownerCommonName', 'sale'], notEqualsValue: [[userCommonName, ...constants.baUserNames], constants.zeroAddress] }
+    const newArgs1 = { ...args, notEqualsField: ['ownerCommonName', 'sale'], notEqualsValue: [[userCert.commonName, ...constants.baUserNames], constants.zeroAddress] }
     const all2 = await marketplaceJs.getAll(rawAdmin, newArgs1, getOptions);
     return {inventoryResults: all.inventoryResults.concat(all2.inventoryResults), inventoryCount: all.inventoryCount + all2.inventoryCount};
   };
@@ -306,7 +306,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     const getOptions = { ...options, app: contractName }
     const newArgs = {
       ...args, notEqualsField: ['sale', 'ownerCommonName'],
-      notEqualsValue: [constants.zeroAddress, userCommonName] , ownerCommonName: constants.baUserNames
+      notEqualsValue: [constants.zeroAddress, userCert.commonName] , ownerCommonName: [constants.baUserNames, userCert.commonName]
     }
     return marketplaceJs.getTopSellingProducts(rawAdmin, newArgs, getOptions)
   }

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -298,7 +298,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
 
   contract.getTopSellingProducts = async function (args = {}, options = optionsNoChainIds) {
     const getOptions = { ...options, app: contractName }
-    const newArgs = { ...args, notEqualsField: 'sale', notEqualsValue: constants.zeroAddress, ownerCommonName: constants.baUserNames }
+    const newArgs = { ...args, notEqualsField: 'sale', notEqualsValue: constants.zeroAddress }
     return marketplaceJs.getTopSellingProducts(rawAdmin, newArgs, getOptions)
   }
 

--- a/marketplace/backend/dapp/orders/sale.js
+++ b/marketplace/backend/dapp/orders/sale.js
@@ -168,7 +168,6 @@ async function getAll(admin, args = {}, defaultOptions) {
     const options = { ...defaultOptions, org: 'BlockApps', app: 'Mercata' }
     let sales;
     if (assetAddresses) {
-        // console.log("")
         sales = await searchAllWithQueryArgs(contractName, {
             assetToBeSold: assetAddresses,
             gtField: saleGtField,

--- a/marketplace/backend/dapp/products/inventory.js
+++ b/marketplace/backend/dapp/products/inventory.js
@@ -364,13 +364,17 @@ async function getAll(admin, args = {}, defaultOptions) {
 
         // added greater than query to make sure we only take the sales with quantity thats available to sell. 
         // If the sale has 0 quantity it will throw an error when checking out, we will not show thee items for the trending search.
-        sales = await saleJs.getAll(admin, { range, isOpen: true, order: 'block_timestamp.desc', limit: '25', offset: '0', gtField: args.gtField, gtValue: args.gtValue}, options);
+        sales = await saleJs.getAll(admin, { range, isOpen: true, order: 'block_timestamp.desc', offset: '0', gtField: args.gtField, gtValue: args.gtValue}, options);
         const trendingAssetAddresses = sales.map(sale => sale.assetToBeSold);
 
         // Match the inventory with the sales
         inventories = await searchAllWithQueryArgs(contractName,
             {
                 address: trendingAssetAddresses,
+                notEqualsField: ['ownerCommonName'],
+                notEqualsValue: [ownerCommonName],
+                order: 'block_timestamp.desc',
+                limit: '25',
             }, options, admin);
     } 
     else {

--- a/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
+++ b/marketplace/ui/src/components/MarketPlace/TopSellingProductCard.js
@@ -29,9 +29,9 @@ const TopSellingProductCard = () => {
   const orderDispatch = useOrderDispatch();
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (hasChecked && !isAuthenticated) {
       actions.fetchTopSellingProducts(marketplaceDispatch, offset, limit);
-    } else {
+    } else if (hasChecked && isAuthenticated) {
       actions.fetchTopSellingProductsLoggedIn(
         marketplaceDispatch,
         offset,

--- a/marketplace/ui/src/contexts/marketplace/actions.js
+++ b/marketplace/ui/src/contexts/marketplace/actions.js
@@ -140,8 +140,6 @@ const actions = {
     dispatch,
     categorys,
     subCategorys,
-    // products,
-    // manufacturers,
     minPrice,
     maxPrice,
     search,
@@ -155,11 +153,6 @@ const actions = {
       ? `&subCategory[]=${subCategorys}`
       : "";
 
-    // const manufacturerQuery = manufacturers
-    //   ? `&manufacturer[]=${manufacturers}`
-    //   : "";
-
-    // const productIdQuery = products ? `&name[]=${products}` : "";
     const searchQuery = search
       ? `&queryValue=${search}&queryFields=name`
       : "";
@@ -205,8 +198,6 @@ const actions = {
     dispatch,
     categorys,
     subCategorys,
-    // products,
-    // manufacturers,
     minPrice,
     maxPrice,
     search,
@@ -220,11 +211,6 @@ const actions = {
       ? `&subCategory[]=${subCategorys}`
       : "";
 
-    // const manufacturerQuery = manufacturers
-    //   ? `&manufacturer[]=${manufacturers}`
-    //   : "";
-
-    // const productIdQuery = products ? `&name[]=${products}` : "";
     const priceQuery = `&range[]=price,${minPrice},${maxPrice}`;
     // const sortLatest = "&order=createdDate.desc"
     const searchQuery = search


### PR DESCRIPTION
Prior to this PR, a logged-in user could see their own published inventories in the `Trending in All Categories` section. This has been fixed.

In this demo, you can see `Testing One Size` and `Some carbon 150` no longer show up after logging in.


https://github.com/blockapps/strato-platform/assets/79778488/b1fd571d-46b9-4daa-8ebd-f2866bd2d83c

