### PR TITLE
Fixed delegatecall semantics and fixed bloc /state array fetch logic

### DIFF
--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -530,4 +530,17 @@ contract Describe_AdminRegistry is Authorizable {
         require(reverted, "Should revert when non-admin non-whitelisted user tries to create issue");
     }
 
+    function it_cannot_execute_internal_functions() {
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(adminRegistry), "_getIssueId", 5000);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(adminRegistry), "_getIssueId", 5000);
+
+        bool reverted = false;
+        try {
+            adminRegistry.castVoteOnIssue(address(adminRegistry), "_getIssueId", address(0xdeadbeef), "parmesan", 7);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should revert when delegatecalling into an internal function");
+    }
+
 }

--- a/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
@@ -18,6 +18,7 @@ where
 import BlockApps.Solidity.SolidityValue
 import BlockApps.Solidity.Value as V
 import Blockchain.Strato.Model.Account (unspecifiedChain)
+import Blockchain.Strato.Model.Util (byteString2Integer)
 import Control.DeepSeq
 import Control.Monad.Extra
 import Data.Bifunctor
@@ -35,6 +36,7 @@ import GHC.Generics
 import SolidVM.Model.SolidString
 import SolidVM.Model.Storable
 import Text.Printf
+import Text.Read
 
 decodeSolidVMValues :: [(T.Text, T.Text)] -> [(T.Text, SolidityValue)]
 decodeSolidVMValues hxs = either (error . printf "decodeSolidVMValues: %s" . show) id $ do
@@ -152,9 +154,27 @@ applyDelta' (Index n : sp) bv (ValueMapping ms) =
    in case M.lookup n' ms of
         Just v -> ValueMapping . (\x -> M.insert n' x ms) <$> applyDelta' sp bv v
         Nothing -> Right . ValueMapping $ M.insert n' (constructFromNothing' sp bv) ms
+applyDelta' (Index n' : sp) bv (ValueArrayDynamic vs) =
+  let n = fromInteger $ byteString2Integer n'
+   in case I.lookup n vs of
+        Just v -> ValueArrayDynamic . (\x -> I.insert n x vs) <$> applyDelta' sp bv v
+        Nothing -> Right . ValueArrayDynamic $ I.insert n (constructFromNothing' sp bv) vs
+applyDelta' (Index n' : sp) bv sent@(ValueArraySentinel len) =
+  let n = fromInteger $ byteString2Integer n'
+   in Right . ValueArrayDynamic $ I.fromList [(n, constructFromNothing' sp bv), (len, sent)]
 applyDelta' [Field "length"] (BInteger n) (ValueArrayDynamic vs) =
   let n' = fromIntegral n
    in Right . ValueArrayDynamic $ I.insert n' (ValueArraySentinel n') vs
+applyDelta' sp@[Field "length"] b@(BInteger n) s@(ValueMapping vs) =
+  let err = Left $ TypeMismatch (StoragePath sp) b s
+      n' = fromIntegral n
+      toArrayElem (ValueInt _ _ k', v') = Right (fromInteger k', v')
+      toArrayElem (ValueString k', v') = maybe err (Right . (,v')) . readMaybe $ T.unpack k'
+      toArrayElem _ = err
+   in ValueArrayDynamic
+      . I.insert n' (ValueArraySentinel n')
+      . I.fromList
+      <$> traverse toArrayElem (M.toList vs)
 applyDelta' [Field "length"] (BInteger n) (ValueArraySentinel {}) = Right . ValueArraySentinel $ fromIntegral n
 applyDelta' [Field _] bv _ = Right $ fromBasic bv -- Handle struct value assignment case
 applyDelta' sp bv (ValueArraySentinel {}) = Right $ constructFromNothing' sp bv

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -442,7 +442,7 @@ call' ::
   m ((SolidString, SolidString), Maybe Value)
 call' from to' fnCalltype functionName valList = do
   (isExternal, storageAddress, codeAddress) <- case fnCalltype of
-    CC.DelegateCall -> return (False, from, to')
+    CC.DelegateCall -> return (True, from, to')
     CC.RawCall -> return (True, to', to')
     _ -> (from /= to', to',) <$> do
       if from == to'
@@ -452,6 +452,7 @@ call' from to' fnCalltype functionName valList = do
             Just callInfo -> pure $ currentCodeAddress callInfo
             _ -> pure to'
         else pure to'
+  let shouldPushSender = bool False (fnCalltype /= CC.DelegateCall) isExternal
   (contract, hsh, cc) <- getCodeAndCollection codeAddress
   (toName, parentName) <- do
     ch <- addressStateCodeHash <$> A.lookupWithDefault (A.Proxy @AddressState) storageAddress
@@ -518,7 +519,7 @@ call' from to' fnCalltype functionName valList = do
         let ro = case mCallInfo of
               Nothing -> False
               Just ci -> readOnly ci
-        pure . bool id (pushSender from) isExternal $
+        pure . bool id (pushSender from) shouldPushSender $
           runTheCall storageAddress codeAddress contract functionName' hsh cc theFunction valList ro False
       -- Handles .call() and .delegatecall() logic
       (Just theFunction, _) -> do
@@ -531,7 +532,7 @@ call' from to' fnCalltype functionName valList = do
             let ro = case mCallInfo of
                   Nothing -> False
                   Just ci -> readOnly ci
-            pure . bool id (pushSender from) isExternal $
+            pure . bool id (pushSender from) shouldPushSender $
               runTheCall storageAddress codeAddress contract functionName' hsh cc theFunction' valList' ro False
           _ -> case M.lookup "fallback" functionsIncludingConstructor of
             Just fallbackFunc -> do
@@ -539,7 +540,7 @@ call' from to' fnCalltype functionName valList = do
               let ro = case mCallInfo of
                     Nothing -> False
                     Just ci -> readOnly ci
-              pure . bool id (pushSender from) isExternal $
+              pure . bool id (pushSender from) shouldPushSender $
                 runTheCall storageAddress codeAddress contract functionName' hsh cc fallbackFunc valList ro False
             _ -> unknownFunction "logFunctionCall" (functionName, valList) -- contract ^. CC.contractName)
       -- Maybe the function is actually a getter
@@ -602,7 +603,7 @@ call' from to' fnCalltype functionName valList = do
             let ro = case mCallInfo of
                   Nothing -> False
                   Just ci -> readOnly ci
-            pure . bool id (pushSender from) isExternal $
+            pure . bool id (pushSender from) shouldPushSender $
               runTheCall storageAddress codeAddress contract functionName hsh cc fallbackFunc valList ro False
           _ -> unknownFunction "logFunctionCall" (functionName, "asdf5" :: String) -- ^. CC.contractName)
 


### PR DESCRIPTION
Fixes issue where delegatecall still let the caller access internal functions, and fixed issue where arrays would only show their length in SMD

<img width="554" height="168" alt="Screenshot 2025-10-21 at 5 57 13 PM" src="https://github.com/user-attachments/assets/04006c0b-3e11-498c-a959-b4f92b13b136" />

My local build now hits a stateroot mismatch because of a call to setDefaultThresholdBps, an internal function