### PR TITLE
Some sync stall improvements

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -22,8 +22,10 @@ so that they could be properly moved to their respective version's subsection.
 ### Changed
 - Allow public keys to be passed to x509-generator in PEM format
 - default `accountNonceLimit` is 2,000
+- max kafka bytes returned to 32MB
 
 ### Fixed
+- fixed logic for how p2p calculates if it is missing parents blocks and needs to backtrack its sync
 
 ### Removed
 

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -26,6 +26,8 @@ so that they could be properly moved to their respective version's subsection.
 
 ### Fixed
 - fixed logic for how p2p calculates if it is missing parents blocks and needs to backtrack its sync
+- `creator` and `root` get populated in collection tables
+- validators run block before voting for it
 
 ### Removed
 

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -209,7 +209,7 @@ handleEvents peer = awaitForever $ \case
     -- check if blockheaders we recieved have parents.
     let parents = map BlockHeader.parentHash headers
     existingParents <- lift $ lookupMany (Proxy @BlockHeader) parents
-    let missingParents = S.fromList parents S.\\ M.keysSet existingParents
+    let missingParents = S.fromList parents S.\\ (M.keysSet existingParents `S.union` S.fromList (blockHeaderHash <$> bHeaders))
     unless (S.null missingParents) $ do
       bestBlock <- lift $ Mod.get (Proxy @BestBlock)
       let fetchNumber = numberFromBestBlock bestBlock + 1

--- a/strato/libs/kafka/milena/Network/Kafka.hs
+++ b/strato/libs/kafka/milena/Network/Kafka.hs
@@ -169,7 +169,7 @@ defaultMinBytes = MinBytes 0
 
 -- | Default: @32 * 1024 * 1024@
 defaultMaxBytes :: MaxBytes
-defaultMaxBytes = 100 * 1024 * 1024
+defaultMaxBytes = 32 * 1024 * 1024
 
 -- | Default: @0@
 defaultMaxWaitTime :: MaxWaitTime


### PR DESCRIPTION
This pr arose when trying to debug a sync stall @zyuzon24 encountered while doing load tests. The real underlying bug for that sync stall is not addressed in this pr but should be tackled once Dr. Hormuzdiar finishes the sequencer updates (has to do with validators being able to recognize that new validators have been added to the network before the block is run in the vm). While I was debugging, I made the following changes for some performance improvement:

- the logic for checking if we're missing parents was incorrect because sometimes we would ask for parents we had just received (ex: you get blocks 15-20, the function would calculate that you're missing parent blocks 15-19 and do an unnecessary syncFetch, which would also sometimes be detrimental to the node's ability to continue syncing).
- returning the max kafka bytes to 32 MB to allow the vm to finish a batch of blocks and update redis more often (allows for more accurate fetch number and knowledge of which block headers we already have)