### PR TITLE
Fixed state management during reverts in SolidVM

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -101,6 +101,8 @@ import Control.Monad.Trans.Reader
 import Data.Bifunctor (first)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
+import Data.Either (isLeft)
+import Data.Foldable (for_)
 import Data.List (find)
 import qualified Data.List.NonEmpty as NE
 import Data.Map (Map)
@@ -132,6 +134,8 @@ data CallInfo = CallInfo
     codeCollection :: CC.CodeCollection,
     collectionHash :: Keccak256,
     localVariables :: NE.NonEmpty (Map SolidString (SVMType.Type, Variable)),
+    stateMap :: !(M.Map Address AddressStateModification),
+    storageMap :: !(M.Map (Address, B.ByteString) B.ByteString),
     readOnly :: Bool,
     isUncheckedSection :: Bool, -- TODO: Perform overflow/underflow checks for all arithmetic operations and revert if so, use this flag to disable checks
     currentSourcePos :: Maybe SourcePosition,
@@ -232,10 +236,49 @@ instance
   ) =>
   (RawStorageKey `A.Alters` RawStorageValue) (SM m)
   where
-  lookup _ = genericLookupRawStorageDB
-  insert _ = genericInsertRawStorageDB
-  delete _ = genericDeleteRawStorageDB
-  lookupWithDefault _ = genericLookupWithDefaultRawStorageDB
+  lookup _ k   = do
+    cs <- gets callStack
+    case foldr (<|>) Nothing $ M.lookup k . storageMap <$> cs of
+      Just v -> pure $ Just v
+      Nothing -> genericLookupRawStorageDB k
+  lookupWithDefault _ k   = do
+    cs <- gets callStack
+    case foldr (<|>) Nothing $ M.lookup k . storageMap <$> cs of
+      Just v -> pure v
+      Nothing -> genericLookupWithDefaultRawStorageDB k
+  insert _ k v = do
+    cs <- gets callStack
+    case cs of
+      [] -> genericInsertRawStorageDB k v
+      (c:cs') -> do
+        let c' = c {
+              storageMap = M.insert k v $ storageMap c
+            }
+        modify $ \ss -> ss{
+          callStack = c':cs'
+        }
+  insertMany _ kvs = do
+    cs <- gets callStack
+    case cs of
+      [] -> genericInsertManyRawStorageDB kvs
+      (c:cs') -> do
+        let c' = c {
+              storageMap = kvs `M.union` storageMap c
+            }
+        modify $ \ss -> ss{
+          callStack = c':cs'
+        }
+  delete _ k   = do
+    cs <- gets callStack
+    case cs of
+      [] -> genericDeleteRawStorageDB k
+      (c:cs') -> do
+        let c' = c {
+              storageMap = M.delete k $ storageMap c
+            }
+        modify $ \ss -> ss{
+          callStack = c':cs'
+        }
 
 instance
   ( MonadUnliftIO m,
@@ -246,9 +289,57 @@ instance
   ) =>
   (Address `A.Alters` AddressState) (SM m)
   where
-  lookup _ = getAddressStateMaybe
-  insert _ = putAddressState
-  delete _ = deleteAddressState
+  lookup _ a = do
+    cs <- gets callStack
+    case foldr (<|>) Nothing $ M.lookup a . stateMap <$> cs of
+      Just (ASModification s) -> pure $ Just s
+      Just ASDeleted -> pure $ Just blankAddressState
+      Nothing -> getAddressStateMaybe a
+  insert _ a s = do
+    cs <- gets callStack
+    case cs of
+      [] -> putAddressState a s
+      (c:cs') -> do
+        let c' = c {
+              stateMap = M.insert a (ASModification s) $ stateMap c
+            }
+        modify $ \ss -> ss{
+          callStack = c':cs'
+        }
+  insertMany _ as = do
+    let asMods = M.map ASModification as
+    cs <- gets callStack
+    case cs of
+      [] -> putAddressStates asMods
+      (c:cs') -> do
+        let c' = c {
+              stateMap = asMods `M.union` stateMap c
+            }
+        modify $ \ss -> ss{
+          callStack = c':cs'
+        }
+  delete _ a = do
+    cs <- gets callStack
+    case cs of
+      [] -> deleteAddressState a
+      (c:cs') -> do
+        let c' = c {
+              stateMap = M.insert a ASDeleted $ stateMap c
+            }
+        modify $ \ss -> ss{
+          callStack = c':cs'
+        }
+  deleteMany _ as = do
+    cs <- gets callStack
+    case cs of
+      [] -> deleteAddressStates as
+      (c:cs') -> do
+        let c' = c {
+              stateMap = M.difference (stateMap c) . M.fromList $ (,ASDeleted) <$> as
+            }
+        modify $ \ss -> ss{
+          callStack = c':cs'
+        }
 
 instance
   ( MonadUnliftIO m,
@@ -259,7 +350,7 @@ instance
   ) =>
   A.Selectable Address AddressState (SM m)
   where
-  select _ = getAddressStateMaybe
+  select = A.lookup
 
 instance
   (MonadUnliftIO m, (Maybe Word256 `A.Alters` MP.StateRoot) m) =>
@@ -652,7 +743,7 @@ withCallInfo ::
 withCallInfo a c fn hsh cc initialLocalVariables ro ff f = do
   addCallInfo a c fn hsh cc initialLocalVariables ro ff
   eRes <- try f
-  popCallInfo
+  popCallInfo $ isLeft eRes
   case eRes of
     Left (e :: SomeException) -> throwIO e
     Right res -> pure res
@@ -677,6 +768,8 @@ addCallInfo a c fn hsh cc initialLocalVariables ro ff = do
             codeCollection = cc,
             collectionHash = hsh,
             localVariables = NE.singleton initialLocalVariables,
+            stateMap = M.empty,
+            storageMap = M.empty,
             readOnly = ro,
             isUncheckedSection = False, -- The rationale here is that unchecked sections only apply to the current stack frame
             currentSourcePos = Nothing,
@@ -695,10 +788,20 @@ uncheckedCallInfo = Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
   [] -> internalError "uncheckedCallInfo was called on an already empty stack" ()
   (ci : rest) -> pure $ ci {isUncheckedSection = True} : ci : rest
 
-popCallInfo :: MonadSM m => m ()
-popCallInfo = Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
-  [] -> internalError "popCallInfo was called on an already empty stack" ()
-  (_ : rest) -> pure rest
+popCallInfo :: MonadSM m => Bool -> m ()
+popCallInfo reverted = do
+  cci <- getCurrentCallInfoIfExists
+  Mod.modify_ (Mod.Proxy @[CallInfo]) $ \case
+    [] -> internalError "popCallInfo was called on an already empty stack" ()
+    (_ : rest) -> pure rest
+
+  unless reverted . for_ cci $ \ci -> do
+    A.insertMany (A.Proxy @RawStorageValue) $ storageMap ci
+    let fromASM ASDeleted = Left ()
+        fromASM (ASModification as) = Right as
+        (deletes, inserts) = M.mapEither fromASM $ stateMap ci
+    A.insertMany (A.Proxy @AddressState) $ inserts
+    A.deleteMany (A.Proxy @AddressState) $ M.keys deletes
 
 withLocalVars :: MonadSM m => m a -> m a
 withLocalVars = bracket_ pushLocalVars popLocalVars
@@ -723,7 +826,7 @@ withTempCallInfo :: MonadSM m => Bool -> m a -> m a
 withTempCallInfo ro f = do
   dupCallInfo ro
   eResult <- try f
-  popCallInfo
+  popCallInfo $ isLeft eResult
   case eResult of
     Left (e :: SomeException) -> throwIO e
     Right result -> pure result
@@ -732,7 +835,7 @@ withUncheckedCallInfo :: MonadSM m => m a -> m a
 withUncheckedCallInfo f = do
   uncheckedCallInfo
   eResult <- try f
-  popCallInfo
+  popCallInfo $ isLeft eResult
   case eResult of
     Left (e :: SomeException) -> throwIO e
     Right result -> pure result

--- a/strato/core/blockapps-mpdbs/src/Blockchain/DB/MemAddressStateDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/DB/MemAddressStateDB.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Blockchain.DB.MemAddressStateDB
@@ -15,9 +16,11 @@ module Blockchain.DB.MemAddressStateDB
     AddressStateModification (..),
     getAddressStateMaybe,
     putAddressState,
+    putAddressStates,
     flushMemAddressStateTxToBlockDB,
     flushMemAddressStateDB,
-    deleteAddressState
+    deleteAddressState,
+    deleteAddressStates,
   )
 where
 
@@ -95,6 +98,14 @@ putAddressState address newState = do
   theMap <- getAddressStateTxDBMap
   putAddressStateTxDBMap (M.insert address (ASModification newState) theMap)
 
+putAddressStates ::
+  (HasMemAddressStateDB m, HasStateDB m, HasHashDB m) =>
+  M.Map Address AddressStateModification ->
+  m ()
+putAddressStates localMap = do
+  txMap <- getAddressStateTxDBMap
+  putAddressStateTxDBMap $ localMap `M.union` txMap
+
 flushMemAddressStateTxToBlockDB ::
   (HasMemAddressStateDB m, HasStateDB m, HasHashDB m) =>
   m ()
@@ -123,3 +134,11 @@ deleteAddressState ::
 deleteAddressState address = do
   theMap <- getAddressStateTxDBMap
   putAddressStateTxDBMap (M.insert address ASDeleted theMap)
+
+deleteAddressStates ::
+  (HasMemAddressStateDB m, HasStateDB m) =>
+  [Address] ->
+  m ()
+deleteAddressStates addresses = do
+  theMap <- getAddressStateTxDBMap
+  putAddressStateTxDBMap . M.difference theMap . M.fromList $ (,ASDeleted) <$> addresses

--- a/strato/core/blockapps-mpdbs/src/Blockchain/DB/RawStorageDB.hs
+++ b/strato/core/blockapps-mpdbs/src/Blockchain/DB/RawStorageDB.hs
@@ -14,6 +14,7 @@ module Blockchain.DB.RawStorageDB
     FullRawStorage,
     genericLookupRawStorageDB,
     genericInsertRawStorageDB,
+    genericInsertManyRawStorageDB,
     genericDeleteRawStorageDB,
     genericLookupWithDefaultRawStorageDB,
     putRawStorageKeyVal',
@@ -147,6 +148,14 @@ genericInsertRawStorageDB ::
 genericInsertRawStorageDB key val = do
   theMap <- getMemRawStorageTxDB
   putMemRawStorageTxMap $ M.insert key val theMap
+
+genericInsertManyRawStorageDB ::
+  HasMemRawStorageDB m =>
+  M.Map RawStorageKey RawStorageValue ->
+  m ()
+genericInsertManyRawStorageDB localMap = do
+  txMap <- getMemRawStorageTxDB
+  putMemRawStorageTxMap $ localMap `M.union` txMap
 
 genericDeleteRawStorageDB ::
   HasMemRawStorageDB m =>


### PR DESCRIPTION
### With `develop`
```sh
dustinnorwood@Mac strato % solid-vm-cli test mercata/contracts/tests/CDP/CDPEngine.test.sol
✅ Unit test 'cdp engine allows safe withdrawal with debt' succeeded
✅ Unit test 'cdp engine calculates collateralization ratio' succeeded
✅ Unit test 'cdp engine can configure collateral asset' succeeded
✅ Unit test 'cdp engine can deposit collateral' succeeded
✅ Unit test 'cdp engine can deposit multiple times' succeeded
✅ Unit test 'cdp engine can liquidate unhealthy position' succeeded
✅ Unit test 'cdp engine can mint max usdst' succeeded
✅ Unit test 'cdp engine can mint usdst' succeeded
✅ Unit test 'cdp engine can pause asset' succeeded
✅ Unit test 'cdp engine can pause globally' succeeded
✅ Unit test 'cdp engine can repay all debt' succeeded
✅ Unit test 'cdp engine can repay debt' succeeded
✅ Unit test 'cdp engine can seize all collateral in severe liquidation' succeeded
✅ Unit test 'cdp engine can withdraw collateral without debt' succeeded
✅ Unit test 'cdp engine can withdraw max without debt' succeeded
✅ Unit test 'cdp engine complete lifecycle deposit borrow repay max' succeeded
✅ Unit test 'cdp engine creates successfully' succeeded
✅ Unit test 'cdp engine enforces debt floor' succeeded
✅ Unit test 'cdp engine has correct constants' succeeded
✅ Unit test 'cdp engine prevents liquidation of healthy position' succeeded
✅ Unit test 'cdp engine prevents unsafe withdrawal' succeeded
✅ Unit test 'cdp engine returns max cr when no debt' succeeded
✅ Unit test 'cdp engine safety buffer vulnerability test' succeeded
❌ Unit test 'cdp engine supports complete lifecycle' failed: Left solidity require failed: SString "Step 11: User should have recovered their initial collateral or more"
❌ Unit test 'cdp engine vault state divergence bug' failed: Left solidity require failed: SString "BUG: Engine vault collateral changed after failed withdrawal!"
✅ Unit test 'cdp engine withdraw max with debt respects liquidation ratio' succeeded
```

### With `solidvm-reverts`
```sh
dustinnorwood@Mac strato % solid-vm-cli test mercata/contracts/tests/CDP/CDPEngine.test.sol
✅ Unit test 'cdp engine allows safe withdrawal with debt' succeeded
✅ Unit test 'cdp engine calculates collateralization ratio' succeeded
✅ Unit test 'cdp engine can configure collateral asset' succeeded
✅ Unit test 'cdp engine can deposit collateral' succeeded
✅ Unit test 'cdp engine can deposit multiple times' succeeded
✅ Unit test 'cdp engine can liquidate unhealthy position' succeeded
✅ Unit test 'cdp engine can mint max usdst' succeeded
✅ Unit test 'cdp engine can mint usdst' succeeded
✅ Unit test 'cdp engine can pause asset' succeeded
✅ Unit test 'cdp engine can pause globally' succeeded
✅ Unit test 'cdp engine can repay all debt' succeeded
✅ Unit test 'cdp engine can repay debt' succeeded
✅ Unit test 'cdp engine can seize all collateral in severe liquidation' succeeded
✅ Unit test 'cdp engine can withdraw collateral without debt' succeeded
✅ Unit test 'cdp engine can withdraw max without debt' succeeded
✅ Unit test 'cdp engine complete lifecycle deposit borrow repay max' succeeded
✅ Unit test 'cdp engine creates successfully' succeeded
✅ Unit test 'cdp engine enforces debt floor' succeeded
✅ Unit test 'cdp engine has correct constants' succeeded
✅ Unit test 'cdp engine prevents liquidation of healthy position' succeeded
✅ Unit test 'cdp engine prevents unsafe withdrawal' succeeded
✅ Unit test 'cdp engine returns max cr when no debt' succeeded
✅ Unit test 'cdp engine safety buffer vulnerability test' succeeded
✅ Unit test 'cdp engine supports complete lifecycle' succeeded
✅ Unit test 'cdp engine vault state divergence bug' succeeded
✅ Unit test 'cdp engine withdraw max with debt respects liquidation ratio' succeeded
```