### PR TITLE
fixed fkey for array table to array type

### DIFF
--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -612,7 +612,9 @@ createArrayTable (creator, a, n) (arr, arrType) c cc = do
       arrSqlType = fromMaybe "text" $ solidityTypeToSQLType False (Just c) cc arrType
   yield $ (createArrayTableQuery (creator, a, n, arr, arrSqlType))
   let fkeys1 = getDeferredForeignKeysForCollection tableName creator a
-      fkeys2 = getDeferredForeignKeysForArrayType tableName creator a arrSqlType
+      fkeys2 = case arrType of
+                (SVMType.UnknownLabel contractNameForFkey _) -> getDeferredForeignKeysForArrayType tableName creator a (T.pack $ contractNameForFkey)
+                _  -> []
   return $ fkeys1 ++ fkeys2
 
 createEventArrayTable ::


### PR DESCRIPTION
Before:
```
createArrayTable/arrType           | UnknownLabel "Asset" Nothing
createArrayTable/arrSqlType      | "text"
createArrayTable/fkeys1             | [ForeignKeyInfo {tableName = CollectionTableName {mtCreator = "BlockApps", mtApplication = "Mercata", mtContractName = "Escrow", mtCollectionName = "assets"}, columnNames = ["address"], foreignTableName = IndexTableName {itCreator = "BlockApps", itApplication = "Mercata", itContractName = "Escrow"}, foreignColumnNames = ["address"]}]
```
Resulted in:
```
createArrayTable/fkeys2             | [ForeignKeyInfo {tableName = CollectionTableName {mtCreator = "BlockApps", mtApplication = "Mercata", mtContractName = "Escrow", mtCollectionName = "assets"}, columnNames = ["value_fkey"], foreignTableName = IndexTableName {itCreator = "BlockApps", itApplication = "Mercata", itContractName = "text"}, foreignColumnNames = ["address"]}]
```


After:
```
createArrayTable/arrType           | UnknownLabel "Asset" Nothing
createArrayTable/arrSqlType      | "text"
createArrayTable/fkeys1             | [ForeignKeyInfo {tableName = CollectionTableName {mtCreator = "BlockApps", mtApplication = "Mercata", mtContractName = "Escrow", mtCollectionName = "assets"}, columnNames = ["address"], foreignTableName = IndexTableName {itCreator = "BlockApps", itApplication = "Mercata", itContractName = "Escrow"}, foreignColumnNames = ["address"]}]
```
Resulted in:
```
createArrayTable/fkeys2             | [ForeignKeyInfo {tableName = CollectionTableName {mtCreator = "BlockApps", mtApplication = "Mercata", mtContractName = "Escrow", mtCollectionName = "assets"}, columnNames = ["value_fkey"], foreignTableName = IndexTableName {itCreator = "BlockApps", itApplication = "Mercata", itContractName = "Asset"}, foreignColumnNames = ["address"]}]
```
