### PR TITLE
Added support for search by partial contract name and contract address

### DIFF
--- a/strato/api/bloc/bloc2/src/Bloc/Server/Contracts.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Contracts.hs
@@ -84,7 +84,7 @@ getContracts mName mOffset mLimit chainId = do
       accountsFilterParams
         { _qaChainId = maybeToList chainId,
           _qaExternal = Just False,
-          _qaContractName = mName,
+          _qaSearch = mName,
           _qaOffset = fromIntegral <$> mOffset,
           _qaLimit = fromIntegral <$> mLimit
         }

--- a/strato/api/core/src/Handlers/AccountInfo.hs
+++ b/strato/api/core/src/Handlers/AccountInfo.hs
@@ -33,6 +33,7 @@ import Data.Source.Map
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8)
+import qualified Database.Esqueleto.Internal.Internal as E
 import qualified Database.Esqueleto.Legacy as E
 import Numeric.Natural
 -- import qualified LabeledError
@@ -69,6 +70,7 @@ type API =
     :> QueryParam "limit" Natural
     :> QueryParam "offset" Natural
     :> QueryParam "ignoreChain" Bool
+    :> QueryParam "search" Text
     :> Get '[JSON] [AddressStateRef']
 
 data AccountsFilterParams = AccountsFilterParams
@@ -89,7 +91,8 @@ data AccountsFilterParams = AccountsFilterParams
     _qaExternal :: Maybe Bool,
     _qaLimit :: Maybe Natural,
     _qaOffset :: Maybe Natural,
-    _qaIgnoreChain :: Maybe Bool
+    _qaIgnoreChain :: Maybe Bool,
+    _qaSearch :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
@@ -111,6 +114,7 @@ accountsFilterParams =
     Nothing
     Nothing
     []
+    Nothing
     Nothing
     Nothing
     Nothing
@@ -138,6 +142,7 @@ uncurryAccountsFilterParams ::
     Maybe Natural ->
     Maybe Natural ->
     Maybe Bool ->
+    Maybe Text ->
     r
   ) ->
   AccountsFilterParams ->
@@ -161,6 +166,7 @@ uncurryAccountsFilterParams f AccountsFilterParams {..} =
     _qaLimit
     _qaOffset
     _qaIgnoreChain
+    _qaSearch
 
 server :: HasSQL m => ServerT API m
 server = getAccount
@@ -201,7 +207,10 @@ instance HasSQL m => Selectable AccountsFilterParams [AddressStateRef] m where
                       -- fmap (\v -> accStateRef E.^. AddressStateRefCode E.==. E.val (toCode v)) _qaCode,
                       fmap (\v -> accStateRef E.^. AddressStateRefCodeHash E.==. E.val (Just v)) _qaCodeHash,
                       fmap (\v -> accStateRef E.^. AddressStateRefContractName E.==. E.val (Just $ T.unpack v)) _qaContractName,
-                      fmap (\v -> accStateRef E.^. AddressStateRefCodePtrAddress E.==. E.val (Just v)) _qaCodePtrAddress
+                      fmap (\v -> accStateRef E.^. AddressStateRefCodePtrAddress E.==. E.val (Just v)) _qaCodePtrAddress,
+                      fmap (\v -> (E.unsafeSqlCastAs "TEXT" (accStateRef E.^. AddressStateRefAddress) `E.like` E.val (T.unpack $ "%" <> v <> "%"))
+                            E.||. (accStateRef E.^. AddressStateRefContractName `E.like` E.val (Just . T.unpack $ "%" <> v <> "%"))
+                           ) _qaSearch
                     ]
 
             E.where_ (foldl1 (E.&&.) criteria)
@@ -231,9 +240,10 @@ getAccount ::
   Maybe Natural ->
   Maybe Natural ->
   Maybe Bool ->
+  Maybe Text ->
   m [AddressStateRef']
-getAccount a b c d e f g h i j k l m n o p q =
-  getAccount' (AccountsFilterParams a b c d e f g h i j k l m n o p q)
+getAccount a b c d e f g h i j k l m n o p q r =
+  getAccount' (AccountsFilterParams a b c d e f g h i j k l m n o p q r)
 
 getAccount' :: Selectable AccountsFilterParams [AddressStateRef] m => AccountsFilterParams -> m [AddressStateRef']
 getAccount' a = do
@@ -260,7 +270,8 @@ accountQueryParams =
     "external",
     "limit",
     "offset",
-    "ignoreChain"
+    "ignoreChain",
+    "search"
   ]
 
 -- toCode :: Text -> BC.ByteString


### PR DESCRIPTION
No more having to type the full name of the contract or click through tons of pages of contracts to get to the one you want
![Screenshot from 2025-05-05 16-33-40](https://github.com/user-attachments/assets/71ee9b51-e437-482a-a53c-cef86560e94b)
![Screenshot from 2025-05-05 16-33-02](https://github.com/user-attachments/assets/e601a092-aed0-4805-b808-1c0a5cd4ec59)
![Screenshot from 2025-05-05 16-37-06](https://github.com/user-attachments/assets/88645cd9-b9e4-467e-b8b2-063e600a8b1a)
