### PR TITLE
admin page does not shift horizontally

### DIFF
--- a/mercata/ui/src/pages/Admin.tsx
+++ b/mercata/ui/src/pages/Admin.tsx
@@ -51,15 +51,15 @@ const Admin = () => {
           <p className="text-gray-600">Manage tokens, pools, liquidity, and asset pricing</p>
         </div>
 
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6 ">
           <div className="w-full overflow-x-auto">
-            <TabsList className="grid grid-cols-5 w-full max-w-5xl min-w-[600px] md:min-w-0">
+            <TabsList className="grid grid-cols-5 w-full min-w-[600px] md:min-w-0">
               <TabsTrigger value="pools" className="flex items-center space-x-1 md:space-x-2 text-xs md:text-sm">
                 <Droplets className="h-3 w-3 md:h-4 md:w-4" />
                 <span className="hidden sm:inline">Create Pools</span>
                 <span className="sm:hidden">Pools</span>
               </TabsTrigger>
-              <DropdownMenu>
+              <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild>
                   <button
                     className={`inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-xs md:text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 space-x-1 md:space-x-2 ${
@@ -85,7 +85,7 @@ const Admin = () => {
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
-              <DropdownMenu>
+              <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild>
                   <button
                     className={`inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-xs md:text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 space-x-1 md:space-x-2 ${


### PR DESCRIPTION
To follow up on PR #5458, I think there are two low priority issues:

1. When you press on the "Token" or "Lending" tab on the Nav Bar, the whole page shifts slightly to the right, and when you unclick it again, it shifts back to the left. I think that is due to the scroll bar to the right disappearing and appearing again.
2. The Nav Bar is not aligned with the form. We should either center the nav bar or space it out to match the width of the main div.

This PR fixes both issues. 