### PR TITLE
change paymentProviders name to paymentServices so cirrus can parse correctly

### DIFF
--- a/marketplace/backend/api/v1/Inventory/inventory.controller.js
+++ b/marketplace/backend/api/v1/Inventory/inventory.controller.js
@@ -280,7 +280,7 @@ class InventoryController {
   static validateListItemArgs(args) {
     const listItemSchema = Joi.object({
       assetToBeSold: Joi.string().required(),
-      paymentProviders: Joi.array().min(1).items(
+      paymentServices: Joi.array().min(1).items(
         Joi.object({
             creator: Joi.string().required(),
             serviceName: Joi.string().required(),
@@ -372,7 +372,7 @@ class InventoryController {
   static validateUpdateSaleArgs(args) {
     const updateSaleItemSchema = Joi.object({
       saleAddress: Joi.string().required(),
-      paymentProviders: Joi.array().min(1).items(
+      paymentServices: Joi.array().min(1).items(
         Joi.string().min(0).required(),
       ).optional(),
       price: Joi.number().greater(0).precision(2).optional(),

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
@@ -16,7 +16,7 @@ abstract contract Sale is Utils {
     Asset public assetToBeSold;
     decimal public price;
     uint public quantity;
-    PaymentProvider[] public paymentProviders;
+    PaymentProvider[] public paymentServices;
     mapping (string => mapping (string => uint)) paymentProvidersMap;
     mapping (string => uint) lockedQuantity;
     uint totalLockedQuantity;
@@ -81,8 +81,8 @@ abstract contract Sale is Utils {
     function addPaymentProviders(PaymentProvider[] _paymentProviders) public requireSeller("add payment providers") {
         for (uint i = 0; i < _paymentProviders.length; i++) {
             PaymentProvider p = _paymentProviders[i];
-            paymentProviders.push(p);
-            paymentProvidersMap[p.serviceName][p.creator] = paymentProviders.length;
+            paymentServices.push(p);
+            paymentProvidersMap[p.serviceName][p.creator] = paymentServices.length;
         }
     }
 
@@ -92,19 +92,19 @@ abstract contract Sale is Utils {
             uint x = paymentProvidersMap[p.serviceName][p.creator];
             if (x > 0) {
                 // TODO not sure if delete keyword works for structs?
-                delete paymentProviders[x-1]; 
+                delete paymentServices[x-1]; 
                 delete paymentProvidersMap[p.serviceName][p.creator];
             }
         }
     }
 
     function clearPaymentProviders() public requireSeller("clear payment providers") {
-        for (uint i = 0; i < paymentProviders.length; i++) {
-            PaymentProvider p = paymentProviders[i];
+        for (uint i = 0; i < paymentServices.length; i++) {
+            PaymentProvider p = paymentServices[i];
             delete paymentProvidersMap[p.serviceName][p.creator];
-            delete paymentProviders[i];
+            delete paymentServices[i];
         }
-        paymentProviders = [];
+        paymentServices = [];
     }
 
     function isPaymentProvider(PaymentProvider _paymentProvider) public returns (bool) {

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/SimpleSale.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/SimpleSale.sol
@@ -8,7 +8,7 @@ contract SimpleSale is Sale {
         address _assetToBeSold,
         decimal _price,
         uint _quantity,
-        PaymentProvider[] _paymentProviders
-    ) Sale(_assetToBeSold, _price, _quantity, _paymentProviders) {
+        PaymentProvider[] _paymentServices
+    ) Sale(_assetToBeSold, _price, _quantity, _paymentServices) {
     }
 }

--- a/marketplace/backend/dapp/orders/sale.js
+++ b/marketplace/backend/dapp/orders/sale.js
@@ -110,7 +110,7 @@ async function get(user, args, options) {
     const newOptions = { ...options, org: 'BlockApps', app: 'Mercata' }
     let sale;
     let searchArgs;
-    const newArgs = { ...restArgs, queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)' } }
+    const newArgs = { ...restArgs, queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentServices(*)' } }
 
     if (assetToBeSold) {
         searchArgs = setSearchQueryOptions(newArgs,
@@ -190,14 +190,14 @@ async function getAll(admin, args = {}, defaultOptions) {
             gtValue: saleGtValue,
             isOpen: isOpen,
             range: range,
-            queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)' }
+            queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentServices(*)' }
         }, options, admin);
     }
     else {
         sales = await searchAllWithQueryArgs(contractName, {
             address: saleAddresses,
             isOpen: isOpen,
-            queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentProviders(*)' },
+            queryOptions: { 'select': '*,BlockApps-Mercata-Sale-paymentServices(*)' },
             ...restArgs,
         }, options, admin);
     }

--- a/marketplace/backend/dapp/products/inventory.js
+++ b/marketplace/backend/dapp/products/inventory.js
@@ -328,7 +328,7 @@ async function updateSale(admin, contract, _args, options) {
                 return agg | (base << 0)
             case 'price':
                 return agg | (base << 1)
-            case 'paymentProviders':
+            case 'paymentServices':
                 return agg | (base << 2)
             default:
                 return agg
@@ -385,7 +385,7 @@ async function get(user, args, options) {
             price: sale.price,
             saleAddress: sale.address,
             saleQuantity: sale.quantity,
-            paymentProviders: sale ? (sale['BlockApps-Mercata-Sale-paymentProviders'] ? sale['BlockApps-Mercata-Sale-paymentProviders'] : null) : null
+            paymentProviders: sale ? (sale['BlockApps-Mercata-Sale-paymentServices'] ? sale['BlockApps-Mercata-Sale-paymentServices'] : null) : null
         }
     }
 
@@ -431,7 +431,7 @@ async function getAll(admin, args = {}, defaultOptions) {
                         saleAddress: itemSale?.address,
                         saleQuantity: itemSale?.quantity,
                         saleDate: itemSale?.block_timestamp,
-                        paymentProviders: itemSale ? (itemSale['BlockApps-Mercata-Sale-paymentProviders'] ? itemSale['BlockApps-Mercata-Sale-paymentProviders'] : null) : null,
+                        paymentProviders: itemSale ? (itemSale['BlockApps-Mercata-Sale-paymentServices'] ? itemSale['BlockApps-Mercata-Sale-paymentServices'] : null) : null,
                         totalLockedQuantity: itemSale?.totalLockedQuantity
                     });
                 }
@@ -492,7 +492,7 @@ async function getAll(admin, args = {}, defaultOptions) {
                                 saleQuantity: sales[0]?.quantity,
                                 saleDate: sales[0]?.block_timestamp,
                                 totalLockedQuantity: sales[0]?.totalLockedQuantity,
-                                paymentProviders: sales[0] ? (sales[0]['BlockApps-Mercata-Sale-paymentProviders'] ? sales[0]['BlockApps-Mercata-Sale-paymentProviders'] : null) : null,
+                                paymentProviders: sales[0] ? (sales[0]['BlockApps-Mercata-Sale-paymentServices'] ? sales[0]['BlockApps-Mercata-Sale-paymentServices'] : null) : null,
                                 'BlockApps-Mercata-Sale': undefined  // Removing the nested sale data to avoid redundancy
                             });
                         }
@@ -504,7 +504,7 @@ async function getAll(admin, args = {}, defaultOptions) {
                             saleQuantity: sales[0]?.quantity,
                             saleDate: sales[0]?.block_timestamp,
                             totalLockedQuantity: sales[0]?.totalLockedQuantity,
-                            paymentProviders: sales[0] ? (sales[0]['BlockApps-Mercata-Sale-paymentProviders'] ? sales[0]['BlockApps-Mercata-Sale-paymentProviders'] : null) : null,
+                            paymentProviders: sales[0] ? (sales[0]['BlockApps-Mercata-Sale-paymentServices'] ? sales[0]['BlockApps-Mercata-Sale-paymentServices'] : null) : null,
                             'BlockApps-Mercata-Sale': undefined  // Removing the nested sale data to avoid redundancy
                         });
                     }

--- a/marketplace/backend/helpers/constants.js
+++ b/marketplace/backend/helpers/constants.js
@@ -37,7 +37,7 @@ export default {
   prodStratsAddress: "b220195543f652f735b7847c4af399d0323e1ff6",
   testnetStratsAddress: "488cd3909d94606051e0684cf6caa5763fb78613",
   attachImagesAndFiles: "*,BlockApps-Mercata-Asset-files(*),BlockApps-Mercata-Asset-images(*),BlockApps-Mercata-Asset-fileNames(*)",
-  attachSalesAndImagesAndFiles: "*,BlockApps-Mercata-Asset-files(*),BlockApps-Mercata-Asset-images(*),BlockApps-Mercata-Asset-fileNames(*),BlockApps-Mercata-Sale!BlockApps-Mercata-Sale_BlockApps-Mercata-Asset_fk(*,BlockApps-Mercata-Sale-paymentProviders(*))",
+  attachSalesAndImagesAndFiles: "*,BlockApps-Mercata-Asset-files(*),BlockApps-Mercata-Asset-images(*),BlockApps-Mercata-Asset-fileNames(*),BlockApps-Mercata-Sale!BlockApps-Mercata-Sale_BlockApps-Mercata-Asset_fk(*,BlockApps-Mercata-Sale-paymentServices(*))",
   attach_saleAddresses_Quantities_completedSales_onOrder: "*,BlockApps-Mercata-Order-saleAddresses(*),BlockApps-Mercata-Order-quantities(*),BlockApps-Mercata-Order-completedSales(*)",
   baUserNames: ['blockapps_carbon', 'blockapps_metals', 'blockapps_clothing', 'blockapps_collectibles', 'blockapps_memberships', 'blockapps_art', 'blockapps_spirits'],
   localHost: 'http://localhost'

--- a/marketplace/ui/src/components/Inventory/ListForSaleModal.js
+++ b/marketplace/ui/src/components/Inventory/ListForSaleModal.js
@@ -205,7 +205,7 @@ const ListForSaleModal = ({ open, handleCancel, inventory, categoryName, limit, 
 
     const handleSubmit = async () => {
         let body = {
-          paymentProviders: paymentTypes
+            paymentServices: paymentTypes
             .filter((p) => availablePaymentProviders[p])
             .map((p) => {
               return {

--- a/marketplace/ui/src/components/MarketPlace/Checkout.js
+++ b/marketplace/ui/src/components/MarketPlace/Checkout.js
@@ -357,7 +357,8 @@ const Checkout = () => {
   ];
 
   const filterPaymentServices = (e) => {
-    const filteredPaymentServices = e.map(assetPaymentServices => paymentServices.find(paymentService => paymentService.creator === JSON.parse(assetPaymentServices.value).creator && paymentService.serviceName === JSON.parse(assetPaymentServices.value).serviceName));
+    console.log(e);
+    const filteredPaymentServices = e.map(assetPaymentServices => paymentServices.find(paymentService => paymentService.creator === assetPaymentServices.value.creator && paymentService.serviceName === assetPaymentServices.value.serviceName));
 
     return filteredPaymentServices;
   }


### PR DESCRIPTION
Too much change just to parse a struct correctly, I would rather parse it wherever we see it on the app. But we can take a vote. This change is only enough to make the sale work; not all terminology was updated in the app for this.