### PR TITLE
Fix Truncate Logic

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -29,6 +29,7 @@ so that they could be properly moved to their respective version's subsection.
 
 ### Fixed
 - patched rare race condition where node updates sync status to true before running the last few blocks left in the sync
+- Fixed truncate logic to actually use truncate rather than round
 
 ### Removed
 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1999,7 +1999,7 @@ expToVar' theFullExp@(CC.FunctionCall _ e args) _ = do
               contract <- getCurrentContract
               let pragmaCheck = CC.resolvePragmaFeature (CC._pragmas parentCC) "strictDecimals"
               case (pragmaCheck, convertedFirstArg) of
-                (True, SInteger n) -> return . Constant $ SDecimal $ roundTo (fromInteger n) v
+                (True, SInteger n) -> return . Constant $ SDecimal $ roundTo' truncate (fromInteger n) v
                 (False, _) -> unknownFunction "truncate" (contract ^. CC.contractName)
                 _ -> invalidArguments ("truncate() called with non-integer value as argument") convertedFirstArg
             _ -> regularFunctionCall Nothing

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -8997,9 +8997,9 @@ contract qq {
 |]
     getFields ["a", "b", "c", "d", "e", "f"]
       `shouldReturn` [BDecimal "5.282", 
-                      BDecimal "5.3", 
-                      BDecimal "3.26", 
-                      BDecimal "6.3",
+                      BDecimal "5.2", 
+                      BDecimal "3.25", 
+                      BDecimal "6.2",
                       BDecimal "3.24000",
                       BDecimal "3.24000000000000000000000000000000000000000000"])
 


### PR DESCRIPTION
Rather than using `roundTo` to round to target decimal to a specified number of decimal places in the truncate function, we should instead use `roundTo'` and supply the `truncate` function to actually truncate the decimal.