### PR TITLE
Pending Rewards in backend/helpers

### DIFF
--- a/mercata/backend/src/api/helpers/rewards/pending.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/pending.helpers.ts
@@ -1,5 +1,5 @@
 import { getTokenBalanceForUser } from "../../services/tokens.service";
-import { getUserInfo, getRewardsChefState } from "./rewardsChef.helpers";
+import { getUserInfo, getRewardsChefState, getPoolsCirrus } from "./rewardsChef.helpers";
 
 // PRECISION_MULTIPLIER from RewardsChef.sol
 const PRECISION_MULTIPLIER = BigInt(1e18);
@@ -118,6 +118,39 @@ export const pendingCata = async (
     return pending.toString();
   } catch (error) {
     console.error("Failed to calculate pending CATA:", error);
+    return "0";
+  }
+};
+
+/**
+ * Calculates total pending CATA rewards for a user across all pools
+ * Replicates the pendingCataAll() logic from RewardsChef.sol
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param userAddress - User address to calculate rewards for
+ * @returns Promise resolving to total pending CATA amount as string
+ */
+export const pendingCataAll = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  userAddress: string
+): Promise<string> => {
+  try {
+    // Get all pools with bonus periods
+    const pools = await getPoolsCirrus(accessToken, rewardsChefAddress, undefined, true);
+
+    // Calculate pending rewards for each pool and sum them
+    let totalPending = 0n;
+
+    for (const pool of pools) {
+      const pending = await pendingCata(accessToken, rewardsChefAddress, pool, userAddress);
+      totalPending += BigInt(pending);
+    }
+
+    return totalPending.toString();
+  } catch (error) {
+    console.error("Failed to calculate total pending CATA:", error);
     return "0";
   }
 };

--- a/mercata/backend/src/api/helpers/rewards/pending.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/pending.helpers.ts
@@ -1,0 +1,41 @@
+/**
+ * Calculates the bonus-adjusted multiplier for a time period
+ * Replicates the getMultiplier() logic from RewardsChef.sol
+ *
+ * @param bonusPeriods - Array of bonus periods sorted by startTimestamp
+ * @param from - Start timestamp
+ * @param to - End timestamp
+ * @returns Bonus-adjusted time multiplier as BigInt
+ */
+const getMultiplier = (
+  bonusPeriods: Array<{ startTimestamp: string; bonusMultiplier: string }>,
+  from: bigint,
+  to: bigint
+): bigint => {
+  if (from == to) {
+    return 0n;
+  }
+
+  const MAX_INT = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+  let totalMultipliedTime = 0n;
+  let currentTime = from;
+
+  for (let i = 0; i < bonusPeriods.length && currentTime < to; i++) {
+    const periodStart = BigInt(bonusPeriods[i].startTimestamp);
+    const periodEnd = (i + 1 < bonusPeriods.length)
+      ? BigInt(bonusPeriods[i + 1].startTimestamp)
+      : MAX_INT;
+
+    if (currentTime < periodStart) {
+      currentTime = periodStart;
+    }
+
+    if (currentTime < to && currentTime < periodEnd) {
+      const segmentEnd = to < periodEnd ? to : periodEnd;
+      const segmentDuration = segmentEnd - currentTime;
+      totalMultipliedTime += segmentDuration * BigInt(bonusPeriods[i].bonusMultiplier);
+      currentTime = segmentEnd;
+    }
+  }
+  return totalMultipliedTime;
+};

--- a/mercata/backend/src/api/helpers/rewards/pending.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/pending.helpers.ts
@@ -1,3 +1,9 @@
+import { getTokenBalanceForUser } from "../../services/tokens.service";
+import { getUserInfo, getRewardsChefState } from "./rewardsChef.helpers";
+
+// PRECISION_MULTIPLIER from RewardsChef.sol
+const PRECISION_MULTIPLIER = BigInt(1e18);
+
 /**
  * Calculates the bonus-adjusted multiplier for a time period
  * Replicates the getMultiplier() logic from RewardsChef.sol
@@ -38,4 +44,80 @@ const getMultiplier = (
     }
   }
   return totalMultipliedTime;
+};
+
+/**
+ * Calculates pending CATA rewards for a user in a specific pool
+ * Replicates the pendingCata() logic from RewardsChef.sol
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param pool - Pool information including bonusPeriods (from getPoolsCirrus with includePeriods=true)
+ * @param userAddress - User address to calculate rewards for
+ * @returns Promise resolving to pending CATA amount as string
+ */
+export const pendingCata = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  pool: {
+    poolIdx: number;
+    lpToken: string;
+    allocPoint: string;
+    accPerToken: string;
+    lastRewardTimestamp: string;
+    bonusPeriods?: Array<{ startTimestamp: string; bonusMultiplier: string }>;
+  },
+  userAddress: string
+): Promise<string> => {
+  try {
+    // Get current timestamp in seconds
+    const currentTimestamp = BigInt(Math.floor(Date.now() / 1000));
+
+    // Get user info
+    const userInfo = await getUserInfo(
+      accessToken,
+      rewardsChefAddress,
+      pool.poolIdx,
+      userAddress
+    );
+
+    // Get global state
+    const globalState = await getRewardsChefState(accessToken, rewardsChefAddress);
+    if (!globalState) {
+      return "0";
+    }
+
+    // Start with current accPerToken
+    let accPerToken = BigInt(pool.accPerToken);
+    const lastRewardTimestamp = BigInt(pool.lastRewardTimestamp);
+
+    // If time has passed since last reward and there are staked tokens, update accPerToken
+    if (currentTimestamp > lastRewardTimestamp) {
+      // Get LP token supply (balance of LP tokens held by RewardsChef contract)
+      const lpSupply = BigInt(await getTokenBalanceForUser(accessToken, pool.lpToken, rewardsChefAddress));
+
+      if (lpSupply !== 0n && pool.bonusPeriods && pool.bonusPeriods.length > 0) {
+        // Calculate multiplier
+        const multiplier = getMultiplier(pool.bonusPeriods, lastRewardTimestamp, currentTimestamp);
+
+        // Calculate cataReward = (multiplier * cataPerSecond * allocPoint) / totalAllocPoint
+        const cataReward =
+          (multiplier * BigInt(globalState.cataPerSecond) * BigInt(pool.allocPoint)) /
+          BigInt(globalState.totalAllocPoint);
+
+        // Update accPerToken = accPerToken + (cataReward * PRECISION_MULTIPLIER) / lpSupply
+        accPerToken += (cataReward * PRECISION_MULTIPLIER) / lpSupply;
+      }
+    }
+
+    // Calculate pending = (user.amount * accPerToken / PRECISION_MULTIPLIER) - user.rewardDebt
+    const userAmount = BigInt(userInfo.amount);
+    const userRewardDebt = BigInt(userInfo.rewardDebt);
+    const pending = (userAmount * accPerToken) / PRECISION_MULTIPLIER - userRewardDebt;
+
+    return pending.toString();
+  } catch (error) {
+    console.error("Failed to calculate pending CATA:", error);
+    return "0";
+  }
 };

--- a/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
@@ -1,0 +1,50 @@
+import { cirrus } from "../../../utils/mercataApiHelper";
+import { constants } from "../../../config/constants";
+
+const { RewardsChef } = constants;
+
+/**
+ * Low-level function to fetch pools from RewardsChef contract using Cirrus
+ * with optional additional query parameters
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param additionalParams - Optional additional Cirrus query parameters for filtering
+ * @returns Promise resolving to array of pool information
+ */
+export const getPoolsCirrus = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  additionalParams?: Record<string, string>
+): Promise<Array<{
+  poolIdx: number;
+  lpToken: string;
+  allocPoint: string;
+  accPerToken: string;
+  lastRewardTimestamp: string;
+}>> => {
+  try {
+    const response = await cirrus.get(accessToken, `/${RewardsChef}-pools`, {
+      params: {
+        address: `eq.${rewardsChefAddress}`,
+        ...additionalParams
+      }
+    });
+
+    // Filter out entries with empty values and map to desired format
+    const pools = response.data
+      ?.filter((entry: any) => entry.value && entry.value !== "")
+      .map((entry: any) => ({
+        poolIdx: entry.key,
+        lpToken: entry.value.lpToken,
+        allocPoint: entry.value.allocPoint,
+        accPerToken: entry.value.accPerToken,
+        lastRewardTimestamp: entry.value.lastRewardTimestamp
+      })) || [];
+
+    return pools;
+  } catch (error) {
+    console.error("Failed to fetch pools from RewardsChef:", error);
+    return [];
+  }
+};

--- a/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
@@ -10,18 +10,21 @@ const { RewardsChef } = constants;
  * @param accessToken - User access token for authentication
  * @param rewardsChefAddress - Address of the RewardsChef contract
  * @param additionalParams - Optional additional Cirrus query parameters for filtering
+ * @param includePeriods - Whether to include bonusPeriods in the result (default: false)
  * @returns Promise resolving to array of pool information
  */
 export const getPoolsCirrus = async (
   accessToken: string,
   rewardsChefAddress: string,
-  additionalParams?: Record<string, string>
+  additionalParams?: Record<string, string>,
+  includePeriods: boolean = false
 ): Promise<Array<{
   poolIdx: number;
   lpToken: string;
   allocPoint: string;
   accPerToken: string;
   lastRewardTimestamp: string;
+  bonusPeriods?: Array<{ startTimestamp: string; bonusMultiplier: string }>;
 }>> => {
   try {
     const response = await cirrus.get(accessToken, `/${RewardsChef}-pools`, {
@@ -34,13 +37,24 @@ export const getPoolsCirrus = async (
     // Filter out entries with empty values and map to desired format
     const pools = response.data
       ?.filter((entry: any) => entry.value && entry.value !== "")
-      .map((entry: any) => ({
-        poolIdx: entry.key,
-        lpToken: entry.value.lpToken,
-        allocPoint: entry.value.allocPoint,
-        accPerToken: entry.value.accPerToken,
-        lastRewardTimestamp: entry.value.lastRewardTimestamp
-      })) || [];
+      .map((entry: any) => {
+        const pool: any = {
+          poolIdx: entry.key,
+          lpToken: entry.value.lpToken,
+          allocPoint: entry.value.allocPoint,
+          accPerToken: entry.value.accPerToken,
+          lastRewardTimestamp: entry.value.lastRewardTimestamp
+        };
+
+        // Include bonusPeriods if requested, sorted by startTimestamp
+        if (includePeriods && entry.value.bonusPeriods) {
+          pool.bonusPeriods = [...entry.value.bonusPeriods].sort(
+            (a: any, b: any) => BigInt(a.startTimestamp) < BigInt(b.startTimestamp) ? -1 : 1
+          );
+        }
+
+        return pool;
+      }) || [];
 
     return pools;
   } catch (error) {

--- a/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
@@ -62,3 +62,43 @@ export const getPoolsCirrus = async (
     return [];
   }
 };
+
+/**
+ * Get user's info (staked balance and reward debt) from RewardsChef
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param poolId - Pool ID to query
+ * @param userAddress - User address to fetch info for
+ * @returns Promise resolving to user info object
+ */
+export const getUserInfo = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  poolId: number,
+  userAddress: string
+): Promise<{ amount: string; rewardDebt: string }> => {
+  try {
+    // Query userInfo mapping from Cirrus
+    // The mapping is indexed with key (poolId) and key2 (userAddress)
+    const response = await cirrus.get(accessToken, `/${RewardsChef}-userInfo`, {
+      params: {
+        address: `eq.${rewardsChefAddress}`,
+        key: `eq.${poolId}`,
+        key2: `eq.${userAddress}`,
+        select: "value",
+        order: "block_timestamp.desc",
+        limit: "1"
+      }
+    });
+
+    const userInfo = response.data?.[0]?.value;
+    return {
+      amount: userInfo?.amount || "0",
+      rewardDebt: userInfo?.rewardDebt || "0"
+    };
+  } catch (error) {
+    console.error("Failed to fetch user info from RewardsChef:", error);
+    return { amount: "0", rewardDebt: "0" };
+  }
+};

--- a/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
@@ -102,3 +102,39 @@ export const getUserInfo = async (
     return { amount: "0", rewardDebt: "0" };
   }
 };
+
+/**
+ * Fetches RewardsChef global state (cataPerSecond and totalAllocPoint)
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @returns Promise resolving to global state
+ */
+export const getRewardsChefState = async (
+  accessToken: string,
+  rewardsChefAddress: string
+): Promise<{ cataPerSecond: string; totalAllocPoint: string } | null> => {
+  try {
+    const response = await cirrus.get(accessToken, `/${RewardsChef}`, {
+      params: {
+        address: `eq.${rewardsChefAddress}`,
+        select: "cataPerSecond::text,totalAllocPoint::text",
+        order: "block_timestamp.desc",
+        limit: "1"
+      }
+    });
+
+    const state = response.data?.[0];
+    if (!state) {
+      return null;
+    }
+
+    return {
+      cataPerSecond: state.cataPerSecond,
+      totalAllocPoint: state.totalAllocPoint
+    };
+  } catch (error) {
+    console.error("Failed to fetch RewardsChef state:", error);
+    return null;
+  }
+};

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -1,6 +1,7 @@
 import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { getTokenBalanceForUser } from "./tokens.service";
+import { getPoolsCirrus } from "../helpers/rewards/rewardsChef.helpers";
 
 const { RewardsChef } = constants;
 
@@ -85,52 +86,6 @@ export const getStakedBalance = async (
   } catch (error) {
     console.error("Failed to fetch staked balance from RewardsChef events:", error);
     return "0";
-  }
-};
-
-/**
- * Low-level function to fetch pools from RewardsChef contract using Cirrus
- * with optional additional query parameters
- *
- * @param accessToken - User access token for authentication
- * @param rewardsChefAddress - Address of the RewardsChef contract
- * @param additionalParams - Optional additional Cirrus query parameters for filtering
- * @returns Promise resolving to array of pool information
- */
-const getPoolsCirrus = async (
-  accessToken: string,
-  rewardsChefAddress: string,
-  additionalParams?: Record<string, string>
-): Promise<Array<{
-  poolIdx: number;
-  lpToken: string;
-  allocPoint: string;
-  accPerToken: string;
-  lastRewardTimestamp: string;
-}>> => {
-  try {
-    const response = await cirrus.get(accessToken, `/${RewardsChef}-pools`, {
-      params: {
-        address: `eq.${rewardsChefAddress}`,
-        ...additionalParams
-      }
-    });
-
-    // Filter out entries with empty values and map to desired format
-    const pools = response.data
-      ?.filter((entry: any) => entry.value && entry.value !== "")
-      .map((entry: any) => ({
-        poolIdx: entry.key,
-        lpToken: entry.value.lpToken,
-        allocPoint: entry.value.allocPoint,
-        accPerToken: entry.value.accPerToken,
-        lastRewardTimestamp: entry.value.lastRewardTimestamp
-      })) || [];
-
-    return pools;
-  } catch (error) {
-    console.error("Failed to fetch pools from RewardsChef:", error);
-    return [];
   }
 };
 

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -1,7 +1,7 @@
 import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
 import { getTokenBalanceForUser } from "./tokens.service";
-import { getPoolsCirrus } from "../helpers/rewards/rewardsChef.helpers";
+import { getPoolsCirrus, getUserInfo } from "../helpers/rewards/rewardsChef.helpers";
 
 const { RewardsChef } = constants;
 
@@ -49,11 +49,9 @@ export const waitForBalanceUpdate = async (
 };
 
 /**
- * Helper function to get user's staked balance from RewardsChef using Cirrus events
+ * Helper function to get user's staked balance from RewardsChef
  *
- * This function queries the latest CurrentUserAmount event for the given user and pool,
- * which contains the current staked balance. This approach avoids on-chain calls while
- * working around the limitation that nested mappings cannot be queried from Cirrus.
+ * This function queries the userInfo mapping from Cirrus to get the current staked balance.
  *
  * @param accessToken - User access token for authentication
  * @param rewardsChefAddress - Address of the RewardsChef contract
@@ -67,26 +65,8 @@ export const getStakedBalance = async (
   poolId: number,
   userAddress: string
 ): Promise<string> => {
-  try {
-    // Query the latest CurrentUserAmount event for this user and pool
-    const response = await cirrus.get(accessToken, `/${RewardsChef}-CurrentUserAmount`, {
-      params: {
-        address: `eq.${rewardsChefAddress}`,
-        user: `eq.${userAddress}`,
-        pid: `eq.${poolId}`,
-        select: "currentAmount::text,block_timestamp",
-        order: "block_timestamp.desc",
-        limit: "1"
-      }
-    });
-
-    // Extract the current amount from the latest event
-    const latestEvent = response.data?.[0];
-    return latestEvent?.currentAmount || "0";
-  } catch (error) {
-    console.error("Failed to fetch staked balance from RewardsChef events:", error);
-    return "0";
-  }
+  const userInfo = await getUserInfo(accessToken, rewardsChefAddress, poolId, userAddress);
+  return userInfo.amount;
 };
 
 /**

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -484,6 +484,29 @@ contract record RewardsChef is Ownable {
         return ((user.amount * accPerToken) / PRECISION_MULTIPLIER) - user.rewardDebt;
     }
 
+    function pendingCataAll(address _user) external view returns (uint256) {
+        uint256 totalPending = 0;
+
+        for (uint256 pid = 0; pid < pools.length; pid++) {
+            PoolInfo storage pool = pools[pid];
+            UserInfo storage user = userInfo[pid][_user];
+
+            uint256 accPerToken = pool.accPerToken;
+            uint256 lpSupply = ERC20(pool.lpToken).balanceOf(address(this));
+
+            if (block.timestamp > pool.lastRewardTimestamp && lpSupply != 0) {
+                uint256 multiplier = getMultiplier(pid, pool.lastRewardTimestamp, block.timestamp);
+                uint256 cataReward = (multiplier * cataPerSecond * pool.allocPoint) / totalAllocPoint;
+                accPerToken += (cataReward * PRECISION_MULTIPLIER) / lpSupply;
+            }
+
+            uint256 pending = ((user.amount * accPerToken) / PRECISION_MULTIPLIER) - user.rewardDebt;
+            totalPending += pending;
+        }
+
+        return totalPending;
+    }
+
     function getBalance(uint256 _pid, address _user) external view returns (uint256) {
         require(_pid < pools.length, "Pool does not exist");
         return userInfo[_pid][_user].amount;


### PR DESCRIPTION
Part of the Pending Rewards #5111 effort

# Context

The `RewardsChef.sol` has a function

```
    function pendingCata(uint256 _pid, address _user) external view returns (uint256) {
        require(_pid < pools.length, "Pool does not exist");

        PoolInfo storage pool = pools[_pid];
        UserInfo storage user = userInfo[_pid][_user];

        uint256 accPerToken = pool.accPerToken;
        uint256 lpSupply = ERC20(pool.lpToken).balanceOf(address(this));

        if (block.timestamp > pool.lastRewardTimestamp && lpSupply != 0) {
            uint256 multiplier = getMultiplier(_pid, pool.lastRewardTimestamp, block.timestamp);
            uint256 cataReward = (multiplier * cataPerSecond * pool.allocPoint) / totalAllocPoint;
            accPerToken += (cataReward * PRECISION_MULTIPLIER) / lpSupply;
        }

        return ((user.amount * accPerToken) / PRECISION_MULTIPLIER) - user.rewardDebt;
    }
```

that calculates pending rewards for a given user on a given rewards pool.

# Task

We need to duplicate this logic on mercata/backend to show users their pending rewards without calling the function on chain.

# Refactor

While working on this task, I've moved `getPoolsCirrus` to `rewardsChef.helpers.ts`