### PR TITLE
Enabled view creation for parent contracts (e.g. ERC20)

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/CodeCollection.hs
@@ -15,6 +15,7 @@ module SolidVM.Model.CodeCollection (
   contracts,
   getParents,
   getParentsAndUsings,
+  getInheritedContracts,
   getTopLevelAbstracts,
   getTopLevelAbstractsForContract,
   flConstants,
@@ -165,6 +166,12 @@ getParentsAndUsings cc c = do
         p' <- toErr (c ^. contractContext) p . M.lookup p $ cc ^. contracts
         (p' :) <$> getParentsAndUsings cc p'
   pure . concat $ ps : us
+
+getInheritedContracts :: CodeCollection -> SolidString -> SolidEither [Contract]
+getInheritedContracts cc cName = map fst . filter snd <$> traverse go (M.elems $ cc ^. contracts)
+  where go c = do
+          parents' <- map _contractName <$> getParents cc c
+          pure (c, cName `elem` parents')
 
 getTopLevelAbstracts :: CodeCollection -> Map SolidString Contract
 getTopLevelAbstracts cc = M.unions . map (getTopLevelAbstractsForContract cc) . M.elems $ _contracts cc

--- a/strato/indexer/slipstream/package.yaml
+++ b/strato/indexer/slipstream/package.yaml
@@ -46,6 +46,7 @@ library:
     - prometheus-client
     - solid-vm-model
     - scientific
+    - source-tools
     - sql-monad
     - strato-conf
     - strato-model

--- a/strato/indexer/slipstream/src/Blockchain/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Blockchain/Slipstream/OutputData.hs
@@ -127,6 +127,7 @@ data SlipstreamQuery = CreateTable
                         }
                      | CreateView
                         { viewName :: TableName
+                        , inheritedContractNames :: [Text]
                         , sourceTableName :: TableName
                         , sourceTableColumns :: [Text]
                         , contractTableColumns :: [Text]
@@ -283,9 +284,10 @@ slipstreamQueryText _ CreateView{..} =
         , tableNameCreator viewName
         , "' AND c.application = '"
         , tableNameApplication viewName
-        , "' AND c.contract_name = '"
+        , "' AND (c.contract_name = '"
         , tableNameContractName viewName
-        , "'"
+        , T.concat $ ("' OR c.contract_name = '" <>) <$> inheritedContractNames
+        , "')"
         , T.concat $ (\(col, val) -> T.concat
             [ " AND s."
             , wrapEscapeDouble col
@@ -577,8 +579,9 @@ createIndexTable ::
   ContractF () ->
   CodeCollectionF () ->
   (Text, Text, Text) ->
+  [Text] ->
   ConduitM () SlipstreamQuery m [ForeignKeyInfo]
-createIndexTable contract cc (creator, a, n) = do
+createIndexTable contract cc (creator, a, n) inherited = do
   let tableName = indexTableName creator a n
       -- histTableName = historyTableName creator a n
       cols = getTableColumnAndType False cc $ map (\(x, y) -> (labelToText x, y ^. varType)) $ Map.toList $ contract ^. storageDefs
@@ -587,6 +590,7 @@ createIndexTable contract cc (creator, a, n) = do
       fkeys = mapMaybe (\(x, t, mf) -> (\f -> ForeignKeyInfo tableName (indexTableName creator a f) x t) <$> mf) cols
   yield $ CreateView
     tableName
+    inherited
     storageTableName
     (fst <$> baseColumns)
     contractCols
@@ -601,15 +605,17 @@ createCollectionTable ::
   (Text, Text, Text) ->
   ContractF () ->
   CodeCollectionF () ->
+  [Text] ->
   (Text, [SVMType.Type], SVMType.Type) ->
   ConduitM () SlipstreamQuery m (Maybe ForeignKeyInfo)
-createCollectionTable (creator, a, n) c cc (collectionName, keyTypes, valueType) = do
+createCollectionTable (creator, a, n) c cc inherited (collectionName, keyTypes, valueType) = do
   let tableName = collectionTableName creator a n collectionName
       keySqlTypes = fromMaybe SqlText . solidityTypeToSQLType False (Just c) cc <$> keyTypes
       keyNames = keyColumnNames keySqlTypes
       mappingCols = (fst <$> baseMappingColumns) ++ ["value"]
   yield $ CreateView
     tableName
+    inherited
     mappingTableName
     mappingCols
     []
@@ -625,9 +631,10 @@ createEventArrayTable ::
   OutputM m =>
   (Text, Text, Text, Text) ->
   CodeCollectionF () ->
+  [Text] ->
   (Text, SVMType.Type) ->
   ConduitM () SlipstreamQuery m (Maybe ForeignKeyInfo)
-createEventArrayTable (creator, a, n, e) cc (arr, arrType) = do
+createEventArrayTable (creator, a, n, e) cc inherited (arr, arrType) = do
   let keyTypes (SVMType.Array t _) = SqlDecimal : keyTypes t
       keyTypes _                   = []
       tableName = eventCollectionTableName creator a n e arr
@@ -642,6 +649,7 @@ createEventArrayTable (creator, a, n, e) cc (arr, arrType) = do
   $logInfoS "createEventArrayTable/(arr, arrType) " (T.pack $ show (arr, arrType))
   yield $ CreateView
     tableName
+    inherited
     eventArrayTableName
     cols
     ["creator", "application", "contract_name"]
@@ -904,10 +912,11 @@ createExpandEventTables ::
   ContractF () ->
   CodeCollectionF () ->
   (Text, Text, Text) ->
+  [Text] ->
   ConduitM () SlipstreamQuery m [ForeignKeyInfo]
-createExpandEventTables c cc nameParts = fmap concat . mapM go . Map.toList $ c ^. events
+createExpandEventTables c cc nameParts inherited = fmap concat . mapM go . Map.toList $ c ^. events
   where
-    go (evName, ev) = createEventTable nameParts evName ev cc
+    go (evName, ev) = createEventTable nameParts evName ev cc inherited
 
 createEventTable ::
   OutputM m =>
@@ -915,8 +924,9 @@ createEventTable ::
   SolidString ->
   EventF () ->
   CodeCollectionF () ->
+  [Text] ->
   ConduitM () SlipstreamQuery m [ForeignKeyInfo]
-createEventTable (creator, a, n) evName ev cc = do
+createEventTable (creator, a, n) evName ev cc inherited = do
   $logInfoS "createEventTable" . T.pack $ show ev
   let (crtr, app, cname) = constructTableNameParameters creator a n
       eventTable = EventTableName crtr app cname (escapeQuotes $ labelToText evName)
@@ -932,6 +942,7 @@ createEventTable (creator, a, n) evName ev cc = do
           cols' = (\(x, v, _) -> (x, v)) <$> cols
        in CreateView
             tableName'
+            inherited
             globalEventTableName
             ("id":(fst <$> eventBaseColumnsQuery))
             ["creator", "application", "contract_name"]
@@ -941,7 +952,7 @@ createEventTable (creator, a, n) evName ev cc = do
             [("event_name", tableNameEventName tableName')]
     ) <$> [False] -- , (True, tableNameToText tableName)]
   arrayFkeys <- forM arrayNamesAndTypes $
-    createEventArrayTable (crtr, app, cname, escapeQuotes $ labelToText evName) cc
+    createEventArrayTable (crtr, app, cname, escapeQuotes $ labelToText evName) cc inherited
   pure $ fcols ++ catMaybes arrayFkeys
 
 -- Function to convert AggregateEvent to ProcessedCollectionRow

--- a/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
@@ -260,7 +260,7 @@ processTheMessages messages = do
         Left err -> do
           $logWarnS "processTheMessages" $ "Failed to get inherited contracts for " <> T.pack (_contractName c) <> ": " <> T.pack (show err)
           pure []
-        Right contracts -> pure $ map (T.pack . _contractName) contracts
+        Right inheritedContracts -> pure $ map (T.pack . _contractName) inheritedContracts
       indexFkeys <- createIndexTable c cc nameParts inherited
       collectionFkeys <- catMaybes <$> traverse (createCollectionTable nameParts c cc inherited) collectionNamesAndTypes
       eventFkeys <- createExpandEventTables c cc nameParts inherited

--- a/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
@@ -256,11 +256,11 @@ processTheMessages messages = do
 
       -- Create collection tables
       let cc' = SourceAnnotation (initialPosition "") (initialPosition "") () <$ cc
-          inherited <- case getInheritedContracts cc' (_contractName c) of
-            Left err -> do
-              $logWarnS "processTheMessages" $ "Failed to get inherited contracts for " <> T.pack (_contractName c) <> ": " <> T.pack (show err)
-              pure []
-            Right contracts -> pure $ map (T.pack . _contractName) contracts
+      inherited <- case getInheritedContracts cc' (_contractName c) of
+        Left err -> do
+          $logWarnS "processTheMessages" $ "Failed to get inherited contracts for " <> T.pack (_contractName c) <> ": " <> T.pack (show err)
+          pure []
+        Right contracts -> pure $ map (T.pack . _contractName) contracts
       indexFkeys <- createIndexTable c cc nameParts inherited
       collectionFkeys <- catMaybes <$> traverse (createCollectionTable nameParts c cc inherited) collectionNamesAndTypes
       eventFkeys <- createExpandEventTables c cc nameParts inherited

--- a/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
@@ -255,9 +255,12 @@ processTheMessages messages = do
       multilineLog "processTheMessages/fields" $ boringBox $ map (show) $ Map.toList $ fmap _varType $ c ^. storageDefs
 
       -- Create collection tables
-
       let cc' = SourceAnnotation (initialPosition "") (initialPosition "") () <$ cc
-          inherited = either (const []) (map $ T.pack . _contractName) . getInheritedContracts cc' $ _contractName c
+          inherited <- case getInheritedContracts cc' (_contractName c) of
+            Left err -> do
+              $logWarnS "processTheMessages" $ "Failed to get inherited contracts for " <> T.pack (_contractName c) <> ": " <> T.pack (show err)
+              pure []
+            Right contracts -> pure $ map (T.pack . _contractName) contracts
       indexFkeys <- createIndexTable c cc nameParts inherited
       collectionFkeys <- catMaybes <$> traverse (createCollectionTable nameParts c cc inherited) collectionNamesAndTypes
       eventFkeys <- createExpandEventTables c cc nameParts inherited

--- a/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
+++ b/strato/indexer/slipstream/src/Blockchain/Slipstream/Processor.hs
@@ -53,6 +53,7 @@ import Data.List (sortOn)
 import qualified Data.Map as Map
 import Data.Maybe
 import Data.Ord (Down (..))
+import Data.Source
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Traversable (for)
@@ -254,9 +255,12 @@ processTheMessages messages = do
       multilineLog "processTheMessages/fields" $ boringBox $ map (show) $ Map.toList $ fmap _varType $ c ^. storageDefs
 
       -- Create collection tables
-      indexFkeys <- createIndexTable c cc nameParts
-      collectionFkeys <- catMaybes <$> traverse (createCollectionTable nameParts c cc) collectionNamesAndTypes
-      eventFkeys <- createExpandEventTables c cc nameParts
+
+      let cc' = SourceAnnotation (initialPosition "") (initialPosition "") () <$ cc
+          inherited = either (const []) (map $ T.pack . _contractName) . getInheritedContracts cc' $ _contractName c
+      indexFkeys <- createIndexTable c cc nameParts inherited
+      collectionFkeys <- catMaybes <$> traverse (createCollectionTable nameParts c cc inherited) collectionNamesAndTypes
+      eventFkeys <- createExpandEventTables c cc nameParts inherited
       pure $ indexFkeys ++ collectionFkeys ++ eventFkeys
 
   inserts <- fmap concat $ do


### PR DESCRIPTION
If I have a contract which is inherited by other contracts, e.g. `ERC20`, I might want to index all instances of `ERC20` in one table, regardless of whether they are `Token`s, `Voucher`s, etc. Currently, this doesn't work, because views only get created for the concrete contract being created.

For example, take the following contracts:
<img width="355" height="150" alt="Screenshot 2025-10-14 at 11 25 05 AM" src="https://github.com/user-attachments/assets/5d53baa8-0702-48d1-b359-f74626b4a1c4" />

When I deploy a `ChildContract` to the testnet, the `ChildContract` is indexed, but nothing is put in the `ParentContract` view:
<img width="686" height="324" alt="Screenshot 2025-10-14 at 11 25 21 AM" src="https://github.com/user-attachments/assets/e442139f-bd55-4139-afb2-214608bdd7fc" />
<img width="615" height="133" alt="Screenshot 2025-10-14 at 11 25 38 AM" src="https://github.com/user-attachments/assets/749d9ab9-9381-44a5-ab2b-565eb7ef5f92" />

With this PR, the row shows up in the `ParentContract` view:
<img width="653" height="290" alt="Screenshot 2025-10-14 at 11 26 09 AM" src="https://github.com/user-attachments/assets/9b8cabd2-6c28-450c-8651-5196a256a2ac" />
