### PR TITLE
Run sync test only when there are changes in the strato directory

### DIFF
--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -284,19 +284,18 @@ pipeline {
                   branch "PR-*"
                   environment(name: "CHANGE_TARGET", value: "develop")
                   expression {
+                    sh(script: '''
+                      echo "[Test Sync check] Checking for strato/ changes..."
+                      git fetch origin develop --quiet
+                      if git diff --name-only origin/develop...HEAD | grep '^strato/'; then
+                        echo "[Test Sync check] Detected changes in strato/"
+                      else
+                        echo "[Test Sync check] No changes in strato/, skipping"
+                      fi
+                    ''', returnStatus: true)
+
                     return sh(
-                      script: '''
-                        echo "Fetching origin/develop to compare..."
-                        git fetch origin develop --quiet
-                        echo "Checking for strato/ changes..."
-                        if git diff --name-only origin/develop...HEAD | grep '^strato/'; then
-                          echo "Detected changes in strato/, proceeding to Test Sync stage."
-                          exit 0
-                        else
-                          echo "No changes in strato/, skipping Test Sync stage."
-                          exit 1
-                        fi
-                      ''',
+                      script: 'git diff --name-only origin/develop...HEAD | grep -q "^strato/"',
                       returnStatus: true
                     ) == 0
                   }

--- a/pipelines/Jenkinsfile.autobuild
+++ b/pipelines/Jenkinsfile.autobuild
@@ -283,7 +283,23 @@ pipeline {
                 allOf {
                   branch "PR-*"
                   environment(name: "CHANGE_TARGET", value: "develop")
-                  changeset "strato/**"
+                  expression {
+                    return sh(
+                      script: '''
+                        echo "Fetching origin/develop to compare..."
+                        git fetch origin develop --quiet
+                        echo "Checking for strato/ changes..."
+                        if git diff --name-only origin/develop...HEAD | grep '^strato/'; then
+                          echo "Detected changes in strato/, proceeding to Test Sync stage."
+                          exit 0
+                        else
+                          echo "No changes in strato/, skipping Test Sync stage."
+                          exit 1
+                        fi
+                      ''',
+                      returnStatus: true
+                    ) == 0
+                  }
                 }
               }
               agent { label "testsync" }


### PR DESCRIPTION
The sync test is supposed to only trigger if there were changes within the `strato/` directory of the `strato-platform`. 

Basically, if there were no changes to the core - no need to test the sync on every git push.

The previous check was only checking if there were changes to the `strato/` directory within the most recent commit