### PR TITLE
P2P bugfix taking down testnet2 validators

### DIFF
--- a/strato/core/strato-p2p/src/Blockchain/Context.hs
+++ b/strato/core/strato-p2p/src/Blockchain/Context.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
@@ -49,7 +50,7 @@ module Blockchain.Context
 import           Conduit
 import           Control.Applicative
 import           Control.Concurrent
-import           Control.Exception                       hiding (bracket)
+import           Control.Exception                       hiding (bracket, catch)
 import           Control.Lens                            hiding (Context)
 import qualified Control.Monad.Change.Alter              as A
 import qualified Control.Monad.Change.Modify             as Mod
@@ -199,7 +200,9 @@ instance RunsClient ContextM where
       let pSource = appSource app
           pSink = appSink app
           conduits = P2pConduits pSource pSink sSource
-      handler conduits
+      catch
+        (handler conduits)
+        (\(e :: SomeException) -> $logErrorS "runClientConnection/Exception" . T.pack $ show e)
 
 instance RunsServer ContextM (LoggingT IO) where
   runServer (TCPPort listenPort) runner handler = do
@@ -209,7 +212,9 @@ instance RunsServer ContextM (LoggingT IO) where
           pSink = appSink app
           conduits = P2pConduits pSource pSink sSource
           ip = fromString . sockAddrToIP $ appSockAddr app
-      handler conduits ip
+      catch
+        (handler conduits ip)
+        (\(e :: SomeException) -> $logErrorS "runServer/Exception" . T.pack $ show e)
 
 instance MonadIO m => Mod.Accessible PublicKey (ReaderT Config m) where
   access _ = asks configPubKey

--- a/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
+++ b/strato/core/strato-p2p/src/Executable/StratoP2PServer.hs
@@ -131,7 +131,6 @@ ethServerHandler pSource pSink seqSrc host = do
                         logAndLengthenPeerDisableBy (fromIntegral $ 2 * flags_connectionTimeout) p
                       _ -> return $ Right ()
                   _ -> return $ Right ()
-                throwIO err
 
 runEthServerConduit ::
   MonadP2P m =>


### PR DESCRIPTION
Removed errant `throwIO` in p2p server's exception handler block, and wrapped runClientConnection and runServer handlers with catch to prevent leaky exceptions from taking down the entire node in the future.

Testnet2 validators were crashing with the error `Network.Socket.accept: failed (Software caused connection abort)`
Additionally, that line was preceded in each case by logs similar to this:
```
[2025-04-17 02:41:00.782288616 UTC]  INFO | ThreadId 26112201 | logAndLengthenPeerDisableBy         | Disabling Peer Host "129.158.46.197", exponential reset will occur in 86400s seconds
[2025-04-17 02:41:00.783315242 UTC]  INFO | ThreadId 26112201 | runEthServer/exit                   |  * Connection ended to <129.158.46.197
strato-p2p: NetworkIDMismatch
```
indicating that a `NetworkIDMismatch` exception had escaped the `try` block inside of `runEthServerConduit`. Upon further inspection, a call to `throwIO` at the end of `ethServerHandler` made it so any exception caught while running a server connection would result in the entire program crashing.
This was triggered by the recent addition of exceptions being thrown on the server side during the handshake,
```hs
  when (peerGH /= genHash) $ throwIO WrongGenesisBlock
  when (networkID' /= computeNetworkID) $ throwIO NetworkIDMismatch
```
but had been a latent bug for over a year.