### PR TITLE
Reverting notification server temp fix

### DIFF
--- a/notification-server/src/routes/notifyRoutes.js
+++ b/notification-server/src/routes/notifyRoutes.js
@@ -22,24 +22,8 @@ router.post("/notify", async (req, res) => {
       return res.status(400).send("Bad Request: Missing usernames or message");
     }
 
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    let emails = [];
-
-    // Iterate over each username
-    for (const username of usernames) {
-      if (emailRegex.test(username)) {
-        // If the username is a valid email, add it directly to the emails array
-        emails.push(username);
-      } else {
-        // If the username is not a valid email, fetch the corresponding email using getEmailsByUsernames
-        const fetchedEmails = await getEmailsByUsernames([username]);
-        emails = emails.concat(fetchedEmails);
-      }
-    }
-
-    // GO BACK TO THIS METHOD
-    // Get emails from db using usernames 
-    // const emails = await getEmailsByUsernames(usernames);
+    // Get emails from db using usernames
+    const emails = await getEmailsByUsernames(usernames);
     // const numbers = await getNumbersByUsernames(usernames);
 
     if (!emails.length) {


### PR DESCRIPTION
Reverting "allow raw email to be passed in as username (TEMP FIX)" because it was only meant as a temporary fix. This will require updates to the payment server for emails to work properly again

This reverts commit 7572ad6847014f878b1921d279a8d0cea03c15f9.