### PR TITLE
Implement price max age feature in CDPEngine and LendingPool contracts

### DIFF
--- a/mercata/contracts/concrete/CDP/CDPEngine.sol
+++ b/mercata/contracts/concrete/CDP/CDPEngine.sol
@@ -55,7 +55,7 @@ contract record CDPEngine is Ownable {
     mapping(address => bool) public record isSupportedAsset;
 
     uint256 public feeToReserveBps; // portion of feeUSD sent to CDPReserve (0..10000)
-    uint public priceMaxAge = 1200; // 20 minutes in seconds
+    uint public priceMaxAge = 1200;
 
     event FeeToReserveBpsSet(uint256 oldBps, uint256 newBps);
     event FeesRouted(address indexed asset, uint256 toReserve, uint256 toCollector);
@@ -168,6 +168,7 @@ contract record CDPEngine is Ownable {
         // @dev important: must be set here for proxied instances; ensure consistency with desired initial values
         RAY = 1e27;
         WAD = 1e18;
+        priceMaxAge = 1200;
 
         require(_registry != address(0), "CDPEngine: invalid registry");
         registry = CDPRegistry(_registry);

--- a/mercata/contracts/concrete/CDP/CDPEngine.sol
+++ b/mercata/contracts/concrete/CDP/CDPEngine.sol
@@ -55,9 +55,11 @@ contract record CDPEngine is Ownable {
     mapping(address => bool) public record isSupportedAsset;
 
     uint256 public feeToReserveBps; // portion of feeUSD sent to CDPReserve (0..10000)
+    uint public priceMaxAge = 1200; // 20 minutes in seconds
 
     event FeeToReserveBpsSet(uint256 oldBps, uint256 newBps);
     event FeesRouted(address indexed asset, uint256 toReserve, uint256 toCollector);
+    event PriceMaxAgeSet(uint oldMaxAge, uint newMaxAge);
 
 
     // ─────────────── Events ───────────────
@@ -189,6 +191,12 @@ contract record CDPEngine is Ownable {
         emit FeeToReserveBpsSet(old, newBps);
     }
 
+    function setPriceMaxAge(uint newMaxAge) external onlyOwner {
+        uint old = priceMaxAge;
+        priceMaxAge = newMaxAge;
+        emit PriceMaxAgeSet(old, newMaxAge);
+    }
+
     /**
      * @notice Internal helper to route fees between Reserve and FeeCollector
      * @dev Mints USDST fees and splits according to feeToReserveBps
@@ -259,8 +267,9 @@ contract record CDPEngine is Ownable {
             maxAmount = vault.collateral;
         } else {
             // Compute collateral required to keep CR >= LR
-            uint price = _cdpPriceOracle().getAssetPrice(asset);
+            (uint price, uint timestamp) = _cdpPriceOracle().getAssetPriceWithTimestamp(asset);
             require(price > 0, "invalid price");
+            require(block.timestamp - timestamp <= priceMaxAge, "CDPEngine: stale price");
             CollateralConfig memory config = collateralConfigs[asset];
             uint requiredCollateralValue = (debt * config.liquidationRatio) / WAD;
             uint requiredCollateral = (requiredCollateralValue * config.unitScale) / price;
@@ -295,8 +304,9 @@ contract record CDPEngine is Ownable {
         // Compute current debt in USD using scaledDebt and rateAccumulator
         uint currentDebt = (userVault.scaledDebt * assetState.rateAccumulator) / RAY;
         // Value collateral in USD and compute borrow headroom from LR
-        uint price = _cdpPriceOracle().getAssetPrice(asset);
+        (uint price, uint timestamp) = _cdpPriceOracle().getAssetPriceWithTimestamp(asset);
         require(price > 0, "invalid price");
+        require(block.timestamp - timestamp <= priceMaxAge, "CDPEngine: stale price");
         uint collateralValueUSD_calc = (userVault.collateral * price) / assetConfig.unitScale;
         uint maxBorrowableUSD = (collateralValueUSD_calc * WAD) / assetConfig.liquidationRatio;
         require(currentDebt + amountUSD < maxBorrowableUSD, "CDPEngine: insufficient collateral");
@@ -333,8 +343,9 @@ contract record CDPEngine is Ownable {
         // Current owed in USD
         uint currentDebt = (userVault.scaledDebt * assetState.rateAccumulator) / RAY;
         // Compute borrow headroom from collateral value and LR
-        uint price = _cdpPriceOracle().getAssetPrice(asset);
+        (uint price, uint timestamp) = _cdpPriceOracle().getAssetPriceWithTimestamp(asset);
         require(price > 0, "invalid price");
+        require(block.timestamp - timestamp <= priceMaxAge, "CDPEngine: stale price");
         uint collateralValueUSD_calc = (userVault.collateral * price) / config.unitScale;
         uint maxBorrowableUSD = (collateralValueUSD_calc * WAD) / config.liquidationRatio;
         require(maxBorrowableUSD > currentDebt, "No borrowing power");
@@ -474,8 +485,9 @@ contract record CDPEngine is Ownable {
         require(borrowerCR < config.liquidationRatio, "CDPEngine: position healthy");
 
         // Prices & caps
-        uint priceColl = _cdpPriceOracle().getAssetPrice(collateralAsset);
+        (uint priceColl, uint timestamp) = _cdpPriceOracle().getAssetPriceWithTimestamp(collateralAsset);
         require(priceColl > 0, "CDPEngine: invalid collateral price");
+        require(block.timestamp - timestamp <= priceMaxAge, "CDPEngine: stale price");
 
         uint totalDebtUSD   = (borrowerVault.scaledDebt * assetState.rateAccumulator) / RAY;
         uint closeFactorCap = (totalDebtUSD * config.closeFactorBps) / 10000;
@@ -775,8 +787,9 @@ contract record CDPEngine is Ownable {
         Vault storage v = vaults[user][asset];
         uint debtUSD = (v.scaledDebt * s.rateAccumulator) / RAY;
         if (debtUSD == 0) return (2**256 - 1); 
-        uint price = _cdpPriceOracle().getAssetPrice(asset);
+        (uint price, uint timestamp) = _cdpPriceOracle().getAssetPriceWithTimestamp(asset);
         require(price > 0, "invalid price");
+        require(block.timestamp - timestamp <= priceMaxAge, "CDPEngine: stale price");
         uint unitScale = collateralConfigs[asset].unitScale;
         uint collateralUSD = unitScale == 0 ? 0 : (v.collateral * price) / unitScale;
         return (collateralUSD * WAD) / debtUSD;

--- a/mercata/contracts/concrete/Lending/LendingPool.sol
+++ b/mercata/contracts/concrete/Lending/LendingPool.sol
@@ -78,7 +78,7 @@ contract record LendingPool is Ownable {
     uint public debtCeilingUSD;   // cap in USD 1e18; 0 disables
 
     uint  public safetyShareBps;      // % of reserves to SM on sweep, e.g. 2000 = 20%
-    uint public priceMaxAge = 1200; // 20 minutes in seconds
+    uint public priceMaxAge = 1200;
 
    // Loan Management - One loan per user
     mapping(address => LoanInfo) public record userLoan; // user => single loan
@@ -110,6 +110,7 @@ contract record LendingPool is Ownable {
         // @dev important: must be set here for proxied instances; ensure consistency with desired initial values
         RAY = 1e27;
         SECONDS_PER_YEAR = 31536000;
+        priceMaxAge = 1200;
         
         require(_registry != address(0), "Invalid registry address");
         registry = LendingRegistry(_registry);

--- a/mercata/contracts/concrete/Lending/LendingPool.sol
+++ b/mercata/contracts/concrete/Lending/LendingPool.sol
@@ -37,6 +37,7 @@ contract record LendingPool is Ownable {
     event BadDebtCovered(uint cover, uint remainingBadDebt);
     event BadDebtWrittenOffFromReserves(uint writeOff, uint badDebt, uint reservesAccrued);
     event DepositorHaircutApplied(uint writeOff, uint badDebt, string calldata reason);
+    event PriceMaxAgeSet(uint oldMaxAge, uint newMaxAge);
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // DATA STRUCTURES
@@ -77,6 +78,7 @@ contract record LendingPool is Ownable {
     uint public debtCeilingUSD;   // cap in USD 1e18; 0 disables
 
     uint  public safetyShareBps;      // % of reserves to SM on sweep, e.g. 2000 = 20%
+    uint public priceMaxAge = 1200; // 20 minutes in seconds
 
    // Loan Management - One loan per user
     mapping(address => LoanInfo) public record userLoan; // user => single loan
@@ -489,10 +491,11 @@ contract record LendingPool is Ownable {
          require(maxBorrowAmount > currentOwed, "No room");
 
          // Prices and LTV
-         uint priceAsset = PriceOracle(_priceOracle()).getAssetPrice(asset); // 1e18
-         uint priceBorrow = PriceOracle(_priceOracle()).getAssetPrice(borrowableAsset); // 1e18
+         (uint priceAsset, uint timestampAsset) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(asset); // 1e18
+         (uint priceBorrow, uint timestampBorrow) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(borrowableAsset); // 1e18
          uint ltv = assetConfigs[asset].ltv; // bps
          require(priceAsset > 0 && priceBorrow > 0 && ltv > 0, "Config");
+         require(block.timestamp - timestampAsset <= priceMaxAge && block.timestamp - timestampBorrow <= priceMaxAge, "Invalid or stale price");
 
          // roomBorrow = maxBorrowAmount - currentOwed (in borrowable units)
          uint roomBorrow = maxBorrowAmount - currentOwed;
@@ -567,9 +570,10 @@ contract record LendingPool is Ownable {
         require(debtToCover <= maxRepay, "Repay amount exceeds allowed limit");
 
          // Calculate collateral to seize
-        uint priceDebt = PriceOracle(_priceOracle()).getAssetPrice(borrowableAsset); // 18 decimals USD
-        uint priceColl = PriceOracle(_priceOracle()).getAssetPrice(collateralAsset);
+        (uint priceDebt, uint timestampDebt) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(borrowableAsset); // 18 decimals USD
+        (uint priceColl, uint timestampColl) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(collateralAsset);
         require(priceDebt > 0 && priceColl > 0, "Invalid oracle price");
+        require(block.timestamp - timestampDebt <= priceMaxAge && block.timestamp - timestampColl <= priceMaxAge, "Invalid or stale price");
 
         uint collateralToSeize = (debtToCover * priceDebt * cConfig.liquidationBonus) / (priceColl * 10000);
         // debtToCover and prices are 1e18, so collateralToSeize is in collateral decimals (assume 18)
@@ -671,9 +675,10 @@ contract record LendingPool is Ownable {
         uint maxRepay = (health < 95e16) ? totalOwed : (totalOwed / 2);
 
         // Coverage cap = borrowerCollateral * priceColl / (priceDebt * bonus)
-        uint priceDebt = PriceOracle(_priceOracle()).getAssetPrice(borrowableAsset);
-        uint priceColl = PriceOracle(_priceOracle()).getAssetPrice(collateralAsset);
+        (uint priceDebt, uint timestampDebt) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(borrowableAsset);
+        (uint priceColl, uint timestampColl) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(collateralAsset);
         require(priceDebt > 0 && priceColl > 0, "Invalid oracle price");
+        require(block.timestamp - timestampDebt <= priceMaxAge && block.timestamp - timestampColl <= priceMaxAge, "Invalid or stale price");
         uint borrowerCollateral = CollateralVault(_collateralVault()).userCollaterals(borrower, collateralAsset);
         uint num = borrowerCollateral * priceColl * 10000;
         uint den = priceDebt * cConfig.liquidationBonus;
@@ -882,7 +887,8 @@ contract record LendingPool is Ownable {
             require(newDebt <= debtCeilingAsset, "Debt ceiling (asset) exceeded");
         }
         if (debtCeilingUSD > 0) {
-            uint p = PriceOracle(_priceOracle()).getAssetPrice(borrowableAsset); // 1e18 USD
+            (uint p, uint timestamp) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(borrowableAsset); // 1e18 USD
+            require(block.timestamp - timestamp <= priceMaxAge, "Invalid or stale price");
             require(p > 0, "No oracle price");
             uint newUsd = (newDebt * p) / 1e18;
             require(newUsd <= debtCeilingUSD, "Debt ceiling (USD) exceeded");
@@ -943,6 +949,12 @@ contract record LendingPool is Ownable {
         safetyShareBps = bps;
     }
 
+    function setPriceMaxAge(uint newMaxAge) external onlyPoolConfigurator {
+        uint old = priceMaxAge;
+        priceMaxAge = newMaxAge;
+        emit PriceMaxAgeSet(old, newMaxAge);
+    }
+
     /// @notice Sweep protocol reserves to FeeCollector (bounded by cash & reserves)
     function sweepReserves(uint amount) external onlyPoolConfigurator {
         if (amount == 0 || reservesAccrued == 0) return;
@@ -989,9 +1001,9 @@ contract record LendingPool is Ownable {
             uint collateralAmount = vault.userCollaterals(user, asset);
             if (collateralAmount == 0) continue;
 
-            uint price = oracle.getAssetPrice(asset);
+            (uint price, uint timestamp) = oracle.getAssetPriceWithTimestamp(asset);
             uint liqThreshold = assetConfigs[asset].liquidationThreshold;
-            if (price == 0 || liqThreshold == 0) continue;
+            if (price == 0 || liqThreshold == 0 || block.timestamp - timestamp > priceMaxAge) continue;
 
             totalValue += (collateralAmount * price * liqThreshold) / (1e18 * 10000);
         }
@@ -1007,8 +1019,8 @@ contract record LendingPool is Ownable {
         uint debt = getUserDebt(user); // scaledDebt * borrowIndex / RAY
         if (debt == 0) return 0;
 
-        uint price = PriceOracle(_priceOracle()).getAssetPrice(borrowableAsset); // USD 1e18
-        if (price == 0) return 0;
+        (uint price, uint timestamp) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(borrowableAsset); // USD 1e18
+        if (price == 0 || block.timestamp - timestamp > priceMaxAge) return 0;
 
         // USD value (18 decimals)
         return (debt * price) / 1e18;
@@ -1043,9 +1055,9 @@ contract record LendingPool is Ownable {
                 }
 
                 if (collateralAmount > 0) {
-                    uint price = PriceOracle(_priceOracle()).getAssetPrice(asset);
+                    (uint price, uint timestamp) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(asset);
 
-                    if (price > 0) {
+                    if (price > 0 && block.timestamp - timestamp <= priceMaxAge) {
                         // Calculate borrowable value using LTV (max borrowing power)
                         uint assetBorrowableValue = (collateralAmount * price * ltv) / (1e18 * 10000);
                         totalCollateralValue += assetBorrowableValue;
@@ -1055,8 +1067,8 @@ contract record LendingPool is Ownable {
         }
 
         // Convert total borrowable value back to borrowableAsset units
-        uint borrowableAssetPrice = PriceOracle(_priceOracle()).getAssetPrice(borrowableAsset);
-        if (borrowableAssetPrice == 0) {
+        (uint borrowableAssetPrice, uint timestamp) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(borrowableAsset);
+        if (borrowableAssetPrice == 0 || block.timestamp - timestamp > priceMaxAge) {
             return 0;
         }
 
@@ -1113,8 +1125,8 @@ contract record LendingPool is Ownable {
     function getTotalBorrowValuePreview(address user) public view returns (uint usdValuePreview) {
         uint debt = getUserDebtPreview(user);
         if (debt == 0) return 0;
-        uint price = PriceOracle(_priceOracle()).getAssetPrice(borrowableAsset); // 1e18 USD
-        if (price == 0) return 0;
+        (uint price, uint timestamp) = PriceOracle(_priceOracle()).getAssetPriceWithTimestamp(borrowableAsset); // 1e18 USD
+        if (price == 0 || block.timestamp - timestamp > priceMaxAge) return 0;
         return (debt * price) / 1e18;
     }
 

--- a/mercata/contracts/concrete/Lending/PoolConfigurator.sol
+++ b/mercata/contracts/concrete/Lending/PoolConfigurator.sol
@@ -223,6 +223,12 @@ contract record PoolConfigurator is Ownable {
         pool.setSafetyShareBps(bps);
     }
 
+    /// @notice Governance setter to update price max age
+    function setPriceMaxAge(uint newMaxAge) external onlyOwner {
+        LendingPool pool = LendingPool(registry.getLendingPool());
+        pool.setPriceMaxAge(newMaxAge);
+    }
+
     // Individual setters for the LendingRegistry
     function setLendingPool(address _lendingPool) external onlyOwner {
         require(_lendingPool != address(0), "Invalid lendingPool address");

--- a/mercata/contracts/tests/CDP/CDPEngine.test.sol
+++ b/mercata/contracts/tests/CDP/CDPEngine.test.sol
@@ -162,6 +162,14 @@ contract Describe_CDPEngine is Authorizable {
     function it_cdp_engine_has_correct_constants() {
         require(cdpEngine.WAD() == WAD, "WAD should be 1e18");
         require(cdpEngine.RAY() == RAY, "RAY should be 1e27");
+        
+        // Test price max age configuration
+        uint initialPriceMaxAge = cdpEngine.priceMaxAge();
+        uint newPriceMaxAge = 1800; // 30 minutes in seconds
+        
+        // Test setter function
+        cdpEngine.setPriceMaxAge(newPriceMaxAge);
+        require(cdpEngine.priceMaxAge() == newPriceMaxAge, "Price max age not updated");
     }
 
     function it_cdp_engine_can_configure_collateral_asset() {

--- a/mercata/contracts/tests/CDP/CDPEngine.test.sol
+++ b/mercata/contracts/tests/CDP/CDPEngine.test.sol
@@ -1469,6 +1469,10 @@ contract Describe_CDPEngine is Authorizable {
         // // Fast forward a bit to avoid timestamp 0 issues
         fastForward(1);
         
+        // Update oracle prices after time advancement to prevent staleness
+        priceOracle.setAssetPrice(collateralTokenAddress, 5e18);
+        priceOracle.setAssetPrice(usdstAddress, 1e18);
+        
         // Set up collateral and mint debt
         uint256 collateralAmount = 1000e18;
         uint256 debtAmount = 100e18; // 100 USDST
@@ -1495,6 +1499,10 @@ contract Describe_CDPEngine is Authorizable {
         uint256 timestampBefore = block.timestamp;
         fastForward(secondsInYear);
         uint256 timestampAfter = block.timestamp;
+        
+        // Update oracle prices after time advancement to prevent staleness
+        priceOracle.setAssetPrice(collateralTokenAddress, 5e18);
+        priceOracle.setAssetPrice(usdstAddress, 1e18);
         
         // log("Time before fastForward", timestampBefore);
         // log("Time after fastForward", timestampAfter);
@@ -1533,6 +1541,10 @@ contract Describe_CDPEngine is Authorizable {
         // Fast forward to avoid timestamp 0
         fastForward(1);
         
+        // Update oracle prices after time advancement to prevent staleness
+        priceOracle.setAssetPrice(collateralTokenAddress, 5e18);
+        priceOracle.setAssetPrice(usdstAddress, 1e18);
+        
         // Set up initial position
         uint256 collateralAmount = 1000e18;
         uint256 debtAmount = 100e18;
@@ -1554,6 +1566,10 @@ contract Describe_CDPEngine is Authorizable {
         uint256 sixMonths = 182 * 24 * 60 * 60; // ~6 months
         fastForward(sixMonths);
         
+        // Update oracle prices after time advancement to prevent staleness
+        priceOracle.setAssetPrice(collateralTokenAddress, 5e18);
+        priceOracle.setAssetPrice(usdstAddress, 1e18);
+        
         // Trigger accrual
         cdpEngine.mint(collateralTokenAddress, 1);
         
@@ -1564,6 +1580,10 @@ contract Describe_CDPEngine is Authorizable {
         
         // Fast forward another 6 months
         fastForward(sixMonths);
+        
+        // Update oracle prices after time advancement to prevent staleness
+        priceOracle.setAssetPrice(collateralTokenAddress, 5e18);
+        priceOracle.setAssetPrice(usdstAddress, 1e18);
         
         // Trigger accrual again
         cdpEngine.mint(collateralTokenAddress, 1);
@@ -1586,6 +1606,10 @@ contract Describe_CDPEngine is Authorizable {
         // Fast forward to avoid timestamp 0
         fastForward(1);
         
+        // Update oracle prices after time advancement to prevent staleness
+        priceOracle.setAssetPrice(collateralTokenAddress, 5e18);
+        priceOracle.setAssetPrice(usdstAddress, 1e18);
+        
         // Set up position
         uint256 collateralAmount = 1000e18;
         uint256 debtAmount = 100e18;
@@ -1601,6 +1625,10 @@ contract Describe_CDPEngine is Authorizable {
         // Fast forward 30 days to accrue some interest
         uint256 thirtyDays = 30 * 24 * 60 * 60;
         fastForward(thirtyDays);
+        
+        // Update oracle prices after time advancement to prevent staleness
+        priceOracle.setAssetPrice(collateralTokenAddress, 5e18);
+        priceOracle.setAssetPrice(usdstAddress, 1e18);
         
         // Trigger accrual with a small mint
         cdpEngine.mint(collateralTokenAddress, 1);
@@ -1639,5 +1667,30 @@ contract Describe_CDPEngine is Authorizable {
         uint256 totalRepaid = debtBefore;
         // log("Total amount repaid", totalRepaid);
         require(totalRepaid > debtAmount, "Should have paid interest on top of principal");
+    }
+
+    function it_cdp_engine_reverts_mint_with_stale_prices() {
+        // Set up collateral
+        uint256 collateralAmount = 1000e18;
+        require(
+            ERC20(collateralTokenAddress).approve(address(cdpVault), collateralAmount),
+            "Collateral approval failed"
+        );
+        cdpEngine.deposit(collateralTokenAddress, collateralAmount);
+        
+        // Set initial price
+        priceOracle.setAssetPrice(collateralTokenAddress, 5e18);
+        
+        // Advance time beyond the staleness threshold (25 minutes > 20 minutes)
+        fastForward(1500); // 25 minutes
+        
+        // Try to mint without updating prices - should fail due to stale price
+        bool reverted = false;
+        try cdpEngine.mint(collateralTokenAddress, 100e18) {
+            // Should not reach here
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Mint should revert with stale prices");
     }
 }

--- a/mercata/contracts/tests/Lending/BadDebt.test.sol
+++ b/mercata/contracts/tests/Lending/BadDebt.test.sol
@@ -136,14 +136,17 @@ contract Describe_BadDebt_Basic is Authorizable {
         uint debtCeilingAssetUnits = 10000000e18; // 10M USDST
         uint debtCeilingUSD = 10000000e18;        // 10M USD value 
         uint safetyShareBps = 1000;              // 10% to safety module
+        uint priceMaxAge = 1800;                 // 30 minutes in seconds
         
         configurator.setDebtCeilings(debtCeilingAssetUnits, debtCeilingUSD);
         configurator.setSafetyShareBps(safetyShareBps);
+        configurator.setPriceMaxAge(priceMaxAge);
         
         // Verify debt ceiling configuration
         require(pool.debtCeilingAsset() == debtCeilingAssetUnits, "Asset debt ceiling not set");
         require(pool.debtCeilingUSD() == debtCeilingUSD, "USD debt ceiling not set");
         require(pool.safetyShareBps() == safetyShareBps, "Safety share not set");
+        require(pool.priceMaxAge() == priceMaxAge, "Price max age not set");
         
         // === STEP 3: Configure USD borrowable asset parameters ===
         

--- a/mercata/contracts/tests/Lending/DustAttack.test.sol
+++ b/mercata/contracts/tests/Lending/DustAttack.test.sol
@@ -169,6 +169,10 @@ contract Describe_DustAttack is Authorizable {
 
         // given time passes to accrue some interest (1 year at 5% APY)
         fastForward(365 * 24 * 60 * 60);
+        
+        // Update oracle prices after time advancement to prevent staleness
+        oracle.setAssetPrice(goldst, 2000e18);   // $2000 Gold (preserve original price)
+        oracle.setAssetPrice(usdst, 1e18);       // $1 USD (preserve original price)
 
         // given a user with collateral wants to borrow dust amount
         User dustBorrower = new User();
@@ -219,6 +223,10 @@ contract Describe_DustAttack is Authorizable {
         for (uint i = 0; i < 10; i++) {
             fastForward(365 * 24 * 60 * 60);
         }
+        
+        // Update oracle prices after time advancement to prevent staleness
+        oracle.setAssetPrice(goldst, 2000e18);   // $2000 Gold (preserve original price)
+        oracle.setAssetPrice(usdst, 1e18);       // $1 USD (preserve original price)
 
         // given a user with collateral wants to borrow dust amount
         User dustBorrower = new User();
@@ -241,5 +249,27 @@ contract Describe_DustAttack is Authorizable {
         // then scaled debt is 1 (proving ceiling division: ceiling(0.5) = 1)
         LoanInfo memory loan = pool.getUserLoan(address(dustBorrower));
         require(loan.scaledDebt == 1, "Scaled debt should be 1 (ceiling of 0.5)");
+    }
+
+    function it_lending_pool_reverts_borrow_with_stale_prices() {
+        // Set up a user with collateral
+        User borrower = new User();
+        setupUserWithCollateral(borrower, goldst, 1e18);
+        
+        // Set initial prices
+        oracle.setAssetPrice(goldst, 2000e18);
+        oracle.setAssetPrice(usdst, 1e18);
+        
+        // Advance time beyond the staleness threshold (25 minutes > 20 minutes)
+        fastForward(1500); // 25 minutes
+        
+        // Try to borrow without updating prices - should fail due to stale price
+        bool reverted = false;
+        try TestUtils.callAs(borrower, address(pool), "borrow(uint256)", 1000e18) {
+            // Should not reach here
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Borrow should revert with stale prices");
     }
 }

--- a/mercata/contracts/tests/Oracle/PriceOracle.test.sol
+++ b/mercata/contracts/tests/Oracle/PriceOracle.test.sol
@@ -313,6 +313,137 @@ contract Describe_PriceOracle {
         require(isFresh, "Price should be fresh with very large max age");
     }
 
+    function it_price_oracle_validates_staleness_with_time_advancement() {
+        uint256 price = 100e8;
+        oracle.setAssetPrice(tokenA, price);
+        
+        // Price should be fresh immediately after setting
+        bool isFresh = oracle.isPriceFresh(tokenA, 1200); // 20 minutes
+        require(isFresh, "Price should be fresh immediately after setting");
+        
+        // Advance time by 10 minutes (600 seconds)
+        fastForward(600);
+        
+        // Price should still be fresh (within 20 minute window)
+        isFresh = oracle.isPriceFresh(tokenA, 1200);
+        require(isFresh, "Price should be fresh after 10 minutes");
+        
+        // Advance time by another 15 minutes (900 seconds total)
+        fastForward(900);
+        
+        // Price should now be stale (25 minutes total > 20 minute window)
+        isFresh = oracle.isPriceFresh(tokenA, 1200);
+        require(!isFresh, "Price should be stale after 25 minutes");
+        
+        // Update the price - should be fresh again
+        oracle.setAssetPrice(tokenA, 150e8);
+        isFresh = oracle.isPriceFresh(tokenA, 1200);
+        require(isFresh, "Updated price should be fresh");
+    }
+
+    function it_price_oracle_staleness_validation_with_different_thresholds() {
+        uint256 price = 200e8;
+        oracle.setAssetPrice(tokenA, price);
+        
+        // Test with 1 minute threshold
+        fastForward(30); // 30 seconds
+        bool isFresh = oracle.isPriceFresh(tokenA, 60); // 1 minute
+        require(isFresh, "Price should be fresh after 30 seconds with 1 minute threshold");
+        
+        fastForward(60); // 90 seconds total
+        isFresh = oracle.isPriceFresh(tokenA, 60);
+        require(!isFresh, "Price should be stale after 90 seconds with 1 minute threshold");
+        
+        // Test with 1 hour threshold
+        oracle.setAssetPrice(tokenA, 250e8); // Reset timestamp
+        fastForward(1800); // 30 minutes
+        isFresh = oracle.isPriceFresh(tokenA, 3600); // 1 hour
+        require(isFresh, "Price should be fresh after 30 minutes with 1 hour threshold");
+        
+        fastForward(3600); // 1.5 hours total
+        isFresh = oracle.isPriceFresh(tokenA, 3600);
+        require(!isFresh, "Price should be stale after 1.5 hours with 1 hour threshold");
+    }
+
+    function it_price_oracle_get_asset_price_with_timestamp_returns_correct_values() {
+        uint256 price = 150e8;
+        oracle.setAssetPrice(tokenA, price);
+        
+        (uint256 retrievedPrice, uint256 timestamp) = oracle.getAssetPriceWithTimestamp(tokenA);
+        require(retrievedPrice == price, "Retrieved price should match set price");
+        require(timestamp > 0, "Timestamp should be set");
+        require(timestamp <= block.timestamp, "Timestamp should not be in the future");
+    }
+
+    function it_price_oracle_get_asset_price_with_timestamp_updates_timestamp_on_price_change() {
+        uint256 initialPrice = 100e8;
+        oracle.setAssetPrice(tokenA, initialPrice);
+        
+        (uint256 price1, uint256 timestamp1) = oracle.getAssetPriceWithTimestamp(tokenA);
+        require(price1 == initialPrice, "Initial price should match");
+        
+        // Advance time and update price
+        fastForward(60); // 1 minute
+        uint256 newPrice = 200e8;
+        oracle.setAssetPrice(tokenA, newPrice);
+        
+        (uint256 price2, uint256 timestamp2) = oracle.getAssetPriceWithTimestamp(tokenA);
+        require(price2 == newPrice, "Updated price should match");
+        require(timestamp2 > timestamp1, "Timestamp should be updated on price change");
+        require(timestamp2 >= block.timestamp - 60, "Timestamp should reflect recent update");
+    }
+
+    function it_price_oracle_get_asset_price_with_timestamp_handles_stale_prices() {
+        uint256 price = 300e8;
+        oracle.setAssetPrice(tokenA, price);
+        
+        // Get initial timestamp
+        (uint256 initialPrice, uint256 initialTimestamp) = oracle.getAssetPriceWithTimestamp(tokenA);
+        require(initialPrice == price, "Initial price should match");
+        
+        // Advance time significantly (2 hours)
+        fastForward(7200);
+        
+        // Price should still be retrievable but timestamp should be old
+        (uint256 stalePrice, uint256 staleTimestamp) = oracle.getAssetPriceWithTimestamp(tokenA);
+        require(stalePrice == price, "Stale price should still be retrievable");
+        require(staleTimestamp == initialTimestamp, "Timestamp should not change without price update");
+        require(block.timestamp - staleTimestamp > 3600, "Price should be considered stale");
+        
+        // Verify staleness check
+        bool isFresh = oracle.isPriceFresh(tokenA, 3600); // 1 hour threshold
+        require(!isFresh, "Price should be stale after 2 hours with 1 hour threshold");
+    }
+
+    function it_price_oracle_get_asset_price_with_timestamp_works_with_multiple_assets() {
+        uint256 priceA = 100e8;
+        uint256 priceB = 200e8;
+        
+        oracle.setAssetPrice(tokenA, priceA);
+        oracle.setAssetPrice(tokenB, priceB);
+        
+        // Get prices and timestamps for both assets
+        (uint256 retrievedPriceA, uint256 timestampA) = oracle.getAssetPriceWithTimestamp(tokenA);
+        (uint256 retrievedPriceB, uint256 timestampB) = oracle.getAssetPriceWithTimestamp(tokenB);
+        
+        require(retrievedPriceA == priceA, "Price A should match");
+        require(retrievedPriceB == priceB, "Price B should match");
+        require(timestampA > 0 && timestampB > 0, "Both timestamps should be set");
+        require(timestampA <= block.timestamp && timestampB <= block.timestamp, "Timestamps should not be in future");
+        
+        // Update only one asset
+        fastForward(120); // 2 minutes
+        oracle.setAssetPrice(tokenA, 150e8);
+        
+        (uint256 newPriceA, uint256 newTimestampA) = oracle.getAssetPriceWithTimestamp(tokenA);
+        (uint256 unchangedPriceB, uint256 unchangedTimestampB) = oracle.getAssetPriceWithTimestamp(tokenB);
+        
+        require(newPriceA == 150e8, "Price A should be updated");
+        require(unchangedPriceB == priceB, "Price B should be unchanged");
+        require(newTimestampA > timestampA, "Timestamp A should be updated");
+        require(unchangedTimestampB == timestampB, "Timestamp B should be unchanged");
+    }
+
     // ============ EDGE CASES AND STRESS TESTS ============
 
     function it_price_oracle_handles_multiple_price_updates() {


### PR DESCRIPTION
- Added `priceMaxAge` variable to both `CDPEngine` and `LendingPool` contracts to define the maximum age of asset prices.
- Introduced `setPriceMaxAge` function in `CDPEngine` to allow the owner to update the `priceMaxAge`.
- Updated price retrieval logic to include checks for price staleness based on the new `priceMaxAge`.
- Enhanced tests in `CDPEngine` and `LendingPool` to validate behavior with stale prices, ensuring proper reversion when prices exceed the defined age.
- Updated relevant test cases to reflect changes in price handling and staleness validation.