### PR TITLE
fix: resolve ES module compatibility issues with jose library

### DIFF
--- a/mercata/backend/src/api/middleware/authHandler.ts
+++ b/mercata/backend/src/api/middleware/authHandler.ts
@@ -1,6 +1,5 @@
 import { Request, RequestHandler } from "express";
 import RestStatus from "http-status-codes";
-import { JWTPayload } from "jose";
 import { verifyAccessTokenSignature } from "../../utils/authHelper";
 import { getServiceToken, createOrGetKey } from "../../utils/authHelper";
 // ————————————————————————————————————————————————————————————————
@@ -25,8 +24,9 @@ function getTokenFromHeader(req: Request): string | null {
   return null;
 }
 
-interface CustomJwtPayload extends JWTPayload {
+interface CustomJwtPayload {
   preferred_username: string;
+  [key: string]: any;
 }
 
 // ————————————————————————————————————————————————————————————————

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -1,5 +1,4 @@
 import { fetchOpenIdConfig } from "../utils/authHelper";
-import { JSONWebKeySet } from "jose";
 
 // Load local .env files when not in production
 if (process.env.NODE_ENV !== "production") {
@@ -22,7 +21,7 @@ if (!process.env.NODE_URL) {
 
 // TODO: potentially add the TTL for cached values, to update values after a period of time
 export let openIdTokenEndpoint: string | undefined;
-export let openIdJwks: JSONWebKeySet | undefined;
+export let openIdJwks: any | undefined;
 /**
  * Init function to be called from the App.js to make sure the app is served after the token endpoint is asynchronously fetched from OpenID Discovery URL 
  */

--- a/mercata/backend/src/utils/authHelper.ts
+++ b/mercata/backend/src/utils/authHelper.ts
@@ -1,9 +1,11 @@
 import axios from "axios";
 import { clientSecret, clientId, openIdTokenEndpoint, openIdJwks } from "../config/config";
-import { createLocalJWKSet, jwtVerify, JWTPayload, JSONWebKeySet } from "jose";
 import { strato } from "./mercataApiHelper";
 import { TokenCache, StratoKeyResponse } from "../types/types";
 import { StratoPaths } from "../config/constants";
+
+// Dynamic imports for jose library to handle ES Module compatibility
+let jose: any;
 
 const CACHED_TOKEN: TokenCache = {};
 
@@ -132,7 +134,7 @@ export async function createOrGetKey(token: string): Promise<string> {
 /**
  * Fetches both token endpoint and JWKS from the OpenID Connect discovery document
  */
-export async function fetchOpenIdConfig(openIdDiscoveryUrl: string | undefined): Promise<{ tokenEndpoint: string; jwks: JSONWebKeySet }> {
+export async function fetchOpenIdConfig(openIdDiscoveryUrl: string | undefined): Promise<{ tokenEndpoint: string; jwks: any }> {
   try {
     if (!openIdDiscoveryUrl) {
       throw new Error("OpenID Discovery URL is not defined");
@@ -149,7 +151,7 @@ export async function fetchOpenIdConfig(openIdDiscoveryUrl: string | undefined):
     }
 
     const jwksResponse = await axios.get(jwks_uri);
-    const jwks = jwksResponse.data as JSONWebKeySet;
+    const jwks = jwksResponse.data;
 
     if (!jwks || !Array.isArray(jwks.keys)) {
       throw new Error("Invalid JWKS response from OpenID provider");
@@ -168,13 +170,19 @@ export async function fetchOpenIdConfig(openIdDiscoveryUrl: string | undefined):
  */
 let cachedJwksVerifier: any | undefined;
 
-export async function verifyAccessTokenSignature(token: string): Promise<JWTPayload> {
+export async function verifyAccessTokenSignature(token: string): Promise<any> {
   if (!openIdJwks) {
     throw new Error("JWKS not initialized");
   }
-  if (!cachedJwksVerifier) {
-    cachedJwksVerifier = createLocalJWKSet(openIdJwks);
+  
+  // Dynamic import of jose library
+  if (!jose) {
+    jose = await import("jose");
   }
-  const { payload } = await jwtVerify(token, cachedJwksVerifier);
+  
+  if (!cachedJwksVerifier) {
+    cachedJwksVerifier = jose.createLocalJWKSet(openIdJwks);
+  }
+  const { payload } = await jose.jwtVerify(token, cachedJwksVerifier);
   return payload;
 }


### PR DESCRIPTION
## Problem
The `jose` library is an ES module but the project is configured as CommonJS, causing import errors when running with ts-node-dev.

## Solution
Replaced static imports of `jose` with dynamic imports to maintain ES module compatibility while preserving CommonJS project structure.

## Changes
- **authHelper.ts**: Implemented dynamic imports for `jose` library functions
- **config.ts**: Removed `JSONWebKeySet` import, simplified type definitions
- **authHandler.ts**: Removed `JWTPayload` import, updated interface to use generic types

## Testing
- ✅ Server starts without ES module errors
- ✅ All JWT verification functionality preserved
- ✅ Health endpoint responds correctly
- ✅ No breaking changes to existing API

## Impact
- Resolves ES module compatibility issues
- Maintains all existing functionality
- Minimal code changes (3 files modified)
- No dependency updates required