### PR TITLE
Oracle fixes

### DIFF
--- a/payment-server/submitPrice.js
+++ b/payment-server/submitPrice.js
@@ -79,12 +79,12 @@ async function distributeRewards(contract, args) {
 }
 
 // After all calls are collected, we run them at once
-async function runDistributeRewardsCalls(token) {
+async function runDistributeRewardsCalls() {
   if (distributeRewardsCallList.length > 0) {
     console.log("Executing batch callList for distributeRewards...");
     let res;
     try {
-      res = await rest.callList(token, distributeRewardsCallList, {
+      res = await rest.callList(await oauthHelper.getServiceToken(), distributeRewardsCallList, {
         config,
         cacheNonce: true,
         isAsync: true,
@@ -94,7 +94,7 @@ async function runDistributeRewardsCalls(token) {
         results.filter((r) => r.status === "Pending").length === 0;
       const action = async (options) =>
         rest.getBlocResults(
-          token,
+          await oauthHelper.getServiceToken(),
           res.map((r) => r.hash),
           options
         );
@@ -108,19 +108,19 @@ async function runDistributeRewardsCalls(token) {
         if (r.status !== "Success") {
           console.error(`Error executing distributeRewards for: ${r.hash}`, r);
           await flagFile.appendToErrorFile(
-            `Error executing distributeRewards for: ${r}`
+            `Error executing distributeRewards for hash: ${r.hash}, r.status=${r.status}. See oracle container logs for more details.`
           );
         }
       }
       console.log("Batch distributeRewards calls completed.");
     } catch (error) {
       console.error("Error executing batch distributeRewards calls:", error);
-      console.log(
+      console.error(
         "The hashes of distribute rewards transactions in a failed batch:",
         res.map((r) => r.hash)
       );
       await flagFile.appendToErrorFile(
-        `Error executing batch distributeRewards calls: ${error.message}`
+        `Error executing batch distributeRewards calls: ${error.message}. See oracle container logs for more details and the failed transaction hashes.`
       );
     } finally {
       // Clear the call list to avoid reprocessing stale calls
@@ -132,7 +132,7 @@ async function runDistributeRewardsCalls(token) {
 }
 
 // Function to fetch all escrow addresses for a given reserve and call distributeRewards
-async function fetchAndSubmitEscrowAddresses(oracleContract, token) {
+async function fetchAndSubmitEscrowAddresses(oracleContract) {
   const reserveSearchOptions = {
     config,
     query: {
@@ -143,7 +143,7 @@ async function fetchAndSubmitEscrowAddresses(oracleContract, token) {
   };
 
   const reserves = await rest.search(
-    token,
+    await oauthHelper.getServiceToken(),
     { name: "BlockApps-Mercata-Reserve" },
     reserveSearchOptions
   );
@@ -170,7 +170,7 @@ async function fetchAndSubmitEscrowAddresses(oracleContract, token) {
 
     // Fetch escrows from Cirrus
     const escrows = await rest.search(
-      token,
+      await oauthHelper.getServiceToken(),
       { name: "BlockApps-Mercata-Escrow" },
       searchOptions
     );
@@ -257,10 +257,7 @@ const submitOraclePricePeriodically = async () => {
         },
         config
       );
-      await fetchAndSubmitEscrowAddresses(
-        oracle,
-        await oauthHelper.getServiceToken()
-      );
+      await fetchAndSubmitEscrowAddresses(oracle);
     } catch (error) {
       console.error(`[Oracle ERROR] Failed to process oracle ${key}:`, error);
       await flagFile.appendToErrorFile(
@@ -268,19 +265,21 @@ const submitOraclePricePeriodically = async () => {
       );
     }
   }
-  await runDistributeRewardsCalls(await oauthHelper.getServiceToken());
+  await runDistributeRewardsCalls();
 };
 
 // Function to update sale prices periodically
 const updateSalePricePeriodically = async () => {
-  const metalToken = await oauthHelper.getUserToken(
-    process.env.METALS_USERNAME,
-    process.env.METALS_PASSWORD
-  );
-  const erc20Token = await oauthHelper.getUserToken(
-    process.env.TOKENS_USERNAME,
-    process.env.TOKENS_PASSWORD
-  );
+  const getMetalAccessToken = async () => 
+      await oauthHelper.getUserToken(
+          process.env.METALS_USERNAME,
+          process.env.METALS_PASSWORD
+      );
+  const getErc20AccessToken = async () => 
+      await oauthHelper.getUserToken(
+          process.env.TOKENS_USERNAME,
+          process.env.TOKENS_PASSWORD
+      );
 
   // Get the current UTC hour and current hour stamp.
   const now = new Date();
@@ -300,7 +299,7 @@ const updateSalePricePeriodically = async () => {
     try {
       // Fetch the asset (with sale details) from the blockchain.
       const assetResult = await fetchAsset(
-        metalToken,
+        await getMetalAccessToken(),
         { address: asset.address },
         config
       );
@@ -336,7 +335,7 @@ const updateSalePricePeriodically = async () => {
       // Update the asset's price with the new data.
       await updateAssetPrice(
         asset.markUp,
-        asset.type === "ERC20" ? erc20Token : metalToken,
+        asset.type === "ERC20" ? await getErc20AccessToken() : await getMetalAccessToken(),
         assetResult[0]?.sale,
         result.price,
         decimals,

--- a/payment-server/submitPrice.js
+++ b/payment-server/submitPrice.js
@@ -422,7 +422,7 @@ async function main() {
 
         // Check if it's time to run the oracle update
         if (
-          (now.getHours() === parseInt(oracleUpdateTime, 10) &&
+          (now.getHours() > parseInt(oracleUpdateTime, 10) &&
             lastOracleRun !== currentDate) ||
           !lastOracleRun
         ) {

--- a/payment-server/submitPrice.js
+++ b/payment-server/submitPrice.js
@@ -397,6 +397,22 @@ async function main() {
     console.log(`Heartbeat server started on port ${port}.`);
   });
 
+  // Custom TimeoutError class
+  class TimeoutError extends Error {
+    constructor(message) {
+      super(message);
+      this.name = 'TimeoutError';
+    }
+  }
+
+  function createTimeoutPromise(seconds, breachMessage) {
+    return new Promise((_, reject) => {
+      setTimeout(() => {
+        reject(new TimeoutError(breachMessage));
+      }, seconds * 1000);
+    });
+  }
+
   // Periodically fetch prices and update
   const runTasks = async () => {
     while (true) {
@@ -411,17 +427,45 @@ async function main() {
           !lastOracleRun
         ) {
           console.log("[Oracle] Running submitOraclePricePeriodically...");
-          await submitOraclePricePeriodically();
-          lastOracleRun = currentDate;
+          try {
+            await Promise.race([
+              submitOraclePricePeriodically(),
+              createTimeoutPromise(seconds=4200, breachMessage="submitOraclePricePeriodically timed out after 4200 seconds")
+            ]);
+            lastOracleRun = currentDate;
+          } catch (error) {
+            if (error instanceof TimeoutError) {
+              console.error("[Oracle] submitOraclePricePeriodically did not respond within the timeout period:", error.message);
+              await flagFile.appendToErrorFile(`submitOraclePricePeriodically did not respond within the timeout period: ${error.message}`);
+              lastOracleRun = currentDate; // still setting that Oracle ran on the currentDate to keep the behavior it had before the timeout implementation
+            } else {
+              console.error("[Oracle] Unhandled error in submitOraclePricePeriodically:", error);
+              await flagFile.appendToErrorFile(`Unhandled error in submitOraclePricePeriodically: ${error.message}`);
+            }
+          }
         } else {
-          console.log("[Oracle] Skipping since interval not reached.");
+          console.log("[Oracle] Skipping 'submitOraclePricePeriodically' since interval not reached.");
         }
 
         // Check if it's time to run the sale price update
         if (process.env.SALE_UPDATE === "true") {
-          await updateSalePricePeriodically();
+          console.log("[Sale] Running updateSalePricePeriodically...");
+          try {
+            await Promise.race([
+              updateSalePricePeriodically(),
+              createTimeoutPromise(seconds=3600, breachMessage="updateSalePricePeriodically timed out after 3600 seconds")
+            ]);
+          } catch (error) {
+            if (error instanceof TimeoutError) {
+              console.error("[Sale] updateSalePricePeriodically did not respond within the timeout period:", error.message);
+              await flagFile.appendToErrorFile(`updateSalePricePeriodically did not respond within the timeout period: ${error.message}`);
+            } else {
+              console.error("[Sale] Unhandled error in updateSalePricePeriodically:", error);
+              await flagFile.appendToErrorFile(`Unhandled error in updateSalePricePeriodically: ${error.message}`);
+            }
+          }
         } else {
-          console.log("[Sale] Skipping since SALE_UPDATE is not set to true.");
+          console.log("[Sale] Skipping 'updateSalePricePeriodically' since SALE_UPDATE is not set to true.");
         }
       } catch (error) {
         console.error("Error in main loop:", error);


### PR DESCRIPTION
Oracle script:
- Use token getters in the code to make sure the token does not expire in the waitUntil loop etc.
- Add timeouts to the high-level oracle jobs - to prevent the script from stalling with nothing happenning (no logs output)
- Replace `===` with `>` in condition `now.getHours() > parseInt(oracleUpdateTime, 10)` - in order to run the submitOraclePricePeriodically() even if it's after 11am while the function did not run today (e.g. if container was down between 10am and 11am)