### PR TITLE
Fixed redirect to redemption details pages

### DIFF
--- a/marketplace/ui/src/components/Order/TransactionTable.js
+++ b/marketplace/ui/src/components/Order/TransactionTable.js
@@ -164,10 +164,10 @@ const TransactionTable = ({ user, download, isAllOrdersLoading }) => {
     }
     else if (data.type === 'Transfer') { }
     else if (data.type === 'Redemption' && data.to === user.commonName) {
-      route = `${routes.RedemptionsIncomingDetails.url.replace(":id", data.redemption_id)
+      route = `${routes.RedemptionsOutgoingDetails.url.replace(":id", data.redemption_id)
         .replace(":redemptionService", data.redemptionService)}`
     } else if (data.type === 'Redemption' && data.from === user.commonName) {
-      route = `${routes.RedemptionsOutgoingDetails.url.replace(":id", data.redemption_id)
+      route = `${routes.RedemptionsIncomingDetails.url.replace(":id", data.redemption_id)
         .replace(":redemptionService", data.redemptionService)}`
     } else { }
     route && navigate(route)


### PR DESCRIPTION
Previously, issuers that navigate to the details page of a redemption were taken to the redemptions (outgoing) page when they are supposed to be taken to the redemptions (incoming) page. Similarly, requestors were taken to the redemptions (incoming) page instead of the redemptions (outgoing) page.


https://github.com/user-attachments/assets/6d53e2de-d639-4bcf-bd9d-6906f40cd482

