### PR TITLE
Fetch RedemptionServices owned by BlockApps

### DIFF
--- a/marketplace/backend/dapp/redemptions/redemptionService.js
+++ b/marketplace/backend/dapp/redemptions/redemptionService.js
@@ -84,7 +84,7 @@ async function get(user, args, defaultOptions) {
     if (address) {
         searchArgs = setSearchQueryOptions(restArgs, [{ key: 'address', value: address }, {key: 'isActive', value: 'true'}]);
     } else {
-        searchArgs = setSearchQueryOptions(restArgs, [{ key: 'serviceName', value: 'BlockApps Redemptions' }, {key: 'isActive', value: 'true'}]);
+        searchArgs = setSearchQueryOptions(restArgs, [{ key: 'ownerCommonName', value: 'BlockApps' }, {key: 'isActive', value: 'true'}]);
     }
   
     redemptionService = await searchOne(contractName, searchArgs, options, user);


### PR DESCRIPTION
Previously the marketplace would fetch redemption services named "BlockApps Redemptions", but now it will fetch redemption services owned by BlockApps. This should be more secure, since anyone could name their service "BlockApps Redemptions"