### PR TITLE
Fixed /transaction and /account endpoint pagination

### DIFF
--- a/strato/api/core/src/Handlers/AccountInfo.hs
+++ b/strato/api/core/src/Handlers/AccountInfo.hs
@@ -24,6 +24,7 @@ import Blockchain.Strato.Model.Address
 import Blockchain.Strato.Model.ChainId
 import Blockchain.Strato.Model.Keccak256
 import Control.Lens
+import Control.Monad (unless)
 import Control.Monad.Change.Alter
 import Control.Monad.Composable.SQL
 import Data.List
@@ -214,7 +215,8 @@ instance HasSQL m => Selectable AccountsFilterParams [AddressStateRef] m where
                         ) _qaSearch
                     ]
 
-            E.where_ (foldl1 (E.&&.) criteria)
+            unless (null criteria) $
+              E.where_ (foldl1 (E.&&.) criteria)
 
             E.offset . fromIntegral $ fromMaybe 0 _qaOffset
             E.limit $ maybe appFetchLimit (min appFetchLimit . fromIntegral) _qaLimit

--- a/strato/api/core/src/Handlers/Block.hs
+++ b/strato/api/core/src/Handlers/Block.hs
@@ -26,6 +26,7 @@ import Blockchain.Strato.Model.Address
 import Blockchain.Strato.Model.ChainId
 import Blockchain.Strato.Model.Keccak256 hiding (hash)
 import Control.Arrow ((&&&), (***))
+import Control.Monad (unless)
 import Control.Monad.Change.Alter
 import Control.Monad.Composable.SQL
 import Data.List
@@ -184,8 +185,9 @@ instance HasSQL m => Selectable BlocksFilterParams [Block] m where
                       fmap (\v -> bdRef E.^. BlockDataRefId E.==. E.val (toBlockDataRefId v)) qbBlockId,
                       fmap (\v -> bdRef E.^. BlockDataRefHash E.==. E.val v) qbHash
                     ]
-
-            E.where_ (foldl1 (E.&&.) criteria)
+            
+            unless (null criteria) $
+              E.where_ (foldl1 (E.&&.) criteria)
 
             E.limit $ appFetchLimit
 

--- a/strato/api/core/src/Handlers/Storage.hs
+++ b/strato/api/core/src/Handlers/Storage.hs
@@ -24,6 +24,7 @@ import Blockchain.DB.SQLDB
 import Blockchain.Data.DataDefs
 import Blockchain.Strato.Model.Address
 import Control.Arrow ((***))
+import Control.Monad (unless)
 import Control.Monad.Change.Alter
 import Control.Monad.Composable.SQL
 import Data.Aeson
@@ -148,8 +149,9 @@ instance HasSQL m => Selectable StorageFilterParams [StorageAddress] m where
                     -- Note: a join is done in StorageInfo
                     fmap (\v -> addrStRef E.^. AddressStateRefAddress E.==. E.val v) qsAddress
                   ]
-
-          E.where_ (foldl1 (E.&&.) criteria2)
+          
+          unless (null criteria2) $
+            E.where_ (foldl1 (E.&&.) criteria2)
 
           E.offset . fromIntegral $ fromMaybe 0 qsOffset
           case qsAddress of

--- a/strato/api/core/src/Handlers/Transaction.hs
+++ b/strato/api/core/src/Handlers/Transaction.hs
@@ -41,7 +41,7 @@ import Blockchain.Strato.Model.Keccak256 hiding (hash)
 import Blockchain.Strato.Model.MicroTime (getCurrentMicrotime)
 import Control.DeepSeq
 import qualified Control.Exception as E
-import Control.Monad (when)
+import Control.Monad (unless, when)
 import Control.Monad.Change.Alter
 import Control.Monad.Composable.SQL
 import Control.Monad.IO.Class
@@ -181,17 +181,17 @@ instance HasSQL m => Selectable TxsFilterParams [RawTransaction] m where
                            in foldr (E.||.) (E.val False) queries
                         ) qtSearch
                     ]
-
-            E.where_ ((foldl1 (E.&&.) criteria)) -- map (getTransFilter rawTx) $ getParameters ))
-            -- FIXME: if more than `limit` transactions per block, we will need to have a tuple as index
-            E.where_ (foldl1 (E.||.) (map (foldl1 (E.&&.)) [criteria]))
+            unless (null criteria) $ do
+              E.where_ (foldl1 (E.&&.) criteria)
+              -- FIXME: if more than `limit` transactions per block, we will need to have a tuple as index
+              E.where_ (foldl1 (E.||.) [foldl1 (E.&&.) criteria])
 
             -- E.offset $ (limit * offset)
             E.offset . fromIntegral $ fromMaybe 0 qtOffset
             E.limit $ maybe appFetchLimit (min appFetchLimit . fromIntegral) qtLimit
-            E.orderBy $
-              [ (sortToOrderBy qtSortby) $ (rawTx E.^. RawTransactionBlockNumber),
-                (sortToOrderBy qtSortby) $ (rawTx E.^. RawTransactionNonce)
+            E.orderBy
+              [ sortToOrderBy qtSortby $ rawTx E.^. RawTransactionBlockNumber,
+                sortToOrderBy qtSortby $ rawTx E.^. RawTransactionNonce
               ]
 
             return rawTx


### PR DESCRIPTION
The use of partial function `foldl1` in some of the strato-api endpoints was causing issues when the new query parameters `limit` and `offset` were passed in, because those passed in without any other params would cause the endpoint's query filter list to be empty, triggering an exception from `foldl1`. The solution is simply to guard against empty lists by using `unless (null criteria)`