### PR TITLE
Disable buttons for paused actions when Lending Pool is on pause

### DIFF
--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -442,7 +442,7 @@ export const collateralAndBalance = async (
     select:
       `lendingPool:lendingPool_fkey(` +
         `assetConfigs:${LendingPool}-assetConfigs(asset:key,AssetConfig:value),` +
-        `borrowableAsset` +
+        `borrowableAsset,_paused` +
       `),` +
       `collateralVault:collateralVault_fkey(` +
         `userCollaterals:${CollateralVault}-userCollaterals(user:key,asset:key2,amount:value::text)` +
@@ -455,6 +455,8 @@ export const collateralAndBalance = async (
   if (!registry.lendingPool || !registry.collateralVault) {
     throw new Error("Lending pool or collateral vault not found");
   }
+
+  const isPaused = registry.lendingPool._paused;
 
   const assets = registry.lendingPool.assetConfigs?.map((a: any) => a.asset).filter((asset: string) => asset !== registry.lendingPool.borrowableAsset) || [];
   const userCollaterals = (registry.collateralVault.userCollaterals || []).filter((c: any) => c.user === userAddress);
@@ -516,6 +518,7 @@ export const collateralAndBalance = async (
         assetPrice,
         ltv,
         liquidationThreshold,
+        isPaused,
       };
     });
 };
@@ -1139,6 +1142,7 @@ export const listLoansForLiquidation = async (
       `address,` +
       `borrowableAsset,` +
       `borrowIndex::text,` +
+      `_paused,` +
       `assetConfigs:${LendingPool}-assetConfigs(asset:key,AssetConfig:value),` +
       `loans:${LendingPool}-userLoan(user:key,LoanInfo:value)` +
     `),` +
@@ -1153,6 +1157,7 @@ export const listLoansForLiquidation = async (
 
   const borrowableAsset: string = registry.lendingPool?.borrowableAsset;
   const borrowIndexStr = registry.lendingPool?.borrowIndex || "0";
+  const isPaused = registry.lendingPool?._paused;
   const assetConfigsArr = registry.lendingPool?.assetConfigs || [];
   const loansArr = registry.lendingPool?.loans || [];
   const collateralsArr = registry.collateralVault?.userCollaterals || [];
@@ -1251,6 +1256,7 @@ export const listLoansForLiquidation = async (
         expectedProfit: expectedProfit.toString(),
         maxRepay: effectiveMaxRepay.toString(),
         liquidationBonus,
+        isPaused,
       };
     })
     // Filter out zero-amount or zero-USD-value collaterals

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -524,11 +524,11 @@ export const liquidityAndBalance = async (
   accessToken: string,
   userAddress: string,
 ) => {
-  // Fetch pool data with explicit select (index fields + userLoan + prices)
+  // Fetch pool data with explicit select (index fields + userLoan + prices + pause status)
   const registry = await getPool(accessToken, {
     select:
       `lendingPool:lendingPool_fkey(` +
-        `address,borrowableAsset,mToken,` +
+        `address,borrowableAsset,mToken,_paused,` +
         `borrowIndex::text,totalScaledDebt::text,reservesAccrued::text,lastAccrual::text,badDebt::text,` +
         `assetConfigs:${LendingPool}-assetConfigs(asset:key,AssetConfig:value),` +
         `userLoan:${LendingPool}-userLoan(user:key,LoanInfo:value)` +
@@ -544,8 +544,9 @@ export const liquidityAndBalance = async (
     "lendingPool.userLoan.key": `eq.${userAddress}`
   });
 
-  const { borrowableAsset, mToken, assetConfigs } = registry.lendingPool || {};
+  const { borrowableAsset, mToken, assetConfigs, _paused } = registry.lendingPool || {};
   const allCollaterals = registry.collateralVault?.userCollaterals || [];
+  const isPaused = _paused;
 
   if (!borrowableAsset || !mToken) {
     throw new Error("Lending pool, borrowable asset, or mToken not found");
@@ -696,6 +697,8 @@ export const liquidityAndBalance = async (
     totalAmountOwedPreview: totalAmountOwedPreviewClamped,
     // Compat:
     totalBorrowPrincipal,
+    // Pause status
+    isPaused,
   };
 };
 

--- a/mercata/ui/src/components/borrow/CollateralManagementTable.tsx
+++ b/mercata/ui/src/components/borrow/CollateralManagementTable.tsx
@@ -9,7 +9,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { HelpCircle, ArrowUpCircle, ArrowDownCircle } from "lucide-react";
+import { HelpCircle, ArrowUpCircle, ArrowDownCircle, PauseCircle } from "lucide-react";
 import { formatBalance } from "@/utils/numberUtils";
 import { CollateralData, NewLoanData } from "@/interface";
 import { getMaxSafeWithdrawAmount } from "@/utils/lendingUtils";
@@ -185,9 +185,12 @@ const CollateralManagementTable = ({
                           const maxWithdrawAmount = getMaxSafeWithdrawAmount(asset, loans);
                           const hasCollateral = BigInt(asset?.collateralizedAmount || 0) > 0n;
                           const canWithdraw = maxWithdrawAmount > 0n;
+                          const isPaused = asset?.isPaused;
 
                           let tooltipMessage = "";
-                          if (canWithdraw) {
+                          if (isPaused) {
+                            tooltipMessage = "Lending Pool is on pause. Action currently disabled.";
+                          } else if (canWithdraw) {
                             tooltipMessage = "Withdraw collateral.\nReduces borrowing power.";
                           } else if (!hasCollateral) {
                             tooltipMessage = "Cannot withdraw.\nNo collateral supplied for this asset.";
@@ -201,13 +204,18 @@ const CollateralManagementTable = ({
                                 <span className="cursor-help">
                                   <Button
                                     onClick={() => onWithdraw(asset)}
-                                    disabled={!canWithdraw || !hasCollateral}
+                                    disabled={!canWithdraw || !hasCollateral || isPaused}
                                   >
+                                    {isPaused ? (
+                                      <PauseCircle className="h-4 w-4 mr-1" />
+                                    ) : (
+                                      <ArrowUpCircle className="h-4 w-4 mr-1" />
+                                    )}
                                     Withdraw
                                   </Button>
                                 </span>
                               </TooltipTrigger>
-                              <TooltipContent>
+                              <TooltipContent className={isPaused ? "bg-amber-50 border-amber-300 text-amber-900" : ""}>
                                 <span>{tooltipMessage}</span>
                               </TooltipContent>
                             </Tooltip>

--- a/mercata/ui/src/components/dashboard/LendingPoolSection.tsx
+++ b/mercata/ui/src/components/dashboard/LendingPoolSection.tsx
@@ -1,5 +1,5 @@
 import { formatUnits } from "ethers";
-import { CircleArrowDown, CircleArrowUp, HelpCircle } from "lucide-react";
+import { CircleArrowDown, CircleArrowUp, HelpCircle, PauseCircle } from "lucide-react";
 import { useLendingContext } from "@/context/LendingContext";
 import { useUser } from "@/context/UserContext";
 import { useUserTokens } from "@/context/UserTokensContext";
@@ -321,25 +321,41 @@ const LendingPoolSection = () => {
                       />
                       <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-xs font-medium">USDST</span>
                     </div>
-                    <Button
-                      onClick={() => handleLiquidityAction("withdraw")}
-                      variant="outline"
-                      className="border-strato-blue text-strato-blue hover:bg-strato-blue/10 w-full sm:w-28 hidden sm:flex sm:items-center sm:justify-center"
-                      disabled={
-                        loadingLiquidity ||
-                        isProcessing ||
-                        !isWithdrawAmountValid()
-                      }
-                    >
-                      {isProcessing ? (
-                        "Processing..."
-                      ) : (
-                        <>
-                          <CircleArrowUp className="mr-2 h-4 w-4" />
-                          Withdraw
-                        </>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="w-full sm:w-28 hidden sm:inline-block">
+                          <Button
+                            onClick={() => handleLiquidityAction("withdraw")}
+                            variant="outline"
+                            className="border-strato-blue text-strato-blue hover:bg-strato-blue/10 w-full"
+                            disabled={
+                              loadingLiquidity ||
+                              isProcessing ||
+                              !isWithdrawAmountValid() ||
+                              liquidityInfo?.isPaused
+                            }
+                          >
+                            {isProcessing ? (
+                              "Processing..."
+                            ) : (
+                              <>
+                                {liquidityInfo?.isPaused ? (
+                                  <PauseCircle className="mr-2 h-4 w-4" />
+                                ) : (
+                                  <CircleArrowUp className="mr-2 h-4 w-4" />
+                                )}
+                                Withdraw
+                              </>
+                            )}
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      {liquidityInfo?.isPaused && (
+                        <TooltipContent className="bg-orange-50 border-orange-200 text-orange-900">
+                          <p>Lending Pool is on pause. This action currently disabled.</p>
+                        </TooltipContent>
                       )}
-                    </Button>
+                    </Tooltip>
                   </div>
                   <div className="text-sm text-gray-500 mt-1">
                     <button
@@ -453,25 +469,41 @@ const LendingPoolSection = () => {
                     );
                   })()}
                   {/* Mobile Button */}
-                  <Button
-                    onClick={() => handleLiquidityAction("withdraw")}
-                    variant="outline"
-                    className="border-strato-blue text-strato-blue hover:bg-strato-blue/10 w-full mt-4 sm:hidden"
-                    disabled={
-                      loadingLiquidity ||
-                      isProcessing ||
-                      !isWithdrawAmountValid()
-                    }
-                  >
-                    {isProcessing ? (
-                      "Processing..."
-                    ) : (
-                      <>
-                        <CircleArrowUp className="mr-2 h-4 w-4" />
-                        Withdraw
-                      </>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="w-full mt-4 sm:hidden block">
+                        <Button
+                          onClick={() => handleLiquidityAction("withdraw")}
+                          variant="outline"
+                          className="border-strato-blue text-strato-blue hover:bg-strato-blue/10 w-full"
+                          disabled={
+                            loadingLiquidity ||
+                            isProcessing ||
+                            !isWithdrawAmountValid() ||
+                            liquidityInfo?.isPaused
+                          }
+                        >
+                          {isProcessing ? (
+                            "Processing..."
+                          ) : (
+                            <>
+                              {liquidityInfo?.isPaused ? (
+                                <PauseCircle className="mr-2 h-4 w-4" />
+                              ) : (
+                                <CircleArrowUp className="mr-2 h-4 w-4" />
+                              )}
+                              Withdraw
+                            </>
+                          )}
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    {liquidityInfo?.isPaused && (
+                      <TooltipContent className="bg-orange-50 border-orange-200 text-orange-900">
+                        <p>Lending Pool is on pause. This action currently disabled.</p>
+                      </TooltipContent>
                     )}
-                  </Button>
+                  </Tooltip>
                 </div>
               </div>
             </div>

--- a/mercata/ui/src/components/dashboard/LiquidationsSection.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidationsSection.tsx
@@ -6,6 +6,7 @@ import LiquidateModal from "./LiquidateModal";
 import { CollateralData } from "@/interface";
 import TokenDisplay from "@/components/ui/TokenDisplay";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Table,
   TableBody,
@@ -14,7 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, PauseCircle } from "lucide-react";
 import { useUser } from "@/context/UserContext";
 const shorten = (addr: string) => addr.slice(0, 6) + "..." + addr.slice(-4);
 const weiToEther = (v?: string) => {
@@ -164,17 +165,29 @@ const LiquidationsSection: React.FC = () => {
                                 />
                                 <span className="font-medium text-sm">{c.symbol || "UNKNOWN"}</span>
                               </div>
-                              <Button 
-                                size="sm" 
-                                variant="destructive" 
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  openModal(ln, c);
-                                }}
-                                disabled={isOwnLoan(ln)}
-                              >
-                                Liquidate
-                              </Button>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span>
+                                    <Button
+                                      size="sm"
+                                      variant="destructive"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        openModal(ln, c);
+                                      }}
+                                      disabled={isOwnLoan(ln) || c.isPaused}
+                                    >
+                                      {c.isPaused && <PauseCircle className="h-4 w-4 mr-1" />}
+                                      Liquidate
+                                    </Button>
+                                  </span>
+                                </TooltipTrigger>
+                                {c.isPaused && (
+                                  <TooltipContent className="bg-amber-50 border-amber-300 text-amber-900">
+                                    <p>Lending Pool is on pause. Action currently disabled.</p>
+                                  </TooltipContent>
+                                )}
+                              </Tooltip>
                             </div>
                             <div className="grid grid-cols-2 gap-2 text-sm">
                               <div>
@@ -236,17 +249,29 @@ const LiquidationsSection: React.FC = () => {
                                   </span>
                                 </TableCell>
                                 <TableCell>
-                                  <Button 
-                                    size="sm" 
-                                    variant="destructive" 
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      openModal(ln, c);
-                                    }}
-                                    disabled={isOwnLoan(ln)}
-                                  >
-                                    Liquidate
-                                  </Button>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <span>
+                                        <Button
+                                          size="sm"
+                                          variant="destructive"
+                                          onClick={(e) => {
+                                            e.stopPropagation();
+                                            openModal(ln, c);
+                                          }}
+                                          disabled={isOwnLoan(ln) || c.isPaused}
+                                        >
+                                          {c.isPaused && <PauseCircle className="h-4 w-4 mr-1" />}
+                                          Liquidate
+                                        </Button>
+                                      </span>
+                                    </TooltipTrigger>
+                                    {c.isPaused && (
+                                      <TooltipContent className="bg-amber-50 border-amber-300 text-amber-900">
+                                        <p>Lending Pool is on pause. Action currently disabled.</p>
+                                      </TooltipContent>
+                                    )}
+                                  </Tooltip>
                                 </TableCell>
                               </TableRow>
                             );

--- a/mercata/ui/src/interface/index.tsx
+++ b/mercata/ui/src/interface/index.tsx
@@ -247,6 +247,7 @@ export interface LiquidityData {
   // new (optional)
   totalAmountOwed?: string;
   totalAmountOwedPreview?: string;
+  isPaused: boolean;              // LendingPool pause status
 }
 
 export interface CollateralRatioItem {

--- a/mercata/ui/src/interface/index.tsx
+++ b/mercata/ui/src/interface/index.tsx
@@ -213,6 +213,7 @@ export interface CollateralData {
   liquidationBonus?: string;
   bonus?: string;
   expectedProfit?: string;
+  isPaused: boolean;              // LendingPool pause status
 }
 
 export interface TokenInfo {


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/5424

# Before this change

The user could still interact with Lending Pool, and actions like "withdraw" were stopped on the contract level.

Not a good experience, especially if you pay for the failed transactions.

# After this change

Actions that are disallowed during pause are now disabled.

* Liquidity withdrawal blocked

<img width="932" height="224" alt="Screenshot 2025-10-28 at 12 39 08" src="https://github.com/user-attachments/assets/099aa8c3-0ea2-430e-9ea0-7ff516e69c8c" />

* Collateral withdrawal blocked

<img width="1656" height="302" alt="Screenshot 2025-10-28 at 13 08 21" src="https://github.com/user-attachments/assets/a94cd890-5968-4961-949f-ad6255d8fe5b" />

* Liquidation blocked

<img width="1562" height="290" alt="Screenshot 2025-10-28 at 13 52 08" src="https://github.com/user-attachments/assets/b01d2e68-7ab4-46af-90f0-fab028641470" />

