### PR TITLE
Solidity compatibility: allow the $ character in identifiers

### DIFF
--- a/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
+++ b/strato/VM/SolidVM/solid-vm-parser/src/SolidVM/Solidity/Parse/Lexer.hs
@@ -192,7 +192,8 @@ solidityLanguage =
           "="
         ],
       P.caseSensitive = True,
-      P.identStart = letter <|> char '_',
+      P.identStart = letter <|> oneOf "$_",
+      P.identLetter = alphaNum <|> oneOf "$_",
       P.nestedComments = False
     }
 


### PR DESCRIPTION
Seen in ERC20Upgradeable.sol: https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/token/ERC20/ERC20Upgradeable.sol#L200

See https://docs.soliditylang.org/en/v0.8.30/grammar.html#a4.SolidityLexer.Identifier for more information