### PR TITLE
Update getOpenIssues to filter out null vote lengths

### DIFF
--- a/mercata/backend/src/api/services/user.service.ts
+++ b/mercata/backend/src/api/services/user.service.ts
@@ -259,6 +259,7 @@ export const getOpenIssues = async (
         address: `eq.${adminRegistry}`,
         select: `*,admins:${AdminRegistry}-admins(address:value),votes:${AdminRegistry}-votes(block_timestamp,issueId:key,index:key2,voter:value),thresholds:${AdminRegistry}-votingThresholds(target:key,func:key2,threshold:value),executed:${AdminRegistry}-IssueExecuted(*)`,
         ['votes.value']: 'neq.""',
+        ['votes.value->>length']: 'is.null',
         ['executed.limit']: 10,
         ['executed.order']: 'block_timestamp.desc',
       },


### PR DESCRIPTION
- Added a condition to the getOpenIssues function to check for null lengths in the votes value, ensuring that only relevant votes are considered in the query.