### PR TITLE
Add ability to stake in RewardsChef for LP tokens for Swap Pools

### DIFF
--- a/mercata/backend/src/api/helpers/swapping.helper.ts
+++ b/mercata/backend/src/api/helpers/swapping.helper.ts
@@ -16,14 +16,14 @@ export const calculateImpliedPrice = (
 ): string => {
   const inBig = safeBigInt(amountIn);
   const outBig = safeBigInt(amountOut);
-  
+
   if (inBig === 0n || outBig === 0n) return '0.00';
-  
+
   // Always calculate as TokenB/TokenA
-  const price = isAToB 
+  const price = isAToB
     ? safeBigIntDivide(outBig * 10n**18n, inBig, "A to B price calculation")  // A→B: out/in
     : safeBigIntDivide(inBig * 10n**18n, outBig, "B to A price calculation"); // B→A: in/out
-  
+
   return (Number(price) / 1e18).toFixed(6);
 };
 
@@ -161,16 +161,16 @@ export const getTradingVolume24hForPools = async (
   (swapEvents as RawSwapEvent[]).forEach(event => {
     const poolAddress = event.address;
     const currentVolume = volumeMap.get(poolAddress) || "0";
-    
+
     const tokenInAddress = event.tokenIn;
     const tokenInPrice = priceMap.get(tokenInAddress) || "0";
-    
+
     const tokenInVolume = safeBigIntDivide(
       safeBigInt(event.amountIn) * safeBigInt(tokenInPrice),
       safeBigInt(10 ** 18),
       "Volume calculation"
     );
-    
+
     const newVolume = safeBigInt(currentVolume) + tokenInVolume;
     volumeMap.set(poolAddress, newVolume.toString());
   });
@@ -179,10 +179,10 @@ export const getTradingVolume24hForPools = async (
 };
 
 export const calculatePoolMetrics = (
-  pool: RawGetPool, 
-  tokenAPrice: string, 
-  tokenBPrice: string, 
-  volume24h: string, 
+  pool: RawGetPool,
+  tokenAPrice: string,
+  tokenBPrice: string,
+  volume24h: string,
   factoryData?: RawPoolFactory
 ): {
   totalLiquidityUSD: string;
@@ -192,23 +192,23 @@ export const calculatePoolMetrics = (
   lpSharePercent: number;
 } => {
   const tokenAValue = safeBigIntDivide(
-    safeBigInt(pool.tokenABalance) * safeBigInt(tokenAPrice), 
-    safeBigInt(10 ** 18), 
+    safeBigInt(pool.tokenABalance) * safeBigInt(tokenAPrice),
+    safeBigInt(10 ** 18),
     "Token A value calculation"
   );
   const tokenBValue = safeBigIntDivide(
-    safeBigInt(pool.tokenBBalance) * safeBigInt(tokenBPrice), 
-    safeBigInt(10 ** 18), 
+    safeBigInt(pool.tokenBBalance) * safeBigInt(tokenBPrice),
+    safeBigInt(10 ** 18),
     "Token B value calculation"
   );
   const totalLiquidityUSD = (tokenAValue + tokenBValue).toString();
-  
+
   const swapFeeRate = pool.swapFeeRate || factoryData?.swapFeeRate || 30;
   const lpSharePercent = pool.lpSharePercent || factoryData?.lpSharePercent || 7000;
-  
+
   const fees24h = calculateLPFees24h(volume24h, swapFeeRate, lpSharePercent);
   const apy = calculatePoolAPY(fees24h, totalLiquidityUSD);
-  
+
   const lpTokenPrice = calculateLPTokenPrice(
     pool.tokenABalance,
     pool.tokenBBalance,
@@ -216,7 +216,7 @@ export const calculatePoolMetrics = (
     tokenBPrice,
     pool.lpToken._totalSupply
   );
-  
+
   return { totalLiquidityUSD, apy, lpTokenPrice, swapFeeRate, lpSharePercent };
 };
 
@@ -233,9 +233,9 @@ export const calculateOracleRatios = (tokenAPrice: string, tokenBPrice: string):
 // ============================================================================
 
 export const buildSwapToken = (
-  token: RawToken, 
-  price: string, 
-  poolBalance: string, 
+  token: RawToken,
+  price: string,
+  poolBalance: string,
   userBalance: string
 ): SwapToken => ({
   address: token.address,
@@ -344,7 +344,7 @@ export const fetchPoolTokenAddresses = async (accessToken: string, poolAddress: 
       select: "tokenA,tokenB"
     }
   });
-  
+
   return poolData[0];
 };
 
@@ -359,8 +359,31 @@ export const fetchPoolBalances = async (accessToken: string, poolAddress: string
       select: "tokenABalance::text,tokenBBalance::text,lpToken:lpToken_fkey(_totalSupply::text)"
     }
   });
-  
+
   return poolData[0];
+};
+
+/**
+ * Fetches the LP token address for a given pool
+ */
+export const fetchLPTokenAddress = async (
+  accessToken: string,
+  poolAddress: string
+): Promise<string> => {
+  const { data: poolData } = await cirrus.get(accessToken, `/${Pool}`, {
+    params: {
+      poolFactory: "eq." + constants.poolFactory,
+      address: "eq." + poolAddress,
+      select: "lpToken"
+    }
+  });
+  const lpTokenAddress = poolData?.[0]?.lpToken;
+
+  if (!lpTokenAddress) {
+    throw new Error("Could not fetch LP token address for pool");
+  }
+
+  return lpTokenAddress;
 };
 
 // ============================================================================

--- a/mercata/backend/src/api/helpers/swapping.helper.ts
+++ b/mercata/backend/src/api/helpers/swapping.helper.ts
@@ -2,6 +2,10 @@ import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { SwapToken, LPToken, RawGetPool, RawPoolFactory, RawToken, RawLPToken, RawSwapEvent, OraclePriceMap } from "@mercata/shared-types";
 import { safeBigInt, safeBigIntDivide } from "../../utils/bigIntUtils";
+import { buildFunctionTx } from "../../utils/txBuilder";
+import { executeTransaction } from "../../utils/txHelper";
+import { waitForBalanceUpdate } from "../services/rewardsChef.service";
+import { rewardsChef } from "../../config/constants";
 
 const { Pool, PoolSwap, swapHistorySelectFields } = constants;
 
@@ -399,3 +403,42 @@ export const buildTokenApprovalTx = (tokenAddress: string, spender: string, amou
   method: "approve",
   args: { spender, value: amount }
 });
+
+/**
+ * Stakes newly minted LP tokens into RewardsChef
+ */
+export const stakeNewLPTokens = async (
+  accessToken: string,
+  userAddress: string,
+  lpTokenAddress: string,
+  rewardsPoolIdx: number,
+  lpTokenBalanceBefore: string
+): Promise<void> => {
+  // Wait for Cirrus to index the new LP token balance with retry logic
+  const lpTokenBalanceAfter = await waitForBalanceUpdate(
+    accessToken,
+    lpTokenAddress,
+    userAddress,
+    lpTokenBalanceBefore,
+    10,  // max retries
+    200  // 200ms delay between retries
+  );
+
+  // Calculate newly minted LP tokens
+  const newlyMintedAmount = (BigInt(lpTokenBalanceAfter) - BigInt(lpTokenBalanceBefore)).toString();
+
+  if (BigInt(newlyMintedAmount) > 0n) {
+    // Stake the newly minted LP tokens
+    const stakingTx = await buildFunctionTx([
+      buildTokenApprovalTx(lpTokenAddress, rewardsChef, newlyMintedAmount),
+      {
+        contractName: "RewardsChef",
+        contractAddress: rewardsChef,
+        method: "deposit",
+        args: { _pid: rewardsPoolIdx, _amount: newlyMintedAmount }
+      }
+    ], userAddress, accessToken);
+
+    await executeTransaction(accessToken, stakingTx);
+  }
+};

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -7,7 +7,7 @@ import * as config from "../../config/config";
 import { getBalance, getTokens, getTokenBalanceForUser } from "./tokens.service";
 import { extractContractName } from "../../utils/utils";
 import { FunctionInput } from "../../types/types";
-import { getStakedBalance, getPools, waitForBalanceUpdate } from "./rewardsChef.service";
+import { getStakedBalance, getPools, waitForBalanceUpdate, findPoolByLpToken } from "./rewardsChef.service";
 import {
   simulateLoan,
   CollateralInfo,
@@ -33,17 +33,6 @@ const {
   PriceOracle,
   RewardsChef,
 } = constants;
-
-/**
- * Helper function to find the RewardsChef pool for a given mToken
- */
-const findPoolForMToken = async (
-  accessToken: string,
-  mToken: string
-) => {
-  const pools = await getPools(accessToken, rewardsChef);
-  return pools.find(pool => pool.lpToken === mToken);
-};
 
 /**
  * Get the latest exchange rate for the lending pool from Cirrus events
@@ -173,13 +162,11 @@ export const depositLiquidity = async (
 
     if (BigInt(newlyMintedAmount) > 0n) {
       // Find the pool for this mToken
-      const poolForMToken = await findPoolForMToken(accessToken, mToken);
+      const rewardsPool = await findPoolByLpToken(accessToken, rewardsChef, mToken);
 
-      if (!poolForMToken) {
+      if (!rewardsPool) {
         throw new Error(`No RewardsChef pool found for mToken ${mToken}. Cannot stake after deposit.`);
       }
-
-      const poolIdx = poolForMToken.poolIdx;
 
       const stakingTx: FunctionInput[] = [
         // First approve mToken for RewardsChef
@@ -194,7 +181,7 @@ export const depositLiquidity = async (
           contractName: extractContractName(RewardsChef),
           contractAddress: rewardsChef,
           method: "deposit",
-          args: { _pid: poolIdx, _amount: newlyMintedAmount },
+          args: { _pid: rewardsPool.poolIdx, _amount: newlyMintedAmount },
         },
       ];
 
@@ -256,13 +243,11 @@ export const withdrawLiquidity = async (
       const amountToUnstake = requiredMTokenWei - unstakedMTokenWei;
 
       // Find the pool for this mToken
-      const poolForMToken = await findPoolForMToken(accessToken, mToken);
+      const rewardsPool = await findPoolByLpToken(accessToken, rewardsChef, mToken);
 
-      if (!poolForMToken) {
+      if (!rewardsPool) {
         throw new Error(`No RewardsChef pool found for mToken ${mToken}. Cannot unstake before withdrawal.`);
       }
-
-      const poolIdx = poolForMToken.poolIdx;
 
       // Build unstaking transaction
       const unstakeTx = await buildFunctionTx({
@@ -270,7 +255,7 @@ export const withdrawLiquidity = async (
         contractAddress: rewardsChef,
         method: "withdraw",
         args: {
-          _pid: poolIdx,
+          _pid: rewardsPool.poolIdx,
           _amount: amountToUnstake.toString()
         }
       }, userAddress, accessToken);
@@ -658,11 +643,11 @@ export const liquidityAndBalance = async (
 
   // Get user's staked balance from RewardsChef
   // Find the pool for this mToken
-  const poolForMToken = await findPoolForMToken(accessToken, mToken);
+  const rewardsPool = await findPoolByLpToken(accessToken, rewardsChef, mToken);
 
   // If no pool found, staked balance is 0
-  const stakedMTokenBalance = poolForMToken
-    ? await getStakedBalance(accessToken, rewardsChef, poolForMToken.poolIdx, userAddress)
+  const stakedMTokenBalance = rewardsPool
+    ? await getStakedBalance(accessToken, rewardsChef, rewardsPool.poolIdx, userAddress)
     : "0";
 
   // User's withdrawable underlying (min of user mToken value and pool cash)

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -129,3 +129,26 @@ export const getPools = async (
     return [];
   }
 };
+
+/**
+ * Finds the RewardsChef pool for a given LP token address
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param lpTokenAddress - Address of the LP token to find
+ * @returns Promise resolving to the pool object, or undefined if not found
+ */
+export const findPoolByLpToken = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  lpTokenAddress: string
+): Promise<{
+  poolIdx: number;
+  lpToken: string;
+  allocPoint: string;
+  accPerToken: string;
+  lastRewardTimestamp: string;
+} | undefined> => {
+  const pools = await getPools(accessToken, rewardsChefAddress);
+  return pools.find(p => p.lpToken === lpTokenAddress);
+};

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -89,15 +89,18 @@ export const getStakedBalance = async (
 };
 
 /**
- * Fetches all pools from RewardsChef contract using Cirrus
+ * Low-level function to fetch pools from RewardsChef contract using Cirrus
+ * with optional additional query parameters
  *
  * @param accessToken - User access token for authentication
  * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param additionalParams - Optional additional Cirrus query parameters for filtering
  * @returns Promise resolving to array of pool information
  */
-export const getPools = async (
+const getPoolsCirrus = async (
   accessToken: string,
-  rewardsChefAddress: string
+  rewardsChefAddress: string,
+  additionalParams?: Record<string, string>
 ): Promise<Array<{
   poolIdx: number;
   lpToken: string;
@@ -108,7 +111,8 @@ export const getPools = async (
   try {
     const response = await cirrus.get(accessToken, `/${RewardsChef}-pools`, {
       params: {
-        address: `eq.${rewardsChefAddress}`
+        address: `eq.${rewardsChefAddress}`,
+        ...additionalParams
       }
     });
 
@@ -131,7 +135,28 @@ export const getPools = async (
 };
 
 /**
+ * Fetches all pools from RewardsChef contract using Cirrus
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @returns Promise resolving to array of pool information
+ */
+export const getPools = async (
+  accessToken: string,
+  rewardsChefAddress: string
+): Promise<Array<{
+  poolIdx: number;
+  lpToken: string;
+  allocPoint: string;
+  accPerToken: string;
+  lastRewardTimestamp: string;
+}>> => {
+  return getPoolsCirrus(accessToken, rewardsChefAddress);
+};
+
+/**
  * Finds the RewardsChef pool for a given LP token address
+ * Uses Cirrus filtering for efficient database-level query
  *
  * @param accessToken - User access token for authentication
  * @param rewardsChefAddress - Address of the RewardsChef contract
@@ -149,6 +174,8 @@ export const findPoolByLpToken = async (
   accPerToken: string;
   lastRewardTimestamp: string;
 } | undefined> => {
-  const pools = await getPools(accessToken, rewardsChefAddress);
-  return pools.find(p => p.lpToken === lpTokenAddress);
+  const pools = await getPoolsCirrus(accessToken, rewardsChefAddress, {
+    "value->>lpToken": `eq.${lpTokenAddress}`
+  });
+  return pools[0]; // Should return at most one pool
 };

--- a/mercata/backend/src/api/services/safety.service.ts
+++ b/mercata/backend/src/api/services/safety.service.ts
@@ -5,21 +5,10 @@ import { StratoPaths, constants, rewardsChef } from "../../config/constants";
 import { extractContractName } from "../../utils/utils";
 import { FunctionInput } from "../../types/types";
 import { getTokenBalanceForUser } from "./tokens.service";
-import { getStakedBalance, getPools, waitForBalanceUpdate } from "./rewardsChef.service";
+import { getStakedBalance, getPools, waitForBalanceUpdate, findPoolByLpToken } from "./rewardsChef.service";
 
 const SafetyModule = "mercata/backend/src/api/contracts/concrete/Lending/SafetyModule.sol";
 const { Token } = constants;
-
-/**
- * Helper function to find the RewardsChef pool for a given sToken
- */
-const findPoolForSToken = async (
-  accessToken: string,
-  sToken: string
-) => {
-  const pools = await getPools(accessToken, rewardsChef);
-  return pools.find(pool => pool.lpToken === sToken);
-};
 
 interface SafetyModuleInfo {
   totalAssets: string;
@@ -201,7 +190,7 @@ export const getSafetyModuleInfo = async (
 
     // Get user's staked sUSDST balance from RewardsChef
     // Find the pool for this sToken
-    const poolForSToken = await findPoolForSToken(accessToken, sTokenAddress);
+    const poolForSToken = await findPoolByLpToken(accessToken, rewardsChef, sTokenAddress);
 
     // If no pool found, staked balance is 0
     const stakedSTokenBalance = poolForSToken
@@ -348,7 +337,7 @@ export const stakeSafetyModule = async (
 
     if (BigInt(newlyMintedAmount) > 0n) {
       // Find the pool for this sToken
-      const poolForSToken = await findPoolForSToken(accessToken, sTokenAddress);
+      const poolForSToken = await findPoolByLpToken(accessToken, rewardsChef, sTokenAddress);
 
       if (!poolForSToken) {
         throw new Error(`No RewardsChef pool found for sToken ${sTokenAddress}. Cannot stake after deposit.`);
@@ -431,7 +420,7 @@ export const redeemSafetyModule = async (
       const amountToUnstake = requiredSTokenWei - unstakedSTokenWei;
 
       // Find the pool for this sToken
-      const poolForSToken = await findPoolForSToken(accessToken, sTokenAddress);
+      const poolForSToken = await findPoolByLpToken(accessToken, rewardsChef, sTokenAddress);
 
       if (!poolForSToken) {
         throw new Error(`No RewardsChef pool found for sToken ${sTokenAddress}. Cannot unstake before redemption.`);

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -16,10 +16,11 @@ import {
   fetchLPTokenAddress,
   buildTokenApprovalTx,
   getTradingVolume24hForPools,
-  getTokenBalance
+  getTokenBalance,
+  stakeNewLPTokens
 } from "../helpers/swapping.helper";
 import { getOraclePrices } from "./oracle.service";
-import { getPools as getRewardsChefPools, getStakedBalance, waitForBalanceUpdate, findPoolByLpToken } from "./rewardsChef.service";
+import { getPools as getRewardsChefPools, getStakedBalance, findPoolByLpToken } from "./rewardsChef.service";
 import { getTokenBalanceForUser } from "./tokens.service";
 import { rewardsChef } from "../../config/constants";
 import {
@@ -44,45 +45,6 @@ import {
 } from "@mercata/shared-types";
 
 const { Pool, PoolFactory, PoolSwap, swapHistorySelectFields, swapTokenSelectFields } = constants;
-
-/**
- * Stakes newly minted LP tokens into RewardsChef
- */
-const stakeNewLPTokens = async (
-  accessToken: string,
-  userAddress: string,
-  lpTokenAddress: string,
-  rewardsPoolIdx: number,
-  lpTokenBalanceBefore: string
-): Promise<void> => {
-  // Wait for Cirrus to index the new LP token balance with retry logic
-  const lpTokenBalanceAfter = await waitForBalanceUpdate(
-    accessToken,
-    lpTokenAddress,
-    userAddress,
-    lpTokenBalanceBefore,
-    10,  // max retries
-    200  // 200ms delay between retries
-  );
-
-  // Calculate newly minted LP tokens
-  const newlyMintedAmount = (BigInt(lpTokenBalanceAfter) - BigInt(lpTokenBalanceBefore)).toString();
-
-  if (BigInt(newlyMintedAmount) > 0n) {
-    // Stake the newly minted LP tokens
-    const stakingTx = await buildFunctionTx([
-      buildTokenApprovalTx(lpTokenAddress, rewardsChef, newlyMintedAmount),
-      {
-        contractName: "RewardsChef",
-        contractAddress: rewardsChef,
-        method: "deposit",
-        args: { _pid: rewardsPoolIdx, _amount: newlyMintedAmount }
-      }
-    ], userAddress, accessToken);
-
-    await executeTransaction(accessToken, stakingTx);
-  }
-};
 
 // ============================================================================
 // READ OPERATIONS

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -44,6 +44,103 @@ import {
 const { Pool, PoolFactory, PoolSwap, swapHistorySelectFields, swapTokenSelectFields } = constants;
 
 // ============================================================================
+// HELPER FUNCTIONS FOR LP TOKEN STAKING
+// ============================================================================
+
+/**
+ * Fetches the LP token address for a given pool
+ */
+const fetchLPTokenAddress = async (
+  accessToken: string,
+  poolAddress: string
+): Promise<string> => {
+  const { data: poolData } = await cirrus.get(accessToken, `/${Pool}`, {
+    params: {
+      poolFactory: "eq." + constants.poolFactory,
+      address: "eq." + poolAddress,
+      select: "lpToken"
+    }
+  });
+  const lpTokenAddress = poolData?.[0]?.lpToken;
+
+  if (!lpTokenAddress) {
+    throw new Error("Could not fetch LP token address for pool");
+  }
+
+  return lpTokenAddress;
+};
+
+/**
+ * Finds the RewardsChef pool index for a given LP token address
+ * Returns undefined if no matching pool is found
+ */
+const findRewardsChefPoolIdx = async (
+  accessToken: string,
+  lpTokenAddress: string
+): Promise<number | undefined> => {
+  const rewardsChefPools = await getRewardsChefPools(accessToken, rewardsChef);
+  const rewardsPool = rewardsChefPools.find(p => p.lpToken === lpTokenAddress);
+  return rewardsPool?.poolIdx;
+};
+
+/**
+ * Gets the user's LP token balance from Cirrus
+ */
+const getUserLPTokenBalance = async (
+  accessToken: string,
+  lpTokenAddress: string,
+  userAddress: string
+): Promise<string> => {
+  const { data: lpTokenData } = await cirrus.get(accessToken, `/BlockApps-Mercata-Token`, {
+    params: {
+      address: `eq.${lpTokenAddress}`,
+      select: `balances:BlockApps-Mercata-Token-_balances(user:key,balance:value::text)`,
+      "balances.key": `eq.${userAddress.toLowerCase()}`
+    }
+  });
+  return lpTokenData?.[0]?.balances?.[0]?.balance || "0";
+};
+
+/**
+ * Stakes newly minted LP tokens into RewardsChef
+ */
+const stakeNewLPTokens = async (
+  accessToken: string,
+  userAddress: string,
+  lpTokenAddress: string,
+  rewardsPoolIdx: number,
+  lpTokenBalanceBefore: string
+): Promise<void> => {
+  // Wait for Cirrus to index the new LP token balance with retry logic
+  const lpTokenBalanceAfter = await waitForBalanceUpdate(
+    accessToken,
+    lpTokenAddress,
+    userAddress,
+    lpTokenBalanceBefore,
+    10,  // max retries
+    200  // 200ms delay between retries
+  );
+
+  // Calculate newly minted LP tokens
+  const newlyMintedAmount = (BigInt(lpTokenBalanceAfter) - BigInt(lpTokenBalanceBefore)).toString();
+
+  if (BigInt(newlyMintedAmount) > 0n) {
+    // Stake the newly minted LP tokens
+    const stakingTx = await buildFunctionTx([
+      buildTokenApprovalTx(lpTokenAddress, rewardsChef, newlyMintedAmount),
+      {
+        contractName: "RewardsChef",
+        contractAddress: rewardsChef,
+        method: "deposit",
+        args: { _pid: rewardsPoolIdx, _amount: newlyMintedAmount }
+      }
+    ], userAddress, accessToken);
+
+    await executeTransaction(accessToken, stakingTx);
+  }
+};
+
+// ============================================================================
 // READ OPERATIONS
 // ============================================================================
 
@@ -278,42 +375,17 @@ export const addLiquidityDualToken = async (
 
   const pool = await fetchPoolTokenAddresses(accessToken, poolAddress);
 
-  // Get LP token address and balance before if we need to stake
+  // Prepare for LP token staking if requested
   let lpTokenAddress: string | undefined;
   let lpTokenBalanceBefore: string = "0";
   let rewardsPoolIdx: number | undefined;
 
   if (stakeLPToken) {
-    // Query pool to get LP token address
-    const { data: poolData } = await cirrus.get(accessToken, `/${Pool}`, {
-      params: {
-        poolFactory: "eq." + constants.poolFactory,
-        address: "eq." + poolAddress,
-        select: "lpToken"
-      }
-    });
-    lpTokenAddress = poolData?.[0]?.lpToken;
+    lpTokenAddress = await fetchLPTokenAddress(accessToken, poolAddress);
+    rewardsPoolIdx = await findRewardsChefPoolIdx(accessToken, lpTokenAddress);
 
-    if (!lpTokenAddress) {
-      throw new Error("Could not fetch LP token address for pool");
-    }
-
-    // Find RewardsChef pool for this LP token
-    const rewardsChefPools = await getRewardsChefPools(accessToken, rewardsChef);
-    const rewardsPool = rewardsChefPools.find(p => p.lpToken === lpTokenAddress);
-
-    if (rewardsPool) {
-      rewardsPoolIdx = rewardsPool.poolIdx;
-
-      // Get user's LP token balance before deposit
-      const { data: lpTokenData } = await cirrus.get(accessToken, `/BlockApps-Mercata-Token`, {
-        params: {
-          address: `eq.${lpTokenAddress}`,
-          select: `balances:BlockApps-Mercata-Token-_balances(user:key,balance:value::text)`,
-          "balances.key": `eq.${userAddress.toLowerCase()}`
-        }
-      });
-      lpTokenBalanceBefore = lpTokenData?.[0]?.balances?.[0]?.balance || "0";
+    if (rewardsPoolIdx !== undefined) {
+      lpTokenBalanceBefore = await getUserLPTokenBalance(accessToken, lpTokenAddress, userAddress);
     }
   }
 
@@ -331,35 +403,9 @@ export const addLiquidityDualToken = async (
 
   const depositResult = await executeTransaction(accessToken, tx);
 
-  // If stakeLPToken and deposit succeeded, stake the newly minted LP tokens
+  // Stake newly minted LP tokens if requested and deposit succeeded
   if (stakeLPToken && depositResult.status === "Success" && lpTokenAddress && rewardsPoolIdx !== undefined) {
-    // Wait for Cirrus to index the new LP token balance with retry logic
-    const lpTokenBalanceAfter = await waitForBalanceUpdate(
-      accessToken,
-      lpTokenAddress,
-      userAddress,
-      lpTokenBalanceBefore,
-      10,  // max retries
-      200  // 200ms delay between retries
-    );
-
-    // Calculate newly minted LP tokens
-    const newlyMintedAmount = (BigInt(lpTokenBalanceAfter) - BigInt(lpTokenBalanceBefore)).toString();
-
-    if (BigInt(newlyMintedAmount) > 0n) {
-      // Stake the newly minted LP tokens
-      const stakingTx = await buildFunctionTx([
-        buildTokenApprovalTx(lpTokenAddress, rewardsChef, newlyMintedAmount),
-        {
-          contractName: "RewardsChef",
-          contractAddress: rewardsChef,
-          method: "deposit",
-          args: { _pid: rewardsPoolIdx, _amount: newlyMintedAmount }
-        }
-      ], userAddress, accessToken);
-
-      await executeTransaction(accessToken, stakingTx);
-    }
+    await stakeNewLPTokens(accessToken, userAddress, lpTokenAddress, rewardsPoolIdx, lpTokenBalanceBefore);
   }
 
   return depositResult;
@@ -375,42 +421,17 @@ export const addLiquiditySingleToken = async (
   const pool = await fetchPoolTokenAddresses(accessToken, poolAddress);
   const depositTokenAddress = isAToB ? pool.tokenA : pool.tokenB;
 
+  // Prepare for LP token staking if requested
   let lpTokenAddress: string | undefined;
+  let lpTokenBalanceBefore: string = "0";
   let rewardsPoolIdx: number | undefined;
-  let lpTokenBalanceBefore = "0";
 
-  // If stakeLPToken is true, get LP balance before deposit
   if (stakeLPToken) {
-    // Query pool to get LP token address
-    const { data: poolData } = await cirrus.get(accessToken, `/${Pool}`, {
-      params: {
-        poolFactory: "eq." + constants.poolFactory,
-        address: "eq." + poolAddress,
-        select: "lpToken"
-      }
-    });
-    lpTokenAddress = poolData?.[0]?.lpToken;
+    lpTokenAddress = await fetchLPTokenAddress(accessToken, poolAddress);
+    rewardsPoolIdx = await findRewardsChefPoolIdx(accessToken, lpTokenAddress);
 
-    if (!lpTokenAddress) {
-      throw new Error("Could not fetch LP token address for pool");
-    }
-
-    // Find RewardsChef pool for this LP token
-    const rewardsChefPools = await getRewardsChefPools(accessToken, rewardsChef);
-    const rewardsPool = rewardsChefPools.find(p => p.lpToken === lpTokenAddress);
-
-    if (rewardsPool) {
-      rewardsPoolIdx = rewardsPool.poolIdx;
-
-      // Get user's LP token balance before deposit
-      const { data: lpTokenData } = await cirrus.get(accessToken, `/BlockApps-Mercata-Token`, {
-        params: {
-          address: `eq.${lpTokenAddress}`,
-          select: `balances:BlockApps-Mercata-Token-_balances(user:key,balance:value::text)`,
-          "balances.key": `eq.${userAddress.toLowerCase()}`
-        }
-      });
-      lpTokenBalanceBefore = lpTokenData?.[0]?.balances?.[0]?.balance || "0";
+    if (rewardsPoolIdx !== undefined) {
+      lpTokenBalanceBefore = await getUserLPTokenBalance(accessToken, lpTokenAddress, userAddress);
     }
   }
 
@@ -427,35 +448,9 @@ export const addLiquiditySingleToken = async (
 
   const depositResult = await executeTransaction(accessToken, tx);
 
-  // If stakeLPToken and deposit succeeded, stake the newly minted LP tokens
+  // Stake newly minted LP tokens if requested and deposit succeeded
   if (stakeLPToken && depositResult.status === "Success" && lpTokenAddress && rewardsPoolIdx !== undefined) {
-    // Wait for Cirrus to index the new LP token balance with retry logic
-    const lpTokenBalanceAfter = await waitForBalanceUpdate(
-      accessToken,
-      lpTokenAddress,
-      userAddress,
-      lpTokenBalanceBefore,
-      10,  // max retries
-      200  // 200ms delay between retries
-    );
-
-    // Calculate newly minted LP tokens
-    const newlyMintedAmount = (BigInt(lpTokenBalanceAfter) - BigInt(lpTokenBalanceBefore)).toString();
-
-    if (BigInt(newlyMintedAmount) > 0n) {
-      // Stake the newly minted LP tokens
-      const stakingTx = await buildFunctionTx([
-        buildTokenApprovalTx(lpTokenAddress, rewardsChef, newlyMintedAmount),
-        {
-          contractName: "RewardsChef",
-          contractAddress: rewardsChef,
-          method: "deposit",
-          args: { _pid: rewardsPoolIdx, _amount: newlyMintedAmount }
-        }
-      ], userAddress, accessToken);
-
-      await executeTransaction(accessToken, stakingTx);
-    }
+    await stakeNewLPTokens(accessToken, userAddress, lpTokenAddress, rewardsPoolIdx, lpTokenBalanceBefore);
   }
 
   return depositResult;
@@ -487,37 +482,15 @@ export const removeLiquidity = async (
 
   // If includeStakedLPToken is true, check if we need to unstake from RewardsChef first
   if (includeStakedLPToken) {
-    // Query pool to get LP token address
-    const { data: poolData } = await cirrus.get(accessToken, `/${Pool}`, {
-      params: {
-        poolFactory: "eq." + constants.poolFactory,
-        address: "eq." + poolAddress,
-        select: "lpToken"
-      }
-    });
-    const lpTokenAddress = poolData?.[0]?.lpToken;
+    const lpTokenAddress = await fetchLPTokenAddress(accessToken, poolAddress);
+    const rewardsPoolIdx = await findRewardsChefPoolIdx(accessToken, lpTokenAddress);
 
-    if (!lpTokenAddress) {
-      throw new Error("Could not fetch LP token address for pool");
-    }
-
-    // Find RewardsChef pool for this LP token
-    const rewardsChefPools = await getRewardsChefPools(accessToken, rewardsChef);
-    const rewardsPool = rewardsChefPools.find(p => p.lpToken === lpTokenAddress);
-
-    if (rewardsPool) {
+    if (rewardsPoolIdx !== undefined) {
       // Get user's wallet LP token balance
-      const { data: lpTokenData } = await cirrus.get(accessToken, `/BlockApps-Mercata-Token`, {
-        params: {
-          address: `eq.${lpTokenAddress}`,
-          select: `balances:BlockApps-Mercata-Token-_balances(user:key,balance:value::text)`,
-          "balances.key": `eq.${userAddress.toLowerCase()}`
-        }
-      });
-      const walletLPBalance = BigInt(lpTokenData?.[0]?.balances?.[0]?.balance || "0");
+      const walletLPBalance = BigInt(await getUserLPTokenBalance(accessToken, lpTokenAddress, userAddress));
 
       // Get staked LP token balance
-      const stakedLPBalance = BigInt(await getStakedBalance(accessToken, rewardsChef, rewardsPool.poolIdx, userAddress));
+      const stakedLPBalance = BigInt(await getStakedBalance(accessToken, rewardsChef, rewardsPoolIdx, userAddress));
 
       // Calculate required LP tokens and how much needs to be unstaked
       const requiredLPTokens = lpTokenAmountBigInt;
@@ -536,7 +509,7 @@ export const removeLiquidity = async (
           contractAddress: rewardsChef,
           method: "withdraw",
           args: {
-            _pid: rewardsPool.poolIdx,
+            _pid: rewardsPoolIdx,
             _amount: amountToUnstake.toString()
           }
         });

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -18,7 +18,7 @@ import {
   getTokenBalance
 } from "../helpers/swapping.helper";
 import { getOraclePrices } from "./oracle.service";
-import { getPools as getRewardsChefPools, getStakedBalance } from "./rewardsChef.service";
+import { getPools as getRewardsChefPools, getStakedBalance, waitForBalanceUpdate } from "./rewardsChef.service";
 import { rewardsChef } from "../../config/constants";
 import {
   SwapHistoryEntry,
@@ -274,10 +274,50 @@ export const addLiquidityDualToken = async (
   params: LiquidityParams,
   userAddress: string
 ): Promise<TransactionResponse> => {
-  const { poolAddress, tokenBAmount, maxTokenAAmount, deadline } = params;
-  
+  const { poolAddress, tokenBAmount, maxTokenAAmount, deadline, stakeLPToken } = params;
+
   const pool = await fetchPoolTokenAddresses(accessToken, poolAddress);
 
+  // Get LP token address and balance before if we need to stake
+  let lpTokenAddress: string | undefined;
+  let lpTokenBalanceBefore: string = "0";
+  let rewardsPoolIdx: number | undefined;
+
+  if (stakeLPToken) {
+    // Query pool to get LP token address
+    const { data: poolData } = await cirrus.get(accessToken, `/${Pool}`, {
+      params: {
+        poolFactory: "eq." + constants.poolFactory,
+        address: "eq." + poolAddress,
+        select: "lpToken"
+      }
+    });
+    lpTokenAddress = poolData?.[0]?.lpToken;
+
+    if (!lpTokenAddress) {
+      throw new Error("Could not fetch LP token address for pool");
+    }
+
+    // Find RewardsChef pool for this LP token
+    const rewardsChefPools = await getRewardsChefPools(accessToken, rewardsChef);
+    const rewardsPool = rewardsChefPools.find(p => p.lpToken === lpTokenAddress);
+
+    if (rewardsPool) {
+      rewardsPoolIdx = rewardsPool.poolIdx;
+
+      // Get user's LP token balance before deposit
+      const { data: lpTokenData } = await cirrus.get(accessToken, `/BlockApps-Mercata-Token`, {
+        params: {
+          address: `eq.${lpTokenAddress}`,
+          select: `balances:BlockApps-Mercata-Token-_balances(user:key,balance:value::text)`,
+          "balances.key": `eq.${userAddress.toLowerCase()}`
+        }
+      });
+      lpTokenBalanceBefore = lpTokenData?.[0]?.balances?.[0]?.balance || "0";
+    }
+  }
+
+  // Execute liquidity deposit
   const tx = await buildFunctionTx([
     buildTokenApprovalTx(pool.tokenA, poolAddress, maxTokenAAmount),
     buildTokenApprovalTx(pool.tokenB, poolAddress, tokenBAmount),
@@ -289,7 +329,40 @@ export const addLiquidityDualToken = async (
     }
   ], userAddress, accessToken);
 
-  return executeTransaction(accessToken, tx);
+  const depositResult = await executeTransaction(accessToken, tx);
+
+  // If stakeLPToken and deposit succeeded, stake the newly minted LP tokens
+  if (stakeLPToken && depositResult.status === "Success" && lpTokenAddress && rewardsPoolIdx !== undefined) {
+    // Wait for Cirrus to index the new LP token balance with retry logic
+    const lpTokenBalanceAfter = await waitForBalanceUpdate(
+      accessToken,
+      lpTokenAddress,
+      userAddress,
+      lpTokenBalanceBefore,
+      10,  // max retries
+      200  // 200ms delay between retries
+    );
+
+    // Calculate newly minted LP tokens
+    const newlyMintedAmount = (BigInt(lpTokenBalanceAfter) - BigInt(lpTokenBalanceBefore)).toString();
+
+    if (BigInt(newlyMintedAmount) > 0n) {
+      // Stake the newly minted LP tokens
+      const stakingTx = await buildFunctionTx([
+        buildTokenApprovalTx(lpTokenAddress, rewardsChef, newlyMintedAmount),
+        {
+          contractName: "RewardsChef",
+          contractAddress: rewardsChef,
+          method: "deposit",
+          args: { _pid: rewardsPoolIdx, _amount: newlyMintedAmount }
+        }
+      ], userAddress, accessToken);
+
+      await executeTransaction(accessToken, stakingTx);
+    }
+  }
+
+  return depositResult;
 };
 
 export const addLiquiditySingleToken = async (
@@ -297,11 +370,51 @@ export const addLiquiditySingleToken = async (
   params: SingleTokenLiquidityParams,
   userAddress: string
 ): Promise<TransactionResponse> => {
-  const { poolAddress, singleTokenAmount, isAToB, deadline } = params;
-  
+  const { poolAddress, singleTokenAmount, isAToB, deadline, stakeLPToken } = params;
+
   const pool = await fetchPoolTokenAddresses(accessToken, poolAddress);
   const depositTokenAddress = isAToB ? pool.tokenA : pool.tokenB;
-  
+
+  let lpTokenAddress: string | undefined;
+  let rewardsPoolIdx: number | undefined;
+  let lpTokenBalanceBefore = "0";
+
+  // If stakeLPToken is true, get LP balance before deposit
+  if (stakeLPToken) {
+    // Query pool to get LP token address
+    const { data: poolData } = await cirrus.get(accessToken, `/${Pool}`, {
+      params: {
+        poolFactory: "eq." + constants.poolFactory,
+        address: "eq." + poolAddress,
+        select: "lpToken"
+      }
+    });
+    lpTokenAddress = poolData?.[0]?.lpToken;
+
+    if (!lpTokenAddress) {
+      throw new Error("Could not fetch LP token address for pool");
+    }
+
+    // Find RewardsChef pool for this LP token
+    const rewardsChefPools = await getRewardsChefPools(accessToken, rewardsChef);
+    const rewardsPool = rewardsChefPools.find(p => p.lpToken === lpTokenAddress);
+
+    if (rewardsPool) {
+      rewardsPoolIdx = rewardsPool.poolIdx;
+
+      // Get user's LP token balance before deposit
+      const { data: lpTokenData } = await cirrus.get(accessToken, `/BlockApps-Mercata-Token`, {
+        params: {
+          address: `eq.${lpTokenAddress}`,
+          select: `balances:BlockApps-Mercata-Token-_balances(user:key,balance:value::text)`,
+          "balances.key": `eq.${userAddress.toLowerCase()}`
+        }
+      });
+      lpTokenBalanceBefore = lpTokenData?.[0]?.balances?.[0]?.balance || "0";
+    }
+  }
+
+  // Execute liquidity deposit
   const tx = await buildFunctionTx([
     buildTokenApprovalTx(depositTokenAddress, poolAddress, singleTokenAmount),
     {
@@ -312,7 +425,40 @@ export const addLiquiditySingleToken = async (
     }
   ], userAddress, accessToken);
 
-  return executeTransaction(accessToken, tx);
+  const depositResult = await executeTransaction(accessToken, tx);
+
+  // If stakeLPToken and deposit succeeded, stake the newly minted LP tokens
+  if (stakeLPToken && depositResult.status === "Success" && lpTokenAddress && rewardsPoolIdx !== undefined) {
+    // Wait for Cirrus to index the new LP token balance with retry logic
+    const lpTokenBalanceAfter = await waitForBalanceUpdate(
+      accessToken,
+      lpTokenAddress,
+      userAddress,
+      lpTokenBalanceBefore,
+      10,  // max retries
+      200  // 200ms delay between retries
+    );
+
+    // Calculate newly minted LP tokens
+    const newlyMintedAmount = (BigInt(lpTokenBalanceAfter) - BigInt(lpTokenBalanceBefore)).toString();
+
+    if (BigInt(newlyMintedAmount) > 0n) {
+      // Stake the newly minted LP tokens
+      const stakingTx = await buildFunctionTx([
+        buildTokenApprovalTx(lpTokenAddress, rewardsChef, newlyMintedAmount),
+        {
+          contractName: "RewardsChef",
+          contractAddress: rewardsChef,
+          method: "deposit",
+          args: { _pid: rewardsPoolIdx, _amount: newlyMintedAmount }
+        }
+      ], userAddress, accessToken);
+
+      await executeTransaction(accessToken, stakingTx);
+    }
+  }
+
+  return depositResult;
 };
 
 export const removeLiquidity = async (
@@ -320,7 +466,7 @@ export const removeLiquidity = async (
   removeLiquidityParams: RemoveLiquidityParams,
   userAddress: string
 ): Promise<TransactionResponse> => {
-  const { poolAddress, lpTokenAmount, deadline } = removeLiquidityParams;
+  const { poolAddress, lpTokenAmount, deadline, includeStakedLPToken } = removeLiquidityParams;
 
   const pool = await fetchPoolBalances(accessToken, poolAddress);
 
@@ -332,12 +478,74 @@ export const removeLiquidity = async (
 
   const tokenAAmount = (tokenABalance * lpTokenAmountBigInt) / lpTokenSupply;
   const tokenBAmount = (tokenBBalance * lpTokenAmountBigInt) / lpTokenSupply;
-  
+
   // Apply 1% slippage tolerance (99 basis points)
   const minTokenAAmount = (tokenAAmount * 99n) / 100n;
   const minTokenBAmount = (tokenBAmount * 99n) / 100n;
-  
-  const tx = await buildFunctionTx({
+
+  const txArray: any[] = [];
+
+  // If includeStakedLPToken is true, check if we need to unstake from RewardsChef first
+  if (includeStakedLPToken) {
+    // Query pool to get LP token address
+    const { data: poolData } = await cirrus.get(accessToken, `/${Pool}`, {
+      params: {
+        poolFactory: "eq." + constants.poolFactory,
+        address: "eq." + poolAddress,
+        select: "lpToken"
+      }
+    });
+    const lpTokenAddress = poolData?.[0]?.lpToken;
+
+    if (!lpTokenAddress) {
+      throw new Error("Could not fetch LP token address for pool");
+    }
+
+    // Find RewardsChef pool for this LP token
+    const rewardsChefPools = await getRewardsChefPools(accessToken, rewardsChef);
+    const rewardsPool = rewardsChefPools.find(p => p.lpToken === lpTokenAddress);
+
+    if (rewardsPool) {
+      // Get user's wallet LP token balance
+      const { data: lpTokenData } = await cirrus.get(accessToken, `/BlockApps-Mercata-Token`, {
+        params: {
+          address: `eq.${lpTokenAddress}`,
+          select: `balances:BlockApps-Mercata-Token-_balances(user:key,balance:value::text)`,
+          "balances.key": `eq.${userAddress.toLowerCase()}`
+        }
+      });
+      const walletLPBalance = BigInt(lpTokenData?.[0]?.balances?.[0]?.balance || "0");
+
+      // Get staked LP token balance
+      const stakedLPBalance = BigInt(await getStakedBalance(accessToken, rewardsChef, rewardsPool.poolIdx, userAddress));
+
+      // Calculate required LP tokens and how much needs to be unstaked
+      const requiredLPTokens = lpTokenAmountBigInt;
+
+      if (requiredLPTokens > walletLPBalance) {
+        // Need to unstake some LP tokens first
+        const amountToUnstake = requiredLPTokens - walletLPBalance;
+
+        if (amountToUnstake > stakedLPBalance) {
+          throw new Error(`Insufficient LP tokens: need ${requiredLPTokens.toString()}, have ${walletLPBalance.toString()} in wallet and ${stakedLPBalance.toString()} staked`);
+        }
+
+        // Add unstake transaction
+        txArray.push({
+          contractName: "RewardsChef",
+          contractAddress: rewardsChef,
+          method: "withdraw",
+          args: {
+            _pid: rewardsPool.poolIdx,
+            _amount: amountToUnstake.toString()
+          }
+        });
+      }
+    }
+  }
+
+  // Add removeLiquidity transaction
+  txArray.push({
     contractName: extractContractName(Pool),
     contractAddress: poolAddress,
     method: "removeLiquidity",
@@ -347,8 +555,9 @@ export const removeLiquidity = async (
       minTokenAAmount: minTokenAAmount.toString(),
       deadline
     },
-  }, userAddress, accessToken);
+  });
 
+  const tx = await buildFunctionTx(txArray, userAddress, accessToken);
   return executeTransaction(accessToken, tx);
 };
 

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -4,7 +4,7 @@ import { executeTransaction } from "../../utils/txHelper";
 import { extractContractName } from "../../utils/utils";
 import { constants } from "../../config/constants";
 import { poolFactory } from "../../config/config";
-import { 
+import {
   calculateImpliedPrice,
   buildPoolParams,
   extractTokenAddresses,
@@ -19,6 +19,7 @@ import {
 } from "../helpers/swapping.helper";
 import { getOraclePrices } from "./oracle.service";
 import { getPools as getRewardsChefPools, getStakedBalance, waitForBalanceUpdate } from "./rewardsChef.service";
+import { getTokenBalanceForUser } from "./tokens.service";
 import { rewardsChef } from "../../config/constants";
 import {
   SwapHistoryEntry,
@@ -81,24 +82,6 @@ const findRewardsChefPoolIdx = async (
   const rewardsChefPools = await getRewardsChefPools(accessToken, rewardsChef);
   const rewardsPool = rewardsChefPools.find(p => p.lpToken === lpTokenAddress);
   return rewardsPool?.poolIdx;
-};
-
-/**
- * Gets the user's LP token balance from Cirrus
- */
-const getUserLPTokenBalance = async (
-  accessToken: string,
-  lpTokenAddress: string,
-  userAddress: string
-): Promise<string> => {
-  const { data: lpTokenData } = await cirrus.get(accessToken, `/BlockApps-Mercata-Token`, {
-    params: {
-      address: `eq.${lpTokenAddress}`,
-      select: `balances:BlockApps-Mercata-Token-_balances(user:key,balance:value::text)`,
-      "balances.key": `eq.${userAddress.toLowerCase()}`
-    }
-  });
-  return lpTokenData?.[0]?.balances?.[0]?.balance || "0";
 };
 
 /**
@@ -385,7 +368,7 @@ export const addLiquidityDualToken = async (
     rewardsPoolIdx = await findRewardsChefPoolIdx(accessToken, lpTokenAddress);
 
     if (rewardsPoolIdx !== undefined) {
-      lpTokenBalanceBefore = await getUserLPTokenBalance(accessToken, lpTokenAddress, userAddress);
+      lpTokenBalanceBefore = await getTokenBalanceForUser(accessToken, lpTokenAddress, userAddress);
     }
   }
 
@@ -431,7 +414,7 @@ export const addLiquiditySingleToken = async (
     rewardsPoolIdx = await findRewardsChefPoolIdx(accessToken, lpTokenAddress);
 
     if (rewardsPoolIdx !== undefined) {
-      lpTokenBalanceBefore = await getUserLPTokenBalance(accessToken, lpTokenAddress, userAddress);
+      lpTokenBalanceBefore = await getTokenBalanceForUser(accessToken, lpTokenAddress, userAddress);
     }
   }
 
@@ -487,7 +470,7 @@ export const removeLiquidity = async (
 
     if (rewardsPoolIdx !== undefined) {
       // Get user's wallet LP token balance
-      const walletLPBalance = BigInt(await getUserLPTokenBalance(accessToken, lpTokenAddress, userAddress));
+      const walletLPBalance = BigInt(await getTokenBalanceForUser(accessToken, lpTokenAddress, userAddress));
 
       // Get staked LP token balance
       const stakedLPBalance = BigInt(await getStakedBalance(accessToken, rewardsChef, rewardsPoolIdx, userAddress));

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -13,6 +13,7 @@ import {
   buildPoolList,
   fetchPoolTokenAddresses,
   fetchPoolBalances,
+  fetchLPTokenAddress,
   buildTokenApprovalTx,
   getTradingVolume24hForPools,
   getTokenBalance
@@ -43,33 +44,6 @@ import {
 } from "@mercata/shared-types";
 
 const { Pool, PoolFactory, PoolSwap, swapHistorySelectFields, swapTokenSelectFields } = constants;
-
-// ============================================================================
-// HELPER FUNCTIONS FOR LP TOKEN STAKING
-// ============================================================================
-
-/**
- * Fetches the LP token address for a given pool
- */
-const fetchLPTokenAddress = async (
-  accessToken: string,
-  poolAddress: string
-): Promise<string> => {
-  const { data: poolData } = await cirrus.get(accessToken, `/${Pool}`, {
-    params: {
-      poolFactory: "eq." + constants.poolFactory,
-      address: "eq." + poolAddress,
-      select: "lpToken"
-    }
-  });
-  const lpTokenAddress = poolData?.[0]?.lpToken;
-
-  if (!lpTokenAddress) {
-    throw new Error("Could not fetch LP token address for pool");
-  }
-
-  return lpTokenAddress;
-};
 
 /**
  * Stakes newly minted LP tokens into RewardsChef
@@ -195,14 +169,14 @@ export const getSwapableTokens = async (
   });
 
   const tokenMap = new Map<string, SwapToken>();
-  
+
   validatedPools.forEach((pool: PoolWithTokens) => {
     [pool.tokenA, pool.tokenB].forEach((token: RawToken, index: number) => {
 
       if (!tokenMap.has(token.address)) {
         const price = priceMap.get(token.address) || "0";
         const poolBalance = index === 0 ? pool.tokenABalance : pool.tokenBBalance;
-        
+
         tokenMap.set(token.address, buildSwapToken(token, price, poolBalance, getTokenBalance(token, userAddress)));
       }
     });
@@ -250,7 +224,7 @@ export const getSwapableTokenPairs = async (
   });
 
   const tokenMap = new Map<string, SwapToken>();
-  
+
   allTokens.forEach(({token, poolBalance}) => {
     if (!tokenMap.has(token.address)) {
       const price = priceMap.get(token.address) || "0";
@@ -299,7 +273,7 @@ export const getSwapHistory = async (
   const swapHistory: SwapHistoryEntry[] = (swapEvents as RawSwapEvent[]).map(event => {
     const { tokenA, tokenB } = event.pool;
     const isAToB = event.tokenIn === tokenA.address;
-    
+
     return {
       id: event.id,
       timestamp: new Date(event.block_timestamp),

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -18,7 +18,7 @@ import {
   getTokenBalance
 } from "../helpers/swapping.helper";
 import { getOraclePrices } from "./oracle.service";
-import { getPools as getRewardsChefPools, getStakedBalance, waitForBalanceUpdate } from "./rewardsChef.service";
+import { getPools as getRewardsChefPools, getStakedBalance, waitForBalanceUpdate, findPoolByLpToken } from "./rewardsChef.service";
 import { getTokenBalanceForUser } from "./tokens.service";
 import { rewardsChef } from "../../config/constants";
 import {
@@ -69,19 +69,6 @@ const fetchLPTokenAddress = async (
   }
 
   return lpTokenAddress;
-};
-
-/**
- * Finds the RewardsChef pool index for a given LP token address
- * Returns undefined if no matching pool is found
- */
-const findRewardsChefPoolIdx = async (
-  accessToken: string,
-  lpTokenAddress: string
-): Promise<number | undefined> => {
-  const rewardsChefPools = await getRewardsChefPools(accessToken, rewardsChef);
-  const rewardsPool = rewardsChefPools.find(p => p.lpToken === lpTokenAddress);
-  return rewardsPool?.poolIdx;
 };
 
 /**
@@ -361,13 +348,13 @@ export const addLiquidityDualToken = async (
   // Prepare for LP token staking if requested
   let lpTokenAddress: string | undefined;
   let lpTokenBalanceBefore: string = "0";
-  let rewardsPoolIdx: number | undefined;
+  let rewardsPool: Awaited<ReturnType<typeof findPoolByLpToken>>;
 
   if (stakeLPToken) {
     lpTokenAddress = await fetchLPTokenAddress(accessToken, poolAddress);
-    rewardsPoolIdx = await findRewardsChefPoolIdx(accessToken, lpTokenAddress);
+    rewardsPool = await findPoolByLpToken(accessToken, rewardsChef, lpTokenAddress);
 
-    if (rewardsPoolIdx !== undefined) {
+    if (rewardsPool) {
       lpTokenBalanceBefore = await getTokenBalanceForUser(accessToken, lpTokenAddress, userAddress);
     }
   }
@@ -387,8 +374,8 @@ export const addLiquidityDualToken = async (
   const depositResult = await executeTransaction(accessToken, tx);
 
   // Stake newly minted LP tokens if requested and deposit succeeded
-  if (stakeLPToken && depositResult.status === "Success" && lpTokenAddress && rewardsPoolIdx !== undefined) {
-    await stakeNewLPTokens(accessToken, userAddress, lpTokenAddress, rewardsPoolIdx, lpTokenBalanceBefore);
+  if (stakeLPToken && depositResult.status === "Success" && lpTokenAddress && rewardsPool) {
+    await stakeNewLPTokens(accessToken, userAddress, lpTokenAddress, rewardsPool.poolIdx, lpTokenBalanceBefore);
   }
 
   return depositResult;
@@ -407,13 +394,13 @@ export const addLiquiditySingleToken = async (
   // Prepare for LP token staking if requested
   let lpTokenAddress: string | undefined;
   let lpTokenBalanceBefore: string = "0";
-  let rewardsPoolIdx: number | undefined;
+  let rewardsPool: Awaited<ReturnType<typeof findPoolByLpToken>>;
 
   if (stakeLPToken) {
     lpTokenAddress = await fetchLPTokenAddress(accessToken, poolAddress);
-    rewardsPoolIdx = await findRewardsChefPoolIdx(accessToken, lpTokenAddress);
+    rewardsPool = await findPoolByLpToken(accessToken, rewardsChef, lpTokenAddress);
 
-    if (rewardsPoolIdx !== undefined) {
+    if (rewardsPool) {
       lpTokenBalanceBefore = await getTokenBalanceForUser(accessToken, lpTokenAddress, userAddress);
     }
   }
@@ -432,8 +419,8 @@ export const addLiquiditySingleToken = async (
   const depositResult = await executeTransaction(accessToken, tx);
 
   // Stake newly minted LP tokens if requested and deposit succeeded
-  if (stakeLPToken && depositResult.status === "Success" && lpTokenAddress && rewardsPoolIdx !== undefined) {
-    await stakeNewLPTokens(accessToken, userAddress, lpTokenAddress, rewardsPoolIdx, lpTokenBalanceBefore);
+  if (stakeLPToken && depositResult.status === "Success" && lpTokenAddress && rewardsPool) {
+    await stakeNewLPTokens(accessToken, userAddress, lpTokenAddress, rewardsPool.poolIdx, lpTokenBalanceBefore);
   }
 
   return depositResult;
@@ -466,14 +453,14 @@ export const removeLiquidity = async (
   // If includeStakedLPToken is true, check if we need to unstake from RewardsChef first
   if (includeStakedLPToken) {
     const lpTokenAddress = await fetchLPTokenAddress(accessToken, poolAddress);
-    const rewardsPoolIdx = await findRewardsChefPoolIdx(accessToken, lpTokenAddress);
+    const rewardsPool = await findPoolByLpToken(accessToken, rewardsChef, lpTokenAddress);
 
-    if (rewardsPoolIdx !== undefined) {
+    if (rewardsPool) {
       // Get user's wallet LP token balance
       const walletLPBalance = BigInt(await getTokenBalanceForUser(accessToken, lpTokenAddress, userAddress));
 
       // Get staked LP token balance
-      const stakedLPBalance = BigInt(await getStakedBalance(accessToken, rewardsChef, rewardsPoolIdx, userAddress));
+      const stakedLPBalance = BigInt(await getStakedBalance(accessToken, rewardsChef, rewardsPool.poolIdx, userAddress));
 
       // Calculate required LP tokens and how much needs to be unstaked
       const requiredLPTokens = lpTokenAmountBigInt;
@@ -492,7 +479,7 @@ export const removeLiquidity = async (
           contractAddress: rewardsChef,
           method: "withdraw",
           args: {
-            _pid: rewardsPoolIdx,
+            _pid: rewardsPool.poolIdx,
             _amount: amountToUnstake.toString()
           }
         });

--- a/mercata/backend/src/api/validators/swapping.validator.ts
+++ b/mercata/backend/src/api/validators/swapping.validator.ts
@@ -52,8 +52,9 @@ export function validateAddLiquidityDualTokenArgs(args: any) {
   const schema = Joi.object({
     tokenBAmount: numericStringField("TokenBAmount").required(),
     maxTokenAAmount: numericStringField("MaxTokenAAmount").required(),
+    stakeLPToken: Joi.boolean().optional(),
   });
-  
+
   const { error } = schema.validate(args);
   if (error) {
     throw new Error("Add Liquidity Dual Token Argument Validation Error: " + error.message);
@@ -64,8 +65,9 @@ export function validateAddLiquiditySingleTokenArgs(args: any) {
   const schema = Joi.object({
     singleTokenAmount: numericStringField("SingleTokenAmount").required(),
     isAToB: Joi.boolean().required(),
+    stakeLPToken: Joi.boolean().optional(),
   });
-  
+
   const { error } = schema.validate(args);
   if (error) {
     throw new Error("Add Liquidity Argument Validation Error: " + error.message);
@@ -75,6 +77,7 @@ export function validateAddLiquiditySingleTokenArgs(args: any) {
 export function validateRemoveLiquidityArgs(args: any) {
   const schema = Joi.object({
     lpTokenAmount: numericStringField("LpTokenAmount"),
+    includeStakedLPToken: Joi.boolean().optional(),
   });
 
   const { error } = schema.validate(args);

--- a/mercata/packages/shared-types/src/swap-types.ts
+++ b/mercata/packages/shared-types/src/swap-types.ts
@@ -21,6 +21,7 @@ export interface LiquidityParams {
   tokenBAmount: string;
   maxTokenAAmount: string;
   deadline: number;
+  stakeLPToken?: boolean; // If true, stake minted LP tokens in RewardsChef
 }
 
 /**
@@ -31,6 +32,7 @@ export interface SingleTokenLiquidityParams {
   singleTokenAmount: string;
   isAToB: boolean;
   deadline: number;
+  stakeLPToken?: boolean; // If true, stake minted LP tokens in RewardsChef
 }
 
 /**
@@ -40,6 +42,7 @@ export interface RemoveLiquidityParams {
   poolAddress: string;
   lpTokenAmount: string;
   deadline: number;
+  includeStakedLPToken?: boolean; // If true, unstake LP tokens from RewardsChef before burning
 }
 
 /**

--- a/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { HelpCircle } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -58,6 +61,7 @@ const LiquidityDepositModal = ({
   const [tokenBBalance, setTokenBBalance] = useState('');
   const [balanceLoading, setBalanceLoading] = useState(false);
   const [depositMode, setDepositMode] = useState<'A' | 'B' | 'A&B'>('A&B');
+  const [stakeLPToken, setStakeLPToken] = useState<boolean>(true);
 
   const { addLiquidityDualToken, addLiquiditySingleToken, getPoolByAddress, fetchTokenBalances, fetchPools } = useSwapContext();
   const { toast } = useToast();
@@ -97,6 +101,7 @@ const LiquidityDepositModal = ({
     setToken1Amount('');
     setToken2Amount('');
     setDepositMode('A');
+    setStakeLPToken(true); // Reset to default (checked)
     onClose();
   };
 
@@ -169,27 +174,30 @@ const LiquidityDepositModal = ({
         await addLiquiditySingleToken({
           poolAddress: selectedPool.address,
           singleTokenAmount: token1AmountWei.toString(),
-          isAToB: true
+          isAToB: true,
+          stakeLPToken: stakeLPToken && selectedPool.lpToken.stakedBalance !== undefined
         });
       } else if (depositMode === 'B') {
         // Single token mode - Token B
         await addLiquiditySingleToken({
           poolAddress: selectedPool.address,
           singleTokenAmount: token2AmountWei.toString(),
-          isAToB: false
+          isAToB: false,
+          stakeLPToken: stakeLPToken && selectedPool.lpToken.stakedBalance !== undefined
         });
       } else {
         // Dual token mode
         const isInitialLiquidity = BigInt(selectedPool.lpToken._totalSupply) === BigInt(0);
-        const tokenAAmount = isInitialLiquidity 
+        const tokenAAmount = isInitialLiquidity
           ? safeParseUnits(token1Amount, 18)
           : safeParseUnits((parseFloat(token1Amount) * 1.02).toFixed(18), 18);
         const tokenBAmount = safeParseUnits(token2Amount, 18);
-        
+
         await addLiquidityDualToken({
           poolAddress: selectedPool.address,
           maxTokenAAmount: tokenAAmount.toString(),
-          tokenBAmount: tokenBAmount.toString()
+          tokenBAmount: tokenBAmount.toString(),
+          stakeLPToken: stakeLPToken && selectedPool.lpToken.stakedBalance !== undefined
         });
       }
 
@@ -652,6 +660,34 @@ const LiquidityDepositModal = ({
             )}
           </div>
 
+          {/* Stake LP Token Checkbox - only show if pool has rewards program */}
+          {selectedPool?.lpToken?.stakedBalance !== undefined && (
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="stake-lp-token"
+                checked={stakeLPToken}
+                onCheckedChange={(checked) => setStakeLPToken(checked as boolean)}
+              />
+              <label
+                htmlFor="stake-lp-token"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                Stake my {selectedPool?.lpToken?._symbol || 'LP Token'} to earn rewards
+              </label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="max-w-xs text-sm">
+                    When providing liquidity to the pool, you'll receive {selectedPool?.lpToken?._symbol ? `a ${selectedPool.lpToken._symbol} token` : 'an LP Token'} representing your share.
+                    If this option is enabled, this token will be automatically staked in the rewards program.
+                    The longer the token is staked, the more rewards it accrues.
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
 
           <div className="pt-2">
             <Button 

--- a/mercata/ui/src/components/dashboard/LiquidityWithdrawModal.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidityWithdrawModal.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { HelpCircle } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -47,6 +50,15 @@ const LiquidityWithdrawModal = ({
     computeMaxTransferable("100", false, voucherBalance, usdstBalance, safeParseUnits(WITHDRAW_FEE).toString(), setFeeError);
   }, [usdstBalance, voucherBalance]);
 
+  const [includeStakedLPToken, setIncludeStakedLPToken] = useState<boolean>(false);
+
+  // Calculate available balance based on checkbox state
+  const availableLPBalance = useMemo(() => {
+    if (!selectedPool) return "0";
+    return includeStakedLPToken && selectedPool.lpToken.totalBalance
+      ? selectedPool.lpToken.totalBalance
+      : selectedPool.lpToken.balance;
+  }, [selectedPool, includeStakedLPToken]);
 
   const { removeLiquidity } = useSwapContext();
   const { toast } = useToast();
@@ -59,6 +71,7 @@ const LiquidityWithdrawModal = ({
 
   const handleClose = () => {
     setWithdrawPercent('');
+    setIncludeStakedLPToken(false);
     onClose();
   };
 
@@ -69,7 +82,7 @@ const LiquidityWithdrawModal = ({
       operationInProgressRef.current = true;
       setWithdrawLoading(true);
 
-      const value = BigInt([{ balance: selectedPool.lpToken.balance }]?.[0]?.balance || "0");
+      const value = BigInt(availableLPBalance || "0");
       const percent = withdrawPercent ? parseFloat(withdrawPercent) : 0;
       const percentScaled = BigInt(Math.floor(percent * 100));
       const calculatedAmount = (value * percentScaled) / BigInt(10000);
@@ -77,13 +90,14 @@ const LiquidityWithdrawModal = ({
       await removeLiquidity({
         poolAddress: selectedPool.address,
         lpTokenAmount: calculatedAmount.toString(),
+        includeStakedLPToken: includeStakedLPToken
       });
 
       await new Promise(resolve => setTimeout(resolve, 2000));
 
       // Calculate the actual token amounts withdrawn
-      const tokenAAmount = Number(BigInt([{ balance: selectedPool.lpToken.balance }]?.[0]?.balance || "0") * BigInt(selectedPool.tokenA.poolBalance || "0") * BigInt(Math.floor(parseFloat(withdrawPercent) * 100)) / (BigInt(selectedPool.lpToken._totalSupply || "1") * BigInt(10000))) / 1e18;
-      const tokenBAmount = Number(BigInt([{ balance: selectedPool.lpToken.balance }]?.[0]?.balance || "0") * BigInt(selectedPool.tokenB.poolBalance || "0") * BigInt(Math.floor(parseFloat(withdrawPercent) * 100)) / (BigInt(selectedPool.lpToken._totalSupply || "1") * BigInt(10000))) / 1e18;
+      const tokenAAmount = Number(BigInt(availableLPBalance || "0") * BigInt(selectedPool.tokenA.poolBalance || "0") * BigInt(Math.floor(parseFloat(withdrawPercent) * 100)) / (BigInt(selectedPool.lpToken._totalSupply || "1") * BigInt(10000))) / 1e18;
+      const tokenBAmount = Number(BigInt(availableLPBalance || "0") * BigInt(selectedPool.tokenB.poolBalance || "0") * BigInt(Math.floor(parseFloat(withdrawPercent) * 100)) / (BigInt(selectedPool.lpToken._totalSupply || "1") * BigInt(10000))) / 1e18;
 
       const tokenAName = selectedPool.poolName?.split('/')[0] || 'Token A';
       const tokenBName = selectedPool.poolName?.split('/')[1] || 'Token B';
@@ -200,14 +214,14 @@ const LiquidityWithdrawModal = ({
               <span className="text-gray-500">{selectedPool?.poolName?.split('/')[0]} position</span>
               <span className="font-medium">
                 {selectedPool?.lpToken?._totalSupply === "0" ? "0" :
-                  (Number(BigInt([{ balance: selectedPool?.lpToken?.balance || "0" }]?.[0]?.balance || "0") * BigInt(selectedPool?.tokenA.poolBalance || "0") / BigInt(selectedPool?.lpToken?._totalSupply || "1")) / 1e18).toFixed(10)}
+                  (Number(BigInt(availableLPBalance || "0") * BigInt(selectedPool?.tokenA.poolBalance || "0") / BigInt(selectedPool?.lpToken?._totalSupply || "1")) / 1e18).toFixed(10)}
               </span>
             </div>
             <div className="flex justify-between items-center text-sm mt-1">
               <span className="text-gray-500">{selectedPool?.poolName?.split('/')[1]} position</span>
               <span className="font-medium">
                 {selectedPool?.lpToken?._totalSupply === "0" ? "0" :
-                  (Number(BigInt([{ balance: selectedPool?.lpToken?.balance || "0" }]?.[0]?.balance || "0") * BigInt(selectedPool?.tokenB.poolBalance || "0") / BigInt(selectedPool?.lpToken?._totalSupply || "1")) / 1e18).toFixed(10)}
+                  (Number(BigInt(availableLPBalance || "0") * BigInt(selectedPool?.tokenB.poolBalance || "0") / BigInt(selectedPool?.lpToken?._totalSupply || "1")) / 1e18).toFixed(10)}
               </span>
             </div>
             <div className="flex justify-between items-center text-sm mt-2 text-gray-500">
@@ -237,7 +251,7 @@ const LiquidityWithdrawModal = ({
                     New {selectedPool.poolName?.split("/")[0]} position
                   </span>
                   <span>
-                    {(Number(BigInt([{ balance: selectedPool.lpToken.balance }]?.[0]?.balance || "0") * BigInt(selectedPool.tokenA.poolBalance || "0") * (BigInt(10000) - BigInt(Math.floor(Number(withdrawPercent) * 100 || 0))) / (BigInt(selectedPool.lpToken._totalSupply || "1") * BigInt(10000))) / 1e18).toFixed(10)}
+                    {(Number(BigInt(availableLPBalance || "0") * BigInt(selectedPool.tokenA.poolBalance || "0") * (BigInt(10000) - BigInt(Math.floor(Number(withdrawPercent) * 100 || 0))) / (BigInt(selectedPool.lpToken._totalSupply || "1") * BigInt(10000))) / 1e18).toFixed(10)}
                   </span>
                 </div>
                 <div className="w-full flex justify-between">
@@ -245,13 +259,41 @@ const LiquidityWithdrawModal = ({
                     New {selectedPool.poolName?.split("/")[1]} position
                   </span>
                   <span>
-                    {(Number(BigInt([{ balance: selectedPool.lpToken.balance }]?.[0]?.balance || "0") * BigInt(selectedPool.tokenB.poolBalance || "0") * (BigInt(10000) - BigInt(Math.floor(Number(withdrawPercent) * 100))) / (BigInt(selectedPool.lpToken._totalSupply || "1") * BigInt(10000))) / 1e18).toFixed(10)}
+                    {(Number(BigInt(availableLPBalance || "0") * BigInt(selectedPool.tokenB.poolBalance || "0") * (BigInt(10000) - BigInt(Math.floor(Number(withdrawPercent) * 100))) / (BigInt(selectedPool.lpToken._totalSupply || "1") * BigInt(10000))) / 1e18).toFixed(10)}
                   </span>
                 </div>
               </>
             )}
           </div>
 
+          {/* Include Staked LP Token Checkbox - only show if pool has rewards program */}
+          {selectedPool?.lpToken?.stakedBalance !== undefined && (
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="include-staked-lp-token"
+                checked={includeStakedLPToken}
+                onCheckedChange={(checked) => setIncludeStakedLPToken(checked as boolean)}
+              />
+              <label
+                htmlFor="include-staked-lp-token"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                Include staked {selectedPool?.lpToken?._symbol || 'LP token'}
+              </label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="max-w-xs text-sm">
+                    Your {selectedPool?.lpToken?._symbol || 'LP token'} may be staked in the rewards program.
+                    When this option is enabled, you can withdraw the {selectedPool?.lpToken?._symbol || 'LP token'} that was staked as well.
+                    If disabled, only unstaked {selectedPool?.lpToken?._symbol || 'LP token'} will be eligible for withdrawal.
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
 
           <div className="pt-2">
             <Button

--- a/mercata/ui/src/context/SwapContext.tsx
+++ b/mercata/ui/src/context/SwapContext.tsx
@@ -204,12 +204,14 @@ export const SwapProvider = ({ children }: { children: ReactNode }) => {
     poolAddress: string;
     tokenBAmount: string;
     maxTokenAAmount: string;
+    stakeLPToken?: boolean;
   }) => {
     setLoading(true);
     try {
       const response = await api.post(`/swap-pools/${data.poolAddress}/liquidity`, {
         tokenBAmount: data.tokenBAmount,
-        maxTokenAAmount: data.maxTokenAAmount
+        maxTokenAAmount: data.maxTokenAAmount,
+        stakeLPToken: data.stakeLPToken
       });
       return response.data;
     } finally {
@@ -221,12 +223,14 @@ export const SwapProvider = ({ children }: { children: ReactNode }) => {
     poolAddress: string;
     singleTokenAmount: string;
     isAToB: boolean;
+    stakeLPToken?: boolean;
   }) => {
     setLoading(true);
     try {
       const response = await api.post(`/swap-pools/${data.poolAddress}/liquidity/single`, {
         singleTokenAmount: data.singleTokenAmount,
-        isAToB: data.isAToB
+        isAToB: data.isAToB,
+        stakeLPToken: data.stakeLPToken
       });
       return response.data;
     } finally {
@@ -237,11 +241,15 @@ export const SwapProvider = ({ children }: { children: ReactNode }) => {
   const removeLiquidity = useCallback(async (data: {
     poolAddress: string;
     lpTokenAmount: string;
+    includeStakedLPToken?: boolean;
   }) => {
     setLoading(true);
     try {
       const response = await api.delete(`/swap-pools/${data.poolAddress}/liquidity`, {
-        data: { lpTokenAmount: data.lpTokenAmount }
+        data: {
+          lpTokenAmount: data.lpTokenAmount,
+          includeStakedLPToken: data.includeStakedLPToken
+        }
       });
       return response.data;
     } finally {


### PR DESCRIPTION
## Feature Overview (User Perspective)

This feature streamlines the process of earning rewards when providing liquidity to swap pools by automatically staking LP tokens into the rewards program.

### Deposit Liquidity
- When depositing liquidity (both dual-token and single-token modes), users can now check a box to "Stake my LP Token to earn rewards"
- This option is only shown for pools that have an active rewards program
- The checkbox is **checked by default** to encourage participation in rewards
- If enabled, the newly minted LP tokens are automatically staked into the RewardsChef contract in a single operation
- Users no longer need to manually stake their LP tokens in a separate transaction

### Withdraw Liquidity
- When withdrawing liquidity, users can now check a box to "Include staked LP token"
- This option is only shown for pools that have an active rewards program
- The checkbox is **unchecked by default** to preserve staked tokens unless explicitly requested
- If enabled, the system automatically unstakes the required amount of LP tokens from RewardsChef before burning them
- The available balance display dynamically updates to show wallet + staked balances when the checkbox is enabled
- Users can withdraw liquidity even if their LP tokens are fully staked in the rewards program

### UI Enhancements
- Both modals include helpful tooltips explaining how LP token staking works
- Position calculations update dynamically based on whether staked tokens are included
- Clear visual feedback about which tokens will be used for the operation

## Implementation Details

### Backend Changes (`swapping.service.ts`)

**Deposit Functions (`addLiquidityDualToken` and `addLiquiditySingleToken`):**
1. Accept optional `stakeLPToken` parameter
2. Before deposit: Query pool to get LP token address and find matching RewardsChef pool by LP token
3. Before deposit: Record user's LP token balance
4. Execute liquidity deposit transaction (mints LP tokens)
5. After successful deposit: Use `waitForBalanceUpdate` to wait for Cirrus to index the new balance (retry logic with 10 attempts, 200ms delay)
6. Calculate newly minted LP tokens by comparing balance before/after
7. If tokens were minted: Build and execute staking transaction (approve + deposit to RewardsChef)

**Withdraw Function (`removeLiquidity`):**
1. Accept optional `includeStakedLPToken` parameter
2. If enabled: Query LP token address and find matching RewardsChef pool
3. If enabled: Check wallet LP balance vs required amount
4. If insufficient wallet balance: Calculate amount to unstake and execute unstake transaction first
5. Execute removeLiquidity transaction

**Key Technical Decisions:**
- Uses `waitForBalanceUpdate` helper (same pattern as `lending.service.ts` and `safety.service.ts`) to handle Cirrus indexing race condition
- Finds RewardsChef pool by matching LP token address (supports multiple reward pools)
- Only stakes if RewardsChef pool exists for the LP token
- Gracefully handles cases where no rewards pool is configured

### Frontend Changes

**`LiquidityDepositModal.tsx`:**
- Added `stakeLPToken` state (default: `true`)
- Added checkbox with tooltip (only shown if `pool.lpToken.stakedBalance !== undefined`)
- Passes `stakeLPToken` parameter to backend for all deposit modes (A, B, A&B)
- Resets checkbox state when modal closes

**`LiquidityWithdrawModal.tsx`:**
- Added `includeStakedLPToken` state (default: `false`)
- Added `availableLPBalance` computed value (wallet balance + staked balance if checkbox enabled)
- Updated all position calculations to use `availableLPBalance` instead of hardcoded wallet balance
- Added checkbox with tooltip (only shown if `pool.lpToken.stakedBalance !== undefined`)
- Passes `includeStakedLPToken` parameter to backend
- Resets checkbox state when modal closes

**`SwapContext.tsx`:**
- Updated API calls to pass new optional parameters

### Type & Validation Updates

**`swap-types.ts`:**
- `LiquidityParams`: Added optional `stakeLPToken?: boolean`
- `SingleTokenLiquidityParams`: Added optional `stakeLPToken?: boolean`
- `RemoveLiquidityParams`: Added optional `includeStakedLPToken?: boolean`

**`swapping.validator.ts`:**
- Added Joi validation for optional boolean fields in all three parameter types

### Race Condition Fix
The implementation uses `waitForBalanceUpdate` from `rewardsChef.service.ts` to handle the race condition where:
1. Transaction completes on-chain and LP tokens are minted
2. Cirrus hasn't indexed the new balance yet
3. Immediate query returns stale balance

This matches the pattern used in `lending.service.ts` (mToken staking) and `safety.service.ts` (sToken staking).
