### PR TITLE
Only can stake after bridge

### DIFF
--- a/marketplace/backend/api/v1/Reserve/reserve.controller.js
+++ b/marketplace/backend/api/v1/Reserve/reserve.controller.js
@@ -191,7 +191,6 @@ class ReserveController {
     const schema = Joi.object({
       eventTxHash: Joi.string().required(),
       assetRootAddress: Joi.string().required(),
-      ownerCommonName: Joi.string().required(),
     });
     ReserveController.validateArgs(args, schema, 'Stake');
   }

--- a/marketplace/backend/api/v1/Reserve/reserve.controller.js
+++ b/marketplace/backend/api/v1/Reserve/reserve.controller.js
@@ -189,13 +189,9 @@ class ReserveController {
 
   static validateStakeAfterBridgeArgs(args) {
     const schema = Joi.object({
-      stakeQuantity: Joi.string().pattern(/^\d+$/).required().messages({
-        'any.required': 'Stake Quantity is required and must be a string.',
-        'string.base': 'Stake Quantity must be a valid string.',
-        'string.pattern.base': 'Stake Quantity must be a valid number.',
-      }),
+      eventTxHash: Joi.string().required(),
+      assetRootAddress: Joi.string().required(),
       ownerCommonName: Joi.string().required(),
-      assetAddress: Joi.string().required(),
     });
     ReserveController.validateArgs(args, schema, 'Stake');
   }

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -2318,38 +2318,19 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   };
 
   contract.stakeAfterBridge = async function (args, options = defaultOptions) {
-    const { assetRootAddress, ownerCommonName, eventTxHash } = args;
+    const { assetRootAddress, eventTxHash } = args;
 
     // Use the MercataETHBridge address to find the Reserve address
     const CREATOR = 'in.(BlockApps,mercata_usdst)';
     const IS_ACTIVE = 'eq.true';
-    const reserveSearchOptions = {
-      ...options,
-      query: {
-        creator: CREATOR,
-        isActive: IS_ACTIVE,
-        assetRootAddress: `eq.${assetRootAddress}`,
-      },
-    };
-
-    const reserves = await rest.search(
-      rawAdmin,
-      { name: 'BlockApps-Mercata-Reserve' },
-      reserveSearchOptions
-    );
-    if (!reserves || reserves.length === 0) {
-      throw new Error('No active reserves found for the given address');
-    }
-
-    const reserve = reserves[0].address;
 
     // Find the Escrows associated with the Reserve (if any, if not set it as zero address)
     const escrowSearchOptions = {
       ...options,
       query: {
-        select: 'address',
-        reserve: `eq.${reserve}`,
-        borrowerCommonName: `eq.${ownerCommonName}`,
+        select: 'address,reserve',
+        assetRootAddress: `eq.${assetRootAddress}`,
+        borrowerCommonName: `eq.${userCommonName}`,
         isActive: IS_ACTIVE,
         creator: CREATOR,
       },
@@ -2359,16 +2340,18 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
       { name: 'BlockApps-Mercata-Escrow' },
       escrowSearchOptions
     );
-    const escrowAddress =
-      escrows && escrows.length > 0
-        ? escrows[0].address
-        : constants.zeroAddress;
+    const firstEscrow = escrows?.[0] || { address: constants.zeroAddress, reserve: constants.zeroAddress };
+    const { address: escrowAddress, reserve: escrowReserveAddress } = firstEscrow;
+    
+    if (escrowReserveAddress === constants.zeroAddress) {
+      throw new Error(`Escrow ${escrowAddress} is not associated with a reserve`);
+    }
 
     // Find the user's latest Asset with the MercataETHBridge address
     const assetSearchOptions = {
       ...options,
       query: {
-        ownerCommonName: `eq.${ownerCommonName}`,
+        ownerCommonName: `eq.${userCommonName}`,
         root: `eq.${assetRootAddress}`,
         address: `neq.${assetRootAddress}`,
         select: 'address,quantity::text',
@@ -2387,7 +2370,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
 
     // Stake the Asset
     const stakeArgs = {
-      reserve,
+      reserve: escrowReserveAddress,
       escrowAddress,
       assets: [asset.address],
       collateralQuantity: asset.quantity,

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -2337,12 +2337,11 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     const IS_ACTIVE = 'eq.true';
 
     // Find the Escrows associated with the Reserve (if any, if not set it as zero address)
-    console.log('stakeAfterBridge - userCommonName: ', userCommonName);
     const escrowSearchOptions = {
       ...options,
       query: {
         select: 'address,reserve',
-        assetRootAddress: `eq.${assetRootAddress}`,
+        assetRootAddress: `eq.${assetRootAddress}:main`,
         borrowerCommonName: `eq.${userCommonName}`,
         isActive: IS_ACTIVE,
         creator: CREATOR,
@@ -2353,7 +2352,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
       { name: 'BlockApps-Mercata-Escrow' },
       escrowSearchOptions
     );
-    console.log('escrows:', escrows);
+
     const firstEscrow = escrows?.[0] || {
       address: constants.zeroAddress,
       reserve: constants.zeroAddress,

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -2364,7 +2364,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     const assetSearchOptions = {
       ...options,
       query: {
-        ownerCommonName: ownerCommonName,
+        ownerCommonName: `eq.${ownerCommonName}`,
         root: `eq.${assetRootAddress}`,
         address: `neq.${assetRootAddress}`,
         queryOptions: { select: 'address,quantity::text' },

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -1183,12 +1183,20 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     return tokensJs.addHash(rawAdmin, args, options);
   };
 
-  contract.getBridgeableAddresses = async function (args, options = defaultOptions) {
+  contract.getBridgeableAddresses = async function (
+    args,
+    options = defaultOptions
+  ) {
     return tokensJs.getBridge(rawAdmin, args, options);
   };
 
   contract.bridgeOut = async function (args, options = defaultOptions) {
-    const { tokenAssetRootAddress, assetAddress, quantity, externalChainWalletAddress } = args;
+    const {
+      tokenAssetRootAddress,
+      assetAddress,
+      quantity,
+      externalChainWalletAddress,
+    } = args;
 
     const bnQauntity = new BigNumber(quantity);
 
@@ -2247,7 +2255,11 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   };
 
   contract.borrow = async function (args, options = defaultOptions) {
-    return await reserveJs.borrow(rawAdmin, { userCommonName, ...args}, options);
+    return await reserveJs.borrow(
+      rawAdmin,
+      { userCommonName, ...args },
+      options
+    );
   };
 
   contract.repay = async function (args, options = defaultOptions) {
@@ -2325,6 +2337,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     const IS_ACTIVE = 'eq.true';
 
     // Find the Escrows associated with the Reserve (if any, if not set it as zero address)
+    console.log('stakeAfterBridge - userCommonName: ', userCommonName);
     const escrowSearchOptions = {
       ...options,
       query: {
@@ -2340,11 +2353,36 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
       { name: 'BlockApps-Mercata-Escrow' },
       escrowSearchOptions
     );
-    const firstEscrow = escrows?.[0] || { address: constants.zeroAddress, reserve: constants.zeroAddress };
-    const { address: escrowAddress, reserve: escrowReserveAddress } = firstEscrow;
-    
-    if (escrowReserveAddress === constants.zeroAddress) {
-      throw new Error(`Escrow ${escrowAddress} is not associated with a reserve`);
+    console.log('escrows:', escrows);
+    const firstEscrow = escrows?.[0] || {
+      address: constants.zeroAddress,
+      reserve: constants.zeroAddress,
+    };
+    let { address: escrowAddress, reserve } = firstEscrow;
+
+    if (reserve === undefined || reserve === constants.zeroAddress) {
+      const reserveSearchOptions = {
+        ...options,
+        query: {
+          creator: CREATOR,
+          isActive: IS_ACTIVE,
+          assetRootAddress: `eq.${assetRootAddress}`,
+          select: 'address',
+        },
+      };
+
+      const reserves = await rest.search(
+        rawAdmin,
+        { name: 'BlockApps-Mercata-Reserve' },
+        reserveSearchOptions
+      );
+      if (!reserves || reserves.length === 0) {
+        throw new Error(
+          'No active reserves found for asset root address: ' + assetRootAddress
+        );
+      }
+
+      reserve = reserves[0].address;
     }
 
     // Find the user's latest Asset with the MercataETHBridge address
@@ -2370,7 +2408,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
 
     // Stake the Asset
     const stakeArgs = {
-      reserve: escrowReserveAddress,
+      reserve,
       escrowAddress,
       assets: [asset.address],
       collateralQuantity: asset.quantity,

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -2344,16 +2344,20 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
     const reserve = reserves[0].address;
 
     // Find the Escrows associated with the Reserve (if any, if not set it as zero address)
-    const escrowQueryArgs = {
-      select: 'address',
-      reserve: `eq.${reserve}`,
-      borrowerCommonName: `eq.${ownerCommonName}`,
-      isActive: IS_ACTIVE,
+    const escrowSearchOptions = {
+      ...options,
+      query: {
+        select: 'address',
+        reserve: `eq.${reserve}`,
+        borrowerCommonName: `eq.${ownerCommonName}`,
+        isActive: IS_ACTIVE,
+        creator: CREATOR,
+      },
     };
-    const escrows = await escrowJs.searchEscrow(
+    const escrows = await rest.search(
       rawAdmin,
-      escrowQueryArgs,
-      options
+      { name: 'BlockApps-Mercata-Escrow' },
+      escrowSearchOptions
     );
     const escrowAddress =
       escrows && escrows.length > 0

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -2318,7 +2318,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
   };
 
   contract.stakeAfterBridge = async function (args, options = defaultOptions) {
-    const { assetAddress, ownerCommonName, stakeQuantity } = args;
+    const { assetRootAddress, ownerCommonName, eventTxHash } = args;
 
     // Use the MercataETHBridge address to find the Reserve address
     const CREATOR = 'in.(BlockApps,mercata_usdst)';
@@ -2328,7 +2328,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
       query: {
         creator: CREATOR,
         isActive: IS_ACTIVE,
-        assetRootAddress: `eq.${assetAddress}`,
+        assetRootAddress: `eq.${assetRootAddress}`,
       },
     };
 
@@ -2361,26 +2361,29 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
         : constants.zeroAddress;
 
     // Find the user's latest Asset with the MercataETHBridge address
-    const assetQueryArgs = {
+    const assetSearchOptions = {
       ownerCommonName: ownerCommonName,
-      originAddress: assetAddress,
-      status: ASSET_STATUS.ACTIVE,
-      queryOptions: { select: 'address,quantity' },
-      notEqualsField: 'quantity',
-      notEqualsValue: '0',
-      order: 'block_timestamp.desc',
+      root: `eq.${assetRootAddress}`,
+      address: `neq.${assetRootAddress}`,
+      queryOptions: { select: 'address,quantity::text' },
+      transaction_hash: `eq.${eventTxHash}`,
       limit: 1,
     };
-    const assets = await inventoryJs.getAll(rawAdmin, assetQueryArgs, options);
+    const assets = await rest.searchUntil(
+      rawAdmin,
+      { name: 'BlockApps-Mercata-Asset' },
+      (r) => r.length === 1,
+      assetSearchOptions
+    );
 
     const asset = assets[0];
 
-    // Stake the Asset 
+    // Stake the Asset
     const stakeArgs = {
       reserve,
       escrowAddress,
       assets: [asset.address],
-      collateralQuantity: stakeQuantity,
+      collateralQuantity: asset.quantity,
     };
     return await reserveJs.stake(rawAdmin, stakeArgs, options);
   };

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -2367,7 +2367,7 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
         ownerCommonName: `eq.${ownerCommonName}`,
         root: `eq.${assetRootAddress}`,
         address: `neq.${assetRootAddress}`,
-        queryOptions: { select: 'address,quantity::text' },
+        select: 'address,quantity::text',
         transaction_hash: `eq.${eventTxHash}`,
         limit: 1,
       },

--- a/marketplace/backend/dapp/dapp/dapp.js
+++ b/marketplace/backend/dapp/dapp/dapp.js
@@ -2362,12 +2362,15 @@ async function bind(rawAdmin, _contract, _defaultOptions, serviceUser = false) {
 
     // Find the user's latest Asset with the MercataETHBridge address
     const assetSearchOptions = {
-      ownerCommonName: ownerCommonName,
-      root: `eq.${assetRootAddress}`,
-      address: `neq.${assetRootAddress}`,
-      queryOptions: { select: 'address,quantity::text' },
-      transaction_hash: `eq.${eventTxHash}`,
-      limit: 1,
+      ...options,
+      query: {
+        ownerCommonName: ownerCommonName,
+        root: `eq.${assetRootAddress}`,
+        address: `neq.${assetRootAddress}`,
+        queryOptions: { select: 'address,quantity::text' },
+        transaction_hash: `eq.${eventTxHash}`,
+        limit: 1,
+      },
     };
     const assets = await rest.searchUntil(
       rawAdmin,

--- a/marketplace/backend/dapp/mercata-base-contracts/Templates/Staking/Reserve.sol
+++ b/marketplace/backend/dapp/mercata-base-contracts/Templates/Staking/Reserve.sol
@@ -142,32 +142,29 @@ abstract contract Reserve is Utils, Structs {
             );
             escrow = Escrow(simpleEscrow);
         } else {
-        try {
-            if (escrow.version() == "2.0") {
-                escrow.attachAssets(
-                    _assets,
-                    _collateralQuantity,
-                    (_oraclePrice * usdstPrice),
-                    loanToValueRatio,
-                    liquidationRatio
-                );
-                }
-            }
-            catch {
-                
+            try {
+                if (escrow.version() == "2.0") {
                     escrow.attachAssets(
                         _assets,
                         _collateralQuantity,
-                        (_oraclePrice * stratstoUSDSTFactor),
+                        (_oraclePrice * usdstPrice),
                         loanToValueRatio,
                         liquidationRatio
                     );
                 }
+            }
+            catch {
+                escrow.attachAssets(
+                    _assets,
+                    _collateralQuantity,
+                    (_oraclePrice * stratstoUSDSTFactor),
+                    loanToValueRatio,
+                    liquidationRatio
+                );
+            }
         }
 
-        uint escrowQuantity = escrow.collateralQuantity();
-
-        emit StakeCreated(escrow.borrower(), address(escrow), escrowQuantity, escrow.maxLoanAmount()); 
+        emit StakeCreated(escrow.borrower(), address(escrow), _collateralQuantity, escrow.maxLoanAmount()); 
         return address(escrow);
     }
 

--- a/marketplace/ui/src/App.js
+++ b/marketplace/ui/src/App.js
@@ -82,8 +82,7 @@ const App = () => {
     try {
       const { data } = lastMessage;
       const parsedData = JSON.parse(data);
-      // TODO: Remove this log when we are in production
-      console.log('WebSocket event:', parsedData);
+
       const { eventEvent, eventTxHash } = parsedData || {};
       if (!eventEvent || !eventTxHash) return;
 

--- a/marketplace/ui/src/App.js
+++ b/marketplace/ui/src/App.js
@@ -78,36 +78,30 @@ const App = () => {
   const { lastMessage } = useEventStream();
 
   useEffect(() => {
-    if (lastMessage) {
-      try {
-        const eventData = JSON.parse(lastMessage.data);
-        const eventName = eventData?.eventEvent?.eventName;
+    if (!lastMessage) return;
+    try {
+      const { data } = lastMessage;
+      const parsedData = JSON.parse(data);
+      const { eventEvent } = parsedData || {};
+      if (!eventEvent) return;
 
-        const eventArgs = eventData?.eventEvent?.eventArgs.reduce(
-          (acc, [key, value]) => {
-            acc[key] = value;
-            return acc;
-          },
-          {}
-        );
+      const { eventName, eventArgs, eventContractAddress } = eventEvent;
+      if (eventName !== 'MintedETHST') return;
 
-        const eventContractAddress = eventData?.eventEvent?.eventContractAddress;
+      // Convert eventArgs array into an object
+      const args = Object.fromEntries(eventArgs);
 
-        if (eventName === 'MintedETHST') {
-          const { amount: stakeQuantity, username: ownerCommonName } =
-            eventArgs;
+      if (user.commonName !== args.username) return;
 
-          const body = {
-            stakeQuantity: new BigNumber(stakeQuantity).toFixed(0),
-            assetAddress: eventContractAddress,
-            ownerCommonName,
-          };
+      const body = {
+        stakeQuantity: new BigNumber(args.amount).toFixed(0),
+        assetAddress: eventContractAddress,
+        ownerCommonName: args.username,
+      };
 
-          inventoryActions.stakeAfterBridge(inventoryDispatch, body);
-        }
-      } catch (error) {
-        console.error('Error parsing WebSocket event:', lastMessage.data);
-      }
+      inventoryActions.stakeAfterBridge(inventoryDispatch, body);
+    } catch (error) {
+      console.error('Error parsing WebSocket event:', lastMessage.data, error);
     }
   }, [lastMessage]);
 

--- a/marketplace/ui/src/App.js
+++ b/marketplace/ui/src/App.js
@@ -82,8 +82,10 @@ const App = () => {
     try {
       const { data } = lastMessage;
       const parsedData = JSON.parse(data);
-      const { eventEvent } = parsedData || {};
-      if (!eventEvent) return;
+      // TODO: Remove this log when we are in production
+      console.log('WebSocket event:', parsedData);
+      const { eventEvent, eventTxHash } = parsedData || {};
+      if (!eventEvent || !eventTxHash) return;
 
       const { eventName, eventArgs, eventContractAddress } = eventEvent;
       if (eventName !== 'MintedETHST') return;
@@ -94,8 +96,8 @@ const App = () => {
       if (user.commonName !== args.username) return;
 
       const body = {
-        stakeQuantity: new BigNumber(args.amount).toFixed(0),
-        assetAddress: eventContractAddress,
+        eventTxHash,
+        assetRootAddress: eventContractAddress,
         ownerCommonName: args.username,
       };
 

--- a/marketplace/ui/src/App.js
+++ b/marketplace/ui/src/App.js
@@ -97,7 +97,6 @@ const App = () => {
       const body = {
         eventTxHash,
         assetRootAddress: eventContractAddress,
-        ownerCommonName: args.username,
       };
 
       inventoryActions.stakeAfterBridge(inventoryDispatch, body);


### PR DESCRIPTION
Staking after bridging is failing with the following error msg:

```Only the owner of the assets can stake the assets```

This error msg comes from the `Reserve.sol` contract, specificallly the `stakeAsset` function. The reason we get this is because the App fetches a bridge event, regardless of which user is running the app instance, and tries to stake it. So if both user A and B are running the app and user A bridges, it could be the case that user B picks up the event and try to stake it before user A. That being said I don't think that this is the root cause of the issue because even if user B is faster, user A should still be able to pick it up and stake on it's own. Another theory that I have is that cirrus doesn't index the newly created asset fast enough. 

The PR solves both by having the app try staking if only the current logged in user matches the event user address and have the backend wait until it sees an asset that hash a tx hash that matches the event.

Another issue that was discovered was that the stake after bridge function on the app backend always created a new escrow when staked. This creates a new escrow for a user even if they have an existing escrow. This PR adds the functionality to fetch the existing escrow of the user and stake the asset/quantity of the newly created asset; thus, reducing the number of escrows a user has. This helps with having a cleaner cirrus table, easier app logic, and distribute rewards function load.

The issues that arrises from fetching existing user escrow comes from the following line inside the `Reserve.sol` contract:
`uint escrowQuantity = escrow.collateralQuantity();`
`emit StakeCreated(escrow.borrower(), address(escrow), escrowQuantity, escrow.maxLoanAmount());`

The transaction page uses the `StakeCreated` event to show the staking history to the user. However, this doesn't correctly show the correct user stake quantity as `escrowQuantity` is the whole escrow collateral quantity and not the amount the user staked. The fix for this would be in the smart contract that I have also included in the PR.

Additionaly, I found another concerning element on bridging. I tried to bridge 1 USDC on testnet2; but, because the USDC we use isn't an actual USDC but Aave's Aave Ethereum USDC (aEthUSDC), our bridging fails because the transfer wasn't just 1 transfer call happenning but multiple. Here is an example [tx](https://sepolia.etherscan.io/token/0x16da4541ad1807f4443d92d26044c1147406eb80). This means that we should change testnet USDC and USDT to an actual ERC20 token from the original creators. This issue doesn't concern prod as we use the actual tokens instaed of an interest accruing token issued from a different source.