### PR TITLE
log the original user ip when a request is proxied

### DIFF
--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -18,6 +18,8 @@ http {
         '"time_local":"$time_local",'
         '"msec":"$msec",'
         '"remote_addr":"$remote_addr",'
+        '"X-Forwarded-For":"$http_x_forwarded_for",'
+        '"CF-Connecting-IP":"$http_cf_connecting_ip",'
         '"request_method":"$request_method",'
         '"request":"$request",'
         '"status": "$status",'


### PR DESCRIPTION
This PR adds the logging of the user's original IP even if the request is proxied (e.g. by Cloudflare).

I tested it on nodes w/ and w/o cloudflare.

The log looks like this when the website is behind the Cloudflare CDN and proxy (note the the `X-Forwarded-For` and `CF-Connecting-IP` headers):
```
{"time_local":"24/Oct/2024:13:37:24 +0000","msec":"1729777044.395","remote_addr":"172.71.194.97","X-Forwarded-For":"52.4.134.5,52.4.134.5","CF-Connecting-IP":"52.4.134.5","request_method":"GET","request":"GET /api/v1/users/me HTTP/1.1","status": "401","request_time":"0.062","request_length":"1654","bytes_sent":"1530","body_bytes_sent":"48","http_user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0.1 Safari/605.1.15","http_referrer":"","remote_user":"","upstream_addr":"172.25.0.13:3030","upstream_status":"401","upstream_response_time":"0.062","upstream_connect_time":"0.006","upstream_header_time":"0.062"}
```

When the website is not proxied (the `X-Forwarded-For` and `CF-Connecting-IP` are empty but the `remote_addr` has the real ip in that case):
```
{"time_local":"24/Oct/2024:13:43:25 +0000","msec":"1729777405.702","remote_addr":"52.4.134.5","X-Forwarded-For":"","CF-Connecting-IP":"","request_method":"GET","request":"GET /health HTTP/1.1","status": "200","request_time":"0.002","request_length":"2678","bytes_sent":"360","body_bytes_sent":"119","http_user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0.1 Safari/605.1.15","http_referrer":"","remote_user":"","upstream_addr":"172.25.0.10:3009","upstream_status":"200","upstream_response_time":"0.003","upstream_connect_time":"0.001","upstream_header_time":"0.003"}
```