### PR TITLE
Greatly reduced number of tables indexed by Slipstream

### DIFF
--- a/blockapps-rest/src/test/fixtures/TestHistory.sol
+++ b/blockapps-rest/src/test/fixtures/TestHistory.sol
@@ -1,4 +1,6 @@
-contract TestHistory {
+pragma solidvm 11.4;
+
+abstract contract ATestHistory {
   uint x;
   constructor(uint _x) {
     x = _x;
@@ -6,4 +8,8 @@ contract TestHistory {
   function setX(uint _x) {
     x = _x;
   }
+}
+
+contract TestHistory is ATestHistory {
+  constructor(uint _x) ATestHistory(_x) { }
 }

--- a/blockapps-rest/src/test/index.test.ts
+++ b/blockapps-rest/src/test/index.test.ts
@@ -374,7 +374,7 @@ describe("history", function() {
       
     const contractHistory = await rest.searchUntil(
       admin,
-      { name: `history@Test-TestHistory` },
+      { name: `history@Test-ATestHistory` },
       (r) => r.length > 1,
       {
         ...options,
@@ -388,7 +388,7 @@ describe("history", function() {
 
     const filteredContractHistory = await rest.searchUntil(
       admin,
-      { name: `history@Test-TestHistory` },
+      { name: `history@Test-ATestHistory` },
       (r) => r.length > 0,
       {
         ...options,

--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -320,7 +320,8 @@ pipeline {
                                 ]) {
                         // Now CLIENT_ID1, CLIENT_SECRET1, and CLIENT_SECRET2 are available as environment variables
                         sh "pip3 install -r requirements.txt"
-                        sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2' 40 30"
+                        // TODO: Uncomment once validators are updated
+                        // sh "python3 slipstream_sync.py '${KEYCLOAK_STRATODEVEL_DEV_ID}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_ID}' '${KEYCLOAK_STRATODEVEL_DEV_SECRET}' '${KEYCLOAK_MERCATATESTNET2_LOCALHOST_SECRET}' 'strato-devel' 'mercata-testnet2' 40 30"
                       }
                     } 
                 

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -16,6 +16,16 @@ so that they could be properly moved to their respective version's subsection.
 
 ## [Unreleased] 
 ### Added
+
+### Changed
+- Only genesis block contracts and top-level abstract contracts are now indexed by Slipstream
+
+### Fixed
+
+### Removed
+
+## [12.0]
+### Added
 - Introduced BlockHeaderV2 constructor to BlockHeader type
 - Added support for BlockHeaderV2 fields to eth db and strato-api
 - Added BlockHeaderV2 fields to BlockView component in SMD

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
@@ -14,6 +14,8 @@ module SolidVM.Model.CodeCollection (
   flFuncs,
   contracts,
   getParents,
+  getTopLevelAbstracts,
+  getTopLevelAbstractsForContract,
   flConstants,
   flStructs,
   flEnums,
@@ -140,6 +142,19 @@ getParents cc c =
    in fmap concat . for (c ^. parents) $ \p -> do
         p' <- toErr (c ^. contractContext) p . M.lookup p $ cc ^. contracts
         (p' :) <$> getParents cc p'
+
+getTopLevelAbstracts :: CodeCollection -> Map SolidString Contract
+getTopLevelAbstracts cc = M.unions . map (getTopLevelAbstractsForContract cc) . M.elems $ _contracts cc
+
+getTopLevelAbstractsForContract :: CodeCollection -> Contract -> Map SolidString Contract
+getTopLevelAbstractsForContract cc = go
+  where
+    go c =
+      let m = doParents c
+       in if _contractType c == AbstractType && M.null m
+            then M.singleton (_contractName c) c
+            else m
+    doParents = M.unions . map (maybe M.empty go . flip M.lookup (_contracts cc)) . _parents
 
 instance Arbitrary CodeCollection where
   arbitrary = do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -970,14 +970,7 @@ getContractsForParents parents' cc =
 
 -- Only get top-level abstract contracts (e.g. Asset, Sale), to reduce Cirrus table bloat
 getAbstractParentsFromContract :: CC.Contract -> CC.CodeCollection -> [CC.Contract]
-getAbstractParentsFromContract c' cc = go c'
-  where
-    go c = case CC._contractType c of
-      CC.AbstractType -> case doParents c of
-        [] -> [c] 
-        cs -> cs
-      _ -> doParents c
-    doParents = concatMap (maybe [] go . flip M.lookup (CC._contracts cc)) . CC._parents
+getAbstractParentsFromContract c cc = M.elems $ CC.getTopLevelAbstractsForContract cc c
 
 getMapNamesFromContract :: CC.Contract -> [T.Text]
 getMapNamesFromContract c =

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -968,15 +968,16 @@ getContractsForParents parents' cc =
   let getContractForParent parent = M.lookup parent cc
    in mapMaybe getContractForParent parents'
 
+-- Only get top-level abstract contracts (e.g. Asset, Sale), to reduce Cirrus table bloat
 getAbstractParentsFromContract :: CC.Contract -> CC.CodeCollection -> [CC.Contract]
-getAbstractParentsFromContract c cc =
-  -- recursively obtain parent + grandparent contracts
-  -- ex. B is A, C is B, then C should also be A
-  let go [] = []
-      go xs = xs ++ (go $ getContractsForParents (concatMap (CC._parents) xs) ccc)
-      ccc = CC._contracts cc
-      parents' = CC._parents c
-   in filter ((== CC.AbstractType) . CC._contractType) (go $ getContractsForParents parents' ccc)
+getAbstractParentsFromContract c' cc = go c'
+  where
+    go c = case CC._contractType c of
+      CC.AbstractType -> case doParents c of
+        [] -> [c] 
+        cs -> cs
+      _ -> doParents c
+    doParents = concatMap (maybe [] go . flip M.lookup (CC._contracts cc)) . CC._parents
 
 getMapNamesFromContract :: CC.Contract -> [T.Text]
 getMapNamesFromContract c =

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -66,6 +66,7 @@ import qualified Data.Map as M
 import qualified Data.Map.Ordered as OMap
 import Data.Maybe
 import Data.Proxy
+import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as UTF8
 import Debugger
@@ -224,7 +225,12 @@ sendOutEvent (OutAction act) = do
                                                   --  . (constructor .~ Nothing)
                                                    . (modifiers .~ M.empty)
                                                    )
-                cc' = emptyCodeCollection & contracts .~ contracts'
+                -- If there are no abstract contracts, emit normal contracts. Else, only emit abstract contracts
+                abstractNames = S.fromList $ snd <$> M.keys abstracts'
+                contracts'' = if S.null abstractNames
+                                then M.filter (isNothing . _importedFrom) contracts'
+                                else M.filterWithKey (\k v -> (isNothing $ _importedFrom v) && (T.pack k `S.member` abstractNames)) contracts'
+                cc' = emptyCodeCollection & contracts .~ contracts''
              in Just $
                   CodeCollectionAdded
                     { codeCollection = const () <$> cc',

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -226,10 +226,10 @@ sendOutEvent (OutAction act) = do
                                                    . (modifiers .~ M.empty)
                                                    )
                 -- If there are no abstract contracts, emit normal contracts. Else, only emit abstract contracts
-                abstractNames = S.fromList $ snd <$> M.keys abstracts'
-                contracts'' = if S.null abstractNames
+                abstractNames = S.fromList . M.keys $ getTopLevelAbstracts cc
+                contracts'' = if cn == ""
                                 then M.filter (isNothing . _importedFrom) contracts'
-                                else M.filterWithKey (\k v -> (isNothing $ _importedFrom v) && (T.pack k `S.member` abstractNames)) contracts'
+                                else M.filterWithKey (\k v -> (isNothing $ _importedFrom v) && (k `S.member` abstractNames)) contracts'
                 cc' = emptyCodeCollection & contracts .~ contracts''
              in Just $
                   CodeCollectionAdded

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -454,7 +454,7 @@ processTheMessages env conn messages = do
     forM_ concatFkeys $ \deferredForeignKey -> do
       createForeignIndexesForJoins deferredForeignKey
 
-  when ((length creates > 0) && any (\k -> length k > 0) fkeys) $ do
+  when (any (not . null) fkeys) $ do
     $logDebugLS "processTheMessages" $ T.pack $ "Updating PostgREST schema cache for " ++ show (sum $ map length fkeys) ++ " foreign key relationships"
     notifyPostgREST conn
 

--- a/tests/e2e/cirrus.test.ts
+++ b/tests/e2e/cirrus.test.ts
@@ -12,14 +12,21 @@ let config:Config = fsUtil.getYaml("config.yaml");
 
 const options = { config };
 const contractName = 'CirrusAccessTest';
+const abstractContractName = `A${contractName}`
 const commonName = "Test"
-const tableName = `${commonName}-${contractName}`
+const tableName = `${commonName}-${abstractContractName}`
 const contractSrc = `
-contract ${contractName} {
+pragma solidvm 11.4;
+
+abstract contract ${abstractContractName} {
   int x;
   constructor(int _x) {
     x = _x;
   }
+}
+
+contract ${contractName} is ${abstractContractName} {
+  constructor(int _x) ${abstractContractName}(_x) { }
 }`;
 
 describe('postgREST allowed methods', function () {

--- a/tests/e2e/multicontract.test.ts
+++ b/tests/e2e/multicontract.test.ts
@@ -29,7 +29,8 @@ config.apiDebug=true;
 const SIZE=10
 const transactions = Array.from(Array(SIZE).keys()).map(i => {
   const name = `ScatterUpload_${i}`
-  return { nonce: i, name: name, src: `contract ${name} \{\}` }
+  const aname = `A${name}`
+  return { nonce: i, name: name, aname: aname, src: `abstract contract ${aname} \{\} contract ${name} is ${aname} \{\}` }
 })
 
 async function sleep(timeout) {
@@ -60,7 +61,7 @@ describe("Concurrent uploads", function() {
     console.log(allResults);
     const query = rest.searchUntil
     const qromises = transactions.map(tx =>
-      query(user, {name: `Test-${tx.name}`}, results => results.length > 0, options));
+      query(user, {name: `Test-${tx.aname}`}, results => results.length > 0, options));
     let allQueries = await Promise.all(qromises);
     console.log(allQueries);
   });

--- a/tests/e2e/slipstream.test.ts
+++ b/tests/e2e/slipstream.test.ts
@@ -48,61 +48,78 @@ describe('Slipstream', function () {
   this.timeout(config.timeout);
   
   const newContract = `
-contract X {
+pragma solidvm 11.4;
+
+abstract contract AX {
   uint public z = 7624;
 }
 
-contract Y {
+contract X is AX { }
+
+abstract contract AY {
   X x;
   constructor() public {
     x = new X();
   }
 }
+
+contract Y is AY {
+  constructor() AY() { }
+}
 `;
   it("can index contracts recursively constructed", async () => {
     const [user, contract] = await upload("Y", newContract, options);
     await sleep(2000);
-    const indexY = await rest.search(user, {...contract, name: toTableName("Y")}, {...options, query: {address: `eq.${contract.address}`}});
+    const indexY = await rest.search(user, {...contract, name: toTableName("AY")}, {...options, query: {address: `eq.${contract.address}`}});
     assert.equal(indexY.length, 1, JSON.stringify(indexY, null, 2));
-    const indexX = await rest.search(user, {...contract, name: toTableName("Y-X")}, options);
+    const indexX = await rest.search(user, {...contract, name: toTableName("Y-AX")}, options);
     console.log(`indexX returned ${JSON.stringify(indexX, null, 2)}`);
     assert.equal(indexX[0].z, "7624", "z");
   });
 
 
   const Counter = `
-contract Z {
+pragma solidvm 11.4;
+
+abstract contract AZ {
   uint public count = 0;
   function incr() public {
     count++;
   }
 }
+
+contract Z is AZ { }
 `;
   it("Will index updates to a contract", async () => {
     const [user, contract] = await upload("Z", Counter, options);
     await sleep(2000);
-    let indexZ = await rest.search(user, {...contract, name: toTableName("Z")}, {...options, query: {address: `eq.${contract.address}`}});
+    let indexZ = await rest.search(user, {...contract, name: toTableName("AZ")}, {...options, query: {address: `eq.${contract.address}`}});
     assert.equal(indexZ.length, 1, JSON.stringify(indexZ, null, 2));
     console.log(`Initial index: ${JSON.stringify(indexZ, null, 2)}`);
     let res = await rest.call(user, {contract, method: "incr", args: {}}, options);
     console.log(`Incr result 1: ${JSON.stringify(res, null, 2)}`);
     await sleep(2000);
-    indexZ = await rest.search(user, {...contract, name: toTableName("Z")}, {...options, query: {count: "eq.1"}});
+    indexZ = await rest.search(user, {...contract, name: toTableName("AZ")}, {...options, query: {count: "eq.1"}});
     console.log(`Second index: ${JSON.stringify(indexZ, null, 2)}`);
     res = await rest.call(user, {contract, method: "incr", args: {}}, options);
     console.log(`Incr result 2: ${JSON.stringify(res, null, 2)}`);
     await sleep(2000);
-    indexZ = await rest.search(user, {...contract, name: toTableName("Z")}, {...options, query: {count: "eq.2"}});
+    indexZ = await rest.search(user, {...contract, name: toTableName("AZ")}, {...options, query: {count: "eq.2"}});
     console.log(`Last index: ${JSON.stringify(indexZ, null, 2)}`);
   });
 
 
 const eventsContract = `
-contract EventTest {
+pragma solidvm 11.4;
+
+abstract contract AEventTest {
   event SlipstreamTest ( uint magic );
   function emitTest ( uint magic ) {
     emit SlipstreamTest ( magic );
   }
+}
+
+contract EventTest is AEventTest {
 }`;
 
   it("Will create and insert into tables for valid solidity events", async () => {
@@ -116,17 +133,17 @@ contract EventTest {
     let magic = 97;
     let res = await rest.call(user, {contract, method: "emitTest", args: {magic}}, vmOptions);
     await sleep(2000);
-    res = await rest.search(user, {...contract, name: toTableName("EventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.97"}});
+    res = await rest.search(user, {...contract, name: toTableName("AEventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.97"}});
     assert.equal(res[0].magic, magic);
     magic = 98;
     res = await rest.call(user, {contract, method: "emitTest", args: {magic}}, vmOptions);
     await sleep(2000);
-    res = await rest.search(user, {...contract, name: toTableName("EventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.98"}});
+    res = await rest.search(user, {...contract, name: toTableName("AEventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.98"}});
     assert.equal(res[0].magic, magic)
     magic = 99;
     res = await rest.call(user, {contract, method: "emitTest", args: {magic}}, vmOptions);
     await sleep(2000);
-    res = await rest.search(user, {...contract, name: toTableName("EventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.99"}});
+    res = await rest.search(user, {...contract, name: toTableName("AEventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.99"}});
    
     assert.equal(res[0].magic, magic)
     
@@ -136,21 +153,26 @@ contract EventTest {
     magic = 97;
     res = await rest.call(user2, {contract: contract2, method: "emitTest", args: {magic}}, vmOptions);
     await sleep(2000);
-    res = await rest.search(user, {...contract, name: toTableName("EventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.97"}});
+    res = await rest.search(user, {...contract, name: toTableName("AEventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.97"}});
     assert.equal(res[0].magic, magic)
     magic = 900;
     res = await rest.call(user2, {contract: contract2, method: "emitTest", args: {magic}}, vmOptions);
     await sleep(2000);
-    res = await rest.search(user, {...contract, name: toTableName("EventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.900"}});
+    res = await rest.search(user, {...contract, name: toTableName("AEventTest-SlipstreamTest")}, {...vmOptions, query: {magic: "eq.900"}});
     assert.equal(res[0].magic, magic)
   });
 
 const keywordEventsContract = `
-contract KeywordEventTest {
+pragma solidvm 11.4;
+
+abstract contract AKeywordEventTest {
   event Keywords (uint from, uint to);
   function emitKeyword (uint from, uint to) {
     emit Keywords(from, to);
   }
+}
+
+contract KeywordEventTest is AKeywordEventTest {
 }`;
 
   it("Will create and insert into event tables using escaped SQL keywords", async () => {
@@ -163,7 +185,7 @@ contract KeywordEventTest {
     let from = 1, to = 2;
     let res = await rest.call(user, {contract, method: "emitKeyword", args: {from, to}}, vmOptions);
     await sleep(2000);
-    res = await rest.search(user, {...contract, name: toTableName("KeywordEventTest-Keywords")}, {...vmOptions, query: {from: "eq.1"}});
+    res = await rest.search(user, {...contract, name: toTableName("AKeywordEventTest-Keywords")}, {...vmOptions, query: {from: "eq.1"}});
     assert.equal(res[0].from, from);
     assert.equal(res[0].to, to);
   });
@@ -171,17 +193,17 @@ contract KeywordEventTest {
 
 
   it("Will expand Cirrus tables when contract versions with new fields are created", async () => {
-    const version1 = "contract ExpansionTest { uint x; constructor() { x = 0; } }";
-    const version2 = "contract ExpansionTest { uint x; uint y; constructor() { x = 2; y = 10; } }";
+    const version1 = "pragma solidvm 11.4; abstract contract AExpansionTest { uint x; constructor() { x = 0; } } contract ExpansionTest is AExpansionTest { constructor() AExpansionTest() { } }";
+    const version2 = "pragma solidvm 11.4; abstract contract AExpansionTest { uint x; uint y; constructor() { x = 2; y = 10; } } contract ExpansionTest is AExpansionTest { constructor() AExpansionTest() { } }";
 
     const [user, contract] = await upload("ExpansionTest", version1, options);
-    const v1SearchList = await rest.searchUntil(user, {...contract, name: toTableName("ExpansionTest")}, (r) => r.length > 0, {...options, query: {address: `eq.${contract.address}`}});
+    const v1SearchList = await rest.searchUntil(user, {...contract, name: toTableName("AExpansionTest")}, (r) => r.length > 0, {...options, query: {address: `eq.${contract.address}`}});
     assert.equal(v1SearchList.length, 1, "one result from Cirrus");
     const v1 = v1SearchList[0];
     assert.equal(v1.x, 0, "first version appears correctly in Cirrus");
 
     const [user2, contract2] = await upload("ExpansionTest", version2, options);
-    const v2SearchList = await rest.searchUntil(user, {...contract, name: toTableName("ExpansionTest")}, (r) => r.length > 0, {...options, query: {address: `eq.${contract2.address}`}});
+    const v2SearchList = await rest.searchUntil(user, {...contract, name: toTableName("AExpansionTest")}, (r) => r.length > 0, {...options, query: {address: `eq.${contract2.address}`}});
     assert.equal(v2SearchList.length, 1, "one result from Cirrus");
     const v2 = v2SearchList[0];
     assert.equal(v2.x, 2, "second version appears correctly in Cirrus");

--- a/tests/e2e/solidvm.test.ts
+++ b/tests/e2e/solidvm.test.ts
@@ -20,7 +20,9 @@ let options:Options = {config};
 let user:BlockChainUser;
 
 const counter = `
-contract Counter {
+pragma solidvm 11.4;
+
+abstract contract ACounter {
     uint count;
 
     function incr() public {
@@ -30,10 +32,14 @@ contract Counter {
         return count;
     }
 }
+
+contract Counter is ACounter { }
 `;
 
 const partialModify = `
-contract PartialModify {
+pragma solidvm 11.4;
+
+abstract contract APartialModify {
   uint x = 83;
   uint y = 72;
 
@@ -41,12 +47,14 @@ contract PartialModify {
     y *= 2;
   }
 }
+
+contract PartialModify is APartialModify { }
 `;
 
 const deployAndModify = `
 ${partialModify}
 
-contract Deployer {
+abstract contract ADeployer {
   PartialModify pm;
 
   constructor() public {
@@ -54,15 +62,27 @@ contract Deployer {
     pm.doubleY();
   }
 }
-`;
 
-const enumContract = `contract EnumContract {
-  enum E {A, B, C, D}
-  E e = E.C;
+contract Deployer is ADeployer {
+  constructor() ADeployer() { }
 }
 `;
 
-const stringsContract = `contract StringReturns {
+const enumContract = `
+pragma solidvm 11.4;
+
+abstract contract AEnumContract {
+  enum E {A, B, C, D}
+  E e = E.C;
+}
+
+contract EnumContract is AEnumContract { }
+`;
+
+const stringsContract = `
+pragma solidvm 11.4;
+
+abstract contract AStringReturns {
 
   function single() returns (string) {
     return "how are you?";
@@ -76,6 +96,8 @@ const stringsContract = `contract StringReturns {
     return (42, "the meaning of life", msg.sender, "STRATO");
   }
 }
+
+contract StringReturns is AStringReturns { }
 `;
 
 async function upload(vm, name, source):Promise<Contract> {
@@ -104,7 +126,7 @@ async function index(contract:Contract) {
 }
 
 function toTableName(contractName){
-  return `Test-${contractName}`; // prepend with Test cuz all users' commonName are Test
+  return `Test-A${contractName}`; // prepend with Test cuz all users' commonName are Test
 }
 
 describe('Solid VM: Contract uploads', function() {


### PR DESCRIPTION
PostgREST cache reload time when syncing to prod went from 13 seconds to <1 second with these changes.
Before:
```
02/Oct/2024:15:06:46 +0000: Starting PostgREST 12.0.0...
02/Oct/2024:15:06:46 +0000: Attempting to connect to the database...
02/Oct/2024:15:06:46 +0000: Connection successful
02/Oct/2024:15:06:46 +0000: Config reloaded
02/Oct/2024:15:06:59 +0000: Schema cache loaded
```

After:
```
02/Oct/2024:16:06:16 +0000: Starting PostgREST 12.0.0...
02/Oct/2024:16:06:16 +0000: Attempting to connect to the database...
02/Oct/2024:16:06:16 +0000: Connection successful
02/Oct/2024:16:06:16 +0000: Config reloaded
02/Oct/2024:16:06:16 +0000: Schema cache loaded
```