### PR TITLE
Primary event fields

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -21,6 +21,7 @@ so that they could be properly moved to their respective version's subsection.
 - Added BlockHeaderV2 fields to BlockView component in SMD
 - Added event array tables to Cirrus
 - Added Kafka composable monad
+- Added capability to use `indexed` keyword in event declarations to index fields as primary keys
 
 ### Changed
 - General cleanup of Kafka-related code

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Event.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Event.hs
@@ -5,14 +5,7 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module SolidVM.Model.CodeCollection.Event
-  ( EventF (..),
-    Event,
-    eventAnonymous,
-    eventLogs,
-    eventContext,
-  )
-where
+module SolidVM.Model.CodeCollection.Event where
 
 import Control.DeepSeq
 import Control.Lens hiding ((.=))
@@ -53,7 +46,7 @@ instance FromJSON EventLog where
       <*> (o .: "type")
   parseJSON o = typeMismatch "SolidVM.EventLog: Expected Object" o
 
-instance Arbitrary a => Arbitrary (EventF a) where
+instance Arbitrary EventLog where
   arbitrary = GR.genericArbitrary GR.uniform
 
 --Changes to this structure should make a change to the unparser :)

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Event.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Event.hs
@@ -27,10 +27,39 @@ import qualified SolidVM.Model.CodeCollection.VarDef as SolidVM
 import Test.QuickCheck
 import Test.QuickCheck.Instances ()
 
+data EventLog = EventLog
+  { _eventLogName    :: Text
+  , _eventLogIndexed :: Bool
+  , _eventLogType    :: SolidVM.IndexedType
+  } deriving (Eq, Show, Generic, NFData)
+
+makeLenses ''EventLog
+
+instance Binary EventLog
+
+instance ToJSON EventLog where
+  toJSON e =
+    object
+      [ "name" .= _eventLogName e,
+        "indexed" .= _eventLogIndexed e,
+        "type" .= _eventLogType e
+      ]
+
+instance FromJSON EventLog where
+  parseJSON (Object o) =
+    EventLog
+      <$> (o .: "name")
+      <*> (o .: "indexed")
+      <*> (o .: "type")
+  parseJSON o = typeMismatch "SolidVM.EventLog: Expected Object" o
+
+instance Arbitrary a => Arbitrary (EventF a) where
+  arbitrary = GR.genericArbitrary GR.uniform
+
 --Changes to this structure should make a change to the unparser :)
 data EventF a = Event
   { _eventAnonymous :: Bool,
-    _eventLogs :: [(Text, SolidVM.IndexedType)],
+    _eventLogs :: [EventLog],
     _eventContext :: a
   }
   deriving (Eq, Show, Generic, NFData, Functor, Foldable, Traversable)

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -405,10 +405,10 @@ functionDeclaration free = do
 functionXabi :: Bool -> SolidityParser SolidVM.Func
 functionXabi free = do
   start <- getSourcePosition
-  functionArgs <- tupleDeclaration
+  functionArgs <- map (fmap snd) <$> tupleDeclaration
 
   let lastParamIsVariadic = maybe False ((==) SVMType.Variadic . fst) (Data.List.uncons . reverse . map snd $ functionArgs)
-      containsOnly1 = length (filter (SVMType.Variadic ==) (map (snd . snd) functionArgs)) == 1
+      containsOnly1 = length (filter (SVMType.Variadic ==) (map snd functionArgs)) == 1
   case (lastParamIsVariadic, containsOnly1) of
     (True, False) -> unexpected "only one variadic parameter is allowed"
     (False, True) -> unexpected "variadic parameter must be the last parameter"
@@ -461,7 +461,7 @@ eventDeclaration = do
       EventDeclaration
         SolidVM.Event
           { SolidVM._eventAnonymous = anon,
-            SolidVM._eventLogs = zipWith (\i (n,(x,t)) -> EventLog n x (SolidVM.IndexedType i t)) [0 ..] logs,
+            SolidVM._eventLogs = zipWith (\i (n,(x,t)) -> SolidVM.EventLog n x (SolidVM.IndexedType i t)) [0 ..] logs,
             SolidVM._eventContext = ctx
             --         objName = name,
             --         objValueType = NoValue,
@@ -506,7 +506,7 @@ tupleDeclaration :: SolidityParser [(Text, (Bool, SVMType.Type))]
 tupleDeclaration = parens $
   commaSep $ do
     partType <- simpleTypeExpression
-    indexed <- fmap (fromMaybe False) . optional $
+    indexed <- option False $
             (True <$ reserved "indexed")
         <|> (False <$ reserved "storage")
         <|> (False <$ reserved "memory")

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Declarations.hs
@@ -408,7 +408,7 @@ functionXabi free = do
   functionArgs <- tupleDeclaration
 
   let lastParamIsVariadic = maybe False ((==) SVMType.Variadic . fst) (Data.List.uncons . reverse . map snd $ functionArgs)
-      containsOnly1 = length (filter (SVMType.Variadic ==) (map snd functionArgs)) == 1
+      containsOnly1 = length (filter (SVMType.Variadic ==) (map (snd . snd) functionArgs)) == 1
   case (lastParamIsVariadic, containsOnly1) of
     (True, False) -> unexpected "only one variadic parameter is allowed"
     (False, True) -> unexpected "variadic parameter must be the last parameter"
@@ -461,7 +461,7 @@ eventDeclaration = do
       EventDeclaration
         SolidVM.Event
           { SolidVM._eventAnonymous = anon,
-            SolidVM._eventLogs = zipWith (\i -> fmap (SolidVM.IndexedType i)) [0 ..] logs,
+            SolidVM._eventLogs = zipWith (\i (n,(x,t)) -> EventLog n x (SolidVM.IndexedType i t)) [0 ..] logs,
             SolidVM._eventContext = ctx
             --         objName = name,
             --         objValueType = NoValue,
@@ -479,7 +479,7 @@ modifierDeclaration = do
   start <- getSourcePosition
   reserved "modifier"
   name <- identifier
-  args <- option [] tupleDeclaration
+  args <- map (fmap snd) <$> option [] tupleDeclaration
   contents <- Just <$> statements <|> (reservedOp ";" >> return Nothing)
   end <- getSourcePosition
   let ctx = SourceAnnotation start end ()
@@ -502,17 +502,17 @@ modifierDeclaration = do
 
 -- | Parses a '(x, y, z)'-style tuple, such as appears in function
 -- arguments and return values.
-tupleDeclaration :: SolidityParser [(Text, SVMType.Type)]
+tupleDeclaration :: SolidityParser [(Text, (Bool, SVMType.Type))]
 tupleDeclaration = parens $
   commaSep $ do
     partType <- simpleTypeExpression
-    optional $
-      reserved "indexed"
-        <|> reserved "storage"
-        <|> reserved "memory"
-        <|> reserved "calldata"
+    indexed <- fmap (fromMaybe False) . optional $
+            (True <$ reserved "indexed")
+        <|> (False <$ reserved "storage")
+        <|> (False <$ reserved "memory")
+        <|> (False <$ reserved "calldata")
     partName <- option "" identifier
-    return (Text.pack partName, partType)
+    return (Text.pack partName, (indexed, partType))
 
 --  ObjDef{
 --    objName = partName,
@@ -549,7 +549,7 @@ functionModifiers ::
 functionModifiers = do
   vals <-
     many $
-      (ReturnsMod <$> returnModifier)
+      (ReturnsMod . map (fmap snd) <$> returnModifier)
         <|> (VisibilityMod <$> visibilityModifier)
         <|> (MutabilityMod <$> mutabilityModifier)
         <|> (VirtualMod <$ reserved "virtual")

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -383,7 +383,7 @@ unparseEvent (name, Event {..}) =
     "event "
       <> labelToText name
       <> "(\n    "
-      <> Text.intercalate ",\n    " (List.map unparseArgs _eventLogs)
+      <> Text.intercalate ",\n    " (List.map (\(EventLog n _ i) -> unparseArgs (n,i)) _eventLogs)
       <> ")"
       <> (if _eventAnonymous then "anonymous" else "")
       <> ";"

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1774,7 +1774,7 @@ statementHelper (EmitStatement eventName vals x) = do
                                     _          -> error "Internal Error: Type is not static"
                            ) vals'
               -- valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
-          let expectedTypes = [indexedTypeType it | (_, it) <- _eventLogs event]
+          let expectedTypes = _eventLogType <$> _eventLogs event
               -- expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
           if length expectedTypes /= length vals''
             then pure . bottom $ "Wrong number of arguments provided" <$ x

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1774,7 +1774,7 @@ statementHelper (EmitStatement eventName vals x) = do
                                     _          -> error "Internal Error: Type is not static"
                            ) vals'
               -- valsStaticDebug = trace ("Static types: " ++ show vals'') vals''
-          let expectedTypes = _eventLogType <$> _eventLogs event
+          let expectedTypes = indexedTypeType . _eventLogType <$> _eventLogs event
               -- expectedTypesDebug = trace ("Expected types: " ++ show expectedTypes) expectedTypes
           if length expectedTypes /= length vals''
             then pure . bottom $ "Wrong number of arguments provided" <$ x

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1356,8 +1356,8 @@ runStatement st@(CC.EmitStatement eventName exptups pos) = do
           -- pair up field names with values one-by-one (no type checking tho, lol)
           -- let pairs = zip (map (T.unpack . fst) $ CC._eventLogs ev) expStrs
 
-          let evArgs = zipWith (\(EventLog name _ (CC.IndexedType _ idxType)) value -> 
-                        (T.unpack name, isIndexed, value, if isTypeArray idxType then "Array" else "Other")) 
+          let evArgs = zipWith (\(CC.EventLog name _ (CC.IndexedType _ idxType)) value -> 
+                        (T.unpack name, value, if isTypeArray idxType then "Array" else "Other")) 
                      (CC._eventLogs ev) expStrs
                 where
                   isTypeArray :: SVMType.Type -> Bool

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1356,8 +1356,8 @@ runStatement st@(CC.EmitStatement eventName exptups pos) = do
           -- pair up field names with values one-by-one (no type checking tho, lol)
           -- let pairs = zip (map (T.unpack . fst) $ CC._eventLogs ev) expStrs
 
-          let evArgs = zipWith (\(name, CC.IndexedType _ idxType) value -> 
-                        (T.unpack name, value, if isTypeArray idxType then "Array" else "Other")) 
+          let evArgs = zipWith (\(EventLog name _ (CC.IndexedType _ idxType)) value -> 
+                        (T.unpack name, isIndexed, value, if isTypeArray idxType then "Array" else "Other")) 
                      (CC._eventLogs ev) expStrs
                 where
                   isTypeArray :: SVMType.Type -> Bool

--- a/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
@@ -127,7 +127,7 @@ tFormEv :: SolidEv.Event -> EVMXabi.Event
 tFormEv SolidEv.Event {..} =
   EVMXabi.Event
     { eventAnonymous = _eventAnonymous,
-      eventLogs = [(a, tFormIndexedType b) | (a, _, b) <- _eventLogs]
+      eventLogs = [(a, tFormIndexedType b) | SolidEv.EventLog a _ b <- _eventLogs]
     }
 
 tFormUs :: [SVMXabi.Using] -> EVMXabi.Using

--- a/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/XabiHelper.hs
@@ -127,7 +127,7 @@ tFormEv :: SolidEv.Event -> EVMXabi.Event
 tFormEv SolidEv.Event {..} =
   EVMXabi.Event
     { eventAnonymous = _eventAnonymous,
-      eventLogs = [(a, tFormIndexedType b) | (a, b) <- _eventLogs]
+      eventLogs = [(a, tFormIndexedType b) | (a, _, b) <- _eventLogs]
     }
 
 tFormUs :: [SVMXabi.Using] -> EVMXabi.Using

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1461,8 +1461,13 @@ createEventTable (creator, a, n) evName ev cc = do
   let (crtr, app, cname) = constructTableNameParameters creator a n
       eventTable = EventTableName crtr app cname (escapeQuotes $ labelToText evName)
       isEvent = True
-      cols = getTableColumnAndType isEvent cc [(x, indexedTypeType y) | (x, y) <- fillFirstEmptyEntries $ ev ^. eventLogs]
-      arrayNamesAndTypes = [(key, extractLabelOrEntry entry) | (key, IndexedType _ (SVMType.Array entry _)) <- ev ^. eventLogs]
+      evLogToPair (EventLog n' _ t') = (n', t')
+      cols = getTableColumnAndType isEvent cc [(x, indexedTypeType y) | (x, y) <- fillFirstEmptyEntries . map evLogToPair $ ev ^. eventLogs]
+      arrayNamesAndTypes = [(key, extractLabelOrEntry entry) | (key, IndexedType _ (SVMType.Array entry _)) <- map evLogToPair $ ev ^. eventLogs]
+      indexedFields = map fst . filter snd . fillFirstEmptyEntries $ [(key, indexed) | (EventLog key indexed _) <- ev ^. eventLogs]
+      primaryKey = case indexedFields of
+        [] -> "(transaction_hash, event_index)"
+        _ -> wrapParens . csv $ "address" : indexedFields
       colsCombined = map (\(x,y)-> x <> " " <> y) cols
       eventFkeys = getDeferredForeignKeysForEvent eventTable crtr app
   $logInfoS "keys" (T.pack $ show arrayNamesAndTypes)
@@ -1474,20 +1479,21 @@ createEventTable (creator, a, n) evName ev cc = do
   --   then return []
   --   else do
     -- setTableCreated eventTable $ colsCombined
-  yieldMany $ createEventTableQuery eventTable colsCombined
+  yieldMany $ createEventTableQuery eventTable colsCombined primaryKey
   eventArrayFkeys <- fmap concat . forM arrayNamesAndTypes $ \anat -> do
     createEventArrayTable (crtr, app, cname, (escapeQuotes $ labelToText evName)) anat
   return $ eventFkeys ++ eventArrayFkeys
 
 
-createEventTableQuery :: TableName -> TableColumns -> [Text]
-createEventTableQuery tableName cols =
+createEventTableQuery :: TableName -> TableColumns -> Text -> [Text]
+createEventTableQuery tableName cols primaryKey =
   (\n -> T.concat
         [ "CREATE TABLE IF NOT EXISTS ",
           n,
           " (",
           csv $ ("id SERIAL NOT NULL" : eventBaseColumnsQuery) ++ cols,
-          ", PRIMARY KEY (transaction_hash, event_index)",
+          ", PRIMARY KEY ",
+          primaryKey,
           ");"
         ]
   ) <$> [tableNameToDoubleQuoteText tableName, oldTableNameToDoubleQuoteText tableName]
@@ -1503,7 +1509,8 @@ expandEventTable  (creator, a, n) evName ev cc = do
   let (crtr, app, cname) = constructTableNameParameters creator a n
       tableName = EventTableName crtr app cname (escapeQuotes $ labelToText evName)
       isEvent = True
-      (allTableCols :: [(T.Text, T.Text)]) = getTableColumnAndType isEvent cc [(x, indexedTypeType y) | (x, y) <- fillFirstEmptyEntries $ ev ^. eventLogs]
+      evLogToPair (EventLog n' _ t') = (n', t')
+      (allTableCols :: [(T.Text, T.Text)]) = getTableColumnAndType isEvent cc [(x, indexedTypeType y) | (x, y) <- fillFirstEmptyEntries . map evLogToPair $ ev ^. eventLogs]
       allTableColsCombined = map (\(x,y)-> x <> " " <> y) allTableCols
   unless (null allTableCols) $ do
     $logInfoS "expandEventTable" . T.pack $ "We just got new fields for a contract that already has a table!"
@@ -1639,14 +1646,26 @@ insertEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
 
    in (\n -> T.concat $
         [ "INSERT INTO ",
-          n,
+          wrapDoubleQuotes $ escapeQuotes n,
           " ",
           keySt,
           "\n  VALUES ( \n",
           vals,
-          " )\n  ON CONFLICT DO NOTHING;"
+          " )\n  ON CONFLICT ON CONSTRAINT ",
+          wrapDoubleQuotes . escapeQuotes $ n <> "_pkey",
+          " DO UPDATE SET",
+          [r|
+    address = excluded.address,
+    block_hash = excluded.block_hash,
+    block_timestamp = excluded.block_timestamp,
+    block_number = excluded.block_number,
+    transaction_hash = excluded.transaction_hash,
+    transaction_sender = excluded.transaction_sender|],
+          if null filledArgs then "" else ",\n    ",
+          tableUpsert filledArgs,
+          ";"
         ]
-      ) <$> [tableNameToDoubleQuoteText tableName,  oldTableNameToDoubleQuoteText tableName]
+      ) <$> [tableNameToText tableName,  oldTableNameToText tableName]
 
 ------------------
 


### PR DESCRIPTION
This PR enables the use of the keyword `indexed` to be used in event declarations to declare primary keys within event tables.
For example, given the contract
```js
contract Test {
    event Yo(string indexed x, uint y);
    event Mama(string indexed x, uint indexed y, uint z);

    constructor() { }

    function yo(string _x, uint _y) public { emit Yo(_x, _y); }

    function mama(string _x, uint _y, uint _z) public { emit Mama(_x, _y, _z); }
}
```

When I call `yo` with the arguments `("Dustin", 1)` and `("Norwood", 2)`, I get the following from Cirrus:
```json
[{"x":"Dustin","y":1}, {"x":"Norwood","y":2}]
```
but if I call `yo` again with arguments `("Dustin", 3)`, instead of a new row being added, the existing `Dustin` row gets updated:
```json
[{"x":"Dustin","y":3}, {"x":"Norwood","y":2}]
```

Similarly, calling the function `mama` with the same values for `_x` and `_y` updates the row in the table, demonstrating that compound primary keys can be created by declaring multiple arguments `indexed`.