### PR TITLE
Fix inventory card button overlap in users page

### DIFF
--- a/marketplace/ui/src/components/UserProfile/index.js
+++ b/marketplace/ui/src/components/UserProfile/index.js
@@ -408,7 +408,7 @@ const UserProfile = ({user}) => {
                 label: "All",
                 key: undefined,
                 children: (
-                  <div className="my-4 grid grid-cols-1 md:grid-cols-2 gap-6 lg:grid-cols-3 3xl:grid-cols-4 5xl:grid-cols-5 sm:place-items-center md:place-items-start  inventoryCard max-w-full">
+                  <div className="my-4 grid grid-cols-1 md:grid-cols-2 gap-6 lg:grid-cols-2 xl:grid-cols-3 3xl:grid-cols-4 5xl:grid-cols-5 sm:place-items-center md:place-items-start  inventoryCard max-w-full">
                     {!isInventoriesLoading ? (
                       inventories.map((inventory, index) => {
                         return (


### PR DESCRIPTION
In the current grid format, it tries to accommodate 3 cards in a row for lg screensizes and 3 buttons in a row. With `Edit, Unlist, Mint` being shorter words they fit together. But `Transfer and Redeem` have a higher word count hence three buttons cannot fit together. 
Increasing the width of the overall card for lg screensizes fixes this problem.  



https://github.com/blockapps/strato-platform/assets/22127980/592aed99-d6f1-499c-96d1-e7811231bd9c
