### PR TITLE
Remove title from BridgeWalletModal for cleaner UI

### DIFF
--- a/marketplace/ui/src/components/ETHST/BridgeWallet.js
+++ b/marketplace/ui/src/components/ETHST/BridgeWallet.js
@@ -171,7 +171,6 @@ const BridgeWalletModal = ({ open, handleCancel, accountDetails, signer }) => {
     <Modal
       open={open}
       onCancel={handleCancel}
-      title={`Bridge Wallet`}
       width={1000}
       footer={[
         <div className="flex justify-center md:block">


### PR DESCRIPTION
<img width="1044" alt="Screenshot 2024-12-30 at 10 57 31 AM" src="https://github.com/user-attachments/assets/33cfc0c5-c1e4-4fec-ae46-4ab6ff5e0cb6" />
<img width="1051" alt="Screenshot 2024-12-30 at 10 57 25 AM" src="https://github.com/user-attachments/assets/1c9bf707-b1ae-40e6-a6b4-929d5e0cf3f1" />
