### PR TITLE
introduce partial support for ipv6 

### DIFF
--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -16,11 +16,12 @@ so that they could be properly moved to their respective version's subsection.
 
 ## [Unrealeased]
 ### Added
-- partial support for ipv6
+- Partial support for ipv6
 
 ### Changed
 
 ### Fixed
+- Ethereum-discovery now looks at udp_enable_time instead of enable_time for bonded/available peers 
 
 ### Removed
 

--- a/strato/CHANGELOG.md
+++ b/strato/CHANGELOG.md
@@ -14,7 +14,17 @@ BlockApps engineers - for more context, see [here](https://blockappsdev.slack.co
 All changes merged to `develop` should be documented in "Unreleased" until the version is finalized
 so that they could be properly moved to their respective version's subsection.
 
-## [Unreleased] 
+## [Unrealeased]
+### Added
+- partial support for ipv6
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [12.2] - 10/28/2024 
 ### Added
 - Added block.proposer to SolidVM
 - Reintroduced wire cache to strato-p2p to reduce redundant blockstanbul messages sent to the sequencer

--- a/strato/core/ethereum-discovery/package.yaml
+++ b/strato/core/ethereum-discovery/package.yaml
@@ -90,5 +90,6 @@ tests:
     ghc-options: -Wall -Werror -dynamic
     dependencies:
       - ethereum-discovery
+      - ethereum-rlp
       - format
       - hspec

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/ContextLite.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
@@ -35,7 +36,7 @@ import Blockchain.Strato.Discovery.UDP (processDataStream')
 import Blockchain.Strato.Model.Secp256k1
 import qualified Blockchain.Strato.RedisBlockDB as RBDB
 import Control.Concurrent (threadDelay)
-import Control.Exception
+import Control.Exception hiding (catch)
 import Control.Monad (void)
 import Control.Monad.Catch hiding (bracket)
 import qualified Control.Monad.Change.Alter as A
@@ -102,7 +103,7 @@ instance MonadUnliftIO m => A.Replaceable IPAsText PPeer (ReaderT ContextLite m)
             [ PPeerPubkey SQL.=. pPeerPubkey peer
             ]
           return (SQL.entityKey peer')
-      getPeerByIP :: HasSQLDB m => String -> m (Maybe (SQL.Entity PPeer))
+      getPeerByIP :: String -> ReaderT ContextLite m (Maybe (SQL.Entity PPeer))
       getPeerByIP ipStr = listToMaybe <$> sqlQuery actions'
         where
           actions' = SQL.selectList [PPeerIp SQL.==. T.pack ipStr] []
@@ -110,7 +111,7 @@ instance MonadUnliftIO m => A.Replaceable IPAsText PPeer (ReaderT ContextLite m)
 instance MonadUnliftIO m => A.Selectable String PPeer (ReaderT ContextLite m) where
   select _ ip = getPeerByIP ip
     where
-      getPeerByIP :: HasSQLDB m => String -> m (Maybe PPeer)
+      getPeerByIP :: String -> ReaderT ContextLite m (Maybe PPeer)
       getPeerByIP ipStr =
         sqlQuery actions >>= \case
           [] -> return Nothing
@@ -121,14 +122,21 @@ instance MonadUnliftIO m => A.Selectable String PPeer (ReaderT ContextLite m) wh
 instance MonadIO m => A.Replaceable SockAddr B.ByteString (ReaderT ContextLite m) where
   replace _ addr packet = do
     sock' <- asks sock
-    void . liftIO $ NB.sendTo sock' packet addr
+    liftIO $ catch 
+      (void $ NB.sendTo sock' packet addr) 
+      (\(err :: IOError) -> runLoggingT . $logErrorS "NB.sendTo" . T.pack $ "Could not send data to " <> show addr <> "; got error: " <> show err)
 
 instance A.Selectable (IPAsText, UDPPort, B.ByteString) Point IO where
-  select _ (IPAsText domain, UDPPort udpPortNum, theMsg) = withSocketsDo $ bracket getSocket close (talk theMsg)
+  select _ (IPAsText domain, UDPPort udpPortNum, theMsg) = catch
+    (withSocketsDo $ bracket getSocket close (talk theMsg))
+    (\(err :: IOError) -> runLoggingT ($logErrorS "withSocketsDo" . T.pack $ "Got error: " <> show err) >> return Nothing)
     where
       getSocket :: IO Socket
       getSocket = do
-        (serveraddr : _) <- getAddrInfo Nothing (Just $ T.unpack domain) (Just $ show udpPortNum)
+        (serveraddr : _) <- getAddrInfo 
+          (Just defaultHints {addrFlags = [AI_ALL]})
+          (Just $ T.unpack domain)
+          (Just $ show udpPortNum)
         s <- socket (addrFamily serveraddr) Datagram defaultProtocol
         _ <- connect s (addrAddress serveraddr)
         return s
@@ -148,11 +156,12 @@ instance MonadIO m => A.Selectable (Maybe IPAsText, UDPPort) SockAddr (ReaderT C
         Nothing
         (Just (show udpPortNum))
   select _ (Just (IPAsText ip), UDPPort udpPortNum) = do
-    fmap (fmap addrAddress . listToMaybe) . liftIO $
-      getAddrInfo
-        Nothing
+    fmap (fmap addrAddress . listToMaybe) . liftIO $ catch
+      (getAddrInfo
+        (Just defaultHints {addrFlags = [AI_ALL]})
         (Just $ T.unpack ip)
-        (Just $ show udpPortNum)
+        (Just $ show udpPortNum))
+      ((\(err :: IOError) -> runLoggingT ($logErrorS "getAddrInfo" . T.pack $ "Got error: " <> show err) >> return []))
 
 instance MonadIO m => A.Selectable (IPAsText, UDPPort, B.ByteString) Point (ReaderT ContextLite m) where
   select p = liftIO . A.select p

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/MemPeerDB.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/MemPeerDB.hs
@@ -48,7 +48,7 @@ instance HasMemPeerDB m => Mod.Accessible AvailablePeers m where
     currentTime <- liftIO getCurrentTime
     IPAsText ip <- accessEnvVar p2pMyIPAddress
     peerMap <- readIORef =<< fmap stringPPeerMap accessEnv
-    return $ AvailablePeers $ filter ((< currentTime) . pPeerEnableTime) $ filter ((/= ip) . pPeerIp) $ M.elems peerMap
+    return $ AvailablePeers $ filter ((< currentTime) . pPeerUdpEnableTime) $ filter ((/= ip) . pPeerIp) $ M.elems peerMap
 
 instance A.Replaceable (IPAsText, TCPPort) ActivityState m where
   replace = error "'A.Replaceable (IPAsText, TCPPort) ActivityState m' not implemented"
@@ -96,13 +96,13 @@ instance HasMemPeerDB m => Mod.Accessible BondedPeersForUDP m where
     peerMap <- readIORef =<< fmap stringPPeerMap accessEnv
     return $ BondedPeersForUDP $ filter f $ M.elems peerMap
 
-instance HasMemPeerDB m => Mod.Accessible UnbondedPeers m where
+instance HasMemPeerDB m => Mod.Accessible UnbondedPeersForUDP m where
   access _ = do
     currentTime <- liftIO getCurrentTime
     IPAsText ip <- accessEnvVar p2pMyIPAddress
-    let f p = pPeerBondState p == 0 && pPeerEnableTime p < currentTime && pPeerIp p /= ip
+    let f p = pPeerBondState p == 0 && pPeerUdpEnableTime p < currentTime && pPeerIp p /= ip
     peerMap <- readIORef =<< fmap stringPPeerMap accessEnv
-    return $ UnbondedPeers $ filter f $ M.elems $ peerMap
+    return $ UnbondedPeersForUDP $ filter f $ M.elems $ peerMap
 
 instance HasMemPeerDB m => A.Selectable IPAsText ClosestPeers m where
   select _ (IPAsText t) = do

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/Peer.hs
@@ -98,7 +98,7 @@ newtype BondedPeers = BondedPeers {unBondedPeers :: [PPeer]}
 
 newtype BondedPeersForUDP = BondedPeersForUDP {unBondedPeersForUDP :: [PPeer]}
 
-newtype UnbondedPeers = UnbondedPeers {unUnbondedPeers :: [PPeer]}
+newtype UnbondedPeersForUDP = UnbondedPeersForUDP {unUnbondedPeers :: [PPeer]}
 
 newtype ClosestPeers = ClosestPeers {unClosestPeers :: [PPeer]}
 
@@ -118,7 +118,7 @@ type HasPeerDB m = (
   A.Selectable (IPAsText, Point) PeerBondingState m,
   Mod.Accessible BondedPeers m,
   Mod.Accessible BondedPeersForUDP m,
-  Mod.Accessible UnbondedPeers m,
+  Mod.Accessible UnbondedPeersForUDP m,
   A.Selectable Point ClosestPeers m,
   A.Replaceable PPeer UdpEnableTime m,
   A.Replaceable PPeer TcpEnableTime m,
@@ -252,8 +252,8 @@ getBondedPeers = try $ unBondedPeers <$> Mod.access (Mod.Proxy @BondedPeers)
 getBondedPeersForUDP :: (MonadUnliftIO m, Mod.Accessible BondedPeersForUDP m) => m (Either SomeException [PPeer])
 getBondedPeersForUDP = try $ unBondedPeersForUDP <$> Mod.access (Mod.Proxy @BondedPeersForUDP)
 
-getUnbondedPeers :: (MonadUnliftIO m, Mod.Accessible UnbondedPeers m) => m [PPeer]
-getUnbondedPeers = unUnbondedPeers <$> Mod.access (Mod.Proxy @UnbondedPeers)
+getUnbondedPeers :: (MonadUnliftIO m, Mod.Accessible UnbondedPeersForUDP m) => m [PPeer]
+getUnbondedPeers = unUnbondedPeers <$> Mod.access (Mod.Proxy @UnbondedPeersForUDP)
 
 thisPeer :: PPeer -> [SQL.Filter PPeer]
 thisPeer peer = [PPeerIp SQL.==. pPeerIp peer, PPeerTcpPort SQL.==. pPeerTcpPort peer]

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/PeerIOWiring.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/Data/PeerIOWiring.hs
@@ -49,7 +49,7 @@ instance MonadIO m => Mod.Accessible AvailablePeers m where
     currentTime <- liftIO getCurrentTime
     fmap (AvailablePeers . map SQL.entityVal) $
       flip runSqlPool sqldb $
-        SQL.selectList [PPeerBondState SQL.==. 2, PPeerEnableTime SQL.<. currentTime] []
+        SQL.selectList [PPeerBondState SQL.==. 2, PPeerUdpEnableTime SQL.<. currentTime] []
 
 instance MonadIO m => A.Replaceable (IPAsText, TCPPort) ActivityState m where
   replace _ (IPAsText ip, TCPPort port) state = liftIO $ withGlobalSQLPool . runSqlPool $ do
@@ -89,12 +89,12 @@ instance MonadIO m => Mod.Accessible BondedPeersForUDP m where
       flip runSqlPool sqldb $
         SQL.selectList [PPeerBondState SQL.==. 2, PPeerUdpEnableTime SQL.<. currentTime] []
 
-instance MonadIO m => Mod.Accessible UnbondedPeers m where
+instance MonadIO m => Mod.Accessible UnbondedPeersForUDP m where
   access _ = liftIO $ withGlobalSQLPool $ \sqldb -> do
     currentTime <- getCurrentTime
-    fmap (UnbondedPeers . map SQL.entityVal) $
+    fmap (UnbondedPeersForUDP . map SQL.entityVal) $
       flip runSqlPool sqldb $
-        SQL.selectList [PPeerBondState SQL.==. 0, PPeerUdpEnableTime SQL.<. currentTime, PPeerEnableTime SQL.<. currentTime] []
+        SQL.selectList [PPeerBondState SQL.==. 0, PPeerUdpEnableTime SQL.<. currentTime] []
 
 instance MonadIO m => A.Selectable Point ClosestPeers m where
   select _ point = liftIO $ withGlobalSQLPool $ \sqldb ->

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/P2PUtil.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/P2PUtil.hs
@@ -5,8 +5,10 @@ module Blockchain.Strato.Discovery.P2PUtil
 where
 
 import Control.Exception.Base (Exception)
+import Data.List (intercalate)
 import Data.Typeable (Typeable)
 import qualified Network.Socket as S
+import Numeric (showHex)
 
 data DiscoverException
   = AffineException
@@ -20,6 +22,6 @@ data DiscoverException
 instance Exception DiscoverException
 
 sockAddrToIP :: S.SockAddr -> String
-sockAddrToIP (S.SockAddrInet6 _ _ host _) = show host
+sockAddrToIP (S.SockAddrInet6 _ _ host _) = let (a, b, c, d, e, f, g, h) = S.hostAddress6ToTuple host in intercalate ":" $ flip showHex "" <$> [a, b, c, d, e, f, g, h] -- horrible!!
 sockAddrToIP (S.SockAddrUnix str) = str
 sockAddrToIP addr' = takeWhile (/= ':') (show addr')

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDP.hs
@@ -101,14 +101,14 @@ stringToIAddr x
   | URI.isIPv4address x = case map read $ splitOn "." x of
     [a, b, c, d] -> IPV4Addr $ a + (b `shift` 8) + (c `shift` 16) + (d `shift` 24)
     _ -> error $ "Invalid IPV4: " ++ x
-  | URI.isIPv6address x = case map (read . ("0x" ++)) $ splitOn ":" x of
+  | URI.isIPv6address x = case map (read . ("0x0" ++)) $ splitOn ":" x of
     [a, b, c, d, e, f, g, h] -> IPV6Addr $ tupleToHostAddress6 (a, b, c, d, e, f, g, h)
-    _ -> error $ "Invalid IPV6: " ++ x
+    _ -> error $ "Invalid IPV6: " ++ x --Note to future dev: we don't support shortened ipv6 notation
   | otherwise = HostName x
 
 instance RLPSerializable IAddr where
   rlpEncode (IPV4Addr x) = rlpEncode $ fromBE32 x
-  rlpEncode x@(IPV6Addr _) = error $ "case not yet covered for rlpEncode for IPV6: " ++ format x
+  rlpEncode (IPV6Addr (x1, x2, x3, x4)) = rlpEncode $ B.toStrict $ encode x4 <> encode x3 <> encode x2 <> encode x1
   rlpEncode (HostName s) = rlpEncode $ (B.pack [255, 255, 255, 255] `B.append` BC.pack s)
   rlpDecode o@(RLPString s)
     | B.length s == 4 = IPV4Addr $ fromBE32 $ rlpDecode o

--- a/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
+++ b/strato/core/ethereum-discovery/src/Blockchain/Strato/Discovery/UDPServer.hs
@@ -59,7 +59,14 @@ connectMe (UDPPort port') = do
   (serveraddr : _) <-
     liftIO $
       getAddrInfo
-        (Just (defaultHints {addrFlags = [AI_PASSIVE]}))
+        (Just 
+          (defaultHints {addrFlags = [AI_PASSIVE] 
+          -- NOTE: I believe on day, we will want to use ipv6 addresses by default. Alas, today is not the day.
+          -- But I will leave this line here with this comment in the hopes that when we do decide the day has come,
+          -- all we need to do is uncomment the line below (will make platform prefer ipv6 over ipv4, so be prepared
+          -- for some confusion :D)
+          -- , addrFamily = AF_INET6  -- AF_INET6 + Datagram allows both ipv4 and ipv6 to be handled by same socket
+          }))
         Nothing
         (Just (show port'))
   sock <- liftIO $ socket (addrFamily serveraddr) Datagram defaultProtocol
@@ -95,7 +102,7 @@ attemptBond = do
     mServerAddr <- A.select (A.Proxy @SockAddr) (Nothing :: Maybe IPAsText, udpPort)
     forM_ mServerAddr \serverAddr ->
       case getHostAddress serverAddr of
-        Left err -> $logInfoS "attemptBond" $ T.pack . show $ err
+        Left err -> $logErrorS "attemptBond" $ T.pack . show $ err
         Right hostAddress -> do
           when (pPeerLastMsg p == T.pack "Ping") $ do
             -- if we've pinged before w/o a response, wait longer before next ping

--- a/strato/core/ethereum-discovery/src/Executable/EthDiscoverySetup.hs
+++ b/strato/core/ethereum-discovery/src/Executable/EthDiscoverySetup.hs
@@ -13,6 +13,7 @@ import Control.Monad
 import Control.Monad.IO.Unlift
 import qualified Data.Text as T
 import Database.Persist.Postgresql
+import Network.URI (isIPv6address)
 
 setup :: (MonadLoggerIO m, MonadUnliftIO m) => Maybe [String] -> m ()
 setup maybeStratoNodes = do
@@ -41,7 +42,7 @@ setup maybeStratoNodes = do
               Just stratoNodes -> zip (repeat "") stratoNodes
 
       forM_ nodesPubkeys $ \(pubkey, node) -> do
-        let peer = createPeer $ "enode://" ++ (if null pubkey then "" else pubkey ++ "@") ++ node ++ ":30303"
+        let peer = createPeer $ "enode://" ++ (if null pubkey then "" else pubkey ++ "@") ++ (if isIPv6address node then "[" ++ node ++ "]" else node) ++ ":30303"
         case peer of
           (Left err) -> logWarnN (T.pack err)
           (Right p) -> void $ insert p

--- a/strato/core/ethereum-discovery/test/Blockchain/Strato/Discovery/UDPSpec.hs
+++ b/strato/core/ethereum-discovery/test/Blockchain/Strato/Discovery/UDPSpec.hs
@@ -4,6 +4,7 @@
 
 module Blockchain.Strato.Discovery.UDPSpec where
 
+import Blockchain.Data.RLP
 import Blockchain.Strato.Discovery.UDP
 import Data.Bits
 import Network.Socket (tupleToHostAddress, tupleToHostAddress6)
@@ -32,3 +33,8 @@ spec = do
 
     it "converts hostnames" $ do
       stringToIAddr "hotdogs.com" `shouldBe` HostName "hotdogs.com"
+  
+  describe "IAddr RLP Serialization" $ do
+    it "parses ipv6 addresses" $ do
+      let addr = rlpDecode . rlpEncode $ stringToIAddr "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+      addr `shouldBe` (IPV6Addr (536939960, 2242052096, 35374, 57701172))

--- a/strato/core/strato-p2p/src/Blockchain/P2PUtil.hs
+++ b/strato/core/strato-p2p/src/Blockchain/P2PUtil.hs
@@ -13,15 +13,17 @@ import Control.Arrow ((>>>))
 import Control.Monad.IO.Class
 import qualified Data.ByteString.Char8 as BC
 import Data.IP (IPv4)
+import Data.List (intercalate)
 import Network.DNS.Lookup
 import Network.DNS.Resolver
 import Network.DNS.Types (DNSError)
 import Network.DNS.Utils (normalize)
 import qualified Network.Socket as S
+import Numeric (showHex)
 import qualified System.IO.Unsafe as I_AM_A_VILE_EXCUSE_FOR_A_HUMAN_BEING
 
 sockAddrToIP :: S.SockAddr -> String
-sockAddrToIP (S.SockAddrInet6 _ _ host _) = show host
+sockAddrToIP (S.SockAddrInet6 _ _ host _) = let (a, b, c, d, e, f, g, h) = S.hostAddress6ToTuple host in intercalate ":" $ flip showHex "" <$> [a, b, c, d, e, f, g, h] -- horrible!!
 sockAddrToIP s@S.SockAddrInet {} = takeWhile (/= ':') (show s)
 sockAddrToIP (S.SockAddrUnix str) = str
 


### PR DESCRIPTION
I would like to thank Maya's prod node for constantly crashing so that I could finally have opportunity to justify a long-awaited feature to the platform: support for ipv6 addresses!!

Unfortunately, this pr only introduces partial support for ipv6 (to the point where we at least don't crash from calling one). However, if I were to make ipv6 the default address family, things would work, but it would cause a lot of confusion, so I will hold off for now. 