### PR TITLE
Fixed payment dropdown in checkout

### DIFF
--- a/marketplace/ui/src/components/MarketPlace/Checkout.js
+++ b/marketplace/ui/src/components/MarketPlace/Checkout.js
@@ -358,7 +358,7 @@ const Checkout = () => {
 
   const filterPaymentServices = (es) => {
     const ps = es.map(p => paymentServices.find(s => s.address === p.value));
-    if (ps.length === 0) {
+    if (ps.length === 0 || ps[0] === undefined) {
       return paymentServices.filter((p) => p && p.serviceName === 'Stripe');
     } else {
       return ps;


### PR DESCRIPTION
If there is no payment provider associated with an Asset (usually an older Asset), we should display Stripe as a payment option. There was incorrect logic in place for this, but has been fixed in this PR.


Before:

<img width="1401" alt="Screenshot 2024-07-24 at 5 27 10 PM" src="https://github.com/user-attachments/assets/9387d769-e26c-4e0b-a231-05894974bd90">

After:

<img width="1380" alt="Screenshot 2024-07-24 at 5 27 34 PM" src="https://github.com/user-attachments/assets/c350cc5c-1ae3-4b78-b539-e2883ef24f67">
