### PR TITLE
Add RewardsChef contract to Genesis 

### DIFF
--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -192,7 +192,7 @@ contract record RewardsChef is Ownable {
     uint256 public minFutureTime;
 
     // Info of each of the stake pool.
-    PoolInfo[] public pools;
+    PoolInfo[] public record pools;
 
     // Info of each user that stakes LP tokens.
     mapping(uint256 => mapping(address => UserInfo)) public record userInfo;

--- a/strato/core/strato-genesis/resources/contracts/concrete/Rewards/RewardsChef.sol
+++ b/strato/core/strato-genesis/resources/contracts/concrete/Rewards/RewardsChef.sol
@@ -4,6 +4,29 @@ pragma solidity ^0.8.0;
 import "../../abstract/ERC20/ERC20.sol";
 import "../Tokens/Token.sol";
 
+// ═════════════════════════════════════════════════════════════════════════
+// DATA STRUCTURES
+// ═════════════════════════════════════════════════════════════════════════
+
+struct UserInfo {
+    uint256 amount;      // How many LP tokens the user has provided.
+    uint256 rewardDebt;  // Reward debt
+}
+
+struct BonusPeriod {
+    uint256 startTimestamp;   // When this bonus period begins
+    uint256 bonusMultiplier;  // The multiplier for this period (not smaller than 1)
+}
+
+struct PoolInfo {
+    address lpToken;             // The LP Token added to the stake pool
+    uint256 allocPoint;          // How many allocation points assigned to
+                          // this pool.  Importance of the pool.
+    uint256 lastRewardTimestamp; // Last time the CATA distribution occurs
+    uint256 accPerToken;         // Accumulated CATA per share (per token)
+    BonusPeriod[] bonusPeriods;  // Array of bonus periods for this pool
+}
+
 /**
  * RewardsChef - A staking contract that allows creating pools for various LP
  * tokens, where users earn CATA token rewards over time for staking their LP
@@ -135,29 +158,7 @@ contract record RewardsChef is Ownable {
     event MinFutureTimeUpdated(uint256 oldMinFutureTime, uint256 newMinFutureTime);
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
-
-    // ═════════════════════════════════════════════════════════════════════════
-    // DATA STRUCTURES
-    // ═════════════════════════════════════════════════════════════════════════
-
-    struct UserInfo {
-        uint256 amount;      // How many LP tokens the user has provided.
-        uint256 rewardDebt;  // Reward debt
-    }
-
-    struct BonusPeriod {
-        uint256 startTimestamp;   // When this bonus period begins
-        uint256 bonusMultiplier;  // The multiplier for this period (not smaller than 1)
-    }
-
-    struct PoolInfo {
-        address lpToken;             // The LP Token added to the stake pool
-        uint256 allocPoint;          // How many allocation points assigned to
-	                             // this pool.  Importance of the pool.
-        uint256 lastRewardTimestamp; // Last time the CATA distribution occurs
-        uint256 accPerToken;         // Accumulated CATA per share (per token)
-        BonusPeriod[] bonusPeriods;  // Array of bonus periods for this pool
-    }
+    event CurrentUserAmount(address indexed user, uint256 indexed pid, uint256 currentAmount);
 
     // ═════════════════════════════════════════════════════════════════════════
     // CONSTANTS
@@ -171,7 +172,7 @@ contract record RewardsChef is Ownable {
     // precision. We multiply when storing rewards per token (accPerToken calculation) and
     // divide when calculating individual user rewards to get the actual reward amount.
     // This multiplier also propagates to rewardDebt calculations to maintain consistency.
-    uint256 private PRECISION_MULTIPLIER = 1e12;
+    uint256 public PRECISION_MULTIPLIER = 1e18;
 
     // ═════════════════════════════════════════════════════════════════════════
     // STATE VARIABLES
@@ -194,7 +195,7 @@ contract record RewardsChef is Ownable {
     PoolInfo[] public pools;
 
     // Info of each user that stakes LP tokens.
-    mapping(uint256 => mapping(address => UserInfo)) public userInfo;
+    mapping(uint256 => mapping(address => UserInfo)) public record userInfo;
 
     // ═════════════════════════════════════════════════════════════════════════
     // CONSTRUCTOR
@@ -330,7 +331,7 @@ contract record RewardsChef is Ownable {
             return;
         }
 
-        uint256 lpSupply = Token(pool.lpToken).balanceOf(address(this));
+        uint256 lpSupply = ERC20(pool.lpToken).balanceOf(address(this));
         if (lpSupply == 0) {
             pool.lastRewardTimestamp = block.timestamp;
             return;
@@ -361,17 +362,24 @@ contract record RewardsChef is Ownable {
         if (user.amount > 0) {
             uint256 pending = ((user.amount * pool.accPerToken) / PRECISION_MULTIPLIER) - user.rewardDebt;
             if (pending > 0) {
-                rewardToken.transfer(msg.sender, pending);
+                ERC20(rewardToken).transfer(msg.sender, pending);
             }
         }
 
         if (_amount > 0) {
-            Token(pool.lpToken).transferFrom(msg.sender, address(this), _amount);
+            ERC20(pool.lpToken).transferFrom(msg.sender, address(this), _amount);
             user.amount += _amount;
         }
 
-        user.rewardDebt = (user.amount * pool.accPerToken) / PRECISION_MULTIPLIER;
+        // ═════════════════════════════════════════════════════════════════════
+        // WARNING!!
+        // ═════════════════════════════════════════════════════════════════════
+        // This has to be set in variable and only then applied to
+        // user.rewardDebt, otherwise the solidvm throws!
+        uint256 rewardDebt = (user.amount * pool.accPerToken) / PRECISION_MULTIPLIER;
+        user.rewardDebt = rewardDebt;
 
+        emit CurrentUserAmount(msg.sender, _pid, user.amount);
         emit Deposit(msg.sender, _pid, _amount);
     }
 
@@ -387,16 +395,23 @@ contract record RewardsChef is Ownable {
 
         uint256 pending = ((user.amount * pool.accPerToken) / PRECISION_MULTIPLIER) - user.rewardDebt;
         if (pending > 0) {
-            rewardToken.transfer(msg.sender, pending);
+            ERC20(rewardToken).transfer(msg.sender, pending);
         }
 
         if (_amount > 0) {
             user.amount -= _amount;
-            Token(pool.lpToken).transfer(msg.sender, _amount);
+            ERC20(pool.lpToken).transfer(msg.sender, _amount);
         }
 
-        user.rewardDebt = (user.amount * pool.accPerToken) / PRECISION_MULTIPLIER;
+        // ═════════════════════════════════════════════════════════════════════
+        // WARNING!!
+        // ═════════════════════════════════════════════════════════════════════
+        // This has to be set in variable and only then applied to
+        // user.rewardDebt, otherwise the solidvm throws!
+        uint256 rewardDebt = (user.amount * pool.accPerToken) / PRECISION_MULTIPLIER;
+        user.rewardDebt = rewardDebt;
 
+        emit CurrentUserAmount(msg.sender, _pid, user.amount);
         emit Withdraw(msg.sender, _pid, _amount);
     }
 
@@ -407,7 +422,7 @@ contract record RewardsChef is Ownable {
         UserInfo storage user = userInfo[_pid][_user];
 
         uint256 accPerToken = pool.accPerToken;
-        uint256 lpSupply = Token(pool.lpToken).balanceOf(address(this));
+        uint256 lpSupply = ERC20(pool.lpToken).balanceOf(address(this));
 
         if (block.timestamp > pool.lastRewardTimestamp && lpSupply != 0) {
             uint256 multiplier = getMultiplier(_pid, pool.lastRewardTimestamp, block.timestamp);
@@ -418,4 +433,8 @@ contract record RewardsChef is Ownable {
         return ((user.amount * accPerToken) / PRECISION_MULTIPLIER) - user.rewardDebt;
     }
 
+    function getBalance(uint256 _pid, address _user) external view returns (uint256) {
+        require(_pid < pools.length, "Pool does not exist");
+        return userInfo[_pid][_user].amount;
+    }
 }

--- a/strato/core/strato-genesis/resources/contracts/concrete/Rewards/RewardsChef.sol
+++ b/strato/core/strato-genesis/resources/contracts/concrete/Rewards/RewardsChef.sol
@@ -192,7 +192,7 @@ contract record RewardsChef is Ownable {
     uint256 public minFutureTime;
 
     // Info of each of the stake pool.
-    PoolInfo[] public pools;
+    PoolInfo[] public record pools;
 
     // Info of each user that stakes LP tokens.
     mapping(uint256 => mapping(address => UserInfo)) public record userInfo;

--- a/strato/core/strato-genesis/src/Blockchain/GenesisBlocks/Contracts/Mercata.hs
+++ b/strato/core/strato-genesis/src/Blockchain/GenesisBlocks/Contracts/Mercata.hs
@@ -37,6 +37,7 @@ filesToEmbed = [
   "contracts/concrete/Pools/Pool.sol",
   "contracts/concrete/Pools/PoolFactory.sol",
   "contracts/concrete/Rewards/RewardsManager.sol",
+  "contracts/concrete/Rewards/RewardsChef.sol",
   "contracts/concrete/Tokens/Token.sol",
   "contracts/concrete/Tokens/TokenAccess.sol",
   "contracts/concrete/Tokens/TokenFaucet.sol",

--- a/strato/core/strato-genesis/src/Blockchain/GenesisBlocks/HeliumGenesisBlock.hs
+++ b/strato/core/strato-genesis/src/Blockchain/GenesisBlocks/HeliumGenesisBlock.hs
@@ -192,6 +192,9 @@ silvstPoolAddress = 0x101d
 silvstLpTokenAddress :: Address
 silvstLpTokenAddress = 0x101e
 
+rewardsChefAddress :: Address
+rewardsChefAddress = 0x101f
+
 -- paxgstPoolAddress :: Address
 -- paxgstPoolAddress = 0x1023
 -- 
@@ -280,6 +283,7 @@ genesisBlock  =
             , voucher
             , mToken
             , rewardsManager
+            , rewardsChef
             , cdpEngine
             , cdpRegistry
             , cdpVault
@@ -697,6 +701,24 @@ mToken = SolidVMContractWithStorage mTokenAddress 0 (CodeAtAccount mercataAddres
      , (".tokenFactory", BContract "TokenFactory" $ unspecifiedChain tokenFactoryAddress)
      , (".status", BEnumVal "TokenStatus" "ACTIVE" 2)
      , ("._balances<a:" <> addrBS blockappsAddress <> ">", BInteger $ 250_000 * oneE18)
+     ]
+
+rewardsChef :: AccountInfo
+rewardsChef = SolidVMContractWithStorage rewardsChefAddress 0 (CodeAtAccount mercataAddress "RewardsChef") $ ownedByBlockApps mercataAddress
+  ++ [ (".MAX_INT", BInteger 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+     , (".PRECISION_MULTIPLIER", BInteger oneE18)
+     , (".rewardToken", BContract "Token" $ unspecifiedChain cataAddress)
+     , (".cataPerSecond", BInteger 100000000000000)
+     , (".totalAllocPoint", BInteger 100)
+     , (".minFutureTime", BInteger 3600)
+     , (".pools[0].lpToken", BAccount $ unspecifiedChain mTokenAddress)
+     , (".pools[0].allocPoint", BInteger 100)
+     , (".pools[0].lastRewardTimestamp", BInteger lastAccrual)
+     , (".pools[0].accPerToken", BInteger 0)
+     , (".pools[0].bonusPeriods[0].startTimestamp", BInteger lastAccrual)
+     , (".pools[0].bonusPeriods[0].bonusMultiplier", BInteger 1)
+     , (".pools[0].bonusPeriods.length", BInteger 1)
+     , (".pools.length", BInteger 1)
      ]
 
 rewardsManager :: AccountInfo


### PR DESCRIPTION
I've run the node locally and got the following output.
It seems that the contract under address `000000000000000000000000000000000000101f` was processed correctly

```
00000000000000001000
[2025-09-30 21:56:49.085502000 UTC]  INFO | ThreadId 4     | initgen                             | ##################### writing to DBs: 000000000000000000000000000000000000101f
[2025-09-30 21:56:49.090261000 UTC]  INFO | ThreadId 4     | populateStorageDBs/toAction         | creator: BlockApps, app: Mercata
[2025-09-30 21:56:49.090386000 UTC]  INFO | ThreadId 4     | populateStorageDBs/toAction         | creatorAddress: 1b7dc206ef2fe3aab27404b88c36470ccf16c0ce, originAddress: 0000000000000000000000000000000000001000
(...)
[2025-09-30 21:56:50.524001000 UTC]  INFO | ThreadId 4     | initgen                             | populateStorageDBs is done
[2025-09-30 21:56:50.524128000 UTC]  INFO | ThreadId 4     | runWorker                           | done. here I am once again
```

so it seems to be working

Also DB

```
select address, "_owner", "MAX_INT", "cataPerSecond", "minFutureTime", "rewardToken", "totalAllocPoint" from "BlockApps-Mercata-RewardsChef";
                 address                  |                  _owner                  |                                    MAX_INT                                     |  cataPerSecond  | minFu
tureTime |               rewardToken                | totalAllocPoint
------------------------------------------+------------------------------------------+--------------------------------------------------------------------------------+-----------------+------
---------+------------------------------------------+-----------------
 000000000000000000000000000000000000101f | 000000000000000000000000000000000000100c | 115792089237316195423570985008687907853269984665640564039457584007913129639935 | 100000000000000 |
    3600 | 2680dc6693021cd3fefb84351570874fbef8332a |             100
    ```
    
    
    ```
    cirrus=# select key, value from "BlockApps-Mercata-RewardsChef-pools";
 key |                                                                                                       value

-----+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--------------------------
   0 | {"lpToken": "000000000000000000000000000000000000100f", "allocPoint": "100", "accPerToken": "0", "bonusPeriods": [{"startTimestamp": "1757995200", "bonusMultiplier": "1"}], "lastReward
Timestamp": "1757995200"}
    ```