### PR TITLE
preventing batchcontract calls when transaction list is empty

### DIFF
--- a/mercata/services/bridge/src/services/bridgeService.ts
+++ b/mercata/services/bridge/src/services/bridgeService.ts
@@ -286,6 +286,12 @@ export const confirmBridgeOut = async (tx: any) => {
 
 export const confirmBridgeOutSafePolling = async (txs: string[]) => {
   console.log("confirmBridgeOutSafePolling ", txs);
+  
+  if (!txs || txs.length === 0) {
+    console.log("No withdrawal transactions to process");
+    return;
+  }
+  
   const bridgeContract = new BridgeContractCall();
   await bridgeContract.batchConfirmWithdrawals({
     txHashes: txs,


### PR DESCRIPTION
Summary
Problem: confirmBridgeOutSafePolling was making unnecessary batch contract calls when transaction arrays were empty.
Solution: Added empty array validation check to prevent batch calls when txs.length === 0, matching the existing pattern in confirmBridgeinSafePolling.