### PR TITLE
Use current ERC20 token price

### DIFF
--- a/payment-server/helpers/oracleHelper.js
+++ b/payment-server/helpers/oracleHelper.js
@@ -174,7 +174,42 @@ async function fetchLBMAMetalPrice(metal, apiKey) {
   }
 }
 
-// Function to fetch and submit ETH price
+// Function to fetch the current price of an ERC20 token
+async function fetchCurrentERC20TokenPrice(name, apiKey) {
+  try {
+    const apiUrl = `https://api.g.alchemy.com/prices/v1/${apiKey}/tokens/by-symbol?symbols=${name}`;
+    const response = await axios.get(apiUrl, {
+      headers: { "accept": "application/json" },
+    });
+    const responseData = response.data;
+    if (!responseData?.data || !Array.isArray(responseData.data)) {
+      console.error("Invalid response format:", responseData);
+      throw new Error("Invalid price data format from API");
+    }
+    console.log(`Received ${responseData.data.length} token entries`);
+    
+    // Find the token data entry matching the given symbol
+    const tokenEntry = responseData.data.find(entry => entry.symbol === name);
+    if (!tokenEntry || !tokenEntry.prices || tokenEntry.prices.length === 0) {
+      throw new Error("No price data available for token");
+    }
+    
+    // Use the first available price data
+    const priceData = tokenEntry.prices[0];
+    const price = parseFloat(priceData.value);
+    // Convert the ISO date string to a Unix timestamp in seconds
+    const timestamp = Math.floor(new Date(priceData.lastUpdatedAt).getTime() / 1000);
+    
+    console.log(`Fetched price for ${name}: $${price} at timestamp ${timestamp}`);
+    return { price, timestamp };
+  } catch (error) {
+    console.error("Failed to fetch current ERC20 token price:", error);
+    throw error;
+  }
+}
+
+// Function to fetch the current historical price (last 24hrs) of an ERC20 token
+// This function uses TWAP (Time Weighted Average Price) to calculate the price
 async function fetchERC20TokenPrice(name, apiKey) {
   try {
     const apiUrl = `https://api.g.alchemy.com/prices/v1/${apiKey}/tokens/historical`;
@@ -243,5 +278,6 @@ export {
   fetchMetalPrice,
   fetchLBMAMetalPrice,
   fetchERC20TokenPrice,
+  fetchCurrentERC20TokenPrice,
   fetchAsset,
 };

--- a/payment-server/submitPrice.js
+++ b/payment-server/submitPrice.js
@@ -8,6 +8,7 @@ import {
   submitPrice,
   updateAssetPrice,
   fetchLBMAMetalPrice,
+  fetchCurrentERC20TokenPrice,
   fetchERC20TokenPrice,
   fetchMetalPrice,
   fetchAsset,
@@ -319,7 +320,7 @@ const updateSalePricePeriodically = async () => {
           process.env.METALS_API_KEY
         );
       } else if (asset.type === "ERC20") {
-        result = await fetchERC20TokenPrice(
+        result = await fetchCurrentERC20TokenPrice(
           asset.name,
           process.env.ALCHEMY_API_KEY
         );

--- a/payment-server/submitPrice.js
+++ b/payment-server/submitPrice.js
@@ -149,7 +149,8 @@ async function fetchAndSubmitEscrowAddresses(oracleContract, token) {
   );
 
   if (!reserves || reserves.length === 0) {
-    throw new Error("No reserves found");
+    console.log("No reserves found for:", oracleContract.name);
+    return;
   }
 
   for (const reserve of reserves) {


### PR DESCRIPTION
When updating the sale price of ERC20 listings from the BlockApps account, we currently use the twap price of the last 24 hours. We don't want this as crypto prices are volatile. This change will allow the script to use the latest price of the ERC20 token and use that when updating the token listings on the marketplace.