### PR TITLE
Remove rewards references from UI

### DIFF
--- a/mercata/ui/src/components/dashboard/LendingPoolSection.tsx
+++ b/mercata/ui/src/components/dashboard/LendingPoolSection.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { LENDING_DEPOSIT_FEE, LENDING_WITHDRAW_FEE } from "@/lib/constants";
 import { formatBalance, safeParseUnits } from "@/utils/numberUtils";
+import { rewardsEnabled } from "@/lib/constants";
 
 const LendingPoolSection = () => {
   const { userAddress } = useUser();
@@ -27,7 +28,7 @@ const LendingPoolSection = () => {
   const [depositAmount, setDepositAmount] = useState<string>("");
   const [withdrawAmount, setWithdrawAmount] = useState<string>("");
   const [isProcessing, setIsProcessing] = useState(false);
-  const [stakeMToken, setStakeMToken] = useState<boolean>(true);
+  const [stakeMToken, setStakeMToken] = useState<boolean>(rewardsEnabled ? true : false);
   const [includeStakedMToken, setIncludeStakedMToken] = useState<boolean>(false);
   const { toast } = useToast();
 
@@ -231,31 +232,33 @@ const LendingPoolSection = () => {
                     Transaction Fee: {LENDING_DEPOSIT_FEE} USDST
                   </div>
                   {/* Stake mUSDST Checkbox */}
-                  <div className="flex items-center space-x-2 mt-3">
-                    <Checkbox
-                      id="stake-musdst"
-                      checked={stakeMToken}
-                      onCheckedChange={(checked) => setStakeMToken(checked as boolean)}
-                    />
-                    <label
-                      htmlFor="stake-musdst"
-                      className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                    >
-                      Stake my mUSDST to earn rewards
-                    </label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p className="max-w-xs text-sm">
-                          When providing liquidity to the pool, you'll receive equivalent mUSDST tokens.
-                          If this option is enabled, these tokens will be automatically staked in the rewards program.
-                          The longer the tokens are staked, the more rewards they accrue.
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
+                  {rewardsEnabled && (
+                    <div className="flex items-center space-x-2 mt-3">
+                      <Checkbox
+                        id="stake-musdst"
+                        checked={stakeMToken}
+                        onCheckedChange={(checked) => setStakeMToken(checked as boolean)}
+                      />
+                      <label
+                        htmlFor="stake-musdst"
+                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                      >
+                        Stake my mUSDST to earn rewards
+                      </label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p className="max-w-xs text-sm">
+                            When providing liquidity to the pool, you'll receive equivalent mUSDST tokens.
+                            If this option is enabled, these tokens will be automatically staked in the rewards program.
+                            The longer the tokens are staked, the more rewards they accrue.
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
                   {/* Fee Warning */}
                   {(() => {
                     const availableWei = BigInt(liquidityInfo?.supplyable?.userBalance || "0");
@@ -380,31 +383,33 @@ const LendingPoolSection = () => {
                     Transaction Fee: {LENDING_WITHDRAW_FEE} USDST
                   </div>
                   {/* Include Staked mUSDST Checkbox */}
-                  <div className="flex items-center space-x-2 mt-3">
-                    <Checkbox
-                      id="include-staked-musdst"
-                      checked={includeStakedMToken}
-                      onCheckedChange={(checked) => setIncludeStakedMToken(checked as boolean)}
-                    />
-                    <label
-                      htmlFor="include-staked-musdst"
-                      className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                    >
-                      Include staked mUSDST
-                    </label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p className="max-w-xs text-sm">
-                          Some of your mUSDST tokens may be staked in the rewards program.
-                          When this option is enabled, you can withdraw assets that were staked as well.
-                          If disabled, only unstaked assets will be eligible for withdrawal.
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
+                  {rewardsEnabled && (
+                    <div className="flex items-center space-x-2 mt-3">
+                      <Checkbox
+                        id="include-staked-musdst"
+                        checked={includeStakedMToken}
+                        onCheckedChange={(checked) => setIncludeStakedMToken(checked as boolean)}
+                      />
+                      <label
+                        htmlFor="include-staked-musdst"
+                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                      >
+                        Include staked mUSDST
+                      </label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p className="max-w-xs text-sm">
+                            Some of your mUSDST tokens may be staked in the rewards program.
+                            When this option is enabled, you can withdraw assets that were staked as well.
+                            If disabled, only unstaked assets will be eligible for withdrawal.
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
                   {/* Withdraw Amount Warning */}
                   {(() => {
                     const withdrawAmountWei = withdrawAmount ? safeParseUnits(withdrawAmount, 18) : 0n;
@@ -590,34 +595,38 @@ const LendingPoolSection = () => {
                     )}
                   </span>
                 </div>
-                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start pl-4">
-                  <span className="text-gray-400 text-xs sm:text-sm">• Staked</span>
-                  <span className="font-medium text-xs sm:text-sm sm:text-right">
-                    {loadingLiquidity ? (
-                      <span className="text-gray-400 animate-pulse">
-                        Loading...
+                {rewardsEnabled && (
+                  <>
+                    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start pl-4">
+                      <span className="text-gray-400 text-xs sm:text-sm">• Staked</span>
+                      <span className="font-medium text-xs sm:text-sm sm:text-right">
+                        {loadingLiquidity ? (
+                          <span className="text-gray-400 animate-pulse">
+                            Loading...
+                          </span>
+                        ) : liquidityInfo?.withdrawable?.userBalanceStaked ? (
+                          formatBalance(liquidityInfo.withdrawable.userBalanceStaked || 0n, undefined, 18, 2, 2)
+                        ) : (
+                          "0.00"
+                        )}
                       </span>
-                    ) : liquidityInfo?.withdrawable?.userBalanceStaked ? (
-                      formatBalance(liquidityInfo.withdrawable.userBalanceStaked || 0n, undefined, 18, 2, 2)
-                    ) : (
-                      "0.00"
-                    )}
-                  </span>
-                </div>
-                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start pl-4">
-                  <span className="text-gray-400 text-xs sm:text-sm">• Unstaked</span>
-                  <span className="font-medium text-xs sm:text-sm sm:text-right">
-                    {loadingLiquidity ? (
-                      <span className="text-gray-400 animate-pulse">
-                        Loading...
+                    </div>
+                    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start pl-4">
+                      <span className="text-gray-400 text-xs sm:text-sm">• Unstaked</span>
+                      <span className="font-medium text-xs sm:text-sm sm:text-right">
+                        {loadingLiquidity ? (
+                          <span className="text-gray-400 animate-pulse">
+                            Loading...
+                          </span>
+                        ) : liquidityInfo?.withdrawable?.userBalance ? (
+                          formatBalance(liquidityInfo.withdrawable.userBalance || 0n, undefined, 18, 2, 2)
+                        ) : (
+                          "0.00"
+                        )}
                       </span>
-                    ) : liquidityInfo?.withdrawable?.userBalance ? (
-                      formatBalance(liquidityInfo.withdrawable.userBalance || 0n, undefined, 18, 2, 2)
-                    ) : (
-                      "0.00"
-                    )}
-                  </span>
-                </div>
+                    </div>
+                  </>
+                )}
                 <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start">
                   <span className="text-gray-500 text-sm sm:text-base">Conversion Rate</span>
                   <span className="font-medium text-sm sm:text-base sm:text-right">{liquidityInfo?.exchangeRate ? "1 mUSDST = " + formatUnits(liquidityInfo?.exchangeRate || 0, 18) + " USDST" : "N/A"}</span>

--- a/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
@@ -16,7 +16,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useUser } from '@/context/UserContext';
 import { formatUnits } from 'ethers';
 import { useSwapContext } from '@/context/SwapContext';
-import { usdstAddress, DEPOSIT_FEE } from "@/lib/constants";
+import { usdstAddress, DEPOSIT_FEE, rewardsEnabled } from "@/lib/constants";
 import { Pool } from '@/interface';
 import { safeParseUnits } from '@/utils/numberUtils';
 
@@ -61,7 +61,7 @@ const LiquidityDepositModal = ({
   const [tokenBBalance, setTokenBBalance] = useState('');
   const [balanceLoading, setBalanceLoading] = useState(false);
   const [depositMode, setDepositMode] = useState<'A' | 'B' | 'A&B'>('A&B');
-  const [stakeLPToken, setStakeLPToken] = useState<boolean>(true);
+  const [stakeLPToken, setStakeLPToken] = useState<boolean>(rewardsEnabled);
 
   const { addLiquidityDualToken, addLiquiditySingleToken, getPoolByAddress, fetchTokenBalances, fetchPools } = useSwapContext();
   const { toast } = useToast();
@@ -101,7 +101,7 @@ const LiquidityDepositModal = ({
     setToken1Amount('');
     setToken2Amount('');
     setDepositMode('A');
-    setStakeLPToken(true); // Reset to default (checked)
+    setStakeLPToken(rewardsEnabled); // Reset to default based on rewardsEnabled
     onClose();
   };
 
@@ -175,7 +175,7 @@ const LiquidityDepositModal = ({
           poolAddress: selectedPool.address,
           singleTokenAmount: token1AmountWei.toString(),
           isAToB: true,
-          stakeLPToken: stakeLPToken && selectedPool.lpToken.stakedBalance !== undefined
+          stakeLPToken: rewardsEnabled && stakeLPToken && selectedPool.lpToken.stakedBalance !== undefined
         });
       } else if (depositMode === 'B') {
         // Single token mode - Token B
@@ -183,7 +183,7 @@ const LiquidityDepositModal = ({
           poolAddress: selectedPool.address,
           singleTokenAmount: token2AmountWei.toString(),
           isAToB: false,
-          stakeLPToken: stakeLPToken && selectedPool.lpToken.stakedBalance !== undefined
+          stakeLPToken: rewardsEnabled && stakeLPToken && selectedPool.lpToken.stakedBalance !== undefined
         });
       } else {
         // Dual token mode
@@ -197,7 +197,7 @@ const LiquidityDepositModal = ({
           poolAddress: selectedPool.address,
           maxTokenAAmount: tokenAAmount.toString(),
           tokenBAmount: tokenBAmount.toString(),
-          stakeLPToken: stakeLPToken && selectedPool.lpToken.stakedBalance !== undefined
+          stakeLPToken: rewardsEnabled && stakeLPToken && selectedPool.lpToken.stakedBalance !== undefined
         });
       }
 
@@ -660,8 +660,8 @@ const LiquidityDepositModal = ({
             )}
           </div>
 
-          {/* Stake LP Token Checkbox - only show if pool has rewards program */}
-          {selectedPool?.lpToken?.stakedBalance !== undefined && (
+          {/* Stake LP Token Checkbox - only show if pool has rewards program AND rewards are enabled */}
+          {rewardsEnabled && selectedPool?.lpToken?.stakedBalance !== undefined && (
             <div className="flex items-center space-x-2">
               <Checkbox
                 id="stake-lp-token"

--- a/mercata/ui/src/components/dashboard/LiquidityWithdrawModal.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidityWithdrawModal.tsx
@@ -13,7 +13,7 @@ import {
 import { useForm } from "react-hook-form";
 import { useToast } from '@/hooks/use-toast';
 import { useSwapContext } from '@/context/SwapContext';
-import { WITHDRAW_FEE } from "@/lib/constants";
+import { WITHDRAW_FEE, rewardsEnabled } from "@/lib/constants";
 import { Pool } from '@/interface';
 import { safeParseUnits } from '@/utils/numberUtils';
 import { handleAmountInputChange, computeMaxTransferable } from '@/utils/transferValidation';
@@ -266,8 +266,8 @@ const LiquidityWithdrawModal = ({
             )}
           </div>
 
-          {/* Include Staked LP Token Checkbox - only show if pool has rewards program */}
-          {selectedPool?.lpToken?.stakedBalance !== undefined && (
+          {/* Include Staked LP Token Checkbox - only show if pool has rewards program AND rewards are enabled */}
+          {rewardsEnabled && selectedPool?.lpToken?.stakedBalance !== undefined && (
             <div className="flex items-center space-x-2">
               <Checkbox
                 id="include-staked-lp-token"

--- a/mercata/ui/src/components/dashboard/SafetyModuleSection.tsx
+++ b/mercata/ui/src/components/dashboard/SafetyModuleSection.tsx
@@ -11,7 +11,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useEffect, useState } from "react";
 import { useToast } from "@/hooks/use-toast";
-import { SAFETY_STAKE_FEE, SAFETY_REDEEM_FEE, usdstAddress, safetyModuleAddress } from "@/lib/constants";
+import { SAFETY_STAKE_FEE, SAFETY_REDEEM_FEE, usdstAddress, safetyModuleAddress, rewardsEnabled } from "@/lib/constants";
 import { formatBalance, safeParseUnits } from "@/utils/numberUtils";
 
 const SafetyModuleSection = () => {
@@ -30,7 +30,7 @@ const SafetyModuleSection = () => {
   const [stakeAmount, setStakeAmount] = useState<string>("");
   const [redeemAmount, setRedeemAmount] = useState<string>("");
   const [isProcessing, setIsProcessing] = useState(false);
-  const [stakeSUSDST, setStakeSUSDST] = useState<boolean>(true);
+  const [stakeSUSDST, setStakeSUSDST] = useState<boolean>(rewardsEnabled);
   const [includeStakedSUSDST, setIncludeStakedSUSDST] = useState<boolean>(false);
   const { toast } = useToast();
 
@@ -119,7 +119,7 @@ const SafetyModuleSection = () => {
       });
 
       // Then stake the tokens
-      await stakeSafety({ amount: amountWei, stakeSToken: stakeSUSDST });
+      await stakeSafety({ amount: amountWei, stakeSToken: rewardsEnabled && stakeSUSDST });
 
       if (stakeSUSDST) {
         toast({
@@ -291,32 +291,34 @@ const SafetyModuleSection = () => {
                   <div className="text-sm text-gray-500 mt-1">
                     Transaction Fee: {SAFETY_STAKE_FEE} USDST
                   </div>
-                  {/* Stake sUSDST Checkbox */}
-                  <div className="flex items-center space-x-2 mt-3">
-                    <Checkbox
-                      id="stake-susdst"
-                      checked={stakeSUSDST}
-                      onCheckedChange={(checked) => setStakeSUSDST(checked as boolean)}
-                    />
-                    <label
-                      htmlFor="stake-susdst"
-                      className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                    >
-                      Stake my sUSDST to earn rewards
-                    </label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p className="max-w-xs text-sm">
-                          When you deposit USDST to the Safety Module, you receive sUSDST tokens representing your share.
-                          If this option is enabled, these sUSDST tokens will be automatically staked in the rewards program to earn additional rewards.
-                          The longer the tokens are staked, the more rewards they accrue.
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
+                  {/* Stake sUSDST Checkbox - only show if rewards are enabled */}
+                  {rewardsEnabled && (
+                    <div className="flex items-center space-x-2 mt-3">
+                      <Checkbox
+                        id="stake-susdst"
+                        checked={stakeSUSDST}
+                        onCheckedChange={(checked) => setStakeSUSDST(checked as boolean)}
+                      />
+                      <label
+                        htmlFor="stake-susdst"
+                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                      >
+                        Stake my sUSDST to earn rewards
+                      </label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p className="max-w-xs text-sm">
+                            When you deposit USDST to the Safety Module, you receive sUSDST tokens representing your share.
+                            If this option is enabled, these sUSDST tokens will be automatically staked in the rewards program to earn additional rewards.
+                            The longer the tokens are staked, the more rewards they accrue.
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
                   {/* Fee Warning */}
                   {(() => {
                     const availableWei = BigInt(usdstBalance);
@@ -526,32 +528,34 @@ const SafetyModuleSection = () => {
                     <div className="text-sm text-gray-500 mt-1">
                       Transaction Fee: {SAFETY_REDEEM_FEE} USDST
                     </div>
-                    {/* Include Staked sUSDST Checkbox */}
-                    <div className="flex items-center space-x-2 mt-3">
-                      <Checkbox
-                        id="include-staked-susdst"
-                        checked={includeStakedSUSDST}
-                        onCheckedChange={(checked) => setIncludeStakedSUSDST(checked as boolean)}
-                      />
-                      <label
-                        htmlFor="include-staked-susdst"
-                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                      >
-                        Include staked sUSDST
-                      </label>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p className="max-w-xs text-sm">
-                            Some of your sUSDST tokens may be staked in the rewards program.
-                            When this option is enabled, you can redeem sUSDST that was staked as well.
-                            If disabled, only unstaked sUSDST will be eligible for redemption.
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
+                    {/* Include Staked sUSDST Checkbox - only show if rewards are enabled */}
+                    {rewardsEnabled && (
+                      <div className="flex items-center space-x-2 mt-3">
+                        <Checkbox
+                          id="include-staked-susdst"
+                          checked={includeStakedSUSDST}
+                          onCheckedChange={(checked) => setIncludeStakedSUSDST(checked as boolean)}
+                        />
+                        <label
+                          htmlFor="include-staked-susdst"
+                          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                        >
+                          Include staked sUSDST
+                        </label>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <HelpCircle className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p className="max-w-xs text-sm">
+                              Some of your sUSDST tokens may be staked in the rewards program.
+                              When this option is enabled, you can redeem sUSDST that was staked as well.
+                              If disabled, only unstaked sUSDST will be eligible for redemption.
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    )}
                     {/* Mobile Button */}
                     <Button
                       onClick={() => handleRedeemAction("redeem")}
@@ -633,34 +637,38 @@ const SafetyModuleSection = () => {
                     )}
                   </span>
                 </div>
-                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start pl-4">
-                  <span className="text-gray-400 text-xs sm:text-sm">• Staked</span>
-                  <span className="font-medium text-xs sm:text-sm sm:text-right">
-                    {loading ? (
-                      <span className="text-gray-400 animate-pulse">
-                        Loading...
+                {rewardsEnabled && (
+                  <>
+                    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start pl-4">
+                      <span className="text-gray-400 text-xs sm:text-sm">• Staked</span>
+                      <span className="font-medium text-xs sm:text-sm sm:text-right">
+                        {loading ? (
+                          <span className="text-gray-400 animate-pulse">
+                            Loading...
+                          </span>
+                        ) : safetyInfo?.userSharesStaked ? (
+                          formatBalance(safetyInfo.userSharesStaked || 0n, undefined, 18, 2, 2)
+                        ) : (
+                          "0.00"
+                        )}
                       </span>
-                    ) : safetyInfo?.userSharesStaked ? (
-                      formatBalance(safetyInfo.userSharesStaked || 0n, undefined, 18, 2, 2)
-                    ) : (
-                      "0.00"
-                    )}
-                  </span>
-                </div>
-                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start pl-4">
-                  <span className="text-gray-400 text-xs sm:text-sm">• Unstaked</span>
-                  <span className="font-medium text-xs sm:text-sm sm:text-right">
-                    {loading ? (
-                      <span className="text-gray-400 animate-pulse">
-                        Loading...
+                    </div>
+                    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start pl-4">
+                      <span className="text-gray-400 text-xs sm:text-sm">• Unstaked</span>
+                      <span className="font-medium text-xs sm:text-sm sm:text-right">
+                        {loading ? (
+                          <span className="text-gray-400 animate-pulse">
+                            Loading...
+                          </span>
+                        ) : safetyInfo?.userShares ? (
+                          formatBalance(safetyInfo.userShares || 0n, undefined, 18, 2, 2)
+                        ) : (
+                          "0.00"
+                        )}
                       </span>
-                    ) : safetyInfo?.userShares ? (
-                      formatBalance(safetyInfo.userShares || 0n, undefined, 18, 2, 2)
-                    ) : (
-                      "0.00"
-                    )}
-                  </span>
-                </div>
+                    </div>
+                  </>
+                )}
                 <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start">
                   <span className="text-gray-500 text-sm sm:text-base">Cooldown Period</span>
                   <span className="font-medium text-sm sm:text-base">

--- a/mercata/ui/src/components/dashboard/SwapPoolsSection.tsx
+++ b/mercata/ui/src/components/dashboard/SwapPoolsSection.tsx
@@ -8,6 +8,7 @@ import { useUserTokens } from '@/context/UserTokensContext';
 import { formatBalance } from '@/utils/numberUtils';
 import { useSwapContext } from '@/context/SwapContext';
 import { Pool } from '@/interface';
+import { rewardsEnabled } from '@/lib/constants';
 import LiquidityDepositModal from './LiquidityDepositModal';
 import LiquidityWithdrawModal from './LiquidityWithdrawModal';
 
@@ -196,7 +197,7 @@ const SwapPoolsSection = () => {
                       <div className="flex items-center text-xs text-gray-500 mt-1">
                         <span>Your Liquidity (Total): {formatBalance(pool.lpToken.totalBalance || "0", undefined, 18, 1, 6)} {pool.lpToken._symbol}</span>
                       </div>
-                      {pool.lpToken.stakedBalance !== undefined && (
+                      {rewardsEnabled && pool.lpToken.stakedBalance !== undefined && (
                         <>
                           <div className="flex items-center text-xs text-gray-400 mt-1 ml-2">
                             <span>• Staked: {formatBalance(pool.lpToken.stakedBalance || "0", undefined, 18, 1, 6)} {pool.lpToken._symbol}</span>

--- a/mercata/ui/src/lib/constants.ts
+++ b/mercata/ui/src/lib/constants.ts
@@ -7,6 +7,16 @@ export const rewardsChefAddress = "000000000000000000000000000000000000101f"
 export const DECIMAL = 18
 
 // ============================================
+// Feature Flags
+// ============================================
+
+/**
+ * Enable/disable rewards functionality in the UI
+ * When false, all rewards-related UI elements will be hidden
+ */
+export const rewardsEnabled = false;
+
+// ============================================
 // Input Validation Patterns
 // ============================================
 

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ import { useLendingContext } from "@/context/LendingContext";
 import { useSwapContext } from "@/context/SwapContext";
 import { useCDP } from "@/context/CDPContext";
 import { useSafetyContext } from "@/context/SafetyContext";
-import { cataAddress } from "@/lib/constants";
+import { cataAddress, rewardsEnabled } from "@/lib/constants";
 import { api } from "@/lib/axios";
 
 const Dashboard = () => {
@@ -42,7 +42,7 @@ const Dashboard = () => {
   const { totalCDPDebt } = useCDP();
   const { poolsLoading: loadingUserPools, userPools, fetchUserPositions } = useSwapContext();
   const { safetyInfo } = useSafetyContext();
-  const { pendingRewards, refetch: refetchPendingRewards } = usePendingRewards(true, 30000);
+  const { pendingRewards, refetch: refetchPendingRewards } = usePendingRewards(rewardsEnabled, 30000);
   const [isClaiming, setIsClaiming] = useState(false);
 
   // Extract CATA token from inactive tokens by address
@@ -145,7 +145,7 @@ const Dashboard = () => {
         />
 
         <main className="p-6">
-          <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 mb-8">
+          <div className={`grid grid-cols-1 ${rewardsEnabled ? 'lg:grid-cols-4' : 'lg:grid-cols-3'} gap-6 mb-8`}>
             <AssetSummary
               title="Net Balance"
               value={`$${totalBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })}`}
@@ -161,14 +161,16 @@ const Dashboard = () => {
               color="bg-purple-500"
             />
 
-            <AssetSummary
-              title="Pending CATA"
-              value={`${parseFloat(pendingRewards).toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA`}
-              icon={isClaiming ? <Loader2 className="text-white animate-spin" size={18} /> : <Banknote className="text-white" size={18} />}
-              color={parseFloat(pendingRewards) > 0 ? "bg-green-500" : "bg-gray-500"}
-              onClick={parseFloat(pendingRewards) > 0 && !isClaiming ? handleClaimRewards : undefined}
-              tooltip={isClaiming ? "Processing claim..." : (parseFloat(pendingRewards) > 0 ? "Click to claim your rewards" : undefined)}
-            />
+            {rewardsEnabled && (
+              <AssetSummary
+                title="Pending CATA"
+                value={`${parseFloat(pendingRewards).toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA`}
+                icon={isClaiming ? <Loader2 className="text-white animate-spin" size={18} /> : <Banknote className="text-white" size={18} />}
+                color={parseFloat(pendingRewards) > 0 ? "bg-green-500" : "bg-gray-500"}
+                onClick={parseFloat(pendingRewards) > 0 && !isClaiming ? handleClaimRewards : undefined}
+                tooltip={isClaiming ? "Processing claim..." : (parseFloat(pendingRewards) > 0 ? "Click to claim your rewards" : undefined)}
+              />
+            )}
 
             <AssetSummary
               title="Total Borrowed"


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/5191

# Feature flag

There is now a feature flag in `mercata/ui/src/lib/constants.ts`

```
// ============================================
// Feature Flags
// ============================================

/**
 * Enable/disable rewards functionality in the UI
 * When false, all rewards-related UI elements will be hidden
 */
export const rewardsEnabled = false;
```

# Example for Dashboard

## When Rewards are enabled

<img width="1528" height="298" alt="Screenshot 2025-10-15 at 15 17 03" src="https://github.com/user-attachments/assets/d470f29c-1229-445f-92d3-7c31e25fdb73" />

## When Rewards are disabled

Example Dasboard

<img width="1551" height="329" alt="Screenshot 2025-10-15 at 15 18 01" src="https://github.com/user-attachments/assets/1092fa8f-dcf5-47cb-a142-430ee57595fc" />
