### PR TITLE
Fix Overview for CATA, show when only non-earning asset

### DIFF
--- a/mercata/ui/src/hooks/useNetBalance.ts
+++ b/mercata/ui/src/hooks/useNetBalance.ts
@@ -32,7 +32,7 @@ export const useNetBalance = ({
   });
 
   useEffect(() => {
-    if (!tokens || tokens.length === 0) {
+    if ((!tokens || tokens.length === 0) && !cataToken) {
       return;
     }
 


### PR DESCRIPTION
Before this change, CATA Points were showing 0 if CATA was the only non-earning asset on the list

<img width="1636" height="695" alt="Screenshot 2025-10-31 at 16 46 09" src="https://github.com/user-attachments/assets/0fe4a3ea-f47b-4aef-ba31-d026d7b86139" />
