### PR TITLE
Removed and adjusted backend logs

### DIFF
--- a/marketplace/backend/api/middleware/errorHandler.js
+++ b/marketplace/backend/api/middleware/errorHandler.js
@@ -7,8 +7,6 @@ const clientErrorHandler = (err, req, res, next) => {
     const statusText = get(err, 'response.statusText')
     const message = get(err, 'response.data')
     console.log(`Unhandled API error. Status: ${JSON.stringify(statusCode)} ${JSON.stringify(statusText)}. Message: ${JSON.stringify(message)}`)
-    console.log(`Request: ${req}`)
-    console.log(`Response: ${res}`)
     return res.status(statusCode).json({ success: false, error: statusText })
   }
 

--- a/marketplace/backend/api/v1/authentication/authentication.controller.js
+++ b/marketplace/backend/api/v1/authentication/authentication.controller.js
@@ -59,7 +59,6 @@ class AuthenticationController {
           console.log('Cert not found in first attempt')
           await new Promise(resolve => setTimeout(resolve, 3000));
           cert = await certificateJs.getCertificateMe(user)
-          console.log('Cert content from second attempt', cert)
 
           if (!cert) {
             console.log('Cert not found even in second attempt')
@@ -106,7 +105,6 @@ class AuthenticationController {
     let adminUserToken
     try {
       adminUserToken = await oauthHelper.getUserToken(adminUserName, adminUserPassword)
-      console.log("adminUserToken", adminUserToken)
     } catch (e) {
       console.error("ERROR: Unable to fetch the user token, check your username and password in your .env", e)
       return next(e)
@@ -120,8 +118,6 @@ class AuthenticationController {
       console.error("ERROR: Unable to fetch the user from the token, check your username and password in your .env", e)
       return next(e)
     }
-
-    console.log("adminResponse: ", adminResponse)
 
     let dapp
     try {

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -1238,7 +1238,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
       await axios.post(new URL(createCustomerAddressRoute, serviceURL).href, { commonName: userCert.commonName, ...restArgs })
         .then(function (res) {
           if (res.status === 200) {
-            console.log(res.data);
+            // Success case
           } else {
             throw new rest.RestError(RestStatus.BAD_REQUEST, `Payment server call failed: ${res.statusText}`);
           }

--- a/marketplace/backend/dapp/orders/orderChain.js
+++ b/marketplace/backend/dapp/orders/orderChain.js
@@ -61,7 +61,6 @@ const getChainArgs = (getKeyResponse, deploy, myCert, args) => {
 async function createOrder(user, args, options) {
     const getKeyResponse = await rest.getKey(user, options);
     const deploy = getYamlFile(`${config.configDirPath}/${config.deployFilename}`);
-    console.log("user\n\n\n\n\n", user);
     const myCert = await certificateJs.getCertificateMe(user)
 
     const chainArgs = getChainArgs(getKeyResponse, deploy, myCert, args);

--- a/marketplace/backend/index.js
+++ b/marketplace/backend/index.js
@@ -57,12 +57,12 @@ let server
           token = jwtDecode(req.headers['x-user-access-token']);
         } catch (err) {
           token = null;
-          console.error("Failed to decode token:", err);
+          console.warn("Failed to decode token:", err);
         }
 
         return {
           userAgent: req.headers['user-agent'],
-          cf_ip: req.headers['cf-connecting-ip'] || req.headers['cf-connecting-ipv6'],
+          cfIp: req.headers['cf-connecting-ip'] || req.headers['cf-connecting-ipv6'],
           xForwardedFor: req.headers['x-forwarded-for'],
           referrer: req.headers['referer'] || req.headers['referrer'],
           user: token?.preferred_username ? token.preferred_username : (token?.email ? token.email : "")

--- a/marketplace/backend/index.js
+++ b/marketplace/backend/index.js
@@ -18,6 +18,7 @@ import websocket from "./websocket";
 import axios from "axios";
 import { cronSyncCall } from "./helpers/cronSyncCall";
 import cronFunc from "./cron";
+import jwtDecode from 'jwt-decode'
 const isLocalHost = config.serverHost === constants.localHost;
 
 let server
@@ -51,11 +52,23 @@ let server
       meta: false,
       expressFormat: true,
       dynamicMeta: (req, res) => {
+        let username;
+        if (req.headers['x-user-access-token']) {
+          const token = jwtDecode(req.headers['x-user-access-token']);
+          if (token.preferred_username) {
+            username = token.preferred_username;
+          } else if (token.email) {
+            username = email;
+          } else {
+            username = "";
+          }
+        }
         return {
           userAgent: req.headers['user-agent'],
           ip: req.headers['cf-connecting-ip'] || req.headers['cf-connecting-ipv6'],
           forwardedFor: req.headers['x-forwarded-for'],
           referrer: req.headers['referer'] || req.headers['referrer'],
+          username: username
         };
       }
     })

--- a/marketplace/backend/index.js
+++ b/marketplace/backend/index.js
@@ -42,14 +42,22 @@ let server
   app.use(helmet());
   app.use(cors());
   app.use(bodyParser.json());
-  app.use(cookieParser())
+  app.use(cookieParser());
   
   // Setup logging
   app.use(
     expressWinston.logger({
       transports: [new winston.transports.Console()],
-      meta: true,
-      expressFormat: true
+      meta: false,
+      expressFormat: true,
+      dynamicMeta: (req, res) => {
+        return {
+          userAgent: req.headers['user-agent'],
+          ip: req.headers['cf-connecting-ip'] || req.headers['cf-connecting-ipv6'],
+          forwardedFor: req.headers['x-forwarded-for'],
+          referrer: req.headers['referer'] || req.headers['referrer'],
+        };
+      }
     })
   );
   

--- a/marketplace/backend/index.js
+++ b/marketplace/backend/index.js
@@ -52,23 +52,13 @@ let server
       meta: false,
       expressFormat: true,
       dynamicMeta: (req, res) => {
-        let username;
-        if (req.headers['x-user-access-token']) {
-          const token = jwtDecode(req.headers['x-user-access-token']);
-          if (token.preferred_username) {
-            username = token.preferred_username;
-          } else if (token.email) {
-            username = email;
-          } else {
-            username = "";
-          }
-        }
+        const token = jwtDecode(req.headers['x-user-access-token']);
         return {
           userAgent: req.headers['user-agent'],
           ip: req.headers['cf-connecting-ip'] || req.headers['cf-connecting-ipv6'],
           forwardedFor: req.headers['x-forwarded-for'],
           referrer: req.headers['referer'] || req.headers['referrer'],
-          username: username
+          user: token?.preferred_username ? token.preferred_username : (token?.email ? token.email : "")
         };
       }
     })

--- a/marketplace/backend/index.js
+++ b/marketplace/backend/index.js
@@ -52,11 +52,18 @@ let server
       meta: false,
       expressFormat: true,
       dynamicMeta: (req, res) => {
-        const token = jwtDecode(req.headers['x-user-access-token']);
+        let token;
+        try {
+          token = jwtDecode(req.headers['x-user-access-token']);
+        } catch (err) {
+          token = null;
+          console.error("Failed to decode token:", err);
+        }
+
         return {
           userAgent: req.headers['user-agent'],
-          ip: req.headers['cf-connecting-ip'] || req.headers['cf-connecting-ipv6'],
-          forwardedFor: req.headers['x-forwarded-for'],
+          cf_ip: req.headers['cf-connecting-ip'] || req.headers['cf-connecting-ipv6'],
+          xForwardedFor: req.headers['x-forwarded-for'],
           referrer: req.headers['referer'] || req.headers['referrer'],
           user: token?.preferred_username ? token.preferred_username : (token?.email ? token.email : "")
         };

--- a/marketplace/ui/src/components/MarketPlace/ResponsiveAddAddress.js
+++ b/marketplace/ui/src/components/MarketPlace/ResponsiveAddAddress.js
@@ -53,7 +53,6 @@ const ResponsiveAddAddress = ({ close, redemptionService }) => {
         event: "add_shipping_address",
       },
     });
-    console.log(body, "body")
     let res = await actions.addShippingAddress(marketplaceDispatch, body);
     if (res != null) {
       await actions.fetchUserAddresses(marketplaceDispatch, redemptionService);


### PR DESCRIPTION
In the marketplace backend logs, we should not log the full `req` object because it contains the real user's access tokens. For the purposes of tracking the user actions we should log the IP address (`CF-Connecting-IP`, `CF-Connecting-IPv6`, `x-forwarded-for`, `http_referrer`) user agent name (`http_user_agent`). But not the full access token.