### PR TITLE
Add fastForward built-in function to SolidVM

### DIFF
--- a/mercata/contracts/tests/fastForward.test.sol
+++ b/mercata/contracts/tests/fastForward.test.sol
@@ -1,0 +1,19 @@
+contract Describe_FastForward {
+
+  function beforeAll() {
+  }
+
+  function beforeEach() {
+  }
+
+  function it_can_call_fastForward() {
+    log("Testing fastForward function");
+    uint256 before = block.timestamp;
+    fastForward(100);
+    uint256 after = block.timestamp;
+    log("Before timestamp", before);
+    log("After timestamp", after);
+    require(after == before + 100, "FastForward did not work");
+  }
+
+}

--- a/strato/VM/SolidVM/solid-vm-compiler/src/Blockchain/SolidVM/CodeCollectionDB.hs
+++ b/strato/VM/SolidVM/solid-vm-compiler/src/Blockchain/SolidVM/CodeCollectionDB.hs
@@ -124,9 +124,10 @@ compileSourceNoInheritance ::
     A.Selectable Address AddressState m
   ) =>
   Bool ->
+  Bool ->
   Map T.Text T.Text ->
   m (Either CompilationError CodeCollection)
-compileSourceNoInheritance typeCheck initCodeMap = runExceptT $ do
+compileSourceNoInheritance isRunningTests typeCheck initCodeMap = runExceptT $ do
   let getNamedSUnits :: T.Text -> T.Text -> Either CompilationError (Positioned UnresolvedFileUnitsF)
       getNamedSUnits fileName src = do
         sourceUnits <- parseSource fileName src
@@ -155,7 +156,7 @@ compileSourceNoInheritance typeCheck initCodeMap = runExceptT $ do
         Import _ i -> pure . Just $ def & ufuImports .~ [i]
         _ -> pure Nothing
   ufuMap <- except . fmap M.fromList . traverse (\(n, s) -> (n,) <$> getNamedSUnits n s) $ M.toList initCodeMap
-  theCC <- withExceptT (\(x,t) -> IEx $ t <$ x) $ resolveImports (codeCollectionFromHashNoCache False typeCheck) (\f -> either (const Nothing) Just . getNamedSUnits f) ufuMap
+  theCC <- withExceptT (\(x,t) -> IEx $ t <$ x) $ resolveImports (codeCollectionFromHashNoCache isRunningTests False typeCheck) (\f -> either (const Nothing) Just . getNamedSUnits f) ufuMap
   pure $ force theCC
 
 --- Don't typecheck in Slipstream!!!
@@ -164,10 +165,11 @@ compileSource ::
     A.Selectable Address AddressState m
   ) =>
   Bool ->
+  Bool ->
   Map T.Text T.Text ->
   m (Either CompilationError CodeCollection)
-compileSource typeCheck mTT = do
-  eCC <- compileSource' typeCheck mTT
+compileSource isRunningTests typeCheck mTT = do
+  eCC <- compileSource' isRunningTests typeCheck mTT
   pure $ first SVMEx . applyInheritanceFunctions =<< eCC
 
 compileSource' ::
@@ -175,18 +177,19 @@ compileSource' ::
     A.Selectable Address AddressState m
   ) =>
   Bool ->
+  Bool ->
   Map T.Text T.Text ->
   m (Either CompilationError CodeCollection)
-compileSource' typeCheck mTT = do
+compileSource' isRunningTests typeCheck mTT = do
   let applyInheritanceE = first SVMEx . applyInheritanceNoFunctions
-  eCC <- compileSourceNoInheritance typeCheck mTT
+  eCC <- compileSourceNoInheritance isRunningTests typeCheck mTT
   pure $ case applyInheritanceE =<< eCC of
     Right cc -> O.detector <$> if typeCheck
           then typeCheckDetector cc
           else Right cc
     Left x -> Left x
   where
-    typeCheckDetector ecc = case TypeChecker.detector ecc <> ConstantFunctions.detector ecc <> MultipleDeclarations.detector ecc of
+    typeCheckDetector ecc = case TypeChecker.detector' isRunningTests ecc <> ConstantFunctions.detector ecc <> MultipleDeclarations.detector ecc of
       [] -> Right ecc
       xs -> Left $ TCEx xs
 
@@ -195,13 +198,16 @@ compileSourceWithAnnotations ::
     A.Selectable Address AddressState m
   ) =>
   Bool ->
+  Bool ->
   Map T.Text T.Text ->
   m (Either [SourceAnnotation T.Text] CodeCollection)
-compileSourceWithAnnotations typeCheck = withAnnotations (compileSource typeCheck)
+compileSourceWithAnnotations isRunningTests typeCheck =
+  withAnnotations (compileSource isRunningTests typeCheck)
 
 compileSourceWithAnnotationsWithoutImports ::
-  Bool -> Map T.Text T.Text -> Either [SourceAnnotation T.Text] CodeCollection
-compileSourceWithAnnotationsWithoutImports typeCheck = runIdentity . runMemCompilerT . withAnnotations (compileSource typeCheck)
+  Bool -> Bool -> Map T.Text T.Text -> Either [SourceAnnotation T.Text] CodeCollection
+compileSourceWithAnnotationsWithoutImports isRunningTests typeCheck =
+  runIdentity . runMemCompilerT . withAnnotations (compileSource isRunningTests typeCheck)
 
 codeCollectionFromSource ::
   ( MonadIO m,
@@ -210,9 +216,10 @@ codeCollectionFromSource ::
     -- , HasCodeCollectionDB m
   ) =>
   Bool ->
+  Bool ->
   B.ByteString ->
   m (Keccak256, CodeCollection)
-codeCollectionFromSource typeCheck initCode = do
+codeCollectionFromSource isRunningTests typeCheck initCode = do
   let initList = case Aeson.decode $ BL.fromStrict initCode of
         Just l -> l
         Nothing -> case Aeson.decode $ BL.fromStrict initCode of
@@ -232,7 +239,7 @@ codeCollectionFromSource typeCheck initCode = do
     (_, Nothing) -> do
       recordCacheEvent StorageWrite
       hsh' <- addCode canonicalInitCode
-      ecc <- compileSource typeCheck initMap
+      ecc <- compileSource isRunningTests typeCheck initMap
       let cc = case ecc of
             Right a -> a
             Left (PEx p) -> parseError "codeCollectionFromSource" p
@@ -249,9 +256,10 @@ codeCollectionFromHash ::
     -- , HasCodeCollectionDB m
   ) =>
   Bool ->
+  Bool ->
   Keccak256 ->
   m CodeCollection
-codeCollectionFromHash typeCheck hsh = do
+codeCollectionFromHash isRunningTests typeCheck hsh = do
   codeCache <- liftIO $ readIORef unsafeCodeCacheLRUIORef
   case LRU.lookup hsh codeCache of
     (newCache, (Just cc)) -> do
@@ -260,7 +268,7 @@ codeCollectionFromHash typeCheck hsh = do
       return cc
     (_, Nothing) -> do
       recordCacheEvent CacheMiss
-      cc <- codeCollectionFromHashNoCache True typeCheck hsh
+      cc <- codeCollectionFromHashNoCache isRunningTests True typeCheck hsh
       liftIO $ modifyIORef' unsafeCodeCacheLRUIORef (LRU.insert hsh cc)
       return cc
 
@@ -270,16 +278,17 @@ codeCollectionFromHashNoCache ::
   ) =>
   Bool ->
   Bool ->
+  Bool ->
   Keccak256 ->
   m CodeCollection
-codeCollectionFromHashNoCache mergeFuncs typeCheck hsh =
+codeCollectionFromHashNoCache isRunningTests mergeFuncs typeCheck hsh =
   getCode hsh >>= \case
     Nothing -> internalError "unknown code hash" hsh
     Just initCode -> do
       let initMap = case Aeson.decode $ BL.fromStrict initCode of
             Just l -> M.fromList l
             Nothing -> M.singleton T.empty (decodeUtf8 initCode)
-      ecc <- (if mergeFuncs then compileSource else compileSource') typeCheck initMap
+      ecc <- (if mergeFuncs then compileSource else compileSource') isRunningTests typeCheck initMap
       case ecc of
         Right a -> pure a
         Left (PEx p) -> parseError "codeCollectionFromHash" p

--- a/strato/VM/SolidVM/solid-vm-fuzzer/exec_src/Main.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/exec_src/Main.hs
@@ -144,7 +144,7 @@ main = do
               . traverse (uncurry parseSourceWithAnnotations)
               . unSourceMap
         compile = runMemCompilerT
-                . compileSourceWithAnnotations True
+                . compileSourceWithAnnotations True True
                 . M.fromList
                 . unSourceMap
         analyze src = compile src >>= \eCC -> pure $ runDetectors parse (const eCC) id src

--- a/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
@@ -19,7 +19,7 @@ import Blockchain.Data.BlockHeader
 import Blockchain.MemVMContext
 import Blockchain.SolidVM.Simple
 import Blockchain.Strato.Model.Address
-import Blockchain.VMContext (VMBase)
+import Blockchain.VMContext (VMBase, runningTests)
 import Control.Lens
 import Control.Monad.Catch (MonadCatch)
 import qualified Control.Monad.Change.Alter as A
@@ -80,7 +80,8 @@ runFuzzer dSettings compile src = compile src >>= \case
   Left errs -> pure $ FuzzerFailure Nothing . fmap ("Compilation error: ",) <$> errs
   Right cc -> do
     let args = FuzzerArgs src "" [] "" [] Nothing
-    runNoLoggingT . evalMemContextM dSettings . flip runReaderT args $
+    runNoLoggingT . evalMemContextM dSettings . flip runReaderT args $ do
+      lift . modify' $ runningTests .~ True
       fmap concat . for (M.toList $ _contracts cc) $ \(cName, c) ->
         if not (describePrefix `T.isPrefixOf` labelToText cName)
           then pure []

--- a/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/SourceTools.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/SourceTools.hs
@@ -71,7 +71,7 @@ defaultSourceTools dSettings =
           . traverse (uncurry parseSourceWithAnnotations)
           . unSourceMap
       compile =
-        compileSourceWithAnnotationsWithoutImports True
+        compileSourceWithAnnotationsWithoutImports True True
           . M.fromList
           . unSourceMap
       analyze = runDetectors parse compile id

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -41,7 +41,8 @@ emptyAnnotation :: SourceAnnotation Text
 emptyAnnotation = (SourceAnnotation (initialPosition "") (initialPosition "") "")
 
 data R = R
-  { codeCollection :: Annotated CodeCollectionF,
+  { isRunningTests :: Bool,
+    codeCollection :: Annotated CodeCollectionF,
     contract :: Annotated ContractF,
     function :: Maybe (Annotated FuncF),
     functName :: Maybe String,
@@ -956,12 +957,12 @@ detector :: CompilerDetector
 detector = detector' False
 
 detector' :: Bool -> CompilerDetector
-detector' isRunningTests cc =
+detector' test cc =
   let cc'@CodeCollection {..} = (\sa -> sa {_sourceAnnotationAnnotation = ""}) <$> cc
    in fromMaybe []
         . fmap (\(a :| as) -> getTypeErrors $ reduceType' emptyAnnotation (a : as))
         . NE.nonEmpty
-        $ contractHelper isRunningTests cc'
+        $ contractHelper test cc'
           <$> M.elems _contracts
 
 contractHelper ::
@@ -969,37 +970,39 @@ contractHelper ::
   Annotated CodeCollectionF ->
   Annotated ContractF ->
   Type'
-contractHelper isRunningTests cc c =
+contractHelper test cc c =
   let constr = maybe M.empty (M.singleton "constructor") $ _constructor c
       funcsAndConstr = constr <> _functions c 
-      varTypes' = reduceType' (_contractContext c) $ varDeclHelper cc c <$> M.elems (_storageDefs c)
-      constTypes' = reduceType' (_contractContext c) $ constDeclHelper cc c <$> M.elems (_constants c)
-      constTypes'' = reduceType' (_contractContext c) $ constDeclHelper cc c <$> M.elems (_flConstants cc)
-      funcTypes' = reduceType' (_contractContext c) $ uncurry (functionHelper isRunningTests cc c) <$> M.toList funcsAndConstr
-      modifierTypes' = reduceType' (_contractContext c) $ modifierHelper cc c <$> M.elems (_modifiers c)
+      varTypes' = reduceType' (_contractContext c) $ varDeclHelper test cc c <$> M.elems (_storageDefs c)
+      constTypes' = reduceType' (_contractContext c) $ constDeclHelper test cc c <$> M.elems (_constants c)
+      constTypes'' = reduceType' (_contractContext c) $ constDeclHelper test cc c <$> M.elems (_flConstants cc)
+      funcTypes' = reduceType' (_contractContext c) $ uncurry (functionHelper test cc c) <$> M.toList funcsAndConstr
+      modifierTypes' = reduceType' (_contractContext c) $ modifierHelper test cc c <$> M.elems (_modifiers c)
   in reduceType' (_contractContext c) [varTypes', constTypes', funcTypes', constTypes'', modifierTypes']
 
 varDeclHelper ::
+  Bool ->
   Annotated CodeCollectionF ->
   Annotated ContractF ->
   Annotated VariableDeclF ->
   Type'
-varDeclHelper cc c VariableDecl {..} =
+varDeclHelper test cc c VariableDecl {..} =
   let ty = Static _varType _varContext
    in case _varInitialVal of
         Nothing -> ty
         Just e ->
-          let r = R cc c Nothing (Just "Nothing") Nothing []
+          let r = R test cc c Nothing (Just "Nothing") Nothing []
            in runReader (evalStateT (ty ~> tcExpr e) ((Nothing, M.empty) :| [])) r
 
 constDeclHelper ::
+  Bool ->
   Annotated CodeCollectionF ->
   Annotated ContractF ->
   Annotated ConstantDeclF ->
   Type'
-constDeclHelper cc c ConstantDecl {..} =
+constDeclHelper test cc c ConstantDecl {..} =
   let ty = Static _constType _constContext
-      r = R cc c Nothing (Just "Nothing") Nothing []
+      r = R test cc c Nothing (Just "Nothing") Nothing []
    in runReader (evalStateT (ty ~> tcExpr _constInitialVal) ((Nothing, M.empty) :| [])) r
 
 checkOverrides ::
@@ -1094,13 +1097,14 @@ checkOverrides cc c funcName f =
                             <$ ctx
 
 modifierHelper ::
+  Bool ->
   Annotated CodeCollectionF ->
   Annotated ContractF ->
   Annotated ModifierF ->
   Type'
-modifierHelper cc c m@SolidVM.Model.CodeCollection.Modifier {..} = 
+modifierHelper test cc c m@SolidVM.Model.CodeCollection.Modifier {..} =
   let r =
-        R cc c Nothing Nothing (Just m) $
+        R test cc c Nothing Nothing (Just m) $
           map
             (fmap $ isJust . _varInitialVal)
             (filter (_isImmutable . snd) . M.toList $ _storageDefs c)
@@ -1124,7 +1128,7 @@ functionHelper ::
   SolidString ->
   Annotated FuncF ->
   Type'
-functionHelper _isRunningTests cc c funcName f@Func {..} =
+functionHelper test cc c funcName f@Func {..} =
   let check = checkOverrides cc c funcName f
    in unlessBottom check $ \t' -> case f ^. funcContents of
         Nothing -> t'
@@ -1133,7 +1137,7 @@ functionHelper _isRunningTests cc c funcName f@Func {..} =
             then case (_funcArgs, _funcVals, _funcStateMutability, _funcVisibility) of
               ([], [], Just Payable, Just External) ->
                 let r =
-                      R cc c (Just f) (Just funcName) Nothing $
+                      R test cc c (Just f) (Just funcName) Nothing $
                         map
                           (fmap $ isJust . _varInitialVal)
                           (filter (_isImmutable . snd) . M.toList $ _storageDefs c)
@@ -1176,7 +1180,7 @@ functionHelper _isRunningTests cc c funcName f@Func {..} =
                 then case (_funcArgs, _funcVals, _funcVisibility) of
                   ([], [], Just External) ->
                     let r =
-                          R cc c (Just f) (Just funcName) Nothing $
+                          R test cc c (Just f) (Just funcName) Nothing $
                             map
                               (fmap $ isJust . _varInitialVal)
                               (filter (_isImmutable . snd) . M.toList $ _storageDefs c)
@@ -1216,7 +1220,7 @@ functionHelper _isRunningTests cc c funcName f@Func {..} =
                   _ -> bottom $ "Function `fallback` must be External, but has not been declared so " <$ _funcContext
             else
               let r =
-                    R cc c (Just f) (Just funcName) Nothing $
+                    R test cc c (Just f) (Just funcName) Nothing $
                       map
                         (fmap $ isJust . _varInitialVal)
                         (filter (_isImmutable . snd) . M.toList $ _storageDefs c)
@@ -1537,7 +1541,11 @@ getVarType' "ecrecover" ctx = pure $ Function (ecrecoverArgs ctx) (addressType' 
 getVarType' "parseCert" ctx = pure $ Function (parseCertArgs ctx) (certType' ctx) ctx [] [] False
 getVarType' "create" ctx = pure $ Function (createFuncArgs ctx) (accountType' ctx) ctx [] [] False
 getVarType' "create2" ctx = pure $ Function (saltCreateArgs ctx) (accountType' ctx) ctx [] [] False
-getVarType' "fastForward" ctx = pure $ Function (fastForwardArgs ctx) (Product [] ctx) ctx [] [] False
+getVarType' "fastForward" ctx = do
+  test <- asks isRunningTests
+  if test
+    then pure $ Function (fastForwardArgs ctx) (Product [] ctx) ctx [] [] False
+    else pure . bottom $ "fastForward can only be called while running tests" <$ ctx
 getVarType' "Util" ctx = pure $ Static (SVMType.UnknownLabel "Util" Nothing) ctx
 getVarType' "msg" ctx = pure $ Static (SVMType.UnknownLabel "msg" Nothing) ctx
 getVarType' "tx" ctx = pure $ Static (SVMType.UnknownLabel "tx" Nothing) ctx

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -6,7 +6,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module SolidVM.Solidity.StaticAnalysis.Typechecker
-  ( detector,
+  ( detector
+  , detector'
   )
 where
 
@@ -952,25 +953,29 @@ const' _ (Bottom e) = Bottom e
 const' t _ = t
 
 detector :: CompilerDetector
-detector cc =
+detector = detector' False
+
+detector' :: Bool -> CompilerDetector
+detector' isRunningTests cc =
   let cc'@CodeCollection {..} = (\sa -> sa {_sourceAnnotationAnnotation = ""}) <$> cc
    in fromMaybe []
         . fmap (\(a :| as) -> getTypeErrors $ reduceType' emptyAnnotation (a : as))
         . NE.nonEmpty
-        $ contractHelper cc'
+        $ contractHelper isRunningTests cc'
           <$> M.elems _contracts
 
 contractHelper ::
+  Bool ->
   Annotated CodeCollectionF ->
   Annotated ContractF ->
   Type'
-contractHelper cc c =
+contractHelper isRunningTests cc c =
   let constr = maybe M.empty (M.singleton "constructor") $ _constructor c
       funcsAndConstr = constr <> _functions c 
       varTypes' = reduceType' (_contractContext c) $ varDeclHelper cc c <$> M.elems (_storageDefs c)
       constTypes' = reduceType' (_contractContext c) $ constDeclHelper cc c <$> M.elems (_constants c)
       constTypes'' = reduceType' (_contractContext c) $ constDeclHelper cc c <$> M.elems (_flConstants cc)
-      funcTypes' = reduceType' (_contractContext c) $ uncurry (functionHelper cc c) <$> M.toList funcsAndConstr
+      funcTypes' = reduceType' (_contractContext c) $ uncurry (functionHelper isRunningTests cc c) <$> M.toList funcsAndConstr
       modifierTypes' = reduceType' (_contractContext c) $ modifierHelper cc c <$> M.elems (_modifiers c)
   in reduceType' (_contractContext c) [varTypes', constTypes', funcTypes', constTypes'', modifierTypes']
 
@@ -1113,12 +1118,13 @@ modifierHelper cc c m@SolidVM.Model.CodeCollection.Modifier {..} =
     in runReader (statementsHelperM (M.fromList args) contents') r
 
 functionHelper ::
+  Bool ->
   Annotated CodeCollectionF ->
   Annotated ContractF ->
   SolidString ->
   Annotated FuncF ->
   Type'
-functionHelper cc c funcName f@Func {..} =
+functionHelper _isRunningTests cc c funcName f@Func {..} =
   let check = checkOverrides cc c funcName f
    in unlessBottom check $ \t' -> case f ^. funcContents of
         Nothing -> t'

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1479,6 +1479,9 @@ createFuncArgs x = Product [stringType' x, stringType' x, Static SVMType.Variadi
 saltCreateArgs :: SourceAnnotation Text -> Type'
 saltCreateArgs x = Product [stringType' x, stringType' x, stringType' x, Static SVMType.Variadic x] x
 
+fastForwardArgs :: SourceAnnotation Text -> Type'
+fastForwardArgs x = intType' x
+
 getVarType' :: String -> SourceAnnotation Text -> SSS Type'
 getVarType' "this" ctx = pure $ Static (SVMType.Account False) ctx
 getVarType' s@('u' : 'i' : 'n' : 't' : n) ctx = case n of
@@ -1528,6 +1531,7 @@ getVarType' "ecrecover" ctx = pure $ Function (ecrecoverArgs ctx) (addressType' 
 getVarType' "parseCert" ctx = pure $ Function (parseCertArgs ctx) (certType' ctx) ctx [] [] False
 getVarType' "create" ctx = pure $ Function (createFuncArgs ctx) (accountType' ctx) ctx [] [] False
 getVarType' "create2" ctx = pure $ Function (saltCreateArgs ctx) (accountType' ctx) ctx [] [] False
+getVarType' "fastForward" ctx = pure $ Function (fastForwardArgs ctx) (Product [] ctx) ctx [] [] False
 getVarType' "Util" ctx = pure $ Static (SVMType.UnknownLabel "Util" Nothing) ctx
 getVarType' "msg" ctx = pure $ Static (SVMType.UnknownLabel "msg" Nothing) ctx
 getVarType' "tx" ctx = pure $ Static (SVMType.UnknownLabel "tx" Nothing) ctx

--- a/strato/VM/SolidVM/solid-vm/bench/CodeBench.hs
+++ b/strato/VM/SolidVM/solid-vm/bench/CodeBench.hs
@@ -47,7 +47,7 @@ wingsContract = BC.unpack $(embedFile "bench/wings.sol")
 wingsCC :: CodeCollection
 wingsCC = do
   let srcMap = M.singleton "Wings.sol" $ T.pack wingsContract
-  let compiled = runIdentity . runMemCompilerT $ compileSource False srcMap 
+  let compiled = runIdentity . runMemCompilerT $ compileSource True False srcMap
   case compiled of
     Left err -> error $ show err
     Right cc -> cc
@@ -133,7 +133,7 @@ sipCCBench =
 readCC :: BC.ByteString -> CodeCollection
 readCC bStr = do
   let srcMap = M.singleton "Wings.sol" $ T.pack $ BC.unpack bStr
-  let compiled = runIdentity . runMemCompilerT $ compileSource False srcMap 
+  let compiled = runIdentity . runMemCompilerT $ compileSource True False srcMap
   case compiled of
     Left err -> error $ show err
     Right cc -> cc

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -222,7 +222,7 @@ create blockData sender' origin' proposer' availableGas newAddress code txHash' 
 
   fmap (either solidvmErrorResults id) . runSM (Just code) env' gasInfo' $ do
 
-    (hsh, cc) <- codeCollectionFromSource True $ DT.encodeUtf8 initCode
+    (hsh, cc) <- codeCollectionFromSource isRunningTests True $ DT.encodeUtf8 initCode
     (issuerAcct, _, issuerName) <- getCreator origin'
     let eArgExps = traverse (runParser parseArg initialParserState "" . T.unpack) argsStrings
         !argExps = either (parseError "create arguments") CC.OrderedArgs eArgExps
@@ -2473,7 +2473,8 @@ callBuiltin "create" args@(SString contractName' : SString contractSrc : argVals
   -- will still work but will have incorrect codeptrs.
   -- Thus, when the testnet wipes, this pragma can largely be removed because the old contracts on the
   -- testnet won't exist anymore and the stateroot mismatches will be fixed.
-  (hsh, cc) <- codeCollectionFromSource True $ BC.pack contractSrc
+  isRunningTests <- Env.runningTests <$> getEnv
+  (hsh, cc) <- codeCollectionFromSource isRunningTests True $ BC.pack contractSrc
   newAddress <- getNewAddress creator
   theEnv <- getEnv
   let origin = Env.origin theEnv
@@ -2494,7 +2495,8 @@ callBuiltin "create2" args@(salt : SString contractName' : SString contractSrc :
   -- will still work but will have incorrect codeptrs.
   -- Thus, when the testnet wipes, this pragma can largely be removed because the old contracts on the
   -- testnet won't exist anymore and the stateroot mismatches will be fixed.
-  (hsh, cc) <- codeCollectionFromSource True $ BC.pack contractSrc
+  isRunningTests <- Env.runningTests <$> getEnv
+  (hsh, cc) <- codeCollectionFromSource isRunningTests True $ BC.pack contractSrc
   let constructorArgVals = OrderedVals argVals
   newAddress <- getNewAddressWithSalt creator salt hsh $ show constructorArgVals
   (ctr, originAddress, ctrName) <- getCreator creator

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -98,10 +98,12 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as DT
 import Data.Time.Clock.POSIX
 import Data.Traversable
+import Data.IORef
 import qualified Data.Vector as V
 import Debugger
 import GHC.Exts hiding (breakpoint)
 import qualified LabeledError
+import System.IO.Unsafe (unsafePerformIO)
 --import Blockchain.DB.RawStorageDB
 --import Blockchain.Data.BlockSummary
 --import Blockchain.DB.MemAddressStateDB
@@ -123,7 +125,12 @@ import Text.Parsec (runParser)
 import Text.Printf
 import Text.Read (readEither, readMaybe)
 import Text.Tools
-import UnliftIO hiding (assert)
+-- import UnliftIO hiding (assert)
+
+-- Global time offset for fastForward functionality
+{-# NOINLINE globalTimeOffset #-}
+globalTimeOffset :: IORef Integer
+globalTimeOffset = unsafePerformIO $ Data.IORef.newIORef 0
 
 type SolidVMBase m = VMBase m
 
@@ -1379,7 +1386,10 @@ expToVar' x@(CC.MemberAccess _ expr name) _ = do
       return $ Constant (flip SAccount False (unspecifiedChain acc))
     (SBuiltinVariable "block", "timestamp") -> do
       env' <- getEnv
-      return $ Constant $ SInteger $ round $ utcTimeToPOSIXSeconds $ BlockHeader.timestamp $ Env.blockHeader env'
+      offset <- liftIO $ Data.IORef.readIORef globalTimeOffset
+      let baseTimestamp = utcTimeToPOSIXSeconds $ BlockHeader.timestamp $ Env.blockHeader env'
+      let finalTimestamp = round $ baseTimestamp + fromIntegral offset
+      return $ Constant $ SInteger finalTimestamp
     (SBuiltinVariable "block", "number") -> (Constant . SInteger . BlockHeader.number . Env.blockHeader) <$> getEnv
     (SBuiltinVariable "block", "coinbase") ->
       pure . Constant $ SAccount (NamedAccount (Address 0) UnspecifiedChain) True -- TODO: fix?
@@ -2502,6 +2512,15 @@ callBuiltin "create2" args@(salt : SString contractName' : SString contractSrc :
   case erNewContractAddress execResults of
     Just nca -> pure $ ((flip SAccount) False) $ NamedAccount nca UnspecifiedChain
     Nothing -> internalError "a call to create did not create an address" execResults
+callBuiltin "fastForward" args = do
+  case args of
+    [SInteger seconds] -> do
+      -- Add seconds to the global time offset
+      liftIO $ Data.IORef.atomicModifyIORef' globalTimeOffset $ \currentOffset -> 
+        (currentOffset + seconds, ())
+      return SNULL
+    _ -> invalidArguments "fastForward expects exactly one integer argument (seconds)" args
+
 callBuiltin x args = unknownFunction ("callBuiltin " ++ show args) x
 
 certificateMap :: Maybe String -> CC.Contract -> Value
@@ -2654,7 +2673,7 @@ runTheConstructors from to hsh cc contractName' argVals' = do
 addLocalVariable :: MonadSM m => SVMType.Type -> SolidString -> Value -> m ()
 addLocalVariable theType name value = do
   --  initializeStorage (AddressedPath (Left LocalVar) . MS.singleton $ BC.pack name) value
-  newVariable <- liftIO $ fmap Variable $ newIORef value
+  newVariable <- liftIO $ fmap Variable $ Data.IORef.newIORef value
   cs <- Mod.get (Mod.Proxy @[CallInfo])
   case cs of
     [] -> internalError "addLocalVariable called with an empty stack" (name, value)
@@ -2731,7 +2750,7 @@ runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
   let locals = args ++ returns
   localVars1 <-
     forM locals $ \(n, (t, v)) -> do
-      newVar <- liftIO $ fmap Variable $ newIORef v
+      newVar <- liftIO $ fmap Variable $ Data.IORef.newIORef v
       return (n, (t, newVar))
 
   val' <- withCallInfo address' contract' funcName hsh cc (M.fromList localVars1) ro ff $ do -- [(n, (t, Constant v)) | (n, (t, v)) <- locals]

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -99,12 +99,10 @@ import qualified Data.Text.Encoding as DT
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Data.Traversable
-import Data.IORef
 import qualified Data.Vector as V
 import Debugger
 import GHC.Exts hiding (breakpoint)
 import qualified LabeledError
-import System.IO.Unsafe (unsafePerformIO)
 --import Blockchain.DB.RawStorageDB
 --import Blockchain.Data.BlockSummary
 --import Blockchain.DB.MemAddressStateDB
@@ -126,7 +124,7 @@ import Text.Parsec (runParser)
 import Text.Printf
 import Text.Read (readEither, readMaybe)
 import Text.Tools
--- import UnliftIO hiding (assert)
+import UnliftIO hiding (assert)
 
 
 type SolidVMBase m = VMBase m
@@ -2521,11 +2519,8 @@ callBuiltin "fastForward" [SInteger seconds] = do
           updatedBlockHeader = (Env.blockHeader env') { BlockHeader.timestamp = newTimestamp }
       -- Update the environment with new block header
       Mod.modify_ (Mod.Proxy @Env.Environment) $ \env ->
-        env { Env.blockHeader = updatedBlockHeader }
+        pure $ env { Env.blockHeader = updatedBlockHeader }
       return SNULL
-
-callBuiltin "fastForward" args =
-  invalidArguments "fastForward expects exactly one integer argument (seconds)" args
 
 callBuiltin x args = unknownFunction ("callBuiltin " ++ show args) x
 
@@ -2679,7 +2674,7 @@ runTheConstructors from to hsh cc contractName' argVals' = do
 addLocalVariable :: MonadSM m => SVMType.Type -> SolidString -> Value -> m ()
 addLocalVariable theType name value = do
   --  initializeStorage (AddressedPath (Left LocalVar) . MS.singleton $ BC.pack name) value
-  newVariable <- liftIO $ fmap Variable $ Data.IORef.newIORef value
+  newVariable <- liftIO $ fmap Variable $ newIORef value
   cs <- Mod.get (Mod.Proxy @[CallInfo])
   case cs of
     [] -> internalError "addLocalVariable called with an empty stack" (name, value)
@@ -2756,7 +2751,7 @@ runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
   let locals = args ++ returns
   localVars1 <-
     forM locals $ \(n, (t, v)) -> do
-      newVar <- liftIO $ fmap Variable $ Data.IORef.newIORef v
+      newVar <- liftIO $ fmap Variable $ newIORef v
       return (n, (t, newVar))
 
   val' <- withCallInfo address' contract' funcName hsh cc (M.fromList localVars1) ro ff $ do -- [(n, (t, Constant v)) | (n, (t, v)) <- locals]

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -96,6 +96,7 @@ import Data.Source
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as DT
+import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Data.Traversable
 import Data.IORef
@@ -127,10 +128,6 @@ import Text.Read (readEither, readMaybe)
 import Text.Tools
 -- import UnliftIO hiding (assert)
 
--- Global time offset for fastForward functionality
-{-# NOINLINE globalTimeOffset #-}
-globalTimeOffset :: IORef Integer
-globalTimeOffset = unsafePerformIO $ Data.IORef.newIORef 0
 
 type SolidVMBase m = VMBase m
 
@@ -1386,10 +1383,8 @@ expToVar' x@(CC.MemberAccess _ expr name) _ = do
       return $ Constant (flip SAccount False (unspecifiedChain acc))
     (SBuiltinVariable "block", "timestamp") -> do
       env' <- getEnv
-      offset <- liftIO $ Data.IORef.readIORef globalTimeOffset
       let baseTimestamp = utcTimeToPOSIXSeconds $ BlockHeader.timestamp $ Env.blockHeader env'
-      let finalTimestamp = round $ baseTimestamp + fromIntegral offset
-      return $ Constant $ SInteger finalTimestamp
+      return $ Constant $ SInteger $ round baseTimestamp
     (SBuiltinVariable "block", "number") -> (Constant . SInteger . BlockHeader.number . Env.blockHeader) <$> getEnv
     (SBuiltinVariable "block", "coinbase") ->
       pure . Constant $ SAccount (NamedAccount (Address 0) UnspecifiedChain) True -- TODO: fix?
@@ -2512,14 +2507,23 @@ callBuiltin "create2" args@(salt : SString contractName' : SString contractSrc :
   case erNewContractAddress execResults of
     Just nca -> pure $ ((flip SAccount) False) $ NamedAccount nca UnspecifiedChain
     Nothing -> internalError "a call to create did not create an address" execResults
-callBuiltin "fastForward" args = do
-  case args of
-    [SInteger seconds] -> do
-      -- Add seconds to the global time offset
-      liftIO $ Data.IORef.atomicModifyIORef' globalTimeOffset $ \currentOffset -> 
-        (currentOffset + seconds, ())
+callBuiltin "fastForward" [SInteger seconds] = do
+  -- Only allow fastForward during testing
+  env' <- getEnv
+  if not (Env.runningTests env')
+    then invalidArguments "fastForward can only be called during testing" [SInteger seconds]
+    else do
+      -- Get current timestamp and add seconds
+      let currentTimestamp = BlockHeader.timestamp $ Env.blockHeader env'
+          newTimestamp = addUTCTime (fromIntegral seconds) currentTimestamp
+          updatedBlockHeader = (Env.blockHeader env') { BlockHeader.timestamp = newTimestamp }
+      -- Update the environment with new block header
+      Mod.modify_ (Mod.Proxy @Env.Environment) $ \env ->
+        env { Env.blockHeader = updatedBlockHeader }
       return SNULL
-    _ -> invalidArguments "fastForward expects exactly one integer argument (seconds)" args
+
+callBuiltin "fastForward" args =
+  invalidArguments "fastForward expects exactly one integer argument (seconds)" args
 
 callBuiltin x args = unknownFunction ("callBuiltin " ++ show args) x
 

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -631,7 +631,8 @@ getVariableOfName name = do
                        "parseCert",
                        "verifyCert",
                        "verifyCertSignedBy",
-                       "verifySignature"
+                       "verifySignature",
+                       "fastForward"
                      ]
           )
           $ t "builtin function" $ Constant $ SFunction name Nothing

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -192,6 +192,7 @@ type MonadSM m =
     Mod.Accessible VariableSet m,
     Mod.Modifiable GasInfo m,
     Mod.Modifiable MemDBs m,
+    Mod.Modifiable Env.Environment m,
     Mod.Modifiable Env.Sender m,
     Mod.Modifiable [CallInfo] m,
     Mod.Modifiable Action m,
@@ -403,6 +404,10 @@ instance (N.NibbleString `A.Alters` N.NibbleString) m => (N.NibbleString `A.Alte
 
 instance MonadUnliftIO m => Mod.Accessible Env.Environment (SM m) where
   access _ = gets env
+
+instance MonadUnliftIO m => Mod.Modifiable Env.Environment (SM m) where
+  get _   = gets env
+  put _ m = modify $ \ss -> ss{ env = m }
 
 instance
   (Mod.Modifiable (Maybe DebugSettings) m) =>

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -1098,7 +1098,8 @@ getCodeAndCollection address' = do
     Just ci -> return (currentContract ci, collectionHash ci, codeCollection ci)
     Nothing -> do
       (contractName', ch) <- getContractNameAndHash address'
-      cc <- codeCollectionFromHash True ch
+      isRunningTests <- Env.runningTests <$> getEnv
+      cc <- codeCollectionFromHash isRunningTests True ch
 
       let !contract' = fromMaybe (missingType "getCodeAndCollection" contractName') $ M.lookup contractName' $ cc ^. CC.contracts
 

--- a/strato/VM/SolidVM/solid-vm/tests/OptimizerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/OptimizerSpec.hs
@@ -53,7 +53,7 @@ instance {-# OVERLAPPING #-} (Keccak256 `A.Alters` DBCode) m => (Keccak256 `A.Al
 
 runOptimizer :: String -> IO CodeCollection
 runOptimizer c = runNewMemCodeDB . runNewMemAddressStateDB . runMainChainT $ do
-  eCC <- compileSourceWithAnnotations True (M.fromList [("", T.pack c)])
+  eCC <- compileSourceWithAnnotations True True (M.fromList [("", T.pack c)])
   case eCC of
     Left _ -> internalError "Compilation Error" ()
     Right cc -> pure cc

--- a/strato/VM/SolidVM/solid-vm/tests/StaticAnalysisSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/StaticAnalysisSpec.hs
@@ -48,7 +48,7 @@ forSource detector c = case parseSourceWithAnnotations "" $ T.pack c of
 
 forContract :: CompilerDetector -> String -> IO [SourceAnnotation Text]
 forContract detector c = runNewMemCodeDB . runNewMemAddressStateDB . runMainChainT $ do
-  eCC <- compileSourceWithAnnotations True (M.fromList [("", T.pack c)])
+  eCC <- compileSourceWithAnnotations True True (M.fromList [("", T.pack c)])
   pure $ case eCC of
     Left anns -> anns
     Right cc -> detector cc

--- a/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
+++ b/strato/VM/SolidVM/solid-vm/tests/TypecheckerSpec.hs
@@ -32,7 +32,7 @@ instance (Keccak256 `A.Alters` DBCode) m => (Keccak256 `A.Alters` DBCode) (MainC
 
 runTypechecker :: String -> IO [SourceAnnotation Text]
 runTypechecker c = runNewMemCodeDB . runNewMemAddressStateDB . runMainChainT $ do
-  eCC <- compileSourceWithAnnotations True (M.fromList [("", T.pack c)])
+  eCC <- compileSourceWithAnnotations True True (M.fromList [("", T.pack c)])
   pure $ case eCC of
     Left anns -> anns
     Right _ -> []

--- a/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
@@ -171,6 +171,7 @@ createMetadataNoCompile ::
   SourceMap ->
   m (Either [SourceAnnotation Text] (Keccak256, CodeCollection))
 createMetadataNoCompile sourceList = do
-  compiledSource <- compileSourceWithAnnotations True (Map.fromList $ unSourceMap sourceList)
+  let isRunningTests = False
+  compiledSource <- compileSourceWithAnnotations isRunningTests True (Map.fromList $ unSourceMap sourceList)
   let srcHash = hash . Text.encodeUtf8 $ serializeSourceMap sourceList
   pure $ (srcHash,) <$> compiledSource

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -340,7 +340,7 @@ populateStorageDBs' getMetadata genesisInfo genesisBlock genesisChainId sr pub =
           -- Maybe the typechecking should be done elsewhere, but this will
           -- allow us to prevent faulty code collections from going into the
           -- genesis block
-          cc <- codeCollectionFromHash True codeHash'
+          cc <- codeCollectionFromHash False True codeHash'
           case cc ^. CC.contracts . at contractName' of
             Nothing -> do
               $logWarnS "populateStorageDBs/toAction" . T.pack $


### PR DESCRIPTION
Test contract written for the proposed changes:
```
contract Describe_FastForward {

  function beforeAll() {
  }

  function beforeEach() {
  }

  function it_can_call_fastForward() {
    log("Testing fastForward function");
    uint256 before = block.timestamp;
    fastForward(100);
    uint256 after = block.timestamp;
    log("Before timestamp", before);
    log("After timestamp", after);
    require(after == before + 100, "FastForward did not work");
  }

}
```

After the proposed changes were built, this test printed these results:
```
╰─ solid-vm-cli test ../mercata/contracts/tests/fast_forward.test.sol
Testing fastForward function
Before timestamp
0
After timestamp
100
✅ Unit test 'can call fastForward' succeeded
```