### PR TITLE
Withdrawn rather than "withdrawed"

### DIFF
--- a/mercata/ui/src/components/dashboard/LendingPoolSection.tsx
+++ b/mercata/ui/src/components/dashboard/LendingPoolSection.tsx
@@ -91,7 +91,7 @@ const LendingPoolSection = () => {
       toast({
         title:
           type === "deposit" ? "Deposit Successful" : "Withdrawal Successful",
-        description: `You have successfully ${type}ed ${amount} USDST.`,
+        description: `You have successfully ${type === "deposit" ? "deposited" : "withdrawn"} ${amount} USDST.`,
         variant: "success",
       });
 


### PR DESCRIPTION
Fix grammar mistake pointed out by #4660 

Does not address the dust on max withdrawal.