### PR TITLE
Update token validation checks in MercataBridge contract

### DIFF
--- a/mercata/contracts/concrete/Bridge/MercataBridge.sol
+++ b/mercata/contracts/concrete/Bridge/MercataBridge.sol
@@ -262,6 +262,7 @@ contract record MercataBridge is Ownable {
         uint256 maxPerTx,
         uint8 permissions
     ) external onlyOwner {
+        require(tokenFactory.isFactoryToken(stratoToken), "MB: token not from factory");
         require(chains[externalChainId].custody != address(0), "MB: chain missing");
         require((permissions & PERMISSION_MASK) == permissions, "MB: invalid permissions");
 
@@ -314,7 +315,6 @@ contract record MercataBridge is Ownable {
         onlyRelayer
         whenDepositsOpen
     {
-        require(tokenFactory.isFactoryToken(stratoToken), "MB: token not from factory");
         AssetInfo memory a = assets[stratoToken][externalChainId];
         require(a.permissions != 0, "MB: asset disabled");
         require(a.externalChainId == externalChainId, "MB: wrong chain");
@@ -476,7 +476,6 @@ contract record MercataBridge is Ownable {
         whenWithdrawalsOpen
         returns (uint256 id)
     {
-        require(tokenFactory.isFactoryToken(stratoToken),"MB: token not from factory");
         AssetInfo memory a = assets[stratoToken][externalChainId];
         require(a.permissions != 0, "MB: asset disabled");
         require(a.externalChainId == externalChainId, "MB: wrong chain");

--- a/mercata/contracts/concrete/Bridge/MercataBridge.sol
+++ b/mercata/contracts/concrete/Bridge/MercataBridge.sol
@@ -31,6 +31,10 @@ contract record MercataBridge is Ownable {
     uint8 public PERMISSION_WRAP = 1;   // 0b01 - permission to wrap original token
     uint8 public PERMISSION_MINT = 2;   // 0b10 - permission to mint USDST
     uint8 public PERMISSION_MASK = 3;   // 0b11 - maximum valid permission value (both wrap and mint)
+
+    function _has(uint8 perms, uint8 flag) private pure returns (bool) {
+        return (perms & flag) != 0;
+    }
 /* --------------------------------------------------------------------- */
 /*                            ─  ENUMS  ─                               */
 /* --------------------------------------------------------------------- */
@@ -262,7 +266,6 @@ contract record MercataBridge is Ownable {
         uint256 maxPerTx,
         uint8 permissions
     ) external onlyOwner {
-        require(tokenFactory.isFactoryToken(stratoToken), "MB: token not from factory");
         require(chains[externalChainId].custody != address(0), "MB: chain missing");
         require((permissions & PERMISSION_MASK) == permissions, "MB: invalid permissions");
 
@@ -322,6 +325,13 @@ contract record MercataBridge is Ownable {
         require(stratoTokenAmount > 0,"MB: zero");
         uint8 need = mintUSDST ? PERMISSION_MINT : PERMISSION_WRAP;
         require((a.permissions & need) != 0, "MB: not permitted");
+
+        // Allow inactive tokens only when minting USDST and asset has MINT permission
+        require(
+            tokenFactory.isTokenActive(stratoToken) ||
+            (mintUSDST && _has(a.permissions, PERMISSION_MINT)),
+            "MB: inactive token"
+        );
 
         // replay protection on composite key
         require(deposits[externalChainId][externalTxHash].bridgeStatus == BridgeStatus.NONE,"MB: dup key");
@@ -486,6 +496,13 @@ contract record MercataBridge is Ownable {
 
         uint256 cap = a.maxPerTx;
         require(cap == 0 || stratoTokenAmount<=cap,"MB: per-tx cap");
+
+        // Allow inactive tokens only when minting USDST and asset has MINT permission
+        require(
+            tokenFactory.isTokenActive(stratoToken) ||
+            (mintUSDST && _has(a.permissions, PERMISSION_MINT)),
+            "MB: inactive token"
+        );
 
         /* pull user funds; bridge holds until approval */
         IERC20(mintUSDST ? USDST_ADDRESS : stratoToken).transferFrom(msg.sender, address(this), stratoTokenAmount);

--- a/mercata/contracts/concrete/Bridge/MercataBridge.sol
+++ b/mercata/contracts/concrete/Bridge/MercataBridge.sol
@@ -314,7 +314,7 @@ contract record MercataBridge is Ownable {
         onlyRelayer
         whenDepositsOpen
     {
-        require(tokenFactory.isTokenActive(stratoToken), "MB: inactive token");
+        require(tokenFactory.isFactoryToken(stratoToken), "MB: token not from factory");
         AssetInfo memory a = assets[stratoToken][externalChainId];
         require(a.permissions != 0, "MB: asset disabled");
         require(a.externalChainId == externalChainId, "MB: wrong chain");
@@ -476,7 +476,7 @@ contract record MercataBridge is Ownable {
         whenWithdrawalsOpen
         returns (uint256 id)
     {
-        require(tokenFactory.isTokenActive(stratoToken),"MB: inactive");
+        require(tokenFactory.isFactoryToken(stratoToken),"MB: token not from factory");
         AssetInfo memory a = assets[stratoToken][externalChainId];
         require(a.permissions != 0, "MB: asset disabled");
         require(a.externalChainId == externalChainId, "MB: wrong chain");

--- a/mercata/contracts/concrete/Bridge/MercataBridge.sol
+++ b/mercata/contracts/concrete/Bridge/MercataBridge.sol
@@ -319,12 +319,11 @@ contract record MercataBridge is Ownable {
         whenDepositsOpen
     {
         AssetInfo memory a = assets[stratoToken][externalChainId];
-        require(a.permissions != 0, "MB: asset disabled");
         require(a.externalChainId == externalChainId, "MB: wrong chain");
         require(chains[externalChainId].enabled, "MB: chain off");
         require(stratoTokenAmount > 0,"MB: zero");
         uint8 need = mintUSDST ? PERMISSION_MINT : PERMISSION_WRAP;
-        require((a.permissions & need) != 0, "MB: not permitted");
+        require(_has(a.permissions, need), "MB: not permitted");
 
         // Allow inactive tokens only when minting USDST and asset has MINT permission
         require(
@@ -487,12 +486,11 @@ contract record MercataBridge is Ownable {
         returns (uint256 id)
     {
         AssetInfo memory a = assets[stratoToken][externalChainId];
-        require(a.permissions != 0, "MB: asset disabled");
         require(a.externalChainId == externalChainId, "MB: wrong chain");
         require(chains[externalChainId].enabled, "MB: chain off");
         require(stratoTokenAmount > 0,"MB: zero");
         uint8 need = mintUSDST ? PERMISSION_MINT : PERMISSION_WRAP;
-        require((a.permissions & need) != 0, "MB: not permitted");
+        require(_has(a.permissions, need), "MB: not permitted");
 
         uint256 cap = a.maxPerTx;
         require(cap == 0 || stratoTokenAmount<=cap,"MB: per-tx cap");


### PR DESCRIPTION
- Changed the validation requirement for stratoToken from isTokenActive to isFactoryToken to ensure only tokens from the factory are accepted.
- Updated error messages for clarity, specifying that the token must be from the factory instead of being inactive.