### PR TITLE
Fixed bug with complex local variable creation

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
@@ -218,8 +218,21 @@ valEquals ct lhs rhs = case (lhs, rhs) of
     todo "comparison of builtin vars requires evaluation: " (v1, v2)
   _ -> todo "unsupported type combination in valEquals: " (lhs, rhs)
 
+createVar' :: MonadIO m => Value -> m Variable
+createVar' val = liftIO $ Variable <$> newIORef val
+
+toVar :: MonadIO m => Variable -> m Variable
+toVar (Constant val) = createVar val
+toVar var            = pure var
+
 createVar :: MonadIO m => Value -> m Variable
-createVar val = liftIO $ fmap Variable $ newIORef val
+createVar val = createVar' =<< case val of
+  SStruct n m -> SStruct n <$> traverse toVar m
+  STuple vs -> STuple <$> traverse toVar vs
+  SArray t vs -> SArray t <$> traverse toVar vs
+  SMap t m -> SMap t <$> traverse toVar m
+  SPush v mv -> SPush v <$> traverse toVar mv
+  _ -> pure val
 
 --TODO- defaultValue is deprecated, will be removed...  Instead use createDefaultValue
 defaultValue :: CC.Contract -> SVMType.Type -> Value

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/Builtins.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/Builtins.hs
@@ -23,8 +23,8 @@ push (SReference apt) _ (OrderedVals [av]) = do
   setVar (Constant (SReference idxPath)) av
   return $ Constant newLen
 push (SArray varType vec) (Just (Variable ref)) (OrderedVals [av]) = do
-  let newVar = Constant av
-      newArr = V.snoc vec newVar
+  newVar <- createVar av
+  let newArr = V.snoc vec newVar
   setVar (Variable ref) (SArray varType newArr)
   return $ Constant (SInteger $ fromIntegral $ V.length newArr)
 push _ _ argVals = do


### PR DESCRIPTION
Consider the following function:
```hs
    function _rewardBalanceOf(address _user, bool _claim) internal returns (TokenRewardBalance[]) {
        TokenRewardBalance[] claimableRewardBalances;
        for (uint j = 0; j < rewardTokens.length; j++) {
            claimableRewardBalances.push(TokenRewardBalance(address(rewardTokens[j]), 0));
        }
        for (uint i = 0; i < eligibleTokens.length; i++) {
            address _token = address(eligibleTokens[i]);
            TokenRewardBalance[] claimableForToken;
            if (rewardDelegate != address(0)) {
                claimableForToken = rewardDelegate.delegatecall("calculateRewardBalanceForToken", _token, _user, _claim);
            } else {
                claimableForToken = _calculateRewardBalanceForToken(_token, _user, _claim);
            }
            for (uint k = 0; k < rewardTokens.length; k++) {
                claimableRewardBalances[k].rewardBalance += claimableForToken[k].rewardBalance; // BUG OCCURS HERE!!
            }
        }
        return claimableRewardBalances;
    }
```
Prior to the change in this branch, `claimableRewardBalances` would be treated as an `SArray` of `Constant` values. On the line with the comment `BUG OCCURS HERE!!`, the contract attempts to add to the struct field `rewardBalance` at element `k` in the array. However, since the `SStruct` value is a `Constant`, the operation fails with the error `Cannot assign immutable or constants after assigned`.

This PR fixes the issue by creating mutable `Variable`s for all elements within the local variable's structure.

I've labeled this PR with `requires network restart` because it causes a stateroot mismatch when syncing to the testnet.