### PR TITLE
Refactor Pool contract's sync and state update methods

### DIFF
--- a/mercata/contracts/concrete/Pools/Pool.sol
+++ b/mercata/contracts/concrete/Pools/Pool.sol
@@ -166,7 +166,7 @@ contract record Pool is Ownable {
     function sync() external onlyOwner {
         tokenABalance = ERC20(tokenA).balanceOf(address(this));
         tokenBBalance = ERC20(tokenB).balanceOf(address(this));
-        _updateStateVars();
+        _updateRatios();
         emit Sync(tokenABalance, tokenBBalance);
     }
 
@@ -186,10 +186,9 @@ contract record Pool is Ownable {
 
         emit Skim(to, excessA, excessB);
     }
-
-    /// @notice Update the pool's state variables (ratios only)
+    /// @notice Update the pool's ratios
     /// @dev Called after operations that change token balances
-    function _updateStateVars() internal {
+    function _updateRatios() internal {
         aToBRatio = _getCurrentTokenRatio(true);
         bToARatio = _getCurrentTokenRatio(false);
     }
@@ -200,8 +199,7 @@ contract record Pool is Ownable {
     function _updateStateVars(uint256 newTokenABalance, uint256 newTokenBBalance) internal {
         tokenABalance = newTokenABalance;
         tokenBBalance = newTokenBBalance;
-        aToBRatio = _getCurrentTokenRatio(true);
-        bToARatio = _getCurrentTokenRatio(false);
+        _updateRatios();
     }
 
     /// @notice Calculate the current exchange ratio between tokens

--- a/mercata/contracts/concrete/Pools/PoolFactory.sol
+++ b/mercata/contracts/concrete/Pools/PoolFactory.sol
@@ -172,6 +172,35 @@ contract record PoolFactory is Ownable {
         emit PoolFeeParametersUpdated(poolAddress, newSwapFeeRate, newLpSharePercent);
     }
 
+    /// @notice Call sync on all pools or select pools
+    /// @param pools Array of pool addresses to sync
+    /// @dev If no pools are provided, sync all pools
+    /// @dev This function is used to sync the pools after a token transfer
+    function syncPools(address[] pools) external onlyOwner {
+        address[] memory targetPools = pools;
+        if (targetPools.length == 0) {
+            targetPools = allPools;
+        }
+        for (uint256 i = 0; i < targetPools.length; i++) {
+            Pool(targetPools[i]).sync();
+        }
+    }
+
+    /// @notice Call skim on all pools or select pools
+    /// @param pools Array of pool addresses to skim
+    /// @param to Address to skim the pools to
+    /// @dev If no pools are provided, skim all pools
+    /// @dev This function is used to skim the pools after a token transfer
+    function skimPools(address[] pools, address to) external onlyOwner {
+        address[] memory targetPools = pools;
+        if (targetPools.length == 0) {
+            targetPools = allPools;
+        }
+        for (uint256 i = 0; i < targetPools.length; i++) {
+            Pool(targetPools[i]).skim(to);
+        }
+    }
+
     // ============ POOL MANAGEMENT ============
     
     /// @notice Create a new pool for tokenA/tokenB


### PR DESCRIPTION
- Renamed `_updateStateVars` to `_updateRatios` for clarity, as it now specifically updates the pool's ratios.
- Updated the `sync` function to call `_updateRatios` instead of `_updateStateVars`.
- Added `syncPools` and `skimPools` functions in the PoolFactory contract to allow syncing and skimming of multiple pools in a single call, enhancing batch operations for the owner.

These changes improve code readability and maintainability while adding functionality for managing multiple pools efficiently.