### PR TITLE
expand abstract tables

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -301,18 +301,18 @@ pipeline {
                     lib.runSyncTester()
                   }
                 }
-                  unstash 'slipstream_integrity_tests'
-                  // script {
-                    dir('strato/indexer/slipstream/integrity_tests') {
-                       withCredentials([
-                            usernamePassword(credentialsId: 'keycloak-strato-devel-dev-client', passwordVariable: 'KEYCLOAK_STRATODEVEL_DEV_SECRET', usernameVariable: 'KEYCLOAK_STRATODEVEL_DEV_ID'),
-                            usernamePassword(credentialsId: 'keycloak-mercata-testnet2-localhost-client', passwordVariable: 'KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET', usernameVariable: 'KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID'),
-                                ]) {
-                        // Now CLIENT_ID1, CLIENT_SECRET1, and CLIENT_SECRET2 are available as environment variables
-                        sh "pip3 install -r requirements.txt"
-                        sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2' 10 30"
-                      }
-                    } 
+                  // unstash 'slipstream_integrity_tests'
+                  // // script {
+                  //   dir('strato/indexer/slipstream/integrity_tests') {
+                  //      withCredentials([
+                  //           usernamePassword(credentialsId: 'keycloak-strato-devel-dev-client', passwordVariable: 'KEYCLOAK_STRATODEVEL_DEV_SECRET', usernameVariable: 'KEYCLOAK_STRATODEVEL_DEV_ID'),
+                  //           usernamePassword(credentialsId: 'keycloak-mercata-testnet2-localhost-client', passwordVariable: 'KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET', usernameVariable: 'KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID'),
+                  //               ]) {
+                  //       // Now CLIENT_ID1, CLIENT_SECRET1, and CLIENT_SECRET2 are available as environment variables
+                  //       sh "pip3 install -r requirements.txt"
+                  //       sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2' 10 30"
+                  //     }
+                  //   } 
                 
               }
               post {

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -21,6 +21,7 @@ so that they could be properly moved to their respective version's subsection.
 - `creatorForkBlockNumber` flag added to customize at which block :creator field should start referring to the common name and not org
 
 ### Changed
+- Expansion of Concrete contract to Abstract contract is accomodated by Cirrus
 - Cirrus table namespacing is of format `creator-contractName` now
 - :creator field refers to user's common name, not org (can be customized to occur after particular block number for backwards compatibility)
 - `eth_<random 20 bytes>` database is now just named `eth`

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -25,7 +25,6 @@ module Slipstream.OutputData (
   insertAbstractTableQuery,
   createIndexTable,
   createMappingTable,
-  createHistoryTable,
   createAbstractTable,
   insertHistoryTable,
   createExpandEventTables,
@@ -48,6 +47,7 @@ import           Control.Arrow                   ((***))
 import           Control.Lens ((^.))
 import           Control.Monad
 import qualified Data.Aeson                      as Aeson
+import           Data.Bool                       (bool)
 import qualified Data.ByteString.Base16         as Base16
 import qualified Data.ByteString.Char8           as BC
 import qualified Data.ByteString                 as B
@@ -349,12 +349,13 @@ notifyPostgREST conn = do
 
 createExpandHistoryTable ::
   OutputM m =>
+  Bool ->
   IORef Globals ->
   ContractF () ->
   (Text, Text) ->
   ConduitM () (Text, Maybe (IORef Globals, TableName, TableColumns)) m ()
-createExpandHistoryTable g c nameParts = do
-  createHistoryTable' g c nameParts
+createExpandHistoryTable isAbstract g c nameParts = do
+  createHistoryTable' isAbstract g c nameParts
   expandHistoryTable g c nameParts
 
 -- getDeferredForeignKeys :: TableName -> ContractF () -> Text -> [ForeignKeyInfo]
@@ -500,11 +501,12 @@ createMappingTable globalsIORef (cn, n) m = do
 
 createHistoryTable' ::
   OutputM m =>
+  Bool ->
   IORef Globals ->
   ContractF () ->
   (Text, Text) ->
   ConduitM () (Text, Maybe (IORef Globals, TableName, TableColumns)) m ()
-createHistoryTable' globalsIORef contract (cn, n) = do
+createHistoryTable' isAbstract globalsIORef contract (cn, n) = do
   let tableName = historyTableName cn n
   tableExists <- isTableCreated globalsIORef tableName
 
@@ -512,27 +514,8 @@ createHistoryTable' globalsIORef contract (cn, n) = do
 
   when (not tableExists) $ do
     incNumHistoryTables
-    yield $ ((createHistoryTableQuery contract (cn, n)), Nothing)
+    yield $ ((createHistoryTableQuery isAbstract contract (cn, n)), Nothing)
     yieldMany $ map (\x -> (x, Nothing)) (addHistoryUnique (cn, n))
-    let list = tableColumns $ map (\(x, y) -> (labelToText x, y ^. varType)) $ Map.toList $ contract ^. storageDefs
-    setTableCreated globalsIORef tableName list
-
-createHistoryTable ::
-  OutputM m =>
-  IORef Globals ->
-  ContractF () ->
-  (Text, Text) ->
-  ConduitM () Text m ()
-createHistoryTable globalsIORef contract (cn, n) = do
-  let tableName = historyTableName cn n
-  tableExists <- isTableCreated globalsIORef tableName
-
-  $logDebugLS "createHistoryTable'/tableExists" ("Table Name: " ++ show tableName ++ ", table exists: " ++ formatBool tableExists)
-
-  when (not tableExists) $ do
-    incNumHistoryTables
-    yield $ createHistoryTableQuery contract (cn, n)
-    yieldMany $ addHistoryUnique (cn, n)
     let list = tableColumns $ map (\(x, y) -> (labelToText x, y ^. varType)) $ Map.toList $ contract ^. storageDefs
     setTableCreated globalsIORef tableName list
 
@@ -795,6 +778,26 @@ insertAbstractTable cs@((_, abTableName, _) : _) = do
   multilineLog "insertAbstractTable/processedContract" $ show cs
   yieldMany $ insertAbstractTableQuery cs
 
+baseColumnsQuery :: [Text]
+baseColumnsQuery = 
+  [ 
+    "address text",
+    "block_hash text",
+    "block_timestamp text",
+    "block_number text",
+    "transaction_hash text",
+    "transaction_sender text"
+  ]
+
+abstractBaseColumnsQuery :: [Text]
+abstractBaseColumnsQuery = 
+  baseColumnsQuery ++ 
+  [
+    "creator text",
+    "contract_name text",
+    "data jsonb"
+  ]
+
 createIndexTableQuery :: ContractF () -> (Text, Text) -> Text
 createIndexTableQuery contract (cn, n) =
   let tableName = indexTableName cn n
@@ -803,15 +806,7 @@ createIndexTableQuery contract (cn, n) =
         [ "CREATE TABLE IF NOT EXISTS ",
           tableNameToDoubleQuoteText tableName,
           " (",
-          csv $
-            [ "address text",
-              "block_hash text",
-              "block_timestamp text",
-              "block_number text",
-              "transaction_hash text",
-              "transaction_sender text"
-            ]
-              ++ tableColumns (map (\(x, y) -> (labelToText x, y ^. varType)) list),
+          csv $ baseColumnsQuery ++ tableColumns (map (\(x, y) -> (labelToText x, y ^. varType)) list),
           ",\n  PRIMARY KEY (address) );"
         ]
 
@@ -822,14 +817,8 @@ createMappingTableQuery (cn, n, m) =
         [ "CREATE TABLE IF NOT EXISTS ",
           tableNameToDoubleQuoteText tableName,
           " (",
-          csv $
-            [ "address text",
-              "block_hash text",
-              "block_timestamp text",
-              "block_number text",
-              "transaction_hash text",
-              "transaction_sender text",
-              "contract_name text",
+          csv $ baseColumnsQuery ++
+            [ "contract_name text",
               "mapname text",
               "key text",
               "value text"
@@ -845,23 +834,12 @@ createAbstractTableQuery contract (cn, n) =
         [ "CREATE TABLE IF NOT EXISTS ",
           tableNameToDoubleQuoteText tableName,
           " (",
-          csv $
-            [ "address text",
-              "block_hash text",
-              "block_timestamp text",
-              "block_number text",
-              "transaction_hash text",
-              "transaction_sender text",
-              "creator text",
-              "contract_name text",
-              "data jsonb"
-            ]
-              ++ tableColumns (map (\(x, y) -> (labelToText x, y ^. varType)) list),
+          csv $ abstractBaseColumnsQuery ++ tableColumns (map (\(x, y) -> (labelToText x, y ^. varType)) list),
           ",\n  PRIMARY KEY (address));"
         ]
 
-createHistoryTableQuery :: ContractF () -> (Text, Text) -> Text
-createHistoryTableQuery contract (cn, n) =
+createHistoryTableQuery :: Bool -> ContractF () -> (Text, Text) -> Text
+createHistoryTableQuery isAbstract contract (cn, n) =
   let tableName = historyTableName cn n
       list = Map.toList $ contract ^. storageDefs
    in T.concat
@@ -869,13 +847,7 @@ createHistoryTableQuery contract (cn, n) =
           tableNameToDoubleQuoteText tableName,
           " (",
           csv $
-            [ "address text NOT NULL",
-              "block_hash text NOT NULL",
-              "block_timestamp text",
-              "block_number text",
-              "transaction_hash text NOT NULL",
-              "transaction_sender text"
-            ]
+            (bool baseColumnsQuery abstractBaseColumnsQuery isAbstract)
               ++ tableColumns (map (\(x, y) -> (labelToText x, y ^. varType)) list),
           ");"
         ]

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1018,26 +1018,31 @@ insertAbstractTableQuery cs isHistoric =
                   wrapAndEscape $ map (wrapSingleQuotes . ($ row)) baseVals ++ [wrapSingleQuotes $ escapeQuotes (tableNameToText contractTableName)] ++ [wrapSingleQuotes . decodeUtf8 . BL.toStrict $ Aeson.encode $ MapWrapper $ aesonHelper $ Map.filterWithKey (\k _ -> k `notElem` abColumns) contractColumns] ++ (map snd $ Map.toList (Map.filterWithKey (\k _ -> k `elem` abColumns) contractColumns))
                 inserts = csv vals
             in (: []) $
-                  T.concat
+                  T.concat $
                     [ "INSERT INTO ",
-                      (bool abTableName ("history@" <> abTableName) isHistoric),
+                      (bool abTableName (wrapDoubleQuotes $ "history@" <> unwrapDoubleQuotes abTableName) isHistoric),
                       " ",
                       keySt,
                       "\n  VALUES ",
-                      inserts,
-                      [r|
-  ON CONFLICT (address) DO UPDATE SET
-    block_hash = excluded.block_hash,
-    block_timestamp = excluded.block_timestamp,
-    block_number = excluded.block_number,
-    transaction_hash = excluded.transaction_hash,
-    transaction_sender = excluded.transaction_sender,
-    contract_name = excluded.contract_name,
-    data = excluded.data|],
-                      if null list' then "" else ",\n    ",
-                      tableUpsert $ list',
-                      ";"
-                    ]
+                      inserts
+                    ] ++
+                    if (not isHistoric) 
+                      then
+                          [[r|
+                          ON CONFLICT (address) DO UPDATE SET
+                            block_hash = excluded.block_hash,
+                            block_timestamp = excluded.block_timestamp,
+                            block_number = excluded.block_number,
+                            transaction_hash = excluded.transaction_hash,
+                            transaction_sender = excluded.transaction_sender,
+                            contract_name = excluded.contract_name,
+                            data = excluded.data
+                          |],
+                          if null list' then "" else ",\n    ",
+                          tableUpsert $ list',
+                          ";"]
+                      else
+                        [[r| ON CONFLICT DO NOTHING;|]]
 
 insertHistoryTableQuery :: [E.ProcessedContract] -> [Text]
 insertHistoryTableQuery [] = error "insertHistoryTableQuery: unhandled empty list"

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1026,8 +1026,10 @@ insertAbstractTableQuery cs isHistoric =
                       "\n  VALUES ",
                       inserts
                     ] ++
-                    if (not isHistoric) 
+                    if isHistoric
                       then
+                        [[r| ON CONFLICT DO NOTHING;|]]
+                      else
                           [[r|
                           ON CONFLICT (address) DO UPDATE SET
                             block_hash = excluded.block_hash,
@@ -1041,8 +1043,6 @@ insertAbstractTableQuery cs isHistoric =
                           if null list' then "" else ",\n    ",
                           tableUpsert $ list',
                           ";"]
-                      else
-                        [[r| ON CONFLICT DO NOTHING;|]]
 
 insertHistoryTableQuery :: [E.ProcessedContract] -> [Text]
 insertHistoryTableQuery [] = error "insertHistoryTableQuery: unhandled empty list"

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -702,7 +702,7 @@ expandAbstractContractTable globalsIORef contract tableName _ _ = do
               T.intercalate ", " extraTableColumns
             ]
         setTableCreated globalsIORef tableName $ cols ++ extraTableColumns
-        yield $ expandTableQuery tableName extraTableColumns
+        yield $ expandAbstractTableQuery tableName extraTableColumns
       case tableName of
         -- AbstractTableName cn _ -> getDeferredForeignKeysAbstract tableName contract cn abstracts' cc
         _ -> return $ []
@@ -712,9 +712,31 @@ expandTableQuery tableName cols =
   T.concat
     [ "ALTER TABLE ",
       tableNameToDoubleQuoteText tableName,
-      " ADD COLUMN ",
-      T.intercalate ", ADD COLUMN " cols,
+      " ADD COLUMN IF NOT EXISTS",
+      T.intercalate ", ADD COLUMN IF NOT EXISTS" cols,
       ";"
+    ]
+
+expandAbstractTableQuery :: TableName -> TableColumns -> Text
+expandAbstractTableQuery tableName cols =
+  T.concat
+    [ "ALTER TABLE ",
+      tableNameToDoubleQuoteText tableName,
+      " ADD COLUMN IF NOT EXISTS",
+      T.intercalate ", ADD COLUMN IF NOT EXISTS" cols,
+      ";",
+      "BEGIN; ALTER TABLE ",
+      tableNameToDoubleQuoteText tableName,
+      " ADD COLUMN IF NOT EXISTS creator text",
+      "; COMMIT;",
+      "BEGIN; ALTER TABLE ",
+      tableNameToDoubleQuoteText tableName,
+      " ADD COLUMN IF NOT EXISTS contract_name text",
+      "; COMMIT;",
+      "BEGIN; ALTER TABLE ",
+      tableNameToDoubleQuoteText tableName,
+      " ADD COLUMN IF NOT EXISTS data jsonb",
+      "; COMMIT;"
     ]
 
 insertIndexTable ::

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -23,6 +23,7 @@ module Slipstream.OutputData (
   insertMappingTableQuery,
   insertAbstractTable,
   insertAbstractTableQuery,
+  insertHistoryAbstractTable,
   createIndexTable,
   createMappingTable,
   createAbstractTable,
@@ -790,15 +791,27 @@ insertHistoryTable contracts@(E.ProcessedContract {commonName = cn, contractName
   $logDebugLS "insertHistoryTable" $ T.pack $ "Inserting row in history table for: " ++ show tableName
   yieldMany $ insertHistoryTableQuery contracts
 
+insertHistoryAbstractTable :: 
+  OutputM m => 
+  [(E.ProcessedContract, T.Text, TableColumns)] ->
+  [E.ProcessedContract] ->
+  ConduitM () Text m ()
+insertHistoryAbstractTable [] _ = pure ()
+insertHistoryAbstractTable _ [] = pure ()
+insertHistoryAbstractTable abstracts hists = do 
+  let historyAbstracts = [(history, tableName, tableCols) | history <- hists, (_, tableName, tableCols) <- abstracts]
+  yieldMany $ insertAbstractTableQuery historyAbstracts True
+
 insertAbstractTable ::
   OutputM m =>
   [(E.ProcessedContract, T.Text, TableColumns)] ->
+  Bool ->
   ConduitM () Text m ()
-insertAbstractTable [] = pure ()
-insertAbstractTable cs@((_, abTableName, _) : _) = do
+insertAbstractTable [] _ = pure ()
+insertAbstractTable cs@((_, abTableName, _) : _) isHistoric = do
   $logInfoS "insertAbstractTable" $ T.pack $ "Inserting row in abstract table for: " ++ show abTableName
   multilineLog "insertAbstractTable/processedContract" $ show cs
-  yieldMany $ insertAbstractTableQuery cs
+  yieldMany $ insertAbstractTableQuery cs isHistoric
 
 baseColumnsQuery :: [Text]
 baseColumnsQuery = 
@@ -978,9 +991,9 @@ insertMappingTableQuery ms =
                       ";"
                     ]
 
-insertAbstractTableQuery :: [(E.ProcessedContract, T.Text, TableColumns)] -> [Text]
-insertAbstractTableQuery [] = error "insertAbstractTableQuery: unhandled empty list"
-insertAbstractTableQuery cs =
+insertAbstractTableQuery :: [(E.ProcessedContract, T.Text, TableColumns)] -> Bool -> [Text]
+insertAbstractTableQuery [] _ = error "insertAbstractTableQuery: unhandled empty list"
+insertAbstractTableQuery cs isHistoric =
   concat $
     let cs' = (\(c@E.ProcessedContract {contractData = contractData}, ab, abColumns) -> ((c, Map.mapMaybe valueToSQLTextFilterContract $ contractData), (ab, abColumns))) <$> cs
      in flip map (map snd $ partitionWith ((length . snd) *** fst) cs') $ \case
@@ -1007,7 +1020,7 @@ insertAbstractTableQuery cs =
             in (: []) $
                   T.concat
                     [ "INSERT INTO ",
-                      abTableName,
+                      (bool abTableName ("history@" <> abTableName) isHistoric),
                       " ",
                       keySt,
                       "\n  VALUES ",

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -357,7 +357,7 @@ createExpandHistoryTable ::
   ConduitM () (Text, Maybe (IORef Globals, TableName, TableColumns)) m ()
 createExpandHistoryTable isAbstract g c nameParts = do
   createHistoryTable' isAbstract g c nameParts
-  expandHistoryTable g c nameParts
+  expandHistoryTable isAbstract g c nameParts
 
 -- getDeferredForeignKeys :: TableName -> ContractF () -> Text -> [ForeignKeyInfo]
 -- getDeferredForeignKeys tableName cn a =
@@ -545,13 +545,18 @@ expandAbstractTable globalsIORef contract (cn, n) abstracts' cc = do
 
 expandHistoryTable ::
   OutputM m =>
+  Bool ->
   IORef Globals ->
   ContractF () ->
   (Text, Text) ->
   ConduitM () (Text, Maybe (IORef Globals, TableName, TableColumns)) m ()
-expandHistoryTable globalsIORef contract (cn, n) = do
+expandHistoryTable isAbstract globalsIORef contract (cn, n) = do
   let tableName = historyTableName cn n
   _ <- expandContractTable' globalsIORef contract tableName
+  when (isAbstract) $ 
+    mapOutput 
+      (\o -> (o, Nothing)) 
+      (void $ expandAbstractContractTable globalsIORef contract tableName Map.empty emptyCodeCollection)
   return ()
 
 expandContractTable' ::

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -552,12 +552,10 @@ expandHistoryTable ::
   ConduitM () (Text, Maybe (IORef Globals, TableName, TableColumns)) m ()
 expandHistoryTable isAbstract globalsIORef contract (cn, n) = do
   let tableName = historyTableName cn n
-  _ <- expandContractTable' globalsIORef contract tableName
-  when (isAbstract) $ 
-    mapOutput 
-      (\o -> (o, Nothing)) 
-      (void $ expandAbstractContractTable globalsIORef contract tableName Map.empty emptyCodeCollection)
-  return ()
+  void $ 
+    if isAbstract
+      then mapOutput (\o -> (o, Nothing)) $ expandAbstractContractTable globalsIORef contract tableName Map.empty emptyCodeCollection
+      else expandContractTable' globalsIORef contract tableName
 
 expandContractTable' ::
   OutputM m =>
@@ -669,7 +667,7 @@ expandAbstractContractTable globalsIORef contract tableName _ _ = do
   columns <- getTableColumns globalsIORef tableName
   case columns of
     Nothing -> do
-      $logErrorLS "expandTable" $
+      $logErrorLS "expandAbstractTable" $
         T.concat
           [ "Table ",
             (tableNameToText tableName),
@@ -682,8 +680,8 @@ expandAbstractContractTable globalsIORef contract tableName _ _ = do
           extras = difference list (partialParseTableColumns cols)
           extraTableColumns = tableColumns extras
       unless (null extraTableColumns) $ do
-        $logInfoS "expandTable" . T.pack $ "We just got new fields for a contract that already has a table!"
-        $logInfoS "expandTable" $
+        $logInfoS "expandAbstractTable" . T.pack $ "We just got new fields for a contract that already has a table!"
+        $logInfoS "expandAbstractTable" $
           T.concat
             [ "Adding columns to ",
               (tableNameToText tableName),
@@ -713,19 +711,10 @@ expandAbstractTableQuery tableName cols =
       tableNameToDoubleQuoteText tableName,
       " ADD COLUMN IF NOT EXISTS",
       T.intercalate ", ADD COLUMN IF NOT EXISTS" cols,
-      ";",
-      "BEGIN; ALTER TABLE ",
-      tableNameToDoubleQuoteText tableName,
-      " ADD COLUMN IF NOT EXISTS creator text",
-      "; COMMIT;",
-      "BEGIN; ALTER TABLE ",
-      tableNameToDoubleQuoteText tableName,
-      " ADD COLUMN IF NOT EXISTS contract_name text",
-      "; COMMIT;",
-      "BEGIN; ALTER TABLE ",
-      tableNameToDoubleQuoteText tableName,
-      " ADD COLUMN IF NOT EXISTS data jsonb",
-      "; COMMIT;"
+      ", ADD COLUMN IF NOT EXISTS creator text",
+      ", ADD COLUMN IF NOT EXISTS contract_name text",
+      ", ADD COLUMN IF NOT EXISTS data jsonb",
+      ";"
     ]
 
 insertIndexTable ::

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -301,16 +301,17 @@ processTheMessages env conn messages = do
             deferredForeignKeys <- case (_contractType c) of
               AbstractType -> do
                 _ <- outputData conn $ createExpandAbstractTable g c nameParts abstracts' cc
+                outputData' conn $ createExpandHistoryTable True g c nameParts
                 -- $logInfoS "processTheMessages/deferredForeignKeys/abstractfkeys" $ T.pack $ show abstractfkeys
                 return []
               _ -> do
                 indexfkeys <- outputData conn $ createExpandIndexTable g c nameParts
                 $logInfoS "processTheMessages/deferredForeignKeys/indexfkeys" $ T.pack $ show indexfkeys
+                outputData' conn $ createExpandHistoryTable False g c nameParts
                 return indexfkeys
 
             $logInfoS "processTheMessages/deferredForeignKeys" $ T.pack $ show deferredForeignKeys
 
-            outputData' conn $ createExpandHistoryTable g c nameParts
 
             outputData conn $ createExpandEventTables g c nameParts
 

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -377,7 +377,7 @@ processTheMessages env conn messages = do
           indexContract <- rowToInsert g abiid row cont oldState
           hs <- rowToHistories g abiid actions cont oldState
           let mapNames = actionMappings row
-              abstracts = actionAbstracts row
+              abstracts = actionAbstracts row -- to get abstract history info, get `actionAbstracts <$> actions`
           --get columns for abstract table
           $logDebugLS "abstractColumns" $ T.pack $ "Getting abstract columns from " ++ (show abstracts)
           abstractColumns <- fmap catMaybes . for (Map.toList abstracts) $ \((_, n'), cn') -> do
@@ -403,7 +403,8 @@ processTheMessages env conn messages = do
     outputData conn $ insertIndexTable $ indexInsert ins
     outputData conn $ insertHistoryTable $ historyInserts ins
     unless ((length (mappingInserts ins) < 1)) $ outputData conn $ insertMappingTable $ mappingInserts ins
-    outputData conn $ insertAbstractTable $ abstractInsert ins
+    outputData conn $ insertAbstractTable (abstractInsert ins) False -- not historic
+    outputData conn $ insertHistoryAbstractTable (abstractInsert ins) (historyInserts ins)
 
   forM_ insertsByCodeHash $ \ins -> do
     insertForeignKeys conn $ indexInsert ins


### PR DESCRIPTION
expanding cirrus tables to use abstract table fields (creator, data, contract_name) when transitioning from concrete to abstract contract types. includes support for both normal tables and history tables