### PR TITLE
Bring back wire cache in p2p

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -17,6 +17,8 @@ so that they could be properly moved to their respective version's subsection.
 ## [Unreleased] 
 ### Added
 - Added block.proposer to SolidVM
+- Reintroduced wire cache to strato-p2p to reduce redundant blockstanbul messages sent to the sequencer
+
 ### Changed
 
 ### Fixed

--- a/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
+++ b/strato/core/strato-p2p/exec_src/StratoP2PMain.hs
@@ -25,6 +25,7 @@ import           Executable.StratoP2P
 import           BlockApps.Init
 import           BlockApps.Logging as BL
 import           Data.IORef
+import           Data.Set.Ordered (empty)
 import           Instrumentation
 
 main :: IO ()
@@ -37,7 +38,8 @@ initP2P = labelTheThread "initP2P" $ do
   liftIO $ resetPeers
   _ <- liftIO $ $initHFlags "Strato P2P"
   setParticipationMode flags_participationMode
-  cfg <- initConfig flags_maxReturnedHeaders
+  wireMessagesRef <- liftIO $ newIORef empty
+  cfg <- initConfig wireMessagesRef flags_maxReturnedHeaders
   let sSource = seqEventNotificationSource . contextKafkaState
       runner f = do
         c' <- initContext

--- a/strato/core/strato-p2p/package.yaml
+++ b/strato/core/strato-p2p/package.yaml
@@ -20,6 +20,7 @@ executables:
       - ethereum-discovery
       - hflags
       - lifted-async
+      - ordered-containers
       - process-monitor
       - strato-model
       - strato-p2p
@@ -66,6 +67,7 @@ library:
     - monad-alter
     - mtl
     - network
+    - ordered-containers
     - persistent
     - prometheus-client
     - random

--- a/strato/core/strato-p2p/src/Blockchain/Context.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Context.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -12,6 +13,8 @@
 
 module Blockchain.Context
     ( MonadP2P
+    , Inbound(..)
+    , Outbound(..)
     , IsValidator(..)
     , Context(..)
     , Config(..)
@@ -73,6 +76,7 @@ import qualified Data.Map.Strict                       as M
 import           Data.Maybe
 import           Data.Proxy
 import           Data.Ranged
+import qualified Data.Set.Ordered as S
 import           Data.String
 import qualified Data.Text                             as T
 import           Data.Time.Clock
@@ -81,6 +85,7 @@ import           GHC.Exts                              (Constraint)
 import           BlockApps.Logging
 import           BlockApps.X509.Certificate
 
+import           Blockchain.Blockstanbul               (WireMessage)
 import           Blockchain.Data.Block
 import           Blockchain.Data.BlockHeader
 import           Blockchain.Data.ChainInfo
@@ -135,6 +140,10 @@ type family All2 (ks :: [DK.Type -> DK.Type -> (DK.Type -> DK.Type) -> Constrain
   All2 (k ': '[]) ts m = All2' k ts m
   All2 (k ': ks) ts m = (All2' k ts m, All2 ks ts m)
 
+newtype Inbound a = Inbound {unInbound :: a}
+
+newtype Outbound a = Outbound {unOutbound :: a}
+
 newtype IsValidator = IsValidator {unIsValidator :: Bool}
 
 data Config = Config
@@ -144,6 +153,7 @@ data Config = Config
     configMaxReturnedHeaders :: MaxReturnedHeaders,
     configVaultClient :: ClientEnv,
     configContext :: IORef Context,
+    configBlockstanbulWireMessages :: IORef (S.OSet Keccak256),
     configPubKey :: PublicKey
   }
 
@@ -169,6 +179,7 @@ data Context = Context
   , remainingBlockHeaders    :: (RemainingBlockHeaders, UTCTime) -- keep track when last updated global headers cache
   , actionTimestamp          :: ActionTimestamp
   , _blockstanbulPeerAddr    :: PeerAddress
+  , _outboundWireMessages :: S.OSet (T.Text, Keccak256)
   }
 
 makeLenses ''Context
@@ -333,6 +344,45 @@ instance MonadIO m => A.Selectable ChainMemberParsedSet [ChainMemberParsedSet] (
 
 instance MonadIO m => A.Selectable ChainMemberParsedSet IsValidator (ReaderT Config m) where
   select _ = fmap (Just . IsValidator) . RBDB.withRedisBlockDB . RBDB.isValidator
+
+instance MonadIO m => (Keccak256 `A.Alters` (Proxy (Inbound WireMessage))) (ReaderT Config m) where
+  lookup _ k = do
+    wms <- readIORef =<< asks configBlockstanbulWireMessages
+    let b = S.member k wms
+    pure $ if b then Just (Proxy @(Inbound WireMessage)) else Nothing
+  insert _ k _ =
+    asks configBlockstanbulWireMessages
+      >>= flip
+        atomicModifyIORef'
+        ( \wms ->
+            let s = S.size wms
+                wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+                !wms'' = wms' S.>| k
+             in (wms'', ())
+        )
+  delete _ k =
+    asks configBlockstanbulWireMessages
+      >>= flip
+        atomicModifyIORef'
+        ( \wms ->
+            let !wms' = S.delete k wms
+             in (wms', ())
+        )
+
+instance MonadIO m => ((T.Text, Keccak256) `A.Alters` (Proxy (Outbound WireMessage))) (ReaderT Config m) where
+  lookup _ k = do
+    wms <- _outboundWireMessages <$> Mod.get (Mod.Proxy @Context)
+    let b = S.member k wms
+    pure $ if b then Just (Proxy @(Outbound WireMessage)) else Nothing
+  insert _ k _ = Mod.modifyStatefully_ (Mod.Proxy @Context) $ do
+    wms <- use outboundWireMessages
+    let s = S.size wms
+        wms' = if s >= 2000 then S.delete (head $ toList wms) wms else wms
+        !wms'' = wms' S.>| k
+    assign outboundWireMessages wms''
+  delete _ k =
+    Mod.modifyStatefully_ (Mod.Proxy @Context) $
+      outboundWireMessages %= S.delete k
 
 instance
   ( MonadUnliftIO m
@@ -526,6 +576,8 @@ type MonadP2P m =
       '[A.Alters]
       '[ '(Keccak256, BlockHeader),
          '(Keccak256, OutputBlock),
+         '(Keccak256, Proxy (Inbound WireMessage)),
+         '((T.Text, Keccak256), Proxy (Outbound WireMessage)),
          '((IPAsText, TCPPort), ActivityState)
        ]
       m
@@ -563,8 +615,8 @@ runContextM ::
   m ()
 runContextM r = void . runResourceT . flip runReaderT r
 
-initConfig :: (MonadLogger m, MonadUnliftIO m) => Int -> m Config
-initConfig maxHeaders = do
+initConfig :: (MonadLogger m, MonadUnliftIO m) => IORef (S.OSet Keccak256) -> Int -> m Config
+initConfig wireMessagesRef maxHeaders = do
   dbs <- openDBs
   redisBDBPool <- liftIO (Redis.checkedConnect lookupRedisBlockDBConfig)
   vaultClient <- do
@@ -584,6 +636,7 @@ initConfig maxHeaders = do
     , configMaxReturnedHeaders = MaxReturnedHeaders maxHeaders
     , configVaultClient = vaultClient
     , configContext = initStateF
+    , configBlockstanbulWireMessages = wireMessagesRef
     , configPubKey = nodePubKey
     }
 
@@ -598,7 +651,8 @@ initContext = do
             , blockHeaders = ([], jamshidBirth)
             , remainingBlockHeaders = (RemainingBlockHeaders [], jamshidBirth)
             , _blockstanbulPeerAddr = PeerAddress Nothing
-            }
+            , _outboundWireMessages = S.empty
+          }
 
 getPeerByIP ::
   A.Selectable IPAsText PPeer m =>

--- a/strato/core/strato-p2p/src/Blockchain/Event.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Event.hs
@@ -23,7 +23,7 @@ where
 import BlockApps.Crossmon (recordMaxBlockNumber)
 import BlockApps.Logging
 import BlockApps.X509.Certificate as XC
-import Blockchain.Blockstanbul (blockstanbulSender)
+import Blockchain.Blockstanbul (blockstanbulSender, WireMessage)
 import Blockchain.Context
 import Blockchain.Data.Block
 import Blockchain.Data.BlockHeader (BlockHeader)
@@ -324,7 +324,26 @@ handleEvents peer = awaitForever $ \case
       setPeerAddrIfUnset $ blockstanbulSender wm
       peerAddr <- unPeerAddress <$> access (Proxy @PeerAddress)
       $logInfoS "handleEvents/Blockstanbul" . T.pack $ "blockstanbulPeerAddr: " ++ show peerAddr
-    yieldL $ ToUnseq [IEBlockstanbul wm]
+    let msgHash = rlpHash wm
+    lift $ insert (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash) Proxy
+    msgExists <- lift $ exists (Proxy @(Proxy (Inbound WireMessage))) msgHash
+    if msgExists
+      then
+        $logInfoS "handleEvents/Blockstanbul" . T.pack $
+          concat
+            [ "Already seen inbound wire message ",
+              format msgHash,
+              ". Not forwarding to Sequencer."
+            ]
+      else do
+        $logInfoS "handleEvents/Blockstanbul" . T.pack $
+          concat
+            [ "First time seeing inbound wire message ",
+              format msgHash,
+              ". Forwarding to Sequencer."
+            ]
+        lift $ insert (Proxy @(Proxy (Inbound WireMessage))) msgHash Proxy
+        yieldL $ ToUnseq [IEBlockstanbul wm]
 
   -- private chains
   MsgEvt (GetChainDetails cids') -> handleGetChainDetails peer $ S.fromList cids'
@@ -433,7 +452,29 @@ handleEvents peer = awaitForever $ \case
             True -> do
               let outbound = Blockstanbul msg
               $logDebugS "handleEvents/P2pBlockstanbul" . T.pack $ "Outgoing mesage: " ++ show outbound
-              yieldR outbound
+              let !msgHash = rlpHash msg
+              lift $ insert (Proxy @(Proxy (Inbound WireMessage))) msgHash Proxy
+              msgExists <- lift $ exists (Proxy @(Proxy (Outbound WireMessage))) (pPeerIp peer, msgHash)
+              if msgExists
+                then
+                  $logInfoS "handleEvents/P2pBlockstanbul" $
+                    T.concat
+                      [ "Already seen outbound wire message ",
+                        T.pack (format msgHash),
+                        ". Not forwarding to peer ",
+                        pPeerIp peer
+                      ]
+                else do
+                  $logInfoS "handleEvents/P2pBlockstanbul" $
+                    T.concat
+                      [ "First time seeing outbound wire message ",
+                        T.pack (format msgHash),
+                        ". Forwarding to peer ",
+                        pPeerIp peer
+                      ]
+                  let !ip = pPeerIp peer
+                  lift $ insert (Proxy @(Proxy (Outbound WireMessage))) (ip, msgHash) Proxy
+                  yieldR outbound
     P2pAskForBlocks start _ _ -> do
       $logDebugS "handleEvents/P2pAskForBlocks" . T.pack $ "syncFetch: " ++ show start
       syncFetch Forward start

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -20,7 +20,7 @@ where
 
 import           BlockApps.Logging
 import           Blockchain.CommunicationConduit
-import           Blockchain.Context
+import           Blockchain.Context hiding (Inbound, Outbound)
 import           Blockchain.Data.PubKey (secPubKeyToPoint)
 import           Blockchain.Display (displayMessage, MsgDirection(..))
 import           Blockchain.EthEncryptionException

--- a/strato/core/strato-p2p/src/Executable/StratoP2PLoopback.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PLoopback.hs
@@ -8,12 +8,16 @@
 module Executable.StratoP2PLoopback (stratoP2PLoopback) where
 
 import BlockApps.Logging
+import Blockchain.Blockstanbul (WireMessage)
 import Blockchain.Context
 import Blockchain.Sequencer.Event
 import Blockchain.Sequencer.Kafka
+import Blockchain.Strato.Model.Keccak256
 import Conduit
+import qualified Control.Monad.Change.Alter as A
 import qualified Data.Text as T
 import Prometheus
+import Text.Format
 
 {-# NOINLINE loopbackEvents #-}
 loopbackEvents :: Vector T.Text Counter
@@ -31,7 +35,17 @@ stratoP2PLoopback runner = do
   $logInfoS "stratoP2PLoopback" "Reflecting PBFT back to unseq since 2019"
   runner $ \sSource -> do
     let toWireMessage = \case
-          P2pBlockstanbul wm -> pure $ Just wm
+          P2pBlockstanbul wm -> do
+            let msgHash = rlpHash wm
+            msgExists <- A.exists (A.Proxy @(A.Proxy (Inbound WireMessage))) msgHash
+            if msgExists
+              then do
+                $logInfoS "stratoP2PLoopback/P2pBlockstanbul" . T.pack $ "Already seen inbound wire message " ++ format msgHash ++ ". Not forwarding to Sequencer."
+                pure Nothing
+              else do
+                $logInfoS "stratoP2PLoopback/P2pBlockstanbul" . T.pack $ "First time seeing inbound wire message " ++ format msgHash ++ ". Forwarding to Sequencer."
+                A.insert (A.Proxy @(A.Proxy (Inbound WireMessage))) msgHash A.Proxy
+                pure $ Just wm
           _ -> pure Nothing
 
     runConduit $

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -17,7 +17,7 @@ where
 
 import BlockApps.Logging
 import Blockchain.CommunicationConduit
-import Blockchain.Context
+import Blockchain.Context hiding (Inbound, Outbound)
 import Blockchain.Data.PubKey (secPubKeyToPoint)
 import Blockchain.Display (displayMessage, MsgDirection(..))
 import Blockchain.EthEncryptionException


### PR DESCRIPTION
This PR seeks to re-introduce the wire cache to strato-p2p. By filtering out redundant blockstanbul messages to and from the sequencer, we are able to improve the efficiency of the sequencer and improve the transactions per second the network can achieve, especially as the number of validators on the network grows. The graph below shows a comparison of TPS with relation to the number of validators on the devnet for both the scenario where all nodes do have the wire cache and where they all do not. 
![Screenshot from 2024-09-17 18-39-55](https://github.com/user-attachments/assets/e865fa64-2450-4822-a6d7-d96b35c80203)

When comparing the strato-p2p memory usage of nodes that do and do not have the wire cache, it seems to add a constant of 100-130 MB from the OS's perspective. In terms of live bytes, we see a constant of about 60 MB more memory being used with the wire cache. There does seem to be a very gradual increase in live bytes (~20 MB increase over the course of 3 days), but this is regardless of whether the node has a wire cache or not. It is worth looking into more, but the wire cache does not seem to contribute to a memory leak