### PR TITLE
Added fix for fetching redemptions on older Assets

### DIFF
--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -361,7 +361,12 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
           redemptionServiceAddresses.push(r.address);
         }
       });
-      const redemptionServices = await redemptionServiceJs.getAll(rawAdmin, { address: redemptionServiceAddresses }, options);
+      let redemptionServices = await redemptionServiceJs.getAll(rawAdmin, { address: redemptionServiceAddresses }, options);
+
+      // handle backwards compatibility case
+      if (Object.keys(redemptionServices).length === 0) {
+        redemptionServices = await redemptionServiceJs.getAll(rawAdmin, { isActive: true, ownerCommonName: "Server" }, options);
+      }
 
       const redemptionPromises = redemptionServices.map(async (rs) => {
         const serviceUrl = rs.serviceURL || rs.data.serviceURL;
@@ -413,7 +418,12 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
       let redemptions = [];
       const redemptionEvents = await redemptionServiceJs.getRedemptions(rawAdmin, { issuer: userCert.commonName }, options);
       const redemptionServiceAddresses = redemptionEvents.map(r => r.address);
-      const redemptionServices = await redemptionServiceJs.getAll(rawAdmin, { address: redemptionServiceAddresses }, options);
+      let redemptionServices = await redemptionServiceJs.getAll(rawAdmin, { address: redemptionServiceAddresses }, options);
+
+      // handle backwards compatibility case
+      if (Object.keys(redemptionServices).length === 0) {
+        redemptionServices = await redemptionServiceJs.getAll(rawAdmin, { isActive: true, ownerCommonName: "Server" }, options);
+      }
 
       const redemptionPromises = redemptionServices.map(async (rs) => {
         const serviceUrl = rs.serviceURL || rs.data.serviceURL;


### PR DESCRIPTION
There was a backwards compatibility issue with Assets (pre-payment server changes, post-initial redemption flow). In the fetch for redemptions, we use the `Redemption` event as a way to retrieve the `RedemptionService` contract that is currently in use. We then use the `RedemptionService` to fetch the user's outgoing/incoming redemptions requests. The issue is that older Assets don't trigger a `Redemption` event, only post-payment server changes Assets do. If the user has no `Redemption` event (they've only requested redemption on an older Asset), they're unable to retrieve the correct `RedemptionService` contract and cannot fetch their outgoing/incoming redemptions.

This wasn't easy to catch during testnet testing b/c if a user had ever received/requested redemption, they would have emitted the `Redemption` event and would be able to see all other redemptions, regardless if it was with an older Asset or not.

The proposed solution is if a user searches for a `Redemption` event and doesn't find one (b/c they've only requested with an older Asset), they should fetch an active `RedemptionService` contract with a `ownerCommonName` of `Server` and use that to fetch their outgoing/incoming redemptions.