### PR TITLE
fix the jenkins pipeline to update the aux servers on testnet nightly

### DIFF
--- a/pipelines/Jenkinsfile.nightlyUpdate
+++ b/pipelines/Jenkinsfile.nightlyUpdate
@@ -65,18 +65,18 @@ pipeline {
       agent { label "mercata-testnet2-rewards" }
       steps {
         withCredentials([usernamePassword(credentialsId: 'blockapps-cd-github', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')]) {
-            dir ('/home/ec2-user/strato-platform/rewards-server') {
-                sh """
-                set -xe
-                git checkout develop
-                git pull https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-platform.git
-                sudo docker compose up --build -d
-              """
-              }
-            }
+          dir ('/home/ec2-user/strato-platform/rewards-server') {
+            sh """
+            set -xe
+            git checkout develop
+            git pull https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/blockapps/strato-platform.git
+            sudo docker compose up --build -d
+          """
           }
+        }
         sh 'sudo docker image prune'
       }
+    }
 
       stage('Update Testnet2 Notification Server') {
       agent { label "mercata-testnet2-notification" }


### PR DESCRIPTION
This PR is to fix the error in the nightly update job in Jenkins with one `sh` command being outside of the steps{} block. There was a bit of a mess with indents, hence the confusion