### PR TITLE
Fixed white screen error in My Transactions page on Safari

### DIFF
--- a/marketplace/ui/src/components/Order/Transaction.js
+++ b/marketplace/ui/src/components/Order/Transaction.js
@@ -7,7 +7,7 @@ import { saveAs } from 'file-saver';
 import { actions as categoryActions } from "../../contexts/category/actions";
 import { useCategoryState, useCategoryDispatch } from "../../contexts/category";
 import startCase from 'lodash/startCase';
-import { epochToDate, getStringDate } from "../../helpers/utils";
+import { epochToDate, getStringDate, groupBy } from "../../helpers/utils";
 import { REDEMPTION_STATUS, TRANSACTION_STATUS, US_DATE_FORMAT } from "../../helpers/constants";
 import TransactionTable from "./TransactionTable";
 import { useTransactionState } from "../../contexts/transaction";
@@ -88,7 +88,7 @@ const Transaction = ({ user }) => {
 
   useEffect(() => {
     const mappedData = mapTransactionData(userTransactions)
-    const { Order, Redemption, Transfer } = Object.groupBy(mappedData, ({ Type }) => Type);
+    const { Order, Redemption, Transfer } = groupBy(mappedData, ({ Type }) => Type);
     if (userTransactions && callExcel && !isTransactionLoading) {
       const wb = XLSX.utils.book_new();
       const wsOrder = XLSX.utils.json_to_sheet(Order ? Order : []);

--- a/marketplace/ui/src/components/Order/TransactionTable.js
+++ b/marketplace/ui/src/components/Order/TransactionTable.js
@@ -265,7 +265,7 @@ const TransactionTable = ({ user, download, isAllOrdersLoading }) => {
       dataIndex: "to",
       key: "to",
       align: "center",
-      width: '150px',
+      width: '160px',
     },
     {
       title: "Hash",

--- a/marketplace/ui/src/helpers/utils.js
+++ b/marketplace/ui/src/helpers/utils.js
@@ -17,6 +17,21 @@ export function arrayToStr(arr) {
 
   return valueString;
 }
+
+export function groupBy(array, keyAccessor) {
+  return array.reduce((accumulator, element) => {
+    const key = keyAccessor(element);
+
+    if (!accumulator[key]) {
+      accumulator[key] = [];
+    }
+
+    accumulator[key].push(element);
+
+    return accumulator;
+  }, {});
+}
+
 export function arrayToCsv(data) {
   return data
     .map((row) =>


### PR DESCRIPTION
A white screen error occurs when navigating to the My Transactions page on Safari. This is because the `Object.groupBy()` function is used which was part of a recent Javascript update that hasn’t been implemented across all browsers yet. 

The solution is to create a custom function which replicates the logic of the `Object.groupBy()` function, but this could be used across all browsers.


Demo (first part shows Google Chrome on desktop/mobile followed by Safari on desktop/mobile):

https://github.com/user-attachments/assets/33df4b73-a1a9-40b3-a506-26a183d88dd0

