### PR TITLE
Fix handling of arrays of strings/addresses in events in slipstream

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1258,7 +1258,7 @@ runStatement st@(CC.EmitStatement eventName exptups pos) = do
   solidVMBreakpoint pos
   exps <- mapM (expToVar . snd) exptups
   expVals <- mapM getVar exps
-  expStrs <- mapM showSM expVals
+  expStrs <- mapM jsonSM expVals
 
   -- checks that the event is declared and that the number of args match
   --   DOES NOT check consistency of arg types

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -19,6 +19,7 @@ module Blockchain.SolidVM.SetGet
     toBasic,
     fromBasic,
     showSM,
+    jsonSM
   )
 where
 
@@ -30,6 +31,7 @@ import Control.Monad
 import Control.Monad.IO.Class
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.UTF8 as UTF8
+import Data.Bool (bool)
 import Data.Foldable (for_)
 import Data.List
 import qualified Data.Map as M
@@ -287,3 +289,45 @@ showSM (SContractFunction maybeContractName address functionName) = do
   return $ "Contract function: " ++ labelToString contractName ++ "/" ++ format address ++ "." ++ labelToString functionName
 showSM (SVariadic xs) = ('[' :) . (++ "]") . intercalate ", " <$> traverse showSM xs
 showSM x = todo "showSM called for unsupported value: " x
+
+jsonSM :: MonadSM m => Value -> m String
+jsonSM = go False
+  where
+    go _ SNULL = return "null"
+    go _ (SInteger v) = return $ show v
+    go b (SString v) = return . bool id show b $ show v
+    go _ (SBool v) = return $ bool "false" "true" v
+    go _ (SEnumVal _ _ num) = return $ show num
+    go b (SAccount a _) = return . bool id show b $ show a
+    go _ (STuple v) = do
+      vals <- mapM getVar (V.toList v)
+      strings <- forM vals (go True)
+      return $ "[" ++ intercalate ", " strings ++ "]"
+    go _ (SArray _ v) = do
+      vals <- mapM getVar (V.toList v)
+      strings <- forM vals (go True)
+      return $ "[" ++ intercalate ", " strings ++ "]"
+    go _ (SStruct name m) = do
+      valStrings <-
+        forM (M.toList m) $ \(n, var) -> do
+          val <- getVar var
+          valString <- go True val
+          return (n, valString)
+      return $
+        labelToString name ++ "{"
+          ++ intercalate ", " (map (\(n, v) -> show (labelToString n) ++ ": " ++ v) valStrings)
+          ++ "}"
+    go _ (SMap _ m) = do
+      valStrings <-
+        forM (M.toList m) $ \(key, var) -> do
+          val <- getVar var
+          valString <- go True val
+          keyString <- go True key
+          return (keyString, valString)
+      return $
+        "{"
+          ++ intercalate ", " (map (\(k, v) -> k ++ ": " ++ v) valStrings)
+          ++ "}"
+    go b (SContract _ address) = return . bool id show b $ show address
+    go _ (SVariadic xs) = ('[' :) . (++ "]") . intercalate ", " <$> traverse (go True) xs
+    go _ _ = return "undefined"

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -295,7 +295,7 @@ jsonSM = go False
   where
     go _ SNULL = return "null"
     go _ (SInteger v) = return $ show v
-    go b (SString v) = return . bool id show b $ show v
+    go b (SString v) = return $ bool id show b v
     go _ (SBool v) = return $ bool "false" "true" v
     go _ (SEnumVal _ _ num) = return $ show num
     go b (SAccount a _) = return . bool id show b $ show a

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1269,7 +1269,7 @@ insertEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
           T.pack . keccak256ToHex . eventTxHash,
           tshow . eventTxSender
         ]
-      vals = csv $ map (wrapSingleQuotes . escapeQuotes . ($ agEv)) baseVals ++ map (wrapSingleQuotes . escapeQuotes . T.pack . snd) (Action.evArgs ev)
+      vals = csv $ map (wrapSingleQuotes . escapeQuotes . ($ agEv)) baseVals ++ map (wrapSingleQuotes . escapeSingleQuotes . T.pack . snd) (Action.evArgs ev)
    in T.concat $
         [ "INSERT INTO ",
           tableNameToDoubleQuoteText tableName,


### PR DESCRIPTION
Previously, events that contained arrays of strings or arrays of addresses would be improperly JSON-formatted, causing slipstream's insert query to fail. The reason this is specific to events is because event values are pre-formatted by SolidVM, using `showSM`, rather than passed as serialized `BasicValue`s to Slipstream, like regular state variables.
Instead of performing the deeper change of passing event values to Slipstream in the same format as state variables, I just added a function, `jsonSM`, which formats these values correctly.
Example:
`emit Event(["hello", "world"], [address(0xdeadbeef)]);`
Before:
`INSERT INTO "EventTable" VALUES ('[hello, world]', '[00000000000000000000000000000000deadbeef]');`
After:
`INSERT INTO "EventTable" VALUES ('["hello", "world"]', '["00000000000000000000000000000000deadbeef"]');`

Reason for making this fix: needed for `PaymentService` contracts, so that sale addresses included in `Payment` events are indexed properly in cirrus.