### PR TITLE
Email Confirmation For STRATS

### DIFF
--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -1059,7 +1059,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   contract.getStratsOrderEvent = async function (args, options = defaultOptions) {
 
     const currentPaymentProvider = await paymentProviderJs.getAll(rawAdmin, {address: args.paymentProvider}, options);
-    if(currentPaymentProvider[0].contract_name === 'BlockApps-StratPaymentService')
+    if(currentPaymentProvider[0].contract_name.includes('StratPaymentService'))
     {
     const orderEvent = await rest.searchUntil(
       rawAdmin,


### PR DESCRIPTION
This PR removes the creator check as `BlockApps` and generically detects if the payment provider is `STRATS` **(StratPaymentService)** before sending the email for order created.

Can be tested on testnet2: https://workspace-neel2-0exm82f.blockapps.net/