### PR TITLE
Bad debt write offs and limit shortfall cover from SM

### DIFF
--- a/mercata/contracts/concrete/Lending/LendingPool.sol
+++ b/mercata/contracts/concrete/Lending/LendingPool.sol
@@ -35,6 +35,8 @@ contract record LendingPool is Ownable {
     event ReservesSweptSafety(uint amount, address to);
     event BadDebtRecognized(uint amount);     // global, no borrower index
     event BadDebtCovered(uint cover, uint remainingBadDebt);
+    event BadDebtWrittenOffFromReserves(uint writeOff, uint badDebt, uint reservesAccrued);
+    event DepositorHaircutApplied(uint writeOff, uint badDebt, string calldata reason);
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // DATA STRUCTURES
@@ -1087,9 +1089,16 @@ contract record LendingPool is Ownable {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════════
-    // BAD DEPT  FUNCTIONS
+    // BAD DEBT  FUNCTIONS
     // ═══════════════════════════════════════════════════════════════════════════════
 
+    /**
+    * @notice Recognize a borrower's remaining loan as bad debt and sweep any residual collateral.
+    * @dev Minimal side effects:
+    *      - Accrues interest, converts scaled → base, removes loan from accrual, bumps `badDebt`.
+    *      - Iterates configured assets and seizes any leftover collateral balances (>0) to `feeCollector`.
+    *      - No-op if borrower still has liquidation-weighted value or has no scaled debt.
+    */
     function recognizeBadDebt(address borrower) external onlyPoolConfigurator {
         _accrue();
         if (_getTotalCollateralValueForHealth(borrower) > 0) return;
@@ -1100,11 +1109,25 @@ contract record LendingPool is Ownable {
 
         uint baseBad = (scaled * borrowIndex) / RAY;
 
+        // stop interest accrual on this borrower
         totalScaledDebt -= scaled;
         ln.scaledDebt = 0;
         delete userLoan[borrower];
 
+        // track non-accruing receivable
         badDebt += baseBad;
+
+        // Sweep any residual collateral (even if liquidation-weighted value was 0)
+        CollateralVault vault = _collateralVault();
+        require (address(feeCollector) != address(0), "LP: Fee collector not set");
+        uint n = configuredAssets.length;
+        for (uint i = 0; i < n; i++) {
+            address collateral = configuredAssets[i];
+            uint amt = vault.userCollaterals(borrower, collateral);
+            if (amt != 0) {
+                vault.seizeCollateral(borrower, address(feeCollector), collateral, amt); // vault emits CollateralRemoved
+            }
+        }
 
         emit BadDebtRecognized(baseBad);
         emit ExchangeRateUpdated(borrowableAsset, getExchangeRate());
@@ -1122,6 +1145,41 @@ contract record LendingPool is Ownable {
         }
 
         // Any excess cash simply improves liquidity until swept to reserves
+        emit ExchangeRateUpdated(borrowableAsset, getExchangeRate());
+    }
+
+    function writeOffBadDebtFromReserves(uint amount) external onlyPoolConfigurator {
+        if (amount == 0) return;
+        _accrue(); 
+
+        // capacity = min(reservesAccrued, badDebt)
+        uint cap = reservesAccrued < badDebt ? reservesAccrued : badDebt;
+        if (cap == 0) return;
+
+        // use at most the amount sent, further capped by capacity
+        uint writeOff = amount <= cap ? amount : cap;
+
+        reservesAccrued -= writeOff;
+        badDebt        -= writeOff;
+
+        emit BadDebtWrittenOffFromReserves(writeOff, badDebt, reservesAccrued);
+        emit ExchangeRateUpdated(borrowableAsset, getExchangeRate());
+    }
+
+    /// @notice LAST-RESORT: write off bad debt without funding (haircut depositors).
+    /// @dev Reduces `badDebt` directly, which lowers getExchangeRate() once, pro-rata for all mToken holders.
+    ///      Use only after attempting SM coverage and reserves write-off.
+    function writeOffBadDebtWithHaircut(uint amount, string calldata reason) external onlyPoolConfigurator
+    {
+        require(amount > 0, "LP:zero");
+        _accrue();
+
+        uint writeOff = amount <= badDebt ? amount : badDebt;
+        if (writeOff == 0) return;
+
+        badDebt -= writeOff;
+
+        emit DepositorHaircutApplied(writeOff, badDebt, reason);
         emit ExchangeRateUpdated(borrowableAsset, getExchangeRate());
     }
 } 

--- a/mercata/contracts/concrete/Lending/PoolConfigurator.sol
+++ b/mercata/contracts/concrete/Lending/PoolConfigurator.sol
@@ -186,7 +186,16 @@ contract record PoolConfigurator is Ownable {
         pool.setFeeCollector(_feeCollector);
     }
 
-     // Setter function for borrowable asset
+    /**
+     * @notice Set safety module address
+     * @param _safetyModule The safety module address
+     */
+    function setSafetyModule(address _safetyModule) external onlyOwner {
+        LendingPool pool = LendingPool(registry.getLendingPool());
+        pool.setSafetyModule(_safetyModule);
+    }
+
+    // Setter function for borrowable asset
     function setBorrowableAsset(address asset) external onlyOwner {
         require(asset != address(0), "Invalid asset address");
         LendingPool pool = LendingPool(registry.getLendingPool());
@@ -220,4 +229,23 @@ contract record PoolConfigurator is Ownable {
         LendingPool pool = LendingPool(registry.getLendingPool());
         pool.sweepReserves(amount);
     }
+
+    /// @notice Forwarder to write off bad debt without funding (haircut depositors)
+    function writeOffBadDebtWithHaircut(uint amount, string calldata reason) external onlyOwner {
+        LendingPool pool = LendingPool(registry.getLendingPool());
+        pool.writeOffBadDebtWithHaircut(amount, reason);
+    }
+
+    /// @notice Forwarder to write off bad debt using protocol reserves
+    function writeOffBadDebtFromReserves(uint amount) external onlyOwner {
+        LendingPool pool = LendingPool(registry.getLendingPool());
+        pool.writeOffBadDebtFromReserves(amount);
+    }
+
+    /// @notice Forwarder to recognize a borrower's remaining loan as bad debt and sweep any residual collateral
+    function recognizeBadDebt(address borrower) external onlyOwner {
+        LendingPool pool = LendingPool(registry.getLendingPool());
+        pool.recognizeBadDebt(borrower);
+    }
+
 } 

--- a/mercata/contracts/concrete/Lending/SafetyModule.sol
+++ b/mercata/contracts/concrete/Lending/SafetyModule.sol
@@ -7,11 +7,10 @@ import "../../abstract/ERC20/access/Ownable.sol";
 import "../../abstract/ERC20/IERC20.sol";
 
 /// @title SafetyModule (clean, 4626-lite)
-/// @notice Holds USDST and issues non-transferable "shares" (sUSDST) via internal accounting.
+/// @notice Holds USDST and issues sUSDST tokens via internal accounting.
 ///         - Rewards in USDST via notifyReward() raise price (exchangeRate).
 ///         - coverShortfall() transfers USDST to LendingPool and writes down system debt; price drops.
 ///         - Cooldown + unstake window enforce exit discipline.
-///         - No Pausable/ReentrancyGuard. Assumes USDST is a well-behaved ERC20.
 
 contract record SafetyModule is Ownable {
     // ─── Events
@@ -68,7 +67,7 @@ contract record SafetyModule is Ownable {
         emit TokenFactoryUpdated(_tokenFactory);
     }
 
-    /// @notice Pull latest endpoints from registry and cache them.
+    /// @notice Pull latest values from registry and cache them.
     /// @dev Validates that LendingPool.borrowableAsset() matches cached (or initializes if first time).
     function syncFromRegistry() external onlyOwner {
         _syncFromRegistry();
@@ -239,19 +238,32 @@ contract record SafetyModule is Ownable {
     /// @notice Slash vault to cover protocol shortfall.
     /// @dev Data plane: send USDST to LiquidityPool.
     /// Control plane: tell LendingPool to consume badDebt (accounting).
-    function coverShortfall(uint amount) external onlyOwner {
+ 
+    function coverShortfall(uint256 amount) external onlyOwner returns (uint256 covered) {
         require(amount > 0, "SM:zero");
-        uint ta = totalAssets();
-        require(amount <= ta, "SM:>assets");
-        uint maxSlash = (ta * MAX_SLASH_BPS) / 10000;
-        require(amount <= maxSlash, "SM:>maxSlash");
 
-        IERC20(asset).transfer(address(liquidityPool), amount);
-        lendingPool.coverShortfall(amount);
+        // Live caps
+        uint256 ta        = totalAssets();                         // SM TVL
+        uint256 bd        = lendingPool.badDebt();                 // live bad debt in base units
+        require(bd > 0, "SM:no bad debt");
 
-        emit ShortfallCovered(amount);
+        uint256 maxSlash  = (ta * MAX_SLASH_BPS) / 10000;
+
+        // Compute the actual amount we are willing & able to cover
+        covered = amount;
+        if (covered > ta)        covered = ta;        // cannot send more than vault assets
+        if (covered > maxSlash)  covered = maxSlash;  // per-event slash cap
+        if (covered > bd)        covered = bd;        // don't overfund beyond bad debt
+
+        require(covered > 0, "SM:nothing to cover");
+
+        // Push exactly what will be consumed, then notify LendingPool
+        IERC20(asset).transfer(address(liquidityPool), covered);
+        lendingPool.coverShortfall(covered);
+
+        emit ShortfallCovered(covered);
     }
-
+    
     // ─────────────────────────────────────────
     // Admin
 


### PR DESCRIPTION
Functionality added/updated
1. Governance method in LendingPool to cover bad debt from the reserves
2. Governance method in LendingPool to write off bad debt without funding (last resort option that impacts liquidity providers and lowers exchange rate) 
3. Governance method in LendingPool to recognize a user loan as bad debt that's liquidatable but not liquidated and sweep any residual collateral
4. Max shortfall cover in SM is now limited to bad debt  