### PR TITLE
Update Dockerfile to include shared-types package in backend build

### DIFF
--- a/mercata/backend/Dockerfile
+++ b/mercata/backend/Dockerfile
@@ -32,7 +32,10 @@ WORKDIR /app
 
 COPY backend/package*.json ./
 
-RUN npm ci --omit=dev
+# Copy the built shared-types package from builder stage
+COPY --from=builder /build/packages/shared-types ./packages/shared-types
+
+RUN npm ci --omit=dev && npm install ./packages/shared-types
 
 COPY --from=builder /build/dist ./dist
 


### PR DESCRIPTION
- Added a step to copy the built shared-types package from the builder stage into the backend Docker image.
- Updated the npm install command to include the shared-types package, ensuring that the latest types are available during the build process.

These changes aim to enhance type safety and consistency across the application by integrating shared types into the backend build.