### PR TITLE
Gas-free autosave for Easy Savings widget via Bridge Service endpoint

### DIFF
--- a/mercata/backend/src/api/services/bridge.service.ts
+++ b/mercata/backend/src/api/services/bridge.service.ts
@@ -72,7 +72,7 @@ export const requestAutoSave = async (
 
   // Bridge service handles transaction execution and polling internally,
   // so we just call it directly and return the result
-  const response = await bridge.post<TransactionResponse>(accessToken, `/requestAutoSave`, params);
+  const response = await bridge.post<TransactionResponse>(accessToken, `/request-autosave`, params);
   return response.data;
 };
 

--- a/mercata/backend/src/api/services/bridge.service.ts
+++ b/mercata/backend/src/api/services/bridge.service.ts
@@ -1,6 +1,6 @@
 import { buildFunctionTx } from "../../utils/txBuilder";
 import { postAndWaitForTx } from "../../utils/txHelper";
-import { strato, cirrus } from "../../utils/mercataApiHelper";
+import { strato, cirrus, bridge } from "../../utils/mercataApiHelper";
 import { StratoPaths, constants } from "../../config/constants";
 import { extractContractName, ensureHexPrefix } from "../../utils/utils";
 import { getTokenMetadata } from "../helpers/cirrusHelpers";
@@ -65,20 +65,15 @@ export const requestAutoSave = async (
   }: AutoSaveRequestParams,
   userAddress: string
 ) : Promise<TransactionResponse> => {
-  const tx = await buildFunctionTx(
-    {
-      contractName: extractContractName(MercataBridge),
-      contractAddress: constants.mercataBridge,
-      method: "requestAutoSave",
-      args: { externalChainId, externalTxHash },
-    },
-    userAddress,
-    accessToken
-  );
+  const params: AutoSaveRequestParams = {
+    externalChainId,
+    externalTxHash,
+  };
 
-  return await postAndWaitForTx(accessToken, () =>
-    strato.post(accessToken, StratoPaths.transactionParallel, tx)
-  );
+  // Bridge service handles transaction execution and polling internally,
+  // so we just call it directly and return the result
+  const response = await bridge.post<TransactionResponse>(accessToken, `/requestAutoSave`, params);
+  return response.data;
 };
 
 export const getBridgeTransactions = async (

--- a/mercata/backend/src/app.ts
+++ b/mercata/backend/src/app.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import cors from "cors";
 import routes from "./api/routes";
-import { initOpenIdConfig } from "./config/config";
+import { initOpenIdConfig, initBridgeConfig } from "./config/config";
 import { errorHandler, notFoundHandler } from "./api/middleware/errorHandler";
 
 const PORT = process.env.PORT || 3001;
@@ -21,6 +21,7 @@ app.use(errorHandler);
 (async () => {
   try {
     await initOpenIdConfig();
+    await initBridgeConfig();
     app.listen(PORT, () => {
       console.log(`Server running at http://localhost:${PORT}`);
     });

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -1,4 +1,4 @@
-import { fetchOpenIdConfig } from "../utils/authHelper";
+import { fetchOpenIdConfig, getServiceToken } from "../utils/authHelper";
 import { JSONWebKeySet } from "jose";
 
 // Load local .env files when not in production
@@ -31,10 +31,40 @@ export async function initOpenIdConfig() {
   openIdTokenEndpoint = tokenEndpoint;
   openIdJwks = jwks;
 }
+
 export const clientId = process.env.OAUTH_CLIENT_ID;
 export const clientSecret = process.env.OAUTH_CLIENT_SECRET;
 export const nodeUrl = process.env.NODE_URL;
 export const baseUrl = process.env.BASE_URL || "http://localhost";
+
+/*
+   Bridge Service URL used for autosave requests;
+   First priority is environment variable BRIDGE_SERVICE_URL;
+   If this is unset, we use the default bridge service url hardcoded below for each network;
+   We determine the network id from the node metadata endpoint.
+*/
+import { eth } from "../utils/mercataApiHelper"; // after nodeUrl is defined
+const defaultBridgeServiceFor: Record<string, string> = {
+  // Helium testnet
+  "114784819836269":"http://localhost:3003", //TODO testnet bridge service url
+
+  // Upquark mainnet
+  "33056204878082667":"TODO_mainnet_bridge_service_url"
+};
+export let bridgeUrl: string | undefined;
+export async function initBridgeConfig() {
+  if (process.env.BRIDGE_SERVICE_URL) {
+    bridgeUrl = process.env.BRIDGE_SERVICE_URL;
+    return;
+  }
+
+  const accessToken = await getServiceToken();
+  const { data } = await eth.get(accessToken, `/metadata`);
+  const networkId: string = data.networkID;
+  bridgeUrl = defaultBridgeServiceFor[networkId];
+}
+
+// Smart contract addresses
 export const poolConfigurator = process.env.POOL_CONFIGURATOR || "0000000000000000000000000000000000001006";
 export const lendingRegistry = process.env.LENDING_REGISTRY || "0000000000000000000000000000000000001007";
 export const mercataBridge = process.env.MERCATA_BRIDGE || "0000000000000000000000000000000000001008";

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -45,11 +45,8 @@ export const baseUrl = process.env.BASE_URL || "http://localhost";
 */
 import { eth } from "../utils/mercataApiHelper"; // after nodeUrl is defined
 const defaultBridgeServiceFor: Record<string, string> = {
-  // Helium testnet
-  "114784819836269":"http://localhost:3003", //TODO testnet bridge service url
-
-  // Upquark mainnet
-  "33056204878082667":"TODO_mainnet_bridge_service_url"
+  "114784819836269":"https://bridge.testnet.stratomercata.com", // Helium testnet
+  "33056204878082667":"https://bridge.stratomercata.com",       // Upquark mainnet
 };
 export let bridgeUrl: string | undefined;
 export async function initBridgeConfig() {

--- a/mercata/backend/src/utils/mercataApiHelper.ts
+++ b/mercata/backend/src/utils/mercataApiHelper.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
-import { nodeUrl } from "../config/config";
+import { nodeUrl, bridgeUrl } from "../config/config";
 
 const createApiClient = (baseURL: string): AxiosInstance =>
   axios.create({
@@ -15,6 +15,7 @@ const _strato = createApiClient(`${nodeUrl}/strato/v2.3`);
 const _cirrus = createApiClient(`${nodeUrl}/cirrus/search`);
 const _bloc = createApiClient(`${nodeUrl}/bloc/v2.2`);
 const _eth = createApiClient(`${nodeUrl}/strato-api/eth/v1.2`);
+const _bridge = createApiClient(`${bridgeUrl}`);
 
 function makeTokenClient(client: AxiosInstance) {
   return {
@@ -53,3 +54,4 @@ export const strato = makeTokenClient(_strato);
 export const cirrus = makeTokenClient(_cirrus);
 export const bloc = makeTokenClient(_bloc);
 export const eth = makeTokenClient(_eth);
+export const bridge = makeTokenClient(_bridge);

--- a/mercata/backend/src/utils/mercataApiHelper.ts
+++ b/mercata/backend/src/utils/mercataApiHelper.ts
@@ -56,15 +56,13 @@ export const eth = makeTokenClient(_eth);
 
 // Bridge client needs to be initialized after bridgeUrl is set
 let bridgeClient: ReturnType<typeof makeTokenClient> | null = null;
-const getBridgeClient = (() => {
-  return () => {
-    if (!bridgeClient) {
-      if (!bridgeUrl) throw new Error("Bridge URL not initialized.");
-      bridgeClient = makeTokenClient(createApiClient(`${bridgeUrl}`));
-    }
-    return bridgeClient;
-  };
-})();
+const getBridgeClient = () => {
+  if (!bridgeClient) {
+    if (!bridgeUrl) throw new Error("Bridge URL not initialized.");
+    bridgeClient = makeTokenClient(createApiClient(`${bridgeUrl}`));
+  }
+  return bridgeClient;
+};
 export const bridge = new Proxy({} as ReturnType<typeof makeTokenClient>, {
   get(_target, prop) {
     return getBridgeClient()[prop as keyof ReturnType<typeof makeTokenClient>];

--- a/mercata/backend/src/utils/mercataApiHelper.ts
+++ b/mercata/backend/src/utils/mercataApiHelper.ts
@@ -15,7 +15,6 @@ const _strato = createApiClient(`${nodeUrl}/strato/v2.3`);
 const _cirrus = createApiClient(`${nodeUrl}/cirrus/search`);
 const _bloc = createApiClient(`${nodeUrl}/bloc/v2.2`);
 const _eth = createApiClient(`${nodeUrl}/strato-api/eth/v1.2`);
-const _bridge = createApiClient(`${bridgeUrl}`);
 
 function makeTokenClient(client: AxiosInstance) {
   return {
@@ -54,4 +53,20 @@ export const strato = makeTokenClient(_strato);
 export const cirrus = makeTokenClient(_cirrus);
 export const bloc = makeTokenClient(_bloc);
 export const eth = makeTokenClient(_eth);
-export const bridge = makeTokenClient(_bridge);
+
+// Bridge client needs to be initialized after bridgeUrl is set
+let bridgeClient: ReturnType<typeof makeTokenClient> | null = null;
+const getBridgeClient = (() => {
+  return () => {
+    if (!bridgeClient) {
+      if (!bridgeUrl) throw new Error("Bridge URL not initialized.");
+      bridgeClient = makeTokenClient(createApiClient(`${bridgeUrl}`));
+    }
+    return bridgeClient;
+  };
+})();
+export const bridge = new Proxy({} as ReturnType<typeof makeTokenClient>, {
+  get(_target, prop) {
+    return getBridgeClient()[prop as keyof ReturnType<typeof makeTokenClient>];
+  },
+});

--- a/mercata/contracts/concrete/Bridge/MercataBridge.sol
+++ b/mercata/contracts/concrete/Bridge/MercataBridge.sol
@@ -589,7 +589,8 @@ contract record MercataBridge is Ownable {
         }
     }
 
-    function requestAutoSave(uint externalChainId, string externalTxHash) external {
+    function requestAutoSave(address user, uint externalChainId, string externalTxHash) external onlyOwner {
+        require(user != address(0), "MB: invalid user");
         require(externalChainId > 0, "MB: invalid external chain id");
         require(chains[externalChainId].enabled, "MB: chain not enabled");
         require(externalTxHash.length > 0, "MB: invalid external tx hash");
@@ -597,9 +598,9 @@ contract record MercataBridge is Ownable {
         string normalizedTxHash = externalTxHash.normalizeHex();
 
         require(deposits[externalChainId][normalizedTxHash].bridgeStatus != BridgeStatus.COMPLETED, "MB: Already completed");
-        autoSaveRequested[msg.sender][externalChainId][normalizedTxHash] = true;
+        autoSaveRequested[user][externalChainId][normalizedTxHash] = true;
 
-        emit AutoSaveRequested(msg.sender, externalChainId, normalizedTxHash);
+        emit AutoSaveRequested(user, externalChainId, normalizedTxHash);
     }
 
     /**

--- a/mercata/contracts/tests/Bridge/MercataBridge.test.sol
+++ b/mercata/contracts/tests/Bridge/MercataBridge.test.sol
@@ -112,6 +112,7 @@ contract Describe_MercataBridge is Authorizable {
         adminRegistry.addWhitelist(address(bridge), "finaliseWithdrawalBatch", address(relayer));
         adminRegistry.addWhitelist(address(bridge), "abortWithdrawal", address(relayer));
         adminRegistry.addWhitelist(address(bridge), "abortWithdrawalBatch", address(relayer));
+        adminRegistry.addWhitelist(address(bridge), "requestAutoSave", address(relayer));
 
         // Create test tokens through token factory with AdminRegistry as owner
         testToken = TestERC20(tokenFactory.createTokenWithInitialOwner("Test Token", "TEST", [], [], [], "TEST", 0, 18, address(adminRegistry)));
@@ -1538,7 +1539,8 @@ contract Describe_MercataBridge is Authorizable {
         // First initiate deposit
         relayer.do(address(bridge), "deposit", externalChainId, externalSender, address(0x6666), amount, txHash, recipient);
 
-        User(recipient).do(address(bridge), "requestAutoSave", externalChainId, txHash);
+
+        relayer.do(address(bridge), "requestAutoSave", recipient, externalChainId, txHash);
 
         // Confirm the deposit with auto save
         relayer.do(address(bridge), "confirmDeposit", externalChainId, txHash);
@@ -1559,7 +1561,7 @@ contract Describe_MercataBridge is Authorizable {
 
         // This is what we expect to actually happen;
         // autoSave request before the bridge service picks up the deposit
-        User(recipient).do(address(bridge), "requestAutoSave", externalChainId, txHash);
+        relayer.do(address(bridge), "requestAutoSave", recipient, externalChainId, txHash);
 
         // First initiate deposit
         relayer.do(address(bridge), "deposit", externalChainId, externalSender, address(0x6666), amount, txHash, recipient);
@@ -1585,7 +1587,7 @@ contract Describe_MercataBridge is Authorizable {
         // First initiate deposit
         relayer.do(address(bridge), "deposit", externalChainId, externalSender, address(0x6666), amount, txHash, recipient);
 
-        User(recipient).do(address(bridge), "requestAutoSave", externalChainId, txHash);
+        relayer.do(address(bridge), "requestAutoSave", recipient, externalChainId, txHash);
 
         // Confirm the deposit with auto save, which will fail due to disabled minting of mUSDST
         adminRegistry.castVoteOnIssue(address(adminRegistry), "removeWhitelist", address(mUSDST), "mint", address(mercata.liquidityPool()));

--- a/mercata/services/bridge/src/auth/index.ts
+++ b/mercata/services/bridge/src/auth/index.ts
@@ -2,6 +2,10 @@ import OAuthUtil from "./oauth";
 import { config } from "../config";
 import { logError } from "../utils/logger";
 import { strato } from "../utils/api";
+import { Request } from "express";
+import axios from "axios";
+import jwt from "jsonwebtoken";
+import jwksClient from "jwks-rsa";
 
 
 // Validation function to check config at runtime
@@ -47,6 +51,34 @@ const TOKEN_LIFETIME_THRESHOLD_SECONDS = 10;
 let oauthInitialized = false;
 let oauthInstance: any = null;
 
+// JWKS client for token verification
+let jwksUri: string | undefined;
+let jwksClientInstance: jwksClient.JwksClient | undefined;
+
+/**
+ * Fetches JWKS URI from the OpenID Connect discovery document
+ */
+async function fetchJwksUri(openIdDiscoveryUrl: string | undefined): Promise<string> {
+  try {
+    if (!openIdDiscoveryUrl) {
+      throw new Error("OpenID Discovery URL is not defined");
+    }
+
+    const discoveryResponse = await axios.get(openIdDiscoveryUrl);
+    const { jwks_uri } = discoveryResponse.data;
+
+    if (!jwks_uri) {
+      throw new Error("JWKS URI not found in OpenID discovery document");
+    }
+
+    console.log("[Auth] Successfully fetched JWKS URI");
+    return jwks_uri;
+  } catch (error) {
+    console.error("[Auth] Failed to fetch OpenID discovery data:", error);
+    throw new Error("Failed to fetch OpenID discovery data");
+  }
+}
+
 export const initOpenIdConfig = async () => {
   // If already initialized, return immediately
   if (oauthInitialized) {
@@ -62,10 +94,20 @@ export const initOpenIdConfig = async () => {
       hasUsername: !!config.auth.baUsername,
       hasPassword: !!config.auth.baPassword
     });
-    
+
+    // Initialize OAuth client
     oauthInstance = await OAuthUtil.init(getOAuthConfig());
+
+    // Fetch JWKS URI for token verification
+    jwksUri = await fetchJwksUri(config.auth.openIdDiscoveryUrl);
+    jwksClientInstance = jwksClient({
+      jwksUri: jwksUri,
+      cache: true,
+      cacheMaxAge: 600000, // 10 minutes
+    });
+
     oauthInitialized = true;
-    
+
     console.log(`[Auth] OAuth initialization completed successfully`);
   } catch (error) {
     console.error(`[Auth] OAuth initialization failed:`, {
@@ -73,7 +115,7 @@ export const initOpenIdConfig = async () => {
       errorName: (error as Error)?.name,
       errorStack: (error as Error)?.stack
     });
-    
+
     logError("Auth", error as Error, { operation: "initOpenIdConfig" });
     throw error;
   }
@@ -150,7 +192,7 @@ export const getBAUserToken = async (): Promise<string> => {
     // Cache the new token
     CACHED_DATA[cacheKey] = { token, expiresAt };
     // console.debug(`[Auth] Token cached successfully`);
-    
+
     return token;
   } catch (error: any) {
     console.error(`[Auth] getBAUserToken error:`, {
@@ -161,7 +203,7 @@ export const getBAUserToken = async (): Promise<string> => {
       hasPassword: !!config.auth.baPassword,
       username: config.auth.baUsername
     });
-    
+
     throw new Error(
       `Failed to fetch user OAuth token: ${error?.message || "Unknown error"}`,
     );
@@ -183,3 +225,137 @@ export const getBAUserAddress = async (): Promise<string> => {
     );
   }
 };
+
+/**
+ * Get signing key from JWKS
+ */
+function getKey(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
+  if (!jwksClientInstance) {
+    return callback(new Error("JWKS client not initialized"));
+  }
+
+  jwksClientInstance.getSigningKey(header.kid, (err, key) => {
+    if (err) {
+      return callback(err);
+    }
+    const signingKey = key?.getPublicKey();
+    callback(null, signingKey);
+  });
+}
+
+/**
+ * Verify access token signature using JWKS
+ */
+export async function verifyAccessTokenSignature(token: string): Promise<jwt.JwtPayload> {
+  if (!jwksClientInstance) {
+    throw new Error("JWKS client not initialized. Call initOpenIdConfig() first");
+  }
+
+  return new Promise((resolve, reject) => {
+    jwt.verify(token, getKey, {
+      algorithms: ['RS256'],
+    }, (err, decoded) => {
+      if (err) {
+        reject(new Error(`Token verification failed: ${err.message}`));
+      } else {
+        resolve(decoded as jwt.JwtPayload);
+      }
+    });
+  });
+}
+
+/**
+ * Get the token from the header (x-user-access-token if it's present, or authorization header if not)
+ * @param req - The request object
+ * @returns The token from the header
+ */
+export function getTokenFromHeader(req: Request): string | null {
+  // Handle header from nginx
+  const headerToken = req.headers["x-user-access-token"] as string | undefined;
+  if (headerToken) return headerToken;
+
+  // Handle header from local development mode
+  const auth = req.headers["authorization"];
+
+  if (typeof auth === "string") {
+    const [bearer, token] = auth.split(" ");
+    if (bearer === "Bearer" && token) return token;
+  }
+  return null;
+}
+
+/**
+ * Try to get an existing STRATO key for a user token.
+ * @returns the address, or null if none exists yet.
+ * @throws on non-400 failures.
+ */
+async function getUserKey(token: string): Promise<string | null> {
+  try {
+    const response = await axios.get(
+      `${config.api.nodeUrl}/strato/v2.3/key`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        timeout: 60000,
+      }
+    );
+    return response.data.address ?? null;
+  } catch (err: any) {
+    // 400 means "no key yet" for that API endpoint
+    if (err.response?.status === 400) {
+      return null;
+    } else {
+      console.error("Error getting user key:", err);
+      throw new Error("Key retrieval failed");
+    }
+  }
+}
+
+/**
+ * Create a STRATO key for a user token.
+ * @returns the address, or null in case of an error
+ * @throws on failures.
+ */
+async function createUserKey(token: string): Promise<string | null> {
+  try {
+    const response = await axios.post(
+      `${config.api.nodeUrl}/strato/v2.3/key`,
+      undefined,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        timeout: 60000,
+      }
+    );
+    return response.data.address ?? null;
+  } catch (err) {
+    console.error("Error creating user key:", err);
+    return null;
+  }
+}
+
+/**
+ * Fetches an existing STRATO key for a user token, or creates one if none exists.
+ *
+ * @param token - Bearer token for authorization
+ * @returns the address string
+ */
+export async function createOrGetUserKey(token: string): Promise<string> {
+  let address = await getUserKey(token);
+  if (!address) {
+    console.info("No key found for the user, creating a new one…");
+    address = await createUserKey(token);
+  }
+
+  if (!address) {
+    throw new Error("Key creation failed: no address returned after attempting to create a new key");
+  }
+
+  return address;
+}

--- a/mercata/services/bridge/src/auth/index.ts
+++ b/mercata/services/bridge/src/auth/index.ts
@@ -285,11 +285,11 @@ export function getTokenFromHeader(req: Request): string | null {
 }
 
 /**
- * Try to get an existing STRATO key for a user token.
+ * Try to get the STRATO address for a user token.
  * @returns the address, or null if none exists yet.
- * @throws on non-400 failures.
+ * @throws on strato API failures or null address response.
  */
-async function getUserKey(token: string): Promise<string | null> {
+export async function getUserKey(token: string): Promise<string> {
   try {
     const response = await axios.get(
       `${config.api.nodeUrl}/strato/v2.3/key`,
@@ -302,60 +302,12 @@ async function getUserKey(token: string): Promise<string | null> {
         timeout: 60000,
       }
     );
-    return response.data.address ?? null;
-  } catch (err: any) {
-    // 400 means "no key yet" for that API endpoint
-    if (err.response?.status === 400) {
-      return null;
-    } else {
-      console.error("Error getting user key:", err);
-      throw new Error("Key retrieval failed");
+    if (!response.data.address) {
+      throw new Error("No address returned from STRATO API");
     }
+    return response.data.address;
+  } catch (err: any) {
+    console.error("Error getting user key:", err);
+    throw new Error("Address retrieval failed");
   }
-}
-
-/**
- * Create a STRATO key for a user token.
- * @returns the address, or null in case of an error
- * @throws on failures.
- */
-async function createUserKey(token: string): Promise<string | null> {
-  try {
-    const response = await axios.post(
-      `${config.api.nodeUrl}/strato/v2.3/key`,
-      undefined,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-        timeout: 60000,
-      }
-    );
-    return response.data.address ?? null;
-  } catch (err) {
-    console.error("Error creating user key:", err);
-    return null;
-  }
-}
-
-/**
- * Fetches an existing STRATO key for a user token, or creates one if none exists.
- *
- * @param token - Bearer token for authorization
- * @returns the address string
- */
-export async function createOrGetUserKey(token: string): Promise<string> {
-  let address = await getUserKey(token);
-  if (!address) {
-    console.info("No key found for the user, creating a new one…");
-    address = await createUserKey(token);
-  }
-
-  if (!address) {
-    throw new Error("Key creation failed: no address returned after attempting to create a new key");
-  }
-
-  return address;
 }

--- a/mercata/services/bridge/src/auth/tokenMiddleware.ts
+++ b/mercata/services/bridge/src/auth/tokenMiddleware.ts
@@ -21,7 +21,7 @@ class AuthHandler {
 
         // Make user address available to request handler
         res.locals.userAddress = userAddress;
-        next();
+        return next();
       } catch (error: any) {
         return res.status(401).json({
           error: "Failed to get user address from token",

--- a/mercata/services/bridge/src/auth/tokenMiddleware.ts
+++ b/mercata/services/bridge/src/auth/tokenMiddleware.ts
@@ -1,0 +1,35 @@
+import {RequestHandler, Request, Response, NextFunction} from "express";
+import { verifyAccessTokenSignature, getTokenFromHeader, getUserKey } from "../auth";
+
+class AuthHandler {
+  /**
+   * Middleware that enforces OAuth on incoming requests
+   * and extracts the user's STRATO address.
+   */
+  static authorizeRequest(): RequestHandler {
+    return async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        // Get token from header
+        const token = getTokenFromHeader(req);
+        if (!token) throw new Error("Missing or invalid authorization header");
+
+        // Verify token signature
+        await verifyAccessTokenSignature(token);
+
+        // Get user address from token
+        const userAddress = await getUserKey(token);
+
+        // Make user address available to request handler
+        res.locals.userAddress = userAddress;
+        next();
+      } catch (error: any) {
+        return res.status(401).json({
+          error: "Failed to get user address from token",
+          message: error.message
+        });
+      }
+    }
+  }
+}
+
+export default AuthHandler;

--- a/mercata/services/bridge/src/controllers/autosave.controller.ts
+++ b/mercata/services/bridge/src/controllers/autosave.controller.ts
@@ -1,0 +1,27 @@
+import { requestAutoSave } from "../services/autosaveService";
+import { Request, Response, NextFunction } from "express";
+
+class AutoSaveController {
+  static async requestAutoSave(req: Request, res: Response, next: NextFunction) {
+    // Get user address from token
+    let userAddress: string = res.locals.userAddress;
+  
+    // Extract and validate request parameters
+    const { externalChainId, externalTxHash } = req.body;
+    if (!externalChainId || !externalTxHash) {
+      return res.status(400).json({
+        error: "Missing required parameters: externalChainId and externalTxHash"
+      });
+    }
+  
+    // Call the logic function, which executes the smart contract call
+    try {
+      const result = await requestAutoSave({ userAddress, externalChainId, externalTxHash });
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+export default AutoSaveController;

--- a/mercata/services/bridge/src/index.ts
+++ b/mercata/services/bridge/src/index.ts
@@ -8,9 +8,10 @@ import { logInfo, logError } from "./utils/logger";
 import { validateBridgeConfig } from "./utils/configValidator";
 import { startMultiChainDepositPolling } from "./polling/alchemyPolling";
 import { initializeMercataPolling } from "./polling/mercataPolling";
-import { initOpenIdConfig, verifyAccessTokenSignature, getTokenFromHeader, createOrGetUserKey } from "./auth";
+import { initOpenIdConfig} from "./auth";
 import { healthMonitor } from "./utils/healthMonitor";
-import { requestAutoSave } from "./services/autosaveService";
+import AutoSaveController from "./controllers/autosave.controller";
+import AuthHandler from "./auth/tokenMiddleware";
 
 const app = express();
 const port = process.env.PORT || 3003;
@@ -34,55 +35,12 @@ app.use(
   },
 );
 
+// Exposed Routes
 app.get("/health", async (_, res) => {
   const errorFileExists = await healthMonitor.errorFileExists();
   res.status(errorFileExists ? 500 : 200).json({status: !errorFileExists, message: 'pong'})
 });
-
-app.post("/requestAutoSave", async (req, res, next) => {
-  try {
-    // Extract and validate token
-    const token = getTokenFromHeader(req);
-    if (!token) {
-      return res.status(401).json({ error: "Missing or invalid authorization header" });
-    }
-
-    // Verify token signature
-    try {
-      await verifyAccessTokenSignature(token);
-    } catch (error: any) {
-      return res.status(401).json({
-        error: "Invalid or expired access token",
-        message: error.message
-      });
-    }
-
-    // Get user address from token
-    let userAddress: string;
-    try {
-      userAddress = await createOrGetUserKey(token);
-    } catch (error: any) {
-      return res.status(401).json({
-        error: "Failed to get user address",
-        message: error.message
-      });
-    }
-
-    // Extract request parameters
-    const { externalChainId, externalTxHash } = req.body;
-    if (!externalChainId || !externalTxHash) {
-      return res.status(400).json({
-        error: "Missing required parameters: externalChainId and externalTxHash"
-      });
-    }
-
-    // Call the service
-    const result = await requestAutoSave({ userAddress, externalChainId, externalTxHash });
-    res.status(200).json(result);
-  } catch (error) {
-    next(error);
-  }
-});
+app.post("/request-autosave", AuthHandler.authorizeRequest(), AutoSaveController.requestAutoSave);
 
 app.listen(port, async () => {
   try {

--- a/mercata/services/bridge/src/index.ts
+++ b/mercata/services/bridge/src/index.ts
@@ -8,8 +8,9 @@ import { logInfo, logError } from "./utils/logger";
 import { validateBridgeConfig } from "./utils/configValidator";
 import { startMultiChainDepositPolling } from "./polling/alchemyPolling";
 import { initializeMercataPolling } from "./polling/mercataPolling";
-import { initOpenIdConfig } from "./auth";
+import { initOpenIdConfig, verifyAccessTokenSignature, getTokenFromHeader, createOrGetUserKey } from "./auth";
 import { healthMonitor } from "./utils/healthMonitor";
+import { requestAutoSave } from "./services/autosaveService";
 
 const app = express();
 const port = process.env.PORT || 3003;
@@ -36,6 +37,51 @@ app.use(
 app.get("/health", async (_, res) => {
   const errorFileExists = await healthMonitor.errorFileExists();
   res.status(errorFileExists ? 500 : 200).json({status: !errorFileExists, message: 'pong'})
+});
+
+app.post("/requestAutoSave", async (req, res, next) => {
+  try {
+    // Extract and validate token
+    const token = getTokenFromHeader(req);
+    if (!token) {
+      return res.status(401).json({ error: "Missing or invalid authorization header" });
+    }
+
+    // Verify token signature
+    try {
+      await verifyAccessTokenSignature(token);
+    } catch (error: any) {
+      return res.status(401).json({
+        error: "Invalid or expired access token",
+        message: error.message
+      });
+    }
+
+    // Get user address from token
+    let userAddress: string;
+    try {
+      userAddress = await createOrGetUserKey(token);
+    } catch (error: any) {
+      return res.status(401).json({
+        error: "Failed to get user address",
+        message: error.message
+      });
+    }
+
+    // Extract request parameters
+    const { externalChainId, externalTxHash } = req.body;
+    if (!externalChainId || !externalTxHash) {
+      return res.status(400).json({
+        error: "Missing required parameters: externalChainId and externalTxHash"
+      });
+    }
+
+    // Call the service
+    const result = await requestAutoSave({ userAddress, externalChainId, externalTxHash });
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
 });
 
 app.listen(port, async () => {

--- a/mercata/services/bridge/src/services/autosaveService.ts
+++ b/mercata/services/bridge/src/services/autosaveService.ts
@@ -1,0 +1,23 @@
+import { config } from "../config";
+import { execute } from "../utils/stratoHelper";
+
+export interface AutoSaveRequestParams {
+  userAddress: string;
+  externalChainId: string;
+  externalTxHash: string;
+}
+
+export const requestAutoSave = async (
+  params: AutoSaveRequestParams,
+) => {
+  return await execute({
+    contractName: "MercataBridge",
+    contractAddress: config.bridge.address!,
+    method: "requestAutoSave",
+    args: {
+      user: params.userAddress,
+      externalChainId: params.externalChainId,
+      externalTxHash: params.externalTxHash,
+    },
+  });
+};

--- a/mercata/services/bridge/src/services/autosaveService.ts
+++ b/mercata/services/bridge/src/services/autosaveService.ts
@@ -1,3 +1,4 @@
+import { logError } from "../utils/logger";
 import { config } from "../config";
 import { execute } from "../utils/stratoHelper";
 
@@ -10,14 +11,19 @@ export interface AutoSaveRequestParams {
 export const requestAutoSave = async (
   params: AutoSaveRequestParams,
 ) => {
-  return await execute({
-    contractName: "MercataBridge",
-    contractAddress: config.bridge.address!,
-    method: "requestAutoSave",
-    args: {
-      user: params.userAddress,
-      externalChainId: params.externalChainId,
-      externalTxHash: params.externalTxHash,
-    },
-  });
+  try {
+    return await execute({
+      contractName: "MercataBridge",
+      contractAddress: config.bridge.address!,
+      method: "requestAutoSave",
+      args: {
+        user: params.userAddress,
+        externalChainId: params.externalChainId,
+        externalTxHash: params.externalTxHash,
+      },
+    });
+  } catch (error) {
+    logError("AutoSaveService", error as Error);
+    throw error;
+  }
 };


### PR DESCRIPTION
Expose /requestAutoSave endpoint in the bridge service, allowing users to request their mint-on-stablecoin-bridge deposit to be supplied as liquidity to the lending pool once it is bridge in, without the user needing to pay a transaction fee; this allows first-time users with no USDST and no vouchers to auto earn with their easy save deposit.

Pending is to supply the correct hardcoded default bridge service URLs for testnet and mainnet.

This involves a smart contract upgrade (currently deployed on testnet), nginx changes (from Nikita), and a new whitelist entry (the bridge relayer service account should be whitelisted for `MercataBridge.requestAutoSave()`).

I need to take a second look at the JWK portion, but this is working and ready for review.