### PR TITLE
User address on transfer modal

### DIFF
--- a/marketplace/ui/src/components/Inventory/TransferModal.js
+++ b/marketplace/ui/src/components/Inventory/TransferModal.js
@@ -18,6 +18,13 @@ import { SearchOutlined, DeleteOutlined } from '@ant-design/icons';
 import { OLD_SADDOG_ORIGIN_ADDRESS } from '../../helpers/constants';
 import { useLocation } from 'react-router-dom';
 
+const truncateAddress = (address) => {
+  if (!address) return '';
+  return (
+    address.substring(0, 6) + '...' + address.substring(address.length - 4)
+  );
+};
+
 const TransferModal = ({
   open,
   handleCancel,
@@ -144,8 +151,8 @@ const TransferModal = ({
     )
     .map((record) => ({
       label: isBurner
-        ? `burner - ${record.organization}`
-        : `${record.commonName} - ${record.organization}`,
+        ? `burner - ${truncateAddress(record.userAddress)}`
+        : `${record.commonName} - ${truncateAddress(record.userAddress)}`,
       value: record.userAddress,
     }));
 
@@ -342,8 +349,8 @@ const TransferModal = ({
           options={filteredUsersList}
           optionFilterProp="value"
           filterOption={(input, option) =>
-            ((option?.label ?? '').toLowerCase().includes(input.toLowerCase()) ||
-             (option?.value ?? '').toLowerCase().includes(input.toLowerCase()))
+            (option?.label ?? '').toLowerCase().includes(input.toLowerCase()) ||
+            (option?.value ?? '').toLowerCase().includes(input.toLowerCase())
           }
           open={record.openDropdown}
           suffixIcon={<SearchOutlined />}
@@ -352,6 +359,7 @@ const TransferModal = ({
           popupClassName="custom-select-dropdown"
           defaultValue={isBurner ? filteredUsersList[0] : null}
           disabled={index !== transfers.length - 1}
+          placeholder={'Search by username or user address'}
         />
       ),
     },
@@ -500,9 +508,11 @@ const TransferModal = ({
             }
             options={filteredUsersList}
             optionFilterProp="value"
-          filterOption={(input, option) =>
-              ((option?.label ?? '').toLowerCase().includes(input.toLowerCase()) ||
-               (option?.value ?? '').toLowerCase().includes(input.toLowerCase()))
+            filterOption={(input, option) =>
+              (option?.label ?? '')
+                .toLowerCase()
+                .includes(input.toLowerCase()) ||
+              (option?.value ?? '').toLowerCase().includes(input.toLowerCase())
             }
             open={mobileTransfer.openDropdown}
             suffixIcon={<SearchOutlined />}
@@ -510,6 +520,7 @@ const TransferModal = ({
             onBlur={() => handleDropdownOpenChange(mobileTransfer.id, false)}
             popupClassName="custom-select-dropdown"
             defaultValue={isBurner ? filteredUsersList[0] : null}
+            placeholder="Search by username or user address"
           />
         </div>
       </div>

--- a/marketplace/ui/src/components/Inventory/TransferModal.js
+++ b/marketplace/ui/src/components/Inventory/TransferModal.js
@@ -342,7 +342,8 @@ const TransferModal = ({
           options={filteredUsersList}
           optionFilterProp="value"
           filterOption={(input, option) =>
-            (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+            ((option?.label ?? '').toLowerCase().includes(input.toLowerCase()) ||
+             (option?.value ?? '').toLowerCase().includes(input.toLowerCase()))
           }
           open={record.openDropdown}
           suffixIcon={<SearchOutlined />}
@@ -499,8 +500,9 @@ const TransferModal = ({
             }
             options={filteredUsersList}
             optionFilterProp="value"
-            filterOption={(input, option) =>
-              (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+          filterOption={(input, option) =>
+              ((option?.label ?? '').toLowerCase().includes(input.toLowerCase()) ||
+               (option?.value ?? '').toLowerCase().includes(input.toLowerCase()))
             }
             open={mobileTransfer.openDropdown}
             suffixIcon={<SearchOutlined />}


### PR DESCRIPTION
Enhance user filtering on transfer modal by including user address in search criteria.

1. Say `Search by username or user address` as a placeholder on the recipient select component.
2. Allow search by user address and username.
3. Remove user org from the select option and replace it with user address.

https://github.com/user-attachments/assets/8eba2817-0342-4907-af85-4e11627b8511

