### PR TITLE
blockapps-rest: peg jsdoc version to prevent build failure

### DIFF
--- a/blockapps-rest/package.json
+++ b/blockapps-rest/package.json
@@ -72,7 +72,7 @@
     "gulp-cli": "^2.0.1",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-typescript": "^6.0.0-alpha.1",
-    "jsdoc": "^3.6.4",
+    "jsdoc": "3.6.7",
     "mocha": "^6.0.2",
     "ts-node": "^10.0.0",
     "typescript": "4.7.4"


### PR DESCRIPTION
This is to fix this problem of building ba-rest:
https://blockappsdev.slack.com/archives/G5E7K3ETX/p1714591113932259