### PR TITLE
Fix global transactions filtering

### DIFF
--- a/marketplace/ui/src/components/Feed/GlobalTransaction.js
+++ b/marketplace/ui/src/components/Feed/GlobalTransaction.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Button,
   Row,
@@ -68,7 +68,6 @@ const GlobalTransaction = ({ user }) => {
   const [isFilterActive, setIsFilterActive] = useState(false);
   const formatter = new Intl.NumberFormat('en-US');
   const formattedNum = (num) => formatter.format(num);
-  const isInitialRender = useRef(true);
 
   const getWeekRange = (offset) => {
     const now = dayjs();
@@ -95,11 +94,6 @@ const GlobalTransaction = ({ user }) => {
   }, [marketplaceDispatch]);
 
   useEffect(() => {
-    if (isInitialRender.current) {
-      isInitialRender.current = false;
-      return;
-    }
-
     transactionAction.fetchGlobalTransaction(
       transactionDispatch,
       limit,

--- a/marketplace/ui/src/components/Feed/GlobalTransaction.js
+++ b/marketplace/ui/src/components/Feed/GlobalTransaction.js
@@ -1,31 +1,22 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import {
   Button,
-  Dropdown,
-  Space,
-  Input,
   Row,
   Col,
   Popover,
   Card,
   Tooltip,
-  Select,
-  DatePicker,
   Spin,
   Typography,
 } from 'antd';
-import {
-  CloseOutlined,
-  DownloadOutlined,
-  FilterOutlined,
-  SearchOutlined,
-} from '@ant-design/icons';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { CloseOutlined, FilterOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
 // Components
 import DataTableComponent from '../DataTableComponent';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import './../Order/ordersTable.css';
 import routes from '../../helpers/routes';
+import dayjs from 'dayjs';
 import { Images } from '../../images';
 // Actions
 import { actions as transactionAction } from '../../contexts/transaction/actions';
@@ -39,17 +30,11 @@ import { useMarketplaceDispatch } from '../../contexts/marketplace';
 // Utils & Constants
 import {
   STRATS_CONVERSION,
-  TRANSACTION_STATUS,
-  TRANSACTION_STATUS_CLASSES,
   TRANSACTION_STATUS_COLOR,
-  DOWNLOAD_OPTIONS,
-  REDEMPTION_STATUS,
-  REDEMPTION_STATUS_CLASSES,
-  US_DATE_FORMAT,
   DATE_TIME_FORMAT,
 } from '../../helpers/constants';
 import { SEO } from '../../helpers/seoConstant';
-import { getAgoTime, getStringDate } from '../../helpers/utils';
+import { getStringDate } from '../../helpers/utils';
 import { TRANSACTION_FILTER } from '../Order/constant';
 import { useCategoryState } from '../../contexts/category';
 import GlobalTransactionResponsive from './GlobalTransactionResponsive';
@@ -69,14 +54,10 @@ const GlobalTransaction = ({ user }) => {
   const { categorys } = useCategoryState();
 
   const navigate = useNavigate();
-  // const location = useLocation();
 
-  // const currentMonth = dayjs().startOf('month').unix();
-  const [limit, setLimit] = useState(15);
+  const [limit, setLimit] = useState(200);
   const [offset, setOffset] = useState(0);
-  const [type, setType] = useState('');
   const [list, setList] = useState([]);
-  const [dateQuery, setDateQuery] = useState('');
   const [transactions, setTransactions] = useState(globalTransactions);
   const [originAddress, setOriginAddress] = useState('');
   const [selectedFilters, setSelectedFilters] = useState([
@@ -87,11 +68,26 @@ const GlobalTransaction = ({ user }) => {
   const [isFilterActive, setIsFilterActive] = useState(false);
   const formatter = new Intl.NumberFormat('en-US');
   const formattedNum = (num) => formatter.format(num);
+  const isInitialRender = useRef(true);
+
+  const getWeekRange = (offset) => {
+    const now = dayjs();
+    const startDate = now
+      .subtract((offset + 1) * 7, 'day')
+      .startOf('day')
+      .unix();
+    const endDate = now
+      .subtract(offset * 7, 'day')
+      .endOf('day')
+      .unix();
+    return [startDate, endDate];
+  };
 
   useEffect(() => {
     async function fetchStratsAddress() {
-      const stratsAddress =
-        await marketplaceActions.fetchStratsAddress(marketplaceDispatch);
+      const stratsAddress = await marketplaceActions.fetchStratsAddress(
+        marketplaceDispatch
+      );
       await marketplaceActions.fetchStratsBalance(marketplaceDispatch);
       setOriginAddress(stratsAddress);
     }
@@ -99,13 +95,19 @@ const GlobalTransaction = ({ user }) => {
   }, [marketplaceDispatch]);
 
   useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
+    }
+
     transactionAction.fetchGlobalTransaction(
       transactionDispatch,
       limit,
       offset,
-      selectedFilters
+      selectedFilters,
+      getWeekRange(offset)
     );
-  }, [dateQuery, limit, offset, selectedFilters]);
+  }, [offset, selectedFilters]);
 
   useEffect(() => {
     let filteredData = globalTransactions;
@@ -233,7 +235,15 @@ const GlobalTransaction = ({ user }) => {
       align: 'right',
       width: '100px',
       render: (data, { quantity, quantityIsDecimal }) => (
-        <span>{quantity ? parseInt(quantity) : '--'}</span>
+        <span>
+          {quantity
+            ? formattedNum(
+                quantityIsDecimal && quantityIsDecimal === 'True'
+                  ? quantity / 100
+                  : quantity
+              )
+            : '--'}
+        </span>
       ),
     },
     {
@@ -258,7 +268,11 @@ const GlobalTransaction = ({ user }) => {
           </p>
           <p className="text-xs">
             {price
-              ? `${formattedNum(quantityIsDecimal && quantityIsDecimal === 'True' ? price * 100 : price)} $`
+              ? `${formattedNum(
+                  quantityIsDecimal && quantityIsDecimal === 'True'
+                    ? price * 100
+                    : price
+                )} $`
               : '--'}
           </p>
         </>
@@ -330,7 +344,9 @@ const GlobalTransaction = ({ user }) => {
                 onClick={() => {
                   handleFilter(label);
                 }}
-                className={`border-lg p-2 m-2 rounded-lg ${bgColor(label)} cursor-pointer`}
+                className={`border-lg p-2 m-2 rounded-lg ${bgColor(
+                  label
+                )} cursor-pointer`}
                 key={label}
               >
                 {' '}
@@ -382,7 +398,7 @@ const GlobalTransaction = ({ user }) => {
   };
 
   const fetchData = () => {
-    setOffset((prev) => prev + 15);
+    setOffset(offset + 1);
   };
 
   return (

--- a/marketplace/ui/src/components/Feed/GlobalTransactionResponsive.js
+++ b/marketplace/ui/src/components/Feed/GlobalTransactionResponsive.js
@@ -87,6 +87,7 @@ const GlobalTransactionResponsive = ({
                 to,
                 status,
                 transaction_hash,
+                quantityIsDecimal,
                 type,
                 price,
                 redemptionService,
@@ -212,14 +213,33 @@ const GlobalTransactionResponsive = ({
                     </Button>
                     {price ? (
                       <p className={`text-right flex justify-end items-center`}>
-                        $ {price} ({formattedNum(price * 100)} {StratsIcon})
+                        ${' '}
+                        {formattedNum(
+                          quantityIsDecimal && quantityIsDecimal === 'True'
+                            ? price * 100
+                            : price
+                        )}{' '}
+                        (
+                        {formattedNum(
+                          quantityIsDecimal && quantityIsDecimal === 'True'
+                            ? price * 10000
+                            : price
+                        )}{' '}
+                        {StratsIcon})
                       </p>
                     ) : (
                       <p className="text-right text-[#13188A] font-bold text-sm">
                         No Price Available
                       </p>
                     )}
-                    <p className="text-right">Qty: {formattedNum(quantity)}</p>
+                    <p className="text-right">
+                      Qty:{' '}
+                      {formattedNum(
+                        quantityIsDecimal && quantityIsDecimal === 'True'
+                          ? quantity / 100
+                          : quantity
+                      )}
+                    </p>
                     <p className="text-right">
                       {moment(block_timestamp.replace(/-/g, '/')).format('lll')}
                     </p>

--- a/marketplace/ui/src/components/Header/Header.js
+++ b/marketplace/ui/src/components/Header/Header.js
@@ -1,11 +1,10 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Layout,
   Input,
   Menu,
   Space,
   Badge,
-  Avatar,
   Dropdown,
   Button,
   Typography,
@@ -34,8 +33,6 @@ import { useCategoryDispatch, useCategoryState } from '../../contexts/category';
 import { SEO } from '../../helpers/seoConstant';
 import LoginModal from '../MarketPlace/LoginModal';
 import { setCookie } from '../../helpers/cookie';
-import TransferStratsModal from '../MarketPlace/TransferStratsModal';
-import StratsTransactionHistoryModal from '../MarketPlace/StratsTransactionHistoryModal';
 
 import { navItems } from '../../helpers/constants';
 import routes from '../../helpers/routes';
@@ -86,8 +83,9 @@ const HeaderComponent = ({
 
   useEffect(() => {
     async function fetchStratsAddress() {
-      const stratsAddress =
-        await marketplaceActions.fetchStratsAddress(marketplaceDispatch);
+      const stratsAddress = await marketplaceActions.fetchStratsAddress(
+        marketplaceDispatch
+      );
       setOriginAddress(stratsAddress);
     }
     fetchStratsAddress();
@@ -111,7 +109,7 @@ const HeaderComponent = ({
     routes.Marketplace.url,
     routes.Transactions.url,
     routes.MyWallet.url,
-    routes.Products.url,
+    routes.GlobalTransactions.url,
   ];
 
   const logout = () => {
@@ -138,7 +136,7 @@ const HeaderComponent = ({
       setSelectedTab('1');
     } else if (pathName.includes('/mywallet')) {
       setSelectedTab('2');
-    } else if (pathName.includes('/products')) {
+    } else if (pathName.includes('/globalTransactions')) {
       setSelectedTab('3');
     } else {
       setSelectedTab('0');
@@ -171,17 +169,11 @@ const HeaderComponent = ({
           ),
           onClick: () =>
             navigate(
-              `${routes.MarketplaceUserProfile.url.replace(':commonName', user.commonName)}`
+              `${routes.MarketplaceUserProfile.url.replace(
+                ':commonName',
+                user.commonName
+              )}`
             ),
-        },
-        {
-          key: '3',
-          label: (
-            <div>
-              <p>Global Transactions</p>
-            </div>
-          ),
-          onClick: () => navigate(routes.GlobalTransactions.url),
         },
         {
           key: '2',
@@ -230,7 +222,9 @@ const HeaderComponent = ({
           key: '2',
           onClick: async () => {
             navigate(
-              `${routes.MarketplaceProductDetail.url.replace(':address', originAddress).replace(':name', 'STRATS')}`
+              `${routes.MarketplaceProductDetail.url
+                .replace(':address', originAddress)
+                .replace(':name', 'STRATS')}`
             );
           },
           label: (
@@ -284,8 +278,8 @@ const HeaderComponent = ({
         }
       : null,
     {
-      value: 'GlobalTransactions',
-      path: '/globalTransactions',
+      value: 'globalTransactions',
+      path: routes.GlobalTransactions.url,
       label: 'Global Transactions',
     },
     user
@@ -312,10 +306,10 @@ const HeaderComponent = ({
       data.value === 'logout'
         ? logout()
         : data.value === 'orders'
-          ? navigate(routes.Orders.url.replace(':type', 'sold'), {
-              state: { defaultKey: 'Sold' },
-            })
-          : navigate(data.path);
+        ? navigate(routes.Orders.url.replace(':type', 'sold'), {
+            state: { defaultKey: 'Sold' },
+          })
+        : navigate(data.path);
       handleMenuTab(data);
     }
   };
@@ -385,7 +379,9 @@ const HeaderComponent = ({
   return (
     <>
       <Header
-        className={`fixed z-[100] !bg-[#ffffff] !pl-2 w-full !pr-4 md:px-12 flex md:!mb-10 ${showMenu ? '' : 'shadow-header'} items-center justify-between md:justify-start`}
+        className={`fixed z-[100] !bg-[#ffffff] !pl-2 w-full !pr-4 md:px-12 flex md:!mb-10 ${
+          showMenu ? '' : 'shadow-header'
+        } items-center justify-between md:justify-start`}
       >
         <Row className="relative flex-grow-0 md:flex-1 ml-2 md:ml-5">
           <Col
@@ -410,7 +406,11 @@ const HeaderComponent = ({
             xs={showSearch ? 24 : 4}
             md={12}
             lg={18}
-            className={`lg:ml-4 mf:ml-20 md:ml-1 bg-[#F6F6F6] shadow-md flex-1 header-search ${showSearch ? ' fixed top-[13px] left-0 flex w-[100vw] z-50 mb-2' : 'hidden md:flex '}`}
+            className={`lg:ml-4 mf:ml-20 md:ml-1 bg-[#F6F6F6] shadow-md flex-1 header-search ${
+              showSearch
+                ? ' fixed top-[13px] left-0 flex w-[100vw] z-50 mb-2'
+                : 'hidden md:flex '
+            }`}
           >
             <Select
               defaultValue="All"
@@ -479,10 +479,11 @@ const HeaderComponent = ({
               if (item.key === '3') {
                 TagManager.dataLayer({
                   dataLayer: {
-                    event: 'view_products_page',
+                    event: 'view_global_transactions_page',
                   },
                 });
-              } else navigate(navUrls[item.key]);
+              }  
+              navigate(navUrls[item.key]);
             }
           }}
           items={navItems}
@@ -602,7 +603,9 @@ const HeaderComponent = ({
             {subMenuItems.map((item) => (
               <Typography
                 onClick={() => handleIntMenuTab(item)}
-                className={`text-base py-3 px-4 cursor-pointer ${item ? '' : 'hidden'}`}
+                className={`text-base py-3 px-4 cursor-pointer ${
+                  item ? '' : 'hidden'
+                }`}
               >
                 {item?.label}
               </Typography>

--- a/marketplace/ui/src/contexts/transaction/actions.js
+++ b/marketplace/ui/src/contexts/transaction/actions.js
@@ -81,7 +81,7 @@ const actions = {
     }
   },
 
-  fetchGlobalTransaction: async (dispatch, limit, offset, type) => {
+  fetchGlobalTransaction: async (dispatch, limit, offset, type, dateRange) => {
     dispatch({ type: actionDescriptors.fetchGlobalTransaction });
 
     let query = '';
@@ -93,6 +93,9 @@ const actions = {
     }
     if (type?.length) {
       query += `&type=${type}`;
+    }
+    if (dateRange) {
+      query += `&startDate=${dateRange[0]}&endDate=${dateRange[1]}`;
     }
 
     try {

--- a/marketplace/ui/src/helpers/constants.js
+++ b/marketplace/ui/src/helpers/constants.js
@@ -309,6 +309,7 @@ export const STRATS_CONVERSION = 100;
 export const navItems = [
   { label: <div id="Transactions">My Transactions</div>, key: '1' },
   { label: <div id="Inventory">My Wallet</div>, key: '2' },
+  { label: <div id="Global Transactions">Global Transactions</div>, key: '3' },
 ];
 
 const metaImg = SEO.IMAGE_META;
@@ -490,7 +491,9 @@ export const BANNER = [
                     />
                     <p className="banner-step">Step {index + 1}</p>
                     <p
-                      className={`banner-step-description ${index === 2 && `rwa-class`}`}
+                      className={`banner-step-description ${
+                        index === 2 && `rwa-class`
+                      }`}
                     >
                       {item.description}
                     </p>

--- a/payment-server/StripeService/stripeService.controller.js
+++ b/payment-server/StripeService/stripeService.controller.js
@@ -328,10 +328,20 @@ class StripeServiceController {
               createdDate: Math.floor(Date.now() / 1000),
               comments: PAYMENT_RECEIVED_MESSAGE,
             } 
-            const returnStatus = await completeOrder(STRIPE_CONTRACT_ADDRESS, callArgs);
+            try {
+              const returnStatus = await completeOrder(STRIPE_CONTRACT_ADDRESS, callArgs);
+            } catch (err) {
+              // this is left empty without any logging because it will flood the payment server with useless
+              // error logs
+            }
 
             // Update payment status in DB
-            const updateResult = await updateStripePayment(p.orderhash, 'PAID');
+            try {
+              const updateResult = await updateStripePayment(p.orderhash, 'PAID');
+            } catch (err) {
+              // this is left empty without any logging because it will flood the payment server with useless
+              // error logs
+            }
             statuses[p.orderhash] = PAYMENT_STATUS['PAID'];
           }
           else{


### PR DESCRIPTION
- Fixed the global transactions so it will now render the transactions in chronological order. In order to do this, the initial render fetches all of the transactions of the past week. As you scroll down to the next render, it will fetch the previous week's transactions and so on.
- Moved `Global Transactions` tab to the main header

Demo:


https://github.com/user-attachments/assets/293a9bb7-5711-4ae8-81dc-44dd4bb0ec31

