### PR TITLE
fix: barrel spelling

### DIFF
--- a/marketplace/backend/dapp/items/contracts/Spirits.sol
+++ b/marketplace/backend/dapp/items/contracts/Spirits.sol
@@ -6,7 +6,7 @@ import <BASE_CODE_COLLECTION>;
 contract UnitOfMeasurement {
 enum UnitOfMeasurement {
     NULL,
-    BARRELL,
+    BARREL,
     BOTTLE  
 }
 }

--- a/marketplace/ui/src/helpers/constants.js
+++ b/marketplace/ui/src/helpers/constants.js
@@ -100,7 +100,7 @@ export const unitOfMeasures = [
 ];
 
 export const unitOfSpiritMeasures = [
-  { name: "Barrell", value: 1 },
+  { name: "Barrel", value: 1 },
   { name: "Bottle", value: 2 }
 ];
 


### PR DESCRIPTION
<img width="544" alt="image" src="https://github.com/blockapps/strato-platform/assets/92960832/9848b016-9f55-4de9-89e0-ce9efcf83264">

Barrel was misspelled for the creation form. 