### PR TITLE
adjust network health field due to monitor changes

### DIFF
--- a/apex/api/daemons/network-health-check-utils.js
+++ b/apex/api/daemons/network-health-check-utils.js
@@ -69,7 +69,7 @@ async function updateNetworkHealthStatus(status, statusMessage) {
   let [stat, created] = await models.CurrentHealth.findOrCreate({
     where: { processName: "NetworkHealthStat" },
     defaults: {
-      latestHealthStatus: !status.needsAttention,
+      latestHealthStatus: status.healthPublicInfo.latestHealthStatus,
       latestCheckTimestamp: currentTime,
       lastFailureTimestamp: currentTime, //default first time marked as failure
       additionalInfo: JSON.stringify({ ...status, statusMessage }),
@@ -79,8 +79,8 @@ async function updateNetworkHealthStatus(status, statusMessage) {
     await stat.update(
       {
         latestCheckTimestamp: currentTime,
-        latestHealthStatus: !status.needsAttention,
-        lastFailureTimestamp: !status.needsAttention
+        latestHealthStatus: status.healthPublicInfo.latestHealthStatus,
+        lastFailureTimestamp: status.healthPublicInfo.latestHealthStatus
           ? stat.lastFailureTimestamp
           : currentTime,
         additionalInfo: JSON.stringify({ ...status, statusMessage }),

--- a/apex/api/daemons/network-health-check-utils.js
+++ b/apex/api/daemons/network-health-check-utils.js
@@ -18,7 +18,9 @@ async function singleCheck() {
     } else {
       updateNetworkHealthStatus(
         {
-          needsAttention: true,
+          healthPublicInfo: {
+            latestHealthStatus: false,
+          }
         },
         "UNKNOWN"
       );
@@ -29,7 +31,9 @@ async function singleCheck() {
     winston.error("Network health status error: " + err.message);
     updateNetworkHealthStatus(
       {
-        needsAttention: true,
+        healthPublicInfo: {
+          latestHealthStatus: false,
+        }
       },
       "UNKNOWN"
     );
@@ -44,12 +48,12 @@ function queryNetworkHealthStatus() {
       );
       const status = await getNetworkStatus();
       winston.debug(
-        `Network is ${status.needsAttention ? "unhealthy" : "healthy"}`
+        `Network is ${!status.healthPublicInfo.latestHealthStatus ? "unhealthy" : "healthy"}`
       );
       winston.info("Updating network health");
       await updateNetworkHealthStatus(
         status,
-        `${status.needsAttention ? "UNHEALTHY" : "HEALTHY"}`
+        `${!status.healthPublicInfo.latestHealthStatus ? "UNHEALTHY" : "HEALTHY"}`
       );
       winston.info("Network health updated");
       return resolve();


### PR DESCRIPTION
With the splitting of the health into `Network Health` and `Overall Node Health` in CMD, the property we look at for network health has changed.