### PR TITLE
Display Minimum Borrow Balance in Repay Modal

### DIFF
--- a/marketplace/ui/src/components/Inventory/RepayModal.js
+++ b/marketplace/ui/src/components/Inventory/RepayModal.js
@@ -103,13 +103,22 @@ const RepayModal = ({
       const USDSTBalance = USDST ? new BigNumber(USDST) : new BigNumber(0);
 
       // Set the outstanding loan amount.
-      setRepayAmount(borrowedAmount);
+      setRepayAmount(
+        borrowedAmount.lt(new BigNumber(0.01))
+          ? new BigNumber(0.01)
+          : borrowedAmount
+      );
 
       // Set the repay amount to the lower of the outstanding loan or the user's USDST balance.
-      if (borrowedAmount.gt(USDSTBalance)) {
-        setRepayValue(USDSTBalance);
+      const defaultRepayValue = borrowedAmount.gt(USDSTBalance)
+        ? USDSTBalance
+        : borrowedAmount;
+
+      // Enforce a minimum repay amount of 0.01 tokens.
+      if (defaultRepayValue.lt(new BigNumber(0.01))) {
+        setRepayValue(new BigNumber(0.01));
       } else {
-        setRepayValue(borrowedAmount);
+        setRepayValue(defaultRepayValue);
       }
       setInitialized(true);
       setDisableButton(USDSTBalance.lte(0));


### PR DESCRIPTION
This PR ensures that when a user opens the repay modal with a borrow balance below $0.01, the modal will display the borrow balance as $0.01. This allows users to repay extremely small borrow amounts. Even though the modal indicates a repayment of $0.01 (for example, for an actual borrow balance of $0.00001), users will only be charged the precise outstanding amount ($0.00001 in this case).


https://github.com/user-attachments/assets/beacfdbb-698d-4f68-80da-7db07e1b4c5f

