### PR TITLE
Fixed quantity in invoice; fixed quantity input in transfer modal

### DIFF
--- a/marketplace/ui/src/components/Inventory/TransferModal.js
+++ b/marketplace/ui/src/components/Inventory/TransferModal.js
@@ -299,18 +299,6 @@ const TransferModal = ({
             handleQuantityChange(record.id, new BigNumber(value))
           }
           disabled={index !== transfers.length - 1}
-          formatter={(val) => {
-            if (val === undefined || val === null) return record.quantity;
-            const strVal = val.toString();
-            // Only modify the string if it contains a decimal point
-            if (strVal.includes('.')) {
-              // Remove trailing zeros and remove a trailing decimal point if it remains
-              return strVal.replace(/0+$/, '').replace(/\.$/, '');
-            }
-
-            // For whole numbers, return the string as is
-            return strVal;
-          }}
           // Parser to limit input to decimals
           parser={(val) => {
             if (!val) return record.quantity;

--- a/marketplace/ui/src/components/Order/InvoiceComponent.js
+++ b/marketplace/ui/src/components/Order/InvoiceComponent.js
@@ -178,7 +178,7 @@ const InvoiceComponent = ({ invoice, decimals }) => {
                   )}
                 </Text>
                 <Text style={[styles.value, styles.tableRowColumn]}>
-                  {formattedNum((quantity / Math.pow(10, decimals)).toFixed(2))}
+                  {formattedNum((quantity / Math.pow(10, decimals)))}
                 </Text>
                 <Text style={[styles.value, styles.tableRowColumn]}>
                   {totalPrice}


### PR DESCRIPTION
Fixed quantity rounding in Invoice (was rounding strictly to 2 decimal places before):

<img width="829" alt="Screenshot 2025-03-10 at 4 35 46 PM" src="https://github.com/user-attachments/assets/d353d6a0-7afb-419f-9238-a86601a6c3be" />


Quantity input in Transfer Modal before (would reset back to 0 if there were any trailing 0s after decimal place which was bad UX):


https://github.com/user-attachments/assets/ce0421d0-cb38-43e9-a5f4-b99a5bbdd846



After:


https://github.com/user-attachments/assets/e094179c-ceb3-4105-aa61-03decb3eaa4d


