### PR TITLE
Addressed Hacken's AdminRegistry recommendations

### DIFF
--- a/mercata/contracts/abstract/ERC20/access/Authorizable.sol
+++ b/mercata/contracts/abstract/ERC20/access/Authorizable.sol
@@ -1,0 +1,32 @@
+abstract contract Authorizable {
+    mapping (address => mapping (address => uint)) public record authorizations;
+
+    bool internal bypassAuthorizations = false;
+
+    /**
+     * @dev The caller account is not authorized to perform an operation.
+     */
+    error AuthorizableUnauthorizedAccount(address account);
+
+    event AccountAuthorized(address indexed account);
+
+    event AuthorizationUsed(address indexed account, uint authorizationsRemaining);
+
+    function _authorize(address _target, address _account, uint _authorizations) internal {
+        authorizations[_target][_account] += _authorizations;
+    }
+
+    function isAuthorized(address _account) external returns (bool) {
+        if (bypassAuthorizations) {
+            return true;
+        } else {
+            uint numAuthorizations = authorizations[msg.sender][_account];
+            if (numAuthorizations > 0) {
+                authorizations[msg.sender][_account]--;
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+}

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -1,6 +1,6 @@
-contract record AdminRegistry {
-    mapping (string => address) public record delegates;
+import "../../abstract/ERC20/access/Authorizable.sol";
 
+contract record AdminRegistry {
     address[] public record admins;
     mapping (address => uint) public record adminMap;
 
@@ -11,9 +11,9 @@ contract record AdminRegistry {
 
     mapping (address => mapping (string => uint)) public record votingThresholds;
 
-    event IssueCreated(address creator, string issueId, address target, string func, variadic args);
-    event IssueVoted(address voter, string issueId, address target, string func, variadic args);
-    event IssueExecuted(address executor, string issueId, address target, string func, variadic args);
+    event IssueCreated(address sender, address creator, string issueId, address target, string func, variadic args);
+    event IssueVoted(address sender, address voter, string issueId, address target, string func, variadic args);
+    event IssueExecuted(address sender, address executor, string issueId, address target, string func, variadic args);
 
     bool public initialized = false;
 
@@ -41,8 +41,8 @@ contract record AdminRegistry {
         castVoteOnIssue(this, "_removeAdmin", _admin);
     }
 
-    function swapAdmin(address _admin) external {
-        castVoteOnIssue(this, "_swapAdmin", _admin);
+    function swapAdmin(address _adminToReplace, address _newAdmin) external {
+        castVoteOnIssue(this, "_swapAdmin", _adminToReplace, _newAdmin);
     }
 
     function isAdminAddress(address _admin) external returns (bool) {
@@ -53,6 +53,15 @@ contract record AdminRegistry {
         if (adminMap[msg.sender] != 0 || adminMap[_target] != 0) {
             address sender = msg.sender;
             if (adminMap[msg.sender] == 0) {
+                if (_target != tx.origin) {
+                    bool authorizationGranted = false;
+                    try {
+                        authorizationGranted = Authorizable(_target).isAuthorized(msg.sender);
+                    } catch {
+
+                    }
+                    require(authorizationGranted, "Cannot forge a vote on behalf of an admin without their consent");
+                }
                 sender = _target;
                 _target = msg.sender;
             }
@@ -60,25 +69,25 @@ contract record AdminRegistry {
             require(votesMap[issueId][sender] == 0, "Cannot cast multiple votes for the same issue");
 
             try {
-                _createIssue(issueId, _target, _func, _args);
+                _createIssue(sender, issueId, _target, _func, _args);
             } catch {
 
             }
 
             if (_shouldExecute(issueId, _target, _func, _args)) {
-                variadic ret = _executeIssue(issueId, _target, _func, _args);
+                variadic ret = _executeIssue(sender, issueId, _target, _func, _args);
                 return (true, ret);
             } else {
                 votes[issueId].push(sender);
                 votesMap[issueId][sender] = votes[issueId].length;
-                emit IssueVoted(sender, issueId, _target, _func, _args);
+                emit IssueVoted(msg.sender, sender, issueId, _target, _func, _args);
                 return (false, issueId);
             }
         } else {
             try {
                 if ( _target == this && (_func == "addWhitelist" || _func == "removeWhitelist") && address(_args[0]) == msg.sender) {
                     string issueId = _getIssueId(_target, _func, _args);
-                    variadic ret = _executeIssue(issueId, _target, _func, _args);
+                    variadic ret = _executeIssue(msg.sender, issueId, _target, _func, _args);
                     return (true, ret);
                 }
             } catch {
@@ -93,33 +102,28 @@ contract record AdminRegistry {
             }
             string issueId = _getIssueId(target, _func, _args);
             if (whitelist[target][_func][sender]) {
-                variadic ret = _executeIssue(issueId, target, _func, _args);
+                variadic ret = _executeIssue(sender, issueId, target, _func, _args);
                 return (true, ret);
             } else {
-                _createIssue(issueId, target, _func, _args);
+                _createIssue(sender, issueId, target, _func, _args);
             }
             return (false, issueId);
         }
     }
 
     function _shouldExecute(string _issueId, address _target, string _func, variadic _args) internal returns (bool) {
-        address delegate = delegates["_shouldExecute"];
-        if (delegate != address(0)) {
-            return delegate.delegatecall("_shouldExecute", _issueId, _target, _func, _args);
+        uint issueVotes = votes[_issueId].length;
+        uint votingThresholdBps = votingThresholds[_target][_func];
+        if (votingThresholdBps > 0) {
+            return 10000 * (issueVotes + 1) >= votingThresholdBps * admins.length;
         } else {
-            uint issueVotes = votes[_issueId].length;
-            uint votingThresholdBps = votingThresholds[_target][_func];
-            if (votingThresholdBps > 0) {
-                return 10000 * (issueVotes + 1) >= votingThresholdBps * admins.length;
-            } else {
-                return 3 * (issueVotes + 1) >= 2 * admins.length;
-            }
+            return 3 * (issueVotes + 1) >= 2 * admins.length;
         }
     }
 
-    function _createIssue(string _issueId, address _target, string _func, variadic _args) internal {
+    function _createIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal {
         require(votes[_issueId].length == 0, "Issue already exists");
-        emit IssueCreated(msg.sender, _issueId, _target, _func, _args);
+        emit IssueCreated(msg.sender, _sender, _issueId, _target, _func, _args);
     }
 
     function getIssueId(address _target, string _func, variadic _args) external returns (string) {
@@ -127,32 +131,17 @@ contract record AdminRegistry {
     }
 
     function _getIssueId(address _target, string _func, variadic _args) internal returns (string) {
-        address delegate = delegates["_getIssueId"];
-        if (delegate != address(0)) {
-            return delegate.delegatecall("_getIssueId", _target, _func, _args);
-        } else {
-            return keccak256(_target, _func, _args);
-        }
+        return keccak256(_target, _func, _args);
     }
 
-    function _executeIssue(string _issueId, address _target, string _func, variadic _args) internal returns (variadic) {
-        address delegate = delegates["_executeIssue"];
-        if (delegate != address(0)) {
-            return delegate.delegatecall("_executeIssue", _issueId, _target, _func, _args);
-        } else {
-            variadic ret = "";
-            if (_target == this && delegates[_func] != address(0)) {
-                ret = delegates[_func].delegatecall(_func, _args);
-            } else {
-                ret = _target.call(_func, _args);
-            }
-            for (uint i = 0; i < votes[_issueId].length; i++) {
-                votesMap[_issueId][votes[_issueId][i]] = 0;
-            }
-            delete votes[_issueId];
-            emit IssueExecuted(msg.sender, _issueId, _target, _func, _args);
-            return ret;
+    function _executeIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal returns (variadic) {
+        variadic ret = _target.call(_func, _args);
+        for (uint i = 0; i < votes[_issueId].length; i++) {
+            votesMap[_issueId][votes[_issueId][i]] = 0;
         }
+        delete votes[_issueId];
+        emit IssueExecuted(msg.sender, _sender, _issueId, _target, _func, _args);
+        return ret;
     }
 
     function _addAdmin(address _admin) internal {
@@ -171,18 +160,31 @@ contract record AdminRegistry {
         admins.length -= 1;
     }
 
-    function _swapAdmin(address _admin) internal {
+    function _swapAdmin(address _adminToReplace, address _admin) internal {
         uint index = adminMap[_admin];
         require(index == 0, "Account is already an admin");
-        index = adminMap[msg.sender];
+        index = adminMap[_adminToReplace];
         require(index > 0, "Caller is not an admin");
         address swap = admins[admins.length - 1];
         admins[index - 1] = _admin;
         adminMap[_admin] = index;
-        adminMap[msg.sender] = 0;
+        adminMap[_adminToReplace] = 0;
     }
 
     function addWhitelist(address _target, string _func, address _user) internal {
+        if (_target == address(this)) {
+            require(
+                keccak256(_func) != keccak256("addWhitelist") &&
+                keccak256(_func) != keccak256("removeWhitelist") &&
+                keccak256(_func) != keccak256("_addAdmin") &&
+                keccak256(_func) != keccak256("_removeAdmin") &&
+                keccak256(_func) != keccak256("_swapAdmin") &&
+                keccak256(_func) != keccak256("setVotingThreshold") &&
+                keccak256(_func) != keccak256("createContract") &&
+                keccak256(_func) != keccak256("createSaltedContract"),
+                "Cannot whitelist internal governance functions"
+            );
+        }
         whitelist[_target][_func][_user] = true;
     }
 
@@ -191,6 +193,7 @@ contract record AdminRegistry {
     }
 
     function setVotingThreshold(address _target, string _func, uint _votingThresholdBps) internal {
+        require(_votingThresholdBps <= 10000, "Voting threshold must be less than 100%");
         votingThresholds[_target][_func] = _votingThresholdBps;
     }
 
@@ -200,9 +203,5 @@ contract record AdminRegistry {
 
     function createSaltedContract(string _salt, string _contractName, string _contractSrc, variadic _args) internal returns (address) {
         return create2(_salt, _contractName, _contractSrc, _args);
-    }
-
-    function updateDelegate(string _func, address _delegate) internal {
-        delegates[_func] = _delegate;
     }
 }

--- a/mercata/contracts/concrete/BaseCodeCollection.sol
+++ b/mercata/contracts/concrete/BaseCodeCollection.sol
@@ -1,4 +1,5 @@
 //ERC20
+import "../abstract/ERC20/access/Authorizable.sol";
 import "../abstract/ERC20/ERC20.sol";
 //import "ERC20/extensions/ERC20Burnable.sol";
 
@@ -43,7 +44,7 @@ import "CDP/CDPReserve.sol";
 import "Proxy/Proxy.sol";
 
 //TODO
-contract record Mercata {
+contract record Mercata is Authorizable {
     RateStrategy public rateStrategy;
     PriceOracle public priceOracle;
     CollateralVault public collateralVault;
@@ -133,6 +134,7 @@ contract record Mercata {
         adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(lendingRegistry), "setRateStrategy", address(poolConfigurator));
         adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(lendingRegistry), "setPriceOracle", address(poolConfigurator));
         adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(lendingRegistry), "setAllComponents", address(poolConfigurator));
+        authorizations[address(adminRegistry)][address(poolConfigurator)] = 1;
         poolConfigurator.initializeProtocol(address(lendingPool),address(liquidityPool),address(collateralVault),address(rateStrategy),address(priceOracle),address(tokenFactory),[],[],[],[],[],[],[],0,0,1000);
 
         // Create Services
@@ -168,6 +170,6 @@ contract record Mercata {
         cdpRegistry.setAllComponents(address(cdpVault), address(cdpEngine), address(priceOracle), address(0x937efa7e3a77e20bbdbd7c0d32b6514f368c1010), address(tokenFactory), address(feeCollector), address(cdpReserve));
         Ownable(cdpRegistry).transferOwnership(address(adminRegistry));
 
-        adminRegistry.castVoteOnIssue(address(adminRegistry), "swapAdmin", msg.sender);
+        adminRegistry.swapAdmin(this, msg.sender);
     }
 }

--- a/mercata/contracts/concrete/Pools/Pool.sol
+++ b/mercata/contracts/concrete/Pools/Pool.sol
@@ -2,7 +2,6 @@
 import "PoolFactory.sol";
 import "../Tokens/Token.sol";
 import "../Tokens/TokenFactory.sol";
-import "../Admin/AdminRegistry.sol";
 import "../Admin/FeeCollector.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
 

--- a/mercata/contracts/concrete/Pools/PoolFactory.sol
+++ b/mercata/contracts/concrete/Pools/PoolFactory.sol
@@ -15,7 +15,6 @@
 
 import "Pool.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
-import "../Admin/AdminRegistry.sol";
 import "../Proxy/Proxy.sol";
 import "../Tokens/TokenFactory.sol";
 import "../Tokens/Token.sol";

--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import "../../concrete/Admin/AdminRegistry.sol";
 import "../../abstract/ERC20/ERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
 
 contract TestERC20 is ERC20, Ownable {
@@ -25,7 +26,7 @@ contract User {
     }
 }
 
-contract Describe_AdminRegistry {
+contract Describe_AdminRegistry is Authorizable {
     AdminRegistry adminRegistry;
     TestERC20 token;
     User user1;
@@ -38,6 +39,7 @@ contract Describe_AdminRegistry {
     address zeroAddress;
 
     function beforeAll() {
+        bypassAuthorizations = true;
         admin1 = address(this);
         admin2 = address(0x2);
         admin3 = address(0x3);

--- a/mercata/contracts/tests/BaseCodeCollection.test.sol
+++ b/mercata/contracts/tests/BaseCodeCollection.test.sol
@@ -1,3 +1,4 @@
+import "../abstract/ERC20/access/Authorizable.sol";
 import "../concrete/BaseCodeCollection.sol";
 import "main.groth16.sol";
 
@@ -8,12 +9,13 @@ contract User {
     }
 }
 
-contract Describe_Mercata {
+contract Describe_Mercata is Authorizable {
     constructor() {
     }
 
     Mercata m;
     function beforeAll() {
+        bypassAuthorizations = true;
         m = new Mercata();
         require(address(m) != address(0), "Mercata address is 0");
     }
@@ -255,7 +257,7 @@ contract Describe_Mercata {
         require(blobOutput == "7hello", "blobOutput was not set correctly");
     }
 
-    function it_can_change_voting_logic() {
+    function xit_can_change_voting_logic() {
         User adminUser = new User();
         User u = new User();
         AdminRegistry admin = new AdminRegistry();

--- a/mercata/contracts/tests/Bridge/MercataBridge.test.sol
+++ b/mercata/contracts/tests/Bridge/MercataBridge.test.sol
@@ -2,6 +2,7 @@ import "../../concrete/Bridge/MercataBridge.sol";
 import "../../concrete/Tokens/TokenFactory.sol";
 import "../../concrete/Tokens/Token.sol";
 import "../../abstract/ERC20/ERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
 import "../../concrete/Admin/AdminRegistry.sol";
 
@@ -47,7 +48,7 @@ contract User {
     }
 }
 
-contract Describe_MercataBridge {
+contract Describe_MercataBridge is Authorizable {
     // Copy structs and enums from MercataBridge.sol for testing
     enum BridgeStatus {
         NONE,         // default (mapping unset)
@@ -117,6 +118,7 @@ contract Describe_MercataBridge {
     string chainName;
 
     function beforeAll() {
+        bypassAuthorizations = true;
         owner = address(this);
         user1 = new User();
         user2 = new User();
@@ -134,7 +136,7 @@ contract Describe_MercataBridge {
         adminRegistry = new AdminRegistry();
         adminRegistry.initialize([owner]);
         tokenFactory = new TokenFactory(address(adminRegistry));
-        bridge = new MercataBridge(owner);
+        bridge = new MercataBridge(address(adminRegistry));
         bridge.initialize(address(tokenFactory), address(this));
         
         // Create test tokens through token factory with AdminRegistry as owner

--- a/mercata/contracts/tests/CDP/CDPBadDebt.test.sol
+++ b/mercata/contracts/tests/CDP/CDPBadDebt.test.sol
@@ -1,5 +1,6 @@
 import "../../concrete/BaseCodeCollection.sol";
 import "../../abstract/ERC20/IERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../concrete/Tokens/Token.sol";
 
 contract User {
@@ -9,7 +10,7 @@ contract User {
     }
 }
 
-contract Describe_BadDebt_Basic {
+contract Describe_BadDebt_Basic is Authorizable {
 
     // CDP struct definitions for accessing record types (must match CDPEngine exactly)
     struct Vault {
@@ -53,6 +54,7 @@ contract Describe_BadDebt_Basic {
     address ETHST;
 
     function beforeAll() public {
+        bypassAuthorizations = true;
         m = new Mercata();
         require(address(m) != address(0), "Mercata address is 0");
     }

--- a/mercata/contracts/tests/CDP/CDPEngine.test.sol
+++ b/mercata/contracts/tests/CDP/CDPEngine.test.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import "../../concrete/BaseCodeCollection.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 
 // Per‑vault state keyed by (user, asset)
 struct Vault {
@@ -15,7 +16,7 @@ contract User {
     }
 }
 
-contract Describe_CDPEngine {
+contract Describe_CDPEngine is Authorizable {
     Mercata m;
     string[] emptyArray;
 
@@ -46,6 +47,7 @@ contract Describe_CDPEngine {
     uint256 UNIT_SCALE = 1e18; // 18 decimals
 
     function beforeAll() {
+        bypassAuthorizations = true;
         m = new Mercata();
         require(address(m) != address(0), "Mercata address is 0");
         emptyArray = new string[](0);

--- a/mercata/contracts/tests/CDP/CDPGeneral.test.sol
+++ b/mercata/contracts/tests/CDP/CDPGeneral.test.sol
@@ -1,5 +1,6 @@
 import "../../concrete/BaseCodeCollection.sol";
 import "../../abstract/ERC20/IERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../concrete/Tokens/Token.sol";
 
 contract User {
@@ -9,7 +10,7 @@ contract User {
     }
 }
 
-contract Describe_CDPGeneral {
+contract Describe_CDPGeneral is Authorizable {
 
     // CDP struct definitions for accessing record types (must match CDPEngine exactly)
     struct Vault {
@@ -53,6 +54,7 @@ contract Describe_CDPGeneral {
     address ETHST;
 
     function beforeAll() public {
+        bypassAuthorizations = true;
         m = new Mercata();
         require(address(m) != address(0), "Mercata address is 0");
     }

--- a/mercata/contracts/tests/Lending/BadDebt.test.sol
+++ b/mercata/contracts/tests/Lending/BadDebt.test.sol
@@ -1,5 +1,6 @@
 import "../../concrete/BaseCodeCollection.sol";
 import "../../abstract/ERC20/IERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../concrete/Tokens/Token.sol";
 
 contract User {
@@ -35,6 +36,7 @@ contract Describe_BadDebt_Basic {
     address SILVST;
 
     function beforeAll() public {
+        bypassAuthorizations = true;
         m = new Mercata();
         require(address(m) != address(0), "Mercata address is 0");
     }

--- a/mercata/contracts/tests/Lending/LendingPool.test.sol
+++ b/mercata/contracts/tests/Lending/LendingPool.test.sol
@@ -1,5 +1,6 @@
 import "../../concrete/BaseCodeCollection.sol";
 import "../../abstract/ERC20/IERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../concrete/Tokens/Token.sol";
 
 contract User {
@@ -9,7 +10,7 @@ contract User {
     }
 }
 
-contract Describe_LendingPool_Basic {
+contract Describe_LendingPool_Basic is Authorizable {
 
     struct LoanInfo {
         uint scaledDebt;     // user debt in index-scaled units
@@ -35,6 +36,7 @@ contract Describe_LendingPool_Basic {
     address SILVST;
 
     function beforeAll() public {
+        bypassAuthorizations = true;
         m = new Mercata();
         require(address(m) != address(0), "Mercata address is 0");
     }

--- a/mercata/contracts/tests/Mercata.template.test.sol
+++ b/mercata/contracts/tests/Mercata.template.test.sol
@@ -1,5 +1,6 @@
 import "../concrete/BaseCodeCollection.sol";
 import "../abstract/ERC20/IERC20.sol";
+import "../abstract/ERC20/access/Authorizable.sol";
 import "../concrete/Tokens/Token.sol";
 
 contract User {
@@ -9,7 +10,7 @@ contract User {
     }
 }
 
-contract Describe_BadDebt_Basic {
+contract Describe_BadDebt_Basic is Authorizable {
 
     constructor() {
     }
@@ -22,6 +23,7 @@ contract Describe_BadDebt_Basic {
     address USDST;
 
     function beforeAll() public {
+        bypassAuthorizations = true;
         m = new Mercata();
         require(address(m) != address(0), "Mercata address is 0");
     }

--- a/mercata/contracts/tests/Pool/Pool.test.sol
+++ b/mercata/contracts/tests/Pool/Pool.test.sol
@@ -1,6 +1,7 @@
 import "../../concrete/BaseCodeCollection.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 
-contract Describe_Pool {
+contract Describe_Pool is Authorizable {
     Mercata m;
     string[] emptyArray;
     
@@ -11,6 +12,7 @@ contract Describe_Pool {
     Pool pool;
 
     function beforeAll() {
+        bypassAuthorizations = true;
         m = new Mercata();
         require(address(m) != address(0), "Mercata address is 0");
         emptyArray = new string[](0);

--- a/mercata/contracts/tests/Pool/PoolFactory.test.sol
+++ b/mercata/contracts/tests/Pool/PoolFactory.test.sol
@@ -7,9 +7,10 @@ import "../../concrete/Tokens/TokenFactory.sol";
 import "../../concrete/Tokens/Token.sol";
 import "../../concrete/BaseCodeCollection.sol";
 import "../../abstract/ERC20/ERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
 
-contract Describe_PoolFactory {
+contract Describe_PoolFactory is Authorizable {
     Mercata m;
     address tokenAAddress;
     address tokenBAddress;
@@ -20,6 +21,7 @@ contract Describe_PoolFactory {
     string[] emptyArray;
 
     function beforeAll() {
+        bypassAuthorizations = true;
         m = new Mercata();
     }
 

--- a/mercata/contracts/tests/Proxy/Proxy.test.sol
+++ b/mercata/contracts/tests/Proxy/Proxy.test.sol
@@ -1,5 +1,6 @@
 import "../../concrete/BaseCodeCollection.sol";
 import "../../abstract/ERC20/IERC20.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../concrete/Tokens/Token.sol";
 
 contract User {
@@ -37,7 +38,7 @@ contract NowAFunction {
     }
 }
 
-contract Describe_BadDebt_Basic {
+contract Describe_BadDebt_Basic is Authorizable {
 
     constructor() {
     }
@@ -54,6 +55,7 @@ contract Describe_BadDebt_Basic {
     }
 
     function beforeAll() public {
+        bypassAuthorizations = true;
         m = new Mercata();
         require(address(m) != address(0), "Mercata address is 0");
 

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.8.30;
 
 import "../../concrete/BaseCodeCollection.sol";
 import "../Util.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
 
-contract Describe_TokenPausable {
+contract Describe_TokenPausable is Authorizable {
     using TestUtils for User;
 
     constructor() {
@@ -23,6 +24,7 @@ contract Describe_TokenPausable {
     uint256 currentTimestamp;
 
     function beforeAll() {
+        bypassAuthorizations = true;
         // Create test users once
         user1 = new User();
         user2 = new User();

--- a/strato/VM/SolidVM/solid-vm-fuzzer/exec_src/Main.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/exec_src/Main.hs
@@ -89,9 +89,11 @@ main = do
           "test" -> do
             let printResult i r = liftIO $ r <$ case r of
                   FuzzerSuccess (SourceAnnotation _ _ (testName, _)) -> do
-                    putStrLn $ "✅ " <> show i <> ". " <> T.unpack testName <> " succeeded"
+                    putStrLn $ "✅ " <> showNum i <> T.unpack testName <> " succeeded"
                   FuzzerFailure _ (SourceAnnotation _ _ (testName, msg)) -> do
-                    putStrLn $ "❌ " <> show i <> ". " <> T.unpack testName <> " failed: " <> T.unpack msg
+                    putStrLn $ "❌ " <> showNum i <> T.unpack testName <> " failed: " <> T.unpack msg
+                showNum 0 = ""
+                showNum i = show i ++ ". "
             xs <- runCli $ fuzz Nothing srcMap $ if j then defaultHook else printResult
             if j
               then printJSON xs

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -27,6 +27,7 @@ import qualified Data.Set as S
 import Data.Source
 import Data.String (IsString, fromString)
 import Data.Text (Text)
+import Data.Traversable (for)
 import qualified Data.Text as T
 import SolidVM.Model.CodeCollection hiding (modifierContext)
 import qualified SolidVM.Model.CodeCollection.Contract as Con
@@ -90,6 +91,10 @@ data TypeF' a
   deriving (Eq, Show, Functor)
 
 type Type' = Annotated TypeF'
+
+withAnn :: Text -> Type' -> Type'
+withAnn msg (Bottom x) = Bottom $ (msg <$) <$> x
+withAnn _   t          = t
 
 showType :: Type -> Text
 showType (SVMType.Int s b) =
@@ -1191,7 +1196,17 @@ functionHelper test cc c funcName f@Func {..} =
                       )
                         <$> (catMaybes $ sequence . swap <$> _funcVals)
                     argVals = M.fromList $ args ++ vals
-                 in runReader (statementsHelper argVals stmts) r
+                 in flip runReader r $ do
+                      argTypes <- flip evalStateT ((Nothing, argVals) :| []) $
+                        fmap catMaybes . for (M.elems argVals) $ \case
+                          VarDefEntry mType _ _ x -> for mType $ \case
+                            SVMType.UnknownLabel l _ -> withAnn ("Unknown type: " <> T.pack l) <$> getVarTypeByName' l x
+                            t -> pure $ Static t x
+                          _ -> pure Nothing
+                      mods <- flip evalStateT ((Nothing, argVals) :| []) $
+                        reduceType' _funcContext <$> traverse (uncurry checkModifier) _funcModifiers
+                      ret <- statementsHelper argVals stmts
+                      pure . reduceType' (f ^. funcContext) $ ret : mods : argTypes
               ([fArg], _, _, _) ->
                 bottom $
                   ( T.concat
@@ -1231,7 +1246,17 @@ functionHelper test cc c funcName f@Func {..} =
                           )
                             <$> (catMaybes $ sequence . swap <$> _funcVals)
                         argVals = M.fromList $ args ++ vals
-                     in runReader (statementsHelper argVals stmts) r
+                     in flip runReader r $ do
+                          argTypes <- flip evalStateT ((Nothing, argVals) :| []) $
+                            fmap catMaybes . for (M.elems argVals) $ \case
+                              VarDefEntry mType _ _ x -> for mType $ \case
+                                SVMType.UnknownLabel l _ -> withAnn ("Unknown type: " <> T.pack l) <$> getVarTypeByName' l x
+                                t -> pure $ Static t x
+                              _ -> pure Nothing
+                          mods <- flip evalStateT ((Nothing, argVals) :| []) $
+                            reduceType' _funcContext <$> traverse (uncurry checkModifier) _funcModifiers
+                          ret <- statementsHelper argVals stmts
+                          pure . reduceType' (f ^. funcContext) $ ret : mods : argTypes
                   _ -> bottom $ "Function `fallback` must be External, but has not been declared so " <$ _funcContext
             else
               let r =
@@ -1253,10 +1278,16 @@ functionHelper test cc c funcName f@Func {..} =
                       <$> (catMaybes $ sequence . swap <$> _funcVals)
                   argVals = M.fromList $ args ++ vals
                in flip runReader r $ do
+                    argTypes <- flip evalStateT ((Nothing, argVals) :| []) $
+                      fmap catMaybes . for (M.elems argVals) $ \case
+                        VarDefEntry mType _ _ x -> for mType $ \case
+                          SVMType.UnknownLabel l _ -> withAnn ("Unknown type: " <> T.pack l) <$> getVarTypeByName' l x
+                          t -> pure $ Static t x
+                        _ -> pure Nothing
                     mods <- flip evalStateT ((Nothing, argVals) :| []) $
                       reduceType' _funcContext <$> traverse (uncurry checkModifier) _funcModifiers
                     ret <- statementsHelper argVals stmts
-                    pure $ reduceType' _funcContext [ret, mods]
+                    pure . reduceType' _funcContext $ ret : mods : argTypes
                   where checkModifier modName modArgs = do
                           e <- getModifierByNameRecursively funcName modName _funcContext
                           a <- productType' _funcContext <$> traverse tcExpr modArgs


### PR DESCRIPTION
Addresses https://github.com/blockapps/strato-platform/issues/5145, https://github.com/blockapps/strato-platform/issues/5144, and several other issues reported by Hacken pertaining to the AdminRegistry contract, including removing the `delegates` mapping, disallowing internal functions from being whitelisted, and preventing voting thresholds greater than 100% from being set.

Most of the changes are straightforward, but one pertaining to vote forgery is a little more involved.
When calling a contract function guarded by `onlyOwner`, the modifier will reroute the call through the AdminRegistry, before calling back into the contract. When this happens, the `onlyOwner` modifier passes `msg.sender` as the `_target`, and the AdminRegistry then swaps these values back. This is done intentionally, to allow admins and whitelisted accounts to call the guarded functions directly, rather than having to call `castVoteOnIssue` for everything.

However, Hacken noted that an attacker could create a malicious contract that forges votes on behalf of all the admins, such as this:
```
contract Muahahaha {
    function doEvil() {
        for(uint i = 0; i < adminsList.length; i++) {
            adminRegistry.castVoteOnIssue(adminsList[i], "dropBombs");
        }
    }

    function dropBombs() {
        // do something bad
    }
}
```

While this attack is limited to functions inside the `Muahahaha` contract, and is arguably useless in practice, Hacken is correct that the event log would make it look like all of the admins intentionally cast a vote to `dropBombs`, when in fact they did not.

To get around this, I added an extra check inside of `castVoteOnIssue`, which requires an admin to be `tx.origin` in this case - if an admin calls a guarded function, and that contract calls into `castVoteOnIssue`, `castVoteOnIssue` can still guarantee that the admin was the one who signed the transaction*.

But wait, there's more! Adding the `tx.origin` check only works if the admin is an external user, but it's conceivable that in the future, some of the admins in the systems may be DAO contracts (and, in our test suites, the `Describe_` and/or `User` contracts already used as admins). To address this scenario, I've added a new contract called `Authorizable`, which allows a contract which acts as an admin to authorize calls on its behalf. Think of this like the admin equivalent of `transferFrom`: the contract calls its internal `_authorize` function to allow the `priceOracle` to vote in the AdminRegistry on its behalf a certain number of times. For the test suites, I added a `bypassAuthorizations` flag that bypasses the need to explicitly authorize each contract, but that can be removed if desired.

*In this case, an attacker could still perform the attack if they were able to get the admin to call their malicious contract, but they would have to get 2/3 of the admins to fall for their attack to get the issue to execute, and even then they'd still only be able to execute functions on their own contract.