### PR TITLE
Consolidate all emitted events to a single table

### DIFF
--- a/strato/indexer/slipstream/exec_src/Main.hs
+++ b/strato/indexer/slipstream/exec_src/Main.hs
@@ -27,7 +27,6 @@ import HFlags
 import Instrumentation
 import Network.Wai.Handler.Warp
 import Network.Wai.Middleware.Prometheus
--- import Slipstream.Processor
 
 import SelectAccessible ()
 import Slipstream.Globals

--- a/strato/indexer/slipstream/exec_src/Main.hs
+++ b/strato/indexer/slipstream/exec_src/Main.hs
@@ -88,6 +88,21 @@ main = do
         [r|create table if not exists
                       contract (id serial primary key, "codeHash" text, contract text, abi text)|]
       migrateCirrus [r|alter table contract add column if not exists "chainId" text|]
+      migrateCirrus
+        [r|CREATE TABLE IF NOT EXISTS events (
+                creator text,
+                application text,
+                contract_name text,
+                address text,
+                block_hash text,
+                block_timestamp text,
+                block_number text,
+                transaction_hash text NOT NULL,
+                transaction_sender text,
+                event_index integer NOT NULL,
+                attributes jsonb,
+                PRIMARY KEY (transaction_hash, event_index)
+            )|]
 
       -- There are three permanent connections/pools to postgres:
       -- 1. The `workerConn` is from persistent-postgresql for the storage worker in the background

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1615,9 +1615,9 @@ insertGlobalEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
   in T.concat
        [ "INSERT INTO events "
        , columns
-       , "VALUES ("
+       , " VALUES ("
        , values
-       , ")"
+       , ");"
        ]
 
 insertEventTables :: 

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1560,8 +1560,6 @@ insertEventTables processedEventArrays processedEventsWithoutArrays = do
   $logInfoS "insertEventTables/processedEventArrays" . T.pack $ show processedEventArrays
   $logInfoS "insertEventTables/processedEventsWithoutArrays" . T.pack $ show processedEventsWithoutArrays
   yieldMany . concat =<< lift (mapM (insertEventTable) processedEventsWithoutArrays)
-      
-  -- yieldMany . catMaybes =<< lift (mapM (insertEventTable) processedEventsWithoutArrays)
   when (not (null processedEventArrays)) $
     yieldMany $ insertEventArrayTableQuery processedEventArrays
 

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -19,6 +19,8 @@ module Slipstream.OutputData (
   outputDataDedup,
   OutputM,
   ProcessedCollectionRow(..),
+  insertGlobalEventTable,
+  pipeInsertGlobalEventTable,
   insertEventTables,
   insertIndexTable,
   insertForeignKeys,
@@ -1550,6 +1552,16 @@ getArraysFromEvents evArgs = do
          let elements = fromMaybe [] (Aeson.decode (BL.fromStrict $ TE.encodeUtf8 $ T.pack arrayStr) :: Maybe [String])
          in (arrayName, zip (map (SimpleValue . ValueString . T.pack . show) [0 :: Int ..]) 
                             (map (SimpleValue . ValueString . T.pack) elements))
+
+pipeInsertGlobalEventTable :: OutputM m => [AggregateEvent] -> ConduitM () Text m ()
+pipeInsertGlobalEventTable aggregatedEvents =
+  yieldMany =<< lift (mapM insertGlobalEventTable aggregatedEvents)
+
+insertGlobalEventTable :: OutputM m => AggregateEvent -> m Text
+insertGlobalEventTable agEv = do
+  let query = insertGlobalEventTableQuery agEv
+  $logInfoS "insertGlobalEventTable/query" query
+  return query
 
 -- | Generates an INSERT SQL statement for the global 'events' table.
 --

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1570,9 +1570,9 @@ insertGlobalEventTable agEv = do
 -- created dynamically per contract/event type, this global table has a fixed
 -- schema and stores all events in a normalized format.
 --
--- TODO (pawel) This function does not include the 'attributes' column yet,
--- which will contain the event arguments in JSON format. That will be added in
--- a future iteration.
+-- Event arguments are converted to a JSON object and stored in the 'attributes'
+-- column, where each argument name becomes a key and its value becomes the
+-- corresponding JSON value.
 insertGlobalEventTableQuery :: AggregateEvent -> Text
 insertGlobalEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
   let creator = T.pack $ Action.evContractCreator ev
@@ -1586,6 +1586,18 @@ insertGlobalEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
       transactionSender = tshow . eventTxSender $ agEv
       eventIdx = tshow . eventIndex $ agEv
 
+      attributesMap =
+        Map.fromList [(T.pack name, T.pack value) | (name, value, _) <- Action.evArgs ev]
+
+      -- Please note that all types are being treated here as strings. This is
+      -- due to how `evArgs` is represented in the `Event` (tuple of strings).
+      --
+      -- TODO (pawel): A good follow-up to this work would be a refactoring of
+      -- `evArgs` in `Event`. By getting rid of this tech debt, we would also
+      -- significantly improve the quality of the `attributes` column in the
+      -- `events` table, making them type-aware.
+      attributesJson = decodeUtf8 . BL.toStrict $ Aeson.encode attributesMap
+
       columns = wrapAndEscapeDouble . map escapeQuotes $
         [ "creator"
         , "application"
@@ -1597,6 +1609,7 @@ insertGlobalEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
         , "transaction_hash"
         , "transaction_sender"
         , "event_index"
+        , "attributes"
         ]
 
       values = csv $ map (wrapSingleQuotes . escapeQuotes)
@@ -1610,7 +1623,7 @@ insertGlobalEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
         , transactionHash
         , transactionSender
         , eventIdx
-        ]
+        ] ++ [wrapSingleQuotes attributesJson <> "::jsonb"]
 
   in T.concat
        [ "INSERT INTO events "

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1551,6 +1551,63 @@ getArraysFromEvents evArgs = do
          in (arrayName, zip (map (SimpleValue . ValueString . T.pack . show) [0 :: Int ..]) 
                             (map (SimpleValue . ValueString . T.pack) elements))
 
+-- | Generates an INSERT SQL statement for the global 'events' table.
+--
+-- This function creates a SQL INSERT statement that adds a single event record
+-- to the centralized 'events' table. Unlike event-specific tables that are
+-- created dynamically per contract/event type, this global table has a fixed
+-- schema and stores all events in a normalized format.
+--
+-- TODO (pawel) This function does not include the 'attributes' column yet,
+-- which will contain the event arguments in JSON format. That will be added in
+-- a future iteration.
+insertGlobalEventTableQuery :: AggregateEvent -> Text
+insertGlobalEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
+  let creator = T.pack $ Action.evContractCreator ev
+      application = T.pack $ Action.evContractApplication ev
+      contractName = T.pack $ Action.evContractName ev
+      address = tshow . Action.evContractAddress $ ev
+      blockHash = T.pack . keccak256ToHex . eventBlockHash $ agEv
+      blockTimestamp = tshow . eventBlockTimestamp $ agEv
+      blockNumber = tshow . eventBlockNumber $ agEv
+      transactionHash = T.pack . keccak256ToHex . eventTxHash $ agEv
+      transactionSender = tshow . eventTxSender $ agEv
+      eventIdx = tshow . eventIndex $ agEv
+
+      columns = wrapAndEscapeDouble . map escapeQuotes $
+        [ "creator"
+        , "application"
+        , "contract_name"
+        , "address"
+        , "block_hash"
+        , "block_timestamp"
+        , "block_number"
+        , "transaction_hash"
+        , "transaction_sender"
+        , "event_index"
+        ]
+
+      values = csv $ map (wrapSingleQuotes . escapeQuotes)
+        [ creator
+        , application
+        , contractName
+        , address
+        , blockHash
+        , blockTimestamp
+        , blockNumber
+        , transactionHash
+        , transactionSender
+        , eventIdx
+        ]
+
+  in T.concat
+       [ "INSERT INTO events "
+       , columns
+       , "VALUES ("
+       , values
+       , ")"
+       ]
+
 insertEventTables :: 
   OutputM m =>
   [ProcessedCollectionRow] ->

--- a/strato/indexer/slipstream/src/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Slipstream/Processor.hs
@@ -388,6 +388,9 @@ processTheMessages env conn messages = do
         
     -- Insert the events into the event tables
     outputData conn $ insertEventTables processedEventArrays processedEventsWithoutArrays
+
+    -- Insert the events into the global 'events' table
+    outputData conn $ pipeInsertGlobalEventTable processedEvents
     
     -- If there are processed event arrays, update the foreign keys
     unless (null processedEventArrays) $

--- a/strato/indexer/slipstream/src/Slipstream/QueryFormatHelper.hs
+++ b/strato/indexer/slipstream/src/Slipstream/QueryFormatHelper.hs
@@ -7,7 +7,6 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AesonKey
 import qualified Data.Map as Map
 import qualified Data.Text as T
---import Slipstream.Data.Globals (TableName (..))
 
 -- TODO: Refactor this type before someone external sees it
 data TableName


### PR DESCRIPTION
This PR fixes https://github.com/blockapps/strato-platform/issues/4163

# Context

* Context: https://github.com/blockapps/strato-platform/issues/4163#issue-3240539975
* Design document: https://github.com/blockapps/strato-platform/issues/4163#issuecomment-3090909025

# Summary

 This PR implements a global `events` table that centralizes all blockchain events in a single table with a normalized schema. It's not replacing the current approach of creating separate tables per contract/event.


# Changes Made

## Database Schema

Added global events table in Cirrus migration with the following schema:
  - Standard event metadata columns (creator, application, contract_name, address, etc.)
  - attributes JSONB column to store all event arguments as key-value pairs
  - Primary key on `(transaction_hash, event_index)`

##  Core Implementation

  - Created `insertGlobalEventTableQuery` function to generate SQL INSERT statements for the global events table
  - Integrated global events insertion into the message processing pipeline via `pipeInsertGlobalEventTable`
  - Enhanced attribute handling: Event arguments are now converted from individual columns to a single JSON object in the attributes column

## Code Quality

  - Removed dead code and fixed SQL query formatting issues
  - Added comprehensive documentation explaining the new centralized approach
  - Added technical debt notes about current string-based type handling in evArgs
  
# Future work

## attributes type-aware

Currently, all event argument types are treated as strings in the attributes JSON column due to the current representation of evArgs in the Event type (tuple of strings). A valuable follow-up would be to refactor evArgs to preserve proper type information, which would significantly improve the quality of the attributes column by making it type-aware rather than string-based

## dedicated event tables as views

Currently, we are duplicating data by keeping events in both global `events` table as well as in dedicated `contract-event` tables. We might consider replacing those `contract-event` tables as views build from `events` table