### PR TITLE
getting common name efficiently

### DIFF
--- a/marketplace/backend/dapp/mercata-base-contracts/AllContractsCombined.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/AllContractsCombined.sol
@@ -791,6 +791,10 @@ abstract contract Sale is Utils {
 
 contract Utils { 
     function getCommonName(address addr) internal returns (string) {
-        return getUserCert(addr)["commonName"];
+        string commonName = getUserCert(addr)["commonName"];
+        if (commonName == ""){
+            commonName = "Contract " + string(addr);
+        }
+        return commonName;
     }
 }

--- a/marketplace/backend/dapp/mercata-base-contracts/AllContractsCombined.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/AllContractsCombined.sol
@@ -1,8 +1,6 @@
 pragma es6;
 pragma strict;
 
-import <509>;
-
 contract Mercata{}
 
 abstract contract Asset is Utils {
@@ -793,14 +791,6 @@ abstract contract Sale is Utils {
 
 contract Utils { 
     function getCommonName(address addr) internal returns (string) {
-        CertificateRegistry r = CertificateRegistry(account(0x509, "main"));
-        Certificate c = CertificateRegistry(account(address(r), "main")).getUserCert(addr);
-        string commonName = "";
-        try {
-            commonName = c.commonName();
-        } catch {
-            commonName = "Contract " + string(addr);
-        }
-        return commonName;
+        return getUserCert(addr)["commonName"];
     }
 }

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Utils/Utils.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Utils/Utils.sol
@@ -3,5 +3,9 @@ pragma strict;
 
 contract Utils { 
     function getCommonName(address addr) internal returns (string) {
-        return getUserCert(addr)["commonName"];
+        string commonName = getUserCert(addr)["commonName"];
+        if (commonName == ""){
+            commonName = "Contract " + string(addr);
+        }
+        return commonName;
 }

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Utils/Utils.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Utils/Utils.sol
@@ -1,18 +1,7 @@
 pragma es6;
 pragma strict;
 
-import <509>;
-
 contract Utils { 
     function getCommonName(address addr) internal returns (string) {
-        CertificateRegistry r = CertificateRegistry(account(0x509, "main"));
-        Certificate c = CertificateRegistry(account(address(r), "main")).getUserCert(addr);
-        string commonName = "";
-        try {
-            commonName = c.commonName();
-        } catch {
-            commonName = "Contract " + string(addr);
-        }
-        return commonName;
-    }
+        return getUserCert(addr)["commonName"];
 }


### PR DESCRIPTION
use built-in cert functionality instead of calling contracts to be more efficient in vm and slipstream; also compatible with salted certs (feature to come)