### PR TITLE
Simplified some types in SolidVM

### DIFF
--- a/mercata/contracts/tests/BaseCodeCollection.test.sol
+++ b/mercata/contracts/tests/BaseCodeCollection.test.sol
@@ -136,4 +136,11 @@ contract Describe_Mercata {
         string h2 = keccak256(t);
         require(h == h2, "Hashes don't match");
     }
+
+    function it_can_add_from_an_uninitialized_map() {
+        mapping (string => uint) nums;
+        mapping (string => string) strs;
+        require(3 + nums["hello"] == 3, "Mapping should return 0, instead got " + string(nums["hello"]));
+        require(strs["hello"] + "yo" + strs["goodbye"] == "yo", "Mapping should return empty string, instead got " + strs["hello"]);
+    }
 }

--- a/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
@@ -213,7 +213,6 @@ fromBasic = \case
   BAccount a -> SimpleValue $! ValueAccount a
   BContract _ c -> ValueContract c
   BEnumVal tipe name num -> ValueEnum (labelToText tipe) (labelToText name) (fromIntegral num)
-  BMappingSentinel -> ValueMapping M.empty
   BDefault -> SimpleValue $ ValueAddress 0x0
 
 fromIndex :: IndexType -> V.SimpleValue

--- a/strato/VM/EVM/evm-solidity/test/BlockApps/SolidVMStorageDecoderSpec.hs
+++ b/strato/VM/EVM/evm-solidity/test/BlockApps/SolidVMStorageDecoderSpec.hs
@@ -247,7 +247,6 @@ spec = do
                 (fromList [Field "array_of_nums", ArrayIndex 3], BInteger 77),
                 (fromList [Field "strukt", Field "first_field"], BInteger 887),
                 (fromList [Field "strukt", Field "second_field"], BString "CLOROX DISINFECTING WIPES"),
-                (fromList [Field "set"], BMappingSentinel),
                 (fromList [Field "set", MapIndex (INum 22)], BBool True),
                 (fromList [Field "set", MapIndex (INum 23)], BBool True),
                 (fromList [Field "set", MapIndex (INum 46)], BBool True)
@@ -281,8 +280,7 @@ spec = do
       let input =
             map
               toInput
-              [ (singleton "strMap", BMappingSentinel),
-                (fromList [Field "strMap", MapIndex (IText "ok")], BInteger 17),
+              [ (fromList [Field "strMap", MapIndex (IText "ok")], BInteger 17),
                 (fromList [Field "strMap", MapIndex (IText "\x76\x90\x00\x90")], BInteger 81)
               ]
           got = decodeSolidVMValues input
@@ -327,10 +325,6 @@ spec = do
       got
         `shouldBe` [("owner", SimpleValue $ ValueAccount $ unspecifiedChain 0xdeadbeef)]
 
-    it "can decode an empty mapping" $ do
-      let input = toInputMap [(singleton "mp", BMappingSentinel)]
-      decodeCacheValues input [] `shouldBe` [("mp", ValueMapping M.empty)]
-
     it "can decode everything (with empty cache)" $ do
       let input =
             toInputMap
@@ -349,7 +343,6 @@ spec = do
                 --                , (fromList [Field "array_of_nums", Field "length"], BInteger 4)
                 --                , (fromList [Field "strukt", Field "first_field"], BInteger 887)
                 --                , (fromList [Field "strukt", Field "second_field"], BString "CLOROX DISINFECTING WIPES")
-                --                , (fromList [Field "set"], BMappingSentinel)
                 --                , (fromList [Field "set", MapIndex (INum 22)], BBool True)
                 --                , (fromList [Field "set", MapIndex (INum 23)], BBool True)
                 --                , (fromList [Field "set", MapIndex (INum 46)], BBool True)

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
@@ -51,9 +51,6 @@ data BasicValue
   | BAccount !NamedAccount
   | BEnumVal !SolidString !SolidString !Word32
   | BContract !SolidString !NamedAccount
-  | -- The sole purpose of this sentinel is to make slipstream reserve
-    -- a column for this mapping
-    BMappingSentinel
   | BDefault -- Indicates a not present value
   deriving (Show, Read, Eq, Generic, NFData, Hashable, Binary)
 
@@ -113,7 +110,6 @@ isDefault (BBool b) = not b
 isDefault (BAccount a) = a == unspecifiedChain 0x0
 isDefault (BEnumVal _ _ w) = w == 0
 isDefault (BContract _ a) = a == unspecifiedChain 0x0
-isDefault BMappingSentinel = False
 isDefault BDefault = True
 
 instance Format BasicValue where
@@ -125,7 +121,6 @@ instance Format BasicValue where
   format (BAccount a) = "account(" ++ show a ++ ")"
   format (BEnumVal n1 n2 w) = labelToString n1 ++ "." ++ labelToString n2 ++ "." ++ show w
   format (BContract n a) = labelToString n ++ "(" ++ show a ++ ")"
-  format BMappingSentinel = "<MappingSentinel>"
   format BDefault = "<unknown>"
 
 formatBasicValueForSQL :: BasicValue -> Text
@@ -137,7 +132,6 @@ formatBasicValueForSQL (BBool False) = "false"
 formatBasicValueForSQL (BAccount a) = T.pack $ show a
 formatBasicValueForSQL (BEnumVal n1 n2 w) = labelToText n1 <> "." <> labelToText n2 <> "." <> T.pack (show w)
 formatBasicValueForSQL (BContract _ a) = T.pack $ show a
-formatBasicValueForSQL BMappingSentinel = "<MappingSentinel>"
 formatBasicValueForSQL BDefault = ""
 
 --function that gives index type, wrap in map index 
@@ -351,7 +345,6 @@ instance RLPSerializable BasicValue where
     BAccount a -> RLPArray [RLPScalar 3, rlpEncode a]
     BContract n a -> RLPArray [RLPScalar 4, rlpEncode n, rlpEncode a]
     BEnumVal a b c -> RLPArray [RLPScalar 5, rlpEncode a, rlpEncode b, rlpEncode c]
-    BMappingSentinel -> RLPArray [RLPScalar 6]
     BDecimal v -> RLPArray [RLPScalar 7, rlpEncode v]
   rlpDecode x@(RLPArray ((RLPScalar t) : s)) =
     case (t, s) of
@@ -361,7 +354,6 @@ instance RLPSerializable BasicValue where
       (3, [f]) -> BAccount $ rlpDecode f
       (4, [f, a']) -> BContract (rlpDecode f) (rlpDecode a')
       (5, [f, s', c']) -> BEnumVal (rlpDecode f) (rlpDecode s') (rlpDecode c')
-      (6, []) -> BMappingSentinel
       (7, [f]) -> BDecimal (rlpDecode f)
       _ -> error $ "invalid type or data length for BasicValue: " ++ show x
   rlpDecode (RLPString "") = BDefault

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
@@ -91,7 +91,7 @@ data Value
   | SStruct SolidString (Map SolidString Variable)
   | STuple (Vector Variable)
   | SArray (Vector Variable)
-  | SMap SVMType.Type (Map Value Variable)
+  | SMap (Map Value Variable)
   | SFunction SolidString CC.Func
   | SBuiltinFunction SolidString (Maybe Value)
   | SBuiltinVariable SolidString
@@ -188,6 +188,7 @@ coerceFromInt ct (SEnumVal tipe _ _) n' =
     enumDef <- fmap fst . M.lookup tipe $ CC._enums ct
     when (n >= length enumDef) $ fail "enum val out of range"
     return $ SEnumVal tipe (enumDef !! n) $ fromIntegral n'
+coerceFromInt _ SNULL n = if n == 0 then SNULL else SInteger n
 coerceFromInt _ t x = typeError "coerceFromInt: invalid literal for type" (t, x)
 
 -- coerceType allows integer literals to initialize integers, addresses, and
@@ -230,14 +231,14 @@ createVar val = createVar' =<< case val of
   SStruct n m -> SStruct n <$> traverse toVar m
   STuple vs -> STuple <$> traverse toVar vs
   SArray vs -> SArray <$> traverse toVar vs
-  SMap t m -> SMap t <$> traverse toVar m
+  SMap m -> SMap <$> traverse toVar m
   SPush v mv -> SPush v <$> traverse toVar mv
   _ -> pure val
 
 --TODO- defaultValue is deprecated, will be removed...  Instead use createDefaultValue
 defaultValue :: CC.Contract -> SVMType.Type -> Value
 defaultValue _ (SVMType.Array _ _) = SArray V.empty
-defaultValue _ (SVMType.Mapping _ _ valType) = SMap valType $ M.empty
+defaultValue _ (SVMType.Mapping _ _ _) = SMap M.empty
 defaultValue _ (SVMType.Int _ _) = SInteger 0
 defaultValue _ SVMType.Bool = SBool False
 defaultValue _ (SVMType.Address _) = (SAccount $ unspecifiedChain (Address 0)) False
@@ -268,7 +269,7 @@ createDefaultValue ::
   SVMType.Type ->
   m Value
 createDefaultValue _ _ (SVMType.Array _ _) = return $ SArray V.empty
-createDefaultValue _ _ (SVMType.Mapping _ _ valType) = return $ SMap valType $ M.empty
+createDefaultValue _ _ (SVMType.Mapping _ _ _) = return $ SMap M.empty
 createDefaultValue _ _ (SVMType.Int _ _) = return $ SInteger 0
 createDefaultValue _ _ SVMType.Bool = return $ SBool False
 createDefaultValue _ _ (SVMType.Address _) = return $ (SAccount $ unspecifiedChain (Address 0)) False
@@ -331,7 +332,7 @@ data BasicType
   | TContract SolidString
   | TStruct SolidString [(B.ByteString, BasicType)]
   | TArray BasicType (Maybe Word)
-  | TMapping BasicType BasicType
+  | TMapping
   | Todo String
   deriving (Show, Eq)
 

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Value.hs
@@ -92,8 +92,7 @@ data Value
   | STuple (Vector Variable)
   | SArray (Vector Variable)
   | SMap (Map Value Variable)
-  | SFunction SolidString CC.Func
-  | SBuiltinFunction SolidString (Maybe Value)
+  | SFunction SolidString (Maybe CC.Func) -- Nothing means it's a builtin function
   | SBuiltinVariable SolidString
   | SSetterGetter String (Maybe Value)
   | SContractDef SolidString
@@ -114,7 +113,6 @@ data Value
   -- supporting indexing into bytes32s.
   | SStringConcat -- for easy concat of multiple arguments
   | SAddressToAscii -- Hack to implement addressToAsciiString without supporting indexing into bytes
-  | SMappingSentinel
   | SBreak
   | SContinue
   | SBytes ByteString

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -66,7 +66,7 @@ import Control.Applicative
 import Control.Arrow ((***))
 import Control.DeepSeq (force)
 import Control.Exception (throw)
-import Control.Lens hiding (Context, assign, from, to)
+import Control.Lens hiding (Context, assign, from, to, uncons, unsnoc)
 import Control.Monad
 import qualified Control.Monad.Catch as EUnsafe
 import qualified Control.Monad.Change.Alter as A
@@ -864,10 +864,10 @@ runStatement st@(CC.SimpleStatement (CC.ExpressionStatement (CC.Binary _ "=" dst
           setVar pVar (SArray newVec)
           return Nothing
         _ -> typeError ("array index value (" ++ (show indVal) ++ ") is not an integer") (unparseStatement st)
-    SMap typ theMap -> do
+    SMap theMap -> do
       theIndex <- getVar =<< expToVar indExp Nothing
       let newMap = M.insert theIndex srcVar theMap
-      setVar pVar (SMap typ newMap)
+      setVar pVar (SMap newMap)
       return Nothing
     _ -> do
       -- If it's a mapping, (expToVar dst) IS a reference, so we can set directly to it
@@ -1500,23 +1500,21 @@ expToVar' x@(CC.IndexAccess _ parent (Just mIndex)) _ = do
           if (fromIntegral i) >= length theVector
             then indexOutOfBounds ("index value was " ++ (show i) ++ ", but the array length was " ++ (show $ length theVector)) $ unparseExpression x
             else return $ theVector V.! fromIntegral i
-        (SMap valType theMap, _) -> case theMap M.!? theIndex of
+        (SMap theMap, _) -> case theMap M.!? theIndex of
           Just v -> return v
-          Nothing -> case valType of
-            SVMType.Int{} -> pure $ Constant $ SInteger 0
-            SVMType.String{} -> pure $ Constant $ SString ""
-            SVMType.Bytes{} -> pure $ Constant $ SString ""
-            SVMType.Decimal -> pure $ Constant $ SDecimal 0.0
-            SVMType.Bool -> pure $ Constant $ SBool False
-            SVMType.Address p -> pure $ Constant $ SAccount (unspecifiedChain 0x0) p
-            SVMType.Account p -> pure $ Constant $ SAccount (unspecifiedChain 0x0) p
-            SVMType.Struct _ n -> pure $ Constant $ SStruct n M.empty
-            SVMType.Enum _ t (Just (n:_)) -> pure $ Constant $ SEnumVal t n 0
-            SVMType.Enum _ t _ -> pure $ Constant $ SEnumVal t "" 0
-            SVMType.Array _ _ -> pure $ Constant $ SArray mempty
-            SVMType.Contract n -> pure $ Constant $ SContractItem (unspecifiedChain 0x0) n
-            SVMType.Mapping _ _ t -> pure $ Constant $ SMap t M.empty
-            _ -> internalError "Type of Mapping not allowed" (show valType)
+          Nothing -> traverse getVar (fmap fst . uncons $ M.elems theMap) >>= \case
+            Nothing -> pure $ Constant SNULL
+            Just SInteger{} -> pure $ Constant $ SInteger 0
+            Just SString{} -> pure $ Constant $ SString ""
+            Just SDecimal{} -> pure $ Constant $ SDecimal 0.0
+            Just SBool{} -> pure $ Constant $ SBool False
+            Just (SAccount _ p) -> pure $ Constant $ SAccount (unspecifiedChain 0x0) p
+            Just (SStruct n _) -> pure $ Constant $ SStruct n M.empty
+            Just (SEnumVal t n _) -> pure $ Constant $ SEnumVal t n 0
+            Just (SArray _) -> pure $ Constant $ SArray mempty
+            Just (SContractItem _ n) -> pure $ Constant $ SContractItem (unspecifiedChain 0x0) n
+            Just (SMap _) -> pure $ Constant $ SMap M.empty
+            _ -> internalError "Type of Mapping not allowed" theMap
         (SReference _, _) -> Constant . SReference <$> expToPath x
         _ -> typeError "unsupported types for index access" $ unparseExpression x
 --    _ -> error $ "unknown case in expToVar' for IndexAccess: " ++ show var
@@ -1562,7 +1560,7 @@ expToVar' (CC.Binary _ "<" expr1 expr2) _ = do
   val1 <- getVar =<< expToVar expr1 Nothing
   val2 <- getVar =<< expToVar expr2 Nothing
   logVals val1 val2
-  case (val1, val2) of
+  case (defaultToInt val1, defaultToInt val2) of
     (SInteger i1, SInteger i2) -> return $ Constant $ SBool $ i1 < i2
     (SDecimal v1, SDecimal v2) -> return $ Constant $ SBool $ v1 < v2
     _ -> typeError "binary '<' on non-ints" (val1, val2)
@@ -1570,7 +1568,7 @@ expToVar' (CC.Binary _ ">" expr1 expr2) _ = do
   val1 <- getVar =<< expToVar expr1 Nothing
   val2 <- getVar =<< expToVar expr2 Nothing
   logVals val1 val2
-  case (val1, val2) of
+  case (defaultToInt val1, defaultToInt val2) of
     (SInteger i1, SInteger i2) -> return $ Constant $ SBool $ i1 > i2
     (SDecimal v1, SDecimal v2) -> return $ Constant $ SBool $ v1 > v2
     _ -> typeError "binary '>' on non-ints" (val1, val2)
@@ -1578,7 +1576,7 @@ expToVar' (CC.Binary _ ">=" expr1 expr2) _ = do
   val1 <- getVar =<< expToVar expr1 Nothing
   val2 <- getVar =<< expToVar expr2 Nothing
   logVals val1 val2
-  case (val1, val2) of
+  case (defaultToInt val1, defaultToInt val2) of
     (SInteger i1, SInteger i2) -> return $ Constant $ SBool $ i1 >= i2
     (SDecimal v1, SDecimal v2) -> return $ Constant $ SBool $ v1 >= v2
     _ -> typeError "binary '>=' used on non-ints" (val1, val2)
@@ -1586,7 +1584,7 @@ expToVar' (CC.Binary _ "<=" expr1 expr2) _ = do
   val1 <- getVar =<< expToVar expr1 Nothing
   val2 <- getVar =<< expToVar expr2 Nothing
   logVals val1 val2
-  case (val1, val2) of
+  case (defaultToInt val1, defaultToInt val2) of
     (SInteger i1, SInteger i2) -> return $ Constant $ SBool $ i1 <= i2
     (SDecimal v1, SDecimal v2) -> return $ Constant $ SBool $ v1 <= v2
     _ -> typeError "binary '<=' used on non-ints" (val1, val2)
@@ -2022,10 +2020,10 @@ expToVar' ep@(CC.Binary _ "=" dst@(CC.IndexAccess _ parent (Just indExp)) src) _
           setVar pVar (SArray newVec)
           return $ Constant $ SBool True
         _ -> typeError ("array index value (" ++ (show indVal) ++ ") is not an integer") (unparseExpression ep)
-    SMap typ theMap -> do
+    SMap theMap -> do
       theIndex <- getVar =<< expToVar indExp Nothing
       let newMap = M.insert theIndex srcVar theMap
-      setVar pVar (SMap typ newMap)
+      setVar pVar (SMap newMap)
       return $ Constant $ SBool True
     _ -> do
       -- If it's a mapping, (expToVar dst) IS a reference, so we can set directly to it
@@ -2102,17 +2100,32 @@ evaluateAccountMember a False itemName = do
   result <- callWithResult from a CC.DefaultCall Nothing itemName False (OrderedVals [])
   return . Constant . fromMaybe SNULL $ result
 
+defaultToInt :: Value -> Value
+defaultToInt SNULL = SInteger 0
+defaultToInt x     = x
+
 expToVarAdd :: MonadSM m => CC.Expression -> CC.Expression -> m Variable
 expToVarAdd expr1 expr2 = do
-  i1 <- getVar =<< expToVar expr1 Nothing
-  i2 <- getVar =<< expToVar expr2 Nothing
-  case (i1, i2) of
-    (SInteger a, SInteger b) -> return . Constant . SInteger $ a + b
-    (SString a, SString b) -> return . Constant . SString $ a ++ b
-    (SDecimal a, SDecimal b) -> return . Constant . SDecimal $ a + b
-    (SDecimal a, SInteger b) -> return . Constant . SDecimal $ a + (Decimal 0 b)
-    (SInteger a, SDecimal b) -> return . Constant . SDecimal $ (Decimal 0 a) + b
-    _ -> typeError "expToVarAdd" (i1, i2)
+  i1' <- getVar =<< expToVar expr1 Nothing
+  i2' <- getVar =<< expToVar expr2 Nothing
+  let addEm i1 i2 = case i1 of
+        SInteger a -> case defaultToInt i2 of
+          SInteger b -> return . Constant . SInteger $ a + b
+          SDecimal b -> return . Constant . SDecimal $ (Decimal 0 a) + b
+          _ -> typeError "expToVarAdd" (i1, i2)
+        SDecimal a -> case defaultToInt i2 of
+          SInteger b -> return . Constant . SDecimal $ a + (Decimal 0 b)
+          SDecimal b -> return . Constant . SDecimal $ a + b
+          _ -> typeError "expToVarAdd" (i1, i2)
+        SString a -> case i2 of
+          SString b -> return . Constant . SString $ a ++ b
+          SNULL -> return . Constant $ SString a
+          _ -> typeError "expToVarAdd" (i1, i2)
+        SNULL -> case i2 of
+          SNULL -> return $ Constant SNULL
+          _ -> addEm i2 i1
+        _ -> typeError "expToVarAdd" (i1, i2)
+  addEm i1' i2'
 
 --decMod operation, implements % w Data.Decimal library functions
 decMod :: Decimal -> Decimal -> Decimal
@@ -2131,7 +2144,7 @@ expToVarArith intOp decOp expr1 expr2 valType = do
   i1 <- getVar =<< expToVar expr1 Nothing
   i2 <- getVar =<< expToVar expr2 Nothing
   let valType' = fromMaybe (SVMType.Int (Just True) Nothing) valType 
-  case (i1, i2, valType') of
+  case (defaultToInt i1, defaultToInt i2, valType') of
     (SInteger a, SInteger b, (SVMType.Int _ _)) -> return . Constant . SInteger $ a `intOp` b
     (SInteger a, SInteger b, SVMType.Decimal) -> return . Constant . SDecimal $ (Decimal 0 a) `decOp` (Decimal 0 b)
     (SDecimal a, SDecimal b, _) -> do
@@ -2159,7 +2172,7 @@ expToVarDivide intOp decOp expr1 expr2 valType = do
   i1 <- getVar =<< expToVar expr1 Nothing
   i2 <- getVar =<< expToVar expr2 Nothing
   let valType' = fromMaybe (SVMType.Int (Just True) Nothing) valType 
-  case (i1, i2, valType') of
+  case (defaultToInt i1, defaultToInt i2, valType') of
     (SInteger a, SInteger b, (SVMType.Int _ _)) -> return . Constant . SInteger $ a `intOp` b
     (SInteger a, SInteger b, SVMType.Decimal) -> 
       return $ Constant $ SDecimal $ roundTo 0 ((Decimal 0 a) `decOp` (Decimal 0 b))
@@ -2196,7 +2209,7 @@ binopAssign' intOp decOp lhs rhs valType = do
   curValue <- readVal lhs
   varToAssign <- expToVar lhs Nothing
   let valType' = fromMaybe (SVMType.Int (Just True) Nothing) valType
-  next <- case (curValue, delta, valType') of
+  next <- case (defaultToInt curValue, defaultToInt delta, valType') of
     (SInteger c, SInteger d, (SVMType.Int _ _)) -> pure . SInteger $ c `intOp` d
     (SInteger a, SInteger b, SVMType.Decimal) -> pure . SDecimal $ (Decimal 0 a) `decOp` (Decimal 0 b)
     (SDecimal a, SDecimal b, _) -> do
@@ -2228,7 +2241,7 @@ binopDivide intOp decOp lhs rhs valType = do
   curValue <- readVal lhs
   varToAssign <- expToVar lhs Nothing
   let valType' = fromMaybe (SVMType.Int (Just True) Nothing) valType
-  next <- case (curValue, delta, valType') of
+  next <- case (defaultToInt curValue, defaultToInt delta, valType') of
     (SInteger c, SInteger d, (SVMType.Int _ _)) -> pure . SInteger $ c `intOp` d
     (SInteger a, SInteger b, SVMType.Decimal) -> 
       return $ SDecimal $ roundTo 0 ((Decimal 0 a) `decOp` (Decimal 0 b))
@@ -2254,7 +2267,7 @@ addAndAssign lhs rhs = do
   delta <- readVal rhs
   curValue <- readVal lhs
   varToAssign <- expToVar lhs Nothing
-  next <- case (curValue, delta) of
+  next <- case (defaultToInt curValue, defaultToInt delta) of
     (SInteger c, SInteger d) -> pure . SInteger $ c + d
     (SString c, SString d) -> pure . SString $ c ++ d
     (SDecimal c, SDecimal d) -> pure . SDecimal $ c + d
@@ -2281,6 +2294,7 @@ intBuiltin [SDecimal v] = SInteger (decimalMantissa $ roundTo 0 v)
 intBuiltin [SString hex] = integerToValue $ parseBaseInt hex 16
 intBuiltin [SString hex, SInteger 16] = integerToValue $ parseBaseInt hex 16
 intBuiltin [SString dec, SInteger 10] = integerToValue $ parseBaseInt dec 10
+intBuiltin [SNULL] = SInteger 0
 intBuiltin args = typeError "numeric cast - invalid args" args
 
 integerToValue :: Either String Integer -> Value
@@ -2295,6 +2309,7 @@ decimalBuiltin [SString str] =
     Right deci -> SDecimal deci
     Left e -> typeError e str
 decimalBuiltin [SDecimal v] = SDecimal v
+decimalBuiltin [SNULL] = SDecimal $ Decimal 0 0
 decimalBuiltin args = typeError "decimal cast - invalid args" args
 
 parseBaseInt :: String -> Integer -> Either String Integer
@@ -2317,6 +2332,7 @@ callBuiltin "string" [SString s] _ = return $ SString s
 callBuiltin "string" [SAccount a _] _ = return . SString $ show a
 callBuiltin "string" [SInteger i] _ = return . SString $ show i
 callBuiltin "string" [SBool b] _ = return . SString $ bool "false" "true" b
+callBuiltin "string" [SNULL] _ = return $ SString ""
 callBuiltin "string" vs _ = typeError "string cast" vs
 callBuiltin "address" [SInteger a] _ = return . ((flip SAccount) False) . unspecifiedChain $ fromIntegral a
 callBuiltin "address" [SAccount na b] _ = return $ SAccount (unspecifiedChain (_namedAccountAddress na)) b
@@ -2326,6 +2342,7 @@ callBuiltin "address" [ss@(SString s)] _ =
     (typeError "address cast" ss)
     (return . ((flip SAccount) False) . (namedAccountChainId .~ UnspecifiedChain))
     $ readMaybe s
+callBuiltin "address" [SNULL] _ = return $ SAccount (unspecifiedChain 0) False
 callBuiltin "address" vs _ = typeError "address cast" vs
 callBuiltin "account" [SInteger a] _ = return . ((flip SAccount) False) . unspecifiedChain $ fromIntegral a
 callBuiltin "account" [a@SAccount {}] _ = return a
@@ -2354,6 +2371,7 @@ callBuiltin "account" [(SAccount a _), SString ('0' : 'x' : xs)] _ = return . ((
     hexChar ch = fromMaybe (invalidArguments "illegal character in chainId hexstring" [ch]) $ elemIndex ch "0123456789ABCDEF"
     base16ToIntegral = foldl' (\n c -> 16 * n + (hexChar $ CHAR.toUpper c)) 0
 callBuiltin "account" [(SAccount a _), SString name] _ = a `castToAncestor` name
+callBuiltin "account" [SNULL] _ = return $ SAccount (unspecifiedChain 0) False
 callBuiltin ("addmod") [SInteger a, SInteger b, SInteger c] _ = return . SInteger $ (a + b) `mod` c
 callBuiltin ("mulmod") [SInteger a, SInteger b, SInteger c] _ = return . SInteger $ (a * b) `mod` c
 callBuiltin ("blockhash") [SInteger blockNum] _ | blockNum < 0 = invalidArguments "blockhash() only accepts arguments greater than or equal to 0" [blockNum]
@@ -2374,8 +2392,10 @@ callBuiltin "account" vs _ = typeError "account cast" vs
 callBuiltin "bool" [SBool b] _ = return $ SBool b
 callBuiltin "bool" [SString "true"] _ = return $ SBool True
 callBuiltin "bool" [SString "false"] _ = return $ SBool False
+callBuiltin "bool" [SNULL] _ = return $ SBool False
 callBuiltin "bool" vs _ = typeError "bool cast" vs
 callBuiltin "byte" [SInteger n] _ = return $ SInteger (n .&. 0xff)
+callBuiltin "byte" [SNULL] _ = return $ SInteger 0
 callBuiltin "byte" vs _ = typeError "byte cast" vs
 callBuiltin "uint" args _ = return $ intBuiltin args
 callBuiltin "int" args _ = return $ intBuiltin args
@@ -2572,8 +2592,8 @@ callBuiltin x args _ = unknownFunction ("callBuiltin " ++ show args) x
 certificateMap :: Maybe String -> CC.Contract -> Value
 certificateMap maybeCert _ =
   case maybeCert of
-    Nothing -> SMap stringToString emptyCertMap
-    Just cert -> SMap stringToString (fromMaybe emptyCertMap $ fmap (certMap cert) (subject cert))
+    Nothing -> SMap emptyCertMap
+    Just cert -> SMap (fromMaybe emptyCertMap $ fmap (certMap cert) (subject cert))
   where
     subject cert = getCertSubject =<< (eitherToMaybe . bytesToCert . BC.pack $ cert)
     rawCert cert = eitherToMaybe . bytesToCert . BC.pack $ cert
@@ -2613,13 +2633,6 @@ certificateMap maybeCert _ =
                 (SString "expirationDate", Constant . SString $ "")
               ]
        in M.union fieldsToUpdate $ emptyFields
-    stringToString =
-      SVMType.Mapping
-        { SVMType.dynamic = Nothing,
-          SVMType.key = SVMType.String Nothing,
-          SVMType.value = SVMType.String Nothing
-        }
-
 
 runTheConstructors :: MonadSM m => Address -> Address -> Keccak256 -> CC.CodeCollection -> SolidString -> ValList -> m ()
 runTheConstructors from to hsh cc contractName' argVals = do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -66,7 +66,7 @@ import Control.Applicative
 import Control.Arrow ((***))
 import Control.DeepSeq (force)
 import Control.Exception (throw)
-import Control.Lens hiding (Context, assign, from, to, uncons, unsnoc)
+import Control.Lens hiding (Context, assign, from, to, uncons)
 import Control.Monad
 import qualified Control.Monad.Catch as EUnsafe
 import qualified Control.Monad.Change.Alter as A

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1298,7 +1298,7 @@ expToVar' (CC.BoolLiteral _ b) _ = return $ Constant $ SBool b
 expToVar' (CC.HexaLiteral _ a) _ = return $ Constant $ SString $ BC.unpack . either (parseError "Couldn't parse hexadecimal literal: ") id . B16.decode $ BC.pack a
 expToVar' (CC.Variable _ "bytes32ToString") _ = return $ Constant $ SHexDecodeAndTrim
 expToVar' (CC.Variable _ "addressToAsciiString") _ = return $ Constant SAddressToAscii
-expToVar' (CC.Variable _ "bytes") _ = return $ Constant $ SBuiltinFunction "identity" Nothing
+expToVar' (CC.Variable _ "bytes") _ = return $ Constant $ SFunction "identity" Nothing
 expToVar' (CC.Variable _ "now") _ = Constant . SInteger . round . utcTimeToPOSIXSeconds . BlockHeader.timestamp . Env.blockHeader <$> getEnv
 expToVar' (CC.Variable _ name) _ = getVariableOfName name
 expToVar' (CC.Unitary _ "-" e) _ = do
@@ -1365,7 +1365,7 @@ expToVar' (CC.MemberAccess _ (CC.Variable _ "Util") "bytes32ToString") _ = do
   return $ Constant $ SHexDecodeAndTrim
 expToVar' (CC.MemberAccess _ (CC.Variable _ "Util") "b32") _ = do
   --TODO- remove this hardcoded case
-  return $ Constant $ SBuiltinFunction "identity" Nothing
+  return $ Constant $ SFunction "identity" Nothing
 expToVar' (CC.MemberAccess _ (CC.Variable _ "string") "concat") _ = do
   return $ Constant $ SStringConcat
 expToVar' x@(CC.MemberAccess _ expr name) _ = do
@@ -1787,10 +1787,10 @@ expToVar' theFullExp@(CC.FunctionCall _ e args) _ = do
                     Just v -> return $ Constant $ v
                     Nothing -> return $ Constant SNULL
                 x -> todo "expToVar'/FunctionCall" x
-            Constant (SBuiltinFunction name o) -> case argVals of
-              OrderedVals vs -> Constant <$> callBuiltin name vs o
+            Constant (SFunction name Nothing) -> case argVals of
+              OrderedVals vs -> Constant <$> callBuiltin name vs
               NamedVals {} -> invalidArguments (printf "expToVar'/builtinfunction: cannot used namedvals with builtin %s" name) argVals
-            Constant (SFunction funcName func) -> do
+            Constant (SFunction funcName (Just func)) -> do
               ro <- readOnly <$> getCurrentCallInfo
               contract' <- getCurrentContract
               address <- getCurrentAddress
@@ -2327,60 +2327,60 @@ castToAncestor :: MonadSM m => NamedAccount -> String -> m Value
 castToAncestor a _ = 
     return $ SAccount (NamedAccount (a^.namedAccountAddress) MainChain) False
 
-callBuiltin :: MonadSM m => SolidString -> [Value] -> Maybe Value -> m Value
-callBuiltin "string" [SString s] _ = return $ SString s
-callBuiltin "string" [SAccount a _] _ = return . SString $ show a
-callBuiltin "string" [SInteger i] _ = return . SString $ show i
-callBuiltin "string" [SBool b] _ = return . SString $ bool "false" "true" b
-callBuiltin "string" [SNULL] _ = return $ SString ""
-callBuiltin "string" vs _ = typeError "string cast" vs
-callBuiltin "address" [SInteger a] _ = return . ((flip SAccount) False) . unspecifiedChain $ fromIntegral a
-callBuiltin "address" [SAccount na b] _ = return $ SAccount (unspecifiedChain (_namedAccountAddress na)) b
-callBuiltin "address" [SContract _ a] _ = return $ SAccount a False
-callBuiltin "address" [ss@(SString s)] _ =
+callBuiltin :: MonadSM m => SolidString -> [Value] -> m Value
+callBuiltin "string" [SString s] = return $ SString s
+callBuiltin "string" [SAccount a _] = return . SString $ show a
+callBuiltin "string" [SInteger i] = return . SString $ show i
+callBuiltin "string" [SBool b] = return . SString $ bool "false" "true" b
+callBuiltin "string" [SNULL] = return $ SString ""
+callBuiltin "string" vs = typeError "string cast" vs
+callBuiltin "address" [SInteger a] = return . ((flip SAccount) False) . unspecifiedChain $ fromIntegral a
+callBuiltin "address" [SAccount na b] = return $ SAccount (unspecifiedChain (_namedAccountAddress na)) b
+callBuiltin "address" [SContract _ a] = return $ SAccount a False
+callBuiltin "address" [ss@(SString s)] =
   maybe
     (typeError "address cast" ss)
     (return . ((flip SAccount) False) . (namedAccountChainId .~ UnspecifiedChain))
     $ readMaybe s
-callBuiltin "address" [SNULL] _ = return $ SAccount (unspecifiedChain 0) False
-callBuiltin "address" vs _ = typeError "address cast" vs
-callBuiltin "account" [SInteger a] _ = return . ((flip SAccount) False) . unspecifiedChain $ fromIntegral a
-callBuiltin "account" [a@SAccount {}] _ = return a
-callBuiltin "account" [SContract _ a] _ = return $ SAccount a False
-callBuiltin "account" [ss@(SString s)] _ =
+callBuiltin "address" [SNULL] = return $ SAccount (unspecifiedChain 0) False
+callBuiltin "address" vs = typeError "address cast" vs
+callBuiltin "account" [SInteger a] = return . ((flip SAccount) False) . unspecifiedChain $ fromIntegral a
+callBuiltin "account" [a@SAccount {}] = return a
+callBuiltin "account" [SContract _ a] = return $ SAccount a False
+callBuiltin "account" [ss@(SString s)] =
   maybe
     (typeError "account cast" ss)
     (return . ((flip SAccount) False))
     $ readMaybe s
-callBuiltin "account" [SInteger a, SInteger b] _ = return . ((flip SAccount) False) $ explicitChain (fromIntegral a) (fromInteger b)
-callBuiltin "account" [SInteger a, SString "main"] _ = return . ((flip SAccount) False) $ mainChain (fromIntegral a)
-callBuiltin "account" [SInteger a, SString "self"] _ = do
+callBuiltin "account" [SInteger a, SInteger b] = return . ((flip SAccount) False) $ explicitChain (fromIntegral a) (fromInteger b)
+callBuiltin "account" [SInteger a, SString "main"] = return . ((flip SAccount) False) $ mainChain (fromIntegral a)
+callBuiltin "account" [SInteger a, SString "self"] = do
   pure . ((flip SAccount) False) $ mainChain (fromIntegral a)
-callBuiltin "account" [SInteger a, SString ('0' : 'x' : xs)] _ = do
+callBuiltin "account" [SInteger a, SString ('0' : 'x' : xs)] = do
   return . ((flip SAccount) False) $ explicitChain (fromIntegral a) (fromIntegral $ base16ToIntegral xs)
   where
     hexChar ch = fromMaybe (invalidArguments "illegal character in chainId hexstring" [ch]) $ elemIndex ch "0123456789ABCDEF"
     base16ToIntegral = foldl' (\n c -> 16 * n + (hexChar $ CHAR.toUpper c)) 0
-callBuiltin "account" [SInteger a, SString name] _ = unspecifiedChain (fromIntegral a) `castToAncestor` name
-callBuiltin "account" [(SAccount a _), SInteger b] _ = return . ((flip SAccount) False) $ (namedAccountChainId .~ ExplicitChain (fromIntegral b)) a
-callBuiltin "account" [(SAccount a _), SString "main"] _ = return . ((flip SAccount) False) $ (namedAccountChainId .~ MainChain) a
-callBuiltin "account" [(SAccount a _), SString "self"] _ = do
+callBuiltin "account" [SInteger a, SString name] = unspecifiedChain (fromIntegral a) `castToAncestor` name
+callBuiltin "account" [(SAccount a _), SInteger b] = return . ((flip SAccount) False) $ (namedAccountChainId .~ ExplicitChain (fromIntegral b)) a
+callBuiltin "account" [(SAccount a _), SString "main"] = return . ((flip SAccount) False) $ (namedAccountChainId .~ MainChain) a
+callBuiltin "account" [(SAccount a _), SString "self"] = do
   pure . ((flip SAccount) False) $ (namedAccountChainId .~ MainChain) a
-callBuiltin "account" [(SAccount a _), SString ('0' : 'x' : xs)] _ = return . ((flip SAccount) False) $ (namedAccountChainId .~ ExplicitChain (fromIntegral $ base16ToIntegral xs)) a
+callBuiltin "account" [(SAccount a _), SString ('0' : 'x' : xs)] = return . ((flip SAccount) False) $ (namedAccountChainId .~ ExplicitChain (fromIntegral $ base16ToIntegral xs)) a
   where
     hexChar ch = fromMaybe (invalidArguments "illegal character in chainId hexstring" [ch]) $ elemIndex ch "0123456789ABCDEF"
     base16ToIntegral = foldl' (\n c -> 16 * n + (hexChar $ CHAR.toUpper c)) 0
-callBuiltin "account" [(SAccount a _), SString name] _ = a `castToAncestor` name
-callBuiltin "account" [SNULL] _ = return $ SAccount (unspecifiedChain 0) False
-callBuiltin ("addmod") [SInteger a, SInteger b, SInteger c] _ = return . SInteger $ (a + b) `mod` c
-callBuiltin ("mulmod") [SInteger a, SInteger b, SInteger c] _ = return . SInteger $ (a * b) `mod` c
-callBuiltin ("blockhash") [SInteger blockNum] _ | blockNum < 0 = invalidArguments "blockhash() only accepts arguments greater than or equal to 0" [blockNum]
-callBuiltin ("blockhash") [SInteger blockNum] _ = do
+callBuiltin "account" [(SAccount a _), SString name] = a `castToAncestor` name
+callBuiltin "account" [SNULL] = return $ SAccount (unspecifiedChain 0) False
+callBuiltin ("addmod") [SInteger a, SInteger b, SInteger c] = return . SInteger $ (a + b) `mod` c
+callBuiltin ("mulmod") [SInteger a, SInteger b, SInteger c] = return . SInteger $ (a * b) `mod` c
+callBuiltin ("blockhash") [SInteger blockNum] | blockNum < 0 = invalidArguments "blockhash() only accepts arguments greater than or equal to 0" [blockNum]
+callBuiltin ("blockhash") [SInteger blockNum] = do
   env' <- getEnv
   let curBlock = Env.blockHeader env'
   maybeTheHash <- getBlockHashWithNumber blockNum (BlockHeader.parentHash curBlock)
   maybe (invalidArguments "the block number given does not exist" [blockNum]) (return . SString . BC.unpack . keccak256ToByteString) maybeTheHash
-callBuiltin ("selfdestruct") [SAccount a _] _ = do
+callBuiltin ("selfdestruct") [SAccount a _] = do
   contract' <- getCurrentAddress
   contractBalance <- addressStateBalance <$> A.lookupWithDefault (A.Proxy @AddressState) contract'
   _destroyRes <- A.adjustWithDefault_ (A.Proxy @AddressState) contract' $ \newAddressState ->
@@ -2388,23 +2388,21 @@ callBuiltin ("selfdestruct") [SAccount a _] _ = do
   sendRes <- pay "selfdestruct function" contract' (a^.namedAccountAddress) contractBalance
   _purgeRes <- purgeStorageMap contract'
   return $ SBool sendRes
-callBuiltin "account" vs _ = typeError "account cast" vs
-callBuiltin "bool" [SBool b] _ = return $ SBool b
-callBuiltin "bool" [SString "true"] _ = return $ SBool True
-callBuiltin "bool" [SString "false"] _ = return $ SBool False
-callBuiltin "bool" [SNULL] _ = return $ SBool False
-callBuiltin "bool" vs _ = typeError "bool cast" vs
-callBuiltin "byte" [SInteger n] _ = return $ SInteger (n .&. 0xff)
-callBuiltin "byte" [SNULL] _ = return $ SInteger 0
-callBuiltin "byte" vs _ = typeError "byte cast" vs
-callBuiltin "uint" args _ = return $ intBuiltin args
-callBuiltin "int" args _ = return $ intBuiltin args
-callBuiltin "decimal" args _ = return $ decimalBuiltin args
-callBuiltin "push" [v] (Just o) = typeError "push (called as func, not as method)" (v, o)
-callBuiltin "call" [v] (Just o) = typeError "call (called as a function, not as a method)" (v, o)
-callBuiltin "identity" [v] Nothing = return v
-callBuiltin "keccak256" args Nothing = SString . keccak256ToHex . hash . rlpSerialize <$> rlpEncodeValues args
-callBuiltin "ecrecover" [SString h, SInteger v, r', s'] _ = case B16.decode (BC.pack h) of
+callBuiltin "account" vs = typeError "account cast" vs
+callBuiltin "bool" [SBool b] = return $ SBool b
+callBuiltin "bool" [SString "true"] = return $ SBool True
+callBuiltin "bool" [SString "false"] = return $ SBool False
+callBuiltin "bool" [SNULL] = return $ SBool False
+callBuiltin "bool" vs = typeError "bool cast" vs
+callBuiltin "byte" [SInteger n] = return $ SInteger (n .&. 0xff)
+callBuiltin "byte" [SNULL] = return $ SInteger 0
+callBuiltin "byte" vs = typeError "byte cast" vs
+callBuiltin "uint" args = return $ intBuiltin args
+callBuiltin "int" args = return $ intBuiltin args
+callBuiltin "decimal" args = return $ decimalBuiltin args
+callBuiltin "identity" [v] = return v
+callBuiltin "keccak256" args = SString . keccak256ToHex . hash . rlpSerialize <$> rlpEncodeValues args
+callBuiltin "ecrecover" [SString h, SInteger v, r', s'] = case B16.decode (BC.pack h) of
   Left err -> invalidArguments err ("" :: String)
   Right bytestringHash -> do
     rIntHash <- case r' of
@@ -2425,21 +2423,21 @@ callBuiltin "ecrecover" [SString h, SInteger v, r', s'] _ = case B16.decode (BC.
     case theSignerAddress of
       Nothing -> return . ((flip SAccount) False) . unspecifiedChain $ fromIntegral theZero
       Just theAddress -> return . ((flip SAccount) False) . unspecifiedChain $ theAddress
-callBuiltin "sha256" args Nothing = SString . BC.unpack . SHA256.hash . rlpSerialize <$> rlpEncodeValues args
-callBuiltin "ripemd160" args Nothing = SString . BC.unpack . RIPEMD160.hash . rlpSerialize <$> rlpEncodeValues args
-callBuiltin ("payable") [SAccount a _] _ = return $ SAccount a True
-callBuiltin "require" (SBool cond : msg) Nothing = do
+callBuiltin "sha256" args = SString . BC.unpack . SHA256.hash . rlpSerialize <$> rlpEncodeValues args
+callBuiltin "ripemd160" args = SString . BC.unpack . RIPEMD160.hash . rlpSerialize <$> rlpEncodeValues args
+callBuiltin ("payable") [SAccount a _] = return $ SAccount a True
+callBuiltin "require" (SBool cond : msg) = do
   case msg of
     [] -> require cond Nothing
     (m : _) -> require cond (Just $ show m)
   return SNULL
-callBuiltin "assert" [SBool cond] Nothing = SNULL <$ assert cond
-callBuiltin "getUserCert" [SAccount a _] _ = do
+callBuiltin "assert" [SBool cond] = SNULL <$ assert cond
+callBuiltin "getUserCert" [SAccount a _] = do
   --Add others
   curContract <- getCurrentContract
   maybeCert <- A.select (A.Proxy @X509Certificate) $ a ^. namedAccountAddress
   return $ certificateMap (fmap (BC.unpack . certToBytes) maybeCert) curContract
-callBuiltin "getCertField" [(SAccount a _), (SString certField)] _ = do
+callBuiltin "getCertField" [(SAccount a _), (SString certField)] = do
   --Add others
   maybeField <- A.select (A.Proxy @X509CertificateField) $ ((a ^. namedAccountAddress), ((T.pack $ show certField)))
   case maybeField of
@@ -2451,7 +2449,7 @@ callBuiltin "getCertField" [(SAccount a _), (SString certField)] _ = do
 -- But verifyCertSignedBy checks that the target of a chained cert is signed by the public key.
 -- Expects the public key to be in PEM format
 -- Raises an error if it can't parse either argument, however perhaps that should't happen...
-callBuiltin "verifyCert" [SString cert, SString pubkey] _ = do
+callBuiltin "verifyCert" [SString cert, SString pubkey] = do
   let ex509Cert = bytesToCert . BC.pack $ cert
   let ePublicKey = bsToPub $ BC.pack pubkey
   case (ex509Cert, ePublicKey) of
@@ -2473,7 +2471,7 @@ callBuiltin "verifyCert" [SString cert, SString pubkey] _ = do
 -- But verifyCertSignedBy checks that the target of a chained cert is signed by the public key.
 -- Expects the public key to be in PEM format
 -- Raises an error if it can't parse either argument, however perhaps that should't happen...
-callBuiltin "verifyCertSignedBy" [SString cert, SString pubkey] _ = do
+callBuiltin "verifyCertSignedBy" [SString cert, SString pubkey] = do
   let ex509Cert = bytesToCert . BC.pack $ cert
   let ePublicKey = bsToPub $ BC.pack pubkey
   case (ex509Cert, ePublicKey) of
@@ -2494,7 +2492,7 @@ callBuiltin "verifyCertSignedBy" [SString cert, SString pubkey] _ = do
 -- Expects the signature as a DER/PEM format encoded string
 -- Expects the public key to be in PEM format
 -- Raises an error if it can't parse either argument, however perhaps that should't happen...
-callBuiltin "verifySignature" [SString msg, SString signature, SString pubkey] _ = do
+callBuiltin "verifySignature" [SString msg, SString signature, SString pubkey] = do
   let eMesgBs = B16.decode $ BC.pack msg
   case eMesgBs of
     Right mesgBs -> do
@@ -2517,10 +2515,10 @@ callBuiltin "verifySignature" [SString msg, SString signature, SString pubkey] _
                     )
               return $ SBool isValid
     Left err -> malformedData "Could not decode hex string" err
-callBuiltin "parseCert" [SString cert] _ = do
+callBuiltin "parseCert" [SString cert] = do
   curContract <- getCurrentContract
   return $ certificateMap (Just cert) curContract
-callBuiltin "create" args@(SString contractName' : SString contractSrc : argVals) _ = do
+callBuiltin "create" args@(SString contractName' : SString contractSrc : argVals) = do
   when (contractName' == "" || contractSrc == "") $
     invalidArguments "The contract name and src arguments for the create function should not be empty" args
 
@@ -2554,7 +2552,7 @@ callBuiltin "create" args@(SString contractName' : SString contractSrc : argVals
                                    ]
       pure $ ((flip SAccount) False) $ NamedAccount nca UnspecifiedChain
     Nothing -> internalError "a call to create did not create an address" execResults
-callBuiltin "create2" args@(salt : SString contractName' : SString contractSrc : argVals) _ = do
+callBuiltin "create2" args@(salt : SString contractName' : SString contractSrc : argVals) = do
   when (contractName' == "" || contractSrc == "") $
     invalidArguments "The contract name and src arguments for the create2 function should not be empty" args
 
@@ -2587,7 +2585,7 @@ callBuiltin "create2" args@(salt : SString contractName' : SString contractSrc :
                                    ]
       pure $ ((flip SAccount) False) $ NamedAccount nca UnspecifiedChain
     Nothing -> internalError "a call to create did not create an address" execResults
-callBuiltin x args _ = unknownFunction ("callBuiltin " ++ show args) x
+callBuiltin x args = unknownFunction ("callBuiltin " ++ show args) x
 
 certificateMap :: Maybe String -> CC.Contract -> Value
 certificateMap maybeCert _ =

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -467,10 +467,10 @@ getVariableOfName name = do
   let maybeLocalValue = fmap snd $ M.lookup name vars
 
   let maybeContractFunction :: Maybe Variable
-      maybeContractFunction = fmap (t "constant function" . Constant . SFunction name) $ M.lookup name $ currentContract currentCallInfo ^. CC.functions
+      maybeContractFunction = fmap (t "constant function" . Constant . SFunction name . Just) $ M.lookup name $ currentContract currentCallInfo ^. CC.functions
 
       maybeFreeFunction :: Maybe Variable
-      maybeFreeFunction = fmap (t "free function" . Constant . SFunction name) $ M.lookup name $ codeCollection currentCallInfo ^. CC.flFuncs
+      maybeFreeFunction = fmap (t "free function" . Constant . SFunction name . Just) $ M.lookup name $ codeCollection currentCallInfo ^. CC.flFuncs
 
       maybeBuiltinFunction :: Maybe Variable
       maybeBuiltinFunction =
@@ -512,7 +512,7 @@ getVariableOfName name = do
                        "verifySignature"
                      ]
           )
-          $ t "builtin function" $ Constant $ SBuiltinFunction name Nothing
+          $ t "builtin function" $ Constant $ SFunction name Nothing
 
       maybeBuiltinVariable :: Maybe Variable
       maybeBuiltinVariable =

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -820,10 +820,7 @@ hintFromType = \case
   SVMType.Array t ml -> do
     t' <- hintFromType t
     pure $ TArray t' ml
-  SVMType.Mapping _ k v -> do
-    k' <- hintFromType k
-    v' <- hintFromType v
-    pure $ TMapping k' v'
+  SVMType.Mapping{} -> pure TMapping
   tt'' -> todo "hintFromType" tt''
 
 getXabiTypeFromContract :: B.ByteString -> CC.Contract -> Maybe SVMType.Type

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -61,20 +61,6 @@ fromBasic = \case
   MS.BMappingSentinel -> SMappingSentinel
   MS.BDefault -> internalError "fromBasic: should never decode" MS.BDefault
 
-basicTypeToType :: BasicType -> SVMType.Type
-basicTypeToType = \case
-  TInteger -> SVMType.Int Nothing Nothing
-  TString -> SVMType.String Nothing
-  TDecimal -> SVMType.Decimal
-  TBool -> SVMType.Bool
-  TAccount -> SVMType.Address False
-  TContract n -> SVMType.Contract n
-  TEnumVal n -> SVMType.Enum Nothing n Nothing
-  TStruct n _ -> SVMType.Struct Nothing n
-  TArray t ml -> SVMType.Array (basicTypeToType t) ml
-  TMapping k v -> SVMType.Mapping Nothing (basicTypeToType k) (basicTypeToType v)
-  Todo msg -> todo "basicTypeToType/todo" msg
-
 findDefault :: BasicType -> Value
 findDefault = \case
   TInteger -> SInteger 0
@@ -86,7 +72,7 @@ findDefault = \case
   TEnumVal n -> SEnumVal n "" 0x0
   TStruct n fs -> SStruct n . M.fromList $ (BC.unpack *** Constant . findDefault) <$> fs
   TArray t ml -> SArray $ maybe V.empty (\l -> V.fromList $ Constant (findDefault t) <$ [0..l-1]) ml
-  TMapping _ v -> SMap (basicTypeToType v) M.empty
+  TMapping -> SMap M.empty
   Todo msg -> todo "findDefault/todo" msg
 
 toBasic :: Value -> Maybe MS.BasicValue
@@ -178,7 +164,7 @@ getVar (Constant (SReference addressedPath@(AccountPath addr key))) = do
       case typeHint of
         TStruct{} -> return $ SReference addressedPath
         TArray{} -> return $ SReference addressedPath
-        TMapping{} -> return $ SReference addressedPath
+        TMapping -> return $ SReference addressedPath
         _ -> return $ findDefault typeHint
     MS.BString bs -> do
       t <- getXabiValueType addressedPath
@@ -213,7 +199,7 @@ getVar (Constant (STuple vct)) = do
       )
       vct
   return $ STuple resolved
-getVar (Constant (SMap ty mp)) = do
+getVar (Constant (SMap mp)) = do
   resolved <-
     mapM
       ( \var -> do
@@ -221,7 +207,7 @@ getVar (Constant (SMap ty mp)) = do
           return $ Constant v
       )
       mp
-  return $ SMap ty resolved
+  return $ SMap resolved
 getVar (Constant (SPush v (Just var))) = do
   resolved <- getVar var
   return $ SPush v (Just $ Constant resolved)
@@ -241,7 +227,7 @@ forceLoadVar (SReference a) = do
         Nothing -> fmap fromIntegral . getInt . Constant . SReference . apSnoc a $ MS.Field "length"
       vs <- traverse (\i -> Constant <$> (forceLoadVar =<< (getVar . Constant . SReference . apSnoc a $ MS.ArrayIndex i))) [0..arrLen-1]
       pure . SArray $ V.fromList vs
-    TMapping{} -> typeError "forceLoadVar/mapping" (SReference a)
+    TMapping -> typeError "forceLoadVar/mapping" (SReference a)
     _ -> pure $ findDefault typeHint
 forceLoadVar v = pure v
 
@@ -250,6 +236,7 @@ getInt p = do
   v <- getVar p
   case v of
     SInteger s -> return s
+    SNULL -> return 0
     _ -> typeError "getInt" (p, v)
 
 getRealNum :: MonadSM m => Variable -> m (Either Integer Decimal)
@@ -258,6 +245,7 @@ getRealNum p = do
   case v of
     SInteger s -> return $ Left s
     SDecimal s -> return $ Right s
+    SNULL -> return $ Left 0
     _ -> typeError "getRealNum" (p, v)
 
 getBool :: MonadSM m => Variable -> m Bool
@@ -265,6 +253,7 @@ getBool p = do
   v <- getVar p
   case v of
     SBool b -> return b
+    SNULL -> return False
     _ -> typeError "getBool" (p, v)
 
 deleteVar :: MonadSM m => Variable -> m ()
@@ -326,7 +315,7 @@ showSM (SStruct name m) = do
     labelToString name ++ "{"
       ++ intercalate ", " (map (\(n, v) -> labelToString n ++ ": " ++ v) valStrings)
       ++ "}"
-showSM (SMap _ m) = do
+showSM (SMap m) = do
   valStrings <-
     forM (M.toList m) $ \(key, var) -> do
       val <- getVar var
@@ -378,7 +367,7 @@ jsonSM = go False
         labelToString name ++ "{"
           ++ intercalate ", " (map (\(n, v) -> show (labelToString n) ++ ": " ++ v) valStrings)
           ++ "}"
-    go _ (SMap _ m) = do
+    go _ (SMap m) = do
       valStrings <-
         forM (M.toList m) $ \(key, var) -> do
           val <- getVar var

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -58,7 +58,6 @@ fromBasic = \case
   MS.BAccount a -> SAccount a False
   MS.BContract n a -> SContract n a
   MS.BEnumVal k v num -> SEnumVal k v num
-  MS.BMappingSentinel -> SMappingSentinel
   MS.BDefault -> internalError "fromBasic: should never decode" MS.BDefault
 
 findDefault :: BasicType -> Value
@@ -84,7 +83,6 @@ toBasic = \case
   SAccount a _ -> Just $ MS.BAccount a
   SContract n a -> Just $ MS.BContract n a
   SEnumVal k t num -> Just $ MS.BEnumVal k t num
-  SMappingSentinel -> Just $ MS.BMappingSentinel
   SUserDefined _ _ x -> toBasic x
   _ -> Nothing
 

--- a/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/SolidVMSpec.hs
@@ -827,7 +827,6 @@ spec = do
                        ]
 
     it "should be able to insert into a mapping" . runTest $ do
-      liftIO $ pendingWith "deal with BMappingSentinel" --TODO- Jim
       runFile "testdata/MappingSet.sol"
       st <- checkStorage
       st `shouldSatisfy` (== 3) . length
@@ -837,10 +836,9 @@ spec = do
           [Field "us", MapIndex (INum 999999)],
           [Field "us", MapIndex (INum 10)]
         ]
-        `shouldReturn` [BMappingSentinel, BInteger 4, BInteger 21, BDefault]
+        `shouldReturn` [BDefault, BInteger 4, BInteger 21, BDefault]
 
     it "should be able to read from a map" . runTest $ do
-      liftIO $ pendingWith "deal with BMappingSentinel" --TODO- Jim
       runFile "testdata/MappingRead.sol"
       st <- checkStorage
       -- The z assignment doesn't count, as at is set to the empty string
@@ -851,7 +849,7 @@ spec = do
           [Field "y"],
           [Field "z"]
         ]
-        `shouldReturn` [BMappingSentinel, BInteger 343, BInteger 343, BDefault]
+        `shouldReturn` [BDefault, BInteger 343, BInteger 343, BDefault]
 
     it "should be able to set array length" . runTest $ do
       runFile "testdata/Length.sol"
@@ -2700,13 +2698,12 @@ contract qq {
     getSolidStorageKeyVal' (x^.namedAccountAddress) (singleton "s") `shouldReturn` BDefault
 
   it "will create a sentinel for mappings" . runTest $ do
-    liftIO $ pendingWith "deal with BMappingSentinel" --TODO- Jim
     runBS
       [r|
 contract qq {
   mapping(string => uint) assoc;
 }|]
-    getFields ["assoc"] `shouldReturn` [BMappingSentinel]
+    getFields ["assoc"] `shouldReturn` [BDefault]
 
   it "can compare contracts to int literals" . runTest $ do
     runBS


### PR DESCRIPTION
The `SMap` constructor in the `Value` type was carrying around an extra type parameter at runtime, and the only purpose for this seems to have been to create a default value of the same type when trying to read at a missing key in an in-memory (local variable) mapping. This technically isn't even legal Solidity, since Solidity doesn't let you declare mappings as local variables, so even hitting this case is a SolidVM enhancement™, and we can define the behavior to be whatever we want. Instead of throwing an exception, we previously chose to load the default value of the mapping's value type. By removing `SMap`'s extra type parameter, we lose the ability to determine the default value directly, but instead we can employ the following strategy:
1. Inspect the type of another element in the in-memory mapping
2. If there are none (i.e. it's an empty mapping), return `SNULL`
3. Swap `SNULL` out for the correct default value elsewhere in the interpreter
By doing this, we can move one step closer to full type erasure at runtime

Next, I removed the type parameters from `TMapping` because they were no longer used after the `SMap` change.

Finally, I collapsed `SBuiltinFunction` into `SFunction`, making the `Func` parameter a `Maybe Func`, where `Nothing` indicates a builtin-function.

My goal is to eventually collapse the `Value` type to the point where it could become something like this:
```hs
data Value = Basic BasicValue
           | SArray ...
           | SMap ...
           | STuple ...
           | SFunction ...
```
and remove all of the other redundant variants of the `Type` and `Value` types.

### Why do all of this?
SolidVM is complex, so eliminating unnecessary complexity makes it a little bit more maintainable. Since we'll be open-sourcing the repo in the near future, eliminating this complexity now will make SolidVM more auditable. Furthermore, SolidVM will be more performant, since there will be fewer edge cases and less (ideally no) type reflection to check per instruction