### PR TITLE
Liquidation UI fixes

### DIFF
--- a/mercata/ui/src/components/dashboard/LiquidateModal.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidateModal.tsx
@@ -118,10 +118,8 @@ const LiquidateModal: React.FC<LiquidateModalProps> = ({
 
   const handlePercentageChange = (value: string) => {
     try {
-      // value is a wei string from PercentageButtons; convert to decimal (18d)
-      const dec = (Number(BigInt(value)) / 1e18).toString();
-      setRepayStr(dec);
-      setDisplayAmount(addCommasToInput(dec));
+      setRepayStr(value);
+      setDisplayAmount(addCommasToInput(value));
     } catch {
       setRepayStr("0");
       setDisplayAmount("0");


### PR DESCRIPTION
- All four percentage buttons cause the amount to go to zero - :wrench: fixed
- Self-liquidation causes an error in Mercata backend but shows the green Liquidation Submitted toast - to fix
- Need to reload page to see available liquidations on Pools page - nice to have