### PR TITLE
RewardsChef improvements

### DIFF
--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -232,6 +232,7 @@ contract record RewardsChef is Ownable {
                 return;
             }
         }
+        require(_lpToken != address(rewardToken), "LP token cannot be the same as reward token");
         require(_bonusMultiplier >= 1, "Bonus multiplier must be at least 1");
 
         totalAllocPoint += _allocPoint;

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -158,6 +158,7 @@ contract record RewardsChef is Ownable {
     event MinFutureTimeUpdated(uint256 oldMinFutureTime, uint256 newMinFutureTime);
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
+    event EmergencyWithdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event CurrentUserAmount(address indexed user, uint256 indexed pid, uint256 currentAmount);
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -417,6 +418,23 @@ contract record RewardsChef is Ownable {
 
         emit CurrentUserAmount(msg.sender, _pid, user.amount);
         emit Withdraw(msg.sender, _pid, _amount);
+    }
+
+    function emergencyWithdraw(uint256 _pid) public {
+        require(_pid < pools.length, "Pool does not exist");
+
+        PoolInfo storage pool = pools[_pid];
+        UserInfo storage user = userInfo[_pid][msg.sender];
+
+        uint256 amount = user.amount;
+        user.amount = 0;
+        user.rewardDebt = 0;
+
+        if (amount > 0) {
+            ERC20(pool.lpToken).transfer(msg.sender, amount);
+        }
+
+        emit EmergencyWithdraw(msg.sender, _pid, amount);
     }
 
     function pendingCata(uint256 _pid, address _user) external view returns (uint256) {

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -233,6 +233,8 @@ contract record RewardsChef is Ownable {
         require(_lpToken != address(rewardToken), "LP token cannot be the same as reward token");
         require(_bonusMultiplier >= 1, "Bonus multiplier must be at least 1");
 
+        massUpdatePools();
+
         totalAllocPoint += _allocPoint;
         require(totalAllocPoint > 0, "Total allocation points must be greater than zero");
         // See 'PRECISION LOSS PREVENTION' section in top comment
@@ -258,6 +260,8 @@ contract record RewardsChef is Ownable {
         uint256 _allocPoint
     ) public onlyOwner {
         require(_pid < pools.length, "Pool does not exist");
+
+        massUpdatePools();
 
         uint256 oldAllocPoint = pools[_pid].allocPoint;
         totalAllocPoint = totalAllocPoint - oldAllocPoint + _allocPoint;

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -200,6 +200,9 @@ contract record RewardsChef is Ownable {
         return (bp.startTimestamp, bp.bonusMultiplier);
     }
 
+    // Tracks whether an LP token is already in use by a pool
+    mapping(address => bool) private lpTokenInUse;
+
     // Info of each user that stakes LP tokens.
     mapping(uint256 => mapping(address => UserInfo)) public record userInfo;
 
@@ -226,13 +229,7 @@ contract record RewardsChef is Ownable {
         address _lpToken,
         uint256 _bonusMultiplier
     ) public onlyOwner {
-        // Check if LP token already exists in pools. If it does exists, return
-        // early
-        for (uint256 i = 0; i < pools.length; i++) {
-            if (pools[i].lpToken == _lpToken) {
-                return;
-            }
-        }
+        require(!lpTokenInUse[_lpToken], "LP token already exists");
         require(_lpToken != address(rewardToken), "LP token cannot be the same as reward token");
         require(_bonusMultiplier >= 1, "Bonus multiplier must be at least 1");
 
@@ -251,6 +248,7 @@ contract record RewardsChef is Ownable {
         poolInfo.bonusPeriods.push(BonusPeriod(block.timestamp, _bonusMultiplier));
 
         pools.push(poolInfo);
+        lpTokenInUse[_lpToken] = true;
 
         emit PoolAdded(pools.length - 1, _lpToken, _allocPoint, _bonusMultiplier);
     }

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -350,6 +350,13 @@ contract record RewardsChef is Ownable {
         pool.lastRewardTimestamp = block.timestamp;
     }
 
+    function massUpdatePools() public {
+        uint256 poolCount = pools.length;
+        for (uint256 pid = 0; pid < poolCount; pid++) {
+            updatePool(pid);
+        }
+    }
+
     // ═════════════════════════════════════════════════════════════════════════
     // USER INTERACTIONS
     // ═════════════════════════════════════════════════════════════════════════

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -280,10 +280,8 @@ contract record RewardsChef is Ownable {
 
         // Ensure new period starts after the last period
         uint256 periodsLength = pools[_pid].bonusPeriods.length;
-        if (periodsLength > 0) {
-            require(_startTimestamp > pools[_pid].bonusPeriods[periodsLength - 1].startTimestamp,
-                    "New period must start after the last period");
-        }
+        require(_startTimestamp > pools[_pid].bonusPeriods[periodsLength - 1].startTimestamp,
+                "New period must start after the last period");
 
         pools[_pid].bonusPeriods.push(BonusPeriod(_startTimestamp, _bonusMultiplier));
 

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -100,6 +100,23 @@ contract Describe_TokenPausable {
         require(chef.totalAllocPoint() == allocationPoints, "Total allocation points should match");
     }
 
+    function it_should_prevent_lp_token_being_same_as_reward_token() {
+        // given
+        uint256 allocationPoints = 1000;
+        uint256 multiplier = 1;
+
+        // when
+        bool reverted = false;
+        try chef.addPool(allocationPoints, address(rewardsToken), multiplier) {
+            // If we get here, the call didn't revert (which is a bug)
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        //then - should revert when trying to add pool with reward token as LP token
+        require(reverted, "Adding pool with LP token same as reward token should revert");
+    }
+
     function it_should_allow_updating_allocation_points() {
         // given
         uint256 initialAllocationPoints = 500;

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -336,4 +336,86 @@ contract Describe_TokenPausable {
         require(pool2AccPerTokenAfter > pool2AccPerTokenBefore, "Pool 2 accPerToken should be updated");
     }
 
+    function it_should_update_existing_pools_before_adding_new_pool() {
+        // given - create first pool and deposit
+        uint256 pool1AllocPoint = 100;
+        uint256 multiplier = 1;
+        uint256 amount1 = 10 * 1e18;
+
+        chef.addPool(pool1AllocPoint, address(lpToken1), multiplier);
+
+        TestUtils.callAs(user1, address(lpToken1), "approve(address, uint256)", address(chef), amount1);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", 0, amount1);
+
+        // Fast forward time so pool 0 has pending rewards
+        fastForward(10);
+
+        // Record pool 0 state before adding pool 1
+        (address lp0, uint alloc0, uint pool0LastRewardBefore, uint pool0AccPerTokenBefore) = chef.pools(0);
+        uint256 currentTime = block.timestamp;
+
+        // Create second LP token
+        address lpToken2Address = m.tokenFactory().createToken(
+            "TestLP2",
+            "Test LP Token 2",
+            [], [], [], "TESTLP2", 0, 18
+        );
+        Token lpToken2 = Token(lpToken2Address);
+
+        // when - add second pool (should update pool 0 first)
+        chef.addPool(200, address(lpToken2), multiplier);
+
+        // then - pool 0 should have been updated
+        (address lp0After, uint alloc0After, uint pool0LastRewardAfter, uint pool0AccPerTokenAfter) = chef.pools(0);
+
+        require(pool0LastRewardAfter == currentTime, "Pool 0 should be updated to current timestamp");
+        require(pool0AccPerTokenAfter > pool0AccPerTokenBefore, "Pool 0 accPerToken should increase");
+    }
+
+    function it_should_update_all_pools_before_changing_allocation_points() {
+        // given - create two pools with deposits
+        uint256 multiplier = 1;
+        uint256 amount = 10 * 1e18;
+
+        // Create second LP token
+        address lpToken2Address = m.tokenFactory().createToken(
+            "TestLP2",
+            "Test LP Token 2",
+            [], [], [], "TESTLP2", 0, 18
+        );
+        Token lpToken2 = Token(lpToken2Address);
+        lpToken2.mint(address(user1), initLpTokensPerUser);
+
+        // Add two pools
+        chef.addPool(100, address(lpToken1), multiplier);
+        chef.addPool(200, address(lpToken2), multiplier);
+
+        // Deposit into both pools
+        TestUtils.callAs(user1, address(lpToken1), "approve(address, uint256)", address(chef), amount);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", 0, amount);
+
+        TestUtils.callAs(user1, address(lpToken2), "approve(address, uint256)", address(chef), amount);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", 1, amount);
+
+        // Fast forward time
+        fastForward(10);
+
+        // Record state before updating allocation
+        (address lp0, uint alloc0, uint pool0LastRewardBefore, uint pool0AccPerTokenBefore) = chef.pools(0);
+        (address lp1, uint alloc1, uint pool1LastRewardBefore, uint pool1AccPerTokenBefore) = chef.pools(1);
+        uint256 currentTime = block.timestamp;
+
+        // when - update allocation points of pool 0
+        chef.updateAllocationPoints(0, 300);
+
+        // then - both pools should be updated
+        (address lp0After, uint alloc0After, uint pool0LastRewardAfter, uint pool0AccPerTokenAfter) = chef.pools(0);
+        (address lp1After, uint alloc1After, uint pool1LastRewardAfter, uint pool1AccPerTokenAfter) = chef.pools(1);
+
+        require(pool0LastRewardAfter == currentTime, "Pool 0 should be updated to current timestamp");
+        require(pool1LastRewardAfter == currentTime, "Pool 1 should be updated to current timestamp");
+        require(pool0AccPerTokenAfter > pool0AccPerTokenBefore, "Pool 0 accPerToken should increase");
+        require(pool1AccPerTokenAfter > pool1AccPerTokenBefore, "Pool 1 accPerToken should increase");
+    }
+
 }

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -285,4 +285,55 @@ contract Describe_TokenPausable {
         require(pool1.accPerToken == expectedAccPerToken, "accPerToken calculation mismatch");
     }
 
+    function it_should_update_all_pools_when_mass_update_is_called() {
+        // given - create two pools with different allocation points
+        uint256 pool1AllocPoint = 100;
+        uint256 pool2AllocPoint = 200;
+        uint256 multiplier = 1;
+        uint256 amount1 = 10 * 1e18;
+        uint256 amount2 = 20 * 1e18;
+
+        // Create second LP token
+        address lpToken2Address = m.tokenFactory().createToken(
+            "TestLP2",
+            "Test LP Token 2",
+            [], [], [], "TESTLP2", 0, 18
+        );
+        require(lpToken2Address != address(0), "LP Token 2 address is 0");
+        Token lpToken2 = Token(lpToken2Address);
+
+        // Mint LP tokens to users
+        lpToken2.mint(address(user1), initLpTokensPerUser);
+
+        // Add two pools
+        chef.addPool(pool1AllocPoint, address(lpToken1), multiplier);
+        chef.addPool(pool2AllocPoint, address(lpToken2), multiplier);
+
+        // Users deposit into both pools
+        TestUtils.callAs(user1, address(lpToken1), "approve(address, uint256)", address(chef), amount1);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", 0, amount1);
+
+        TestUtils.callAs(user1, address(lpToken2), "approve(address, uint256)", address(chef), amount2);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", 1, amount2);
+
+        // Record initial state
+        (address lp1Before, uint alloc1Before, uint pool1LastRewardBefore, uint pool1AccPerTokenBefore) = chef.pools(0);
+        (address lp2Before, uint alloc2Before, uint pool2LastRewardBefore, uint pool2AccPerTokenBefore) = chef.pools(1);
+
+        // Fast forward time
+        fastForward(10);
+
+        // when - call massUpdatePools
+        chef.massUpdatePools();
+
+        // then - verify both pools were updated
+        (address lp1After, uint alloc1After, uint pool1LastRewardAfter, uint pool1AccPerTokenAfter) = chef.pools(0);
+        (address lp2After, uint alloc2After, uint pool2LastRewardAfter, uint pool2AccPerTokenAfter) = chef.pools(1);
+
+        require(pool1LastRewardAfter > pool1LastRewardBefore, "Pool 1 lastRewardTimestamp should be updated");
+        require(pool2LastRewardAfter > pool2LastRewardBefore, "Pool 2 lastRewardTimestamp should be updated");
+        require(pool1AccPerTokenAfter > pool1AccPerTokenBefore, "Pool 1 accPerToken should be updated");
+        require(pool2AccPerTokenAfter > pool2AccPerTokenBefore, "Pool 2 accPerToken should be updated");
+    }
+
 }

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -117,6 +117,27 @@ contract Describe_TokenPausable {
         require(reverted, "Adding pool with LP token same as reward token should revert");
     }
 
+    function it_should_prevent_adding_duplicate_pool() {
+        // given
+        uint256 allocationPoints = 1000;
+        uint256 multiplier = 1;
+
+        // given a pool already exists
+        chef.addPool(allocationPoints, address(lpToken1), multiplier);
+
+        // when trying to add the same pool again
+        bool reverted = false;
+        try chef.addPool(allocationPoints, address(lpToken1), multiplier) {
+            // If we get here, the call didn't revert (which is a bug)
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+
+        // then - should revert when trying to add duplicate LP token
+        require(reverted, "Adding duplicate LP token should revert");
+    }
+
     function it_should_allow_updating_allocation_points() {
         // given
         uint256 initialAllocationPoints = 500;

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -184,6 +184,48 @@ contract Describe_TokenPausable {
 		"User1 should have back his LP tokens");
     }
 
+    function it_should_allow_emergency_withdraw_without_claiming_rewards() {
+        // given
+        uint256 allocationPoints = 100;
+        uint256 multiplier = 1;
+        uint256 poolId = 0;
+        uint256 amount = 10 * 1e18;
+
+        // given there is a pool
+        chef.addPool(allocationPoints, address(lpToken1), multiplier);
+
+        // given user has deposited lp tokens
+        TestUtils.callAs(user1, address(lpToken1), "approve(address, uint256)", address(chef), amount);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", poolId, amount);
+
+        // given time has passed so there are pending rewards
+        fastForward(10);
+
+        // Record balances before emergency withdraw
+        uint256 userRewardBalanceBefore = ERC20(rewardsToken).balanceOf(address(user1));
+        uint256 pendingRewards = chef.pendingCata(poolId, address(user1));
+
+        // Verify there ARE rewards to forfeit
+        require(pendingRewards > 0, "There should be pending rewards before emergency withdraw");
+
+        // when - emergency withdraw
+        TestUtils.callAs(user1, address(chef), "emergencyWithdraw(uint256)", poolId);
+
+        // then - LP tokens are returned
+        require(ERC20(lpToken1).balanceOf(address(chef)) == 0,
+		"Chef should not have the deposited LP tokens");
+        require(ERC20(lpToken1).balanceOf(address(user1)) == initLpTokensPerUser,
+		"User1 should have all LP tokens back");
+
+        // then - rewards are NOT transferred (forfeited)
+        require(ERC20(rewardsToken).balanceOf(address(user1)) == userRewardBalanceBefore,
+		"User should not receive rewards during emergency withdraw");
+
+        // then - user info is reset
+        uint256 userBalance = chef.getBalance(poolId, address(user1));
+        require(userBalance == 0, "User balance should be reset to 0");
+    }
+
 
     function it_should_update_accrued_rewards_for_pool() {
         uint256 allocationPoints = 100;


### PR DESCRIPTION
* Fixes #5061

Remove redundant zero-length check in RewardsChef.addBonusPeriod

Pools are always created with an initial bonus period, making the periodsLength
> 0 guard unreachable and redundant. This reduces unnecessary bytecode and
branches.

* Fixes #5058

Revert when adding to rewards pool the reward itself

* Fixes #5064

Add emergency withdraw from RewardsChef

* Fixes #5066

Fail fast on duplicates

Change behavior from silent return to explicit revert to catch
configuration errors during deployment.

* Fixes #5065

Optimize duplicate pool check. 
Replace O(n) linear scan with O(1) mapping lookup for pool existence
check. 

* Fixes #5060

Fix the Retroactive reward dilution issue

When existing pools are updated BEFORE totalAllocPoint changes, their rewards
for the elapsed time are calculated using the OLD allocation ratios. This
ensures users receive fair rewards based on the allocation that was active when
they were staking, not retroactively diluted rewards calculated with the NEW
allocation.

Example:
  - Pool 0 has 100 alloc points, totalAlloc = 100 (100% of rewards)
  - 10 seconds pass
  - Owner adds Pool 1 with 100 alloc points
  - Without fix: Pool 0's 10 seconds calculated as 100/200 = 50% (WRONG - retroactive dilution)
  - With fix: Pool 0's 10 seconds calculated as 100/100 = 100% (CORRECT), THEN Pool 1 added