### PR TITLE
Improved Create Issue modal in Admin Vote tab

### DIFF
--- a/mercata/backend/src/api/controllers/user.controller.ts
+++ b/mercata/backend/src/api/controllers/user.controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
-import { getAdmin, isUserAdmin, addAdmin, removeAdmin, castVoteOnIssue, getOpenIssues } from "../services/user.service";
+import { getAdmin, isUserAdmin, addAdmin, removeAdmin, castVoteOnIssue, getOpenIssues,
+         contractSearch, getContractDetails,
+ } from "../services/user.service";
 import { validateUserAddress, validateAddressField } from "../validators/common.validators";
 
 class UserController {
@@ -118,6 +120,38 @@ class UserController {
       const { accessToken } = req;
       const issues = await getOpenIssues(accessToken);
       res.status(RestStatus.OK).json(issues);
+      next();
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async contractSearch(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, query } = req;
+      const { search } = query;
+      const searchResults = await contractSearch(accessToken, `${search}`);
+      res.status(RestStatus.OK).json(searchResults);
+      next();
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async getContractDetails(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, query } = req;
+      const { address } = query;
+      const contractDetails = await getContractDetails(accessToken, `${address}`);
+      res.status(RestStatus.OK).json(contractDetails);
       next();
     } catch (e) {
       next(e);

--- a/mercata/backend/src/api/routes/user.routes.ts
+++ b/mercata/backend/src/api/routes/user.routes.ts
@@ -9,6 +9,8 @@ router.get("/me", authHandler.authorizeRequest(), UserController.me);
 router.get("/admin", authHandler.authorizeRequest(), UserController.admin);
 router.post("/admin", authHandler.authorizeRequest(), UserController.addAdmin);
 router.delete("/admin", authHandler.authorizeRequest(), UserController.removeAdmin);
+router.get("/admin/contract/search", authHandler.authorizeRequest(), UserController.contractSearch);
+router.get("/admin/contract/details", authHandler.authorizeRequest(), UserController.getContractDetails);
 router.post("/admin/vote", authHandler.authorizeRequest(), UserController.castVoteOnIssue);
 router.get("/admin/issues", authHandler.authorizeRequest(), UserController.getOpenIssues);
 

--- a/mercata/backend/src/api/services/user.service.ts
+++ b/mercata/backend/src/api/services/user.service.ts
@@ -1,4 +1,4 @@
-import { cirrus, strato } from "../../utils/mercataApiHelper";
+import { bloc, cirrus, eth, strato } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { buildFunctionTx } from "../../utils/txBuilder";
 import { postAndWaitForTx } from "../../utils/txHelper";
@@ -177,5 +177,63 @@ export const getOpenIssues = async (
     return { admins, votes, thresholds, executed, issues: issuesResponse?.data };
   } catch (error) {
     return [];
+  }
+};
+
+export const contractSearch = async (
+  accessToken: string,
+  search: string,
+): Promise<object> => {
+  try {
+    const accountResponse = await eth.get(accessToken, "/account", {
+      params: {
+        search
+      },
+    });
+
+    const storageResponse = await eth.get(accessToken, "/storage", {
+      params: {
+        search
+      },
+    });
+
+    if (storageResponse.status !== 200) {
+      return {};
+    }
+
+    let responseData: any[] = [];
+
+    if (accountResponse.data && Array.isArray(storageResponse.data)) {
+      responseData = [ ...responseData, ...accountResponse.data];
+    }
+
+    if (storageResponse.data && Array.isArray(storageResponse.data)) {
+      responseData = [ ...responseData, ...storageResponse.data];
+    }
+
+    return responseData;
+  } catch (error) {
+    return [];
+  }
+};
+
+export const getContractDetails = async (
+  accessToken: string,
+  address: string,
+): Promise<object> => {
+  try {
+    const response = await bloc.get(accessToken, `/contracts/contract/${address}/details`);
+
+    if (response.status !== 200) {
+      return {};
+    }
+
+    if (!response.data) {
+      return {};
+    }
+
+    return response.data;
+  } catch (error) {
+    return {};
   }
 };

--- a/mercata/ui/src/components/admin/CreateAdminIssueModal.tsx
+++ b/mercata/ui/src/components/admin/CreateAdminIssueModal.tsx
@@ -1,10 +1,13 @@
+import { useEffect, useState} from 'react';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage, FormDescription } from '@/components/ui/form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Loader2, Plus, X } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { useUser } from '@/context/UserContext';
 import * as React from 'react';
 
 type CreateAdminIssueFormValues = {
@@ -17,7 +20,7 @@ interface CreateAdminIssueModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   // Will be called with JSON-stringified target/func and a JSON array (string[])
-  handleCastVoteOnIssue: (target: string, func: string, args: string[]) => Promise<void> | void;
+  handleCastVoteOnIssue: (target: string, func: string, args: any[]) => Promise<void> | void;
 }
 
 const CreateAdminIssueModal: React.FC<CreateAdminIssueModalProps> = ({
@@ -26,6 +29,18 @@ const CreateAdminIssueModal: React.FC<CreateAdminIssueModalProps> = ({
   handleCastVoteOnIssue,
 }) => {
   const { toast } = useToast();
+  const { contractSearch, contractSearchResults, contractSearchResultsLoading,
+          getContractDetails, contractDetailsResults, contractDetailsResultsLoading } = useUser();
+  const [selectedFunction, setSelectedFunction] = useState('');
+  const searchObjects = contractSearchResults.reduce((b, a) => {
+    if (a['address']) {
+      const aa = { ...b[a['address']], ...a } 
+      return { ...b, [a['address']]: aa };
+    } else {
+      return b;
+    }
+  }, {});
+  const searchAddresses = Object.keys(searchObjects);
 
   const form = useForm<CreateAdminIssueFormValues>({
     defaultValues: {
@@ -36,22 +51,38 @@ const CreateAdminIssueModal: React.FC<CreateAdminIssueModalProps> = ({
     mode: 'onChange',
   });
 
-  const {
-    fields,
-    append,
-    remove,
-  } = useFieldArray({
-    control: form.control,
-    name: 'args',
-  });
+  const allContractFunctions = (contractDetailsResults || {})['_functions'] || {};
+  const contractFunctions = (Object.entries(allContractFunctions) || []).filter(([N, t]) => {
+    return form.getValues().target === '000000000000000000000000000000000000100c'
+      || (t['_funcVisibility'] !== 'internal' && t['_funcVisibility'] !== 'private');
+  }).map(([N, t]) => N);
+
+  const { fields, replace } = useFieldArray({ control: form.control, name: 'args' });
+
+  const functionArgs = (allContractFunctions[selectedFunction] || {})._funcArgs as Array<[string, { type?: { tag?: string } }]> | undefined;
+  
+  useEffect(() => {
+    if (Array.isArray(functionArgs) && functionArgs.length > 0) {
+      replace(functionArgs.map(() => ({ value: '' })));
+    } else {
+      replace([{ value: '' }]);
+    }
+  }, [functionArgs?.length, replace]);
 
   const onSubmit = async (values: CreateAdminIssueFormValues) => {
     // Clean up whitespace and empty args
     const trimmedTarget = values.target.trim();
     const trimmedFunc = values.func.trim();
     const argsArray = values.args
-      .map(a => a.value.trim())
-      .filter(v => v.length > 0);
+      .map((a, i) => {
+        if (functionArgs[i][1].type?.tag === 'Int') {
+          return parseInt(a.value.trim());
+        }
+        if (functionArgs[i][1].type?.tag === 'Bool') {
+          return a.value.toLocaleLowerCase() === 'true';
+        }
+        return a.value.trim();
+      });
 
     // Build payload with JSON-stringified target/func, and a JSON array for args
     const payload = {
@@ -107,21 +138,40 @@ const CreateAdminIssueModal: React.FC<CreateAdminIssueModalProps> = ({
               name="target"
               rules={{
                 required: 'Contract address is required',
-                validate: (v) =>
-                  v.trim().length > 0 || 'Contract address cannot be empty',
+                validate: (v) => v.trim().length > 0 || 'Contract address cannot be empty',
               }}
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Contract Address</FormLabel>
                   <FormControl>
-                    <Input
-                      placeholder="..."
-                      {...field}
-                    />
+                    <div>
+                      <Input
+                        {...field}
+                        list="contract-search"
+                        onChange={(e) => {
+                          field.onChange(e);
+                          contractSearch(e.target.value);
+                        }}
+                        onBlur={(e) => {
+                          field.onBlur();
+                          const val = e.target.value.trim();
+                          if (searchAddresses.includes(val)) {
+                            getContractDetails(val);
+                          }
+                        }}
+                      />
+                      <datalist id="contract-search">
+                        {Object.entries(searchObjects).map(([address, val]: any) => (
+                          <option
+                            key={address}
+                            value={address}
+                            label={`${val.contractName ?? 'Storage'}`}
+                          />
+                        ))}
+                      </datalist>
+                    </div>
                   </FormControl>
-                  <FormDescription>
-                    The on-chain address of the target contract.
-                  </FormDescription>
+                  <FormDescription>The on-chain address of the target contract.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -133,21 +183,31 @@ const CreateAdminIssueModal: React.FC<CreateAdminIssueModalProps> = ({
               name="func"
               rules={{
                 required: 'Function name is required',
-                validate: (v) =>
-                  v.trim().length > 0 || 'Function name cannot be empty',
+                validate: (v) => v.trim().length > 0 || 'Function name cannot be empty',
               }}
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Function Name</FormLabel>
                   <FormControl>
-                    <Input
-                      placeholder="setTokenStatus"
-                      {...field}
-                    />
+                    <Select
+                      value={field.value}
+                      onValueChange={(v) => {
+                        field.onChange(v);
+                        setSelectedFunction(v);
+                      }}
+                      disabled={contractSearchResultsLoading || contractDetailsResultsLoading}
+                    >
+                      <SelectTrigger id="select-function">
+                        <SelectValue placeholder="Select function" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {contractFunctions.map((fn) => (
+                          <SelectItem key={fn} value={fn}>{fn}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </FormControl>
-                  <FormDescription>
-                    The exact name of the function to call on the target contract.
-                  </FormDescription>
+                  <FormDescription>The exact function to call.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -157,57 +217,41 @@ const CreateAdminIssueModal: React.FC<CreateAdminIssueModalProps> = ({
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <FormLabel>Arguments</FormLabel>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => append({ value: '' })}
-                  disabled={isSubmitting}
-                >
-                  <Plus className="h-4 w-4 mr-1" />
-                  Add argument
-                </Button>
               </div>
 
               <div className="space-y-2">
-                {fields.map((field, idx) => (
-                  <FormField
-                    key={field.id}
-                    control={form.control}
-                    name={`args.${idx}.value`}
-                    render={({ field: argField }) => (
-                      <FormItem>
-                        <div className="flex items-center gap-2">
-                          <FormControl className="flex-1">
-                            <Input
-                              placeholder={`Argument ${idx + 1}`}
-                              {...argField}
-                            />
-                          </FormControl>
-                          {fields.length > 1 && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => remove(idx)}
-                              disabled={isSubmitting}
-                              className="shrink-0"
-                              title="Remove argument"
-                            >
-                              <X className="h-4 w-4" />
-                            </Button>
-                          )}
-                        </div>
-                        {idx === 0 && (
-                          <FormDescription>
-                            Enter each argument in call order. Click “Add argument” to append more.
-                          </FormDescription>
-                        )}
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                ))}
+                {fields.map((f, idx) => {
+                  const abi = functionArgs?.[idx];
+                  const abiName = abi?.[0];
+                  const abiType = abi?.[1]?.type?.tag?.toLocaleLowerCase();
+              
+                  return (
+                    <FormField
+                      key={f.id}
+                      control={form.control}
+                      name={`args.${idx}.value`}
+                      rules={{
+                        required: 'Argument is required',
+                        // add per-type validation here if desired (e.g., address, uint, etc.)
+                      }}
+                      render={({ field: argField }) => (
+                        <FormItem>
+                          <div className="flex items-center gap-2">
+                            <FormControl className="flex-1">
+                              <Input
+                                {...argField}
+                                placeholder={
+                                  abiName ? `${abiName}: ${abiType}` : `Argument ${idx + 1}`
+                                }
+                              />
+                            </FormControl>
+                          </div>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  );
+                })}
               </div>
             </div>
 
@@ -226,14 +270,7 @@ const CreateAdminIssueModal: React.FC<CreateAdminIssueModalProps> = ({
                 disabled={isSubmitting || !form.formState.isValid}
                 className="bg-strato-blue hover:bg-strato-blue/90"
               >
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Submitting…
-                  </>
-                ) : (
-                  'Create Issue'
-                )}
+                {isSubmitting ? (<> <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Submitting… </>) : 'Create Issue'}
               </Button>
             </div>
           </form>

--- a/mercata/ui/src/components/admin/VoteTab.tsx
+++ b/mercata/ui/src/components/admin/VoteTab.tsx
@@ -24,22 +24,9 @@ const VoteTab = () => {
     getOpenIssues();
   }, []);
 
-  const handleCastVoteOnIssue = (target: string, func: string, args: string[]) => {
+  const handleCastVoteOnIssue = (target: string, func: string, args: any[]) => {
     castVoteOnIssue(target, func, args);
   };
-
-  const flatten = (arr: any[]) => {
-    let ret = [];
-    for (let i = 0; i < arr.length; i++) {
-      if (Array.isArray(arr[i])) {
-        ret = [ ...ret, ...arr[i]];
-      } else {
-        ret = [ ...ret, arr[i]];
-      }
-    }
-    return ret;
-  }
-
 
   if (openIssuesLoading) {
     return (
@@ -165,7 +152,7 @@ const VoteTab = () => {
                         <TableCell className="max-w-[60px]">
                           <Button 
                             size="sm" 
-                            onClick={() => handleCastVoteOnIssue(address, issue.func, flatten(issue.args))}
+                            onClick={() => handleCastVoteOnIssue(address, issue.func, issue.args)}
                             disabled={alreadyVoted}
                             className="bg-strato-blue hover:bg-strato-blue/90 text-xs"
                           >

--- a/mercata/ui/src/context/UserContext.tsx
+++ b/mercata/ui/src/context/UserContext.tsx
@@ -17,6 +17,12 @@ interface UserContextType {
   openIssues: object;
   openIssuesLoading: boolean;
   getOpenIssues: () => Promise<void>;
+  contractSearchResults: object[];
+  contractSearchResultsLoading: boolean;
+  contractSearch: (search: string) => Promise<void>;
+  contractDetailsResults: object;
+  contractDetailsResultsLoading: boolean;
+  getContractDetails: (address: string) => Promise<void>;
   castVoteOnIssue: (target: string, func: string, args: string[]) => Promise<void>;
 }
 
@@ -29,7 +35,11 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const [userName, setUserName] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(true);
   const [openIssues, setOpenIssues] = useState<object>({})
-  const [openIssuesLoading, setOpenIssuesLoading] = useState<boolean>(true);
+  const [openIssuesLoading, setOpenIssuesLoading] = useState<boolean>(false);
+  const [contractSearchResults, setContractSearchResults] = useState<object[]>([])
+  const [contractSearchResultsLoading, setContractSearchResultsLoading] = useState<boolean>(false)
+  const [contractDetailsResults, setContractDetailsResults] = useState<object>({});
+  const [contractDetailsResultsLoading, setContractDetailsResultsLoading] = useState<boolean>(false);
 
   const checkAuthenticationStatus = async (initialCheck = false) => {
     try {
@@ -85,7 +95,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
-  const castVoteOnIssue = async (target: string, func: string, args: string[]) => {
+  const castVoteOnIssue = async (target: string, func: string, args: any[]) => {
     try {
       await api.post('/user/admin/vote', {target, func, args});
     } catch (error) {
@@ -105,6 +115,32 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
       }
     } finally {
       setOpenIssuesLoading(false);
+    }
+  };
+
+  const contractSearch = async (search: string) => {
+    try {
+      setContractSearchResultsLoading(true);
+      try {
+        const response = await api.get(`/user/admin/contract/search?search=${search}`);
+        setContractSearchResults(response?.data || []);
+      } catch (error) {
+      }
+    } finally {
+      setContractSearchResultsLoading(false);
+    }
+  };
+
+  const getContractDetails = async (address: string) => {
+    try {
+      setContractDetailsResultsLoading(true);
+      try {
+        const response = await api.get(`/user/admin/contract/details?address=${address}`);
+        setContractDetailsResults(response?.data || {});
+      } catch (error) {
+      }
+    } finally {
+      setContractDetailsResultsLoading(false);
     }
   };
 
@@ -137,7 +173,17 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     openIssues,
     getOpenIssues,
     castVoteOnIssue,
-  }), [userAddress, isLoggedIn, isAdmin, loading, userName, openIssues, getOpenIssues, castVoteOnIssue]);
+    contractSearch,
+    contractSearchResults,
+    contractSearchResultsLoading,
+    getContractDetails,
+    contractDetailsResults,
+    contractDetailsResultsLoading,
+  }), [userAddress, isLoggedIn, isAdmin, loading, userName,
+    openIssues, openIssuesLoading, getOpenIssues, castVoteOnIssue,
+    contractSearch, contractSearchResults, contractSearchResultsLoading,
+    getContractDetails, contractDetailsResults, contractDetailsResultsLoading,
+  ]);
 
   return (
     <UserContext.Provider value={contextValue}>


### PR DESCRIPTION
Added functionality for the Admin Vote tab to search for contract instances based on the search query, to prevent having to type the entire address, then load the contract's xabi when selected, to prevent the admin from selecting a non-existent function, or having to lookup the function's arguments when building the issue.


https://github.com/user-attachments/assets/527d8e5f-e6a0-4501-b1f0-c1bfcef00f99

