### PR TITLE
Fixes and upgrades in RewardsChef

### DIFF
--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -173,7 +173,7 @@ contract record RewardsChef is Ownable {
     // precision. We multiply when storing rewards per token (accPerToken calculation) and
     // divide when calculating individual user rewards to get the actual reward amount.
     // This multiplier also propagates to rewardDebt calculations to maintain consistency.
-    uint256 public PRECISION_MULTIPLIER = 1e12;
+    uint256 public PRECISION_MULTIPLIER = 1e18;
 
     // ═════════════════════════════════════════════════════════════════════════
     // STATE VARIABLES

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "../../abstract/ERC20/ERC20.sol";
 import "../Tokens/Token.sol";
+import "../../interfaces/ITimeProvider.sol";
 
 // ═════════════════════════════════════════════════════════════════════════
 // DATA STRUCTURES
@@ -191,6 +192,9 @@ contract record RewardsChef is Ownable {
     // Minimum time in the future for new bonus periods
     uint256 public minFutureTime;
 
+    // Time provider for getting current timestamp
+    ITimeProvider public timeProvider;
+
     // Info of each of the stake pool.
     PoolInfo[] public pools;
 
@@ -203,12 +207,26 @@ contract record RewardsChef is Ownable {
 
     constructor(address initialOwner,
 		address _rewardToken,
-		uint256 _cataPerSecond
+		uint256 _cataPerSecond,
+		address _timeProvider
 	        ) Ownable(initialOwner) {
         rewardToken = Token(_rewardToken);
         cataPerSecond = _cataPerSecond;
+        timeProvider = ITimeProvider(_timeProvider);
         pools = [];
         minFutureTime = 3600; // Initialize with 1 hour
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // TIMESTAMP UTILITIES
+    // ═════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @dev Returns the current timestamp using the injected time provider
+     * @return Current timestamp in seconds since Unix epoch
+     */
+    function currentTimestamp() internal view returns (uint256) {
+        return timeProvider.currentTimestamp();
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -238,10 +256,10 @@ contract record RewardsChef is Ownable {
         PoolInfo memory poolInfo;
         poolInfo.lpToken = _lpToken;
         poolInfo.allocPoint = _allocPoint;
-        poolInfo.lastRewardTimestamp = block.timestamp;
+        poolInfo.lastRewardTimestamp = currentTimestamp();
         poolInfo.accPerToken = 0;
         poolInfo.bonusPeriods = [];
-        poolInfo.bonusPeriods.push(BonusPeriod(block.timestamp, _bonusMultiplier));
+        poolInfo.bonusPeriods.push(BonusPeriod(currentTimestamp(), _bonusMultiplier));
 
         pools.push(poolInfo);
 
@@ -271,7 +289,7 @@ contract record RewardsChef is Ownable {
     ) public onlyOwner {
         require(_pid < pools.length, "Pool does not exist");
         require(_bonusMultiplier >= 1, "Bonus multiplier must be at least 1");
-        require(_startTimestamp >= block.timestamp + minFutureTime, "Start timestamp must be far enough in the future");
+        require(_startTimestamp >= currentTimestamp() + minFutureTime, "Start timestamp must be far enough in the future");
 
         // Ensure new period starts after the last period
         uint256 periodsLength = pools[_pid].bonusPeriods.length;
@@ -327,24 +345,24 @@ contract record RewardsChef is Ownable {
         require(_pid < pools.length, "Pool does not exist");
 
         PoolInfo storage pool = pools[_pid];
-        if (block.timestamp <= pool.lastRewardTimestamp) {
+        if (currentTimestamp() <= pool.lastRewardTimestamp) {
             return;
         }
 
         uint256 lpSupply = ERC20(pool.lpToken).balanceOf(address(this));
         if (lpSupply == 0) {
-            pool.lastRewardTimestamp = block.timestamp;
+            pool.lastRewardTimestamp = currentTimestamp();
             return;
         }
 
-        uint256 multiplier = getMultiplier(_pid, pool.lastRewardTimestamp, block.timestamp);
+        uint256 multiplier = getMultiplier(_pid, pool.lastRewardTimestamp, currentTimestamp());
         // totalAllocPoint is always greater than zero OR there are no pools yet added
         uint256 cataReward = (multiplier * cataPerSecond * pool.allocPoint) / totalAllocPoint;
 
         rewardToken.mint(address(this), cataReward);
 
         pool.accPerToken += (cataReward * PRECISION_MULTIPLIER) / lpSupply;
-        pool.lastRewardTimestamp = block.timestamp;
+        pool.lastRewardTimestamp = currentTimestamp();
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -424,8 +442,8 @@ contract record RewardsChef is Ownable {
         uint256 accPerToken = pool.accPerToken;
         uint256 lpSupply = ERC20(pool.lpToken).balanceOf(address(this));
 
-        if (block.timestamp > pool.lastRewardTimestamp && lpSupply != 0) {
-            uint256 multiplier = getMultiplier(_pid, pool.lastRewardTimestamp, block.timestamp);
+        if (currentTimestamp() > pool.lastRewardTimestamp && lpSupply != 0) {
+            uint256 multiplier = getMultiplier(_pid, pool.lastRewardTimestamp, currentTimestamp());
             uint256 cataReward = (multiplier * cataPerSecond * pool.allocPoint) / totalAllocPoint;
             accPerToken += (cataReward * PRECISION_MULTIPLIER) / lpSupply;
         }

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -371,7 +371,14 @@ contract record RewardsChef is Ownable {
             user.amount += _amount;
         }
 
-        user.rewardDebt = (user.amount * pool.accPerToken) / PRECISION_MULTIPLIER;
+        // ═════════════════════════════════════════════════════════════════════
+	// WARNING!!
+        // ═════════════════════════════════════════════════════════════════════
+	//
+	// This has to be set in variable and only then applied to
+	// user.rewardDebt, otherwise the solidvm throws!
+	uint256 rewardDebt = (user.amount * pool.accPerToken) / PRECISION_MULTIPLIER;
+        user.rewardDebt = rewardDebt;
 
         emit Deposit(msg.sender, _pid, _amount);
     }

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -173,7 +173,7 @@ contract record RewardsChef is Ownable {
     // precision. We multiply when storing rewards per token (accPerToken calculation) and
     // divide when calculating individual user rewards to get the actual reward amount.
     // This multiplier also propagates to rewardDebt calculations to maintain consistency.
-    uint256 private PRECISION_MULTIPLIER = 1e12;
+    uint256 public PRECISION_MULTIPLIER = 1e12;
 
     // ═════════════════════════════════════════════════════════════════════════
     // STATE VARIABLES

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -403,7 +403,14 @@ contract record RewardsChef is Ownable {
             ERC20(pool.lpToken).transfer(msg.sender, _amount);
         }
 
-        user.rewardDebt = (user.amount * pool.accPerToken) / PRECISION_MULTIPLIER;
+        // ═════════════════════════════════════════════════════════════════════
+	// WARNING!!
+        // ═════════════════════════════════════════════════════════════════════
+	//
+	// This has to be set in variable and only then applied to
+	// user.rewardDebt, otherwise the solidvm throws!
+	uint256 rewardDebt = (user.amount * pool.accPerToken) / PRECISION_MULTIPLIER;
+        user.rewardDebt = rewardDebt;
 
         emit Withdraw(msg.sender, _pid, _amount);
     }

--- a/mercata/contracts/concrete/Time/BlockTimeProvider.sol
+++ b/mercata/contracts/concrete/Time/BlockTimeProvider.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../interfaces/ITimeProvider.sol";
+
+/**
+ * @title BlockTimeProvider
+ * @dev Production implementation of ITimeProvider that returns the actual
+ * block.timestamp. This is used in production deployments.
+ */
+contract BlockTimeProvider is ITimeProvider {
+    /**
+     * @dev Returns the current block timestamp
+     * @return Current block timestamp in seconds since Unix epoch
+     */
+    function currentTimestamp() external view override returns (uint256) {
+        return block.timestamp;
+    }
+}

--- a/mercata/contracts/interfaces/ITimeProvider.sol
+++ b/mercata/contracts/interfaces/ITimeProvider.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title ITimeProvider
+ * @dev Interface for providing current timestamp functionality.
+ * This allows for dependency injection of time providers, enabling
+ * both production use (with actual block.timestamp) and testing
+ * scenarios (with controllable mock time).
+ */
+interface ITimeProvider {
+    /**
+     * @dev Returns the current timestamp
+     * @return Current timestamp in seconds since Unix epoch
+     */
+    function currentTimestamp() external view returns (uint256);
+}

--- a/mercata/contracts/tests/MockTimeProvider.sol
+++ b/mercata/contracts/tests/MockTimeProvider.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/ITimeProvider.sol";
+
+/**
+ * @title MockTimeProvider
+ * @dev Test implementation of ITimeProvider that allows manual control
+ * of time progression. Used in unit tests to simulate the passage of time
+ * without waiting for actual time to pass.
+ */
+contract MockTimeProvider is ITimeProvider {
+    uint256 private mockTime;
+
+    /**
+     * @dev Constructor initializes mock time to current block timestamp
+     */
+    constructor() {
+        mockTime = block.timestamp;
+    }
+
+    /**
+     * @dev Returns the mock timestamp
+     * @return Current mock timestamp in seconds since Unix epoch
+     */
+    function currentTimestamp() external view override returns (uint256) {
+        return mockTime;
+    }
+
+    /**
+     * @dev Sets the mock time to a specific timestamp
+     * @param _time The timestamp to set
+     */
+    function setTime(uint256 _time) external {
+        mockTime = _time;
+    }
+
+    /**
+     * @dev Advances the mock time by a specified number of seconds
+     * @param _seconds Number of seconds to advance
+     */
+    function advanceTime(uint256 _seconds) external {
+        mockTime += _seconds;
+    }
+
+    /**
+     * @dev Returns the current mock time (convenience function for tests)
+     * @return Current mock timestamp
+     */
+    function getCurrentTime() external view returns (uint256) {
+        return mockTime;
+    }
+}

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -1,5 +1,6 @@
 import "../../concrete/BaseCodeCollection.sol";
 import "../Util.sol";
+import "../MockTimeProvider.sol";
 
 contract Describe_TokenPausable {
     using TestUtils for User;
@@ -15,6 +16,7 @@ contract Describe_TokenPausable {
     uint256 initLpTokensPerUser = 1000;
 
     RewardsChef chef;
+    MockTimeProvider mockTime;
     uint256 cataPerSecond;
     uint256 currentTimestamp;
 
@@ -56,7 +58,10 @@ contract Describe_TokenPausable {
 	cataPerSecond = 1000;
         currentTimestamp = block.timestamp;
 
-        chef = new RewardsChef(address(this), tokenAddress, cataPerSecond);
+        // Create mock time provider
+        mockTime = new MockTimeProvider();
+
+        chef = new RewardsChef(address(this), tokenAddress, cataPerSecond, address(mockTime));
     }
 
     // ═════════════════════════════════════════════════════════════════════════

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -131,5 +131,27 @@ contract Describe_TokenPausable {
 		"User1 should not own LP token");
     }
 
+    function it_should_allow_user_to_withdraw_lp_token() {
+        // given
+        uint256 allocationPoints = 100;
+        uint256 multiplier = 1;
+        uint256 poolId = 0;
+        uint256 amount = 10;
 
+        // given there is a pool
+        chef.addPool(allocationPoints, address(lpToken1), multiplier);
+
+        // given user has deposited lp tokens
+        TestUtils.callAs(user1, address(lpToken1), "approve(address, uint256)", address(chef), amount);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", poolId, amount);
+
+        // when
+        TestUtils.callAs(user1, address(chef), "withdraw(uint256, uint256)", poolId, amount);
+
+        // then
+        require(ERC20(lpToken1).balanceOf(address(chef)) == 0,
+		"Chef should not have the deposited LP tokens");
+        require(ERC20(lpToken1).balanceOf(address(user1)) == initLpTokensPerUser,
+		"User1 should have back his LP tokens");
+    }
 }

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -1,13 +1,9 @@
 import "../../concrete/BaseCodeCollection.sol";
-
-contract User {
-    function do(address a, string f, variadic args) public returns (variadic) {
-        variadic result = address(a).call(f, args);
-        return result;
-    }
-}
+import "../Util.sol";
 
 contract Describe_TokenPausable {
+    using TestUtils for User;
+
     constructor() {
     }
 
@@ -109,6 +105,30 @@ contract Describe_TokenPausable {
         PoolInfo pool1 = chef.pools()[poolId];
         require(pool1.allocPoint == updatedAllocationPoints, "Allocation points should be updated");
         require(chef.totalAllocPoint() == updatedAllocationPoints, "Total allocation points should be updated");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // USER INTERACTIONS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_allow_user_to_deposit_lp_tokens() {
+        // given
+        uint256 allocationPoints = 100;
+        uint256 multiplier = 1;
+        uint256 poolId = 0;
+        uint256 amount = 10;
+
+        chef.addPool(allocationPoints, address(lpToken1), multiplier);
+
+        // when
+        TestUtils.callAs(user1, address(lpToken1), "approve(address, uint256)", address(chef), amount);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", poolId, amount);
+
+        // then
+        require(ERC20(lpToken1).balanceOf(address(chef)) == amount,
+		"Chef should have received the deposited LP tokens");
+        require(ERC20(lpToken1).balanceOf(address(user1)) == (initLpTokensPerUser - amount),
+		"User1 should not own LP token");
     }
 
 

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -1,6 +1,7 @@
 import "../../concrete/BaseCodeCollection.sol";
 import "../Util.sol";
 import "../MockTimeProvider.sol";
+import "../../abstract/ERC20/access/Ownable.sol";
 
 contract Describe_TokenPausable {
     using TestUtils for User;
@@ -62,6 +63,9 @@ contract Describe_TokenPausable {
         mockTime = new MockTimeProvider();
 
         chef = new RewardsChef(address(this), tokenAddress, cataPerSecond, address(mockTime));
+
+        // Transfer ownership of the reward token to the chef so it can mint rewards
+        Ownable(tokenAddress).transferOwnership(address(chef));
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -159,4 +163,41 @@ contract Describe_TokenPausable {
         require(ERC20(lpToken1).balanceOf(address(user1)) == initLpTokensPerUser,
 		"User1 should have back his LP tokens");
     }
+
+
+    function it_should_update_accrued_rewards_for_pool() {
+        uint256 allocationPoints = 100;
+        uint256 multiplier = 1;
+        uint256 poolId = 0;
+        uint256 amount = 10;
+
+        // given there is a pool
+        chef.addPool(allocationPoints, address(lpToken1), multiplier);
+
+        // given user has deposited lp tokens
+        TestUtils.callAs(user1, address(lpToken1), "approve(address, uint256)", address(chef), amount);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", poolId, amount);
+
+	// given 10 seconds has passed
+	uint256 ten_seconds = 10;
+	mockTime.advanceTime(ten_seconds);
+
+        // when
+	chef.updatePool(poolId);
+
+        // then
+        PoolInfo pool1 = chef.pools()[poolId];
+        uint256 lp1Supply = ERC20(lpToken1).balanceOf(address(chef));
+        uint256 reward = ten_seconds * cataPerSecond;
+
+	// then reward was minted
+        require(ERC20(rewardsToken).balanceOf(address(chef)) == reward,
+		"Chef should have minted reward to itself");
+
+	// then accumulated reward per share is properly calculated
+        uint256 expectedAccPerToken =
+	    (reward * chef.PRECISION_MULTIPLIER()) / lp1Supply;
+        require(pool1.accPerToken == expectedAccPerToken, "accPerToken calculation mismatch");
+    }
+
 }

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -14,7 +14,7 @@ contract Describe_TokenPausable {
     Token lpToken1;
     User user1;
     User user2;
-    uint256 initLpTokensPerUser = 1000;
+    uint256 initLpTokensPerUser = 1000 * 1e18;
 
     RewardsChef chef;
     MockTimeProvider mockTime;
@@ -169,7 +169,7 @@ contract Describe_TokenPausable {
         uint256 allocationPoints = 100;
         uint256 multiplier = 1;
         uint256 poolId = 0;
-        uint256 amount = 10;
+        uint256 amount = 10 * 1e18;
 
         // given there is a pool
         chef.addPool(allocationPoints, address(lpToken1), multiplier);
@@ -197,6 +197,7 @@ contract Describe_TokenPausable {
 	// then accumulated reward per share is properly calculated
         uint256 expectedAccPerToken =
 	    (reward * chef.PRECISION_MULTIPLIER()) / lp1Supply;
+	require(expectedAccPerToken != 0, "expectedAccPerToken should not be zero");
         require(pool1.accPerToken == expectedAccPerToken, "accPerToken calculation mismatch");
     }
 

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -16,6 +16,7 @@ contract Describe_TokenPausable {
     Token lpToken1;
     User user1;
     User user2;
+    uint256 initLpTokensPerUser = 1000;
 
     RewardsChef chef;
     uint256 cataPerSecond;
@@ -52,9 +53,9 @@ contract Describe_TokenPausable {
         require(lpToken1Address != address(0), "LP Token address is 0");
         lpToken1 = Token(lpToken1Address);
 
-        // Mint 1000 LP tokens to each user
-        lpToken1.mint(address(user1), 1000);
-        lpToken1.mint(address(user2), 1000);
+        // Mint initLpTokensPerUser LP tokens to each user
+        lpToken1.mint(address(user1), initLpTokensPerUser);
+        lpToken1.mint(address(user2), initLpTokensPerUser);
 
 	cataPerSecond = 1000;
         currentTimestamp = block.timestamp;


### PR DESCRIPTION
* RewardsChef updated
* TimeProvider added (allowing time mocks in tests)
* Finally ability to test `updatePool`

```
% solid-vm-cli test mercata/contracts/tests/Rewards/RewardsChef.test.sol                                                                                     
✅ Unit test 'should allow adding new pool' succeeded
✅ Unit test 'should allow updating allocation points' succeeded
✅ Unit test 'should allow user to deposit lp tokens' succeeded
✅ Unit test 'should allow user to withdraw lp token' succeeded
✅ Unit test 'should start with no pools' succeeded
✅ Unit test 'should update accrued rewards for pool' succeeded
```