### PR TITLE
optimize the lastProcessedBlock logic in bridge to minimize mercata txs

### DIFF
--- a/mercata/services/bridge/.gitignore
+++ b/mercata/services/bridge/.gitignore
@@ -1,0 +1,3 @@
+bridge-error.flag
+.env
+lastProcessedBlocks.json

--- a/mercata/services/bridge/src/config/index.ts
+++ b/mercata/services/bridge/src/config/index.ts
@@ -53,7 +53,7 @@ const config = {
   balance: {
     gasFeeUSDST: BigInt(process.env.GAS_FEE_USDST || '1') * BigInt(1e16),
     gasFeeVoucher: BigInt(process.env.GAS_FEE_VOUCHER || '100') * BigInt(1e16),
-    minTransactionsThreshold: BigInt(process.env.MIN_TRANSACTIONS_THRESHOLD || '500'),
+    minTransactionsThreshold: BigInt(process.env.MIN_TRANSACTIONS_THRESHOLD || '200'),
   },
   strato: {
     gas: {

--- a/mercata/services/bridge/src/polling/alchemyPolling.ts
+++ b/mercata/services/bridge/src/polling/alchemyPolling.ts
@@ -3,7 +3,8 @@ import {
   getEnabledChains,
   getEnabledAssets,
 } from "../services/cirrusService";
-import { depositBatch, updateLastProcessedBlock } from "../services/bridgeService";
+import { depositBatch } from "../services/bridgeService";
+import { blockTrackingService } from "../services/blockTrackingService";
 import { NonEmptyArray, Deposit, ChainInfo } from "../types";
 import {
   getCurrentBlockNumber,
@@ -75,8 +76,16 @@ const parseDepositEvents = async (logs: any[], externalChainId: number) => {
 const pollChainForDeposits = async (chainInfo: ChainInfo) => {
   const externalChainId = chainInfo.externalChainId;
   const depositRouter = chainInfo.depositRouter;
-  const lastProcessedBlock = parseInt(chainInfo.lastProcessedBlock) || 0;
+  const blockchainLastProcessedBlock = parseInt(chainInfo.lastProcessedBlock) || 0;
+  
+  // Get the effective last processed block (max of blockchain and local storage)
+  const lastProcessedBlock = await blockTrackingService.getEffectiveLastProcessedBlock(
+    externalChainId, 
+    blockchainLastProcessedBlock
+  );
+  
   let currentBlock: number | null = null;
+  let depositsProcessed = false;
 
   try {
     if (!isChainConfigured(externalChainId)) return;
@@ -95,6 +104,8 @@ const pollChainForDeposits = async (chainInfo: ChainInfo) => {
     );
 
     if (logs.length === 0) {
+      // No deposits found - only update locally
+      await blockTrackingService.updateLastProcessedBlockLocally(externalChainId, currentBlock);
       return;
     }
 
@@ -108,6 +119,7 @@ const pollChainForDeposits = async (chainInfo: ChainInfo) => {
     // Process valid deposits first
     if (filteredDeposits.length > 0) {
       await depositBatch(filteredDeposits as NonEmptyArray<Deposit>);
+      depositsProcessed = true;
     }
 
     // If there were parse failures, throw error after processing valid ones
@@ -115,13 +127,17 @@ const pollChainForDeposits = async (chainInfo: ChainInfo) => {
       throw new Error(`Failed to parse ${failedParses} out of ${validDeposits.length} deposits for chain ${externalChainId}`);
     }
   } finally {
-    // Always update lastProcessedBlock if we got a currentBlock
+    // Update lastProcessedBlock based on whether deposits were processed
     if (currentBlock !== null && currentBlock > lastProcessedBlock) {
       try {
-        await updateLastProcessedBlock(externalChainId, currentBlock);
+        if (depositsProcessed) {
+          // Deposits were processed - update both local and blockchain
+          await blockTrackingService.updateLastProcessedBlockEverywhere(externalChainId, currentBlock);
+        }
+        // Note: Local-only update for no deposits case is already handled above in the "no logs" section
       } catch (updateError) {
         // Enhance error with context before re-throwing
-        const enhancedError = new Error(`updateLastProcessedBlock failed for chain ${externalChainId} block ${currentBlock}: ${(updateError as Error).message}\nOriginal stack: ${(updateError as Error).stack}`);
+        const enhancedError = new Error(`Block update failed for chain ${externalChainId} block ${currentBlock}: ${(updateError as Error).message}\nOriginal stack: ${(updateError as Error).stack}`);
         throw enhancedError;
       }
     }

--- a/mercata/services/bridge/src/services/blockTrackingService.ts
+++ b/mercata/services/bridge/src/services/blockTrackingService.ts
@@ -1,0 +1,113 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { logInfo, logError } from '../utils/logger';
+import { config } from '../config';
+import { execute } from '../utils/stratoHelper';
+
+const BLOCK_TRACKING_FILE = 'lastProcessedBlocks.json';
+const BLOCK_TRACKING_PATH = path.join(process.cwd(), BLOCK_TRACKING_FILE);
+
+interface BlockTrackingData {
+  [chainId: string]: number;
+}
+
+class BlockTrackingService {
+  private cachedData: BlockTrackingData | null = null;
+
+  /**
+   * Load block tracking data from file
+   */
+  private async loadBlockData(): Promise<BlockTrackingData> {
+    if (this.cachedData !== null) {
+      return this.cachedData;
+    }
+
+    try {
+      const fileContent = await fs.readFile(BLOCK_TRACKING_PATH, 'utf-8');
+      this.cachedData = JSON.parse(fileContent);
+      return this.cachedData!;
+    } catch (error) {
+      // File doesn't exist or is invalid, return empty object
+      this.cachedData = {};
+      return this.cachedData;
+    }
+  }
+
+  /**
+   * Save block tracking data to file
+   */
+  private async saveBlockData(data: BlockTrackingData): Promise<void> {
+    try {
+      await fs.writeFile(BLOCK_TRACKING_PATH, JSON.stringify(data, null, 2));
+      this.cachedData = data;
+      logInfo('BlockTrackingService', `Saved block tracking data to ${BLOCK_TRACKING_FILE}`);
+    } catch (error) {
+      logError('BlockTrackingService', error as Error, {
+        operation: 'saveBlockData',
+        filePath: BLOCK_TRACKING_PATH,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Get the last processed block for a chain (locally stored)
+   */
+  async getLastProcessedBlock(chainId: number): Promise<number> {
+    const data = await this.loadBlockData();
+    return data[chainId.toString()] || 0;
+  }
+
+  /**
+   * Update the last processed block locally
+   */
+  async updateLastProcessedBlockLocally(chainId: number, blockNumber: number): Promise<void> {
+    const data = await this.loadBlockData();
+    data[chainId.toString()] = blockNumber;
+    await this.saveBlockData(data);
+    
+    logInfo('BlockTrackingService', `Updated local lastProcessedBlock for chain ${chainId}: ${blockNumber}`);
+  }
+
+  /**
+   * Get the difference between blockchain and local block numbers
+   * Returns the local block number if it's higher than blockchain, otherwise blockchain value
+   */
+  async getEffectiveLastProcessedBlock(chainId: number, blockchainLastBlock: number): Promise<number> {
+    const localLastBlock = await this.getLastProcessedBlock(chainId);
+    return Math.max(localLastBlock, blockchainLastBlock);
+  }
+
+  /**
+   * Update the last processed block on the blockchain
+   */
+  async updateLastProcessedBlockOnBlockchain(chainId: number, blockNumber: number): Promise<void> {
+    await execute({
+      contractName: "MercataBridge",
+      contractAddress: config.bridge.address!,
+      method: "setLastProcessedBlock",
+      args: {
+        externalChainId: chainId,
+        lastProcessedBlock: blockNumber,
+      },
+    });
+    
+    logInfo(
+      "BlockTrackingService",
+      `Updated lastProcessedBlock on blockchain for chain ${chainId}: ${blockNumber}`,
+    );
+  }
+
+  /**
+   * Update last processed block both locally and on blockchain
+   * Use this when deposits have been processed and blockchain state should be updated
+   */
+  async updateLastProcessedBlockEverywhere(chainId: number, blockNumber: number): Promise<void> {
+    await Promise.all([
+      this.updateLastProcessedBlockLocally(chainId, blockNumber),
+      this.updateLastProcessedBlockOnBlockchain(chainId, blockNumber)
+    ]);
+  }
+}
+
+export const blockTrackingService = new BlockTrackingService();

--- a/mercata/services/bridge/src/services/bridgeService.ts
+++ b/mercata/services/bridge/src/services/bridgeService.ts
@@ -255,17 +255,3 @@ export const handleRejectedWithdrawalBatch = async (
   }
 };
 
-export const updateLastProcessedBlock = async (
-  externalChainId: number,
-  blockNumber: number,
-): Promise<void> => {
-  await execute({
-    contractName: "MercataBridge",
-    contractAddress: config.bridge.address!,
-    method: "setLastProcessedBlock",
-    args: {
-      externalChainId,
-      lastProcessedBlock: blockNumber,
-    },
-  });
-};

--- a/mercata/services/bridge/src/utils/balanceCheck.ts
+++ b/mercata/services/bridge/src/utils/balanceCheck.ts
@@ -58,7 +58,7 @@ export const checkBalances = async (): Promise<void> => {
     
     // Check if total transactions are below minimum threshold
     if (totalTransactions < config.balance.minTransactionsThreshold) {
-      const error = `Total possible transactions (${totalTransactions}) below minimum threshold (${config.balance.minTransactionsThreshold}). Voucher: ${voucherBalanceUSD} (${voucherTransactions} txs), USDST: ${usdstBalanceUSD} (${usdstTransactions} txs)`;
+      const error = `WARNING: Total possible transactions (${totalTransactions}) below minimum threshold (${config.balance.minTransactionsThreshold}). Voucher: ${voucherBalanceUSD} (${voucherTransactions} txs), USDST: ${usdstBalanceUSD} (${usdstTransactions} txs)`;
       logError('BalanceChecker', new Error(error));
       
       // Exit if critically low (less than 1 transaction possible)

--- a/mercata/services/oracle/.gitignore
+++ b/mercata/services/oracle/.gitignore
@@ -1,0 +1,2 @@
+oracle-error.flag
+.env


### PR DESCRIPTION
New business logic flow:

1. Poll Alchemy API for new blocks

2. Check for deposit events in new blocks (filter by range between:
`MAX(LastProcessedBlockLocal, LastProcessedBlockBlockchain) + 1` and 
current Ethereum block)

3a. NO DEPOSITS FOUND:
    → Update lastProcessedBlock locally only ✅
    → Skip blockchain transaction (LESS TRANSACTIONS!)
   
3b. DEPOSITS FOUND:
    → Process deposits via depositBatch()
    → Update lastProcessedBlock locally AND blockchain ✅
    → Necessary blockchain state update