### PR TITLE
Option for strict mode for blockstanbul but disabled by default

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -189,6 +189,7 @@ services:
     - SEQUENCER_DEBUG_LOG=${SEQUENCER_DEBUG_LOG:-false}
     - SLIPSTREAM_DEBUG_LOG=${SLIPSTREAM_DEBUG_LOG:-false}
     - SLIPSTREAM_OPTIONAL=${SLIPSTREAM_OPTIONAL}
+    - strictBlockstanbul=${strictBlockstanbul}
     - STRIPE_PAYMENT_SERVER_URL=${STRIPE_PAYMENT_SERVER_URL}
     - svmTrace=${svmTrace}
     - sqlDiff=${sqlDiff}

--- a/strato/core/blockstanbul/package.yaml
+++ b/strato/core/blockstanbul/package.yaml
@@ -24,6 +24,7 @@ library:
   - extra
   - format
   - generic-arbitrary
+  - hflags
   - lens
   - mtl
   - prometheus-client

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Authentication.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Authentication.hs
@@ -15,6 +15,7 @@ import BlockApps.Logging
 import BlockApps.X509.Certificate
 import Blockchain.Blockstanbul.Messages hiding (sequence)
 import Blockchain.Blockstanbul.Model.Authentication
+import Blockchain.Blockstanbul.Options (flags_strictBlockstanbul)
 import Blockchain.Blockstanbul.StateMachine
 import Blockchain.Data.ArbitraryInstances ()
 import Blockchain.Data.Block
@@ -63,6 +64,9 @@ signMessage tm = do
   sig <- sign mesg
   return $ OMsg (MsgAuth (fromJust addr) sig) $ tm
 
+blockstanbulError :: (MonadError String m) => String -> m a
+blockstanbulError = if flags_strictBlockstanbul then error else throwError
+
 authenticate :: (A.Selectable Address X509CertInfoState m) => InEvent -> m Bool
 authenticate (IMsg (MsgAuth cm sig) tm) = do
   let msgHash = getHash tm
@@ -109,7 +113,7 @@ replayHistoricBlock realValidators seqNo blk = do
   propValidator <- getValidatorFromAddress' prop
 
   unless (propValidator `elem` realValidators) $
-    error $
+    blockstanbulError $
       "proposer " ++ formatAddressWithoutColor prop ++ " (" ++ format propValidator ++ ")  not a validator"
       ++ "\nreal validator list: " ++ show (map format $ S.toList realValidators)
 
@@ -117,7 +121,7 @@ replayHistoricBlock realValidators seqNo blk = do
 --  let expectedValidatorList = [c | CommonName _ _ c _ <- S.toList (unChainMembers _validatorList)]
 
   unless (expectedValidatorList == realValidators) $
-    error $
+    blockstanbulError $
       "real validator list doesn't match expected validator list for block #" ++ show (number . blockBlockData $ blk)
       ++ "\nreal validator list: " ++ show (map format $ S.toList realValidators)
       ++ "\nblock validator list: " ++ show (map format $ S.toList expectedValidatorList)
@@ -126,14 +130,14 @@ replayHistoricBlock realValidators seqNo blk = do
         let unexplained = intercalate "," . map format . S.toList $ signerRes S.\\ realValidators
         if (signerRes S.\\ realValidators) `S.isSubsetOf` futureValidatorsHack
           then $logErrorS "replayHistoricBlock" . T.pack $ "future validators " ++ show unexplained ++ " jumped the gun, signed block #" ++ show blockNo ++ " before they were authorized to do so.  I'll throw the block away and wait for another validator to send me the properly signed block"
-          else error $
+          else blockstanbulError $
                "unknown signers in block #" ++ show blockNo ++ ": " ++ unexplained
                ++ "\nsignerRes: " ++ show (map format $ S.toList signerRes)
                ++ "\nreal validator list: " ++ show (map format $ S.toList realValidators)
                ++ "\nblock validator list: " ++ show (map format $ S.toList expectedValidatorList)
 
   unless (3 * S.size signerRes > 2 * S.size realValidators) $
-    error $
+    blockstanbulError $
       printf "not enough commit seals (have %d out of %d)" (S.size signerRes) (S.size realValidators)
       ++ ": signerRes = " ++ show signerRes
       ++ ", realValidators = " ++ show realValidators

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Options.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/Options.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Blockchain.Blockstanbul.Options
+(
+    flags_strictBlockstanbul
+)
+where
+
+import HFlags
+
+defineFlag "strictBlockstanbul" (False :: Bool) "Strict Blockstanbul will crash on any authentication error"
+

--- a/strato/core/strato-sequencer/exec-src/Main.hs
+++ b/strato/core/strato-sequencer/exec-src/Main.hs
@@ -8,6 +8,7 @@ module Main where
 import BlockApps.Init
 import BlockApps.Logging
 import Blockchain.Blockstanbul
+import Blockchain.Blockstanbul.Options ()
 import Blockchain.Data.GenesisInfo
 import Blockchain.EthConf
 import Blockchain.Generation

--- a/strato/extraFiles/strato/doit.sh
+++ b/strato/extraFiles/strato/doit.sh
@@ -158,6 +158,10 @@ function newnode {
      --minLogLevel=$p2pMinLogLevel \
      ${networkFlag} "${iFlag}" &>> logs/strato-p2p
 
+  if [ -n "${strictBlockstanbul}" ]; then
+      sBFlag="--strictBlockstanbul=${strictBlockstanbul}"
+  fi
+
   echo "Starting strato-sequencer"
   runBackgroundProcess strato-sequencer \
     --blockstanbul=true \
@@ -168,7 +172,7 @@ function newnode {
     --seq_max_events_per_iter=${seqMaxEventsPerIter:-500} \
     --seq_max_us_per_iter=${seqMaxUsPerIter:-50000} \
     --validatorBehavior=${validatorBehavior:-true} \
-    "${networkFlag}" "${iFlag}" \
+    "${networkFlag}" "${iFlag}" "${sBFlag}" \
     +RTS "${seqRTSOPTs:-}" -N1 &>> logs/strato-sequencer
 
   echo "Starting strato-api-indexer"


### PR DESCRIPTION
tested and if you run your node with `strictBlockstanbul=true`, then it will crash on any block that fails blockstanbul authentication. Running with the flag set to `false` or not using the flag will make the sequencer just `throwError` but not crash