### PR TITLE
Prevent login redirect when opening the app

### DIFF
--- a/marketplace/ui/src/contexts/marketplace/actions.js
+++ b/marketplace/ui/src/contexts/marketplace/actions.js
@@ -512,7 +512,6 @@ const actions = {
           type: actionDescriptors.fetchStratsBalanceFailed,
           payload: "Error while fetching STRATS",
         });
-        window.location.href = body.error.loginUrl;
       }
       if (response.status === RestStatus.OK) {
         dispatch({
@@ -540,7 +539,6 @@ const actions = {
           type: actionDescriptors.fetchStratsAddressFailed,
           payload: "Error while fetching STRATS address",
         });
-        window.location.href = body.error.loginUrl;
         return null;
       }
   


### PR DESCRIPTION
When loading in the app, an API call is made to fetch the user's STRATS balance. It was set so that if the call failed with an Unauthorized error (b/c the user isn't logged-in), the user is navigated to the login page. This functionality was taken out as part of this PR.


https://github.com/user-attachments/assets/8d2fb0fc-cd7f-4be1-881e-be8057dfa4e8

