### PR TITLE
Strato-p2p Exception Handling

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -16,6 +16,18 @@ so that they could be properly moved to their respective version's subsection.
 
 ## [Unreleased] 
 ### Added
+- Added block.proposer to SolidVM
+### Changed
+
+### Fixed
+- Bugfix in slipstream to support decoding structs
+- Foreign keys in cirrus properly updated
+- Bugfix in p2p to prevent peers from continuously attempting to connect to offline peers
+
+### Removed
+
+## [12.0.0] - 9/23/2024
+### Added
 - Introduced BlockHeaderV2 constructor to BlockHeader type
 - Added support for BlockHeaderV2 fields to eth db and strato-api
 - Added BlockHeaderV2 fields to BlockView component in SMD
@@ -28,7 +40,6 @@ so that they could be properly moved to their respective version's subsection.
 - Added `<best_sequenced_block>` to reduce the redundant block requests in p2p
 - Added strict mode to sequencer that will cause crash on block authentication
 - Added `INSTRUMENTATION` flag to see finer-grained memory usage in processes
-- Added block.proposer to SolidVM
 
 ### Changed
 - General cleanup of Kafka-related code

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -302,10 +302,12 @@ lengthenPeerDisableBy ::
   NominalDiffTime ->
   PPeer ->
   m (Either SomeException ())
-lengthenPeerDisableBy secs peer' = try $ do
+lengthenPeerDisableBy secs peer = try $ do
   currentTime <- liftIO getCurrentTime
-  let disable = SetPeerDisableTime (TcpEnableTime $ 5 `addUTCTime` currentTime) 5 (secs `addUTCTime` currentTime)
-  A.replace (A.Proxy @PeerDisable) peer' disable
+  let disable = if (currentTime < pPeerDisableExpiration peer)
+                then ExtendPeerDisableTime (TcpEnableTime $ fromIntegral (pPeerNextDisableWindowSeconds peer) `addUTCTime` currentTime) 2
+                else SetPeerDisableTime (TcpEnableTime $ 5 `addUTCTime` currentTime) 5 (secs `addUTCTime` currentTime)
+  A.replace (A.Proxy @PeerDisable) peer disable
 
 -- A variation of 'lengthenPeerDisable' but for UDP instead, currently used for ethereum-discovery.
 lengthenPeerDisable' ::

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -40,7 +40,7 @@ import           Blockchain.TimerSource
 import           Control.Concurrent hiding (yield)
 import           Control.Exception.Base (ErrorCall (..))
 import           Control.Lens ((^.))
-import           Control.Monad (forever, forM_, void)
+import           Control.Monad (forever, forM_, when, void)
 import qualified Control.Monad.Change.Alter as A
 import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
@@ -51,6 +51,7 @@ import qualified Data.Conduit.List as CL
 import           Data.Either.Combinators
 import           Data.Maybe
 import qualified Data.Text as T
+import           Data.Time.Clock (NominalDiffTime)
 import           GHC.IO.Exception
 import qualified Text.Colors as C
 import           Text.Format
@@ -195,57 +196,41 @@ stratoP2PClient runner = runner $ \_ -> labelTheThread "strato P2P Client main l
       Left e -> do
         $logInfoS "stratoP2PClient/handleRunPeerResult" $ T.pack $ "Connection ended: " ++ show (e :: SomeException)
         recordException thePeer e
-        eErr <- case e of
+        case e of
           e' | Just WrongGenesisBlock <- fromException e' -> do
-            udpErr <- disableUDPPeerForSeconds thePeer 86400
-            whenLeft udpErr $ \theUDPErr -> do
-              $logErrorLS "stratoP2PClient/handleRunPeerResult" theUDPErr
-            disErr <- storeDisableException thePeer (T.pack "WrongGenesisBlock")
-            whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
+            disableException thePeer "WrongGenesisBlock" Nothing True
             case pPeerPubkey thePeer of 
               Just pubkey -> A.replace (A.Proxy @PeerBondingState) (IPAsText $ pPeerIp thePeer, pubkey) (PeerBondingState 3) -- 3 indicates wrong genesis block/networkID
               Nothing -> return ()
-            lengthenPeerDisable thePeer
           e' | Just HeadMacIncorrect <- fromException e' -> do
-            disErr <- storeDisableException thePeer (T.pack "HeadMacIncorrect")
-            whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-            lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
+            disableException thePeer "HeadMacIncorrect" (Just . fromIntegral $ 2 * flags_connectionTimeout) False
           e' | Just NetworkIDMismatch <- fromException e' -> do
-            udpErr <- disableUDPPeerForSeconds thePeer 86400
-            whenLeft udpErr $ \theUDPErr -> do
-              $logErrorLS "stratoP2PClient/handleRunPeerResult" theUDPErr
-            disErr <- storeDisableException thePeer (T.pack "NetworkIDMismatch")
-            whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
+            disableException thePeer "NetworkIDMismatch" Nothing True
             case pPeerPubkey thePeer of 
               Just pubkey -> A.replace (A.Proxy @PeerBondingState) (IPAsText $ pPeerIp thePeer, pubkey) (PeerBondingState 3) -- 3 indicates wrong genesis block/networkID
               Nothing -> return ()
-            lengthenPeerDisable thePeer
           e' | Just PeerDisconnected <- fromException e' -> do
-            disErr <- storeDisableException thePeer (T.pack "PeerDisconnected")
-            whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-            lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
+            disableException thePeer "PeerDisconnected" (Just . fromIntegral $ 2 * flags_connectionTimeout) True
           e' | Just PeerNonResponsive <- fromException e' -> do
-            disErr <- storeDisableException thePeer (T.pack "PeerNonResponsive")
-            whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-            lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
+            disableException thePeer "PeerNonResponsive" (Just . fromIntegral $ 2 * flags_connectionTimeout) False
           e' | Just NoPeerCertificate <- fromException e' -> do
-            disErr <- storeDisableException thePeer (T.pack "NoPeerCertificate")
-            whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-            udpErr <- disableUDPPeerForSeconds thePeer 86400
-            whenLeft udpErr $ \theUDPErr -> do
-              $logErrorLS "stratoP2PClient/handleRunPeerResult" theUDPErr
-            lengthenPeerDisable thePeer
+            disableException thePeer "NoPeerCertificate" Nothing True
           e' | Just (IOError _ ioErrType _ _ _ _) <- fromException e' -> do
             case ioErrType of
-              NoSuchThing -> do
-                udpErr <- disableUDPPeerForSeconds thePeer 86400
-                whenLeft udpErr $ \theUDPErr -> do
-                  $logErrorLS "stratoP2PClient/handleRunPeerResult" theUDPErr
-                disErr <- storeDisableException thePeer (T.pack "ioErrType: NoSuchThing")
-                whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
-                lengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) thePeer
-              _ -> return $ Right ()
-          _ -> return $ Right ()
-        whenLeft eErr $ \err -> do
-          $logErrorLS "stratoP2PClient/handleRunPeerResult" err
+              NoSuchThing -> disableException thePeer "ioErrType: NoSuchThing" (Just . fromIntegral $ 2 * flags_connectionTimeout) True
+              i -> disableException thePeer ("ioErrType: " <> show i) Nothing True
+          _ -> return ()
       Right _ -> return ()
+
+  -- where 
+    disableException :: MonadP2P m => PPeer -> String -> Maybe NominalDiffTime -> Bool -> m ()
+    disableException p exception disableBy disableUDP = do
+      disErr <- storeDisableException p (T.pack exception)
+      whenLeft disErr $ \err2 -> $logErrorS "stratoP2PClient/handleRunPeerResult" . T.pack $ "Unable to store disable exception: " ++ show err2
+      _ <- case disableBy of 
+        Just secs -> lengthenPeerDisableBy secs p
+        Nothing -> lengthenPeerDisable p
+      when disableUDP $ do 
+        udpErr <- disableUDPPeerForSeconds p 86400
+        whenLeft udpErr $ \theUDPErr -> do
+          $logErrorLS "stratoP2PClient/handleRunPeerResult" theUDPErr

--- a/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PClient.hs
@@ -192,11 +192,15 @@ stratoP2PClient runner = runner $ \_ -> labelTheThread "strato P2P Client main l
   where
     handleRunPeerResult :: MonadP2P m => PPeer -> Either SomeException () -> m ()
     handleRunPeerResult thePeer = \case
-      Left e | Just (ErrorCall x) <- fromException e -> error x
       Left e -> do
         $logInfoS "stratoP2PClient/handleRunPeerResult" $ T.pack $ "Connection ended: " ++ show (e :: SomeException)
         recordException thePeer e
         case e of
+          e' | Just (ErrorCall x) <- fromException e' -> do 
+            disableException thePeer x Nothing False 
+            error x
+          e' | Just (HandshakeException _) <- fromException e' -> do 
+            disableException thePeer "HandshakeException" Nothing False 
           e' | Just WrongGenesisBlock <- fromException e' -> do
             disableException thePeer "WrongGenesisBlock" Nothing True
             case pPeerPubkey thePeer of 


### PR DESCRIPTION
Refactoring the `handleRunPeerResult` function and allowing the backoff to double in most cases (except in cases where it's likely that this could be a validator-nonvalidator connection and we should not disconnect for too long)