### PR TITLE
lucky orange integration and a runtime config in mercata ui

### DIFF
--- a/docker-compose.allDocker.tpl.yml
+++ b/docker-compose.allDocker.tpl.yml
@@ -46,6 +46,7 @@ services:
     image: ${MERCATAUI_IMAGE:-<REPO_URL>mercata-ui:<VERSION>}
     environment:
       - LUCKY_ORANGE_SITE_ID=${LUCKY_ORANGE_SITE_ID}
+      - GOOGLE_ANALYTICS_ID=${GOOGLE_ANALYTICS_ID}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/docker-compose.allDocker.tpl.yml
+++ b/docker-compose.allDocker.tpl.yml
@@ -44,6 +44,8 @@ services:
       - mercata-backend
     build: ./mercata/ui
     image: ${MERCATAUI_IMAGE:-<REPO_URL>mercata-ui:<VERSION>}
+    environment:
+      - LUCKY_ORANGE_SITE_ID=${LUCKY_ORANGE_SITE_ID}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -45,6 +45,7 @@ services:
     image: ${MERCATAUI_IMAGE:-<REPO_URL>mercata-ui:<VERSION>}
     environment:
       - LUCKY_ORANGE_SITE_ID=${LUCKY_ORANGE_SITE_ID}
+      - GOOGLE_ANALYTICS_ID=${GOOGLE_ANALYTICS_ID}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -43,6 +43,8 @@ services:
       - mercata-backend
     build: ./mercata/ui
     image: ${MERCATAUI_IMAGE:-<REPO_URL>mercata-ui:<VERSION>}
+    environment:
+      - LUCKY_ORANGE_SITE_ID=${LUCKY_ORANGE_SITE_ID}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/mercata/docker-compose.yml
+++ b/mercata/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - LENDING_REGISTRY=${LENDING_REGISTRY}
       - TOKEN_FACTORY=${TOKEN_FACTORY}
       - ADMIN_REGISTRY=${ADMIN_REGISTRY}
-      - BRIDGE_API_BASE_URL=${BRIDGE_API_BASE_URL}
+      - MERCATA_BRIDGE=${MERCATA_BRIDGE}
       - WAGMI_PROJECT_ID=${WAGMI_PROJECT_ID}
     restart: unless-stopped
     logging:
@@ -26,6 +26,8 @@ services:
       - backend
     build: ./ui
     image: mercata-ui:latest
+    environment:
+      - LUCKY_ORANGE_SITE_ID=${LUCKY_ORANGE_SITE_ID}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/mercata/docker-compose.yml
+++ b/mercata/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     image: mercata-ui:latest
     environment:
       - LUCKY_ORANGE_SITE_ID=${LUCKY_ORANGE_SITE_ID}
+      - GOOGLE_ANALYTICS_ID=${GOOGLE_ANALYTICS_ID}
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/mercata/ui/Dockerfile
+++ b/mercata/ui/Dockerfile
@@ -28,6 +28,7 @@ RUN npm install -g serve
 
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./
+COPY ui/docker-run.sh ./
 
 EXPOSE 8080
 
@@ -36,4 +37,4 @@ HEALTHCHECK --interval=5s --timeout=2s --start-period=180s \
   CMD lsof -i :8080 || \
     exit 1
 
-CMD ["serve", "-s", "dist", "-l", "8080"]
+CMD ["sh", "docker-run.sh"]

--- a/mercata/ui/docker-run.sh
+++ b/mercata/ui/docker-run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Generate runtime configuration file
+cat > dist/config.js << EOF
+window.ENV = {
+  LUCKY_ORANGE_SITE_ID: "${LUCKY_ORANGE_SITE_ID:-}"
+};
+EOF
+
+serve -s dist -l 8080

--- a/mercata/ui/docker-run.sh
+++ b/mercata/ui/docker-run.sh
@@ -3,7 +3,8 @@
 # Generate runtime configuration file
 cat > dist/config.js << EOF
 window.ENV = {
-  LUCKY_ORANGE_SITE_ID: "${LUCKY_ORANGE_SITE_ID:-}"
+  LUCKY_ORANGE_SITE_ID: "${LUCKY_ORANGE_SITE_ID:-}",
+  GOOGLE_ANALYTICS_ID: "${GOOGLE_ANALYTICS_ID:-}"
 };
 EOF
 

--- a/mercata/ui/index.html
+++ b/mercata/ui/index.html
@@ -15,12 +15,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@stratomercata" />
     <meta name="twitter:image" content="/marketplaceBG.png" />
-
-    <script async defer src="https://tools.luckyorange.com/core/lo.js?site-id=%VITE_LUCKY_ORANGE_SITE_ID%"></script>
   </head>
 
   <body>
     <div id="root"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/mercata/ui/public/config.js
+++ b/mercata/ui/public/config.js
@@ -1,5 +1,6 @@
 // Runtime configuration (generated at container startup in production)
 // For local development, this file provides default values
 window.ENV = {
-  LUCKY_ORANGE_SITE_ID: ""
+  LUCKY_ORANGE_SITE_ID: "",
+  GOOGLE_ANALYTICS_ID: ""
 };

--- a/mercata/ui/public/config.js
+++ b/mercata/ui/public/config.js
@@ -1,0 +1,5 @@
+// Runtime configuration (generated at container startup in production)
+// For local development, this file provides default values
+window.ENV = {
+  LUCKY_ORANGE_SITE_ID: ""
+};

--- a/mercata/ui/src/main.tsx
+++ b/mercata/ui/src/main.tsx
@@ -2,4 +2,15 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
+// Conditionally load Lucky Orange script
+// Use runtime config (from /config.js) if available, fallback to build-time env var
+const siteId = (window as any).ENV?.LUCKY_ORANGE_SITE_ID || import.meta.env.VITE_LUCKY_ORANGE_SITE_ID;
+if (siteId && siteId.trim() !== '') {
+  const script = document.createElement('script');
+  script.src = `https://tools.luckyorange.com/core/lo.js?site-id=${siteId}`;
+  script.async = true;
+  script.defer = true;
+  document.head.appendChild(script);
+}
+
 createRoot(document.getElementById("root")!).render(<App />);

--- a/mercata/ui/src/main.tsx
+++ b/mercata/ui/src/main.tsx
@@ -13,4 +13,23 @@ if (siteId && siteId.trim() !== '') {
   document.head.appendChild(script);
 }
 
+// Conditionally load Google Analytics
+// Use runtime config (from /config.js) if available, fallback to build-time env var
+const gaId = (window as any).ENV?.GOOGLE_ANALYTICS_ID || import.meta.env.VITE_GOOGLE_ANALYTICS_ID;
+if (gaId && gaId.trim() !== '') {
+  // Load gtag.js library
+  const gtagScript = document.createElement('script');
+  gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
+  gtagScript.async = true;
+  document.head.appendChild(gtagScript);
+
+  // Initialize dataLayer and gtag
+  (window as any).dataLayer = (window as any).dataLayer || [];
+  function gtag(...args: any[]) {
+    (window as any).dataLayer.push(args);
+  }
+  gtag('js', new Date());
+  gtag('config', gaId);
+}
+
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
This approach is required to avoid the lucky orange with empty id to be attempted to load on all nodes which don't have the LUCKY_ORANGE_ID variable set. It would give the error in the browser console otherwise