### PR TITLE
Separate ormolu, implicit-hie from buildbase

### DIFF
--- a/Dockerfile.buildbase
+++ b/Dockerfile.buildbase
@@ -7,8 +7,7 @@ RUN apt-get update && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean 
-RUN stack upgrade # hotfix for issue with stack 2.13.1 (provided in fpco/stack-build <=22.04) not being able to find the haddock stackage bucket for stack install commands. The issue does not persist in stack v2.15.7
-RUN stack install ormolu implicit-hie
+
 RUN git clone https://github.com/blockapps/secp256k1 && \
     cd secp256k1/ && \
     ./autogen.sh && \

--- a/Dockerfile.formatter
+++ b/Dockerfile.formatter
@@ -1,0 +1,11 @@
+ARG STACK_RESOLVER
+
+FROM fpco/stack-build:${STACK_RESOLVER}
+
+RUN stack upgrade # hotfix for issue with stack 2.13.1 (provided in fpco/stack-build <=22.04) not being able to find the haddock stackage bucket for stack install commands. The issue does not persist in stack v2.15.7
+
+RUN stack install ormolu implicit-hie
+
+WORKDIR /strato-platform
+
+ADD . .

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ build_buildbase:
 	@echo building buildbase...
 	docker build --build-arg STACK_RESOLVER=${STACK_RESOLVER} --tag=strato-buildbase:${STACK_RESOLVER} - < Dockerfile.buildbase
 
+build_formatter:
+	@echo building code formatter...
+	docker build --build-arg STACK_RESOLVER=${STACK_RESOLVER} --tag=strato-formatter:${STACK_RESOLVER} - < Dockerfile.formatter
+
 build_common: build_buildbase
 	@echo building haskell libraries and creating directories
 	mkdir -p ${HIGHWAYDIR}
@@ -117,11 +121,13 @@ build_common_fast: build_buildbase
 		--fast --no-run-tests \
 		--copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin
 
-pretty: build_buildbase
+pretty: build_formatter
 	@echo formatting STRATO Haskell code...
-	cd strato && \
-		gen-hie > hie.yaml && \
-		ormolu --mode inplace `git ls-files '*.hs'`
+	docker run --rm -v .:/strato-platform strato-formatter:${STACK_RESOLVER} ormolu --mode inplace `git ls-files '*.hs'`
+
+gen-hie: build_formatter develop
+	@echo generating hie.yaml file...
+	docker run --rm -v .:/strato-platform strato-formatter:${STACK_RESOLVER} `cd strato && gen-hie > hie.yaml`
 
 hoogle: build_buildbase
 	@echo generating and serving STRATO documentation...

--- a/strato/hie.yaml
+++ b/strato/hie.yaml
@@ -27,6 +27,9 @@ cradle:
     - path: "VM/SolidVM/solid-vm/bench/Paths_solid_vm.hs"
       component: "solid-vm:bench:codebench"
 
+    - path: "VM/SolidVM/solid-vm-compiler/src/"
+      component: "solid-vm-compiler:lib"
+
     - path: "VM/SolidVM/solid-vm-fuzzer/src/"
       component: "solid-vm-fuzzer:lib"
 
@@ -83,27 +86,6 @@ cradle:
 
     - path: "api/core/src"
       component: "core-api2:lib"
-
-    - path: "api/ethereum-jsonrpc/src/Main.hs"
-      component: "ethereum-jsonrpc:exe:ethereum-jsonrpc"
-
-    - path: "api/ethereum-jsonrpc/src/APIProxy.hs"
-      component: "ethereum-jsonrpc:exe:ethereum-jsonrpc"
-
-    - path: "api/ethereum-jsonrpc/src/Binary.hs"
-      component: "ethereum-jsonrpc:exe:ethereum-jsonrpc"
-
-    - path: "api/ethereum-jsonrpc/src/Commands.hs"
-      component: "ethereum-jsonrpc:exe:ethereum-jsonrpc"
-
-    - path: "api/ethereum-jsonrpc/src/RPC.hs"
-      component: "ethereum-jsonrpc:exe:ethereum-jsonrpc"
-
-    - path: "api/ethereum-jsonrpc/src/Server.hs"
-      component: "ethereum-jsonrpc:exe:ethereum-jsonrpc"
-
-    - path: "api/ethereum-jsonrpc/src/Paths_ethereum_jsonrpc.hs"
-      component: "ethereum-jsonrpc:exe:ethereum-jsonrpc"
 
     - path: "api/strato-api/exec_src/Main.hs"
       component: "strato-api:exe:strato-api"
@@ -261,9 +243,6 @@ cradle:
     - path: "core/strato-init/src/"
       component: "strato-init:lib"
 
-    - path: "core/strato-init/exec_src/FromRestore.hs"
-      component: "strato-init:exe:from-restore"
-
     - path: "core/strato-init/exec_src/GenesisBuilder.hs"
       component: "strato-init:exe:genesis-builder"
 
@@ -300,9 +279,6 @@ cradle:
     - path: "core/strato-p2p/exec_src/Paths_strato_p2p.hs"
       component: "strato-p2p:exe:strato-p2p"
 
-    - path: "core/strato-p2p/test"
-      component: "strato-p2p:test:strato-p2p-client-test"
-
     - path: "core/strato-redis-blockdb/src"
       component: "strato-redis-blockdb:lib"
 
@@ -320,9 +296,6 @@ cradle:
 
     - path: "core/strato-sequencer/exec-src/Flags.hs"
       component: "strato-sequencer:exe:strato-sequencer"
-
-    - path: "core/strato-sequencer/test"
-      component: "strato-sequencer:test:strato-sequencer-spec"
 
     - path: "core/strato-sequencer/bench/BlockstanbulSend.hs"
       component: "strato-sequencer:bench:send-to-blockstanbul"
@@ -356,6 +329,24 @@ cradle:
 
     - path: "core/vm-tools/test/"
       component: "vm-tools:test:contextm-test"
+
+    - path: "highway/api/src"
+      component: "blockapps-highway-api:lib"
+
+    - path: "highway/client/src"
+      component: "blockapps-highway-client:lib"
+
+    - path: "highway/server/src"
+      component: "blockapps-highway-server:lib"
+
+    - path: "highway/server/app/Main.hs"
+      component: "blockapps-highway-server:exe:blockapps-highway-server"
+
+    - path: "highway/server/app/Options.hs"
+      component: "blockapps-highway-server:exe:blockapps-highway-server"
+
+    - path: "highway/server/test/"
+      component: "blockapps-highway-server:test:highway-spec"
 
     - path: "identity-provider/api/src"
       component: "blockapps-identity-provider-api:lib"
@@ -393,10 +384,19 @@ cradle:
     - path: "indexer/strato-index/exec_src/ApiIndexerMain.hs"
       component: "strato-index:exe:strato-api-indexer"
 
+    - path: "indexer/strato-index/exec_src/Wiring.hs"
+      component: "strato-index:exe:strato-api-indexer"
+
     - path: "indexer/strato-index/exec_src/P2PIndexerMain.hs"
       component: "strato-index:exe:strato-p2p-indexer"
 
+    - path: "indexer/strato-index/exec_src/Wiring.hs"
+      component: "strato-index:exe:strato-p2p-indexer"
+
     - path: "indexer/strato-index/exec_src/TxrIndexerMain.hs"
+      component: "strato-index:exe:strato-txr-indexer"
+
+    - path: "indexer/strato-index/exec_src/Wiring.hs"
       component: "strato-index:exe:strato-txr-indexer"
 
     - path: "indexer/strato-index/test/"
@@ -420,11 +420,17 @@ cradle:
     - path: "libs/common-log/test/"
       component: "common-log:test:common-log-test"
 
+    - path: "libs/composable-monads/composable-monads-base/src"
+      component: "composable-monads-base:lib"
+
     - path: "libs/composable-monads/identity-monad/src"
       component: "identity-monad:lib"
 
     - path: "libs/composable-monads/kafka-monad/src"
       component: "kafka-monad:lib"
+
+    - path: "libs/composable-monads/redis-monad/src"
+      component: "redis-monad:lib"
 
     - path: "libs/composable-monads/sql-monad/src"
       component: "sql-monad:lib"
@@ -522,18 +528,6 @@ cradle:
     - path: "libs/x509-certs/test/"
       component: "x509-certs:test:x509-test"
 
-    - path: "simulator/strato-lite/src/"
-      component: "strato-lite:lib"
-
-    - path: "simulator/strato-lite/exec_src/Main.hs"
-      component: "strato-lite:exe:strato-lite"
-
-    - path: "simulator/strato-lite/exec_src/Paths_strato_lite.hs"
-      component: "strato-lite:exe:strato-lite"
-
-    - path: "simulator/strato-lite/tests/"
-      component: "strato-lite:test:simulator-spec"
-
     - path: "tools/blockapps-tools/src/"
       component: "blockapps-tools:lib"
 
@@ -544,16 +538,13 @@ cradle:
       component: "blockapps-tools:exe:modifyDate"
 
     - path: "tools/blockapps-tools/exec_src/Main.hs"
-      component: "blockapps-tools:exe:queryStrato"
+      component: "blockapps-tools:exe:strato-barometer"
 
     - path: "tools/blockapps-tools/test/"
       component: "blockapps-tools:test:blockapps-tools-test"
 
     - path: "tools/debugger-tools/exec_src/ghc-debug.hs"
       component: "debugger-tools:exe:ghc-debug"
-
-    - path: "tools/x509-tools/exec_src/X509CertRegistry.hs"
-      component: "x509-tools:exe:x509-certificate-registry"
 
     - path: "tools/x509-tools/exec_src/X509CertGenerator.hs"
       component: "x509-tools:exe:x509-generator"


### PR DESCRIPTION
This PR separates the `ormolu` and `implicit-hie` installs from the project buildbase into a separate Dockerfile. This will help reduce the build time of the buildbase.

- `Dockerfile.formatter` creates the `stack` environment that contains the ghc base and the `ormolu` and `implicit-hie` binaries.
- `make pretty` will strictly format all of the .hs files in the repo using the `ormolu` code formatter.
- `make gen-hie` is a new command that calls `implicit-hie` to create a `hie.yaml` file which IDEs use for auto-completions and what not (`make pretty` use to do this but `gen-hie` requires the project to be fully built to properly work so it made more sense to separate the two).