### PR TITLE
Set payment-server nginx timeout to 70s

### DIFF
--- a/payment-server-nginx/nginx.tpl.conf
+++ b/payment-server-nginx/nginx.tpl.conf
@@ -102,7 +102,7 @@ http {
       }
 
       location / {
-        proxy_read_timeout 10s;
+        proxy_read_timeout 70s;
         proxy_pass http://__STRIPE_PS_HOST__/;
       }
 

--- a/payment-server-nginx/nginx.tpl.conf
+++ b/payment-server-nginx/nginx.tpl.conf
@@ -45,7 +45,7 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
-    keepalive_timeout  65;
+    keepalive_timeout  75s;
 
     #gzip  on;
 
@@ -102,7 +102,7 @@ http {
       }
 
       location / {
-        proxy_read_timeout 70s;
+        proxy_read_timeout 65s;
         proxy_pass http://__STRIPE_PS_HOST__/;
       }
 


### PR DESCRIPTION
It turns out the `rest.call` function in blockapps-rest already performs the resolve functionality we want, by calling `callResolve` internally, so I think all we need to do to prevent the payment server timeouts is to increase the nginx timeout

https://github.com/blockapps/strato-platform/blob/develop/blockapps-rest/src/rest.ts#L938-L956