### PR TITLE
Removed dependency on universum

### DIFF
--- a/strato/core/strato-init/package.yaml
+++ b/strato/core/strato-init/package.yaml
@@ -63,7 +63,6 @@ library:
   - text
   - transformers
   - turtle
-  - universum
   - unliftio
   - unliftio-core
   - vm-tools

--- a/strato/core/strato-init/src/Blockchain/Init/Generator.hs
+++ b/strato/core/strato-init/src/Blockchain/Init/Generator.hs
@@ -45,8 +45,6 @@ import Turtle (chmod, roo)
 import UnliftIO.Directory
 import UnliftIO.IO hiding (withFile)
 
-import Universum.Lifted.File
-
 genesisFiles :: [(FilePath, C8.ByteString)]
 genesisFiles = $(embedDir "genesisBlocks")
 
@@ -149,7 +147,7 @@ sendAccountInfo accountInfoFileName = do
               liftIO $ TIO.appendFile accountFile acs
 
               sendChunks h
-      withFile accountInfoFileName ReadMode $ \h -> do
+      bracket (openFile accountInfoFileName ReadMode) hClose $ \h -> do
         hSetBuffering h (BlockBuffering (Just (1024 * 1024)))
         sendChunks h
     else case lookup accountInfoFileName genesisFiles of


### PR DESCRIPTION
Small change - this dependency was only being used for the `withFile` function, but that function was just implemented using `bracket` from `Control.Monad.Catch`, which we already import.