### PR TITLE
Add app and network management commands

### DIFF
--- a/.cursor/commands/app.md
+++ b/.cursor/commands/app.md
@@ -1,0 +1,172 @@
+# App
+
+Start or stop the Mercata application in development mode.
+
+## Command
+
+```bash
+set -e
+
+# Navigate to project root
+cd /Users/ariya/Documents/BlockApps/strato-platform
+
+# Parse command line arguments
+COMMAND=${1:-start}
+
+# Handle stop command
+if [ "$COMMAND" = "stop" ]; then
+    echo "Stopping Mercata application..."
+    
+    # Stop nginx container
+    echo "Stopping nginx container..."
+    cd mercata/nginx
+    docker compose -f docker-compose.nginx-standalone.yml stop 2>/dev/null || true
+    cd ../..
+    
+    # Kill backend and UI processes
+    echo "Stopping backend and UI processes..."
+    pkill -f "ts-node-dev.*src/app.ts" 2>/dev/null || true
+    pkill -f "vite.*dev" 2>/dev/null || true
+    
+    # Force kill processes on ports if still running
+    echo "Cleaning up ports..."
+    lsof -ti:3001 | xargs kill -9 2>/dev/null || true
+    lsof -ti:8080 | xargs kill -9 2>/dev/null || true
+    lsof -ti:5173 | xargs kill -9 2>/dev/null || true
+    
+    echo "✅ App stopped successfully!"
+    exit 0
+fi
+
+# Start the application
+echo "Starting Mercata application..."
+
+# Build shared types package
+echo "Building shared types..."
+cd mercata/packages/shared-types
+npm install --silent
+npm run build
+cd ../../..
+
+# Setup backend environment
+echo "Setting up backend environment..."
+cd mercata/backend
+
+# Create .env file if it doesn't exist
+if [ ! -f ".env" ]; then
+    echo "Creating .env file..."
+    cat > .env << 'EOF'
+OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/mercata/.well-known/openid-configuration
+OAUTH_CLIENT_ID=localhost
+OAUTH_CLIENT_SECRET=client-secret-here
+NODE_URL=https://node5.mercata-testnet.blockapps.net
+BASE_URL=http://localhost
+POOL_FACTORY=0x100a
+LENDING_REGISTRY=0x1007
+TOKEN_FACTORY=0x100b
+ADMIN_REGISTRY=0x100c
+EOF
+    echo "Created .env file. Update OAUTH_CLIENT_SECRET with your actual value."
+fi
+
+# Start backend service
+echo "Starting backend..."
+npm install --silent
+npm run dev &
+BACKEND_PID=$!
+
+# Start UI service
+echo "Starting UI..."
+cd ../ui
+npm install --silent
+npm run dev &
+UI_PID=$!
+
+# Wait for services to initialize
+echo "Waiting for services to start..."
+sleep 5
+
+# Start nginx service
+echo "Starting nginx..."
+cd ../nginx
+
+# Load OAuth configuration from backend .env file
+if [ -f "../backend/.env" ]; then
+    source ../backend/.env
+    echo "Loaded OAuth configuration from backend .env"
+else
+    echo "Warning: Backend .env not found, using defaults"
+    OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/mercata/.well-known/openid-configuration
+    OAUTH_CLIENT_ID=localhost
+    OAUTH_CLIENT_SECRET=client-secret-here
+fi
+
+# Determine nginx container state and start accordingly
+CONTAINER_STATUS=$(docker compose -f docker-compose.nginx-standalone.yml ps nginx 2>/dev/null | grep nginx || echo "")
+
+if echo "$CONTAINER_STATUS" | grep -q "Up"; then
+    echo "Nginx container already running"
+elif echo "$CONTAINER_STATUS" | grep -qE "(Exited|Created)"; then
+    echo "Starting existing nginx container..."
+    OAUTH_DISCOVERY_URL="$OAUTH_DISCOVERY_URL" \
+      OAUTH_CLIENT_ID="$OAUTH_CLIENT_ID" \
+      OAUTH_CLIENT_SECRET="$OAUTH_CLIENT_SECRET" \
+      ssl=false \
+      docker compose -f docker-compose.nginx-standalone.yml start
+else
+    echo "Building and starting nginx container..."
+    OAUTH_DISCOVERY_URL="$OAUTH_DISCOVERY_URL" \
+      OAUTH_CLIENT_ID="$OAUTH_CLIENT_ID" \
+      OAUTH_CLIENT_SECRET="$OAUTH_CLIENT_SECRET" \
+      ssl=false \
+      docker compose -f docker-compose.nginx-standalone.yml up -d
+fi
+
+# Wait for nginx to initialize
+echo "Waiting for nginx to start..."
+sleep 3
+
+echo ""
+echo "✅ Mercata application started successfully!"
+echo ""
+echo "🌐 Access the application at: http://localhost"
+echo ""
+echo "📋 Services running:"
+echo "   • Nginx (OAuth): http://localhost (ports 80/443)"
+echo "   • Backend API: http://localhost:3001"
+echo "   • UI Dev Server: http://localhost:8080"
+echo ""
+echo "🛑 To stop: /app stop"
+```
+
+## Description
+
+This command manages the Mercata application with two modes:
+
+**Start Mode** (`/app` or `/app start`):
+- Builds shared types package
+- Creates .env file for backend if it doesn't exist
+- Starts backend service (Express.js API on port 3001)
+- Starts UI service (Vite React dev server on port 8080)
+- Starts nginx container with OAuth authentication (ports 80/443)
+- Smart container management (reuses existing containers when possible)
+
+**Stop Mode** (`/app stop`):
+- Stops nginx Docker container
+- Kills backend and UI processes
+- Cleans up all ports (3001, 8080, 5173)
+- Ensures complete shutdown
+
+**Services**:
+- **Backend**: Express.js API server on port 3001
+- **UI**: Vite React development server on port 8080
+- **Nginx**: OAuth authentication and reverse proxy on port 80/443
+
+**Environment Variables**:
+- Backend uses `.env` file in the backend directory
+- Nginx reads OAuth credentials from the backend's `.env` file
+- Default values are provided if `.env` doesn't exist
+
+**Usage**:
+- Start: `/app` or `/app start`
+- Stop: `/app stop`

--- a/.cursor/commands/network.md
+++ b/.cursor/commands/network.md
@@ -1,0 +1,192 @@
+# Network
+
+Start or stop the STRATO network with optional modes.
+
+## Command
+
+```bash
+set -e
+
+# Navigate to project root
+cd /Users/ariya/Documents/BlockApps/strato-platform
+
+# Parse command line arguments
+COMMAND=${1:-start}
+MODE=${2:-}
+
+# Handle stop command
+if [ "$COMMAND" = "stop" ]; then
+    echo "Stopping STRATO network..."
+    
+    # Check if Docker is running
+    if ! docker info >/dev/null 2>&1; then
+        echo "Docker is not running. Nothing to stop."
+        exit 0
+    fi
+    
+    if [ "$MODE" = "hard" ]; then
+        echo "Performing hard cleanup (nuclear option)..."
+        
+        # Stop all running containers
+        if docker ps -q | grep -q .; then
+            docker stop $(docker ps -q) || true
+        fi
+        
+        # Remove all containers
+        if docker ps -aq | grep -q .; then
+            docker rm $(docker ps -aq) || true
+        fi
+        
+        # Remove STRATO-related images
+        docker images --format "{{.Repository}}:{{.Tag}}" | \
+            grep -E "(mercata-backend|mercata-ui|smd|apex|strato|postgrest|nginx|mercata-bridge|mercata-nginx|prometheus|swaggerapi|postgres|zookeeper|kafka|redis)" | \
+            xargs -r docker rmi -f || true
+        
+        # Remove dangling images
+        docker images -f "dangling=true" -q | xargs -r docker rmi -f || true
+        
+        # Remove STRATO-related volumes
+        docker volume ls -q | grep -E "strato" | xargs -r docker volume rm -f || true
+        
+        # Remove STRATO-related networks
+        docker network ls --format "{{.Name}}" | grep -E "strato" | xargs -r docker network rm || true
+        
+        # Complete system cleanup
+        docker system prune --all --volumes --force || true
+        docker builder prune -af || true
+        docker buildx prune --all --force || true
+        
+        # Clean up build artifacts
+        find . -maxdepth 3 -type d \( -name "dist*" -o -name ".stack-work" -o -name "node_modules" -o -name "build" \) -exec rm -rf {} + 2>/dev/null || true
+        find . -name "*.o" -o -name "*.hi" -o -name "*.chi" -o -name "*.chs.h" | xargs -r rm -f || true
+        find . -name "*.log" -o -name "*.tmp" | xargs -r rm -f || true
+        
+        # Remove generated files
+        rm -f docker-compose*.yml bridge_image_tag* stripe_image_tag* || true
+        rm -rf app || true
+        
+        echo "✅ Network stopped and cleaned up (hard mode)."
+    else
+        echo "Performing light cleanup..."
+        # Stop only mercata/strato containers
+        docker ps -a --format "{{.Names}}" | grep -E "(mercata|strato)" | xargs -r docker stop || true
+        docker ps -a --format "{{.Names}}" | grep -E "(mercata|strato)" | xargs -r docker rm || true
+        echo "✅ Mercata containers stopped."
+    fi
+    
+    exit 0
+fi
+
+# Start the network
+echo "Starting STRATO network..."
+
+# Check for fresh mode
+FRESH_MODE=false
+if [ "$COMMAND" = "start" ] && [ "$MODE" = "fresh" ]; then
+    FRESH_MODE=true
+    echo "Fresh mode enabled - will apply Generator.hs changes and wipe data"
+fi
+
+# Check and start Docker if needed
+if ! docker info >/dev/null 2>&1; then
+    if command -v open >/dev/null 2>&1; then
+        echo "Starting Docker Desktop..."
+        open -a Docker
+        sleep 10
+        
+        # Wait for Docker to be ready
+        for i in {1..30}; do
+            if docker info >/dev/null 2>&1; then
+                break
+            fi
+            sleep 2
+        done
+    else
+        echo "❌ Error: Docker is not running and cannot be started automatically."
+        exit 1
+    fi
+fi
+
+# Clean up existing containers
+echo "Cleaning up existing containers..."
+if docker ps -q | grep -q .; then
+    docker stop $(docker ps -q) || true
+fi
+if docker ps -aq | grep -q .; then
+    docker rm $(docker ps -aq) || true
+fi
+
+# Apply Generator.hs changes if in fresh mode
+if [ "$FRESH_MODE" = true ]; then
+    echo "Applying Generator.hs changes for fresh mode..."
+    cd strato/core/strato-init/src/Blockchain/Init/
+    sed -i '' 's/--network=helium/--network=helium_aa/g' Generator.hs
+    sed -i '' 's/--test_mode_bypass_blockstanbul=false/--test_mode_bypass_blockstanbul=true/g' Generator.hs
+    cd /Users/ariya/Documents/BlockApps/strato-platform
+fi
+
+# Build the project
+echo "Building STRATO network..."
+make
+
+# Wipe existing data
+if [ -f "./forceWipe" ]; then
+    echo "Wiping existing data..."
+    ./forceWipe
+fi
+
+# Remove app directory if it exists
+if [ -d "app" ]; then
+    rm -rf app
+fi
+
+# Start the network
+echo "Starting network services..."
+make
+./start app &
+
+# Restore Generator.hs to original state if in fresh mode
+if [ "$FRESH_MODE" = true ]; then
+    echo "Restoring Generator.hs to original state..."
+    cd strato/core/strato-init/src/Blockchain/Init/
+    sed -i '' 's/--network=helium_aa/--network=helium/g' Generator.hs
+    sed -i '' 's/--test_mode_bypass_blockstanbul=true/--test_mode_bypass_blockstanbul=false/g' Generator.hs
+fi
+
+echo ""
+echo "✅ STRATO network started successfully!"
+echo ""
+echo "📋 Check status with: docker ps"
+echo "🛑 To stop: /network stop"
+echo "💥 To stop hard: /network stop hard"
+```
+
+## Description
+
+This command manages the STRATO network with multiple modes:
+
+**Start Modes**:
+- `/network` or `/network start`: Start network normally
+- `/network start fresh`: Apply Generator.hs changes, wipe data, and start fresh
+
+**Stop Modes**:
+- `/network stop`: Light cleanup - only stop mercata/strato containers
+- `/network stop hard`: Complete nuclear cleanup including images, volumes, build cache
+
+**Start Features**:
+- Checks and starts Docker Desktop if needed
+- Stops and removes all running containers
+- Builds the project with `make`
+- Wipes existing data with `./forceWipe`
+- Starts network services in background
+- Fresh mode temporarily applies Generator.hs changes
+
+**Stop Features**:
+- **Light mode**: Only stops mercata/strato containers
+- **Hard mode**: Complete cleanup of containers, images, volumes, build cache, and files
+
+**Usage**:
+- Start: `/network` or `/network start`
+- Start fresh: `/network start fresh`
+- Stop: `/network stop`
+- Stop hard: `/network stop hard`

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ docker-compose.notification.push.yml
 docker-compose.notification.yml
 docker-compose.oracle.ecr.yml
 docker-compose.oracle.yml
+
+/app


### PR DESCRIPTION
- Introduced `/app` command to start or stop the Mercata application, managing backend, UI, and nginx services.
- Added `/network` command to start or stop the STRATO network with options for light and hard cleanup.
- Updated .gitignore to exclude the newly created /app directory.