### PR TITLE
temporary hotfix to prevent the openresty build fail due to 3rd party repo issue

### DIFF
--- a/highway-nginx/Dockerfile
+++ b/highway-nginx/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER BlockApps Inc.
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+# Hardcoding IP as a temporary fix for https://github.com/openresty/openresty/issues/1035
+RUN echo "3.125.51.27 openresty.org" >> /etc/hosts && \
+    apt-get update && \
     apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/hoogle-nginx/Dockerfile
+++ b/hoogle-nginx/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER BlockApps Inc.
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+# Hardcoding IP as a temporary fix for https://github.com/openresty/openresty/issues/1035
+RUN echo "3.125.51.27 openresty.org" >> /etc/hosts && \
+    apt-get update && \
     apt-get install -y apache2-utils curl openresty-opm && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/identity-nginx/Dockerfile
+++ b/identity-nginx/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER BlockApps Inc.
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+# Hardcoding IP as a temporary fix for https://github.com/openresty/openresty/issues/1035
+RUN echo "3.125.51.27 openresty.org" >> /etc/hosts && \
+    apt-get update && \
     apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils python3 python3-pip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/nginx-packager/Dockerfile
+++ b/nginx-packager/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER BlockApps Inc.
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+# Hardcoding IP as a temporary fix for https://github.com/openresty/openresty/issues/1035
+RUN echo "3.125.51.27 openresty.org" >> /etc/hosts && \
+    apt-get update && \
     apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils jq iproute2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/notification-server-nginx/Dockerfile
+++ b/notification-server-nginx/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER BlockApps Inc.
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+# Hardcoding IP as a temporary fix for https://github.com/openresty/openresty/issues/1035
+RUN echo "3.125.51.27 openresty.org" >> /etc/hosts && \
+    apt-get update && \
     apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/payment-server-nginx/Dockerfile
+++ b/payment-server-nginx/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER BlockApps Inc.
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+# Hardcoding IP as a temporary fix for https://github.com/openresty/openresty/issues/1035
+RUN echo "3.125.51.27 openresty.org" >> /etc/hosts && \
+    apt-get update && \
     apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/vault-nginx/Dockerfile
+++ b/vault-nginx/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER BlockApps Inc.
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+# Hardcoding IP as a temporary fix for https://github.com/openresty/openresty/issues/1035
+RUN echo "3.125.51.27 openresty.org" >> /etc/hosts && \
+    apt-get update && \
     apt-get install -y apache2-utils curl wget vim nano openresty-opm dnsutils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \


### PR DESCRIPTION
I will later update to more recent debian, luarocks and lua-openidc framework