### PR TITLE
Restructure the admin panel

### DIFF
--- a/mercata/ui/src/pages/Admin.tsx
+++ b/mercata/ui/src/pages/Admin.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Shield, Coins, DollarSign, Droplets, Settings, ArrowLeft, ToggleLeft, Cog, CreditCard, TrendingUp, Vote, Database } from 'lucide-react';
+import { Shield, Coins, DollarSign, Droplets, Settings, ArrowLeft, ToggleLeft, Cog, CreditCard, TrendingUp, Vote, Database, ChevronDown } from 'lucide-react';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import CreateTokenForm from '@/components/admin/CreateTokenForm';
 import CreatePoolForm from '@/components/admin/CreatePoolForm';
 import SetAssetPriceForm from '@/components/admin/SetAssetPriceForm';
@@ -52,12 +53,7 @@ const Admin = () => {
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
           <div className="w-full overflow-x-auto">
-            <TabsList className="grid grid-cols-8 w-full max-w-8xl min-w-[1000px] md:min-w-0">
-              <TabsTrigger value="tokens" className="flex items-center space-x-1 md:space-x-2 text-xs md:text-sm">
-                <Coins className="h-3 w-3 md:h-4 md:w-4" />
-                <span className="hidden sm:inline">Create Tokens</span>
-                <span className="sm:hidden">Tokens</span>
-              </TabsTrigger>
+            <TabsList className="grid grid-cols-5 w-full max-w-5xl min-w-[600px] md:min-w-0">
               <TabsTrigger value="pools" className="flex items-center space-x-1 md:space-x-2 text-xs md:text-sm">
                 <Droplets className="h-3 w-3 md:h-4 md:w-4" />
                 <span className="hidden sm:inline">Create Pools</span>
@@ -68,25 +64,44 @@ const Admin = () => {
                 <span className="hidden sm:inline">Lending</span>
                 <span className="sm:hidden">Lending</span>
               </TabsTrigger>
-              <TabsTrigger value="pricing" className="flex items-center space-x-1 md:space-x-2 text-xs md:text-sm">
-                <DollarSign className="h-3 w-3 md:h-4 md:w-4" />
-                <span className="hidden sm:inline">Set Prices</span>
-                <span className="sm:hidden">Prices</span>
-              </TabsTrigger>
-              <TabsTrigger value="configs" className="flex items-center space-x-1 md:space-x-2 text-xs md:text-sm">
-                <Cog className="h-3 w-3 md:h-4 md:w-4" />
-                <span className="hidden sm:inline">Token Configs</span>
-                <span className="sm:hidden">Configs</span>
-              </TabsTrigger>
-              <TabsTrigger value="status" className="flex items-center space-x-1 md:space-x-2 text-xs md:text-sm">
-                <ToggleLeft className="h-3 w-3 md:h-4 md:w-4" />
-                <span className="hidden sm:inline">Token Status</span>
-                <span className="sm:hidden">Status</span>
-              </TabsTrigger>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className={`inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-xs md:text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 space-x-1 md:space-x-2 ${
+                      ['tokens', 'pricing', 'configs', 'status'].includes(activeTab)
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'hover:bg-muted hover:text-accent-foreground'
+                    }`}
+                  >
+                    <Settings className="h-3 w-3 md:h-4 md:w-4" />
+                    <span className="hidden sm:inline">Token</span>
+                    <span className="sm:hidden">Token</span>
+                    <ChevronDown className="h-3 w-3" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem onClick={() => setActiveTab('tokens')}>
+                    <Coins className="h-4 w-4 mr-2" />
+                    Create Tokens
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setActiveTab('pricing')}>
+                    <DollarSign className="h-4 w-4 mr-2" />
+                    Set Prices
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setActiveTab('configs')}>
+                    <Cog className="h-4 w-4 mr-2" />
+                    Token Configs
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setActiveTab('status')}>
+                    <ToggleLeft className="h-4 w-4 mr-2" />
+                    Token Status
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
               <TabsTrigger value="cdp" className="flex items-center space-x-1 md:space-x-2 text-xs md:text-sm">
                 <Database className="h-3 w-3 md:h-4 md:w-4" />
                 <span className="hidden sm:inline">CDP Config</span>
-                <span className="sm:hidden">CDP</span>  
+                <span className="sm:hidden">CDP</span>
               </TabsTrigger>
               <TabsTrigger value="vote" className="flex items-center space-x-1 md:space-x-2 text-xs md:text-sm">
                 <Vote className="h-3 w-3 md:h-4 md:w-4" />

--- a/mercata/ui/src/pages/Admin.tsx
+++ b/mercata/ui/src/pages/Admin.tsx
@@ -59,16 +59,37 @@ const Admin = () => {
                 <span className="hidden sm:inline">Create Pools</span>
                 <span className="sm:hidden">Pools</span>
               </TabsTrigger>
-              <TabsTrigger value="lending" className="flex items-center space-x-1 md:space-x-2 text-xs md:text-sm">
-                <TrendingUp className="h-3 w-3 md:h-4 md:w-4" />
-                <span className="hidden sm:inline">Lending</span>
-                <span className="sm:hidden">Lending</span>
-              </TabsTrigger>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button
                     className={`inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-xs md:text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 space-x-1 md:space-x-2 ${
-                      ['tokens', 'pricing', 'configs', 'status'].includes(activeTab)
+                      ['lending', 'configs'].includes(activeTab)
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'hover:bg-muted hover:text-accent-foreground'
+                    }`}
+                  >
+                    <TrendingUp className="h-3 w-3 md:h-4 md:w-4" />
+                    <span className="hidden sm:inline">Lending</span>
+                    <span className="sm:hidden">Lending</span>
+                    <ChevronDown className="h-3 w-3" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem onClick={() => setActiveTab('lending')}>
+                    <TrendingUp className="h-4 w-4 mr-2" />
+                    Lending Config
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setActiveTab('configs')}>
+                    <Cog className="h-4 w-4 mr-2" />
+                    Token Configs
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className={`inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-xs md:text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 space-x-1 md:space-x-2 ${
+                      ['tokens', 'pricing', 'status'].includes(activeTab)
                         ? 'bg-background text-foreground shadow-sm'
                         : 'hover:bg-muted hover:text-accent-foreground'
                     }`}
@@ -87,10 +108,6 @@ const Admin = () => {
                   <DropdownMenuItem onClick={() => setActiveTab('pricing')}>
                     <DollarSign className="h-4 w-4 mr-2" />
                     Set Prices
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => setActiveTab('configs')}>
-                    <Cog className="h-4 w-4 mr-2" />
-                    Token Configs
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => setActiveTab('status')}>
                     <ToggleLeft className="h-4 w-4 mr-2" />


### PR DESCRIPTION
Fixes #https://github.com/blockapps/strato-platform/issues/5457

The admin page now has a cleaner structure with 5 tabs instead of 8.

<img width="1140" height="352" alt="image" src="https://github.com/user-attachments/assets/3c4c5940-51e0-43f3-a28f-540907432c17" />
