### PR TITLE
Changed checkout dropdown to use different field

### DIFF
--- a/marketplace/ui/src/components/MarketPlace/ConfirmOrder.js
+++ b/marketplace/ui/src/components/MarketPlace/ConfirmOrder.js
@@ -267,7 +267,7 @@ const ConfirmOrder = ({ paymentProviders = [], data, columns }) => {
                   >
                     {paymentProviders && paymentProviders.map(provider => (
                       provider && <Option className='payment-dropdown' key={provider?.serviceName} value={provider?.serviceName}>
-                        {provider?.checkoutText}
+                        Checkout with {provider?.serviceName}
                         <img src={provider?.imageURL} alt={provider?.serviceName} style={{ width: 20, height: 20, marginRight: 8 }} />
                       </Option>
                     ))}

--- a/marketplace/ui/src/components/MarketPlace/ResponsiveCart.js
+++ b/marketplace/ui/src/components/MarketPlace/ResponsiveCart.js
@@ -302,7 +302,7 @@ const ResponsiveCart = ({
               >
                 {paymentProviders && paymentProviders.map(provider => (
                   provider && <Option className='payment-dropdown' key={provider?.serviceName} value={provider?.serviceName}>
-                    {provider?.checkoutText}
+                    Checkout with {provider?.serviceName}
                     <img src={provider?.imageURL} alt={provider?.serviceName} style={{ width: 20, height: 20, marginRight: 8 }} />
                   </Option>
                 ))}


### PR DESCRIPTION
In the checkout page, we currently use `checkoutText` but changed it to use “Checkout with `serviceName`" instead.


<img width="516" alt="Screenshot 2024-07-22 at 9 26 08 PM" src="https://github.com/user-attachments/assets/ef9cad16-2e9a-4a50-b28a-04f2a10a7d14">
