### PR TITLE
Removed code for old creator fork

### DIFF
--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -137,7 +137,6 @@ services:
     - blockTime=${blockTime}
     - bootnode=${bootnode}
     - connectionTimeout=${connectionTimeout}
-    - creatorForkBlockNumber=${creatorForkBlockNumber}
     - debugFail=${debugFail}
     - debugPort=${debugPort}
     - debugWSHost=${debugWSHost}

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -56,7 +56,6 @@ import Blockchain.Strato.Model.Event
 import Blockchain.Strato.Model.ExtendedWord
 import Blockchain.Strato.Model.Gas
 import Blockchain.Strato.Model.Keccak256
-import Blockchain.Strato.Model.Options (computeNetworkID)
 import qualified Blockchain.Strato.Model.Secp256k1 as SEC
 import Blockchain.Stream.Action (Action)
 import qualified Blockchain.Stream.Action as Action
@@ -331,9 +330,8 @@ create' creator maybeCodePtr originAddress issuerAcct issuerName newAddress ch c
       maybeUseWallet = M.lookup "useWallet" =<< metadata
       !useWallet = maybe False (const True) maybeUseWallet
       parentName' = bool parentName "" (useWallet && parentName == "User")
-      issuer = if shouldDoCreatorFork . blockHeaderBlockNumber $ Env.blockHeader env then issuerAcct else Env.origin env
   -- set creator
-  setCreator issuer originAddress newAddress contract' (BlockHeader.number $ Env.blockHeader env)
+  setCreator issuerAcct originAddress newAddress contract' (BlockHeader.number $ Env.blockHeader env)
 
   -- Run the constructor
   runTheConstructors creator newAddress ch cc contractName' argExps
@@ -342,7 +340,7 @@ create' creator maybeCodePtr originAddress issuerAcct issuerName newAddress ch c
 
   void . withCallInfo newAddress contract' (stringToLabel $ labelToString contractName' ++ " constructor") ch cc M.empty False False $ do
     -- set creator again, in case the caller's cert changed during constructor execution
-    setCreator issuer originAddress newAddress contract' (BlockHeader.number $ Env.blockHeader env)
+    setCreator issuerAcct originAddress newAddress contract' (BlockHeader.number $ Env.blockHeader env)
 
   Mod.modifyStatefully_ (Mod.Proxy @Action) $
     Action.actionData %= Action.omapAdjust (Action.actionDataCreator .~ (T.pack issuerName)) newAddress
@@ -713,11 +711,7 @@ callWithResult from to fnCalltype mContract functionName isRCC argExps = snd <$>
 setCreator :: MonadSM m => Address -> Address -> Address -> CC.Contract -> Integer -> m ()
 setCreator creator originAddress contract _ _ = do
   maybeCert <- A.select (A.Proxy @X509Certificate) creator
-  blockNumber <- blockHeaderBlockNumber . Env.blockHeader <$> getEnv
-  let forkYeah = shouldDoCreatorFork blockNumber
-      _cn = if forkYeah
-                then fromMaybe "" $ fmap subCommonName $ getCertSubject =<< maybeCert
-                else fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
+  let _cn = fromMaybe "" $ fmap subCommonName $ getCertSubject =<< maybeCert
 
   case maybeCert of
     (Just cert) -> do
@@ -735,8 +729,7 @@ setCreator creator originAddress contract _ _ = do
     else do
       $logDebugS "setCreator/versioning" . T.pack . C.red $ "Ignoring creator field for empty creator field"
   
-  when forkYeah $ do
-    putSolidStorageKeyVal' contract (MS.StoragePath [MS.Field ":originAddress"]) (MS.BAccount $ NamedAccount originAddress MainChain)
+  putSolidStorageKeyVal' contract (MS.StoragePath [MS.Field ":originAddress"]) (MS.BAccount $ NamedAccount originAddress MainChain)
 
 getCreator :: MonadSM m => Address -> m (Address, Address, String) -- (creatorAddress, originAddress, creatorName)
 getCreator caller = do
@@ -748,10 +741,7 @@ getCreator caller = do
       -- caller is a user account, so they are creating the first instance of this app
       -- we will look up their cert in the DB and use it to get the org name for this app
       maybeCert <- A.select (A.Proxy @X509Certificate) caller
-      blockNumber <- blockHeaderBlockNumber . Env.blockHeader <$> getEnv
-      let creator' = if shouldDoCreatorFork blockNumber
-                        then fromMaybe "" $ fmap subCommonName $ getCertSubject =<< maybeCert
-                        else fromMaybe "" $ fmap subOrg $ getCertSubject =<< maybeCert
+      let creator' = fromMaybe "" $ fmap subCommonName $ getCertSubject =<< maybeCert
       $logDebugS "getCreator/versioning" . T.pack $ "The creator is " ++ (show creator')
       return (caller, caller, creator')
     x -> do
@@ -775,14 +765,6 @@ getCreator caller = do
             (_ , _)-> do
               $logDebugS "getCreator/versioning" . T.pack $ "Its creator is unset. Returning empty string"
               return (caller, caller, "") --TODO: have better sane default
-  
--- helper function for getCreator and setCreator
--- once mercata-hydrogen and mercata networks dismantled, this function and flag will be obsolete
-shouldDoCreatorFork :: Integer -> Bool
-shouldDoCreatorFork curBlockNo = case (flags_creatorForkBlockNumber, computeNetworkID) of 
-  (-1, 7596898649924658542) -> curBlockNo >= 37000 -- on mercata-hydrogen, switch at block 37,000
-  (-1, 6909499098523985262) -> curBlockNo >= 6200 -- on mercata, switch at block 6,200
-  (b, _) -> curBlockNo >= b -- do whatever the flag says
 
 logFunctionCall :: MonadSM m => ValList -> Address -> CC.Contract -> SolidString -> m (Maybe Value) -> m (Maybe Value)
 logFunctionCall args address contract functionName f = do

--- a/strato/core/vm-tools/src/Blockchain/VMOptions.hs
+++ b/strato/core/vm-tools/src/Blockchain/VMOptions.hs
@@ -12,7 +12,6 @@ module Blockchain.VMOptions
     flags_startingBlock,
     flags_txSizeLimit,
     flags_gasLimit,
-    flags_creatorForkBlockNumber,
     flags_strictGas,
     flags_strictGasLimit,
   )
@@ -38,6 +37,5 @@ defineFlag "transactionRootVerification" False "Flag to turn transaction root ve
 defineFlag "startingBlock" (-1 :: Integer) "block in kafka to start running the VM on"
 defineFlag "svmDev" (False :: Bool) "Whether to crash on SolidVM exceptions"
 defineFlag "svmTrace" (True :: Bool) "Whether to have verbose logging in SolidVM"
-defineFlag "creatorForkBlockNumber" (-1 :: Integer) "The block number at which to use commonName for the creator value instead of organization"
 defineFlag "strictGas" (True :: Bool) "Whether to restrict transactions to approximately 2 second gas timeout"
 defineFlag "strictGasLimit" (400000 :: Integer) "The maximum amount of gas that can be used for a transaction in strict mode"

--- a/strato/extraFiles/strato/doit.sh
+++ b/strato/extraFiles/strato/doit.sh
@@ -189,9 +189,6 @@ function newnode {
   if [ -n "${gasLimit}" ]; then
       gasFlag="--gasLimit=${gasLimit}"
   fi
-  if [ -n "${creatorForkBlockNumber}" ]; then
-      creatorFlag="--creatorForkBlockNumber=${creatorForkBlockNumber}"
-  fi
   if [ -n "${idServerUrl}" ]; then
       idServer="--identityServerUrl=${idServerUrl}"
   fi
@@ -240,7 +237,6 @@ function newnode {
     ${networkFlag} \
     "${txsFlag}" \
     "${gasFlag}" \
-    "${creatorFlag}" \
     "${iFlag}" \
     "${sgFlag}" \
     "${sglFlag}" \


### PR DESCRIPTION
Removes code supporting the old creator fork. I've added the DO NOT MERGE label for now because this changes causes a stateroot mismatch with the testnet, and should only be merged right before doing a network restart

EDIT: It looks like the default behavior for helium is for the creator fork block number to be 0, so removing it has no effect. Therefore, this PR syncs to testnet and can be merged without needing a network restart