### PR TITLE
Fixed date format to work for all browsers

### DIFF
--- a/marketplace/ui/src/components/Order/TransactionTable.js
+++ b/marketplace/ui/src/components/Order/TransactionTable.js
@@ -49,7 +49,7 @@ const TransactionTable = ({ user, download, isAllOrdersLoading }) => {
 
   const formatter = new Intl.NumberFormat('en-US');
   const formattedNum = (num) => formatter.format(num);
-  const defaultDate =  dateQuery ? dayjs.unix(dayjs(dateQuery).startOf('month').unix()) : dayjs.unix(currentMonth);
+  const defaultDate =  dateQuery ? dayjs.unix(dayjs(dateQuery, 'MMMM YYYY').startOf('month').unix()) : dayjs.unix(currentMonth);
 
   useEffect(() => {
     async function fetchStratsAddress() {
@@ -120,18 +120,20 @@ const TransactionTable = ({ user, download, isAllOrdersLoading }) => {
       const selectedMonthYear = dayjs(dateQuery, "MMMM YYYY");
   
       filteredData = filteredData.filter((item) => {
-        const itemDate = dayjs(item.block_timestamp); // Convert block timestamp to dayjs object
-  
+        let blockTimestamp = item.block_timestamp;
+        if (blockTimestamp.includes('UTC')) {
+          blockTimestamp = blockTimestamp.replace(' UTC', 'Z'); 
+        }
+        const itemDate = dayjs(blockTimestamp);
+        
         // Compare both month and year
         return itemDate.isSame(selectedMonthYear, 'month') && itemDate.isSame(selectedMonthYear, 'year');
       });
     }
-  
+
     setTransactions(filteredData);
   }, [userTransactions, type, search, dateQuery]);
   
-
-
   // Handle the date change event. Update the URL and state
   const onDateChange = (date) => {
     const unixTimestamp = dayjs(date).unix();
@@ -140,13 +142,14 @@ const TransactionTable = ({ user, download, isAllOrdersLoading }) => {
     navigate(`/transactions?type=${currentType}&date=${formattedDate}`);
     setDateQuery(formattedDate); // Update the date state
   };
-  
 
   const dateReturn = (date) => {
-    const startDate = dayjs(date).startOf('month').unix();
-    const endDate = dayjs(date).endOf('month').unix();
-    return [startDate, endDate]
+    const parsedDate = dayjs(date, 'MMMM YYYY').startOf('month');
+    const startDate = parsedDate.unix();
+    const endDate = parsedDate.endOf('month').unix();
+    return [startDate, endDate];
   }
+  
 
   const Content = ({ data }) => {
     const price = data?.assetPrice || data?.price


### PR DESCRIPTION
Previously, date filtering by month didn't work in the My Transactions page on Safari desktop/mobile.

Demo:


https://github.com/user-attachments/assets/f2dbcc1f-39c3-43d3-9540-fc8c23962544

