### PR TITLE
Fixed payment service dropdown in my profile page

### DIFF
--- a/marketplace/ui/src/components/UserProfile/index.js
+++ b/marketplace/ui/src/components/UserProfile/index.js
@@ -427,6 +427,7 @@ const UserProfile = ({user}) => {
                             key={index}
                             // debouncedSearchTerm={debouncedSearchTerm}
                             allSubcategories={allSubcategories}
+                            user={user}
                           />
                         );
                       })
@@ -453,6 +454,7 @@ const UserProfile = ({user}) => {
                             key={index}
                             // debouncedSearchTerm={debouncedSearchTerm}
                             allSubcategories={allSubcategories}
+                            user={user}
                           />
                         );
                       })
@@ -479,6 +481,7 @@ const UserProfile = ({user}) => {
                             key={index}
                             // debouncedSearchTerm={debouncedSearchTerm}
                             allSubcategories={allSubcategories}
+                            user={user}
                           />
                         );
                       })


### PR DESCRIPTION
Previously, only STRATS would show up as a payment option when trying to list an item in the My Profile page.


<img width="1433" alt="Screenshot 2024-09-12 at 5 43 39 PM" src="https://github.com/user-attachments/assets/0167a32c-dec1-4dd7-ab94-b79f88b09915">
