### PR TITLE
Generate report on stateroot mismatch

### DIFF
--- a/strato/core/merkle-patricia-db/package.yaml
+++ b/strato/core/merkle-patricia-db/package.yaml
@@ -31,6 +31,7 @@ library:
   - deepseq
   - format
   - mtl
+  - QuickCheck
   - Ranged-sets
 
 

--- a/strato/core/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/NodeData.hs
+++ b/strato/core/merkle-patricia-db/src/Blockchain/Database/MerklePatricia/NodeData.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE IncoherentInstances #-}
@@ -37,6 +38,7 @@ import Control.Monad (liftM)
 import qualified Control.Monad.Change.Alter as A
 import Control.Monad.State
 import Data.Bifunctor (first)
+import qualified Data.Binary as Bin
 import Data.Bitraversable (bitraverse)
 import Data.Bits
 import qualified Data.ByteString as B
@@ -48,7 +50,9 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import qualified Data.NibbleString as N
 import Data.Ranged
+import GHC.Generics
 import Numeric
+import Test.QuickCheck hiding ((.&.))
 import Text.Colors
 import Text.Format
 
@@ -91,7 +95,7 @@ data NodeDataF a
       { nextNibbleString :: Key,
         nextVal :: Either (NodeRefF a) Val
       }
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 instance Functor NodeDataF where
   fmap _ EmptyNodeData = EmptyNodeData
@@ -107,6 +111,13 @@ instance Traversable NodeDataF where
   traverse _ EmptyNodeData = pure EmptyNodeData
   traverse f (FullNodeData cs v) = flip FullNodeData v <$> traverse (traverse f) cs
   traverse f (ShortcutNodeData k v) = ShortcutNodeData k <$> bitraverse (traverse f) pure v
+
+instance Bin.Binary NodeData where
+  get = rlpDecode . rlpDeserialize <$> Bin.get
+  put = Bin.put . rlpSerialize . rlpEncode
+
+instance Arbitrary NodeData where
+  arbitrary = pure EmptyNodeData -- TODO? make real instance?
 
 instance Monad m => (StateRoot `A.Alters` NodeData) (StateT (Map StateRoot NodeData) m) where
   lookup _ k = M.lookup k <$> get

--- a/strato/core/seqevents/package.yaml
+++ b/strato/core/seqevents/package.yaml
@@ -20,6 +20,7 @@ library:
     - format
     - generic-arbitrary
     - lens
+    - merkle-patricia-db
     - milena
     - monad-alter
     - prometheus-client

--- a/strato/core/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/strato/core/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -17,6 +17,7 @@ import Blockchain.Data.Json
 import Blockchain.Data.RLP
 import qualified Blockchain.Data.TXOrigin as TO
 import qualified Blockchain.Data.Transaction as TX
+import Blockchain.Database.MerklePatricia.NodeData (NodeData)
 import Blockchain.Sequencer.BinaryInstances ()
 import Blockchain.Sequencer.DB.Witnessable
 import qualified Blockchain.Strato.Model.Address as A
@@ -25,6 +26,7 @@ import Blockchain.Strato.Model.Class
 import Blockchain.Strato.Model.ExtendedWord (Word256)
 import Blockchain.Strato.Model.Keccak256 (Keccak256)
 import Blockchain.Strato.Model.MicroTime
+import Blockchain.Strato.Model.StateRoot
 import Control.DeepSeq
 import Control.Lens
 import Data.Aeson hiding (encode)
@@ -52,6 +54,9 @@ instance Format SeqLoopEvent where
   format (UnseqEvent ev) = "UnseqEvent " ++ format ev
   format WaitTerminated = "WaitTerminated"
 
+class ShowConstructor a where
+  showConstructor :: a -> String
+
 data IngestEvent
   = IETx Timestamp IngestTx
   | IEBlock IngestBlock
@@ -65,6 +70,10 @@ data IngestEvent
   | IEForcedConfigChange PBFT.ForcedConfigChange
   | IEValidatorBehavior PBFT.ForcedValidatorChange
   | IEDeleteDepBlock Keccak256
+  | IEGetMPNodes [StateRoot]
+  | IEGetMPNodesRequest TO.TXOrigin [StateRoot]
+  | IEMPNodesResponse TO.TXOrigin [NodeData]
+  | IEMPNodesReceived [NodeData]
   deriving (Eq, Show, GHCG.Generic)
 
 data IngestEventType
@@ -80,6 +89,10 @@ data IngestEventType
   | IETForcedConfigChange
   | IETValidatorBehavior
   | IETDeleteDepBlock
+  | IETGetMPNodes
+  | IETGetMPNodesRequest
+  | IETMPNodesResponse
+  | IETMPNodesReceived
   deriving (Eq, Ord, Show)
 
 iEventType :: IngestEvent -> IngestEventType
@@ -96,6 +109,10 @@ iEventType = \case
   IEForcedConfigChange {} -> IETForcedConfigChange
   IEValidatorBehavior {} -> IETValidatorBehavior
   IEDeleteDepBlock {} -> IETDeleteDepBlock
+  IEGetMPNodes {} -> IETGetMPNodes
+  IEGetMPNodesRequest {} -> IETGetMPNodesRequest
+  IEMPNodesResponse {} -> IETMPNodesResponse
+  IEMPNodesReceived {} -> IETMPNodesReceived
 
 instance Format IngestEvent where
   format (IETx ts o) = show ts ++ " " ++ format o
@@ -110,6 +127,28 @@ instance Format IngestEvent where
   format (IEForcedConfigChange o) = format o
   format (IEValidatorBehavior o) = show o
   format (IEDeleteDepBlock o) = show o
+  format (IEGetMPNodes o) = format o
+  format (IEGetMPNodesRequest o s) = format o ++ "requested: " ++ format s
+  format (IEMPNodesResponse o n) = "Response to " ++ format o ++ ": " ++ show n
+  format (IEMPNodesReceived o) = show o
+
+instance ShowConstructor IngestEvent where
+  showConstructor IETx{} = "IETx"
+  showConstructor IEBlock{} = "IEBlock"
+  showConstructor IEGenesis{} = "IEGenesis"
+  showConstructor IENewCertRegistered{} =  "IENewCertRegistered"
+  showConstructor IECertRevoked{} =  "IECertRevoked"
+  showConstructor IENewChainOrgName{} = "IENewChainOrgName"
+  showConstructor IEValidatorAdded{} = "IEValidatorAdded"
+  showConstructor IEValidatorRemoved{} = "IEValidatorRemoved"
+  showConstructor IEBlockstanbul{} = "IEBlockstanbul"
+  showConstructor IEForcedConfigChange{} = "IEForcedConfigChange"
+  showConstructor IEValidatorBehavior{} = "IEValidatorBehavior"
+  showConstructor IEDeleteDepBlock{} = "IEDeleteDepBlock"
+  showConstructor IEGetMPNodes{} = "IEGetMPNodes"
+  showConstructor IEGetMPNodesRequest{} = "IEGetMPNodesRequest"
+  showConstructor IEMPNodesResponse{} = "IEMPNodesResponse"
+  showConstructor IEMPNodesReceived{} = "IEMPNodesReceived"
 
 type Timestamp = Microtime
 
@@ -117,7 +156,7 @@ data IngestTx = IngestTx
   { itOrigin :: TO.TXOrigin,
     itTransaction :: TX.Transaction
   }
-  deriving (Eq, Read, Show, GHCG.Generic, Data)
+  deriving (Eq, Read, Show, GHCG.Generic)
 
 data IngestBlock = IngestBlock
   { ibOrigin :: TO.TXOrigin,
@@ -125,7 +164,7 @@ data IngestBlock = IngestBlock
     ibReceiptTransactions :: [TX.Transaction],
     ibBlockUncles :: [DD.BlockData]
   }
-  deriving (Eq, Read, Show, GHCG.Generic, Data)
+  deriving (Eq, Read, Show, GHCG.Generic)
 
 data IngestGenesis = IngestGenesis
   { igOrigin :: TO.TXOrigin,
@@ -161,7 +200,9 @@ data P2pEvent
   | -- Ask and push for inclusive ranges of blocks
     P2pAskForBlocks {askStart :: Integer, askEnd :: Integer, askPeer :: ChainMemberParsedSet}
   | P2pPushBlocks {pushStart :: Integer, pushEnd :: Integer, pushPeer :: ChainMemberParsedSet}
-  deriving (Eq, Show, GHCG.Generic, Data)
+  | P2pGetMPNodes [StateRoot]
+  | P2pMPNodesResponse TO.TXOrigin [NodeData]
+  deriving (Eq, Show, GHCG.Generic)
 
 instance Format P2pEvent where
   format (P2pTx o) = format o
@@ -171,7 +212,22 @@ instance Format P2pEvent where
   format (P2pGetTx shas) = "[" ++ (intercalate "," $ map format shas) ++ "]"
   format (P2pNewOrgName c cm) = intercalate ", " [CL.yellow $ format c, show cm]
   format (P2pBlockstanbul o) = format o
+  format (P2pGetMPNodes srs) = "[" ++ (intercalate "," $ map format srs) ++ "]"
+  format (P2pMPNodesResponse o nds) = "Response to " ++ show o ++ ": [" ++ (intercalate "," $ map show nds) ++ "]"
   format x = show x
+
+instance ShowConstructor P2pEvent where
+  showConstructor P2pTx{} = "P2pTx"
+  showConstructor P2pBlock{} = "P2pBlock"
+  showConstructor P2pGenesis{} = "P2pGenesis"
+  showConstructor P2pGetChain{} = "P2pGetChain"
+  showConstructor P2pGetTx{} = "P2pGetTx"
+  showConstructor P2pNewOrgName{} = "P2pNewOrgName"
+  showConstructor P2pBlockstanbul{} = "P2pBlockstanbul"
+  showConstructor P2pAskForBlocks{} = "P2pAskForBlocks"
+  showConstructor P2pPushBlocks{} = "P2pPushBlocks"
+  showConstructor P2pGetMPNodes{} = "P2pGetMPNodes"
+  showConstructor P2pMPNodesResponse{} = "P2pMPNodesResponse"
 
 data VmEvent
   = VmTx Timestamp OutputTx
@@ -180,13 +236,27 @@ data VmEvent
   | VmJsonRpcCommand JsonRpcCommand
   | VmCreateBlockCommand
   | VmPrivateTx OutputTx
-  deriving (Eq, Show, GHCG.Generic, Data)
+  | VmGetMPNodesRequest TO.TXOrigin [StateRoot]
+  | VmMPNodesReceived [NodeData]
+  deriving (Eq, Show, GHCG.Generic)
 
 instance Format VmEvent where
   format (VmTx ts o) = show ts ++ " " ++ format o
   format (VmBlock o) = format o
   format (VmGenesis o) = show o
+  format (VmGetMPNodesRequest o srs) = show o ++ " requested: " ++ format srs
+  format (VmMPNodesReceived nds) = show nds
   format x = show x
+
+instance ShowConstructor VmEvent where
+  showConstructor VmTx{} = "VmTx"
+  showConstructor VmBlock{} = "VmBlock"
+  showConstructor VmGenesis{} = "VmGenesis"
+  showConstructor VmJsonRpcCommand{} = "VmJsonRpcCommand"
+  showConstructor VmCreateBlockCommand{} = "VmCreateBlockCommand"
+  showConstructor VmPrivateTx{} = "VmPrivateTx"
+  showConstructor VmGetMPNodesRequest{} = "VmGetMPNodesRequest"
+  showConstructor VmMPNodesReceived{} = "VmMPNodesReceived"
 
 data OutputTx = OutputTx
   { otOrigin :: TO.TXOrigin,

--- a/strato/core/seqevents/src/Blockchain/Sequencer/Kafka/Metrics.hs
+++ b/strato/core/seqevents/src/Blockchain/Sequencer/Kafka/Metrics.hs
@@ -2,9 +2,9 @@
 
 module Blockchain.Sequencer.Kafka.Metrics where
 
+import Blockchain.Sequencer.Event
 import Control.Monad
 import Control.Monad.IO.Class
-import Data.Data
 import Data.Text
 import Prometheus
 
@@ -39,8 +39,8 @@ seqVMWrites = buildCounter "seq_vm_writes" "Events written to seq_vm_events by k
 seqVMReads :: Vector Text Counter
 seqVMReads = buildCounter "seq_vm_reads" "Events read from seq_vm_events by kind"
 
-recordEvents :: (Data a, MonadIO m) => Vector Text Counter -> [a] -> m ()
-recordEvents vec = recordEvents' vec . fmap (show . toConstr)
+recordEvents :: (ShowConstructor a, MonadIO m) => Vector Text Counter -> [a] -> m ()
+recordEvents vec = recordEvents' vec . fmap (show . showConstructor)
 
 recordEvents' :: MonadIO m => Vector Text Counter -> [String] -> m ()
 recordEvents' vec events = liftIO $

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -60,6 +60,7 @@ library:
     - lens
     - lifted-async
     - lifted-base
+    - merkle-patricia-db
     - milena
     - milena-tools
     - monad-alter

--- a/strato/core/strato-p2p/src/Blockchain/Data/Wire.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Data/Wire.hs
@@ -21,8 +21,10 @@ import Blockchain.Data.ChainInfo
 import Blockchain.Data.PubKey ()
 import Blockchain.Data.RLP
 import Blockchain.Data.Transaction
+import Blockchain.Database.MerklePatricia.NodeData (NodeData)
 import Blockchain.Strato.Model.ExtendedWord
 import Blockchain.Strato.Model.Keccak256
+import Blockchain.Strato.Model.StateRoot
 import Crypto.Types.PubKey.ECC
 import qualified Data.ByteString as B
 import Data.List
@@ -188,6 +190,8 @@ data Message
     GetChainDetails [Word256]
   | ChainDetails [(Word256, ChainInfo)]
   | GetTransactions [Keccak256]
+  | GetMPNodes [StateRoot]
+  | MPNodes [NodeData]
   deriving (Eq, Show)
 
 instance Format Message where
@@ -265,6 +269,10 @@ instance Format Message where
           ++ formatPairs xs
   format (GetTransactions txHashes) =
     CL.blue "GetTransactions\n" ++ "requested transaction hashes: " ++ (intercalate "\n" (show <$> txHashes))
+  format (GetMPNodes mpNodes) =
+    CL.blue "GetMPNodes\n" ++ "requested MP nodes: " ++ (intercalate "\n" (format <$> mpNodes))
+  format (MPNodes mpNodes) =
+    CL.blue "MPNodes\n" ++ "received MP nodes: " ++ (intercalate "\n" (format <$> mpNodes))
 
 --format x = error $ "missing value in format for Wire Message: " ++ show x
 
@@ -311,6 +319,10 @@ obj2WireMessage 0x1d (RLPArray chDetPairs) =
   ChainDetails $ rlpDecode <$> chDetPairs
 obj2WireMessage 0x1e (RLPArray trHashes) =
   GetTransactions $ rlpDecode <$> trHashes
+obj2WireMessage 0x1f (RLPArray (RLPScalar 0 : mpNodes)) =
+  GetMPNodes $ rlpDecode <$> mpNodes
+obj2WireMessage 0x1f (RLPArray (RLPScalar 1 : mpNodes)) =
+  MPNodes $ rlpDecode <$> mpNodes
 obj2WireMessage x y = error ("Missing case in obj2WireMessage: " ++ show x ++ ", " ++ format y)
 
 -- Convert Message into RLPObject and corresponding message code
@@ -371,5 +383,9 @@ wireMessage2Obj (ChainDetails chpairs) =
   (0x1d, RLPArray $ rlpEncode <$> chpairs)
 wireMessage2Obj (GetTransactions trhashes) =
   (0x1e, RLPArray $ rlpEncode <$> trhashes)
+wireMessage2Obj (GetMPNodes mpNodes) =
+  (0x1f, RLPArray . (RLPScalar 0 :) $ rlpEncode <$> mpNodes)
+wireMessage2Obj (MPNodes mpNodes) =
+  (0x1f, RLPArray . (RLPScalar 1 :) $ rlpEncode <$> mpNodes)
 
 --wireMessage2Obj x = error $ "Missing case in wireMessage2Obj: " ++ show x

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -362,6 +362,11 @@ handleEvents peer = awaitForever $ \case
     myX509 <- lift getMyX509
     let peerCheck (cId, _) = checkPeerIsMember myX509 peerX509 . fromMaybe def $ M.lookup cId mems
     yieldR . Transactions . map (morphTx . snd) $ filter peerCheck ptrs
+  MsgEvt (GetMPNodes srs) -> do
+    let txo = Origin.PeerString (peerString peer)
+    yieldL $ ToUnseq [IEGetMPNodesRequest txo srs]
+  MsgEvt (MPNodes nds) -> do
+    yieldL $ ToUnseq [IEMPNodesReceived nds]
   MsgEvt (Disconnect _) -> do
     $logInfoS "handleEvents/Disconnect" $ T.pack $ "Disconnect event received in Event handler"
     throwIO PeerDisconnected
@@ -463,6 +468,8 @@ handleEvents peer = awaitForever $ \case
         let outbound = BlockHeaders $ morphBlockHeader . unCanonical . snd <$> chain
         $logDebugS "handleEvents/P2pPushBlocks" . T.pack $ "Outgoing message: " ++ show outbound
         yieldR outbound
+    P2pGetMPNodes srs -> yieldR $ GetMPNodes srs
+    P2pMPNodesResponse o nds -> when (shouldRespond peer o) . yieldR $ MPNodes nds
   TimerEvt -> do
     maybeOldTS <- unActionTimestamp <$> lift getActionTimestamp
     case maybeOldTS of
@@ -544,6 +551,11 @@ syncFetch d num = do
   mrh <- lift $ unMaxReturnedHeaders <$> access (Proxy @MaxReturnedHeaders)
   yieldR $ GetBlockHeaders (BlockNumber num) mrh 0 d
   lift stampActionTimestamp
+
+shouldRespond :: PPeer -> Origin.TXOrigin -> Bool
+shouldRespond peer txo = case txo of
+  Origin.PeerString ps -> ps == peerString peer
+  _ -> False
 
 shouldSend :: PPeer -> Origin.TXOrigin -> Bool
 shouldSend peer txo = case txo of

--- a/strato/core/strato-p2p/src/Blockchain/Metrics.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Metrics.hs
@@ -89,6 +89,8 @@ recordMessage' msgVect msg = do
         GetChainDetails _ -> "get_chain_details"
         ChainDetails _ -> "chain_details"
         GetTransactions _ -> "get_transactions"
+        GetMPNodes _ -> "get_mp_nodes"
+        MPNodes _ -> "mp_nodes"
   liftIO $ withLabel msgVect label incCounter
 
 gossipDecisions :: Vector Text Counter

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -698,6 +698,18 @@ splitEvents es = forM_ (splitWith iEventType es) $ \(eventType, events) ->
         IETDeleteDepBlock -> do
           record "inevent_type_delete_dep_block" "DeleteDepBlock"
           traverse_ (\(IEDeleteDepBlock k) -> A.delete (A.Proxy @DependentBlockEntry) k) events
+        IETGetMPNodes -> do
+          record "inevent_type_get_mp_nodes" "GetMPNodes"
+          yieldMany $ map (\(IEGetMPNodes srs) -> ToP2p $ P2pGetMPNodes srs) events
+        IETGetMPNodesRequest -> do
+          record "inevent_type_get_mp_nodes_request" "GetMPNodesRequest"
+          yieldMany $ map (\(IEGetMPNodesRequest o srs) -> ToVm $ VmGetMPNodesRequest o srs) events
+        IETMPNodesResponse -> do
+          record "inevent_type_mp_nodes_response" "MPNodesResponse"
+          yieldMany $ map (\(IEMPNodesResponse o nds) -> ToP2p $ P2pMPNodesResponse o nds) events
+        IETMPNodesReceived -> do
+          record "inevent_type_mp_nodes_received" "MPNodesReceived"
+          yieldMany $ map (\(IEMPNodesReceived nds) -> ToVm $ VmMPNodesReceived nds) events
 
 prettyIBlock :: IngestBlock -> String
 prettyIBlock IngestBlock {ibOrigin = o, ibBlockData = bd, ibReceiptTransactions = txs} = "Block #" ++ blockNonce ++ "/" ++ bHash ++ " (via " ++ format o ++ ", " ++ show (length txs) ++ " txs)"

--- a/strato/core/strato-statediff/src/Blockchain/Strato/StateDiff.hs
+++ b/strato/core/strato-statediff/src/Blockchain/Strato/StateDiff.hs
@@ -14,6 +14,7 @@ module Blockchain.Strato.StateDiff
     Detailed (..),
     chainDiff,
     stateDiff,
+    stateDiff',
     eventualAccountState,
     incrementalAccountState,
   )
@@ -208,14 +209,30 @@ stateDiff chainId blockNumber blockHash oldRoot newRoot = do
   lift $ putChainBestBlock chainId blockHash blockNumber
   mOldSR <- lift $ A.lookup (A.Proxy @MP.StateRoot) chainId
   lift $ A.insert (A.Proxy @MP.StateRoot) chainId newRoot
-  let go _ diffs Nothing = yield $ reverse diffs
-      go 100 diffs d = yield (reverse diffs) >> go 0 [] d
-      go n diffs (Just d) = await >>= go (n + 1) (d : diffs)
+  stateDiff' chainId blockNumber blockHash oldRoot newRoot
+  lift $ A.alter_ (A.Proxy @MP.StateRoot) chainId $ pure . const mOldSR
+
+stateDiff' ::
+  ( MonadLogger m,
+    HasCodeDB m,
+    HasHashDB m,
+    (MP.StateRoot `Alters` MP.NodeData) m,
+    Selectable Account AddressState m
+  ) =>
+  Maybe Word256 ->
+  Integer ->
+  Keccak256 ->
+  StateRoot ->
+  StateRoot ->
+  ConduitT i StateDiff m ()
+stateDiff' chainId blockNumber blockHash oldRoot newRoot = do
   Diff.dbDiff oldRoot newRoot
     .| (await >>= go (0 :: Integer) [])
     .| awaitForever (\i -> collectModes i emitDiff)
-  lift $ A.alter_ (A.Proxy @MP.StateRoot) chainId $ pure . const mOldSR
   where
+    go _ diffs Nothing = yield $ reverse diffs
+    go 100 diffs d = yield (reverse diffs) >> go 0 [] d
+    go n diffs (Just d) = await >>= go (n + 1) (d : diffs)
     collectModes diffs f = do
       (c, d, u) <- coll [] [] [] diffs
       f c d u
@@ -413,7 +430,7 @@ lookupAddress (N.pack -> addrHash) = fromMaybe (Address 0) <$> lookupInMPDB "add
 lookupCode :: (MonadLogger m, HasHashDB m, HasCodeDB m, Selectable Account AddressState m) => CodePtr -> m (CodeKind, ByteString)
 lookupCode (ExternallyOwned ch) = fromMaybe (EVM, "") <$> lookupInMPDB "contract code" getCode ch
 lookupCode (SolidVMCode _ ch) = fromMaybe (SolidVM, "") <$> lookupInMPDB "contract code" getCode ch
-lookupCode cp@(CodeAtAccount _ _) = maybe (pure (EVM, "")) lookupCode =<< unsafeResolveCodePtr cp
+lookupCode cp@(CodeAtAccount _ _) = maybe (pure (SolidVM, "")) lookupCode =<< unsafeResolveCodePtr cp
 
 lookupInMPDB ::
   (MonadLogger m, Format a) =>

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE IncoherentInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -53,6 +54,7 @@ import qualified Blockchain.Database.MerklePatricia as MP
 import Blockchain.Event
 import Blockchain.Sequencer.Event
 import qualified Blockchain.SolidVM as SolidVM
+import Blockchain.StateRootMismatch
 import Blockchain.Strato.Indexer.Model (IndexEvent (..))
 import Blockchain.Strato.Model.Account
 import Blockchain.Strato.Model.Address
@@ -156,36 +158,45 @@ addBlocks unfiltered = do
       didReplaceBest <- newIORef False
       ranPrivateTxs <- newIORef M.empty
       replacedBest <- newIORef (error "addBlocks.replacedBest: evaluating uninitialized BestBlockInfo!")
-      srLog <- flip State.execStateT Nothing $
-        forM_ filtered $ \block -> do
-          let !blockNo = blockDataNumber $ obBlockData block
-              !txCount = length $ obReceiptTransactions block
-          timeit (printf "Block #%d (%d TXs insertion)" blockNo txCount) timerToUse $ do
-            lift $ addBlock block
-            (didReplaceThisTime, ranPriv, replacedBits@(hsh, num, _)) <- lift . lift $ replaceBestIfBetter block
-            when didReplaceThisTime $ do
-              writeIORef didReplaceBest True
-              writeIORef replacedBest replacedBits
-              -- Gather a chain of better block stateroots. The last one found should be the best block,
-              -- and the intermediate ones increase the granularity at which we can compute a sequence
-              -- of diffs. The number of blocks to skip between stateroots is determined by the cost of
-              -- the diff between them, which is estimated by the number of transactions.
-              State.put $! Just (blockDataStateRoot $ obBlockData block, hsh, num)
-            unless (M.null ranPriv) $
-              modifyIORef' ranPrivateTxs $
-                flip M.unionWith ranPriv $
-                  \(n1, s1) (n2, s2) -> if n1 > n2 then (n1, s1) else (n2, s2)
-      $logDebugLS "addBlocks/srLog" srLog
-      didReplaceBest' <- readIORef didReplaceBest
-      ranPrivateTxs' <- readIORef ranPrivateTxs
-      when didReplaceBest' $ do
-        $logInfoS "addBlocks" "done inserting, now will emit stateDiff if necessary"
-        nbb <- readIORef replacedBest
-        yield . OutIndexEvent $ NewBestBlock nbb
-        when flags_sqlDiff $
-          timeit "calculateAndEmitStateDiffs" timerToUse $
-            calculateAndEmitStateDiffs srLog oldHeader
-      when (flags_sqlDiff && not (M.null ranPrivateTxs')) $ calculateAndEmitChainDiffs ranPrivateTxs'
+      let go block = do
+            let !blockNo = blockDataNumber $ obBlockData block
+                !txCount = length $ obReceiptTransactions block
+            timeit (printf "Block #%d (%d TXs insertion)" blockNo txCount) timerToUse $ do
+              mSRMismatch <- lift $ addBlock block
+              when (isNothing mSRMismatch) $ do
+                (didReplaceThisTime, ranPriv, replacedBits@(hsh, num, _)) <- lift . lift $ replaceBestIfBetter block
+                when didReplaceThisTime $ do
+                  writeIORef didReplaceBest True
+                  writeIORef replacedBest replacedBits
+                  -- Gather a chain of better block stateroots. The last one found should be the best block,
+                  -- and the intermediate ones increase the granularity at which we can compute a sequence
+                  -- of diffs. The number of blocks to skip between stateroots is determined by the cost of
+                  -- the diff between them, which is estimated by the number of transactions.
+                  State.put $! Just (blockDataStateRoot $ obBlockData block, hsh, num)
+                unless (M.null ranPriv) $
+                  modifyIORef' ranPrivateTxs $
+                    flip M.unionWith ranPriv $
+                      \(n1, s1) (n2, s2) -> if n1 > n2 then (n1, s1) else (n2, s2)
+              pure mSRMismatch
+          loop [] = pure Nothing
+          loop (b:bs) = go b >>= \case
+            Just srm -> pure $ Just srm
+            Nothing  -> loop bs
+      (mSRMismatch, srLog) <- flip State.runStateT Nothing $ loop filtered
+      case mSRMismatch of
+        Just srMismatch -> yield $ OutStateRootMismatch srMismatch
+        Nothing -> do
+          $logDebugLS "addBlocks/srLog" srLog
+          didReplaceBest' <- readIORef didReplaceBest
+          ranPrivateTxs' <- readIORef ranPrivateTxs
+          when didReplaceBest' $ do
+            $logInfoS "addBlocks" "done inserting, now will emit stateDiff if necessary"
+            nbb <- readIORef replacedBest
+            yield . OutIndexEvent $ NewBestBlock nbb
+            when flags_sqlDiff $
+              timeit "calculateAndEmitStateDiffs" timerToUse $
+                calculateAndEmitStateDiffs srLog oldHeader
+          when (flags_sqlDiff && not (M.null ranPrivateTxs')) $ calculateAndEmitChainDiffs ranPrivateTxs'
 
 setParentStateRoot ::
   (MonadFail m, MonadIO m, BSDB.HasBlockSummaryDB m) =>
@@ -195,7 +206,7 @@ setParentStateRoot OutputBlock {..} = do
   liftIO $ setTitle $ "Block #" ++ show (blockDataNumber obBlockData)
   BSDB.getBSum (blockDataParentHash obBlockData)
 
-addBlock :: (MonadFail m, Bagger.MonadBagger m, MonadMonitor m) => OutputBlock -> ConduitT a VmOutEvent m ()
+addBlock :: (MonadFail m, Bagger.MonadBagger m, MonadMonitor m) => OutputBlock -> ConduitT a VmOutEvent m (Maybe StateRootMismatch)
 addBlock b@OutputBlock {obBlockData = bd, obReceiptTransactions = otxs} =
   let obh = outputBlockHash b
    in withCurrentBlockHash obh $ do
@@ -232,25 +243,30 @@ addBlock b@OutputBlock {obBlockData = bd, obReceiptTransactions = otxs} =
 
         postRewardSR <- A.lookup (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256)
 
-        when (Just (blockDataStateRoot (obBlockData b)) /= postRewardSR) $ do
-          $logInfoS "addBlock/mined" . T.pack $ "newStateRoot: " ++ format postRewardSR
-          error $ "stateRoot mismatch!!  New stateRoot doesn't match block stateRoot: " ++ format (blockDataStateRoot $ obBlockData b)
+        if (Just (blockDataStateRoot (obBlockData b)) /= postRewardSR)
+          then do
+            $logInfoS "addBlock/mined" . T.pack $ "newStateRoot: " ++ format postRewardSR
+            pure . Just $ StateRootMismatch (blockDataNumber $ obBlockData b)
+                                            obh
+                                            (blockDataStateRoot $ obBlockData b)
+                                            (fromMaybe MP.emptyTriePtr postRewardSR)
+          else do
+            valid <- checkValidity (blockIsHomestead $ blockDataNumber bd) bSum b
+            case valid of
+              Nothing -> lift $ P.incCounter vmBlocksValid
+              Just _ -> lift $ P.incCounter vmBlocksInvalid -- error err -- todo: i dont think we ACTUALLY need to error here
+            when flags_debug $ do
+              bhr'' <- Mod.get (Proxy @BlockHashRoot)
+              $logDebugS "addBlock" $ T.pack $ "New blockhash root after running block: " ++ format bhr''
+              mcr'' <- getChainRoot $ blockHash b
+              case mcr'' of
+                Nothing -> $logDebugS "addBlock" $ T.pack $ "Could not locate new chain root after running block. Using emptyTriePtr"
+                Just cr -> $logDebugS "addBlock" $ T.pack $ "New chain root after running block: " ++ format cr
 
-        valid <- checkValidity (blockIsHomestead $ blockDataNumber bd) bSum b
-        case valid of
-          Nothing -> lift $ P.incCounter vmBlocksValid
-          Just _ -> lift $ P.incCounter vmBlocksInvalid -- error err -- todo: i dont think we ACTUALLY need to error here
-        when flags_debug $ do
-          bhr'' <- Mod.get (Proxy @BlockHashRoot)
-          $logDebugS "addBlock" $ T.pack $ "New blockhash root after running block: " ++ format bhr''
-          mcr'' <- getChainRoot $ blockHash b
-          case mcr'' of
-            Nothing -> $logDebugS "addBlock" $ T.pack $ "Could not locate new chain root after running block. Using emptyTriePtr"
-            Just cr -> $logDebugS "addBlock" $ T.pack $ "New chain root after running block: " ++ format cr
-
-        lift $ P.incCounter vmBlocksMined
-        lift $ P.incCounter vmBlocksProcessed
-        $logInfoS "addBlock" . T.pack $ "Inserted block became #" ++ show (blockDataNumber $ obBlockData b) ++ " (" ++ format obh ++ ")."
+            lift $ P.incCounter vmBlocksMined
+            lift $ P.incCounter vmBlocksProcessed
+            $logInfoS "addBlock" . T.pack $ "Inserted block became #" ++ show (blockDataNumber $ obBlockData b) ++ " (" ++ format obh ++ ")."
+            pure Nothing
 
 addBlockTransactions :: (Bagger.MonadBagger m, MonadMonitor m) => OutputBlock -> ConduitT a VmOutEvent m ()
 addBlockTransactions OutputBlock {obBlockData = bd, obReceiptTransactions = transactions} = do

--- a/strato/core/vm-runner/src/Blockchain/Event.hs
+++ b/strato/core/vm-runner/src/Blockchain/Event.hs
@@ -22,11 +22,15 @@ import Blockchain.DB.MemAddressStateDB
 import Blockchain.Data.ChainInfo
 import Blockchain.Data.DataDefs
 import Blockchain.Data.ExecResults
+import Blockchain.Database.MerklePatricia.NodeData (NodeData)
+import Blockchain.Data.TXOrigin
 import Blockchain.Sequencer.Event
+import Blockchain.StateRootMismatch (StateRootMismatch)
 import Blockchain.Strato.Indexer.Model (IndexEvent (..))
 import Blockchain.Strato.Model.Account
 import Blockchain.Strato.Model.ExtendedWord
 import Blockchain.Strato.Model.Keccak256
+import Blockchain.Strato.Model.StateRoot
 import Blockchain.Strato.StateDiff
 import Blockchain.Stream.Action (Action)
 import qualified Data.ByteString as B
@@ -43,11 +47,13 @@ data VmInEventBatch = InBatch
     blocksAndNewChains :: [Either OutputGenesis OutputBlock],
     bLen :: {-# UNPACK #-} !Int,
     createBlock :: !Bool,
-    privateTxs :: [OutputTx]
+    privateTxs :: [OutputTx],
+    mpNodesReqs :: [(TXOrigin, [StateRoot])],
+    mpNodesResps :: [[NodeData]]
   }
 
 newInBatch :: VmInEventBatch
-newInBatch = InBatch [] [] 0 [] 0 False []
+newInBatch = InBatch [] [] 0 [] 0 False [] [] []
 
 insertInBatch :: VmInEvent -> VmInEventBatch -> VmInEventBatch
 insertInBatch e b = case e of
@@ -57,6 +63,8 @@ insertInBatch e b = case e of
   VmBlock ob -> b {blocksAndNewChains = (Right ob) : blocksAndNewChains b, bLen = bLen b + 1}
   VmCreateBlockCommand -> b {createBlock = True}
   VmPrivateTx otx -> b {privateTxs = otx : privateTxs b}
+  VmGetMPNodesRequest o srs -> b {mpNodesReqs = (o, srs) : mpNodesReqs b}
+  VmMPNodesReceived nds -> b {mpNodesResps = nds : mpNodesResps b}
 
 data VmOutEvent
   = OutAction Action
@@ -69,6 +77,9 @@ data VmOutEvent
   | OutTXR TransactionResult
   | OutASM (Map Account AddressStateModification)
   | OutJSONRPC String B.ByteString
+  | OutStateRootMismatch StateRootMismatch
+  | OutGetMPNodes [StateRoot]
+  | OutMPNodesResponse TXOrigin [NodeData]
 
 data VmOutEventBatch = OutBatch
   { outActions :: DL.DList Action,
@@ -81,7 +92,10 @@ data VmOutEventBatch = OutBatch
     outEvents :: DL.DList EventDB,
     outTXRs :: DL.DList TransactionResult,
     outASMs :: DL.DList (Map Account AddressStateModification),
-    outJSONRPCs :: DL.DList (String, B.ByteString)
+    outJSONRPCs :: DL.DList (String, B.ByteString),
+    outStateRootMismatch :: Maybe StateRootMismatch,
+    outGetMPNodes :: DL.DList [StateRoot],
+    outMPNodesResponses :: DL.DList (TXOrigin, [NodeData])
   }
 
 newOutBatch :: VmOutEventBatch
@@ -98,6 +112,9 @@ newOutBatch =
     DL.empty
     DL.empty
     DL.empty
+    Nothing
+    DL.empty
+    DL.empty
 
 insertOutBatch :: VmOutEvent -> VmOutEventBatch -> VmOutEventBatch
 insertOutBatch e b = case e of
@@ -111,3 +128,6 @@ insertOutBatch e b = case e of
   OutTXR a -> b {outTXRs = outTXRs b `DL.snoc` a}
   OutASM a -> b {outASMs = outASMs b `DL.snoc` a}
   OutJSONRPC x y -> b {outJSONRPCs = outJSONRPCs b `DL.snoc` (x, y)}
+  OutStateRootMismatch srm -> b {outStateRootMismatch = Just srm}
+  OutGetMPNodes srs -> b {outGetMPNodes = outGetMPNodes b `DL.snoc` srs}
+  OutMPNodesResponse o nds -> b {outMPNodesResponses = outMPNodesResponses b `DL.snoc` (o, nds)}

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -37,9 +37,11 @@ import Blockchain.JsonRpcCommand
 import qualified Blockchain.MilenaTools as K
 import Blockchain.Sequencer.Event
 import Blockchain.Sequencer.Kafka
+import Blockchain.StateRootMismatch
 import Blockchain.Strato.Indexer.Kafka (produceIndexEvents)
 import Blockchain.Strato.Indexer.Model (IndexEvent (..))
 import qualified Blockchain.Strato.Model.Keccak256 as Keccak256
+import Blockchain.Strato.StateDiff          (stateDiff')
 import Blockchain.Strato.StateDiff.Database (commitSqlDiffs)
 import Blockchain.Stream.Action (Action)
 import qualified Blockchain.Stream.Action as Action
@@ -57,6 +59,7 @@ import qualified Control.Monad.Change.Modify as Mod
 import Control.Monad.Composable.Kafka
 import Control.Monad.Composable.SQL
 import qualified Data.ByteString.Char8 as BC
+import Data.Conduit.List (mapMaybeM)
 import Data.Foldable hiding (fold)
 import Data.List
 import qualified Data.Map as M
@@ -88,22 +91,30 @@ ethereumVM d = runResourceT $ do
 
     Bagger.processNewBestBlock cpHash cpHead [] -- bootstrap Bagger with genesis block
 
-    consume "evm/loop" consumerGroup seqVmEventsTopicName $ \_ seqEvents -> do
+    StateRootMismatch{..} <- runConsume "evm/loop" consumerGroup seqVmEventsTopicName $ \_ seqEvents -> do
         recordBaggerMetrics =<< contextGets _baggerState
         logEventSummaries seqEvents
 
         let !vmInEventBatch = foldr insertInBatch newInBatch seqEvents
-        void . runConduit $
+        mSRMismatch <- fmap listToMaybe . runConduit $
           yield vmInEventBatch
             .| handleVmEvents
-            .| mapM_C sendOutEvent
+            .| mapMaybeM routeOutEvent
+            .| sinkList
 
         loopTimeit "compactContextM" $ compactContextM
 
         baggerData <- uncurry EVMCheckpoint <$> Bagger.getCheckpointableState
         checkpointData <- baggerData <$> getContextBestBlockInfo
         withChainroot <- checkpointData . unBlockHashRoot <$> Mod.get Proxy
-        return withChainroot
+        return (mSRMismatch, withChainroot)
+    
+    let err = "stateRoot mismatch!!  New stateRoot doesn't match block stateRoot: " ++ format _srmBlockSR 
+    runStateRootMismatchM $ do
+      sd <- runConduit $ stateDiff' Nothing _srmBlockNumber _srmBlockHash _srmBlockSR _srmNewSR
+         .| headDefC (error $ err ++ "\nError encountered while analyzing stateRoot mismatch")
+      $logErrorS "ethereumVM/StateRootMismatch" . T.pack $ formatStateRootMismatch sd
+    error err
 
 initializeCheckpointAndBlockSummary ::
   ( HasBlockSummaryDB m,
@@ -149,6 +160,8 @@ logEventSummaries events = do
     getNames (VmJsonRpcCommand _) = "JsonRpcCommand"
     getNames VmCreateBlockCommand = "CreateBlockCommand"
     getNames (VmPrivateTx _) = "PrivateTx"
+    getNames (VmGetMPNodesRequest _ _) = "GetMPNodesRequest"
+    getNames (VmMPNodesReceived _) = "MPNodesReceived"
 
     numberIt :: Int -> String -> String
     numberIt 1 x = "1 " ++ x
@@ -156,7 +169,11 @@ logEventSummaries events = do
 
 -- KAFKA
 
-sendOutEvent :: (MonadLogger m, HasKafka m, HasSQL m, HasContext m) => VmOutEvent -> m ()
+routeOutEvent :: (MonadLogger m, HasKafka m, HasSQL m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => VmOutEvent -> m (Maybe StateRootMismatch)
+routeOutEvent (OutStateRootMismatch srm) = pure $ Just srm
+routeOutEvent oev = Nothing <$ sendOutEvent oev
+
+sendOutEvent :: (MonadLogger m, HasKafka m, HasSQL m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => VmOutEvent -> m ()
 sendOutEvent (OutAction act) = do
   let extractCodeCollectionAddedMessages :: Action -> Maybe VMEvent
       extractCodeCollectionAddedMessages a =
@@ -212,6 +229,9 @@ sendOutEvent (OutASM asm) =
         ]
 sendOutEvent (OutJSONRPC s b) = liftIO $ produceResponse s b
 sendOutEvent (OutBlock o) = void . execKafka $ writeUnseqEvents [IEBlock $ blockToIngestBlock TO.Quarry $ outputBlockToBlock o]
+sendOutEvent (OutStateRootMismatch _) = pure ()
+sendOutEvent (OutGetMPNodes mpNodes) = void . execKafka $ writeUnseqEvents [IEGetMPNodes mpNodes]
+sendOutEvent (OutMPNodesResponse o nds) = void . execKafka $ writeUnseqEvents [IEMPNodesResponse o nds]
 
 consumerGroup :: KP.ConsumerGroup
 consumerGroup = lookupConsumerGroup "ethereum-vm"
@@ -224,13 +244,13 @@ getFirstBlockFromSequencer = do
 -- this one starts at 1, 0 is reserved for genesis block and is used to
 -- bootstrap a ton of this
 -- Also seeds the BlockSummaryDatabase
-initializeCheckpointAndBlockSummaryKafka :: (MonadLogger m, MonadFail m, HasKafka m, HasContext m) => m ()
+initializeCheckpointAndBlockSummaryKafka :: (MonadLogger m, MonadFail m, HasKafka m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => m ()
 initializeCheckpointAndBlockSummaryKafka = do
   block <- getFirstBlockFromSequencer
   checkpoint <- initializeCheckpointAndBlockSummary block
   setCheckpoint 1 checkpoint
 
-getCheckpoint :: (MonadLogger m, MonadFail m, HasKafka m, HasContext m) => m (KP.Offset, EVMCheckpoint)
+getCheckpoint :: (MonadLogger m, MonadFail m, HasKafka m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => m (KP.Offset, EVMCheckpoint)
 getCheckpoint = do
   let topic = seqVmEventsTopicName
       cg = consumerGroup

--- a/strato/core/vm-runner/src/Executable/EthereumVM2.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM2.hs
@@ -86,6 +86,11 @@ handleVmEvents ::
   (MonadFail m, Bagger.MonadBagger m, MonadMonitor m) =>
   ConduitT VmInEventBatch VmOutEvent m ()
 handleVmEvents = awaitForever $ \InBatch {..} -> do
+  mpResps <- lift $ for mpNodesReqs $ \(o, srs) -> do
+    nds <- catMaybes <$> traverse (A.lookup (A.Proxy @MP.NodeData)) srs
+    pure $! OutMPNodesResponse o nds
+  yieldMany $! mpResps
+
   rpcResps <- lift $ do
     bbHash <- maybe Keccak256.zeroHash fst <$> getChainBestBlock Nothing
     resps <- withCurrentBlockHash bbHash $ traverse runJsonRpcCommand' rpcCommands

--- a/strato/core/vm-tools/package.yaml
+++ b/strato/core/vm-tools/package.yaml
@@ -20,6 +20,7 @@ library:
     - Blockchain.Data.ExecResults
     - Blockchain.DB.BlockSummaryDB
     - Blockchain.DB.ModifyStateDB
+    - Blockchain.StateRootMismatch
     - Blockchain.Stream.Action
     - Blockchain.Stream.VMEvent
     - Blockchain.Stream.VMOutput

--- a/strato/core/vm-tools/src/Blockchain/StateRootMismatch.hs
+++ b/strato/core/vm-tools/src/Blockchain/StateRootMismatch.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# OPTIONS -fno-warn-orphans      #-}
+
+module Blockchain.StateRootMismatch
+  ( StateRootMismatch(..),
+    srmBlockNumber,
+    srmBlockHash,
+    srmBlockSR,
+    srmNewSR,
+    StateRootMismatchM(..),
+    formatStateRootMismatch
+  )
+where
+
+import BlockApps.Init ()
+import BlockApps.Logging
+import Blockchain.Data.RLP
+import qualified Blockchain.Database.MerklePatricia as MP
+import Blockchain.EthConf
+import Blockchain.Sequencer.Event
+import Blockchain.Sequencer.Kafka
+import Blockchain.Strato.Model.CodePtr ()
+import Blockchain.Strato.Model.Keccak256
+import Blockchain.Strato.StateDiff
+import Control.Applicative ((<|>))
+import Control.Lens hiding (Context (..))
+import Control.Monad (void)
+import qualified Control.Monad.Change.Alter as A
+import Control.Monad.Composable.Kafka
+import Control.Monad.IO.Class
+import Control.Monad.Reader
+import Control.Monad.Trans.Resource
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as BC
+import Data.Foldable (for_)
+import Data.List (intercalate)
+import qualified Data.Map as M
+import Data.Maybe (fromMaybe)
+import SolidVM.Model.Storable
+import Text.Format
+import Text.Tools
+import UnliftIO
+
+data StateRootMismatch = StateRootMismatch
+  { _srmBlockNumber :: Integer
+  , _srmBlockHash   :: Keccak256
+  , _srmBlockSR     :: MP.StateRoot
+  , _srmNewSR       :: MP.StateRoot
+  } deriving (Eq, Show)
+
+makeLenses ''StateRootMismatch
+
+newtype StateRootMismatchM m a = StateRootMismatchM { runStateRootMismatchM :: m a }
+
+instance Functor m => Functor (StateRootMismatchM m) where
+  fmap f (StateRootMismatchM a) = StateRootMismatchM $ f <$> a
+
+instance Applicative m => Applicative (StateRootMismatchM m) where
+  pure a = StateRootMismatchM $ pure a
+  (StateRootMismatchM fa) <*> (StateRootMismatchM fb) = StateRootMismatchM $ fa <*> fb
+
+instance Monad m => Monad (StateRootMismatchM m) where
+  (StateRootMismatchM ma) >>= f = StateRootMismatchM $ ma >>= runStateRootMismatchM . f
+
+instance MonadTrans StateRootMismatchM where
+  lift = StateRootMismatchM
+
+instance MonadLogger m => MonadLogger (StateRootMismatchM m)
+
+instance MonadIO m => MonadIO (StateRootMismatchM m) where
+  liftIO = lift . liftIO
+
+instance MonadUnliftIO m => MonadUnliftIO (StateRootMismatchM m) where
+  withRunInIO inner = StateRootMismatchM $ withRunInIO $ \run ->
+    inner (run . runStateRootMismatchM)
+
+instance ( MonadUnliftIO m
+         , MonadLogger m
+         , HasKafka m
+         , (MP.StateRoot `A.Alters` MP.NodeData) m
+         )
+      => (MP.StateRoot `A.Alters` MP.NodeData) (StateRootMismatchM m) where
+  lookup _ k = lift (A.lookup (A.Proxy @MP.NodeData) k) >>= \case
+    Just nd -> pure $ Just nd
+    Nothing -> do
+      StateRootMismatchM . void . execKafka $ writeUnseqEvents [IEGetMPNodes [k]]
+      fmap (Just . fromMaybe MP.EmptyNodeData) . timeout 10000000 $
+        runConsume "StateRootMismatchM/lookup" (lookupConsumerGroup "ethereum-vm") seqVmEventsTopicName $ \_ evs -> do
+          let findND (VmMPNodesReceived [nd]) | k == MP.sha2StateRoot (rlpHash nd) = Just nd
+              findND _ = Nothing
+              mND = foldr (<|>) Nothing (findND <$> evs)
+          for_ mND $ lift . A.insert (A.Proxy @MP.NodeData) k
+          pure (mND, B.empty)
+  insert _ = error "StateRootMismatchM insert StateDB"
+  delete _ = error "StateRootMismatchM delete StateDB"
+
+formatStateRootMismatch :: StateDiff -> String
+formatStateRootMismatch (StateDiff _ _ _ _ c d u) = intercalate "\n" $
+  [ "\nAccounts found in local state, but not block state"
+  , "--------------------------------------------------"
+  , intercalate "\n" $ (\(k,v) -> "Address " ++ format k ++ "\n" ++ tab (showEvAccDiff v)) <$> M.toList c
+  , "\nAccounts missing from local state, but found in block state"
+  , "-----------------------------------------------------------"
+  , intercalate "\n" $ (\(k,v) -> "Address " ++ format k ++ "\n" ++ tab (showEvAccDiff v)) <$> M.toList d
+  , "\nAccounts found in both local and block states, but with different values"
+  , "------------------------------------------------------------------------"
+  , intercalate "\n" $ (\(k,v) -> "Address " ++ format k ++ "\n" ++ tab (showIncAccDiff v)) <$> M.toList u
+  ]
+
+showIncAccDiff :: AccountDiff 'Incremental -> String
+showIncAccDiff AccountDiff{..} = intercalate "\n"
+  [ "Nonce: " ++ maybe "Nothing" (showIncDiff show) nonce
+  , "Balance: " ++ maybe "Nothing" (showIncDiff show) balance
+  , "Code: " ++ maybe "Nothing" (showIncDiff BC.unpack) code
+  , "CodeHash: " ++ format codeHash
+  , "Contract Root: " ++ maybe "Nothing" (showIncDiff format) contractRoot
+  , "Storage:\n" ++ tab (showIncStorDiff storage)
+  ]
+
+showEvAccDiff :: AccountDiff 'Eventual -> String
+showEvAccDiff AccountDiff{..} = intercalate "\n"
+  [ "Nonce: " ++ maybe "Nothing" (showEvDiff show) nonce
+  , "Balance: " ++ maybe "Nothing" (showEvDiff show) balance
+  , "Code: " ++ maybe "Nothing" (showEvDiff BC.unpack) code
+  , "CodeHash: " ++ format codeHash
+  , "Contract Root: " ++ maybe "Nothing" (showEvDiff format) contractRoot
+  , "Storage:\n" ++ tab (showEvStorDiff storage)
+  ]
+
+showIncStorDiff :: StorageDiff 'Incremental -> String
+showIncStorDiff (EVMDiff e) = intercalate "\n" $ (\(k,v) -> format k ++ ": " ++ showIncDiff format v) <$> M.toList e
+showIncStorDiff (SolidVMDiff s) = intercalate "\n" $ (\(k,v) -> BC.unpack k ++ ": " ++ showIncDiff (format . rlpDecode @BasicValue . rlpDeserialize) v) <$> M.toList s
+
+showEvStorDiff :: StorageDiff 'Eventual -> String
+showEvStorDiff (EVMDiff e) = intercalate "\n" $ (\(k,v) -> format k ++ ": " ++ showEvDiff format v) <$> M.toList e
+showEvStorDiff (SolidVMDiff s) = intercalate "\n" $ (\(k,v) -> BC.unpack k ++ ": " ++ showEvDiff (format . rlpDecode @BasicValue . rlpDeserialize) v) <$> M.toList s
+
+showIncDiff :: (a -> String) -> (Diff a 'Incremental) -> String
+showIncDiff f (Create a)   = "In local state: " ++ f a
+showIncDiff f (Delete a)   = "In block state: " ++ f a
+showIncDiff f (Update a b) = "In block state: " ++ f a ++ ", in local state: " ++ f b
+
+showEvDiff :: (a -> String) -> (Diff a 'Eventual) -> String
+showEvDiff f (Value a) = f a

--- a/strato/core/vm-tools/src/Blockchain/Wiring.hs
+++ b/strato/core/vm-tools/src/Blockchain/Wiring.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -57,6 +59,7 @@ import qualified Control.Monad.Change.Modify as Mod
 import Control.Monad.Composable.Base
 import Control.Monad.Composable.SQL
 import Control.Monad.IO.Class
+import Control.Monad.Reader (ReaderT)
 import qualified Data.ByteString as B
 import Data.Default
 import Data.Either.Extra
@@ -204,20 +207,20 @@ instance HasContext m => HasMemAddressStateDB m where
   getAddressStateBlockDBMap = gets $ view $ memDBs . stateBlockMap
   putAddressStateBlockDBMap theMap = modify $ memDBs . stateBlockMap .~ theMap
 
-instance HasContext m => (MP.StateRoot `A.Alters` MP.NodeData) m where
+instance MonadUnliftIO m => (MP.StateRoot `A.Alters` MP.NodeData) (ReaderT Context m) where
   lookup _ = MP.genericLookupDB $ getStateDB
   insert _ = MP.genericInsertDB $ getStateDB
   delete _ = MP.genericDeleteDB $ getStateDB
 
-instance (MonadLogger m, HasContext m) => (Account `A.Alters` AddressState) m where
+instance (MonadLogger m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => (Account `A.Alters` AddressState) m where
   lookup _ = getAddressStateMaybe
   insert _ = putAddressState
   delete _ = deleteAddressState
 
-instance (MonadLogger m, HasContext m) => A.Selectable Account AddressState m where
+instance (MonadLogger m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => A.Selectable Account AddressState m where
   select _ = getAddressStateMaybe
 
-instance (MonadLogger m, HasContext m) => (Maybe Word256 `A.Alters` MP.StateRoot) m where
+instance (MonadLogger m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => (Maybe Word256 `A.Alters` MP.StateRoot) m where
   lookup _ chainId = do
     mBH <- gets $ view $ memDBs . currentBlock
     fmap join . for mBH $ \(CurrentBlockHash bh) -> do
@@ -240,7 +243,7 @@ instance (MonadLogger m, HasContext m) => (Maybe Word256 `A.Alters` MP.StateRoot
         modify $ memDBs . stateRoots %~ M.delete (bh, chainId)
         deleteChainStateRoot chainId bh
 
-instance HasContext m => A.Selectable Word256 ParentChainIds m where
+instance (HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => A.Selectable Word256 ParentChainIds m where
   select _ chainId = fmap (\(_, _, p) -> ParentChainIds p) <$> getChainGenesisInfo (Just chainId)
 
 instance HasContext m => (Keccak256 `A.Alters` DBCode) m where
@@ -248,14 +251,14 @@ instance HasContext m => (Keccak256 `A.Alters` DBCode) m where
   insert _ = genericInsertCodeDB $ getCodeDB
   delete _ = genericDeleteCodeDB $ getCodeDB
 
-instance (MonadLogger m, HasContext m) => ((Address, T.Text) `A.Selectable` X509CertificateField) m where
+instance (MonadLogger m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => ((Address, T.Text) `A.Selectable` X509CertificateField) m where
   select _ (k, t) = do
     let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8
     mCertAddress <- lookupX509AddrFromCBHash k
     fmap join . for mCertAddress $ \certAddress -> do
       maybe Nothing (readMaybe . T.unpack . Text.decodeUtf8) <$> A.lookup (A.Proxy) (certKey certAddress t)
 
-instance (MonadLogger m, HasContext m) => (Address `A.Selectable` X509Certificate) m where
+instance (MonadLogger m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => (Address `A.Selectable` X509Certificate) m where
   select _ k = do
     let certKey addr = ((Account addr Nothing),) . Text.encodeUtf8
     mCertAddress <- lookupX509AddrFromCBHash k
@@ -277,7 +280,7 @@ instance (HasContext m) => HasMemRawStorageDB m where
   getMemRawStorageBlockDB = gets $ view $ memDBs . storageBlockMap
   putMemRawStorageBlockMap theMap = modify $ memDBs . storageBlockMap .~ theMap
 
-instance (MonadLogger m, HasContext m) => (RawStorageKey `A.Alters` RawStorageValue) m where
+instance (MonadLogger m, HasContext m, (MP.StateRoot `A.Alters` MP.NodeData) m) => (RawStorageKey `A.Alters` RawStorageValue) m where
   lookup _ = genericLookupRawStorageDB
   insert _ = genericInsertRawStorageDB
   delete _ = genericDeleteRawStorageDB
@@ -306,4 +309,3 @@ instance (MonadLogger m, HasContext m) => Mod.Modifiable GasCap m where
   put _ (GasCap g) = do
     contextModify (vmGasCap .~ g)
     $logDebugS "#### Mod.put @vmGasCap" . T.pack $ "VM Gas Cap updated to: " ++ show g
-

--- a/strato/libs/composable-monads/kafka-monad/src/Control/Monad/Composable/Kafka.hs
+++ b/strato/libs/composable-monads/kafka-monad/src/Control/Monad/Composable/Kafka.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 {-# OPTIONS -fno-warn-unused-top-binds #-}
@@ -19,6 +21,7 @@ module Control.Monad.Composable.Kafka (
   fetchSingleOffset,
   produceItems,
   consume,
+  runConsume,
   fetchItems,
   KafkaString(..),
   KafkaAddress,
@@ -34,7 +37,7 @@ module Control.Monad.Composable.Kafka (
 import BlockApps.Logging
 import Blockchain.MilenaTools
 import Control.Lens
-import Control.Monad (forever)
+import Control.Monad (void)
 import Control.Monad.Composable.Base
 import Control.Monad.IO.Unlift
 import Control.Monad.Reader
@@ -49,6 +52,7 @@ import Data.IORef
 import Data.List
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Void (Void)
 import Network.Kafka
 import Network.Kafka.Consumer
 import Network.Kafka.Producer
@@ -159,15 +163,23 @@ produceItems topicName events = do
 
 consume :: (Binary a, Binary md, MonadLogger m, HasKafka m) =>
            Text -> ConsumerGroup -> TopicName -> (md -> [a] -> m md) -> m ()
-consume name consumerGroup topicName f = 
-  forever $ do
-    $logInfoS name "About to fetch blocks"
-    (offset, md) <- getKafkaCheckpoint consumerGroup topicName
-    items <- fetchItems topicName offset
-    $logInfoS name . T.pack $ "Fetched " ++ show (length items) ++ " events starting from " ++ show offset
-    md' <- f (unpackMetadata md) items
-    let nextOffset' = offset + fromIntegral (length items)
-    setKafkaCheckpoint consumerGroup topicName nextOffset' $ packMetadata md'
+consume name consumerGroup topicName f = void $ runConsume name consumerGroup topicName (\md a -> (Nothing :: Maybe Void,) <$> f md a)
+
+runConsume :: (Binary a, Binary md, MonadLogger m, HasKafka m) =>
+              Text -> ConsumerGroup -> TopicName -> (md -> [a] -> m (Maybe b, md)) -> m b
+runConsume name consumerGroup topicName f = consumeOnce
+  where
+    consumeOnce = do
+      $logInfoS name "About to fetch blocks"
+      (offset, md) <- getKafkaCheckpoint consumerGroup topicName
+      items <- fetchItems topicName offset
+      $logInfoS name . T.pack $ "Fetched " ++ show (length items) ++ " events starting from " ++ show offset
+      (mReturnVal, md') <- f (unpackMetadata md) items
+      let nextOffset' = offset + fromIntegral (length items)
+      setKafkaCheckpoint consumerGroup topicName nextOffset' $ packMetadata md'
+      case mReturnVal of
+        Just returnVal -> pure returnVal
+        Nothing -> consumeOnce
 
 fetchItems :: (Binary a, HasKafka m) =>
               TopicName -> Offset -> m [a]


### PR DESCRIPTION
In this PR, when a node encounters a stateroot mismatch, it will pull MP data from other nodes to determine which values are different between its local stateroot, and the stateroot in the block header.

The report generated when adding the following code to `BlockChain.hs`
```hs
        when (blockDataNumber bd == 1500) $ do
          let acc = Account (Address 0xdeadbeef) Nothing
          lift $ A.insert (Proxy @AddressState) acc $ blankAddressState{addressStateBalance = 100000, addressStateCodeHash = SolidVMCode "DEADBEEF" emptyHash}
          lift $ A.delete (Proxy @AddressState) (Account (Address 0x100) Nothing)
          lift $ A.adjust_ (Proxy @AddressState) (Account (Address 0x509) Nothing) $ \a -> pure a{addressStateNonce = 420}
```

is

```
Accounts found in local state, but not block state
---------------------------------
Address 00000000000000000000000000000000deadbeef
    Nonce: 0
    Balance: 100000
    Code: 
    CodeHash: <SolidVMCode: DEADBEEF, <blank>>
    Contract Root: <empty>
    Storage:
        

Accounts missing from local state, but found in block state
----------------
Address 0000000000000000000000000000000000000100
    Nonce: 0
    Balance: 1707817106289403472925302664653978454636093876651603025325876069
    Code: ... (it actually prints the whole code collection) ...
    CodeHash: <SolidVMCode: MercataGovernance, 13c7823f773d9efdfdce2875f60a70bcfba6877a74b95fbfe052058d69b7ac94>
    Contract Root: 8e7e806cd3184d10bd8d6a76b0cf29523b3271ec70f54bf75851afdfef84e86d
    Storage:
        .adminCount: 3
        .adminMap<"BlockApps"><"Mercata"><"James Hormuzdiar">: account(000000000000000000000000000041646d696e75:main)
        .adminMap<"BlockApps"><"Mercata"><"Kieren James-Lubin">: account(000000000000000000000000000041646d696e73:main)
        .adminMap<"BlockApps"><"Mercata"><"Victor Wong">: account(000000000000000000000000000041646d696e74:main)
        .owner: account(74f014fef932d2728c6c7e2b4d3b88ac37a7e1d0:main)
        .validatorCount: 4
        .validatorMap<"BlockApps"><"Mercata"><"NodeFour">: account(0000000000000000000056616c696461746f7276:main)
        .validatorMap<"BlockApps"><"Mercata"><"NodeOne">: account(0000000000000000000056616c696461746f7273:main)
        .validatorMap<"BlockApps"><"Mercata"><"NodeThree">: account(0000000000000000000056616c696461746f7275:main)
        .validatorMap<"BlockApps"><"Mercata"><"NodeTwo">: account(0000000000000000000056616c696461746f7274:main)

Accounts found in both local and block states, but with different values
----------------
Address 0000000000000000000000000000000000000509
    Nonce: In block state: 132, in local state: 420
    Balance: Nothing
    Code: Nothing
    CodeHash: <SolidVMCode: CertificateRegistry, a879af150c8a6bc7809602f76b985ca942e1860c13a36c32a4c652bc0a4ef1ff>
    Contract Root: Nothing
    Storage:
```

The report is printed to the end of the `vm-runner` logs