### PR TITLE
Sort STRAT addresses by quantity descending

### DIFF
--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -1823,7 +1823,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
             queryOptions: { select: 'address, quantity' },
             notEqualsField: 'quantity',
             notEqualsValue: '0',
-            order: 'block_timestamp.desc',
+            order: 'quantity.desc',
           },
           options
         );


### PR DESCRIPTION
This should minimize the number of STRAT addresses needed to be sent in to checkoutInitialized, hopefully preventing gas limit errors from occurring