### PR TITLE
Fix case where admin is upgrading AdminRegistry

### DIFF
--- a/mercata/contracts/abstract/ERC20/access/Ownable.sol
+++ b/mercata/contracts/abstract/ERC20/access/Ownable.sol
@@ -46,8 +46,12 @@ abstract contract Ownable is Context {
             _checkOwner();
             _;
         } catch {
-            AdminRegistry admin = AdminRegistry(owner());
+            address myOwner = owner();
+            AdminRegistry admin = AdminRegistry(myOwner);
             address sender = _msgSender();
+            if (myOwner == this) {
+                sender = this;
+            }
             (bool didExecute, variadic ret) = admin.castVoteOnIssue(sender, msg.sig, msg.data);
             return ret;
         }


### PR DESCRIPTION
When an admin calls `setLogicContract` on the `AdminRegistry` itself, the `onlyOwner` modifier calls `castVoteOnIssue` with `_target` set to the user's address. Normally, if this was from the context of a different contract, inside `castVoteOnIssue`, `msg.sender` would be the address of the target contract, so the swap of `sender = _target; _target = msg.sender;` would work fine. However, when the target is `AdminRegistry`, `msg.sender` remains as the user's address, so regardless of whether `castVoteOnIssue` swaps the `_target` and `sender` values, they'll both be set to the user's address.

The solution I have here is to handle this case in the `onlyOwner` modifier, by checking whether `owner() == this`. If this case is true, `onlyOwner` will now send `this` as the `_target` address, which is the correct behavior.