### PR TITLE
Fix Health Factor on Borrow Page

### DIFF
--- a/mercata/backend/src/api/helpers/lending.helper.ts
+++ b/mercata/backend/src/api/helpers/lending.helper.ts
@@ -129,10 +129,11 @@ export const simulateLoan = (
   loan: LoanInfo | null,
   collaterals: CollateralInfo[],
   assetConfigs: Map<string, AssetConfig>,
-  borrowIndex: string
+  borrowIndex: string,
+  borrowableAsset: string
 ) => {
   // 1) Borrowable asset config (single borrowable asset model)
-  const borrowableAssetConfig = Array.from(assetConfigs.values())[0];
+  const borrowableAssetConfig = assetConfigs.get(borrowableAsset);
   if (!borrowableAssetConfig) {
     throw new Error("No borrowable asset configuration found");
   }

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -540,6 +540,7 @@ export const getLoan = async (
   });
 
   const borrowIndex = registry.lendingPool?.borrowIndex || "0";
+  const borrowableAsset = registry.lendingPool?.borrowableAsset;
 
   // Build asset configs map (with prices) for health/limits
   const assetConfigs = new Map<string, AssetConfig>();
@@ -560,7 +561,7 @@ export const getLoan = async (
       .filter((c: any) => c.user === userAddress)
       .map((c: any) => ({ asset: c.asset, amount: c.amount }));
 
-    return simulateLoan(userLoan || null, userCollaterals, assetConfigs, borrowIndex);
+    return simulateLoan(userLoan || null, userCollaterals, assetConfigs, borrowIndex, borrowableAsset);
   }
 
   // All users
@@ -575,7 +576,7 @@ export const getLoan = async (
       .filter((c: any) => c.user === userAddr)
       .map((c: any) => ({ asset: c.asset, amount: c.amount }));
 
-    const simulatedLoan = simulateLoan(userLoan || null, userCollaterals, assetConfigs, borrowIndex);
+    const simulatedLoan = simulateLoan(userLoan || null, userCollaterals, assetConfigs, borrowIndex, borrowableAsset);
     allLoans.push({ user: userAddr, ...simulatedLoan });
   }
 

--- a/mercata/ui/src/components/Positions.tsx
+++ b/mercata/ui/src/components/Positions.tsx
@@ -120,7 +120,7 @@ const PositionSection = ({ loanData }: BorrowingSectionProps) => {
                       return "No Loan";
                     }
                     // Check if health factor is valid
-                    if (loanData?.healthFactor && !isNaN((loanData.healthFactor))) {
+                    if (loanData?.healthFactor !== undefined && !isNaN((loanData.healthFactor))) {
                       return (loanData.healthFactor).toFixed(2);
                     }
                     return "N/A";


### PR DESCRIPTION
- Addresses (1) and (2) from https://github.com/blockapps/strato-platform/issues/4290#issuecomment-3272126706
- Health Factor now calculated correctly on Borrow page, and warning correctly absent from repay page when a sufficient repayment is offered
- simulateLoan no longer assumes first element in AssetConfig mapping is the borrowable asset
- Additionally, zero health factor (due to zero collateral for nonzero loan balance, which happens when a very unhealthy loan is liquidated) shows as red 0.00 rather than as red "N/A".