### PR TITLE
Improved staking dustin

### DIFF
--- a/marketplace/backend/config/localhost.deploy.yaml
+++ b/marketplace/backend/config/localhost.deploy.yaml
@@ -2,4 +2,4 @@ url: https://marketplace.mercata-testnet2.blockapps.net/
 dapp:
   contract:
     name: Mercata
-    address: c002c4039c97a37d66067b482d0005659913f330
+    address: 18f104b2fe1fc68ad4d7789d9d4c0fbf3405f5f5

--- a/marketplace/backend/config/localhost.deploy.yaml
+++ b/marketplace/backend/config/localhost.deploy.yaml
@@ -2,4 +2,4 @@ url: https://marketplace.mercata-testnet2.blockapps.net/
 dapp:
   contract:
     name: Mercata
-    address: bc4c46c75798d06733b1c7609946ee609f455617
+    address: 3d50f9315e9f9aa6c0ca1d279813a58018ca5cc9

--- a/marketplace/backend/config/localhost.deploy.yaml
+++ b/marketplace/backend/config/localhost.deploy.yaml
@@ -2,4 +2,4 @@ url: https://marketplace.mercata-testnet2.blockapps.net/
 dapp:
   contract:
     name: Mercata
-    address: 18f104b2fe1fc68ad4d7789d9d4c0fbf3405f5f5
+    address: bc4c46c75798d06733b1c7609946ee609f455617

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Oracles/OracleService.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Oracles/OracleService.sol
@@ -5,10 +5,6 @@ import <509>;
 import "../Enums/RestStatus.sol";
 import "../Utils/Utils.sol";
 
-interface OracleSubscriber {
-    function oraclePriceUpdated(decimal _price, uint _timestamp) public virtual;
-}
-
 abstract contract OracleService is Utils {
     decimal public consensusPrice;
     uint public consensusPriceTimestamp;
@@ -20,8 +16,7 @@ abstract contract OracleService is Utils {
 
     bool public isActive;
 
-    address[] public subscribers;
-    mapping (address => uint) subscriberMap;
+    event PriceUpdated(decimal price, uint timestamp);
 
     constructor(
         string _name    ) {
@@ -47,11 +42,7 @@ abstract contract OracleService is Utils {
     function _submitPrice(decimal _price, uint _timestamp) internal  requireActive("submit price") {
         consensusPriceTimestamp = _timestamp;
     	consensusPrice = _price;
-        for (uint i = 0; i < subscribers.length; i++) {
-            if (subscribers[i] != address(0)) {
-                OracleSubscriber(subscribers[i]).oraclePriceUpdated(consensusPrice, consensusPriceTimestamp);
-            }
-        }
+        emit PriceUpdated(_price, _timestamp);
     }
 
     function _transferOwnership(address _newOwner) internal requireActive("transfer ownership") {
@@ -61,20 +52,5 @@ abstract contract OracleService is Utils {
 
     function getLatestPrice() public view requireActive("get latest price") returns (decimal, uint) {
         return (consensusPrice, consensusPriceTimestamp);
-    }
-
-    function subscribe() public {
-        if (subscriberMap[msg.sender] == 0) {
-            subscribers.push(msg.sender);
-            subscriberMap[msg.sender] = subscribers.length;
-        }
-    }
-
-    function unsubscribe() public {
-        uint index = subscriberMap[msg.sender];
-        if (index > 0) {
-            subscribers[index - 1] = address(0);
-            subscriberMap[msg.sender] = 0;
-        }
     }
 }

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Escrow.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Sales/Escrow.sol
@@ -9,6 +9,7 @@ contract Escrow is Sale {
     uint public maxStratsLoanAmount;
     decimal public totalCataRewardInDollars;
     decimal public borrowedAmount;
+    uint public lastRewardTimestamp;
 
     constructor(
         address _borrower,
@@ -23,6 +24,7 @@ contract Escrow is Sale {
         borrower = _borrower;
         maxStratsLoanAmount = _maxStratsLoanAmount;
         totalCataRewardInDollars = 0.0; // Assuming the CATA reward rate is provided externally
+        lastRewardTimestamp = block.timestamp;
         reserve = msg.sender;
     }
 
@@ -48,6 +50,8 @@ contract Escrow is Sale {
         collateralValue = collateralQuantity * _newPrice.truncate(2);
 
         maxStratsLoanAmount = uint(collateralValue * decimal(_loanToValueRatio));
+
+        lastRewardTimestamp = block.timestamp;
     }
 
     function updateTotalCataReward(decimal _newCataReward) external {
@@ -55,5 +59,9 @@ contract Escrow is Sale {
         totalCataRewardInDollars += _newCataReward;
     }
 
+    function updateReserve(address _newReserve) external {
+        require(msg.sender == reserve, "Only the existing reserve can update the reserve address");
+        reserve = _newReserve;
+    }
 
 }

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Staking/Reserve.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Staking/Reserve.sol
@@ -45,12 +45,12 @@ abstract contract Reserve is Utils, Structs {
         _;
     }
 
-    function distributeRewards(address[] _escrows) external {
+    function distributeRewards(address[] _escrowAddresses) external {
         // Update the price of the collateral in the escrow
         (decimal oraclePrice, uint oracleTimestamp) = oracle.getLatestPrice();
 
-        for (uint i = 0; i < _escrows.length; i++) {
-            Escrow escrow = Escrow(_escrows[i]);
+        for (uint i = 0; i < _escrowAddresses.length; i++) {
+            Escrow escrow = Escrow(_escrowAddresses[i]);
             require(address(escrow).creator == this.creator, "Escrow contract " + string(address(escrow)) + " was not created by a valid Reserve contract");
             try {
                 uint lastRewardTimestamp = escrow.lastRewardTimestamp();

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Staking/Reserve.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Staking/Reserve.sol
@@ -9,7 +9,7 @@ import "../Utils/Utils.sol";
 import "../Structs/Structs.sol";
 import "../Oracle/OracleService.sol";
 
-abstract contract Reserve is Utils, Structs, OracleSubscriber {
+abstract contract Reserve is Utils, Structs {
     OracleService public oracle; // Asset Oracle service for fetching price data
     Asset public stratsToken;
     Asset public cataToken;
@@ -23,18 +23,13 @@ abstract contract Reserve is Utils, Structs, OracleSubscriber {
 
     uint public loanToValueRatio = 50; // LTV ratio as percentage
     uint public cataAPYRate = 10; // 10% APY for CATA rewards
-    uint public lastUpdatedTimestamp = 0;
     
     event StakeCreated(address indexed user, address escrow, uint assetAmount, decimal stratsLoan);
     event StakeUnlocked(address indexed user, address escrow);
     event CataTransferred(address indexed from, address indexed to, uint amount);
 
-    Escrow[] public escrows;
-    mapping (address => uint) escrowMap;
-
     constructor(address _assetOracle, string _name, address _assetRootAddress) {
         oracle = OracleService(_assetOracle);
-        oracle.subscribe();
         owner = msg.sender;
         name = _name;
         assetRootAddress = _assetRootAddress;
@@ -50,39 +45,38 @@ abstract contract Reserve is Utils, Structs, OracleSubscriber {
         _;
     }
 
-    function oraclePriceUpdated(decimal _newPrice, uint _timestamp) external override {
+    function distributeRewards(address[] _escrows) external {
         // Update the price of the collateral in the escrow
-        require(msg.sender == address(oracle), "Only the oracle can call oraclePriceUpdated");
-        
-        if(lastUpdatedTimestamp == 0){
-            lastUpdatedTimestamp = _timestamp;
-        }
+        (decimal oraclePrice, uint oracleTimestamp) = oracle.getLatestPrice();
 
-        uint delta = _timestamp - lastUpdatedTimestamp;
-
-        if(delta > 0){
-        for (uint i = 0; i < escrows.length; i++) {
-            if (address(escrows[i]) != address(0)) {
-                escrows[i].updateOnPriceChange(_newPrice, loanToValueRatio);
+        for (uint i = 0; i < _escrows.length; i++) {
+            Escrow escrow = Escrow(_escrows[i]);
+            require(address(escrow).creator == this.creator, "Escrow contract " + string(address(escrow)) + " was not created by a valid Reserve contract");
+            try {
+                uint lastRewardTimestamp = escrow.lastRewardTimestamp();
+                uint delta = block.timestamp - lastRewardTimestamp;
+                escrow.updateOnPriceChange(oraclePrice, loanToValueRatio);
                 //get cata reward from escrow
-                decimal cataReward = calculateCATAReward(escrows[i].collateralQuantity(), _newPrice.truncate(2), delta); //per day 0.08, per hour 0.0033, per 10 minutes 0.00055
-                escrows[i].updateTotalCataReward(cataReward * 10**18);
+                if (delta > 0) {
+                    decimal cataReward = calculateCATAReward(escrow.collateralQuantity(), oraclePrice.truncate(2), delta); //per day 0.08, per hour 0.0033, per 10 minutes 0.00055
+                    escrow.updateTotalCataReward(cataReward * 10**18);
 
-                uint transferNumber = (uint(block.number + 16 + i) + block.timestamp) % 1000000;
+                    uint transferNumber = (uint(block.number + 16 + i) + block.timestamp) % 1000000;
 
-                // Transfer Cata from reserve to borrower
-                cataToken.transferOwnership(
-                    escrows[i].borrower(),
-                    uint(cataReward * 10**18), //per day 8, per hour 0.33, per 10 minutes 0.055
-                    true,
-                    transferNumber,
-                    0.1000000000000000000 / 10**18
-                    );
-                emit CataTransferred(address(this), escrows[i].borrower(), uint(cataReward * 10**18));
+                    // Transfer Cata from reserve to borrower
+                    cataToken.transferOwnership(
+                        escrow.borrower(),
+                        uint(cataReward * 10**18), //per day 8, per hour 0.33, per 10 minutes 0.055
+                        true,
+                        transferNumber,
+                        0.1000000000000000000 / 10**18
+                        );
+                    emit CataTransferred(address(this), escrow.borrower(), uint(cataReward * 10**18));
                 }
+            } catch {
+                revert("Rewards distribution failed for escrow contract " + string(address(escrow)));
             }
         }
-        lastUpdatedTimestamp = _timestamp;
     }
 
     function stakeAsset(uint _collateralQuantity, address _assetAddress, PaymentServiceInfo _stratPaymentService) public requireActive() returns (address) {
@@ -104,9 +98,6 @@ abstract contract Reserve is Utils, Structs, OracleSubscriber {
             address(_assetToBeSold),
             [_stratPaymentService]
         );
-
-        escrows.push(Escrow(escrow));
-        escrowMap[address(escrow)] = escrows.length;
 
         emit StakeCreated(msg.sender, address(escrow), _collateralQuantity, _maxStratsLoanAmount); 
         return address(escrow);
@@ -160,15 +151,11 @@ abstract contract Reserve is Utils, Structs, OracleSubscriber {
 
     function deactivate() public requireActive() requireOwner("deactivate reserve") {
         isActive = false;
-        oracle.unsubscribe();
     }
 
     function setOracle(address _newOracle) public requireOwner("update oracle") {
         require(_newOracle != address(0), "Invalid oracle address");
-        oracle.unsubscribe();
-
         oracle = OracleService(_newOracle);
-        oracle.subscribe(); 
     }
 
     //Setters for state variables
@@ -202,12 +189,6 @@ abstract contract Reserve is Utils, Structs, OracleSubscriber {
         require(escrow.borrowedAmount() == 0, "Must repay borrowed STRATS before unstaking");
 
         escrow.closeSale();
-
-        uint index = escrowMap[address(escrow)];
-        if (index > 0) {
-            escrows[index - 1] = Escrow(address(0));
-            escrowMap[address(escrow)] = 0;
-        }
 
         // Emit unstake event
         emit StakeUnlocked(msg.sender, _escrowAddress);

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Staking/Reserve.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Staking/Reserve.sol
@@ -204,4 +204,10 @@ abstract contract Reserve is Utils, Structs {
         return (decimal(collateralQuantity) * livePriceOfCollateral * decimal(cataAPYRate)/100.0000000000000000000 * decimal(delta)) / 
                (priceOfCATA * secondsPerYear);
     }
+
+    function migrateReserve(address _newReserve, address[] _escrows) external requireOwner("migrate the Reserve") {
+        for (uint i = 0; i < _escrows.length; i++) {
+            Escrow(_escrows[i]).updateReserve(_newReserve);
+        }
+    }
 }


### PR DESCRIPTION
Updated the OracleService, Reserve, and Escrow contracts so that oracle price updates no longer trigger CATA disbursements. Instead, calls to the `distributeRewards` function in the Reserve contracts trigger the rewards by reading the current price from the oracle and using the existing logic from the `oraclePriceUpdated` function to determine the amount of CATA to distribute to the holder of each Escrow contract passed in the function arguments. To ensure the correct amount of rewards are sent to the Escrow contracts, the last reward timestamp is now held in the Escrow contract, and the timestamp delta is calculated based on the difference between block.timestamp and the Escrow's `lastRewardTimestamp` field. Because of this, access to the  `distributeRewards` function doesn't need to be restricted to the Reserve's owner or any other party, because the caller will (eventually) incur the fees associated with making the call, discouraging spamming the function, which will only distribute the amount of CATA accrued between successive calls to the function