### PR TITLE
Validators talk to each other

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -168,6 +168,7 @@ services:
     - OAUTH_VAULT_PROXY_ALT_CLIENT_ID=${OAUTH_VAULT_PROXY_ALT_CLIENT_ID}
     - OAUTH_VAULT_PROXY_ALT_CLIENT_SECRET=${OAUTH_VAULT_PROXY_ALT_CLIENT_SECRET}
     - OAUTH_RESERVE_SECONDS=${OAUTH_RESERVE_SECONDS}
+    - P2P_DEBUG_LOG=${P2P_DEBUG_LOG}
     - postgres_host=postgres
     - postgres_password=${postgres_password:-api}
     - postgres_port=5432

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -438,7 +438,10 @@ handleEvents peer = awaitForever $ \case
                 " does not have a registered certificate"
               ]
         Just cm ->
-          maybe False unIsValidator <$> lift (select (Proxy @IsValidator) cm) >>= \case
+          let cm' = case cm of 
+                CommonName _ _ name b -> CommonName "" "" name b
+                x -> x
+          in maybe False unIsValidator <$> lift (select (Proxy @IsValidator) cm') >>= \case
             False ->
               $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $
                 concat

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -438,10 +438,7 @@ handleEvents peer = awaitForever $ \case
                 " does not have a registered certificate"
               ]
         Just cm ->
-          let cm' = case cm of 
-                CommonName _ _ name b -> CommonName "" "" name b
-                x -> x
-          in maybe False unIsValidator <$> lift (select (Proxy @IsValidator) cm') >>= \case
+          maybe False unIsValidator <$> lift (select (Proxy @IsValidator) cm) >>= \case
             False ->
               $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $
                 concat

--- a/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
+++ b/strato/core/strato-redis-blockdb/src/Blockchain/Strato/RedisBlockDB.hs
@@ -114,7 +114,7 @@ import Blockchain.Strato.Model.ExtendedWord (Word256)
 import Blockchain.Strato.Model.Gas
 import Blockchain.Strato.Model.Keccak256
 import Blockchain.Strato.RedisBlockDB.Models as Models
-import Blockchain.Strato.Model.Validator (Validator)
+import Blockchain.Strato.Model.Validator (Validator(..))
 import Control.Arrow (second, (&&&), (***))
 import Control.Concurrent (threadDelay)
 import Control.Monad
@@ -231,10 +231,11 @@ putChainInfo cId cInfo = do
 isValidator ::
   CM.ChainMemberParsedSet ->
   Redis Bool
-isValidator val =
-  sismember (namespaceToKeyPrefix Validators) (toValue val) >>= \case
+isValidator (CM.CommonName _ _ v _) =
+  sismember (namespaceToKeyPrefix Validators) (toValue (Validator v)) >>= \case
     Right b -> pure b
     _ -> pure False
+isValidator _ = pure False
 
 getValidatorAddresses :: Redis [Address]
 getValidatorAddresses = do 

--- a/strato/extraFiles/strato/doit.sh
+++ b/strato/extraFiles/strato/doit.sh
@@ -116,6 +116,7 @@ function newnode {
   seqMinLogLevel=LevelInfo
   slipMinLogLevel=LevelInfo
   vmMinLogLevel=LevelInfo
+  p2pMinLogLevel=LevelInfo
 
   if ${API_DEBUG_LOG:-false} || ${FULL_DEBUG_LOG:-false}; 
   then apiDebugMode=LevelDebug
@@ -133,6 +134,10 @@ function newnode {
   then vmMinLogLevel=LevelDebug
   fi
 
+  if ${P2P_DEBUG_LOG:-false} || ${FULL_DEBUG_LOG:-false}; 
+  then p2pMinLogLevel=LevelDebug
+  fi
+
   echo "Starting ethereum-discover"
   runBackgroundProcess ethereum-discover  &>> logs/ethereum-discover
 
@@ -146,6 +151,7 @@ function newnode {
      --networkID=${networkID:--1} \
      --sqlPeers=true \
      --txGossipFanout=${txGossipFanount:-3} \
+     --minLogLevel=$p2pMinLogLevel \
      ${networkFlag} &>> logs/strato-p2p
 
   echo "Starting strato-sequencer"


### PR DESCRIPTION
Testnet is currently stalled because there was a bug introduced when we changed how validator info is stored in redis, causing the validators to no longer send pbft messages to one another. This fix will allow them to exchange pbft messages once more, allowing the network to continue. 