### PR TITLE
Claim Rewards

### DIFF
--- a/mercata/backend/src/api/controllers/rewardsChef.controller.ts
+++ b/mercata/backend/src/api/controllers/rewardsChef.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
 import { getPendingCataAll } from "../services/rewardsChef.service";
 import { rewardsChef } from "../../config/constants";
+import { claimAll } from "../services/rewardsChef.service";
 
 class RewardsChefController {
   static async getPendingRewards(
@@ -18,6 +19,22 @@ class RewardsChefController {
       );
 
       res.status(RestStatus.OK).json(result);
+  }
+
+  static async claimRewards(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, address: userAddress } = req;
+
+      const result = await claimAll(accessToken, userAddress);
+
+      res.status(RestStatus.OK).json(result);
+    } catch (error) {
+      next(error);
+    }
   }
 }
 

--- a/mercata/backend/src/api/routes/rewards.routes.ts
+++ b/mercata/backend/src/api/routes/rewards.routes.ts
@@ -35,4 +35,31 @@ const router = Router();
  */
 router.get("/pending", authHandler.authorizeRequest(), RewardsChefController.getPendingRewards);
 
+/**
+ * @openapi
+ * /rewards/claim:
+ *   post:
+ *     summary: Claim all pending CATA rewards from all pools
+ *     tags: [Rewards]
+ *     responses:
+ *       200:
+ *         description: Claim transaction result
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   description: Transaction status
+ *                   example: "success"
+ *                 hash:
+ *                   type: string
+ *                   description: Transaction hash
+ *                   example: "0x123abc..."
+ *       401:
+ *         description: Unauthorized
+ */
+router.post("/claim", authHandler.authorizeRequest(), RewardsChefController.claimRewards);
+
 export default router;

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -1,11 +1,14 @@
-import { cirrus } from "../../utils/mercataApiHelper";
-import { constants } from "../../config/constants";
+import { strato } from "../../utils/mercataApiHelper";
+import { constants, rewardsChef as rewardsChefAddress, StratoPaths } from "../../config/constants";
 import { getTokenBalanceForUser } from "./tokens.service";
 import { getPoolsCirrus, getUserInfo } from "../helpers/rewards/rewardsChef.helpers";
 import { pendingCataAll } from "../helpers/rewards/pending.helpers";
 import {
   PendingRewardsData
 } from "@mercata/shared-types";
+import { buildFunctionTx } from "../../utils/txBuilder";
+import { postAndWaitForTx } from "../../utils/txHelper";
+import { extractContractName } from "../../utils/utils";
 
 const { RewardsChef } = constants;
 
@@ -138,4 +141,27 @@ export const findPoolByLpToken = async (
     "value->>lpToken": `eq.${lpTokenAddress}`
   });
   return pools[0]; // Should return at most one pool
+};
+
+/**
+ * Calls claimAll on RewardsChef contract to claim all pending rewards from all pools
+ *
+ * @param accessToken - User access token for authentication
+ * @param userAddress - Address of the user claiming rewards
+ * @returns Promise resolving to transaction result
+ */
+export const claimAll = async (
+  accessToken: string,
+  userAddress: string
+): Promise<{ status: string; hash: string }> => {
+  const builtTx = await buildFunctionTx({
+    contractName: extractContractName(RewardsChef),
+    contractAddress: rewardsChefAddress,
+    method: "claimAll",
+    args: {}
+  }, userAddress, accessToken);
+
+  return await postAndWaitForTx(accessToken, () =>
+    strato.post(accessToken, StratoPaths.transactionParallel, builtTx)
+  );
 };

--- a/mercata/contracts/concrete/Rewards/RewardsChef.sol
+++ b/mercata/contracts/concrete/Rewards/RewardsChef.sol
@@ -160,6 +160,7 @@ contract record RewardsChef is Ownable {
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event EmergencyWithdraw(address indexed user, uint256 indexed pid, uint256 amount);
+    event Claim(address indexed user, uint256 indexed pid, uint256 amount);
     event CurrentUserAmount(address indexed user, uint256 indexed pid, uint256 currentAmount);
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -464,6 +465,39 @@ contract record RewardsChef is Ownable {
         }
 
         emit EmergencyWithdraw(msg.sender, _pid, amount);
+    }
+
+    function claim(uint256 _pid) public {
+        require(_pid < pools.length, "Pool does not exist");
+
+        PoolInfo storage pool = pools[_pid];
+        UserInfo storage user = userInfo[_pid][msg.sender];
+
+        updatePool(_pid);
+
+        uint256 pending = ((user.amount * pool.accPerToken) / PRECISION_MULTIPLIER) - user.rewardDebt;
+        if (pending > 0) {
+            rewardToken.transfer(msg.sender, pending);
+        }
+
+        // ═════════════════════════════════════════════════════════════════════
+        // WARNING!!
+        // ═════════════════════════════════════════════════════════════════════
+        // This has to be set in variable and only then applied to
+        // user.rewardDebt, otherwise the solidvm throws!
+        uint256 rewardDebt = (user.amount * pool.accPerToken) / PRECISION_MULTIPLIER;
+        user.rewardDebt = rewardDebt;
+
+        emit Claim(msg.sender, _pid, pending);
+    }
+
+    function claimAll() public {
+        for (uint256 pid = 0; pid < pools.length; pid++) {
+            UserInfo storage user = userInfo[pid][msg.sender];
+            if (user.amount > 0) {
+                claim(pid);
+            }
+        }
     }
 
     function pendingCata(uint256 _pid, address _user) external view returns (uint256) {

--- a/mercata/contracts/tests/Rewards/RewardsChef.test.sol
+++ b/mercata/contracts/tests/Rewards/RewardsChef.test.sol
@@ -563,4 +563,39 @@ contract Describe_TokenPausable is Authorizable {
         require(accPerToken1 == newAccPerToken1, "Pool 1 should have correct accPerToken at new rate");
     }
 
+    function it_should_allow_user_to_claim_rewards() {
+        // given - add pool with 100 allocation points
+        uint256 poolId = 0;
+        uint256 depositAmount = 1000 * 1e18;
+        chef.addPool(100, address(lpToken1), 1);
+
+        // given - user1 deposits LP tokens
+        TestUtils.callAs(user1, address(lpToken1), "approve(address, uint256)", address(chef), depositAmount);
+        TestUtils.callAs(user1, address(chef), "deposit(uint256, uint256)", poolId, depositAmount);
+
+        // given - time passes (100 seconds)
+        fastForward(100);
+
+        // then - user has zero CATA balance initially
+        uint256 userCataBalanceBefore = ERC20(rewardsToken).balanceOf(address(user1));
+        require(userCataBalanceBefore == 0, "User should have zero CATA before claiming");
+
+        // then - pending CATA should be some value X
+        // Expected: 100 seconds * 1000 CATA/second * (100 allocPoint / 100 totalAllocPoint) = 100000 CATA
+        uint256 expectedPendingCata = 100000;
+        uint256 pendingCataBefore = chef.pendingCata(poolId, address(user1));
+        require(pendingCataBefore == expectedPendingCata, "Pending CATA should match expected value");
+
+        // when - user calls claim
+        TestUtils.callAs(user1, address(chef), "claim(uint256)", poolId);
+
+        // then - user now has X CATA
+        uint256 userCataBalanceAfter = ERC20(rewardsToken).balanceOf(address(user1));
+        require(userCataBalanceAfter == expectedPendingCata, "User should receive claimed CATA rewards");
+
+        // then - pending CATA is zero (which also proves rewardDebt was updated correctly)
+        uint256 pendingCataAfter = chef.pendingCata(poolId, address(user1));
+        require(pendingCataAfter == 0, "Pending CATA should be zero after claim");
+    }
+
 }

--- a/mercata/ui/src/components/dashboard/AssetSummary.tsx
+++ b/mercata/ui/src/components/dashboard/AssetSummary.tsx
@@ -7,9 +7,10 @@ interface AssetSummaryProps {
   icon: React.ReactNode;
   color: string;
   tooltip?: string;
+  onClick?: () => void;
 }
 
-const AssetSummary = ({ title, value, icon, color, tooltip }: AssetSummaryProps) => {
+const AssetSummary = ({ title, value, icon, color, tooltip, onClick }: AssetSummaryProps) => {
   return (
     <div className="bg-white rounded-xl border border-gray-100 p-5 shadow-sm hover:shadow-md transition-shadow">
       <div className="flex justify-between items-start">
@@ -31,7 +32,8 @@ const AssetSummary = ({ title, value, icon, color, tooltip }: AssetSummaryProps)
         </div>
 
         <div
-          className={`w-10 h-10 rounded-full flex items-center justify-center ${color}`}
+          className={`w-10 h-10 rounded-full flex items-center justify-center ${color} ${onClick ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''}`}
+          onClick={onClick}
         >
           {icon}
         </div>

--- a/mercata/ui/src/lib/constants.ts
+++ b/mercata/ui/src/lib/constants.ts
@@ -3,6 +3,7 @@ export const safetyModuleAddress = "0000000000000000000000000000000000001015"
 export const sUsdstAddress = "0000000000000000000000000000000000001016"
 export const mUsdstAddress = "000000000000000000000000000000000000100f"
 export const cataAddress = "2680dc6693021cd3fefb84351570874fbef8332a"
+export const rewardsChefAddress = "000000000000000000000000000000000000101f"
 export const DECIMAL = 18
 
 // ============================================

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import AssetSummary from "../components/dashboard/AssetSummary";
 import AssetsList from "../components/dashboard/AssetsList";
 import DashboardFAQ from "../components/dashboard/DashboardFAQ";
 import BorrowingSection from "../components/dashboard/BorrowingSection";
-import { Wallet, Coins, Shield, Banknote } from "lucide-react";
+import { Wallet, Coins, Shield, Banknote, Loader2 } from "lucide-react";
 import { useUserTokens } from "@/context/UserTokensContext";
 import { useUser } from "@/context/UserContext";
 import { useLendingMetrics } from "@/hooks/useLendingMetrics";
@@ -22,6 +22,7 @@ import { useSwapContext } from "@/context/SwapContext";
 import { useCDP } from "@/context/CDPContext";
 import { useSafetyContext } from "@/context/SafetyContext";
 import { cataAddress } from "@/lib/constants";
+import { api } from "@/lib/axios";
 
 const Dashboard = () => {
   const [searchParams] = useSearchParams();
@@ -41,7 +42,8 @@ const Dashboard = () => {
   const { totalCDPDebt } = useCDP();
   const { poolsLoading: loadingUserPools, userPools, fetchUserPositions } = useSwapContext();
   const { safetyInfo } = useSafetyContext();
-  const { pendingRewards } = usePendingRewards(true, 30000);
+  const { pendingRewards, refetch: refetchPendingRewards } = usePendingRewards(true, 30000);
+  const [isClaiming, setIsClaiming] = useState(false);
 
   // Extract CATA token from inactive tokens by address
   const cataToken = inactiveTokens?.find(token =>
@@ -99,6 +101,30 @@ const Dashboard = () => {
 
   // Net balance calculation is now handled by the useNetBalance hook above
 
+  const handleClaimRewards = async () => {
+    if (isClaiming || parseFloat(pendingRewards) <= 0) {
+      return;
+    }
+
+    try {
+      setIsClaiming(true);
+      await api.post("/rewards/claim");
+
+      toast?.({
+        title: "Rewards Claimed",
+        description: `Successfully claimed ${pendingRewards} CATA tokens!`,
+      });
+
+      // Refresh data after successful claim
+      await Promise.all([
+        fetchTokens(),
+        refetchPendingRewards(),
+      ]);
+    } finally {
+      setIsClaiming(false);
+    }
+  };
+
   // Don't render anything until component is properly mounted
   if (!isComponentMounted) {
     return null;
@@ -138,8 +164,10 @@ const Dashboard = () => {
             <AssetSummary
               title="Pending CATA"
               value={`${parseFloat(pendingRewards).toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA`}
-              icon={<Banknote className="text-white" size={18} />}
-              color={pendingRewards == "0" ? "bg-gray-500" : "bg-green-500"}
+              icon={isClaiming ? <Loader2 className="text-white animate-spin" size={18} /> : <Banknote className="text-white" size={18} />}
+              color={parseFloat(pendingRewards) > 0 ? "bg-green-500" : "bg-gray-500"}
+              onClick={parseFloat(pendingRewards) > 0 && !isClaiming ? handleClaimRewards : undefined}
+              tooltip={isClaiming ? "Processing claim..." : (parseFloat(pendingRewards) > 0 ? "Click to claim your rewards" : undefined)}
             />
 
             <AssetSummary


### PR DESCRIPTION
Fixes #5130 

When you have a Pending CATA, the system adds tooltip, giving you a hint that you can claim by clicking the icon

<img width="954" height="331" alt="Screenshot 2025-10-14 at 15 53 40" src="https://github.com/user-attachments/assets/e72053f2-345a-4380-a4cb-4816dbfbbc7e" />

When you click it, it starts spinning

<img width="635" height="246" alt="Screenshot 2025-10-14 at 15 53 44" src="https://github.com/user-attachments/assets/9a1e2d84-449b-424c-bc10-c575c7e44ae2" />

And once it's done, the rewards are yours!

<img width="787" height="218" alt="Screenshot 2025-10-14 at 16 22 28" src="https://github.com/user-attachments/assets/1bdebf40-4253-47b8-b16e-49b190852dc3" />

