### PR TITLE
Load logic contract code when contract being called is a Proxy

### DIFF
--- a/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
@@ -74,7 +74,7 @@ getContractByAddress a funcName = runMaybeT $ do
         & qaAddress ?~ a
   codePtr <- case addressStateRefContractName r of
     -- TODO: This block of code is a hack. Figure out a better solution
-    Just "Proxy" | funcName /= "setLogicContract" -> do
+    Just "Proxy" | funcName `notElem` ["setLogicContract", "owner", "renounceOwnership", "transferOwnership"] -> do
       (StorageAddress _ v _) <- MaybeT
         . fmap listToMaybe
         . getStorage'

--- a/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
@@ -63,8 +63,9 @@ getContractByAddress ::
     A.Selectable StorageFilterParams [StorageAddress] m
   ) =>
   Address ->
+  Text ->
   m (Maybe Contract)
-getContractByAddress a = runMaybeT $ do
+getContractByAddress a funcName = runMaybeT $ do
   (AddressStateRef' r _) <-
     MaybeT
       . fmap listToMaybe
@@ -72,7 +73,8 @@ getContractByAddress a = runMaybeT $ do
       $ accountsFilterParams
         & qaAddress ?~ a
   codePtr <- case addressStateRefContractName r of
-    Just "Proxy" -> do -- TODO: This block of code is a hack. Figure out a better solution
+    -- TODO: This block of code is a hack. Figure out a better solution
+    Just "Proxy" | funcName /= "setLogicContract" -> do
       (StorageAddress _ v _) <- MaybeT
         . fmap listToMaybe
         . getStorage'

--- a/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
@@ -46,6 +46,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Handlers.AccountInfo
+import Handlers.Storage
 import SQLM
 import SolidVM.Model.CodeCollection
 import Text.Format
@@ -58,7 +59,8 @@ getContractByAddress ::
     HasCodeDB m,
     A.Selectable Address AddressState m,
     (Keccak256 `A.Selectable` SourceMap) m,
-    A.Selectable AccountsFilterParams [AddressStateRef] m
+    A.Selectable AccountsFilterParams [AddressStateRef] m,
+    A.Selectable StorageFilterParams [StorageAddress] m
   ) =>
   Address ->
   m (Maybe Contract)
@@ -69,7 +71,24 @@ getContractByAddress a = runMaybeT $ do
       . getAccount'
       $ accountsFilterParams
         & qaAddress ?~ a
-  codePtr <- MaybeT . pure $ addressStateRefCodePtr r
+  codePtr <- case addressStateRefContractName r of
+    Just "Proxy" -> do -- TODO: This block of code is a hack. Figure out a better solution
+      (StorageAddress _ v _) <- MaybeT
+        . fmap listToMaybe
+        . getStorage'
+        $ storageFilterParams
+            { qsAddress = Just a
+            , qsKey = Just ".logicContract"
+            }
+      logicContract <- MaybeT . pure . stringAddress $ Text.unpack v
+      (AddressStateRef' l _) <- MaybeT
+        . fmap listToMaybe
+        . getAccount'
+        $ accountsFilterParams
+          & qaAddress ?~ logicContract
+      MaybeT . pure $ addressStateRefCodePtr l
+
+    _ -> MaybeT . pure $ addressStateRefCodePtr r
   MaybeT $ either (const Nothing) (Just . snd) <$> getContractDetailsByCodeHash codePtr
 
 getContractDetailsByCodeHash ::

--- a/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Database/Queries.hs
@@ -74,6 +74,16 @@ getContractByAddress a funcName = runMaybeT $ do
         & qaAddress ?~ a
   codePtr <- case addressStateRefContractName r of
     -- TODO: This block of code is a hack. Figure out a better solution
+    --
+    -- This is a quick hack to get around the issues with calling Proxy 
+    -- contracts through the API. If the contract is named "Proxy", and 
+    -- the function name being called is not "setLogicContract", then 
+    -- the API will load the ".logicContract" storage element from the 
+    -- contract's storage, then load the code for that address. 
+    -- 
+    -- Ideally, we wouldn't have to hardcode any of these names in 
+    -- the API, but this should get us back up and running for the
+    --  time being. 
     Just "Proxy" | funcName `notElem` ["setLogicContract", "owner", "renounceOwnership", "transferOwnership"] -> do
       (StorageAddress _ v _) <- MaybeT
         . fmap listToMaybe

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -206,7 +206,7 @@ postBlocTransactionBody (PostBlocTransactionRequest mAddr txList txParams msrcs)
           contract <- case mContract of
             Just x -> pure x
             Nothing -> do
-              mContract' <- lift $ getContractByAddress methodcallContractAddress
+              mContract' <- lift $ getContractByAddress methodcallContractAddress methodcallMethodName
               x <- case mContract' of
                 Nothing -> lift $ throwIO . UserError $ "Could not find contract " <> Text.pack (format methodcallContractAddress)
                 Just x -> pure x
@@ -342,7 +342,7 @@ postBlocTransactionUnsigned (PostBlocTransactionRequest mAddr txList txParams ms
           contract <- case mContract of
             Just x -> pure x
             Nothing -> do
-              mContract' <- lift $ getContractByAddress methodcallContractAddress
+              mContract' <- lift $ getContractByAddress methodcallContractAddress methodcallMethodName
               x <- case mContract' of
                 Nothing -> lift $ throwIO . UserError $ "Could not find contract " <> Text.pack (format methodcallContractAddress)
                 Just x -> pure x
@@ -918,7 +918,7 @@ postUsersContractMethodList' cacheNonce FunctionListParameters {..} = do
           contract <- case mContract of
             Just x -> pure x
             Nothing -> do
-              mContract' <- lift $ getContractByAddress methodcallContractAddress
+              mContract' <- lift $ getContractByAddress methodcallContractAddress methodcallMethodName
               x <- case mContract' of
                 Nothing -> lift $ throwIO . UserError $ "Could not find contract " <> Text.pack (show methodcallContractAddress)
                 Just x -> pure x
@@ -978,7 +978,7 @@ postUsersContractMethod' cacheNonce FunctionParameters {..} = do
             ]
   contract <-
     maybe (throwIO err) pure
-      =<< getContractByAddress contractAddr
+      =<< getContractByAddress contractAddr funcName
   case M.lookup (Text.unpack funcName) (contract ^. functions) of
     Just _ -> pure ()
     Nothing -> throwIO . UserError $ "Contract doesn't have a method named '" <> funcName <> "'"

--- a/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs
@@ -12,8 +12,6 @@
 
 {-# LANGUAGE BlockArguments #-}
 
-{-# OPTIONS -fno-warn-unused-matches #-}
-
 module Bloc.Server.Transaction
   ( postBlocTransaction,
     postBlocTransactionBody,
@@ -28,12 +26,11 @@ import Bloc.API.Utils
 import Bloc.Database.Queries (getContractByAddress, getContractDetailsForContract)
 import Bloc.Monad
 import Bloc.Server.Contracts (getSourceMapFromAddress)
-import Bloc.Server.TransactionResult hiding (constructArgValuesAndSource)
+import Bloc.Server.TransactionResult
 import Bloc.Server.Utils
 import BlockApps.Logging
 import BlockApps.Solidity.ArgValue
 import BlockApps.Solidity.Contract ()
-import BlockApps.Solidity.Storage
 import BlockApps.Solidity.Type
 import BlockApps.Solidity.Value
 import qualified BlockApps.Solidity.Xabi.Type as Xabi
@@ -65,8 +62,6 @@ import Control.Monad.Extra
 import Control.Monad.Reader
 import Control.Monad.Trans.State.Lazy
 import Data.Bool
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as ByteString
 import qualified Data.Cache as Cache
 import qualified Data.Cache.Internal as Cache
 import Data.Foldable
@@ -83,10 +78,10 @@ import qualified Data.Set as S
 import Data.Source.Map
 import Data.Text (Text, unpack)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 import Data.Time.Clock
 import qualified Data.Vector as V
 import Handlers.AccountInfo
+import Handlers.Storage
 import Handlers.Transaction
 import SQLM
 import SolidVM.Model.CodeCollection.Contract
@@ -112,6 +107,7 @@ postBlocTransactionBody ::
   ( MonadIO m,
     MonadLogger m,
     A.Selectable AccountsFilterParams [AddressStateRef] m,
+    A.Selectable StorageFilterParams [StorageAddress] m,
     A.Selectable Address AddressState m,
     A.Selectable Keccak256 SourceMap m,
     HasCodeDB m,
@@ -134,7 +130,7 @@ postBlocTransactionBody (PostBlocTransactionRequest mAddr txList txParams msrcs)
       txsWithParams <- genNonces (Don't CacheNonce) addr sendtransactionTxParams ts
       txs'' <-
         mapM
-          ( \(SendTransaction toAddr params md) -> do
+          ( \(SendTransaction toAddr params _) -> do
               let header =
                     TransactionHeader
                       (Just toAddr)
@@ -161,7 +157,7 @@ postBlocTransactionBody (PostBlocTransactionRequest mAddr txList txParams msrcs)
           getSrc p = fromMaybe mempty $ src' p <|> srcMap p
           mapUploadList =
             map
-              ( \p@(ContractPayload _ c a x _ m) -> do
+              ( \p@(ContractPayload _ c a x _ _) -> do
                   UploadListContract
                     (fromJust c)
                     (getSrc p)
@@ -173,7 +169,7 @@ postBlocTransactionBody (PostBlocTransactionRequest mAddr txList txParams msrcs)
               ps
       txsWithParams <- genNonces (Don't CacheNonce) addr uploadlistcontractTxParams mapUploadList
       forStateT Map.empty txsWithParams $
-        \(UploadListContract name srcs args params md cPtr) -> do
+        \(UploadListContract name srcs args params _ cPtr) -> do
           (src, contract) <- do
             cd <-
               fmap snd . lift $
@@ -184,7 +180,7 @@ postBlocTransactionBody (PostBlocTransactionRequest mAddr txList txParams msrcs)
 
           let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
               xabiArgs = Map.fromList . catMaybes . maybe [] (map f . _funcArgs) $ _constructor contract
-          (_, argsAsSource) <- lift $ constructArgValuesAndSource (Just args) xabiArgs
+          argsAsSource <- lift $ constructArgValuesAndSource (Just args) xabiArgs
           
           tx <- lift . signAndPrepare addr $
               TransactionHeader
@@ -215,13 +211,13 @@ postBlocTransactionBody (PostBlocTransactionRequest mAddr txList txParams msrcs)
                 Nothing -> lift $ throwIO . UserError $ "Could not find contract " <> Text.pack (format methodcallContractAddress)
                 Just x -> pure x
               at methodcallContractAddress <?= x
-          sel <- case M.lookup (Text.unpack methodcallMethodName) (contract ^. functions) of
-            Just _ -> return $ Text.encodeUtf8 methodcallMethodName
+          case M.lookup (Text.unpack methodcallMethodName) (contract ^. functions) of
+            Just _ -> pure ()
             Nothing -> throwIO . UserError $ "Contract doesn't have a method named '" <> methodcallMethodName <> "'"
 
           let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
               xabiArgs = Map.fromList . catMaybes . maybe [] (map f . _funcArgs) . Map.lookup (Text.unpack methodcallMethodName) $ contract ^. functions
-          (argsBin, argsAsSource) <- lift $ constructArgValuesAndSource (Just methodcallArgs) xabiArgs
+          argsAsSource <- lift $ constructArgValuesAndSource (Just methodcallArgs) xabiArgs
           tx <- lift . signAndPrepare addr $
             TransactionHeader
               (Just methodcallContractAddress)
@@ -251,6 +247,7 @@ postBlocTransactionUnsigned ::
   ( MonadIO m,
     MonadLogger m,
     A.Selectable AccountsFilterParams [AddressStateRef] m,
+    A.Selectable StorageFilterParams [StorageAddress] m,
     A.Selectable Address AddressState m,
     A.Selectable Keccak256 SourceMap m,
     HasCodeDB m,
@@ -272,7 +269,7 @@ postBlocTransactionUnsigned (PostBlocTransactionRequest mAddr txList txParams ms
       let t = (\(TransferPayload t' x m) -> SendTransaction t' (mergeTxParams x txParams) m) tx'
       txsWithParams <- genNonces (Don't CacheNonce) addr sendtransactionTxParams [t]
       mapM
-        ( \(SendTransaction toAddr params md) -> do
+        ( \(SendTransaction toAddr params _) -> do
             let header =
                   TransactionHeader
                     (Just toAddr)
@@ -297,7 +294,7 @@ postBlocTransactionUnsigned (PostBlocTransactionRequest mAddr txList txParams ms
               else Just $ contractpayloadSrc p
           getSrc p = fromMaybe mempty $ src' p <|> srcMap p
           upload =
-            ( \p@(ContractPayload _ c a x _ m) -> do
+            ( \p@(ContractPayload _ c a x _ _) -> do
                 UploadListContract
                   (fromJust c)
                   (getSrc p)
@@ -309,7 +306,7 @@ postBlocTransactionUnsigned (PostBlocTransactionRequest mAddr txList txParams ms
               ps
       txsWithParams <- genNonces (Don't CacheNonce) addr uploadlistcontractTxParams [upload]
       forStateT Map.empty txsWithParams $
-        \(UploadListContract name srcs args params md cPtr) -> do
+        \(UploadListContract name srcs args params _ cPtr) -> do
           (src, contract) <- do
             cd <-
               fmap snd . lift $
@@ -320,7 +317,7 @@ postBlocTransactionUnsigned (PostBlocTransactionRequest mAddr txList txParams ms
 
           let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
               xabiArgs = Map.fromList . catMaybes . maybe [] (map f . _funcArgs) $ _constructor contract
-          (_, argsAsSource) <- lift $ constructArgValuesAndSource (Just args) xabiArgs
+          argsAsSource <- lift $ constructArgValuesAndSource (Just args) xabiArgs
           
           lift . prepareUnsignedRawTx name argsAsSource $
               TransactionHeader
@@ -350,14 +347,13 @@ postBlocTransactionUnsigned (PostBlocTransactionRequest mAddr txList txParams ms
                 Nothing -> lift $ throwIO . UserError $ "Could not find contract " <> Text.pack (format methodcallContractAddress)
                 Just x -> pure x
               at methodcallContractAddress <?= x
-          sel <- case M.lookup (Text.unpack methodcallMethodName) (contract ^. functions) of
-            Just _ -> return $ Text.encodeUtf8 methodcallMethodName
+          case M.lookup (Text.unpack methodcallMethodName) (contract ^. functions) of
+            Just _ -> pure ()
             Nothing -> throwIO . UserError $ "Contract doesn't have a method named '" <> methodcallMethodName <> "'"
           
           let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
               xabiArgs = Map.fromList . catMaybes . maybe [] (map f . _funcArgs) . Map.lookup (Text.unpack methodcallMethodName) $ contract ^. functions
-          (argsBin, argsAsSource) <-
-            lift $ constructArgValuesAndSource (Just methodcallArgs) xabiArgs
+          argsAsSource <- lift $ constructArgValuesAndSource (Just methodcallArgs) xabiArgs
           lift . prepareUnsignedRawTx methodcallMethodName argsAsSource $
             TransactionHeader
               (Just methodcallContractAddress)
@@ -402,6 +398,7 @@ postBlocTransactionParallel ::
     Mod.Accessible (Maybe BestBlock) m,
     Mod.Accessible (Maybe WorldBestBlock) m,
     A.Selectable AccountsFilterParams [AddressStateRef] m,
+    A.Selectable StorageFilterParams [StorageAddress] m,
     A.Selectable Address AddressState m,
     A.Selectable Address Certificate m,
     A.Selectable Keccak256 [TransactionResult] m,
@@ -425,6 +422,7 @@ postBlocTransaction ::
     Mod.Accessible (Maybe BestBlock) m,
     Mod.Accessible (Maybe WorldBestBlock) m,
     A.Selectable AccountsFilterParams [AddressStateRef] m,
+    A.Selectable StorageFilterParams [StorageAddress] m,
     A.Selectable Address AddressState m,
     A.Selectable Address Certificate m,
     A.Selectable Keccak256 [TransactionResult] m,
@@ -448,6 +446,7 @@ postBlocTransaction' ::
     Mod.Accessible (Maybe BestBlock) m,
     Mod.Accessible (Maybe WorldBestBlock) m,
     A.Selectable AccountsFilterParams [AddressStateRef] m,
+    A.Selectable StorageFilterParams [StorageAddress] m,
     A.Selectable Address AddressState m,
     A.Selectable Address Certificate m,
     A.Selectable Keccak256 [TransactionResult] m,
@@ -533,7 +532,7 @@ postBlocTransaction' cacheNonce mUseWallet resolve (PostBlocTransactionRequest m
 
             let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
                 xabiArgs = Map.fromList . catMaybes $ maybe [] (map f . _funcArgs) _constructor
-            (_, argsAsSource) <- constructArgValuesAndSource contractArgs xabiArgs
+            argsAsSource <- constructArgValuesAndSource contractArgs xabiArgs
 
             let bcp =
                   FunctionParameters
@@ -584,7 +583,7 @@ postBlocTransaction' cacheNonce mUseWallet resolve (PostBlocTransactionRequest m
 
                               let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
                                   xabiArgs = Map.fromList . catMaybes $ maybe [] (map f . _funcArgs) _constructor
-                              (_, argsAsSource) <- constructArgValuesAndSource a xabiArgs
+                              argsAsSource <- constructArgValuesAndSource a xabiArgs
                               pure $ MethodCall 
                                 userContractAddr 
                                 "createContract"  
@@ -781,7 +780,7 @@ postUsersContractSolidVM' cacheNonce ContractParameters {..} = do
 
   let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
       xabiArgs = Map.fromList . catMaybes $ maybe [] (map f . _funcArgs) _constructor
-  (_, argsAsSource) <- constructArgValuesAndSource args xabiArgs
+  argsAsSource <- constructArgValuesAndSource args xabiArgs
 
   tx <-
     signAndPrepare fromAddr $
@@ -823,7 +822,7 @@ postUsersUploadListSolidVM' cacheNonce ContractListParameters {..} = do
   txSizeLimit <- fmap txSizeLimit getBlocEnv
   txsWithParams <- genNonces cacheNonce fromAddr uploadlistcontractTxParams contracts
   namesTxs <- forStateT Map.empty txsWithParams $
-    \(UploadListContract name srcs args params md cPtr) -> do
+    \(UploadListContract name srcs args params _ cPtr) -> do
       (src, contract) <- do
         cd <-
           fmap snd . lift $
@@ -834,7 +833,7 @@ postUsersUploadListSolidVM' cacheNonce ContractListParameters {..} = do
 
       let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
           xabiArgs = Map.fromList . catMaybes . maybe [] (map f . _funcArgs) $ _constructor contract
-      (_, argsAsSource) <- lift $ constructArgValuesAndSource (Just args) xabiArgs
+      argsAsSource <- lift $ constructArgValuesAndSource (Just args) xabiArgs
       
       tx <-
         lift . signAndPrepare fromAddr $
@@ -873,7 +872,7 @@ postUsersSendList' cacheNonce TransferListParameters {..} = do
   txSizeLimit <- fmap txSizeLimit getBlocEnv
   txs'' <-
     mapM
-      ( \(SendTransaction toAddr params md) -> do
+      ( \(SendTransaction toAddr params _) -> do
           let header =
                 TransactionHeader
                   (Just toAddr)
@@ -894,6 +893,7 @@ postUsersContractMethodList' ::
   ( MonadUnliftIO m,
     MonadLogger m,
     A.Selectable AccountsFilterParams [AddressStateRef] m,
+    A.Selectable StorageFilterParams [StorageAddress] m,
     A.Selectable Address AddressState m,
     A.Selectable Keccak256 [TransactionResult] m,
     A.Selectable TxsFilterParams [RawTransaction] m,
@@ -923,13 +923,13 @@ postUsersContractMethodList' cacheNonce FunctionListParameters {..} = do
                 Nothing -> lift $ throwIO . UserError $ "Could not find contract " <> Text.pack (show methodcallContractAddress)
                 Just x -> pure x
               at methodcallContractAddress <?= x
-          sel <- case M.lookup (Text.unpack methodcallMethodName) (contract ^. functions) of
-            Just _ -> return $ Text.encodeUtf8 methodcallMethodName
+          case M.lookup (Text.unpack methodcallMethodName) (contract ^. functions) of
+            Just _ -> pure ()
             Nothing -> throwIO . UserError $ "Contract doesn't have a method named '" <> methodcallMethodName <> "'"
 
           let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
               xabiArgs = Map.fromList . catMaybes . maybe [] (map f . _funcArgs) . Map.lookup (Text.unpack methodcallMethodName) $ contract ^. functions
-          (argsBin, argsAsSource) <- lift $ constructArgValuesAndSource (Just methodcallArgs) xabiArgs
+          argsAsSource <- lift $ constructArgValuesAndSource (Just methodcallArgs) xabiArgs
           tx <- lift . signAndPrepare fromAddr $
             TransactionHeader
               (Just methodcallContractAddress)
@@ -953,6 +953,7 @@ postUsersContractMethod' ::
   ( MonadUnliftIO m,
     MonadLogger m,
     A.Selectable AccountsFilterParams [AddressStateRef] m,
+    A.Selectable StorageFilterParams [StorageAddress] m,
     A.Selectable Address AddressState m,
     A.Selectable Keccak256 [TransactionResult] m,
     A.Selectable TxsFilterParams [RawTransaction] m,
@@ -978,13 +979,13 @@ postUsersContractMethod' cacheNonce FunctionParameters {..} = do
   contract <-
     maybe (throwIO err) pure
       =<< getContractByAddress contractAddr
-  sel <- case M.lookup (Text.unpack funcName) (contract ^. functions) of
-    Just _ -> return $ Text.encodeUtf8 funcName
+  case M.lookup (Text.unpack funcName) (contract ^. functions) of
+    Just _ -> pure ()
     Nothing -> throwIO . UserError $ "Contract doesn't have a method named '" <> funcName <> "'"
 
   let f = sequence . ((Text.pack . fromMaybe "") *** indexedTypeToEvmIndexedType)
       xabiArgs = Map.fromList . catMaybes . maybe [] (map f . _funcArgs) . Map.lookup (Text.unpack funcName) $ contract ^. functions
-  (argsBin, argsAsSource) <- constructArgValuesAndSource (Just args) xabiArgs
+  argsAsSource <- constructArgValuesAndSource (Just args) xabiArgs
 
   let network = "mercata"
 
@@ -1021,7 +1022,7 @@ prepareUnsignedTx gasLimit TransactionHeader {..} =
         transactionS = 0,
         transactionV = 0
       }
-    Just toAddr ->
+    Just _ ->
       MessageTX
       { transactionNonce = fromIntegral $ fromMaybe 0 (txparamsNonce transactionheaderTxParams),
         transactionGasLimit = fromIntegral $ fromMaybe (Gas gasLimit) (txparamsGasLimit transactionheaderTxParams),
@@ -1039,7 +1040,7 @@ preparePostTx ::
   Address ->
   Transaction ->
   RawTransaction'
-preparePostTx time from tx =
+preparePostTx time _ tx =
   flip RawTransaction' "" $
     txAndTime2RawTX API tx 0 time
 
@@ -1102,20 +1103,14 @@ constructArgValuesAndSource ::
   (MonadIO m, MonadLogger m) =>
   Maybe (Map Text ArgValue) ->
   Map Text Xabi.IndexedType ->
-  m (ByteString, [Text])
+  m [Text]
 constructArgValuesAndSource args argNamesTypes = do
   case args of
     Nothing ->
       if Map.null argNamesTypes
-        then return (ByteString.empty, [])
+        then return []
         else throwIO (UserError "no arguments provided to function.")
-    Just argsMap -> do
-      vals <- getArgValues argsMap argNamesTypes
-      let valsAsText = map valueToText vals
-      return $
-        ( toStorage (ValueArrayFixed (fromIntegral (length vals)) vals),
-          valsAsText
-        )
+    Just argsMap -> map valueToText <$> getArgValues argsMap argNamesTypes
 
 getAccountTxParams ::
   ( MonadIO m

--- a/strato/api/bloc/bloc2/src/Bloc/Server/TransactionResult.hs
+++ b/strato/api/bloc/bloc2/src/Bloc/Server/TransactionResult.hs
@@ -18,7 +18,6 @@ module Bloc.Server.TransactionResult
     getBatchBlocTransactionResult',
     getBlocTransactionResult',
     forStateT,
-    constructArgValuesAndSource,
     recurseTRDs,
     TRD (..),
   )
@@ -34,7 +33,6 @@ import BlockApps.Logging
 import BlockApps.Solidity.ArgValue
 import BlockApps.Solidity.Contract ()
 import BlockApps.Solidity.SolidityValue
-import BlockApps.Solidity.Storage
 import BlockApps.Solidity.Type
 import BlockApps.Solidity.Value
 import qualified BlockApps.Solidity.Xabi.Type as Xabi
@@ -50,7 +48,6 @@ import qualified Control.Monad.Change.Alter as A
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.State.Lazy
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as ByteString
 import Data.Either
 import Data.Foldable
 import Data.Int (Int32)
@@ -350,25 +347,6 @@ expressionToValue _ = Nothing
 
 -- TODO: implement expressionToValue for tuples and mappings
 --expressionToValue (TupleExpression _ n) = Just $ SMV.STuple $ traverse expressionToValue n -- [SMV.Value]
-
-constructArgValuesAndSource ::
-  (MonadIO m, MonadLogger m) =>
-  Maybe (Map Text ArgValue) ->
-  Map Text Xabi.IndexedType ->
-  m (ByteString, Text)
-constructArgValuesAndSource args argNamesTypes = do
-  case args of
-    Nothing ->
-      if Map.null argNamesTypes
-        then return (ByteString.empty, "()")
-        else throwIO (UserError "no arguments provided to function.")
-    Just argsMap -> do
-      vals <- getArgValues argsMap argNamesTypes
-      let valsAsText = map valueToText vals
-      return $
-        ( toStorage (ValueArrayFixed (fromIntegral (length vals)) vals),
-          "(" <> Text.intercalate "," valsAsText <> ")"
-        )
 
 getArgValues ::
   (MonadIO m, MonadLogger m) =>


### PR DESCRIPTION
This is a quick hack to get around the issues with calling Proxy contracts through the API. If the contract is named "Proxy", and the function name being called is not "setLogicContract", then the API will load the ".logicContract" storage element from the contract's storage, then load the code for that address. Ideally, we wouldn't have to hardcode any of these names in the API, but this should get us back up and running for the time being. I added a TODO comment where this hack occurs