### PR TITLE
Change CATA to CATA Points on Dashboard page

### DIFF
--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -154,9 +154,9 @@ const Dashboard = () => {
             />
 
             <AssetSummary
-              title="CATA Rewards"
-              value={`${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA`}
-              tooltip={cataBalance === 0 ? "No rewards yet - start staking to earn CATA!" : undefined}
+              title="CATA Points Rewards"
+              value={`${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA Points`}
+              tooltip={cataBalance === 0 ? "No rewards yet - start staking to earn CATA Points!" : undefined}
               icon={<Coins className="text-white" size={18} />}
               color="bg-purple-500"
             />

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -154,9 +154,8 @@ const Dashboard = () => {
             />
 
             <AssetSummary
-              title="CATA Points Rewards"
+              title="Rewards"
               value={`${cataBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })} CATA Points`}
-              tooltip={cataBalance === 0 ? "No rewards yet - start staking to earn CATA Points!" : undefined}
               icon={<Coins className="text-white" size={18} />}
               color="bg-purple-500"
             />


### PR DESCRIPTION
# After this PR

<img width="677" height="299" alt="Screenshot 2025-10-27 at 16 06 28" src="https://github.com/user-attachments/assets/54097f52-807d-491b-9c89-888ef828b3eb" />
<img width="636" height="249" alt="Screenshot 2025-10-27 at 16 06 39" src="https://github.com/user-attachments/assets/23ec24f2-212d-4077-94a7-daab10a38331" />

# Different approach

* Maybe it should be "Rewards" (in gray), not "CATA Points Rewards"
* Or in gray "CATA Points", and in black "x Points"

?
