### PR TITLE
[Highway] Throw clearer errors

### DIFF
--- a/strato/highway/server/app/Main.hs
+++ b/strato/highway/server/app/Main.hs
@@ -102,10 +102,7 @@ initHighway = do
                                                     (T.pack flags_awss3bucket)
                                                     (T.pack flags_highwayUrl)
                                         $logInfoS "highway/initHighway" $ T.pack $ "Initialization successful!"
-                                        --liftIO $ run 8080 $ appHighwayWrapper env
-                                        liftIO $ runSettings settings' --defaultSetting { settingsPort = 8080
-                                                                       --               , settingsOnExceptionResponse = highwayOnExceptionResponse
-                                                                       --               }
+                                        liftIO $ runSettings settings' 
                                                $ appHighwayWrapper env
   where highwayOnExceptionResponse e
           | Just (pe :: RequestParseException) <- fromException e =
@@ -118,7 +115,7 @@ initHighway = do
                   ( DBLC8.pack $ show pe
                   )
           | otherwise = defaultOnExceptionResponse e
-        settings  = setPort 3000
+        settings  = setPort 8080
                             defaultSettings
         settings' = setOnExceptionResponse highwayOnExceptionResponse
                                            settings

--- a/strato/highway/server/app/Main.hs
+++ b/strato/highway/server/app/Main.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE TypeFamilies      #-}
-{-# LANGUAGE TypeOperators     #-}
-{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE QuasiQuotes         #-}
 
 module Main where
 
@@ -16,17 +17,21 @@ import BlockApps.Logging
 import Options
 
 import Aws as Aws (makeCredentials)
+import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Unlift
 import Data.ByteString.Char8 as DBC8
+import Data.ByteString.Lazy.Char8 as DBLC8
 import Data.Text as T
 import HFlags
 import Network.HTTP.Client hiding (Proxy)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.Wai
 import Network.Wai.Handler.Warp
 import Network.Wai.Middleware.Cors
 import Network.Wai.Middleware.Prometheus
-import Network.Wai.Parse (defaultParseRequestBodyOptions,setMaxRequestKeyLength,setMaxRequestFileSize)
+import Network.Wai.Parse (defaultParseRequestBodyOptions,setMaxRequestKeyLength,setMaxRequestFileSize,RequestParseException(..))
+import Network.HTTP.Types
 import Servant
 import Servant.Multipart
 import Servant.Multipart.Client
@@ -97,7 +102,26 @@ initHighway = do
                                                     (T.pack flags_awss3bucket)
                                                     (T.pack flags_highwayUrl)
                                         $logInfoS "highway/initHighway" $ T.pack $ "Initialization successful!"
-                                        liftIO $ run 8080 $ appHighwayWrapper env
+                                        --liftIO $ run 8080 $ appHighwayWrapper env
+                                        liftIO $ runSettings settings' --defaultSetting { settingsPort = 8080
+                                                                       --               , settingsOnExceptionResponse = highwayOnExceptionResponse
+                                                                       --               }
+                                               $ appHighwayWrapper env
+  where highwayOnExceptionResponse e
+          | Just (pe :: RequestParseException) <- fromException e =
+              responseLBS
+                  badRequest400
+                  [ ( hContentType
+                    , "text/plain; charset=utf-8"
+                    )
+                  ]
+                  ( DBLC8.pack $ show pe
+                  )
+          | otherwise = defaultOnExceptionResponse e
+        settings  = setPort 3000
+                            defaultSettings
+        settings' = setOnExceptionResponse highwayOnExceptionResponse
+                                           settings
 
 appHighwayWrapper :: HighwayWrapperEnv -> Application
 appHighwayWrapper env =

--- a/strato/highway/server/package.yaml
+++ b/strato/highway/server/package.yaml
@@ -44,6 +44,7 @@ library:
     - servant-server
     - text
     - unliftio-core
+    - wai-extra
 
 executables:
   blockapps-highway-server:

--- a/strato/highway/server/package.yaml
+++ b/strato/highway/server/package.yaml
@@ -61,12 +61,14 @@ executables:
       - hflags
       - http-client
       - http-client-tls
+      - http-types
       - raw-strings-qq
       - servant-multipart
       - servant-multipart-client
       - servant-server
       - text
       - unliftio-core
+      - wai
       - wai-cors
       - wai-extra
       - wai-middleware-prometheus

--- a/strato/highway/server/src/Strato/Monad.hs
+++ b/strato/highway/server/src/Strato/Monad.hs
@@ -22,6 +22,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.Stack
 import Network.HTTP.Client
+import Network.Wai.Parse
 import Servant
 import UnliftIO hiding (Handler (..))
 
@@ -65,6 +66,7 @@ data HighwayWrapperError
   | BadPostError
   | UserError Text
   | RuntimeError SomeException
+  | ParseError RequestParseException
   deriving (Show, Exception)
 
 --------------------------------------------------------------------------------
@@ -78,9 +80,16 @@ runHighwayToIO :: HighwayWrapperEnv -> HighwayM a -> IO (Either HighwayWrapperEr
 runHighwayToIO env = try . runHighwayWithEnv env
 
 handleRuntimeError :: SomeException -> HighwayM a
-handleRuntimeError (e :: SomeException) = case fromException e of
-  Just (_ :: HighwayWrapperError) -> throwIO e
-  Nothing -> throwIO $ RuntimeError e
+handleRuntimeError (e :: SomeException) =
+  case fromException e of
+    Just (_ :: HighwayWrapperError) -> throwIO e
+    Nothing -> throwIO $ RuntimeError e
+
+--handleParseError :: SomeException -> HighwayM a 
+--handleParseError (e :: SomeException) =
+--  case fromException e of
+--    Just (pe :: RequestParseException) -> throwIO $ ParseError pe
+--    Nothing -> throwIO e
 
 handleHighwayError :: HighwayWrapperError -> HighwayM a
 handleHighwayError = \case
@@ -98,13 +107,21 @@ handleHighwayError = \case
     $logErrorS "handleHighwayError/RuntimeError" . Text.pack $
       show e ++ "\n  callstack missing for runtime errors"
     throwIO e
+  --e@(RequestParseException (MaxParamSizeExceeded i)) -> do
+  e@(ParseError pe) -> do
+    $logErrorS "handleHighwayError/ParseError" . Text.pack $
+      show pe
+    throwIO e
   e -> do
     $logErrorLS "handleHighwayError" e
     throwIO e
 
 enterHighwayWrapper :: HighwayWrapperEnv -> HighwayM x -> Handler x
 enterHighwayWrapper env x = Handler $ do
-  eRes <- liftIO . runHighwayToIO env $ x `catch` handleRuntimeError `catch` handleHighwayError
+  eRes <- liftIO . runHighwayToIO env $ x                  `catch`
+                                        --handleParseError   `catch`
+                                        handleRuntimeError `catch`
+                                        handleHighwayError
   case eRes of
     Right a -> return a
     Left e -> throwE $ reThrowError e
@@ -140,13 +157,53 @@ enterHighwayWrapper env x = Handler $ do
                       Text.unpack err
                     ]
             }
-        RuntimeError _ ->
-          err500
-            { errBody =
-                fromString $
-                  unlines
-                    [ "Runtime Error!",
-                      "Something wrong has happened inside of STRATO.",
-                      "Please contact your network administrator to have this problem fixed."
-                    ]
-            }
+        RuntimeError e ->
+          case fromException e of
+            Just (pe :: RequestParseException) ->
+              err400
+                { errBody =
+                    fromString $
+                      show pe
+                }
+            Nothing                            ->
+              err500
+                { errBody =
+                    fromString $
+                      unlines
+                        [ "Runtime Error!",
+                          "Something wrong has happened inside of STRATO.",
+                          "Please contact your network administrator to have this problem fixed."
+                        ]
+                }
+        ParseError e ->
+          case e of
+            MaxParamSizeExceeded i  ->
+              err413
+                { errBody =
+                    fromString $
+                      "Maximum parameter size exceeded: " ++ show i
+                }
+            ParamNameTooLong s i    ->
+              err413
+                { errBody =
+                    fromString $
+                      "Param name: " ++ show s ++ ", is too long: " ++ show i
+                }
+            MaxFileNumberExceeded i ->
+              err413
+                { errBody =
+                    fromString $
+                      "Maximum number of files exceeded: " ++ show i
+                }
+            FilenameTooLong s i     ->
+              err413
+                { errBody =
+                    fromString $
+                      "File name: " ++ show s ++ ", is too long: " ++ show i
+                }
+            TooManyHeaderLines i    ->
+              err413
+                { errBody =
+                    fromString $
+                      "Too many lines in mime/multipart header: " ++ show i
+                }

--- a/strato/highway/server/src/Strato/Monad.hs
+++ b/strato/highway/server/src/Strato/Monad.hs
@@ -66,7 +66,6 @@ data HighwayWrapperError
   | BadPostError
   | UserError Text
   | RuntimeError SomeException
-  | ParseError RequestParseException
   deriving (Show, Exception)
 
 --------------------------------------------------------------------------------
@@ -100,10 +99,6 @@ handleHighwayError = \case
   e@(RuntimeError _) -> do
     $logErrorS "handleHighwayError/RuntimeError" . Text.pack $
       show e ++ "\n  callstack missing for runtime errors"
-    throwIO e
-  e@(ParseError pe) -> do
-    $logErrorS "handleHighwayError/ParseError" . Text.pack $
-      show pe
     throwIO e
   e -> do
     $logErrorLS "handleHighwayError" e
@@ -166,36 +161,4 @@ enterHighwayWrapper env x = Handler $ do
                           "Something wrong has happened inside of STRATO.",
                           "Please contact your network administrator to have this problem fixed."
                         ]
-                }
-        ParseError e ->
-          case e of
-            MaxParamSizeExceeded i  ->
-              err413
-                { errBody =
-                    fromString $
-                      "Maximum parameter size exceeded: " ++ show i
-                }
-            ParamNameTooLong s i    ->
-              err413
-                { errBody =
-                    fromString $
-                      "Param name: " ++ show s ++ ", is too long: " ++ show i
-                }
-            MaxFileNumberExceeded i ->
-              err413
-                { errBody =
-                    fromString $
-                      "Maximum number of files exceeded: " ++ show i
-                }
-            FilenameTooLong s i     ->
-              err413
-                { errBody =
-                    fromString $
-                      "File name: " ++ show s ++ ", is too long: " ++ show i
-                }
-            TooManyHeaderLines i    ->
-              err413
-                { errBody =
-                    fromString $
-                      "Too many lines in mime/multipart header: " ++ show i
                 }

--- a/strato/highway/server/src/Strato/Monad.hs
+++ b/strato/highway/server/src/Strato/Monad.hs
@@ -85,12 +85,6 @@ handleRuntimeError (e :: SomeException) =
     Just (_ :: HighwayWrapperError) -> throwIO e
     Nothing -> throwIO $ RuntimeError e
 
---handleParseError :: SomeException -> HighwayM a 
---handleParseError (e :: SomeException) =
---  case fromException e of
---    Just (pe :: RequestParseException) -> throwIO $ ParseError pe
---    Nothing -> throwIO e
-
 handleHighwayError :: HighwayWrapperError -> HighwayM a
 handleHighwayError = \case
   BadGetError -> do
@@ -107,7 +101,6 @@ handleHighwayError = \case
     $logErrorS "handleHighwayError/RuntimeError" . Text.pack $
       show e ++ "\n  callstack missing for runtime errors"
     throwIO e
-  --e@(RequestParseException (MaxParamSizeExceeded i)) -> do
   e@(ParseError pe) -> do
     $logErrorS "handleHighwayError/ParseError" . Text.pack $
       show pe
@@ -119,7 +112,6 @@ handleHighwayError = \case
 enterHighwayWrapper :: HighwayWrapperEnv -> HighwayM x -> Handler x
 enterHighwayWrapper env x = Handler $ do
   eRes <- liftIO . runHighwayToIO env $ x                  `catch`
-                                        --handleParseError   `catch`
                                         handleRuntimeError `catch`
                                         handleHighwayError
   case eRes of

--- a/strato/stack.yaml
+++ b/strato/stack.yaml
@@ -107,6 +107,7 @@ extra-deps:
 - bitwise-1.0.0.1
 - contra-tracer-0.2.0.0
 - dom-lt-0.2.3
+- wai-extra-3.1.14@sha256:1b093366842dc0057cebb4a23dbf9a29269321d70fd242c7695ce0bbd80d32fb,8056
 
 
 #- git: https://github.com/blockapps/milena


### PR DESCRIPTION
This PR seeks to add clearer and cleaner error handling/throwing.

This adds additional code in `strato/highway/server/src/Strato/Monad.hs` to handle `RequestParseException`s that weren't being handled previously.

Additionally, this PR adds code to handle `RequestParseException`s outside of the `appHighwayWrapper`, which allows the capture/throwing of these errors outside of `HighwayM`.