### PR TITLE
Fix paymentProviders fetch in product details page

### DIFF
--- a/marketplace/backend/dapp/orders/sale.js
+++ b/marketplace/backend/dapp/orders/sale.js
@@ -110,9 +110,10 @@ async function get(user, args, options) {
     const newOptions = { ...options, org: 'BlockApps', app: 'Mercata' }
     let sale;
     let searchArgs;
+    const newArgs = { ...restArgs, queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)' } }
 
     if (assetToBeSold) {
-        searchArgs = setSearchQueryOptions(restArgs,
+        searchArgs = setSearchQueryOptions(newArgs,
             [{
                 key: "assetToBeSold",
                 value: assetToBeSold,
@@ -124,7 +125,7 @@ async function get(user, args, options) {
             ]);
     }
     else {
-        searchArgs = setSearchQueryOptions(restArgs,
+        searchArgs = setSearchQueryOptions(newArgs,
             [{
                 key: "address",
                 value: address,
@@ -189,15 +190,15 @@ async function getAll(admin, args = {}, defaultOptions) {
             gtValue: saleGtValue,
             isOpen: isOpen,
             range: range,
-            queryOptions: {'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)'}
+            queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)' }
         }, options, admin);
     }
     else {
-        sales = await searchAllWithQueryArgs(contractName, { 
-            address: saleAddresses, 
-            isOpen: isOpen, 
-            queryOptions: {'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)'},
-            ...restArgs, 
+        sales = await searchAllWithQueryArgs(contractName, {
+            address: saleAddresses,
+            isOpen: isOpen,
+            queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)' },
+            ...restArgs,
         }, options, admin);
     }
 

--- a/marketplace/backend/dapp/products/inventory.js
+++ b/marketplace/backend/dapp/products/inventory.js
@@ -385,6 +385,7 @@ async function get(user, args, options) {
             price: sale.price,
             saleAddress: sale.address,
             saleQuantity: sale.quantity,
+            paymentProviders: sale ? (sale['BlockApps-Mercata-Sale-paymentProviders'] ? sale['BlockApps-Mercata-Sale-paymentProviders'] : null) : null
         }
     }
 


### PR DESCRIPTION
Before, if you tried to fetch an Asset from the product details page, it wouldn't fetch the `paymentProviders`. This is because it is stored as an array which needs to be explicitly fetched as it is its own table. This caused the available `paymentProviders` specific to the Asset to not show up as an option in the checkout page. Instead, it would just default to Stripe as the only payment option.

Demo (beginning shows before fixes and then after fixes):


https://github.com/user-attachments/assets/a7f0373f-cfc9-4b54-a5e4-cc36f0e1ffb6

