### PR TITLE
payment server use user's common name instead of email

### DIFF
--- a/marketplace/backend/api/v1/Order/order.controller.js
+++ b/marketplace/backend/api/v1/Order/order.controller.js
@@ -73,7 +73,7 @@ class OrderController {
         orderEvent[0].status === '3' &&
         orderEvent[0].currency === 'STRATS'
       ) {
-        await sendEmail(body.email, 'Your Order Confirmation', htmlContents[0]);
+        await sendEmail(body.user, 'Your Order Confirmation', htmlContents[0]);
         console.log('*Buyer placed order*', orderEvent);
       }
       return next();
@@ -241,7 +241,6 @@ class OrderController {
       orderTotal: Joi.number().required(),
       tax: Joi.number().required(),
       user: Joi.string().required(),
-      email: Joi.string().required(),
     }).required();
 
     const validation = paymentSchema.validate(args);

--- a/payment-server/StripeService/stripe.service.js
+++ b/payment-server/StripeService/stripe.service.js
@@ -4,7 +4,7 @@ const stripe = Stripe(STRIPE_ENV.CREDENTIALS.STRIPE_SECRET_KEY);
 
 class StripeService {
     // TODO implement orderDetail to create actual order line items 
-    static initiatePayment(marketplaceUrl, checkoutHash, orderDetails, email, CONNECTED_ACCOUNT_ID = '') {
+    static initiatePayment(marketplaceUrl, checkoutHash, orderDetails, CONNECTED_ACCOUNT_ID = '') {
         try {
             // Create a checkout session with Stripe
             return stripe.checkout.sessions.create({
@@ -36,7 +36,7 @@ class StripeService {
                     // },
                 },
                 mode: "payment",
-                success_url: `${SERVER_CONFIRM_URL}?email=${encodeURIComponent(email)}&checkoutHash=${checkoutHash}&redirectUrl=${marketplaceUrl}`,
+                success_url: `${SERVER_CONFIRM_URL}?checkoutHash=${checkoutHash}&redirectUrl=${marketplaceUrl}`,
                 cancel_url: `${SERVER_CANCEL_URL}?checkoutHash=${checkoutHash}&redirectUrl=${marketplaceUrl}`,
             }, {
                 stripeAccount: CONNECTED_ACCOUNT_ID

--- a/payment-server/StripeService/stripeService.controller.js
+++ b/payment-server/StripeService/stripeService.controller.js
@@ -121,7 +121,7 @@ class StripeServiceController {
     try {
       // Validation
       StripeServiceController.validateStripeCheckoutArgs(req.query);
-      const { checkoutHash, redirectUrl, email } = req.query;
+      const { checkoutHash, redirectUrl } = req.query;
 
       // Check if the payment session already exists for the token
       const paymentDetails = await getStripePaymentFromToken(checkoutHash);
@@ -162,7 +162,7 @@ class StripeServiceController {
       }
 
       // Create checkout session and store in DB
-      const session = await stripeService.initiatePayment(redirectUrl, checkoutHash, orderDetails, email, sellerAccount);
+      const session = await stripeService.initiatePayment(redirectUrl, checkoutHash, orderDetails, sellerAccount);
       const insertResult = await insertStripePayment(checkoutHash, session.id, sellerCommonName);
 
       // Redirect to Stripe payment session
@@ -177,7 +177,7 @@ class StripeServiceController {
     try {
       // Validation
       StripeServiceController.validateStripeCheckoutConfirmArgs(req.query);
-      const { checkoutHash, redirectUrl, email } = req.query;
+      const { checkoutHash, redirectUrl } = req.query;
 
       // Retrieve the session
       const paymentDetails = await getStripePaymentFromToken(checkoutHash);
@@ -215,7 +215,7 @@ class StripeServiceController {
           const orderString = prepareOrderData(checkoutEvent, assetData);
           const htmlContents = buildConcatenatedOrderString(checkoutEvent[0].purchasersCommonName, orderString, assetData);
       
-          await sendEmail(email, "Your Order Confirmation", htmlContents);
+          await sendEmail(checkoutEvent[0].purchasersCommonName, "Your Order Confirmation", htmlContents);
           console.log("*Buyer placed order*");
         } catch (emailError) {
           console.error("Error sending email confirmation for credit card:", emailError);
@@ -251,7 +251,7 @@ class StripeServiceController {
           const orderString = prepareOrderData(checkoutEvent, assetData);
           const htmlContents = buildConcatenatedOrderString(checkoutEvent[0].purchasersCommonName, orderString, assetData);
       
-          await sendEmail(email, "Your Order Confirmation", htmlContents);
+          await sendEmail(checkoutEvent[0].purchasersCommonName, "Your Order Confirmation", htmlContents);
           console.log("*Buyer placed order*");
         } catch (emailError) {
           console.error("Error sending email confirmation for ACH:", emailError);
@@ -433,7 +433,6 @@ class StripeServiceController {
     const stripeCheckoutSchema = Joi.object({
       checkoutHash: Joi.string().required(),
       redirectUrl: Joi.string().required(),
-      email: Joi.string().required(),
     });
 
     const validation = stripeCheckoutSchema.validate(args);
@@ -447,7 +446,6 @@ class StripeServiceController {
     const stripeCheckoutConfirmSchema = Joi.object({
       checkoutHash: Joi.string().required(),
       redirectUrl: Joi.string().required(),
-      email: Joi.string().required(),
     });
 
     const validation = stripeCheckoutConfirmSchema.validate(args);


### PR DESCRIPTION
- Removing requirement that email be provided for calls to create orders (both for STRAT and for payment server calls)
- Payment server uses user's common name when calling `sendEmail` instead of email address (this will prevent issues once this PR gets merged to prevent that option within the notification server: https://github.com/blockapps/strato-platform/pull/3570)
- This PR is needed to be merged in order for ory users to be able to place orders on marketplace
- I have tested these changes using my ory account and was able to successfully purchase with STRAT, credit card, and ACH (received emails for credit card and ACH, so payment server changes to `sendEmail` are correct)