### PR TITLE
Strato 3324 typecheck in emit statements

### DIFF
--- a/marketplace/backend/dapp/orders/sale.js
+++ b/marketplace/backend/dapp/orders/sale.js
@@ -110,9 +110,10 @@ async function get(user, args, options) {
     const newOptions = { ...options, org: 'BlockApps', app: 'Mercata' }
     let sale;
     let searchArgs;
+    const newArgs = { ...restArgs, queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)' } }
 
     if (assetToBeSold) {
-        searchArgs = setSearchQueryOptions(restArgs,
+        searchArgs = setSearchQueryOptions(newArgs,
             [{
                 key: "assetToBeSold",
                 value: assetToBeSold,
@@ -124,7 +125,7 @@ async function get(user, args, options) {
             ]);
     }
     else {
-        searchArgs = setSearchQueryOptions(restArgs,
+        searchArgs = setSearchQueryOptions(newArgs,
             [{
                 key: "address",
                 value: address,
@@ -189,15 +190,15 @@ async function getAll(admin, args = {}, defaultOptions) {
             gtValue: saleGtValue,
             isOpen: isOpen,
             range: range,
-            queryOptions: {'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)'}
+            queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)' }
         }, options, admin);
     }
     else {
-        sales = await searchAllWithQueryArgs(contractName, { 
-            address: saleAddresses, 
-            isOpen: isOpen, 
-            queryOptions: {'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)'},
-            ...restArgs, 
+        sales = await searchAllWithQueryArgs(contractName, {
+            address: saleAddresses,
+            isOpen: isOpen,
+            queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)' },
+            ...restArgs,
         }, options, admin);
     }
 

--- a/marketplace/backend/dapp/products/inventory.js
+++ b/marketplace/backend/dapp/products/inventory.js
@@ -385,6 +385,7 @@ async function get(user, args, options) {
             price: sale.price,
             saleAddress: sale.address,
             saleQuantity: sale.quantity,
+            paymentProviders: sale ? (sale['BlockApps-Mercata-Sale-paymentProviders'] ? sale['BlockApps-Mercata-Sale-paymentProviders'] : null) : null
         }
     }
 

--- a/marketplace/ui/src/components/MarketPlace/NewTrendingCard.js
+++ b/marketplace/ui/src/components/MarketPlace/NewTrendingCard.js
@@ -133,7 +133,7 @@ const NewTrendingCard = ({ topSellingProduct, addItemToCart, parent = "", api, c
                 <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                     {topSellingProduct?.price &&
                         <Typography className="font-semibold">
-                        {`$${topSellingProduct?.price} `} <span className="font-normal text-xs mr-2 text-primary"><b> {`(${topSellingProduct?.price * STRATS_CONVERSION} STRATS)`} </b></span>
+                        {`$${topSellingProduct?.price} `} <span className="font-normal text-xs mr-2 text-primary"><b> {`(${(topSellingProduct?.price * STRATS_CONVERSION).toFixed(0)} STRATS)`} </b></span>
                     </Typography>
                     
                     }

--- a/marketplace/ui/src/components/MarketPlace/ProductDetails.js
+++ b/marketplace/ui/src/components/MarketPlace/ProductDetails.js
@@ -518,7 +518,7 @@ const ProductDetails = ({ user, users }) => {
                   <Paragraph level={4} id="price" className=" text-[#13188A] text-xl font-bold lg:text-2xl lg:font-semibold">
                     {details?.price ? (
                       <>
-                        ${details?.price} <span className="font-normal text-xs mr-2 text-primary"><b>({details?.price * STRATS_CONVERSION} STRATS)</b></span>
+                        ${details?.price} <span className="font-normal text-xs mr-2 text-primary"><b>({(details?.price * STRATS_CONVERSION).toFixed(0)} STRATS)</b></span>
                       </>
                     ) : (
                       "No Price Available"

--- a/strato/VM/SolidVM/solid-vm-static-analysis/package.yaml
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/package.yaml
@@ -32,3 +32,4 @@ library:
   - source-tools
   - text
   - transformers
+  - data-default

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -38,7 +38,7 @@ import SolidVM.Solidity.StaticAnalysis.Types
 import Text.Read (readMaybe)
 --import qualified Text.Colors                          as C
 --import           Control.Monad.IO.Class
---import Debug.Trace
+import Debug.Trace
 
 emptyAnnotation :: SourceAnnotation Text
 emptyAnnotation = (SourceAnnotation (initialPosition "") (initialPosition "") "")
@@ -1620,17 +1620,25 @@ statementHelper (EmitStatement eventName vals x) = do
   c  <- asks contract
   case M.lookup eventName (_events c) of 
     Just event -> do
-      let vals' =     fmap (\(_,b) -> let r = R cc c Nothing "Nothing" []
-                                        in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
-                          ) vals
+      let vals' = fmap (\(_, b) -> 
+                          let r = R cc c Nothing "Nothing" []
+                          in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
+                       ) vals
+          valsDebug = trace ("Evaluated types: " ++ show vals') vals'
+      
       let vals'' = map (\y -> case y of
                                 Static s _ -> s
                                 _          -> error "Type is not static"
-                       ) vals'
-      if [indexedTypeType it | (_,it) <- _eventLogs event] /= vals''
-        then pure . bottom $ "Type is not Static" <$ x
+                       ) valsDebug
+          valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
+      
+      let expectedTypes = [indexedTypeType it | (_, it) <- _eventLogs event]
+          expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
+      
+      if expectedTypesDebug /= valsStaticDebug
+        then pure . bottom $ "Type mismatch in event arguments" <$ x
         else reduceType' x <$> traverse (tcExpr . snd) vals
-    Nothing -> pure . bottom $ "Event does not exist" <$ x 
+    Nothing -> pure . bottom $ "Event does not exist" <$ x
 
 
 statementHelper (RevertStatement _ (NamedArgs vals) x) =

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1588,8 +1588,32 @@ statementHelper (Throw e x) = do
   et <- tcExpr e
   pure $ reduceType' x [et]
 statementHelper (ModifierExecutor x) = pure $ topType' x
-statementHelper (EmitStatement _ vals x) =
+statementHelper (EmitStatement eventName vals x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
+  {-
+       
+    data StatementF a
+    = EmitStatement String [(Maybe String, (ExpressionF a))] a
+
+    data ContractF a = Contract
+    {
+     _events :: Map SolidString (SolidVM.EventF a)
+    }
+
+    data EventF a = Event
+    { _eventAnonymous :: Bool,
+      _eventLogs :: [(Text, SolidVM.IndexedType)],
+      _eventContext :: a
+    }
+    
+    usage:
+      event EventName(dataType y); 
+      emit EventName(expression)
+    
+    Typecheck: 
+      1. Look for EventName in events (in contractF.events) and error out if it does not exist
+      2. Ensure that the type for each argument in EventName matches with the dataType (also have to be in the same order)
+  -}
 statementHelper (RevertStatement _ (NamedArgs vals) x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement _ (OrderedArgs vals) x) =

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1624,18 +1624,21 @@ statementHelper (EmitStatement eventName vals x) = do
                           let r = R cc c Nothing "Nothing" []
                           in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
                        ) vals
+          -- Debugging: Print evaluated types
           valsDebug = trace ("Evaluated types: " ++ show vals') vals'
       
       let vals'' = map (\y -> case y of
                                 Static s _ -> s
                                 _          -> error "Type is not static"
                        ) valsDebug
+          -- Debugging: Print static types
           valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
       
       let expectedTypes = [indexedTypeType it | (_, it) <- _eventLogs event]
+          -- Debugging: Print expected types
           expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
       
-      if expectedTypesDebug /= valsStaticDebug
+      if not (and $ zipWith isSameType expectedTypesDebug valsStaticDebug)
         then pure . bottom $ "Type mismatch in event arguments" <$ x
         else reduceType' x <$> traverse (tcExpr . snd) vals
     Nothing -> pure . bottom $ "Event does not exist" <$ x
@@ -1649,6 +1652,28 @@ statementHelper (UncheckedStatement body x) =
   statementsHelper' x body
 statementHelper (AssemblyStatement _ x) = pure $ topType' x
 statementHelper (SimpleStatement stmt x) = simpleStatementHelper x stmt
+
+-----idk if this is right but it is what it is----
+isSameType :: Type -> Type -> Bool
+isSameType (SVMType.Int _ _) (SVMType.Int _ _) = True
+isSameType (SVMType.String _) (SVMType.String _) = True
+isSameType (SVMType.Bytes _ _) (SVMType.Bytes _ _) = True
+isSameType SVMType.Decimal SVMType.Decimal = True
+isSameType SVMType.Bool SVMType.Bool = True
+isSameType (SVMType.Address _) (SVMType.Address _) = True
+isSameType (SVMType.Account _) (SVMType.Account _) = True
+isSameType (SVMType.UnknownLabel s1 _) (SVMType.UnknownLabel s2 _) = s1 == s2
+isSameType (SVMType.Struct _ t1) (SVMType.Struct _ t2) = t1 == t2
+isSameType (SVMType.UserDefined a1 _) (SVMType.UserDefined a2 _) = a1 == a2
+isSameType (SVMType.Enum _ t1 _) (SVMType.Enum _ t2 _) = t1 == t2
+isSameType (SVMType.Error _ t1) (SVMType.Error _ t2) = t1 == t2
+isSameType (SVMType.Array e1 _) (SVMType.Array e2 _) = isSameType e1 e2
+isSameType (SVMType.Contract t1) (SVMType.Contract t2) = t1 == t2
+isSameType (SVMType.Mapping _ k1 v1) (SVMType.Mapping _ k2 v2) = isSameType k1 k2 && isSameType v1 v2
+isSameType SVMType.Variadic SVMType.Variadic = True
+isSameType _ _ = False
+
+
 
 simpleStatementHelper :: SourceAnnotation Text -> Annotated SimpleStatementF -> SSS Type'
 simpleStatementHelper x (VariableDefinition vdefs mExpr) = do

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -19,6 +19,7 @@ import Control.Monad.Trans.State
 import Data.Bool (bool)
 import Data.Foldable (traverse_)
 -- import           Data.Functor.Identity (runIdentity)
+import Data.List (find)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -1589,27 +1590,32 @@ statementHelper (Throw e x) = do
 statementHelper (ModifierExecutor x) = pure $ topType' x
 statementHelper (EmitStatement eventName vals x) = do
   cc <- asks codeCollection
-  c  <- asks contract
-  case M.lookup eventName (_events c) of 
-    Just event -> do
-      let vals' = fmap (\(_, b) -> 
-                          let r = R cc c Nothing "Nothing" []
-                          in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
-                       ) vals
-          -- valsDebug = trace ("Evaluated types: " ++ show vals') vals'
-      let vals'' = map (\y -> case y of
-                                Static s _ -> s
-                                _          -> error "Internal Error: Type is not static"
-                       ) vals'
-          -- valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
-      let expectedTypes = [indexedTypeType it | (_, it) <- _eventLogs event]
-          -- expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
-      if length expectedTypes /= length vals''
-        then pure . bottom $ "Wrong number of arguments provided" <$ x
-        else if not (and $ zipWith isSameType expectedTypes vals'')
-          then pure . bottom $ "Type mismatch in event arguments" <$ x
-          else reduceType' x <$> traverse (tcExpr . snd) vals 
-    Nothing -> pure . bottom $ "Event does not exist" <$ x
+  let solidVMVersion = maybe "" snd $ find ((== "solidvm") . fst) $ _pragmas cc
+  case solidVMVersion of
+    "11.4" -> do
+      c  <- asks contract
+      case M.lookup eventName (_events c) of 
+        Just event -> do
+          let vals' = fmap (\(_, b) -> 
+                              let r = R cc c Nothing "Nothing" []
+                              in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
+                           ) vals
+              -- valsDebug = trace ("Evaluated types: " ++ show vals') vals'
+          let vals'' = map (\y -> case y of
+                                    Static s _ -> s
+                                    _          -> error "Internal Error: Type is not static"
+                           ) vals'
+              -- valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
+          let expectedTypes = [indexedTypeType it | (_, it) <- _eventLogs event]
+              -- expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
+          if length expectedTypes /= length vals''
+            then pure . bottom $ "Wrong number of arguments provided" <$ x
+            else if not (and $ zipWith isSameType expectedTypes vals'')
+              then pure . bottom $ "Type mismatch in event arguments" <$ x
+              else reduceType' x <$> traverse (tcExpr . snd) vals 
+        Nothing -> pure . bottom $ "Event does not exist" <$ x
+    _    ->
+      reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement _ (NamedArgs vals) x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement _ (OrderedArgs vals) x) =

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1239,7 +1239,7 @@ boolArgs x =
       :| [ boolType' x
          ]
 
-byteArgs :: SourceAnnotation Text -> Type'
+byteArgs :: SourceAnnotation Text -> Type's
 byteArgs x = intType' x
 
 keccak256Args :: SourceAnnotation Text -> Type'

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -38,7 +38,7 @@ import SolidVM.Solidity.StaticAnalysis.Types
 import Text.Read (readMaybe)
 --import qualified Text.Colors                          as C
 --import           Control.Monad.IO.Class
-import Debug.Trace
+-- import Debug.Trace
 
 emptyAnnotation :: SourceAnnotation Text
 emptyAnnotation = (SourceAnnotation (initialPosition "") (initialPosition "") "")
@@ -1588,34 +1588,6 @@ statementHelper (Throw e x) = do
   pure $ reduceType' x [et]
 statementHelper (ModifierExecutor x) = pure $ topType' x
 statementHelper (EmitStatement eventName vals x) = do
-  
-  {-
-       
-    data StatementF a
-    = EmitStatement String [(Maybe String, (ExpressionF a))] a
-
-    data ContractF a = Contract
-    {
-     _events :: Map SolidString (SolidVM.EventF a)
-    }
-
-    data EventF a = Event
-    { _eventAnonymous :: Bool,
-      _eventLogs :: [(Text, SolidVM.IndexedType)],
-      _eventContext :: a
-    }
-
-
-    data IndexedType = IndexedType {indexedTypeIndex :: Int32, indexedTypeType :: Type}
-    
-    usage:
-      event EventName(dataType y); 
-      emit EventName(expression)
-    
-    Typecheck: 
-      1. Look for EventName in events (in contractF.events) and error out if it does not exist
-      2. Ensure that the type for each argument in EventName matches with the dataType (also have to be in the same order)
-  -}
   cc <- asks codeCollection
   c  <- asks contract
   case M.lookup eventName (_events c) of 
@@ -1624,26 +1596,20 @@ statementHelper (EmitStatement eventName vals x) = do
                           let r = R cc c Nothing "Nothing" []
                           in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
                        ) vals
-          -- Debugging: Print evaluated types
-          valsDebug = trace ("Evaluated types: " ++ show vals') vals'
-      
+          -- valsDebug = trace ("Evaluated types: " ++ show vals') vals'
       let vals'' = map (\y -> case y of
                                 Static s _ -> s
-                                _          -> error "Type is not static"
-                       ) valsDebug
-          -- Debugging: Print static types
-          valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
-      
+                                _          -> error "Internal Error: Type is not static"
+                       ) vals'
+          -- valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
       let expectedTypes = [indexedTypeType it | (_, it) <- _eventLogs event]
-          -- Debugging: Print expected types
-          expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
-      
-      if not (and $ zipWith isSameType expectedTypesDebug valsStaticDebug)
-        then pure . bottom $ "Type mismatch in event arguments" <$ x
-        else reduceType' x <$> traverse (tcExpr . snd) vals
+          -- expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
+      if length expectedTypes /= length vals''
+        then pure . bottom $ "Wrong number of arguments provided" <$ x
+        else if not (and $ zipWith isSameType expectedTypes vals'')
+          then pure . bottom $ "Type mismatch in event arguments" <$ x
+          else reduceType' x <$> traverse (tcExpr . snd) vals 
     Nothing -> pure . bottom $ "Event does not exist" <$ x
-
-
 statementHelper (RevertStatement _ (NamedArgs vals) x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement _ (OrderedArgs vals) x) =
@@ -1653,7 +1619,6 @@ statementHelper (UncheckedStatement body x) =
 statementHelper (AssemblyStatement _ x) = pure $ topType' x
 statementHelper (SimpleStatement stmt x) = simpleStatementHelper x stmt
 
------idk if this is right but it is what it is----
 isSameType :: Type -> Type -> Bool
 isSameType (SVMType.Int _ _) (SVMType.Int _ _) = True
 isSameType (SVMType.String _) (SVMType.String _) = True
@@ -1672,8 +1637,6 @@ isSameType (SVMType.Contract t1) (SVMType.Contract t2) = t1 == t2
 isSameType (SVMType.Mapping _ k1 v1) (SVMType.Mapping _ k2 v2) = isSameType k1 k2 && isSameType v1 v2
 isSameType SVMType.Variadic SVMType.Variadic = True
 isSameType _ _ = False
-
-
 
 simpleStatementHelper :: SourceAnnotation Text -> Annotated SimpleStatementF -> SSS Type'
 simpleStatementHelper x (VariableDefinition vdefs mExpr) = do

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -36,7 +36,6 @@ import SolidVM.Model.Type (Type)
 import qualified SolidVM.Model.Type as SVMType
 import SolidVM.Solidity.StaticAnalysis.Types
 import Text.Read (readMaybe)
-
 --import qualified Text.Colors                          as C
 --import           Control.Monad.IO.Class
 --import Debug.Trace
@@ -1239,7 +1238,7 @@ boolArgs x =
       :| [ boolType' x
          ]
 
-byteArgs :: SourceAnnotation Text -> Type's
+byteArgs :: SourceAnnotation Text -> Type'
 byteArgs x = intType' x
 
 keccak256Args :: SourceAnnotation Text -> Type'
@@ -1588,8 +1587,8 @@ statementHelper (Throw e x) = do
   et <- tcExpr e
   pure $ reduceType' x [et]
 statementHelper (ModifierExecutor x) = pure $ topType' x
-statementHelper (EmitStatement eventName vals x) =
-  reduceType' x <$> traverse (tcExpr . snd) vals
+statementHelper (EmitStatement eventName vals x) = do
+  
   {-
        
     data StatementF a
@@ -1605,6 +1604,9 @@ statementHelper (EmitStatement eventName vals x) =
       _eventLogs :: [(Text, SolidVM.IndexedType)],
       _eventContext :: a
     }
+
+
+    data IndexedType = IndexedType {indexedTypeIndex :: Int32, indexedTypeType :: Type}
     
     usage:
       event EventName(dataType y); 
@@ -1614,6 +1616,23 @@ statementHelper (EmitStatement eventName vals x) =
       1. Look for EventName in events (in contractF.events) and error out if it does not exist
       2. Ensure that the type for each argument in EventName matches with the dataType (also have to be in the same order)
   -}
+  cc <- asks codeCollection
+  c  <- asks contract
+  case M.lookup eventName (_events c) of 
+    Just event -> do
+      let vals' =     fmap (\(_,b) -> let r = R cc c Nothing "Nothing" []
+                                        in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
+                          ) vals
+      let vals'' = map (\y -> case y of
+                                Static s _ -> s
+                                _          -> error "Type is not static"
+                       ) vals'
+      if [indexedTypeType it | (_,it) <- _eventLogs event] /= vals''
+        then pure . bottom $ "Type is not Static" <$ x
+        else reduceType' x <$> traverse (tcExpr . snd) vals
+    Nothing -> pure . bottom $ "Event does not exist" <$ x 
+
+
 statementHelper (RevertStatement _ (NamedArgs vals) x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement _ (OrderedArgs vals) x) =


### PR DESCRIPTION
Currently, the typechecker does not load the definition of the error that is being emitted in an EmitStatement, and instead just checks that each argument within the EmitStatement typechecks (e.g. you can’t do event MyEvent(uint); function a() { emit MyEvent(7 * false); }, but you currently can do event MyEvent(uint); function a() { emit MyEvent("hello"); }. The relevant code is lines 1593 and 1594 of `Typechecker.hs`:

```
statementHelper (EmitStatement _ vals x) =
  reduceType' x <$> traverse (tcExpr . snd) vals
```

The typechecker needs to load the definition of the errors being emitted from the code collection/contracts (scoped approached, check contract first for the error name, then file level errors for the error name if it is not found first in the contract), and typecheck each argument against the definition. Currently, the event name is being ignored (the _ after EmitStatement). 


(You can check out the examples regarding the use case in the jira ticket)
