### PR TITLE
Interleave output in solid-vm-cli

### DIFF
--- a/strato/VM/SolidVM/solid-vm-fuzzer/exec_src/Main.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/exec_src/Main.hs
@@ -86,23 +86,23 @@ main = do
             Left xs -> if j
                          then printJSON xs
                          else putStrLn "Parse errors:" >> traverse_ print xs
-          "test" -> runCli (fuzz Nothing srcMap) >>= \xs ->
-              if j
-                then printJSON xs
-                else do
-                  traverse_ (\case
-                        FuzzerSuccess (SourceAnnotation _ _ (testName, _)) ->
-                          putStrLn . T.unpack $ "✅ " <> testName <> " succeeded"
-                        FuzzerFailure _ (SourceAnnotation _ _ (testName, msg)) -> do
-                          putStrLn . T.unpack $ "❌ " <> testName <> " failed: " <> msg
-                      ) xs
-                  let totalTests = length xs
-                      passedTests = length $ filter isFuzzerSuccess xs
-                      isFuzzerSuccess (FuzzerSuccess _) = True
-                      isFuzzerSuccess _ = False
-                  when (totalTests > 0) $ do
-                    putStrLn ""
-                    putStrLn $ "(" ++ show passedTests ++ " / " ++ show totalTests ++ " tests passed)"
+          "test" -> do
+            let printResult i r = liftIO $ r <$ case r of
+                  FuzzerSuccess (SourceAnnotation _ _ (testName, _)) -> do
+                    putStrLn $ "✅ " <> show i <> ". " <> T.unpack testName <> " succeeded"
+                  FuzzerFailure _ (SourceAnnotation _ _ (testName, msg)) -> do
+                    putStrLn $ "❌ " <> show i <> ". " <> T.unpack testName <> " failed: " <> T.unpack msg
+            xs <- runCli $ fuzz Nothing srcMap $ if j then defaultHook else printResult
+            if j
+              then printJSON xs
+              else do
+                let totalTests = length xs
+                    passedTests = length $ filter isFuzzerSuccess xs
+                    isFuzzerSuccess (FuzzerSuccess _) = True
+                    isFuzzerSuccess _ = False
+                when (totalTests > 0) $ do
+                  putStrLn ""
+                  putStrLn $ "(" ++ show passedTests ++ " / " ++ show totalTests ++ " tests passed)"
           "compile" -> runCli (compile srcMap) >>= \case
             Right cc -> if j
                           then printJSON cc
@@ -142,7 +142,7 @@ main = do
                               Just resp -> atomically $ writeTQueue q resp
                             loop
                 void . runConcurrently . asum $ map Concurrently
-                  [ void $ runCli (fuzz (Just dSettings) srcMap')
+                  [ void $ runCli (fuzz (Just dSettings) srcMap' defaultHook)
                   , loop
                   , forever $ handleOutput dSettings >>= atomically . writeTQueue q
                   , forever $ atomically (readTQueue q) >>= printJSON
@@ -156,7 +156,7 @@ main = do
                 . M.fromList
                 . unSourceMap
         analyze src = compile src >>= \eCC -> pure $ runDetectors parse (const eCC) id src
-        fuzz dSettings = runFuzzer dSettings compile
+        fuzz dSettings = runFuzzerWithHook dSettings compile
         handleInput :: DebugSettings -> JsonRpcMessage -> IO (Maybe JsonRpcMessage)
         handleInput dSettings (Rpc i m _ v) = case m of
           "pause" -> Nothing <$ pause dSettings

--- a/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
@@ -9,7 +9,9 @@
 {-# LANGUAGE TupleSections #-}
 
 module SolidVM.Solidity.Fuzzer
-  ( runFuzzer,
+  ( defaultHook,
+    runFuzzer,
+    runFuzzerWithHook,
     module SolidVM.Solidity.Fuzzer.Types,
   )
 where
@@ -28,9 +30,10 @@ import Control.Monad.Trans.Reader
 import qualified Data.Aeson as Aeson
 import Data.Bool (bool)
 import qualified Data.ByteString.Lazy as BL
+import Data.Foldable (foldlM)
 import Data.List (sortBy)
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, fromMaybe, maybeToList)
+import Data.Maybe (fromMaybe, maybeToList)
 import Data.Ord (comparing)
 import Data.Source
 import qualified Data.Text as T
@@ -73,12 +76,23 @@ withTestName = fmap . fmap . (,) . formatTestName
 success :: Applicative f => SourceAnnotation a -> f FuzzerResult
 success ctx = pure . FuzzerSuccess $ "Test succeeded" <$ ctx
 
+defaultHook :: Monad m => Int -> FuzzerTestAndResult -> m FuzzerTestAndResult
+defaultHook _ r = pure r
+
 runFuzzer :: (MonadUnliftIO m, MonadCatch m, A.Selectable FilePath (Either String String) m) =>
   Maybe DebugSettings ->
   (SourceMap -> m (Either [SourceAnnotation T.Text] CodeCollection)) ->
   SourceMap ->
   m [FuzzerTestAndResult]
-runFuzzer dSettings compile src = compile src >>= \case
+runFuzzer dSettings compile src = runFuzzerWithHook dSettings compile src defaultHook
+
+runFuzzerWithHook :: (MonadUnliftIO m, MonadCatch m, A.Selectable FilePath (Either String String) m) =>
+  Maybe DebugSettings ->
+  (SourceMap -> m (Either [SourceAnnotation T.Text] CodeCollection)) ->
+  SourceMap ->
+  (Int -> FuzzerTestAndResult -> m FuzzerTestAndResult) ->
+  m [FuzzerTestAndResult]
+runFuzzerWithHook dSettings compile src hook = compile src >>= \case
   Left errs -> pure $ FuzzerFailure Nothing . fmap ("Compilation error: ",) <$> errs
   Right cc -> do
     let args = FuzzerArgs src "" [] "" [] Nothing
@@ -94,8 +108,9 @@ runFuzzer dSettings compile src = compile src >>= \case
             _ -> fuzzContract cName (_contractContext c) $ \bh addr -> do
               _ <- for (M.lookup "beforeAll" $ _functions c) $ test bh addr "beforeAll"
               let functionsInSourceOrder = sortBy (comparing (\(_, f') -> f' ^. funcContext . sourceAnnotationStart)) (M.toList $ _functions c)
-              testResults <- fmap catMaybes . for functionsInSourceOrder $ \(fName, f) -> fmap (fmap (withTestName $ T.pack fName)) $
-                if
+              testResults <- fmap (reverse . snd) $ foldlM (\(i, ran) (fName, f) -> do
+                mResult <- fmap (fmap (withTestName $ T.pack fName)) $
+                  if
                     | testPrefix `T.isPrefixOf` labelToText fName -> do
                         _ <- for (M.lookup "beforeEach" $ _functions c) $ test bh addr "beforeEach"
                         result <- Just <$> test bh addr fName f
@@ -107,6 +122,8 @@ runFuzzer dSettings compile src = compile src >>= \case
                         _ <- for (M.lookup "afterEach" $ _functions c) $ test bh addr "afterEach"
                         pure result
                     | otherwise -> pure Nothing
+                maybe (i, ran) (\r -> (i+1, r:ran)) <$> traverse (lift . lift . lift . hook i) mResult
+                ) (1, []) functionsInSourceOrder
               _ <- for (M.lookup "afterAll" $ _functions c) $ test bh addr "afterAll"
               pure testResults
 


### PR DESCRIPTION
solid-vm-cli now interleaves test results with logging, so it's easier to tell which logs correspond to which tests

```sh
dustinnorwood@Mac strato-platform % solid-vm-cli test mercata/contracts/tests/Lending/BadDebt.test.sol
✅ 1. Unit test 'aa can deploy Mercata' succeeded
✅ 2. Unit test 'ab checks that contracts are set' succeeded
✅ 3. Unit test 'ac can create and activate tokens' succeeded
✅ 4. Unit test 'ad can activate tokens' succeeded
✅ 5. Unit test 'ae can whitelist tokens' succeeded
✅ 6. Unit test 'af can configure lending pool' succeeded
✅ 7. Unit test 'ag persists accross tests' succeeded
✅ 8. Unit test 'ah can verify exchange rate calculation' succeeded
✅ 9. Unit test 'ai can set oracle prices' succeeded
Hello, world! We're at fae9aeb4a582d45074ccfb35de64648c4d61aa65
✅ 10. Unit test 'aj can display logs' succeeded
✅ 11. Unit test 'ak can mint and burn tokens' succeeded
✅ 12. Unit test 'al can simulate users' succeeded
✅ 13. Unit test 'am can configure safety module' succeeded
✅ 14. Unit test 'an can accept liquidity deposits' succeeded
✅ 15. Unit test 'ao can accept safety module deposits' succeeded
✅ 16. Unit test 'ap can accept collateral vault deposits' succeeded
✅ 17. Unit test 'aq can accept borrows' succeeded
healthFactor: 533333333333333333
            / 1000000000000000000
✅ 18. Unit test 'ar can tank gold price' succeeded
as badDebt: 547619047619047619047
✅ 19. Unit test 'as can liquidate borrower' succeeded
at exchangeRate before: 1000000000000000000
at toCover: 600000000000000000000
at exchangeRate after: 1000000000000000000
✅ 20. Unit test 'at can cover bad debt' succeeded
✅ 21. Unit test 'ba can write off bad debt' succeeded

(21 / 21 tests passed)
```