### PR TITLE
forced config change of sequence number

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -19,6 +19,7 @@ so that they could be properly moved to their respective version's subsection.
 ### Added
 - POST `/transaction` allows users to create contracts by providing an address through the `codePtr` field
 - `creatorForkBlockNumber` flag added to customize at which block :creator field should start referring to the common name and not org
+- `forced-config-change` executable can now update `sequence_number` in addition to `round_number` of sequencer view
 
 ### Changed
 - Expansion of Concrete contract to Abstract contract is accomodated by Cirrus

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -236,6 +236,12 @@ eventLoop ctx = execStateC ctx $
                 else
                   $logErrorS "blockstanbul/config_change" . T.pack $
                     printf "Refusing to move round backwards in time %d to %d" (_round v) rn
+            ForcedSequence s ->
+              if s >= _sequence v
+                then nextRound (Sequence s)
+                else 
+                  $logErrorS "blockstanbul/config_change" . T.pack $
+                    printf "Refusing to move sequence backwards in time %d to %d" (_sequence v) s
         PreviousBlock blk -> do
           realValidators <- use validators
           seqNo <- use $ view . sequence

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Messages.hs
@@ -98,6 +98,7 @@ makeLenses ''WireMessage
 
 -- TODO: Allow changing blockstanbul admins without a restart
 data ForcedConfigChange = ForcedRound RoundNumber
+                        | ForcedSequence SequenceNumber
   deriving (Eq, Show, Generic, Binary, NFData, Data)
 
 instance Format ForcedConfigChange where

--- a/strato/core/strato-sequencer/exec-src/ForcedConfigChange.hs
+++ b/strato/core/strato-sequencer/exec-src/ForcedConfigChange.hs
@@ -21,6 +21,10 @@ defineFlag
   \ This obviously is not ideal, and so this tool provides a way to circumvent the normal\
   \ PBFT controls in case of emergency. This tool is authenticated by being able to write\
   \ to the kafka topic instead of through signatures."
+defineFlag
+  "sequence_number"
+  (-1 :: Integer)
+  "Forced PBFT to transition to a specific sequence number."
 
 $(return [])
 
@@ -37,5 +41,15 @@ main = do
     resp <- runKafkaConfigured (KP.KString "forced-config-change") $ do
       writeUnseqEvents [msg]
     print resp
-    exitSuccess
-  die "no config change flags provided"
+  when (flags_sequence_number >= 0) $ do
+    let msg =
+          IEForcedConfigChange
+            . ForcedSequence
+            $ fromIntegral flags_sequence_number
+    print msg
+    resp <- runKafkaConfigured (KP.KString "forced-config-change") $ do
+      writeUnseqEvents [msg]
+    print resp
+  if (flags_round_number >= 0 || flags_sequence_number >= 0)
+    then exitSuccess
+    else die "no config change flags provided"


### PR DESCRIPTION
This tool allows us to forcibly update the sequence number of the sequencer's view. This is not a proper fix for the bug where the sequence number is not properly set after updating to a new strato image in-place, but since I wrote the code anyways, I figured it doesn't hurt to have the tool in case of emergencies.