### PR TITLE
Ory nginx single port

### DIFF
--- a/highway-nginx/openid.tpl.lua
+++ b/highway-nginx/openid.tpl.lua
@@ -42,8 +42,8 @@ local authenticate_opts = {
   token_endpoint_auth_method = "client_secret_post",
   ssl_verify = "<IS_SSL_PLACEHOLDER_YES_NO>",
   redirect_uri_scheme = "<REDIRECT_URI_SCHEME_PLACEHOLDER_HTTP_HTTPS>",
-  -- 'id_token' to get user data; 'access_token' for access and refresh tokens; 'user' to get additional user data (some providers include 'email' in user object instead of id_token)
-  session_contents = {access_token=true}, -- comment out to keep everything; other options: user=true, id_token=true, enc_id_token=true
+  -- 'id_token' to get user data; 'access_token' for access and refresh tokens; 'user' to get additional user data (some providers include 'email' in user object instead of id_token), enc_id_token - required for ory logout (id_token_hint)
+  session_contents = {access_token=true, enc_id_token=true},
   renew_access_token_on_expiry = true,
   access_token_expires_in = 300,
   logout_path = "/auth/logout",

--- a/nginx-packager/openid.tpl.lua
+++ b/nginx-packager/openid.tpl.lua
@@ -21,8 +21,8 @@ local authenticate_opts = {
   token_endpoint_auth_method = "client_secret_basic",
   ssl_verify = "<IS_SSL_PLACEHOLDER_YES_NO>",
   redirect_uri_scheme = "<REDIRECT_URI_SCHEME_PLACEHOLDER_HTTP_HTTPS>",
-  -- 'id_token' to get user data; 'access_token' for access and refresh tokens; 'user' to get additional user data (some providers include 'email' in user object instead of id_token)
-  session_contents = {access_token=true}, -- comment out to keep everything; other options: user=true, id_token=true, enc_id_token=true
+  -- 'id_token' to get user data; 'access_token' for access and refresh tokens; 'user' to get additional user data (some providers include 'email' in user object instead of id_token), enc_id_token - required for ory logout (id_token_hint)
+  session_contents = {access_token=true, enc_id_token=true},
   renew_access_token_on_expiry = true,
   access_token_expires_in = 300,
   access_token_expires_leeway = 3,

--- a/ory/ory-init/resources/docker-compose.tmp.yml
+++ b/ory/ory-init/resources/docker-compose.tmp.yml
@@ -41,7 +41,7 @@ services:
     environment:
     - ssl=true
     - sslCertFileType=${sslCertFileType}
-    image: nginx
+    image: nginx:1.27-alpine
     ports:
     - "443:443"
     volumes:

--- a/ory/ory-init/resources/docker-compose.tmp.yml
+++ b/ory/ory-init/resources/docker-compose.tmp.yml
@@ -8,8 +8,7 @@ services:
     image: oryd/hydra:v2.2.0
     command: serve -c /etc/config/hydra/hydra.yml all --dev
     volumes:
-      # TODO: limit what files are mapped in every service
-      - ./:/etc/config/hydra
+      - ./hydra.yml:/etc/config/hydra/hydra.yml
     environment:
       - DSN=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
       - STRATEGIES_ACCESS_TOKEN=jwt
@@ -23,8 +22,7 @@ services:
       - DSN=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4  # TODO: replace at boot time
     command: migrate -c /etc/config/hydra/hydra.yml sql -e --yes
     volumes:
-      # TODO: limit what files are mapped in every service
-      - ./:/etc/config/hydra
+      - ./hydra.yml:/etc/config/hydra/hydra.yml
     restart: on-failure
 
   postgresd:
@@ -71,7 +69,6 @@ services:
       - COOKIE_SECRET=changeme  # TODO: replace at boot time
       - CSRF_COOKIE_NAME=__host-${domainName}-x-csrf-token
       - CSRF_COOKIE_SECRET=changemetoo  # TODO: replace at boot time
-      - DANGEROUSLY_DISABLE_SECURE_CSRF_COOKIES=true # TODO: remove??
     restart: unless-stopped
 
   kratos-migrate:
@@ -81,8 +78,8 @@ services:
     environment:
       - DSN=postgres://kratos:secret@kpostgresd:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4  # TODO: replace at boot time
     volumes:
-      # TODO: limit what files are mapped in every service
-      - ./:/etc/config/kratos
+      - ./kratos.yml:/etc/config/kratos/kratos.yml
+      - ./default.schema.json:/etc/config/kratos/default.schema.json
     command:
       -c /etc/config/kratos/kratos.yml migrate sql -e --yes
     restart: on-failure

--- a/ory/ory-init/resources/docker-compose.tmp.yml
+++ b/ory/ory-init/resources/docker-compose.tmp.yml
@@ -1,82 +1,88 @@
 version: "3.9"
 services:
+  
   hydra:
+    depends_on:
+      - postgresd
+      - hydra-migrate
     image: oryd/hydra:v2.2.0
     command: serve -c /etc/config/hydra/hydra.yml all --dev
     volumes:
       # TODO: limit what files are mapped in every service
-      - type: bind
-        source: .
-        target: /etc/config/hydra
+      - ./:/etc/config/hydra
     environment:
       - DSN=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
       - STRATEGIES_ACCESS_TOKEN=jwt
     restart: unless-stopped
-    depends_on:
-      - hydra-migrate
+
   hydra-migrate:
+    depends_on:
+      - postgresd
     image: oryd/hydra:v2.2.0
     environment:
-      - DSN=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
+      - DSN=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4  # TODO: replace at boot time
     command: migrate -c /etc/config/hydra/hydra.yml sql -e --yes
     volumes:
       # TODO: limit what files are mapped in every service
-      - type: bind
-        source: .
-        target: /etc/config/hydra
+      - ./:/etc/config/hydra
     restart: on-failure
+
   postgresd:
     image: postgres:11.8
-    ports:
-      - "5432:5432" # TODO: REMOVE!
     environment:
       - POSTGRES_USER=hydra
-      - POSTGRES_PASSWORD=secret
+      - POSTGRES_PASSWORD=secret  # TODO: replace at boot time
       - POSTGRES_DB=hydra
+
   nginx:
     depends_on:
       - hydra
       - kratos
       - kratos-selfservice-ui-node
     environment:
-    - ssl=true
-    - sslCertFileType=${sslCertFileType}
+      - ssl=true
+      - sslCertFileType=${sslCertFileType}
     image: nginx:1.27-alpine
     command: ["nginx", "-g", "daemon off;"]
     ports:
-    - "8443:8443"
+      - "8443:8443"
     volumes:
-    - ${sslDir}:/etc/ssl:ro
-    - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ${sslDir}:/etc/ssl:ro
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
     restart: unless-stopped
     logging:
       driver: "json-file"
       options:
         max-size: "100m"
         max-file: "3"
+
   kratos-selfservice-ui-node:
-    image: oryd/kratos-selfservice-ui-node:v1.1.0
+    depends_on:
+      - kratos
+      - hydra
+    image: oryd/kratos-selfservice-ui-node:v1.3.1
     environment:
       - BASE_PATH=/ui
       - PORT=4455
       - HYDRA_ADMIN_URL=http://hydra:4445
+      - KRATOS_ADMIN_URL=http://kratos:4434
       - KRATOS_PUBLIC_URL=http://kratos:4433
       - KRATOS_BROWSER_URL=https://${domainName}:8443
-      - COOKIE_SECRET=changeme
-      - CSRF_COOKIE_NAME=cookie_name
-      - CSRF_COOKIE_SECRET=changeme
-      - DANGEROUSLY_DISABLE_SECURE_CSRF_COOKIES=true
-    restart: on-failure
+      - COOKIE_SECRET=changeme  # TODO: replace at boot time
+      - CSRF_COOKIE_NAME=__host-${domainName}-x-csrf-token
+      - CSRF_COOKIE_SECRET=changemetoo  # TODO: replace at boot time
+      - DANGEROUSLY_DISABLE_SECURE_CSRF_COOKIES=true # TODO: remove??
+    restart: unless-stopped
+
   kratos-migrate:
-    image: oryd/kratos:v1.1.0
+    depends_on:
+      - kpostgresd
+    image: oryd/kratos:v1.3.1
     environment:
-      - DSN=postgres://kratos:secret@kpostgresd:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
+      - DSN=postgres://kratos:secret@kpostgresd:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4  # TODO: replace at boot time
     volumes:
       # TODO: limit what files are mapped in every service
-      -
-        type: bind
-        source: .
-        target: /etc/config/kratos
+      - ./:/etc/config/kratos
     command:
       -c /etc/config/kratos/kratos.yml migrate sql -e --yes
     restart: on-failure
@@ -84,24 +90,22 @@ services:
   kratos:
     depends_on:
       - kratos-migrate
-    image: oryd/kratos:v1.1.0
+      - kpostgresd
+    image: oryd/kratos:v1.3.1
     restart: unless-stopped
     environment:
-      - DSN=postgres://kratos:secret@kpostgresd:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
+      - DSN=postgres://kratos:secret@kpostgresd:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4  # TODO: replace at boot time
       - OAUTH2_PROVIDER_URL=http://hydra:4445/
     command:
       serve -c /etc/config/kratos/kratos.yml --dev
     volumes:
-      -
-        type: bind
-        source: .
-        target: /etc/config/kratos
+      - ./:/etc/config/kratos
 
   kpostgresd:
     image: postgres:11.8
     environment:
       - POSTGRES_USER=kratos
-      - POSTGRES_PASSWORD=secret
+      - POSTGRES_PASSWORD=secret  # TODO: replace at boot time
       - POSTGRES_DB=kratos
 
 

--- a/ory/ory-init/resources/docker-compose.tmp.yml
+++ b/ory/ory-init/resources/docker-compose.tmp.yml
@@ -1,9 +1,10 @@
-
+version: "3.9"
 services:
   hydra:
     image: oryd/hydra:v2.2.0
     command: serve -c /etc/config/hydra/hydra.yml all --dev
     volumes:
+      # TODO: limit what files are mapped in every service
       - type: bind
         source: .
         target: /etc/config/hydra
@@ -19,6 +20,7 @@ services:
       - DSN=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
     command: migrate -c /etc/config/hydra/hydra.yml sql -e --yes
     volumes:
+      # TODO: limit what files are mapped in every service
       - type: bind
         source: .
         target: /etc/config/hydra
@@ -26,7 +28,7 @@ services:
   postgresd:
     image: postgres:11.8
     ports:
-      - "5432:5432"
+      - "5432:5432" # TODO: REMOVE!
     environment:
       - POSTGRES_USER=hydra
       - POSTGRES_PASSWORD=secret
@@ -41,9 +43,7 @@ services:
     - sslCertFileType=${sslCertFileType}
     image: nginx
     ports:
-    - "4444:4444"
-    - "4433:4433"
-    - "4455:4455"
+    - "443:443"
     volumes:
     - ${sslDir}:/etc/ssl:ro
     - ./nginx.conf:/etc/nginx/nginx.conf:ro
@@ -56,6 +56,7 @@ services:
   kratos-selfservice-ui-node:
     image: oryd/kratos-selfservice-ui-node:v1.1.0
     environment:
+      - BASE_PATH=/ui
       - PORT=4455
       - HYDRA_ADMIN_URL=http://hydra:4445
       - KRATOS_PUBLIC_URL=http://kratos:4433
@@ -70,6 +71,7 @@ services:
     environment:
       - DSN=postgres://kratos:secret@kpostgresd:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
     volumes:
+      # TODO: limit what files are mapped in every service
       -
         type: bind
         source: .

--- a/ory/ory-init/resources/docker-compose.tmp.yml
+++ b/ory/ory-init/resources/docker-compose.tmp.yml
@@ -60,7 +60,7 @@ services:
       - PORT=4455
       - HYDRA_ADMIN_URL=http://hydra:4445
       - KRATOS_PUBLIC_URL=http://kratos:4433
-      - KRATOS_BROWSER_URL=https://${domainName}:8443/
+      - KRATOS_BROWSER_URL=https://${domainName}:8443
       - COOKIE_SECRET=changeme
       - CSRF_COOKIE_NAME=cookie_name
       - CSRF_COOKIE_SECRET=changeme

--- a/ory/ory-init/resources/docker-compose.tmp.yml
+++ b/ory/ory-init/resources/docker-compose.tmp.yml
@@ -43,7 +43,7 @@ services:
     - sslCertFileType=${sslCertFileType}
     image: nginx:1.27-alpine
     ports:
-    - "443:443"
+    - "8443:8443"
     volumes:
     - ${sslDir}:/etc/ssl:ro
     - ./nginx.conf:/etc/nginx/nginx.conf:ro
@@ -60,7 +60,7 @@ services:
       - PORT=4455
       - HYDRA_ADMIN_URL=http://hydra:4445
       - KRATOS_PUBLIC_URL=http://kratos:4433
-      - KRATOS_BROWSER_URL=https://${domainName}/
+      - KRATOS_BROWSER_URL=https://${domainName}:8443/
       - COOKIE_SECRET=changeme
       - CSRF_COOKIE_NAME=cookie_name
       - CSRF_COOKIE_SECRET=changeme

--- a/ory/ory-init/resources/docker-compose.tmp.yml
+++ b/ory/ory-init/resources/docker-compose.tmp.yml
@@ -1,6 +1,12 @@
 version: "3.9"
+
+volumes:
+  hydra_pgdata:
+    driver: local
+  kratos_pgdata:
+    driver: local
+
 services:
-  
   hydra:
     depends_on:
       - postgresd
@@ -10,7 +16,7 @@ services:
     volumes:
       - ./hydra.yml:/etc/config/hydra/hydra.yml
     environment:
-      - DSN=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
+      - DSN=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4  # TODO: replace at boot time
       - STRATEGIES_ACCESS_TOKEN=jwt
     restart: unless-stopped
 
@@ -31,6 +37,8 @@ services:
       - POSTGRES_USER=hydra
       - POSTGRES_PASSWORD=secret  # TODO: replace at boot time
       - POSTGRES_DB=hydra
+    volumes:
+      - hydra_pgdata:/var/lib/postgresql/data
 
   nginx:
     depends_on:
@@ -104,5 +112,7 @@ services:
       - POSTGRES_USER=kratos
       - POSTGRES_PASSWORD=secret  # TODO: replace at boot time
       - POSTGRES_DB=kratos
+    volumes:
+      - kratos_pgdata:/var/lib/postgresql/data
 
 

--- a/ory/ory-init/resources/docker-compose.tmp.yml
+++ b/ory/ory-init/resources/docker-compose.tmp.yml
@@ -60,7 +60,7 @@ services:
       - PORT=4455
       - HYDRA_ADMIN_URL=http://hydra:4445
       - KRATOS_PUBLIC_URL=http://kratos:4433
-      - KRATOS_BROWSER_URL=https://${domainName}:4433
+      - KRATOS_BROWSER_URL=https://${domainName}/
       - COOKIE_SECRET=changeme
       - CSRF_COOKIE_NAME=cookie_name
       - CSRF_COOKIE_SECRET=changeme

--- a/ory/ory-init/resources/docker-compose.tmp.yml
+++ b/ory/ory-init/resources/docker-compose.tmp.yml
@@ -42,6 +42,7 @@ services:
     - ssl=true
     - sslCertFileType=${sslCertFileType}
     image: nginx:1.27-alpine
+    command: ["nginx", "-g", "daemon off;"]
     ports:
     - "8443:8443"
     volumes:

--- a/ory/ory-init/resources/hydra.yml
+++ b/ory/ory-init/resources/hydra.yml
@@ -4,10 +4,10 @@ serve:
 
 urls:
   self:
-    issuer: https://${domainName}:4444
-  consent: https://${domainName}:4455/consent
-  login: https://${domainName}:4455/login
-  logout: https://${domainName}:4444/logout
+    issuer: https://${domainName}
+  consent: https://${domainName}/ui/consent
+  login: https://${domainName}/ui/login
+  logout: https://${domainName}/ui/logout
 
 secrets:
   system:

--- a/ory/ory-init/resources/hydra.yml
+++ b/ory/ory-init/resources/hydra.yml
@@ -1,6 +1,7 @@
 serve:
   cookies:
     same_site_mode: Lax
+    domain: ${domainName}
 
 urls:
   self:
@@ -11,7 +12,7 @@ urls:
 
 secrets:
   system:
-    - youReallyNeedToChangeThis
+    - youReallyNeedToChangeThis  # TODO: replace at boot time
 
 oidc:
   subject_identifiers:
@@ -19,4 +20,11 @@ oidc:
       - pairwise
       - public
     pairwise:
-      salt: youReallyNeedToChangeThis
+      salt: youReallyNeedToChangeThis  # TODO: replace at boot time
+
+log:
+  level: info
+  # TODO: Cleanup
+  #level: debug
+  #leak_sensitive_values: true
+  format: json

--- a/ory/ory-init/resources/hydra.yml
+++ b/ory/ory-init/resources/hydra.yml
@@ -4,10 +4,10 @@ serve:
 
 urls:
   self:
-    issuer: https://${domainName}
-  consent: https://${domainName}/ui/consent
-  login: https://${domainName}/ui/login
-  logout: https://${domainName}/ui/logout
+    issuer: https://${domainName}:8443
+  consent: https://${domainName}:8443/ui/consent
+  login: https://${domainName}:8443/ui/login
+  logout: https://${domainName}:8443/ui/logout
 
 secrets:
   system:

--- a/ory/ory-init/resources/kratos.yml
+++ b/ory/ory-init/resources/kratos.yml
@@ -5,16 +5,16 @@ dsn: memory
 
 serve:
   public:
-    base_url: https://${domainName}:4433
+    base_url: https://${domainName}
     cors:
       enabled: true
   admin:
     base_url: http://kratos:4434
 
 selfservice:
-  default_browser_return_url: https://${domainName}:4455/
+  default_browser_return_url: https://${domainName}/ui/
   allowed_return_urls:
-    - https://${domainName}:4455
+    - https://${domainName}/ui/
 
   methods:
     password:
@@ -26,18 +26,18 @@ selfservice:
 
   flows:
     error:
-      ui_url: https://${domainName}:4455/error
+      ui_url: https://${domainName}/ui/error
 
     settings:
-      ui_url: https://${domainName}:4455/settings
+      ui_url: https://${domainName}/ui/settings
       privileged_session_max_age: 15m
       required_aal: highest_available
 
     login:
-      ui_url: https://${domainName}:4455/login
+      ui_url: https://${domainName}/ui/login
 
     registration:
-      ui_url: https://${domainName}:4455/registration
+      ui_url: https://${domainName}/ui/registration
 
 identity:
   schemas:

--- a/ory/ory-init/resources/kratos.yml
+++ b/ory/ory-init/resources/kratos.yml
@@ -5,14 +5,14 @@ dsn: memory
 
 serve:
   public:
-    base_url: https://${domainName}
+    base_url: https://${domainName}:8443
     cors:
       enabled: true
   admin:
     base_url: http://kratos:4434
 
 selfservice:
-  default_browser_return_url: https://${domainName}/ui/
+  default_browser_return_url: https://${domainName}:8443/ui/
   allowed_return_urls:
     - https://${domainName}/ui/
 
@@ -26,18 +26,18 @@ selfservice:
 
   flows:
     error:
-      ui_url: https://${domainName}/ui/error
+      ui_url: https://${domainName}:8443/ui/error
 
     settings:
-      ui_url: https://${domainName}/ui/settings
+      ui_url: https://${domainName}:8443/ui/settings
       privileged_session_max_age: 15m
       required_aal: highest_available
 
     login:
-      ui_url: https://${domainName}/ui/login
+      ui_url: https://${domainName}:8443/ui/login
 
     registration:
-      ui_url: https://${domainName}/ui/registration
+      ui_url: https://${domainName}:8443/ui/registration
 
 identity:
   schemas:

--- a/ory/ory-init/resources/kratos.yml
+++ b/ory/ory-init/resources/kratos.yml
@@ -1,4 +1,3 @@
-
 version: v1.1.0
 
 dsn: memory
@@ -12,9 +11,9 @@ serve:
     base_url: http://kratos:4434
 
 selfservice:
-  default_browser_return_url: https://${domainName}:8443/ui/
+  default_browser_return_url: https://${domainName}/
   allowed_return_urls:
-    - https://${domainName}:8443/ui/
+    - https://${domainName}/
 
   methods:
     password:
@@ -46,7 +45,11 @@ identity:
 
 courier:
   smtp:
-    connection_uri: "smtp://abcd"
+    connection_uri: "smtp://abcd"  # TODO: replace at boot time ("smtp://username:password@smtp.example.com:587")
 
 log:
-  level: debug
+  level: info
+  # TODO: Cleanup
+  #level: debug
+  #leak_sensitive_values: true
+  format: json

--- a/ory/ory-init/resources/kratos.yml
+++ b/ory/ory-init/resources/kratos.yml
@@ -14,7 +14,7 @@ serve:
 selfservice:
   default_browser_return_url: https://${domainName}:8443/ui/
   allowed_return_urls:
-    - https://${domainName}/ui/
+    - https://${domainName}:8443/ui/
 
   methods:
     password:

--- a/ory/ory-init/resources/nginx.tpl.conf
+++ b/ory/ory-init/resources/nginx.tpl.conf
@@ -1,7 +1,7 @@
 user root;
 worker_processes  1;
 
-error_log  /tmp/error.log warn;
+error_log  /dev/stderr warn;
 pid        /var/run/nginx.pid;
 
 events {
@@ -40,7 +40,7 @@ http {
         /_ping    0;
     }
 
-    access_log  /tmp/access.log  json_combined if=$loggable;
+    access_log  /dev/stdout  json_combined if=$loggable;
 
     sendfile        on;
 

--- a/ory/ory-init/resources/nginx.tpl.conf
+++ b/ory/ory-init/resources/nginx.tpl.conf
@@ -56,7 +56,7 @@ http {
 
 
     upstream kratos_public {
-        server kratos:4433:;  # Kratos service
+        server kratos:4433;  # Kratos service
     }
 
     upstream hydra_public {

--- a/ory/ory-init/resources/nginx.tpl.conf
+++ b/ory/ory-init/resources/nginx.tpl.conf
@@ -108,7 +108,7 @@ http {
       # Kratos Self-Service UI (see BASE_PATH in docker-compose.yml for path prefix)
       location /ui {
         proxy_read_timeout 30s;
-        proxy_pass http://kratos_selfservice_ui:4455/ui/;
+        proxy_pass http://kratos_selfservice_ui/ui/;
       }
 
     }

--- a/ory/ory-init/resources/nginx.tpl.conf
+++ b/ory/ory-init/resources/nginx.tpl.conf
@@ -54,8 +54,22 @@ http {
 
     limit_req_zone $binary_remote_addr zone=healthcheck:1m rate=3r/s;
 
+
+    upstream kratos_public {
+        server kratos:4433:;  # Kratos service
+    }
+
+    upstream hydra_public {
+        server hydra:4444;  # Hydra Public API (for OAuth2, OpenID Connect)
+    }
+
+    upstream kratos_selfservice_ui {
+      server kratos-selfservice-ui-node:4455;  # Kratos Self-Service UI Node
+    }
+
+
     server {
-      listen 4444 ssl;
+      listen 443 ssl;
 
       ssl_certificate    /etc/ssl/certs/server.pem;
       ssl_certificate_key  /etc/ssl/private/server.key;
@@ -71,61 +85,28 @@ http {
         return 200 'pong';
       }
 
-      location / {
-        proxy_read_timeout 30s;
-        proxy_pass http://hydra:4444/;
-      }
-
-    }
-
-    server {
-      listen 4433 ssl;
-
-      ssl_certificate    /etc/ssl/certs/server.pem;
-      ssl_certificate_key  /etc/ssl/private/server.key;
-
-      # Restrict older SSL and TLS versions for better security
-      ssl_protocols TLSv1.2 TLSv1.3;
-
-      resolver 127.0.0.11 8.8.8.8 ipv6=off;
-
-      large_client_header_buffers 4 32k;
-
-      location /_ping {
-        return 200 'pong';
+      location ~ ^/(.well-known|oauth2/auth|oauth2/token|oauth2/sessions|oauth2/revoke|oauth2/fallbacks/consent|oauth2/fallbacks/error|userinfo)/? {
+        proxy_pass http://hydra_public;
+        proxy_redirect    off;
+        proxy_set_header  Host              $host;
+        proxy_set_header  X-Real-IP         $remote_addr;
+        proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Proto $http_x_forwarded_proto;
       }
 
       location / {
+        proxy_pass http://public_api;
+        proxy_redirect    off;
+        proxy_set_header  Host            $host;
+        proxy_set_header  X-Real-IP       $remote_addr;
+        proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+      }
+
+      location /ui {
         proxy_read_timeout 30s;
-        proxy_pass http://kratos:4433/;
+        proxy_pass http://kratos_selfservice_ui:4455/ui/;
       }
 
     }
-
-    server {
-      listen 4455 ssl;
-
-      ssl_certificate    /etc/ssl/certs/server.pem;
-      ssl_certificate_key  /etc/ssl/private/server.key;
-
-      # Restrict older SSL and TLS versions for better security
-      ssl_protocols TLSv1.2 TLSv1.3;
-
-      resolver 127.0.0.11 8.8.8.8 ipv6=off;
-
-      large_client_header_buffers 4 32k;
-
-      location /_ping {
-        return 200 'pong';
-      }
-
-      location / {
-        proxy_read_timeout 30s;
-        proxy_pass http://kratos-selfservice-ui-node:4455/;
-      }
-
-    }
-
-
 
 }

--- a/ory/ory-init/resources/nginx.tpl.conf
+++ b/ory/ory-init/resources/nginx.tpl.conf
@@ -69,7 +69,7 @@ http {
 
 
     server {
-      listen 443 ssl;
+      listen 8443 ssl;
 
       ssl_certificate    /etc/ssl/certs/server.pem;
       ssl_certificate_key  /etc/ssl/private/server.key;

--- a/ory/ory-init/resources/nginx.tpl.conf
+++ b/ory/ory-init/resources/nginx.tpl.conf
@@ -108,9 +108,8 @@ http {
       # Kratos Self-Service UI (see BASE_PATH in docker-compose.yml for path prefix)
       location /ui {
         proxy_read_timeout 30s;
-        proxy_pass http://kratos_selfservice_ui/ui/;
+        proxy_pass http://kratos_selfservice_ui/ui;
       }
 
     }
-
 }

--- a/ory/ory-init/resources/nginx.tpl.conf
+++ b/ory/ory-init/resources/nginx.tpl.conf
@@ -85,6 +85,17 @@ http {
         return 200 'pong';
       }
 
+      # Kratos Public API
+      location / {
+        proxy_pass http://kratos_public;
+        proxy_redirect    off;
+        proxy_set_header  Host            $host;
+        proxy_set_header  X-Real-IP       $remote_addr;
+        proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+      }
+
+      # Hydra Public API
+      # The paths are taken from official docs here: https://www.ory.sh/docs/hydra/self-hosted/deploy-hydra-example#install-and-configure-nginx
       location ~ ^/(.well-known|oauth2/auth|oauth2/token|oauth2/sessions|oauth2/revoke|oauth2/fallbacks/consent|oauth2/fallbacks/error|userinfo)/? {
         proxy_pass http://hydra_public;
         proxy_redirect    off;
@@ -94,14 +105,7 @@ http {
         proxy_set_header  X-Forwarded-Proto $http_x_forwarded_proto;
       }
 
-      location / {
-        proxy_pass http://public_api;
-        proxy_redirect    off;
-        proxy_set_header  Host            $host;
-        proxy_set_header  X-Real-IP       $remote_addr;
-        proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-      }
-
+      # Kratos Self-Service UI (see BASE_PATH in docker-compose.yml for path prefix)
       location /ui {
         proxy_read_timeout 30s;
         proxy_pass http://kratos_selfservice_ui:4455/ui/;

--- a/payment-server-nginx/openid.tpl.lua
+++ b/payment-server-nginx/openid.tpl.lua
@@ -42,8 +42,8 @@ local authenticate_opts = {
   token_endpoint_auth_method = "client_secret_post",
   ssl_verify = "<IS_SSL_PLACEHOLDER_YES_NO>",
   redirect_uri_scheme = "<REDIRECT_URI_SCHEME_PLACEHOLDER_HTTP_HTTPS>",
-  -- 'id_token' to get user data; 'access_token' for access and refresh tokens; 'user' to get additional user data (some providers include 'email' in user object instead of id_token)
-  session_contents = {access_token=true}, -- comment out to keep everything; other options: user=true, id_token=true, enc_id_token=true
+  -- 'id_token' to get user data; 'access_token' for access and refresh tokens; 'user' to get additional user data (some providers include 'email' in user object instead of id_token), enc_id_token - required for ory logout (id_token_hint)
+  session_contents = {access_token=true, enc_id_token=true},
   renew_access_token_on_expiry = true,
   access_token_expires_in = 300,
   logout_path = "/auth/logout",


### PR DESCRIPTION
- Ory services are all served under a single port 8443 with nginx
- Nginx logging is fixed
- Logout is fixed
- Kratos and Kratos-selfervice-ui are updated to latest versions
- Critical security fixes
- Postgres data is stored in docker volumes now
- Other cleanup

The version is running on https://multinode304.ci.blockapps.net

To run this version, strato-getting-started from branch `ory-single-port` should be used (contains some startValidator and stopValidator script fixes/changes)


**PR can be squashed when merging.**