### PR TITLE
Enhance event filtering logic to validate block numbers and event names

### DIFF
--- a/rewards-server/src/helper/eventFilter.js
+++ b/rewards-server/src/helper/eventFilter.js
@@ -1,13 +1,56 @@
+let latestBlockNumber = 0; // Variable to track the largest block number
+
 async function filterMessages(msg) {
-  if (msg === "pong") {
-    // Handle the pong message
-    console.log("Received pong message");
-    return false;
+  try {
+    if (msg === "pong") {
+      // Handle the pong message
+      console.log("Received pong message");
+      return false;
+    }
+
+    let event;
+    try {
+      event = JSON.parse(msg);
+    } catch (error) {
+      console.error("Error parsing message:", error);
+      return false; // Ignore invalid messages
+    }
+
+    // Check if the event and necessary properties exist
+    const eventName = event?.eventEvent?.eventName;
+    const currentBlockNumber = event?.eventBlockNumber;
+
+    // If the block number is missing or not a number, ignore the message
+    if (!currentBlockNumber || typeof currentBlockNumber !== 'number') {
+      console.log("Invalid or missing block number");
+      return false;
+    }
+
+    // If the block number is less than or equal to the last seen block number, ignore it
+    if (currentBlockNumber < latestBlockNumber) {
+      console.log("Ignoring old event with block number:", currentBlockNumber);
+      return false;
+    }
+
+    // Update the latest block number
+    latestBlockNumber = currentBlockNumber;
+
+    // List of allowed event names
+    const allowedEvents = ["CertificateRegistered", "Order"];
+
+    // Check if the event name is one of the allowed events
+    if (!eventName || !allowedEvents.includes(eventName)) {
+      console.log("Event not allowed or missing event name:", eventName);
+      return false;
+    }
+    console.log("Received event:", eventName);
+
+    // The event passes all checks and is valid
+    return true;
+  } catch (error) {
+    console.error("An unexpected error occurred:", error);
+    return false; // Safely handle any unexpected error
   }
-  const event = JSON.parse(msg);
-  console.log("Received event:", event?.eventEvent?.eventName);
-  const allowedEvents = ["CertificateRegistered", "Order"];
-  return allowedEvents.includes(event?.eventEvent?.eventName);
 }
 
 module.exports = { filterMessages };

--- a/rewards-server/src/helper/eventFilter.js
+++ b/rewards-server/src/helper/eventFilter.js
@@ -28,7 +28,6 @@ async function filterMessages(msg) {
 
     // If the block number is less than or equal to the last seen block number, ignore it
     if (currentBlockNumber < latestBlockNumber) {
-      console.log("Ignoring old event with block number:", currentBlockNumber);
       return false;
     }
 
@@ -40,7 +39,6 @@ async function filterMessages(msg) {
 
     // Check if the event name is one of the allowed events
     if (!eventName || !allowedEvents.includes(eventName)) {
-      console.log("Event not allowed or missing event name:", eventName);
       return false;
     }
     console.log("Received event:", eventName);


### PR DESCRIPTION
When the testnet MP node syncs, the Reward Server still listens to the events that the node is emitting and in turn also sends out rewards. We want to have a check where we see if the event that is coming has a blocknumber higher or equal to the latest blocknumber the rewards server has seen.

This is not an issue with prod because the prod MP node is always in sync.

How to test:
Turn on the rewards server locally and or on testnet pointing to a syncing node. See the logs to make sure its not sending out rewards.