### PR TITLE
[MKT-545] Added blockapps_tokens for presenting sold out inventory

### DIFF
--- a/marketplace/backend/helpers/constants.js
+++ b/marketplace/backend/helpers/constants.js
@@ -39,7 +39,7 @@ export default {
   attachImagesAndFiles: "*,BlockApps-Mercata-Asset-files(*),BlockApps-Mercata-Asset-images(*),BlockApps-Mercata-Asset-fileNames(*)",
   attachSalesAndImagesAndFiles: "*,BlockApps-Mercata-Asset-files(*),BlockApps-Mercata-Asset-images(*),BlockApps-Mercata-Asset-fileNames(*),BlockApps-Mercata-Sale!BlockApps-Mercata-Sale_BlockApps-Mercata-Asset_fk(*,BlockApps-Mercata-Sale-paymentProviders(*))",
   attach_saleAddresses_Quantities_completedSales_onOrder: "*,BlockApps-Mercata-Order-saleAddresses(*),BlockApps-Mercata-Order-quantities(*),BlockApps-Mercata-Order-completedSales(*)",
-  baUserNames: ['blockapps_carbon', 'blockapps_metals', 'blockapps_clothing', 'blockapps_collectibles', 'blockapps_memberships', 'blockapps_art', 'blockapps_spirits'],
+  baUserNames: ['blockapps_carbon', 'blockapps_metals', 'blockapps_clothing', 'blockapps_collectibles', 'blockapps_memberships', 'blockapps_art', 'blockapps_spirits', 'blockapps_tokens'],
   localHost: 'http://localhost'
 };
 


### PR DESCRIPTION
This PR adds **blockapps_tokens** to showcase **sold out** inventory. Changes:
- Added the username `blockapps_tokens` to the list of `baUserNames`.