### PR TITLE
Fix event indexing in cirrus

### DIFF
--- a/strato/indexer/slipstream/src/Blockchain/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Blockchain/Slipstream/OutputData.hs
@@ -660,7 +660,7 @@ createEventArrayTable (creator, a, n, e) cc inherited (arr, arrType) = do
     ["creator", "application", "contract_name"]
     keyNames
     "key"
-    (["address", "transaction_hash", "event_index", "collection_name"] ++ (fst <$> keyNames))
+    (["address", "block_hash", "event_index", "collection_name"] ++ (fst <$> keyNames))
     [ ([Right "event_name"], Nothing, wrapEscapeSingle $ tableNameEventName tableName)
     , ([Right "collection_name"], Nothing, wrapEscapeSingle $ tableNameCollectionName tableName)
     ]
@@ -953,7 +953,7 @@ createEventTable (creator, a, n) evName ev cc inherited = do
             ["creator", "application", "contract_name"]
             cols'
             "attributes"
-            ["transaction_hash", "event_index"]
+            ["block_hash", "event_index"]
             [([Right "event_name"], Nothing, wrapEscapeSingle $ tableNameEventName tableName')]
     ) <$> [False] -- , (True, tableNameToText tableName)]
   arrayFkeys <- forM arrayNamesAndTypes $
@@ -1239,7 +1239,7 @@ initialSlipstreamQueries =
       , ("event_name", SqlText)
       , ("attributes", SqlJsonb)
       ]
-      ["transaction_hash", "event_index"]
+      ["block_hash", "event_index"]
       (Just $ Foreign "contract_event" ["address"] storageTableName ["address"])
   , CreateTable
       eventArrayTableName
@@ -1259,6 +1259,6 @@ initialSlipstreamQueries =
       , ("key", SqlJsonb)
       , ("value", SqlJsonb)
       ]
-      ["address", "transaction_hash", "event_index", "collection_name", "key"]
-      (Just $ Foreign "event_event_array" ["transaction_hash", "event_index"] globalEventTableName ["transaction_hash", "event_index"])
+      ["address", "block_hash", "event_index", "collection_name", "key"]
+      (Just $ Foreign "event_event_array" ["block_hash", "event_index"] globalEventTableName ["block_hash", "event_index"])
   ]


### PR DESCRIPTION
Since Actions now operate per block and not per transaction, make the primary key on the event and event_array tables be (block_hash, event_index) instead of (transaction_hash, event_index). This is also necessary because the transaction_hash field is no longer being populated, making it impossible to use as a primary key for the events table.

Validator1 (without fix):

https://validator1.testnet.stratomercata.com/cirrus/search/event?select=block_number,event_index.max(),block_timestamp&order=block_timestamp

```json
[
{
"block_number": "0",
"max": 542,
"block_timestamp": "1970-01-01 00:00:00 UTC"
},
{
"block_number": "1",
"max": 3,
"block_timestamp": "2025-10-28 19:04:18 UTC"
},
{
"block_number": "11",
"max": 5,
"block_timestamp": "2025-10-28 19:45:06 UTC"
},
{
"block_number": "30",
"max": 6,
"block_timestamp": "2025-10-28 21:00:07 UTC"
}
]
```

localhost (with fix):

http://localhost:8080/cirrus/search/event?select=block_number,event_index.max(),block_timestamp&order=block_timestamp

```json
[{"block_number":"0","max":542,"block_timestamp":"1970-01-01 00:00:00 UTC"}, 
 {"block_number":"1","max":3,"block_timestamp":"2025-10-28 19:04:18 UTC"}, 
 {"block_number":"2","max":3,"block_timestamp":"2025-10-28 19:05:31 UTC"}, 
 {"block_number":"3","max":3,"block_timestamp":"2025-10-28 19:05:33 UTC"}, 
 {"block_number":"4","max":3,"block_timestamp":"2025-10-28 19:15:02 UTC"}, 
 {"block_number":"5","max":3,"block_timestamp":"2025-10-28 19:15:05 UTC"}, 
 {"block_number":"6","max":3,"block_timestamp":"2025-10-28 19:16:19 UTC"}, 
 {"block_number":"7","max":3,"block_timestamp":"2025-10-28 19:16:21 UTC"}, 
 {"block_number":"8","max":3,"block_timestamp":"2025-10-28 19:30:05 UTC"}, 
 {"block_number":"9","max":3,"block_timestamp":"2025-10-28 19:30:06 UTC"}, 
 {"block_number":"10","max":3,"block_timestamp":"2025-10-28 19:45:05 UTC"}, 
 {"block_number":"11","max":5,"block_timestamp":"2025-10-28 19:45:06 UTC"}, 
 {"block_number":"12","max":2,"block_timestamp":"2025-10-28 19:47:35 UTC"}, 
 {"block_number":"13","max":5,"block_timestamp":"2025-10-28 19:49:18 UTC"}, 
 {"block_number":"14","max":1,"block_timestamp":"2025-10-28 19:49:19 UTC"}, 
 {"block_number":"15","max":3,"block_timestamp":"2025-10-28 19:49:21 UTC"}, 
 {"block_number":"16","max":3,"block_timestamp":"2025-10-28 20:00:06 UTC"}, 
 {"block_number":"17","max":3,"block_timestamp":"2025-10-28 20:00:07 UTC"}, 
 {"block_number":"18","max":3,"block_timestamp":"2025-10-28 20:15:05 UTC"}, 
 {"block_number":"19","max":3,"block_timestamp":"2025-10-28 20:15:06 UTC"}, 
 {"block_number":"20","max":3,"block_timestamp":"2025-10-28 20:30:05 UTC"}, 
 {"block_number":"21","max":3,"block_timestamp":"2025-10-28 20:30:06 UTC"}, 
 {"block_number":"22","max":3,"block_timestamp":"2025-10-28 20:45:04 UTC"}, 
 {"block_number":"23","max":5,"block_timestamp":"2025-10-28 20:45:05 UTC"}, 
 {"block_number":"24","max":3,"block_timestamp":"2025-10-28 20:52:31 UTC"}, 
 {"block_number":"25","max":3,"block_timestamp":"2025-10-28 20:54:38 UTC"}, 
 {"block_number":"26","max":3,"block_timestamp":"2025-10-28 20:56:30 UTC"}, 
 {"block_number":"27","max":5,"block_timestamp":"2025-10-28 20:56:32 UTC"}, 
 {"block_number":"28","max":3,"block_timestamp":"2025-10-28 20:57:42 UTC"}, 
 {"block_number":"29","max":3,"block_timestamp":"2025-10-28 21:00:06 UTC"}, 
 {"block_number":"30","max":6,"block_timestamp":"2025-10-28 21:00:07 UTC"}, 
 {"block_number":"31","max":2,"block_timestamp":"2025-10-28 21:09:17 UTC"}, 
 {"block_number":"32","max":3,"block_timestamp":"2025-10-28 21:09:53 UTC"}, 
 {"block_number":"33","max":3,"block_timestamp":"2025-10-28 21:15:05 UTC"}, 
 {"block_number":"34","max":5,"block_timestamp":"2025-10-28 21:15:06 UTC"}, 
 {"block_number":"35","max":3,"block_timestamp":"2025-10-28 21:27:19 UTC"}, 
 {"block_number":"36","max":3,"block_timestamp":"2025-10-28 21:30:05 UTC"}, 
 {"block_number":"37","max":3,"block_timestamp":"2025-10-28 21:30:06 UTC"}, 
 {"block_number":"38","max":3,"block_timestamp":"2025-10-28 21:35:23 UTC"}, 
 {"block_number":"39","max":5,"block_timestamp":"2025-10-28 21:35:25 UTC"}, 
 {"block_number":"40","max":3,"block_timestamp":"2025-10-28 21:36:23 UTC"}, 
 {"block_number":"41","max":3,"block_timestamp":"2025-10-28 21:36:25 UTC"}, 
 {"block_number":"42","max":3,"block_timestamp":"2025-10-28 21:37:23 UTC"}, 
 {"block_number":"43","max":5,"block_timestamp":"2025-10-28 21:37:25 UTC"}, 
 {"block_number":"44","max":3,"block_timestamp":"2025-10-28 21:38:23 UTC"}, 
 {"block_number":"45","max":2,"block_timestamp":"2025-10-28 21:38:25 UTC"}, 
 {"block_number":"46","max":1,"block_timestamp":"2025-10-28 21:38:53 UTC"}, 
 {"block_number":"47","max":2,"block_timestamp":"2025-10-28 21:38:54 UTC"}, 
 {"block_number":"48","max":1,"block_timestamp":"2025-10-28 21:39:19 UTC"}, 
 {"block_number":"49","max":3,"block_timestamp":"2025-10-28 21:39:20 UTC"}, 
 {"block_number":"50","max":3,"block_timestamp":"2025-10-28 21:39:22 UTC"}, 
 {"block_number":"51","max":2,"block_timestamp":"2025-10-28 21:39:24 UTC"}, 
 {"block_number":"52","max":1,"block_timestamp":"2025-10-28 21:39:51 UTC"}, 
 {"block_number":"53","max":5,"block_timestamp":"2025-10-28 21:39:52 UTC"}, 
 {"block_number":"54","max":3,"block_timestamp":"2025-10-28 21:40:22 UTC"}, 
 {"block_number":"55","max":2,"block_timestamp":"2025-10-28 21:40:24 UTC"}, 
 {"block_number":"56","max":1,"block_timestamp":"2025-10-28 21:41:05 UTC"}, 
 {"block_number":"57","max":3,"block_timestamp":"2025-10-28 21:41:06 UTC"}, 
 {"block_number":"58","max":3,"block_timestamp":"2025-10-28 21:41:23 UTC"}, 
 {"block_number":"59","max":5,"block_timestamp":"2025-10-28 21:41:25 UTC"}, 
 {"block_number":"60","max":3,"block_timestamp":"2025-10-28 21:42:23 UTC"}, 
 {"block_number":"61","max":2,"block_timestamp":"2025-10-28 21:42:25 UTC"}, 
 {"block_number":"62","max":3,"block_timestamp":"2025-10-28 21:44:40 UTC"}, 
 {"block_number":"63","max":3,"block_timestamp":"2025-10-28 21:44:41 UTC"}, 
 {"block_number":"64","max":3,"block_timestamp":"2025-10-28 21:45:04 UTC"}, 
 {"block_number":"65","max":3,"block_timestamp":"2025-10-28 21:45:05 UTC"}, 
 {"block_number":"66","max":2,"block_timestamp":"2025-10-28 21:45:24 UTC"}, 
 {"block_number":"67","max":3,"block_timestamp":"2025-10-28 21:45:43 UTC"}, 
 {"block_number":"68","max":3,"block_timestamp":"2025-10-28 21:45:44 UTC"}, 
 {"block_number":"69","max":3,"block_timestamp":"2025-10-28 21:46:22 UTC"}, 
 {"block_number":"70","max":3,"block_timestamp":"2025-10-28 21:46:24 UTC"}, 
 {"block_number":"71","max":2,"block_timestamp":"2025-10-28 21:47:22 UTC"}, 
 {"block_number":"72","max":3,"block_timestamp":"2025-10-28 21:50:08 UTC"}, 
 {"block_number":"73","max":3,"block_timestamp":"2025-10-28 21:50:09 UTC"}, 
 {"block_number":"74","max":2,"block_timestamp":"2025-10-28 21:50:24 UTC"}, 
 {"block_number":"75","max":3,"block_timestamp":"2025-10-28 21:50:47 UTC"}, 
 {"block_number":"76","max":3,"block_timestamp":"2025-10-28 21:50:48 UTC"}, 
 {"block_number":"77","max":3,"block_timestamp":"2025-10-28 21:51:23 UTC"}, 
 {"block_number":"78","max":3,"block_timestamp":"2025-10-28 21:51:24 UTC"}, 
 {"block_number":"79","max":3,"block_timestamp":"2025-10-28 21:51:25 UTC"}, 
 {"block_number":"80","max":3,"block_timestamp":"2025-10-28 21:51:27 UTC"}, 
 {"block_number":"81","max":5,"block_timestamp":"2025-10-28 21:52:23 UTC"}, 
 {"block_number":"82","max":3,"block_timestamp":"2025-10-28 21:52:24 UTC"}, 
 {"block_number":"83","max":2,"block_timestamp":"2025-10-28 21:52:27 UTC"}, 
 {"block_number":"84","max":3,"block_timestamp":"2025-10-28 21:56:45 UTC"}, 
 {"block_number":"85","max":3,"block_timestamp":"2025-10-28 21:56:46 UTC"}, 
 {"block_number":"86","max":3,"block_timestamp":"2025-10-28 21:57:24 UTC"}, 
 {"block_number":"87","max":3,"block_timestamp":"2025-10-28 21:58:23 UTC"}, 
 {"block_number":"88","max":3,"block_timestamp":"2025-10-28 22:00:05 UTC"}, 
 {"block_number":"89","max":3,"block_timestamp":"2025-10-28 22:00:07 UTC"}, 
 {"block_number":"90","max":3,"block_timestamp":"2025-10-28 22:15:03 UTC"}]
```