### PR TITLE
Security of transfer and transferFrom

### DIFF
--- a/mercata/contracts/abstract/ERC20/ERC20.sol
+++ b/mercata/contracts/abstract/ERC20/ERC20.sol
@@ -21,6 +21,15 @@ import "./utils/Context.sol";
  * instead returning `false` on failure. This behavior is nonetheless
  * conventional and does not conflict with the expectations of ERC-20
  * applications.
+ *
+ * WARNING: CRITICAL DEPENDENCY - READ BEFORE MODIFYING
+ * =====================================================
+
+ * This ERC20 implementation uses "revert-on-failure" behavior (instead of returning false).
+ * Many contracts in this codebase depend on this behavior and will break if changed.
+ * See detailed explanation in: ../../concrete/Tokens/Token.sol (FYI comment at top).
+ * Any modifications to transfer/transferFrom error handling MUST be coordinated with
+ * all dependent contracts to prevent silent failure vulnerabilities.
  */
 abstract contract ERC20 is Context, IERC20, IERC20Metadata { //MERCATA_COMPATIBILITY: Inherits also from Context.sol but that affects slipstream indexing of the ERC20 contract so copied over the same funcs for now.
     mapping(address => uint256) public record _balances; //MERCATA_COMPATIBILITY: This is private by default but we need to make them public and add record for slipstream

--- a/mercata/contracts/concrete/Tokens/Token.sol
+++ b/mercata/contracts/concrete/Tokens/Token.sol
@@ -43,7 +43,7 @@ contract record Token is ERC20, Ownable, TokenMetadata, TokenAccess {
     TokenStatus public status;
     TokenFactory public tokenFactory;
     RewardsManager public rewardsManager;
-    
+
     event StatusChanged(TokenStatus newStatus);
 
     modifier onlyTokenFactory() {
@@ -95,7 +95,7 @@ contract record Token is ERC20, Ownable, TokenMetadata, TokenAccess {
 
     function mint(address to, uint256 amount) external {
         require(
-            TokenAccess(this).isMinter(msg.sender), 
+            TokenAccess(this).isMinter(msg.sender),
             "Token: Caller is not a minter"
         );
         _mint(to, amount);
@@ -121,7 +121,7 @@ contract record Token is ERC20, Ownable, TokenMetadata, TokenAccess {
     function setAttribute(string key, string value) external onlyOwner {
         _setAttribute(key, value);
     }
-    
+
     function decimals() external view virtual override returns (uint8) {
         return customDecimals;
     }

--- a/mercata/contracts/concrete/Tokens/Token.sol
+++ b/mercata/contracts/concrete/Tokens/Token.sol
@@ -6,6 +6,36 @@ import "../Admin/AdminRegistry.sol";
 import "../Rewards/RewardsManager.sol";
 import "./TokenFactory.sol";
 
+/**
+ * FYI: IMPORTANT NOTICE FOR ERC20 REIMPLEMENTATION
+ *
+ * Anyone planning to modify this Token contract or reimplement ERC20 functionality should read this:
+ *
+ * 1. This Token contract inherits from ERC20 (../../abstract/ERC20.sol), which is a copy of
+ *    OpenZeppelin's ERC20 implementation with some modifications.
+ *
+ * 2. CRITICAL BEHAVIOR: The current ERC20.sol implementation deviates from the ERC20 standard
+ *    in that transfer() and transferFrom() functions ALWAYS REVERT on invalid states
+ *    (e.g., insufficient funds) instead of returning false as specified in the ERC20 standard.
+ *    This means these functions will either:
+ *    - Return true (success), OR
+ *    - Throw/revert (failure)
+ *    They will NEVER return false.
+ *
+ * 3. OpenZeppelin's reference implementation follows the same pattern (revert on failure).
+ *
+ * 4. DEPENDENCY: Other contracts in this codebase leverage this "revert-on-failure" behavior.
+ *    They call transfer()/transferFrom() and assume the call will either succeed or revert,
+ *    without checking the return value in many cases.
+ *
+ * 5. BREAKING CHANGE WARNING: If you replace ERC20.sol with an implementation that returns
+ *    false on failure (instead of reverting), this will break other contracts that depend
+ *    on the current behavior. Many contracts will silently accept failed transfers as successful.
+ *
+ * 6. Consider this dependency whenever modifying ERC20.sol or Token.sol. Any changes to the
+ *    error handling behavior must be coordinated with updates to all dependent contracts.
+ */
+
 enum TokenStatus { NULL, PENDING, ACTIVE, LEGACY }
 
 contract record Token is ERC20, Ownable, TokenMetadata, TokenAccess {


### PR DESCRIPTION
# Context

* Reported issue: "Unchecked External Calls - Silent failures and fund lossToken transfers return false but don't revert, state updated incorrectly."
* Recommended approach: "Use SafeERC20 for all token operations"

# Research

* SafeERC20.sol, though referenced in some obsolete contracts in the codebase, does not exists anymore
* The implementation of ERC20.sol is secured as it throws each time transfer was not possible
* Some contracts check for the returned value after calling `transfer` and `transferFrom` - though this is not mandatory as both of them will revert on failure
* Risk: hypothetical reimplementation of ERC20 that does not throw, still adheres to the contract as defined in `IERC20.sol`, but will break other contracts that depend on the current behavior

# Actions

* Warnings added to both `ERC20.sol` and `Token.sol` in case of ERC20 reimplementation