### PR TITLE
Modify startCooldown in SafetyModule to query RewardsChef for balance

### DIFF
--- a/mercata/contracts/concrete/Lending/SafetyModule.sol
+++ b/mercata/contracts/concrete/Lending/SafetyModule.sol
@@ -3,6 +3,7 @@ import "./LendingRegistry.sol";
 import "./LiquidityPool.sol";
 import "../Tokens/Token.sol";
 import "../Tokens/TokenFactory.sol";
+import "../Rewards/RewardsChef.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
 import "../../abstract/ERC20/IERC20.sol";
 
@@ -11,6 +12,11 @@ import "../../abstract/ERC20/IERC20.sol";
 ///         - Rewards in USDST via notifyReward() raise price (exchangeRate).
 ///         - coverShortfall() transfers USDST to LendingPool and writes down system debt; price drops.
 ///         - Cooldown + unstake window enforce exit discipline.
+
+struct RewardsChefInfo {
+    address rewardsChef;
+    uint256 poolId;
+}
 
 contract record SafetyModule is Ownable {
     // ─── Events
@@ -24,12 +30,14 @@ contract record SafetyModule is Ownable {
     event TokenFactoryUpdated(address _tokenFactory);
     event EndpointsSynced(address _lendingPool, address _liquidityPool, address newAsset);
     event RegistryUpdated(address _lendingRegistry);
+    event RewardsChefUpdated(address _rewardsChef, uint256 _poolId);
 
     // ─── Core
     LendingRegistry public lendingRegistry;
     LendingPool public  lendingPool;
     LiquidityPool public liquidityPool;
     TokenFactory public tokenFactory;
+    RewardsChefInfo public record rewardsChefInfo;
     address public  asset;   // USDST
     address public  sToken;  // sUSDST (ERC-20)
 
@@ -108,17 +116,17 @@ contract record SafetyModule is Ownable {
     // ─────────────────────────────────────────
     // Views / math
     // Vault TVL in underlying (pulls live ERC20 balance)
-    function totalAssets() public view returns (uint) 
-    { 
+    function totalAssets() public view returns (uint)
+    {
         require(asset != address(0), "SM:asset not set");
-        return IERC20(asset).balanceOf(address(this)); 
+        return IERC20(asset).balanceOf(address(this));
     }
 
     // Total shares outstanding (assumes sToken implements ERC20 totalSupply)
-    function totalShares() public view returns (uint) 
-    { 
+    function totalShares() public view returns (uint)
+    {
         require(sToken != address(0), "SM:sToken not set");
-        return IERC20(sToken).totalSupply(); 
+        return IERC20(sToken).totalSupply();
     }
 
     /// @notice Current sUSDST price in USDST units (1e18 = 1.0).
@@ -132,7 +140,7 @@ contract record SafetyModule is Ownable {
         if (s == 0) return 1e18;
         return (totalAssets() * 1e18) / s;
     }
-    
+
     /// @notice Pure estimate of shares minted for depositing `assetsIn` right now.
     /// @dev
     ///  - Uses the CURRENT ratio only; ignores transfer fees and donation guard.
@@ -146,7 +154,7 @@ contract record SafetyModule is Ownable {
         uint s = totalShares();
         uint a = totalAssets();
         if (s == 0) return assetsIn;           // initial 1:1
-        require(a > 0, "SM:price=0");          // shares exist but vault has no assets 
+        require(a > 0, "SM:price=0");          // shares exist but vault has no assets
         return (assetsIn * s) / a;             // floor by design
     }
 
@@ -160,7 +168,7 @@ contract record SafetyModule is Ownable {
     function previewRedeem(uint sharesIn) external view returns (uint) {
         require(sharesIn > 0, "SM:zero");
         uint s = totalShares();
-        require(s > 0, "SM:no shares"); 
+        require(s > 0, "SM:no shares");
         return (sharesIn * totalAssets()) / s;
     }
 
@@ -180,7 +188,7 @@ contract record SafetyModule is Ownable {
         if (s == 0) {
             require(beforeBal == 0, "SM:init stray funds"); // donation guard
         } else {
-            require(beforeBal > 0, "SM:price=0");  // prevent (s>0, a==0) 
+            require(beforeBal > 0, "SM:price=0");  // prevent (s>0, a==0)
         }
 
         IERC20(asset).transferFrom(msg.sender, address(this), assetsIn);
@@ -200,9 +208,18 @@ contract record SafetyModule is Ownable {
     }
 
     /// @notice Start cooldown. After COOLDOWN_SECONDS elapse, you have UNSTAKE_WINDOW to redeem.
-    /// @dev Overwrites previous starts. Requires wallet-held shares (not Chef).
+    /// @dev Overwrites previous starts. Checks both wallet-held shares and RewardsChef staked shares.
     function startCooldown() external {
-        require(IERC20(sToken).balanceOf(msg.sender) > 0, "SM:no shares");
+        uint walletBalance = IERC20(sToken).balanceOf(msg.sender);
+        uint stakedBalance = 0;
+
+        // Check RewardsChef staked balance if configured
+        if (rewardsChefInfo.rewardsChef != address(0)) {
+            RewardsChef chef = RewardsChef(rewardsChefInfo.rewardsChef);
+            stakedBalance = chef.getBalance(rewardsChefInfo.poolId, msg.sender);
+        }
+
+        require(walletBalance > 0 || stakedBalance > 0, "SM:no shares");
         uint start = block.timestamp;
         cooldownStart[msg.sender] = start;
         emit UnstakeCooldown(msg.sender, start, start + COOLDOWN_SECONDS);
@@ -247,7 +264,7 @@ contract record SafetyModule is Ownable {
     /// @notice Slash vault to cover protocol shortfall.
     /// @dev Data plane: send USDST to LiquidityPool.
     /// Control plane: tell LendingPool to consume badDebt (accounting).
- 
+
     function coverShortfall(uint256 amount) external onlyOwner returns (uint256 covered) {
         require(amount > 0, "SM:zero");
 
@@ -272,7 +289,7 @@ contract record SafetyModule is Ownable {
 
         emit ShortfallCovered(covered);
     }
-    
+
     // ─────────────────────────────────────────
     // Admin
 
@@ -299,6 +316,16 @@ contract record SafetyModule is Ownable {
         sToken = _sToken;
         asset = _asset;
         emit TokensUpdated(_asset, _sToken);
+    }
+
+    /// @notice Set the RewardsChef reference and poolId for checking staked balances
+    /// @dev Used to check both wallet and staked balances when starting cooldown.
+    ///      Note: Owner should ensure the pool exists and uses sToken as LP token.
+    function setRewardsChef(address _rewardsChef, uint256 _poolId) external onlyOwner {
+        require(_rewardsChef != address(0), "SM:zero addr");
+        rewardsChefInfo.rewardsChef = _rewardsChef;
+        rewardsChefInfo.poolId = _poolId;
+        emit RewardsChefUpdated(_rewardsChef, _poolId);
     }
 
     /// @notice Rescue stray tokens (not the vault asset).

--- a/mercata/contracts/tests/Lending/SafetyModule.test.sol
+++ b/mercata/contracts/tests/Lending/SafetyModule.test.sol
@@ -172,4 +172,136 @@ contract Describe_SafetyModule {
         }
         require(reverted, "startCooldown should fail after transferring all tokens");
     }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // REWARDSCHEF INTEGRATION TESTS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_prevent_cooldown_when_tokens_staked_in_rewardschef_without_config() public {
+        // ensure block.timestamp is not 0
+        fastForward(10);
+
+        uint amount = 1000e18;
+        uint256 allocationPoints = 100;
+        uint256 multiplier = 1;
+        uint256 poolId = 0;
+
+        // Setup RewardsChef
+        RewardsChef chef = m.rewardsChef();
+
+        // Transfer ownership to test contract
+        m.adminRegistry().castVoteOnIssue(address(chef), "transferOwnership", address(this));
+        Ownable(address(chef)).transferOwnership(address(this));
+
+        // Create rewards token for RewardsChef
+        address rewardsTokenAddress = m.tokenFactory().createToken(
+            "CATA",
+            "CATA Token",
+            [], [], [], "CATA", 0, 18
+        );
+        Token rewardsToken = Token(rewardsTokenAddress);
+
+        // Initialize RewardsChef
+        chef.initialize(rewardsTokenAddress, 1000);
+
+        // Transfer ownership of rewards token to chef so it can mint
+        Ownable(rewardsTokenAddress).transferOwnership(address(chef));
+
+        // Add pool with sUSDST as LP token
+        chef.addPool(allocationPoints, sUSDST, multiplier);
+
+        // Mint USDST to user1 and stake to SafetyModule
+        Token(USDST).mint(address(user1), amount);
+        TestUtils.callAs(user1, USDST, "approve(address, uint256)", address(sm), amount);
+        TestUtils.callAs(user1, address(sm), "stake(uint256, uint256)", amount, 0);
+
+        // User should have sUSDST
+        uint sUSDSTBalance = IERC20(sUSDST).balanceOf(address(user1));
+        require(sUSDSTBalance > 0, "User should have sUSDST tokens");
+
+        // User stakes all sUSDST to RewardsChef
+        TestUtils.callAs(user1, sUSDST, "approve(address, uint256)", address(chef), sUSDSTBalance);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", poolId, sUSDSTBalance);
+
+        // Verify user has no sUSDST in wallet
+        require_equal(IERC20(sUSDST).balanceOf(address(user1)), 0, "User should have no sUSDST in wallet");
+
+        // Verify user has sUSDST staked in RewardsChef
+        uint256 stakedBalance = chef.getBalance(poolId, address(user1));
+        require(stakedBalance > 0, "User should have sUSDST staked in RewardsChef");
+
+        // Try to start cooldown - should FAIL because RewardsChef is not configured in SafetyModule
+        bool reverted = false;
+        try user1.do(address(sm), "startCooldown") {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "startCooldown should fail when tokens are in RewardsChef but SafetyModule not configured");
+    }
+
+    function it_should_allow_cooldown_when_tokens_staked_in_rewardschef_with_config() public {
+        // ensure block.timestamp is not 0
+        fastForward(10);
+
+        uint amount = 1000e18;
+        uint256 allocationPoints = 100;
+        uint256 multiplier = 1;
+        uint256 poolId = 0;
+
+        // Setup RewardsChef
+        RewardsChef chef = m.rewardsChef();
+
+        // Transfer ownership to test contract
+        m.adminRegistry().castVoteOnIssue(address(chef), "transferOwnership", address(this));
+        Ownable(address(chef)).transferOwnership(address(this));
+
+        // Create rewards token for RewardsChef
+        address rewardsTokenAddress = m.tokenFactory().createToken(
+            "CATA",
+            "CATA Token",
+            [], [], [], "CATA", 0, 18
+        );
+        Token rewardsToken = Token(rewardsTokenAddress);
+
+        // Initialize RewardsChef
+        chef.initialize(rewardsTokenAddress, 1000);
+
+        // Transfer ownership of rewards token to chef so it can mint
+        Ownable(rewardsTokenAddress).transferOwnership(address(chef));
+
+        // Add pool with sUSDST as LP token
+        chef.addPool(allocationPoints, sUSDST, multiplier);
+
+        // Configure RewardsChef in SafetyModule
+        sm.setRewardsChef(address(chef), poolId);
+
+        // Mint USDST to user1 and stake to SafetyModule
+        Token(USDST).mint(address(user1), amount);
+        TestUtils.callAs(user1, USDST, "approve(address, uint256)", address(sm), amount);
+        TestUtils.callAs(user1, address(sm), "stake(uint256, uint256)", amount, 0);
+
+        // User should have sUSDST
+        uint sUSDSTBalance = IERC20(sUSDST).balanceOf(address(user1));
+        require(sUSDSTBalance > 0, "User should have sUSDST tokens");
+
+        // User stakes all sUSDST to RewardsChef
+        TestUtils.callAs(user1, sUSDST, "approve(address, uint256)", address(chef), sUSDSTBalance);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", poolId, sUSDSTBalance);
+
+        // Verify user has no sUSDST in wallet
+        require_equal(IERC20(sUSDST).balanceOf(address(user1)), 0, "User should have no sUSDST in wallet");
+
+        // Verify user has sUSDST staked in RewardsChef
+        uint256 stakedBalance = chef.getBalance(poolId, address(user1));
+        require(stakedBalance > 0, "User should have sUSDST staked in RewardsChef");
+
+        // Try to start cooldown - should SUCCEED because RewardsChef is configured
+        user1.do(address(sm), "startCooldown");
+
+        // Verify cooldown was started
+        uint cooldownStart = sm.cooldownStart(address(user1));
+        require(cooldownStart > 0, "Cooldown should be started");
+        require_equal(cooldownStart, block.timestamp, "Cooldown start should be current timestamp");
+    }
 }

--- a/mercata/contracts/tests/Lending/SafetyModule.test.sol
+++ b/mercata/contracts/tests/Lending/SafetyModule.test.sol
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import "../../concrete/BaseCodeCollection.sol";
+import "../Util.sol";
+import "../../abstract/ERC20/IERC20.sol";
+import "../../concrete/Tokens/Token.sol";
+
+contract Describe_SafetyModule {
+    using TestUtils for User;
+
+    constructor() {
+    }
+
+    Mercata m;
+    User user1;
+    User user2;
+
+    address USDST;
+    address mUSDST;
+    address sUSDST;
+
+    SafetyModule sm;
+
+    function beforeAll() {
+        // Create test users once
+        user1 = new User();
+        user2 = new User();
+    }
+
+    function beforeEach() {
+        // Create fresh Mercata infrastructure for each test
+        m = new Mercata();
+        require(address(m) != address(0), "Mercata address is 0");
+
+        // Get SafetyModule
+        sm = m.safetyModule();
+
+        // Create tokens
+        USDST = m.tokenFactory().createToken("USDST", "USDST Token", [], [], [], "USDST", 0, 18);
+        mUSDST = m.tokenFactory().createToken("mUSDST", "mUSDST Token", [], [], [], "mUSDST", 0, 18);
+        sUSDST = m.tokenFactory().createToken("sUSDST", "sUSDST Token", [], [], [], "sUSDST", 0, 18);
+
+        require(address(USDST) != address(0), "Failed to create USDST token");
+        require(address(mUSDST) != address(0), "Failed to create mUSDST token");
+        require(address(sUSDST) != address(0), "Failed to create sUSDST token");
+
+        // Activate tokens
+        Token(USDST).setStatus(2);
+        Token(mUSDST).setStatus(2);
+        Token(sUSDST).setStatus(2);
+
+        // Whitelist tokens
+        Token(mUSDST).addWhitelist(address(m.adminRegistry()), "mint", address(m.liquidityPool()));
+        Token(mUSDST).addWhitelist(address(m.adminRegistry()), "burn", address(m.liquidityPool()));
+        Token(sUSDST).addWhitelist(address(m.adminRegistry()), "mint", address(sm));
+        Token(sUSDST).addWhitelist(address(m.adminRegistry()), "burn", address(sm));
+
+        // Configure lending pool
+        PoolConfigurator configurator = m.poolConfigurator();
+        configurator.setBorrowableAsset(USDST);
+        configurator.setMToken(mUSDST);
+
+        // Configure SafetyModule
+        uint cooldown = 100; // 100 seconds for testing
+        uint window = 200;   // 200 seconds window
+        uint maxSlashBps = 3000;
+        sm.setParams(cooldown, window, maxSlashBps);
+        sm.syncFromRegistry();
+        sm.setTokens(sUSDST, USDST);
+
+
+    }
+
+    function require_equal(uint observed, uint expected, string memory message) public {
+        require(observed == expected, message + " Got: " + string(observed) + ", expected: " + string(expected));
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // COOLDOWN TESTS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_prevent_cooldown_with_no_stake() public {
+	// ensure block.timestamp is not 0
+        fastForward(10);
+
+        // User has no sUSDST tokens
+        require_equal(IERC20(sUSDST).balanceOf(address(user1)), 0, "User should have no sUSDST initially");
+
+        // Try to start cooldown - should fail
+        bool reverted = false;
+        try user1.do(address(sm), "startCooldown") {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "startCooldown should fail with no stake");
+    }
+
+    function it_should_allow_cooldown_after_deposit() public {
+	// ensure block.timestamp is not 0
+        fastForward(10);
+
+        uint amount = 1000e18;
+
+        // Mint and stake
+        Token(USDST).mint(address(user1), amount);
+        TestUtils.callAs(user1, USDST, "approve(address, uint256)", address(sm), amount);
+        TestUtils.callAs(user1, address(sm), "stake(uint256, uint256)", amount, 0);
+
+        // User should have sUSDST
+        uint balance = IERC20(sUSDST).balanceOf(address(user1));
+        require(balance > 0, "User should have sUSDST tokens");
+
+        // Start cooldown - should succeed
+        user1.do(address(sm), "startCooldown");
+
+        // Verify cooldown was started
+        uint cooldownStart = sm.cooldownStart(address(user1));
+        require(cooldownStart > 0, "Cooldown should be started");
+        require_equal(cooldownStart, block.timestamp, "Cooldown start should be current timestamp");
+    }
+
+    function it_should_allow_multiple_cooldown_starts() public {
+	// ensure block.timestamp is not 0
+        fastForward(10);
+
+        uint amount = 1000e18;
+
+        // Mint and stake
+        Token(USDST).mint(address(user1), amount);
+        TestUtils.callAs(user1, USDST, "approve(address, uint256)", address(sm), amount);
+        TestUtils.callAs(user1, address(sm), "stake(uint256, uint256)", amount, 0);
+
+        // Start cooldown first time
+        user1.do(address(sm), "startCooldown");
+        uint firstCooldownStart = sm.cooldownStart(address(user1));
+        require(firstCooldownStart > 0, "Should have initial cooldown");
+
+        // Fast forward time
+        fastForward(10);
+
+        // Start cooldown again - should update the timestamp
+        user1.do(address(sm), "startCooldown");
+        uint secondCooldownStart = sm.cooldownStart(address(user1));
+        require(secondCooldownStart > firstCooldownStart, "Cooldown should be updated to later timestamp");
+    }
+
+    function it_should_prevent_cooldown_after_transferring_all_tokens() public {
+	// ensure block.timestamp is not 0
+        fastForward(10);
+
+        uint amount = 1000e18;
+
+        // Mint and stake
+        Token(USDST).mint(address(user1), amount);
+        TestUtils.callAs(user1, USDST, "approve(address, uint256)", address(sm), amount);
+        TestUtils.callAs(user1, address(sm), "stake(uint256, uint256)", amount, 0);
+
+        // User transfers all sUSDST to another address
+        uint balance = IERC20(sUSDST).balanceOf(address(user1));
+        TestUtils.callAs(user1, sUSDST, "transfer(address, uint256)", address(user2), balance);
+
+        require_equal(IERC20(sUSDST).balanceOf(address(user1)), 0, "User should have no sUSDST after transfer");
+
+        // Try to start cooldown - should fail
+        bool reverted = false;
+        try user1.do(address(sm), "startCooldown") {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "startCooldown should fail after transferring all tokens");
+    }
+}


### PR DESCRIPTION
Fixes #5137

# Changes

* [Add unit tests for SafetyModule, the startCooldown function](https://github.com/blockapps/strato-platform/commit/998f9e13d071107d1cf4cb23d6644e15c1659b1d)
* [Allow setting RewardsChef in SafetyModule](https://github.com/blockapps/strato-platform/commit/21e249d76bed84a1d2143d8b9f12585f52f5d838)

# Notes

* We have to explicitly set `RewardsChef` in the `SafetyModule` and instruct it which rewards pool stakes the `sToken`. We currently don't do any checks when setting RewardsChef, assuming that the user knows what they are doing. Maybe it make sense to verify that the sToken pool actually exists in RewardsChef?

* Please review but don't merge!
 - please review first
 - however after rewview we want to upgrade the `SafetyModule` proxy with this version and see if it works
 - only when we confirm that proxy works with new impl, we will merge this PR
 
* Once we merge this PR, we need to create a separate one that will modify genesis 