### PR TITLE
Enhance button disable logic in BridgeIn and MintWidget components

### DIFF
--- a/mercata/ui/src/components/bridge/BridgeIn.tsx
+++ b/mercata/ui/src/components/bridge/BridgeIn.tsx
@@ -742,7 +742,9 @@ const BridgeIn: React.FC = () => {
             !selectedToken ||
             !isConnected ||
             !isCorrectNetwork ||
-            !isTokenPermitted
+            !isTokenPermitted ||
+            !!errors.amount ||
+            !!errors.network
           }
           className="bg-gradient-to-r from-[#1f1f5f] via-[#293b7d] to-[#16737d] text-white hover:opacity-90"
         >

--- a/mercata/ui/src/components/mint/MintWidget.tsx
+++ b/mercata/ui/src/components/mint/MintWidget.tsx
@@ -514,7 +514,7 @@ const MintWidget: React.FC = () => {
       <div className="flex justify-end">
         <Button
           onClick={handleMint}
-          disabled={isLoading || !selectedMintToken || !amount || !isConnected || !isCorrectNetwork}
+          disabled={isLoading || !selectedMintToken || !amount || !isConnected || !isCorrectNetwork || !!errors.amount || !!errors.network}
           className="bg-gradient-to-r from-[#1f1f5f] via-[#293b7d] to-[#16737d] text-white hover:opacity-90"
         >
           {isLoading ? "Processing..." : "Get USDST"}


### PR DESCRIPTION
- Updated the conditions for disabling buttons in both the BridgeIn and MintWidget components to include error states for amount and network.
- This change ensures that buttons are only enabled when all necessary conditions are met, improving user experience and preventing invalid actions.