### PR TITLE
Fix msg.sender value as parent constructor argument

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2935,7 +2935,7 @@ runTheConstructors from to hsh cc contractName' argExps = do
           var <- createVar correctedVal
           return (n, (t, var))
 
-  void . withCallInfo to contract' (stringToLabel $ labelToString contractName' ++ " constructor") hsh cc (M.fromList zipped) False False $ do
+  void . withCallInfo to contract' (stringToLabel $ labelToString contractName' ++ " constructor") hsh cc (M.fromList zipped) False False . pushSender from $ do
 
     forM_ [(n, e, theType) | (n, CC.VariableDecl theType _ (Just e) _ _ _) <- M.toList $ contract' ^. CC.storageDefs] $ \(n, e, theType) -> do
       v <- expToVar e $ Just theType
@@ -2981,7 +2981,7 @@ runTheConstructors from to hsh cc contractName' argExps = do
         let (lhs, rhs) = foldr (\(a, b) (c, d) -> (a ++ c, b ++ d)) ([], []) (map (span isNotModExec) modContentsList)
         logVals lhs rhs
         _ <- runStatementBlock' lhs
-        _ <- pushSender from $ runStatementBlock commands
+        _ <- runStatementBlock commands
         _ <- runStatementBlock' rhs
         pure ()
       Nothing -> return ()

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -67,7 +67,7 @@ findDefault = \case
   TBool -> SBool False
   TAccount -> (SAccount $ unspecifiedChain 0x0) False
   TContract n -> SContract n $ unspecifiedChain 0x0
-  TEnumVal n -> SEnumVal n (todo "findDefault/enumval" n) 0x0
+  TEnumVal n -> SEnumVal n "" 0x0
   TStruct n fs -> todo "findDefault/struct" (n, fs)
   TComplex -> todo "finddefault/complex" TComplex
   Todo msg -> todo "findDefault/todo" msg


### PR DESCRIPTION
Tested on testnet, crashes at block 262 on a stateroot mismatch, which is expected, because the LP token that failed to create before now gets created successfully with the fix in place. 