### PR TITLE
Fix warnings

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/package.yaml
+++ b/strato/VM/SolidVM/solid-vm-model/package.yaml
@@ -11,7 +11,7 @@ default-extensions:
 library:
   source-dirs: src/
   dependencies:
-  - aeson ==2.1.1.0
+  - aeson >=2.1.1.0 && <2.2
   - aeson-casing
   - attoparsec
   - base16-bytestring

--- a/strato/libs/json-rpc-client/json-rpc-client.cabal
+++ b/strato/libs/json-rpc-client/json-rpc-client.cabal
@@ -40,15 +40,15 @@ flag demo
 library
   exposed-modules:     Network.JsonRpc.Client
                        Network.JsonRpc.ServerAdapter
-  build-depends:       base >=4.3.1 && <4.13,
+  build-depends:       base >=4.3.1 && <5,
                        json-rpc-server >=0.2 && <0.3,
-                       aeson >=0.7 && <1.5,
-                       bytestring >=0.9.1 && <0.11,
-                       mtl >=2.2.1 && <2.3,
-                       text >=0.11.2 && <1.3,
+                       aeson >=0.7 && <2.2,
+                       bytestring >=0.9.1 && <0.12,
+                       mtl >=2.2.1 && <2.4,
+                       text >=0.11.2 && <2.1,
                        transformers,
-                       vector >=0.10 && <0.13,
-                       vector-algorithms >=0.5.4 && <0.9
+                       vector >=0.10 && <0.14,
+                       vector-algorithms >=0.5.4 && <0.10
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/strato/libs/json-rpc-server/json-rpc-server.cabal
+++ b/strato/libs/json-rpc-server/json-rpc-server.cabal
@@ -8,7 +8,7 @@ maintainer:          Kristen Kozak <grayjay@wordroute.com>
 synopsis:            JSON-RPC 2.0 on the server side.
 build-type:          Simple
 extra-source-files:  changelog.md
-cabal-version:       >=1.8
+cabal-version:       >=1.10
 tested-with:         GHC == 7.0.1, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.1,
                      GHC == 7.10.2, GHC == 7.10.3, GHC == 8.0.1, GHC == 8.0.2,
                      GHC == 8.2.2, GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.1,

--- a/strato/libs/json-rpc-server/json-rpc-server.cabal
+++ b/strato/libs/json-rpc-server/json-rpc-server.cabal
@@ -37,13 +37,13 @@ flag demo
 library
   exposed-modules:     Network.JsonRpc.Server
   other-modules:       Network.JsonRpc.Types
-  build-depends:       base >=4.3 && <4.16,
+  build-depends:       base >=4.3 && <5,
                        aeson (>=0.6 && <1.6) || (>=2.1 && <2.2),
                        deepseq >= 1.1 && <1.5,
-                       bytestring >=0.9 && <0.11,
-                       mtl >=2.2.1 && <2.3,
-                       text >=0.11 && <1.3,
-                       vector >=0.7.1 && <0.13,
+                       bytestring >=0.9 && <0.12,
+                       mtl >=2.2.1 && <2.4,
+                       text >=0.11 && <2.1,
+                       vector >=0.7.1 && <0.14,
                        unordered-containers >=0.1 && <0.3
   hs-source-dirs:      src
   ghc-options:         -Wall

--- a/strato/libs/kafka/milena/package.yaml
+++ b/strato/libs/kafka/milena/package.yaml
@@ -46,19 +46,19 @@ library:
 
   dependencies:
     - base >=4.7 && <5
-    - bytestring >=0.10 && <0.11
+    - bytestring >=0.10 && <0.12
     - cereal >=0.4 && <0.6
     - containers >=0.5 && <0.7
     - digest >=0.0.1.0 && <0.1
-    - lens >=4.4 && <4.20
+    - lens >=4.4 && <5.3
     - lifted-base >=0.2.3.6 && <0.3
     - monad-control >=1.0 && <1.1
-    - mtl >=2.1 && <2.3
+    - mtl >=2.1 && <2.4
     - murmur-hash >=0.1.0.8 && <0.2
     - network 
-    - random >=1.0 && <1.2
-    - resource-pool >=0.2.3.2 && <0.3
-    - transformers >=0.3 && <0.6
+    - random >=1.0 && <1.3
+    - resource-pool >=0.2.3.2 && <0.5
+    - transformers >=0.3 && <0.7
     - zlib >=0.6.1.2 && <0.7
 
 tests:

--- a/strato/libs/type-lits/package.yaml
+++ b/strato/libs/type-lits/package.yaml
@@ -5,7 +5,7 @@ library:
   source-dirs: src
   dependencies:
     - base
-    - aeson ==2.1.1.0
+    - aeson >=2.1.1.0 && <2.2
     - bifunctors
     - comonad
     - QuickCheck

--- a/strato/stack.yaml
+++ b/strato/stack.yaml
@@ -134,6 +134,8 @@ nix:
   # See https://docs.haskellstack.org/en/stable/nix_integration/#using-a-custom-shellnix-file
   shell-file: nix/stack-integration.nix
 
+notify-if-nix-on-path: false
+
 resolver: lts-22.4 #also duplicated in docker section below
 compiler-check: newer-minor
 extra-include-dirs:


### PR DESCRIPTION
# Motivation

While these changes are trivial from a functionality perspective, maintaining warning-free compiler output provides significant benefits:

Improved signal-to-noise ratio: Real issues don't get buried in routine warnings
Faster development cycles: Developers can quickly spot actual problems without scanning through known warnings
Better CI/CD reliability: Automated builds can treat warnings as errors without false positives
Professional polish: Clean build output reflects well-maintained code and attention to detail
Easier debugging: When something does go wrong, the relevant messages stand out clearly

# Changes

* Remove Stack's nix warnings visible for devs with nix on the PATH
* Fix Cabal version specification in json-rpc-server
* Update dependency bounds to resolve Stack build warnings