### PR TITLE
Improved SolidVM hashing and ecrecover

### DIFF
--- a/mercata/contracts/tests/BaseCodeCollection.test.sol
+++ b/mercata/contracts/tests/BaseCodeCollection.test.sol
@@ -1,16 +1,34 @@
-pragma solidvm 12.0;
+import "../concrete/BaseCodeCollection.sol";
 
-import "../abstract/BaseCodeCollection.sol";
+contract User {
+    function do(address a, string f, variadic args) public returns (variadic) {
+        variadic result = address(a).call(f, args);
+        return result;
+    }
+    
+    function callApprove(address a, address to, uint amount) public returns (bool) {
+        return ERC20(a).approve(to, amount);
+    }
+    
+    function callSwap(address a, bool isAToB, uint amountIn, uint minAmountOut) public returns (uint) {
+        return Pool(a).swap(isAToB, amountIn, minAmountOut);
+    }
+}
 
 contract Describe_Mercata {
+    constructor() {
+    }
+
+    Mercata m;
     function beforeAll() {
+        m = new Mercata();
+        require(address(m) != address(0), "Mercata address is 0");
     }
 
     function beforeEach() {
     }
 
     function it_can_deploy_Mercata() {
-        Mercata m = new Mercata();
         require(address(m) != address(0), "address is 0");
     }
 

--- a/mercata/contracts/tests/BaseCodeCollection.test.sol
+++ b/mercata/contracts/tests/BaseCodeCollection.test.sol
@@ -15,9 +15,115 @@ contract Describe_Mercata {
     }
 
     function it_checks_that_lending_pool_is_set() {
-        Mercata m = new Mercata();
-        require(address(m) != address(0), "Mercata address is 0");
-        require(address(m.collateralVault().lendingPool()) != address(0), "CollateralVault's LendingPool address is 0");
-        require(address(m.liquidityPool().lendingPool()) != address(0), "LiquidityPool's LendingPool address is 0");
+        require(address(m.collateralVault().registry().lendingPool()) != address(0), "CollateralVault's LendingPool address is 0");
+        require(address(m.liquidityPool().registry().lendingPool()) != address(0), "LiquidityPool's LendingPool address is 0");
+    }
+
+    function it_can_create_tokens() {
+        address t = m.tokenFactory().createToken("USDST", "USDST Token", [], [], [], "USDST", 0, 18);
+        require(t != address(0), "Failed to create Token");
+    }
+
+    function it_can_create_pools() {
+        address t1 = m.tokenFactory().createToken("ETHST", "ETHST Token", [], [], [], "ETHST", 0, 18);
+        Token(t1).setStatus(2);
+        address t2 = m.tokenFactory().createToken("USDST", "USDST Token", [], [], [], "USDST", 0, 18);
+        Token(t2).setStatus(2);
+        User u1 = new User();
+        User u2 = new User();
+        Token(t1).mint(address(this), 8000e18);
+        Token(t2).mint(address(this), 20000000e18);
+        Token(t1).mint(address(u1), 4e18);
+        Token(t2).mint(address(u1), 10000e18);
+        Token(t1).mint(address(u1), 4e18);
+        Token(t2).mint(address(u2), 10000e18);
+        address p1 = m.poolFactory().createPool(t1,t2);
+        require(p1 != address(0), "Failed to create pool 1");
+        // address p2 = m.poolFactory().createPool(t2,t1);
+        // require(p2 != address(0), "Failed to create pool 2");
+        require(ERC20(t1).approve(address(p1), 4000e18), "Approval failed for t1");
+        require(ERC20(t2).approve(address(p1), 10000000e18), "Approval failed for t2");
+        uint l1 = Pool(p1).addLiquidity(10000000e18, 4000e18);
+        require(l1 > 0, "Failed to add liquidity to pool 1");
+        // uint l2 = Pool(p2).addLiquidity(4000e18, 10000000e18);
+        // require(l2 > 0, "Failed to add liquidity to pool 2");
+        require(u1.callApprove(t1, p1, 1e18), "Approval failed for u1");
+        uint o1 = u1.callSwap(p1, true, 1e18, 2000e18);
+        require(o1 > 2490e18, "Swap 1 returned less money than expected: " + string(o1));
+        require(u1.callApprove(t2, p1, o1), "Approval failed for u1");
+        uint o2 = u1.callSwap(p1, false, o1, 990e15);
+        require(o2 > 994e15, "Swap returned less money than expected: " + string(o2));
+    }
+
+    function it_cannot_bankrupt_a_pool() {
+        address t1 = m.tokenFactory().createToken("ETHST", "ETHST Token", [], [], [], "ETHST", 0, 18);
+        Token(t1).setStatus(2);
+        address t2 = m.tokenFactory().createToken("USDST", "USDST Token", [], [], [], "USDST", 0, 18);
+        Token(t2).setStatus(2);
+        User u1 = new User();
+        User u2 = new User();
+        Token(t1).mint(address(this), 8000e18);
+        Token(t2).mint(address(this), 20000000e18);
+        uint u1t1Amt = 16000000000000000e18;
+        Token(t1).mint(address(u1), u1t1Amt);
+        Token(t2).mint(address(u1), 20000000e18);
+        address p1 = m.poolFactory().createPool(t1,t2);
+        require(p1 != address(0), "Failed to create pool 1");
+        require(ERC20(t1).approve(address(p1), 4000e18), "Approval failed for t1");
+        require(ERC20(t2).approve(address(p1), 10000000e18), "Approval failed for t2");
+        uint l1 = Pool(p1).addLiquidity(10000000e18, 4000e18);
+        require(l1 > 0, "Failed to add liquidity to pool 1");
+        require(u1.callApprove(t1, p1, u1t1Amt), "Approval failed for u1");
+        uint o1 = u1.callSwap(p1, true, u1t1Amt, 2000e18);
+        require(o1 > 0, "Swap 1 returned less money than expected: " + string(o1));
+    }
+
+    function it_can_hash_last_piecewise_transaction_data() {
+        uint ver = 2;
+        uint nonce = 1620;
+        uint gasLimit = 150000;
+        address to = address(0x000000000000000000000000000000000000100e);
+        string funcName = "mint";
+        string[] args = ["0xac840dd68e2ab32e98c8d7ccd3b9a725139f1aa7","10000000000000000000"];
+        string network = "mercata";
+        uint v = 0x1c;
+        uint r = 0xa3a96e57d33654b676751ba4e4e39fa2ba6d870ad9932c31e8485f5011f701e9;
+        uint s = 0x11d7a39195e4eea4f66e735455db97d63b1e48f3d5af34c54c39264cef9d4f19;
+
+        string h = keccak256(ver, nonce, gasLimit, to, funcName, args, network, v, r, s);
+        string u = keccak256(ver, nonce, gasLimit, to, funcName, args, network);
+        address from = ecrecover(u, v, r, s);
+        require(from == address(0x1b7dc206ef2fe3aab27404b88c36470ccf16c0ce), "Signed tx hash: " + h + ", unsigned tx hash: " + u + ", Signer: 0x" + string(from) + " didn't match 0x1b7dc206ef2fe3aab27404b88c36470ccf16c0ce");
+    }
+
+    struct Transaction {
+        uint aversion;
+        uint bnonce;
+        uint cgasLimit;
+        address dto;
+        string efuncName;
+        string[] fargs;
+        string gnetwork;
+        uint hv;
+        uint ir;
+        uint js;
+    }
+
+    function it_can_hash_transaction_data() {
+        uint ver = 2;
+        uint nonce = 1620;
+        uint gasLimit = 150000;
+        address to = address(0x000000000000000000000000000000000000100e);
+        string funcName = "mint";
+        string[] args = ["0xac840dd68e2ab32e98c8d7ccd3b9a725139f1aa7","10000000000000000000"];
+        string network = "mercata";
+        uint v = 0x1c;
+        uint r = 0xa3a96e57d33654b676751ba4e4e39fa2ba6d870ad9932c31e8485f5011f701e9;
+        uint s = 0x11d7a39195e4eea4f66e735455db97d63b1e48f3d5af34c54c39264cef9d4f19;
+        Transaction t = Transaction(ver, nonce, gasLimit, to, funcName, args, network, v, r, s);
+
+        string h = keccak256(ver, nonce, gasLimit, to, funcName, args, network, v, r, s);
+        string h2 = keccak256(t);
+        require(h == h2, "Hashes don't match");
     }
 }

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
@@ -9,6 +9,9 @@ module SolidVM.Model.Value
     Typo (..),
     ValList (..),
     IndexType (..),
+    rlpEncodeVariable,
+    rlpEncodeValue,
+    rlpEncodeValues,
     createVar,
     coerceType,
     apSnoc,
@@ -150,6 +153,26 @@ instance RLPSerializable Value where
   rlpDecode (RLPArray [RLPString "I", i]) = SInteger $ rlpDecode i
   rlpDecode (RLPArray [RLPString "S", s]) = SString $ rlpDecode s
   rlpDecode x = todo "Value/rlpDecode" x
+
+rlpEncodeVariable :: MonadIO m => Variable -> m RLPObject
+rlpEncodeVariable (Variable r) = rlpEncodeValue =<< liftIO (readIORef r)
+rlpEncodeVariable (Constant v) = rlpEncodeValue v
+
+rlpEncodeValue :: MonadIO m => Value -> m RLPObject
+rlpEncodeValue (SInteger i) = pure $ rlpEncode i
+rlpEncodeValue (SString s) = pure $ rlpEncode s
+rlpEncodeValue (SDecimal decimal) = pure $ rlpEncode $ show decimal
+rlpEncodeValue (SBool b) = pure $ rlpEncode b
+rlpEncodeValue (SAccount a _) = pure $ rlpEncode a
+rlpEncodeValue (SEnumVal _ _ i) = pure $ rlpEncode i
+rlpEncodeValue (SStruct _ m) = RLPArray <$> traverse (rlpEncodeVariable . snd) (M.toList m)
+rlpEncodeValue (STuple v) = RLPArray <$> traverse rlpEncodeVariable (V.toList v)
+rlpEncodeValue (SArray _ v) = RLPArray <$> traverse rlpEncodeVariable (V.toList v)
+rlpEncodeValue _ = pure $ RLPArray []
+
+rlpEncodeValues :: MonadIO m => [Value] -> m RLPObject
+rlpEncodeValues [x] = rlpEncodeValue x
+rlpEncodeValues xs = rlpEncodeValue $ STuple $ V.fromList $ Constant <$> xs
 
 -- coerceFromInt is useful to force integer literals
 -- to assume the type that was intended for them, once

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1343,13 +1343,13 @@ byteArgs :: SourceAnnotation Text -> Type'
 byteArgs x = intType' x
 
 keccak256Args :: SourceAnnotation Text -> Type'
-keccak256Args x = MultiVariate (stringType' x) x
+keccak256Args x = topType' x
 
 sha256Args :: SourceAnnotation Text -> Type'
-sha256Args x = MultiVariate (stringType' x) x
+sha256Args x = topType' x
 
 ripemd160Args :: SourceAnnotation Text -> Type'
-ripemd160Args x = MultiVariate (stringType' x) x
+ripemd160Args x = topType' x
 
 --This function should have multivariate type that represents any amount of string types
 stringConcatArgs :: SourceAnnotation Text -> Type'
@@ -1387,7 +1387,11 @@ blockhashArgs :: SourceAnnotation Text -> Type'
 blockhashArgs x = intType' x
 
 ecrecoverArgs :: SourceAnnotation Text -> Type'
-ecrecoverArgs x = Product [stringType' x, intType' x, stringType' x, stringType' x] x
+ecrecoverArgs x = Product [ stringType' x
+                          , intType' x
+                          , Sum $ (stringType' x) :| [intType' x]
+                          , Sum $ (stringType' x) :| [intType' x]
+                          ] x
 
 addmodArgs :: SourceAnnotation Text -> Type'
 addmodArgs x = Product [intType' x, intType' x, intType' x] x

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -35,6 +35,7 @@ import Blockchain.Data.AddressStateDB
 import Blockchain.Data.BlockHeader (BlockHeader)
 import qualified Blockchain.Data.BlockHeader as BlockHeader
 import Blockchain.Data.ExecResults
+import Blockchain.Data.RLP
 import Blockchain.Data.Transaction (whoSignedThisTransactionEcrecover)
 import qualified Blockchain.Database.MerklePatricia as MP
 import qualified Blockchain.SolidVM.Builtins as Builtins
@@ -2598,52 +2599,30 @@ callBuiltin "decimal" args _ = return $ decimalBuiltin args
 callBuiltin "push" [v] (Just o) = typeError "push (called as func, not as method)" (v, o)
 callBuiltin "call" [v] (Just o) = typeError "call (called as a function, not as a method)" (v, o)
 callBuiltin "identity" [v] Nothing = return v
-callBuiltin "keccak256" args Nothing = do
-  let allStrings [] = True
-      allStrings ((SString _) : xs) = True && (allStrings xs)
-      allStrings _ = False
-      customConcat :: [Value] -> String 
-      customConcat [] = ""
-      customConcat ((SString str) : ys) = str ++ customConcat ys
-      customConcat _ = invalidArguments "cannot use a non string arguments in keccak256" args
-  case allStrings args of
-    False -> invalidArguments "cannot use a non string arguments in keccak256" args
-    True -> return . SString . keccak256ToHex . hash . BC.pack $ customConcat args
-callBuiltin ("ecrecover") [SString h, SInteger v, SString r, SString s] _ = case B16.decode (BC.pack h) of
+callBuiltin "keccak256" args Nothing = SString . keccak256ToHex . hash . rlpSerialize <$> rlpEncodeValues args
+callBuiltin "ecrecover" [SString h, SInteger v, r', s'] _ = case B16.decode (BC.pack h) of
   Left err -> invalidArguments err ("" :: String)
   Right bytestringHash -> do
-    rIntHash <- case Numeric.readHex r of
-      [(x, "")] -> return x
-      _ -> invalidArguments "parseHex: error parsing r: " r
-    sIntHash <- case Numeric.readHex s of
-      [(y, "")] -> return y
-      _ -> invalidArguments "parseHex: error parsing s: " s
+    rIntHash <- case r' of
+      SInteger r -> pure r
+      SString r -> case Numeric.readHex r of
+        [(x, "")] -> return x
+        _ -> invalidArguments "parseHex: error parsing r: " r
+      _ -> invalidArguments "ecrecover: r must be a hex string or an integer" r'
+    sIntHash <- case s' of
+      SInteger s -> pure s
+      SString s -> case Numeric.readHex s of
+        [(y, "")] -> return y
+        _ -> invalidArguments "parseHex: error parsing s: " s
+      _ -> invalidArguments "ecrecover: s must be a hex string or an integer" s'
     let theSignerAddress = whoSignedThisTransactionEcrecover (unsafeCreateKeccak256FromByteString bytestringHash) rIntHash sIntHash v
     let theZero :: Integer
         theZero = 0
     case theSignerAddress of
       Nothing -> return . ((flip SAccount) False) . unspecifiedChain $ fromIntegral theZero
       Just theAddress -> return . ((flip SAccount) False) . unspecifiedChain $ theAddress
-callBuiltin ("sha256") args Nothing = do
-  let allStrings [] = True
-      allStrings ((SString _) : xs) = True && (allStrings xs)
-      allStrings _ = False
-      customConcat [] = ""
-      customConcat ((SString str) : ys) = str ++ customConcat ys
-      customConcat _ = invalidArguments "cannot use a non string arguments in sha256" args
-  case allStrings args of
-    False -> invalidArguments "cannot use a non string arguments in sha256" args
-    True -> return . SString . BC.unpack . SHA256.hash . BC.pack $ customConcat args
-callBuiltin ("ripemd160") args Nothing = do
-  let allStrings [] = True
-      allStrings ((SString _) : xs) = True && (allStrings xs)
-      allStrings _ = False
-      customConcat [] = ""
-      customConcat ((SString str) : ys) = str ++ customConcat ys
-      customConcat _ = invalidArguments "cannot use a non string arguments in ripemd160" args
-  case allStrings args of
-    False -> invalidArguments "cannot use a non string arguments in ripemd160" args
-    True -> return . SString . BC.unpack . RIPEMD160.hash . BC.pack $ customConcat args
+callBuiltin "sha256" args Nothing = SString . BC.unpack . SHA256.hash . rlpSerialize <$> rlpEncodeValues args
+callBuiltin "ripemd160" args Nothing = SString . BC.unpack . RIPEMD160.hash . rlpSerialize <$> rlpEncodeValues args
 callBuiltin ("payable") [SAccount a _] _ = return $ SAccount a True
 callBuiltin "require" (SBool cond : msg) Nothing = do
   case msg of


### PR DESCRIPTION
- Allow `keccak256`, `sha256`, and `ripemd160` to accept any types as arguments
- RLP-serialize arguments before hashing
- Allow `ecrecover` to accept `string` or `uint` for `r` and `s` values
- Added unit test cases to BaseCodeCollection.test.sol (currently only tests `keccak256` because that is what we use for transaction signing and ecrecover)