### PR TITLE
Pre-4163 cleanups formats

### DIFF
--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -74,11 +74,8 @@ import           Bloc.Server.Utils               (partitionWith)
 import           BlockApps.Logging
 import           Blockchain.Strato.Model.Account
 import           Blockchain.Strato.Model.Address
--- import           Blockchain.Strato.Model.CodePtr
 import qualified Blockchain.Strato.Model.Event   as Action
 import           Blockchain.Strato.Model.Keccak256
--- import           Data.Bifunctor                  (first)
--- import           Data.Function                   (on)
 import           Data.List                       ( groupBy, nubBy, sortBy)
 import           Data.Ord (comparing)
 import           Data.Text.Encoding              (decodeUtf8, decodeUtf8', encodeUtf8)
@@ -109,7 +106,6 @@ instance Functor (First b) where
 
 data ProcessedCollectionRow = ProcessedCollectionRow
   { address :: Address,
-    -- codehash :: Maybe CodePtr,
     creator :: Text,
     cc_creator :: Maybe Text,
     root :: Text,
@@ -306,8 +302,6 @@ baseAbstractColumns =
     "data"
   ]
 
--- baseTableColumns :: TableColumns
--- baseTableColumns = baseColumns
 
 baseTableColumnsForEvent :: TableColumns
 baseTableColumnsForEvent = baseEventColumns
@@ -1289,8 +1283,6 @@ insertAbstractTableQuery cs =
                   let baseRowVals = map (wrapSingleQuotes . ($ row)) baseVals 
                       contractNameVal = [wrapSingleQuotes $ escapeQuotes (tableNameToText contractTableName)] 
                       dataVals = [wrapSingleQuotes (decodeUtf8 . BL.toStrict $ Aeson.encode $ MapWrapper $ aesonHelper (Map.filterWithKey (\k _ -> k `notElem` abColumns) contractColumns )) <> "::jsonb"]
-                      -- jsonPathz = T.concat ["'{", csv (map (\(k, _) -> T.concat ["\"", escapeQuotes k, "\""]) (Map.toList dataVals)), "}'"]
-                      -- jsonValuez = csv (map (wrapSingleQuotes . wrapDoubleQuotes . removeSingleQuotes . removeSingleQuotes) $ Map.elems dataVals)
                       regularVals = [(snd kv) | kv@(k, _) <- Map.toList contractColumns, k `elem` keysForSQL]
                       fkeyVals = ["NULL" | k <- fkeyColumns, k `elem` keysForSQL]  -- This avoids circular dependencies as the inserts occur first and set fkeys=null
                       valsForSQL = baseRowVals ++ contractNameVal ++ dataVals ++ regularVals ++ fkeyVals
@@ -1458,14 +1450,6 @@ createEventTable (creator, a, n) evName ev cc = do
       colsCombined = map (\(x,y)-> x <> " " <> y) cols
       eventFkeys = getDeferredForeignKeysForEvent eventTable crtr app
   $logInfoS "keys" (T.pack $ show arrayNamesAndTypes)
-  -- eventAlreadyCreated <- isTableCreated eventTable
-  -- unless eventAlreadyCreated $ do
-  --   setTableCreated globalsIORef eventTable $ colsCombined
-  --   yield $ createEventTableQuery eventTable colsCombined
-  -- if eventAlreadyCreated
-  --   then return []
-  --   else do
-    -- setTableCreated eventTable $ colsCombined
   yieldMany $ createEventTableQuery eventTable colsCombined uniqueConstraint
   eventArrayFkeys <- fmap concat . forM arrayNamesAndTypes $ \anat -> do
     createEventArrayTable (crtr, app, cname, (escapeQuotes $ labelToText evName)) anat
@@ -1601,16 +1585,6 @@ processParents ae = createNewEvent <$> Map.toList (eventAbstracts ae)
           }
       }
 
--- insertEventTable ::
---   OutputM m =>
---   AggregateEvent ->
---   m (Text)
--- insertEventTable agEv = do
---   let q = insertEventTableQuery agEv
---   multilineDebugLog "insertEventTable/SQL" $ T.unpack q
---   return q
-
-
 insertEventTable ::
   OutputM m =>
   AggregateEvent ->
@@ -1684,14 +1658,12 @@ solidityTypeToSQLType _ _ _ (SVMType.Account _) = Just "text"
 solidityTypeToSQLType isEvent _ _ (SVMType.Array _ _) = if isEvent then Just "jsonb" else Nothing
 solidityTypeToSQLType _ _ _ (SVMType.Mapping _ _ _) = Nothing -- Just "jsonb"
 solidityTypeToSQLType _ mc cc (SVMType.UnknownLabel l _) = Just . maybe "text" (const "jsonb") $ (\c -> structDef c cc l) =<< mc
---solidityTypeToSQLType _ (SVMType.UnknownLabel x) = Just $ "text references " <> T.pack x <> "(id)"
 solidityTypeToSQLType _ _ _ (SVMType.Struct _ _) = Just "jsonb"
 solidityTypeToSQLType _ _ _ (SVMType.Enum _ _ _) = Just "text"
 solidityTypeToSQLType _ _ _ (SVMType.Contract _) = Just "text"
 solidityTypeToSQLType _ _ _ (SVMType.Error _ _) = Just "text"
 solidityTypeToSQLType _ _ _ SVMType.Variadic = Nothing
 
---solidityTypeToSQLType x = error $ "undefined type in solidityTypeToSQLType: " ++ show (varType x)
 
 ------------------
 

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -239,7 +239,8 @@ outputDataDedup ::
   PGConnection ->
   ConduitM () Text m a ->
   m a
-outputDataDedup conn c = runConduit $ c `fuseUpstream` (dedupC .| mapM_C (dbQueryCatchError conn))
+outputDataDedup conn c =
+  runConduit $ c `fuseUpstream` (dedupC .| mapM_C (dbQueryCatchError conn))
 
 baseColumns :: TableColumns
 baseColumns =

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1645,7 +1645,10 @@ insertEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
 
 ------------------
 
---This is a temporary function that converts solidity types to a sample value...  I am just using this now to convert table creation from the old way (value based when values come through) to the new way (direct from the types when a CC is registered)
+-- This is a temporary function that converts solidity types to a sample
+-- value...  I am just using this now to convert table creation from the old way
+-- (value based when values come through) to the new way (direct from the types
+-- when a CC is registered)
 solidityTypeToSQLType :: Bool -> Maybe (ContractF ()) -> CodeCollectionF () -> SVMType.Type -> Maybe Text
 solidityTypeToSQLType _ _ _ SVMType.Bool = Just "bool"
 solidityTypeToSQLType _ _ _ (SVMType.Int _ _) = Just "decimal"

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -255,11 +255,11 @@ processTheMessages env conn messages = do
         [(cc, cp, cr, ap, abs', rm) | VME.CodeCollectionAdded cc cp cr ap abs' rm <- messages]
       transactionResults = [tr | VME.NewTransactionResult tr <- messages]
 
-  fkeys' <- outputDataDedup conn . forM creates $ \(cc, cp, cr, ap, abstracts', _) -> do
+  fkeys <- outputDataDedup conn . forM creates $ \(cc, cp, cr, ap, abstracts', _) -> do
         $logInfoS "processTheMessages" $ "CodeCollection Added: " <> T.pack (format cp) 
         multilineLog "processTheMessages/contracts" $ boringBox $ map show (Map.keys $ cc ^. contracts)
 
-        deferredForeignKeys <- fmap concat $
+        fmap concat $
           forM (filter (_isContractRecord . snd) . Map.toList $ cc ^. contracts) $ \(_, c) -> do
             -- Here we will get the storageDefs attribute of the contract (c)
             -- and iterate through the Map of (Text, VariableDecl) and look for
@@ -298,10 +298,7 @@ processTheMessages env conn messages = do
 
             return $ deferredForeignKeys ++ deferredForeignKeysForCollections ++ deferredForeignKeysForEvents
 
-        pure $ Right deferredForeignKeys
-
-  let fkeys = rights $ fkeys' -- ++ dfkeys'
-      concatFkeys = concat fkeys
+  let concatFkeys = concat fkeys
 
   inserts <- fmap concat $ enterBloc2 env $ do
     forM changes $ \(_, actions) -> do
@@ -402,3 +399,4 @@ processTheMessages env conn messages = do
   forM_ transactionResults $ putTransactionResult
 
   return events'
+

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -249,9 +249,10 @@ processTheMessages env conn messages = do
 
   let changes = parseActions messages
       events' = parseEvents messages
-      -- TODO (Dan) : would be nice if we didn't just rip events out at the top level like this
-      creates = [(cc, cp, cr, ap, abs', rm) | VME.CodeCollectionAdded cc cp cr ap abs' rm <- messages]
-      -- delegates = [d | DelegatecallMade d <- messages]
+      -- TODO (Dan) : would be nice if we didn't just rip events out at the top
+      -- level like this
+      creates =
+        [(cc, cp, cr, ap, abs', rm) | VME.CodeCollectionAdded cc cp cr ap abs' rm <- messages]
       transactionResults = [tr | VME.NewTransactionResult tr <- messages]
 
   fkeys' <- outputDataDedup conn . forM creates $ \(cc, cp, cr, ap, abstracts', _) -> do
@@ -362,13 +363,15 @@ processTheMessages env conn messages = do
     forM_ insertsByCodeHash $ \ins -> do
       insertIndexTable $ indexInsert ins
       insertAbstractTable (abstractInserts ins)-- not historic
-      unless ((length (collectionInserts ins) < 1)) $ insertCollectionTable $ collectionInserts ins
+      unless ((length (collectionInserts ins) < 1)) $
+        insertCollectionTable $ collectionInserts ins
 
       --updating the foreign keys from null
     forM_ insertsByCodeHash $ \ins -> do
       updateForeignKeysFromNULLAbstract (abstractInserts ins) -- not historic
       updateForeignKeysFromNULLIndex (indexInsert ins)
-      unless ((length (collectionInserts ins) < 1)) $ updateForeignKeysFromNULLArray (collectionInserts ins)
+      unless ((length (collectionInserts ins) < 1)) $
+        updateForeignKeysFromNULLArray (collectionInserts ins)
 
     forM_ concatFkeys $ \deferredForeignKey -> do
       createForeignIndexesForJoins deferredForeignKey
@@ -378,11 +381,13 @@ processTheMessages env conn messages = do
     notifyPostgREST conn
 
   when (not (null events')) $ do
-    --Getting event entries that go into the parent abstract tables and event array inserts
+    -- Getting event entries that go into the parent abstract tables and event
+    -- array inserts
     let processedEvents = concatMap getAllEvents events'
         processedEventArrays = concatMap aggEventToCollectionRows processedEvents
-         -- TODO: Remove arrays once marketplace switches over to using event array tables
-        processedEventsWithoutArrays = processedEvents -- map (\ae -> ae { eventEvent = removeArrayEvArgs (eventEvent ae) }) processedEvents
+         -- TODO: Remove arrays once marketplace switches over to using event
+         -- array tables
+        processedEventsWithoutArrays = processedEvents
         
     -- Insert the events into the event tables
     outputData conn $ insertEventTables processedEventArrays processedEventsWithoutArrays
@@ -391,7 +396,8 @@ processTheMessages env conn messages = do
     unless (null processedEventArrays) $
       outputData conn $ updateForeignKeysFromNULLArray processedEventArrays
 
-  $logInfoS "processTheMessages" . T.pack $ "Inserting " ++ show (length transactionResults) ++ " transaction results"
+  $logInfoS "processTheMessages" . T.pack $
+    "Inserting " ++ show (length transactionResults) ++ " transaction results"
 
   forM_ transactionResults $ putTransactionResult
 

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -260,8 +260,11 @@ processTheMessages env conn messages = do
 
         deferredForeignKeys <- fmap concat $
           forM (filter (_isContractRecord . snd) . Map.toList $ cc ^. contracts) $ \(_, c) -> do
-            -- Here we will get the storageDefs attribute of the contract (c) and iterate through the Map of (Text, VariableDecl) and look for VariableDecls that have the last attribute (isRecord) true and thetype are mappings
-            -- We will then create a table for each of these collections and add a foreign key to the main table
+            -- Here we will get the storageDefs attribute of the contract (c)
+            -- and iterate through the Map of (Text, VariableDecl) and look for
+            -- VariableDecls that have the last attribute (isRecord) true and
+            -- thetype are mappings We will then create a table for each of
+            -- these collections and add a foreign key to the main table
 
             let collectionNamesAndTypes = getCollectionsFromContract c
             $logInfoS "processTheMessages/collectionNamesAndTypes" $ T.pack $ show collectionNamesAndTypes

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -39,15 +39,12 @@ import qualified Blockchain.Stream.Action as Action
 import qualified Blockchain.Stream.VMEvent as VME
 import Control.Lens ((^.))
 import Control.Monad (forM, forM_, unless, when)
--- import qualified Control.Monad.Change.Modify as Mod
 import Control.Monad.Composable.SQL
 import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Reader
--- import Control.Monad.Trans.State.Strict hiding (state)
 import Data.Either (lefts, rights)
 import Data.Foldable (toList)
 import Data.Function
--- import Data.IORef
 import qualified Data.IntMap as I
 import qualified Data.Map.Ordered as OMap
 import Data.List (sortOn)
@@ -124,13 +121,6 @@ processedContract ABIID {..} state AggregateAction {..} =
       transactionSender = actionTxSender
     }
 
--- readPreviousSolidVMState ::
---   MonadIO m =>
---   IORef Globals ->
---   Account ->
---   m [(Text, Value)]
--- readPreviousSolidVMState gref acct = fromMaybe [] <$> getContractState gref acct
-
 rowToInsert ::
   MonadIO m =>
   ABIID ->
@@ -141,7 +131,6 @@ rowToInsert abiid row cont =
   let newState = case actionStorage row of
         Action.EVMDiff mp -> SVR.decodeCacheValues cont (flip Map.lookup mp) []
         Action.SolidVMDiff mp -> SolidVM.decodeCacheValues mp
-  -- setContractState gref (actionAccount row) newState
   in return $ processedContract abiid (Map.fromList $ newState) row
 
 
@@ -300,43 +289,12 @@ processTheMessages env conn messages = do
             $logInfoS "processTheMessages/deferredForeignKeysForCollections" $ T.pack $ show deferredForeignKeysForCollections
 
 
-            -- outputData conn $ createExpandEventTables g c cc nameParts
             deferredForeignKeysForEvents <- createExpandEventTables c cc nameParts
 
 
             return $ deferredForeignKeys ++ deferredForeignKeysForCollections ++ deferredForeignKeysForEvents
 
-        -- forM_ deferredForeignKeys $ \deferredForeignKey -> do
-        --   outputData conn $ createForeignIndexesForJoins deferredForeignKey
         pure $ Right deferredForeignKeys
-  -- TODO: Add delegatecall indexing back in
-  -- dfkeys' <- forM delegates $ \d@(Action.Delegatecall s c' o a) -> do
-  --   dels <- getDelegates  s
-  --   $logInfoS "processTheMessages" $ "Got delegates for " <> T.pack (format s) <> ": " <> T.pack (show dels)
-  --   if c' `elem` dels
-  --     then do
-  --       $logInfoS "processTheMessages" $ T.pack (format c') <> " was already seen as a delegate of " <> T.pack (format s)
-  --       pure $ Right []
-  --     else do
-  --       $logInfoS "processTheMessages" $ T.pack (format c') <> " was not a delegate of " <> T.pack (format s)
-  --       $logInfoS "processTheMessages" $ "Delegatecall made: " <> T.pack (format d)
-  --       mStorageContract <- select (Proxy @Contract) s
-  --       mCodeContract <- select (Proxy @Contract) c'
-  --       mCodeCollection <- select (Proxy @CodeCollection) c' 
-  --       deferredForeignKeys <- case (,,) <$> mStorageContract <*> mCodeContract <*> mCodeCollection of
-  --         Nothing -> pure []
-  --         Just (sc, cc, _') -> do
-  --           let c = cc {_contractName = _contractName sc}
-  --               mapNames = getMapNamesFromContract c
-  --           nameParts <- resolveNameParts o a c
-  --           forM_ mapNames $ outputData conn . createCollectionTable  nameParts
-  --           deferredForeignKeys <- outputData conn $ createExpandIndexTable c nameParts
-  --           outputData' conn $ createExpandHistoryTable c nameParts
-  --           outputData conn $ createExpandEventTables c nameParts
-  --           pure deferredForeignKeys
-        -- forM_ deferredForeignKeys $ outputData conn . createForeignIndexesForJoins
-  --       addDelegate  s c'
-  --       pure $ Right deferredForeignKeys
 
   let fkeys = rights $ fkeys' -- ++ dfkeys'
       concatFkeys = concat fkeys


### PR DESCRIPTION
# Context

I've started reading code to find the best place to plug the `event` creation logic. While searching and grepping I would find occurrences of dead code or some parts of the logic that did not makes sens.

I've cleaned those up, prefer to push them before further work, so later I don't have too much of rebase conflict resolutions.

# How to read

Best commit by commit. The first three commits are about dead code removal and formatting. The more interesting one is the last commit "Simplify the procesMessages code" https://github.com/blockapps/strato-platform/commit/13a6b17f3a2be8bcdde4afae198bd02e6067adb7

