### PR TITLE
Rewardable Draft

### DIFF
--- a/mercata/contracts/abstract/ERC20/utils/Rewardable.sol
+++ b/mercata/contracts/abstract/ERC20/utils/Rewardable.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+import "../../../concrete/Rewards/Rewards.sol";
+
+/**
+ * @dev Contract module which allows children to implement reward tracking
+ * for protocol actions via the Rewards controller.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `rewardable`, which can be applied to functions to automatically track
+ * one-time actions (e.g., swaps) in the Rewards contract.
+ *
+ * Note that the Rewards contract must be initialized with the appropriate
+ * activity and the contract must be set as the allowed caller for that activity.
+ */
+abstract contract Rewardable {
+    /// @notice The Rewards contract address (can be zero if rewards are disabled)
+    Rewards public rewards;
+
+    /**
+     * @dev Set the Rewards contract address
+     * @param rewardsAddr The address of the Rewards contract
+     */
+    function _setRewards(address rewardsAddr) internal {
+        require(rewardsAddr != address(0), "Invalid rewards address");
+        rewards = Rewards(rewardsAddr);
+    }
+
+    /**
+     * @dev Modifier to track a one-time action in the Rewards contract
+     * @param activityId The activity ID registered in the Rewards contract (0 = disabled)
+     * @param user The user performing the action
+     * @param amount The amount/value of the action to track
+     * @dev This modifier calls rewards.occurred() after the function executes
+     * @dev If rewards is not set (address(0)), the modifier does nothing
+     */
+    modifier rewardable(uint256 activityId, address user, uint256 amount) {
+        _;
+        if (address(rewards) != address(0)) {
+            rewards.occurred(activityId, user, amount);
+        }
+    }
+}
+

--- a/mercata/contracts/abstract/ERC20/utils/Rewardable.sol
+++ b/mercata/contracts/abstract/ERC20/utils/Rewardable.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import "../../../concrete/Rewards/Rewards.sol";
+import "../access/Ownable.sol";
 
 /**
  * @dev Contract module which allows children to implement reward tracking
@@ -12,16 +13,15 @@ import "../../../concrete/Rewards/Rewards.sol";
  * Note that the Rewards contract must be initialized with the appropriate
  * activity and the contract must be set as the allowed caller for that activity.
  */
-abstract contract Rewardable {
+abstract contract Rewardable is Ownable {
     /// @notice The Rewards contract address (can be zero if rewards are disabled)
     Rewards public rewards;
 
     /**
-     * @dev Set the Rewards contract address
-     * @param rewardsAddr The address of the Rewards contract
+     * @dev Set the Rewards contract address (admin only)
+     * @param rewardsAddr The address of the Rewards contract (address(0) to disable rewards)
      */
-    function _setRewards(address rewardsAddr) internal {
-        require(rewardsAddr != address(0), "Invalid rewards address");
+    function setRewards(address rewardsAddr) public onlyOwner {
         rewards = Rewards(rewardsAddr);
     }
 

--- a/mercata/contracts/concrete/Pools/Pool.sol
+++ b/mercata/contracts/concrete/Pools/Pool.sol
@@ -4,6 +4,7 @@ import "../Tokens/Token.sol";
 import "../Tokens/TokenFactory.sol";
 import "../Admin/FeeCollector.sol";
 import "../../abstract/ERC20/access/Ownable.sol";
+import "../../abstract/ERC20/utils/Rewardable.sol";
 
 /**
  * @title Pool
@@ -25,7 +26,7 @@ import "../../abstract/ERC20/access/Ownable.sol";
  * @author Mercata Protocol
  * @version 1.0.0
  */
-contract record Pool is Ownable {
+contract record Pool is Ownable, Rewardable {
     
     // ============ EVENTS ============
     
@@ -347,12 +348,13 @@ contract record Pool is Ownable {
     /// @dev The user must approve input tokens for transfer before calling this function
     /// @dev Fees are automatically deducted and distributed between protocol and LP providers
     /// @dev Reentrancy protection is applied to prevent attacks
+    /// @dev Rewards are tracked if rewards contract and activity ID are configured
     function swap(
         bool isAToB,
         uint256 amountIn,
         uint256 minAmountOut,
         uint256 deadline
-    ) external nonReentrant returns (uint256 amountOut) {
+    ) external nonReentrant rewardable(0, msg.sender, amountIn) returns (uint256 amountOut) {
         require(amountIn > 0 && minAmountOut > 0, "Invalid input");
         require(block.timestamp <= deadline, "EXPIRED");
 
@@ -422,6 +424,19 @@ contract record Pool is Ownable {
     /// @dev When enabled, zap swaps follow the same fee structure as regular swaps
     function setZapSwapFeesEnabled(bool enabled) external onlyOwner {
         zapSwapFeesEnabled = enabled;
+    }
+
+    /// @notice Set the Rewards contract address and swap activity ID (factory only)
+    /// @param rewardsAddr The address of the Rewards contract (address(0) to disable rewards)
+    /// @param activityId The activity ID for swap rewards (0 = disable rewards)
+    /// @dev This function can only be called by the PoolFactory contract
+    /// @dev The activity must be registered in the Rewards contract with this pool as the allowed caller
+    function setRewards(address rewardsAddr, uint256 activityId) external onlyPoolFactory {
+        if (rewardsAddr != address(0)) {
+            _setRewards(rewardsAddr);
+        }
+        // If rewardsAddr is address(0), leave rewards as-is (can be set to zero via direct assignment if needed)
+        swapActivityId = activityId;
     }
 
     // ===========================================================

--- a/mercata/contracts/concrete/Pools/Pool.sol
+++ b/mercata/contracts/concrete/Pools/Pool.sol
@@ -426,19 +426,6 @@ contract record Pool is Ownable, Rewardable {
         zapSwapFeesEnabled = enabled;
     }
 
-    /// @notice Set the Rewards contract address and swap activity ID (factory only)
-    /// @param rewardsAddr The address of the Rewards contract (address(0) to disable rewards)
-    /// @param activityId The activity ID for swap rewards (0 = disable rewards)
-    /// @dev This function can only be called by the PoolFactory contract
-    /// @dev The activity must be registered in the Rewards contract with this pool as the allowed caller
-    function setRewards(address rewardsAddr, uint256 activityId) external onlyPoolFactory {
-        if (rewardsAddr != address(0)) {
-            _setRewards(rewardsAddr);
-        }
-        // If rewardsAddr is address(0), leave rewards as-is (can be set to zero via direct assignment if needed)
-        swapActivityId = activityId;
-    }
-
     // ===========================================================
     // ============ ZAP-IN (SINGLE TOKEN LIQUIDITY) ============
     // ===========================================================


### PR DESCRIPTION
This implementation eliminates the need for platform level changes or a polling server. 

Simply inherit the `rewardable` modifier from the `Rewardable` contract and apply it to functions that should be processed by `Rewards` by passing the function's corresponding `acitivityId`.

I've applied it to `swap()` in `Pool` as an example. 