### PR TITLE
Load contract events from Solidity sources

### DIFF
--- a/mercata/backend/src/api/controllers/events.controller.ts
+++ b/mercata/backend/src/api/controllers/events.controller.ts
@@ -1,6 +1,249 @@
+import fs from "fs";
+import path from "path";
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
 import { getEvents } from "../services/events.service";
+
+type ContractRecord = {
+  name: string;
+  bases: string[];
+  events: Set<string>;
+};
+
+type ContractInfoResponse = {
+  contracts: { name: string; events: string[] }[];
+};
+
+const CONTRACTS_ROOT = path.resolve(__dirname, "../../../../contracts");
+const IGNORED_DIRECTORIES = new Set([
+  "node_modules",
+  "artifacts",
+  "build",
+  "cache",
+  "tests"
+]);
+
+let cachedContractInfo: ContractInfoResponse | null = null;
+let cachedContractInfoError: Error | null = null;
+
+const stripComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+const collectSolidityFiles = (directory: string): string[] => {
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+
+    const fullPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+      files.push(...collectSolidityFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".sol")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+};
+
+const extractBlock = (source: string, startIndex: number): string => {
+  let depth = 0;
+
+  for (let index = startIndex; index < source.length; index += 1) {
+    const char = source[index];
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(startIndex + 1, index);
+      }
+    }
+  }
+
+  return "";
+};
+
+const parseContracts = (source: string): ContractRecord[] => {
+  const contracts: ContractRecord[] = [];
+  const sanitizedSource = stripComments(source);
+  const patterns: RegExp[] = [
+    /\b(?:abstract\s+)?contract\s+([A-Za-z0-9_]+)\s*(?:is\s*([^\{;]+))?\s*\{/g,
+    /\binterface\s+([A-Za-z0-9_]+)\s*(?:is\s*([^\{;]+))?\s*\{/g,
+    /\blibrary\s+([A-Za-z0-9_]+)\s*(?:is\s*([^\{;]+))?\s*\{/g
+  ];
+
+  for (const pattern of patterns) {
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(sanitizedSource)) !== null) {
+      const contractName = match[1];
+      const bases = (match[2] || "")
+        .split(",")
+        .map((base) => base.trim().split(" ")[0])
+        .map((base) => base.split("(")[0].trim())
+        .filter(Boolean);
+
+      const bodyStart = sanitizedSource.indexOf("{", match.index);
+      const body = bodyStart >= 0 ? extractBlock(sanitizedSource, bodyStart) : "";
+
+      const eventRegex = /\bevent\s+([A-Za-z0-9_]+)\s*\(/g;
+      const events = new Set<string>();
+      let eventMatch: RegExpExecArray | null;
+
+      while ((eventMatch = eventRegex.exec(body)) !== null) {
+        events.add(eventMatch[1]);
+      }
+
+      contracts.push({
+        name: contractName,
+        bases,
+        events
+      });
+    }
+  }
+
+  return contracts;
+};
+
+const buildContractGraph = (files: string[]): Map<string, ContractRecord> => {
+  const contractMap = new Map<string, ContractRecord>();
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, "utf8");
+    for (const contract of parseContracts(source)) {
+      const existing = contractMap.get(contract.name);
+
+      if (existing) {
+        for (const base of contract.bases) {
+          if (!existing.bases.includes(base)) {
+            existing.bases.push(base);
+          }
+        }
+        for (const event of contract.events) {
+          existing.events.add(event);
+        }
+      } else {
+        contractMap.set(contract.name, {
+          name: contract.name,
+          bases: [...contract.bases],
+          events: new Set(contract.events)
+        });
+      }
+    }
+  }
+
+  return contractMap;
+};
+
+const collectInheritedEvents = (
+  contract: ContractRecord,
+  contractMap: Map<string, ContractRecord>,
+  visited: Set<string>
+): Set<string> => {
+  if (visited.has(contract.name)) {
+    return new Set();
+  }
+
+  visited.add(contract.name);
+
+  const aggregated = new Set(contract.events);
+
+  for (const baseName of contract.bases) {
+    const baseContract = contractMap.get(baseName);
+    if (!baseContract) {
+      continue;
+    }
+
+    const inheritedEvents = collectInheritedEvents(
+      baseContract,
+      contractMap,
+      new Set(visited)
+    );
+
+    for (const event of inheritedEvents) {
+      aggregated.add(event);
+    }
+  }
+
+  return aggregated;
+};
+
+const deriveLeafContracts = (contractMap: Map<string, ContractRecord>): ContractInfoResponse => {
+  const referencedBases = new Set<string>();
+
+  for (const contract of contractMap.values()) {
+    for (const base of contract.bases) {
+      if (contractMap.has(base)) {
+        referencedBases.add(base);
+      }
+    }
+  }
+
+  const leafContracts = Array.from(contractMap.values()).filter(
+    (contract) => !referencedBases.has(contract.name)
+  );
+
+  const contracts = leafContracts
+    .map((contract) => {
+      const events = collectInheritedEvents(contract, contractMap, new Set());
+      return {
+        name: contract.name,
+        events: Array.from(events).sort()
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return { contracts };
+};
+
+const loadContractInfo = (): ContractInfoResponse => {
+  const solidityFiles = collectSolidityFiles(CONTRACTS_ROOT);
+  const contractGraph = buildContractGraph(solidityFiles);
+  return deriveLeafContracts(contractGraph);
+};
+
+const warmContractInfoCache = (): void => {
+  try {
+    cachedContractInfo = loadContractInfo();
+    cachedContractInfoError = null;
+  } catch (error) {
+    cachedContractInfo = null;
+    cachedContractInfoError = error as Error;
+    console.error("Failed to load contract info:", error);
+  }
+};
+
+const getCachedContractInfo = (forceRefresh = false): ContractInfoResponse => {
+  if (forceRefresh || !cachedContractInfo) {
+    warmContractInfoCache();
+  }
+
+  if (!cachedContractInfo) {
+    throw (
+      cachedContractInfoError ||
+      new Error("Contract information is not available")
+    );
+  }
+
+  return cachedContractInfo;
+};
+
+warmContractInfoCache();
 
 class EventsController {
   static async getEvents(
@@ -23,102 +266,12 @@ class EventsController {
     next: NextFunction
   ): Promise<void> {
     try {
-      // Hardcoded contract information based on the Mercata contracts
-      const contractInfo = {
-        contracts: [
-          {
-            name: "LendingPool",
-            events: [
-              "Deposited",
-              "Withdrawn", 
-              "Borrowed",
-              "Repaid",
-              "Liquidated",
-              "SuppliedCollateral",
-              "WithdrawnCollateral",
-              "ExchangeRateUpdated",
-              "InterestDistributed",
-              "AssetConfigured"
-            ]
-          },
-          {
-            name: "Pool",
-            events: [
-              "Swap",
-              "AddLiquidity",
-              "RemoveLiquidity"
-            ]
-          },
-          {
-            name: "Token",
-            events: [
-              "Transfer",
-              "Approval",
-              "StatusChanged"
-            ]
-          },
-          {
-            name: "MercataEthBridge",
-            events: [
-              "DepositInitiated",
-              "DepositCompleted",
-              "WithdrawalInitiated",
-              "WithdrawalPendingApproval",
-              "WithdrawalCompleted",
-              "RelayerUpdated",
-              "MinAmountUpdated",
-              "TokenFactoryUpdated"
-            ]
-          },
-          {
-            name: "RewardsManager",
-            events: [
-              "RewardTokenAdded",
-              "RewardTokenRemoved",
-              "EligibleTokenAdded", 
-              "EligibleTokenRemoved",
-              "RewardFactorSet",
-              "RewardBalanceUpdated",
-              "RewardClaimed",
-              "RewardDelegateUpdated"
-            ]
-          },
-          {
-            name: "PoolFactory",
-            events: [
-              "PoolCreated"
-            ]
-          },
-          {
-            name: "TokenFactory",
-            events: [
-              "TokenCreated",
-              "TokenStatusUpdated"
-            ]
-          },
-          {
-            name: "LendingRegistry",
-            events: [
-              "AssetRegistered",
-              "AssetUnregistered"
-            ]
-          },
-          {
-            name: "CollateralVault",
-            events: [
-              "CollateralDeposited",
-              "CollateralWithdrawn"
-            ]
-          },
-          {
-            name: "PriceOracle",
-            events: [
-              "PriceUpdated"
-            ]
-          }
-        ]
-      };
-
+      const query = req.query as Record<string, string | string[] | undefined> | undefined;
+      const refreshParam = query?.refresh;
+      const forceRefresh = Array.isArray(refreshParam)
+        ? refreshParam.includes("true")
+        : refreshParam === "true";
+      const contractInfo = getCachedContractInfo(forceRefresh);
       res.status(RestStatus.OK).json(contractInfo);
     } catch (error) {
       next(error);

--- a/strato-vscode/package-lock.json
+++ b/strato-vscode/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "strato-mercata",
 			"version": "0.0.1",
 			"dependencies": {
+				"@solidity-parser/parser": "^0.18.0",
 				"@vscode/debugadapter": "^1.68.0",
 				"await-notify": "1.0.1",
 				"axios": "^1.4.0",
@@ -280,13 +281,10 @@
 			}
 		},
 		"node_modules/@solidity-parser/parser": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
-			"integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
-			"license": "MIT",
-			"dependencies": {
-				"antlr4ts": "^0.5.0-alpha.4"
-			}
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.18.0.tgz",
+			"integrity": "sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==",
+			"license": "MIT"
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
@@ -892,6 +890,15 @@
 			},
 			"engines": {
 				"node": ">= 10.1.0"
+			}
+		},
+		"node_modules/blockapps-rest/node_modules/@solidity-parser/parser": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
+			"integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
+			"license": "MIT",
+			"dependencies": {
+				"antlr4ts": "^0.5.0-alpha.4"
 			}
 		},
 		"node_modules/blockapps-rest/node_modules/argparse": {

--- a/strato-vscode/package.json
+++ b/strato-vscode/package.json
@@ -319,12 +319,13 @@
 		"test": "node ./out/test/runTest.js"
 	},
 	"dependencies": {
+		"@solidity-parser/parser": "^0.18.0",
+		"@vscode/debugadapter": "^1.68.0",
 		"await-notify": "1.0.1",
 		"axios": "^1.4.0",
 		"blockapps-rest": "^8.4.0",
 		"js-yaml": "^4.0.0",
 		"qs": "^6.11.2",
-		"@vscode/debugadapter": "^1.68.0",
 		"ws": "^7.4.2"
 	},
 	"devDependencies": {

--- a/strato-vscode/src/cirrus.ts
+++ b/strato-vscode/src/cirrus.ts
@@ -1,14 +1,54 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { promises as fsPromises } from 'fs';
+import * as parser from '@solidity-parser/parser';
+import type { ContractDefinition, EventDefinition } from '@solidity-parser/parser/dist/src/ast-types';
 import { rest } from 'blockapps-rest';
 import { getApplicationUser } from './auth';
 import getConfig from './load.config';
 import getOptions from './load.options';
 
+type CirrusViewMode = 'remote' | 'local';
+
+interface ContractEventsItem {
+  label: string;
+  description: string;
+  tooltip: string;
+  events: EventTreeItemData[];
+  filePaths: string[];
+}
+
+interface EventTreeItemData {
+  label: string;
+  description: string;
+  tooltip: string;
+  signature: string;
+  definedIn: string;
+  filePath: string;
+}
+
+interface ParsedContractInfo {
+  name: string;
+  filePaths: string[];
+  events: ParsedEventInfo[];
+  bases: string[];
+}
+
+interface ParsedEventInfo {
+  name: string;
+  signature: string;
+  definedIn: string;
+  filePath: string;
+}
+
 export class CirrusProvider implements vscode.TreeDataProvider<CirrusItem> {
   _queryString: string;
+  private _mode: CirrusViewMode;
+  private _localContracts: ContractEventsItem[];
   constructor() {
     this._queryString = '';
+    this._mode = 'remote';
+    this._localContracts = [];
   }
 
   getTreeItem(element: CirrusItem): vscode.TreeItem {
@@ -17,12 +57,49 @@ export class CirrusProvider implements vscode.TreeDataProvider<CirrusItem> {
 
   getChildren(element?: CirrusItem): Thenable<CirrusItem[]> {
     if (element) {
-        const entries = Object.entries(element._item)
-        const items = entries.map((e) => new CirrusItem({label: `${e[0]}`, description: `${e[1]}`, tooltip: `${e[1]}`}, vscode.TreeItemCollapsibleState.None))
+      if (element.itemType === 'contract') {
+        const events: EventTreeItemData[] = element._item.events || [];
+        const items = events.map((event) =>
+          new CirrusItem(
+            {
+              label: event.label,
+              description: event.description,
+              tooltip: event.tooltip,
+              signature: event.signature,
+              definedIn: event.definedIn,
+              filePath: event.filePath
+            },
+            vscode.TreeItemCollapsibleState.None,
+            'event'
+          )
+        );
         return Promise.resolve(items);
-    } else {
-      return this.queryCirrus();
+      }
+
+      if (element.itemType === 'remote') {
+        const entries = Object.entries(element._item);
+        const items = entries.map((e) =>
+          new CirrusItem(
+            {
+              label: `${e[0]}`,
+              description: `${e[1]}`,
+              tooltip: `${e[1]}`
+            },
+            vscode.TreeItemCollapsibleState.None,
+            'detail'
+          )
+        );
+        return Promise.resolve(items);
+      }
+
+      return Promise.resolve([]);
     }
+
+    if (this._mode === 'local') {
+      return this.getLocalContracts();
+    }
+
+    return this.queryCirrus();
   }
 
   async callCirrus(name, query): Promise<string[]> {
@@ -49,7 +126,8 @@ export class CirrusProvider implements vscode.TreeDataProvider<CirrusItem> {
         const dep = { ..._dep, label: acct(_dep), tooltip: acct(_dep), description: '' }
         return new CirrusItem(
           dep,
-          vscode.TreeItemCollapsibleState.Collapsed
+          vscode.TreeItemCollapsibleState.Collapsed,
+          'remote'
         );
       };
 
@@ -57,6 +135,29 @@ export class CirrusProvider implements vscode.TreeDataProvider<CirrusItem> {
     } else {
       return [];
     }
+  }
+
+  private async getLocalContracts(): Promise<CirrusItem[]> {
+    const items = this._localContracts;
+    return items.map((contract) =>
+      new CirrusItem(
+        {
+          label: contract.label,
+          description: contract.description,
+          tooltip: contract.tooltip,
+          events: contract.events,
+          filePaths: contract.filePaths
+        },
+        vscode.TreeItemCollapsibleState.Collapsed,
+        'contract'
+      )
+    );
+  }
+
+  async showLocalEvents(): Promise<void> {
+    this._mode = 'local';
+    this._localContracts = await this.collectLocalContractEvents();
+    this.refresh();
   }
 
   private _onDidChangeTreeData: vscode.EventEmitter<
@@ -72,23 +173,226 @@ export class CirrusProvider implements vscode.TreeDataProvider<CirrusItem> {
 
   query(queryString: string): void {
     this._queryString = queryString;
+    this._mode = 'remote';
     this._onDidChangeTreeData.fire(undefined);
+  }
+
+  private async collectLocalContractEvents(): Promise<ContractEventsItem[]> {
+    const configPath = vscode.workspace.getConfiguration().get('strato-vscode.configPath', '') as string;
+    const config = getConfig() || {};
+
+    if (!configPath || configPath === '') {
+      vscode.window.showWarningMessage('Configure a STRATO config file to scan local contract events.');
+      return [];
+    }
+
+    if (!config.contractsPath) {
+      vscode.window.showWarningMessage('No contractsPath found in the selected configuration file.');
+      return [];
+    }
+
+    const resolvedContractsPath = path.isAbsolute(config.contractsPath)
+      ? config.contractsPath
+      : path.resolve(path.dirname(configPath), config.contractsPath);
+
+    let stats;
+    try {
+      stats = await fsPromises.stat(resolvedContractsPath);
+    } catch (err) {
+      vscode.window.showWarningMessage(`Contracts directory not found at ${resolvedContractsPath}.`);
+      return [];
+    }
+
+    if (!stats.isDirectory()) {
+      vscode.window.showWarningMessage(`Contracts path ${resolvedContractsPath} is not a directory.`);
+      return [];
+    }
+
+    const solidityFiles = await this.collectSolidityFiles(resolvedContractsPath);
+    if (solidityFiles.length === 0) {
+      vscode.window.showInformationMessage('No Solidity files found in the configured contracts directory.');
+      return [];
+    }
+
+    const contractMap = await this.parseSolidityContracts(solidityFiles);
+
+    const referencedBases = new Set<string>();
+    for (const contract of contractMap.values()) {
+      for (const base of contract.bases) {
+        if (contractMap.has(base)) {
+          referencedBases.add(base);
+        }
+      }
+    }
+
+    const leaves = Array.from(contractMap.values()).filter((contract) => !referencedBases.has(contract.name));
+
+    const contractItems: ContractEventsItem[] = [];
+    for (const contract of leaves) {
+      const events = this.collectEventsForContract(contract, contractMap, new Set<string>());
+      const uniqueEvents = this.dedupeEvents(events);
+      if (uniqueEvents.length === 0) continue;
+
+      const relativePaths = contract.filePaths.map((filePath) => this.toRelativePath(filePath));
+      contractItems.push({
+        label: contract.name,
+        description: relativePaths.join(', '),
+        tooltip: [contract.name, ...relativePaths].join('\n'),
+        filePaths: contract.filePaths,
+        events: uniqueEvents.map((event) => ({
+          label: event.name,
+          description: event.definedIn === contract.name ? 'defined here' : `inherited from ${event.definedIn}`,
+          tooltip: `${event.signature}\n${this.toRelativePath(event.filePath)}`,
+          signature: event.signature,
+          definedIn: event.definedIn,
+          filePath: event.filePath
+        }))
+      });
+    }
+
+    return contractItems.sort((a, b) => a.label.localeCompare(b.label));
+  }
+
+  private async collectSolidityFiles(dir: string): Promise<string[]> {
+    let entries;
+    try {
+      entries = await fsPromises.readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      return [];
+    }
+
+    const files: string[] = [];
+    for (const entry of entries) {
+      const resolved = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        const nested = await this.collectSolidityFiles(resolved);
+        files.push(...nested);
+      } else if (entry.isFile() && entry.name.endsWith('.sol')) {
+        files.push(resolved);
+      }
+    }
+
+    return files;
+  }
+
+  private async parseSolidityContracts(files: string[]): Promise<Map<string, ParsedContractInfo>> {
+    const contractMap = new Map<string, ParsedContractInfo>();
+
+    for (const filePath of files) {
+      let source: string;
+      try {
+        source = await fsPromises.readFile(filePath, 'utf8');
+      } catch (err) {
+        continue;
+      }
+
+      let ast;
+      try {
+        ast = parser.parse(source, { loc: true, range: true, tolerant: true });
+      } catch (err) {
+        vscode.window.showWarningMessage(`Failed to parse Solidity file: ${filePath}`);
+        continue;
+      }
+
+      parser.visit(ast, {
+        ContractDefinition: (node: ContractDefinition) => {
+          const events = (node.subNodes || [])
+            .filter((subNode) => subNode.type === 'EventDefinition')
+            .map((subNode) => this.toEventInfo(subNode as EventDefinition, node, filePath, source));
+
+          const bases = (node.baseContracts || []).map((base) =>
+            base.baseName.type === 'UserDefinedTypeName'
+              ? base.baseName.namePath
+              : (base.baseName as any).name || ''
+          ).filter((name) => name && typeof name === 'string');
+
+          const existing = contractMap.get(node.name);
+          if (existing) {
+            existing.events.push(...events);
+            existing.filePaths = Array.from(new Set([...existing.filePaths, filePath]));
+            existing.bases = Array.from(new Set([...existing.bases, ...bases]));
+          } else {
+            contractMap.set(node.name, {
+              name: node.name,
+              filePaths: [filePath],
+              events: events,
+              bases: bases
+            });
+          }
+        }
+      });
+    }
+
+    return contractMap;
+  }
+
+  private toEventInfo(event: EventDefinition, contract: ContractDefinition, filePath: string, source: string): ParsedEventInfo {
+    const signature = event.range ? source.slice(event.range[0], event.range[1]).trim() : `event ${event.name}`;
+    return {
+      name: event.name,
+      signature,
+      definedIn: contract.name,
+      filePath
+    };
+  }
+
+  private collectEventsForContract(
+    contract: ParsedContractInfo,
+    contractMap: Map<string, ParsedContractInfo>,
+    visited: Set<string>
+  ): ParsedEventInfo[] {
+    if (visited.has(contract.name)) {
+      return [];
+    }
+
+    visited.add(contract.name);
+    let events: ParsedEventInfo[] = [...contract.events];
+
+    for (const baseName of contract.bases) {
+      const base = contractMap.get(baseName);
+      if (base) {
+        events = events.concat(this.collectEventsForContract(base, contractMap, visited));
+      }
+    }
+
+    return events;
+  }
+
+  private dedupeEvents(events: ParsedEventInfo[]): ParsedEventInfo[] {
+    const unique = new Map<string, ParsedEventInfo>();
+    events.forEach((event) => {
+      const key = `${event.definedIn}::${event.name}::${event.signature}`;
+      if (!unique.has(key)) {
+        unique.set(key, event);
+      }
+    });
+    return Array.from(unique.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private toRelativePath(filePath: string): string {
+    try {
+      return vscode.workspace.asRelativePath(filePath, false);
+    } catch (err) {
+      return filePath;
+    }
   }
 }
 
 class CirrusItem extends vscode.TreeItem {
   _item: any;
+  itemType: 'remote' | 'contract' | 'event' | 'detail';
   constructor(
     public readonly item: any,
-    public readonly collapsibleState: vscode.TreeItemCollapsibleState
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly _itemType: 'remote' | 'contract' | 'event' | 'detail' = 'remote'
   ) {
     super(item.label, collapsibleState);
     this.tooltip = item.tooltip;
     this.description = item.description;
-    delete item.tooltip
-    delete item.description
-    delete item.label
-    this._item = item;
+    this.itemType = _itemType;
+    const { tooltip, description, label, ...rest } = item;
+    this._item = rest;
+    this.contextValue = _itemType;
   }
 
   iconPath = {

--- a/strato-vscode/src/extension.ts
+++ b/strato-vscode/src/extension.ts
@@ -216,14 +216,40 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Register the Cirrus provider
 	const cirrusProvider = new CirrusProvider();
-	vscode.commands.registerCommand('cirrus.queryCirrus', async () => {
-		const argInput = await vscode.window.showInputBox({
-			placeHolder: 'ex: BlockApps-Mercata-Asset?address=eq.9b617d82a19cde1a5ad3489bfb91716c88f928a6',
-			prompt: `Enter cirrus query.`
-		});
-		if (!argInput) return;
-		cirrusProvider.query(argInput);
-	});
+        vscode.commands.registerCommand('cirrus.queryCirrus', async () => {
+                const action = await vscode.window.showQuickPick<{
+                        label: string;
+                        description: string;
+                        value: 'remote' | 'local';
+                }>([
+                        {
+                                label: 'Search Cirrus',
+                                description: 'Query Cirrus with a custom filter',
+                                value: 'remote'
+                        },
+                        {
+                                label: 'Scan Local Contract Events',
+                                description: 'Parse Solidity contracts from the configured contractsPath',
+                                value: 'local'
+                        }
+                ], {
+                        placeHolder: 'Select how you want to populate the Cirrus explorer'
+                });
+
+                if (!action) return;
+
+                if (action.value === 'remote') {
+                        const argInput = await vscode.window.showInputBox({
+                                placeHolder: 'ex: BlockApps-Mercata-Asset?address=eq.9b617d82a19cde1a5ad3489bfb91716c88f928a6',
+                                prompt: `Enter cirrus query.`
+                        });
+                        if (!argInput) return;
+                        cirrusProvider.query(argInput);
+                        return;
+                }
+
+                await cirrusProvider.showLocalEvents();
+        });
 	vscode.window.registerTreeDataProvider('cirrus', cirrusProvider)
 
 	// Register the nodes provider


### PR DESCRIPTION
## Summary
- parse Solidity sources in `mercata/contracts` to build contract and event metadata for the `/contracts` endpoint
- cache parsed contract information on startup with optional refresh support when requested
- return leaf contracts with inherited events derived from local Solidity inheritance graphs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5e1b722408328a4a885c1f2de0d83