### PR TITLE
fix: prevent stack‑overflow in calculatePriceFluctuation by switching to BigNumber loop

### DIFF
--- a/marketplace/backend/helpers/constants.js
+++ b/marketplace/backend/helpers/constants.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import BigNumber from 'bignumber.js';
 dayjs.extend(utc);
 
 export default {

--- a/marketplace/backend/helpers/constants.js
+++ b/marketplace/backend/helpers/constants.js
@@ -180,8 +180,22 @@ export const calculateAverageSalePrice = (records, decimals) => {
 };
 
 export const calculatePriceFluctuation = (records, decimals) => {
-  const prices = records.map((record) => record.price);
-  return { min: Math.min(...prices) * Math.pow(10, decimals), max: Math.max(...prices) * Math.pow(10, decimals) };
+  const len = records?.length;
+  if (!len) return { min: 0, max: 0 };
+
+  const factor = new BigNumber(10).pow(decimals);
+  // Initialize from the first record
+  const firstScaled = new BigNumber(records[0].price).times(factor);
+  let min = firstScaled;
+  let max = firstScaled;
+
+  for (let i = 1; i < len; i++) {
+    const scaled = new BigNumber(records[i].price).times(factor);
+    if (scaled.lt(min)) min = scaled;
+    if (scaled.gt(max)) max = scaled;
+  }
+
+  return { min: min.toNumber(), max: max.toNumber() };
 };
 
 export const calculateVolumeTraded = (records, decimals) => {


### PR DESCRIPTION
🧩 Problem

The existing calculatePriceFluctuation used Math.min(...prices)/Math.max(...prices) with the spread operator — which crashes with a RangeError: Maximum call stack size exceeded when price history arrays grow large. It also did decimal scaling after computing min/max, causing incorrect comparisons for values expressed in base units (e.g. 30/1e18).

✨ Solution

Replace the spread‑based min/max logic with a single‑pass for loop that:
	•	Uses BigNumber for correct arbitrary‑precision arithmetic
	•	Applies the decimal scaling before comparison
	•	Converts results back to plain JS numbers at the end
	•	Runs in O(n) time with O(1) extra memory (no temporary arrays)

🛠 Changes
	•	Import and use bignumber.js
	•	Initialize min/max from the first record’s scaled value
	•	Loop through remaining records comparing with .lt()/.gt()
	•	Return { min: Number, max: Number }