### PR TITLE
Refactor monitorSafeTransactionStatusBatch to use a for loop instead …

### DIFF
--- a/mercata/services/bridge/src/services/safeService.ts
+++ b/mercata/services/bridge/src/services/safeService.ts
@@ -97,12 +97,14 @@ export const monitorSafeTransactionStatusBatch = async (
 
   const results = new Map<Number, "executed" | "rejected" | "pending">();
   
-  await Promise.all(
-    withdrawals.map(async ({ id, safeTxHash }) => {
-      const status = await checkSafeTxStatus(safeTxHash, apiKit);
-      results.set(id, status);
-    })
-  );
+  for (let i = 0; i < withdrawals.length; i++) {
+    const { id, safeTxHash } = withdrawals[i];
+    const status = await checkSafeTxStatus(safeTxHash, apiKit);
+    results.set(id, status);
+    if (i < withdrawals.length - 1) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
 
   return results;
 };


### PR DESCRIPTION
…of Promise.all for sequential processing of withdrawals. This change introduces a delay of 1 second between each status check to prevent potential rate limiting issues.