### PR TITLE
Strato 3317 typecheck in revertstatement

### DIFF
--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1857,6 +1857,29 @@ statementHelper (UncheckedStatement body x) =
   statementsHelper' x body
 statementHelper (AssemblyStatement _ x) = pure $ topType' x
 statementHelper (SimpleStatement stmt x) = simpleStatementHelper x stmt
+
+isSameType :: Type -> Type -> Bool
+isSameType (SVMType.Int _ _) (SVMType.Int _ _) = True
+isSameType (SVMType.String _) (SVMType.String _) = True
+isSameType (SVMType.Bytes _ _) (SVMType.Bytes _ _) = True
+isSameType SVMType.Decimal SVMType.Decimal = True
+isSameType SVMType.Bool SVMType.Bool = True
+isSameType (SVMType.Address _) (SVMType.Address _) = True
+isSameType (SVMType.Account _) (SVMType.Account _) = True
+isSameType (SVMType.UnknownLabel s1 _) (SVMType.UnknownLabel s2 _) = s1 == s2
+isSameType (SVMType.Struct _ t1) (SVMType.Struct _ t2) = t1 == t2
+isSameType (SVMType.UserDefined a1 _) (SVMType.UserDefined a2 _) = a1 == a2
+isSameType (SVMType.Enum _ t1 _) (SVMType.Enum _ t2 _) = t1 == t2
+isSameType (SVMType.Error _ t1) (SVMType.Error _ t2) = t1 == t2
+isSameType (SVMType.Array e1 _) (SVMType.Array e2 _) = isSameType e1 e2
+isSameType (SVMType.Contract t1) (SVMType.Contract t2) = t1 == t2
+isSameType (SVMType.Mapping _ k1 v1) (SVMType.Mapping _ k2 v2) = isSameType k1 k2 && isSameType v1 v2
+isSameType SVMType.Variadic SVMType.Variadic = True
+isSameType _ _ = False
+
+allDifferent :: (Eq a) => [a] -> Bool
+allDifferent []     = True
+allDifferent (x:xs) = x `notElem` xs && allDifferent xs
 simpleStatementHelper :: SourceAnnotation Text -> Annotated SimpleStatementF -> SSS Type'
 simpleStatementHelper x (VariableDefinition vdefs mExpr) = do
   pushLocalVariables vdefs

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -36,7 +36,7 @@ import SolidVM.Model.Type (Type)
 import qualified SolidVM.Model.Type as SVMType
 import SolidVM.Solidity.StaticAnalysis.Types
 import Text.Read (readMaybe)
-
+import Data.List (find)
 --import qualified Text.Colors                          as C
 --import           Control.Monad.IO.Class
 --import Debug.Trace
@@ -1591,42 +1591,84 @@ statementHelper (ModifierExecutor x) = pure $ topType' x
 statementHelper (EmitStatement _ vals x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement errorName (NamedArgs vals) x) =
+  reduceType' x <$> traverse (tcExpr . snd) vals
+statementHelper (RevertStatement errorName (OrderedArgs vals) x) = do
+  
+  {-
+  data StatementF a = 
+    | EmitStatement String [(Maybe String, (ExpressionF a))] a
+    | RevertStatement (Maybe String) (ArgListF a) a
 
-  -- _errors :: Map SolidString [(SolidString, SolidVM.IndexedType, a)],
-  --   _events :: Map SolidString (SolidVM.EventF a),
-  cc <- asks codeCollection
-  let solidVMVersion = maybe "" snd $ find ((== "solidvm") . fst) $ _pragmas cc
-  case solidVMVersion of
-    "11.4" -> do
-      c  <- asks contract
-      case M.lookup errorName (_errors c) of 
-        Just error -> do
-          let vals' = fmap (\(_, b) -> 
-                              let r = R cc c Nothing "Nothing" []
-                              in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
-                           ) vals
-              -- valsDebug = trace ("Evaluated types: " ++ show vals') vals'
-          let vals'' = map (\y -> case y of
-                                    Static s _ -> s
-                                    _          -> error "Internal Error: Type is not static"
-                           ) vals'
-              -- valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
-          let expectedTypes = [indexedTypeType it | (_, it) <- _eventLogs event]
-              -- expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
-          if length expectedTypes /= length vals''
-            then pure . bottom $ "Wrong number of arguments provided" <$ x
-            else if not (and $ zipWith isSameType expectedTypes vals'')
-              then pure . bottom $ "Type mismatch in error arguments" <$ x
-              else reduceType' x <$> traverse (tcExpr . snd) vals 
-        Nothing -> pure . bottom $ "Error does not exist" <$ x
-    _    ->
-      reduceType' x <$> traverse (tcExpr . snd) vals
-statementHelper (RevertStatement _ (OrderedArgs vals) x) =
-  reduceType' x <$> traverse tcExpr vals
+  data ArgListF a = OrderedArgs [ExpressionF a] | NamedArgs [(SolidString, (ExpressionF a))]
+
+
+  data ContractF a = Contract
+    _events :: Map SolidString (SolidVM.EventF a)
+    _errors :: Map SolidString [(SolidString, SolidVM.IndexedType, a)],
+
+  data IndexedType = IndexedType {indexedTypeIndex :: Int32, indexedTypeType :: Type}
+
+
+  usage ex:
+
+    error errorName(string x,string y);
+    revert()
+    revert("some string")
+  -}
+
+    cc <- asks codeCollection
+    let solidVMVersion = maybe "" snd $ find ((== "solidvm") . fst) $ _pragmas cc
+    case solidVMVersion of
+      "11.4" -> do
+        case errorName of 
+          Just errorName -> do
+            c  <- asks contract
+            case M.lookup errorName (_errors c) of 
+              Just err -> do
+                let vals' = fmap (\b -> 
+                                    let r = R cc c Nothing "Nothing" []
+                                    in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
+                                 ) vals
+                    -- valsDebug = trace ("Evaluated types: " ++ show vals') vals'
+                let vals'' = map (\y -> case y of
+                                          Static s _ -> s
+                                          _          -> error "Internal Error: Type is not static"
+                                 ) vals'
+                    -- valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
+                let expectedTypes = [indexedTypeType it | (_, it, _) <- err]
+                    -- expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
+                if length expectedTypes /= length vals''
+                  then pure . bottom $ "Wrong number of arguments provided" <$ x
+                  else if not (and $ zipWith isSameType expectedTypes vals'')
+                    then pure . bottom $ "Type mismatch in error arguments" <$ x
+                    else reduceType' x <$> traverse $ tcExpr vals
+              Nothing -> pure . bottom $ "Error does not exist" <$ x
+          Nothing -> reduceType' x <$> traverse $ tcExpr vals
+      _    ->
+        reduceType' x <$> traverse $ tcExpr vals
 statementHelper (UncheckedStatement body x) =
   statementsHelper' x body
 statementHelper (AssemblyStatement _ x) = pure $ topType' x
 statementHelper (SimpleStatement stmt x) = simpleStatementHelper x stmt
+
+isSameType :: Type -> Type -> Bool
+isSameType (SVMType.Int _ _) (SVMType.Int _ _) = True
+isSameType (SVMType.String _) (SVMType.String _) = True
+isSameType (SVMType.Bytes _ _) (SVMType.Bytes _ _) = True
+isSameType SVMType.Decimal SVMType.Decimal = True
+isSameType SVMType.Bool SVMType.Bool = True
+isSameType (SVMType.Address _) (SVMType.Address _) = True
+isSameType (SVMType.Account _) (SVMType.Account _) = True
+isSameType (SVMType.UnknownLabel s1 _) (SVMType.UnknownLabel s2 _) = s1 == s2
+isSameType (SVMType.Struct _ t1) (SVMType.Struct _ t2) = t1 == t2
+isSameType (SVMType.UserDefined a1 _) (SVMType.UserDefined a2 _) = a1 == a2
+isSameType (SVMType.Enum _ t1 _) (SVMType.Enum _ t2 _) = t1 == t2
+isSameType (SVMType.Error _ t1) (SVMType.Error _ t2) = t1 == t2
+isSameType (SVMType.Array e1 _) (SVMType.Array e2 _) = isSameType e1 e2
+isSameType (SVMType.Contract t1) (SVMType.Contract t2) = t1 == t2
+isSameType (SVMType.Mapping _ k1 v1) (SVMType.Mapping _ k2 v2) = isSameType k1 k2 && isSameType v1 v2
+isSameType SVMType.Variadic SVMType.Variadic = True
+isSameType _ _ = False
 
 simpleStatementHelper :: SourceAnnotation Text -> Annotated SimpleStatementF -> SSS Type'
 simpleStatementHelper x (VariableDefinition vdefs mExpr) = do

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1590,8 +1590,37 @@ statementHelper (Throw e x) = do
 statementHelper (ModifierExecutor x) = pure $ topType' x
 statementHelper (EmitStatement _ vals x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
-statementHelper (RevertStatement _ (NamedArgs vals) x) =
+statementHelper (RevertStatement errorName (NamedArgs vals) x) = do
   reduceType' x <$> traverse (tcExpr . snd) vals
+  cc <- asks codecollection
+  let solidVMVersion = maybe "" snd $ find ((== "solidvm") . fst) $ _pragmas cc
+  case solidVMVersion of
+    "11.4" ->
+      case errorName of
+        Just erName -> do
+          c <- asks contract
+          case M.lookup erName (_errors c) of
+            Just err ->
+              case allDifferent $ map fst err of
+                False -> pure . bottom $ "Same parameter name used in error" <$ x
+                True  -> 
+                  case allDifferent $ map fst vals of
+                    False -> pure . bottom $ "Same parameter name used in revertStatement" <$ x
+                    True  -> do
+                      let errKeys = map (\(en, _, _) -> en) err
+                      if all (\(en, _) -> en `elem` errKeys) vals
+                        then do
+                          let matched = [(b,c) | (a, b) <- vals, (a', c, d) <- err, a == a']
+                          for matched $ \(valB, errC) -> do
+                            -- TODO, convert valB to to the type using the tcexpr and make sure it matches the expected type from errC
+                        else pure . bottom $ "Parameter does not exist" <$ x
+
+            Nothihng -> pure . bottom $ "Error does not exist" <$ x           
+        Nothing -> pure . bottom $ "Cannot have arguments without custom error" <$ x
+    _    ->
+        reduceType' x <$> traverse tcExpr vals
+      
+
 statementHelper (RevertStatement errorName (OrderedArgs vals) x) = do
   
   {-
@@ -1611,9 +1640,12 @@ statementHelper (RevertStatement errorName (OrderedArgs vals) x) = do
 
   usage ex:
 
-    error errorName(string x,string y);
+    error errorName(string y,int y);
     revert()
     revert("some string")
+    revert someError("blah")
+
+    revert errorName({y : "somestring", x : "some other string"})
   -}
 
     cc <- asks codeCollection
@@ -1650,6 +1682,10 @@ statementHelper (UncheckedStatement body x) =
   statementsHelper' x body
 statementHelper (AssemblyStatement _ x) = pure $ topType' x
 statementHelper (SimpleStatement stmt x) = simpleStatementHelper x stmt
+
+allDifferent :: (Eq a) => [a] -> Bool
+allDifferent []     = True
+allDifferent (x:xs) = x `notElem` xs && allDifferent xs
 
 isSameType :: Type -> Type -> Bool
 isSameType (SVMType.Int _ _) (SVMType.Int _ _) = True

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1590,8 +1590,37 @@ statementHelper (Throw e x) = do
 statementHelper (ModifierExecutor x) = pure $ topType' x
 statementHelper (EmitStatement _ vals x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
-statementHelper (RevertStatement _ (NamedArgs vals) x) =
-  reduceType' x <$> traverse (tcExpr . snd) vals
+statementHelper (RevertStatement errorName (NamedArgs vals) x) =
+
+  -- _errors :: Map SolidString [(SolidString, SolidVM.IndexedType, a)],
+  --   _events :: Map SolidString (SolidVM.EventF a),
+  cc <- asks codeCollection
+  let solidVMVersion = maybe "" snd $ find ((== "solidvm") . fst) $ _pragmas cc
+  case solidVMVersion of
+    "11.4" -> do
+      c  <- asks contract
+      case M.lookup errorName (_errors c) of 
+        Just error -> do
+          let vals' = fmap (\(_, b) -> 
+                              let r = R cc c Nothing "Nothing" []
+                              in runReader (evalStateT (tcExpr b) ((Nothing, M.empty) :| [])) r
+                           ) vals
+              -- valsDebug = trace ("Evaluated types: " ++ show vals') vals'
+          let vals'' = map (\y -> case y of
+                                    Static s _ -> s
+                                    _          -> error "Internal Error: Type is not static"
+                           ) vals'
+              -- valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
+          let expectedTypes = [indexedTypeType it | (_, it) <- _eventLogs event]
+              -- expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
+          if length expectedTypes /= length vals''
+            then pure . bottom $ "Wrong number of arguments provided" <$ x
+            else if not (and $ zipWith isSameType expectedTypes vals'')
+              then pure . bottom $ "Type mismatch in error arguments" <$ x
+              else reduceType' x <$> traverse (tcExpr . snd) vals 
+        Nothing -> pure . bottom $ "Error does not exist" <$ x
+    _    ->
+      reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement _ (OrderedArgs vals) x) =
   reduceType' x <$> traverse tcExpr vals
 statementHelper (UncheckedStatement body x) =

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1591,63 +1591,44 @@ statementHelper (ModifierExecutor x) = pure $ topType' x
 statementHelper (EmitStatement _ vals x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement errorName (NamedArgs vals) x) = do
-  reduceType' x <$> traverse (tcExpr . snd) vals
-  cc <- asks codecollection
+  cc <- asks codeCollection
   let solidVMVersion = maybe "" snd $ find ((== "solidvm") . fst) $ _pragmas cc
   case solidVMVersion of
     "11.4" ->
       case errorName of
+        Nothing -> pure . bottom $ "Cannot have arguments without custom error" <$ x
         Just erName -> do
           c <- asks contract
           case M.lookup erName (_errors c) of
+            Nothing -> pure . bottom $ "Error does not exist" <$ x  
             Just err ->
-              case allDifferent $ map fst err of
-                False -> pure . bottom $ "Same parameter name used in error" <$ x
+              case allDifferent $ map (\(a,_,_) -> a) err of
+                False -> pure . bottom $ "Multiple use of same parameter name in error statement" <$ x
                 True  -> 
                   case allDifferent $ map fst vals of
-                    False -> pure . bottom $ "Same parameter name used in revertStatement" <$ x
+                    False -> pure . bottom $ "Same parameter name used in revert statement" <$ x
                     True  -> do
                       let errKeys = map (\(en, _, _) -> en) err
-                      if all (\(en, _) -> en `elem` errKeys) vals
-                        then do
-                          let matched = [(b,c) | (a, b) <- vals, (a', c, d) <- err, a == a']
-                          for matched $ \(valB, errC) -> do
-                            -- TODO, convert valB to to the type using the tcexpr and make sure it matches the expected type from errC
-                        else pure . bottom $ "Parameter does not exist" <$ x
-
-            Nothihng -> pure . bottom $ "Error does not exist" <$ x           
-        Nothing -> pure . bottom $ "Cannot have arguments without custom error" <$ x
+                      case all (\(en, _) -> en `elem` errKeys) vals of 
+                        False -> pure . bottom $ "Parameter does not exist" <$ x
+                        True  -> do
+                          let matched = [(b,d) | (a, b) <- vals, (a', d, _) <- err, a == a']
+                          let matched' = map (\(valB, errC) -> do
+                                                 let valB' = runReader (evalStateT (tcExpr valB) ((Nothing, M.empty) :| [])) (R cc c Nothing "Nothing" [])
+                                                 let valB'' = case valB' of
+                                                                Static s _ -> s
+                                                                _          -> error "Internal Error: Type is not static"
+                                                 let expectedType = indexedTypeType errC
+                                                 case isSameType expectedType valB'' of
+                                                   False -> False
+                                                   True  -> True
+                                             ) matched
+                          case all (==True) matched' of 
+                            False -> pure . bottom $ "Type mismatch in error arguments" <$ x
+                            True  -> reduceType' x <$> traverse (tcExpr . snd) vals 
     _    ->
-        reduceType' x <$> traverse tcExpr vals
-      
-
+        reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement errorName (OrderedArgs vals) x) = do
-  
-  {-
-  data StatementF a = 
-    | EmitStatement String [(Maybe String, (ExpressionF a))] a
-    | RevertStatement (Maybe String) (ArgListF a) a
-
-  data ArgListF a = OrderedArgs [ExpressionF a] | NamedArgs [(SolidString, (ExpressionF a))]
-
-
-  data ContractF a = Contract
-    _events :: Map SolidString (SolidVM.EventF a)
-    _errors :: Map SolidString [(SolidString, SolidVM.IndexedType, a)],
-
-  data IndexedType = IndexedType {indexedTypeIndex :: Int32, indexedTypeType :: Type}
-
-
-  usage ex:
-
-    error errorName(string y,int y);
-    revert()
-    revert("some string")
-    revert someError("blah")
-
-    revert errorName({y : "somestring", x : "some other string"})
-  -}
-
     cc <- asks codeCollection
     let solidVMVersion = maybe "" snd $ find ((== "solidvm") . fst) $ _pragmas cc
     case solidVMVersion of

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1590,7 +1590,7 @@ statementHelper (Throw e x) = do
 statementHelper (ModifierExecutor x) = pure $ topType' x
 statementHelper (EmitStatement _ vals x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
-statementHelper (RevertStatement errorName (NamedArgs vals) x) =
+statementHelper (RevertStatement _ (NamedArgs vals) x) =
   reduceType' x <$> traverse (tcExpr . snd) vals
 statementHelper (RevertStatement errorName (OrderedArgs vals) x) = do
   
@@ -1621,9 +1621,9 @@ statementHelper (RevertStatement errorName (OrderedArgs vals) x) = do
     case solidVMVersion of
       "11.4" -> do
         case errorName of 
-          Just errorName -> do
+          Just erName -> do
             c  <- asks contract
-            case M.lookup errorName (_errors c) of 
+            case M.lookup erName (_errors c) of 
               Just err -> do
                 let vals' = fmap (\b -> 
                                     let r = R cc c Nothing "Nothing" []
@@ -1641,11 +1641,11 @@ statementHelper (RevertStatement errorName (OrderedArgs vals) x) = do
                   then pure . bottom $ "Wrong number of arguments provided" <$ x
                   else if not (and $ zipWith isSameType expectedTypes vals'')
                     then pure . bottom $ "Type mismatch in error arguments" <$ x
-                    else reduceType' x <$> traverse $ tcExpr vals
+                    else reduceType' x <$> traverse tcExpr vals
               Nothing -> pure . bottom $ "Error does not exist" <$ x
-          Nothing -> reduceType' x <$> traverse $ tcExpr vals
+          Nothing -> reduceType' x <$> traverse tcExpr vals
       _    ->
-        reduceType' x <$> traverse $ tcExpr vals
+        reduceType' x <$> traverse tcExpr vals
 statementHelper (UncheckedStatement body x) =
   statementsHelper' x body
 statementHelper (AssemblyStatement _ x) = pure $ topType' x

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -7534,7 +7534,7 @@ contract qq {
   function randomFunction(uint checker)
   {
     if(a==checker)
-      revert({x:"logic flag"});
+      revert("logic flag");
   }
 }|]
       )


### PR DESCRIPTION
Currently, the typechecker does not load the definition of the error that is being emitted in an RevertStatement, and instead just checks that each argument within the RevertStatement typechecks (e.g. you can’t do event MyEvent(uint); function a() { emit MyEvent(7 * false); }, but you currently can do event MyEvent(uint); function a() { emit MyEvent("hello"); }. The relevant code is lines 1593 and 1594 of Typechecker.hs:



statementHelper (RevertStatement _ (NamedArgs vals) x) =
  reduceType' x <$> traverse (tcExpr . snd) vals
The typechecker needs to load the definition of the errors being emitted from the code collection/contracts (scoped approached, check contract first for the error name, then file level errors for the error name if it is not found first in the contract), and typecheck each argument against the definition. Currently, the event name is being ignored (the _ after RevertStatement. 

More examples on the expected usage can be found in the Jira ticket. 