### PR TITLE
Added check to prevent negative quantity transfer

### DIFF
--- a/marketplace/backend/dapp/items/contracts/CarbonDAO.sol
+++ b/marketplace/backend/dapp/items/contracts/CarbonDAO.sol
@@ -19,6 +19,7 @@ contract CarbonDAO is SemiFungible {
     }
 
     function mint(uint _quantity) internal override returns (UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         CarbonDAO newAsset = new CarbonDAO(
             name,
             description,

--- a/marketplace/backend/dapp/items/contracts/Clothing.sol
+++ b/marketplace/backend/dapp/items/contracts/Clothing.sol
@@ -42,6 +42,7 @@ contract Clothing is Mintable {
     }
 
     function mint(uint _quantity) internal override returns (UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         Clothing newAsset = new Clothing(
             name,
             description,

--- a/marketplace/backend/dapp/items/contracts/Collectibles.sol
+++ b/marketplace/backend/dapp/items/contracts/Collectibles.sol
@@ -30,6 +30,7 @@ contract Collectibles is Mintable {
     }
 
     function mint(uint _quantity) internal override returns (UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         Collectibles newAsset = new Collectibles(
             name,
             description,

--- a/marketplace/backend/dapp/items/contracts/Membership.sol
+++ b/marketplace/backend/dapp/items/contracts/Membership.sol
@@ -24,6 +24,7 @@ contract Membership is SemiFungible {
     }
 
     function mint(uint _quantity) internal override returns(UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         Membership newAsset = new Membership(
             name,
             description,

--- a/marketplace/backend/dapp/items/contracts/STRATS.sol
+++ b/marketplace/backend/dapp/items/contracts/STRATS.sol
@@ -29,6 +29,7 @@ contract STRATSTokens is Tokens {
     }
     
     function mint(uint _quantity) internal override returns (UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         STRATSTokens newSTRATS = new STRATSTokens(name, description, images, files, fileNames, createdDate, _quantity, status, address(redemptionService), paymentServiceCreator, paymentServiceName);
         return UTXO(address(newSTRATS)); 
     }
@@ -44,6 +45,7 @@ contract STRATSTokens is Tokens {
     
     function purchaseTransfer(address _newOwner, uint _quantity, uint _transferNumber, decimal _price) public fromPaymentService("make a purchase") {
         require(_quantity <= quantity, "Cannot transfer more than available quantity.");
+        require(_quantity > 0, "Quantity must be greater than 0");
         // regular transfer - isUserTransfer: false, transferNumber: 0
         // transfer feature - isUserTransfer: true, transferNumber: >0
         _transfer(_newOwner, _quantity, true, _transferNumber, _price);

--- a/marketplace/backend/dapp/items/contracts/Spirits.sol
+++ b/marketplace/backend/dapp/items/contracts/Spirits.sol
@@ -42,6 +42,7 @@ contract Spirits is Mintable, UnitOfMeasurement {
     }
 
     function mint(uint _quantity) internal override returns (UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         Spirits newAsset = new Spirits(
             name,
             description,

--- a/marketplace/backend/dapp/items/contracts/Tokens.sol
+++ b/marketplace/backend/dapp/items/contracts/Tokens.sol
@@ -19,6 +19,7 @@ contract Tokens is Mintable {
     ) public Mintable(_name, _description, _images, _files, _fileNames, _createdDate, _quantity, _status, _redemptionService) {}
 
     function mint(uint _quantity) internal override returns (UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         Tokens newToken = new Tokens(name, description, images, files, fileNames, createdDate, _quantity, status, address(redemptionService));
         return UTXO(address(newToken)); 
     }

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Asset.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Asset.sol
@@ -189,6 +189,7 @@ abstract contract Asset is Utils {
     function automaticTransfer(address _newOwner, decimal _price, uint _quantity, uint _transferNumber) public requireOwner("automatic transfer") returns (uint) {
         require(status != AssetStatus.PENDING_REDEMPTION, "Asset is not in ACTIVE state.");
         require(status != AssetStatus.RETIRED, "Asset is not in ACTIVE state.");
+        require(_quantity > 0, "Quantity must be greater than 0");
         require(_quantity <= quantity, "Cannot transfer more than available quantity.");
         if (sale == address(0)) {
             // transfer feature - isUserTransfer: true, transferNumber: >0

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Asset.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Asset.sol
@@ -66,6 +66,7 @@ abstract contract Asset is Utils {
         AssetStatus _status
     ) {
         // TODO: Get ownerCommonName by getting commonName field from on-chain wallet at that address
+        require(_quantity > 0, "Quantity must be greater than 0");
         owner  = msg.sender;
         ownerCommonName = getCommonName(msg.sender);
         name = _name;

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Asset.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Asset.sol
@@ -145,6 +145,7 @@ abstract contract Asset is Utils {
     function _transfer(address _newOwner, uint _quantity, bool _isUserTransfer, uint _transferNumber, decimal _price) internal virtual {
         require(status != AssetStatus.PENDING_REDEMPTION, "Asset is not in ACTIVE state.");
         require(status != AssetStatus.RETIRED, "Asset is not in ACTIVE state.");
+        require(_quantity > 0, "Quantity must be greater than 0");
         string newOwnerCommonName = getCommonName(_newOwner);
 
         if(_isUserTransfer && _transferNumber>0){

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Mintable.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Mintable.sol
@@ -46,6 +46,7 @@ abstract contract Mintable is Redeemable {
     }
 
     function mint(uint _quantity) internal virtual override returns (UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         Mintable m = new Mintable(name, description, images, files, fileNames, createdDate, _quantity, status, address(redemptionService));
         return UTXO(address(m));
     }
@@ -54,6 +55,7 @@ abstract contract Mintable is Redeemable {
         require(isMint, "Only the mint contract can mint new units");
         require(status != AssetStatus.PENDING_REDEMPTION, "Asset is not in ACTIVE state.");
         require(status != AssetStatus.RETIRED, "Asset is not in ACTIVE state.");
+        require(_quantity > 0, "Quantity must be greater than 0");
         require(getCommonName(msg.sender) == minterCommonName, "Only the minter can mint new units");
         emit OwnershipTransfer(
             originAddress,

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Redeemable.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/Redeemable.sol
@@ -30,10 +30,12 @@ abstract contract Redeemable is UTXO {
     }
 
     function mint(uint _quantity) internal virtual override returns (UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         return UTXO(new Redeemable(name, description, images, files, fileNames, createdDate, _quantity, status, address(redemptionService)));
     }
 
     function _callMint(address _newOwner, uint _quantity) internal virtual override {
+        require(_quantity > 0, "Quantity must be greater than 0");
         UTXO newAsset = mint(_quantity);
         Asset(newAsset).transferOwnership(_newOwner, _quantity, false, 0, 0);
     }
@@ -56,6 +58,7 @@ abstract contract Redeemable is UTXO {
     function requestRedemption(string _redemptionId, uint _quantity) requireOwner("request redemption") public returns (uint, address) {
         require(status != AssetStatus.PENDING_REDEMPTION, "Asset is not in ACTIVE state.");
         require(status != AssetStatus.RETIRED, "Asset is not in ACTIVE state.");
+        require(_quantity > 0, "Quantity must be greater than 0");
 
         UTXO newAsset = mint(_quantity);
         quantity -= _quantity;

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/SemiFungible.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/SemiFungible.sol
@@ -47,6 +47,8 @@ abstract contract SemiFungible is Mintable {
     function _callMint(address _newOwner, uint _quantity) internal override{
         require(status != AssetStatus.PENDING_REDEMPTION, "Asset is not in ACTIVE state.");
         require(status != AssetStatus.RETIRED, "Asset is not in ACTIVE state.");
+        require(_quantity > 0, "Quantity must be greater than 0");
+        
         for (uint i = 0; i < _quantity; i++) {
             UTXO newAsset = mint(1);
             // regular transfer - isUserTransfer: false, transferNumber: 0, transferPrice:0

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/UTXO.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/UTXO.sol
@@ -25,6 +25,7 @@ abstract contract UTXO is Asset {
     }
 
     function mint(uint _quantity) internal virtual returns (UTXO) {
+        require(_quantity > 0, "Quantity must be greater than 0");
         return new UTXO(name, description, images, files, fileNames, createdDate, _quantity, status);
     }
 
@@ -76,6 +77,7 @@ abstract contract UTXO is Asset {
     }
 
     function _callMint(address _newOwner, uint _quantity) internal virtual{
+        require(_quantity > 0, "Quantity must be greater than 0");
         UTXO newAsset = mint(_quantity);
         Asset(newAsset).transferOwnership(_newOwner, _quantity, false, 0, 0);
     }

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/UTXO.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Assets/UTXO.sol
@@ -32,6 +32,7 @@ abstract contract UTXO is Asset {
     function _transfer(address _newOwner, uint _quantity, bool _isUserTransfer, uint _transferNumber, decimal _price) internal override {
         require(status != AssetStatus.PENDING_REDEMPTION, "Asset is not in ACTIVE state.");
         require(status != AssetStatus.RETIRED, "Asset is not in ACTIVE state.");
+        require(_quantity > 0, "Quantity must be greater than 0");
         require(checkCondition(), "Condition is not met");
         // Create a new UTXO with a portion of the units
         try {

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
@@ -129,6 +129,7 @@ abstract contract Sale is Utils {
 
     function automaticTransfer(address _newOwner, decimal _price, uint _quantity, uint _transferNumber) public returns (uint) {
         require(msg.sender == address(assetToBeSold), "Only the underlying Asset can call automaticTransfer.");
+        require(_quantity > 0, "Quantity must be greater than 0");
         uint assetQuantity = assetToBeSold.quantity();
         require(_quantity <= assetQuantity - totalLockedQuantity, "Cannot transfer more units than are available.");
         if (_quantity > quantity) { // We can transfer more than the Sale quantity

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Sale.sol
@@ -28,9 +28,10 @@ abstract contract Sale is Utils {
         uint _quantity,
         PaymentService[] _paymentServices
     ) {    
+        require(_quantity > 0, "Quantity must be greater than 0");
+        require(assetToBeSold.quantity() >= _quantity, "Cannot sell more units than what are owned.");
         assetToBeSold = Asset(_assetToBeSold);
         price = _price;
-        require(assetToBeSold.quantity() >= _quantity, "Cannot sell more units than what are owned.");
         quantity = _quantity;
         totalLockedQuantity = 0;
         isOpen = true;


### PR DESCRIPTION
If a user was to call `automaticTransfer(<your own address>, -1, true, 1, 0)`, it will increase the quantity of the Asset because you are passing through a negative number. In the transfer logic, we subtract the Asset’s quantity by the quantity being passed through the parameter. Subtracting by a negative number causes the quantity to be increased. 

The solution here is to add this check `require(0 < _quantity)` which prevents a negative quantity from being passed through. This would be a solution for newly created Assets, but not previously created ones.