### PR TITLE
Fixed mint modal

### DIFF
--- a/marketplace/ui/src/components/Inventory/ResellModal.js
+++ b/marketplace/ui/src/components/Inventory/ResellModal.js
@@ -1,24 +1,17 @@
 import { Button, InputNumber, Modal, Table } from "antd";
 import { useEffect, useState } from "react";
 import { actions } from "../../contexts/inventory/actions";
-import { actions as itemActions } from "../../contexts/item/actions";
 import { useInventoryDispatch, useInventoryState } from "../../contexts/inventory";
-import { useItemDispatch } from "../../contexts/item";
 import { useAuthenticateState } from "../../contexts/authentication";
 
 const ResellModal = ({ open, handleCancel, inventory, categoryName, limit, offset }) => {
     const [quantity, setQuantity] = useState(1);
     const inventoryDispatch = useInventoryDispatch();
-    const itemDispatch = useItemDispatch();
     const [canResell, setCanResell] = useState(true);
     const {
         isReselling
     } = useInventoryState();
     const { user } = useAuthenticateState();
-
-    useEffect(() => {
-        itemActions.fetchItem(itemDispatch, "", 0, inventory.address);
-    }, [])
 
     useEffect(() => {
         if (quantity <= 0) {
@@ -61,19 +54,18 @@ const ResellModal = ({ open, handleCancel, inventory, categoryName, limit, offse
             title={`Mint - ${decodeURIComponent(inventory.name)}`}
             width={650}
             footer={[
-                <Button type="primary" className="w-32 h-9" onClick={handleSubmit} disabled={!canResell || inventory.status === "1"} loading={isReselling}>
+                <Button type="primary" className="w-32 h-9" onClick={handleSubmit} disabled={!canResell} loading={isReselling}>
                     Mint
                 </Button>
             ]}
         >
             <div className="head">
 
-            <Table
-            
-                columns={columns()}
-                dataSource={[inventory]}
-                pagination={false}
-            />
+                <Table
+                    columns={columns()}
+                    dataSource={[inventory]}
+                    pagination={false}
+                />
             </div>
         </Modal>
     )


### PR DESCRIPTION
Before, we were disabling the mint. modal  `if inventory.status === "1"` which was checking if the inventory was `PUBLISHED`. `inventory.status` is no longer used in this way so it was removed from this logic.

https://github.com/blockapps/strato-platform/assets/79778488/9513453f-2d16-499e-9be5-622f974de3af

