### PR TITLE
Quick fix for the premature circuit breaking the useNetBalance

### DIFF
--- a/mercata/ui/src/hooks/useNetBalance.ts
+++ b/mercata/ui/src/hooks/useNetBalance.ts
@@ -32,7 +32,12 @@ export const useNetBalance = ({
   });
 
   useEffect(() => {
-    if ((!tokens || tokens.length === 0) && !cataToken) {
+    const hasTokens = tokens && tokens.length > 0;
+    const hasCata = !!cataToken;
+    const hasLendingPool = !!(liquidityInfo?.withdrawable as any)?.withdrawValue;
+    const hasSafety = !!(safetyInfo?.userShares && safetyInfo?.exchangeRate);
+
+    if (!hasTokens && !hasCata && !hasLendingPool && !hasSafety) {
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/5530

# Before

4000 net balance (sUSDST and mUSDST), but 0 on the overview panel.

<img width="1654" height="696" alt="Screenshot 2025-11-04 at 13 00 16" src="https://github.com/user-attachments/assets/7cfe60cc-1d3d-499a-8efa-1bf8fab1a2c9" />

# After

<img width="1666" height="698" alt="Screenshot 2025-11-04 at 13 21 56" src="https://github.com/user-attachments/assets/58183ca7-c472-4b50-b4cd-b86de58b3ebc" />


Overview shows $4000 net worth balance

