### PR TITLE
Fixed array indexing in cirrus

### DIFF
--- a/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/SolidVMStorageDecoder.hs
@@ -152,11 +152,12 @@ applyDelta' (Index n : sp) bv (ValueMapping ms) =
    in case M.lookup n' ms of
         Just v -> ValueMapping . (\x -> M.insert n' x ms) <$> applyDelta' sp bv v
         Nothing -> Right . ValueMapping $ M.insert n' (constructFromNothing' sp bv) ms
-applyDelta' (Index n' : sp) bv (ValueArrayDynamic vs) =
-  let n = fromInteger $ byteString2Integer n'
-   in case I.lookup n vs of
-        Just v -> ValueArrayDynamic . (\x -> I.insert n x vs) <$> applyDelta' sp bv v
-        Nothing -> Right . ValueArrayDynamic $ I.insert n (constructFromNothing' sp bv) vs
+applyDelta' (Index n' : sp) bv s@(ValueArrayDynamic vs) = do
+  let err = Left $ TypeMismatch (StoragePath sp) bv s
+  n <- maybe err Right . readMaybe . T.unpack $ decodeUtf8 n'
+  case I.lookup n vs of
+    Just v -> ValueArrayDynamic . (\x -> I.insert n x vs) <$> applyDelta' sp bv v
+    Nothing -> Right . ValueArrayDynamic $ I.insert n (constructFromNothing' sp bv) vs
 applyDelta' (Index n' : sp) bv sent@(ValueArraySentinel len) =
   let n = fromInteger $ byteString2Integer n'
    in Right . ValueArrayDynamic $ I.fromList [(n, constructFromNothing' sp bv), (len, sent)]


### PR DESCRIPTION
Fixes the issue where array elements were showing up as their ASCII ordinal values, e.g. 48 for 0, 49 for 1, etc.

https://github.com/blockapps/strato-platform/issues/5353