### PR TITLE
Solid-VM-CLI: Execute tests in source order

### DIFF
--- a/mercata/contracts/tests/ExecutionOrder.test.sol
+++ b/mercata/contracts/tests/ExecutionOrder.test.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+contract Describe_ExecutionOrder {
+
+  function beforeAll() {
+  }
+
+  function beforeEach() {
+  }
+
+  function it_B() {
+    log("Calling B");
+  }
+
+  function it_A() {
+    log("Calling A");
+  }
+
+}

--- a/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
@@ -28,8 +28,10 @@ import Control.Monad.Trans.Reader
 import qualified Data.Aeson as Aeson
 import Data.Bool (bool)
 import qualified Data.ByteString.Lazy as BL
+import Data.List (sortBy)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, maybeToList)
+import Data.Ord (comparing)
 import Data.Source
 import qualified Data.Text as T
 import Data.Text.Encoding as T
@@ -82,14 +84,17 @@ runFuzzer dSettings compile src = compile src >>= \case
     let args = FuzzerArgs src "" [] "" [] Nothing
     runNoLoggingT . evalMemContextM dSettings . flip runReaderT args $ do
       lift . modify' $ runningTests .~ True
-      fmap concat . for (M.toList $ _contracts cc) $ \(cName, c) ->
+      let contractsInSourceOrder =
+            sortBy (comparing (\(_, c') -> c' ^. contractContext . sourceAnnotationStart)) (M.toList $ _contracts cc)
+       in fmap concat . for contractsInSourceOrder $ \(cName, c) ->
         if not (describePrefix `T.isPrefixOf` labelToText cName)
           then pure []
           else case _funcArgs <$> _constructor c of
             Just (_ : _) -> pure . fmap (\f -> FuzzerFailure Nothing $ ("Contract constructor", "Expected constructor to have zero arguments") <$ _funcContext f) . maybeToList $ _constructor c
             _ -> fuzzContract cName (_contractContext c) $ \bh addr -> do
               _ <- for (M.lookup "beforeAll" $ _functions c) $ test bh addr "beforeAll"
-              fmap catMaybes . for (M.toList $ _functions c) $ \(fName, f) -> fmap (fmap (withTestName $ T.pack fName)) $
+              let functionsInSourceOrder = sortBy (comparing (\(_, f') -> f' ^. funcContext . sourceAnnotationStart)) (M.toList $ _functions c)
+               in fmap catMaybes . for functionsInSourceOrder $ \(fName, f) -> fmap (fmap (withTestName $ T.pack fName)) $
                 if
                     | testPrefix `T.isPrefixOf` labelToText fName -> do
                         _ <- for (M.lookup "beforeEach" $ _functions c) $ test bh addr "beforeEach"


### PR DESCRIPTION
The following test contract:
```
contract Describe_ExecutionOrder {

  function beforeAll() {
  }

  function beforeEach() {
  }

  function it_B() {
    log("Calling B");
  }

  function it_A() {
    log("Calling A");
  }

}
```
Generated the following output after the proposed implementation:
```
╰─ solid-vm-cli test ../mercata/contracts/tests/ExecutionOrder.test.sol
Calling B
Calling A
✅ Unit test 'B' succeeded
✅ Unit test 'A' succeeded
```