### PR TITLE
Added authorize function to User contract

### DIFF
--- a/strato/core/strato-genesis/resources/strato/UserRegistry.sol
+++ b/strato/core/strato-genesis/resources/strato/UserRegistry.sol
@@ -118,4 +118,8 @@ contract record User is Proxy, Authorizable {
         variadic result = address(contractToCall).call(functionName, args);
         return result;
     }
+
+    function authorize(address _target, address _account, uint _authorizations) public onlyOwner {
+        _authorize(_target, _account, _authorizations);
+    }
 }


### PR DESCRIPTION
Allows the owner of a `User` contract to use the `Authorizable` functionality of the `User` contract, which allows us to vote in `User` contracts as network admins in the `AdminRegistry`