### PR TITLE
[SolidVM] STRATO-3323 Add pragma solidvm 11.4

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -17,6 +17,7 @@ so that they could be properly moved to their respective version's subsection.
 ## [Unreleased] 
 ### Added
 - Added `pragma safeExternalCalls` for contracts that want to enforce extra type safety on external calls from other contracts
+- Added `pragma solidvm 11.4` that includes all existing pragmas and their features
 
 ### Changed
 

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
@@ -22,6 +22,7 @@ module SolidVM.Model.CodeCollection (
   imports,
   usesStrictModifiers,
   getContractsBySolidString,
+  resolvePragmaFeature,
   module SolidVM.Model.CodeCollection.Contract,
   --module SolidVM.Model.CodeCollection.Def,
   module SolidVM.Model.CodeCollection.Function,
@@ -156,8 +157,21 @@ instance Arbitrary CodeCollection where
       ]
 
 usesStrictModifiers :: CodeCollectionF a -> Bool
-usesStrictModifiers = isJust . find ((== "strict") . fst) . _pragmas
+usesStrictModifiers = flip resolvePragmaFeature "strict" . _pragmas
 
 -- Function to get all ContractF values matching a SolidString
 getContractsBySolidString :: SolidString -> CodeCollectionF a -> Maybe (ContractF a)
 getContractsBySolidString solidStr codeCollection = M.lookup solidStr (_contracts codeCollection)
+
+resolvePragmaFeature :: [(String, String)] -> String -> Bool
+resolvePragmaFeature pragmaList feature = 
+  let solidVMVersion = maybe "" snd $ find ((== "solidvm") . fst) pragmaList
+  in case (solidVMVersion) of
+      ("11.4") -> 
+        case feature of
+          "es6" -> True
+          "strict" -> True
+          "builtinCreates" -> True
+          "safeExternalCalls" -> True
+          _ -> False
+      (_) -> isJust $ find ((== feature) . fst) pragmaList

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/ParserTypes.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/ParserTypes.hs
@@ -76,7 +76,18 @@ setContractName cn =
 addPragma :: String -> String -> SolidityParser ()
 addPragma k v = do
   ParserState {..} <- getState
-  putState $ ParserState contractName pragmaVersion (M.insert k v pragmas) userDefinedTypes contractSrcLength
+  case k of
+    "solidvm" ->
+      let versionPragmaMap = resolveSolidVMVersion v
+          newPragmas = M.union versionPragmaMap pragmas
+      in putState $ ParserState contractName pragmaVersion newPragmas userDefinedTypes contractSrcLength
+    _ -> putState $ ParserState contractName pragmaVersion (M.insert k v pragmas) userDefinedTypes contractSrcLength
+  where
+    resolveSolidVMVersion :: String -> M.Map String String
+    resolveSolidVMVersion version =
+      case version of
+        "11.4" -> M.fromList $ [("es6", ""), ("strict", ""), ("builtinCreates", ""), ("safeExternalCalls", "")]
+        _ -> M.empty
 
 addUserDefinedType :: String -> String -> SolidityParser ()
 addUserDefinedType k v =

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2697,7 +2697,7 @@ callBuiltin "create" args@[SString contractName', SString contractSrc, SString a
   -- will still work but will have incorrect codeptrs.
   -- Thus, when the testnet wipes, this pragma can largely be removed because the old contracts on the
   -- testnet won't exist anymore and the stateroot mismatches will be fixed.
-  let pragmaCheck = isJust $ find ((== "builtinCreates") . fst) $ CC._pragmas parentCC
+  let pragmaCheck = CC.resolvePragmaFeature (CC._pragmas parentCC) "builtinCreates"
   (hsh, cc) <- codeCollectionFromSource True $ BC.pack contractSrc
   newAddress <- getNewAddress creator
   let constructorArgs = case runParser parseArgs initialParserState "" argString of
@@ -2742,7 +2742,7 @@ callBuiltin "create2" args@[salt, SString contractName', SString contractSrc, SS
   -- will still work but will have incorrect codeptrs.
   -- Thus, when the testnet wipes, this pragma can largely be removed because the old contracts on the
   -- testnet won't exist anymore and the stateroot mismatches will be fixed.
-  let pragmaCheck = isJust $ find ((== "builtinCreates") . fst) $ CC._pragmas parentCC
+  let pragmaCheck = CC.resolvePragmaFeature (CC._pragmas parentCC) "builtinCreates"
   (hsh, cc) <- codeCollectionFromSource True $ BC.pack contractSrc
   let constructorArgs = case runParser parseArgs initialParserState "" argString of
         Right parsedArgs -> parsedArgs
@@ -2902,7 +2902,7 @@ runTheConstructors from to hsh cc contractName' argExps = do
           for_ (toBasic defVal) $ markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n])
     -- SVMType.Bool -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n]) $ MS.BBool False
 
-    let isStrict = isJust $ find ((== "strict") . fst) $ CC._pragmas cc
+    let isStrict = CC.resolvePragmaFeature (CC._pragmas cc) "strict"
     forM_ (reverse $ contract' ^. CC.parents) $ \parent -> do
       if isStrict
         then for_ (M.lookup parent . CC._funcConstructorCalls =<< contract' ^. CC.constructor) $ \args'' -> do
@@ -2990,7 +2990,7 @@ runTheCall address' contract' funcName hsh cc theFunction argVals ro ff = do
 
   -- 'pragma safeExternalCalls' is used for contracts that may receive external calls
   -- and want to enforce a typecheck on arguments given by other contracts
-  let pragmaCheck = isJust $ find ((== "safeExternalCalls") . fst) $ CC._pragmas cc
+  let pragmaCheck = CC.resolvePragmaFeature (CC._pragmas cc) "safeExternalCalls"
   when pragmaCheck $ do
    unlessM (validateFunctionArguments theFunction argVals) $
     typeError

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -185,6 +185,10 @@ anyImmutableError :: Selector HandledException
 anyImmutableError (HE Blockchain.SolidVM.Exception.ImmutableError {}) = True
 anyImmutableError _ = False
 
+specificTypeError :: String -> Selector HandledException
+specificTypeError str (HE (Blockchain.SolidVM.Exception.TypeError _ mes)) = mes == str
+specificTypeError _ _ = False 
+
 failedToAttainRunTimCodeError :: Selector HandledException
 failedToAttainRunTimCodeError (HE Blockchain.SolidVM.Exception.FailedToAttainRunTimCode {}) = True
 failedToAttainRunTimCodeError _ = False
@@ -8934,6 +8938,95 @@ contract qq {
 
     res <- runBS' [r|
 pragma safeExternalCalls;
+contract qq {
+    bool public myVal;
+
+    function changeMyVal(bool b){
+        myVal = b;
+    }
+}|]
+
+    case getAddressFromResult res of
+      Nothing -> error "No address returned"
+      Just address -> runCall' "changeMyValOfTest" (T.pack $ "(0x"++ formatAddressWithoutColor address ++", 3 )" ) [r|
+contract Test {
+    int public myVal;
+
+    function changeMyVal(int b){
+        myVal = b;
+    }
+}
+contract qq {
+    function changeMyValOfTest(address a, int v) returns (int) {
+        Test(a).changeMyVal(v);
+        return Test(a).myVal();
+    }
+}|]) `shouldThrow` anyTypeError
+
+  it "can use es6 imports with solidvm 11.4 pragma" $ runTest ( do
+    runBS [r|
+pragma solidvm 11.4;
+import { someFunc } from <123>;
+
+contract qq {
+  int x = 0;
+
+  constructor() {
+    x = 5;
+  }
+}
+|]) `shouldThrow` specificTypeError "\"Could not find file <0000000000000000000000000000000000000123>\""
+
+  it "can use strict modifiers with solidvm 11.4 pragma" $ runTest ( do
+    runBS [r|
+pragma solidvm 11.4;
+
+contract A {
+  int y = 5;
+  
+  function getY() private returns (int) {
+    return y;
+  }
+}
+
+contract qq is A {
+  A a = new A();
+  int x = 0;
+
+  constructor() {
+    x = a.getY();
+  }
+}
+|]) `shouldThrow` specificTypeError "\" (line 17, column 9) - (line 17, column 10): \\\"Missing label: ABottom ( (line 17, column 9) - (line 17, column 10): \\\\\\\"cannot access function getY because it is marked as private\\\\\\\"  :| []) is not a known enum, struct, or contract.\\\" \""
+
+  it "can use create and create2 built-in function calls with solidvm 11.4 pragma" . runTest $ do
+    runBS
+      [r|
+pragma solidvm 11.4;
+
+contract qq {
+  account a;
+  account b;
+
+  constructor() {
+    a = create("A", "contract A {\n uint x = 1;\n string y;\n constructor (uint _x, string _y) {\n  x = _x;\n  y = _y;\n }\n}", "(3, 'hi')");
+    b = create2("salt", "B", "contract B {\n uint x = 2;\n constructor (uint _x) {\n  x = _x;\n }\n}", "(4)");
+  }
+}|]
+    getFields ["b"]
+      `shouldReturn` [BAccount $ NamedAccount (deriveAddressWithSalt (stringAddress "e8279be14e9fe2ad2d8e52e42ca96fb33a813bbe") "salt" (Just . hash $ BC.pack "contract B {\n uint x = 2;\n constructor (uint _x) {\n  x = _x;\n }\n}") (Just "OrderedVals [SInteger 4]")) UnspecifiedChain]
+    [BAccount a] <- getFields ["a"]
+    [BAccount b] <- getFields ["b"]
+    getSolidStorageKeyVal' (namedAccountToAccount Nothing a) (singleton "x") `shouldReturn` BInteger 3
+    getSolidStorageKeyVal' (namedAccountToAccount Nothing a) (singleton "y") `shouldReturn` BString "hi"
+    getSolidStorageKeyVal' (namedAccountToAccount Nothing b) (singleton "x") `shouldReturn` BInteger 4
+
+  it "can error handle improperly referenced overloaded contracts using solidvm 11.4 pragma" $ runTest ( do 
+    let getAddressFromResult :: ExecResults -> Maybe Address 
+        getAddressFromResult res = _accountAddress <$> erNewContractAccount res
+
+    res <- runBS' [r|
+pragma solidvm 11.4;
 contract qq {
     bool public myVal;
 

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -330,7 +330,7 @@ mineTransactions' header remGas ran unran@(tx : txs) = do
   trr <- setNewAddresses $ TxRunResult tx result time' beforeMap afterMap []
   case result of
     Right execResult ->
-      let supportedPragmas = [("es6", ""), ("strict", ""), ("builtinCreates", ""), ("safeExternalCalls", "")]
+      let supportedPragmas = [("es6", ""), ("strict", ""), ("builtinCreates", ""), ("safeExternalCalls", ""), ("solidvm", "11.4")]
           findInvalidPragmas pragma = if fst pragma == "solidity" || pragma `elem` supportedPragmas then id else (pragma :) -- include solidity pragma for backwards compatibility
           invalidPragmasUsed = foldr findInvalidPragmas [] (erPragmas execResult)
        in if not $ null invalidPragmasUsed


### PR DESCRIPTION
The new `pragma solidvm 11.4` encompasses all the pre-existing pragmas and is also responsible for guarding the new SolidVM features. Adding `pragma solidvm 11.4` is the equivalent to having the pragmas `es6, strict, builtinCreates, safeExternalCalls` in your contract.