### PR TITLE
Fixed bagger tx dropping logic around fee payment failures

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
@@ -83,7 +83,7 @@ data SolidException
   | InvalidCertificate String String
   | MalformedData String String
   | TooMuchGas Integer Integer
-  | PaymentError String String
+  | PaymentError Integer (String, Integer)
   | ReservedWordError String String
   | ImmutableError String String
   | FailedToAttainRunTimCode String String
@@ -128,7 +128,7 @@ showSolidException (InvalidWrite a b) = printf "invalid write: %s: %s" a b
 showSolidException (InvalidCertificate a b) = printf "invalid certificate: %s: %s" a b
 showSolidException (MalformedData a b) = printf "Malformed data: %s: %s" a b
 showSolidException (TooMuchGas a b) = printf "You've run out of gas, the original alotment was %d, but the current gasInfo was: %d" a b
-showSolidException (PaymentError a b) = printf "There was an error sending %s wei to the following address: %s" a b
+showSolidException (PaymentError a (addr, b)) = printf "There was an error sending %d wei to the following address with a balance of %d: %s" a b addr
 showSolidException (ReservedWordError a b) = printf "%s is a reserved word in version %s and up." b a
 showSolidException (ImmutableError a b) = printf "%s is an immutable variable in line '%s'" a b
 showSolidException (FailedToAttainRunTimCode a b) = printf "%s failed to aquire run time code '%s'" a b
@@ -229,8 +229,8 @@ malformedData = toThrower MalformedData
 tooMuchGas :: Integer -> Integer -> a
 tooMuchGas limit actual = throw $ TooMuchGas limit actual
 
-paymentError :: (Show v) => String -> v -> a
-paymentError = toThrower PaymentError
+paymentError :: Integer -> (String, Integer) -> a
+paymentError limit actual = throw $ PaymentError limit actual
 
 reservedWordError :: (Show v) => String -> v -> a
 reservedWordError = toThrower ReservedWordError

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1780,8 +1780,10 @@ expToVar' (CC.FunctionCall _ e args) _ = do
                   res <- pay "built-in transfer function" from (address' ^. namedAccountAddress) amount
                   case res of
                     True -> return $ Constant SNULL
-                    _ -> paymentError (show amount) (show address')
-                _ -> paymentError "unknown" (show address')
+                    _ -> do
+                      balance <- addressStateBalance <$> A.lookupWithDefault (A.Proxy :: A.Proxy AddressState) from
+                      paymentError amount (show address', balance)
+                _ -> typeError "transfer arguments" argVals
 
             -- Send Wei return bool on failure or success
             -- TODO: When gas gets more implemented ensure that this function does not

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -72,7 +73,7 @@ import qualified Blockchain.Stream.Action as Action
 import Blockchain.Stream.VMEvent
 import Blockchain.TheDAOFork
 import Blockchain.Timing
-import Blockchain.VM.SolidException (SolidException( TooMuchGas ))
+import Blockchain.VM.SolidException (SolidException(PaymentError, TooMuchGas))
 import Blockchain.VMConstants
 import Blockchain.VMContext
 import Blockchain.VMMetrics
@@ -374,6 +375,10 @@ mineTransactions' header remGas ran unran@(tx : txs) mSelfAddress = do
                   putAddressStateTxDBMap M.empty
                   putMemRawStorageTxMap M.empty
                   return $ Bagger.TxMiningResult (Just $ TFTransactionGasExceeded limit actual tx) (DL.toList ran) unran remGas
+                Just (Left (PaymentError limit (_, actual))) -> do
+                  putAddressStateTxDBMap M.empty
+                  putMemRawStorageTxMap M.empty
+                  return $ Bagger.TxMiningResult (Just $ TFInsufficientFunds limit actual tx) (DL.toList ran) unran remGas
                 _ -> do
                   let nextRemGas = remGas - (transactionGasLimit bt - calculateReturned bt execResult)
                   flushMemAddressStateTxToBlockDB
@@ -454,7 +459,9 @@ addTransaction b remainingBlockGas t@OutputTx {otSigner = tAddr} proposer = do
             lift $ A.delete (Proxy @AddressState) address'
           lift $ P.incCounter vmTxsSuccessful
       return $ attachFeeResult execResults
-    else throwE $ TFInsufficientFunds 100000000000000000 0 t -- TODO: Get the actual tx cost and user's USDST balance
+    else case erException feeResult of
+      Just (Left PaymentError{}) -> pure feeResult
+      _ -> pure $ feeResult{ erException = Just . Left $ PaymentError 10_000_000_000_000_000 (show tAddr, 0) } -- TODO: Make Fee contract throw a PaymentError and remove this case
 
 runCodeForTransaction ::
   (VMBase m) =>

--- a/strato/core/vm-tools/src/Blockchain/Bagger.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger.hs
@@ -106,7 +106,7 @@ runFromStateRoot mineTransactions remainingGas theBlockHeader txs mSelfAddress= 
     Just TFBlockGasLimitExceeded {} -> Left (GasLimitReached ranTxs unranTxs newStateRoot newGas)
     Just f@TFInsufficientFunds {} -> recoverable f
     Just f@TFIntrinsicGasExceedsTxLimit {} -> recoverable f
-    Just f@TFNonceMismatch {} -> recoverable f -- error $ "mineTransactions' we messed up: " ++ format f -- TODO: figure out why this happens when a user runs out of USDST
+    Just f@TFNonceMismatch {} -> error $ "mineTransactions' we messed up: " ++ format f
     Just f@TFCodeCollectionNotFound {} -> recoverable f
     Just f@TFInvalidPragma {} -> recoverable f
     Just f@TFTXSizeLimitExceeded {} -> recoverable f

--- a/strato/core/vm-tools/src/Blockchain/Bagger/BaggerState.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger/BaggerState.hs
@@ -134,7 +134,7 @@ modifyATL f address atl = case M.lookup address atl of
 purgeFromATL :: Address -> Integer -> ATL -> ATL
 purgeFromATL address nonce' atl = case M.lookup address atl of
   Nothing -> atl
-  Just tl -> let newTL = M.filterWithKey (const . (< nonce')) tl in M.insert address newTL atl
+  Just tl -> let newTL = M.delete nonce' tl in M.insert address newTL atl
 
 calculateIntrinsicTxFee :: BaggerState -> (OutputTx -> Integer)
 calculateIntrinsicTxFee bs t@OutputTx {} =

--- a/strato/core/vm-tools/src/Blockchain/Bagger/TransactionList.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger/TransactionList.hs
@@ -31,14 +31,8 @@ singletonTransactionList t = M.singleton (transactionNonce $ otBaseTx t) t
 insertTransaction :: OutputTx -> TransactionList -> (Maybe OutputTx, OutputTx, TransactionList)
 insertTransaction t tl =
   let nonce' = nonce t
-      oldTx = M.lookup nonce' tl
-   in case oldTx of
-        Nothing -> (Nothing, t, M.insert nonce' t tl)
-        Just existing ->
---          if gasPrice existing <= gasPrice t
-          if False
-            then (oldTx, t, M.insert nonce' t tl)
-            else (Just t, existing, tl)
+      (oldTx, newTL) = M.insertLookupWithKey (\_ a _ -> a) nonce' t tl
+   in (oldTx, t, newTL)
 
 trimBelowNonce :: Integer -> TransactionList -> ([OutputTx], TransactionList)
 trimBelowNonce nonce' tl = let (lt, gte) = M.partitionWithKey (\k _ -> k < nonce') tl in (M.elems lt, gte)


### PR DESCRIPTION
This PR attempts to improve the behavior around transactions that fail the fee payment. First, it reinstates some logic around the bagger's transaction selection that was changed about 4 months ago, which is that when the bagger receives a new transaction from the same sender and with the same nonce, it throws away the one it already has, instead of throwing away the new one. This provides a smoother UX in practice, because if the user gets a Pending result on a first attempt, and submits a second attempt, the second attempt will be retained and the first one dropped (at least within the local bagger). About 4 months ago, the logic became reversed, causing the bagger to drop the second attempt and retain the first, causing the "more lucrative" transaction errors seen by some people.

However, this does not entirely solve the UX when a user runs out of vouchers and USDST. If a user posts a transaction to a non-validator node, and does not have enough balance to pay the tx fee, the non-validator node will not drop the transaction, because it does not build blocks through its bagger. Instead, it will broadcast the transaction to validator nodes, which will drop it due to insufficient funds, but the validator nodes won't reflect this decision back to the non-validator nodes. Instead, from the non-validator's perspective, the transaction just never makes it into a block, and the status remains Pending forever. This is why when posting to "some" nodes, the result is a proper failure for insufficient funds, but on "others", the result is a pending state (or a more lucrative transaction error until now): the "some" are the validators, and the "others" are the non-validators. Solving this issue is a bit trickier and is independent from the issue of fee payment failures.

A line I've uncommented in this PR reinstates throwing errors in the bagger if the bagger runs a transaction that has a nonce mismatch:
> Just f@TFNonceMismatch {} -> error $ "mineTransactions' we messed up: " ++ format f

This should be a proper `error`, because the bagger should never hit that case. However, previously with fee payment failures, it was hitting that case somehow, and I never figured out why.
Unfortunately, I can't reproduce the error on a local single node, so I'd like to run it on the testnet with these latest changes to see if it's fixed.