### PR TITLE
Resolve Linux-hosted Docker networking issues, plus minor comment cleanup

### DIFF
--- a/mercata/README.md
+++ b/mercata/README.md
@@ -2,8 +2,7 @@
 
 The app consists of multiple parts:
 - backend (ExpressJS-based API server)
-- ui (Vite/React-based UI) 
-  - with legacy next.js-based UI in `frontend/` dir
+- ui (Vite/React-based UI)
 - nginx
   - The purpose of the Nginx in the app:
     - Handle OAuth2 authentication and authorization
@@ -14,16 +13,6 @@ The app consists of multiple parts:
   - The purpose of the services directory is to store offchain functionalities that are tied to the web application.
   - Currently there is only the Stripe service for token on ramping.
   - Look at the individual services read me for further details.
-
-## Global Project Prerequisites
-- Git submodules
-  - Fetch the git submodules code:
-    ```shell
-    git submodule update --init --recursive
-    ```
-    - `ui/` is a git submodule from https://github.com/blockapps/mercata-ui repo
-    - To work with ui/ codebase, please learn how git submodules work.
-
 
 ---
 
@@ -63,14 +52,23 @@ npm run dev
 cd ../nginx
 OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/mercata/.well-known/openid-configuration \
   OAUTH_CLIENT_ID=localhost \
-  OAUTH_CLIENT_SECRET=client-secret-here \
+  OAUTH_CLIENT_SECRET=client-secret-here  
   ssl=false \
   HOST_IP=host.docker.internal \
   docker compose -f docker-compose.nginx-standalone.yml up -d --build
 ```
-- On Linux, use `HOST_IP=172.17.0.1 \` (the default Docker host IP), or use any static local IP of your host machine.
+
+- BEWARE! Disable any VPN on your host machine.  It can interfere with the Docker network bridge and cause a hang on http://localhost.
+- In most Linux scenarios 'host.docker.internal' will work just fine.  If it is not working then you can drop-back to a hardcoded IP address - usually `HOST_IP=172.17.0.1 \` (the default Docker host IP), or any static local IP of your host machine.  More details here: https://github.com/blockapps/strato-platform/issues/3959#issuecomment-3051025844
+- You may also need to explicitly open ports in your Linux host's firewall configuration to allow Docker to communicate with the node processes running on your host.  See iptables example below.
 - Nginx also supports the live updates of the Next.js app during development, when it is deployed with `npm run dev`.
 
+iptables example for Docker network bridge port setup:
+
+    0     0 ACCEPT     6    --  *      *       172.17.0.0/16        0.0.0.0/0            tcp dpt:8080
+    0     0 ACCEPT     17   --  *      *       172.17.0.0/16        0.0.0.0/0            udp dpt:8080
+    0     0 ACCEPT     6    --  *      *       172.17.0.0/16        0.0.0.0/0            tcp dpt:3001
+    0     0 ACCEPT     17   --  *      *       172.17.0.0/16        0.0.0.0/0            udp dpt:3001
 ---
 
 ## PROD MODE - DOCKERIZED

--- a/mercata/README.md
+++ b/mercata/README.md
@@ -52,14 +52,14 @@ npm run dev
 cd ../nginx
 OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/mercata/.well-known/openid-configuration \
   OAUTH_CLIENT_ID=localhost \
-  OAUTH_CLIENT_SECRET=client-secret-here  
+  OAUTH_CLIENT_SECRET=client-secret-here \
   ssl=false \
   HOST_IP=host.docker.internal \
   docker compose -f docker-compose.nginx-standalone.yml up -d --build
 ```
 
 - BEWARE! Disable any VPN on your host machine.  It can interfere with the Docker network bridge and cause a hang on http://localhost.
-- In most Linux scenarios 'host.docker.internal' will work just fine.  If it is not working then you can drop-back to a hardcoded IP address - usually `HOST_IP=172.17.0.1 \` (the default Docker host IP), or any static local IP of your host machine.  More details here: https://github.com/blockapps/strato-platform/issues/3959#issuecomment-3051025844
+- In most Linux scenarios 'host.docker.internal' will work just fine.  If it is not working then you can drop back to a hardcoded IP address - usually `HOST_IP=172.17.0.1 \` (the default Docker host IP), or any static local IP of your host machine.  More details here: https://github.com/blockapps/strato-platform/issues/3959#issuecomment-3051025844
 - You may also need to explicitly open ports in your Linux host's firewall configuration to allow Docker to communicate with the node processes running on your host.  See iptables example below.
 - Nginx also supports the live updates of the Next.js app during development, when it is deployed with `npm run dev`.
 

--- a/mercata/nginx/docker-compose.nginx-standalone.yml
+++ b/mercata/nginx/docker-compose.nginx-standalone.yml
@@ -7,11 +7,16 @@ services:
     - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
     - ssl=${ssl:-false}
     - DOCKERIZED_APP=false
-    - HOST_IP=${HOST_IP}
+    - HOST_IP=${HOST_IP:-host.docker.internal}
     build:
       context: .
       extra_hosts:
       - "openresty.org=3.125.51.27"
+    # This is a workaround to ensure "host.docker.internal" works for command-line Docker
+    # on Linux. Requires Docker 20.10 (released Dec 2020) and newer. Details here:
+    # https://github.com/blockapps/strato-platform/issues/3959#issuecomment-3051025844
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     image: mercata-nginx
     ports:
     - 80:80

--- a/mercata/nginx/docker-run.sh
+++ b/mercata/nginx/docker-run.sh
@@ -34,11 +34,9 @@ if [ ! -f /usr/local/openresty/nginx/conf/nginx.conf ]; then
   if [ "$DOCKERIZED_APP" = true ]; then
     sed -i "s|__BACKEND_HOST__|backend|g" /tmp/nginx.conf
     sed -i "s|__UI_HOST__|ui|g" /tmp/nginx.conf
-    sed -i "s|__FRONTEND_HOST__|frontend|g" /tmp/nginx.conf  # LEGACY FRONTEND
   else
     sed -i "s|__BACKEND_HOST__|$HOST_IP|g" /tmp/nginx.conf
     sed -i "s|__UI_HOST__|$HOST_IP|g" /tmp/nginx.conf
-    sed -i "s|__FRONTEND_HOST__|$HOST_IP|g" /tmp/nginx.conf  # LEGACY FRONTEND
   fi
 
   ########

--- a/mercata/nginx/nginx.tpl.conf
+++ b/mercata/nginx/nginx.tpl.conf
@@ -107,10 +107,6 @@ http {
     upstream ui {
         server __UI_HOST__:8080;
     }
-    # Legacy frontend:
-    #upstream frontend {
-    #    server __FRONTEND_HOST__:3000;
-    #}
 
     server {
       listen 80;
@@ -181,20 +177,6 @@ http {
         proxy_http_version 1.1;
         proxy_pass http://ui/vite-hmr;
       }
-      
-      # Legacy frontend:
-      #location / {
-      #  set $is_ui "true";
-      #  rewrite_by_lua_file  lua/openid.lua; # TODO: To be removed when the anonymous mode is added in the UI
-      #  proxy_set_header Accept-Encoding "";
-      #  proxy_pass http://frontend/;
-      #}
-      #location /_next/webpack-hmr {
-      #  proxy_set_header Upgrade $http_upgrade;
-      #  proxy_set_header Connection "upgrade";
-      #  proxy_http_version 1.1;
-      #  proxy_pass http://frontend/_next/webpack-hmr;
-      #}
 
       location = /api/v1 {
         return 302 /api/v1/;


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/3959

- Added support required for "host.docker.internal" to work on command-line Docker on Linux systems.  Requires Docker 20.10 (released Dec 2020) and newer.  Details on the issue and workaround: https://github.com/blockapps/strato-platform/issues/3959#issuecomment-3051025844
- Stripped out misleading instructions about git submodules which were already merged into the monorepo.
- Stripped out some nginx dead wood related to the old `frontend` application