### PR TITLE
[MKT-532] Marketplace Redirect 

### DIFF
--- a/marketplace/backend/api/v1/Order/index.js
+++ b/marketplace/backend/api/v1/Order/index.js
@@ -55,6 +55,13 @@ router.get(
   OrderController.getAllUserAddress
 )
 
+router.get(
+  Order.waitForOrderEvent,
+  authHandler.authorizeRequest(),
+  loadDapp,
+  OrderController.waitForOrderEvent
+)
+
 router.post(
   Order.cancelSaleOrder,
   authHandler.authorizeRequest(),

--- a/marketplace/backend/api/v1/Order/order.controller.js
+++ b/marketplace/backend/api/v1/Order/order.controller.js
@@ -83,6 +83,21 @@ class OrderController {
       return next(e)
     }
   }
+
+  static async waitForOrderEvent(req, res, next) {
+    try {
+      const { dapp, query } = req
+      const { orderHash } = query;
+      const orderEvent = await dapp.waitForOrderEvent({orderHash: orderHash}, options)
+       if(orderEvent && orderEvent.length === 1)
+      {
+        rest.response.status200(res, orderEvent)
+      }
+      return next()
+    } catch (e) {
+      return next(e)
+    }
+  }
   
   static async export(req, res, next) {
     try {

--- a/marketplace/backend/api/v1/endpoints.js
+++ b/marketplace/backend/api/v1/endpoints.js
@@ -155,6 +155,7 @@ export const Order = {
   cancelSaleOrder: '/sale/cancel',
   checkSaleQuantity: '/saleQuantity',
   executeSale: '/closeSale',
+  waitForOrderEvent: '/wait/event',
   updateOrderComment: '/updateComment',
   export: '/exportOrders'
 }

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -1076,6 +1076,23 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     }
   }
 
+
+  contract.waitForOrderEvent = async function (args, options = defaultOptions) {
+      const orderEvent = await rest.searchUntil(
+        rawAdmin,
+        { name: "BlockApps-Mercata-PaymentService.Order" },
+        (r) => r.length === 1,
+        {
+          ...options,
+          query: {
+            limit: 1,
+            orderHash: `eq.${args.orderHash}`,
+          }
+        }
+      );
+      return orderEvent;
+  }
+
   contract.createUserAddress = async function (args, options = defaultOptions) {
     const { redemptionService, ...restArgs } = args;
     try {

--- a/marketplace/backend/dapp/orders/saleOrder.js
+++ b/marketplace/backend/dapp/orders/saleOrder.js
@@ -281,7 +281,7 @@ async function getAll(admin, args = {}, options) {
   if (saleOrders) {
     for (let i = 0; i < saleOrders.length; i++) {
       const order = saleOrders[i];
-      if (order.status === '2') {
+      if (parseInt(order.status) === 2) {
         if (paymentProvidersToOrderHashes[order.address]) {
           paymentProvidersToOrderHashes[order.address].push(order.orderHash);
         }

--- a/marketplace/ui/src/components/MarketPlace/ConfirmOrder.js
+++ b/marketplace/ui/src/components/MarketPlace/ConfirmOrder.js
@@ -203,7 +203,7 @@ const ConfirmOrder = ({ paymentProviders = [], data, columns }) => {
         const url = `${serviceURL}${checkoutRoute}?email=${encodeURIComponent(user.email)}&checkoutHash=${checkoutHash}&redirectUrl=${window.location.protocol}//${window.location.host}/order/status`;
         window.location.replace(url);
       } else {
-        window.location.replace(`/order/status?assets=${assets}`);
+        window.location.replace(`/order/status?assets=${assets}&orderHash=${checkoutHash}`);
       }
     }
   };

--- a/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
+++ b/marketplace/ui/src/components/MarketPlace/ProcessingOrder.js
@@ -20,10 +20,11 @@ const ProcessingOrder = ({ user }) => {
   const orderDispatch = useOrderDispatch();
   const marketplaceDispatch = useMarketplaceDispatch();
   const [error, setError] = useState(null)
-  const { message, success } = useOrderState();
+  const { message, success, isOrderEventLoading } = useOrderState();
   const [api, contextHolder] = notification.useNotification();
   const [called, setCalled] = useState(false);
   const { cartList } = useMarketplaceState();
+  const [orderHash, setOrderHash] = useState("");
 
   // const storedData = useMemo(() => {
   //   return JSON.parse(window.localStorage.getItem("cartList") ?? []);
@@ -42,25 +43,38 @@ const ProcessingOrder = ({ user }) => {
 
   useEffect(() => {
     setAssetAddresses(query.get("assets"));
+    setOrderHash(query.get("orderHash"));
   }, [routeMatch, query]);
-
+  
+  useEffect(() => {
+    if (orderHash) {
+      orderActions.waitForOrderEvent(orderDispatch, orderHash);
+    }
+  }, [orderHash]);
+  
   useEffect(() => {
     if (assetAddresses !== undefined && user !== undefined && !called) {
       setCalled(true);
-      getCartData();
     }
-  }, [assetAddresses, user]);
-
+  }, [assetAddresses, user, called]);
+  
   useEffect(() => {
     const errorMsg = query.get("error");
     if (errorMsg) {
       setError(new Error(errorMsg));
     }
   }, [query]);
-
+  
+  useEffect(() => {
+    // Trigger getCartData when isOrderEventLoading changes to false
+    if (!isOrderEventLoading && called) {
+      getCartData();
+    }
+  }, [isOrderEventLoading, called]);
+  
   const getCartData = async () => {
     try {
-      if (assetAddresses) {
+      if (orderHash) {
         let updatedCart = [];
         storedConfirmList.forEach(cart => {
           if (!assetAddresses.includes(cart.action)) {
@@ -68,9 +82,9 @@ const ProcessingOrder = ({ user }) => {
           }
         });
         actions.addItemToCart(marketplaceDispatch, updatedCart);
-        setTimeout(() => {
-          navigate(routes.Orders.url.replace(':type', 'bought'));
-        }, 500);
+  
+        // Navigate to bought once the cart is updated
+        navigate(routes.Orders.url.replace(':type', 'bought'));
       } else {
         setTimeout(() => {
           navigate(routes.Checkout.url);
@@ -79,8 +93,8 @@ const ProcessingOrder = ({ user }) => {
     } catch (err) {
       setError(err);
     }
-  }
-
+  };
+  
   const openToastMarketplace = (placement) => {
     if (error != null) {
       api.error({

--- a/marketplace/ui/src/components/MarketPlace/ResponsiveCart.js
+++ b/marketplace/ui/src/components/MarketPlace/ResponsiveCart.js
@@ -134,7 +134,7 @@ const ResponsiveCart = ({
         const url = `${serviceURL}${checkoutRoute}?email=${encodeURIComponent(user.email)}&checkoutHash=${checkoutHash}&redirectUrl=${window.location.protocol}//${window.location.host}/order/status`;
         window.location.replace(url);
       } else {
-        window.location.replace(`/order/status?assets=${assets}`);
+        window.location.replace(`/order/status?assets=${assets}&orderHash=${checkoutHash}`);
       }
     }
   };

--- a/marketplace/ui/src/contexts/order/actions.js
+++ b/marketplace/ui/src/contexts/order/actions.js
@@ -530,6 +530,11 @@ const actions = {
           error: "Unauthorized while fetching users" 
         });
         window.location.href = body.error.loginUrl;
+      } else if(response.status === RestStatus.GATEWAY_TIMEOUT) {
+        dispatch({ 
+          type: actionDescriptors.waitForOrderEventFailed, 
+          error: "There was a problem processing your order, reach out to sales@blockapps.net for next steps." 
+        });
       }
 
       dispatch({

--- a/marketplace/ui/src/contexts/order/actions.js
+++ b/marketplace/ui/src/contexts/order/actions.js
@@ -37,6 +37,9 @@ const actionDescriptors = {
   executeSale: "execute_sale",
   executeSaleSuccessful: "execute_sale_successful",
   executeSaleFailed: "execute_sale_failed",
+  waitForOrderEvent: "wait_for_order_event",
+  waitForOrderEventSuccessful: "wait_for_order_event_successful",
+  waitForOrderEventFailed: "wait_for_order_event_failed",
   updateOrderComment: "update_order_comment",
   updateOrderCommentSuccessful: "update_order_comment_successful",
   updateOrderCommentFailed: "update_order_comment_failed",
@@ -500,6 +503,47 @@ const actions = {
         error: "Error while fulfilling order",
       });
       actions.setMessage(dispatch, "Error while fulfilling order");
+    }
+  },
+
+
+  waitForOrderEvent: async (dispatch, orderHash) => {
+    dispatch({ type: actionDescriptors.waitForOrderEvent });
+
+    try {
+      const response = await fetch(`${apiUrl}/order/wait/event?orderHash=${orderHash}`, {
+        method: HTTP_METHODS.GET
+      });
+
+      const body = await response.json();
+
+      if (response.status === RestStatus.OK) {
+        dispatch({
+          type: actionDescriptors.waitForOrderEventSuccessful,
+          payload: body.data,
+        });
+        actions.setMessage(dispatch, "Order retrieved successfully", true);
+        return body.data;
+      } else if(response.status === RestStatus.UNAUTHORIZED) {
+        dispatch({ 
+          type: actionDescriptors.waitForOrderEventFailed, 
+          error: "Unauthorized while fetching users" 
+        });
+        window.location.href = body.error.loginUrl;
+      }
+
+      dispatch({
+        type: actionDescriptors.waitForOrderEventFailed,
+        error: "Error while fulfilling order",
+      });
+      actions.setMessage(dispatch, "Error while retrieving order");
+      return false;
+    } catch (err) {
+      dispatch({
+        type: actionDescriptors.waitForOrderEventFailed,
+        error: "Error while fulfilling order",
+      });
+      actions.setMessage(dispatch, "Error while retrieving order");
     }
   },
 

--- a/marketplace/ui/src/contexts/order/index.js
+++ b/marketplace/ui/src/contexts/order/index.js
@@ -35,7 +35,8 @@ const OrdersProvider = ({ children }) => {
     allOrders: {},
     isAllOrdersLoading: false,
     saleQuantity: [],
-    saleQuantityLoading: false
+    saleQuantityLoading: false,
+    isOrderEventLoading: true,
   };
 
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/marketplace/ui/src/contexts/order/reducer.js
+++ b/marketplace/ui/src/contexts/order/reducer.js
@@ -201,6 +201,22 @@ const reducer = (state, action) => {
         error: action.error,
         isCreateOrderSubmitting: false,
       }
+      case actionDescriptors.waitForOrderEvent:
+        return {
+          ...state,
+          isOrderEventLoading: true,
+        }
+      case actionDescriptors.waitForOrderEventSuccessful:
+        return {
+          ...state,
+          isOrderEventLoading: false,
+        }
+      case actionDescriptors.waitForOrderEventFailed:
+        return {
+          ...state,
+          error: action.error,
+          isOrderEventLoading: false,
+        }      
     case actionDescriptors.updateOrderComment:
       return {
         ...state,

--- a/payment-server/StripeService/stripeService.controller.js
+++ b/payment-server/StripeService/stripeService.controller.js
@@ -184,7 +184,7 @@ class StripeServiceController {
       const session = await stripeService.getPaymentSession(paymentDetails.paymentsessionid, paymentDetails.accountid);
 
       // Redirect back to marketplace
-      res.redirect(`${redirectUrl}?assets=[]`);
+      res.redirect(`${redirectUrl}?assets=[]&orderHash=${checkoutHash}`);
 
       // Verify payment and perform onchain transfer
       let returnStatus;

--- a/payment-server/StripeService/stripeService.controller.js
+++ b/payment-server/StripeService/stripeService.controller.js
@@ -185,6 +185,7 @@ class StripeServiceController {
 
       // Verify payment and perform onchain transfer
       let returnStatus;
+      res.redirect(`${redirectUrl}`);
       if (session.payment_status === 'paid') {
         // Get the payment event from Cirrus
         const checkoutEvent = await getCheckoutEvent(checkoutHash);
@@ -201,7 +202,6 @@ class StripeServiceController {
           comments: PAYMENT_RECEIVED_MESSAGE,
         } 
         returnStatus = await completeOrder(STRIPE_CONTRACT_ADDRESS, callArgs);
-        res.redirect(`${redirectUrl}?assets=${returnStatus}`);
 
         // Update payment status in DB
         const updateResult = await updateStripePayment(checkoutHash, "PAID");
@@ -238,7 +238,6 @@ class StripeServiceController {
           comments: "",
         } 
         returnStatus = await generateIntermediateOrder(STRIPE_CONTRACT_ADDRESS, callArgs);
-        res.redirect(`${redirectUrl}?assets=${returnStatus}`);
 
         // Update payment status in DB
         const updateResult = await updateStripePayment(checkoutHash, "INITIALIZED");

--- a/payment-server/StripeService/stripeService.controller.js
+++ b/payment-server/StripeService/stripeService.controller.js
@@ -201,6 +201,7 @@ class StripeServiceController {
           comments: PAYMENT_RECEIVED_MESSAGE,
         } 
         returnStatus = await completeOrder(STRIPE_CONTRACT_ADDRESS, callArgs);
+        res.redirect(`${redirectUrl}?assets=${returnStatus}`);
 
         // Update payment status in DB
         const updateResult = await updateStripePayment(checkoutHash, "PAID");
@@ -237,6 +238,7 @@ class StripeServiceController {
           comments: "",
         } 
         returnStatus = await generateIntermediateOrder(STRIPE_CONTRACT_ADDRESS, callArgs);
+        res.redirect(`${redirectUrl}?assets=${returnStatus}`);
 
         // Update payment status in DB
         const updateResult = await updateStripePayment(checkoutHash, "INITIALIZED");
@@ -261,8 +263,6 @@ class StripeServiceController {
 
       console.log("returnStatus", returnStatus);
 
-      // Redirect back to marketplace
-      res.redirect(`${redirectUrl}?assets=${returnStatus}`);
       return next();
     } catch(e) {
       next(e);

--- a/payment-server/StripeService/stripeService.controller.js
+++ b/payment-server/StripeService/stripeService.controller.js
@@ -183,9 +183,8 @@ class StripeServiceController {
       const paymentDetails = await getStripePaymentFromToken(checkoutHash);
       const session = await stripeService.getPaymentSession(paymentDetails.paymentsessionid, paymentDetails.accountid);
 
-      const assets = { 0: "asset" }; // hacky solution to allow for a proper redirect
       // Redirect back to marketplace
-      res.redirect(`${redirectUrl}?assets=${assets}`);
+      res.redirect(`${redirectUrl}?assets=[]`);
 
       // Verify payment and perform onchain transfer
       let returnStatus;

--- a/payment-server/StripeService/stripeService.controller.js
+++ b/payment-server/StripeService/stripeService.controller.js
@@ -183,9 +183,12 @@ class StripeServiceController {
       const paymentDetails = await getStripePaymentFromToken(checkoutHash);
       const session = await stripeService.getPaymentSession(paymentDetails.paymentsessionid, paymentDetails.accountid);
 
+      const assets = { 0: "asset" }; // hacky solution to allow for a proper redirect
+      // Redirect back to marketplace
+      res.redirect(`${redirectUrl}?assets=${assets}`);
+
       // Verify payment and perform onchain transfer
       let returnStatus;
-      res.redirect(`${redirectUrl}`);
       if (session.payment_status === 'paid') {
         // Get the payment event from Cirrus
         const checkoutEvent = await getCheckoutEvent(checkoutHash);


### PR DESCRIPTION
This PR handles the redirection after stripe checkout form is filled, so that users see a loading page(payment-server resolves tasks in the background) and end-up at Orders tab.

Changes are as follows:

#### [Payment Server -> Stripe Checkout Confirm]:
- While users fill out the form details and submit, the payment server redirects them to the marketplace and carries out its tasks
- Redirected to `/order/status?assets=[]&orderHash=<HASH_FROM_PAYMENT_SERVER>` which renders processing order component from marketplace UI.

#### MP UI:
- `ConfirmOrder.js` and `ResponsiveCart.js`file changes to pass additional param of **orderHash**
- STRATS orders also follow `/order/status?assets=[]&orderHash=<HASH_RECEIVED_FROM_CONTRACT_EXECUTION>`
- `ProcessingOrder.js`: Based on the orderHash, the event is checked if the payment-server has ultimately created an order and only then the Orders Tab is presented to the buyer(user)

