### PR TITLE
Added check for integers in Create Item fields

### DIFF
--- a/marketplace/backend/api/v1/Membership/membership.controller.js
+++ b/marketplace/backend/api/v1/Membership/membership.controller.js
@@ -46,7 +46,8 @@ class MembershipController {
         quantity: Joi.number().integer().min(1).required(),
         images: Joi.array().items(Joi.string().allow(null)).required(),
         files: Joi.array().items(Joi.string().allow(null)).required(),
-        fileNames: Joi.array().items(Joi.string().allow(null)).required()
+        fileNames: Joi.array().items(Joi.string().allow(null)).required(),
+        redemptionService: Joi.string().required(),
       }).required()
     });
 

--- a/marketplace/ui/src/components/Inventory/CategoryFields.js
+++ b/marketplace/ui/src/components/Inventory/CategoryFields.js
@@ -353,15 +353,30 @@ export const categoricalProperties = (form, handleClothingTypeChange, clothingTy
                     <Form.Item
                         label="Least Sellable Unit(s)"
                         name="leastSellableUnits"
-                        className=" w-full sm:w-[200px] md:w-30"
+                        className="w-full sm:w-[200px] md:w-30"
                         rules={[
                             {
                                 required: true,
                                 message: 'Please enter the least sellable unit',
                             },
+                            {
+                                type: 'number',
+                                min: 1,
+                                message: 'Least sellable unit must be greater than or equal to 1',
+                            },
+                            {
+                                validator: (_, value) =>
+                                  value && Number.isInteger(value)
+                                    ? Promise.resolve()
+                                    : Promise.reject(new Error('Least sellable unit must be an integer')),
+                            },
                         ]}
                     >
-                        <Input placeholder="Enter Least Sellable Units" />
+                        <InputNumber 
+                            style={{ width: '100%', height: '42px', display: 'flex', alignItems: 'center' }}  
+                            min={1} 
+                            placeholder="Enter Least Sellable Units" 
+                        />
                     </Form.Item>
                     <Form.Item
                         label="Quantity"
@@ -405,9 +420,24 @@ export const categoricalProperties = (form, handleClothingTypeChange, clothingTy
                                 required: true,
                                 message: 'Please enter an expiration period',
                             },
+                            {
+                                type: 'number',
+                                min: 1,
+                                message: 'Expiration period must be greater than or equal to 1',
+                            },
+                            {
+                                validator: (_, value) =>
+                                  value && Number.isInteger(value)
+                                    ? Promise.resolve()
+                                    : Promise.reject(new Error('Expiration period must be an integer')),
+                            },
                         ]}
                     >
-                        <Input placeholder="Enter Expiration (in months)" />
+                        <InputNumber 
+                            style={{ width: '100%', height: '42px', display: 'flex', alignItems: 'center' }}  
+                            min={1} 
+                            placeholder="Enter Expiration" 
+                        />
                     </Form.Item>
                     <Form.Item
                         label="Quantity"


### PR DESCRIPTION
There are two fields which weren't being properly checked if the value was an integer or not. These fields are `leastSellableUnit` in `Metals` and `expirationPeriodInMonths` in `Membership`

https://github.com/user-attachments/assets/af0b94a8-e74a-4f0c-b939-a71d3ec06b57

