### PR TITLE
Safety Module Accepts and Properly Accounts for Rewards

### DIFF
--- a/mercata/backend/src/api/services/safety.service.ts
+++ b/mercata/backend/src/api/services/safety.service.ts
@@ -178,6 +178,8 @@ export const getSafetyModuleInfo = async (
     
     // Get totalAssets from SafetyModule's USDST balance (nested structure)
     const totalAssets = usdstContractBalance?.[0]?.balance || "0";
+
+    const managedAssets = safetyModule._managedAssets || "0";
     
     // Get totalShares from sToken's total supply
     const totalShares = sTokenTotalSupply?.[0]?._totalSupply || "0";
@@ -201,7 +203,7 @@ export const getSafetyModuleInfo = async (
 
     // Calculate exchange rate (assets per share)
     const exchangeRate = totalShares !== "0" && BigInt(totalShares) > 0n 
-      ? (BigInt(totalAssets) * BigInt("1000000000000000000")) / BigInt(totalShares) // 18 decimals
+      ? (BigInt(managedAssets) * BigInt("1000000000000000000")) / BigInt(totalShares) // 18 decimals
       : BigInt("1000000000000000000"); // 1:1 ratio initially
 
     // Calculate cooldown status

--- a/mercata/contracts/concrete/BaseCodeCollection.sol
+++ b/mercata/contracts/concrete/BaseCodeCollection.sol
@@ -127,6 +127,7 @@ contract record Mercata is Authorizable {
         lendingPool = LendingPool(address(new Proxy(lendingPoolImpl, this)));
         lendingPool.initialize(address(lendingRegistry), address(poolConfigurator), address(tokenFactory), address(feeCollector), address(safetyModule));
         Ownable(lendingPool).transferOwnership(address(adminRegistry));
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(safetyModule), "notifyReward", address(lendingPool));
 
         adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(lendingRegistry), "setLendingPool", address(poolConfigurator));
         adminRegistry.castVoteOnIssue(address(adminRegistry), "addWhitelist", address(lendingRegistry), "setLiquidityPool", address(poolConfigurator));

--- a/mercata/contracts/concrete/Lending/LendingPool.sol
+++ b/mercata/contracts/concrete/Lending/LendingPool.sol
@@ -980,8 +980,7 @@ contract record LendingPool is Ownable, Pausable {
         // Pay SM directly from LiquidityPool
         if (toSafety > 0 && address(safetyModule) != address(0)) {
             LiquidityPool(_liquidityPool()).transferReserve(toSafety, address(safetyModule));
-            // Optional: if you want a log inside SM, you could later have governance call SM.notifyReward(toSafety).
-            // Not required for accounting; SM.totalAssets() reads its balance directly.
+            SafetyModule(address(safetyModule)).notifyReward(toSafety);
         }
 
         // Pay treasury/feeCollector as usual

--- a/mercata/contracts/concrete/Lending/LendingPool.sol
+++ b/mercata/contracts/concrete/Lending/LendingPool.sol
@@ -980,7 +980,7 @@ contract record LendingPool is Ownable, Pausable {
         // Pay SM directly from LiquidityPool
         if (toSafety > 0 && address(safetyModule) != address(0)) {
             LiquidityPool(_liquidityPool()).transferReserve(toSafety, address(safetyModule));
-            SafetyModule(address(safetyModule)).notifyReward(toSafety);
+            safetyModule.notifyReward(toSafety);
         }
 
         // Pay treasury/feeCollector as usual

--- a/mercata/contracts/concrete/Lending/SafetyModule.sol
+++ b/mercata/contracts/concrete/Lending/SafetyModule.sol
@@ -246,17 +246,11 @@ contract record SafetyModule is Ownable {
     // ─────────────────────────────────────────
     // Rewards / Shortfall
     // ─────────────────────────────────────────
-    /// @notice Pull USDST from owner and treat as rewards (price ↑ for all holders).
+    /// @notice Recognize USDST receipt and treat as rewards (price ↑ for all holders).
     function notifyReward(uint amount) external onlyOwner {
         require(amount > 0, "SM:zero");
-
-        uint256 bal = IERC20(asset).balanceOf(address(this));
-        require(IERC20(asset).transferFrom(msg.sender, address(this), amount), "SM: notifyReward transfer failed");
-        uint256 delta = IERC20(asset).balanceOf(address(this)) - bal;
-        require(delta > 0, "SM:no delta");
-        _managedAssets += delta;
-
-        emit RewardNotified(delta);
+        _managedAssets += amount;
+        emit RewardNotified(amount);
     }
 
     /// @notice Slash vault to cover protocol shortfall.

--- a/mercata/contracts/tests/Lending/BadDebt.test.sol
+++ b/mercata/contracts/tests/Lending/BadDebt.test.sol
@@ -500,4 +500,78 @@ contract Describe_BadDebt_Basic is Authorizable {
         require(pool.getExchangeRate() < 1e18, "Exchange rate should fall due to mUSDST haircut");
     }
 
+    function it_can_notify_safety_module_of_rewards() public {
+        SafetyModule sm = m.safetyModule();
+        LendingPool pool = m.lendingPool();
+        PoolConfigurator configurator = m.poolConfigurator();
+        CollateralVault cv = m.collateralVault();
+        PriceOracle oracle = m.priceOracle();
+
+        // === SETUP: Ensure liquidity in the pool ===
+        Token(USDST).mint(address(this), 100000e18);
+        IERC20(USDST).approve(address(m.liquidityPool()), 100000e18);
+        pool.depositLiquidity(100000e18);
+
+        // === SETUP: Create a borrower with debt ===
+        User borrower = new User();
+        
+        // Mint and supply collateral (Gold) for the borrower
+        oracle.setAssetPrice(GOLDST, 2000e18);
+        Token(GOLDST).mint(address(borrower), 10e18);
+        borrower.do(GOLDST, "approve", address(cv), 10e18);
+        borrower.do(address(pool), "supplyCollateral", GOLDST, 10e18);
+        
+        // Borrow against collateral
+        uint borrowAmount = 10000e18; // Borrow $10,000 USDST
+        borrower.do(address(pool), "borrow", borrowAmount);
+        
+        // Verify debt was created
+        uint initialDebt = pool.getUserDebt(address(borrower));
+        require(initialDebt == borrowAmount, "Initial debt should equal borrow amount");
+        
+        // === STEP 1: Record state before time advancement ===
+        uint borrowIndexBefore = pool.borrowIndex();
+        uint totalScaledDebtBefore = pool.totalScaledDebt();
+        uint reservesBefore = pool.reservesAccrued();
+        
+        // === STEP 2: Fast forward time to accrue interest ===
+        fastForward(365 * 24 * 60 * 60);
+        
+        // === STEP 3: Trigger interest accrual ===
+        // Interest is accrued lazily - need to trigger it with a state-changing action
+        // We'll make a tiny deposit to trigger _accrue() internally
+        Token(USDST).mint(address(this), 1e18);
+        IERC20(USDST).approve(address(m.liquidityPool()), 1e18);
+        pool.depositLiquidity(1e18); // This triggers _accrue() internally
+        
+        // Now read the updated state
+        uint borrowIndexAfter = pool.borrowIndex();
+        uint totalScaledDebtAfter = pool.totalScaledDebt();
+        uint reservesAfter = pool.reservesAccrued();
+        uint debtAfter = pool.getUserDebt(address(borrower));
+        
+        // === STEP 4: Verify interest accrued ===
+        require(borrowIndexAfter > borrowIndexBefore, "Borrow index should increase after time passes");
+        require(debtAfter > initialDebt, "User debt should increase due to interest accrual");
+        require(reservesAfter > reservesBefore, "Reserves should accrue from interest (reserve factor = 10%)");
+        
+        // === STEP 5: Sweep reserves to safety module ===
+        uint reservesToSweep = reservesAfter;
+        require(reservesToSweep > 0, "Should have reserves to sweep");
+        
+        uint smBalanceBefore = IERC20(USDST).balanceOf(address(sm));
+        uint smExRateBefore = sm.exchangeRate();
+        
+        configurator.sweepReserves(reservesToSweep);
+        
+        uint smBalanceAfter = IERC20(USDST).balanceOf(address(sm));
+        uint reservesAfterSweep = pool.reservesAccrued();
+        uint smExRateAfter = sm.exchangeRate();
+        
+        // === STEP 6: Verify reserves were swept to safety module ===
+        require(reservesAfterSweep == 0, "Reserves should be 0 after sweeping all reserves");
+        require(smBalanceAfter > smBalanceBefore, "Safety module should receive the swept reserves");
+        require(smExRateAfter > smExRateBefore, "Exchange rate should increase after sweep");
+    }
+
 }


### PR DESCRIPTION
Fixes #5508 

Does not address the mercata-side exchange rate calculation issue; this should be deployed together with that fix in order to avoid discrepancies.
(EDIT: Mercata-side exchange rate update added to this PR in `e2d9d7315dd7ea1ea51df85d1098d7da70533ee2`)

Not yet tested, but would like comment on whether this is basically the approach we want.