### PR TITLE
Updated payment service fetch

### DIFF
--- a/marketplace/backend/api/v1/PaymentService/paymentService.controller.js
+++ b/marketplace/backend/api/v1/PaymentService/paymentService.controller.js
@@ -6,9 +6,10 @@ class PaymentServiceController {
 
   static async getAll(req, res, next) {
     try {
-      const { dapp, params } = req
+      const { dapp, query } = req
+      const { onlyActive } = query;
 
-      const result = await dapp.getPaymentServices(params)
+      const result = await dapp.getPaymentServices({ onlyActive: onlyActive })
       rest.response.status200(res, result)
 
       return next()

--- a/marketplace/backend/dapp/payments/paymentProvider.js
+++ b/marketplace/backend/dapp/payments/paymentProvider.js
@@ -179,8 +179,14 @@ async function get(user, args, defaultOptions) {
 }
 
 async function getAll(admin, args = {}, baseOptions) {
+    const { onlyActive, ...restArgs } = args;
     const options = { ...baseOptions, org: 'BlockApps', app: 'Mercata' };
-    const searchArgs = setSearchQueryOptions(args, {})
+    let searchArgs;
+    if (onlyActive) {
+      searchArgs = setSearchQueryOptions(restArgs, [{ key: 'isActive', value: 'true' }]) 
+    } else {
+      searchArgs = setSearchQueryOptions(restArgs, {})
+    }
     const paymentProviders = await searchAllWithQueryArgs(contractName, searchArgs, options, admin);
     return paymentProviders.map((paymentProvider) => marshalOut(paymentProvider));
 }

--- a/marketplace/ui/src/components/Inventory/ListForSaleModal.js
+++ b/marketplace/ui/src/components/Inventory/ListForSaleModal.js
@@ -33,7 +33,7 @@ const ListForSaleModal = ({ open, handleCancel, inventory, categoryName, limit, 
     const inputQuantityMobileRef = useRef(null);
 
     useEffect(() => {
-        paymentServiceActions.getPaymentServices(paymentServiceDispatch);
+        paymentServiceActions.getPaymentServices(paymentServiceDispatch, true);
         paymentServiceActions.getNotOnboarded(paymentServiceDispatch, user?.commonName, 10, 0);
     }, [paymentServiceDispatch, user]);
 

--- a/marketplace/ui/src/components/Inventory/index.js
+++ b/marketplace/ui/src/components/Inventory/index.js
@@ -86,7 +86,7 @@ const Inventory = ({ user }) => {
 
   useEffect(() => {
     if (user && user.commonName) {
-      paymentServiceActions.getPaymentServices(paymentServiceDispatch);
+      paymentServiceActions.getPaymentServices(paymentServiceDispatch, true);
       paymentServiceActions.getNotOnboarded(paymentServiceDispatch, user.commonName, 10, 0);
     }
   }, [paymentServiceDispatch, user]);

--- a/marketplace/ui/src/components/MarketPlace/Checkout.js
+++ b/marketplace/ui/src/components/MarketPlace/Checkout.js
@@ -78,7 +78,7 @@ const Checkout = () => {
   }, [marketplaceDispatch, cartList]);
 
   useEffect(() => {
-    paymentServiceActions.getPaymentServices(paymentServiceDispatch);
+    paymentServiceActions.getPaymentServices(paymentServiceDispatch, false);
   }, [paymentServiceDispatch]);
 
   useEffect(() => {

--- a/marketplace/ui/src/contexts/payment/actions.js
+++ b/marketplace/ui/src/contexts/payment/actions.js
@@ -12,14 +12,14 @@ const actionDescriptors = {
 
 const actions = {
 
-  getPaymentServices: async (dispatch, limit, offset, queryValue) => {
-    const query = queryValue ? `&serviceName=${queryValue}` : ``;
+  getPaymentServices: async (dispatch, queryValue) => {
+    const query = queryValue ? `&onlyActive=${queryValue}` : ``;
 
     dispatch({ type: actionDescriptors.getPaymentServices });
 
     try {
       const response = await fetch(
-        `${apiUrl}/payment?limit=${limit}&offset=${offset}${query}`,
+        `${apiUrl}/payment?${query}`,
         {
           method: HTTP_METHODS.GET,
         }


### PR DESCRIPTION
Updated `fetchPaymentServices` so that you can filter by active/inactive payment services. This was needed to fix the listing modal.

Before:

https://github.com/user-attachments/assets/a6a54c99-4886-4f3a-85bc-1aeab90579c9



After:

https://github.com/user-attachments/assets/ce1426b2-8b00-4181-aa0c-6c58b71ed3cf


