### PR TITLE
Added specific handling for slippage check failure, so you get a useful message in the toast for swaps

### DIFF
--- a/mercata/ui/src/components/swap/SwapWidget.tsx
+++ b/mercata/ui/src/components/swap/SwapWidget.tsx
@@ -767,7 +767,9 @@ const SwapWidget = () => {
       console.error("Swap error:", error);
       toast({
         title: "Error",
-        description: "Swap failed. Please try again.",
+        description: error.message === "Slippage check failed"
+          ? "Your slippage tolerance was exceeded, so the swap was reverted to protect you from a worse-than-expected price."
+          : error.message || "Swap failed. Please try again.",
         variant: "destructive",
       });
     } finally {
@@ -904,4 +906,4 @@ useEffect(() => {
   );
 };
 
-export default SwapWidget; 
+export default SwapWidget;

--- a/mercata/ui/src/context/SwapContext.tsx
+++ b/mercata/ui/src/context/SwapContext.tsx
@@ -151,7 +151,12 @@ export const SwapProvider = ({ children }: { children: ReactNode }) => {
       const res = await api.post("/swap", data);
       return res.data;
     } catch (err: any) {
-      throw new Error(err.response?.data?.message || err.message || "Swap transaction failed");
+      throw new Error(
+        err.response?.data?.error?.message ||
+        err.response?.data?.message ||
+        err.message ||
+        "Swap transaction failed"
+      );
     }
   }, []);
 


### PR DESCRIPTION
In the swap page, propagating error messages from backend to frontend better.

Also added specific handling for slippage check failure, so you get a useful message in the toast. Not just a generic "Swap transaction failed"

This addresses part of https://github.com/blockapps/strato-platform/issues/3958.   I am not sure if there are still outstanding issues, or whether with this and other changes that we might have something which is now good enough.