### PR TITLE
Expose RewardsChef functionality via endpoint, some tech-debt removal

### DIFF
--- a/mercata/backend/src/api/controllers/rewardsChef.controller.ts
+++ b/mercata/backend/src/api/controllers/rewardsChef.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
-import { getPendingCataAll, getStakedBalanceForPool, claimAll } from "../services/rewardsChef.service";
+import { getPendingCataAll, getStakedBalanceForPool, claimAll, getPools } from "../services/rewardsChef.service";
 import { rewardsChef } from "../../config/constants";
 
 class RewardsChefController {
@@ -59,6 +59,22 @@ class RewardsChefController {
       );
 
       res.status(RestStatus.OK).json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getPools(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken } = req;
+
+      const pools = await getPools(accessToken, rewardsChef);
+
+      res.status(RestStatus.OK).json({ pools });
     } catch (error) {
       next(error);
     }

--- a/mercata/backend/src/api/controllers/rewardsChef.controller.ts
+++ b/mercata/backend/src/api/controllers/rewardsChef.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
-import { getPendingCataAll, getStakedBalanceForPool, claimAll, getPools, findPoolByLpToken } from "../services/rewardsChef.service";
+import { getPendingCataAll, getStakedBalanceForPool, claimAll, getPools, findPoolByLpToken, getRewardsChefState } from "../services/rewardsChef.service";
 import { rewardsChef } from "../../config/constants";
 
 class RewardsChefController {
@@ -97,6 +97,27 @@ class RewardsChefController {
       }
 
       res.status(RestStatus.OK).json({ pool });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getState(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken } = req;
+
+      const state = await getRewardsChefState(accessToken, rewardsChef);
+
+      if (!state) {
+        res.status(RestStatus.NOT_FOUND).json({ error: "RewardsChef state not found" });
+        return;
+      }
+
+      res.status(RestStatus.OK).json(state);
     } catch (error) {
       next(error);
     }

--- a/mercata/backend/src/api/controllers/rewardsChef.controller.ts
+++ b/mercata/backend/src/api/controllers/rewardsChef.controller.ts
@@ -1,8 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
-import { getPendingCataAll } from "../services/rewardsChef.service";
+import { getPendingCataAll, getStakedBalanceForPool, claimAll } from "../services/rewardsChef.service";
 import { rewardsChef } from "../../config/constants";
-import { claimAll } from "../services/rewardsChef.service";
 
 class RewardsChefController {
   static async getPendingRewards(
@@ -30,6 +29,34 @@ class RewardsChefController {
       const { accessToken, address: userAddress } = req;
 
       const result = await claimAll(accessToken, userAddress);
+
+      res.status(RestStatus.OK).json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getStakedBalanceForPool(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, address: userAddress } = req;
+      const { poolId } = req.params;
+
+      const poolIdNumber = parseInt(poolId, 10);
+      if (isNaN(poolIdNumber)) {
+        res.status(RestStatus.BAD_REQUEST).json({ error: "Invalid pool ID" });
+        return;
+      }
+
+      const result = await getStakedBalanceForPool(
+        accessToken,
+        rewardsChef,
+        poolIdNumber,
+        userAddress
+      );
 
       res.status(RestStatus.OK).json(result);
     } catch (error) {

--- a/mercata/backend/src/api/controllers/rewardsChef.controller.ts
+++ b/mercata/backend/src/api/controllers/rewardsChef.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
-import { getPendingCataAll, getStakedBalanceForPool, claimAll, getPools } from "../services/rewardsChef.service";
+import { getPendingCataAll, getStakedBalanceForPool, claimAll, getPools, findPoolByLpToken } from "../services/rewardsChef.service";
 import { rewardsChef } from "../../config/constants";
 
 class RewardsChefController {
@@ -75,6 +75,28 @@ class RewardsChefController {
       const pools = await getPools(accessToken, rewardsChef);
 
       res.status(RestStatus.OK).json({ pools });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async findPoolByLpToken(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken } = req;
+      const { lpTokenAddress } = req.params;
+
+      const pool = await findPoolByLpToken(accessToken, rewardsChef, lpTokenAddress);
+
+      if (!pool) {
+        res.status(RestStatus.NOT_FOUND).json({ error: "Pool not found for the given LP token address" });
+        return;
+      }
+
+      res.status(RestStatus.OK).json({ pool });
     } catch (error) {
       next(error);
     }

--- a/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
@@ -1,6 +1,7 @@
 import { cirrus } from "../../../utils/mercataApiHelper";
 import { constants } from "../../../config/constants";
 import { getTokenBalanceForUser } from "../../services/tokens.service";
+import { RewardsPool } from "@mercata/shared-types";
 
 const { RewardsChef } = constants;
 
@@ -19,14 +20,7 @@ export const getPoolsCirrus = async (
   rewardsChefAddress: string,
   additionalParams?: Record<string, string>,
   includePeriods: boolean = false
-): Promise<Array<{
-  poolIdx: number;
-  lpToken: string;
-  allocPoint: string;
-  accPerToken: string;
-  lastRewardTimestamp: string;
-  bonusPeriods?: Array<{ startTimestamp: string; bonusMultiplier: string }>;
-}>> => {
+): Promise<RewardsPool[]> => {
   try {
     const response = await cirrus.get(accessToken, `/${RewardsChef}-pools`, {
       params: {

--- a/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
@@ -1,7 +1,7 @@
 import { cirrus } from "../../../utils/mercataApiHelper";
 import { constants } from "../../../config/constants";
 import { getTokenBalanceForUser } from "../../services/tokens.service";
-import { RewardsPool } from "@mercata/shared-types";
+import { RewardsPool, RewardsChefState } from "@mercata/shared-types";
 
 const { RewardsChef } = constants;
 
@@ -108,7 +108,7 @@ export const getUserInfo = async (
 export const getRewardsChefState = async (
   accessToken: string,
   rewardsChefAddress: string
-): Promise<{ cataPerSecond: string; totalAllocPoint: string } | null> => {
+): Promise<RewardsChefState | null> => {
   try {
     const response = await cirrus.get(accessToken, `/${RewardsChef}`, {
       params: {

--- a/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
@@ -154,6 +154,26 @@ export const getStakedBalance = async (
 };
 
 /**
+ * Finds the RewardsChef pool for a given LP token address
+ * Uses Cirrus filtering for efficient database-level query
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param lpTokenAddress - Address of the LP token to find
+ * @returns Promise resolving to the pool object, or undefined if not found
+ */
+export const findPoolByLpToken = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  lpTokenAddress: string
+): Promise<RewardsPool | undefined> => {
+  const pools = await getPoolsCirrus(accessToken, rewardsChefAddress, {
+    "value->>lpToken": `eq.${lpTokenAddress}`
+  });
+  return pools[0]; // Should return at most one pool
+};
+
+/**
  * Helper function to wait for Cirrus to index the new balance
  *
  * This addresses a race condition where a transaction is confirmed on-chain

--- a/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
@@ -1,5 +1,6 @@
 import { cirrus } from "../../../utils/mercataApiHelper";
 import { constants } from "../../../config/constants";
+import { getTokenBalanceForUser } from "../../services/tokens.service";
 
 const { RewardsChef } = constants;
 
@@ -137,4 +138,47 @@ export const getRewardsChefState = async (
     console.error("Failed to fetch RewardsChef state:", error);
     return null;
   }
+};
+
+/**
+ * Helper function to wait for Cirrus to index the new balance
+ *
+ * This addresses a race condition where a transaction is confirmed on-chain
+ * but Cirrus hasn't indexed the new state yet. When querying immediately after
+ * a transaction, Cirrus may return stale data.
+ *
+ * This is particularly important when:
+ * - Depositing to Safety Module or Lending Pool (mints sToken/mToken)
+ * - Then immediately staking those tokens to RewardsChef
+ *
+ * @param accessToken - User access token for authentication
+ * @param tokenAddress - Address of the token to check balance for
+ * @param userAddress - User address to check balance for
+ * @param previousBalance - The balance before the transaction (in wei)
+ * @param maxRetries - Maximum number of retry attempts (default: 10)
+ * @param delayMs - Delay between retries in milliseconds (default: 200)
+ * @returns Promise resolving to the updated balance as string (in wei)
+ */
+export const waitForBalanceUpdate = async (
+  accessToken: string,
+  tokenAddress: string,
+  userAddress: string,
+  previousBalance: string,
+  maxRetries: number = 10,
+  delayMs: number = 200
+): Promise<string> => {
+  for (let i = 0; i < maxRetries; i++) {
+    const currentBalance = await getTokenBalanceForUser(accessToken, tokenAddress, userAddress);
+
+    if (BigInt(currentBalance) > BigInt(previousBalance)) {
+      return currentBalance;
+    }
+
+    // Wait before next retry
+    if (i < maxRetries - 1) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+
+  return previousBalance;
 };

--- a/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
+++ b/mercata/backend/src/api/helpers/rewards/rewardsChef.helpers.ts
@@ -141,6 +141,25 @@ export const getRewardsChefState = async (
 };
 
 /**
+ * Get user's staked balance from RewardsChef for a specific pool
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @param poolId - Pool ID to query
+ * @param userAddress - User address to fetch balance for
+ * @returns Promise resolving to staked balance as string (in wei)
+ */
+export const getStakedBalance = async (
+  accessToken: string,
+  rewardsChefAddress: string,
+  poolId: number,
+  userAddress: string
+): Promise<string> => {
+  const userInfo = await getUserInfo(accessToken, rewardsChefAddress, poolId, userAddress);
+  return userInfo.amount;
+};
+
+/**
  * Helper function to wait for Cirrus to index the new balance
  *
  * This addresses a race condition where a transaction is confirmed on-chain

--- a/mercata/backend/src/api/helpers/swapping.helper.ts
+++ b/mercata/backend/src/api/helpers/swapping.helper.ts
@@ -4,7 +4,7 @@ import { SwapToken, LPToken, RawGetPool, RawPoolFactory, RawToken, RawLPToken, R
 import { safeBigInt, safeBigIntDivide } from "../../utils/bigIntUtils";
 import { buildFunctionTx } from "../../utils/txBuilder";
 import { executeTransaction } from "../../utils/txHelper";
-import { waitForBalanceUpdate } from "../services/rewardsChef.service";
+import { waitForBalanceUpdate } from "./rewards/rewardsChef.helpers";
 import { rewardsChef } from "../../config/constants";
 
 const { Pool, PoolSwap, swapHistorySelectFields } = constants;

--- a/mercata/backend/src/api/routes/rewards.routes.ts
+++ b/mercata/backend/src/api/routes/rewards.routes.ts
@@ -62,4 +62,45 @@ router.get("/pending", authHandler.authorizeRequest(), RewardsChefController.get
  */
 router.post("/claim", authHandler.authorizeRequest(), RewardsChefController.claimRewards);
 
+/**
+ * @openapi
+ * /rewards/pools/{poolId}/balance:
+ *   get:
+ *     summary: Get user's staked balance in a specific RewardsChef pool
+ *     tags: [Rewards]
+ *     parameters:
+ *       - in: path
+ *         name: poolId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: The pool ID to query
+ *         example: 0
+ *     responses:
+ *       200:
+ *         description: User's staked balance in the pool
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 poolId:
+ *                   type: integer
+ *                   description: The pool ID
+ *                   example: 0
+ *                 stakedBalance:
+ *                   type: string
+ *                   description: Staked balance in wei (raw value)
+ *                   example: "1000000000000000000"
+ *                 stakedBalanceFormatted:
+ *                   type: string
+ *                   description: Staked balance formatted with 2 decimals
+ *                   example: "1.00"
+ *       400:
+ *         description: Invalid pool ID
+ *       401:
+ *         description: Unauthorized
+ */
+router.get("/pools/:poolId/balance", authHandler.authorizeRequest(), RewardsChefController.getStakedBalanceForPool);
+
 export default router;

--- a/mercata/backend/src/api/routes/rewards.routes.ts
+++ b/mercata/backend/src/api/routes/rewards.routes.ts
@@ -199,4 +199,33 @@ router.get("/pools", authHandler.authorizeRequest(), RewardsChefController.getPo
  */
 router.get("/pools/by-lp-token/:lpTokenAddress", authHandler.authorizeRequest(), RewardsChefController.findPoolByLpToken);
 
+/**
+ * @openapi
+ * /rewards/state:
+ *   get:
+ *     summary: Get RewardsChef global state
+ *     tags: [Rewards]
+ *     responses:
+ *       200:
+ *         description: RewardsChef global state
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 cataPerSecond:
+ *                   type: string
+ *                   description: CATA tokens emitted per second
+ *                   example: "1000000000000000000"
+ *                 totalAllocPoint:
+ *                   type: string
+ *                   description: Total allocation points across all pools
+ *                   example: "1000"
+ *       404:
+ *         description: RewardsChef state not found
+ *       401:
+ *         description: Unauthorized
+ */
+router.get("/state", authHandler.authorizeRequest(), RewardsChefController.getState);
+
 export default router;

--- a/mercata/backend/src/api/routes/rewards.routes.ts
+++ b/mercata/backend/src/api/routes/rewards.routes.ts
@@ -103,4 +103,48 @@ router.post("/claim", authHandler.authorizeRequest(), RewardsChefController.clai
  */
 router.get("/pools/:poolId/balance", authHandler.authorizeRequest(), RewardsChefController.getStakedBalanceForPool);
 
+/**
+ * @openapi
+ * /rewards/pools:
+ *   get:
+ *     summary: Get all RewardsChef pools
+ *     tags: [Rewards]
+ *     responses:
+ *       200:
+ *         description: List of all pools in RewardsChef
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 pools:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       poolIdx:
+ *                         type: integer
+ *                         description: Pool index
+ *                         example: 0
+ *                       lpToken:
+ *                         type: string
+ *                         description: LP token address for this pool
+ *                         example: "0x1234567890abcdef1234567890abcdef12345678"
+ *                       allocPoint:
+ *                         type: string
+ *                         description: Allocation points for this pool
+ *                         example: "100"
+ *                       accPerToken:
+ *                         type: string
+ *                         description: Accumulated rewards per token
+ *                         example: "1000000000000000000"
+ *                       lastRewardTimestamp:
+ *                         type: string
+ *                         description: Last timestamp when rewards were calculated
+ *                         example: "1640000000"
+ *       401:
+ *         description: Unauthorized
+ */
+router.get("/pools", authHandler.authorizeRequest(), RewardsChefController.getPools);
+
 export default router;

--- a/mercata/backend/src/api/routes/rewards.routes.ts
+++ b/mercata/backend/src/api/routes/rewards.routes.ts
@@ -147,4 +147,56 @@ router.get("/pools/:poolId/balance", authHandler.authorizeRequest(), RewardsChef
  */
 router.get("/pools", authHandler.authorizeRequest(), RewardsChefController.getPools);
 
+/**
+ * @openapi
+ * /rewards/pools/by-lp-token/{lpTokenAddress}:
+ *   get:
+ *     summary: Find RewardsChef pool by LP token address
+ *     tags: [Rewards]
+ *     parameters:
+ *       - in: path
+ *         name: lpTokenAddress
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The LP token address to search for
+ *         example: "0x1234567890abcdef1234567890abcdef12345678"
+ *     responses:
+ *       200:
+ *         description: Pool found for the LP token
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 pool:
+ *                   type: object
+ *                   properties:
+ *                     poolIdx:
+ *                       type: integer
+ *                       description: Pool index
+ *                       example: 0
+ *                     lpToken:
+ *                       type: string
+ *                       description: LP token address for this pool
+ *                       example: "0x1234567890abcdef1234567890abcdef12345678"
+ *                     allocPoint:
+ *                       type: string
+ *                       description: Allocation points for this pool
+ *                       example: "100"
+ *                     accPerToken:
+ *                       type: string
+ *                       description: Accumulated rewards per token
+ *                       example: "1000000000000000000"
+ *                     lastRewardTimestamp:
+ *                       type: string
+ *                       description: Last timestamp when rewards were calculated
+ *                       example: "1640000000"
+ *       404:
+ *         description: Pool not found for the given LP token address
+ *       401:
+ *         description: Unauthorized
+ */
+router.get("/pools/by-lp-token/:lpTokenAddress", authHandler.authorizeRequest(), RewardsChefController.findPoolByLpToken);
+
 export default router;

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -7,8 +7,8 @@ import * as config from "../../config/config";
 import { getBalance, getTokens, getTokenBalanceForUser } from "./tokens.service";
 import { extractContractName } from "../../utils/utils";
 import { FunctionInput } from "../../types/types";
-import { getStakedBalance, getPools, findPoolByLpToken } from "./rewardsChef.service";
-import { waitForBalanceUpdate } from "../helpers/rewards/rewardsChef.helpers";
+import { getPools, findPoolByLpToken } from "./rewardsChef.service";
+import { waitForBalanceUpdate, getStakedBalance } from "../helpers/rewards/rewardsChef.helpers";
 import {
   simulateLoan,
   CollateralInfo,

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -7,7 +7,8 @@ import * as config from "../../config/config";
 import { getBalance, getTokens, getTokenBalanceForUser } from "./tokens.service";
 import { extractContractName } from "../../utils/utils";
 import { FunctionInput } from "../../types/types";
-import { getStakedBalance, getPools, waitForBalanceUpdate, findPoolByLpToken } from "./rewardsChef.service";
+import { getStakedBalance, getPools, findPoolByLpToken } from "./rewardsChef.service";
+import { waitForBalanceUpdate } from "../helpers/rewards/rewardsChef.helpers";
 import {
   simulateLoan,
   CollateralInfo,

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -7,8 +7,8 @@ import * as config from "../../config/config";
 import { getBalance, getTokens, getTokenBalanceForUser } from "./tokens.service";
 import { extractContractName } from "../../utils/utils";
 import { FunctionInput } from "../../types/types";
-import { getPools, findPoolByLpToken } from "./rewardsChef.service";
-import { waitForBalanceUpdate, getStakedBalance } from "../helpers/rewards/rewardsChef.helpers";
+import { getPools } from "./rewardsChef.service";
+import { waitForBalanceUpdate, getStakedBalance, findPoolByLpToken } from "../helpers/rewards/rewardsChef.helpers";
 import {
   simulateLoan,
   CollateralInfo,

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -5,7 +5,8 @@ import { getPoolsCirrus, getStakedBalance } from "../helpers/rewards/rewardsChef
 import { pendingCataAll } from "../helpers/rewards/pending.helpers";
 import {
   PendingRewardsData,
-  StakedBalanceData
+  StakedBalanceData,
+  RewardsPool
 } from "@mercata/shared-types";
 import { buildFunctionTx } from "../../utils/txBuilder";
 import { postAndWaitForTx } from "../../utils/txHelper";
@@ -74,13 +75,7 @@ export const getStakedBalanceForPool = async (
 export const getPools = async (
   accessToken: string,
   rewardsChefAddress: string
-): Promise<Array<{
-  poolIdx: number;
-  lpToken: string;
-  allocPoint: string;
-  accPerToken: string;
-  lastRewardTimestamp: string;
-}>> => {
+): Promise<RewardsPool[]> => {
   return getPoolsCirrus(accessToken, rewardsChefAddress);
 };
 
@@ -97,13 +92,7 @@ export const findPoolByLpToken = async (
   accessToken: string,
   rewardsChefAddress: string,
   lpTokenAddress: string
-): Promise<{
-  poolIdx: number;
-  lpToken: string;
-  allocPoint: string;
-  accPerToken: string;
-  lastRewardTimestamp: string;
-} | undefined> => {
+): Promise<RewardsPool | undefined> => {
   const pools = await getPoolsCirrus(accessToken, rewardsChefAddress, {
     "value->>lpToken": `eq.${lpTokenAddress}`
   });

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -6,7 +6,8 @@ import { pendingCataAll } from "../helpers/rewards/pending.helpers";
 import {
   PendingRewardsData,
   StakedBalanceData,
-  RewardsPool
+  RewardsPool,
+  RewardsChefState
 } from "@mercata/shared-types";
 import { buildFunctionTx } from "../../utils/txBuilder";
 import { postAndWaitForTx } from "../../utils/txHelper";
@@ -93,6 +94,20 @@ export const findPoolByLpToken = async (
   lpTokenAddress: string
 ): Promise<RewardsPool | undefined> => {
   return Helpers.findPoolByLpToken(accessToken, rewardsChefAddress, lpTokenAddress);
+};
+
+/**
+ * Fetches RewardsChef global state (cataPerSecond and totalAllocPoint)
+ *
+ * @param accessToken - User access token for authentication
+ * @param rewardsChefAddress - Address of the RewardsChef contract
+ * @returns Promise resolving to global state
+ */
+export const getRewardsChefState = async (
+  accessToken: string,
+  rewardsChefAddress: string
+): Promise<RewardsChefState | null> => {
+  return Helpers.getRewardsChefState(accessToken, rewardsChefAddress);
 };
 
 /**

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -1,7 +1,7 @@
 import { strato } from "../../utils/mercataApiHelper";
 import { constants, rewardsChef as rewardsChefAddress, StratoPaths } from "../../config/constants";
 import { getTokenBalanceForUser } from "./tokens.service";
-import { getPoolsCirrus, getStakedBalance } from "../helpers/rewards/rewardsChef.helpers";
+import { getPoolsCirrus, getStakedBalance, findPoolByLpToken as findPoolByLpTokenHelper } from "../helpers/rewards/rewardsChef.helpers";
 import { pendingCataAll } from "../helpers/rewards/pending.helpers";
 import {
   PendingRewardsData,
@@ -81,7 +81,6 @@ export const getPools = async (
 
 /**
  * Finds the RewardsChef pool for a given LP token address
- * Uses Cirrus filtering for efficient database-level query
  *
  * @param accessToken - User access token for authentication
  * @param rewardsChefAddress - Address of the RewardsChef contract
@@ -93,10 +92,7 @@ export const findPoolByLpToken = async (
   rewardsChefAddress: string,
   lpTokenAddress: string
 ): Promise<RewardsPool | undefined> => {
-  const pools = await getPoolsCirrus(accessToken, rewardsChefAddress, {
-    "value->>lpToken": `eq.${lpTokenAddress}`
-  });
-  return pools[0]; // Should return at most one pool
+  return findPoolByLpTokenHelper(accessToken, rewardsChefAddress, lpTokenAddress);
 };
 
 /**

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -34,49 +34,6 @@ export const getPendingCataAll = async (
 
 
 /**
- * Helper function to wait for Cirrus to index the new balance
- *
- * This addresses a race condition where a transaction is confirmed on-chain
- * but Cirrus hasn't indexed the new state yet. When querying immediately after
- * a transaction, Cirrus may return stale data.
- *
- * This is particularly important when:
- * - Depositing to Safety Module or Lending Pool (mints sToken/mToken)
- * - Then immediately staking those tokens to RewardsChef
- *
- * @param accessToken - User access token for authentication
- * @param tokenAddress - Address of the token to check balance for
- * @param userAddress - User address to check balance for
- * @param previousBalance - The balance before the transaction (in wei)
- * @param maxRetries - Maximum number of retry attempts (default: 10)
- * @param delayMs - Delay between retries in milliseconds (default: 200)
- * @returns Promise resolving to the updated balance as string (in wei)
- */
-export const waitForBalanceUpdate = async (
-  accessToken: string,
-  tokenAddress: string,
-  userAddress: string,
-  previousBalance: string,
-  maxRetries: number = 10,
-  delayMs: number = 200
-): Promise<string> => {
-  for (let i = 0; i < maxRetries; i++) {
-    const currentBalance = await getTokenBalanceForUser(accessToken, tokenAddress, userAddress);
-
-    if (BigInt(currentBalance) > BigInt(previousBalance)) {
-      return currentBalance;
-    }
-
-    // Wait before next retry
-    if (i < maxRetries - 1) {
-      await new Promise(resolve => setTimeout(resolve, delayMs));
-    }
-  }
-
-  return previousBalance;
-};
-
-/**
  * Helper function to get user's staked balance from RewardsChef
  *
  * This function queries the userInfo mapping from Cirrus to get the current staked balance.

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -1,7 +1,7 @@
 import { strato } from "../../utils/mercataApiHelper";
 import { constants, rewardsChef as rewardsChefAddress, StratoPaths } from "../../config/constants";
 import { getTokenBalanceForUser } from "./tokens.service";
-import { getPoolsCirrus, getStakedBalance, findPoolByLpToken as findPoolByLpTokenHelper } from "../helpers/rewards/rewardsChef.helpers";
+import * as Helpers from "../helpers/rewards/rewardsChef.helpers";
 import { pendingCataAll } from "../helpers/rewards/pending.helpers";
 import {
   PendingRewardsData,
@@ -53,7 +53,7 @@ export const getStakedBalanceForPool = async (
   poolId: number,
   userAddress: string
 ): Promise<StakedBalanceData> => {
-  const stakedBalance = await getStakedBalance(accessToken, rewardsChefAddress, poolId, userAddress);
+  const stakedBalance = await Helpers.getStakedBalance(accessToken, rewardsChefAddress, poolId, userAddress);
 
   // Format with proper decimals (wei to tokens with 18 decimals)
   const stakedBalanceFormatted = (Number(stakedBalance) / 1e18).toFixed(2);
@@ -76,7 +76,7 @@ export const getPools = async (
   accessToken: string,
   rewardsChefAddress: string
 ): Promise<RewardsPool[]> => {
-  return getPoolsCirrus(accessToken, rewardsChefAddress);
+  return Helpers.getPoolsCirrus(accessToken, rewardsChefAddress);
 };
 
 /**
@@ -92,7 +92,7 @@ export const findPoolByLpToken = async (
   rewardsChefAddress: string,
   lpTokenAddress: string
 ): Promise<RewardsPool | undefined> => {
-  return findPoolByLpTokenHelper(accessToken, rewardsChefAddress, lpTokenAddress);
+  return Helpers.findPoolByLpToken(accessToken, rewardsChefAddress, lpTokenAddress);
 };
 
 /**

--- a/mercata/backend/src/api/services/rewardsChef.service.ts
+++ b/mercata/backend/src/api/services/rewardsChef.service.ts
@@ -1,10 +1,11 @@
 import { strato } from "../../utils/mercataApiHelper";
 import { constants, rewardsChef as rewardsChefAddress, StratoPaths } from "../../config/constants";
 import { getTokenBalanceForUser } from "./tokens.service";
-import { getPoolsCirrus, getUserInfo } from "../helpers/rewards/rewardsChef.helpers";
+import { getPoolsCirrus, getStakedBalance } from "../helpers/rewards/rewardsChef.helpers";
 import { pendingCataAll } from "../helpers/rewards/pending.helpers";
 import {
-  PendingRewardsData
+  PendingRewardsData,
+  StakedBalanceData
 } from "@mercata/shared-types";
 import { buildFunctionTx } from "../../utils/txBuilder";
 import { postAndWaitForTx } from "../../utils/txHelper";
@@ -34,24 +35,33 @@ export const getPendingCataAll = async (
 
 
 /**
- * Helper function to get user's staked balance from RewardsChef
+ * Get user's staked balance from RewardsChef for a specific pool
  *
- * This function queries the userInfo mapping from Cirrus to get the current staked balance.
+ * This function queries the userInfo mapping from Cirrus to get the current staked balance
+ * and returns a rich data object with both raw and formatted values.
  *
  * @param accessToken - User access token for authentication
  * @param rewardsChefAddress - Address of the RewardsChef contract
  * @param poolId - Pool ID to query
  * @param userAddress - User address to fetch balance for
- * @returns Promise resolving to staked balance as string (in wei)
+ * @returns Promise resolving to staked balance data with formatted values
  */
-export const getStakedBalance = async (
+export const getStakedBalanceForPool = async (
   accessToken: string,
   rewardsChefAddress: string,
   poolId: number,
   userAddress: string
-): Promise<string> => {
-  const userInfo = await getUserInfo(accessToken, rewardsChefAddress, poolId, userAddress);
-  return userInfo.amount;
+): Promise<StakedBalanceData> => {
+  const stakedBalance = await getStakedBalance(accessToken, rewardsChefAddress, poolId, userAddress);
+
+  // Format with proper decimals (wei to tokens with 18 decimals)
+  const stakedBalanceFormatted = (Number(stakedBalance) / 1e18).toFixed(2);
+
+  return {
+    poolId,
+    stakedBalance,
+    stakedBalanceFormatted
+  };
 };
 
 /**

--- a/mercata/backend/src/api/services/safety.service.ts
+++ b/mercata/backend/src/api/services/safety.service.ts
@@ -5,8 +5,8 @@ import { StratoPaths, constants, rewardsChef } from "../../config/constants";
 import { extractContractName } from "../../utils/utils";
 import { FunctionInput } from "../../types/types";
 import { getTokenBalanceForUser } from "./tokens.service";
-import { getStakedBalance, getPools, findPoolByLpToken } from "./rewardsChef.service";
-import { waitForBalanceUpdate } from "../helpers/rewards/rewardsChef.helpers";
+import { getPools, findPoolByLpToken } from "./rewardsChef.service";
+import { waitForBalanceUpdate, getStakedBalance } from "../helpers/rewards/rewardsChef.helpers";
 
 const SafetyModule = "mercata/backend/src/api/contracts/concrete/Lending/SafetyModule.sol";
 const { Token } = constants;

--- a/mercata/backend/src/api/services/safety.service.ts
+++ b/mercata/backend/src/api/services/safety.service.ts
@@ -5,7 +5,8 @@ import { StratoPaths, constants, rewardsChef } from "../../config/constants";
 import { extractContractName } from "../../utils/utils";
 import { FunctionInput } from "../../types/types";
 import { getTokenBalanceForUser } from "./tokens.service";
-import { getStakedBalance, getPools, waitForBalanceUpdate, findPoolByLpToken } from "./rewardsChef.service";
+import { getStakedBalance, getPools, findPoolByLpToken } from "./rewardsChef.service";
+import { waitForBalanceUpdate } from "../helpers/rewards/rewardsChef.helpers";
 
 const SafetyModule = "mercata/backend/src/api/contracts/concrete/Lending/SafetyModule.sol";
 const { Token } = constants;

--- a/mercata/backend/src/api/services/safety.service.ts
+++ b/mercata/backend/src/api/services/safety.service.ts
@@ -5,8 +5,8 @@ import { StratoPaths, constants, rewardsChef } from "../../config/constants";
 import { extractContractName } from "../../utils/utils";
 import { FunctionInput } from "../../types/types";
 import { getTokenBalanceForUser } from "./tokens.service";
-import { getPools, findPoolByLpToken } from "./rewardsChef.service";
-import { waitForBalanceUpdate, getStakedBalance } from "../helpers/rewards/rewardsChef.helpers";
+import { getPools } from "./rewardsChef.service";
+import { waitForBalanceUpdate, getStakedBalance, findPoolByLpToken } from "../helpers/rewards/rewardsChef.helpers";
 
 const SafetyModule = "mercata/backend/src/api/contracts/concrete/Lending/SafetyModule.sol";
 const { Token } = constants;

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -20,7 +20,8 @@ import {
   stakeNewLPTokens
 } from "../helpers/swapping.helper";
 import { getOraclePrices } from "./oracle.service";
-import { getPools as getRewardsChefPools, getStakedBalance, findPoolByLpToken } from "./rewardsChef.service";
+import { getPools as getRewardsChefPools, findPoolByLpToken } from "./rewardsChef.service";
+import { getStakedBalance } from "../helpers/rewards/rewardsChef.helpers";
 import { getTokenBalanceForUser } from "./tokens.service";
 import { rewardsChef } from "../../config/constants";
 import {
@@ -396,7 +397,8 @@ export const removeLiquidity = async (
       const walletLPBalance = BigInt(await getTokenBalanceForUser(accessToken, lpTokenAddress, userAddress));
 
       // Get staked LP token balance
-      const stakedLPBalance = BigInt(await getStakedBalance(accessToken, rewardsChef, rewardsPool.poolIdx, userAddress));
+      const stakedBalance = await getStakedBalance(accessToken, rewardsChef, rewardsPool.poolIdx, userAddress);
+      const stakedLPBalance = BigInt(stakedBalance);
 
       // Calculate required LP tokens and how much needs to be unstaked
       const requiredLPTokens = lpTokenAmountBigInt;

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -20,8 +20,8 @@ import {
   stakeNewLPTokens
 } from "../helpers/swapping.helper";
 import { getOraclePrices } from "./oracle.service";
-import { getPools as getRewardsChefPools, findPoolByLpToken } from "./rewardsChef.service";
-import { getStakedBalance } from "../helpers/rewards/rewardsChef.helpers";
+import { getPools as getRewardsChefPools } from "./rewardsChef.service";
+import { getStakedBalance, findPoolByLpToken } from "../helpers/rewards/rewardsChef.helpers";
 import { getTokenBalanceForUser } from "./tokens.service";
 import { rewardsChef } from "../../config/constants";
 import {

--- a/mercata/packages/shared-types/src/rewards.ts
+++ b/mercata/packages/shared-types/src/rewards.ts
@@ -22,3 +22,8 @@ export interface RewardsPool {
   lastRewardTimestamp: string;
   bonusPeriods?: BonusPeriod[];
 }
+
+export interface RewardsChefState {
+  cataPerSecond: string;
+  totalAllocPoint: string;
+}

--- a/mercata/packages/shared-types/src/rewards.ts
+++ b/mercata/packages/shared-types/src/rewards.ts
@@ -8,3 +8,17 @@ export interface StakedBalanceData {
   stakedBalance: string;
   stakedBalanceFormatted: string;
 }
+
+export interface BonusPeriod {
+  startTimestamp: string;
+  bonusMultiplier: string;
+}
+
+export interface RewardsPool {
+  poolIdx: number;
+  lpToken: string;
+  allocPoint: string;
+  accPerToken: string;
+  lastRewardTimestamp: string;
+  bonusPeriods?: BonusPeriod[];
+}

--- a/mercata/packages/shared-types/src/rewards.ts
+++ b/mercata/packages/shared-types/src/rewards.ts
@@ -2,3 +2,9 @@ export interface PendingRewardsData {
   pendingCata: string;
   pendingCataFormatted: string;
 }
+
+export interface StakedBalanceData {
+  poolId: number;
+  stakedBalance: string;
+  stakedBalanceFormatted: string;
+}


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/5186

* routes call controllers
* controllers call service functions (1:1 mapping)
* some service just calls helpers and return results, some do additional "magic" on top of the returned type
* every utility function moved to helpers