### PR TITLE
Prevent accidental addition of null admin

### DIFF
--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -139,6 +139,7 @@ contract record AdminRegistry is Ownable {
     }
 
     function _addAdmin(address _admin) external onlyOwner {
+        require(_admin != address(0), "Invalid admin address");
         require(adminMap[_admin] == 0, "Account is already an admin");
         admins.push(_admin);
         adminMap[_admin] = admins.length;

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -33,6 +33,7 @@ contract record AdminRegistry is Ownable {
         defaultVotingThresholdBps = 6000; // 3/5
         require(admins.length == 0, "AdminRegistry is already initialized");
         for (uint i = 0; i < _initialAdmins.length; i++) {
+            require(_initialAdmins[i] != address(0), "Invalid admin address");
             admins.push(_initialAdmins[i]);
             adminMap[_initialAdmins[i]] = admins.length;
         }

--- a/strato/core/strato-genesis/resources/contracts/concrete/Admin/AdminRegistry.sol
+++ b/strato/core/strato-genesis/resources/contracts/concrete/Admin/AdminRegistry.sol
@@ -139,6 +139,7 @@ contract record AdminRegistry is Ownable {
     }
 
     function _addAdmin(address _admin) external onlyOwner {
+        require(_admin != address(0), "Invalid admin address");
         require(adminMap[_admin] == 0, "Account is already an admin");
         admins.push(_admin);
         adminMap[_admin] = admins.length;

--- a/strato/core/strato-genesis/resources/contracts/concrete/Admin/AdminRegistry.sol
+++ b/strato/core/strato-genesis/resources/contracts/concrete/Admin/AdminRegistry.sol
@@ -33,6 +33,7 @@ contract record AdminRegistry is Ownable {
         defaultVotingThresholdBps = 6000; // 3/5
         require(admins.length == 0, "AdminRegistry is already initialized");
         for (uint i = 0; i < _initialAdmins.length; i++) {
+            require(_initialAdmins[i] != address(0), "Invalid admin address");
             admins.push(_initialAdmins[i]);
             adminMap[_initialAdmins[i]] = admins.length;
         }


### PR DESCRIPTION
Fixes #5353 

Addition of a null admin seem like it might break solidvm and/or cirrus.

Instead of spending time debugging that issue, it would be faster to just ensure that null admins are never added accidentally, which we should be asserting anyway.