### PR TITLE
Allow fastForward behavior to persist beyond beforeAll, beforeEach, and tests

### DIFF
--- a/mercata/contracts/tests/fastForward.test.sol
+++ b/mercata/contracts/tests/fastForward.test.sol
@@ -5,7 +5,7 @@ import "../concrete/BaseCodeCollection.sol";
 
 /// @title Test to verify fastForward behavior in beforeEach
 /// @notice This test demonstrates a bug where fastForward in beforeEach doesn't persist to test execution
-contract Describe_BeforeEach_FastForward_Bug {
+contract Describe_FastForward {
 
     constructor() {
     }
@@ -31,5 +31,15 @@ contract Describe_BeforeEach_FastForward_Bug {
 
         // Now block.timestamp should be 30
         require(block.timestamp == 30, "block.timestamp should be 30 after fastForward(10) in test. Got: " + string(block.timestamp));
+    }
+
+    function it_can_call_fastForward() {
+      log("Testing fastForward function");
+      uint256 before = block.timestamp;
+      fastForward(100);
+      uint256 after = block.timestamp;
+      log("Before timestamp", before);
+      log("After timestamp", after);
+      require(after == before + 100, "FastForward did not work");
     }
 }

--- a/mercata/contracts/tests/fastForward.test.sol
+++ b/mercata/contracts/tests/fastForward.test.sol
@@ -1,22 +1,35 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-contract Describe_FastForward {
+import "../concrete/BaseCodeCollection.sol";
 
-  function beforeAll() {
-  }
+/// @title Test to verify fastForward behavior in beforeEach
+/// @notice This test demonstrates a bug where fastForward in beforeEach doesn't persist to test execution
+contract Describe_BeforeEach_FastForward_Bug {
 
-  function beforeEach() {
-  }
+    constructor() {
+    }
 
-  function it_can_call_fastForward() {
-    log("Testing fastForward function");
-    uint256 before = block.timestamp;
-    fastForward(100);
-    uint256 after = block.timestamp;
-    log("Before timestamp", before);
-    log("After timestamp", after);
-    require(after == before + 100, "FastForward did not work");
-  }
+    function beforeEach() public {
+        // Fast forward time by 10 seconds
+        fastForward(10);
+    }
 
+    /// @notice This test will FAIL if fastForward in beforeEach doesn't work
+    /// @dev Expected: block.timestamp should be 10 after fastForward(10) in beforeEach
+    ///      Actual (if bug exists): block.timestamp will be 0
+    function it_should_have_block_timestamp_of_10_after_beforeEach() public {
+        // If fastForward in beforeEach worked, block.timestamp should be 10
+        require(block.timestamp == 10, "block.timestamp should be 10 after fastForward(10) in beforeEach. Got: " + string(block.timestamp));
+    }
+
+    /// @notice This test will PASS because fastForward is called within the test
+    /// @dev This proves that fastForward works when called inside the test function
+    function it_should_have_block_timestamp_of_30_when_called_in_test() public {
+        // Fast forward in the test itself
+        fastForward(10);
+
+        // Now block.timestamp should be 30
+        require(block.timestamp == 30, "block.timestamp should be 30 after fastForward(10) in test. Got: " + string(block.timestamp));
+    }
 }

--- a/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
@@ -17,9 +17,8 @@ module SolidVM.Solidity.Fuzzer
 where
 
 import BlockApps.Logging
-import Blockchain.Data.BlockHeader
 import Blockchain.MemVMContext
-import Blockchain.SolidVM.Simple
+import Blockchain.SolidVM.Simple hiding (runningTests)
 import Blockchain.Strato.Model.Address
 import Blockchain.VMContext (VMBase, runningTests)
 import Control.Lens
@@ -96,7 +95,8 @@ runFuzzerWithHook dSettings compile src hook = compile src >>= \case
   Left errs -> pure $ FuzzerFailure Nothing . fmap ("Compilation error: ",) <$> errs
   Right cc -> do
     let args = FuzzerArgs src "" [] "" [] Nothing
-    runNoLoggingT . evalMemContextM dSettings . flip runReaderT args $ do
+    ctx <- FuzzerContext args <$> newIORef (error "_fuzzerContextBlockHeader not initialized")
+    runNoLoggingT . evalMemContextM dSettings . flip runReaderT ctx $ do
       lift . modify' $ runningTests .~ True
       let contractsInSourceOrder =
             sortBy (comparing (\(_, c') -> c' ^. contractContext . sourceAnnotationStart)) (M.toList $ _contracts cc)
@@ -105,8 +105,8 @@ runFuzzerWithHook dSettings compile src hook = compile src >>= \case
           then pure []
           else case _funcArgs <$> _constructor c of
             Just (_ : _) -> pure . fmap (\f -> FuzzerFailure Nothing $ ("Contract constructor", "Expected constructor to have zero arguments") <$ _funcContext f) . maybeToList $ _constructor c
-            _ -> fuzzContract cName (_contractContext c) $ \bh addr -> do
-              beforeAllRes <- for (M.lookup "beforeAll" $ _functions c) $ test bh addr "beforeAll"
+            _ -> fuzzContract cName (_contractContext c) $ \addr -> do
+              beforeAllRes <- for (M.lookup "beforeAll" $ _functions c) $ test addr "beforeAll"
               case beforeAllRes of
                 Just ff@FuzzerFailure{} -> do
                   let res = withTestName "beforeAll" ff
@@ -118,19 +118,19 @@ runFuzzerWithHook dSettings compile src hook = compile src >>= \case
                     mResult <- fmap (fmap (withTestName $ T.pack fName)) $
                       if
                         | testPrefix `T.isPrefixOf` labelToText fName -> do
-                            _ <- for (M.lookup "beforeEach" $ _functions c) $ test bh addr "beforeEach"
-                            result <- Just <$> test bh addr fName f
-                            _ <- for (M.lookup "afterEach" $ _functions c) $ test bh addr "afterEach"
+                            _ <- for (M.lookup "beforeEach" $ _functions c) $ test addr "beforeEach"
+                            result <- Just <$> test addr fName f
+                            _ <- for (M.lookup "afterEach" $ _functions c) $ test addr "afterEach"
                             pure result
                         | propertyPrefix `T.isPrefixOf` labelToText fName -> do
-                            _ <- for (M.lookup "beforeEach" $ _functions c) $ test bh addr "beforeEach"
-                            result <- Just <$> prop bh addr fName f
-                            _ <- for (M.lookup "afterEach" $ _functions c) $ test bh addr "afterEach"
+                            _ <- for (M.lookup "beforeEach" $ _functions c) $ test addr "beforeEach"
+                            result <- Just <$> prop addr fName f
+                            _ <- for (M.lookup "afterEach" $ _functions c) $ test addr "afterEach"
                             pure result
                         | otherwise -> pure Nothing
                     maybe (i, ran) (\r -> (i+1, r:ran)) <$> traverse (lift . lift . lift . hook i) mResult
                     ) (1, []) functionsInSourceOrder
-                  _ <- for (M.lookup "afterAll" $ _functions c) $ test bh addr "afterAll"
+                  _ <- for (M.lookup "afterAll" $ _functions c) $ test addr "afterAll"
                   pure testResults
 
 accessible :: Maybe Visibility -> Bool
@@ -144,12 +144,12 @@ emptyOrBool []                                = True
 emptyOrBool [(_, IndexedType _ SVMType.Bool)] = True
 emptyOrBool _                                 = False
 
-test :: VMBase m => BlockHeader -> Address -> SolidString -> Func -> FuzzerM m FuzzerResult
-test bh addr fName f =
+test :: VMBase m => Address -> SolidString -> Func -> FuzzerM m FuzzerResult
+test addr fName f =
   if accessible $ _funcVisibility f
     then if null $ _funcArgs f
            then if emptyOrBool $ _funcVals f
-                  then fuzzFunction bh addr (_funcContext f) fName []
+                  then fuzzFunction addr (_funcContext f) fName []
                   else pure . FuzzerFailure Nothing $ ("Test must return () or (bool).") <$ _funcContext f
            else pure . FuzzerFailure Nothing $ ("Expected unit test to have zero arguments. To write a property test, prefix the function name with " <> propertyPrefix <> ".") <$ _funcContext f
     else pure . FuzzerFailure Nothing $ "Test must be a public or external function" <$ _funcContext f
@@ -184,8 +184,8 @@ generateArgs = traverse generateArg
     generateArg (SVMType.Error _ _) = pure "<error>" -- haha xd
     generateArg (SVMType.Variadic) = pure "<variadic>"
 
-prop :: VMBase m => BlockHeader -> Address -> SolidString -> Func -> FuzzerM m FuzzerResult
-prop bh addr fName f =
+prop :: VMBase m => Address -> SolidString -> Func -> FuzzerM m FuzzerResult
+prop addr fName f =
   if accessible $ _funcVisibility f
     then if null $ _funcArgs f
            then pure . FuzzerFailure Nothing $ ("Expected property test to have at least one argument. To write a unit test, prefix the function name with " <> testPrefix <> ".") <$ _funcContext f
@@ -196,21 +196,21 @@ prop bh addr fName f =
   where
     runProp :: VMBase m => FuzzerM m FuzzerResult
     runProp = do
-      n <- asks $ fromMaybe defaultFuzzerRuns . view fuzzerArgsMaxRuns
+      n <- asks $ fromMaybe defaultFuzzerRuns . view (fuzzerContextArgs . fuzzerArgsMaxRuns)
       runPropNTimes n
     runPropNTimes :: VMBase m => Integer -> FuzzerM m FuzzerResult
     runPropNTimes n | n <= 0 = success $ _funcContext f
     runPropNTimes n = do
       args <- liftIO . generateArgs $ indexedTypeType . snd <$> _funcArgs f
       $logInfoS "runPropNTimes/generateArgs" $ "(" <> T.intercalate ", " args <> ")"
-      r <- fuzzFunction bh addr (_funcContext f) fName args
+      r <- fuzzFunction addr (_funcContext f) fName args
       case r of
         FuzzerSuccess _ -> runPropNTimes $ n - 1
         _ -> pure r
 
-fuzzContract :: VMBase m => SolidString -> SourceAnnotation a -> (BlockHeader -> Address -> FuzzerM m [FuzzerTestAndResult]) -> FuzzerM m [FuzzerTestAndResult]
-fuzzContract cName ctx f = local ((fuzzerArgsContractName .~ cName) . (fuzzerArgsCreateArgs .~ [])) $ do
-  ~FuzzerArgs {..} <- ask
+fuzzContract :: VMBase m => SolidString -> SourceAnnotation a -> (Address -> FuzzerM m [FuzzerTestAndResult]) -> FuzzerM m [FuzzerTestAndResult]
+fuzzContract cName ctx f = local ((fuzzerContextArgs . fuzzerArgsContractName .~ cName) . (fuzzerContextArgs . fuzzerArgsCreateArgs .~ [])) $ do
+  FuzzerContext FuzzerArgs{..} bhRef <- ask
   contractAddress <- liftIO $ generate arbitrary
   let svmErr (Left e) = e
       svmErr (Right e) = InternalError "SolidVM for non-solidvm code" (show e)
@@ -222,21 +222,25 @@ fuzzContract cName ctx f = local ((fuzzerArgsContractName .~ cName) . (fuzzerArg
           & createArgs . argsMetadata ?~ M.empty
       failure txs e = pure [FuzzerFailure (Just $ FuzzerFailureDetails contractAddress _fuzzerArgsContractName _fuzzerArgsCreateArgs txs) $ (labelToText cName <> " constructor", e) <$ ctx]
       exception txs = failure txs . T.pack . show
-  createResults <- lift $ create txArgs
+  (env, createResults) <- lift $ createReturnEnv txArgs
   case erException createResults of
     Just e -> exception [] $ svmErr e
-    Nothing -> f (txArgs ^. createArgs . argsBlockData) contractAddress
+    Nothing -> do
+      writeIORef bhRef $ blockHeader env
+      f contractAddress
 
-fuzzFunction :: VMBase m => BlockHeader -> Address -> SourceAnnotation a -> SolidString -> [T.Text] -> FuzzerM m FuzzerResult
-fuzzFunction bh contractAddress ctx fName args = local ((fuzzerArgsFuncName .~ fName) . (fuzzerArgsCallArgs .~ args)) $ do
-  ~FuzzerArgs {..} <- ask
+fuzzFunction :: VMBase m => Address -> SourceAnnotation a -> SolidString -> [T.Text] -> FuzzerM m FuzzerResult
+fuzzFunction contractAddress ctx fName args = local ((fuzzerContextArgs . fuzzerArgsFuncName .~ fName) . (fuzzerContextArgs . fuzzerArgsCallArgs .~ args)) $ do
+  FuzzerContext FuzzerArgs{..} bhRef <- ask
+  bh <- liftIO $ readIORef bhRef
   let txArgs' =
         def & callArgs . argsBlockData .~ bh
           & callCodeAddress .~ contractAddress
           & callFuncName .~ labelToText _fuzzerArgsFuncName
           & callArgs . argsArgs .~ _fuzzerArgsCallArgs
           & callArgs . argsMetadata ?~ M.empty
-  callResults <- lift $ call txArgs'
+  (env, callResults) <- lift $ callReturnEnv txArgs'
+  liftIO . writeIORef bhRef $ blockHeader env
   let failure txs e = pure . FuzzerFailure (Just $ FuzzerFailureDetails contractAddress _fuzzerArgsContractName _fuzzerArgsCreateArgs txs) $ e <$ ctx
       exception txs = failure txs . T.pack . show
       failure' = failure [FuzzerTx _fuzzerArgsFuncName _fuzzerArgsCallArgs]

--- a/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer/Types.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer/Types.hs
@@ -5,6 +5,7 @@
 
 module SolidVM.Solidity.Fuzzer.Types where
 
+import Blockchain.Data.BlockHeader
 import Blockchain.Strato.Model.Address
 import Control.Lens
 import Control.Monad.Trans.Reader
@@ -13,6 +14,7 @@ import Data.Source
 import Data.Text (Text)
 import GHC.Generics
 import SolidVM.Model.SolidString
+import UnliftIO
 
 data FuzzerArgs = FuzzerArgs
   { _fuzzerArgsSrc :: SourceMap,
@@ -26,7 +28,14 @@ data FuzzerArgs = FuzzerArgs
 
 makeLenses ''FuzzerArgs
 
-type FuzzerM m = ReaderT FuzzerArgs m
+data FuzzerContext = FuzzerContext
+  { _fuzzerContextArgs :: FuzzerArgs
+  , _fuzzerContextBlockHeader :: IORef BlockHeader
+  }
+
+makeLenses ''FuzzerContext
+
+type FuzzerM m = ReaderT FuzzerContext m
 
 data FuzzerTx = FuzzerTx
   { _fuzzerTxFuncName :: SolidString,

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -22,6 +22,8 @@ module Blockchain.SolidVM
   ( SolidVMBase,
     call,
     create,
+    callReturnEnv,
+    createReturnEnv,
   )
 where
 
@@ -194,6 +196,22 @@ create ::
 --create isRunningTests' isHomestead preExistingSuicideList b callDepth sender origin
 --       value gasPrice availableGas newAddress initCode txHash chainId metadata =
 create blockData sender' origin' proposer' availableGas newAddress code txHash' contractName argsStrings = do
+  snd <$> createReturnEnv blockData sender' origin' proposer' availableGas newAddress code txHash' contractName argsStrings
+
+createReturnEnv ::
+  SolidVMBase m =>
+  BlockHeader ->
+  Address ->
+  Address ->
+  Address ->
+  Gas ->
+  Address ->
+  Code ->
+  Keccak256 ->
+  Text ->
+  [Text] ->
+  m (Env.Environment, ExecResults)
+createReturnEnv blockData sender' origin' proposer' availableGas newAddress code txHash' contractName argsStrings = do
   isRunningTests <- checkIfRunningTests
 
   initCode <- case code of
@@ -221,7 +239,7 @@ create blockData sender' origin' proposer' availableGas newAddress code txHash' 
             _gasMetadata = ""
           }
 
-  fmap (either solidvmErrorResults id) . runSM (Just code) env' gasInfo' $ do
+  fmap (fmap $ either solidvmErrorResults id) . runSM (Just code) env' gasInfo' $ do
 
     (hsh, cc) <- codeCollectionFromSource isRunningTests True $ DT.encodeUtf8 initCode
     (issuerAcct, _, issuerName) <- getCreator origin'
@@ -357,6 +375,22 @@ call ::
 --  call isRunningTests' isHomestead noValueTransfer preExistingSuicideList b callDepth receiveAddress
 --       (Address codeAddress) sender value gasPrice theData availableGas origin txHash chainId metadata =
 call blockData codeAddress sender' proposer' availableGas origin' txHash' funcName argsStrings mFuncCallType = do
+  snd <$> callReturnEnv blockData codeAddress sender' proposer' availableGas origin' txHash' funcName argsStrings mFuncCallType
+
+callReturnEnv ::
+  SolidVMBase m =>
+  BlockHeader ->
+  Address ->
+  Address ->
+  Address ->
+  Gas ->
+  Address ->
+  Keccak256 ->
+  Text ->
+  [Text] ->
+  Maybe CC.FunctionCallType ->
+  m (Env.Environment, ExecResults)
+callReturnEnv blockData codeAddress sender' proposer' availableGas origin' txHash' funcName argsStrings mFuncCallType = do
   recordCall
   isRunningTests <- checkIfRunningTests
   let env' =
@@ -379,7 +413,7 @@ call blockData codeAddress sender' proposer' availableGas origin' txHash' funcNa
             _gasMetadata = ""
           }
 
-  fmap (either solidvmErrorResults id) . runSM Nothing env' gasInfo' $ do
+  fmap (fmap $ either solidvmErrorResults id) . runSM Nothing env' gasInfo' $ do
     --requireOriginCert origin'
     let -- maybeSrcLength = M.lookup "srcLength" =<< metadata
         -- !srcLength = maybe 0 (\sl -> read (T.unpack sl) :: Int) maybeSrcLength

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -478,22 +478,23 @@ runSM ::
   Env.Environment ->
   GasInfo ->
   SM m a ->
-  m (Either SolidException a)
-runSM maybeCode env gi f = do
+  m (Env.Environment, Either SolidException a)
+runSM maybeCode envBefore gi f = do
   csMemDBs <- _memDBs <$> Mod.get (Mod.Proxy @ContextState)
   GasCap gasCap <- Mod.get (Mod.Proxy @GasCap)
   $logInfoS "runSM/GasCap/status" . T.pack $ "Current gas cap: " ++ CL.green (show gasCap)
   let !startingState =
         SState
-          { env = env,
+          { env = envBefore,
             callStack = [],
             _ssMemDBs = csMemDBs,
-            _action = startingAction maybeCode env,
+            _action = startingAction maybeCode envBefore,
             _gasInfo = gi {_gasLeft = min (_gasLeft gi) gasCap} -- capping the transaction gas limit
           }
   startingStateRef <- newIORef startingState
   eVal <- try $ runReaderT f startingStateRef
   sstateAfter <- readIORef startingStateRef
+  let envAfter = env sstateAfter
   case eVal of
     -- NO errors will crash the VM.
     -- InternalError should *never* happen.
@@ -506,10 +507,10 @@ runSM maybeCode env gi f = do
         then do
           $logErrorLS "runSM/error_code" maybeCode
           throwIO se
-        else return $ Left se
+        else return (envAfter, Left se)
     Right value -> do
       Mod.modifyStatefully_ (Mod.Proxy @ContextState) $ memDBs .= _ssMemDBs sstateAfter
-      return $ Right value
+      return (envAfter, Right value)
 
 -- When calling a remote contract, the new `msg.sender` is the contract
 -- that the call is initiated from.

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/Simple.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/Simple.hs
@@ -28,7 +28,10 @@ module Blockchain.SolidVM.Simple
     _SolidVMCreate,
     _SolidVMCall,
     create,
+    createReturnEnv,
     call,
+    callReturnEnv,
+    Env.Environment(..),
     module Blockchain.Strato.Model.Code,
     module Blockchain.Data.DataDefs,
     module Blockchain.Data.ExecResults,
@@ -46,6 +49,7 @@ import Blockchain.Data.DataDefs
 import Blockchain.Data.ExecResults
 import qualified Blockchain.Database.MerklePatricia as MP
 import qualified Blockchain.SolidVM as SolidVM
+import qualified Blockchain.SolidVM.Environment as Env
 import Blockchain.Strato.Model.Account
 import Blockchain.Strato.Model.Address
 import Blockchain.Strato.Model.ChainMember
@@ -164,12 +168,46 @@ create s =
     (s ^. createContractName)
     (s ^. createArgs . argsArgs)
 
+createReturnEnv ::
+  (SolidVM.SolidVMBase m) =>
+  SolidVMCreateArgs ->
+  m (Env.Environment, ExecResults)
+createReturnEnv s =
+  SolidVM.createReturnEnv
+    (s ^. createArgs . argsBlockData)
+    (s ^. createArgs . argsSender)
+    (s ^. createArgs . argsOrigin)
+    (s ^. createArgs . argsProposer)
+    (Gas 100000000)
+    (s ^. createNewAddress)
+    (s ^. createCode)
+    (s ^. createArgs . argsTxHash)
+    (s ^. createContractName)
+    (s ^. createArgs . argsArgs)
+
 call ::
   (SolidVM.SolidVMBase m) =>
   SolidVMCallArgs ->
   m ExecResults
 call s =
   SolidVM.call
+    (s ^. callArgs . argsBlockData)
+    (s ^. callCodeAddress)
+    (s ^. callArgs . argsSender)
+    (s ^. callArgs . argsProposer)
+    (Gas 100000000)
+    (s ^. callArgs . argsOrigin)
+    (s ^. callArgs . argsTxHash)
+    (s ^. callFuncName)
+    (s ^. callArgs . argsArgs)
+    Nothing
+
+callReturnEnv ::
+  (SolidVM.SolidVMBase m) =>
+  SolidVMCallArgs ->
+  m (Env.Environment, ExecResults)
+callReturnEnv s =
+  SolidVM.callReturnEnv
     (s ^. callArgs . argsBlockData)
     (s ^. callCodeAddress)
     (s ^. callArgs . argsSender)


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/5139

```sh
dustinnorwood@Mac strato % solid-vm-cli test mercata/contracts/tests/fastForward.test.sol
✅ 1. Unit test 'should have block timestamp of 10 after beforeEach' succeeded
✅ 2. Unit test 'should have block timestamp of 30 when called in test' succeeded
Testing fastForward function
Before timestamp
40
After timestamp
140
✅ 3. Unit test 'can call fastForward' succeeded
```