### PR TITLE
feat: copy button on addresses

### DIFF
--- a/mercata/ui/src/components/dashboard/DashboardHeader.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardHeader.tsx
@@ -1,24 +1,15 @@
 
-import { Copy } from 'lucide-react';
 import { Avatar, AvatarFallback } from "../ui/avatar";
-import { useState } from "react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { useUser } from '@/context/UserContext';
+import CopyButton from '../ui/copy';
 
 interface DashboardHeaderProps {
   title: string;
 }
 
 const DashboardHeader = ({ title }: DashboardHeaderProps) => {
-  const [copied, setCopied] = useState(false);
   const { userAddress, userName } = useUser()
-  
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(userAddress);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-  
+
   const truncateAddress = (address: string) => {
     return `${address?.substring(0, 6)}...${address?.substring(address.length - 4)}`;
   };
@@ -26,26 +17,14 @@ const DashboardHeader = ({ title }: DashboardHeaderProps) => {
   return (
     <header className="bg-white border-b border-gray-100 py-4 px-6 flex items-center justify-between">
       <h1 className="text-xl font-bold">{title}</h1>
-      
+
       <div className="flex items-center space-x-4">
         <div className="flex items-center">
           <div className="flex flex-col items-end mr-3">
             <span className="text-sm font-medium">{userName || "N/A"}</span>
             <div className="flex items-center">
               <span className="text-xs text-gray-500">{userAddress ? truncateAddress(userAddress) : "N/A"}</span>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button 
-                    onClick={copyToClipboard} 
-                    className="ml-1 text-gray-400 hover:text-gray-600 transition-colors"
-                  >
-                    <Copy size={12} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>{copied ? "Copied!" : "Copy address"}</p>
-                </TooltipContent>
-              </Tooltip>
+              <CopyButton address={userAddress}/>
             </div>
           </div>
           <Avatar className="w-8 h-8 bg-strato-blue">

--- a/mercata/ui/src/components/dashboard/LiquidationsSection.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidationsSection.tsx
@@ -2,19 +2,6 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import CopyButton from "../ui/copy";
-
-interface LiquidationEntry {
-  id: string;
-  user: string;
-  asset: string;
-  assetSymbol?: string;
-  amount: string;
-  collateralAsset: string;
-  collateralSymbol?: string;
-  collateralAmount: string;
-  healthFactor: number;
-  expectedProfit?: string;
-}
 import { useLiquidationContext } from "@/context/LiquidationContext";
 
 const shorten = (addr: string) => addr.slice(0, 6) + "..." + addr.slice(-4);

--- a/mercata/ui/src/components/dashboard/LiquidationsSection.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidationsSection.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { api } from "@/lib/axios";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
+import CopyButton from "../ui/copy";
 
 interface LiquidationEntry {
   id: string;
@@ -69,7 +70,12 @@ const LiquidationsSection: React.FC = () => {
   const renderRow = (l: LiquidationEntry, showAction: boolean) => (
     <tr key={l.id} className="border-t">
       <td className="px-4 py-2 text-sm">{l.id}</td>
-      <td className="px-4 py-2 text-sm">{shorten(l.user)}</td>
+      <td className="px-4 py-2 text-sm">
+        <div className="flex items-center space-x-2">
+          <span className="truncate">{shorten(l.user)}</span>
+          <CopyButton address={l?.user} />
+        </div>
+      </td>
       <td className="px-4 py-2 text-sm">
         {weiToEther(l.collateralAmount).toFixed(2)} {l.collateralSymbol || shorten(l.collateralAsset)}
       </td>
@@ -82,9 +88,9 @@ const LiquidationsSection: React.FC = () => {
       <td className="px-4 py-2 text-sm">
         {l.expectedProfit ? (
           parseFloat(l.expectedProfit) > 0 ? (
-            <span className="text-green-600">${(parseFloat(l.expectedProfit)/1e18).toFixed(2)}</span>
+            <span className="text-green-600">${(parseFloat(l.expectedProfit) / 1e18).toFixed(2)}</span>
           ) : (
-            <span className="text-red-600">${(parseFloat(l.expectedProfit)/1e18).toFixed(2)}</span>
+            <span className="text-red-600">${(parseFloat(l.expectedProfit) / 1e18).toFixed(2)}</span>
           )
         ) : "--"}
       </td>

--- a/mercata/ui/src/components/ui/copy.tsx
+++ b/mercata/ui/src/components/ui/copy.tsx
@@ -2,7 +2,7 @@ import { Copy, CopyCheck } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 import { useState } from "react";
 
-const CopyButton = ({address}) => {  
+const CopyButton = ({ address }) => {
   const [copied, setCopied] = useState(false)
 
   const copyToClipboard = () => {
@@ -12,7 +12,7 @@ const CopyButton = ({address}) => {
   };
 
   return (
-    <Tooltip open={copied || undefined}>
+    address && <Tooltip open={copied || undefined}>
       <TooltipTrigger asChild>
         <button
           onClick={copyToClipboard}

--- a/mercata/ui/src/components/ui/copy.tsx
+++ b/mercata/ui/src/components/ui/copy.tsx
@@ -1,0 +1,38 @@
+import { Copy, CopyCheck } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+import { useState } from "react";
+
+const CopyButton = ({address}) => {  
+  const [copied, setCopied] = useState(false)
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(address);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+
+  return (
+    <Tooltip open={copied || undefined}>
+      <TooltipTrigger asChild>
+        <button
+          onClick={copyToClipboard}
+          className={`ml-1 transition-colors duration-200 ${copied ? "text-green-600" : "text-gray-400 hover:text-gray-600"
+            }`}
+          aria-label="Copy address"
+          onBlur={() => setCopied(false)}
+        >
+          {copied ? (
+            <CopyCheck size={14} />
+          ) : (
+            <Copy size={14} />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{copied ? "Copied!" : "Copy address"}</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export default CopyButton

--- a/mercata/ui/src/pages/AssetDetail.tsx
+++ b/mercata/ui/src/pages/AssetDetail.tsx
@@ -18,6 +18,7 @@ import {
   YAxis,
   CartesianGrid,
 } from "recharts";
+import CopyButton from '@/components/ui/copy';
 
 const generatePriceData = (basePrice: number, days: number = 30) => {
   const data = [];
@@ -188,6 +189,7 @@ const AssetDetail = () => {
                         {asset?.token?._owner
                           ? `${asset.token._owner.slice(0, 6)}...${asset.token._owner.slice(-4)}`
                           : 'N/A'}
+                      <CopyButton address={asset?.token?._owner} />
                       </span>
                     </div>
 
@@ -197,6 +199,7 @@ const AssetDetail = () => {
                         {asset?.address
                           ? `${asset.address.slice(0, 6)}...${asset.address.slice(-4)}`
                           : 'N/A'}
+                        <CopyButton address={asset?.address} />
                       </span>
                     </div>
 


### PR DESCRIPTION
This pr includes - 
A new component for copy button which can be reused at several places
Usage of copy component on assets detail page , dashboard header and pools liquidation page