### PR TITLE
Added checks for unsigned integer underflow

### DIFF
--- a/mercata/contracts/tests/Math/Math.test.sol
+++ b/mercata/contracts/tests/Math/Math.test.sol
@@ -1,0 +1,42 @@
+contract Describe_Math_Test {
+    constructor() {
+    }
+
+    function beforeAll() {
+    }
+
+    function beforeEach() {
+    }
+
+    function property_throws_on_underflow(uint x, uint y) {
+        uint z = 0;
+        bool thrown = false;
+        try {
+            z = x - y;
+        } catch {
+            thrown = true;
+        }
+
+        if (x < y) {
+            require(thrown, "SolidVM didn't throw when x < y: " + string(x) + ", " + string(y));
+            require(z == 0, "z was still updated: " + string(z));
+        } else {
+            require(!thrown, "SolidVM threw when x >= y" + string(x) + ", " + string(y));
+        }
+    }
+
+    function property_allows_unchecked(uint x, uint y) {
+        uint z = 0;
+        bool thrown = false;
+        try {
+            unchecked {
+                z = x - y;
+            }
+        } catch {
+            thrown = true;
+        }
+
+        require(!thrown, "SolidVM threw when x >= y" + string(x) + ", " + string(y));
+    }
+}
+

--- a/mercata/contracts/tests/Pool/Pool.test.sol
+++ b/mercata/contracts/tests/Pool/Pool.test.sol
@@ -774,6 +774,7 @@ contract Describe_Pool {
     }
 
     function it_pool_handles_expired_deadlines() {
+        fastForward(3600);
         uint256 amountA = 1000e18;
         uint256 amountB = 2000e18;
         

--- a/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/Blockchain/VM/SolidException.hs
@@ -6,6 +6,7 @@ module Blockchain.VM.SolidException
     showSolidException,
     typeError,
     todo,
+    arithmeticException,
     indexOutOfBounds,
     checkArity,
     arityMismatch,
@@ -57,6 +58,7 @@ import Text.Printf (printf)
 data SolidException
   = TypeError String String
   | InternalError String String
+  | ArithmeticException String String
   | InvalidArguments String String
   | IndexOutOfBounds String String
   | TODO String String
@@ -101,6 +103,7 @@ instance Show SolidException where
 showSolidException :: SolidException -> String
 showSolidException (ArityMismatch m got want) = printf "arity mismatch: %s: got %d, want %d" m got want
 showSolidException (InternalError m v) = printf "internal error: %s: %s" m v
+showSolidException (ArithmeticException a b) = printf "integer out of bounds: %s: %s" a b
 showSolidException (InvalidArguments m v) = printf "invalid arguments: %s: %s" m v
 showSolidException (IndexOutOfBounds a b) = printf "index out of bounds: %s: %s" a b
 showSolidException (MissingField m v) = printf "missing field: %s: %s" m v
@@ -150,6 +153,9 @@ todo = toThrower TODO
 
 internalError :: (Show v) => String -> v -> a
 internalError = toThrower InternalError
+
+arithmeticException :: (Show v) => String -> v -> a
+arithmeticException = toThrower ArithmeticException
 
 invalidArguments :: (Show v) => String -> v -> a
 invalidArguments = toThrower InvalidArguments

--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection/Statement.hs
@@ -181,6 +181,10 @@ data ExpressionF a
   | Variable a SolidString
   | ObjectLiteral a (Map.Map SolidString (ExpressionF a))
   | HexaLiteral a SolidString -- if type clash remove ie hex"0F3A"
+    -- I wanted to make this a generic InlineAssert, but that would require either adding redundant
+    -- expressions to the AST, introducing partially-applied expressions, or some other phantom
+    -- expressions that I want to avoid. Instead, I give you InlineBoundsCheck as a compromise
+  | InlineBoundsCheck a (Maybe Integer) (Maybe Integer) (ExpressionF a)
   deriving (Show, Eq, Generic, Generic1, NFData, Functor, Foldable, Traversable)
 
 extractExpression :: ExpressionF a -> a
@@ -202,6 +206,7 @@ extractExpression (TupleExpression a _) = a
 extractExpression (ArrayExpression a _) = a
 extractExpression (Variable a _) = a
 extractExpression (HexaLiteral a _) = a
+extractExpression (InlineBoundsCheck a _ _ _) = a
 extractExpression (ObjectLiteral a _) = a
 
 type Expression = Positioned ExpressionF

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
@@ -62,9 +62,9 @@ statement =
     <|> (Break <$> (position (reserved "break") <* semi))
     <|> (reserved "assembly" >> inlineAssembly)
     <|> (ModifierExecutor <$> (position (reserved "_") <* semi)) -- This parses the "_;" statement, which is used to signify when in a modifier the function should run
-    <|> ((\(a, e) -> SimpleStatement (ExpressionStatement e) a) <$> ((withPosition expression) <* semi))
     <|> revertStatement
     <|> uncheckedStatement
+    <|> ((\(a, e) -> SimpleStatement (ExpressionStatement e) a) <$> ((withPosition expression) <* semi))
 
 {-
 Statement = IfStatement | WhileStatement | ForStatement | Block | InlineAssemblyStatement |
@@ -139,7 +139,7 @@ ifStatement = do
   pure $ IfStatement i t e a
 
 uncheckedStatement :: SolidityParser Statement
-uncheckedStatement = do
+uncheckedStatement = try $ do
   ~(a, s) <- withPosition $ do
     reserved "unchecked"
     statements

--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/UnParser.hs
@@ -337,6 +337,7 @@ unparseExpression (DecimalLiteral _ v) = show $ unwrapDecimal v
 unparseExpression (StringLiteral _ s) = ('"' :) . (++ "\"") $ s
 unparseExpression (AccountLiteral _ a) = ('<' :) . (++ ">") $ show a
 unparseExpression (HexaLiteral _ a) = "hex\"" ++ (labelToString a) ++ "\""
+unparseExpression (InlineBoundsCheck _ _ _ a) = unparseExpression a
 unparseExpression (TupleExpression _ vals) = "(" ++ List.intercalate ", " (map (maybe "" unparseExpression) vals) ++ ")"
 unparseExpression (IndexAccess _ e maybeVal) = unparseExpression e ++ "[" ++ fromMaybe "" (fmap unparseExpression maybeVal) ++ "]"
 unparseExpression (FunctionCall _ e args) =

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/BooleanLiterals.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/BooleanLiterals.hs
@@ -115,3 +115,4 @@ expressionHelper (ArrayExpression _ es) = concat $ expressionHelper <$> es
 expressionHelper (Variable _ _) = []
 expressionHelper (ObjectLiteral _ _) = []
 expressionHelper (HexaLiteral _ _) = []
+expressionHelper (InlineBoundsCheck _ _ _ _) = []

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/DivideBeforeMultiply.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Expressions/DivideBeforeMultiply.hs
@@ -114,3 +114,4 @@ expressionHelper (ArrayExpression _ es) = concat $ expressionHelper <$> es
 expressionHelper (Variable _ _) = []
 expressionHelper (ObjectLiteral _ _) = []
 expressionHelper (HexaLiteral _ _) = []
+expressionHelper (InlineBoundsCheck _ _ _ _) = []

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Functions/ConstantFunctions.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Functions/ConstantFunctions.hs
@@ -392,3 +392,4 @@ expressionHelper (Variable x name) =
   localVarReadHelper name x
 expressionHelper (ObjectLiteral _ _) = pure []
 expressionHelper (HexaLiteral _ _) = pure []
+expressionHelper (InlineBoundsCheck _ _ _ _) = pure []

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Optimizer.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Optimizer.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module SolidVM.Solidity.StaticAnalysis.Optimizer
@@ -9,13 +10,14 @@ where
 
 import Control.Applicative ((<|>))
 import Control.Lens
-import Control.Monad (join)
 import Control.Monad.Reader
 import Control.Monad.Trans.State
 import Data.Decimal
+import Data.Foldable (for_)
 import Data.Functor.Compose
-import Data.Map as M
+import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
+import Data.Source.Annotation
 import SolidVM.Model.CodeCollection
 import SolidVM.Model.SolidString (SolidString)
 import qualified SolidVM.Model.Type as SVMType
@@ -25,7 +27,10 @@ data R = R
     contract :: Maybe Contract
   }
 
-type SSS = StateT (M.Map SolidString (Expression)) (Reader R) -- Is there a better data structure for this job?
+type SSS = StateT ([M.Map SolidString SVMType.Type], Bool) (Reader R) -- Is there a better data structure for this job?
+
+runSSS :: R -> SSS a -> a
+runSSS r f = runReader (evalStateT f ([M.empty], False)) r
 
 detector :: CodeCollection -> CodeCollection
 detector cc =
@@ -54,7 +59,7 @@ varDeclHelper cc c v = case _varType v of
   where
     run e t =
       let r = R cc c
-       in runReader (evalStateT (optimizeExpression e (Just t)) M.empty) r
+       in runSSS r $ optimizeExpression e (Just t)
 
 constDeclHelper ::
   CodeCollection ->
@@ -68,7 +73,7 @@ constDeclHelper cc c v =
   where
     run e =
       let r = R cc c
-       in runReader (evalStateT (optimizeExpression e Nothing) M.empty) r
+       in runSSS r $ optimizeExpression e Nothing
 
 -- TODO clean this code up
 functionHelper ::
@@ -83,10 +88,12 @@ functionHelper cc mc f =
       if ((Just True) ==) $ M.null <$> (_userDefined <$> mc)
         then
           let r = R cc mc
-           in f {_funcContents = Just $ runReader (optimizeStatements stmts) r}
+           in f {_funcContents = Just $ runSSS r $ optimizeStatements stmts}
         else
           let r = R cc mc
-           in functionHelperForUserDefined f {_funcContents = Just $ runReader (optimizeStatements stmts) r}
+           in functionHelperForUserDefined f {_funcContents = Just $
+                  runSSS r $ optimizeStatements stmts
+                }
 
 functionHelperForUserDefined :: Func -> Func
 functionHelperForUserDefined f = f {_funcArgs = tForm $ _funcArgs f, _funcVals = tForm $ _funcVals f}
@@ -99,47 +106,89 @@ functionHelperForUserDefined f = f {_funcArgs = tForm $ _funcArgs f, _funcVals =
             (xxxx, _) -> (xxxx, (IndexedType z y))
         )
 
-optimizeStatements :: [Statement] -> Reader R [Statement]
-optimizeStatements [] = pure $ []
+pushVar :: String -> SVMType.Type -> SSS ()
+pushVar n t = modify $ \(ms',uc) -> case ms' of
+  [] -> ([], uc)
+  (m:ms) -> ((M.insert n t m):ms, uc)
+
+getVar :: String -> SSS (Maybe SVMType.Type)
+getVar n = foldr (\a b -> M.lookup n a <|> b) Nothing <$> gets fst
+
+withFrame :: SSS a -> SSS a
+withFrame f = do
+  modify $ \(ms,uc) -> (M.empty:ms, uc)
+  a <- f
+  modify (\case
+      ((_:xs), uc) -> (xs, uc)
+      s -> s
+    )
+  pure a
+
+withUnchecked :: SSS a -> SSS a
+withUnchecked f = do
+  currentCheckedness <- gets snd
+  modify $ \(ms,_) -> (ms, True)
+  a <- f
+  modify $ \(ms,_) -> (ms, currentCheckedness)
+  pure a
+
+checkIntBounds ::
+  Maybe Bool ->
+  Maybe Integer ->
+  Maybe Integer ->
+  a ->
+  String ->
+  ExpressionF a ->
+  SSS (ExpressionF a)
+checkIntBounds s mL mU b var expr = gets snd >>= \uc -> getVariableByName var >>= \case
+  Just (SVMType.Int s' _) | not uc && fromMaybe True ((==) <$> s <*> s') ->
+    pure $ InlineBoundsCheck b mL mU expr
+  _ -> pure expr
+
+checkUintUnderflow :: a -> String -> ExpressionF a -> SSS (ExpressionF a)
+checkUintUnderflow = checkIntBounds (Just False) (Just 0) Nothing
+
+optimizeStatements :: [Statement] -> SSS [Statement]
+optimizeStatements [] = pure []
 optimizeStatements ((IfStatement cond thens mElse x) : ss) = do
-  cond' <- (evalStateT (optimizeExpression cond Nothing) M.empty)
+  cond' <- optimizeExpression cond Nothing
   case cond' of
     BoolLiteral _ True -> do
-      thens' <- optimizeStatements thens
+      thens' <- withFrame $ optimizeStatements thens
       (thens' ++) <$> optimizeStatements ss
     BoolLiteral _ False -> do
-      elses' <- optimizeStatements $ fromMaybe [] mElse
+      elses' <- withFrame . optimizeStatements $ fromMaybe [] mElse
       (elses' ++) <$> optimizeStatements ss
     _ -> do
-      thens' <- optimizeStatements thens
-      elses' <- traverse optimizeStatements mElse
+      thens' <- withFrame $ optimizeStatements thens
+      elses' <- withFrame $ traverse optimizeStatements mElse
       (IfStatement cond' thens' elses' x :) <$> optimizeStatements ss
 optimizeStatements ((TryCatchStatement tryStatements catchMap x) : ss) = do
-  tryStatements' <- optimizeStatements tryStatements
-  catchMap' <- getCompose <$> traverse optimizeStatements (Compose catchMap)
+  tryStatements' <- withFrame $ optimizeStatements tryStatements
+  catchMap' <- getCompose <$> traverse (withFrame . optimizeStatements) (Compose catchMap)
   (TryCatchStatement tryStatements' catchMap' x :) <$> optimizeStatements ss
 optimizeStatements ((SolidityTryCatchStatement expr mtpl successStatements catchMap x) : ss) = do
-  expr' <- (evalStateT (optimizeExpression expr Nothing) M.empty)
-  successStatements' <- optimizeStatements successStatements
-  catchMap' <- getCompose <$> traverse optimizeStatements (Compose catchMap)
+  expr' <- optimizeExpression expr Nothing
+  successStatements' <- withFrame $ optimizeStatements successStatements
+  catchMap' <- getCompose <$> traverse (withFrame . optimizeStatements) (Compose catchMap)
   (SolidityTryCatchStatement expr' mtpl successStatements' catchMap' x :) <$> optimizeStatements ss
 optimizeStatements ((WhileStatement cond body x) : ss) = do
-  cond' <- (evalStateT (optimizeExpression cond Nothing) M.empty)
+  cond' <- optimizeExpression cond Nothing
   case cond' of
     BoolLiteral _ False -> optimizeStatements ss
     _ -> do
-      body' <- optimizeStatements body
+      body' <- withFrame $ optimizeStatements body
       (WhileStatement cond' body' x :) <$> optimizeStatements ss
 optimizeStatements ((ForStatement mInit mCond mPost body x) : ss) = do
-  let getExpression = (\xxx -> (evalStateT (optimizeExpression xxx Nothing) M.empty))
+  let getExpression = (\xxx -> optimizeExpression xxx Nothing)
   mCond' <- traverse getExpression mCond
   mPost' <- traverse getExpression mPost
-  body' <- optimizeStatements body
+  body' <- withFrame $ optimizeStatements body
   (ForStatement mInit mCond' mPost' body' x :) <$> optimizeStatements ss
 optimizeStatements ((Block _) : ss) = optimizeStatements ss
 optimizeStatements ((DoWhileStatement body cond x) : ss) = do
-  body' <- optimizeStatements body
-  cond' <- (evalStateT (optimizeExpression cond Nothing) M.empty)
+  body' <- withFrame $ optimizeStatements body
+  cond' <- optimizeExpression cond Nothing
   case cond' of
     BoolLiteral _ False -> (body' ++) <$> optimizeStatements ss
     _ -> (DoWhileStatement body' cond' x :) <$> optimizeStatements ss
@@ -149,13 +198,15 @@ optimizeStatements (s@(Throw _ _) : _) = pure [s]
 optimizeStatements (s@(ModifierExecutor _) : ss) = (s :) <$> optimizeStatements ss
 optimizeStatements (s@(EmitStatement {}) : ss) = (s :) <$> optimizeStatements ss
 optimizeStatements (s@(RevertStatement {}) : _) = pure [s]
-optimizeStatements (s@(UncheckedStatement _ _) : ss) = (s :) <$> optimizeStatements ss
+optimizeStatements (UncheckedStatement uss x : ss) = do
+  uss' <- withUnchecked $ optimizeStatements uss
+  (UncheckedStatement uss' x:) <$> optimizeStatements ss
 optimizeStatements (s@(AssemblyStatement _ _) : ss) = (s :) <$> optimizeStatements ss
 optimizeStatements (s@(SimpleStatement _ _) : ss) = do
-  simpleStatementOptimized <- evalStateT (simpleStatementFHelper' s) M.empty
+  simpleStatementOptimized <- simpleStatementFHelper' s
   (simpleStatementOptimized :) <$> optimizeStatements ss
 optimizeStatements (s@(Return (Just _) _) : ss) = do
-  ssss <- evalStateT (simpleStatementFHelper' s) M.empty
+  ssss <- simpleStatementFHelper' s
   (ssss :) <$> optimizeStatements ss
 optimizeStatements (s@(Return _ _) : _) = pure [s]
 
@@ -165,52 +216,61 @@ optimizeStatements (s@(Return _ _) : _) = pure [s]
 simpleStatementFHelper' :: Statement -> SSS (Statement)
 simpleStatementFHelper' (SimpleStatement (ExpressionStatement xpr) b) = do
   x <- optimizeExpression xpr Nothing
-  _ <- case x of -- Double check this logic -- This needs to be fixed Not 100% sure what this should be?
-    (Binary _ "= " (Variable _ var) xprOptimized) -> modify (M.insert var xprOptimized)
-    _ -> pure ()
   pure $ (SimpleStatement (ExpressionStatement x) b)
 simpleStatementFHelper' (SimpleStatement (VariableDefinition [(VarDefEntry typ loc nam a)] maybeExpression) b) = do
-  mExpr <- case maybeExpression of
-    Nothing -> pure $ maybeExpression
-    Just xpr -> do
-      x <- optimizeExpression xpr Nothing
-      pure $ Just $ x
+  for_ typ $ pushVar nam
+  mExpr <- traverse (flip optimizeExpression Nothing) maybeExpression
   let resVdef = case typ of Just (SVMType.UserDefined _ actual) -> Just actual; _ -> typ --- Unwarp Userdefined types to original type
   -- _ <- case x of --- WTF IS THIS? Oh it puts it in the stack
   --   (Binary _ "= " (Variable _ var) xprOptimized) -> modify (M.insert var xprOptimized); _ -> pure ()
-  pure $ (SimpleStatement (VariableDefinition [(VarDefEntry resVdef loc nam a)] mExpr) b)
+  mExpr' <- traverse (checkUintUnderflow a nam) mExpr
+  pure $ SimpleStatement (VariableDefinition [(VarDefEntry resVdef loc nam a)] mExpr') b
 simpleStatementFHelper' (Return (Just expr) b) = do
   x <- optimizeExpression expr Nothing
   pure $ Return (Just x) b
-simpleStatementFHelper' a = pure $ a
+simpleStatementFHelper' a = pure a
 
-_getVariableByName :: SolidString -> SSS (Maybe Expression) --VariableDeclF (SourceAnnotation ()) -- Maybe SVMType.Type
-_getVariableByName name = do
-  mc <- asks contract
-  case mc of
-    Just c -> do
-      cc <- asks codeCollection
-      pure $
-        (_constInitialVal <$> M.lookup name (_constants c))
-          <|> join (_varInitialVal <$> M.lookup name (_storageDefs c))
-          <|> (_constInitialVal <$> M.lookup name (_flConstants cc))
-    -- TODO
-    -- <|> () <$> M.lookup name (_enums c))
-    -- <|> () <$> M.lookup name (_flEnums cc))
-    -- <|> () <$> M.lookup name (_flStructs cc))
-    -- <|> () <$> M.lookup name (_structs c))
-    -- <|> () <$> M.lookup name (_errors c))
-    -- <|> () <$> M.lookup name (_flErrors cc))
+getVariableByName :: SolidString -> SSS (Maybe SVMType.Type) --VariableDeclF (SourceAnnotation ()) -- Maybe SVMType.Type
+getVariableByName name = do
+  mVar <- getVar name
+  case mVar of
+    Just t -> pure $ Just t
     Nothing -> do
-      mVar <- M.lookup name <$> get
-      case mVar of
-        Nothing -> pure $ Nothing
-        _ -> pure $ mVar
+      mc <- asks contract
+      case mc of
+        Just c -> do
+          cc <- asks codeCollection
+          pure $
+            (_constType <$> M.lookup name (_constants c))
+              <|> (_varType <$> M.lookup name (_storageDefs c))
+              <|> (_constType <$> M.lookup name (_flConstants cc))
+        Nothing -> pure Nothing
+        -- TODO
+        -- <|> () <$> M.lookup name (_enums c))
+        -- <|> () <$> M.lookup name (_flEnums cc))
+        -- <|> () <$> M.lookup name (_flStructs cc))
+        -- <|> () <$> M.lookup name (_structs c))
+        -- <|> () <$> M.lookup name (_errors c))
+        -- <|> () <$> M.lookup name (_flErrors cc))
+
+optimizeSetter ::
+  Maybe SVMType.Type ->
+  SourceAnnotation () ->
+  String ->
+  Expression ->
+  Expression ->
+  SSS Expression
+optimizeSetter t z op' lhs rhs = do
+  lhs' <- optimizeExpression lhs t
+  rhs' <- optimizeExpression rhs t
+  optimizeExpression (Binary z "=" lhs' $ Binary z op' lhs' rhs') t
 
 optimizeExpression :: Expression -> Maybe SVMType.Type -> SSS Expression
 optimizeExpression (Binary x "=" a b) t = do
   b' <- optimizeExpression b t
-  pure $ Binary x "=" a b'
+  case a of
+    Variable x' a' -> Binary x "=" a <$> checkUintUnderflow x' a' b'
+    _ -> pure $ Binary x "=" a b'
 --pure $ Binary x "=" a' b' ---TODO maybe for later fix
 --   case (a', b') of
 --     (NumberLiteral y valA w, NumberLiteral z valB _) -> pure $ NumberLiteral (y <> z) (valA + valB) w
@@ -255,6 +315,22 @@ optimizeExpression (Binary x "%" a b) t = do
   case (a', b') of
     (NumberLiteral y valA w, NumberLiteral z valB _) -> pure $ NumberLiteral (y <> z) (valA `mod` valB) w
     _ -> pure $ Binary x "%" a' b'
+optimizeExpression (Binary     z "+=" lhs rhs) t = optimizeSetter t z "+" lhs rhs
+optimizeExpression (Binary     z "-=" lhs rhs) t = optimizeSetter t z "-" lhs rhs
+optimizeExpression (Binary     z "*=" lhs rhs) t = optimizeSetter t z "*" lhs rhs
+optimizeExpression (Binary     z "/=" lhs rhs) t = optimizeSetter t z "/" lhs rhs
+optimizeExpression (Binary     z "%=" lhs rhs) t = optimizeSetter t z "%" lhs rhs
+optimizeExpression (Binary     z "&=" lhs rhs) t = optimizeSetter t z "&" lhs rhs
+optimizeExpression (Binary     z "|=" lhs rhs) t = optimizeSetter t z "|" lhs rhs
+optimizeExpression (Binary     z "^=" lhs rhs) t = optimizeSetter t z "^" lhs rhs
+optimizeExpression (Unitary    z "++" lhs    ) t = optimizeSetter t z "+" lhs (NumberLiteral z 1 Nothing)
+optimizeExpression (Unitary    z "--" lhs    ) t = optimizeSetter t z "-" lhs (NumberLiteral z 1 Nothing)
+optimizeExpression (MinusMinus z      expr   ) t = optimizeExpression expr t >>= \case
+  Variable x var -> MinusMinus z <$> checkIntBounds (Just False) (Just 1) Nothing x var (Variable x var)
+  expr' -> pure $ MinusMinus z expr'
+optimizeExpression (PlusPlus z      expr   ) t = optimizeExpression expr t >>= \case
+  Variable x var -> PlusPlus z <$> checkIntBounds (Just False) (Just (-1)) Nothing x var (Variable x var)
+  expr' -> pure $ PlusPlus z expr'
 optimizeExpression (FunctionCall x1 (MemberAccess x2 (Variable x3 nam) "wrap") args) _ = do
   mc <- asks contract
   case mc of
@@ -269,6 +345,9 @@ optimizeExpression (FunctionCall x1 (MemberAccess x2 (Variable x3 nam) "unwrap")
       OrderedArgs [x] | M.member nam (_userDefined c) -> optimizeExpression x Nothing
       _ -> pure $ FunctionCall x1 (MemberAccess x2 (Variable x3 nam) "unwrap") args
     Nothing -> pure $ FunctionCall x1 (MemberAccess x2 (Variable x3 nam) "unwrap") args
+optimizeExpression (FunctionCall x1 (Variable x3 f@('u':'i':'n':'t':_)) (OrderedArgs (xp:args))) _ = do
+  let xp' = Ternary x3 (Binary x3 "<" xp (NumberLiteral x3 0 Nothing)) (Unitary x3 "-" xp) xp
+  pure $ FunctionCall x1 (Variable x3 f) (OrderedArgs (xp':args))
 
 -- This needs further research before letting loose on the code base
 -- This function as of now is neutured

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/WriteAfterWrite.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Statements/WriteAfterWrite.hs
@@ -195,6 +195,7 @@ expressionHelper (DecimalLiteral _ _) = pure []
 expressionHelper (StringLiteral _ _) = pure []
 expressionHelper (AccountLiteral _ _) = pure []
 expressionHelper (HexaLiteral _ _) = pure []
+expressionHelper (InlineBoundsCheck _ _ _ _) = pure []
 expressionHelper (TupleExpression _ es) =
   concat <$> traverse (maybe (pure []) expressionHelper) es
 expressionHelper (ArrayExpression _ es) = concat <$> traverse expressionHelper es

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -2023,7 +2023,7 @@ tcExpr (FunctionCall x expr args) = do
   case args of
     NamedArgs es -> apply e a $ Just (fst <$> es)
     _ -> apply e a Nothing
-tcExpr (Unitary x "-" a) = sumType' (intType' x) (decimalType' x) ~> tcExpr a
+tcExpr (Unitary x "-" a) = sumType' (Static (SVMType.Int (Just True) Nothing) x) (decimalType' x) ~> tcExpr a
 tcExpr (Unitary x "++" a) = intType' x ~> (mutable <$> tcExpr a)
 tcExpr (Unitary x "--" a) = intType' x ~> (mutable <$> tcExpr a)
 tcExpr (Unitary x "!" a) = boolType' x ~> tcExpr a
@@ -2037,11 +2037,14 @@ tcExpr (Unitary _ _ a) = tcExpr a
 tcExpr (Ternary x a b c) =
   boolType' x ~> tcExpr a !> tcExpr b <~> tcExpr c
 tcExpr (BoolLiteral x _) = pure $ boolType' x
-tcExpr (NumberLiteral x _ _) = pure $ intType' x
+tcExpr (NumberLiteral x n _) = if n < 0
+                                  then pure $ Static (SVMType.Int (Just True) Nothing) x
+                                  else pure $ intType' x
 tcExpr (DecimalLiteral x _) = pure $ decimalType' x
 tcExpr (StringLiteral x _) = pure $ stringType' x
 tcExpr (AccountLiteral x _) = pure $ accountType' x
 tcExpr (HexaLiteral x _) = pure $ stringType' x
+tcExpr (InlineBoundsCheck x _ _ a) = intType' x ~> tcExpr a
 tcExpr (TupleExpression x es) =
   productType' x <$> traverse (maybe (pure $ topType' x) tcExpr) es
 tcExpr (ArrayExpression x es) = do

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Variables/StateVariables.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Variables/StateVariables.hs
@@ -242,3 +242,4 @@ expressionHelper (Variable x name) =
   [] <$ stateVarReadHelper name x
 expressionHelper (ObjectLiteral _ _) = pure []
 expressionHelper (HexaLiteral _ _) = pure []
+expressionHelper (InlineBoundsCheck _ _ _ _) = pure []

--- a/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
+++ b/strato/VM/SolidVM/solid-vm/exec_src/ExprsNeeded.hs
@@ -80,6 +80,10 @@ expressionCrawler = \case
       expressionCrawler expr
   BoolLiteral {} -> ["BoolLiteral"]
   HexaLiteral {} -> ["HexaLiteral"]
+  InlineBoundsCheck _ mL mU expr ->
+    let l = maybe "" (T.pack . show) mL
+        u = maybe "" (T.pack . show) mU
+     in ("InlineBoundsCheck (" <> l <> "," <> u <> ")") : expressionCrawler expr
   NumberLiteral {} -> ["NumberLiteral"]
   DecimalLiteral {} -> ["DecimalLiteral"]
   StringLiteral {} -> ["StringLiteral"]

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -901,22 +901,20 @@ runStatement s@(CC.SimpleStatement (CC.VariableDefinition entries maybeExpressio
       printf "             creating and setting variables: (%s)\n" $
         intercalate ", " (map (labelToString . toName) entries)
     withSrcPos pos $ printf "             to: %s\n" valueString
-  let ensureType :: Maybe SVMType.Type -> SVMType.Type
-      ensureType = fromMaybe (todo "type inference not implemented" s)
 
   case (entries, value) of
-    ([CC.VarDefEntry mType _ name _], _) -> addLocalVariable (ensureType mType) name value
+    ([CC.VarDefEntry _ _ name _], _) -> addLocalVariable name value
     ([CC.BlankEntry], _) -> parseError "cannot declare single nameless variable" s
     (_, STuple variables) -> do
       checkArity "var declaration tuple" (V.length variables) (length entries)
-      let nonBlanks = [(ensureType t, n, v) | (CC.VarDefEntry t _ n _, v) <- zip entries $ V.toList variables]
+      let nonBlanks = [(n, v) | (CC.VarDefEntry _ _ n _, v) <- zip entries $ V.toList variables]
       --We get the values first so in the case of (x,y) = (y,x) we can still set the variables to the correct values
-      nonBlanks' <- forM nonBlanks $ \(t, n, v) -> do
+      nonBlanks' <- forM nonBlanks $ \(n, v) -> do
         v' <- getVar v
-        return (t, n, v')
-      forM_ nonBlanks' $ \(theType', name', v) -> do
+        return (n, v')
+      forM_ nonBlanks' $ \(name', v) -> do
         logAssigningVariable v
-        addLocalVariable theType' name' v
+        addLocalVariable name' v
     _ -> typeError "VariableDefinition expected a tuple" value
 
   return Nothing
@@ -943,9 +941,9 @@ runStatement (CC.SolidityTryCatchStatement tryExpression returnsDecl statementsF
               if length vars /= length returnsDecl
                 then typeError "try/catch statement expected a tuple of the same length as the returns statement" (tryExpression, aRealVal)
                 else do
-                  forM_ (zip vars xs) $ \(var, (name, ty)) -> do
+                  forM_ (zip vars xs) $ \(var, (name, _)) -> do
                     val <- getVar var
-                    addLocalVariable ty name val
+                    addLocalVariable name val
                   sfsRes' <- runStatementBlock statementsForSuccess
                   return sfsRes'
             _ -> typeError "try/catch statement expected a tuple" (tryExpression, aRealVal)
@@ -1186,7 +1184,7 @@ expToPath (CC.Variable _ x) = do
   callInfo <- getCurrentCallInfo
   let path = MS.singleton $ BC.pack $ labelToString x
   case x `M.lookup` NE.head (localVariables callInfo) of
-    Just (_, var) -> do
+    Just var -> do
       val <- weakGetVar var
       case val of
         SReference apt -> return apt
@@ -1263,6 +1261,12 @@ expToVar' (CC.DecimalLiteral _ v) _ = return $ Constant $ SDecimal $ CC.unwrapDe
 expToVar' (CC.AccountLiteral _ a) _ = return $ Constant $ SAccount a False
 expToVar' (CC.BoolLiteral _ b) _ = return $ Constant $ SBool b
 expToVar' (CC.HexaLiteral _ a) _ = return $ Constant $ SString $ BC.unpack . either (parseError "Couldn't parse hexadecimal literal: ") id . B16.decode $ BC.pack a
+expToVar' (CC.InlineBoundsCheck _ mL mU expr) _ = do
+  var <- expToVar expr Nothing
+  value <- getInt var
+  when (fromMaybe False $ (value <) <$> mL) $ arithmeticException "underflow: " (mL, value)
+  when (fromMaybe False $ (value >) <$> mU) $ arithmeticException "overflow: " (mU, value)
+  pure . Constant $ SInteger value
 expToVar' (CC.Variable _ "bytes32ToString") _ = return $ Constant $ SHexDecodeAndTrim
 expToVar' (CC.Variable _ "addressToAsciiString") _ = return $ Constant SAddressToAscii
 expToVar' (CC.Variable _ "bytes") _ = return $ Constant $ SFunction "identity" Nothing
@@ -1359,7 +1363,7 @@ expToVar' x@(CC.MemberAccess _ expr name) _ = do
       callInfo <- getCurrentCallInfo
       let argList = maybe [] CC._funcArgs $ contract' ^. CC.functions . at functionName
           localVars = NE.head $ localVariables callInfo
-      argVals <- forM argList (\(n, _) -> getVar . snd $ localVars M.! (fromMaybe "" n))
+      argVals <- forM argList (\(n, _) -> getVar $ localVars M.! (fromMaybe "" n))
       return . Constant $ SVariadic argVals
     (SBuiltinVariable "msg", "sig") -> do
       functionName <- getCurrentFunctionName
@@ -2642,7 +2646,7 @@ runTheConstructors from to hsh cc contractName' argVals' = do
               let correctedVal = coerceType contract' t v
               var <- createVar correctedVal
               ((n,(t,var)):) <$> go tns vs' 
-        go argTypeNames vals
+        map (fmap snd) <$> go argTypeNames vals
       NamedVals ns -> do
         let argTypes =
               M.fromList $
@@ -2660,7 +2664,7 @@ runTheConstructors from to hsh cc contractName' argVals' = do
         forM (M.toList typeAndVal) $ \(n, (CC.IndexedType _ t, v)) -> do
           let correctedVal = coerceType contract' t v
           var <- createVar correctedVal
-          return (n, (t, var))
+          return (n, var)
 
   void . withCallInfo to contract' "constructor" hsh cc (M.fromList zipped) False False . pushSender from $ do
 
@@ -2704,8 +2708,8 @@ runTheConstructors from to hsh cc contractName' argVals' = do
   return ()
 
 -- Note: this is intentionally nonstrict in `theType`
-addLocalVariable :: MonadSM m => SVMType.Type -> SolidString -> Value -> m ()
-addLocalVariable theType name value = do
+addLocalVariable :: MonadSM m => SolidString -> Value -> m ()
+addLocalVariable name value = do
   --  initializeStorage (AddressedPath (Left LocalVar) . MS.singleton $ BC.pack name) value
   newVariable <- liftIO $ fmap Variable $ newIORef value
   cs <- Mod.get (Mod.Proxy @[CallInfo])
@@ -2716,7 +2720,7 @@ addLocalVariable theType name value = do
       Mod.put (Mod.Proxy @[CallInfo]) $
         currentSlice
           { localVariables =
-              M.insert name (theType, newVariable) lvs
+              M.insert name newVariable lvs
                 NE.:| lvs'
           } :
         rest
@@ -2736,7 +2740,7 @@ runTheCall ::
 runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
   let !returnNamesAndTypes = [(n, t) | (Just n, CC.IndexedType _ t) <- CC._funcVals theFunction]
       !theModifierNames = map fst $ (CC._funcModifiers theFunction)
-  !returns <- traverse (\(n, t) -> ((n,) . (t,)) <$> createDefaultValue cc contract' t) returnNamesAndTypes
+  !returns <- traverse (\(n, t) -> (n,) <$> createDefaultValue cc contract' t) returnNamesAndTypes
 
   theModifiers' <- forM theModifierNames $ \name -> do
     case M.lookup name (contract' ^. CC.modifiers) of
@@ -2764,7 +2768,7 @@ runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
               go ((n,t):nts) (v:vs') =
                 let v' = coerceType contract' t v
                  in (n,(t,v')) : go nts vs' 
-           in go argMeta vs
+           in fmap snd <$> go argMeta vs
         NamedVals ns ->
           let strTypes = M.fromList $ map (\(maybeName, y) -> (fromMaybe "" maybeName, y)) $ CC._funcArgs theFunction
               typeAndVal =
@@ -2778,14 +2782,14 @@ runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
               -- when added to the call info.
               sortedArgs =
                 map snd . sortWith fst
-                  . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
+                  . map (\(n, (CC.IndexedType i _, v)) -> (i, (n, v)))
                   $ M.toList typeAndVal
            in sortedArgs
   let locals = args ++ returns
   localVars1 <-
-    forM locals $ \(n, (t, v)) -> do
+    forM locals $ \(n, v) -> do
       newVar <- liftIO $ fmap Variable $ newIORef v
-      return (n, (t, newVar))
+      return (n, newVar)
 
   val' <- withCallInfo address' contract' funcName hsh cc (M.fromList localVars1) ro ff $ do -- [(n, (t, Constant v)) | (n, (t, v)) <- locals]
     matchedArgvals <- forM theModifiers $ \modi -> do
@@ -2796,8 +2800,8 @@ runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
       margVals <- argsToVals margList
       case margVals of
         OrderedVals vs -> do
-          let argMeta = map (\(n, CC.IndexedType _ t) -> (n, t)) $ CC._modifierArgs modi
-          return (zipWith (\(n, t) v -> (n, (t, v))) argMeta vs)
+          let argMeta = fst <$> CC._modifierArgs modi
+          return $ zip argMeta vs
         NamedVals ns -> do
           let strTypes = M.fromList $ CC._modifierArgs modi
               typeAndVal =
@@ -2811,7 +2815,7 @@ runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
               -- when added to the call info.
               !sortedArgs =
                 map snd . sortWith fst
-                  . map (\(n, (CC.IndexedType i t, v)) -> (i, (n, (t, v))))
+                  . map (\(n, (CC.IndexedType i _, v)) -> (i, (n, v)))
                   $ M.toList typeAndVal
           return sortedArgs
     -- ++ (map (\(x,y) -> (T.unpack x, y)) (concat matchedArgvals)) --modArgsToBeLocals
@@ -2825,8 +2829,8 @@ runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
     --       newVar <- liftIO $ fmap Variable $ newIORef v
     --       myCombinerForEfficiency ((n, (t, newVar)) : xs) ys
 
-    forM_ (map (\(x, y) -> (T.unpack x, y)) (concat matchedArgvals)) $ \(n, (t, v)) -> do
-      addLocalVariable t n v
+    forM_ (map (\(x, y) -> (T.unpack x, y)) (concat matchedArgvals)) $ \(n, v) -> do
+      addLocalVariable n v
 
     -- theCallInfo <- getCurrentCallInfo
     -- when (True || (not $ null matchedArgvals)) $ error (show theCallInfo)
@@ -2845,7 +2849,7 @@ runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
               let mReturnVar = M.lookup name . NE.head $ localVariables currentCallInfo
               case mReturnVar of
                 Nothing -> unknownVariable "findNamedReturns" name
-                Just returnVar -> fmap Just . forceLoadVar =<< getVar (snd returnVar)
+                Just returnVar -> fmap Just . forceLoadVar =<< getVar returnVar
             xs ->
               Just . STuple . V.fromList <$> do
                 currentCallInfo <- getCurrentCallInfo
@@ -2853,7 +2857,7 @@ runTheCall address' contract' funcName hsh cc theFunction argVals' ro ff = do
                   let mReturnVar = M.lookup name . NE.head $ localVariables currentCallInfo
                   case mReturnVar of
                     Nothing -> unknownVariable "findNamedReturns" name
-                    Just returnVar -> fmap Constant . forceLoadVar =<< getVar (snd returnVar)
+                    Just returnVar -> fmap Constant . forceLoadVar =<< getVar returnVar
     val' <- case val of
       Nothing -> findNamedReturns
       Just SNULL -> findNamedReturns
@@ -2948,8 +2952,8 @@ solidityExceptionHandlerHelper cbm s1 s2 errCode errFunc = do
         Nothing -> do
           res' <-  runStatementBlock block
           return res'
-        Just (varName, varType) -> do
-          addLocalVariable varType varName (SInteger errCode)
+        Just (varName, _) -> do
+          addLocalVariable varName (SInteger errCode)
           res <- runStatementBlock block
           return res
 
@@ -2967,8 +2971,8 @@ solidityExceptionHandlerHelper' cbm s1 errCode errFunc = do
         Nothing -> do
           res' <-  runStatementBlock block
           return res'
-        Just (varName, varType) -> do
-          addLocalVariable varType varName (SInteger errCode)
+        Just (varName, _) -> do
+          addLocalVariable varName (SInteger errCode)
           res <- runStatementBlock block
           return res
 
@@ -2986,8 +2990,8 @@ solidityExceptionHandlerHelper'' cbm s1 s2 vals errCode errFunc = do
         Nothing -> do
           res' <-  runStatementBlock block
           return res'
-        Just (varName, varType) -> do
-          addLocalVariable varType varName (SInteger errCode)
+        Just (varName, _) -> do
+          addLocalVariable varName (SInteger errCode)
           res <- runStatementBlock block
           return res
 
@@ -3007,8 +3011,8 @@ solidityExceptionHandlerHelperRequire cbm s1  = do
               Nothing -> do
                 res' <-  runStatementBlock block
                 return res'
-              Just (varName, varType) -> do
-                addLocalVariable varType varName (SString (fromMaybe "Require Error" s1))
+              Just (varName, _) -> do
+                addLocalVariable varName (SString (fromMaybe "Require Error" s1))
                 res <- runStatementBlock block
                 return res
 
@@ -3028,8 +3032,8 @@ solidityExceptionHandlerHelperAssert cbm  = do
             Nothing -> do
               res' <-  runStatementBlock block
               return res'
-            Just (varName, varType) -> do
-              addLocalVariable varType varName (SString "Assertion Error")
+            Just (varName, _) -> do
+              addLocalVariable varName (SString "Assertion Error")
               res <- runStatementBlock block
               return res
 {- BEN WILL REFACTOR THIS SOMEDAY -}
@@ -3041,6 +3045,9 @@ solidityExceptionHandler catchBlockMap ex =
       return res
     (TypeError s1 s2) -> do
       res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 2 typeError
+      return res
+    (ArithmeticException s1 s2) -> do
+      res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 4 arithmeticException
       return res
     (InvalidArguments s1 s2) -> do
       res <- solidityExceptionHandlerHelper catchBlockMap s1 s2 3 invalidArguments
@@ -3146,8 +3153,8 @@ solidityExceptionHandler catchBlockMap ex =
       case M.lookup name catchBlockMap of
         Nothing -> solidityExceptionHandlerHelper'' catchBlockMap s1 name vals 34 customError 
         Just (Nothing, _) -> solidityExceptionHandlerHelper'' catchBlockMap s1 name vals 34 customError 
-        Just (Just (name', type'), block) -> do
-          mapM_ (\x -> addLocalVariable type' name' x) $ map fromBasic vals
+        Just (Just (name', _), block) -> do
+          mapM_ (\x -> addLocalVariable name' x) $ map fromBasic vals
           res <- runStatementBlock block
           return res
     (DuplicateContract s1) -> do
@@ -3170,6 +3177,12 @@ solidVMExceptionHandler catchBlockMap ex =
     (InternalError s1 s2) -> do
       case M.lookup "InternalError" catchBlockMap of
         Nothing -> solidVMExceptionHelper catchBlockMap $ internalError s1 s2
+        Just (_, block) -> do
+          res <- runStatementBlock block
+          return res
+    (ArithmeticException s1 s2) ->
+      case M.lookup "ArithmeticException" catchBlockMap of
+        Nothing -> solidVMExceptionHelper catchBlockMap $ arithmeticException s1 s2
         Just (_, block) -> do
           res <- runStatementBlock block
           return res
@@ -3331,7 +3344,7 @@ solidVMExceptionHandler catchBlockMap ex =
                 Nothing -> []
           _ <-
             if length args > 0
-              then mapM (\(x, ((_, (CC.IndexedType _ y), _), z)) -> addLocalVariable y x z) $ zip argsToSolidString zipped
+              then mapM (\(x, (_, z)) -> addLocalVariable x z) $ zip argsToSolidString zipped
               else pure $ [()]
           res <- runStatementBlock block
           return res

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -27,8 +27,6 @@ module Blockchain.SolidVM.SM
     withTempCallInfo,
     withUncheckedCallInfo,
     withLocalVars,
-    getLocal,
-    setLocal,
     getCurrentCallInfo,
     getCurrentCallInfoIfExists,
     getCurrentContract,
@@ -135,7 +133,7 @@ data CallInfo = CallInfo
     currentContract :: CC.Contract,
     codeCollection :: CC.CodeCollection,
     collectionHash :: Keccak256,
-    localVariables :: NE.NonEmpty (Map SolidString (SVMType.Type, Variable)),
+    localVariables :: NE.NonEmpty (Map SolidString Variable),
     stateMap :: !(M.Map Address AddressStateModification),
     storageMap :: !(M.Map (Address, B.ByteString) B.ByteString),
     readOnly :: Bool,
@@ -588,7 +586,7 @@ getVariableOfName name = do
 
   -- when (name == "theSixthSense") (internalError "M. Night Shyamalan presents" currentCallInfo)
 
-  let maybeLocalValue = fmap snd $ M.lookup name vars
+  let maybeLocalValue = M.lookup name vars
 
   let maybeContractFunction :: Maybe Variable
       maybeContractFunction = fmap (t "constant function" . Constant . SFunction name . Just) $ M.lookup name $ currentContract currentCallInfo ^. CC.functions
@@ -743,7 +741,7 @@ withCallInfo ::
   SolidString ->
   Keccak256 ->
   CC.CodeCollection ->
-  Map SolidString (SVMType.Type, Variable) ->
+  Map SolidString Variable ->
   Bool ->
   Bool ->
   m a ->
@@ -763,7 +761,7 @@ addCallInfo ::
   SolidString ->
   Keccak256 ->
   CC.CodeCollection ->
-  Map SolidString (SVMType.Type, Variable) ->
+  Map SolidString Variable ->
   Bool ->
   Bool ->
   m ()
@@ -892,24 +890,6 @@ getCurrentFunctionName = do
   case cs of
     (currentCallInfo : _) -> return $ currentFunctionName currentCallInfo
     _ -> internalError "getCurrentFunctionName called with an empty stack" ()
-
-getLocal :: MonadSM m => SolidString -> m (Maybe (SVMType.Type, Variable))
-getLocal name = do
-  currentCallInfo <- getCurrentCallInfo
-  return . M.lookup name . NE.head $ localVariables currentCallInfo
-
-setLocal :: MonadSM m => SolidString -> Variable -> m ()
-setLocal name val = do
-  stack <- Mod.get (Mod.Proxy @[CallInfo])
-  let (info, rest) = case stack of
-        (ci : r) -> (ci, r)
-        [] -> internalError "setLocal stack underflow" ()
-      locals NE.:| locals' = localVariables info
-      (theType, _) =
-        fromMaybe (unknownVariable "setLocal called for variable that doesn't exist" name) $
-          M.lookup name locals
-      newVariables = M.insert name (theType, val) locals NE.:| locals'
-  Mod.put (Mod.Proxy @[CallInfo]) $ info {localVariables = newVariables} : rest
 
 addFunctionToCurrentContractInCurrentCallInfo :: MonadSM m => SolidString -> CC.Func -> m ()
 addFunctionToCurrentContractInCurrentCallInfo funcName funcObject = do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/TraceTools.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/TraceTools.hs
@@ -16,7 +16,7 @@ import Text.Tools
 
 showVariables :: MonadSM m => CallInfo -> m [String]
 showVariables ci = do
-  forM (M.toList . NE.head $ localVariables ci) $ \(name, (_, var)) -> do
+  forM (M.toList . NE.head $ localVariables ci) $ \(name, var) -> do
     val <- getVar var
     valueString <- showSM val
     return $ "    \"" ++ labelToString name ++ "\": " ++ valueString


### PR DESCRIPTION
This PR adds unsigned integer underflow checking to SolidVM, with the ability to bypass this check inside of `unchecked` blocks.
The way this is accomplished is by leveraging the SolidVM's optimizer layer, which performs safe transformations on the AST, with the intent of improving performance. In this case, since the optimizer has full access to type information, we can splice in a new `InlineBoundsCheck` expression wherever there is an assignment to an unsigned integer variable. This new expression is a "phantom" expression, because it has no lexical representation, i.e. it cannot be created by the parser. It is needed because there is no equivalent of `require` or `assert` at the expression level (these are full-on `Statement`s). The `InlineBoundsCheck` is then interpreted at runtime, and allows SolidVM to throw an `ArithmeticException` if the value in the bounds check falls outside the bounds. This means `InlineBoundsCheck` could also be used for arithmetic overflow checking, if we ever wanted to enforce integer bid widths, but is currently limited to unsigned underflow checking. Finally, the optimizer does not splice in the `InlineBoundsCheck` if the assignment occurs within an `unchecked` block, meaning SolidVM performs signed arithmetic (i.e. no wrap-around!) like it currently does