### PR TITLE
MKT 366 - Leverage creator field for redemption flow

### DIFF
--- a/marketplace/backend/api/v1/Redemption/redemption.controller.js
+++ b/marketplace/backend/api/v1/Redemption/redemption.controller.js
@@ -87,10 +87,10 @@ class RedemptionController {
             assetAddresses: Joi.array().items(Joi.string()),
             assetName: Joi.string().required(),
             status: Joi.number().integer().min(1).max(1).required(),
-            originAssetAddress: Joi.string().required(),
             quantity: Joi.number().integer().greater(0).required(),
             shippingAddressId: Joi.number().integer().required(),
             ownerCommonName: Joi.string().required(),
+            issuerCommonName: Joi.string().required(),
             ownerComments: Joi.string().allow("")
         });
 

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -286,15 +286,12 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   }
 
   contract.requestRedemption = async function (args, options = defaultOptions) {
-    const getOptions = { ...options, app: contractName, };
-    const { originAssetAddress, assetAddresses, quantity, ...restArgs } = args;
+    const { assetAddresses, quantity, ...restArgs } = args;
 
     const contract = { address: assetAddresses[0] };
     const [requestRedemptionStatus, assetAddress] = await inventoryJs.requestRedemption(rawAdmin, contract, { quantity: quantity }, options);
 
-    const originAsset = await inventoryJs.get(rawAdmin, { address: originAssetAddress }, getOptions);
-    const issuerCommonName = originAsset.ownerCommonName;
-    const finalArgs = { redemption_id: parseInt(util.uid()), issuerCommonName, assetAddresses: [assetAddress], quantity, ...restArgs }
+    const finalArgs = { redemption_id: parseInt(util.uid()), assetAddresses: [assetAddress], quantity, ...restArgs }
 
     if (requestRedemptionStatus) {
       try {

--- a/marketplace/ui/src/components/Inventory/RedeemModal.js
+++ b/marketplace/ui/src/components/Inventory/RedeemModal.js
@@ -76,12 +76,12 @@ const RedeemModal = ({ open, handleCancel, inventory, categoryName, limit, offse
     const handleSubmit = async () => {
         const body = {
             assetAddresses: [inventory.address],
-            originAssetAddress: inventory.originAddress,
             assetName: inventory.name,
             status: REDEMPTION_STATUS.PENDING,
             quantity: quantity,
             shippingAddressId: userAddresses[selectedAddress].address_id,
             ownerCommonName: user.commonName,
+            issuerCommonName: inventory.creator,
             ownerComments: comments
         };
 

--- a/marketplace/ui/src/components/Order/RedemptionsIncomingDetails.js
+++ b/marketplace/ui/src/components/Order/RedemptionsIncomingDetails.js
@@ -133,7 +133,6 @@ const RedemptionsIncomingDetails = ({ user }) => {
             key: "name",
             render: (text, record) => (
                 <p
-                    // href={routes.BoughtOrderDetails.url}
                     className="text-primary text-[17px] cursor-pointer"
                     onClick={() => { navigate(`${routes.MarketplaceProductDetail.url.replace(":address", record.address).replace(":name", record.name)}`) }}
                 >
@@ -276,8 +275,8 @@ const RedemptionsIncomingDetails = ({ user }) => {
                                                 />
                                                 <Divider type="vertical" className="h-14 bg-secondryD" />
                                                 <OrderData
-                                                    title="Issuer"
-                                                    value={redemption.issuerCommonName}
+                                                    title="Requestor"
+                                                    value={redemption.ownerCommonName}
                                                 />
                                                 <Divider type="vertical" className="h-14 bg-secondryD" />
                                                 <OrderData
@@ -298,7 +297,7 @@ const RedemptionsIncomingDetails = ({ user }) => {
                                             <Row className="my-2 md:hidden flex-col gap-[6px] justify-between p-4 rounded">
                                                 <div className="flex gap-4">
                                                     <NewOrderData className="w-2/4" title="Redemption Number" value={'#' + redemption.redemption_id} />
-                                                    <NewOrderData className="w-2/4" title="Issuer" value={redemption.issuerCommonName} />
+                                                    <NewOrderData className="w-2/4" title="Requestor" value={redemption.ownerCommonName} />
                                                 </div>
                                                 <div className="flex gap-4">
                                                     <NewOrderData className="w-2/4" title="Requestor" value={redemption.ownerCommonName} />


### PR DESCRIPTION
Before, we were using `originAddress` to fetch the original Asset and get the original issuer’s info from there. Now that the creator fork (37,000 blocks) has passed, newly created Assets will have a `creator` field which is the issuer’s `commonName`. This can be used in the redemption flow instead of fetching the original Asset.
There are no changes in the flow from a UI/UX perspective.

Jira ticket: https://blockapps.atlassian.net/jira/software/c/projects/MKT/boards/95?assignee=62e2c361f6dd8b8b0eac12ff&selectedIssue=MKT-366