### PR TITLE
Return 0 for SNULL and SReference

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2670,7 +2670,8 @@ encodeForReturn' (SStruct _ vs) = do
                      . encodeForReturn' =<< getVar v
   encodedItems <- mapM (uncurry encodePair) $ M.toList vs
   pure $ "{" ++ intercalate "," encodedItems ++ "}"
-encodeForReturn' SNULL = pure "[]"
+encodeForReturn' SNULL = pure "0"
+encodeForReturn' SReference{} = pure "0"
 encodeForReturn' x = todo "Cannot encode this return type: " x
 
 --formatAddressWithoutColor : padded the address with 40 bytes


### PR DESCRIPTION
This will allow functions like `paused()` to not throw when called from SMD, when `_paused` is `false`. For now, the response will be the number 0 instead of `false`, but that can be handled on the API side, which has access to the CodeCollection for that contract