### PR TITLE
Show compilation errors in solid-vm-cli test again

### DIFF
--- a/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
+++ b/strato/VM/SolidVM/solid-vm-fuzzer/src/SolidVM/Solidity/Fuzzer.hs
@@ -67,7 +67,7 @@ formatTestName :: T.Text -> T.Text
 formatTestName fName = case T.splitOn "_" fName of
   ("it" : rest) -> "Unit test '" <> T.intercalate " " rest <> "'"
   ("property" : rest) -> "Property test '" <> T.intercalate " " rest <> "'"
-  _ -> "Custom test '" <> fName <> "'"
+  _ -> fName
 
 withTestName :: (Functor f, Functor g) => T.Text -> f (g a) -> f (g (T.Text, a))
 withTestName = fmap . fmap . (,) . formatTestName
@@ -92,7 +92,10 @@ runFuzzerWithHook :: (MonadUnliftIO m, MonadCatch m, A.Selectable FilePath (Eith
   (Int -> FuzzerTestAndResult -> m FuzzerTestAndResult) ->
   m [FuzzerTestAndResult]
 runFuzzerWithHook dSettings compile src hook = compile src >>= \case
-  Left errs -> pure $ FuzzerFailure Nothing . fmap ("Compilation error: ",) <$> errs
+  Left errs -> do
+    let ffs = FuzzerFailure Nothing . fmap ("compilation",) <$> errs
+    _ <- traverse (hook 0) ffs
+    pure ffs
   Right cc -> do
     let args = FuzzerArgs src "" [] "" [] Nothing
     ctx <- FuzzerContext args <$> newIORef (error "_fuzzerContextBlockHeader not initialized")

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1191,7 +1191,7 @@ expToPath x = todo "expToPath/unhandled" x
 
 expToVar :: MonadSM m => CC.Expression -> Maybe SVMType.Type -> m Variable
 expToVar x t = do
-  liftIO $ putStrLn $ C.cyan $ "expToVar: " ++ show x
+  -- liftIO $ putStrLn $ C.cyan $ "expToVar: " ++ show x
   v <- expToVar' x t
   decrementGas 1
   return v


### PR DESCRIPTION
```sh
dustinnorwood@Mac strato % solid-vm-cli test mercata/contracts/tests/BaseCodeCollection.test.sol
❌ compilation failed: Unknown variable adress
❌ compilation failed: Unknown variable adress
❌ compilation failed: Unknown variable adress
❌ compilation failed: Unknown variable adress
❌ compilation failed: Unknown variable adress
❌ compilation failed: Unknown variable adress
❌ compilation failed: Unknown variable adress
❌ compilation failed: Type mismatch: label adress and account do not match.
❌ compilation failed: Type mismatch: account and label adress do not match.
❌ compilation failed: Type mismatch: address and label adress do not match.
❌ compilation failed: Type mismatch: label adress and address do not match.
```