### PR TITLE
[STRATO-3316] Fix Decimal interaction with Int types

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+
 module ParserSpec where
 
 import Control.Monad

--- a/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/tests/ParserSpec.hs
@@ -9,6 +9,7 @@ import Data.Source.Annotation as SA
 import Data.Source.Position as SP
 import SolidVM.Model.CodeCollection.Statement
 import SolidVM.Model.Type
+import SolidVM.Solidity.Parse.Declarations
 import SolidVM.Solidity.Parse.Lexer
 import SolidVM.Solidity.Parse.ParserTypes
 import SolidVM.Solidity.Parse.Statement
@@ -129,18 +130,18 @@ spec = do
   --               ]
   --   forM_ cases $ \(input, want) -> do
   --     it ("can parse " ++ input) $ parseDecl input `shouldBe` Right ((show want), want)
-  {-}
 
+  {-
   --"contract qq {\n  uint x = 3;\n  modifier myModifier(uint _x) {\n      require(_x == 3 , string.concat('x is not 3 : ', string(_x)));\n    x = 4;    _;\n    require(x == 5 , 'x is not 5');\n  }\n\n  constructor() public myModifier(3) {\n    x = 5;\n    return;\n  }\n}\n"
     describe "Contract Parsing" $ do
-      let parseContract = runParser solidityContract "" ""
-          cases = [ ( "contract qq {\n  uint constant c = 2022;\n  constructor() public\n {\n    c = 666;\n  }\n}", DummySourceUnit)
+      let parseContract = runParser solidityContract initialParserState ""
+          ccases = [ ( "contract qq {\n  decimal b = 2;\n  constructor()\n {}\n}", DummySourceUnit)
                   --, ("contract qq {\n  uint x;\n  modifier myModifier() {\n      require(false, 'bigTest');\n  }\n  function a() public myModifier() returns (bool) {\n    x = 5;\n    return true;\n  }\n}" , DummySourceUnit)
                   ]
-      forM_ cases $ \(input, want) -> do
+      forM_ ccases $ \(input, want) -> do
         it ("can parse " ++ input) $ parseContract input `shouldBe` Right want
-
   -}
+
 
   describe "Statement parsing" $ do
     let parseStatement = fmap (fmap (const ())) . runParser statement initialParserState ""

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Optimizer.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Optimizer.hs
@@ -14,8 +14,9 @@ import Control.Monad.Reader
 import Control.Monad.Trans.State
 import Data.Decimal
 import Data.Functor.Compose
+import Data.List (find)
 import Data.Map as M
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import SolidVM.Model.CodeCollection
 import SolidVM.Model.SolidString (SolidString)
 import qualified SolidVM.Model.Type as SVMType
@@ -269,7 +270,12 @@ optimizeExpression (FunctionCall x1 (MemberAccess x2 (Variable x3 nam) "unwrap")
       OrderedArgs [x] | M.member nam (_userDefined c) -> optimizeExpression x Nothing
       _ -> pure $ FunctionCall x1 (MemberAccess x2 (Variable x3 nam) "unwrap") args
     Nothing -> pure $ FunctionCall x1 (MemberAccess x2 (Variable x3 nam) "unwrap") args
-
+optimizeExpression n@(NumberLiteral x val _) (Just (SVMType.Decimal)) = do
+  cc <- asks codeCollection
+  let pragmaCheck = find (== ("solidvm", "11.5")) $ _pragmas cc
+  if (isJust pragmaCheck)
+    then pure $ DecimalLiteral x $ WrappedDecimal $ Decimal 0 val
+    else pure n
 --This needs further research before letting loose on the code base
 --This function as of now is neutured
 optimizeExpression (Variable x name) _ = do

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -932,6 +932,40 @@ const' :: Type' -> Type' -> Type'
 const' _ (Bottom e) = Bottom e
 const' t _ = t
 
+containsInt :: 
+  Annotated CodeCollectionF ->
+  Annotated ContractF ->
+  (NonEmpty (Maybe Type', M.Map SolidString (Annotated VarDefEntryF))) ->
+  Annotated ExpressionF -> 
+  Bool
+containsInt cc c localVars v@(Variable _ name) =
+  let r = R cc c Nothing (Just "Nothing") Nothing []
+      t = runReader (evalStateT (tcExpr v) ((Nothing, M.empty) :| [])) r
+  in case t of
+      Static (SVMType.Int _ _) _ -> True
+      Bottom _ -> case M.lookup name (snd $ NE.head $ localVars) of
+        Just (VarDefEntry (Just (SVMType.Int _ _)) _ _ _) -> True
+        _ -> False
+      _ -> False
+containsInt _ _ _ _ = False
+
+lowkeyAnInt ::
+  Annotated CodeCollectionF ->
+  Annotated ContractF ->
+  (NonEmpty (Maybe Type', M.Map SolidString (Annotated VarDefEntryF))) ->
+  Annotated ExpressionF -> 
+  Bool
+lowkeyAnInt cc c localVars (PlusPlus _ expr) = lowkeyAnInt cc c localVars expr
+lowkeyAnInt cc c localVars (MinusMinus _ expr) = lowkeyAnInt cc c localVars expr
+lowkeyAnInt _ _ _ (NewExpression _ (SVMType.Int _ _)) = True
+lowkeyAnInt cc c localVars (IndexAccess _ expr _) = lowkeyAnInt cc c localVars expr
+lowkeyAnInt cc c localVars (MemberAccess _ expr _) = lowkeyAnInt cc c localVars expr
+lowkeyAnInt cc c localVars (FunctionCall _ expr _) = lowkeyAnInt cc c localVars expr
+lowkeyAnInt cc c localVars (Unitary _ _ expr) = lowkeyAnInt cc c localVars expr
+lowkeyAnInt cc c localVars (Binary _ _ expr1 expr2) = lowkeyAnInt cc c localVars expr1 || lowkeyAnInt cc c localVars expr2
+lowkeyAnInt cc c localVars v@(Variable _ _) = containsInt cc c localVars v 
+lowkeyAnInt _ _ _ _ = False
+
 -- type CompilerDetector = CodeCollection -> [SourceAnnotation T.Text]
 detector :: CompilerDetector
 detector cc =
@@ -973,9 +1007,20 @@ varDeclHelper ::
   Type'
 varDeclHelper cc c VariableDecl {..} =
   let ty = Static _varType _varContext
-   in case _varInitialVal of
-        Nothing -> ty
-        Just e ->
+      notValidForDecimals = maybe False (lowkeyAnInt cc c (NE.fromList [])) _varInitialVal
+   in case (ty, _varInitialVal, notValidForDecimals) of
+        (_, Nothing, _) -> ty
+        ((Static (SVMType.Decimal) _), (Just (NumberLiteral _ _ _)), _) ->
+          ty
+        ((Static (SVMType.Decimal) x), Just e, True) ->
+          let r = R cc c Nothing (Just "Nothing") Nothing []
+              t = runReader (evalStateT (tcExpr e) ((Nothing, M.empty) :| [])) r
+          in bottom $ "Type mismatch: "
+               <> "decimals" 
+               <> " and "
+               <> showType' t
+               <> " do not match." <$ x
+        (_, Just e, _) ->
           let r = R cc c Nothing (Just "Nothing") Nothing []
            in runReader (evalStateT (ty ~> tcExpr e) ((Nothing, M.empty) :| [])) r
 
@@ -1880,11 +1925,22 @@ allDifferent []     = True
 allDifferent (x:xs) = x `notElem` xs && allDifferent xs
 simpleStatementHelper :: SourceAnnotation Text -> Annotated SimpleStatementF -> SSS Type'
 simpleStatementHelper x (VariableDefinition vdefs mExpr) = do
+  cc <- asks codeCollection
+  c <- asks contract
   pushLocalVariables vdefs
+  localVars <- get
   let ts' = foldr varDefsToType' (topType' x) vdefs
   mExpr' <- maybe (pure $ topType' x) tcExpr mExpr
-  case (ts', mExpr') of
-    ((Static a@(SVMType.Int _ _) _), (Static b@(SVMType.Decimal) _)) -> pure . bottom $
+  let notValidForDecimals = maybe False (lowkeyAnInt cc c localVars) mExpr
+  case (ts', mExpr', notValidForDecimals) of
+    (a@(Static SVMType.Decimal _), (Static (SVMType.Int _ _) _), False) -> pure a
+    (a@(Static SVMType.Decimal _), b, True) -> pure . bottom $
+      "Type mismatch: "
+        <> showType' a
+        <> " and "
+        <> showType' b
+        <> " do not match." <$ x 
+    ((Static a@(SVMType.Int _ _) _), (Static b@(SVMType.Decimal) _), _) -> pure . bottom $
       "Type mismatch: "
         <> showType a
         <> " and "
@@ -1909,47 +1965,48 @@ checkIfImmuteOperationValid (Variable y a) = do
         else tcExpr (Variable y a)
 checkIfImmuteOperationValid a = tcExpr a
 
+tcExprArithmeticHelper :: 
+  Annotated ExpressionF -> 
+  Annotated ExpressionF -> 
+  SourceAnnotation Text ->
+  Type' -> 
+  Bool -> 
+  SSS Type'
+tcExprArithmeticHelper a b x expectedTypes assignBool = do
+  cc <- asks codeCollection
+  c <- asks contract
+  localVars <- get
+  let notValidForDecimals = lowkeyAnInt cc c localVars b
+      dontAssignDecimalHere = lowkeyAnInt cc c localVars a
+  a' <- tcExpr a
+  b' <- tcExpr b
+  case (a', b', notValidForDecimals, assignBool, dontAssignDecimalHere) of
+    ((Static (SVMType.Decimal) _), _, True, _, _) -> pure . bottom $
+      "Type mismatch: "
+        <> showType' a'
+        <> " and "
+        <> showType' b'
+        <> " do not match." <$ x
+    ((Static (SVMType.Int _ _) _), (Static (SVMType.Decimal) _), _, _, True) ->  pure . bottom $
+      "Type mismatch: "
+        <> showType' a'
+        <> " and "
+        <> showType' b'
+        <> " do not match." <$ x
+    (_, _, _, False, _) -> expectedTypes ~> tcExpr a <~> tcExpr b
+    _ -> expectedTypes ~> (checkIfImmuteOperationValid a) <~> tcExpr b
+
 tcExpr :: Annotated ExpressionF -> SSS Type'
 tcExpr (Binary x "+" a b) = do
-  typeOne <- tcExpr a
-  typeTwo <- tcExpr b
-  case ((typeOne, a), (typeTwo, b)) of
-    (((Static (SVMType.Int _ _) _), (Variable _ _)), ((Static (SVMType.Decimal) _), _)) -> pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    (((Static (SVMType.Decimal) _), _), ((Static (SVMType.Int _ _) _), (Variable _ _))) -> pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    _ -> sumType (intType' x) (stringType' x) (decimalType' x) ~> tcExpr a <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType (intType' x) (stringType' x) (decimalType' x)) False
 tcExpr (Binary x "-" a b) = do
-  typeOne <- tcExpr a
-  typeTwo <- tcExpr b
-  case ((typeOne, a), (typeTwo, b)) of
-    (((Static (SVMType.Int _ _) _), (Variable _ _)), ((Static (SVMType.Decimal) _), _)) -> pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    (((Static (SVMType.Decimal) _), _), ((Static (SVMType.Int _ _) _), (Variable _ _))) -> pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    _ -> sumType' (intType' x) (decimalType' x) ~> tcExpr a <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType' (intType' x) (decimalType' x)) False
 tcExpr (Binary x "*" a b) = do
-  typeOne <- tcExpr a
-  typeTwo <- tcExpr b
-  case ((typeOne, a), (typeTwo, b)) of
-    (((Static (SVMType.Int _ _) _), (Variable _ _)), ((Static (SVMType.Decimal) _), _)) -> pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    (((Static (SVMType.Decimal) _), _), ((Static (SVMType.Int _ _) _), (Variable _ _))) -> pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    _ -> sumType' (intType' x) (decimalType' x) ~> tcExpr a <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType' (intType' x) (decimalType' x)) False
 tcExpr (Binary x "/" a b) = do
-  typeOne <- tcExpr a
-  typeTwo <- tcExpr b
-  case ((typeOne, a), (typeTwo, b)) of
-    (((Static (SVMType.Int _ _) _), (Variable _ _)), ((Static (SVMType.Decimal) _), _)) -> pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    (((Static (SVMType.Decimal) _), _), ((Static (SVMType.Int _ _) _), (Variable _ _))) -> pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    _ -> sumType' (intType' x) (decimalType' x) ~> tcExpr a <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType' (intType' x) (decimalType' x)) False
 tcExpr (Binary x "%" a b) = do
-  typeOne <- tcExpr a
-  typeTwo <- tcExpr b
-  case ((typeOne, a), (typeTwo, b)) of
-    -- Int % Decimal
-    (((Static (SVMType.Int _ _) _), (Variable _ _)), ((Static (SVMType.Decimal) _), _)) ->
-      pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    -- Decimal % Int
-    (((Static (SVMType.Decimal) _), _), ((Static (SVMType.Int _ _) _), (Variable _ _))) ->
-      pure . bottom $ ("Cannot perform arithmetic with explicit 'decimal' and 'int' types") <$ x
-    -- Default: Int % Int or Decimal % Decimal
-    _ -> sumType' (intType' x) (decimalType' x) ~> tcExpr a <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType' (intType' x) (decimalType' x)) False
 tcExpr (Binary x "|" a b) =
   intType' x ~> tcExpr a <~> tcExpr b
 tcExpr (Binary x "&" a b) =
@@ -1971,60 +2028,15 @@ tcExpr (Binary x ">>=" a b) =
 tcExpr (Binary x "<<=" a b) =
   intType' x ~> tcExpr a <~> tcExpr b
 tcExpr (Binary x "+=" a b) = do
-  a' <- tcExpr a
-  b' <- tcExpr b
-  case (a', b') of
-    ((Static c@(SVMType.Int _ _) _), (Static d@(SVMType.Decimal) _)) ->  pure . bottom $
-      "Type mismatch: "
-        <> showType c
-        <> " and "
-        <> showType d
-        <> " do not match." <$ x
-    _ -> sumType (intType' x) (stringType' x) (decimalType' x) ~> (checkIfImmuteOperationValid a) <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType (intType' x) (stringType' x) (decimalType' x)) True
 tcExpr (Binary x "-=" a b) = do
-  a' <- tcExpr a
-  b' <- tcExpr b
-  case (a', b') of
-    ((Static c@(SVMType.Int _ _) _), (Static d@(SVMType.Decimal) _)) ->  pure . bottom $
-      "Type mismatch: "
-        <> showType c
-        <> " and "
-        <> showType d
-        <> " do not match." <$ x
-    _ -> sumType' (intType' x) (decimalType' x) ~> (checkIfImmuteOperationValid a) <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType' (intType' x) (decimalType' x)) True 
 tcExpr (Binary x "*=" a b) = do
-  a' <- tcExpr a
-  b' <- tcExpr b
-  case (a', b') of
-    ((Static c@(SVMType.Int _ _) _), (Static d@(SVMType.Decimal) _)) ->  pure . bottom $
-      "Type mismatch: "
-        <> showType c
-        <> " and "
-        <> showType d
-        <> " do not match." <$ x
-    _ -> sumType' (intType' x) (decimalType' x) ~> (checkIfImmuteOperationValid a) <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType' (intType' x) (decimalType' x)) True
 tcExpr (Binary x "/=" a b) = do
-  a' <- tcExpr a
-  b' <- tcExpr b
-  case (a', b') of
-    ((Static c@(SVMType.Int _ _) _), (Static d@(SVMType.Decimal) _)) ->  pure . bottom $
-      "Type mismatch: "
-        <> showType c
-        <> " and "
-        <> showType d
-        <> " do not match." <$ x
-    _ -> sumType' (intType' x) (decimalType' x) ~> (checkIfImmuteOperationValid a) <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType' (intType' x) (decimalType' x)) True
 tcExpr (Binary x "%=" a b) = do
-  a' <- tcExpr a
-  b' <- tcExpr b
-  case (a', b') of
-    ((Static c@(SVMType.Int _ _) _), (Static d@(SVMType.Decimal) _)) ->  pure . bottom $
-      "Type mismatch: "
-        <> showType c
-        <> " and "
-        <> showType d
-        <> " do not match." <$ x
-    _ -> sumType' (intType' x) (decimalType' x) ~> (checkIfImmuteOperationValid a) <~> tcExpr b
+  tcExprArithmeticHelper a b x (sumType' (intType' x) (decimalType' x)) True
 tcExpr (Binary x "|=" a b) =
   intType' x ~> tcExpr a <~> tcExpr b
 tcExpr (Binary x "&=" a b) =
@@ -2048,14 +2060,24 @@ tcExpr (Binary x ">=" a b) =
 tcExpr (Binary x "<=" a b) =
   sumType' (intType' x) (decimalType' x) ~> tcExpr a <~> tcExpr b !> pure (boolType' x)
 tcExpr (Binary x "=" a b) = do
+  cc <- asks codeCollection
+  c <- asks contract
+  localVars <- get
+  let notValidForDecimals = lowkeyAnInt cc c localVars b
   a' <- tcExpr a
   b' <- tcExpr b
-  case (a', b') of
-    ((Static c@(SVMType.Int _ _) _), (Static d@(SVMType.Decimal) _)) ->  pure . bottom $
+  case (a', b', notValidForDecimals) of
+    ((Static (SVMType.Decimal) _), _, True) -> pure . bottom $
       "Type mismatch: "
-        <> showType c
+        <> showType' a'
         <> " and "
-        <> showType d
+        <> showType' b'
+        <> " do not match." <$ x
+    ((Static (SVMType.Int _ _) _), (Static (SVMType.Decimal) _), _) ->  pure . bottom $
+      "Type mismatch: "
+        <> showType' a'
+        <> " and "
+        <> showType' b'
         <> " do not match." <$ x
     _ -> (checkIfImmuteOperationValid a) <~> tcExpr b
 tcExpr (Binary _ _ a b) =

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 module SolidVMSpec where
 
@@ -80,7 +81,7 @@ import qualified LabeledError
 import qualified Numeric (readHex, showHex)
 import SolidVM.Model.SolidString
 import SolidVM.Model.Storable as MS
-import Test.Hspec (Selector, Spec, anyException, it, pendingWith, shouldThrow, xdescribe, xit)
+import Test.Hspec (Selector, Spec, anyException, it, pendingWith, shouldThrow, xdescribe, xit, fit)
 import Test.Hspec.Expectations.Lifted
 import Text.Printf
 import Text.RawString.QQ
@@ -9147,3 +9148,13 @@ contract qq {
 |]
     getFields ["x"]
       `shouldReturn` [BInteger 5])
+
+  it "can now assign number literals as decimals rather than integer" . runTest $ do
+    runBS [r| 
+pragma solidvm 11.5;
+contract qq {
+    decimal a = 3;
+  }
+|]
+    getFields ["a"]
+      `shouldReturn` [BDecimal "3"]

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -9153,8 +9153,20 @@ contract qq {
     runBS [r| 
 pragma solidvm 11.5;
 contract qq {
-    decimal a = 3;
+  decimal a = 3;
+}
+|]
+    getFields ["a"]
+      `shouldReturn` [BDecimal "3"]
+
+  it "can test stuff" . runTest $ do
+    runBS [r| 
+pragma solidvm 11.5;
+contract qq {
+  decimal a = 3;
+  constructor() {
   }
+}
 |]
     getFields ["a"]
       `shouldReturn` [BDecimal "3"]

--- a/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
@@ -2171,3 +2171,45 @@ contract qq {
   }
   |]
       length anns `shouldBe` 0
+
+    it "cannot assign an int variable to a decimal on the contract level" $ do
+      anns <-
+        liftIO $
+          runTypechecker
+            [r|
+  contract qq {
+    uint a = 5;
+    decimal b = a;
+    constructor(){
+    }
+  }
+  |]
+      length anns `shouldBe` 1
+
+    it "cannot assign an int variable to a decimal within a function" $ do
+      anns <-
+        liftIO $
+          runTypechecker
+            [r|
+  contract qq {
+    decimal b;
+    constructor(uint _b){
+      b = _b;
+    }
+  }
+  |]
+      length anns `shouldBe` 1
+
+    it "cannot assign an int variable to a decimal within a function part 2" $ do
+      anns <-
+        liftIO $
+          runTypechecker
+            [r|
+  contract qq {
+    constructor(){
+      uint b = 5;
+      decimal c = b;
+    }
+  }
+  |]
+      length anns `shouldBe` 1


### PR DESCRIPTION
This PR aims to improve the decimal features in SolidVM.
Things changed in this PR:
1. Number literals assigned to decimal types will now be properly stored as a decimal rather than an integer. This is locked behind `pragma solidvm 11.5`.
2. Explicitly defined Integer types will no longer be able to be typechecked with decimals on the contract and function level within the typechecker.

This still needs to be thoroughly tested (syncing and manually test). 