### PR TITLE
Refactor: Remove transaction_hash from various interfaces and components

### DIFF
--- a/mercata/backend/src/api/helpers/bridge.helper.ts
+++ b/mercata/backend/src/api/helpers/bridge.helper.ts
@@ -11,12 +11,12 @@ interface QueryConfig {
 const QUERY_CONFIGS: Record<string, QueryConfig> = {
   withdrawal: {
     tableName: `${constants.MercataBridge}-withdrawals`,
-    selectFields: "withdrawalId:key,WithdrawalInfo:value,block_timestamp,transaction_hash",
+    selectFields: "withdrawalId:key,WithdrawalInfo:value,block_timestamp",
     countField: "count()",
   },
   deposit: {
     tableName: `${constants.MercataBridge}-deposits`,
-    selectFields: "externalChainId:key,externalTxHash:key2,DepositInfo:value,block_timestamp,transaction_hash",
+    selectFields: "externalChainId:key,externalTxHash:key2,DepositInfo:value,block_timestamp",
     countField: "count()",
   }
 };

--- a/mercata/backend/src/api/services/events.service.ts
+++ b/mercata/backend/src/api/services/events.service.ts
@@ -8,13 +8,14 @@ export const getEvents = async (
 ): Promise<EventResponse> => {
   const params = {
     ...query,
-    order: query.order || "block_timestamp.desc"
+    order: query.order || "block_timestamp.desc",
+    select: "*,storage!inner(contract!inner(contract_name))"
   };
 
-  const countParams = { ...params, limit: undefined, offset: undefined, order: undefined };
+  const countParams = { ...params, limit: undefined, offset: undefined, order: undefined, select: "count(),storage!inner(contract!inner(contract_name))" };
   
   const [countResponse, eventsResponse] = await Promise.all([
-    cirrus.get(accessToken, `/${constants.Event}?select=count()`, { 
+    cirrus.get(accessToken, `/${constants.Event}`, { 
       params: countParams 
     }),
     cirrus.get(accessToken, `/${constants.Event}`, { params })
@@ -23,8 +24,16 @@ export const getEvents = async (
   const total = countResponse.data?.[0]?.count || 0;
   const data = eventsResponse.data;
   
+  const events = (data || []).map((event: any) => {
+    const { storage, ...eventWithoutStorage } = event;
+    return {
+      ...eventWithoutStorage,
+      contract_name: event.storage?.contract?.[0]?.contract_name || ""
+    };
+  });
+  
   return {
-    events: data || [],
+    events,
     total: total
   };
 };
@@ -36,18 +45,18 @@ export const getContractInfo = async (
 
   const { data } = await cirrus.get(accessToken, `/${constants.Event}`, {
     params: {
-      select: "contract_name,event_name,event_name.count()",
-      order: "contract_name.asc,event_name.asc"
+      select: "event_name,event_name.count(),storage!inner(contract!inner(contract_name))",
+      "storage.contract.contract_name": "neq.Proxy",
     }
   });
 
   (data as EventData[])?.forEach(event => {
-    if (!event?.event_name || !event?.contract_name) return;
+    if (!event?.event_name || !event?.storage?.contract?.[0]?.contract_name) return;
     
-    if (!contracts.has(event.contract_name)) {
-      contracts.set(event.contract_name, new Set());
+    if (!contracts.has(event.storage.contract?.[0]?.contract_name)) {
+      contracts.set(event.storage.contract?.[0]?.contract_name, new Set());
     }
-    contracts.get(event.contract_name)!.add(event.event_name);
+    contracts.get(event.storage.contract?.[0]?.contract_name)!.add(event.event_name);
   });
 
   return {

--- a/mercata/backend/src/utils/txHelper.ts
+++ b/mercata/backend/src/utils/txHelper.ts
@@ -95,31 +95,31 @@ export const postAndWaitForTx = async (
   }
 };
 
-export const waitOnCirrus = async (
-  accessToken: string,
-  tableName: string,
-  txHash: string,
-  timeout: number = 60000
-): Promise<{ status: string; hash: string }> => {
-  const predicate = (results: any[]) =>
-    results.every((r) => r.status !== "Pending");
+// export const waitOnCirrus = async (
+//   accessToken: string,
+//   tableName: string,
+//   txHash: string,
+//   timeout: number = 60000
+// ): Promise<{ status: string; hash: string }> => {
+//   const predicate = (results: any[]) =>
+//     results.every((r) => r.status !== "Pending");
 
-  const action = async () => {
-    const res = await cirrus.get(accessToken, tableName, {
-      params: { transaction_hash: txHash },
-    });
-    return res.data;
-  };
+//   const action = async () => {
+//     const res = await cirrus.get(accessToken, tableName, {
+//       params: { transaction_hash: txHash },
+//     });
+//     return res.data;
+//   };
 
-  const finalResult = await until(predicate, action, timeout);
+//   const finalResult = await until(predicate, action, timeout);
 
-  const statusInfo = finalResult[0];
+//   const statusInfo = finalResult[0];
 
-  return {
-    status: statusInfo.status,
-    hash: statusInfo.hash,
-  };
-};
+//   return {
+//     status: statusInfo.status,
+//     hash: statusInfo.hash,
+//   };
+// };
 
 /**
  * Executes a transaction and returns the result

--- a/mercata/packages/shared-types/src/bridge-types.ts
+++ b/mercata/packages/shared-types/src/bridge-types.ts
@@ -45,7 +45,6 @@ export interface BridgeToken {
  * Bridge transaction information
  */
 export interface BridgeTransaction {
-  transaction_hash: string;
   block_timestamp: string;
   chainId?: number;
   from: string;

--- a/mercata/packages/shared-types/src/event-types.ts
+++ b/mercata/packages/shared-types/src/event-types.ts
@@ -15,7 +15,11 @@ export interface ContractInfo {
  */
 export interface EventData {
   event_name?: string;
-  contract_name?: string;
+  storage?: {
+    contract?: Array<{
+      contract_name?: string;
+    }>;
+  };
 }
 
 /**

--- a/mercata/packages/shared-types/src/event-types.ts
+++ b/mercata/packages/shared-types/src/event-types.ts
@@ -27,7 +27,6 @@ export interface Event {
   block_hash: string;
   block_timestamp: string;
   block_number: string;
-  transaction_hash: string;
   transaction_sender: string;
   event_index: number;
   contract_name: string;

--- a/mercata/ui/src/components/dashboard/ActivityFeedList.tsx
+++ b/mercata/ui/src/components/dashboard/ActivityFeedList.tsx
@@ -243,7 +243,6 @@ const ActivityFeedList = () => {
             `"${event.contract_name}"`,
             event.block_number,
             `"${formatTimestamp(event.block_timestamp)}"`,
-            `"${event.transaction_hash}"`,
             `"${event.transaction_sender}"`,
             `"${event.address}"`,
             event.id
@@ -369,22 +368,6 @@ const ActivityFeedList = () => {
       <CardContent className="px-3 sm:px-6 pt-3">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 sm:gap-4">
           <div className="space-y-2">
-            <div className="flex items-center gap-1 sm:gap-2 text-xs sm:text-sm">
-              <Hash className="h-3 w-3 sm:h-4 sm:w-4 text-gray-500" />
-              <span className="font-medium">Transaction:</span>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <code className="text-xs bg-gray-100 px-2 py-1 rounded cursor-help">
-                      {event?.transaction_hash ? formatAddress(event?.transaction_hash) : 'N/A'}
-                    </code>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="font-mono text-xs">{event?.transaction_hash ? event?.transaction_hash : 'N/A'}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
             <div className="flex items-center gap-1 sm:gap-2 text-xs sm:text-sm">
               <User className="h-3 w-3 sm:h-4 sm:w-4 text-gray-500" />
               <span className="font-medium">Sender:</span>

--- a/mercata/ui/src/components/dashboard/DepositTransactionDetails.tsx
+++ b/mercata/ui/src/components/dashboard/DepositTransactionDetails.tsx
@@ -245,7 +245,7 @@ const DepositTransactionDetails = ({ mintUSDST = false }: { mintUSDST?: boolean 
               </div>
             ),
           }}
-          rowKey={(record, index) => `${record.transaction_hash}-${record.block_timestamp || ''}-${index}`}
+          rowKey={(_, index) => `${index}`}
         />
       </div>
     </div>

--- a/mercata/ui/src/components/dashboard/WithdrawTransactionDetails.tsx
+++ b/mercata/ui/src/components/dashboard/WithdrawTransactionDetails.tsx
@@ -250,7 +250,7 @@ const WithdrawTransactionDetails = ({ mintUSDST = false }: { mintUSDST?: boolean
               </div>
             ),
           }}
-          rowKey={(record, index) => `${record.transaction_hash}-${record.block_timestamp || ''}-${index}`}
+          rowKey={(_, index) => `${index}`}
         />
       </div>
     </div>

--- a/mercata/ui/src/lib/activityFeed.ts
+++ b/mercata/ui/src/lib/activityFeed.ts
@@ -19,7 +19,7 @@ export const activityFeedApi = {
     if (filters.limit) params.append('limit', filters.limit.toString());
     if (filters.offset) params.append('offset', filters.offset.toString());
     
-    if (filters.contract_name) params.append('contract_name', filters.contract_name);
+    if (filters.contract_name) params.append('storage.contract.contract_name', filters.contract_name);
     if (filters.event_name) params.append('event_name', filters.event_name);
     if (filters.transaction_sender) params.append('transaction_sender', filters.transaction_sender);
 

--- a/mercata/ui/src/lib/bridge/types.ts
+++ b/mercata/ui/src/lib/bridge/types.ts
@@ -59,7 +59,6 @@ export interface ContractValidationResult {
 
 // Transaction Detail Interfaces
 export interface DepositTransaction {
-  transaction_hash: string;
   block_timestamp: string;
   chainId?: number;
   from: string;
@@ -76,7 +75,6 @@ export interface DepositTransaction {
 }
 
 export interface WithdrawTransaction {
-  transaction_hash: string;
   block_timestamp: string;
   from: string;
   to: string;


### PR DESCRIPTION
- Removed `transaction_hash` field from `BridgeTransaction`, `Event`, `DepositTransaction`, and `WithdrawTransaction` interfaces.
- Updated `selectFields` in `QUERY_CONFIGS` to exclude `transaction_hash` for both withdrawal and deposit queries.
- Commented out the `waitOnCirrus` function in `txHelper.ts` to indicate it is no longer in use.
- Adjusted `rowKey` in `ActivityFeedList`, `DepositTransactionDetails`, and `WithdrawTransactionDetails` components to use index instead of `transaction_hash`.

These changes streamline the codebase by eliminating unused fields and functions, contributing to improved maintainability.