### PR TITLE
Handle address that start with 0x

### DIFF
--- a/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/ArgValue.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/ArgValue.hs
@@ -182,7 +182,7 @@ argValueToSimpleValue theType argVal = case theType of
   TypeAddress -> case argVal of
     ArgString str ->
       ValueAddress <$> case stringAddress (Text.unpack str) of
-        Nothing -> Left $ "argValueToSimpleValue: could not decode as address: " <> str
+        Nothing -> Left $ "argValueToSimpleValue: provided argument '" <> str <> "' is not a valid address"
         Just x -> return x
     o -> Left . Text.pack $ "argValueToSimpleValue: Expected TypeAddress to be a string, but got " ++ show o
   TypeAccount -> case argVal of

--- a/strato/core/blockDB/test/BlockSpec.hs
+++ b/strato/core/blockDB/test/BlockSpec.hs
@@ -129,6 +129,8 @@ spec = do
     prop "has inverse Form Url decode/encode" $ formProp @Address
     prop "has inverse String decode/encode" $ \address ->
       stringAddress (formatAddressWithoutColor address) === Just address
+    prop "has inverse String decode/encode (even if encoded prefixed with 0x)" $ \address ->
+      stringAddress ("0x" <> formatAddressWithoutColor address) === Just address
 
   describe "Keccak256" $ do
     prop "has inverse JSON decode/encode" $ jsonProp @Keccak256

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -167,8 +167,27 @@ instance PersistFieldSql Address where
 
 --  sqlType _ = SqlOther "varchar(64)"
 
+-- | Parse a hexadecimal string into an 'Address'.
+--
+-- The input string can be either:
+--
+-- * A 40-character hexadecimal string without "0x" prefix (e.g., "deadbeef00000000000000000000000000000000")
+-- * A 42-character hexadecimal string with "0x" prefix (e.g., "0xdeadbeef00000000000000000000000000000000")
+--
+-- Returns 'Nothing' if the string is not valid hexadecimal or has incorrect length.
+--
+-- >>> stringAddress "deadbeef00000000000000000000000000000000"
+-- Just (Address 0xdeadbeef00000000000000000000000000000000)
+--
+-- >>> stringAddress "0xdeadbeef00000000000000000000000000000000"
+-- Just (Address 0xdeadbeef00000000000000000000000000000000)
+--
+-- >>> stringAddress "invalid"
+-- Nothing
 stringAddress :: String -> Maybe Address
-stringAddress string = Address . fromInteger <$> readMaybe ("0x" ++ string)
+stringAddress string =
+  let prefixedString = if take 2 string == "0x" then string else "0x" ++ string
+  in Address . fromInteger <$> readMaybe prefixedString
 
 ------------------------------------
 


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/4067

* Provide "intelligently" stripping 0x if the address is prefixed by it
* Provide a more comprehensive error message if the encoded address is still not correct