### PR TITLE
Admin fixes - self owning and no double-add

### DIFF
--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -143,6 +143,7 @@ contract record AdminRegistry {
     }
 
     function _addAdmin(address _admin) internal {
+        require(adminMap[_admin] == 0, "Account is already an admin");
         admins.push(_admin);
         adminMap[_admin] = admins.length;
     }

--- a/strato/core/strato-genesis/resources/contracts/concrete/Admin/AdminRegistry.sol
+++ b/strato/core/strato-genesis/resources/contracts/concrete/Admin/AdminRegistry.sol
@@ -66,19 +66,21 @@ contract record AdminRegistry {
                 _target = msg.sender;
             }
             string issueId = _getIssueId(_target, _func, _args);
-            bool hasVoted = votesMap[issueId][sender] != 0;
+            require(votesMap[issueId][sender] == 0, "Cannot cast multiple votes for the same issue");
 
-            _createIssue(sender, issueId, _target, _func, _args);
+            try {
+                _createIssue(sender, issueId, _target, _func, _args);
+            } catch {
+
+            }
 
             if (_shouldExecute(issueId, _target, _func, _args)) {
                 variadic ret = _executeIssue(sender, issueId, _target, _func, _args);
                 return (true, ret);
             } else {
-                if (!hasVoted) {
-                    votes[issueId].push(sender);
-                    votesMap[issueId][sender] = votes[issueId].length;
-                    emit IssueVoted(msg.sender, sender, issueId, _target, _func, _args);
-                }
+                votes[issueId].push(sender);
+                votesMap[issueId][sender] = votes[issueId].length;
+                emit IssueVoted(msg.sender, sender, issueId, _target, _func, _args);
                 return (false, issueId);
             }
         } else {
@@ -93,7 +95,8 @@ contract record AdminRegistry {
             }
             address sender = msg.sender;
             address target = _target;
-            if (!whitelist[target][_func][sender] && whitelist[sender][_func][target]) {
+            require(whitelist[target][_func][sender] || whitelist[sender][_func][target], "Only an admin or a whitelisted account can call castVoteOnIssue");
+            if (!whitelist[target][_func][sender]) {
                 sender = _target;
                 target = msg.sender;
             }
@@ -119,9 +122,8 @@ contract record AdminRegistry {
     }
 
     function _createIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal {
-        if(votes[_issueId].length == 0) {
-            emit IssueCreated(msg.sender, _sender, _issueId, _target, _func, _args);
-        }
+        require(votes[_issueId].length == 0, "Issue already exists");
+        emit IssueCreated(msg.sender, _sender, _issueId, _target, _func, _args);
     }
 
     function getIssueId(address _target, string _func, variadic _args) external returns (string) {
@@ -173,17 +175,14 @@ contract record AdminRegistry {
     function addWhitelist(address _target, string _func, address _user) internal {
         if (_target == address(this)) {
             require(
-                _func != "addWhitelist" &&
-                _func != "removeWhitelist" &&
-                _func != "_addAdmin" &&
-                _func != "_createIssue" &&
-                _func != "_executeIssue" &&
-                _func != "_removeAdmin" &&
-                _func != "_shouldExecute" &&
-                _func != "_swapAdmin" &&
-                _func != "setVotingThreshold" &&
-                _func != "createContract" &&
-                _func != "createSaltedContract",
+                keccak256(_func) != keccak256("addWhitelist") &&
+                keccak256(_func) != keccak256("removeWhitelist") &&
+                keccak256(_func) != keccak256("_addAdmin") &&
+                keccak256(_func) != keccak256("_removeAdmin") &&
+                keccak256(_func) != keccak256("_swapAdmin") &&
+                keccak256(_func) != keccak256("setVotingThreshold") &&
+                keccak256(_func) != keccak256("createContract") &&
+                keccak256(_func) != keccak256("createSaltedContract"),
                 "Cannot whitelist internal governance functions"
             );
         }

--- a/strato/core/strato-genesis/resources/contracts/concrete/Admin/AdminRegistry.sol
+++ b/strato/core/strato-genesis/resources/contracts/concrete/Admin/AdminRegistry.sol
@@ -66,21 +66,19 @@ contract record AdminRegistry {
                 _target = msg.sender;
             }
             string issueId = _getIssueId(_target, _func, _args);
-            require(votesMap[issueId][sender] == 0, "Cannot cast multiple votes for the same issue");
+            bool hasVoted = votesMap[issueId][sender] != 0;
 
-            try {
-                _createIssue(sender, issueId, _target, _func, _args);
-            } catch {
-
-            }
+            _createIssue(sender, issueId, _target, _func, _args);
 
             if (_shouldExecute(issueId, _target, _func, _args)) {
                 variadic ret = _executeIssue(sender, issueId, _target, _func, _args);
                 return (true, ret);
             } else {
-                votes[issueId].push(sender);
-                votesMap[issueId][sender] = votes[issueId].length;
-                emit IssueVoted(msg.sender, sender, issueId, _target, _func, _args);
+                if (!hasVoted) {
+                    votes[issueId].push(sender);
+                    votesMap[issueId][sender] = votes[issueId].length;
+                    emit IssueVoted(msg.sender, sender, issueId, _target, _func, _args);
+                }
                 return (false, issueId);
             }
         } else {
@@ -95,8 +93,7 @@ contract record AdminRegistry {
             }
             address sender = msg.sender;
             address target = _target;
-            require(whitelist[target][_func][sender] || whitelist[sender][_func][target], "Only an admin or a whitelisted account can call castVoteOnIssue");
-            if (!whitelist[target][_func][sender]) {
+            if (!whitelist[target][_func][sender] && whitelist[sender][_func][target]) {
                 sender = _target;
                 target = msg.sender;
             }
@@ -122,8 +119,9 @@ contract record AdminRegistry {
     }
 
     function _createIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal {
-        require(votes[_issueId].length == 0, "Issue already exists");
-        emit IssueCreated(msg.sender, _sender, _issueId, _target, _func, _args);
+        if(votes[_issueId].length == 0) {
+            emit IssueCreated(msg.sender, _sender, _issueId, _target, _func, _args);
+        }
     }
 
     function getIssueId(address _target, string _func, variadic _args) external returns (string) {
@@ -145,6 +143,7 @@ contract record AdminRegistry {
     }
 
     function _addAdmin(address _admin) internal {
+        require(adminMap[_admin] == 0, "Account is already an admin");
         admins.push(_admin);
         adminMap[_admin] = admins.length;
     }
@@ -174,14 +173,17 @@ contract record AdminRegistry {
     function addWhitelist(address _target, string _func, address _user) internal {
         if (_target == address(this)) {
             require(
-                keccak256(_func) != keccak256("addWhitelist") &&
-                keccak256(_func) != keccak256("removeWhitelist") &&
-                keccak256(_func) != keccak256("_addAdmin") &&
-                keccak256(_func) != keccak256("_removeAdmin") &&
-                keccak256(_func) != keccak256("_swapAdmin") &&
-                keccak256(_func) != keccak256("setVotingThreshold") &&
-                keccak256(_func) != keccak256("createContract") &&
-                keccak256(_func) != keccak256("createSaltedContract"),
+                _func != "addWhitelist" &&
+                _func != "removeWhitelist" &&
+                _func != "_addAdmin" &&
+                _func != "_createIssue" &&
+                _func != "_executeIssue" &&
+                _func != "_removeAdmin" &&
+                _func != "_shouldExecute" &&
+                _func != "_swapAdmin" &&
+                _func != "setVotingThreshold" &&
+                _func != "createContract" &&
+                _func != "createSaltedContract",
                 "Cannot whitelist internal governance functions"
             );
         }

--- a/strato/core/strato-genesis/src/Blockchain/GenesisBlocks/HeliumGenesisBlock.hs
+++ b/strato/core/strato-genesis/src/Blockchain/GenesisBlocks/HeliumGenesisBlock.hs
@@ -555,7 +555,7 @@ assetToEvents asset = (\(a, evs) -> (a, (\(n,v) -> Event KECCAK256.zeroHash "Blo
 
 -- To be deleted
 rateStrategy :: AccountInfo
-rateStrategy = SolidVMContractWithStorage rateStrategyAddress 0 proxy $ createdByBlockApps mercataAddress
+rateStrategy = SolidVMContractWithStorage rateStrategyAddress 0 proxy $ ownedByBlockApps mercataAddress
   ++ [(".logicContract", BAccount $ unspecifiedChain rateStrategyImplAddress)]
 
 priceOracle :: AccountInfo
@@ -763,7 +763,7 @@ tokenFactory = SolidVMContractWithStorage tokenFactoryAddress 0 proxy $ ownedByB
   ++ ((\(i, GA.Asset{..}) -> (".allTokens[" <> BC.pack (show i) <> "]", BAccount $ unspecifiedChain root)) <$> zip [(9 :: Integer)..] GA.assets)
 
 adminRegistry :: AccountInfo
-adminRegistry = SolidVMContractWithStorage adminRegistryAddress 0 proxy $ createdByBlockApps mercataAddress
+adminRegistry = SolidVMContractWithStorage adminRegistryAddress 0 proxy $ ownedByBlockApps mercataAddress
   ++ [ (".adminMap<a:" <> addrBS blockappsAddress <> ">", BInteger 1)
      , (".logicContract", BAccount $ unspecifiedChain adminRegistryImplAddress)
      , (".admins[0]", BAccount $ unspecifiedChain blockappsAddress)


### PR DESCRIPTION
Also copies recent AdminRegistry changes from contracts into genesis.

Fixes #5242, Fixes #5241
