### PR TITLE
Process delegatecalls directly for action to ensure all views get refreshed

### DIFF
--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -67,7 +67,7 @@ import Control.Monad.Change.Alter (Alters, Selectable)
 import qualified Control.Monad.Change.Alter as A
 import Control.Monad.Composable.Redis
 import Control.Monad.IO.Class
-import Data.Foldable (for_, toList)
+import Data.Foldable (for_)
 import qualified Data.Map as Map
 import Data.Map.Strict (Map)
 import qualified Data.Map.Ordered as OMap
@@ -396,8 +396,7 @@ populateStorageDBs' getMetadata genesisInfo genesisBlock genesisChainId sr pub =
               A._events = addressEvents,
               A._delegatecalls = delegatecalls
             }
-          dcms = Just . DelegatecallMade <$> toList delegatecalls
-      pure $ catMaybes $ [cca, act] ++ dcms
+      pure $ catMaybes [cca, act]
       where
 
         fromDiff :: Diff a 'Eventual -> a

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -94,7 +94,6 @@ import Data.Bool (bool)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.DList as DL
-import Data.Foldable (toList)
 import Data.List
 import qualified Data.Map as M
 import qualified Data.Map.Ordered as O
@@ -654,10 +653,9 @@ outputTransactionResult b hashFunction (TxRunResult ot@OutputTx {otHash = theHas
     else case erAction <$> result of
       Right (Just act) ->
         let ccEvents = maybeToList $ extractCodeCollectionAddedMessages act
-            dcEvents = DelegatecallMade <$> toList (act ^. Action.delegatecalls)
             act' = act { Action._actionData = Action.omapMap (Action.actionDataCodeCollection .~ mempty) (Action._actionData act) }
             actionEvents = [NewAction act']
-         in ccEvents ++ dcEvents ++ actionEvents
+         in ccEvents ++ actionEvents
       _ -> []
 
 extractCodeCollectionAddedMessages :: Action.Action -> Maybe VMEvent

--- a/strato/core/vm-tools/src/Blockchain/Stream/VMEvent.hs
+++ b/strato/core/vm-tools/src/Blockchain/Stream/VMEvent.hs
@@ -14,7 +14,7 @@ import Blockchain.EthConf
 import Blockchain.KafkaTopics
 import Blockchain.Strato.Model.Address
 import Blockchain.Strato.Model.CodePtr
-import Blockchain.Stream.Action (Action, Delegatecall)
+import Blockchain.Stream.Action (Action)
 import Conduit
 import Control.Monad.Composable.Kafka
 import qualified Data.Aeson as JSON
@@ -35,7 +35,6 @@ data VMEvent
         application :: Text,
         abstracts :: Map (Address, Text) (Text, Text, [Text])
       }
-  | DelegatecallMade Delegatecall
   | NewTransactionResult TransactionResult
   deriving (Show, Generic)
 
@@ -48,8 +47,6 @@ instance Format VMEvent where
   format (NewAction a) = "NewAction:\n" ++ tab (format a)
   format (CodeCollectionAdded _ cp cr ap _) =
     "CodeCollectionAdded: (" ++ show cr ++ "/" ++ show ap ++ ") " ++ vmType cp
-  format (DelegatecallMade d) =
-    "DelegatecallMade: " ++ format d
   format (NewTransactionResult tr) = "NewTransactionResult:\n" ++ tab (format tr)
 
 instance Binary VMEvent

--- a/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
@@ -231,8 +231,8 @@ processTheMessages messages = do
       -- level like this
       creates =
         [(cc, cp, cr, ap) | VME.CodeCollectionAdded cc cp cr ap _ <- messages]
-      delegatecalls =
-        [d | VME.DelegatecallMade d <- messages]
+      delegatecalls = concatMap toList
+        [Action._delegatecalls a | VME.NewAction a <- messages]
       transactionResults = [tr | VME.NewTransactionResult tr <- messages]
 
   fkeys <- mapOutput Right . outputDataDedup . fmap concat . forM creates $ \(cc, cp, cr, ap) -> do


### PR DESCRIPTION
The reason buildtest and other nodes have some discrepancies in cirrus seems to be that sometimes some views aren't being refreshed when they should be. Upon inspection of the underlying `storage`, `contract`, and `event` tables, the correct data is there, so it is just a matter of refreshing the views on that data.

I think the issue is that, since delegatecall info was being sent in separate `DelegatecallMade` events, if Slipstream happened to read a batch from Kafka that ended right between the `DelegatecallMade` event(s) for a transaction and the transaction's `NewAction` event, the logic that lets Slipstream know to refresh the views for the Proxy contracts would not run, causing the views to go unrefreshed.

The fix I have here is to remove the separate `DelegatecallMade` events from Kafka, and have Slipstream use the _same_ delegatecall info that's already in the `NewAction` event 🤦, completely removing the chance that Kafka might split the events into separate batches.

I've tested locally and everything looks good, but I'd like to get this on all the other nodes to see if the problem is really fixed. 