### PR TITLE
Show Pending Rewards on the overview page

### DIFF
--- a/mercata/backend/src/api/controllers/rewardsChef.controller.ts
+++ b/mercata/backend/src/api/controllers/rewardsChef.controller.ts
@@ -1,0 +1,96 @@
+import { Request, Response, NextFunction } from "express";
+import RestStatus from "http-status-codes";
+import { calculatePendingCata, getPools } from "../services/rewardsChef.service";
+import { rewardsChef as rewardsChefAddress } from "../../config/constants";
+import { cirrus } from "../../utils/mercataApiHelper";
+import { constants } from "../../config/constants";
+
+const { RewardsChef } = constants;
+
+class RewardsChefController {
+  /**
+   * GET /api/rewards/pending
+   * Calculate pending CATA rewards for a user in a specific pool
+   *
+   * Query params:
+   * - poolId: Pool ID (required)
+   * - userAddress: User address (optional, defaults to authenticated user)
+   */
+  static async getPendingRewards(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, address: authenticatedUserAddress } = req;
+      const { poolId, userAddress } = req.query;
+
+      if (!poolId) {
+        res.status(RestStatus.BAD_REQUEST).json({ error: "poolId is required" });
+        return;
+      }
+
+      const targetUserAddress = (userAddress as string) || authenticatedUserAddress;
+      const poolIdNum = parseInt(poolId as string, 10);
+
+      if (isNaN(poolIdNum)) {
+        res.status(RestStatus.BAD_REQUEST).json({ error: "poolId must be a valid number" });
+        return;
+      }
+
+      // Fetch cataPerSecond and totalAllocPoint from the contract
+      const contractStateResponse = await cirrus.get(accessToken, `/${RewardsChef}`, {
+        params: {
+          address: `eq.${rewardsChefAddress}`,
+          select: "cataPerSecond::text,totalAllocPoint::text"
+        }
+      });
+
+      const contractState = contractStateResponse.data?.[0];
+      if (!contractState) {
+        res.status(RestStatus.NOT_FOUND).json({ error: "RewardsChef contract not found" });
+        return;
+      }
+
+      const pendingCata = await calculatePendingCata(
+        accessToken,
+        rewardsChefAddress,
+        poolIdNum,
+        targetUserAddress,
+        contractState.cataPerSecond,
+        contractState.totalAllocPoint
+      );
+
+      res.status(RestStatus.OK).json({
+        poolId: poolIdNum,
+        userAddress: targetUserAddress,
+        pendingCata,
+        pendingCataFormatted: (BigInt(pendingCata) / BigInt(10 ** 18)).toString() // Human-readable format
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/rewards/pools
+   * Get all RewardsChef pools
+   */
+  static async getPools(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken } = req;
+
+      const pools = await getPools(accessToken, rewardsChefAddress);
+
+      res.status(RestStatus.OK).json({ pools });
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+export default RewardsChefController;

--- a/mercata/backend/src/api/controllers/rewardsChef.controller.ts
+++ b/mercata/backend/src/api/controllers/rewardsChef.controller.ts
@@ -1,6 +1,11 @@
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
-import { calculatePendingCata, getPools } from "../services/rewardsChef.service";
+import {
+  calculatePendingCata,
+  calculateTotalPendingCata,
+  getPools,
+  getRewardsChefState
+} from "../services/rewardsChef.service";
 import { rewardsChef as rewardsChefAddress } from "../../config/constants";
 import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
@@ -61,11 +66,15 @@ class RewardsChefController {
         contractState.totalAllocPoint
       );
 
+      // Format with proper decimals (wei to CATA with 18 decimals)
+      const pendingCataBigInt = BigInt(pendingCata);
+      const pendingCataFormatted = (Number(pendingCataBigInt) / 1e18).toFixed(2);
+
       res.status(RestStatus.OK).json({
         poolId: poolIdNum,
         userAddress: targetUserAddress,
         pendingCata,
-        pendingCataFormatted: (BigInt(pendingCata) / BigInt(10 ** 18)).toString() // Human-readable format
+        pendingCataFormatted
       });
     } catch (error) {
       next(error);
@@ -87,6 +96,44 @@ class RewardsChefController {
       const pools = await getPools(accessToken, rewardsChefAddress);
 
       res.status(RestStatus.OK).json({ pools });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/rewards/pending/total
+   * Calculate total pending CATA rewards across all pools for a user
+   *
+   * Query params:
+   * - userAddress: User address (optional, defaults to authenticated user)
+   */
+  static async getTotalPendingRewards(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, address: authenticatedUserAddress } = req;
+      const { userAddress } = req.query;
+
+      const targetUserAddress = (userAddress as string) || authenticatedUserAddress;
+
+      const totalPending = await calculateTotalPendingCata(
+        accessToken,
+        rewardsChefAddress,
+        targetUserAddress
+      );
+
+      // Format with proper decimals (wei to CATA with 18 decimals)
+      const totalPendingNum = Number(BigInt(totalPending)) / 1e18;
+      const formatted = totalPendingNum.toFixed(2);
+
+      res.status(RestStatus.OK).json({
+        userAddress: targetUserAddress,
+        totalPendingCata: totalPending,
+        totalPendingCataFormatted: formatted
+      });
     } catch (error) {
       next(error);
     }

--- a/mercata/backend/src/api/routes.ts
+++ b/mercata/backend/src/api/routes.ts
@@ -13,6 +13,7 @@ import lendingRoutes from "./routes/lending.routes";
 import eventsRoutes from "./routes/events.routes";
 import bridgeRoutes from "./routes/bridge.routes";
 import cdpRoutes from "./routes/cdp.routes";
+import rewardsRoutes from "./routes/rewards.routes";
 
 const router = Router();
 
@@ -52,6 +53,9 @@ router.use("/bridge", bridgeRoutes);
 
 // ----- CDP Routes -----
 router.use("/cdp", cdpRoutes);
+
+// ----- Rewards Routes -----
+router.use("/rewards", rewardsRoutes);
 
 // ----- Health Check -----
 router.get("/health", (_req: Request, res: Response, next: NextFunction) => {

--- a/mercata/backend/src/api/routes/rewards.routes.ts
+++ b/mercata/backend/src/api/routes/rewards.routes.ts
@@ -8,6 +8,9 @@ const router = Router();
 // Get all pools
 router.get("/pools", authHandler.authorizeRequest(true), RewardsChefController.getPools);
 
+// Get total pending CATA rewards across all pools for a user
+router.get("/pending/total", authHandler.authorizeRequest(), RewardsChefController.getTotalPendingRewards);
+
 // Get pending CATA rewards for a user in a specific pool
 router.get("/pending", authHandler.authorizeRequest(), RewardsChefController.getPendingRewards);
 

--- a/mercata/backend/src/api/routes/rewards.routes.ts
+++ b/mercata/backend/src/api/routes/rewards.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import authHandler from "../middleware/authHandler";
+import RewardsChefController from "../controllers/rewardsChef.controller";
+
+const router = Router();
+
+// ----- RewardsChef Information -----
+// Get all pools
+router.get("/pools", authHandler.authorizeRequest(true), RewardsChefController.getPools);
+
+// Get pending CATA rewards for a user in a specific pool
+router.get("/pending", authHandler.authorizeRequest(), RewardsChefController.getPendingRewards);
+
+export default router;

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -202,6 +202,42 @@ const calculateMultiplier = (
 
 
 /**
+ * Fetches RewardsChef global state (cataPerSecond and totalAllocPoint)
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @returns Promise resolving to global state
+ */
+export const getRewardsChefState = async (
+  accessToken: string,
+  rewardsChefAddress: string
+): Promise<{ cataPerSecond: string; totalAllocPoint: string } | null> => {
+  try {
+    const response = await cirrus.get(accessToken, `/${RewardsChef}`, {
+      params: {
+        address: `eq.${rewardsChefAddress}`,
+        select: "cataPerSecond::text,totalAllocPoint::text",
+        order: "block_timestamp.desc",
+        limit: "1"
+      }
+    });
+
+    const state = response.data?.[0];
+    if (!state) {
+      return null;
+    }
+
+    return {
+      cataPerSecond: state.cataPerSecond,
+      totalAllocPoint: state.totalAllocPoint
+    };
+  } catch (error) {
+    console.error("Failed to fetch RewardsChef state:", error);
+    return null;
+  }
+};
+
+/**
  * Calculates pending CATA rewards for a user in a specific pool
  * Replicates the pendingCata() logic from RewardsChef.sol
  *
@@ -284,6 +320,79 @@ export const calculatePendingCata = async (
     return pending > 0n ? pending.toString() : "0";
   } catch (error) {
     console.error("Failed to calculate pending CATA:", error);
+    return "0";
+  }
+};
+
+/**
+ * Calculates total pending CATA rewards for a user across all pools
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param userAddress - User address to calculate rewards for
+ * @returns Promise resolving to total pending CATA amount as string (in wei)
+ */
+export const calculateTotalPendingCata = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  userAddress: string
+): Promise<string> => {
+  try {
+    // Fetch global state
+    const state = await getRewardsChefState(accessToken, rewardsChefAddress);
+    if (!state) {
+      return "0";
+    }
+
+    // Fetch all pools
+    const pools = await getPools(accessToken, rewardsChefAddress);
+    if (pools.length === 0) {
+      return "0";
+    }
+
+    // Fetch all user positions (userInfo entries for this user)
+    const userInfoResponse = await cirrus.get(accessToken, `/${RewardsChef}-userInfo`, {
+      params: {
+        address: `eq.${rewardsChefAddress}`,
+        key2: `eq.${userAddress}`,
+        select: "key,value",
+        order: "block_timestamp.desc"
+      }
+    });
+
+    // Group by pool ID (key) and take the latest entry for each pool
+    const userPositionsMap = new Map();
+    for (const entry of userInfoResponse.data || []) {
+      const poolId = entry.key;
+      if (!userPositionsMap.has(poolId) && entry.value?.amount !== "0") {
+        userPositionsMap.set(poolId, entry.value);
+      }
+    }
+
+    // If user has no positions, return 0
+    if (userPositionsMap.size === 0) {
+      return "0";
+    }
+
+    // Calculate pending for each pool the user has staked in
+    let totalPending = 0n;
+
+    for (const [poolId, _userInfo] of userPositionsMap) {
+      const pending = await calculatePendingCata(
+        accessToken,
+        rewardsChefAddress,
+        Number(poolId),
+        userAddress,
+        state.cataPerSecond,
+        state.totalAllocPoint
+      );
+
+      totalPending += BigInt(pending);
+    }
+
+    return totalPending.toString();
+  } catch (error) {
+    console.error("Failed to calculate total pending CATA:", error);
     return "0";
   }
 };

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -48,11 +48,48 @@ export const waitForBalanceUpdate = async (
 };
 
 /**
- * Helper function to get user's staked balance from RewardsChef using Cirrus events
+ * Helper function to get user's info (staked balance and reward debt) from RewardsChef
  *
- * This function queries the latest CurrentUserAmount event for the given user and pool,
- * which contains the current staked balance. This approach avoids on-chain calls while
- * working around the limitation that nested mappings cannot be queried from Cirrus.
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param poolId - Pool ID to query
+ * @param userAddress - User address to fetch info for
+ * @returns Promise resolving to user info object
+ */
+export const getUserInfo = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  poolId: number,
+  userAddress: string
+): Promise<{ amount: string; rewardDebt: string }> => {
+  try {
+    // Query userInfo mapping from Cirrus
+    // The mapping is indexed with key (poolId) and key2 (userAddress)
+    const response = await cirrus.get(accessToken, `/${RewardsChef}-userInfo`, {
+      params: {
+        address: `eq.${rewardsChefAddress}`,
+        key: `eq.${poolId}`,
+        key2: `eq.${userAddress}`,
+        select: "value",
+        order: "block_timestamp.desc",
+        limit: "1"
+      }
+    });
+
+    const userInfo = response.data?.[0]?.value;
+    return {
+      amount: userInfo?.amount || "0",
+      rewardDebt: userInfo?.rewardDebt || "0"
+    };
+  } catch (error) {
+    console.error("Failed to fetch user info from RewardsChef:", error);
+    return { amount: "0", rewardDebt: "0" };
+  }
+};
+
+/**
+ * Helper function to get user's staked balance from RewardsChef
+ * Backward compatibility wrapper for getUserInfo
  *
  * @param accessToken - User access token for authentication
  * @param rewardsChefAddress - Address of the RewardsChef contract
@@ -66,26 +103,8 @@ export const getStakedBalance = async (
   poolId: number,
   userAddress: string
 ): Promise<string> => {
-  try {
-    // Query the latest CurrentUserAmount event for this user and pool
-    const response = await cirrus.get(accessToken, `/${RewardsChef}-CurrentUserAmount`, {
-      params: {
-        address: `eq.${rewardsChefAddress}`,
-        user: `eq.${userAddress}`,
-        pid: `eq.${poolId}`,
-        select: "currentAmount::text,block_timestamp",
-        order: "block_timestamp.desc",
-        limit: "1"
-      }
-    });
-
-    // Extract the current amount from the latest event
-    const latestEvent = response.data?.[0];
-    return latestEvent?.currentAmount || "0";
-  } catch (error) {
-    console.error("Failed to fetch staked balance from RewardsChef events:", error);
-    return "0";
-  }
+  const userInfo = await getUserInfo(accessToken, rewardsChefAddress, poolId, userAddress);
+  return userInfo.amount;
 };
 
 /**
@@ -104,28 +123,167 @@ export const getPools = async (
   allocPoint: string;
   accPerToken: string;
   lastRewardTimestamp: string;
+  bonusPeriods: Array<{ startTimestamp: string; bonusMultiplier: string }>;
 }>> => {
   try {
     const response = await cirrus.get(accessToken, `/${RewardsChef}-pools`, {
       params: {
-        address: `eq.${rewardsChefAddress}`
+        address: `eq.${rewardsChefAddress}`,
+        select: "key,value",
+        order: "block_timestamp.desc"
       }
     });
 
-    // Filter out entries with empty values and map to desired format
-    const pools = response.data
-      ?.filter((entry: any) => entry.value && entry.value !== "")
-      .map((entry: any) => ({
-        poolIdx: entry.key,
-        lpToken: entry.value.lpToken,
-        allocPoint: entry.value.allocPoint,
-        accPerToken: entry.value.accPerToken,
-        lastRewardTimestamp: entry.value.lastRewardTimestamp
-      })) || [];
+    // Group by key (poolIdx) and take the latest entry for each pool
+    const poolsMap = new Map();
+    for (const entry of response.data || []) {
+      if (entry.value && !poolsMap.has(entry.key)) {
+        poolsMap.set(entry.key, {
+          poolIdx: entry.key,
+          lpToken: entry.value.lpToken,
+          allocPoint: entry.value.allocPoint,
+          accPerToken: entry.value.accPerToken,
+          lastRewardTimestamp: entry.value.lastRewardTimestamp,
+          bonusPeriods: entry.value.bonusPeriods || []
+        });
+      }
+    }
 
-    return pools;
+    return Array.from(poolsMap.values()).sort((a, b) => a.poolIdx - b.poolIdx);
   } catch (error) {
     console.error("Failed to fetch pools from RewardsChef:", error);
     return [];
+  }
+};
+
+
+/**
+ * Calculates the bonus-adjusted multiplier for a time period
+ * Replicates the getMultiplier() logic from RewardsChef.sol
+ *
+ * @param bonusPeriods - Array of bonus periods sorted by startTimestamp
+ * @param from - Start timestamp
+ * @param to - End timestamp
+ * @returns Bonus-adjusted time multiplier as BigInt
+ */
+const calculateMultiplier = (
+  bonusPeriods: Array<{ startTimestamp: string; bonusMultiplier: string }>,
+  from: bigint,
+  to: bigint
+): bigint => {
+  if (from >= to) {
+    return 0n;
+  }
+
+  const MAX_INT = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+  let totalMultipliedTime = 0n;
+  let currentTime = from;
+
+  for (let i = 0; i < bonusPeriods.length && currentTime < to; i++) {
+    const periodStart = BigInt(bonusPeriods[i].startTimestamp);
+    const periodEnd = (i + 1 < bonusPeriods.length)
+      ? BigInt(bonusPeriods[i + 1].startTimestamp)
+      : MAX_INT;
+
+    if (currentTime < periodStart) {
+      currentTime = periodStart;
+    }
+
+    if (currentTime < to && currentTime < periodEnd) {
+      const segmentEnd = to < periodEnd ? to : periodEnd;
+      const segmentDuration = segmentEnd - currentTime;
+      totalMultipliedTime += segmentDuration * BigInt(bonusPeriods[i].bonusMultiplier);
+      currentTime = segmentEnd;
+    }
+  }
+
+  return totalMultipliedTime;
+};
+
+
+/**
+ * Calculates pending CATA rewards for a user in a specific pool
+ * Replicates the pendingCata() logic from RewardsChef.sol
+ *
+ * This directly queries the userInfo mapping from Cirrus which contains both
+ * the user's staked amount and their rewardDebt. This makes the calculation
+ * accurate and simple.
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param poolId - Pool ID
+ * @param userAddress - User address to calculate rewards for
+ * @param cataPerSecond - CATA tokens created per second (in wei)
+ * @param totalAllocPoint - Sum of all allocation points across pools
+ * @returns Promise resolving to pending CATA amount as string (in wei)
+ */
+export const calculatePendingCata = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  poolId: number,
+  userAddress: string,
+  cataPerSecond: string,
+  totalAllocPoint: string
+): Promise<string> => {
+  try {
+    // Fetch pool data (includes bonusPeriods)
+    const pools = await getPools(accessToken, rewardsChefAddress);
+    const pool = pools.find(p => p.poolIdx === poolId);
+
+    if (!pool) {
+      return "0";
+    }
+
+    // Fetch user info (amount and rewardDebt)
+    const userInfo = await getUserInfo(
+      accessToken,
+      rewardsChefAddress,
+      poolId,
+      userAddress
+    );
+
+    const userAmount = BigInt(userInfo.amount);
+    if (userAmount === 0n) {
+      return "0";
+    }
+
+    const userRewardDebt = BigInt(userInfo.rewardDebt);
+
+    // Constants
+    const PRECISION_MULTIPLIER = BigInt("1000000000000000000"); // 1e18
+    const lastRewardTimestamp = BigInt(pool.lastRewardTimestamp);
+    const currentTimestamp = BigInt(Math.floor(Date.now() / 1000));
+
+    // Get LP token balance in the contract
+    const lpSupply = await getTokenBalanceForUser(accessToken, pool.lpToken, rewardsChefAddress);
+    const lpSupplyBigInt = BigInt(lpSupply);
+
+    // Calculate current accPerToken (as pendingCata does in the contract)
+    let accPerToken = BigInt(pool.accPerToken);
+
+    // If time has passed since last pool update and there's liquidity, simulate the update
+    if (currentTimestamp > lastRewardTimestamp && lpSupplyBigInt !== 0n) {
+      const multiplier = calculateMultiplier(
+        pool.bonusPeriods,
+        lastRewardTimestamp,
+        currentTimestamp
+      );
+      const cataReward = (
+        multiplier *
+        BigInt(cataPerSecond) *
+        BigInt(pool.allocPoint)
+      ) / BigInt(totalAllocPoint);
+
+      accPerToken += (cataReward * PRECISION_MULTIPLIER) / lpSupplyBigInt;
+    }
+
+    // Calculate pending rewards: (user.amount * accPerToken) / PRECISION - user.rewardDebt
+    const pending = (userAmount * accPerToken) / PRECISION_MULTIPLIER - userRewardDebt;
+
+    // Ensure we don't return negative values
+    return pending > 0n ? pending.toString() : "0";
+  } catch (error) {
+    console.error("Failed to calculate pending CATA:", error);
+    return "0";
   }
 };

--- a/mercata/ui/src/components/dashboard/AssetSummary.tsx
+++ b/mercata/ui/src/components/dashboard/AssetSummary.tsx
@@ -1,25 +1,41 @@
+import { HelpCircle } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
 interface AssetSummaryProps {
   title: string;
   value: string;
   icon: React.ReactNode;
   color: string;
+  tooltip?: string;
 }
 
-const AssetSummary = ({ title, value, icon, color }: AssetSummaryProps) => {
+const AssetSummary = ({ title, value, icon, color, tooltip }: AssetSummaryProps) => {
   return (
     <div className="bg-white rounded-xl border border-gray-100 p-5 shadow-sm hover:shadow-md transition-shadow">
       <div className="flex justify-between items-start">
         <div>
-          <p className="text-gray-500 text-sm">{title}</p>
+          <div className="flex items-center gap-1">
+            <p className="text-gray-500 text-sm">{title}</p>
+            {tooltip && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="max-w-xs text-sm">{tooltip}</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
           <h3 className="text-2xl font-bold mt-1">{value}</h3>
         </div>
-        
-        <div 
+
+        <div
           className={`w-10 h-10 rounded-full flex items-center justify-center ${color}`}
         >
           {icon}
         </div>
-      </div>      
+      </div>
     </div>
   );
 };

--- a/mercata/ui/src/hooks/usePendingRewards.ts
+++ b/mercata/ui/src/hooks/usePendingRewards.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect } from "react";
+import { api } from "@/lib/axios";
+import { useUser } from "@/context/UserContext";
+
+interface PendingRewardsData {
+  totalPendingCata: string;
+  totalPendingCataFormatted: string;
+  userAddress: string;
+}
+
+/**
+ * Hook to fetch total pending CATA rewards across all pools
+ *
+ * @param enabled - Whether to fetch (default: true)
+ * @param refreshInterval - Auto-refresh interval in ms (default: 10000 = 10 seconds)
+ * @returns Pending rewards data and loading state
+ */
+export const usePendingRewards = (enabled = true, refreshInterval = 10000) => {
+  const { userAddress, isLoggedIn } = useUser();
+  const [pendingRewards, setPendingRewards] = useState<string>("0");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchPendingRewards = async () => {
+    if (!isLoggedIn || !userAddress || !enabled) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await api.get<PendingRewardsData>("/rewards/pending/total");
+      setPendingRewards(response.data.totalPendingCataFormatted);
+    } catch (err) {
+      console.error("Failed to fetch pending rewards:", err);
+      setError(err instanceof Error ? err : new Error("Unknown error"));
+      setPendingRewards("0");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    // Initial fetch
+    fetchPendingRewards();
+
+    // Set up auto-refresh
+    const interval = setInterval(fetchPendingRewards, refreshInterval);
+
+    return () => clearInterval(interval);
+  }, [userAddress, isLoggedIn, enabled, refreshInterval]);
+
+  return {
+    pendingRewards,
+    loading,
+    error,
+    refetch: fetchPendingRewards,
+  };
+};

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -141,7 +141,7 @@ const Dashboard = () => {
               title="Pending CATA"
               value={`${parseFloat(pendingRewards).toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA `}
               icon={<Banknote className="text-white" size={18} />}
-              color="bg-green-500"
+              color={pendingRewards == "0" ? "bg-gray-500" : "bg-green-500"}
             />
 
             <AssetSummary

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -134,6 +134,7 @@ const Dashboard = () => {
               value={`${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA `}
               icon={<Coins className="text-white" size={18} />}
               color="bg-purple-500"
+              tooltip={cataBalance === 0 ? "No rewards yet - start staking to earn CATA!" : undefined}
             />
 
 

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -21,6 +21,7 @@ import { useSwapContext } from "@/context/SwapContext";
 import { useCDP } from "@/context/CDPContext";
 import { useSafetyContext } from "@/context/SafetyContext";
 import { cataAddress } from "@/lib/constants";
+import { usePendingRewards } from "@/hooks/usePendingRewards";
 
 const Dashboard = () => {
   const [searchParams] = useSearchParams();
@@ -55,6 +56,9 @@ const Dashboard = () => {
     totalCDPDebt,
     safetyInfo
   });
+
+  // Fetch pending CATA rewards across all pools
+  const { pendingRewards } = usePendingRewards(true, 10000);
 
 
   // Add visibility states to prevent flashing
@@ -127,7 +131,11 @@ const Dashboard = () => {
 
             <AssetSummary
               title="CATA Rewards"
-              value={`${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA`}
+              value={
+                pendingRewards !== "0"
+                  ? `${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA (+${parseFloat(pendingRewards).toLocaleString("en-US", { maximumFractionDigits: 2 })} pending)`
+                  : `${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA`
+              }
               icon={<Coins className="text-white" size={18} />}
               color="bg-purple-500"
             />

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import AssetSummary from "../components/dashboard/AssetSummary";
 import AssetsList from "../components/dashboard/AssetsList";
 import DashboardFAQ from "../components/dashboard/DashboardFAQ";
 import BorrowingSection from "../components/dashboard/BorrowingSection";
-import { Wallet, Coins, Shield } from "lucide-react";
+import { Wallet, Coins, Shield, Banknote } from "lucide-react";
 import { useUserTokens } from "@/context/UserTokensContext";
 import { useUser } from "@/context/UserContext";
 import { useLendingMetrics } from "@/hooks/useLendingMetrics";
@@ -121,7 +121,7 @@ const Dashboard = () => {
         />
 
         <main className="p-6">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 mb-8">
             <AssetSummary
               title="Net Balance"
               value={`$${totalBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })}`}
@@ -131,13 +131,17 @@ const Dashboard = () => {
 
             <AssetSummary
               title="CATA Rewards"
-              value={
-                pendingRewards !== "0"
-                  ? `${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA (+${parseFloat(pendingRewards).toLocaleString("en-US", { maximumFractionDigits: 2 })} pending)`
-                  : `${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA`
-              }
+              value={`${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA `}
               icon={<Coins className="text-white" size={18} />}
               color="bg-purple-500"
+            />
+
+
+            <AssetSummary
+              title="Pending CATA"
+              value={`${parseFloat(pendingRewards).toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA `}
+              icon={<Banknote className="text-white" size={18} />}
+              color="bg-green-500"
             />
 
             <AssetSummary
@@ -152,10 +156,10 @@ const Dashboard = () => {
           {isDataInitialized && (
             <>
               <div className="mb-8">
-                <AssetsList 
-                  loading={loading} 
-                  tokens={tokens} 
-                  inActiveTokens={inactiveTokens} 
+                <AssetsList
+                  loading={loading}
+                  tokens={tokens}
+                  inActiveTokens={inactiveTokens}
                   shouldPreventFlash={true}
                 />
               </div>
@@ -190,4 +194,3 @@ const Dashboard = () => {
 };
 
 export default Dashboard;
-


### PR DESCRIPTION
Fixes #5111
Fixes https://github.com/blockapps/strato-platform/issues/4797

# Changes
  - New API endpoints (mercata/backend/src/api/controllers/rewardsChef.controller.ts:143):
    - GET /rewards/pending - Calculate pending rewards for a user in a specific pool
    - GET /rewards/pending/total - Calculate total pending CATA across all pools
    - GET /rewards/pools - Retrieve all RewardsChef pools
  - Enhanced RewardsChef service to calculate pending rewards based on pool allocations, user stakes, and time elapsed
  - New React hook usePendingRewards (mercata/ui/src/hooks/usePendingRewards.ts:64) - Auto-refreshes every 10 seconds to fetch updated pending rewards
  - Dashboard UI updates (mercata/ui/src/pages/Dashboard.tsx):
    - Added new "Pending CATA" summary card (expanded from 3-column to 4-column grid)
    - Dynamic color coding: green when rewards are pending, gray when zero
    - Uses Banknote icon for visual distinction
  
# Preview

## 0 CATA (tooltip info)

<img width="1681" height="205" alt="Screenshot 2025-10-10 at 15 49 06" src="https://github.com/user-attachments/assets/8397fcb9-66d6-4983-8bb5-28e3e8faaa9f" />


## No Pending Rewards

<img width="1672" height="203" alt="Screenshot 2025-10-10 at 15 23 24" src="https://github.com/user-attachments/assets/26fbe627-afb3-432e-9cdd-0c5bedcec41b" />

## Pending Rewards

<img width="1642" height="176" alt="Screenshot 2025-10-10 at 15 16 52" src="https://github.com/user-attachments/assets/bc081464-30cb-4a91-ab4a-1356d88d34cc" />
