### PR TITLE
expose proxy to POST /signature endpoint of vault

### DIFF
--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -315,6 +315,12 @@ http {
         proxy_pass http://__STRATO_HOSTNAME__:__STRATO_PORT_VAULT_PROXY__/strato/v2.3/key;
       }
 
+      location /strato/v2.3/signature {
+        rewrite_by_lua_file lua/openid.lua;
+#         auth_request /_api_counter;                                             #TEMPLATE_MARK_STATS_ENABLED
+        proxy_pass http://__STRATO_HOSTNAME__:__STRATO_PORT_VAULT_PROXY__/strato/v2.3/signature;
+      }
+
       location /strato/v2.3/users {
         rewrite_by_lua_file lua/openid.lua;
 #         auth_request /_api_counter;                                             #TEMPLATE_MARK_STATS_ENABLED


### PR DESCRIPTION
You can use strato as a proxy to the vault it is connected to, but for some reason, we didn't expose the POST /signature endpoint. Remedying that now because we would actually like to be able to call it