### PR TITLE
Fix: refresh swap history data post swap

### DIFF
--- a/mercata/ui/src/components/swap/SwapHistory.tsx
+++ b/mercata/ui/src/components/swap/SwapHistory.tsx
@@ -5,12 +5,11 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Copy } from 'lucide-react';
 import { useSwapContext } from '@/context/SwapContext';
 import { formatWeiAmount, formatHash } from '@/utils/numberUtils';
-import { SwapHistoryEntry } from '@/interface';
 
 const SwapHistory: React.FC = () => {
-  const { fetchSwapHistory, fromAsset, toAsset, pool } = useSwapContext();
+  const { refreshSwapHistory, fromAsset, toAsset, pool, swapHistory, swapHistoryCount} = useSwapContext();
   const tableRef = useRef<HTMLDivElement>(null);
-  
+
   const copyToClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
@@ -20,61 +19,47 @@ const SwapHistory: React.FC = () => {
       console.error('Failed to copy text: ', err);
     }
   };
-  
+
   // State
-  const [swapHistory, setSwapHistory] = useState<SwapHistoryEntry[]>([]);
+  const itemsPerPage = 10;
   const [swapHistoryLoading, setSwapHistoryLoading] = useState(false);
   const [swapHistoryError, setSwapHistoryError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(0);
-  const [totalSwaps, setTotalSwaps] = useState(0);
   const [copiedHash, setCopiedHash] = useState<string | null>(null);
-  const itemsPerPage = 10;
+  const totalPages = Math.ceil(swapHistoryCount / itemsPerPage);
 
-  // Reset page when pool changes
+   // Reset page when pool changes
   useEffect(() => {
     setCurrentPage(0);
   }, [pool?.address, fromAsset?.address, toAsset?.address]);
 
   // Fetch swap history when pool address changes
   useEffect(() => {
-    if (pool?.address && fromAsset && toAsset) {
-      setSwapHistoryLoading(true);
-      setSwapHistoryError(null);
-      
-      const offset = currentPage * itemsPerPage;
-      const params = {
-        limit: itemsPerPage.toString(),
-        offset: offset.toString()
-      };
-      
-      fetchSwapHistory(pool.address, params)
-        .then(({ data: history, totalCount }) => {
-          setSwapHistory(history);
-          setTotalSwaps(totalCount);
-          setTotalPages(Math.ceil(totalCount / itemsPerPage));
-        })
-        .catch((error) => {
-          console.error('Error fetching swap history:', error);
+    const fetch = async () => {
+      if (pool?.address && fromAsset && toAsset) {
+        setSwapHistoryLoading(true);
+        setSwapHistoryError(null);
+        
+        try {
+          await refreshSwapHistory({
+            limit: itemsPerPage.toString(),
+            offset: (currentPage * itemsPerPage).toString(),
+          });
+        } catch (error) {
+          console.error('Error refreshing swap history:', error);
           setSwapHistoryError('Failed to load swap history');
-          setSwapHistory([]);
-        })
-        .finally(() => {
+        } finally {
           setSwapHistoryLoading(false);
-        });
-    } else {
-      setSwapHistory([]);
-      setSwapHistoryError(null);
-      setCurrentPage(0);
-      setTotalPages(0);
-      setTotalSwaps(0);
-    }
-  }, [pool?.address, fromAsset?.address, toAsset?.address, currentPage, fetchSwapHistory, itemsPerPage]);
+        }
+      }
+    };
+    fetch();
+  }, [pool?.address, fromAsset?.address, toAsset?.address, currentPage, refreshSwapHistory]);
 
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-semibold">Swap History</h3>
-      
+
       {fromAsset && toAsset ? (
         <div ref={tableRef} className="bg-white rounded-lg border">
           <Table>
@@ -99,16 +84,16 @@ const SwapHistory: React.FC = () => {
               ) : swapHistory.length > 0 ? (
                 swapHistory.map((swap) => (
                   <TableRow key={swap.id}>
-                                          <TableCell className="text-sm">
-                        {swap.timestamp.toLocaleDateString([], {
-                          year: 'numeric',
-                          month: 'short',
-                          day: 'numeric',
-                          hour: '2-digit',
-                          minute: '2-digit',
+                    <TableCell className="text-sm">
+                      {swap.timestamp.toLocaleDateString([], {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
                           hour12: false
-                        })}
-                      </TableCell>
+                      })}
+                    </TableCell>
                     <TableCell className="font-medium text-sm">
                       {swap.tokenIn}
                     </TableCell>
@@ -156,41 +141,41 @@ const SwapHistory: React.FC = () => {
               )}
             </TableBody>
           </Table>
-              
-              {/* Pagination Controls */}
-              <div className="flex items-center justify-between px-6 py-4 border-t">
-                <div className="text-sm text-gray-500">
-                  {totalPages > 1 ? (
-                    `Showing ${currentPage * itemsPerPage + 1} to ${Math.min((currentPage + 1) * itemsPerPage, totalSwaps)} of ${totalSwaps} swaps`
-                  ) : (
-                    `Showing ${swapHistory.length} swap${swapHistory.length !== 1 ? 's' : ''}`
-                  )}
-                </div>
-                {totalPages > 1 && (
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setCurrentPage(Math.max(0, currentPage - 1))}
-                      disabled={currentPage === 0 || swapHistoryLoading}
-                    >
-                      Previous
-                    </Button>
-                    <span className="text-sm text-gray-600">
-                      Page {currentPage + 1} of {totalPages}
-                      {swapHistoryLoading && <span className="ml-2 text-blue-500">Loading...</span>}
-                    </span>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setCurrentPage(Math.min(totalPages - 1, currentPage + 1))}
-                      disabled={currentPage === totalPages - 1 || swapHistoryLoading}
-                    >
-                      Next
-                    </Button>
-                  </div>
-                )}
+
+          {/* Pagination Controls */}
+          <div className="flex items-center justify-between px-6 py-4 border-t">
+            <div className="text-sm text-gray-500">
+              {totalPages > 1 ? (
+                `Showing ${currentPage * itemsPerPage + 1} to ${Math.min((currentPage + 1) * itemsPerPage, swapHistoryCount)} of ${swapHistoryCount} swaps`
+              ) : (
+                `Showing ${swapHistory.length} swap${swapHistory.length !== 1 ? 's' : ''}`
+              )}
+            </div>
+            {totalPages > 1 && (
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage(Math.max(0, currentPage - 1))}
+                  disabled={currentPage === 0 || swapHistoryLoading}
+                >
+                  Previous
+                </Button>
+                <span className="text-sm text-gray-600">
+                  Page {currentPage + 1} of {totalPages}
+                  {swapHistoryLoading && <span className="ml-2 text-blue-500">Loading...</span>}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage(Math.min(totalPages - 1, currentPage + 1))}
+                  disabled={currentPage === totalPages - 1 || swapHistoryLoading}
+                >
+                  Next
+                </Button>
               </div>
+            )}
+          </div>
         </div>
       ) : (
         <div className="bg-gray-50 rounded-lg p-6 text-center">
@@ -201,4 +186,4 @@ const SwapHistory: React.FC = () => {
   );
 };
 
-export default SwapHistory; 
+export default SwapHistory;

--- a/mercata/ui/src/components/swap/SwapWidget.tsx
+++ b/mercata/ui/src/components/swap/SwapWidget.tsx
@@ -370,7 +370,7 @@ const SlippageControl = ({ slippage, autoSlippage, onSlippageChange, onAutoToggl
 };
 
 const SwapWidget = () => {
-  const { swappableTokens, pairableTokens, fetchPairableTokens, calculateSwap, swap, getPoolByTokenPair, fromAsset, toAsset, pool, setFromAsset, setToAsset, setPool,getTokenBalance } = useSwapContext();
+  const { swappableTokens, pairableTokens, fetchPairableTokens, calculateSwap, swap, getPoolByTokenPair, fromAsset, toAsset, pool, setFromAsset, setToAsset, setPool,getTokenBalance, refreshSwapHistory } = useSwapContext();
   const { userAddress } = useUser();
   const { usdstBalance, fetchUsdstBalance, fetchTokens } = useUserTokens();
   const { refreshLoans, refreshCollateral } = useLendingContext();
@@ -863,6 +863,7 @@ const SwapWidget = () => {
       setEditingField(null);
       lastCalculatedFromRef.current = "";
 
+      await refreshSwapHistory()
       // Refresh all contexts to ensure borrow page shows updated balances
       await Promise.all([
         getTokenBalanceFromContext(fromAsset, true),

--- a/mercata/ui/src/context/SwapContext.tsx
+++ b/mercata/ui/src/context/SwapContext.tsx
@@ -53,6 +53,9 @@ type SwapContextType = {
   lpTokens: LiquidityPool[]
   fetchLpTokensPositions: () => Promise<void>;
   fetchSwapHistory: (poolAddress: string, params?: Record<string, string>) => Promise<{ data: SwapHistoryEntry[]; totalCount: number }>;
+  refreshSwapHistory: (params?: Record<string, string>) => Promise<void>;
+  swapHistory: SwapHistoryEntry[];
+  swapHistoryCount: number
 };
 
 const SwapContext = createContext<SwapContextType | undefined>(undefined);
@@ -67,6 +70,8 @@ export const SwapProvider = ({ children }: { children: ReactNode }) => {
   const [fromAsset, setFromAsset] = useState<SwappableToken | undefined>();
   const [toAsset, setToAsset] = useState<SwappableToken | undefined>();
   const [pool, setPool] = useState<LiquidityPool | null>(null);
+  const [swapHistory, setSwapHistory] = useState<SwapHistoryEntry[]>([]);
+  const [swapHistoryCount, setSwapHistoryCount] = useState(0);
 
   const fetchSwappableTokens = useCallback(async () => {
     setLoading(true);
@@ -240,20 +245,36 @@ export const SwapProvider = ({ children }: { children: ReactNode }) => {
     }));
   }, []);
 
-  const fetchSwapHistory = useCallback(async (poolAddress: string, params?: Record<string, string>): Promise<{ data: SwapHistoryEntry[]; totalCount: number }> => {
-    if (!poolAddress) return { data: [], totalCount: 0 };
-    
+ const fetchSwapHistory = useCallback(async (poolAddress: string, params?: Record<string, string>): Promise<{ data: SwapHistoryEntry[]; totalCount: number }> => {
+  if (!poolAddress) return { data: [], totalCount: 0 };
+
     // Fetch swap history with total count from the updated backend service
-    const response = await api.get(`/swap-history/${poolAddress}`, { params });
-    
+  const response = await api.get(`/swap-history/${poolAddress}`, { params });
+
     // Convert timestamp strings back to Date objects
-    const data = response.data.data.map((item: any) => ({
-      ...item,
-      timestamp: new Date(item.timestamp)
-    }));
-    
-    return { data, totalCount: response.data.totalCount };
-  }, []);
+  const data = response.data.data.map((item: any) => ({
+    ...item,
+    timestamp: new Date(item.timestamp)
+  }));
+
+  return { data, totalCount: response.data.totalCount };
+}, []);
+
+const refreshSwapHistory = useCallback(
+  async (params?: Record<string, string>) => {
+    if (!pool?.address) return;
+    try {
+      const { data, totalCount } = await fetchSwapHistory(pool.address, params);
+      setSwapHistory(data);               // ✅ Set new history
+      setSwapHistoryCount(totalCount);   // ✅ Set new count
+    } catch (err) {
+      console.error("Failed to refresh swap history", err);
+      setSwapHistory([]);                // Optional fallback
+      setSwapHistoryCount(0);            // Optional fallback
+    }
+  },
+  [pool?.address, fetchSwapHistory]
+);
 
   useEffect(() => {
     fetchSwappableTokens();
@@ -290,6 +311,9 @@ export const SwapProvider = ({ children }: { children: ReactNode }) => {
         lpTokens,
         fetchLpTokensPositions,
         fetchSwapHistory,
+        refreshSwapHistory,
+        swapHistory,
+        swapHistoryCount
       }}
     >
       {children}


### PR DESCRIPTION
This pr fixes the refresh the swap history data after swapping is done.
fixes #4172 

[Screencast from 07-29-2025 04:42:47 PM.webm](https://github.com/user-attachments/assets/da562284-1449-4288-93a3-0f5ef8463110)

