### PR TITLE
No abort withdrawal if safe transaction is proposed

### DIFF
--- a/mercata/contracts/concrete/Bridge/MercataBridge.sol
+++ b/mercata/contracts/concrete/Bridge/MercataBridge.sol
@@ -618,14 +618,14 @@ contract record MercataBridge is Ownable {
     }
 
     /**
-     * Abort – user (after 48 h) *or* owner may cancel and refund the
-     * escrowed tokens.  Covers the scenario where Custody tx is never signed
-     * or relayer disappears.
+     * Abort – user (after 48 h) *or* owner may cancel and refund the escrowed tokens.
+     * Covers the scenario where relayer disappears before confirming.
+     * Does not cover the scenario where Custody tx is waiting to be signed.
      */
     function abortWithdrawal(uint256 id) external {
         WithdrawalInfo storage w = withdrawals[id];
         require(
-            w.bridgeStatus == BridgeStatus.INITIATED || w.bridgeStatus == BridgeStatus.PENDING_REVIEW,
+            w.bridgeStatus == BridgeStatus.INITIATED,
             "MB: not abortable"
         );
 


### PR DESCRIPTION
Or more precisely, after the relayer has confirmed the withdrawal on the Strato side.

The user no longer may abort to recover their tokens on StratoVM due to the Custody Safe owners not signing the ethereum-side withdrawal transaction; the tokens will remain in escrow on Strato until the relayer informs the bridge that the Safe tx has been approved or rejected.

The user may still abort before the relayer has confirmed the withdrawal on the Strato side, in which case the confirmation call, if it comes, will revert; we need to ensure that in this case, no Safe transaction is approved. (!!)

Addresses concerns in #4416.