### PR TITLE
Borrow modal calculations

### DIFF
--- a/marketplace/ui/src/components/Inventory/BorrowModal.js
+++ b/marketplace/ui/src/components/Inventory/BorrowModal.js
@@ -224,19 +224,26 @@ const BorrowModal = ({
       matchedReserve?.name.toLowerCase().includes('ethst') ||
       matchedReserve?.name.toLowerCase().includes('wbtcst')
     ) {
-      return Math.floor(collateralValue ? collateralValue * LTV : 0);
+      return collateralValue ? collateralValue * LTV : 0;
     } else {
       return computeMaxLoanAmount(inventory);
     }
   }, [inventory, collateralValue]);
 
   const marketValueDisplay = (collateralValue / Math.pow(10, 18)).toFixed(2);
-  const borrowedAmountDisplay = (borrowedAmount / Math.pow(10, 18)).toFixed(2);
-  const loanableAmountDisplay = (Math.floor(maxLoanAmount / Math.pow(10, 18) - borrowedAmountDisplay)).toFixed(2);
+  // the extra math on borrowedAmountDisplay and roundedMaxLoanAmount is to round down to 2 decimal places
+  const borrowedAmountDisplay = (
+    Math.floor((borrowedAmount / Math.pow(10, 18)) * 100) / 100
+  ).toFixed(2);
+  const roundedMaxLoanAmount =
+    Math.floor((maxLoanAmount / Math.pow(10, 18)) * 100) / 100;
+  const loanableAmountDisplay = (
+    roundedMaxLoanAmount - borrowedAmountDisplay
+  ).toFixed(2);
 
   // Desired loan amount in USDST
   const [desiredLoanAmount, setDesiredLoanAmount] = useState(
-    (Math.floor(maxLoanAmount / Math.pow(10, 18) - borrowedAmountDisplay)).toFixed(2) || 0
+    loanableAmountDisplay || 0
   );
 
   useEffect(() => {

--- a/marketplace/ui/src/components/Inventory/ItemActions.js
+++ b/marketplace/ui/src/components/Inventory/ItemActions.js
@@ -210,6 +210,56 @@ const ItemActions = ({
     setBridgeModalOpen(false);
   };
 
+  // Calculate collateralQuantity
+  const uniqueEscrows = new Set();
+  let collateralQuantity = inventory?.inventories
+    ? inventory.inventories.reduce((sum, item) => {
+        const escrowAddress = item?.escrow?.address;
+        const escrowCollateral = item?.escrow?.collateralQuantity || 0;
+        if (escrowAddress && !uniqueEscrows.has(escrowAddress)) {
+          uniqueEscrows.add(escrowAddress);
+          return sum + escrowCollateral;
+        }
+        return sum;
+      }, 0)
+    : inventory?.escrow?.collateralQuantity > inventory?.quantity
+    ? inventory?.quantity
+    : inventory?.escrow?.collateralQuantity || 0;
+
+  if (decimals > 0) {
+    collateralQuantity /= Math.pow(10, decimals);
+  }
+
+  // Calculate borrowedAmount
+  const uniqueBorrowedAddresses = new Set();
+  let borrowAmount = inventory?.inventories
+    ? inventory.inventories.reduce((sum, item) => {
+        const escrowAddress = item?.escrow?.address;
+        const borrowedValue = item?.escrow?.borrowedAmount || 0;
+        if (escrowAddress && !uniqueBorrowedAddresses.has(escrowAddress)) {
+          uniqueBorrowedAddresses.add(escrowAddress);
+          return sum + borrowedValue;
+        }
+        return sum;
+      }, 0)
+    : inventory?.escrow?.borrowedAmount || 0;
+
+  // Calculate maxLoanAmount
+  const uniqueEscrowsThree = new Set();
+  let maxLoanAmount = inventory?.inventories
+    ? inventory.inventories.reduce((sum, item) => {
+        const escrowAddress = item?.escrow?.address;
+        const maxLoanValue = item?.escrow?.maxLoanAmount || 0;
+        if (escrowAddress && !uniqueEscrowsThree.has(escrowAddress)) {
+          uniqueEscrowsThree.add(escrowAddress);
+          return sum + maxLoanValue;
+        }
+        return sum;
+      }, 0)
+    : inventory?.escrow?.maxLoanAmount || 0;
+  maxLoanAmount =
+    Math.floor(maxLoanAmount / Math.pow(10, 18)) * Math.pow(10, 18);
+
   return (
     <div className="flex justify-center">
       {(!stakeable || (!inventory?.escrow && stakeable)) && (
@@ -284,7 +334,7 @@ const ItemActions = ({
             type="link"
             className="text-[#13188A] font-semibold"
             onClick={() => showBorrowModal('Unstake')}
-            disabled={inventory?.escrow?.borrowedAmount > 0}
+            disabled={borrowAmount >= maxLoanAmount || collateralQuantity <= 0}
           >
             <BankOutlined /> Borrow
           </Button>

--- a/marketplace/ui/src/components/Inventory/RepayModal.js
+++ b/marketplace/ui/src/components/Inventory/RepayModal.js
@@ -135,7 +135,7 @@ const RepayModal = ({
         <div className="flex -mr-1">
           {logo} &nbsp;
           {Number(repayAmount).toLocaleString('en-US', {
-            maximumFractionDigits: 6,
+            maximumFractionDigits: 2,
             minimumFractionDigits: 2,
           })}
         </div>
@@ -149,7 +149,7 @@ const RepayModal = ({
           <InputNumber
             // Convert BigNumber to a native number for display.
             value={Number(repayValue).toLocaleString('en-US', {
-              maximumFractionDigits: 6,
+              maximumFractionDigits: 2,
               minimumFractionDigits: 2,
             })}
             onChange={(value) => {

--- a/marketplace/ui/src/components/Inventory/StakeItemActions.js
+++ b/marketplace/ui/src/components/Inventory/StakeItemActions.js
@@ -103,7 +103,8 @@ const StakeItemActions = ({
         return sum;
       }, 0)
     : inventory?.escrow?.maxLoanAmount || 0;
-    maxLoanAmount = Math.floor(maxLoanAmount / Math.pow(10, 18)) * Math.pow(10, 18);
+  maxLoanAmount =
+    Math.floor(maxLoanAmount / Math.pow(10, 18)) * Math.pow(10, 18);
 
   /**
    * If the inventory.root is in assetsWithEighteenDecimalPlaces, we need to scale down values by 1e18.
@@ -171,9 +172,7 @@ const StakeItemActions = ({
           type="link"
           className="text-[#13188A] font-semibold"
           onClick={() => showBorrowModal()}
-          disabled={
-            borrowAmount >= maxLoanAmount || collateralQuantity <= 0
-          }
+          disabled={borrowAmount >= maxLoanAmount || collateralQuantity <= 0}
         >
           <BankOutlined /> Borrow
         </Button>

--- a/marketplace/ui/src/components/Inventory/StakeModal.js
+++ b/marketplace/ui/src/components/Inventory/StakeModal.js
@@ -340,8 +340,8 @@ const StakeModal = ({
         body
       );
       if (isStaked) {
-        await refreshDataAfterAction();
         handleCancel();
+        refreshDataAfterAction();
       }
     }
 
@@ -359,8 +359,8 @@ const StakeModal = ({
         body
       );
       if (isUnstaked) {
-        await refreshDataAfterAction();
         handleCancel();
+        refreshDataAfterAction();
       }
     }
   };


### PR DESCRIPTION
- Changed Borrow Modal calculations to round to 2 decimals instead of nearest dollar.
- Fixed Borrow button from being disabled in My Wallet page after partial borrow.
- Rounded Repay Modal values to 2 decimal places.
- Fixed rendering glitch after successful staking/unstaking.