### PR TITLE
Add events to BlockInfo enabling proper event handling during genesis block processing

### DIFF
--- a/strato/core/strato-genesis/package.yaml
+++ b/strato/core/strato-genesis/package.yaml
@@ -52,6 +52,7 @@ tests:
       - aeson
       - blockapps-data
       - bytestring
+      - containers
       - hspec
       - json-stream
       - labeled-error

--- a/strato/core/strato-genesis/src/Blockchain/Data/AccountInfo.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Data/AccountInfo.hs
@@ -3,7 +3,8 @@
 
 module Blockchain.Data.AccountInfo
   ( AccountInfo (..),
-    accountExtractor
+    accountExtractor,
+    acctInfoAddress
   )
 where
 
@@ -30,6 +31,12 @@ data AccountInfo
   | ContractWithStorage Address Integer CodePtr [(Word256, Word256)]
   | SolidVMContractWithStorage Address Integer CodePtr [(B.ByteString, BasicValue)]
   deriving (Show, Eq, Read)
+
+acctInfoAddress :: AccountInfo ->  Address
+acctInfoAddress (NonContract a _) = a
+acctInfoAddress (ContractNoStorage a _ _) = a
+acctInfoAddress (ContractWithStorage a _ _ _) = a
+acctInfoAddress (SolidVMContractWithStorage a _ _ _) = a
 
 instance Format AccountInfo where
   format (NonContract addr nonce) =

--- a/strato/core/strato-genesis/src/Blockchain/Data/GenesisInfo.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Data/GenesisInfo.hs
@@ -20,6 +20,8 @@ where
 
 import Blockchain.Data.AccountInfo
 import Blockchain.Data.CodeInfo
+import Blockchain.Strato.Model.Event
+import Blockchain.Strato.Model.Address
 import qualified Blockchain.Data.AccountInfoOld as OLD
 import qualified Blockchain.Data.CodeInfoOld as OLD
 import qualified Blockchain.Data.GenesisInfoOld as OLD
@@ -40,6 +42,8 @@ import GHC.Generics (Generic)
 import qualified LabeledError
 import Text.Format
 import Text.Tools
+import qualified Data.Map.Strict as M
+import qualified Data.Sequence as S
 
 data GenesisInfo = GenesisInfo
   { genesisInfoParentHash :: Keccak256,
@@ -57,7 +61,8 @@ data GenesisInfo = GenesisInfo
     genesisInfoTimestamp :: UTCTime,
     genesisInfoExtraData :: Integer,
     genesisInfoMixHash :: Keccak256,
-    genesisInfoNonce :: Word64
+    genesisInfoNonce :: Word64,
+    genesisInfoEvents :: M.Map Address (S.Seq Event)
   }
   deriving (Show, Read, Eq, Generic)
 
@@ -111,7 +116,8 @@ defaultGenesisInfo =
       genesisInfoTimestamp = read "1970-01-01 00:00:00 UTC" :: UTCTime,
       genesisInfoExtraData = 0,
       genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
-      genesisInfoNonce = 42
+      genesisInfoNonce = 42,
+      genesisInfoEvents = M.empty
     }
 
 instance FromJSON GenesisInfo where
@@ -133,6 +139,7 @@ instance FromJSON GenesisInfo where
       <*> o .: "extraData"
       <*> o .: "mixHash"
       <*> o .: "nonce"
+      <*> o .:? "events" .!= M.empty
   parseJSON x = error $ "couldn't parse JSON for genesis block: " ++ show x
 
 instance ToJSON GenesisInfo where
@@ -158,6 +165,7 @@ genesisParser =
     <*> "extraData" JS..: JS.value
     <*> "mixHash" JS..: JS.value
     <*> "nonce" JS..: JS.value
+    <*> ("codeInfo" JS..: JS.value JS..| M.empty)
 
 getGenesisInfo :: MonadIO m => m GenesisInfo
 getGenesisInfo = do
@@ -186,6 +194,7 @@ convertFromOld OLD.GenesisInfo{..} =
     genesisInfoExtraData
     genesisInfoMixHash
     genesisInfoNonce
+    M.empty
   where
     convertFromOldAccountInfo :: OLD.AccountInfo -> AccountInfo
     convertFromOldAccountInfo (OLD.NonContract address nonce) = NonContract address nonce

--- a/strato/core/strato-genesis/src/Blockchain/Data/GenesisInfo.hs
+++ b/strato/core/strato-genesis/src/Blockchain/Data/GenesisInfo.hs
@@ -165,7 +165,7 @@ genesisParser =
     <*> "extraData" JS..: JS.value
     <*> "mixHash" JS..: JS.value
     <*> "nonce" JS..: JS.value
-    <*> ("codeInfo" JS..: JS.value JS..| M.empty)
+    <*> ("events" JS..: JS.value JS..| M.empty)
 
 getGenesisInfo :: MonadIO m => m GenesisInfo
 getGenesisInfo = do

--- a/strato/core/strato-genesis/test/JsonSpec.hs
+++ b/strato/core/strato-genesis/test/JsonSpec.hs
@@ -7,6 +7,7 @@ import Blockchain.Database.MerklePatricia.StateRoot
 import Blockchain.Strato.Model.Address
 import Blockchain.Strato.Model.ChainMember
 import Blockchain.Strato.Model.CodePtr
+import qualified Data.Map.Strict as M
 import Blockchain.Strato.Model.Keccak256
 import Data.Aeson
 import qualified Data.ByteString as BS
@@ -124,7 +125,9 @@ spec = do
                   genesisInfoTimestamp = UTCTime (fromGregorian 1970 0 1) (secondsToDiffTime 0),
                   genesisInfoExtraData = 0,
                   genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
-                  genesisInfoNonce = 42
+                  genesisInfoNonce = 42,
+                  genesisInfoEvents = M.empty
+
                 }
           got = eitherDecode input
        in got `shouldBe` want
@@ -181,8 +184,10 @@ spec = do
                   genesisInfoTimestamp = UTCTime (fromGregorian 1970 0 1) (secondsToDiffTime 0),
                   genesisInfoExtraData = 0,
                   genesisInfoMixHash = unsafeCreateKeccak256FromWord256 0,
-                  genesisInfoNonce = 42
+                  genesisInfoNonce = 42,
+                  genesisInfoEvents = M.empty
                 }
             ]
           got = JS.parseLazyByteString genesisParser input
+
        in got `shouldBe` want

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -195,7 +195,6 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
   A.insert (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256) sr
   let addresses = acctInfoAddress <$> genesisInfoAccountInfo genesisInfo
   for_ addresses $ \address -> do
-    -- address <- fmap (fromMaybe (error $ "missing key value in hash table: " ++ BC.unpack (B16.encode $ nibbleString2ByteString keyHash))) $ getAddressFromHash keyHash
     fullAddressState <- A.selectWithDefault (A.Proxy @AddressState) address
 
     $logInfoS "initgen" $ T.pack $ "##################### writing to DBs: " ++ format address

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -197,7 +197,8 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
   for_ addresses $ \address -> do
     fullAddressState <- A.selectWithDefault (A.Proxy @AddressState) address
 
-    $logInfoS "initgen" $ T.pack $ "##################### writing to DBs: " ++ format address
+    $logInfoS "initgen" $ T.pack $
+      "##################### writing to DBs: " ++ format address
 
     -- For now, we are just clumsily filtering out any state changes for the
     -- Vitu vehicle manager, since this contract has giant arrays that would

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -260,8 +260,10 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
                   pure (abstrs', mappings, arrays, cc)
             _ -> pure (Map.empty, [], [], emptyCodeCollection)
           let cca = case ch of
-                SolidVMCode n _ -> Just $ CodeCollectionAdded (const () <$> cc) ch creator' (T.pack n) abstrs maps
-                _ -> Nothing
+                SolidVMCode n _ ->
+                  Just $ CodeCollectionAdded (const () <$> cc) ch creator' (T.pack n) abstrs maps
+                ExternallyOwned _ -> Nothing
+                CodeAtAccount {} -> Nothing
               act = Just . NewAction $ A.Action
                 { A._blockHash = blockHeaderHash $ blockHeader genesisBlock,
                   A._blockTimestamp =

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -257,7 +257,12 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
             _ -> pure (Map.empty, [], [], emptyCodeCollection)
           let cca = case ch of
                 SolidVMCode n _ ->
-                  Just $ CodeCollectionAdded (const () <$> cc) ch creator' (T.pack n) abstrs maps
+                  let
+                    application' = T.pack n
+                    codeCollection' = () <$ cc
+                    codeCollectionAdded =
+                      CodeCollectionAdded codeCollection' ch creator' application' abstrs maps
+                  in Just codeCollectionAdded
                 ExternallyOwned _ -> Nothing
                 CodeAtAccount {} -> Nothing
               act = Just . NewAction $ A.Action

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -173,6 +173,50 @@ initializeGenesisBlock = do
   populateStorageDBs findMetadata genesisInfo genesisBlock genesisChainId
   $logInfoS "initgen" "populateStorageDBs is done"
 
+
+  -- | Populate storage databases with genesis block state and generate
+  -- corresponding events
+  --
+  -- This function performs several critical initialization tasks for the
+  -- genesis block:
+  --
+  -- 1. **State Root Management**: Retrieves current state root and temporarily
+  --    replaces it during processing to ensure consistent state handling
+  --
+  -- 2. **Kafka Topic Setup**: Ensures StateDiff topic exists in Kafka for event
+  -- streaming
+  --
+  -- 3. **Address Processing**: Iterates through all genesis account addresses
+  -- and:
+  --
+  --    - Fetches full address state from the state database
+  --    - Applies special filtering for Vitu vehicle manager contract (0x7000...0000)
+  --      to prevent performance issues with large arrays
+  --
+  -- 4. **State Diff Generation**: Creates SQL database diffs representing
+  --    account creation events for the genesis block, including:
+  --
+  --    - Block metadata (chain ID, block number, block hash, state root)
+  --    - Account state changes (all accounts are marked as "created")
+  --
+  -- 5. **VM Event Production**: Generates and publishes VM events to Kafka,
+  -- including:
+  --
+  --    - Contract deployment events for SolidVM contracts
+  --    - Action events with transaction metadata
+  --    - Code collection information and storage diffs
+  --    - Creator and origin address tracking
+  --
+  -- 6. **Contract Metadata Processing**: For SolidVM contracts, extracts and
+  -- processes:
+  --
+  --    - Abstract parent contracts
+  --    - Contract mappings and arrays
+  --    - Source code and contract names from metadata
+  --
+  -- The function ensures that both the SQL database and Kafka event stream are
+  -- properly initialized with the genesis block state, enabling proper
+  -- blockchain operation.
 populateStorageDBs ::
   ( MonadLogger m,
     HasSQLDB m,
@@ -188,18 +232,26 @@ populateStorageDBs ::
   Maybe Word256 ->
   m ()
 populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
+  -- Step 1: State Root Management - Retrieve current state root and temporarily replace it
   sr <- getStateRoot genesisChainId
+
+  -- Step 2: Kafka Topic Setup - Ensure StateDiff topic exists for event streaming
   liftIO . runKafkaMConfigured "strato-init" $ do
     assertStateDiffTopicCreation
   mSR <- A.lookup (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256)
   A.insert (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256) sr
+
+  -- Step 3: Address Processing - Iterate through all genesis account addresses
   let addresses = acctInfoAddress <$> genesisInfoAccountInfo genesisInfo
   for_ addresses $ \address -> do
+    -- Fetch full address state from the state database
     fullAddressState <- A.selectWithDefault (A.Proxy @AddressState) address
 
     $logInfoS "initgen" $ T.pack $
       "##################### writing to DBs: " ++ format address
 
+    -- Apply special filtering for Vitu vehicle manager contract (0x7000...0000)
+    -- to prevent performance issues with large arrays
     -- For now, we are just clumsily filtering out any state changes for the
     -- Vitu vehicle manager, since this contract has giant arrays that would
     -- choke strato (yes, this temprary feature is hardcoded into the whole
@@ -213,7 +265,9 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
         filteredAddrStates = [(acct, filteredAddressState)]
         squashMap f = fmap concat . mapM (uncurry f) . Map.toList
 
+    -- Step 4: State Diff Generation - Create SQL database diffs for account creation
     fullAccountDiffs <- mapM eventualAccountState . Map.fromList $ fullAddrStates
+    -- Step 5: VM Event Production - Generate and publish VM events to Kafka
     vmEvents <- squashMap toAction =<< mapM eventualAccountState (Map.fromList filteredAddrStates)
     commitSqlDiffs (mkStateDiff fullAccountDiffs)
     _ <- produceVMEvents vmEvents

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -222,13 +222,11 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
           let storageDiff = case storage d of
                 SolidVMDiff m -> A.SolidVMDiff $ Map.map fromDiff m
                 EVMDiff m -> A.EVMDiff $ Map.map fromDiff m
-              theMetadata =
-                getMetadata
-                ( case cp of
+              genesisBlockCodePtr = case cp of
                     ExternallyOwned ch' -> ch'
                     SolidVMCode _ ch' -> ch'
                     _ -> error $ "Could not resolve code ptr in genesis block" ++ show cp
-                )
+              theMetadata =getMetadata genesisBlockCodePtr
               lookupSolidDiff k (A.SolidVMDiff m) = Map.lookup k m
               lookupSolidDiff _ _                 = Nothing
               mCreator' = (\case BString str -> Just $ T.decodeUtf8 str; _ -> Nothing) . rlpDecode . rlpDeserialize =<< lookupSolidDiff ".:creator" storageDiff

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -212,7 +212,7 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
     -- platform for one client)
     let acct = address
         filteredAddressState =
-          if (address /= Ad.Address 0x7000000000000000000000000000000000000000)
+          if address /= Ad.Address 0x7000000000000000000000000000000000000000
             then fullAddressState
             else fullAddressState {addressStateContractRoot = MP.blankStateRoot}
         fullAddrStates = [(acct, fullAddressState)]

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -194,11 +194,7 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
     assertStateDiffTopicCreation
   mSR <- A.lookup (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256)
   A.insert (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256) sr
-  let acctInfoAddress (NonContract a _) = a
-      acctInfoAddress (ContractNoStorage a _ _) = a
-      acctInfoAddress (ContractWithStorage a _ _ _) = a
-      acctInfoAddress (SolidVMContractWithStorage a _ _ _) = a
-      addresses = acctInfoAddress <$> genesisInfoAccountInfo genesisInfo
+  let addresses = acctInfoAddress <$> genesisInfoAccountInfo genesisInfo
   for_ addresses $ \address -> do
     -- address <- fmap (fromMaybe (error $ "missing key value in hash table: " ++ BC.unpack (B16.encode $ nibbleString2ByteString keyHash))) $ getAddressFromHash keyHash
     fullAddressState <- A.selectWithDefault (A.Proxy @AddressState) address

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -140,7 +140,7 @@ initializeGenesisBlock = do
   $logInfoS "initgen" "Genesis Block put"
   $logInfoS "initgen" "State diff has been generated"
 
-  _ <- execRedis $ putBestSequencedBlockInfo $ BestSequencedBlock (blockHash genesisBlock) 0 validators 
+  _ <- execRedis $ putBestSequencedBlockInfo $ BestSequencedBlock (blockHash genesisBlock) 0 validators
 
   let genesisChainId = Nothing -- TODO: It's possible that we would call this function for private chain creation
   $logInfoS "initgen" "Beginning to write to redis"
@@ -192,7 +192,6 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
   sr <- getStateRoot genesisChainId
   liftIO . runKafkaMConfigured "strato-init" $ do
     assertStateDiffTopicCreation
-
   mSR <- A.lookup (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256)
   A.insert (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256) sr
   let acctInfoAddress (NonContract a _) = a

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -46,6 +46,7 @@ import Blockchain.SolidVM.SM
 import qualified Blockchain.Strato.Indexer.ApiIndexer as ApiIndexer
 import qualified Blockchain.Strato.Indexer.Kafka as IdxKafka
 import qualified Blockchain.Strato.Indexer.Model as IdxModel
+import Blockchain.Strato.Model.Event
 import Blockchain.Strato.Model.Account
 import qualified Blockchain.Strato.Model.Address as Ad
 import Blockchain.Strato.Model.Class
@@ -243,6 +244,8 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
 
   -- Step 3: Address Processing - Iterate through all genesis account addresses
   let addresses = acctInfoAddress <$> genesisInfoAccountInfo genesisInfo
+      events = genesisInfoEvents genesisInfo
+
   for_ addresses $ \address -> do
     -- Fetch full address state from the state database
     fullAddressState <- A.selectWithDefault (A.Proxy @AddressState) address
@@ -268,7 +271,8 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
     -- Step 4: State Diff Generation - Create SQL database diffs for account creation
     fullAccountDiffs <- mapM eventualAccountState . Map.fromList $ fullAddrStates
     -- Step 5: VM Event Production - Generate and publish VM events to Kafka
-    vmEvents <- squashMap toAction =<< mapM eventualAccountState (Map.fromList filteredAddrStates)
+    let addressEvents = Map.findWithDefault S.empty address  events
+    vmEvents <- squashMap (toAction addressEvents) =<< mapM eventualAccountState (Map.fromList filteredAddrStates)
     commitSqlDiffs (mkStateDiff fullAccountDiffs)
     void $ produceVMEvents vmEvents
 
@@ -294,8 +298,12 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
       , HasCodeDB m
       , HasStorageDB m
       , Selectable Ad.Address AddressState m
-      ) => Ad.Address -> AccountDiff 'Eventual -> m [VMEvent]
-    toAction a d = do
+      )
+      => S.Seq Event
+      -> Ad.Address
+      -> AccountDiff 'Eventual
+      -> m [VMEvent]
+    toAction addressEvents a d = do
       let ch = codeHash d
       cPtr <- fromMaybe ch <$> resolveCodePtr ch
       let
@@ -363,7 +371,7 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
                     [A.Create]),
               A._src = join $ fmap (Map.lookup "src") theMetadata,
               A._name = join $ fmap (Map.lookup "name") theMetadata,
-              A._events = S.empty,
+              A._events = addressEvents,
               A._delegatecalls = S.empty
             }
       pure $ catMaybes [cca, act]

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -206,9 +206,10 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
 
     $logInfoS "initgen" $ T.pack $ "##################### writing to DBs: " ++ format address
 
-    --For now, we are just clumsily filtering out any state changes for the Vitu vehicle manager,
-    --since this contract has giant arrays that would choke strato
-    --(yes, this temprary feature is hardcoded into the whole platform for one client)
+    -- For now, we are just clumsily filtering out any state changes for the
+    -- Vitu vehicle manager, since this contract has giant arrays that would
+    -- choke strato (yes, this temprary feature is hardcoded into the whole
+    -- platform for one client)
     let acct = address
         -- fullAddressState = rlpDecode . rlpDeserialize . rlpDecode $ value :: AddressState
         filteredAddressState =
@@ -239,7 +240,10 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
           appName' <- (\case Just (SolidVMCode n _) -> T.pack n; _ -> "") <$> resolveCodePtrParent ch
           (abstrs, maps, arrs, cc) <- case cp of
             SolidVMCode contractName' codeHash' -> do
-              cc <- codeCollectionFromHash True codeHash' -- Maybe the typechecking should be done elsewhere, but this will allow us to prevent faulty code collections from going into the genesis block
+              -- Maybe the typechecking should be done elsewhere, but this will
+              -- allow us to prevent faulty code collections from going into the
+              -- genesis block
+              cc <- codeCollectionFromHash True codeHash'
               case cc ^. CC.contracts . at contractName' of
                 Nothing -> do
                   $logWarnS "populateStorageDBs/toAction" . T.pack $ "Couldn't find a contract named " ++ contractName' ++ " in code collection " ++ format codeHash'

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -211,110 +211,139 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
             else fullAddressState {addressStateContractRoot = MP.blankStateRoot}
         fullAddrStates = [(acct, fullAddressState)]
         filteredAddrStates = [(acct, filteredAddressState)]
-        toAction a d = do
-          let ch = codeHash d
-          cp <- fromMaybe ch <$> resolveCodePtr ch
-          let storageDiff = case storage d of
-                SolidVMDiff m -> A.SolidVMDiff $ Map.map fromDiff m
-                EVMDiff m -> A.EVMDiff $ Map.map fromDiff m
-              genesisBlockCodePtr = case cp of
-                    ExternallyOwned ch' -> ch'
-                    SolidVMCode _ ch' -> ch'
-                    _ -> error $ "Could not resolve code ptr in genesis block" ++ show cp
-              theMetadata =getMetadata genesisBlockCodePtr
-              lookupSolidDiff k (A.SolidVMDiff m) = Map.lookup k m
-              lookupSolidDiff _ _                 = Nothing
-              mCreator' = (\case BString str -> Just $ T.decodeUtf8 str; _ -> Nothing) . rlpDecode . rlpDeserialize =<< lookupSolidDiff ".:creator" storageDiff
-              creator' = fromMaybe "" mCreator'
-              creatorAddress' = (\case BAccount (NamedAccount a' _) -> T.pack $ show a'; _ -> "") . maybe BDefault (rlpDecode . rlpDeserialize) $ lookupSolidDiff ".:creatorAddress" storageDiff
-              originAddress' = (\case BAccount (NamedAccount a' _) -> T.pack $ show a'; _ -> "") . maybe BDefault (rlpDecode . rlpDeserialize) $ lookupSolidDiff ".:originAddress" storageDiff
-          appName' <- (\case Just (SolidVMCode n _) -> T.pack n; _ -> "") <$> resolveCodePtrParent ch
-          (abstrs, maps, arrs, cc) <- case cp of
-            SolidVMCode contractName' codeHash' -> do
-              -- Maybe the typechecking should be done elsewhere, but this will
-              -- allow us to prevent faulty code collections from going into the
-              -- genesis block
-              cc <- codeCollectionFromHash True codeHash'
-              case cc ^. CC.contracts . at contractName' of
-                Nothing -> do
-                  $logWarnS "populateStorageDBs/toAction" . T.pack $
-                    "Couldn't find a contract named " ++ contractName' ++
-                    " in code collection " ++ format codeHash'
-                  pure (Map.empty, [], [], cc)
-                Just contract' -> do
-                  let !abstracts' = getAbstractParentsFromContract contract' cc
-                      !mappings = getMapNamesFromContract contract'
-                      !arrays = getArrayNamesFromContract contract'
-                  $logInfoS "populateStorageDBs/toAction" . T.pack $
-                    "creator: " ++ T.unpack creator' ++ ", app: "
-                    ++ T.unpack appName'
-                  $logInfoS "populateStorageDBs/toAction" . T.pack $
-                    "creatorAddress: " ++ T.unpack creatorAddress' ++
-                    ", originAddress: " ++ T.unpack originAddress'
-                  !abstrs' <- Map.fromList <$> traverse (resolveNameParts a creator' appName') abstracts'
-                  pure (abstrs', mappings, arrays, cc)
-            _ -> pure (Map.empty, [], [], emptyCodeCollection)
-          let cca = case ch of
-                SolidVMCode n _ ->
-                  let
-                    application' = T.pack n
-                    codeCollection' = () <$ cc
-                    codeCollectionAdded =
-                      CodeCollectionAdded codeCollection' ch creator' application' abstrs maps
-                  in Just codeCollectionAdded
-                ExternallyOwned _ -> Nothing
-                CodeAtAccount {} -> Nothing
-              act = Just . NewAction $ A.Action
-                { A._blockHash = blockHeaderHash $ blockHeader genesisBlock,
-                  A._blockTimestamp =
-                    blockHeaderTimestamp $ blockHeader genesisBlock,
-                  A._blockNumber =
-                    blockHeaderBlockNumber $ blockHeader genesisBlock,
-                  A._transactionHash =
-                    unsafeCreateKeccak256FromWord256 $ fromMaybe 0 genesisChainId,
-                  A._transactionSender = Ad.Address 0,
-                  A._actionData =
-                    OMap.singleton (a,
-                      A.ActionData
-                        cp
-                        emptyCodeCollection
-                        creator'
-                        mCreator'
-                        originAddress'
-                        appName'
-                        storageDiff
-                        abstrs maps arrs
-                        [A.Create]),
-                  A._src = join $ fmap (Map.lookup "src") theMetadata,
-                  A._name = join $ fmap (Map.lookup "name") theMetadata,
-                  A._events = S.empty,
-                  A._delegatecalls = S.empty
-                }
-          pure $ catMaybes [cca, act]
-        fromDiff :: Diff a 'Eventual -> a
-        fromDiff (Value v) = v
         squashMap f = fmap concat . mapM (uncurry f) . Map.toList
 
     fullAccountDiffs <- mapM eventualAccountState . Map.fromList $ fullAddrStates
     vmEvents <- squashMap toAction =<< mapM eventualAccountState (Map.fromList filteredAddrStates)
-
-    let statediff ad =
-          StateDiff
-            { StateDiff.chainId = genesisChainId,
-              blockNumber = 0,
-              StateDiff.blockHash = blockHash genesisBlock,
-              StateDiff.stateRoot =
-                MP.StateRoot . blockHeaderStateRoot $ blockHeader genesisBlock,
-              createdAccounts = ad,
-              deletedAccounts = Map.empty,
-              updatedAccounts = Map.empty
-            }
-
-    commitSqlDiffs (statediff fullAccountDiffs)
-
+    commitSqlDiffs (mkStateDiff fullAccountDiffs)
     _ <- produceVMEvents vmEvents
     return ()
   for_ mSR $ A.insert (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256)
+  where
+
+    mkStateDiff ad =
+      StateDiff
+        { StateDiff.chainId = genesisChainId,
+          blockNumber = 0,
+          StateDiff.blockHash = blockHash genesisBlock,
+          StateDiff.stateRoot =
+            MP.StateRoot . blockHeaderStateRoot $ blockHeader genesisBlock,
+          createdAccounts = ad,
+          deletedAccounts = Map.empty,
+          updatedAccounts = Map.empty
+        }
+
+    toAction ::
+      ( MonadLogger m
+      , MonadIO m
+      , HasCodeDB m
+      , HasStorageDB m
+      , Selectable Ad.Address AddressState m
+      ) => Ad.Address -> AccountDiff 'Eventual -> m [VMEvent]
+    toAction a d = do
+      let ch = codeHash d
+      cPtr <- fromMaybe ch <$> resolveCodePtr ch
+      let
+          theMetadata = getMetadata $ genesisBlockCodePtr cPtr
+          creator' = fromMaybe "" mkCreator
+          creatorAddress' = mkCreatorAddress
+          originAddress' = mkOriginAddress
+
+      appName' <- (\case Just (SolidVMCode n _) -> T.pack n; _ -> "") <$> resolveCodePtrParent ch
+      (abstrs, maps, arrs, cc) <- case cPtr of
+        SolidVMCode contractName' codeHash' -> do
+          -- Maybe the typechecking should be done elsewhere, but this will
+          -- allow us to prevent faulty code collections from going into the
+          -- genesis block
+          cc <- codeCollectionFromHash True codeHash'
+          case cc ^. CC.contracts . at contractName' of
+            Nothing -> do
+              $logWarnS "populateStorageDBs/toAction" . T.pack $
+                "Couldn't find a contract named " ++ contractName' ++
+                " in code collection " ++ format codeHash'
+              pure (Map.empty, [], [], cc)
+            Just contract' -> do
+              let !abstracts' = getAbstractParentsFromContract contract' cc
+                  !mappings = getMapNamesFromContract contract'
+                  !arrays = getArrayNamesFromContract contract'
+              $logInfoS "populateStorageDBs/toAction" . T.pack $
+                "creator: " ++ T.unpack creator' ++ ", app: "
+                ++ T.unpack appName'
+              $logInfoS "populateStorageDBs/toAction" . T.pack $
+                "creatorAddress: " ++ T.unpack creatorAddress' ++
+                ", originAddress: " ++ T.unpack originAddress'
+              !abstrs' <- Map.fromList <$> traverse (resolveNameParts a creator' appName') abstracts'
+              pure (abstrs', mappings, arrays, cc)
+        _ -> pure (Map.empty, [], [], emptyCodeCollection)
+      let cca = case ch of
+            SolidVMCode n _ ->
+              let
+                application' = T.pack n
+                codeCollection' = () <$ cc
+                codeCollectionAdded =
+                  CodeCollectionAdded codeCollection' ch creator' application' abstrs maps
+              in Just codeCollectionAdded
+            ExternallyOwned _ -> Nothing
+            CodeAtAccount {} -> Nothing
+          act = Just . NewAction $ A.Action
+            { A._blockHash = blockHeaderHash $ blockHeader genesisBlock,
+              A._blockTimestamp =
+                blockHeaderTimestamp $ blockHeader genesisBlock,
+              A._blockNumber =
+                blockHeaderBlockNumber $ blockHeader genesisBlock,
+              A._transactionHash =
+                unsafeCreateKeccak256FromWord256 $ fromMaybe 0 genesisChainId,
+              A._transactionSender = Ad.Address 0,
+              A._actionData =
+                OMap.singleton (a,
+                  A.ActionData
+                    cPtr
+                    emptyCodeCollection
+                    creator'
+                    mkCreator
+                    originAddress'
+                    appName'
+                    storageDiff
+                    abstrs maps arrs
+                    [A.Create]),
+              A._src = join $ fmap (Map.lookup "src") theMetadata,
+              A._name = join $ fmap (Map.lookup "name") theMetadata,
+              A._events = S.empty,
+              A._delegatecalls = S.empty
+            }
+      pure $ catMaybes [cca, act]
+      where
+
+        fromDiff :: Diff a 'Eventual -> a
+        fromDiff (Value v) = v
+
+        mkCreator =
+            (\case BString str -> Just $ T.decodeUtf8 str; _ -> Nothing)
+          . rlpDecode
+          . rlpDeserialize =<< lookupSolidDiff ".:creator" storageDiff
+
+        mkCreatorAddress =
+            (\case BAccount (NamedAccount a' _) -> T.pack $ show a'; _ -> "")
+          . maybe BDefault (rlpDecode . rlpDeserialize)
+          $ lookupSolidDiff ".:creatorAddress" storageDiff
+
+        mkOriginAddress =
+            (\case BAccount (NamedAccount a' _) -> T.pack $ show a'; _ -> "")
+          . maybe BDefault (rlpDecode . rlpDeserialize)
+          $ lookupSolidDiff ".:originAddress" storageDiff
+
+        storageDiff = case storage d of
+          SolidVMDiff m -> A.SolidVMDiff $ Map.map fromDiff m
+          EVMDiff m -> A.EVMDiff $ Map.map fromDiff m
+
+        genesisBlockCodePtr (ExternallyOwned ch') = ch'
+        genesisBlockCodePtr (SolidVMCode _ ch') = ch'
+        genesisBlockCodePtr cp =
+          error $ "Could not resolve code ptr in genesis block" ++ show cp
+
+        lookupSolidDiff k (A.SolidVMDiff m) = Map.lookup k m
+        lookupSolidDiff _ _                 = Nothing
+
 
 bootstrapIndexer :: OutputBlock -> IO ()
 bootstrapIndexer obGB = do

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -270,9 +270,10 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
     -- Step 5: VM Event Production - Generate and publish VM events to Kafka
     vmEvents <- squashMap toAction =<< mapM eventualAccountState (Map.fromList filteredAddrStates)
     commitSqlDiffs (mkStateDiff fullAccountDiffs)
-    _ <- produceVMEvents vmEvents
-    return ()
+    void $ produceVMEvents vmEvents
+
   for_ mSR $ A.insert (A.Proxy @MP.StateRoot) (Nothing :: Maybe Word256)
+
   where
 
     mkStateDiff ad =

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -244,14 +244,20 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
               cc <- codeCollectionFromHash True codeHash'
               case cc ^. CC.contracts . at contractName' of
                 Nothing -> do
-                  $logWarnS "populateStorageDBs/toAction" . T.pack $ "Couldn't find a contract named " ++ contractName' ++ " in code collection " ++ format codeHash'
+                  $logWarnS "populateStorageDBs/toAction" . T.pack $
+                    "Couldn't find a contract named " ++ contractName' ++
+                    " in code collection " ++ format codeHash'
                   pure (Map.empty, [], [], cc)
                 Just contract' -> do
                   let !abstracts' = getAbstractParentsFromContract contract' cc
                       !mappings = getMapNamesFromContract contract'
                       !arrays = getArrayNamesFromContract contract'
-                  $logInfoS "populateStorageDBs/toAction" . T.pack $ "creator: " ++ T.unpack creator' ++ ", app: " ++ T.unpack appName'
-                  $logInfoS "populateStorageDBs/toAction" . T.pack $ "creatorAddress: " ++ T.unpack creatorAddress' ++ ", originAddress: " ++ T.unpack originAddress'
+                  $logInfoS "populateStorageDBs/toAction" . T.pack $
+                    "creator: " ++ T.unpack creator' ++ ", app: "
+                    ++ T.unpack appName'
+                  $logInfoS "populateStorageDBs/toAction" . T.pack $
+                    "creatorAddress: " ++ T.unpack creatorAddress' ++
+                    ", originAddress: " ++ T.unpack originAddress'
                   !abstrs' <- Map.fromList <$> traverse (resolveNameParts a creator' appName') abstracts'
                   pure (abstrs', mappings, arrays, cc)
             _ -> pure (Map.empty, [], [], emptyCodeCollection)
@@ -260,9 +266,12 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
                 _ -> Nothing
               act = Just . NewAction $ A.Action
                 { A._blockHash = blockHeaderHash $ blockHeader genesisBlock,
-                  A._blockTimestamp = blockHeaderTimestamp $ blockHeader genesisBlock,
-                  A._blockNumber = blockHeaderBlockNumber $ blockHeader genesisBlock,
-                  A._transactionHash = unsafeCreateKeccak256FromWord256 $ fromMaybe 0 genesisChainId,
+                  A._blockTimestamp =
+                    blockHeaderTimestamp $ blockHeader genesisBlock,
+                  A._blockNumber =
+                    blockHeaderBlockNumber $ blockHeader genesisBlock,
+                  A._transactionHash =
+                    unsafeCreateKeccak256FromWord256 $ fromMaybe 0 genesisChainId,
                   A._transactionSender = Ad.Address 0,
                   A._actionData =
                     OMap.singleton (a,
@@ -294,7 +303,8 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
             { StateDiff.chainId = genesisChainId,
               blockNumber = 0,
               StateDiff.blockHash = blockHash genesisBlock,
-              StateDiff.stateRoot = MP.StateRoot . blockHeaderStateRoot $ blockHeader genesisBlock,
+              StateDiff.stateRoot =
+                MP.StateRoot . blockHeaderStateRoot $ blockHeader genesisBlock,
               createdAccounts = ad,
               deletedAccounts = Map.empty,
               updatedAccounts = Map.empty

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -173,7 +173,6 @@ initializeGenesisBlock = do
   populateStorageDBs findMetadata genesisInfo genesisBlock genesisChainId
   $logInfoS "initgen" "populateStorageDBs is done"
 
---------------------------------------
 populateStorageDBs ::
   ( MonadLogger m,
     HasSQLDB m,

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -211,7 +211,6 @@ populateStorageDBs getMetadata genesisInfo genesisBlock genesisChainId = do
     -- choke strato (yes, this temprary feature is hardcoded into the whole
     -- platform for one client)
     let acct = address
-        -- fullAddressState = rlpDecode . rlpDeserialize . rlpDecode $ value :: AddressState
         filteredAddressState =
           if (address /= Ad.Address 0x7000000000000000000000000000000000000000)
             then fullAddressState


### PR DESCRIPTION
First part of the https://github.com/blockapps/strato-platform/issues/4281

# Note to reviewer

The very first 15 commits are refactoring, reformatting, dropping dead code etc.
Those commits have tiny granularity so you can quickly navigate through them.

# Changes

The important changes are in the last two commits:

1. https://github.com/blockapps/strato-platform/pull/4359/commits/44d21c8e763214cab24805006e5c65c6993526f6

Extend GenesisInfo with events (Model.Event)
Both the JS parser and Aeson FromJSON assume that this field does not have to
exists, if not present, empty map is assumed (no events).


2.  https://github.com/blockapps/strato-platform/pull/4359/commits/be4ccf9daf2680772d02b9ee555d0cb73c2bc393

Integrate genesis events into VM actions during initialization.
Pass address-specific events from GenesisInfo to VM actions instead of using
empty event sequences, enabling proper event handling during the genesis block
processing.



