### PR TITLE
Fix brief screen flash when switching to overview from side nav menu

### DIFF
--- a/mercata/ui/src/components/dashboard/AssetsList.tsx
+++ b/mercata/ui/src/components/dashboard/AssetsList.tsx
@@ -14,6 +14,7 @@ interface AssetsProps {
   tokens: Token[];
   isDashboard?: boolean;
   inActiveTokens: Token[];
+  shouldPreventFlash?: boolean;
 }
 
 const AssetsList = ({
@@ -21,6 +22,7 @@ const AssetsList = ({
   tokens,
   inActiveTokens,
   isDashboard = true,
+  shouldPreventFlash = false,
 }: AssetsProps) => {
   const [isOptionsModalOpen, setIsOptionsModalOpen] = useState(false);
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
@@ -33,6 +35,9 @@ const AssetsList = ({
       setIsDepositModalOpen(true);
     }
   };
+
+  // Don't show loading indicator immediately if shouldPreventFlash is true
+  const shouldShowLoading = loading && !shouldPreventFlash;
 
   return (
     <div className="bg-white rounded-xl border border-gray-100 shadow-sm w-full overflow-hidden">
@@ -84,7 +89,7 @@ const AssetsList = ({
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
-              {loading ? (
+              {shouldShowLoading ? (
                 <tr className="hover:bg-gray-50 transition-colors">
                   <td
                     colSpan={6}
@@ -251,7 +256,7 @@ const AssetsList = ({
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-100">
-                  {loading ? (
+                  {shouldShowLoading ? (
                     <tr className="hover:bg-gray-50 transition-colors">
                       <td
                         colSpan={5}

--- a/mercata/ui/src/components/dashboard/MyPoolParticipationSection.tsx
+++ b/mercata/ui/src/components/dashboard/MyPoolParticipationSection.tsx
@@ -10,7 +10,21 @@ import { useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import LPTokenDropdown from "./LPTokenDropdown";
 
-export default function MyPoolParticipationSection({ liquidityInfo, loadingLiquidity, lpTokens, loadingLpTokens }) {
+interface PoolParticipationProps {
+  liquidityInfo: any;
+  loadingLiquidity: any;
+  lpTokens: any;
+  loadingLpTokens: any;
+  shouldPreventFlash?: boolean;
+}
+
+export default function MyPoolParticipationSection({ 
+  liquidityInfo, 
+  loadingLiquidity, 
+  lpTokens, 
+  loadingLpTokens,
+  shouldPreventFlash = false
+}: PoolParticipationProps) {
   
   const [expandedTokens, setExpandedTokens] = useState<Set<string>>(new Set());
   
@@ -34,6 +48,9 @@ export default function MyPoolParticipationSection({ liquidityInfo, loadingLiqui
     setExpandedTokens(newExpanded);
   };
 
+  // Don't show loading indicator immediately if shouldPreventFlash is true
+  const shouldShowLoading = (loadingLiquidity || loadingLpTokens) && !shouldPreventFlash;
+
   return (
     <Card className="rounded-2xl shadow-sm w-full mb-6">
       <CardHeader>
@@ -51,7 +68,7 @@ export default function MyPoolParticipationSection({ liquidityInfo, loadingLiqui
           <div className="text-right">Value</div>
         </div>
 
-        {loadingLiquidity || loadingLpTokens ? (
+        {shouldShowLoading ? (
           <div className="flex items-center justify-center gap-2">
             <div className="animate-spin rounded-full h-5 w-5 border-t-2 border-b-2 border-primary"></div>
             <span className="text-sm text-gray-600">Loading...</span>

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -35,13 +35,27 @@ const Dashboard = () => {
   const { loadingLiquidity, liquidityInfo, refreshLoans } = useLendingContext();
   const { loading: loadingLpTokens, lpTokens, fetchLpTokensPositions } = useSwapContext();
 
+  // Add visibility states to prevent flashing
+  const [isComponentMounted, setIsComponentMounted] = useState(false);
+  const [isDataInitialized, setIsDataInitialized] = useState(false);
+
   useEffect(() => {
     document.title = "Dashboard | STRATO Mercata";
-    setTimeout(() => {
-      fetchTokens();
-    }, 500);
+    
+    // Set mounted state immediately to prevent flash
+    setIsComponentMounted(true);
+    
+    // Remove the timeout to prevent loading flash
+    fetchTokens();
     refreshLoans();
     fetchLpTokensPositions();
+
+    // Mark data as initialized after a brief delay to ensure proper rendering
+    const initTimer = setTimeout(() => {
+      setIsDataInitialized(true);
+    }, 100);
+
+    return () => clearTimeout(initTimer);
   }, [userAddress]);
 
   useEffect(() => {
@@ -98,6 +112,11 @@ const Dashboard = () => {
     setCataBalance(cataTotal);
   }, [tokens, loans]);
 
+  // Don't render anything until component is properly mounted
+  if (!isComponentMounted) {
+    return null;
+  }
+
   return (
     <div className="min-h-screen bg-gray-50">
       <DashboardSidebar />
@@ -139,23 +158,39 @@ const Dashboard = () => {
             />
           </div>
 
-          <div className="mb-8">
-            <AssetsList loading={loading} tokens={tokens} inActiveTokens={inactiveTokens} />
-          </div>
+          {/* Only render lower sections after data initialization to prevent flash */}
+          {isDataInitialized && (
+            <>
+              <div className="mb-8">
+                <AssetsList 
+                  loading={loading} 
+                  tokens={tokens} 
+                  inActiveTokens={inactiveTokens} 
+                  shouldPreventFlash={true}
+                />
+              </div>
 
-          <div className="mb-8">
-            <BorrowingSection 
-              loanData={loans}
-            />
-          </div>
+              <div className="mb-8">
+                <BorrowingSection 
+                  loanData={loans}
+                />
+              </div>
 
-          <div className="mb-8">
-            <MyPoolParticipationSection loadingLpTokens={loadingLpTokens} loadingLiquidity={loadingLiquidity} liquidityInfo={liquidityInfo} lpTokens={lpTokens} /> 
-          </div>
+              <div className="mb-8">
+                <MyPoolParticipationSection 
+                  loadingLpTokens={loadingLpTokens} 
+                  loadingLiquidity={loadingLiquidity} 
+                  liquidityInfo={liquidityInfo} 
+                  lpTokens={lpTokens}
+                  shouldPreventFlash={true}
+                /> 
+              </div>
 
-          <div className="mb-8">
-            <DashboardFAQ />
-          </div>
+              <div className="mb-8">
+                <DashboardFAQ />
+              </div>
+            </>
+          )}
         </main>
       </div>
     </div>


### PR DESCRIPTION
First browser tab is current state of the app.
Second browser tab is how the app will behave after this branch is merged.
Demonstrates issue #4253:

> When switching from any other section to Overview, a set of lower-section elements (like extended asset rows) briefly flashes on screen for like 0.5ms before the actual Overview data fully renders.
> 
> This content should only appear after scrolling,
> 
> but it flashes during tab change breaking the intended visual flow and causing a distracting flicker.
> 
> Fix recommends: Add Conditional Rendering / Visibility Lock
> 
> Ensure that lower-section elements are not visible until the user scrolls or until the main Overview content finishes mounting:



https://github.com/user-attachments/assets/21459e5e-e9fa-426d-8541-c0e744db2c33

