### PR TITLE
Remove wallet balance check from SafetyModule.startCooldown()

### DIFF
--- a/mercata/contracts/concrete/Lending/SafetyModule.sol
+++ b/mercata/contracts/concrete/Lending/SafetyModule.sol
@@ -41,7 +41,7 @@ contract record SafetyModule is Ownable {
     // Policy
     uint public MAX_SLASH_BPS = 3000; // 30% per event
 
-    constructor(address _owner) Ownable(_owner) { }
+    constructor(address initialOwner) Ownable(initialOwner) { }
 
     function initialize(address _lendingRegistry, address _tokenFactory) external onlyOwner {
         // @dev important: must be set here for proxied instances; ensure consistency with desired initial values
@@ -200,9 +200,8 @@ contract record SafetyModule is Ownable {
     }
 
     /// @notice Start cooldown. After COOLDOWN_SECONDS elapse, you have UNSTAKE_WINDOW to redeem.
-    /// @dev Overwrites previous starts. Requires wallet-held shares (not Chef).
+    /// @dev Overwrites previous starts.
     function startCooldown() external {
-        require(IERC20(sToken).balanceOf(msg.sender) > 0, "SM:no shares");
         uint start = block.timestamp;
         cooldownStart[msg.sender] = start;
         emit UnstakeCooldown(msg.sender, start, start + COOLDOWN_SECONDS);


### PR DESCRIPTION
# Context

The issue was found while working on https://github.com/blockapps/strato-platform/pull/5031, and it is related to that functionality

# The Change

Remove wallet balance check from SafetyModule.startCooldown()

# Why

Allow users to start cooldown even when all sUSDST shares are staked in RewardsChef. The cooldown is just a timestamp and doesn't require shares to be in the wallet at that moment.

The actual share balance verification happens during redeem(), where it's appropriate. This prevents "SM:no shares" errors when users have shares staked in rewards but not in their wallet.

Added TODO comment suggesting future enhancement: check both wallet and RewardsChef staked balances to prevent meaningless cooldowns when users have zero total shares.