### PR TITLE
Per process monitoring

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -45,6 +45,7 @@ COPY \
   ./usr/local/bin/init-worker \
   ./usr/local/bin/strato-barometer \
   ./usr/local/bin/modifyDate \ 
+  ./usr/local/bin/process-monitor-exe \
   ./usr/local/bin/slipstream \
   ./usr/local/bin/strato-api \
   ./usr/local/bin/strato-api-indexer \

--- a/prometheus-packager/strato_prometheus.yml
+++ b/prometheus-packager/strato_prometheus.yml
@@ -62,6 +62,14 @@ scrape_configs:
       - target_label: instance
         replacement: '__NODE_HOST_MARKER__'
 
+  - job_name: 'strato-process-monitor'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['strato:10778']
+    metric_relabel_configs:
+      - target_label: instance
+        replacement: '__NODE_HOST_MARKER__'
+
 # TODO: move to Vault's prometheus when implemented
 #   - job_name: 'vault-wrapper'
 #     metrics_path: '/strato/v2.3/metrics'

--- a/strato/extraFiles/strato/doit.sh
+++ b/strato/extraFiles/strato/doit.sh
@@ -271,6 +271,9 @@ function newnode {
       runBackgroundProcess $SLIPSTREAM_CMD &>> logs/slipstream
   fi
 
+  echo "Starting process monitoring..."
+  runBackgroundProcess process-monitor-exe &>> logs/process-monitoring
+
   echo "Configuring log rotation..."
   runBackgroundProcess logRotation
 

--- a/strato/stack.yaml
+++ b/strato/stack.yaml
@@ -73,6 +73,7 @@ packages:
 
 - tools/blockapps-tools
 - tools/debugger-tools
+- tools/process-monitor
 - tools/x509-tools
 
 - vault/api

--- a/strato/tools/process-monitor/Setup.hs
+++ b/strato/tools/process-monitor/Setup.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMain

--- a/strato/tools/process-monitor/exec_src/Main.hs
+++ b/strato/tools/process-monitor/exec_src/Main.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wall #-}
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (race_)
+import Control.Monad (forever)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Network.Wai.Middleware.Prometheus
+import Network.Wai.Handler.Warp
+import Prometheus
+import System.Process
+import Text.Read (readMaybe)
+
+stratoP2pMemoryUsage :: Gauge
+stratoP2pMemoryUsage = unsafeRegister $ gauge (Info "strato_p2p_memory" "strato-p2p memory usage")
+
+stratoP2pCpuUsage :: Gauge
+stratoP2pCpuUsage = unsafeRegister $ gauge (Info "strato_p2p_cpu" "strato-p2p CPU usage")
+
+stratoSequencerMemoryUsage :: Gauge
+stratoSequencerMemoryUsage = unsafeRegister $ gauge (Info "strato_sequencer_memory" "strato-sequencer memory usage")
+
+stratoSequencerCpuUsage :: Gauge
+stratoSequencerCpuUsage = unsafeRegister $ gauge (Info "strato_sequencer_cpu" "strato-sequencer CPU usage")
+
+vmRunnerMemoryUsage :: Gauge
+vmRunnerMemoryUsage = unsafeRegister $ gauge (Info "vm_runner_memory" "vm-runner memory usage")
+
+vmRunnerCpuUsage :: Gauge
+vmRunnerCpuUsage = unsafeRegister $ gauge (Info "vm_runner_cpu" "vm-runner CPU usage")
+
+slipstreamMemoryUsage :: Gauge
+slipstreamMemoryUsage = unsafeRegister $ gauge (Info "slipstream_memory" "slipstream memory usage")
+
+slipstreamCpuUsage :: Gauge
+slipstreamCpuUsage = unsafeRegister $ gauge (Info "slipstream_cpu" "slipstream CPU usage")
+
+stratoApiMemoryUsage :: Gauge
+stratoApiMemoryUsage = unsafeRegister $ gauge (Info "strato_api_memory" "strato-api memory usage")
+
+stratoApiCpuUsage :: Gauge
+stratoApiCpuUsage = unsafeRegister $ gauge (Info "strato_api_cpu" "strato-api CPU usage")
+
+stratoApiIndexerMemoryUsage :: Gauge
+stratoApiIndexerMemoryUsage = unsafeRegister $ gauge (Info "strato_api_indexer_memory" "strato-api-indexer memory usage")
+
+stratoApiIndexerCpuUsage :: Gauge
+stratoApiIndexerCpuUsage = unsafeRegister $ gauge (Info "strato_api_indexer_cpu" "strato-api-indexer CPU usage")
+
+stratoP2pIndexerMemoryUsage :: Gauge
+stratoP2pIndexerMemoryUsage = unsafeRegister $ gauge (Info "strato_p2p_indexer_memory" "strato-p2p-indexer memory usage")
+
+stratoP2pIndexerCpuUsage :: Gauge
+stratoP2pIndexerCpuUsage = unsafeRegister $ gauge (Info "strato_p2p_indexer_cpu" "strato-p2p-indexer CPU usage")
+
+stratoTxrIndexerMemoryUsage :: Gauge
+stratoTxrIndexerMemoryUsage = unsafeRegister $ gauge (Info "strato_txr_indexer_memory" "strato-txr-indexer memory usage")
+
+stratoTxrIndexerCpuUsage :: Gauge
+stratoTxrIndexerCpuUsage = unsafeRegister $ gauge (Info "strato_txr_indexer_cpu" "strato-txr-indexer CPU usage")
+
+vaultProxyMemoryUsage :: Gauge
+vaultProxyMemoryUsage = unsafeRegister $ gauge (Info "vault_proxy_memory" "vault-proxy memory usage")
+
+vaultProxyCpuUsage :: Gauge
+vaultProxyCpuUsage = unsafeRegister $ gauge (Info "vault_proxy_cpu" "vault-proxy CPU usage")
+
+processMonitorMemoryUsage :: Gauge
+processMonitorMemoryUsage = unsafeRegister $ gauge (Info "process_monitor_memory" "process-monitor memory usage")
+
+processMonitorCpuUsage :: Gauge
+processMonitorCpuUsage = unsafeRegister $ gauge (Info "process_monitor_cpu" "process-monitor CPU usage")
+
+updateGauge :: Gauge -> String -> Map String ProcessInfo -> (ProcessInfo -> IO (Maybe Double)) -> IO ()
+updateGauge g l m f = do
+  case M.lookup (take 15 l) m of
+    Nothing -> pure ()
+    Just a -> f a >>= \a' -> case a' of
+      Nothing -> pure ()
+      Just a'' -> setGauge g a''
+
+updateGauges :: Map String ProcessInfo -> IO ()
+updateGauges m = do
+  -- updateGauge stratoP2pMemoryUsage "pid1" m (\p -> let r = piRes p in print r >> pure (readMaybe r))
+  updateGauge stratoP2pMemoryUsage "strato-p2p" m (\p -> let r = piPercentMem p in print r >> pure (fmap (1000*) $ readMaybe r))
+  updateGauge stratoP2pCpuUsage "strato-p2p" m (pure . readMaybe . piPercentCpu)
+  updateGauge stratoSequencerMemoryUsage "strato-sequencer" m (pure . fmap (1000*) . readMaybe . piPercentMem)
+  updateGauge stratoSequencerCpuUsage "strato-sequencer" m (pure . readMaybe . piPercentCpu)
+  updateGauge vmRunnerMemoryUsage "vm-runner" m (pure . fmap (1000*) . readMaybe . piPercentMem)
+  updateGauge vmRunnerCpuUsage "vm-runner" m (pure . readMaybe . piPercentCpu)
+  updateGauge slipstreamMemoryUsage "slipstream" m (pure . fmap (1000*) . readMaybe . piPercentMem)
+  updateGauge slipstreamCpuUsage "slipstream" m (pure . readMaybe . piPercentCpu)
+  updateGauge stratoApiMemoryUsage "strato-api" m (pure . fmap (1000*) . readMaybe . piPercentMem)
+  updateGauge stratoApiCpuUsage "strato-api" m (pure . readMaybe . piPercentCpu)
+  updateGauge stratoApiIndexerMemoryUsage "strato-api-indexer" m (pure . fmap (1000*) . readMaybe . piPercentMem)
+  updateGauge stratoApiIndexerCpuUsage "strato-api-indexer" m (pure . readMaybe . piPercentCpu)
+  updateGauge stratoP2pIndexerMemoryUsage "strato-p2p-indexer" m (pure . fmap (1000*) . readMaybe . piPercentMem)
+  updateGauge stratoP2pIndexerCpuUsage "strato-p2p-indexer" m (pure . readMaybe . piPercentCpu)
+  updateGauge stratoTxrIndexerMemoryUsage "strato-txr-indexer" m (pure . fmap (1000*) . readMaybe . piPercentMem)
+  updateGauge stratoTxrIndexerCpuUsage "strato-txr-indexer" m (pure . readMaybe . piPercentCpu)
+  updateGauge vaultProxyMemoryUsage "vault-proxy" m (pure . fmap (1000*) . readMaybe . piPercentMem)
+  updateGauge vaultProxyCpuUsage "vault-proxy" m (pure . readMaybe . piPercentCpu)
+  updateGauge processMonitorMemoryUsage "process-monitor-exe" m (pure . fmap (1000*) . readMaybe . piPercentMem)
+  updateGauge processMonitorCpuUsage "process-monitor-exe" m (pure . readMaybe . piPercentCpu)
+
+data ProcessInfo = ProcessInfo
+  { piPercentCpu :: String
+  , piPercentMem :: String
+  , piCommand    :: String
+  } deriving (Eq, Show)
+
+parseProcessInfo :: String -> Either String ProcessInfo
+parseProcessInfo input = case words input of
+  (cpu : mem : cmd : _) ->
+    Right $ ProcessInfo cpu mem cmd
+  _ -> Left $ "Could not parse ProcessInfo: " ++ input
+
+mergeProcessInfo :: ProcessInfo -> Map String ProcessInfo -> Map String ProcessInfo
+mergeProcessInfo p m = m <> M.singleton (take 15 $ piCommand p) p
+
+createProcessMap :: [String] -> IO (Map String ProcessInfo)
+createProcessMap = go M.empty
+  where go m [] = pure m
+        go m (l:ls) = do
+          case parseProcessInfo l of
+            Left e -> putStrLn e >> pure m
+            Right p -> go (mergeProcessInfo p m) ls
+
+runProcessMonitoring :: IO ()
+runProcessMonitoring = forever $ do
+  threadDelay 1000000
+  output <- readCreateProcess (shell "ps -eo %cpu,rss,cmd --sort -%cpu") ""
+  mapM_ putStrLn $ lines output
+  putStrLn "-------------------------------------------"
+  m <- createProcessMap . drop 1 $ lines output
+  updateGauges m
+  print m
+
+main :: IO ()
+main = do
+  race_ runProcessMonitoring
+    . run 10778
+    $ metricsApp

--- a/strato/tools/process-monitor/exec_src/Main.hs
+++ b/strato/tools/process-monitor/exec_src/Main.hs
@@ -2,143 +2,31 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -Wall #-}
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race_)
 import Control.Monad (forever)
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Foldable (traverse_)
+import Data.Metrics
+import Data.ProcessInfo
 import Network.Wai.Middleware.Prometheus
 import Network.Wai.Handler.Warp
 import Prometheus
 import System.Process
-import Text.Read (readMaybe)
 
-stratoP2pMemoryUsage :: Gauge
-stratoP2pMemoryUsage = unsafeRegister $ gauge (Info "strato_p2p_memory" "strato-p2p memory usage")
-
-stratoP2pCpuUsage :: Gauge
-stratoP2pCpuUsage = unsafeRegister $ gauge (Info "strato_p2p_cpu" "strato-p2p CPU usage")
-
-stratoSequencerMemoryUsage :: Gauge
-stratoSequencerMemoryUsage = unsafeRegister $ gauge (Info "strato_sequencer_memory" "strato-sequencer memory usage")
-
-stratoSequencerCpuUsage :: Gauge
-stratoSequencerCpuUsage = unsafeRegister $ gauge (Info "strato_sequencer_cpu" "strato-sequencer CPU usage")
-
-vmRunnerMemoryUsage :: Gauge
-vmRunnerMemoryUsage = unsafeRegister $ gauge (Info "vm_runner_memory" "vm-runner memory usage")
-
-vmRunnerCpuUsage :: Gauge
-vmRunnerCpuUsage = unsafeRegister $ gauge (Info "vm_runner_cpu" "vm-runner CPU usage")
-
-slipstreamMemoryUsage :: Gauge
-slipstreamMemoryUsage = unsafeRegister $ gauge (Info "slipstream_memory" "slipstream memory usage")
-
-slipstreamCpuUsage :: Gauge
-slipstreamCpuUsage = unsafeRegister $ gauge (Info "slipstream_cpu" "slipstream CPU usage")
-
-stratoApiMemoryUsage :: Gauge
-stratoApiMemoryUsage = unsafeRegister $ gauge (Info "strato_api_memory" "strato-api memory usage")
-
-stratoApiCpuUsage :: Gauge
-stratoApiCpuUsage = unsafeRegister $ gauge (Info "strato_api_cpu" "strato-api CPU usage")
-
-stratoApiIndexerMemoryUsage :: Gauge
-stratoApiIndexerMemoryUsage = unsafeRegister $ gauge (Info "strato_api_indexer_memory" "strato-api-indexer memory usage")
-
-stratoApiIndexerCpuUsage :: Gauge
-stratoApiIndexerCpuUsage = unsafeRegister $ gauge (Info "strato_api_indexer_cpu" "strato-api-indexer CPU usage")
-
-stratoP2pIndexerMemoryUsage :: Gauge
-stratoP2pIndexerMemoryUsage = unsafeRegister $ gauge (Info "strato_p2p_indexer_memory" "strato-p2p-indexer memory usage")
-
-stratoP2pIndexerCpuUsage :: Gauge
-stratoP2pIndexerCpuUsage = unsafeRegister $ gauge (Info "strato_p2p_indexer_cpu" "strato-p2p-indexer CPU usage")
-
-stratoTxrIndexerMemoryUsage :: Gauge
-stratoTxrIndexerMemoryUsage = unsafeRegister $ gauge (Info "strato_txr_indexer_memory" "strato-txr-indexer memory usage")
-
-stratoTxrIndexerCpuUsage :: Gauge
-stratoTxrIndexerCpuUsage = unsafeRegister $ gauge (Info "strato_txr_indexer_cpu" "strato-txr-indexer CPU usage")
-
-vaultProxyMemoryUsage :: Gauge
-vaultProxyMemoryUsage = unsafeRegister $ gauge (Info "vault_proxy_memory" "vault-proxy memory usage")
-
-vaultProxyCpuUsage :: Gauge
-vaultProxyCpuUsage = unsafeRegister $ gauge (Info "vault_proxy_cpu" "vault-proxy CPU usage")
-
-processMonitorMemoryUsage :: Gauge
-processMonitorMemoryUsage = unsafeRegister $ gauge (Info "process_monitor_memory" "process-monitor memory usage")
-
-processMonitorCpuUsage :: Gauge
-processMonitorCpuUsage = unsafeRegister $ gauge (Info "process_monitor_cpu" "process-monitor CPU usage")
-
-updateGauge :: Gauge -> String -> Map String ProcessInfo -> (ProcessInfo -> IO (Maybe Double)) -> IO ()
-updateGauge g l m f = do
-  case M.lookup (take 15 l) m of
-    Nothing -> pure ()
-    Just a -> f a >>= \a' -> case a' of
-      Nothing -> pure ()
-      Just a'' -> setGauge g a''
-
-updateGauges :: Map String ProcessInfo -> IO ()
-updateGauges m = do
-  -- updateGauge stratoP2pMemoryUsage "pid1" m (\p -> let r = piRes p in print r >> pure (readMaybe r))
-  updateGauge stratoP2pMemoryUsage "strato-p2p" m (\p -> let r = piPercentMem p in print r >> pure (fmap (1000*) $ readMaybe r))
-  updateGauge stratoP2pCpuUsage "strato-p2p" m (pure . readMaybe . piPercentCpu)
-  updateGauge stratoSequencerMemoryUsage "strato-sequencer" m (pure . fmap (1000*) . readMaybe . piPercentMem)
-  updateGauge stratoSequencerCpuUsage "strato-sequencer" m (pure . readMaybe . piPercentCpu)
-  updateGauge vmRunnerMemoryUsage "vm-runner" m (pure . fmap (1000*) . readMaybe . piPercentMem)
-  updateGauge vmRunnerCpuUsage "vm-runner" m (pure . readMaybe . piPercentCpu)
-  updateGauge slipstreamMemoryUsage "slipstream" m (pure . fmap (1000*) . readMaybe . piPercentMem)
-  updateGauge slipstreamCpuUsage "slipstream" m (pure . readMaybe . piPercentCpu)
-  updateGauge stratoApiMemoryUsage "strato-api" m (pure . fmap (1000*) . readMaybe . piPercentMem)
-  updateGauge stratoApiCpuUsage "strato-api" m (pure . readMaybe . piPercentCpu)
-  updateGauge stratoApiIndexerMemoryUsage "strato-api-indexer" m (pure . fmap (1000*) . readMaybe . piPercentMem)
-  updateGauge stratoApiIndexerCpuUsage "strato-api-indexer" m (pure . readMaybe . piPercentCpu)
-  updateGauge stratoP2pIndexerMemoryUsage "strato-p2p-indexer" m (pure . fmap (1000*) . readMaybe . piPercentMem)
-  updateGauge stratoP2pIndexerCpuUsage "strato-p2p-indexer" m (pure . readMaybe . piPercentCpu)
-  updateGauge stratoTxrIndexerMemoryUsage "strato-txr-indexer" m (pure . fmap (1000*) . readMaybe . piPercentMem)
-  updateGauge stratoTxrIndexerCpuUsage "strato-txr-indexer" m (pure . readMaybe . piPercentCpu)
-  updateGauge vaultProxyMemoryUsage "vault-proxy" m (pure . fmap (1000*) . readMaybe . piPercentMem)
-  updateGauge vaultProxyCpuUsage "vault-proxy" m (pure . readMaybe . piPercentCpu)
-  updateGauge processMonitorMemoryUsage "process-monitor-exe" m (pure . fmap (1000*) . readMaybe . piPercentMem)
-  updateGauge processMonitorCpuUsage "process-monitor-exe" m (pure . readMaybe . piPercentCpu)
-
-data ProcessInfo = ProcessInfo
-  { piPercentCpu :: String
-  , piPercentMem :: String
-  , piCommand    :: String
-  } deriving (Eq, Show)
-
-parseProcessInfo :: String -> Either String ProcessInfo
-parseProcessInfo input = case words input of
-  (cpu : mem : cmd : _) ->
-    Right $ ProcessInfo cpu mem cmd
-  _ -> Left $ "Could not parse ProcessInfo: " ++ input
-
-mergeProcessInfo :: ProcessInfo -> Map String ProcessInfo -> Map String ProcessInfo
-mergeProcessInfo p m = m <> M.singleton (take 15 $ piCommand p) p
-
-createProcessMap :: [String] -> IO (Map String ProcessInfo)
-createProcessMap = go M.empty
-  where go m [] = pure m
-        go m (l:ls) = do
-          case parseProcessInfo l of
-            Left e -> putStrLn e >> pure m
-            Right p -> go (mergeProcessInfo p m) ls
+updateGauges :: ProcessInfo -> IO ()
+updateGauges ProcessInfo{..} = do
+  withLabel cpuMetric piCommand $ flip setGauge piPercentCpu
+  withLabel memMetric piCommand $ flip setGauge piMemUsage
 
 runProcessMonitoring :: IO ()
 runProcessMonitoring = forever $ do
   threadDelay 1000000
   output <- readCreateProcess (shell "ps -eo %cpu,rss,cmd --sort -%cpu") ""
-  mapM_ putStrLn $ lines output
-  putStrLn "-------------------------------------------"
-  m <- createProcessMap . drop 1 $ lines output
-  updateGauges m
-  print m
+  traverse_ updateGauges . createProcessMap . drop 1 $ lines output
 
 main :: IO ()
 main = do

--- a/strato/tools/process-monitor/package.yaml
+++ b/strato/tools/process-monitor/package.yaml
@@ -9,6 +9,9 @@ description:   A per-process resource monitor for STRATO services
 
 dependencies:
   - base
+  - containers
+  - prometheus-client
+  - text
 
 library:
   source-dirs: src/
@@ -21,8 +24,6 @@ executables:
     dependencies:
       - async
       - process-monitor
-      - containers
       - process
-      - prometheus-client
       - wai-middleware-prometheus
       - warp

--- a/strato/tools/process-monitor/package.yaml
+++ b/strato/tools/process-monitor/package.yaml
@@ -1,0 +1,28 @@
+name: process-monitor
+version: 0.0.1
+build-type: Simple
+author: Dustin
+maintainer:    dustin@blockapps.net
+synopsis:      A per-process resource monitor for STRATO services
+category:      Monitoring?
+description:   A per-process resource monitor for STRATO services
+
+dependencies:
+  - base
+
+library:
+  source-dirs: src/
+
+executables:
+  process-monitor-exe:
+    source-dirs: exec_src/
+    main: Main.hs
+    other-modules: []
+    dependencies:
+      - async
+      - process-monitor
+      - containers
+      - process
+      - prometheus-client
+      - wai-middleware-prometheus
+      - warp

--- a/strato/tools/process-monitor/src/Data/Metrics.hs
+++ b/strato/tools/process-monitor/src/Data/Metrics.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Data.Metrics where
+
+import Data.Text (Text)
+import Prometheus
+
+{-# NOINLINE cpuMetric #-}
+cpuMetric :: Vector Text Gauge
+cpuMetric =
+  unsafeRegister
+    . vector "process"
+    . gauge
+    $ Info "strato_cpu_usage" "Process CPU usage"
+
+{-# NOINLINE memMetric #-}
+memMetric :: Vector Text Gauge
+memMetric =
+  unsafeRegister
+    . vector "process"
+    . gauge
+    $ Info "strato_memory_usage" "Process memory usage"

--- a/strato/tools/process-monitor/src/Data/ProcessInfo.hs
+++ b/strato/tools/process-monitor/src/Data/ProcessInfo.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE Strict #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Data.ProcessInfo where
+
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import Text.Read (readMaybe)
+
+data ProcessInfo = ProcessInfo
+  { piPercentCpu :: !Double
+  , piMemUsage   :: !Double
+  , piCommand    :: !Text
+  }
+
+parseProcessInfo :: String -> Maybe ProcessInfo
+parseProcessInfo input = case words input of
+  (cpuStr : memStr : cmd : _) -> do
+    cpu <- readMaybe cpuStr
+    mem <- (1000*) <$> readMaybe memStr
+    pure $ ProcessInfo cpu mem (T.pack cmd)
+  _ -> Nothing
+
+mergeProcessInfo :: ProcessInfo -> Map Text ProcessInfo -> Map Text ProcessInfo
+mergeProcessInfo p m = m <> M.singleton (piCommand p) p
+
+createProcessMap :: [String] -> Map Text ProcessInfo
+createProcessMap = foldr go M.empty
+  where go cmd m = maybe m (flip mergeProcessInfo m) $ parseProcessInfo cmd


### PR DESCRIPTION
This PR adds a new program called "process-monitor" to the strato container, which polls `ps` every second, and adds the memory and CPU usage of each process to Prometheus metrics. Hopefully, this process should give us more real-time insight into processes that begin exhibiting signs of memory leaks, idle CPU usage, etc., without having to comping them with profiling enabled.
![Screenshot from 2024-08-16 11-47-15](https://github.com/user-attachments/assets/a7c22b56-fb7e-4974-a716-56947e27e4e2)
![Screenshot from 2024-08-16 11-46-48](https://github.com/user-attachments/assets/9cce740c-0d6e-4d8c-8452-d433fdc05bfb)
