### PR TITLE
Remove faulty #TEMPLATE_MARK_BLOCKSTANBUL to prevent mismatched braces

### DIFF
--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -381,10 +381,10 @@ http {
 
       location /strato/v2.3/metrics {
         proxy_pass http://__STRATO_HOSTNAME__:__STRATO_PORT_VAULT_PROXY__/strato/v2.3/metrics;
-      }                                                                          #TEMPLATE_MARK_BLOCKSTANBUL
+      }
 
       location /vm-debug/ {                                                 #TEMPLATE_MARK_DEBUG
-        access_by_lua_file lua/openid.lua;                                 #TEMPLATE_MARK_DEBUG
+        access_by_lua_file lua/openid.lua;                                  #TEMPLATE_MARK_DEBUG
         proxy_pass http://__STRATO_HOSTNAME__:<DEBUG_PORT_PLACEHOLDER>/;    #TEMPLATE_MARK_DEBUG
       }                                                                     #TEMPLATE_MARK_DEBUG
 


### PR DESCRIPTION
Fixes #4453. Jim also used this fix in localBuild https://blockappsdev.slack.com/archives/G5E7K3ETX/p1755114230168669