### PR TITLE
Parse hex strings as AccountLiterals, and allow runtime conversion from address to string

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Statement.hs
@@ -511,7 +511,11 @@ literal =
       do
         ~(a, (n, u)) <- withPosition $ (,) <$> integer <*> optionMaybe numberUnit
         pure $ NumberLiteral a n u,
-      uncurry StringLiteral <$> withPosition stringLiteral,
+      do
+        (a, str) <- withPosition stringLiteral
+        pure $ case readMaybe str of
+          Just addr -> AccountLiteral a (NamedAccount addr UnspecifiedChain)
+          _ -> StringLiteral a str,
       uncurry AccountLiteral <$> withPosition accountLiteral,
       uncurry BoolLiteral <$> withPosition (False <$ reserved "false"),
       uncurry BoolLiteral <$> withPosition (True <$ reserved "true"),

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -3393,6 +3393,8 @@ validateFunctionArguments func argVals = checkFunc $ func : CC._funcOverload fun
         (SBool b, SVMType.Bool) -> pure . Just $ SBool b
         (SAccount a _, SVMType.Address b) -> pure . Just $ SAccount a b
         (SAccount a _, SVMType.Account b) -> pure . Just $ SAccount a b
+        (SAccount (NamedAccount a _) _, SVMType.String _) -> pure . Just . SString $ show a
+        (SAccount (NamedAccount a _) _, SVMType.Int _ _) -> pure . Just . SInteger . fromIntegral $ unAddress a
         (SEnumVal r x y, SVMType.UnknownLabel u _) -> pure . bool Nothing (Just $ SEnumVal r x y) $ r == u
         (SStruct r x, SVMType.UnknownLabel u _) -> pure . bool Nothing (Just $ SStruct r x) $ r == u
         (SContract r x, SVMType.UnknownLabel u _) -> pure . bool Nothing (Just $ SContract r x) $ r == u


### PR DESCRIPTION
Should fix admin voting issues