### PR TITLE
WIP -  History tab, which shows the most recent 100 transactions.

### DIFF
--- a/mercata/backend/src/api/controllers/transactions.controller.ts
+++ b/mercata/backend/src/api/controllers/transactions.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import axios from "axios";
+import { getTransactions } from "../services/transactions.service";
 
 class TransactionsController {
   static async get(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -9,32 +9,8 @@ class TransactionsController {
         res.status(400).json({ error: "Missing or invalid address" });
         return;
       }
-      // Use NODE_URL for Strato node API endpoint
-      const stratoUrl = process.env.NODE_URL;
-      if (!stratoUrl) {
-        res.status(500).json({ error: "NODE_URL environment variable not set" });
-        return;
-      }
-      const apiUrl = `${stratoUrl}/strato-api/eth/v1.2/transaction/last/100`;
-      console.log("[/transactions] Fetching from Strato node URL:", apiUrl);
-      const response = await axios.get(apiUrl, {
-        headers: {
-          Authorization: `Bearer ${req.accessToken}`,
-        },
-      });
-      console.log("[/transactions] Strato API response.data:", response.data);
-      if (Array.isArray(response.data) && response.data.length > 0) {
-        console.log("[/transactions] First tx object:", response.data[0]);
-      }
-      // Return all transactions (no filtering)
-      const txs = (Array.isArray(response.data) ? response.data : []).map((tx: any) => ({
-        timestamp: tx.timestamp || tx.time || tx.blockTimestamp || "",
-        hash: tx.hash,
-        from: tx.from,
-        to: tx.to,
-        type: tx.type || tx.transactionType || "Unknown",
-      }));
-      console.log("[/transactions] mapped txs:", txs);
+      // Delegate to service
+      const txs = await getTransactions(req.accessToken, address);
       res.json(txs);
       return;
     } catch (error) {

--- a/mercata/backend/src/api/controllers/transactions.controller.ts
+++ b/mercata/backend/src/api/controllers/transactions.controller.ts
@@ -2,16 +2,18 @@ import { Request, Response, NextFunction } from "express";
 import axios from "axios";
 
 class TransactionsController {
-  static async get(req: Request, res: Response, next: NextFunction) {
+  static async get(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const { address } = req.query;
       if (!address || typeof address !== "string") {
-        return res.status(400).json({ error: "Missing or invalid address" });
+        res.status(400).json({ error: "Missing or invalid address" });
+        return;
       }
       // Use NODE_URL for Strato node API endpoint
       const stratoUrl = process.env.NODE_URL;
       if (!stratoUrl) {
-        return res.status(500).json({ error: "NODE_URL environment variable not set" });
+        res.status(500).json({ error: "NODE_URL environment variable not set" });
+        return;
       }
       const apiUrl = `${stratoUrl}/strato-api/eth/v1.2/transaction/last/100`;
       console.log("[/transactions] Fetching from Strato node URL:", apiUrl);
@@ -37,6 +39,7 @@ class TransactionsController {
       return;
     } catch (error) {
       next(error);
+      return;
     }
   }
 }

--- a/mercata/backend/src/api/controllers/transactions.controller.ts
+++ b/mercata/backend/src/api/controllers/transactions.controller.ts
@@ -1,0 +1,44 @@
+import { Request, Response, NextFunction } from "express";
+import axios from "axios";
+
+class TransactionsController {
+  static async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { address } = req.query;
+      if (!address || typeof address !== "string") {
+        return res.status(400).json({ error: "Missing or invalid address" });
+      }
+      // Use NODE_URL for Strato node API endpoint
+      const stratoUrl = process.env.NODE_URL;
+      if (!stratoUrl) {
+        return res.status(500).json({ error: "NODE_URL environment variable not set" });
+      }
+      const apiUrl = `${stratoUrl}/strato-api/eth/v1.2/transaction/last/100`;
+      console.log("[/transactions] Fetching from Strato node URL:", apiUrl);
+      const response = await axios.get(apiUrl, {
+        headers: {
+          Authorization: `Bearer ${req.accessToken}`,
+        },
+      });
+      console.log("[/transactions] Strato API response.data:", response.data);
+      if (Array.isArray(response.data) && response.data.length > 0) {
+        console.log("[/transactions] First tx object:", response.data[0]);
+      }
+      // Return all transactions (no filtering)
+      const txs = (Array.isArray(response.data) ? response.data : []).map((tx: any) => ({
+        timestamp: tx.timestamp || tx.time || tx.blockTimestamp || "",
+        hash: tx.hash,
+        from: tx.from,
+        to: tx.to,
+        type: tx.type || tx.transactionType || "Unknown",
+      }));
+      console.log("[/transactions] mapped txs:", txs);
+      res.json(txs);
+      return;
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+export default TransactionsController;

--- a/mercata/backend/src/api/routes.ts
+++ b/mercata/backend/src/api/routes.ts
@@ -11,6 +11,7 @@ import OracleController from "./controllers/oracle.controller";
 import userRoutes from "./routes/user.routes";
 import swapRoutes from "./routes/swap.routes";
 import lendingRoutes from "./routes/lending.routes";
+import TransactionsController from "./controllers/transactions.controller";
 
 const router = Router();
 const bridgeController = new BridgeController();
@@ -54,6 +55,9 @@ router.get("/bridge/bridgeOutTokens", authHandler.authorizeRequest(), bridgeCont
 router.get("/bridge/config", bridgeController.getBridgeConfig);
 router.get("/bridge/depositStatus/:status", authHandler.authorizeRequest(), bridgeController.userDepositStatus);
 router.get("/bridge/withdrawalStatus/:status", authHandler.authorizeRequest(), bridgeController.userWithdrawalStatus);
+
+// ----- Transaction/History Routes -----
+router.get("/transactions", authHandler.authorizeRequest(true), TransactionsController.get);
 
 // ----- Health Check -----
 router.get("/health", (_req: Request, res: Response, next: NextFunction) => {

--- a/mercata/backend/src/api/services/transactions.service.ts
+++ b/mercata/backend/src/api/services/transactions.service.ts
@@ -1,0 +1,47 @@
+import axios from "axios";
+
+/**
+ * Fetches the last 100 transactions from Strato for the given address.
+ * @param accessToken The user's access token for authorization.
+ * @param address The address to filter transactions for (currently not used for filtering).
+ * @returns Array of mapped transaction objects.
+ */
+export const getTransactions = async (
+  accessToken: string,
+  address: string
+): Promise<
+  Array<{
+    timestamp: string;
+    hash: string;
+    from: string;
+    to: string;
+    type: string;
+  }>
+> => {
+  if (!address) {
+    throw new Error("Missing or invalid address");
+  }
+  const stratoUrl = process.env.NODE_URL;
+  if (!stratoUrl) {
+    throw new Error("NODE_URL environment variable not set");
+  }
+  const apiUrl = `${stratoUrl}/strato-api/eth/v1.2/transaction/last/100`;
+
+  // Explicitly set the Authorization header as in the original code
+  const response = await axios.get(apiUrl, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  // Defensive: ensure response.data is an array
+  const txs = (Array.isArray(response.data) ? response.data : []).map((tx: any) => ({
+    timestamp: tx.timestamp || tx.time || tx.blockTimestamp || "",
+    hash: tx.hash,
+    from: tx.from,
+    to: tx.to,
+    type: tx.type || tx.transactionType || "Unknown",
+  }));
+
+  return txs;
+};

--- a/mercata/services/payment/stripe/src/utils/mercataApiHelper.ts
+++ b/mercata/services/payment/stripe/src/utils/mercataApiHelper.ts
@@ -14,7 +14,7 @@ const createApiClient = (baseURL: string): AxiosInstance =>
 const _strato = createApiClient(`${nodeUrl}/strato/v2.3`);
 const _cirrus = createApiClient(`${nodeUrl}/cirrus/search`);
 const _bloc = createApiClient(`${nodeUrl}/bloc/v2.2`);
-const _eth = createApiClient(`${nodeUrl}//strato-api/eth/v1.2`);
+const _eth = createApiClient(`${nodeUrl}/strato-api/eth/v1.2`);
 
 function makeTokenClient(client: AxiosInstance) {
   return {

--- a/mercata/ui/src/App.tsx
+++ b/mercata/ui/src/App.tsx
@@ -21,6 +21,7 @@ import Assets from "./pages/Assets";
 import AssetDetail from "./pages/AssetDetail";
 import Pools from "./pages/Pools";
 import NotFound from "./pages/NotFound";
+import History from "./pages/History";
 
 // Import dashboard components
 import BridgePage from "./pages/BridgePage";
@@ -90,6 +91,14 @@ const App = () => (
                                   element={
                                     <ProtectedRoute>
                                       <Dashboard />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/dashboard/history"
+                                  element={
+                                    <ProtectedRoute>
+                                      <History />
                                     </ProtectedRoute>
                                   }
                                 />
@@ -180,4 +189,3 @@ const App = () => (
 );
 
 export default App;
-

--- a/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { LayoutDashboard, Wallet, Database, LogOut, ArrowLeft, ArrowRight, Book, ArrowRightLeft, Send, Shield } from 'lucide-react';
+import { LayoutDashboard, Wallet, Database, LogOut, ArrowLeft, ArrowRight, Book, ArrowRightLeft, Send, Shield, Clock } from 'lucide-react';
 import { useUser } from '@/context/UserContext';
 import MERCATALOGO from '@/assets/mercata.png';
 import MERCATAICON from '@/assets/icon.png';
@@ -16,6 +16,7 @@ const DashboardSidebar = () => {
     { icon: <Book size={20} />, label: 'Borrow', path: '/dashboard/borrow' },
     { icon: <ArrowRightLeft size={20} />, label: 'Swap', path: '/dashboard/swap' },
     { icon: <Database size={20} />, label: 'Pools', path: '/dashboard/pools' },
+    { icon: <Clock size={20} />, label: 'History', path: '/dashboard/history' },
     { icon: <Shield size={20} />, label: 'Admin', path: '/dashboard/admin' },
   ];
 

--- a/mercata/ui/src/components/dashboard/HistorySection.tsx
+++ b/mercata/ui/src/components/dashboard/HistorySection.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { useUser } from "@/context/UserContext";
+
+type Tx = {
+  hash: string;
+  type: string;
+  timestamp: string;
+  from?: string;
+  to?: string;
+};
+
+const fetchTransactions = async (address: string): Promise<Tx[]> => {
+  if (!address) return [];
+  const res = await fetch(`/api/transactions?address=${address}`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  // TEMP: Log the raw data array for diagnostics
+  if (Array.isArray(data) && data.length > 0) {
+    // eslint-disable-next-line no-console
+    console.log("[HistorySection] Raw data from backend:", data[0]);
+  }
+  // Map to Tx[]
+  return (Array.isArray(data) ? data : []).map((tx: any) => ({
+    hash: tx.hash,
+    type: tx.type || tx.transactionType || "Unknown",
+    timestamp: tx.timestamp || "",
+    from: tx.from || "",
+    to: tx.to || "",
+  }));
+};
+
+const HistorySection = () => {
+  const { userAddress } = useUser();
+  const [txs, setTxs] = useState<Tx[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!userAddress) return;
+    setLoading(true);
+    fetchTransactions(userAddress)
+      .then((txs) => {
+        if (txs.length > 0) {
+          // eslint-disable-next-line no-console
+          console.log("[HistorySection] First tx from backend:", txs[0]);
+        }
+        setTxs(txs);
+      })
+      .finally(() => setLoading(false));
+  }, [userAddress]);
+
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-bold mb-4">Transaction History</h2>
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        <table className="bg-white border border-gray-200">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 border-b border-r text-left">Date/Time</th>
+              <th className="px-2 py-1 border-b border-r text-left">Hash</th>
+              <th className="px-2 py-1 border-b border-r text-left">From</th>
+              <th className="px-2 py-1 border-b border-r text-left">To</th>
+              <th className="px-2 py-1 border-b text-left">Type</th>
+            </tr>
+          </thead>
+          <tbody>
+            {txs.map((tx) => (
+              <tr key={tx.hash}>
+                <td className="px-2 py-1 border-b border-r">{new Date(tx.timestamp).toLocaleString()}</td>
+                <td className="px-2 py-1 border-b border-r font-mono">
+                  {tx.hash && tx.hash.length > 16
+                    ? `${tx.hash.slice(0, 8)}...${tx.hash.slice(-8)}`
+                    : tx.hash}
+                </td>
+                <td className="px-2 py-1 border-b border-r font-mono">
+                  {tx.from && tx.from.toLowerCase() === userAddress?.toLowerCase() ? (
+                    <span className="text-red-600 font-bold">
+                      {tx.from.length > 16
+                        ? `${tx.from.slice(0, 8)}...${tx.from.slice(-8)}`
+                        : tx.from}
+                    </span>
+                  ) : (
+                    tx.from && tx.from.length > 16
+                      ? `${tx.from.slice(0, 8)}...${tx.from.slice(-8)}`
+                      : tx.from
+                  )}
+                </td>
+                <td className="px-2 py-1 border-b border-r font-mono">
+                  {tx.to && tx.to.toLowerCase() === userAddress?.toLowerCase() ? (
+                    <span className="text-red-600 font-bold">
+                      {tx.to.length > 16
+                        ? `${tx.to.slice(0, 8)}...${tx.to.slice(-8)}`
+                        : tx.to}
+                    </span>
+                  ) : (
+                    tx.to && tx.to.length > 16
+                      ? `${tx.to.slice(0, 8)}...${tx.to.slice(-8)}`
+                      : tx.to
+                  )}
+                </td>
+                <td className="px-2 py-1 border-b">{tx.type}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {(!loading && txs.length === 0) && (
+        <div className="mt-4 text-gray-500">No transactions found.</div>
+      )}
+    </div>
+  );
+};
+
+export default HistorySection;

--- a/mercata/ui/src/pages/History.tsx
+++ b/mercata/ui/src/pages/History.tsx
@@ -1,0 +1,13 @@
+import DashboardSidebar from "../components/dashboard/DashboardSidebar";
+import HistorySection from "../components/dashboard/HistorySection";
+
+const History = () => (
+  <div className="min-h-screen bg-gray-50 flex">
+    <DashboardSidebar />
+    <div className="flex-1 ml-64">
+      <HistorySection />
+    </div>
+  </div>
+);
+
+export default History;

--- a/mercata/ui/src/pages/History.tsx
+++ b/mercata/ui/src/pages/History.tsx
@@ -1,10 +1,12 @@
 import DashboardSidebar from "../components/dashboard/DashboardSidebar";
+import DashboardHeader from "../components/dashboard/DashboardHeader";
 import HistorySection from "../components/dashboard/HistorySection";
 
 const History = () => (
   <div className="min-h-screen bg-gray-50 flex">
     <DashboardSidebar />
     <div className="flex-1 ml-64">
+      <DashboardHeader title="History" />
       <HistorySection />
     </div>
   </div>


### PR DESCRIPTION
Added a History tab which shows the most recent 100 transactions.

<img width="252" height="503" alt="Screenshot from 2025-07-10 19-56-24" src="https://github.com/user-attachments/assets/19dd54b6-f8df-479d-b53b-30f2909dd4bf" />

<img width="1218" height="508" alt="Screenshot from 2025-07-10 19-56-36" src="https://github.com/user-attachments/assets/af1b23d2-ce0c-45a7-b6b7-ea7c36398095" />

This functionality is similar to STRATOSCAN.  We don't have an instance of STRATOSCAN live for the testnet yet, though that is planned: https://github.com/blockapps/strato-scan/issues/9.   Having this directly integrated into the application

We would not want exactly the same kind of view here within the consumer application.  We would want to present something which is just showing the transactions which the user has made with descriptive names, not a bunch of hashes, but this is better than nothing for now.

The list shows all transactions, but highlights any "to" and "from" for the user's own account in red.   We have not yet found a good way to get a list of transactions just for a particular account, though maybe there is a good way to do that in Cirrus?   So both here and in STRATOSCAN we currently just grab a batch of recent ones and that is good enough.  It does mean, though, that you cannot go back all the way through all of your transactions.

This recent window is probably good enough for now so that people can see their txs fly past.