### PR TITLE
fix: use built in os module for avg load

### DIFF
--- a/apex/api/daemons/node-health-check-utils.js
+++ b/apex/api/daemons/node-health-check-utils.js
@@ -463,7 +463,7 @@ async function checkSystemInfo() {
     const currentLoad = metadataLoad.currentLoad;
     const avgLoads = os.loadavg();
     //grab 15 min load
-    const avgLoad = (avgLoads == null || avgLoads.length < 3) ? 0 : (avgLoads[2] * 100);
+    const avgLoad = (avgLoads == null || avgLoads.length < 3) ? 0 : avgLoads[2];
     
     const previousCpuCurrentLoadAlert = prevSysInfo.cpu?.currentLoad?.isHealthy === false;
     const previousCpuAvgLoadAlert = prevSysInfo.cpu?.avgLoad?.isHealthy === false;

--- a/apex/api/daemons/node-health-check-utils.js
+++ b/apex/api/daemons/node-health-check-utils.js
@@ -463,7 +463,7 @@ async function checkSystemInfo() {
     const currentLoad = metadataLoad.currentLoad;
     const avgLoads = os.loadavg();
     //grab 15 min load
-    const avgLoad = (avgLoads == null || avgsLoads.length < 3) ? 0 : avgLoads[2] * 100;
+    const avgLoad = (avgLoads == null || avgLoads.length < 3) ? 0 : (avgLoads[2] * 100);
     
     const previousCpuCurrentLoadAlert = prevSysInfo.cpu?.currentLoad?.isHealthy === false;
     const previousCpuAvgLoadAlert = prevSysInfo.cpu?.avgLoad?.isHealthy === false;

--- a/apex/api/daemons/node-health-check-utils.js
+++ b/apex/api/daemons/node-health-check-utils.js
@@ -461,7 +461,11 @@ async function checkSystemInfo() {
     }
 
     const currentLoad = metadataLoad.currentLoad;
-    const avgLoads = os.loadavg();
+    const cpuCount = os.cpus().length;
+    
+    //covert loads to percents
+    const avgLoads = os.loadavg()?.map(load => (load / cpuCount) * 100);
+    
     //grab 15 min load
     const avgLoad = (avgLoads == null || avgLoads.length < 3) ? 0 : avgLoads[2];
     

--- a/apex/api/daemons/node-health-check-utils.js
+++ b/apex/api/daemons/node-health-check-utils.js
@@ -485,14 +485,14 @@ async function checkSystemInfo() {
         isHealthy: !cpuCurrentLoadAlert
       },
       avgLoad: {
-        value: +((metadataLoad.avgLoad * 100) / cpudata.cores).toFixed(2),
+        value: +avgLoad.toFixed(2),
         isHealthy: !cpuAvgLoadAlert
       },
     };
     if (!sysInfoCollected.cpu.avgLoad.isHealthy) {
       isHealthy = false;
       additional_info.push(
-        `Average CPU load is high (${metadataLoad.avgLoad.toFixed(2)})`
+        `Average CPU load is high (${avgLoad.toFixed(2)})`
       );
     }
     if (!sysInfoCollected.cpu.currentLoad.isHealthy) {

--- a/apex/api/daemons/node-health-check-utils.js
+++ b/apex/api/daemons/node-health-check-utils.js
@@ -499,12 +499,15 @@ async function checkSystemInfo() {
         `Average CPU load is high (${avgLoad.toFixed(2)})`
       );
     }
-    if (!sysInfoCollected.cpu.currentLoad.isHealthy) {
-      isHealthy = false;
-      additional_info.push(
-        `Current CPU load is high (${metadataLoad.currentLoad.toFixed(2)})`
-      );
-    }
+    
+
+    // 12/17/24 - comment out current CPU load alarm
+    // if (!sysInfoCollected.cpu.currentLoad.isHealthy) {
+    //   isHealthy = false;
+    //   additional_info.push(
+    //     `Current CPU load is high (${metadataLoad.currentLoad.toFixed(2)})`
+    //   );
+    // }
 
     // FILESYSTEM
     const fsData = [];

--- a/apex/api/daemons/node-health-check-utils.js
+++ b/apex/api/daemons/node-health-check-utils.js
@@ -8,6 +8,7 @@ const si = require("systeminformation");
 const config = require("../config/app.config");
 const getPbftData = require("../controllers/health")["getPbftData"];
 const findView = require("../controllers/health")["findView"];
+const os = require('os');
 
 // TODO: do the mass-refactoring of the daemon. Use the OOP! Really, don't even try refactoring this without the main Object (SingleCheck object with methods and shared params). Don't change any db data formats.
 
@@ -460,7 +461,9 @@ async function checkSystemInfo() {
     }
 
     const currentLoad = metadataLoad.currentLoad;
-    const avgLoad = (metadataLoad.avgLoad * 100) / cpudata.cores;
+    const avgLoads = os.loadavg();
+    //grab 15 min load
+    const avgLoad = (avgLoads == null || avgsLoads.length < 3) ? 0 : avgLoads[2] * 100;
     
     const previousCpuCurrentLoadAlert = prevSysInfo.cpu?.currentLoad?.isHealthy === false;
     const previousCpuAvgLoadAlert = prevSysInfo.cpu?.avgLoad?.isHealthy === false;

--- a/apex/api/daemons/node-health-check-utils.js
+++ b/apex/api/daemons/node-health-check-utils.js
@@ -464,7 +464,7 @@ async function checkSystemInfo() {
     const cpuCount = os.cpus().length;
     
     //covert loads to percents
-    const avgLoads = os.loadavg()?.map(load => (load / cpuCount) * 100);
+    const avgLoads = os.loadavg()?.map(load => (load / cpuCount) * (100/2));
     
     //grab 15 min load
     const avgLoad = (avgLoads == null || avgLoads.length < 3) ? 0 : avgLoads[2];


### PR DESCRIPTION
currently running on my workspace node: https://workspace-jadarius-92uhef3.blockapps.net/prometheus/graph?g0.expr=system_cpu_avg_load&g0.tab=0&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1h