### PR TITLE
Provide idempotency with a monotonic sequence identifier

### DIFF
--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -20,6 +20,7 @@ enum ActionType {
 }
 
 struct Action {
+    uint256 actionId;    // Unique identifier for idempotency (monotonically increasing)
     uint256 activityId;  // The activity being updated
     address user;        // The user whose stake is changing
     uint256 amount;      // The amount of stake change
@@ -102,6 +103,9 @@ contract record Rewards is Ownable {
 
     // Last block number when _handleAction was called
     uint256 public lastBlockHandled;
+
+    // Last handled action ID for idempotency (monotonically increasing)
+    uint256 public lastHandledActionId;
 
     // ═════════════════════════════════════════════════════════════════════════
     // CONSTRUCTOR
@@ -269,44 +273,50 @@ contract record Rewards is Ownable {
 
     /**
      * @dev Deposit/increase stake for a user in an activity
+     * @param actionId Unique identifier for idempotency
      * @param activityId The activity to deposit into
      * @param user The user whose stake is increasing
      * @param amount The amount to deposit
      */
     function deposit(
+        uint256 actionId,
         uint256 activityId,
         address user,
         uint256 amount
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Deposit));
+        _handleAction(Action(actionId, activityId, user, amount, ActionType.Deposit));
     }
 
     /**
      * @dev Withdraw/decrease stake for a user in an activity
+     * @param actionId Unique identifier for idempotency
      * @param activityId The activity to withdraw from
      * @param user The user whose stake is decreasing
      * @param amount The amount to withdraw
      */
     function withdraw(
+        uint256 actionId,
         uint256 activityId,
         address user,
         uint256 amount
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Withdraw));
+        _handleAction(Action(actionId, activityId, user, amount, ActionType.Withdraw));
     }
 
     /**
      * @dev Record a one-time action occurrence for a user
+     * @param actionId Unique identifier for idempotency
      * @param activityId The one-time activity that occurred
      * @param user The user who performed the action
      * @param amount The amount/value of the action
      */
     function occurred(
+        uint256 actionId,
         uint256 activityId,
         address user,
         uint256 amount
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Occurred));
+        _handleAction(Action(actionId, activityId, user, amount, ActionType.Occurred));
     }
 
     /**
@@ -328,6 +338,11 @@ contract record Rewards is Ownable {
      * @param action The action to process
      */
     function _handleAction(Action action) internal {
+        // Idempotency check: silently ignore actions already processed or out of order
+        if (action.actionId <= lastHandledActionId) {
+            return;
+        }
+
         Activity storage activity = activities[action.activityId];
 
         // Validate action type against activity type
@@ -342,6 +357,9 @@ contract record Rewards is Ownable {
 
         // Access control: only allowed caller can update this activity
         require(msg.sender == activity.allowedCaller, "Caller not allowed");
+
+        // Update idempotency tracker
+        lastHandledActionId = action.actionId;
 
         // Track last block handled
         lastBlockHandled = block.number;

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -24,6 +24,9 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     uint256 liquidityEmissionRate = 900; // 900 CATA per second
     uint256 borrowEmissionRate = 100;    // 100 CATA per second
 
+    // Action ID counter for idempotency
+    uint256 nextActionId = 1;
+
     function beforeAll() {
         bypassAuthorizations = true;
         // Create test users once
@@ -73,7 +76,7 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_for_single_liquidity_provider() {
         // given - user1 deposits 1000 units of liquidity
         uint256 depositAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount);
+        rewards.deposit(nextActionId++, liquidityActivityId, address(user1), depositAmount);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -99,11 +102,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_split_rewards_proportionally_between_two_users() {
         // given - user1 deposits 600 units
         uint256 user1Deposit = 600 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), user1Deposit);
+        rewards.deposit(nextActionId++, liquidityActivityId, address(user1), user1Deposit);
 
         // given - user2 deposits 400 units
         uint256 user2Deposit = 400 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user2), user2Deposit);
+        rewards.deposit(nextActionId++, liquidityActivityId, address(user2), user2Deposit);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -137,11 +140,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_from_multiple_activities() {
         // given - user1 deposits liquidity (activity 1)
         uint256 liquidityAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), liquidityAmount);
+        rewards.deposit(nextActionId++, liquidityActivityId, address(user1), liquidityAmount);
 
         // given - user1 borrows (activity 2)
         uint256 borrowAmount = 500 * 1e18;
-        rewards.deposit(borrowActivityId, address(user1), borrowAmount);
+        rewards.deposit(nextActionId++, borrowActivityId, address(user1), borrowAmount);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -172,14 +175,14 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_handle_partial_withdrawal_and_continue_accruing() {
         // given - user1 deposits 1000 units
         uint256 initialDeposit = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), initialDeposit);
+        rewards.deposit(nextActionId++, liquidityActivityId, address(user1), initialDeposit);
 
         // given - 50 seconds pass
         fastForward(50);
 
         // when - user1 withdraws 400 units (leaving 600)
         uint256 withdrawAmount = 400 * 1e18;
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount);
+        rewards.withdraw(nextActionId++, liquidityActivityId, address(user1), withdrawAmount);
 
         // given - another 50 seconds pass
         fastForward(50);

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import "../../concrete/BaseCodeCollection.sol";
+import "../Util.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
+import "../../abstract/ERC20/access/Ownable.sol";
+import "../../concrete/Rewards/Rewards.sol";
+
+contract Describe_Rewards_Idempotency is Authorizable {
+    using TestUtils for User;
+
+    constructor() {
+    }
+
+    Mercata m;
+    Token rewardToken;
+    Rewards rewards;
+    User user1;
+    User user2;
+
+    uint256 activityId = 1;
+    uint256 emissionRate = 100;
+
+    function beforeAll() {
+        bypassAuthorizations = true;
+        user1 = new User();
+        user2 = new User();
+    }
+
+    function beforeEach() {
+        // Create fresh Mercata infrastructure for each test
+        m = new Mercata();
+        require(address(m) != address(0), "Mercata address is 0");
+
+        // Deploy reward token
+        address tokenAddress = m.tokenFactory().createToken(
+            "TestCATA",
+            "Test CATA Token",
+            [], [], [], "TESTCATA", 0, 18
+        );
+        require(tokenAddress != address(0), "Token address is 0");
+        rewardToken = Token(tokenAddress);
+
+        // Use Rewards from Mercata
+        rewards = m.rewards();
+
+        // Whitelist test contract to transfer ownership via adminRegistry voting
+        m.adminRegistry().castVoteOnIssue(address(rewards), "transferOwnership", address(this));
+
+        // Transfer ownership to test contract (now whitelisted)
+        Ownable(address(rewards)).transferOwnership(address(this));
+
+        // Initialize Rewards contract (now that we own it)
+        rewards.initialize(tokenAddress);
+
+        // Add a Position activity - test contract is the allowed caller
+        rewards.addActivity(activityId, "Test Activity", ActivityType.Position, emissionRate, address(this), address(this));
+
+        // Fund the Rewards contract with CATA tokens
+        uint256 fundingAmount = 1000000 * 1e18;
+        rewardToken.mint(address(rewards), fundingAmount);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY TESTS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_process_action_with_valid_actionId() {
+        // given - initial state
+        require(rewards.lastHandledActionId() == 0, "Initial lastHandledActionId should be 0");
+
+        // when - deposit with actionId = 1
+        uint256 depositAmount = 100 * 1e18;
+        rewards.deposit(1, activityId, address(user1), depositAmount);
+
+        // then - action should be processed
+        (uint256 stake, ) = rewards.userInfo(activityId, address(user1));
+        require(stake == depositAmount, "Stake should be updated");
+        require(rewards.lastHandledActionId() == 1, "lastHandledActionId should be 1");
+    }
+
+    function it_should_silently_ignore_duplicate_actionId() {
+        // given - first deposit with actionId = 1
+        uint256 depositAmount = 100 * 1e18;
+        rewards.deposit(1, activityId, address(user1), depositAmount);
+
+        (uint256 stakeAfterFirst, ) = rewards.userInfo(activityId, address(user1));
+        require(stakeAfterFirst == depositAmount, "First deposit should be processed");
+
+        // when - try to deposit again with same actionId = 1 (duplicate)
+        rewards.deposit(1, activityId, address(user1), depositAmount);
+
+        // then - duplicate should be silently ignored, stake unchanged
+        (uint256 stakeAfterDuplicate, ) = rewards.userInfo(activityId, address(user1));
+        require(stakeAfterDuplicate == depositAmount, "Stake should remain unchanged after duplicate");
+        require(rewards.lastHandledActionId() == 1, "lastHandledActionId should still be 1");
+    }
+
+    function it_should_silently_ignore_out_of_order_actionId() {
+        // given - deposit with actionId = 5
+        uint256 depositAmount = 100 * 1e18;
+        rewards.deposit(5, activityId, address(user1), depositAmount);
+
+        require(rewards.lastHandledActionId() == 5, "lastHandledActionId should be 5");
+
+        // when - try to deposit with lower actionId = 3 (out of order)
+        rewards.deposit(3, activityId, address(user1), depositAmount);
+
+        // then - out of order action should be silently ignored
+        (uint256 stake, ) = rewards.userInfo(activityId, address(user1));
+        require(stake == depositAmount, "Stake should remain unchanged after out-of-order action");
+        require(rewards.lastHandledActionId() == 5, "lastHandledActionId should still be 5");
+    }
+
+    function it_should_process_sequential_actionIds_correctly() {
+        // given/when - process multiple actions with sequential actionIds
+        uint256 depositAmount = 100 * 1e18;
+
+        rewards.deposit(1, activityId, address(user1), depositAmount);
+        require(rewards.lastHandledActionId() == 1, "After action 1");
+
+        rewards.deposit(2, activityId, address(user1), depositAmount);
+        require(rewards.lastHandledActionId() == 2, "After action 2");
+
+        rewards.deposit(3, activityId, address(user1), depositAmount);
+        require(rewards.lastHandledActionId() == 3, "After action 3");
+
+        // then - all deposits should be processed
+        (uint256 stake, ) = rewards.userInfo(activityId, address(user1));
+        require(stake == depositAmount * 3, "All three deposits should be processed");
+    }
+
+    function it_should_allow_gaps_in_actionIds() {
+        // given/when - process actions with gaps in actionIds (1, 5, 100)
+        uint256 depositAmount = 100 * 1e18;
+
+        rewards.deposit(1, activityId, address(user1), depositAmount);
+        require(rewards.lastHandledActionId() == 1, "After action 1");
+
+        rewards.deposit(5, activityId, address(user1), depositAmount);
+        require(rewards.lastHandledActionId() == 5, "After action 5");
+
+        rewards.deposit(100, activityId, address(user1), depositAmount);
+        require(rewards.lastHandledActionId() == 100, "After action 100");
+
+        // then - all deposits should be processed
+        (uint256 stake, ) = rewards.userInfo(activityId, address(user1));
+        require(stake == depositAmount * 3, "All three deposits should be processed");
+    }
+
+    function it_should_handle_idempotency_across_different_action_types() {
+        // given - deposit with actionId = 1
+        uint256 amount = 100 * 1e18;
+        rewards.deposit(1, activityId, address(user1), amount);
+
+        // when - withdraw with actionId = 2
+        rewards.withdraw(2, activityId, address(user1), amount / 2);
+
+        // then
+        (uint256 stake, ) = rewards.userInfo(activityId, address(user1));
+        require(stake == amount / 2, "Stake should be 50 after withdraw");
+        require(rewards.lastHandledActionId() == 2, "lastHandledActionId should be 2");
+
+        // when - try duplicate withdraw with actionId = 2
+        rewards.withdraw(2, activityId, address(user1), amount / 2);
+
+        // then - duplicate should be ignored
+        (uint256 stakeAfterDuplicate, ) = rewards.userInfo(activityId, address(user1));
+        require(stakeAfterDuplicate == amount / 2, "Stake should remain 50 after duplicate withdraw");
+    }
+
+    function it_should_handle_batch_actions_with_idempotency() {
+        // given - prepare batch of actions
+        Action[] memory actions = new Action[](3);
+        actions[0] = Action(1, activityId, address(user1), 100 * 1e18, ActionType.Deposit);
+        actions[1] = Action(2, activityId, address(user1), 50 * 1e18, ActionType.Deposit);
+        actions[2] = Action(3, activityId, address(user1), 25 * 1e18, ActionType.Deposit);
+
+        // when - process batch
+        rewards.batchHandleAction(actions);
+
+        // then - all actions should be processed
+        (uint256 stake, ) = rewards.userInfo(activityId, address(user1));
+        require(stake == 175 * 1e18, "All batch deposits should be processed");
+        require(rewards.lastHandledActionId() == 3, "lastHandledActionId should be 3");
+
+        // when - try to replay same batch
+        rewards.batchHandleAction(actions);
+
+        // then - replayed batch should be ignored
+        (uint256 stakeAfterReplay, ) = rewards.userInfo(activityId, address(user1));
+        require(stakeAfterReplay == 175 * 1e18, "Stake should remain unchanged after batch replay");
+    }
+
+    function it_should_handle_partial_batch_replay() {
+        // given - process first batch with actionIds 1, 2, 3
+        Action[] memory batch1 = new Action[](3);
+        batch1[0] = Action(1, activityId, address(user1), 100 * 1e18, ActionType.Deposit);
+        batch1[1] = Action(2, activityId, address(user1), 100 * 1e18, ActionType.Deposit);
+        batch1[2] = Action(3, activityId, address(user1), 100 * 1e18, ActionType.Deposit);
+        rewards.batchHandleAction(batch1);
+
+        (uint256 stakeAfterBatch1, ) = rewards.userInfo(activityId, address(user1));
+        require(stakeAfterBatch1 == 300 * 1e18, "First batch should be processed");
+
+        // when - process second batch with actionIds 2, 3, 4, 5 (2,3 are duplicates)
+        Action[] memory batch2 = new Action[](4);
+        batch2[0] = Action(2, activityId, address(user1), 100 * 1e18, ActionType.Deposit);  // duplicate
+        batch2[1] = Action(3, activityId, address(user1), 100 * 1e18, ActionType.Deposit);  // duplicate
+        batch2[2] = Action(4, activityId, address(user1), 100 * 1e18, ActionType.Deposit);  // new
+        batch2[3] = Action(5, activityId, address(user1), 100 * 1e18, ActionType.Deposit);  // new
+        rewards.batchHandleAction(batch2);
+
+        // then - only new actions (4, 5) should be processed
+        (uint256 stakeAfterBatch2, ) = rewards.userInfo(activityId, address(user1));
+        require(stakeAfterBatch2 == 500 * 1e18, "Only new actions in second batch should be processed");
+        require(rewards.lastHandledActionId() == 5, "lastHandledActionId should be 5");
+    }
+
+}

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -19,6 +19,9 @@ contract Describe_Rewards_Management is Authorizable {
     User user1;
     User user2;
 
+    // Action ID counter for idempotency
+    uint256 nextActionId = 1;
+
     function beforeAll() {
         bypassAuthorizations = true;
         // Create test users once
@@ -345,7 +348,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to deposit on OneTime activity
         bool reverted = false;
-        try rewards.deposit(activityId, address(user1), 100) {
+        try rewards.deposit(nextActionId++, activityId, address(user1), 100) {
             reverted = false;
         } catch {
             reverted = true;
@@ -360,7 +363,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to withdraw on OneTime activity
         bool reverted = false;
-        try rewards.withdraw(activityId, address(user1), 100) {
+        try rewards.withdraw(nextActionId++, activityId, address(user1), 100) {
             reverted = false;
         } catch {
             reverted = true;
@@ -375,7 +378,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to call occurred on Position activity
         bool reverted = false;
-        try rewards.occurred(activityId, address(user1), 100) {
+        try rewards.occurred(nextActionId++, activityId, address(user1), 100) {
             reverted = false;
         } catch {
             reverted = true;
@@ -389,7 +392,7 @@ contract Describe_Rewards_Management is Authorizable {
         rewards.addActivity(activityId, "Swap Activity", ActivityType.OneTime, 100, address(this), address(this));
 
         // when - call occurred
-        rewards.occurred(activityId, address(user1), 100);
+        rewards.occurred(nextActionId++, activityId, address(user1), 100);
 
         // then - check user stake increased
         (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));


### PR DESCRIPTION
When we look at the event table cirrus/search/event the rows in that table have a column called id.

If we assume that it is a monotonic sequence (that only grows) and uniquely identifies an event among any cirrus table (no matter which node), then we can go with a very simple and elegant solution proposed