### PR TITLE
Fix the SafetyModule UI BUG

### DIFF
--- a/mercata/ui/src/components/dashboard/SafetyModuleSection.tsx
+++ b/mercata/ui/src/components/dashboard/SafetyModuleSection.tsx
@@ -469,7 +469,7 @@ const SafetyModuleSection = () => {
                             value={redeemAmount}
                             onChange={(e) => setRedeemAmount(e.target.value)}
                             className={`pl-16 ${!isRedeemAmountValid() ? 'text-red-600' : ''}`}
-                            disabled={!safetyInfo?.canRedeem || BigInt(safetyInfo?.userShares || "0") === 0n}
+                            disabled={!safetyInfo?.canRedeem || (includeStakedSUSDST ? BigInt(safetyInfo?.userSharesTotal || "0") === 0n : BigInt(safetyInfo?.userShares || "0") === 0n)}
                           />
                           <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-xs font-medium">sUSDST</span>
                         </div>
@@ -505,10 +505,10 @@ const SafetyModuleSection = () => {
 
                           setRedeemAmount(clampedClean);
                         }}
-                        className={`mr-2 ${safetyInfo?.canRedeem && BigInt(safetyInfo?.userShares || "0") > 0n
+                        className={`mr-2 ${safetyInfo?.canRedeem && (includeStakedSUSDST ? BigInt(safetyInfo?.userSharesTotal || "0") > 0n : BigInt(safetyInfo?.userShares || "0") > 0n)
                           ? "text-blue-600 hover:underline cursor-pointer"
                           : "text-gray-400 cursor-not-allowed"}`}
-                        disabled={!safetyInfo?.canRedeem || BigInt(safetyInfo?.userShares || "0") === 0n}
+                        disabled={!safetyInfo?.canRedeem || (includeStakedSUSDST ? BigInt(safetyInfo?.userSharesTotal || "0") === 0n : BigInt(safetyInfo?.userShares || "0") === 0n)}
                       >
                         Max
                       </button>


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/5231

The Problem

When a user stakes all sUSDST to the rewards program (userShares = 0, userSharesStaked > 0) and starts a cooldown, the withdraw input field was incorrectly disabled even when the "Include staked sUSDST" checkbox was enabled.

Root Cause

The disable logic at SafetyModuleSection.tsx only checked userShares (unstaked balance), ignoring that the user might have userSharesStaked (staked in rewards) available when "Include staked sUSDST" is checked.

How It Works Now

- When "Include staked sUSDST" is unchecked: only userShares (unstaked) are considered
- When "Include staked sUSDST" is checked: userSharesTotal (unstaked + staked) are considered

The fix ensures users can properly withdraw their sUSDST from rewards during the cooldown unstake window.