### PR TITLE
cfginit as part of the platform build

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,5 +1,6 @@
-FROM ubuntu:22.04 as base
+FROM ubuntu:22.04 AS os
 
+FROM os AS base
 RUN apt-get -y update && apt-get install -y \
       autoconf \
       curl \
@@ -36,7 +37,7 @@ ENV LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
     LC_ALL="en_US.UTF-8"
 
-FROM base as strato
+FROM base AS strato
 COPY \
   ./usr/local/bin/blockapps-pem-vault-wrapper-server \
   ./usr/local/bin/blockapps-vault-proxy-server \
@@ -67,7 +68,7 @@ HEALTHCHECK --interval=5s --timeout=1s --start-period=20s \
 WORKDIR /var/lib/strato
 ENTRYPOINT ["/strato/doit.sh"]
 
-FROM base as highway
+FROM base AS highway
 COPY usr/local/bin/blockapps-highway-server /usr/local/bin/
 COPY ./highway /highway
 EXPOSE 8080
@@ -76,7 +77,7 @@ HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
 ENTRYPOINT ["/highway/doit.sh"]
 
 
-FROM base as vault-wrapper
+FROM base AS vault-wrapper
 COPY usr/local/bin/blockapps-vault-wrapper-server /usr/local/bin/
 COPY ./vault-wrapper /vault-wrapper
 EXPOSE 8000
@@ -84,7 +85,7 @@ HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
   CMD curl --silent --output /dev/null --fail localhost:8000/strato/v2.3/_ping || exit 1
 ENTRYPOINT ["/vault-wrapper/doit.sh"]
 
-FROM base as identity-provider
+FROM base AS identity-provider
 COPY \
   usr/local/bin/identity-provider-server \
   usr/local/bin/blockapps-vault-proxy-server \
@@ -100,7 +101,7 @@ HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
 WORKDIR /var/lib/identity
 ENTRYPOINT ["/identity-provider/doit.sh"]
 
-FROM base as identity-service
+FROM base AS identity-service
 COPY \
   usr/local/bin/identity-service-server \
     /usr/local/bin/
@@ -115,10 +116,16 @@ HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
 WORKDIR /var/lib/identity
 ENTRYPOINT ["/identity-service/doit.sh"]
 
-FROM base as subject-signing-tool
+FROM base AS subject-signing-tool
 COPY \
   ./usr/local/bin/x509-sign-subject \
     /usr/local/bin/
 COPY ./strato /
 WORKDIR /
 ENTRYPOINT ["/strato/subject-signing-tool.sh"]
+
+FROM os AS cfginit
+RUN mkdir /cfg
+WORKDIR /cfg
+COPY usr/local/bin/ory-init /usr/local/bin/
+

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ all: build_all docker-compose eks
 
 all_develop: build_develop docker-compose eks
 
-build_all: strato apex highway highway-nginx nginx postgrest prometheus smd marketplace-backend marketplace-ui vault-wrapper vault-nginx identity-provider identity-service identity-nginx payment-server payment-server-nginx subject-signing-tool notification-server notification-server-nginx
+build_all: strato apex highway highway-nginx nginx postgrest prometheus smd marketplace-backend marketplace-ui vault-wrapper vault-nginx identity-provider identity-service identity-nginx payment-server payment-server-nginx subject-signing-tool notification-server notification-server-nginx cfginit
 
-build_develop: develop apex highway highway-nginx nginx postgrest prometheus smd marketplace-backend marketplace-ui vault-wrapper vault-nginx identity-provider identity-service identity-nginx payment-server payment-server-nginx subject-signing-tool notification-server notification-server-nginx
+build_develop: develop apex highway highway-nginx nginx postgrest prometheus smd marketplace-backend marketplace-ui vault-wrapper vault-nginx identity-provider identity-service identity-nginx payment-server payment-server-nginx subject-signing-tool notification-server notification-server-nginx cfginit
 
-.PHONY: strato apex highway highway-nginx ory nginx postgrest prometheus smd marketplace-backend marketplace-ui vault-wrapper vault-nginx identity-provider identity-service identity-nginx payment-server payment-server-nginx subject-signing-tool notification-server notification-server-nginx build_buildbase build_common build_common_profiled eks
+.PHONY: strato apex highway highway-nginx ory nginx postgrest prometheus smd marketplace-backend marketplace-ui vault-wrapper vault-nginx identity-provider identity-service identity-nginx payment-server payment-server-nginx subject-signing-tool notification-server notification-server-nginx build_buildbase build_common build_common_profiled eks ory-init cfginit
 
 apex:
 	@echo Now building apex...
@@ -199,8 +199,17 @@ vault-nginx:
 	@echo Now building vault-nginx...
 	BASIL_DOCKER_TAG=${REPO_URL}vault-nginx:${VERSION} ECR_DOCKER_TAG=${REPO_AWS_ECR_URL}vault-nginx:${VERSION} make --directory=vault-nginx/
 
+# ory-init build and install locally (for development)
 ory:
 	cd ory && stack install
+
+ory-init:
+	cd ory && \
+	  stack build --copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin
+
+cfginit: ory-init
+	docker build --target cfginit --tag ${REPO_URL}cfginit:${VERSION} --file Dockerfile.multi ${FAKEROOT}
+	docker tag ${REPO_URL}cfginit:${VERSION} ${REPO_AWS_ECR_URL}cfginit:${VERSION}
 
 identity-provider: build_common
 	@echo Now building Identity Server...
@@ -241,6 +250,8 @@ docker-compose:
 	sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.payment.tpl.yml > docker-compose.payment.push.ecr.yml
 	sed -e 's|<REPO_URL>|'"${REPO_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.notification.tpl.yml > docker-compose.notification.push.yml
 	sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.notification.tpl.yml > docker-compose.notification.push.ecr.yml
+  sed -e 's|<REPO_URL>|'"${REPO_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.cfginit.tpl.yml > docker-compose.cfginit.push.yml
+  sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.cfginit.tpl.yml > docker-compose.cfginit.push.ecr.yml
 
 	@echo Creating the final docker-compose.yml...
 	awk '/build: ./{getline} 1' docker-compose.push.yml > docker-compose.yml
@@ -263,6 +274,8 @@ docker-compose:
 	awk '/build: ./{getline} 1' docker-compose.payment.push.ecr.yml > docker-compose.payment.ecr.yml
 	awk '/build: ./{getline} 1' docker-compose.notification.push.yml > docker-compose.notification.yml
 	awk '/build: ./{getline} 1' docker-compose.notification.push.ecr.yml > docker-compose.notification.ecr.yml
+  awk '/build: ./{getline} 1' docker-compose.cfginit.push.yml > docker-compose.cfginit.yml
+  awk '/build: ./{getline} 1' docker-compose.cfginit.push.ecr.yml > docker-compose.cfginit.ecr.yml
 
 docker-build:
 	cp -fr strato/extraFiles/* ${STRATODIR}

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ ory:
 
 ory-init:
 	cd ory && \
-	  stack build --copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin
+		stack build --copy-bins --local-bin-path=${FAKEROOT}/usr/local/bin
 
 cfginit: ory-init
 	docker build --target cfginit --tag ${REPO_URL}cfginit:${VERSION} --file Dockerfile.multi ${FAKEROOT}
@@ -250,8 +250,8 @@ docker-compose:
 	sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.payment.tpl.yml > docker-compose.payment.push.ecr.yml
 	sed -e 's|<REPO_URL>|'"${REPO_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.notification.tpl.yml > docker-compose.notification.push.yml
 	sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.notification.tpl.yml > docker-compose.notification.push.ecr.yml
-  sed -e 's|<REPO_URL>|'"${REPO_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.cfginit.tpl.yml > docker-compose.cfginit.push.yml
-  sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.cfginit.tpl.yml > docker-compose.cfginit.push.ecr.yml
+	sed -e 's|<REPO_URL>|'"${REPO_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.cfginit.tpl.yml > docker-compose.cfginit.push.yml
+	sed -e 's|<REPO_URL>|'"${REPO_AWS_ECR_URL}"'|g' -e 's|<VERSION>|'"${VERSION}"'|g' docker-compose.cfginit.tpl.yml > docker-compose.cfginit.push.ecr.yml
 
 	@echo Creating the final docker-compose.yml...
 	awk '/build: ./{getline} 1' docker-compose.push.yml > docker-compose.yml
@@ -274,8 +274,8 @@ docker-compose:
 	awk '/build: ./{getline} 1' docker-compose.payment.push.ecr.yml > docker-compose.payment.ecr.yml
 	awk '/build: ./{getline} 1' docker-compose.notification.push.yml > docker-compose.notification.yml
 	awk '/build: ./{getline} 1' docker-compose.notification.push.ecr.yml > docker-compose.notification.ecr.yml
-  awk '/build: ./{getline} 1' docker-compose.cfginit.push.yml > docker-compose.cfginit.yml
-  awk '/build: ./{getline} 1' docker-compose.cfginit.push.ecr.yml > docker-compose.cfginit.ecr.yml
+	awk '/build: ./{getline} 1' docker-compose.cfginit.push.yml > docker-compose.cfginit.yml
+	awk '/build: ./{getline} 1' docker-compose.cfginit.push.ecr.yml > docker-compose.cfginit.ecr.yml
 
 docker-build:
 	cp -fr strato/extraFiles/* ${STRATODIR}

--- a/docker-compose.cfginit.tpl.yml
+++ b/docker-compose.cfginit.tpl.yml
@@ -1,0 +1,8 @@
+#strato-version:<VERSION>
+#strato-getting-started-min-version:5.0.0
+version: "3"
+services:
+  cfginit:
+    build: .
+    image: ${CFGINIT_IMAGE:-<REPO_URL>cfginit:<VERSION>}
+    restart: "no"

--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -246,22 +246,26 @@ pipeline {
                     docker compose -f docker-compose.highway.push.yml push 2>&1
                     docker compose -f docker-compose.payment.push.yml push 2>&1
                     docker compose -f docker-compose.notification.push.yml push 2>&1
+                    docker compose -f docker-compose.cfginit.push.yml push 2>&1
                     AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} AWS_DEFAULT_REGION="us-east-1" aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 406773134706.dkr.ecr.us-east-1.amazonaws.com
                     docker compose -f docker-compose.push.ecr.yml push 2>&1
                     docker compose -f docker-compose.server.push.ecr.yml push 2>&1
                     docker compose -f docker-compose.client.push.ecr.yml push 2>&1
                     docker compose -f docker-compose.vault.push.ecr.yml push 2>&1
                     docker compose -f docker-compose.identity.push.ecr.yml push 2>&1
+                    docker compose -f docker-compose.identity-service.push.ecr.yml push 2>&1
+                    docker compose -f docker-compose.subject-signing-tool.push.ecr.yml push 2>&1
                     docker compose -f docker-compose.highway.push.ecr.yml push 2>&1
                     docker compose -f docker-compose.payment.push.ecr.yml push 2>&1
                     docker compose -f docker-compose.notification.push.ecr.yml push 2>&1
+                    docker compose -f docker-compose.cfginit.push.ecr.yml push 2>&1
                   '''
                   stash includes: 'strato-getting-started/**', name: 'stratoGettingStarted'
                   stash includes: 'strato/indexer/slipstream/integrity_tests/**', name: 'slipstream_integrity_tests'
                 }
                 
                 // Push docker-compose files to Jenkins artifacts and AWS S3
-                archiveArtifacts artifacts: "docker-compose.yml, docker-compose.server.yml, docker-compose.client.yml, docker-compose.vault.yml, docker-compose.identity.yml, docker-compose.identity-service.yml, docker-compose.subject-signing-tool.yml, docker-compose.highway.yml, docker-compose.payment.yml, docker-compose.notification.yml, docker-compose.ecr.yml, docker-compose.server.ecr.yml, docker-compose.client.ecr.yml, docker-compose.vault.ecr.yml, docker-compose.identity.ecr.yml, docker-compose.highway.ecr.yml, docker-compose.payment.ecr.yml, docker-compose.notification.ecr.yml, devops/**"
+                archiveArtifacts artifacts: "docker-compose.yml, docker-compose.server.yml, docker-compose.client.yml, docker-compose.vault.yml, docker-compose.identity.yml, docker-compose.identity-service.yml, docker-compose.subject-signing-tool.yml, docker-compose.highway.yml, docker-compose.payment.yml, docker-compose.notification.yml, docker-compose.cfginit.yml, docker-compose.ecr.yml, docker-compose.server.ecr.yml, docker-compose.client.ecr.yml, docker-compose.vault.ecr.yml, docker-compose.identity.ecr.yml, docker-compose.identity-service.ecr.yml, docker-compose.subject-signing-tool.ecr.yml, docker-compose.highway.ecr.yml, docker-compose.payment.ecr.yml, docker-compose.notification.ecr.yml, docker-compose.cfginit.ecr.yml, devops/**"
                 withCredentials([
                     usernamePassword(credentialsId: 'block-apps-jenkins-s3',  passwordVariable: 'AWS_SECRET_ACCESS_KEY', usernameVariable: 'AWS_ACCESS_KEY_ID'),
                 ]) {
@@ -279,13 +283,17 @@ pipeline {
                     aws s3 cp docker-compose.highway.yml s3://blockapps-build-artifacts/${version}/
                     aws s3 cp docker-compose.payment.yml s3://blockapps-build-artifacts/${version}/
                     aws s3 cp docker-compose.notification.yml s3://blockapps-build-artifacts/${version}/
+                    aws s3 cp docker-compose.cfginit.yml s3://blockapps-build-artifacts/${version}/
                     aws s3 cp docker-compose.ecr.yml s3://blockapps-build-artifacts/${version}/
                     aws s3 cp docker-compose.server.ecr.yml s3://blockapps-build-artifacts/${version}/
                     aws s3 cp docker-compose.client.ecr.yml s3://blockapps-build-artifacts/${version}/
                     aws s3 cp docker-compose.vault.ecr.yml s3://blockapps-build-artifacts/${version}/
                     aws s3 cp docker-compose.identity.ecr.yml s3://blockapps-build-artifacts/${version}/
+                    aws s3 cp docker-compose.identity-service.ecr.yml s3://blockapps-build-artifacts/${version}/
+                    aws s3 cp docker-compose.subject-signing-tool.ecr.yml s3://blockapps-build-artifacts/${version}/
                     aws s3 cp docker-compose.payment.ecr.yml s3://blockapps-build-artifacts/${version}/
                     aws s3 cp docker-compose.notification.ecr.yml s3://blockapps-build-artifacts/${version}/
+                    aws s3 cp docker-compose.cfginit.ecr.yml s3://blockapps-build-artifacts/${version}/
                   '''
                 }
               }
@@ -474,6 +482,16 @@ pipeline {
             }
           }
         }
+        
+//        stage('Ory init') {
+//          steps{
+//            script{
+//              dir("strato-getting-started") {
+//                // TODO: use strato-getting-started v5.0+ to fetch ory-init from cfginit image and test a simple command
+//              }
+//            }
+//          }
+//        }
       }
     }
   }

--- a/pipelines/Jenkinsfile.nightly
+++ b/pipelines/Jenkinsfile.nightly
@@ -226,15 +226,19 @@ pipeline {
                       docker compose -f docker-compose.highway.push.yml push 2>&1
                       docker compose -f docker-compose.payment.push.yml push 2>&1
                       docker compose -f docker-compose.notification.push.yml push 2>&1
+                      docker compose -f docker-compose.cfginit.push.yml push 2>&1
                       AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} AWS_DEFAULT_REGION="us-east-1" aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 406773134706.dkr.ecr.us-east-1.amazonaws.com
                       docker compose -f docker-compose.push.ecr.yml push 2>&1
                       docker compose -f docker-compose.server.push.ecr.yml push 2>&1
                       docker compose -f docker-compose.client.push.ecr.yml push 2>&1
                       docker compose -f docker-compose.vault.push.ecr.yml push 2>&1
                       docker compose -f docker-compose.identity.push.ecr.yml push 2>&1
+                      docker compose -f docker-compose.identity-service.push.ecr.yml push 2>&1
+                      docker compose -f docker-compose.subject-signing-tool.push.ecr.yml push 2>&1
                       docker compose -f docker-compose.highway.push.ecr.yml push 2>&1
                       docker compose -f docker-compose.payment.push.ecr.yml push 2>&1
                       docker compose -f docker-compose.notification.push.ecr.yml push 2>&1
+                      docker compose -f docker-compose.cfginit.push.ecr.yml push 2>&1
                     '''
                   }
                   stash includes: 'strato-getting-started/**', name: 'stratoGettingStarted'
@@ -242,7 +246,7 @@ pipeline {
                 
                 // Push docker-compose files to Jenkins artifacts and AWS S3
                 dir ('strato-worktree') {
-                  archiveArtifacts artifacts: "docker-compose.yml, docker-compose.server.yml, docker-compose.client.yml, docker-compose.vault.yml, docker-compose.identity.yml, docker-compose.identity-service.yml, docker-compose.highway.yml, docker-compose.payment.yml, docker-compose.notification.yml, docker-compose.ecr.yml, docker-compose.server.ecr.yml, docker-compose.client.ecr.yml, docker-compose.vault.ecr.yml, docker-compose.identity.ecr.yml, docker-compose.highway.ecr.yml, docker-compose.payment.ecr.yml, docker-compose.notification.ecr.yml, devops/**"
+                  archiveArtifacts artifacts: "docker-compose.yml, docker-compose.server.yml, docker-compose.client.yml, docker-compose.vault.yml, docker-compose.identity.yml, docker-compose.identity-service.yml, docker-compose.subject-signing-tool.yml, docker-compose.highway.yml, docker-compose.payment.yml, docker-compose.notification.yml, docker-compose.cfginit.yml, docker-compose.ecr.yml, docker-compose.server.ecr.yml, docker-compose.client.ecr.yml, docker-compose.vault.ecr.yml, docker-compose.identity.ecr.yml, docker-compose.identity-service.ecr.yml, docker-compose.subject-signing-tool.ecr.yml, docker-compose.highway.ecr.yml, docker-compose.payment.ecr.yml, docker-compose.notification.ecr.yml, docker-compose.cfginit.ecr.yml, devops/**"
                   withCredentials([
                       usernamePassword(credentialsId: 'block-apps-jenkins-s3',  passwordVariable: 'AWS_SECRET_ACCESS_KEY', usernameVariable: 'AWS_ACCESS_KEY_ID'),
                   ]) {
@@ -260,19 +264,21 @@ pipeline {
                       aws s3 cp docker-compose.highway.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.payment.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.notification.yml s3://blockapps-build-artifacts/${version}/
+                      aws s3 cp docker-compose.cfginit.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.ecr.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.server.ecr.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.client.ecr.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.vault.ecr.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.identity.ecr.yml s3://blockapps-build-artifacts/${version}/
+                      aws s3 cp docker-compose.identity-service.ecr.yml s3://blockapps-build-artifacts/${version}/
+                      aws s3 cp docker-compose.subject-signing-tool.ecr.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.highway.ecr.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.payment.ecr.yml s3://blockapps-build-artifacts/${version}/
                       aws s3 cp docker-compose.notification.ecr.yml s3://blockapps-build-artifacts/${version}/
-
+                      aws s3 cp docker-compose.cfginit.ecr.yml s3://blockapps-build-artifacts/${version}/
                     '''
                   }
                 }
-
               }
             }
             
@@ -442,6 +448,16 @@ pipeline {
             }
           }
         }
+        
+//        stage('Ory init') {
+//          steps{
+//            script{
+//              dir("strato-getting-started") {
+//                // TODO: use strato-getting-started v5.0+ to fetch ory-init from cfginit image and test a simple command
+//              }
+//            }
+//          }
+//        }
       }
     }
 /*

--- a/pipelines/Jenkinsfile.release
+++ b/pipelines/Jenkinsfile.release
@@ -225,18 +225,28 @@ pipeline {
               set -x
               docker login -u $DOCKER_USER -p $DOCKER_PASSWD registry-aws.blockapps.net:5000
               docker compose -f docker-compose.push.yml push 2>&1
+              docker compose -f docker-compose.server.push.yml push 2>&1
+              docker compose -f docker-compose.client.push.yml push 2>&1
               docker compose -f docker-compose.vault.push.yml push 2>&1
               docker compose -f docker-compose.identity.push.yml push 2>&1
+              docker compose -f docker-compose.identity-service.push.yml push 2>&1
+              docker compose -f docker-compose.subject-signing-tool.push.yml push 2>&1
               docker compose -f docker-compose.highway.push.yml push 2>&1
               docker compose -f docker-compose.payment.push.yml push 2>&1
               docker compose -f docker-compose.notification.push.yml push 2>&1
+              docker compose -f docker-compose.cfginit.push.yml push 2>&1
               AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} AWS_DEFAULT_REGION="us-east-1" aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 406773134706.dkr.ecr.us-east-1.amazonaws.com
               docker compose -f docker-compose.push.ecr.yml push 2>&1
+              docker compose -f docker-compose.server.push.ecr.yml push 2>&1
+              docker compose -f docker-compose.client.push.ecr.yml push 2>&1
               docker compose -f docker-compose.vault.push.ecr.yml push 2>&1
               docker compose -f docker-compose.identity.push.ecr.yml push 2>&1
+              docker compose -f docker-compose.identity-service.push.ecr.yml push 2>&1
+              docker compose -f docker-compose.subject-signing-tool.push.ecr.yml push 2>&1
               docker compose -f docker-compose.highway.push.ecr.yml push 2>&1
               docker compose -f docker-compose.payment.push.ecr.yml push 2>&1
               docker compose -f docker-compose.notification.push.ecr.yml push 2>&1
+              docker compose -f docker-compose.cfginit.push.ecr.yml push 2>&1
             '''
 
             // Release to blockapps/strato-getting-started
@@ -252,17 +262,27 @@ pipeline {
               github-release release $STRATOGS_RELEASE_DETAILS_STABLE --name "${RELEASE_VERSION}${RELEASE_SUFFIX}"
               sleep 5
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.yml" --file ./docker-compose.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.server.yml" --file ./docker-compose.server.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.client.yml" --file ./docker-compose.client.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.vault.yml" --file ./docker-compose.vault.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.identity.yml" --file ./docker-compose.identity.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.identity-service.yml" --file ./docker-compose.identity-service.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.subject-signing-tool.yml" --file ./docker-compose.subject-signing-tool.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.highway.yml" --file ./docker-compose.highway.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.payment.yml" --file ./docker-compose.payment.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.notification.yml" --file ./docker-compose.notification.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.cfginit.yml" --file ./docker-compose.cfginit.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.ecr.yml" --file ./docker-compose.ecr.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.server.ecr.yml" --file ./docker-compose.server.ecr.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.client.ecr.yml" --file ./docker-compose.client.ecr.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.vault.ecr.yml" --file ./docker-compose.vault.ecr.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.identity.ecr.yml" --file ./docker-compose.identity.ecr.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.identity-service.ecr.yml" --file ./docker-compose.identity-service.ecr.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.subject-signing-tool.ecr.yml" --file ./docker-compose.subject-signing-tool.ecr.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.highway.ecr.yml" --file ./docker-compose.highway.ecr.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.payment.ecr.yml" --file ./docker-compose.payment.ecr.yml
               github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.notification.ecr.yml" --file ./docker-compose.notification.ecr.yml
+              github-release upload $STRATOGS_RELEASE_DETAILS_STABLE --name "docker-compose.cfginit.ecr.yml" --file ./docker-compose.cfginit.ecr.yml
             '''
 
             // Merge release code to ${env.RELEASE_TYPE}


### PR DESCRIPTION
This PR adds the build of ory-init with each strato build (`make` command). 
It also adds the ory-init into a docker image called `cfginit` and tags it with the same version as the other platform containers.

This will help with ory-init versioning. Another PR in strato-gs will automate the pull of the ory-init executable of a  version corresponding to the same strato version.

The cfginit name of the image is used assuming that the future strato-init executable will be added into it as well.

It is also possible to execute the initial files within the docker container environment in future, to make it cross-platform. But that's not a high priority atm.