### PR TITLE
Flush mempool

### DIFF
--- a/strato/core/blockapps-datadefs/src/Blockchain/Data/TransactionResultStatus.hs
+++ b/strato/core/blockapps-datadefs/src/Blockchain/Data/TransactionResultStatus.hs
@@ -38,6 +38,7 @@ data TransactionFailureType
   | TXSizeLimitError
   | GasLimitError
   | KnownFailedTXError
+  | AdminFlushedError
   deriving (Eq, Read, Show, Generic, NFData)
 
 derivePersistField "TransactionResultStatus"

--- a/strato/core/seqevents/src/Blockchain/Sequencer/Event.hs
+++ b/strato/core/seqevents/src/Blockchain/Sequencer/Event.hs
@@ -5,6 +5,8 @@ module Blockchain.Sequencer.Event (
   ShowConstructor,
   showConstructor,
   IngestEvent(..),
+  FlushMempoolRequest(..),
+  FlushMempoolScope(..),
   VmEvent(..),
   P2pEvent(..),
   Timestamp,
@@ -41,6 +43,25 @@ instance Format SeqLoopEvent where
 class ShowConstructor a where
   showConstructor :: a -> String
 
+data FlushMempoolScope
+  = FlushPending
+  | FlushQueued
+  | FlushAll
+  deriving (Eq, Show, Read, GHCG.Generic)
+
+instance Binary FlushMempoolScope
+
+data FlushMempoolRequest = FlushMempoolRequest
+  { flushScope :: FlushMempoolScope
+  , flushRequestId :: String  -- For tracking/logging
+  } deriving (Eq, Show, GHCG.Generic)
+
+instance Binary FlushMempoolRequest
+
+instance Format FlushMempoolRequest where
+  format (FlushMempoolRequest scope reqId) =
+    "FlushMempool{scope=" ++ show scope ++ ", id=" ++ reqId ++ "}"
+
 data IngestEvent
   = IETx Timestamp IngestTx
   | IEBlock IngestBlock
@@ -53,6 +74,7 @@ data IngestEvent
   | IEMPNodesResponse TO.TXOrigin [NodeData]
   | IEMPNodesReceived [NodeData]
   | IEPreprepareResponse PBFT.PreprepareDecision
+  | IEFlushMempool FlushMempoolRequest
   deriving (Eq, Show, GHCG.Generic)
 
 instance Format IngestEvent where
@@ -67,6 +89,7 @@ instance Format IngestEvent where
   format (IEMPNodesResponse o n) = "Response to " ++ format o ++ ": " ++ show n
   format (IEMPNodesReceived o) = show o
   format (IEPreprepareResponse d) = format d
+  format (IEFlushMempool req) = format req
 
 type Timestamp = Microtime
 
@@ -115,6 +138,7 @@ data VmEvent
   | VmMPNodesReceived [NodeData]
   | VmRunPreprepare BDB.Block
   | VmSelfAddress Address
+  | VmFlushMempool FlushMempoolRequest
   deriving (Eq, Show, GHCG.Generic)
 
 instance Format VmEvent where
@@ -122,6 +146,7 @@ instance Format VmEvent where
   format (VmBlock o) = format o
   format (VmGetMPNodesRequest o srs) = show o ++ " requested: " ++ format srs
   format (VmMPNodesReceived nds) = show nds
+  format (VmFlushMempool req) = format req
   format x = show x
 
 instance ShowConstructor VmEvent where
@@ -133,6 +158,7 @@ instance ShowConstructor VmEvent where
   showConstructor VmMPNodesReceived{} = "VmMPNodesReceived"
   showConstructor VmRunPreprepare{} = "VmRunPreprepare"
   showConstructor VmSelfAddress{} = "VmSelfAddress"
+  showConstructor VmFlushMempool{} = "VmFlushMempool"
 
 instance Binary IngestEvent
 

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -173,6 +173,10 @@ unseqEventHandler events = do
         (IEPreprepareResponse decis) -> do
           record "inevent_type_preprepare_response" "PreprepareResponse" 1
           blockstanbulSend [PreprepareResponse decis]
+        (IEFlushMempool req) -> do
+          record "inevent_type_flush_mempool" "FlushMempool" 1
+          yield $ Right [VmFlushMempool req]
+          return ()
 
 bootstrapBlockstanbul :: (MonadBlockstanbul m, Mod.Accessible View m) =>
                          ConduitT i SeqOutEvent m ()

--- a/strato/core/vm-runner/package.yaml
+++ b/strato/core/vm-runner/package.yaml
@@ -35,6 +35,7 @@ library:
   - dlist
   - ethereum-rlp
 #  - ethereum-vm
+  - exceptions
   - extra
   - format
   - lens

--- a/strato/core/vm-runner/src/Blockchain/Event.hs
+++ b/strato/core/vm-runner/src/Blockchain/Event.hs
@@ -70,6 +70,7 @@ insertInBatch e b = case e of
   VmMPNodesReceived nds -> b {mpNodesResps = nds : mpNodesResps b}
   VmRunPreprepare b' -> b {preprepareBlock = Just b'}
   VmSelfAddress sa -> b {selfAddress = Just sa}
+  VmFlushMempool _ -> b  -- Flush mempool events are handled immediately, not batched
   
 data BlockDelta a = BlockDelta 
   { _inBlock :: a

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -21,6 +21,8 @@ where
 
 import BlockApps.Logging
 import qualified Blockchain.Bagger as Bagger
+import qualified Blockchain.Bagger.Transactions as Flush
+import qualified Blockchain.Bagger.Transactions (FlushScope)
 --import Blockchain.BlockChain
 import Blockchain.BlockDB
 import Blockchain.DB.ChainDB
@@ -81,6 +83,12 @@ ethereumVM d = runResourceT $ do
         case maybeSelfAddress of
           Just x -> contextModify' $ \cs@(ContextState{}) -> cs{_selfAddress = x}
           Nothing -> pure ()
+
+        -- Handle flush mempool events immediately
+        forM_ seqEvents $ \event -> case event of
+          VmFlushMempool req -> handleVmFlushMempool req
+          _ -> return ()
+
         recordBaggerMetrics =<< contextGets _baggerState
         logEventSummaries seqEvents
 
@@ -163,6 +171,7 @@ logEventSummaries evs = do
     getNames (VmMPNodesReceived _) = "MPNodesReceived"
     getNames (VmRunPreprepare _) = "VmRunPreprepare"
     getNames (VmSelfAddress _) = "VmSelfAddress"
+    getNames (VmFlushMempool _) = "FlushMempool"
 
     numberIt :: Int -> String -> String
     numberIt 1 x = "1 " ++ x
@@ -199,3 +208,17 @@ sendOutEvent (OutPreprepareResponse dec) = void $ writeUnseqEvents [IEPreprepare
 consumerGroup :: ConsumerGroup
 consumerGroup = "ethereum-vm"
 
+-- | Handle flush mempool event by converting scope and calling Bagger.flush
+handleVmFlushMempool :: (MonadLogger m, MonadIO m) => FlushMempoolRequest -> m ()
+handleVmFlushMempool (FlushMempoolRequest scope reqId) = do
+  $logInfoS "EthereumVM.flush" $ T.pack $
+    "Processing flush request " ++ reqId ++ " with scope " ++ show scope
+  flushedTxs <- Bagger.flush (convertFlushScope scope)
+  $logInfoS "EthereumVM.flush" $ T.pack $
+    "Flushed " ++ show (length flushedTxs) ++ " transactions for request " ++ reqId
+  where
+    -- Convert event scope to Bagger scope
+    convertFlushScope :: FlushMempoolScope -> FlushScope
+    convertFlushScope FlushPending = Flush.FlushPending
+    convertFlushScope FlushQueued = Flush.FlushQueued
+    convertFlushScope FlushAll = Flush.FlushAll

--- a/strato/core/vm-runner/src/Executable/EthereumVM.hs
+++ b/strato/core/vm-runner/src/Executable/EthereumVM.hs
@@ -22,7 +22,6 @@ where
 import BlockApps.Logging
 import qualified Blockchain.Bagger as Bagger
 import qualified Blockchain.Bagger.Transactions as Flush
-import qualified Blockchain.Bagger.Transactions (FlushScope)
 --import Blockchain.BlockChain
 import Blockchain.BlockDB
 import Blockchain.DB.ChainDB
@@ -209,7 +208,7 @@ consumerGroup :: ConsumerGroup
 consumerGroup = "ethereum-vm"
 
 -- | Handle flush mempool event by converting scope and calling Bagger.flush
-handleVmFlushMempool :: (MonadLogger m, MonadIO m) => FlushMempoolRequest -> m ()
+handleVmFlushMempool :: Bagger.MonadBagger m => FlushMempoolRequest -> m ()
 handleVmFlushMempool (FlushMempoolRequest scope reqId) = do
   $logInfoS "EthereumVM.flush" $ T.pack $
     "Processing flush request " ++ reqId ++ " with scope " ++ show scope
@@ -218,7 +217,7 @@ handleVmFlushMempool (FlushMempoolRequest scope reqId) = do
     "Flushed " ++ show (length flushedTxs) ++ " transactions for request " ++ reqId
   where
     -- Convert event scope to Bagger scope
-    convertFlushScope :: FlushMempoolScope -> FlushScope
+    convertFlushScope :: FlushMempoolScope -> Flush.FlushScope
     convertFlushScope FlushPending = Flush.FlushPending
     convertFlushScope FlushQueued = Flush.FlushQueued
     convertFlushScope FlushAll = Flush.FlushAll

--- a/strato/core/vm-tools/src/Blockchain/Bagger.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger.hs
@@ -192,6 +192,8 @@ baggerRejectionToTransactionResultBits rejection = case rejection of
     (p s q ++ "transaction gas limit exceeded. Limit: " ++ show l ++ " Actual: " ++ show e, hsh)
   KnownFailedTX s q OutputTx {otHash = hsh} ->
     (p s q ++ "known failed tx: " ++ format hsh, hsh)
+  AdminFlushed s q scope OutputTx {otHash = hsh} ->
+    (p s q ++ "administratively flushed from mempool with scope " ++ show scope, hsh)
   where
     p stage queue = "Rejected from mempool at " ++ show stage ++ "/" ++ show queue ++ " due to "
     p' s q = p s q ++ "low "
@@ -212,6 +214,25 @@ addTransactionsToMempool txs = do
   withBagger $ do
     sequence_ (addToQueued Insertion <$> txs)
     promoteExecutables
+
+flush :: MonadBagger m => FlushScope -> m [OutputTx]
+flush scope = do
+  state <- getBaggerState
+  let txShas = B.bestBlockTxHashes (B.miningCache state)
+  $logInfoS "Bagger.flush" . T.pack $ "Flushing mempool with scope: " ++ show scope
+  let (flushedTxsWithQueue, newState) = case scope of
+        FlushPending -> B.flushPendingOnly state
+        FlushQueued -> B.flushQueuedOnly state
+        FlushAll -> B.flushBoth state
+  -- Clear the 'seen' set for flushed transactions
+  let flushedTxs = map fst flushedTxsWithQueue
+  let newState' = foldl (flip B.removeFromSeen) newState flushedTxs
+  putBaggerState newState'
+  $logInfoS "Bagger.flush" . T.pack $ "Flushed " ++ show (length flushedTxs) ++ " transactions"
+  -- Notify that transactions were dropped, using the correct queue for each transaction
+  let rejections = map (\(tx, queue) -> AdminFlushed Demotion queue scope tx) flushedTxsWithQueue
+  txsDroppedCallback rejections txShas
+  return flushedTxs
 
 processNewBestBlock :: MonadBagger m => Keccak256 -> BlockHeader -> [Keccak256] -> m ()
 processNewBestBlock bh bd txShas = do

--- a/strato/core/vm-tools/src/Blockchain/Bagger/BaggerState.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger/BaggerState.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 
 module Blockchain.Bagger.BaggerState where
 
@@ -14,6 +15,7 @@ import Blockchain.Strato.Model.Address
 import Blockchain.Strato.Model.Keccak256
 import Control.Applicative (Alternative, empty)
 import Control.DeepSeq
+import Control.Monad.State (runState, state)
 import qualified Data.DList as DL
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -201,3 +203,19 @@ upsertPT tx@OutputTx {otSigner = addr, otBaseTx = bt} pt = ret
     filtered = filter (not . (\t -> otSigner t == addr && nonce' (otBaseTx t) <= nonce' bt)) pt
     nonce' = TD.transactionNonce
     !ret = tx : filtered
+
+flushPendingOnly :: BaggerState -> ([(OutputTx, BaggerTxQueue)], BaggerState)
+flushPendingOnly s@BaggerState {pending = p} =
+  (map (, Pending) $ concatMap toList $ M.elems p, s {pending = M.empty})
+
+flushQueuedOnly :: BaggerState -> ([(OutputTx, BaggerTxQueue)], BaggerState)
+flushQueuedOnly s@BaggerState {queued = q} =
+  (map (, Queued) $ concatMap toList $ M.elems q, s {queued = M.empty})
+
+flushBoth :: BaggerState -> ([(OutputTx, BaggerTxQueue)], BaggerState)
+flushBoth s = runState flushBothState s
+  where
+    flushBothState = do
+      pendingTxs <- state flushPendingOnly
+      queuedTxs <- state flushQueuedOnly
+      return (pendingTxs ++ queuedTxs)

--- a/strato/core/vm-tools/src/Blockchain/Bagger/Transactions.hs
+++ b/strato/core/vm-tools/src/Blockchain/Bagger/Transactions.hs
@@ -82,6 +82,7 @@ data TxRejection
   | TXSizeLimitExceeded BaggerStage BaggerTxQueue Integer Integer OutputTx
   | GasLimitExceeded BaggerStage BaggerTxQueue Integer Integer OutputTx
   | KnownFailedTX BaggerStage BaggerTxQueue OutputTx
+  | AdminFlushed BaggerStage BaggerTxQueue FlushScope OutputTx
   deriving (Eq, Read, Show)
 
 rejectedTx :: TxRejection -> OutputTx
@@ -94,8 +95,11 @@ rejectedTx (InvalidPragma _ _ _ t) = t
 rejectedTx (TXSizeLimitExceeded _ _ _ _ t) = t
 rejectedTx (GasLimitExceeded _ _ _ _ t) = t
 rejectedTx (KnownFailedTX _ _ t) = t
+rejectedTx (AdminFlushed _ _ _ t) = t
 
 data BaggerStage = Insertion | Validation | Promotion | Demotion | Execution deriving (Read, Eq, Show)
+
+data FlushScope = FlushPending | FlushQueued | FlushAll deriving (Read, Eq, Show)
 
 instance Format TxRejection where
   format (NonceTooLow stage queue actual o@OutputTx {otHash = hash}) =
@@ -170,6 +174,13 @@ instance Format TxRejection where
       ++ format hash
       ++ "\n"
       ++ format o
+  format (AdminFlushed stage queue scope o@OutputTx {otHash = hash}) =
+    "AdminFlushed at stage " ++ show stage ++ " in queue " ++ show queue
+      ++ " with scope " ++ show scope
+      ++ "\n\ttx hash "
+      ++ format hash
+      ++ "\n"
+      ++ format o
 
 txRejectionToAPIFailureCause :: TxRejection -> TransactionResultStatus
 txRejectionToAPIFailureCause (NonceTooLow stage queue needed tx) =
@@ -190,6 +201,8 @@ txRejectionToAPIFailureCause (GasLimitExceeded stage queue actual limit _) =
   Failure (show stage) (Just $ show queue) Blockchain.Data.TransactionResultStatus.GasLimitError (Just limit) (Just actual) (Just $ "The transaction takes " ++ show actual ++ " gas but the limit is " ++ show limit)
 txRejectionToAPIFailureCause (KnownFailedTX stage queue t) =
   Failure (show stage) (Just $ show queue) Blockchain.Data.TransactionResultStatus.KnownFailedTXError Nothing Nothing (Just $ "The transaction " ++ show (otHash t) ++ " is known to fail")
+txRejectionToAPIFailureCause (AdminFlushed stage queue scope t) =
+  Failure (show stage) (Just $ show queue) Blockchain.Data.TransactionResultStatus.AdminFlushedError Nothing Nothing (Just $ "The transaction " ++ show (otHash t) ++ " was administratively flushed from mempool with scope " ++ show scope)
 
 tfToBaggerTxRejection :: TransactionFailureCause -> TxRejection
 tfToBaggerTxRejection (TFInsufficientFunds cost balance tx) = BalanceTooLow Execution Queued cost balance tx


### PR DESCRIPTION
Fixes #5296

# Why 

Admin realizes mempool is clogged with old transactions, sends flush command

# What was done

Added a new mempool flush functionality with configurable scope to allow administrative control over transaction queue management.

Changes:

- New event type: IEFlushMempool with configurable scope (FlushPending, FlushQueued, FlushAll)
- Event pipeline integration: Flush events flow through Sequencer and route to VM for processing
- VM handler: handleVmFlushMempool clears transactions from Bagger mempool based on scope

# Order of processing

  Flush events are processed before the current batch of VM events. This ensures:
  - The flush targets the existing mempool state (old/stuck transactions)
  - New transactions arriving in the same Kafka batch are processed normally after the flush
  - Administrative intent is preserved: clear problematic old transactions, not penalize concurrent new ones

Example:

  1. Mempool has: `[old_tx_1, old_tx_2, stuck_tx_3, ...]`
  2. Admin sends flush command via API
  3. Kafka batch arrives: `[new_tx_A, new_tx_B, VmFlushMempool]`
  4. VM processes:
      * Flush executes → removes `[old_tx_1, old_tx_2, stuck_tx_3]`
     * Batch processes → `new_tx_A` and `new_tx_B` are added to now-clean mempool
     
#  Next Decision

Determine access method: REST API endpoint (e.g `POST /eth/1.2/mempool/flush`) vs. standalone executable for triggering flush operations.

This is an action that only the node operator should call
