### PR TITLE
Renamed events table to event, added event_name column

### DIFF
--- a/strato/indexer/slipstream/exec_src/Main.hs
+++ b/strato/indexer/slipstream/exec_src/Main.hs
@@ -89,10 +89,7 @@ main = do
                       contract (id serial primary key, "codeHash" text, contract text, abi text)|]
       migrateCirrus [r|alter table contract add column if not exists "chainId" text|]
       migrateCirrus
-        [r|CREATE TABLE IF NOT EXISTS events (
-                creator text,
-                application text,
-                contract_name text,
+        [r|CREATE TABLE IF NOT EXISTS event (
                 address text,
                 block_hash text,
                 block_timestamp text,
@@ -100,6 +97,10 @@ main = do
                 transaction_hash text NOT NULL,
                 transaction_sender text,
                 event_index integer NOT NULL,
+                creator text,
+                application text,
+                contract_name text,
+                event_name text,
                 attributes jsonb,
                 PRIMARY KEY (transaction_hash, event_index)
             )|]

--- a/strato/indexer/slipstream/src/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Slipstream/OutputData.hs
@@ -1578,6 +1578,7 @@ insertGlobalEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
   let creator = T.pack $ Action.evContractCreator ev
       application = T.pack $ Action.evContractApplication ev
       contractName = T.pack $ Action.evContractName ev
+      eventName = T.pack $ Action.evName ev
       address = tshow . Action.evContractAddress $ ev
       blockHash = T.pack . keccak256ToHex . eventBlockHash $ agEv
       blockTimestamp = tshow . eventBlockTimestamp $ agEv
@@ -1599,34 +1600,31 @@ insertGlobalEventTableQuery agEv@AggregateEvent {eventEvent = ev} =
       attributesJson = decodeUtf8 . BL.toStrict $ Aeson.encode attributesMap
 
       columns = wrapAndEscapeDouble . map escapeQuotes $
+        baseEventColumns ++
         [ "creator"
         , "application"
         , "contract_name"
-        , "address"
-        , "block_hash"
-        , "block_timestamp"
-        , "block_number"
-        , "transaction_hash"
-        , "transaction_sender"
-        , "event_index"
+        , "event_name"
         , "attributes"
         ]
 
       values = csv $ map (wrapSingleQuotes . escapeQuotes)
-        [ creator
-        , application
-        , contractName
-        , address
+        [ address
         , blockHash
         , blockTimestamp
         , blockNumber
         , transactionHash
         , transactionSender
         , eventIdx
-        ] ++ [wrapSingleQuotes attributesJson <> "::jsonb"]
+        , creator
+        , application
+        , contractName
+        , eventName
+        , wrapSingleQuotes attributesJson <> "::jsonb"
+        ]
 
   in T.concat
-       [ "INSERT INTO events "
+       [ "INSERT INTO event "
        , columns
        , " VALUES ("
        , values


### PR DESCRIPTION
The table name slipped by me while reviewing the last PR, but it needs to be `event` because `event` is a reserved word in Solidity, so no one can create a contract called `event`. However, someone could create a contract called `events`, which would then interfere with the table as it is currently named. I also added the `event_name` column, which Ariya and I noticed was missing after looking at the table on node5. The column reordering is just for uniformity with our other tables.