### PR TITLE
Deduplicate event names in Activity Feed dropdown

### DIFF
--- a/mercata/ui/src/components/dashboard/ActivityFeedFilters.tsx
+++ b/mercata/ui/src/components/dashboard/ActivityFeedFilters.tsx
@@ -68,6 +68,11 @@ const ActivityFeedFilters = memo(({
     ? eventNames.filter(event => event.contract === filters.contract_name)
     : eventNames;
 
+  // Deduplicate event names to prevent "DepositedDeposited" when "All Contracts" is selected
+  const uniqueEventNames = Array.from(
+    new Map(availableEvents.map(event => [event.name, event])).values()
+  );
+
   return (
     <div className="mb-4 sm:mb-6 p-3 sm:p-4 border rounded-lg bg-gray-50">
       <div className="flex items-center gap-2 mb-2 sm:mb-3">
@@ -118,7 +123,7 @@ const ActivityFeedFilters = memo(({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">All Events</SelectItem>
-              {availableEvents.map((event) => (
+              {uniqueEventNames.map((event) => (
                 <SelectItem key={`${event.contract}-${event.name}`} value={event.name}>
                   {event.name}
                 </SelectItem>


### PR DESCRIPTION
Fixes #5014

No longer DepositedDeposited:

<img width="3164" height="949" alt="Image" src="https://github.com/user-attachments/assets/7d4619a9-ac97-4f9d-8ead-54f5d3ecb463" />

Still shows events from all contracts that have an event of this name:

<img width="3721" height="2108" alt="Image" src="https://github.com/user-attachments/assets/948c354b-a98a-4d85-8711-496a1f33fc1a" />