### PR TITLE
Transaction page fixes

### DIFF
--- a/marketplace/backend/api/v1/Transactions/transaction.controller.js
+++ b/marketplace/backend/api/v1/Transactions/transaction.controller.js
@@ -97,6 +97,7 @@ class TransactionController {
 
                 return {
                 ...item,
+                createdDate: item.transferDate || item.redemptionDate || item.createdDate,
                 from: item.oldOwnerCommonName || item.sellersCommonName || item.issuerCommonName || item.sellerCommonName,
                 to: item.newOwnerCommonName || item.purchasersCommonName || item.ownerCommonName,
                 price: item.price || '',

--- a/marketplace/ui/src/components/Header/Header.js
+++ b/marketplace/ui/src/components/Header/Header.js
@@ -233,7 +233,7 @@ const HeaderComponent = ({ user, loginUrl, showMenu, handleSubMenu, handleMenuTa
   }, [user])
 
   const subMenuItems = [
-    { value: "transactions", path: routes.Transactions.url, label: "Transactions" },
+    { value: "transactions", path: routes.Transactions.url, label: "My Transactions" },
     { value: "myitems", path: "/myitems", label: "My Items" },
     user ? {
       value: "my-profile",

--- a/marketplace/ui/src/components/Order/BoughtOrderDetails.js
+++ b/marketplace/ui/src/components/Order/BoughtOrderDetails.js
@@ -360,7 +360,7 @@ const BoughtOrderDetails = ({ user, users }) => {
           <Breadcrumb.Item href="" onClick={e => e.preventDefault()}>
             <div onClick={() => { navigate(routes.Transactions.url) }}>
               <p className="text-sm text-[#13188A] font-semibold">
-                Orders (bought)
+                My Transactions
               </p>
             </div>
           </Breadcrumb.Item>

--- a/marketplace/ui/src/components/Order/RedemptionsIncomingDetails.js
+++ b/marketplace/ui/src/components/Order/RedemptionsIncomingDetails.js
@@ -206,7 +206,7 @@ const RedemptionsIncomingDetails = ({ user }) => {
                         </Breadcrumb.Item>
                         <Breadcrumb.Item href="" onClick={e => e.preventDefault()}>
                             <div onClick={() => { navigate(routes.Transactions.url) }}>
-                                <p className="text-sm text-primary font-semibold">Redemptions (incoming)</p>
+                                <p className="text-sm text-primary font-semibold">My Transactions</p>
                             </div>
                         </Breadcrumb.Item>
                         <Breadcrumb.Item className="text-sm text-[#202020] font-medium">

--- a/marketplace/ui/src/components/Order/RedemptionsOutgoingDetails.js
+++ b/marketplace/ui/src/components/Order/RedemptionsOutgoingDetails.js
@@ -162,7 +162,7 @@ const RedemptionsOutgoingDetails = ({ user }) => {
                         </Breadcrumb.Item>
                         <Breadcrumb.Item href="" onClick={e => e.preventDefault()}>
                             <div onClick={() => { navigate(routes.Transactions.url) }}>
-                                <p className="text-sm text-primary font-semibold">Redemptions (outgoing)</p>
+                                <p className="text-sm text-primary font-semibold">My Transactions</p>
                             </div>
                         </Breadcrumb.Item>
                         <Breadcrumb.Item className="text-sm text-[#202020] font-medium">

--- a/marketplace/ui/src/components/Order/SoldOrderDetails.js
+++ b/marketplace/ui/src/components/Order/SoldOrderDetails.js
@@ -321,7 +321,7 @@ const SoldOrderDetails = ({ user, users }) => {
           </Breadcrumb.Item>
           <Breadcrumb.Item href="" onClick={e => e.preventDefault()}>
             <div onClick={() => { navigate(routes.Transactions.url) }}>
-              <p className="text-sm text-primary font-semibold">Orders (sold)</p>
+              <p className="text-sm text-primary font-semibold">My Transactions</p>
             </div>
           </Breadcrumb.Item>
           <Breadcrumb.Item className="text-sm text-[#202020] font-medium">

--- a/marketplace/ui/src/components/Order/Transaction.js
+++ b/marketplace/ui/src/components/Order/Transaction.js
@@ -1,8 +1,5 @@
 import { Breadcrumb, notification } from "antd";
 import React, { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import dayjs from "dayjs";
-
 import routes from "../../helpers/routes";
 import ClickableCell from "../ClickableCell";
 import * as XLSX from 'xlsx';
@@ -10,8 +7,8 @@ import { saveAs } from 'file-saver';
 import { actions as categoryActions } from "../../contexts/category/actions";
 import { useCategoryState, useCategoryDispatch } from "../../contexts/category";
 import startCase from 'lodash/startCase';
-import { epochToDate } from "../../helpers/utils";
-import { ORDER_STATUS, REDEMPTION_STATUS, TRANSACTION_STATUS } from "../../helpers/constants";
+import { epochToDate, getStringDate } from "../../helpers/utils";
+import { REDEMPTION_STATUS, TRANSACTION_STATUS, US_DATE_FORMAT } from "../../helpers/constants";
 import TransactionTable from "./TransactionTable";
 import { useTransactionState } from "../../contexts/transaction";
 
@@ -76,7 +73,7 @@ const Transaction = ({ user }) => {
           from: transaction.from,
           to: transaction.to,
           hash: transaction.transaction_hash,
-          date: transaction?.block_timestamp,
+          date: getStringDate(transaction?.createdDate, US_DATE_FORMAT),
           Status: transaction?.type === "Transfer" ? 'Closed' : (transaction?.type === "Redemption"
             ? REDEMPTION_STATUS[transaction.status]
             : TRANSACTION_STATUS[transaction.status])

--- a/marketplace/ui/src/components/Order/TransactionTable.js
+++ b/marketplace/ui/src/components/Order/TransactionTable.js
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { Button, Dropdown, Space, Typography, Input, Row, Col, Popover, Card, Tooltip, Select, DatePicker, Spin } from "antd";
+import { Button, Dropdown, Space, Input, Row, Col, Popover, Card, Tooltip, Select, DatePicker, Spin } from "antd";
 import { DownloadOutlined, SearchOutlined } from "@ant-design/icons";
 import { useNavigate, useLocation } from "react-router-dom";
 import classNames from "classnames";
 import dayjs from "dayjs";
-import moment from "moment";
 // Components
 import DataTableComponent from "../DataTableComponent";
 import { TRANSACTION_FILTER } from "./constant";
@@ -19,10 +18,11 @@ import { actions as transactionAction } from "../../contexts/transaction/actions
 import { useTransactionDispatch, useTransactionState } from "../../contexts/transaction";
 // Utils & Constants
 import {
-  STRATS_CONVERSION, TRANSACTION_STATUS, TRANSACTION_STATUS_CLASSES, TRANSACTION_SORT,
-  TRANSACTION_STATUS_COLOR, DOWNLOAD_OPTIONS, REDEMPTION_STATUS, REDEMPTION_STATUS_CLASSES
+  STRATS_CONVERSION, TRANSACTION_STATUS, TRANSACTION_STATUS_CLASSES, TRANSACTION_STATUS_COLOR, 
+  DOWNLOAD_OPTIONS, REDEMPTION_STATUS, REDEMPTION_STATUS_CLASSES, US_DATE_FORMAT
 } from "../../helpers/constants";
 import { SEO } from "../../helpers/seoConstant";
+import { getStringDate } from "../../helpers/utils";
 
 const limit = '', offset = '';
 
@@ -265,7 +265,7 @@ const TransactionTable = ({ user, download, isAllOrdersLoading }) => {
       dataIndex: "date",
       key: "date",
       width: '150px',
-      render: (text,{block_timestamp}) => <p>{moment(block_timestamp).format('L')}</p>,
+      render: (text,{createdDate}) => <p>{getStringDate(createdDate, US_DATE_FORMAT)}</p>,
       title: (
         <div style={{ display: "flex" }}>
           <div className="mt-1.5">{"Date"}</div>

--- a/marketplace/ui/src/components/Order/TransactionTable.js
+++ b/marketplace/ui/src/components/Order/TransactionTable.js
@@ -336,7 +336,7 @@ const TransactionTable = ({ user, download, isAllOrdersLoading }) => {
               <Col xs={24} xl={24}>
                 <Row className="w-full md:w-auto md:flex md:justify-between items-center mb-5 mt-4">
                   <Col xs={24} md={7} className="flex justify-center mt-2 md:mt-0">
-                    <Select className="block lg:block w-full md:w-4/5 rounded-md mx-auto" onChange={(val) => { handleFilter(val) }} placeholder="Select Type" defaultValue={type || ''}>
+                    <Select className="block lg:block w-full md:w-4/5 rounded-md mx-auto" onChange={(val) => { handleFilter(val) }} placeholder="Select Type" value={type} defaultValue={type || ''}>
                       {TRANSACTION_FILTER.map(({ label, value }) =>
                         <Select.Option value={value}> {label} </Select.Option>
                       )}
@@ -354,6 +354,7 @@ const TransactionTable = ({ user, download, isAllOrdersLoading }) => {
                       <DatePicker onChange={onDateChange}
                         className="w-full"
                         defaultValue={defaultDate}
+                        value={defaultDate}
                         picker="month"
                         disabledDate={(current) => { return current && current > dayjs().endOf('month') }}
                         format={(value) => dayjs(value).format('MMMM YYYY')}


### PR DESCRIPTION
Fixed `Transactions` to `My Transactions` in mobile menu

<img width="320" alt="Screenshot 2024-09-10 at 12 42 08 PM" src="https://github.com/user-attachments/assets/44252f74-7d0b-4455-b07c-3964bda39d4b">


Fixed breadcrumbs leading to My Transactions page from Sold/Bought Orders Details page and Redemptions Incoming/Outgoing details page

<img width="728" alt="Screenshot 2024-09-10 at 12 43 51 PM" src="https://github.com/user-attachments/assets/459805b0-5e69-42b3-a631-bce44a640675">

Fixed filter state in My Transactions page after leaving page and coming back (given that the Breadcrumb wasn't clicked):

https://github.com/user-attachments/assets/f4a23bd7-1988-4642-8ca5-2628b1b98696



Fixed dates in My Transactions page and transaction details page so that they're both correct

