### PR TITLE
[DO NOT MERGE] Nginx alpine fat

### DIFF
--- a/highway-nginx/Dockerfile
+++ b/highway-nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-RUN apk add bash apache2-utils vim nano bind-tools && \
+RUN apk add bash apache2-utils vim nano bind-tools jq && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \

--- a/highway-nginx/Dockerfile
+++ b/highway-nginx/Dockerfile
@@ -1,21 +1,11 @@
-FROM openresty/openresty:1.19.3.1-7-buster
+FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
-    apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+RUN apk add bash apache2-utils vim nano bind-tools && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
-    opm get zmartzone/lua-resty-openidc=1.7.4 && \
-    opm remove bungle/lua-resty-session && \
-    opm get bungle/lua-resty-session=3.10    
-    # ^ Remove lines to reinstall lua-resty-session once switched to lua-resty-openidc=1.7.6-3 (when 1.7.6 is available in OPM, see here in the bottoms: https://opm.openresty.org/package/zmartzone/lua-resty-openidc/ )
-    # ^ Additional dependency issue context: https://github.com/zmartzone/lua-resty-openidc/issues/463
-    # ^ NOTE: There is a same workaround used in STRATO nginx
+    luarocks install lua-resty-openidc 1.7.6
 
 HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
   CMD curl  --silent --output /dev/null --fail localhost:80/_ping || \

--- a/hoogle-nginx/Dockerfile
+++ b/hoogle-nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-RUN apk add bash apache2-utils vim nano bind-tools && \
+RUN apk add bash apache2-utils vim nano bind-tools jq && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \

--- a/hoogle-nginx/Dockerfile
+++ b/hoogle-nginx/Dockerfile
@@ -1,18 +1,11 @@
-FROM openresty/openresty:1.21.4.1-6-bullseye
+FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
-    apt-get install -y apache2-utils curl openresty-opm && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+RUN apk add bash apache2-utils vim nano bind-tools && \
     mkdir -p /usr/local/openresty/nginx/lua && \
+    wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
-    opm get zmartzone/lua-resty-openidc=1.7.5 && \
-    curl -fLo /usr/local/openresty/lualib/resty/openidc.lua https://raw.githubusercontent.com/zmartzone/lua-resty-openidc/v1.7.6/lib/resty/openidc.lua && \
-    opm remove bungle/lua-resty-session && \
-    opm get bungle/lua-resty-session=3.10
+    luarocks install lua-resty-openidc 1.7.6
 
 HEALTHCHECK --interval=5s --timeout=1s --start-period=20s \
   CMD curl  --silent --output /dev/null --fail --insecure https://localhost:443/_ping || \

--- a/identity-nginx/Dockerfile
+++ b/identity-nginx/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add bash apache2-utils vim nano bind-tools && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
     luarocks install lua-resty-openidc 1.7.6
 
-RUN apk add python3  # Adding with a separate layer to match previous steps with other nginx images. TODO: refactor to reuse build base
+RUN apk add python3 py-yaml py-requests  # Adding with a separate layer to make the previous steps match with other nginx images. TODO: refactor to reuse build base
 
 HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
   CMD curl  --silent --output /dev/null --fail localhost:80/_ping || \

--- a/identity-nginx/Dockerfile
+++ b/identity-nginx/Dockerfile
@@ -1,22 +1,11 @@
-FROM openresty/openresty:1.19.3.1-7-buster
+FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
-    apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils python3 python3-pip && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+RUN apk add bash apache2-utils vim nano bind-tools && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
-    pip3 install pyyaml requests && \
-    opm get zmartzone/lua-resty-openidc=1.7.4 && \
-    opm remove bungle/lua-resty-session && \
-    opm get bungle/lua-resty-session=3.10    
-    # ^ Remove lines to reinstall lua-resty-session once switched to lua-resty-openidc=1.7.6-3 (when 1.7.6 is available in OPM, see here in the bottoms: https://opm.openresty.org/package/zmartzone/lua-resty-openidc/ )
-    # ^ Additional dependency issue context: https://github.com/zmartzone/lua-resty-openidc/issues/463
-    # ^ NOTE: There is a same workaround used in STRATO nginx
+    luarocks install lua-resty-openidc 1.7.6
 
 HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
   CMD curl  --silent --output /dev/null --fail localhost:80/_ping || \

--- a/identity-nginx/Dockerfile
+++ b/identity-nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-RUN apk add bash apache2-utils vim nano bind-tools && \
+RUN apk add bash apache2-utils vim nano bind-tools jq && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \

--- a/identity-nginx/Dockerfile
+++ b/identity-nginx/Dockerfile
@@ -7,6 +7,8 @@ RUN apk add bash apache2-utils vim nano bind-tools && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
     luarocks install lua-resty-openidc 1.7.6
 
+RUN apk add python3  # Adding with a separate layer to match previous steps with other nginx images. TODO: refactor to reuse build base
+
 HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
   CMD curl  --silent --output /dev/null --fail localhost:80/_ping || \
         exit 1

--- a/nginx-packager/Dockerfile
+++ b/nginx-packager/Dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-RUN apk add bash apache2-utils vim nano bind-tools && \
+RUN apk add bash apache2-utils vim nano bind-tools jq && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \

--- a/nginx-packager/Dockerfile
+++ b/nginx-packager/Dockerfile
@@ -1,21 +1,11 @@
-FROM openresty/openresty:1.19.3.1-7-buster
+FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
-    apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils jq iproute2 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+RUN apk add bash apache2-utils vim nano bind-tools && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
-    opm get zmartzone/lua-resty-openidc=1.7.5 && \
-    opm remove bungle/lua-resty-session && \
-    opm get bungle/lua-resty-session=3.10
-    # ^ Remove lines to reinstall lua-resty-session once switched to lua-resty-openidc=1.7.6-3 (when 1.7.6 is available in OPM, see here in the bottoms: https://opm.openresty.org/package/zmartzone/lua-resty-openidc/ )
-    # ^ Additional dependency issue context: https://github.com/zmartzone/lua-resty-openidc/issues/463
-    # ^ NOTE: There is a same workaround used in VAULT nginx
+    luarocks install lua-resty-openidc 1.7.6
 
 HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
   CMD curl  --silent --output /dev/null --fail localhost:80/_ping || \

--- a/notification-server-nginx/Dockerfile
+++ b/notification-server-nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-RUN apk add bash apache2-utils vim nano bind-tools && \
+RUN apk add bash apache2-utils vim nano bind-tools jq && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \

--- a/notification-server-nginx/Dockerfile
+++ b/notification-server-nginx/Dockerfile
@@ -1,21 +1,11 @@
-FROM openresty/openresty:1.19.3.1-7-buster
+FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
-    apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+RUN apk add bash apache2-utils vim nano bind-tools && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
-    opm get zmartzone/lua-resty-openidc=1.7.4 && \
-    opm remove bungle/lua-resty-session && \
-    opm get bungle/lua-resty-session=3.10    
-    # ^ Remove lines to reinstall lua-resty-session once switched to lua-resty-openidc=1.7.6-3 (when 1.7.6 is available in OPM, see here in the bottoms: https://opm.openresty.org/package/zmartzone/lua-resty-openidc/ )
-    # ^ Additional dependency issue context: https://github.com/zmartzone/lua-resty-openidc/issues/463
-    # ^ NOTE: There is a same workaround used in STRATO nginx
+    luarocks install lua-resty-openidc 1.7.6
 
 HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
   CMD curl  --silent --output /dev/null --fail localhost:80/_ping || \

--- a/payment-server-nginx/Dockerfile
+++ b/payment-server-nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-RUN apk add bash apache2-utils vim nano bind-tools && \
+RUN apk add bash apache2-utils vim nano bind-tools jq && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \

--- a/payment-server-nginx/Dockerfile
+++ b/payment-server-nginx/Dockerfile
@@ -1,21 +1,11 @@
-FROM openresty/openresty:1.19.3.1-7-buster
+FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
-    apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+RUN apk add bash apache2-utils vim nano bind-tools && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
-    opm get zmartzone/lua-resty-openidc=1.7.4 && \
-    opm remove bungle/lua-resty-session && \
-    opm get bungle/lua-resty-session=3.10    
-    # ^ Remove lines to reinstall lua-resty-session once switched to lua-resty-openidc=1.7.6-3 (when 1.7.6 is available in OPM, see here in the bottoms: https://opm.openresty.org/package/zmartzone/lua-resty-openidc/ )
-    # ^ Additional dependency issue context: https://github.com/zmartzone/lua-resty-openidc/issues/463
-    # ^ NOTE: There is a same workaround used in STRATO nginx
+    luarocks install lua-resty-openidc 1.7.6
 
 HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
   CMD curl  --silent --output /dev/null --fail localhost:80/_ping || \

--- a/vault-nginx/Dockerfile
+++ b/vault-nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-RUN apk add bash apache2-utils vim nano bind-tools && \
+RUN apk add bash apache2-utils vim nano bind-tools jq && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \

--- a/vault-nginx/Dockerfile
+++ b/vault-nginx/Dockerfile
@@ -1,21 +1,11 @@
-FROM openresty/openresty:1.19.3.1-7-buster
+FROM openresty/openresty:1.21.4.4-1-alpine-fat
 MAINTAINER BlockApps Inc.
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
-    apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+RUN apk add bash apache2-utils vim nano bind-tools && \
     mkdir -p /usr/local/openresty/nginx/lua && \
     wget -P /usr/local/openresty/nginx/lua https://raw.githubusercontent.com/knyar/nginx-lua-prometheus/0.20181120/prometheus.lua && \
     rm /usr/local/openresty/nginx/conf/nginx.conf && \
-    opm get zmartzone/lua-resty-openidc=1.7.4 && \
-    opm remove bungle/lua-resty-session && \
-    opm get bungle/lua-resty-session=3.10    
-    # ^ Remove lines to reinstall lua-resty-session once switched to lua-resty-openidc=1.7.6-3 (when 1.7.6 is available in OPM, see here in the bottoms: https://opm.openresty.org/package/zmartzone/lua-resty-openidc/ )
-    # ^ Additional dependency issue context: https://github.com/zmartzone/lua-resty-openidc/issues/463
-    # ^ NOTE: There is a same workaround used in STRATO nginx
+    luarocks install lua-resty-openidc 1.7.6
 
 HEALTHCHECK --interval=5s --timeout=1s --start-period=180s \
   CMD curl  --silent --output /dev/null --fail localhost:80/_ping || \


### PR DESCRIPTION
**Pull in an emergency**

This PR switches all nginx containers to the Alpine-fat base image of openresty. 
This is to fix the issue with all the debian-based openresty images caused by this problem: https://github.com/openresty/openresty/issues/1035

But the alpine-fat image is twice as "heavy" in terms of disk size as the previously used image.
So, we should only merge this if all Jenkins builds start failing.

But the ideal scenario would be if the` apt update` start working on the debian images (completely a third-party issue).

To test, execute in any environment:
```
sudo docker run -it openresty/openresty:1.27.1.1-3-bookworm apt update
```



IF MERGING - SQUASH
