### PR TITLE
Show 2 decimal places for cents in the Net Balance displays

### DIFF
--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -148,7 +148,7 @@ const Dashboard = () => {
           <div className={`grid grid-cols-1 ${rewardsEnabled ? 'lg:grid-cols-4' : 'lg:grid-cols-3'} gap-6 mb-8`}>
             <AssetSummary
               title="Net Balance"
-              value={`$${totalBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })}`}
+              value={`$${totalBalance.toLocaleString("en-US", { maximumFractionDigits: 2, minimumFractionDigits: 2 })}`}
               icon={<Wallet className="text-white" size={18} />}
               color="bg-blue-500"
             />

--- a/mercata/ui/src/pages/DepositsPage.tsx
+++ b/mercata/ui/src/pages/DepositsPage.tsx
@@ -122,7 +122,7 @@ const DepositsPage = () => {
               <div className="mb-6">
                 <AssetSummary 
                   title="Net Balance" 
-                  value={`$${totalBalance.toLocaleString("en-US", { maximumFractionDigits: 2 })}`}
+                  value={`$${totalBalance.toLocaleString("en-US", { maximumFractionDigits: 2, minimumFractionDigits: 2 })}`}
                   icon={<Wallet className="text-white" size={18} />}
                   color="bg-blue-500"
                 />


### PR DESCRIPTION
Addresses a comment by Jim.

Before:
<img width="3183" height="583" alt="image" src="https://github.com/user-attachments/assets/d2c106d6-60ba-4498-ac0d-770227e059a2" />

After:
<img width="3183" height="583" alt="image" src="https://github.com/user-attachments/assets/1eff846e-f9e8-43b9-b68b-e1ec284156b5" />
