### PR TITLE
Fix race condition where sync status updated before blocks run

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -20,6 +20,7 @@ so that they could be properly moved to their respective version's subsection.
 ### Changed
 
 ### Fixed
+- patched rare race condition where node updates sync status to true before running the last few blocks left in the sync
 
 ### Removed
 

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -193,10 +193,10 @@ addBlocks unfiltered = do
           when didReplaceBest' $ do
             $logInfoS "addBlocks" "done inserting, now will emit stateDiff if necessary"
             nbb <- readIORef replacedBest
-            yield . OutIndexEvent $ NewBestBlock nbb
             when flags_sqlDiff $
               timeit "calculateAndEmitStateDiffs" timerToUse $
                 calculateAndEmitStateDiffs srLog oldHeader
+            yield . OutIndexEvent $ NewBestBlock nbb
           when (flags_sqlDiff && not (M.null ranPrivateTxs')) $ calculateAndEmitChainDiffs ranPrivateTxs'
 
 setParentStateRoot ::


### PR DESCRIPTION
An issue we encountered when testing on the prod marketplace node is that a user was allowed to post transactions before a node was fully synced because we update the best block before calculating and applying the statediffs. This resulted in the node reporting that it was synced without having yet applied the latest blocks' diffs, so the api allowed the transaction to pass to the vm, but the vm rejected it (causing mysterious errors for the user). The theoretical fix is to just wait until after the statediff to update the best block, but I have not been able to replicate the issue in order to test out the fix.