### PR TITLE
Added int to hex string conversion in SolidVM

### DIFF
--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1403,7 +1403,8 @@ stringArgs x =
       :| [ addressType' x,
            accountType' x,
            intType' x,
-           boolType' x
+           boolType' x,
+           Product [intType' x, intType' x] x
          ]
 
 addressArgs :: SourceAnnotation Text -> Type'

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -106,7 +106,7 @@ import qualified LabeledError
 --import Blockchain.DB.MemAddressStateDB
 
 import Network.Haskoin.Crypto.BigWord ()
-import qualified Numeric (readHex)
+import qualified Numeric (readHex, showHex)
 import qualified SolidVM.Model.CodeCollection as CC
 import SolidVM.Model.SolidString
 import qualified SolidVM.Model.Storable as MS
@@ -2166,6 +2166,8 @@ callBuiltin :: MonadSM m => SolidString -> [Value] -> m Value
 callBuiltin "string" [SString s] = return $ SString s
 callBuiltin "string" [SAccount a _] = return . SString $ show a
 callBuiltin "string" [SInteger i] = return . SString $ show i
+callBuiltin "string" [SInteger i, SInteger 10] = return . SString $ show i
+callBuiltin "string" [SInteger i, SInteger 16] = return . SString $ Numeric.showHex i ""
 callBuiltin "string" [SBool b] = return . SString $ bool "false" "true" b
 callBuiltin "string" [SNULL] = return $ SString ""
 callBuiltin "string" [SReference{}] = return $ SString ""


### PR DESCRIPTION
To use, do:
```sol
uint x = 0xdeadbeef;
string str = string(x, 16); // Returns "deadbeef"
```

For hex string case normalizations, the roundtrip
```sol
string normalized = string(uint(unnormalized, 16), 16);
```
works

Also, SolidVM parses strings to integers as hex by default, so
```sol
string normalized = string(uint(unnormalized), 16);
```
works too