### PR TITLE
Fix the bug when unstaking mUSDST from rewards in lending pool

### DIFF
--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -242,9 +242,11 @@ export const withdrawLiquidity = async (
     const exchangeRate = exchangeRateResponse || "1000000000000000000"; // Default 1:1 if not available
 
     // Convert withdrawal amount (USDST) to required mTokens
+    // Use ceiling division to ensure we unstake enough mTokens to cover the withdrawal
     const amountWei = BigInt(amount);
     const exchangeRateWei = BigInt(exchangeRate);
-    const requiredMTokenWei = (amountWei * (10n ** 18n)) / exchangeRateWei;
+    const numerator = amountWei * (10n ** 18n);
+    const requiredMTokenWei = (numerator + exchangeRateWei - 1n) / exchangeRateWei; // Ceiling division
 
     // Check if we need to unstake
     const unstakedMTokenWei = BigInt(unstakedMTokenBalance);


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/5131

# Problem Analysis

The issue occurred in the `withdrawLiquidity` function when the `includeStakedMToken` option was enabled. The root cause was integer division truncation when converting the withdrawal amount (in USDST) to the required mToken amount using the exchange rate. The calculation `(amountWei * 10^18) / exchangeRateWei` was using floor division, which rounds down and loses precision.

# Solution Implementation

The fix implements ceiling division instead of floor division to ensure we always calculate enough mTokens to cover the withdrawal. The formula was changed from `(amountWei * 10^18) / exchangeRateWei` to `(numerator + exchangeRateWei - 1n) / exchangeRateWei`, where `numerator = amountWei * 10^18`. This uses the mathematical property that `ceil(a/b) = floor((a + b - 1) / b)` for integer division. 