### PR TITLE
Subscribe then register

### DIFF
--- a/strato/identity-provider/server/src/IdentityProvider/Server.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/Server.hs
@@ -233,12 +233,12 @@ putIdentity accessToken uuid idProv name mEmail mCo mSub = do
               certInCirrus accessToken rd a >>= \case
                 -- User has no cert, create cert and wallet.
                 [] -> do
-                  createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
-                  registerUserWalletAsync realmToken rd name' realm uuid' a
                   -- subscribe if can and should
-                  case (realmNoficicationServerUrl rd, fromMaybe True mSub) of 
+                  _ <- case (realmNoficicationServerUrl rd, fromMaybe True mSub) of 
                     (Just url, True) -> runNotificationM url $ subscribeUser accessToken (T.pack name')
                     (_, _) -> return ()
+                  createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
+                  registerUserWalletAsync realmToken rd name' realm uuid' a
                 -- User has a cert but no wallet, create wallet using cert's common name. This is for backwards compatibility with existing users.
                 [cert] -> do
                   hasWallet <- walletInCirrus accessToken rd (T.unpack $ certCommonName cert)
@@ -254,12 +254,12 @@ putIdentity accessToken uuid idProv name mEmail mCo mSub = do
             Nothing -> do
               -- no vault key, so make key and register cert
               AddressAndKey a k <- postVaultKey accessToken
-              createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
-              registerUserWalletAsync realmToken rd name' realm uuid' a
               -- subscribe if can and should
               _ <- case (realmNoficicationServerUrl rd, fromMaybe True mSub) of 
                 (Just url, True) -> runNotificationM url $ subscribeUser accessToken (T.pack name')
                 (_, _) -> return ()
+              createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
+              registerUserWalletAsync realmToken rd name' realm uuid' a
               return a
         (_, Nothing) -> do
           $logErrorS "putIdentity" "uh oh! We couldn't retrieve an access token for our realm"

--- a/strato/identity-provider/server/src/IdentityProvider/Server.hs
+++ b/strato/identity-provider/server/src/IdentityProvider/Server.hs
@@ -234,7 +234,7 @@ putIdentity accessToken uuid idProv name mEmail mCo mSub = do
                 -- User has no cert, create cert and wallet.
                 [] -> do
                   -- subscribe if can and should
-                  _ <- case (realmNoficicationServerUrl rd, fromMaybe True mSub) of 
+                  void . async $ case (realmNoficicationServerUrl rd, fromMaybe True mSub) of 
                     (Just url, True) -> runNotificationM url $ subscribeUser accessToken (T.pack name')
                     (_, _) -> return ()
                   createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k
@@ -255,7 +255,7 @@ putIdentity accessToken uuid idProv name mEmail mCo mSub = do
               -- no vault key, so make key and register cert
               AddressAndKey a k <- postVaultKey accessToken
               -- subscribe if can and should
-              _ <- case (realmNoficicationServerUrl rd, fromMaybe True mSub) of 
+              void . async $ case (realmNoficicationServerUrl rd, fromMaybe True mSub) of 
                 (Just url, True) -> runNotificationM url $ subscribeUser accessToken (T.pack name')
                 (_, _) -> return ()
               createAndRegisterCert name' (T.unpack <$> mEmail) org uuid' realmToken rd k


### PR DESCRIPTION
The identity server only treats transactions whose result is explicitly "success"  as successful (we err on the side of caution and try again if the result is "pending"). Due to the long transaction times on prod, the identity server occasionally errors out prematurely when attempting to create the user's account, so it never reaches the step where it tries to subscribe them to the notification server. This pr changes the ordering the steps for account creation so it spawns a thread to handle the subscription first and then does the typical account creation work. This code is currently live on the testnet identity server, and the registration experience is still seamless, even if an error occurs while trying to subscribe the user.