### PR TITLE
Fixed a couple more typechecker bugs

### DIFF
--- a/mercata/contracts/concrete/CDP/CDPEngine.sol
+++ b/mercata/contracts/concrete/CDP/CDPEngine.sol
@@ -155,7 +155,7 @@ contract record CDPEngine is Ownable {
 
     modifier onlyActiveAsset(address asset) {
         require(isSupportedAsset[asset], "unsupported");
-        require(TokenFactory(_tokenFactory()).isTokenActive(asset), "inactive");
+        require(_tokenFactory().isTokenActive(asset), "inactive");
         _;
     }
     
@@ -216,7 +216,7 @@ contract record CDPEngine is Ownable {
     function deposit(address asset, uint amount) external whenNotPaused(asset) onlyActiveAsset(asset) {
         require(amount > 0, "CDPEngine: Invalid amount");
         // Move collateral into vault custody and update in-memory vault balance
-        CDPVault(_cdpVault()).deposit(msg.sender, asset, amount);
+        _cdpVault().deposit(msg.sender, asset, amount);
         vaults[msg.sender][asset].collateral += amount;
         emit Deposited(msg.sender, asset, amount);
         emit VaultUpdated(msg.sender, asset, vaults[msg.sender][asset].collateral, vaults[msg.sender][asset].scaledDebt);
@@ -239,7 +239,7 @@ contract record CDPEngine is Ownable {
             require(crAfter >= collateralConfigs[asset].liquidationRatio, "CDPEngine: Undercollateralized");
         }
         // Perform custody move after checks
-        CDPVault(_cdpVault()).withdraw(msg.sender, asset, amount);
+        _cdpVault().withdraw(msg.sender, asset, amount);
         emit Withdrawn(msg.sender, asset, amount);
         emit VaultUpdated(msg.sender, asset, vault.collateral, vault.scaledDebt);
     }
@@ -259,7 +259,7 @@ contract record CDPEngine is Ownable {
             maxAmount = vault.collateral;
         } else {
             // Compute collateral required to keep CR >= LR
-            uint price = PriceOracle(_cdpPriceOracle()).getAssetPrice(asset);
+            uint price = _cdpPriceOracle().getAssetPrice(asset);
             require(price > 0, "invalid price");
             CollateralConfig memory config = collateralConfigs[asset];
             uint requiredCollateralValue = (debt * config.liquidationRatio) / WAD;
@@ -274,7 +274,7 @@ contract record CDPEngine is Ownable {
         if (maxAmount > 0) {
             // Update vault balance then move funds from custody
             vault.collateral -= maxAmount;
-            CDPVault(_cdpVault()).withdraw(msg.sender, asset, maxAmount);
+            _cdpVault().withdraw(msg.sender, asset, maxAmount);
             emit Withdrawn(msg.sender, asset, maxAmount);
             emit VaultUpdated(msg.sender, asset, vault.collateral, vault.scaledDebt);
         }
@@ -295,7 +295,7 @@ contract record CDPEngine is Ownable {
         // Compute current debt in USD using scaledDebt and rateAccumulator
         uint currentDebt = (userVault.scaledDebt * assetState.rateAccumulator) / RAY;
         // Value collateral in USD and compute borrow headroom from LR
-        uint price = PriceOracle(_cdpPriceOracle()).getAssetPrice(asset);
+        uint price = _cdpPriceOracle().getAssetPrice(asset);
         require(price > 0, "invalid price");
         uint collateralValueUSD_calc = (userVault.collateral * price) / assetConfig.unitScale;
         uint maxBorrowableUSD = (collateralValueUSD_calc * WAD) / assetConfig.liquidationRatio;
@@ -333,7 +333,7 @@ contract record CDPEngine is Ownable {
         // Current owed in USD
         uint currentDebt = (userVault.scaledDebt * assetState.rateAccumulator) / RAY;
         // Compute borrow headroom from collateral value and LR
-        uint price = PriceOracle(_cdpPriceOracle()).getAssetPrice(asset);
+        uint price = _cdpPriceOracle().getAssetPrice(asset);
         require(price > 0, "invalid price");
         uint collateralValueUSD_calc = (userVault.collateral * price) / config.unitScale;
         uint maxBorrowableUSD = (collateralValueUSD_calc * WAD) / config.liquidationRatio;
@@ -474,7 +474,7 @@ contract record CDPEngine is Ownable {
         require(borrowerCR < config.liquidationRatio, "CDPEngine: position healthy");
 
         // Prices & caps
-        uint priceColl = PriceOracle(_cdpPriceOracle()).getAssetPrice(collateralAsset);
+        uint priceColl = _cdpPriceOracle().getAssetPrice(collateralAsset);
         require(priceColl > 0, "CDPEngine: invalid collateral price");
 
         uint totalDebtUSD   = (borrowerVault.scaledDebt * assetState.rateAccumulator) / RAY;
@@ -523,7 +523,7 @@ contract record CDPEngine is Ownable {
         }
 
         borrowerVault.collateral -= collateralToSeize;
-        CDPVault(_cdpVault()).seize(borrower, collateralAsset, msg.sender, collateralToSeize);
+        _cdpVault().seize(borrower, collateralAsset, msg.sender, collateralToSeize);
 
         // Dust cleanup first, then emit events with final state
         uint remainingDebtUSD = (borrowerVault.scaledDebt * assetState.rateAccumulator) / RAY;
@@ -536,7 +536,7 @@ contract record CDPEngine is Ownable {
         if (borrowerVault.collateral > 0 && borrowerVault.collateral <= collateralDustThreshold) {
             // Transfer dust collateral to liquidator and zero it out
             dustCollateralSeized = borrowerVault.collateral;
-            CDPVault(_cdpVault()).seize(borrower, collateralAsset, msg.sender, borrowerVault.collateral);
+            _cdpVault().seize(borrower, collateralAsset, msg.sender, borrowerVault.collateral);
             borrowerVault.collateral = 0;
         }
         
@@ -610,7 +610,7 @@ contract record CDPEngine is Ownable {
         
         // Seize any remaining dust collateral to caller as reward
         if (borrowerVault.collateral > 0) {
-            CDPVault(_cdpVault()).seize(borrower, collateralAsset, msg.sender, borrowerVault.collateral);
+            _cdpVault().seize(borrower, collateralAsset, msg.sender, borrowerVault.collateral);
             borrowerVault.collateral = 0;
         }
         
@@ -775,7 +775,7 @@ contract record CDPEngine is Ownable {
         Vault storage v = vaults[user][asset];
         uint debtUSD = (v.scaledDebt * s.rateAccumulator) / RAY;
         if (debtUSD == 0) return (2**256 - 1); 
-        uint price = PriceOracle(_cdpPriceOracle()).getAssetPrice(asset);
+        uint price = _cdpPriceOracle().getAssetPrice(asset);
         require(price > 0, "invalid price");
         uint unitScale = collateralConfigs[asset].unitScale;
         uint collateralUSD = unitScale == 0 ? 0 : (v.collateral * price) / unitScale;
@@ -852,7 +852,7 @@ contract record CDPEngine is Ownable {
         if (juniorIndex == 0) juniorIndex = 1e27;
 
         address reserveAddr = address(registry.cdpReserve());
-        uint256 reserveBal = ERC20(address(_usdst())).balanceOf(reserveAddr);
+        uint256 reserveBal = _usdst().balanceOf(reserveAddr);
 
         // Nothing new to index
         if (reserveBal <= prevReserveBalance) return;
@@ -975,7 +975,7 @@ contract record CDPEngine is Ownable {
         // Calculate effective index including unaccounted reserve inflows
         uint256 effectiveIndex = juniorIndex == 0 ? 1e27 : juniorIndex;
         address reserveAddr = address(registry.cdpReserve());
-        uint256 reserveBalance = ERC20(address(_usdst())).balanceOf(reserveAddr);
+        uint256 reserveBalance = _usdst().balanceOf(reserveAddr);
         
         if (reserveBalance > prevReserveBalance && totalJuniorOutstandingUSDST > 0) {
             uint256 newInflows = reserveBalance - prevReserveBalance;
@@ -998,7 +998,7 @@ contract record CDPEngine is Ownable {
         require(entitlement > 0, "junior: nothing to claim");
 
         address reserveAddr = address(registry.cdpReserve());
-        uint256 reserveBalance = ERC20(address(_usdst())).balanceOf(reserveAddr);
+        uint256 reserveBalance = _usdst().balanceOf(reserveAddr);
         require(reserveBalance > 0, "junior: reserve empty");
 
         uint256 payAmount = entitlement <= reserveBalance ? entitlement : reserveBalance;

--- a/mercata/contracts/concrete/CDP/CDPReserve.sol
+++ b/mercata/contracts/concrete/CDP/CDPReserve.sol
@@ -38,7 +38,7 @@ contract record CDPReserve is Ownable {
   /// @notice Called by Engine to pay out USDST to `to`.
   function transferTo(address to, uint256 amount) external onlyEngine {
     require(to != address(0), "Reserve: to=0");
-    require(ERC20(address(_usdst())).transfer(to, amount), "Reserve: transfer failed");
+    require(_usdst().transfer(to, amount), "Reserve: transfer failed");
     emit Transferred(to, amount);
   }
 

--- a/mercata/contracts/concrete/Pools/Pool.sol
+++ b/mercata/contracts/concrete/Pools/Pool.sol
@@ -180,8 +180,8 @@ contract record Pool is Ownable {
     /// @notice Sync the pool's reserves with current balances (external version)
     /// @dev Updates reserves to match current token balances
     function sync() external onlyPoolFactory {
-        tokenABalance = ERC20(tokenA).balanceOf(address(this));
-        tokenBBalance = ERC20(tokenB).balanceOf(address(this));
+        tokenABalance = tokenA.balanceOf(address(this));
+        tokenBBalance = tokenB.balanceOf(address(this));
         _updateRatios();
         emit Sync(tokenABalance, tokenBBalance);
     }
@@ -190,14 +190,14 @@ contract record Pool is Ownable {
     /// @param to Address to send the excess tokens to
     function skim(address to) external onlyPoolFactory {
         require(to != address(0), "Invalid recipient");
-        uint256 excessA = ERC20(tokenA).balanceOf(address(this)) - tokenABalance;
-        uint256 excessB = ERC20(tokenB).balanceOf(address(this)) - tokenBBalance;
+        uint256 excessA = tokenA.balanceOf(address(this)) - tokenABalance;
+        uint256 excessB = tokenB.balanceOf(address(this)) - tokenBBalance;
 
         if (excessA > 0) {
-            require(ERC20(tokenA).transfer(to, excessA), "TokenA skim failed");
+            require(tokenA.transfer(to, excessA), "TokenA skim failed");
         }
         if (excessB > 0) {
-            require(ERC20(tokenB).transfer(to, excessB), "TokenB skim failed");
+            require(tokenB.transfer(to, excessB), "TokenB skim failed");
         }
 
         emit Skim(to, excessA, excessB);
@@ -255,7 +255,7 @@ contract record Pool is Ownable {
         require(tokenBAmount > 0 && maxTokenAAmount > 0, "Invalid inputs");
         require(block.timestamp <= deadline, "EXPIRED");
         
-        uint256 totalLiquidity = ERC20(lpToken).totalSupply();
+        uint256 totalLiquidity = lpToken.totalSupply();
         uint256 tokenAAmount;
         uint256 mintAmount;
         
@@ -269,8 +269,8 @@ contract record Pool is Ownable {
         }
 
         lpToken.mint(msg.sender, mintAmount);
-        require(ERC20(tokenB).transferFrom(msg.sender, address(this), tokenBAmount), "TokenB transfer failed");
-        require(ERC20(tokenA).transferFrom(msg.sender, address(this), tokenAAmount), "TokenA transfer failed");
+        require(tokenB.transferFrom(msg.sender, address(this), tokenBAmount), "TokenB transfer failed");
+        require(tokenA.transferFrom(msg.sender, address(this), tokenAAmount), "TokenA transfer failed");
 
         _updateStateVars(tokenABalance + tokenAAmount, tokenBBalance + tokenBAmount);
         emit AddLiquidity(msg.sender, tokenBAmount, tokenAAmount);
@@ -293,7 +293,7 @@ contract record Pool is Ownable {
     ) external returns (uint256, uint256) {
         require(lpTokenAmount > 0 && minTokenBAmount > 0 && minTokenAAmount > 0, "Invalid inputs");
         require(block.timestamp <= deadline, "EXPIRED");
-        uint256 totalLiquidity = ERC20(lpToken).totalSupply();
+        uint256 totalLiquidity = lpToken.totalSupply();
         require(totalLiquidity > 0, "No liquidity");
         uint256 tokenAReserve = tokenABalance;
         uint256 tokenBReserve = tokenBBalance;
@@ -302,8 +302,8 @@ contract record Pool is Ownable {
         
         require(tokenBAmount >= minTokenBAmount && tokenAAmount >= minTokenAAmount, "Insufficient amounts");
 
-        require(ERC20(tokenB).transfer(msg.sender, tokenBAmount), "TokenB transfer failed");
-        require(ERC20(tokenA).transfer(msg.sender, tokenAAmount), "TokenA transfer failed");
+        require(tokenB.transfer(msg.sender, tokenBAmount), "TokenB transfer failed");
+        require(tokenA.transfer(msg.sender, tokenAAmount), "TokenA transfer failed");
 
         lpToken.burn(msg.sender, lpTokenAmount);
         _updateStateVars(tokenABalance - tokenAAmount, tokenBBalance - tokenBAmount);
@@ -361,15 +361,15 @@ contract record Pool is Ownable {
         uint256 netInput = amountIn - fee;
 
         // Transfer full amount to pool
-        require(ERC20(inputToken).transferFrom(msg.sender, address(this), amountIn), "Input transfer failed");
+        require(inputToken.transferFrom(msg.sender, address(this), amountIn), "Input transfer failed");
         
         // Send protocol fee to fee collector
-        require(ERC20(inputToken).transfer(_feeCollector(), protocolFee), "Protocol fee transfer failed");
+        require(inputToken.transfer(_feeCollector(), protocolFee), "Protocol fee transfer failed");
 
         amountOut = getInputPrice(netInput, inputReserve, outputReserve);
         require(amountOut >= minAmountOut, "Slippage check failed");
 
-        require(ERC20(outputToken).transfer(msg.sender, amountOut), "Output xfer failed");
+        require(outputToken.transfer(msg.sender, amountOut), "Output xfer failed");
 
         // Update balances: net input stays in pool, output is sent out
         if (isAToB) {
@@ -466,7 +466,7 @@ contract record Pool is Ownable {
 
             // protocol fee sent to collector
             Token inputToken = isAToB ? tokenA : tokenB;
-            require(ERC20(inputToken).transfer(_feeCollector(), protocolFee), "Fee transfer failed");
+            require(inputToken.transfer(_feeCollector(), protocolFee), "Fee transfer failed");
         } else {
             netInput = amountIn; // no fees charged
         }
@@ -481,7 +481,7 @@ contract record Pool is Ownable {
         uint256 tokenBContribution,
         uint256 tokenAContribution
     ) internal returns (uint256 liquidityMinted) {
-        uint256 totalLiquidity = ERC20(lpToken).totalSupply();
+        uint256 totalLiquidity = lpToken.totalSupply();
         uint256 tokenBReserve = tokenBBalance;
         liquidityMinted = tokenBContribution * totalLiquidity / tokenBReserve;
         
@@ -501,12 +501,12 @@ contract record Pool is Ownable {
     ) external returns (uint256 liquidityMinted) {
         require(amountIn > 0, "Invalid inputs");
         require(block.timestamp <= deadline, "EXPIRED");
-        require(ERC20(lpToken).totalSupply() > 0, "POOL_EMPTY");
+        require(lpToken.totalSupply() > 0, "POOL_EMPTY");
 
         // Transfer full amount from user to pool
         Token depositToken = isAToB ? tokenA : tokenB;
         uint256 reserveIn = isAToB ? tokenABalance : tokenBBalance; // reserve before deposit
-        require(ERC20(depositToken).transferFrom(msg.sender, address(this), amountIn), "Deposit transfer failed");
+        require(depositToken.transferFrom(msg.sender, address(this), amountIn), "Deposit transfer failed");
         
         uint256 feeBps = zapSwapFeesEnabled ? _swapFeeRate() : 0;
         uint256 swapAmt = _getOptimalSwapAmount(reserveIn, amountIn, feeBps);

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -367,7 +367,7 @@ contract record RewardsChef is Ownable {
         if (user.amount > 0) {
             uint256 pending = ((user.amount * pool.accPerToken) / PRECISION_MULTIPLIER) - user.rewardDebt;
             if (pending > 0) {
-                ERC20(rewardToken).transfer(msg.sender, pending);
+                rewardToken.transfer(msg.sender, pending);
             }
         }
 

--- a/mercata/contracts/tests/Bridge/MercataBridge.test.sol
+++ b/mercata/contracts/tests/Bridge/MercataBridge.test.sol
@@ -243,7 +243,7 @@ contract Describe_MercataBridge {
         uint256 newBlock = 1500;
         bridge.setLastProcessedBlock(externalChainId, newBlock);
         
-        (address _1, address _2, uint lastProcessedBlock, bool _4, string _5) = bridge.chains(externalChainId);
+        (,, uint lastProcessedBlock,,) = bridge.chains(externalChainId);
         uint256 setLastBlock = lastProcessedBlock;
         require(setLastBlock == newBlock, "Last processed block not updated");
     }
@@ -291,7 +291,7 @@ contract Describe_MercataBridge {
         
         bridge.setAssetMetadata(address(testToken), externalChainId, newName, newSymbol);
         
-        (address _1, uint _2, uint _3, string externalName, string externalSymbol, uint _6, uint8 _7) = bridge.assets(address(testToken), externalChainId);
+        (,,, string externalName, string externalSymbol,,) = bridge.assets(address(testToken), externalChainId);
         require(keccak256(externalName) == keccak256(newName), "Name not updated correctly");
         require(keccak256(externalSymbol) == keccak256(newSymbol), "Symbol not updated correctly");
     }
@@ -300,7 +300,7 @@ contract Describe_MercataBridge {
         uint256 newLimit = 2000000e18;
         bridge.setTokenLimits(address(testToken), externalChainId, newLimit);
         
-        (address _1, uint _2, uint _3, string _4, string _5, uint maxPerTx, uint8 _7) = bridge.assets(address(testToken), externalChainId);
+        (,,,,, uint maxPerTx,) = bridge.assets(address(testToken), externalChainId);
         require(maxPerTx == newLimit, "Token limit not updated correctly");
     }
 
@@ -395,7 +395,7 @@ contract Describe_MercataBridge {
         bridge.deposit(externalChainId, externalSender, txHash, address(testToken), amount, recipient, true);
         
         // Check that deposit was created
-        (address stratoToken, address _2, uint _3, address _4, BridgeStatus _5, bool _6, uint _7) = bridge.deposits(externalChainId, txHash);
+        (address stratoToken,,,,,,) = bridge.deposits(externalChainId, txHash);
         require(stratoToken == address(testToken), "Token should be set");
     }
 
@@ -411,7 +411,7 @@ contract Describe_MercataBridge {
         bridge.confirmDeposit(externalChainId, txHash);
         
         // Check that deposit was confirmed
-        (address stratoToken, address _2, uint _3, address _4, BridgeStatus _5, bool _6, uint _7) = bridge.deposits(externalChainId, txHash);
+        (address stratoToken,,,,,,) = bridge.deposits(externalChainId, txHash);
         require(stratoToken == address(testToken), "Token should be set");
     }
 
@@ -426,7 +426,7 @@ contract Describe_MercataBridge {
         // Then mark for review
         bridge.reviewDeposit(externalChainId, txHash);
         
-        (address stratoToken, address _2, uint _3, address _4, BridgeStatus _5, bool _6, uint _7) = bridge.deposits(externalChainId, txHash);
+        (address stratoToken,,,,,,) = bridge.deposits(externalChainId, txHash);
         require(stratoToken == address(testToken), "Token should be set");
     }
 
@@ -456,8 +456,8 @@ contract Describe_MercataBridge {
         
         bridge.depositBatch(chainIds, txHashes, tokens, amounts, recipients, senders, mintUSDSTs);
         
-        (address stratoToken1, address _2, uint _3, address _4, BridgeStatus _5, bool _6, uint _7) = bridge.deposits(externalChainId, "0xhash1");
-        (address stratoToken2, address _12, uint _13, address _14, BridgeStatus _15, bool _16, uint _17) = bridge.deposits(externalChainId, "0xhash2");
+        (address stratoToken1,,,,,,) = bridge.deposits(externalChainId, "0xhash1");
+        (address stratoToken2,,,,,,) = bridge.deposits(externalChainId, "0xhash2");
         require(stratoToken1 == address(testToken), "First deposit token should be set");
         require(stratoToken2 == address(testToken), "Second deposit token should be set");
     }
@@ -478,7 +478,7 @@ contract Describe_MercataBridge {
         
         bridge.confirmDepositBatch(chainIds, txHashes);
         
-        (address stratoToken, address _2, uint _3, address _4, BridgeStatus _5, bool _6, uint _7) = bridge.deposits(externalChainId, txHash);
+        (address stratoToken,,,,,,) = bridge.deposits(externalChainId, txHash);
         require(stratoToken == address(testToken), "Token should be set");
     }
 
@@ -498,7 +498,7 @@ contract Describe_MercataBridge {
         
         bridge.reviewDepositBatch(chainIds, txHashes);
         
-        (address stratoToken, address _2, uint _3, address _4, BridgeStatus _5, bool _6, uint _7) = bridge.deposits(externalChainId, txHash);
+        (address stratoToken,,,,,,) = bridge.deposits(externalChainId, txHash);
         require(stratoToken == address(testToken), "Token should be set");
     }
 
@@ -599,7 +599,7 @@ contract Describe_MercataBridge {
         require(withdrawalId == 1, "Withdrawal ID should be 1");
         require(bridge.withdrawalCounter() == 1, "Withdrawal counter should be 1");
         
-        (uint _1, address _2, address stratoToken, uint _4, address _5, BridgeStatus _6, bool _7, uint _8, uint _9) = bridge.withdrawals(withdrawalId);
+        (,, address stratoToken,,,,,,) = bridge.withdrawals(withdrawalId);
         require(stratoToken == address(withdrawalToken), "Token should be set");
     }
 
@@ -615,7 +615,7 @@ contract Describe_MercataBridge {
         uint256 withdrawalId = user1.do(address(bridge), "requestWithdrawal", externalChainId, recipient, address(usdstToken), amount, true);
         require(withdrawalId == 1, "Withdrawal ID should be 1");
         
-        (uint _1, address _2, address stratoToken, uint _4, address _5, BridgeStatus _6, bool _7, uint _8, uint _9) = bridge.withdrawals(withdrawalId);
+        (,, address stratoToken,,,,,,) = bridge.withdrawals(withdrawalId);
         require(stratoToken == address(usdstToken), "Token should be set");
     }
 
@@ -632,7 +632,7 @@ contract Describe_MercataBridge {
         // Confirm withdrawal
         bridge.confirmWithdrawal(withdrawalId, custodyTxHash);
         
-        (uint _1, address _2, address stratoToken, uint _4, address _5, BridgeStatus _6, bool _7, uint _8, uint _9) = bridge.withdrawals(withdrawalId);
+        (,, address stratoToken,,,,,,) = bridge.withdrawals(withdrawalId);
         require(stratoToken == address(testToken), "Token should be set");
     }
 
@@ -650,7 +650,7 @@ contract Describe_MercataBridge {
         bridge.confirmWithdrawal(withdrawalId, custodyTxHash);
         bridge.finaliseWithdrawal(withdrawalId, custodyTxHash);
         
-        (uint _1, address _2, address stratoToken, uint _4, address _5, BridgeStatus _6, bool _7, uint _8, uint _9) = bridge.withdrawals(withdrawalId);
+        (,, address stratoToken,,,,,,) = bridge.withdrawals(withdrawalId);
         require(stratoToken == address(testToken), "Token should be set");
     }
 
@@ -672,7 +672,7 @@ contract Describe_MercataBridge {
         }
         require(reverted, "Should revert due to 48h wait period");
         
-        (uint _1, address _2, address stratoToken, uint _4, address _5, BridgeStatus _6, bool _7, uint _8, uint _9) = bridge.withdrawals(withdrawalId);
+        (,, address stratoToken,,,,,,) = bridge.withdrawals(withdrawalId);
         require(stratoToken == address(testToken), "Token should be set");
     }
 
@@ -688,7 +688,7 @@ contract Describe_MercataBridge {
         // Abort by relayer (should succeed)
         bridge.abortWithdrawal(withdrawalId);
         
-        (uint _1, address _2, address stratoToken, uint _4, address _5, BridgeStatus _6, bool _7, uint _8, uint _9) = bridge.withdrawals(withdrawalId);
+        (,, address stratoToken,,,,,,) = bridge.withdrawals(withdrawalId);
         require(stratoToken == address(testToken), "Token should be set");
     }
 
@@ -717,8 +717,8 @@ contract Describe_MercataBridge {
         
         bridge.confirmWithdrawalBatch(ids, txHashes);
         
-        (uint _1, address _2, address stratoToken1, uint _4, address _5, BridgeStatus _6, bool _7, uint _8, uint _9) = bridge.withdrawals(withdrawalId1);
-        (uint _11, address _12, address stratoToken2, uint _14, address _15, BridgeStatus _16, bool _17, uint _18, uint _19) = bridge.withdrawals(withdrawalId2);
+        (,, address stratoToken1,,,,,,) = bridge.withdrawals(withdrawalId1);
+        (,, address stratoToken2,,,,,,) = bridge.withdrawals(withdrawalId2);
         require(stratoToken1 == address(testToken), "First withdrawal token should be set");
         require(stratoToken2 == address(usdstToken), "Second withdrawal token should be set");
     }
@@ -744,7 +744,7 @@ contract Describe_MercataBridge {
         
         bridge.finaliseWithdrawalBatch(ids, txHashes);
         
-        (uint _, address _2, address _3, uint _4, address _5, BridgeStatus bridgeStatus, bool _7, uint _8, uint _9) = bridge.withdrawals(withdrawalId);
+        (,,,,, BridgeStatus bridgeStatus,,,) = bridge.withdrawals(withdrawalId);
         require(bridgeStatus == BridgeStatus.COMPLETED, "Status should be COMPLETED");
     }
 
@@ -769,8 +769,8 @@ contract Describe_MercataBridge {
         
         bridge.abortWithdrawalBatch(ids);
         
-        (uint _1, address _2, address _3, uint _4, address _5, BridgeStatus bridgeStatus, bool _7, uint _8, uint _9) = bridge.withdrawals(withdrawalId1);
-        (uint _11, address _12, address _13, uint _14, address _15, BridgeStatus bridgeStatus2, bool _17, uint _18, uint _19) = bridge.withdrawals(withdrawalId2);
+        (,,,,, BridgeStatus bridgeStatus,,,) = bridge.withdrawals(withdrawalId1);
+        (,,,,, BridgeStatus bridgeStatus2,,,) = bridge.withdrawals(withdrawalId2);
         require(bridgeStatus == BridgeStatus.ABORTED, "First withdrawal should be ABORTED");
         require(bridgeStatus2 == BridgeStatus.ABORTED, "Second withdrawal should be ABORTED");
     }
@@ -889,8 +889,8 @@ contract Describe_MercataBridge {
         bridge.deposit(chainId1, externalSender, "0xtx1", address(testToken), 1000e18, address(0x1111), false);
         bridge.deposit(chainId2, externalSender, "0xtx2", address(testToken), 2000e18, address(0x2222), false);
         
-        (address _1, address _2, uint _3, address _4, BridgeStatus bridgeStatus1, bool _6, uint _7) = bridge.deposits(chainId1, "0xtx1");
-        (address _11, address _12, uint _13, address _14, BridgeStatus bridgeStatus2, bool _16, uint _17) = bridge.deposits(chainId2, "0xtx2");
+        (,,,, BridgeStatus bridgeStatus1,,) = bridge.deposits(chainId1, "0xtx1");
+        (,,,, BridgeStatus bridgeStatus2,,) = bridge.deposits(chainId2, "0xtx2");
         require(bridgeStatus1 == BridgeStatus.INITIATED, "First chain deposit should be INITIATED");
         require(bridgeStatus2 == BridgeStatus.INITIATED, "Second chain deposit should be INITIATED");
     }

--- a/mercata/contracts/tests/CDP/CDPEngine.test.sol
+++ b/mercata/contracts/tests/CDP/CDPEngine.test.sol
@@ -1400,7 +1400,7 @@ contract Describe_CDPEngine {
         
         // STEP 4: Test failed withdrawal - THIS IS THE CRITICAL TEST
         // log("=== BEFORE FAILED WITHDRAWAL ATTEMPT ===");
-        (uint engineCollateralBefore, uint _2) = cdpEngine.vaults(address(this), collateralTokenAddress);
+        (uint engineCollateralBefore,) = cdpEngine.vaults(address(this), collateralTokenAddress);
         uint256 vaultCollateralBefore = cdpVault.userCollaterals(address(this), collateralTokenAddress);
         uint256 userBalanceBefore = ERC20(collateralTokenAddress).balanceOf(address(this));
         

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -22,7 +22,7 @@ import Data.Foldable (traverse_)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, fromJust, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Set as S
 import Data.Source
 import Data.String (IsString, fromString)
@@ -171,21 +171,16 @@ mutable m@(Product ts _) =
 mutable m@(Sum (t :| ts)) =
   let isMutable Mutable{} = True
       isMutable _ = False
-   in if all isMutable $ t:ts
-        then m
-        else bottom $ "Cannot mutate immutable value" <$ context' m
+   in case filter isMutable $ t:ts of
+        [] -> bottom $ "Cannot mutate immutable value" <$ context' m
+        (j:js) -> Sum $ j :| js
 mutable t = bottom $ "Cannot mutate immutable value" <$ context' t
 
-varDefsToType' :: Annotated VarDefEntryF -> Type' -> Type'
-varDefsToType' BlankEntry t = Product [topType' (context' t), t] (context' t)
-varDefsToType' VarDefEntry {..} t | vardefType == Nothing = t
-varDefsToType' VarDefEntry {..} Top{} = Mutable $ Static (fromJust vardefType) vardefContext
-varDefsToType' VarDefEntry {..} t@Static{} = Product [Mutable $ Static (fromJust vardefType) vardefContext, t] vardefContext
-varDefsToType' VarDefEntry {..} t@Mutable{} = Product [Mutable $ Static (fromJust vardefType) vardefContext, t] vardefContext
-varDefsToType' VarDefEntry {..} t@Sum{} = Product [Mutable $ Static (fromJust vardefType) vardefContext, t] vardefContext
-varDefsToType' VarDefEntry {..} (Product ts _) = Product (Mutable (Static (fromJust vardefType) vardefContext) : ts) vardefContext
-varDefsToType' VarDefEntry {} (Bottom es) = Bottom es
-varDefsToType' VarDefEntry {..} _ = bottom $ "Could not match variable definition with function type" <$ vardefContext
+varDefsToType' :: SourceAnnotation Text -> Annotated VarDefEntryF -> Type'
+varDefsToType' x BlankEntry = topType' x
+varDefsToType' _ VarDefEntry {..} = case vardefType of
+  Nothing -> topType' vardefContext
+  Just t  -> Mutable $ Static t vardefContext
 
 lookupEnum :: SolidString -> SSS [SolidString]
 lookupEnum name = do
@@ -337,7 +332,6 @@ lookupContractFunction x cName fName = do
     constructGetterType y t = pure $ Function (Product [] y) (Static t y) y [] [] False
 
 productType' :: SourceAnnotation Text -> [Type'] -> Type'
-productType' _ [Bottom es] = Bottom es
 productType' _ [t] = t
 productType' x ts = case reduceType' x ts of
   Bottom es -> Bottom es
@@ -791,6 +785,7 @@ typecheckMember (Mutable t) member = do
     Static{} -> Mutable t'
     Top{} -> Mutable t'
     _ -> t'
+typecheckMember (Product [t] _) member = typecheckMember t member
 typecheckMember (Static (SVMType.Array _ _) x) "length" = pure $ Static (SVMType.Int Nothing Nothing) x
 typecheckMember (Static (SVMType.Array t _) x) "push" = pure $ Function (Static t x) (Product [] x) x [] [] False
 typecheckMember (Static (SVMType.Array _ _) x) n = pure . bottom $ ("Unknown member of SVMType.Array: " <> labelToText n) <$ x
@@ -1829,7 +1824,7 @@ statementHelper (SimpleStatement stmt x) = simpleStatementHelper x stmt
 simpleStatementHelper :: SourceAnnotation Text -> Annotated SimpleStatementF -> SSS Type'
 simpleStatementHelper x (VariableDefinition vdefs mExpr) = do
   pushLocalVariables vdefs
-  let ts' = foldr varDefsToType' (topType' x) vdefs
+  let ts' = Product (varDefsToType' x <$> vdefs) x
   ts' ~> maybe (pure $ topType' x) tcExpr mExpr
 simpleStatementHelper _ (ExpressionStatement expr) =
   tcExpr expr


### PR DESCRIPTION
Removed the need for extra typecasts:
`uint256 reserveBalance = ERC20(address(_usdst())).balanceOf(reserveAddr);`
becomes
`uint256 reserveBalance = _usdst().balanceOf(reserveAddr);`

and removed the need to name unused variables in tuple expressions:
`(address stratoToken1, address _2, uint _3, address _4, BridgeStatus _5, bool _6, uint _7) = bridge.deposits(externalChainId, "0xhash1");`
becomes
`(address stratoToken1,,,,,,) = bridge.deposits(externalChainId, "0xhash1");`