### PR TITLE
Add Idempotency for Rewards Contract

### DIFF
--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -24,6 +24,8 @@ struct Action {
     address user;        // The user whose stake is changing
     uint256 amount;      // The amount of stake change
     ActionType actionType; // The type of action
+    uint256 blockNumber; // Block number this event originated from (for idempotency)
+    uint256 eventHash;   // Unique hash identifying this event (for idempotency)
 }
 
 struct RewardsUserInfo {
@@ -100,8 +102,18 @@ contract record Rewards is Ownable {
     // Total unclaimed rewards per user
     mapping(address => uint256) public record unclaimedRewards;
 
-    // Last block number when _handleAction was called
-    uint256 public lastBlockHandled;
+    // ═══════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY STATE
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // Current block number being processed (for idempotency)
+    uint256 public currentBlock;
+
+    // Mapping of event hashes processed in the current block
+    mapping(uint256 => bool) public processedHashes;
+
+    // Array of event hashes in current block (for clearing the mapping)
+    uint256[] public processedHashList;
 
     // ═════════════════════════════════════════════════════════════════════════
     // CONSTRUCTOR
@@ -272,13 +284,17 @@ contract record Rewards is Ownable {
      * @param activityId The activity to deposit into
      * @param user The user whose stake is increasing
      * @param amount The amount to deposit
+     * @param blockNumber The block number this event originated from (for idempotency)
+     * @param eventHash Unique hash identifying this event (for idempotency)
      */
     function deposit(
         uint256 activityId,
         address user,
-        uint256 amount
+        uint256 amount,
+        uint256 blockNumber,
+        uint256 eventHash
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Deposit));
+        _handleAction(Action(activityId, user, amount, ActionType.Deposit, blockNumber, eventHash));
     }
 
     /**
@@ -286,13 +302,17 @@ contract record Rewards is Ownable {
      * @param activityId The activity to withdraw from
      * @param user The user whose stake is decreasing
      * @param amount The amount to withdraw
+     * @param blockNumber The block number this event originated from (for idempotency)
+     * @param eventHash Unique hash identifying this event (for idempotency)
      */
     function withdraw(
         uint256 activityId,
         address user,
-        uint256 amount
+        uint256 amount,
+        uint256 blockNumber,
+        uint256 eventHash
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Withdraw));
+        _handleAction(Action(activityId, user, amount, ActionType.Withdraw, blockNumber, eventHash));
     }
 
     /**
@@ -300,18 +320,22 @@ contract record Rewards is Ownable {
      * @param activityId The one-time activity that occurred
      * @param user The user who performed the action
      * @param amount The amount/value of the action
+     * @param blockNumber The block number this event originated from (for idempotency)
+     * @param eventHash Unique hash identifying this event (for idempotency)
      */
     function occurred(
         uint256 activityId,
         address user,
-        uint256 amount
+        uint256 amount,
+        uint256 blockNumber,
+        uint256 eventHash
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Occurred));
+        _handleAction(Action(activityId, user, amount, ActionType.Occurred, blockNumber, eventHash));
     }
 
     /**
      * @dev Process multiple actions in a single call
-     * @param actions Array of actions to process
+     * @param actions Array of actions to process (each action includes blockNumber and eventHash)
      */
     function batchHandleAction(Action[] calldata actions) external {
         for (uint256 i = 0; i < actions.length; i++) {
@@ -324,10 +348,42 @@ contract record Rewards is Ownable {
     // ═════════════════════════════════════════════════════════════════════════
 
     /**
-     * @dev Internal function to handle stake changes
-     * @param action The action to process
+     * @dev Internal function to handle stake changes with idempotency
+     * @param action The action to process (includes blockNumber and eventHash for idempotency)
      */
     function _handleAction(Action action) internal {
+        // ═══════════════════════════════════════════════════════════════════════
+        // IDEMPOTENCY CHECK
+        // ═══════════════════════════════════════════════════════════════════════
+
+        // If blockNumber < currentBlock, this is an old event - silently ignore
+        if (action.blockNumber < currentBlock) {
+            return;
+        }
+
+        // If blockNumber > currentBlock, we've moved to a new block
+        if (action.blockNumber > currentBlock) {
+            // Clear the processed hashes from the previous block
+            _clearProcessedHashes();
+            // Update to the new block
+            currentBlock = action.blockNumber;
+        }
+
+        // blockNumber == currentBlock at this point
+        // Check if we've already processed this event hash
+        if (processedHashes[action.eventHash]) {
+            // Already processed - silently ignore (idempotency)
+            return;
+        }
+
+        // Mark this event hash as processed
+        processedHashes[action.eventHash] = true;
+        processedHashList.push(action.eventHash);
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // ACTION PROCESSING
+        // ═══════════════════════════════════════════════════════════════════════
+
         Activity storage activity = activities[action.activityId];
 
         // Validate action type against activity type
@@ -342,9 +398,6 @@ contract record Rewards is Ownable {
 
         // Access control: only allowed caller can update this activity
         require(msg.sender == activity.allowedCaller, "Caller not allowed");
-
-        // Track last block handled
-        lastBlockHandled = block.number;
 
         // 1) Update global index using current totalStake (before user update)
         _updateActivityIndex(action.activityId);
@@ -381,6 +434,18 @@ contract record Rewards is Ownable {
         activity.totalStake = activity.totalStake + newStake - oldStake;
 
         emit UserStakeUpdated(action.activityId, action.user, oldStake, newStake, pendingRewards);
+    }
+
+    /**
+     * @dev Clear all processed hashes when moving to a new block
+     * This keeps storage bounded to only the hashes of the current block
+     */
+    function _clearProcessedHashes() internal {
+        for (uint256 i = 0; i < processedHashList.length; i++) {
+            delete processedHashes[processedHashList[i]];
+        }
+        // Clear the array
+        processedHashList = [];
     }
 
     /**

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -25,6 +25,7 @@ struct Action {
     uint256 amount;      // The amount of stake change
     ActionType actionType; // The type of action
     uint256 blockNumber; // Block number this event originated from (for idempotency)
+    uint256 eventIndex;  // Event index within the block (for idempotency)
 }
 
 struct RewardsUserInfo {
@@ -284,14 +285,16 @@ contract record Rewards is Ownable {
      * @param user The user whose stake is increasing
      * @param amount The amount to deposit
      * @param blockNumber The block number this event originated from (for idempotency)
+     * @param eventIndex The event index within the block (for idempotency)
      */
     function deposit(
         uint256 activityId,
         address user,
         uint256 amount,
-        uint256 blockNumber
+        uint256 blockNumber,
+        uint256 eventIndex
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Deposit, blockNumber));
+        _handleAction(Action(activityId, user, amount, ActionType.Deposit, blockNumber, eventIndex));
     }
 
     /**
@@ -300,14 +303,16 @@ contract record Rewards is Ownable {
      * @param user The user whose stake is decreasing
      * @param amount The amount to withdraw
      * @param blockNumber The block number this event originated from (for idempotency)
+     * @param eventIndex The event index within the block (for idempotency)
      */
     function withdraw(
         uint256 activityId,
         address user,
         uint256 amount,
-        uint256 blockNumber
+        uint256 blockNumber,
+        uint256 eventIndex
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Withdraw, blockNumber));
+        _handleAction(Action(activityId, user, amount, ActionType.Withdraw, blockNumber, eventIndex));
     }
 
     /**
@@ -316,14 +321,16 @@ contract record Rewards is Ownable {
      * @param user The user who performed the action
      * @param amount The amount/value of the action
      * @param blockNumber The block number this event originated from (for idempotency)
+     * @param eventIndex The event index within the block (for idempotency)
      */
     function occurred(
         uint256 activityId,
         address user,
         uint256 amount,
-        uint256 blockNumber
+        uint256 blockNumber,
+        uint256 eventIndex
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Occurred, blockNumber));
+        _handleAction(Action(activityId, user, amount, ActionType.Occurred, blockNumber, eventIndex));
     }
 
     /**
@@ -371,8 +378,8 @@ contract record Rewards is Ownable {
             currentBlockHandled = action.blockNumber;
         }
 
-        // Calculate event hash from action attributes
-        string eventHash = keccak256(action.user, action.amount, action.activityId, action.actionType, action.blockNumber);
+        // Calculate event hash from blockNumber and eventIndex (uniquely identifies event on chain)
+        string eventHash = keccak256(action.blockNumber, action.eventIndex);
 
         // blockNumber == currentBlockHandled at this point
         // Check if we've already processed this event hash

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -343,6 +343,15 @@ contract record Rewards is Ownable {
         }
     }
 
+    /**
+     * @dev Emergency function to reset idempotency state
+     * @param newBlockNumber The block number to set as currentBlockHandled
+     */
+    function emergencyOverride(uint256 newBlockNumber) external onlyOwner {
+        _clearProcessedHashes();
+        currentBlockHandled = newBlockNumber;
+    }
+
     // ═════════════════════════════════════════════════════════════════════════
     // INTERNAL FUNCTIONS
     // ═════════════════════════════════════════════════════════════════════════

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -25,7 +25,6 @@ struct Action {
     uint256 amount;      // The amount of stake change
     ActionType actionType; // The type of action
     uint256 blockNumber; // Block number this event originated from (for idempotency)
-    uint256 eventHash;   // Unique hash identifying this event (for idempotency)
 }
 
 struct RewardsUserInfo {
@@ -110,10 +109,10 @@ contract record Rewards is Ownable {
     uint256 public currentBlockHandled;
 
     // Mapping of event hashes processed in the current block
-    mapping(uint256 => bool) public processedHashes;
+    mapping(string => bool) public processedHashes;
 
     // Array of event hashes in current block (for clearing the mapping)
-    uint256[] public processedHashList;
+    string[] public processedHashList;
 
     // ═════════════════════════════════════════════════════════════════════════
     // CONSTRUCTOR
@@ -285,16 +284,14 @@ contract record Rewards is Ownable {
      * @param user The user whose stake is increasing
      * @param amount The amount to deposit
      * @param blockNumber The block number this event originated from (for idempotency)
-     * @param eventHash Unique hash identifying this event (for idempotency)
      */
     function deposit(
         uint256 activityId,
         address user,
         uint256 amount,
-        uint256 blockNumber,
-        uint256 eventHash
+        uint256 blockNumber
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Deposit, blockNumber, eventHash));
+        _handleAction(Action(activityId, user, amount, ActionType.Deposit, blockNumber));
     }
 
     /**
@@ -303,16 +300,14 @@ contract record Rewards is Ownable {
      * @param user The user whose stake is decreasing
      * @param amount The amount to withdraw
      * @param blockNumber The block number this event originated from (for idempotency)
-     * @param eventHash Unique hash identifying this event (for idempotency)
      */
     function withdraw(
         uint256 activityId,
         address user,
         uint256 amount,
-        uint256 blockNumber,
-        uint256 eventHash
+        uint256 blockNumber
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Withdraw, blockNumber, eventHash));
+        _handleAction(Action(activityId, user, amount, ActionType.Withdraw, blockNumber));
     }
 
     /**
@@ -321,21 +316,19 @@ contract record Rewards is Ownable {
      * @param user The user who performed the action
      * @param amount The amount/value of the action
      * @param blockNumber The block number this event originated from (for idempotency)
-     * @param eventHash Unique hash identifying this event (for idempotency)
      */
     function occurred(
         uint256 activityId,
         address user,
         uint256 amount,
-        uint256 blockNumber,
-        uint256 eventHash
+        uint256 blockNumber
     ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Occurred, blockNumber, eventHash));
+        _handleAction(Action(activityId, user, amount, ActionType.Occurred, blockNumber));
     }
 
     /**
      * @dev Process multiple actions in a single call
-     * @param actions Array of actions to process (each action includes blockNumber and eventHash)
+     * @param actions Array of actions to process (each action includes blockNumber for idempotency)
      */
     function batchHandleAction(Action[] calldata actions) external {
         for (uint256 i = 0; i < actions.length; i++) {
@@ -358,7 +351,7 @@ contract record Rewards is Ownable {
 
     /**
      * @dev Internal function to handle stake changes with idempotency
-     * @param action The action to process (includes blockNumber and eventHash for idempotency)
+     * @param action The action to process (includes blockNumber for idempotency)
      */
     function _handleAction(Action action) internal {
         // ═══════════════════════════════════════════════════════════════════════
@@ -378,16 +371,19 @@ contract record Rewards is Ownable {
             currentBlockHandled = action.blockNumber;
         }
 
+        // Calculate event hash from action attributes
+        string eventHash = keccak256(action.user, action.amount, action.activityId, action.actionType, action.blockNumber);
+
         // blockNumber == currentBlockHandled at this point
         // Check if we've already processed this event hash
-        if (processedHashes[action.eventHash]) {
+        if (processedHashes[eventHash]) {
             // Already processed - silently ignore (idempotency)
             return;
         }
 
         // Mark this event hash as processed
-        processedHashes[action.eventHash] = true;
-        processedHashList.push(action.eventHash);
+        processedHashes[eventHash] = true;
+        processedHashList.push(eventHash);
 
         // ═══════════════════════════════════════════════════════════════════════
         // ACTION PROCESSING

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -107,7 +107,7 @@ contract record Rewards is Ownable {
     // ═══════════════════════════════════════════════════════════════════════
 
     // Current block number being processed (for idempotency)
-    uint256 public currentBlock;
+    uint256 public currentBlockHandled;
 
     // Mapping of event hashes processed in the current block
     mapping(uint256 => bool) public processedHashes;
@@ -356,20 +356,20 @@ contract record Rewards is Ownable {
         // IDEMPOTENCY CHECK
         // ═══════════════════════════════════════════════════════════════════════
 
-        // If blockNumber < currentBlock, this is an old event - silently ignore
-        if (action.blockNumber < currentBlock) {
+        // If blockNumber < currentBlockHandled, this is an old event - silently ignore
+        if (action.blockNumber < currentBlockHandled) {
             return;
         }
 
-        // If blockNumber > currentBlock, we've moved to a new block
-        if (action.blockNumber > currentBlock) {
+        // If blockNumber > currentBlockHandled, we've moved to a new block
+        if (action.blockNumber > currentBlockHandled) {
             // Clear the processed hashes from the previous block
             _clearProcessedHashes();
             // Update to the new block
-            currentBlock = action.blockNumber;
+            currentBlockHandled = action.blockNumber;
         }
 
-        // blockNumber == currentBlock at this point
+        // blockNumber == currentBlockHandled at this point
         // Check if we've already processed this event hash
         if (processedHashes[action.eventHash]) {
             // Already processed - silently ignore (idempotency)

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -24,6 +24,10 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     uint256 liquidityEmissionRate = 900; // 900 CATA per second
     uint256 borrowEmissionRate = 100;    // 100 CATA per second
 
+    // For idempotency testing - simulate block numbers and unique event hashes
+    uint256 testBlockNumber = 100;
+    uint256 nextEventHash = 1;
+
     function beforeAll() {
         bypassAuthorizations = true;
         // Create test users once
@@ -65,7 +69,7 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_for_single_liquidity_provider() {
         // given - user1 deposits 1000 units of liquidity
         uint256 depositAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, testBlockNumber, nextEventHash++);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -91,11 +95,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_split_rewards_proportionally_between_two_users() {
         // given - user1 deposits 600 units
         uint256 user1Deposit = 600 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), user1Deposit);
+        rewards.deposit(liquidityActivityId, address(user1), user1Deposit, testBlockNumber, nextEventHash++);
 
         // given - user2 deposits 400 units
         uint256 user2Deposit = 400 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user2), user2Deposit);
+        rewards.deposit(liquidityActivityId, address(user2), user2Deposit, testBlockNumber, nextEventHash++);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -129,11 +133,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_from_multiple_activities() {
         // given - user1 deposits liquidity (activity 1)
         uint256 liquidityAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), liquidityAmount);
+        rewards.deposit(liquidityActivityId, address(user1), liquidityAmount, testBlockNumber, nextEventHash++);
 
         // given - user1 borrows (activity 2)
         uint256 borrowAmount = 500 * 1e18;
-        rewards.deposit(borrowActivityId, address(user1), borrowAmount);
+        rewards.deposit(borrowActivityId, address(user1), borrowAmount, testBlockNumber, nextEventHash++);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -164,14 +168,14 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_handle_partial_withdrawal_and_continue_accruing() {
         // given - user1 deposits 1000 units
         uint256 initialDeposit = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), initialDeposit);
+        rewards.deposit(liquidityActivityId, address(user1), initialDeposit, testBlockNumber, nextEventHash++);
 
         // given - 50 seconds pass
         fastForward(50);
 
         // when - user1 withdraws 400 units (leaving 600)
         uint256 withdrawAmount = 400 * 1e18;
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount);
+        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, testBlockNumber, nextEventHash++);
 
         // given - another 50 seconds pass
         fastForward(50);

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -24,9 +24,9 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     uint256 liquidityEmissionRate = 900; // 900 CATA per second
     uint256 borrowEmissionRate = 100;    // 100 CATA per second
 
-    // For idempotency testing - simulate block numbers and unique event hashes
     uint256 testBlockNumber = 100;
-    uint256 nextEventHash = 1;
+    // Use different amounts for different events to ensure unique hashes
+    uint256 nextUniqueAmount = 0;
 
     function beforeAll() {
         bypassAuthorizations = true;
@@ -69,7 +69,7 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_for_single_liquidity_provider() {
         // given - user1 deposits 1000 units of liquidity
         uint256 depositAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, testBlockNumber, nextEventHash++);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, testBlockNumber);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -95,11 +95,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_split_rewards_proportionally_between_two_users() {
         // given - user1 deposits 600 units
         uint256 user1Deposit = 600 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), user1Deposit, testBlockNumber, nextEventHash++);
+        rewards.deposit(liquidityActivityId, address(user1), user1Deposit, testBlockNumber);
 
         // given - user2 deposits 400 units
         uint256 user2Deposit = 400 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user2), user2Deposit, testBlockNumber, nextEventHash++);
+        rewards.deposit(liquidityActivityId, address(user2), user2Deposit, testBlockNumber);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -133,11 +133,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_from_multiple_activities() {
         // given - user1 deposits liquidity (activity 1)
         uint256 liquidityAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), liquidityAmount, testBlockNumber, nextEventHash++);
+        rewards.deposit(liquidityActivityId, address(user1), liquidityAmount, testBlockNumber);
 
         // given - user1 borrows (activity 2)
         uint256 borrowAmount = 500 * 1e18;
-        rewards.deposit(borrowActivityId, address(user1), borrowAmount, testBlockNumber, nextEventHash++);
+        rewards.deposit(borrowActivityId, address(user1), borrowAmount, testBlockNumber);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -168,14 +168,14 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_handle_partial_withdrawal_and_continue_accruing() {
         // given - user1 deposits 1000 units
         uint256 initialDeposit = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), initialDeposit, testBlockNumber, nextEventHash++);
+        rewards.deposit(liquidityActivityId, address(user1), initialDeposit, testBlockNumber);
 
         // given - 50 seconds pass
         fastForward(50);
 
         // when - user1 withdraws 400 units (leaving 600)
         uint256 withdrawAmount = 400 * 1e18;
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, testBlockNumber, nextEventHash++);
+        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, testBlockNumber);
 
         // given - another 50 seconds pass
         fastForward(50);

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -25,8 +25,7 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     uint256 borrowEmissionRate = 100;    // 100 CATA per second
 
     uint256 testBlockNumber = 100;
-    // Use different amounts for different events to ensure unique hashes
-    uint256 nextUniqueAmount = 0;
+    uint256 nextEventIndex = 0;
 
     function beforeAll() {
         bypassAuthorizations = true;
@@ -69,7 +68,7 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_for_single_liquidity_provider() {
         // given - user1 deposits 1000 units of liquidity
         uint256 depositAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, testBlockNumber);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, testBlockNumber, nextEventIndex++);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -95,11 +94,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_split_rewards_proportionally_between_two_users() {
         // given - user1 deposits 600 units
         uint256 user1Deposit = 600 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), user1Deposit, testBlockNumber);
+        rewards.deposit(liquidityActivityId, address(user1), user1Deposit, testBlockNumber, nextEventIndex++);
 
         // given - user2 deposits 400 units
         uint256 user2Deposit = 400 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user2), user2Deposit, testBlockNumber);
+        rewards.deposit(liquidityActivityId, address(user2), user2Deposit, testBlockNumber, nextEventIndex++);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -133,11 +132,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_from_multiple_activities() {
         // given - user1 deposits liquidity (activity 1)
         uint256 liquidityAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), liquidityAmount, testBlockNumber);
+        rewards.deposit(liquidityActivityId, address(user1), liquidityAmount, testBlockNumber, nextEventIndex++);
 
         // given - user1 borrows (activity 2)
         uint256 borrowAmount = 500 * 1e18;
-        rewards.deposit(borrowActivityId, address(user1), borrowAmount, testBlockNumber);
+        rewards.deposit(borrowActivityId, address(user1), borrowAmount, testBlockNumber, nextEventIndex++);
 
         // given - 100 seconds pass
         fastForward(100);
@@ -168,14 +167,14 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_handle_partial_withdrawal_and_continue_accruing() {
         // given - user1 deposits 1000 units
         uint256 initialDeposit = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), initialDeposit, testBlockNumber);
+        rewards.deposit(liquidityActivityId, address(user1), initialDeposit, testBlockNumber, nextEventIndex++);
 
         // given - 50 seconds pass
         fastForward(50);
 
         // when - user1 withdraws 400 units (leaving 600)
         uint256 withdrawAmount = 400 * 1e18;
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, testBlockNumber);
+        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, testBlockNumber, nextEventIndex++);
 
         // given - another 50 seconds pass
         fastForward(50);

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -51,18 +51,19 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     // ═════════════════════════════════════════════════════════════════════════
     // IDEMPOTENCY: Duplicate events in same block are silently ignored
+    // Hash is calculated from keccak256(user, amount, activityId, actionType, blockNumber)
     // ═════════════════════════════════════════════════════════════════════════
 
     function it_should_ignore_duplicate_event_in_same_block() {
-        // given - user1 deposits 1000 units with eventHash=42 in block 100
+        // given - user1 deposits 1000 units in block 100
         uint256 depositAmount = 1000 * 1e18;
         uint256 blockNum = 100;
-        uint256 eventHash = 42;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, eventHash);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum);
 
-        // when - the same event is sent again (same blockNumber and eventHash)
+        // when - the same event is sent again (same user, amount, activityId, actionType, blockNumber)
         // This simulates a duplicate event from the indexer
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, eventHash);
+        // Hash = keccak256(user, amount, activityId, actionType, blockNumber) - all same = duplicate
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum);
 
         // then - user's stake should only be 1000 (not 2000), proving the duplicate was ignored
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -78,15 +79,16 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 newerBlock = 200;
         uint256 olderBlock = 100;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, newerBlock, 1);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, newerBlock);
 
         // when - an event from an older block (100) arrives late
         // This simulates out-of-order or replayed old events
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, olderBlock, 2);
+        // Use different amount to show it's not rejected due to hash match, but due to old block
+        rewards.deposit(liquidityActivityId, address(user1), 500 * 1e18, olderBlock);
 
         // then - user's stake should still be 1000 (old block event ignored)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
-        require(stake == depositAmount, "Old block event should be ignored - stake should be 1000, not 2000");
+        require(stake == depositAmount, "Old block event should be ignored - stake should be 1000, not 1500");
 
         // then - currentBlock should still be 200
         require(rewards.currentBlockHandled() == newerBlock, "currentBlock should remain at 200");
@@ -94,24 +96,25 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     // ═════════════════════════════════════════════════════════════════════════
     // IDEMPOTENCY: Hash set is cleared when moving to a new block
+    // Since blockNumber is part of the hash, same user+amount in different blocks = different hash
     // ═════════════════════════════════════════════════════════════════════════
 
     function it_should_clear_hash_set_when_moving_to_new_block() {
-        // given - process event with hash=42 in block 100
+        // given - process event in block 100
         uint256 depositAmount = 500 * 1e18;
         uint256 block100 = 100;
         uint256 block101 = 101;
-        uint256 eventHash = 42;
 
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block100, eventHash);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block100);
 
-        // when - move to block 101 and use the SAME eventHash (42)
-        // This should work because hash set is cleared when moving to a new block
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block101, eventHash);
+        // when - move to block 101 with same user and amount
+        // Since blockNumber is part of the hash, this produces a different hash
+        // Hash set is also cleared when moving to a new block
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block101);
 
         // then - user's stake should be 1000 (both deposits processed)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
-        require(stake == depositAmount * 2, "Same hash in different blocks should both be processed");
+        require(stake == depositAmount * 2, "Events in different blocks should both be processed");
 
         // then - currentBlock should be 101
         require(rewards.currentBlockHandled() == block101, "currentBlock should be 101");
@@ -119,23 +122,24 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     // ═════════════════════════════════════════════════════════════════════════
     // IDEMPOTENCY: Different hashes in same block are all processed
+    // Different amounts produce different hashes
     // ═════════════════════════════════════════════════════════════════════════
 
     function it_should_process_different_hashes_in_same_block() {
-        // given - multiple events with different hashes in the same block
-        uint256 depositAmount = 100 * 1e18;
+        // given - multiple events with different amounts (hence different hashes) in the same block
         uint256 blockNum = 100;
 
-        // when - process 5 different events in the same block
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 2);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 3);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 4);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 5);
+        // when - process 5 different events in the same block with different amounts
+        // Each has unique hash because amount differs
+        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, blockNum);
+        rewards.deposit(liquidityActivityId, address(user1), 200 * 1e18, blockNum);
+        rewards.deposit(liquidityActivityId, address(user1), 300 * 1e18, blockNum);
+        rewards.deposit(liquidityActivityId, address(user1), 400 * 1e18, blockNum);
+        rewards.deposit(liquidityActivityId, address(user1), 500 * 1e18, blockNum);
 
-        // then - all 5 deposits should be processed (total 500)
+        // then - all 5 deposits should be processed (total 1500)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
-        require(stake == depositAmount * 5, "All unique events in same block should be processed");
+        require(stake == 1500 * 1e18, "All unique events in same block should be processed");
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -147,13 +151,14 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 withdrawAmount = 400 * 1e18;
         uint256 blockNum = 100;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum);
 
-        // when - withdraw with eventHash=2
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum, 2);
+        // when - withdraw 400 units
+        // Note: deposit and withdraw have different actionTypes, so different hashes even with same amount
+        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum);
 
-        // when - duplicate withdraw event (same hash)
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum, 2);
+        // when - duplicate withdraw event (same user, amount, activityId, actionType, blockNumber = same hash)
+        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum);
 
         // then - stake should be 600 (1000 - 400), not 200 (1000 - 400 - 400)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -166,21 +171,21 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     function it_should_handle_batch_actions_idempotently() {
         // given - prepare a batch of actions with some duplicates
-        uint256 depositAmount = 100 * 1e18;
+        // Same user + amount + activityId + actionType + blockNumber = same hash = duplicate
         uint256 blockNum = 100;
 
         Action[] memory actions = new Action[](4);
-        actions[0] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1);
-        actions[1] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 2);
-        actions[2] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1); // duplicate
-        actions[3] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 3);
+        actions[0] = Action(liquidityActivityId, address(user1), 100 * 1e18, ActionType.Deposit, blockNum);
+        actions[1] = Action(liquidityActivityId, address(user1), 200 * 1e18, ActionType.Deposit, blockNum);
+        actions[2] = Action(liquidityActivityId, address(user1), 100 * 1e18, ActionType.Deposit, blockNum); // duplicate of actions[0]
+        actions[3] = Action(liquidityActivityId, address(user1), 300 * 1e18, ActionType.Deposit, blockNum);
 
         // when - process batch
         rewards.batchHandleAction(actions);
 
-        // then - only 3 unique events should be processed (hashes 1, 2, 3)
+        // then - only 3 unique events should be processed (amounts 100, 200, 300)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
-        require(stake == depositAmount * 3, "Batch should ignore duplicate hashes");
+        require(stake == 600 * 1e18, "Batch should ignore duplicate hashes");
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -189,10 +194,9 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     function it_should_allow_owner_to_emergency_override() {
         // given - process some events in block 100
-        uint256 depositAmount = 100 * 1e18;
         uint256 blockNum = 100;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 2);
+        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, blockNum);
+        rewards.deposit(liquidityActivityId, address(user1), 200 * 1e18, blockNum);
 
         require(rewards.currentBlockHandled() == 100, "currentBlockHandled should be 100");
 
@@ -202,18 +206,18 @@ contract Describe_Rewards_Idempotency is Authorizable {
         // then - currentBlockHandled should be 50
         require(rewards.currentBlockHandled() == 50, "currentBlockHandled should be reset to 50");
 
-        // then - old hashes should be cleared, so hash 1 can be reused
-        // (this would normally be ignored if we were still at block 100)
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
+        // then - old hashes should be cleared, so same hash can be reprocessed
+        // Deposit same amount as first deposit - would be duplicate if hash set wasn't cleared
+        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, blockNum);
 
-        // then - stake should be 300 (original 200 + new 100)
+        // then - stake should be 400 (original 100 + 200 + new 100)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
-        require(stake == depositAmount * 3, "Hash should be reprocessed after emergency override");
+        require(stake == 400 * 1e18, "Hash should be reprocessed after emergency override");
     }
 
     function it_should_prevent_non_owner_from_emergency_override() {
         // given - some state exists
-        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, 100, 1);
+        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, 100);
 
         // when - non-owner tries to call emergencyOverride
         bool reverted = false;

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -89,7 +89,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         require(stake == depositAmount, "Old block event should be ignored - stake should be 1000, not 2000");
 
         // then - currentBlock should still be 200
-        require(rewards.currentBlock() == newerBlock, "currentBlock should remain at 200");
+        require(rewards.currentBlockHandled() == newerBlock, "currentBlock should remain at 200");
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -114,7 +114,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         require(stake == depositAmount * 2, "Same hash in different blocks should both be processed");
 
         // then - currentBlock should be 101
-        require(rewards.currentBlock() == block101, "currentBlock should be 101");
+        require(rewards.currentBlockHandled() == block101, "currentBlock should be 101");
     }
 
     // ═════════════════════════════════════════════════════════════════════════

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import "../../concrete/BaseCodeCollection.sol";
+import "../Util.sol";
+import "../../abstract/ERC20/access/Authorizable.sol";
+import "../../abstract/ERC20/access/Ownable.sol";
+import "../../concrete/Rewards/Rewards.sol";
+
+contract Describe_Rewards_Idempotency is Authorizable {
+    using TestUtils for User;
+
+    constructor() {
+    }
+
+    Mercata m;
+    Token rewardToken;
+    Rewards rewards;
+    User user1;
+    User user2;
+
+    uint256 liquidityActivityId = 1;
+    uint256 liquidityEmissionRate = 900;
+
+    function beforeAll() {
+        bypassAuthorizations = true;
+        user1 = new User();
+        user2 = new User();
+    }
+
+    function beforeEach() {
+        m = new Mercata();
+        require(address(m) != address(0), "Mercata address is 0");
+
+        address tokenAddress = m.tokenFactory().createToken(
+            "TestCATA",
+            "Test CATA Token",
+            [], [], [], "TESTCATA", 0, 18
+        );
+        require(tokenAddress != address(0), "Token address is 0");
+        rewardToken = Token(tokenAddress);
+
+        rewards = new Rewards(address(this));
+        rewards.initialize(tokenAddress);
+
+        rewards.addActivity(liquidityActivityId, "Lending Pool Liquidity", ActivityType.Position, liquidityEmissionRate, address(this), address(this));
+
+        uint256 fundingAmount = 1000000 * 1e18;
+        rewardToken.mint(address(rewards), fundingAmount);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY: Duplicate events in same block are silently ignored
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_ignore_duplicate_event_in_same_block() {
+        // given - user1 deposits 1000 units with eventHash=42 in block 100
+        uint256 depositAmount = 1000 * 1e18;
+        uint256 blockNum = 100;
+        uint256 eventHash = 42;
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, eventHash);
+
+        // when - the same event is sent again (same blockNumber and eventHash)
+        // This simulates a duplicate event from the indexer
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, eventHash);
+
+        // then - user's stake should only be 1000 (not 2000), proving the duplicate was ignored
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        require(stake == depositAmount, "Duplicate event should be ignored - stake should be 1000, not 2000");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY: Old block events are silently ignored
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_ignore_old_block_events() {
+        // given - process an event in block 200
+        uint256 depositAmount = 1000 * 1e18;
+        uint256 newerBlock = 200;
+        uint256 olderBlock = 100;
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, newerBlock, 1);
+
+        // when - an event from an older block (100) arrives late
+        // This simulates out-of-order or replayed old events
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, olderBlock, 2);
+
+        // then - user's stake should still be 1000 (old block event ignored)
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        require(stake == depositAmount, "Old block event should be ignored - stake should be 1000, not 2000");
+
+        // then - currentBlock should still be 200
+        require(rewards.currentBlock() == newerBlock, "currentBlock should remain at 200");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY: Hash set is cleared when moving to a new block
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_clear_hash_set_when_moving_to_new_block() {
+        // given - process event with hash=42 in block 100
+        uint256 depositAmount = 500 * 1e18;
+        uint256 block100 = 100;
+        uint256 block101 = 101;
+        uint256 eventHash = 42;
+
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block100, eventHash);
+
+        // when - move to block 101 and use the SAME eventHash (42)
+        // This should work because hash set is cleared when moving to a new block
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block101, eventHash);
+
+        // then - user's stake should be 1000 (both deposits processed)
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        require(stake == depositAmount * 2, "Same hash in different blocks should both be processed");
+
+        // then - currentBlock should be 101
+        require(rewards.currentBlock() == block101, "currentBlock should be 101");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY: Different hashes in same block are all processed
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_process_different_hashes_in_same_block() {
+        // given - multiple events with different hashes in the same block
+        uint256 depositAmount = 100 * 1e18;
+        uint256 blockNum = 100;
+
+        // when - process 5 different events in the same block
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 2);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 3);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 4);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 5);
+
+        // then - all 5 deposits should be processed (total 500)
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        require(stake == depositAmount * 5, "All unique events in same block should be processed");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY: Withdraw is also idempotent
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_handle_withdraw_idempotently() {
+        // given - user deposits 1000 units
+        uint256 depositAmount = 1000 * 1e18;
+        uint256 withdrawAmount = 400 * 1e18;
+        uint256 blockNum = 100;
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
+
+        // when - withdraw with eventHash=2
+        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum, 2);
+
+        // when - duplicate withdraw event (same hash)
+        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum, 2);
+
+        // then - stake should be 600 (1000 - 400), not 200 (1000 - 400 - 400)
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        require(stake == depositAmount - withdrawAmount, "Duplicate withdraw should be ignored");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY: Batch actions also respect idempotency
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_handle_batch_actions_idempotently() {
+        // given - prepare a batch of actions with some duplicates
+        uint256 depositAmount = 100 * 1e18;
+        uint256 blockNum = 100;
+
+        Action[] memory actions = new Action[](4);
+        actions[0] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1);
+        actions[1] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 2);
+        actions[2] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1); // duplicate
+        actions[3] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 3);
+
+        // when - process batch
+        rewards.batchHandleAction(actions);
+
+        // then - only 3 unique events should be processed (hashes 1, 2, 3)
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        require(stake == depositAmount * 3, "Batch should ignore duplicate hashes");
+    }
+
+}

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -183,4 +183,48 @@ contract Describe_Rewards_Idempotency is Authorizable {
         require(stake == depositAmount * 3, "Batch should ignore duplicate hashes");
     }
 
+    // ═════════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY: Emergency override resets state
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_allow_owner_to_emergency_override() {
+        // given - process some events in block 100
+        uint256 depositAmount = 100 * 1e18;
+        uint256 blockNum = 100;
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 2);
+
+        require(rewards.currentBlockHandled() == 100, "currentBlockHandled should be 100");
+
+        // when - owner calls emergencyOverride to reset to block 50
+        rewards.emergencyOverride(50);
+
+        // then - currentBlockHandled should be 50
+        require(rewards.currentBlockHandled() == 50, "currentBlockHandled should be reset to 50");
+
+        // then - old hashes should be cleared, so hash 1 can be reused
+        // (this would normally be ignored if we were still at block 100)
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
+
+        // then - stake should be 300 (original 200 + new 100)
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        require(stake == depositAmount * 3, "Hash should be reprocessed after emergency override");
+    }
+
+    function it_should_prevent_non_owner_from_emergency_override() {
+        // given - some state exists
+        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, 100, 1);
+
+        // when - non-owner tries to call emergencyOverride
+        bool reverted = false;
+        try TestUtils.callAs(user1, address(rewards), "emergencyOverride(uint256)", 50) {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+
+        // then - should revert
+        require(reverted, "Non-owner should not be able to call emergencyOverride");
+    }
+
 }

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -51,19 +51,20 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     // ═════════════════════════════════════════════════════════════════════════
     // IDEMPOTENCY: Duplicate events in same block are silently ignored
-    // Hash is calculated from keccak256(user, amount, activityId, actionType, blockNumber)
+    // Hash is calculated from keccak256(blockNumber, eventIndex)
     // ═════════════════════════════════════════════════════════════════════════
 
     function it_should_ignore_duplicate_event_in_same_block() {
-        // given - user1 deposits 1000 units in block 100
+        // given - user1 deposits 1000 units in block 100, eventIndex 0
         uint256 depositAmount = 1000 * 1e18;
         uint256 blockNum = 100;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum);
+        uint256 eventIndex = 0;
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, eventIndex);
 
-        // when - the same event is sent again (same user, amount, activityId, actionType, blockNumber)
+        // when - the same event is sent again (same blockNumber and eventIndex)
         // This simulates a duplicate event from the indexer
-        // Hash = keccak256(user, amount, activityId, actionType, blockNumber) - all same = duplicate
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum);
+        // Hash = keccak256(blockNumber, eventIndex) - same = duplicate
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, eventIndex);
 
         // then - user's stake should only be 1000 (not 2000), proving the duplicate was ignored
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -79,12 +80,11 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 newerBlock = 200;
         uint256 olderBlock = 100;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, newerBlock);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, newerBlock, 0);
 
         // when - an event from an older block (100) arrives late
         // This simulates out-of-order or replayed old events
-        // Use different amount to show it's not rejected due to hash match, but due to old block
-        rewards.deposit(liquidityActivityId, address(user1), 500 * 1e18, olderBlock);
+        rewards.deposit(liquidityActivityId, address(user1), 500 * 1e18, olderBlock, 0);
 
         // then - user's stake should still be 1000 (old block event ignored)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -96,21 +96,20 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     // ═════════════════════════════════════════════════════════════════════════
     // IDEMPOTENCY: Hash set is cleared when moving to a new block
-    // Since blockNumber is part of the hash, same user+amount in different blocks = different hash
     // ═════════════════════════════════════════════════════════════════════════
 
     function it_should_clear_hash_set_when_moving_to_new_block() {
-        // given - process event in block 100
+        // given - process event in block 100, eventIndex 0
         uint256 depositAmount = 500 * 1e18;
         uint256 block100 = 100;
         uint256 block101 = 101;
 
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block100);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block100, 0);
 
-        // when - move to block 101 with same user and amount
+        // when - move to block 101 with same eventIndex (0)
         // Since blockNumber is part of the hash, this produces a different hash
         // Hash set is also cleared when moving to a new block
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block101);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block101, 0);
 
         // then - user's stake should be 1000 (both deposits processed)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -121,25 +120,24 @@ contract Describe_Rewards_Idempotency is Authorizable {
     }
 
     // ═════════════════════════════════════════════════════════════════════════
-    // IDEMPOTENCY: Different hashes in same block are all processed
-    // Different amounts produce different hashes
+    // IDEMPOTENCY: Different eventIndex in same block are all processed
     // ═════════════════════════════════════════════════════════════════════════
 
     function it_should_process_different_hashes_in_same_block() {
-        // given - multiple events with different amounts (hence different hashes) in the same block
+        // given - multiple events with different eventIndex in the same block
         uint256 blockNum = 100;
+        uint256 depositAmount = 100 * 1e18;
 
-        // when - process 5 different events in the same block with different amounts
-        // Each has unique hash because amount differs
-        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, blockNum);
-        rewards.deposit(liquidityActivityId, address(user1), 200 * 1e18, blockNum);
-        rewards.deposit(liquidityActivityId, address(user1), 300 * 1e18, blockNum);
-        rewards.deposit(liquidityActivityId, address(user1), 400 * 1e18, blockNum);
-        rewards.deposit(liquidityActivityId, address(user1), 500 * 1e18, blockNum);
+        // when - process 5 different events in the same block with different eventIndex
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 0);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 2);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 3);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 4);
 
-        // then - all 5 deposits should be processed (total 1500)
+        // then - all 5 deposits should be processed (total 500)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
-        require(stake == 1500 * 1e18, "All unique events in same block should be processed");
+        require(stake == 500 * 1e18, "All unique events in same block should be processed");
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -151,14 +149,13 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 withdrawAmount = 400 * 1e18;
         uint256 blockNum = 100;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 0);
 
-        // when - withdraw 400 units
-        // Note: deposit and withdraw have different actionTypes, so different hashes even with same amount
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum);
+        // when - withdraw 400 units with eventIndex 1
+        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum, 1);
 
-        // when - duplicate withdraw event (same user, amount, activityId, actionType, blockNumber = same hash)
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum);
+        // when - duplicate withdraw event (same blockNumber and eventIndex = same hash)
+        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum, 1);
 
         // then - stake should be 600 (1000 - 400), not 200 (1000 - 400 - 400)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -171,21 +168,22 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     function it_should_handle_batch_actions_idempotently() {
         // given - prepare a batch of actions with some duplicates
-        // Same user + amount + activityId + actionType + blockNumber = same hash = duplicate
+        // Same blockNumber + eventIndex = same hash = duplicate
         uint256 blockNum = 100;
+        uint256 depositAmount = 100 * 1e18;
 
         Action[] memory actions = new Action[](4);
-        actions[0] = Action(liquidityActivityId, address(user1), 100 * 1e18, ActionType.Deposit, blockNum);
-        actions[1] = Action(liquidityActivityId, address(user1), 200 * 1e18, ActionType.Deposit, blockNum);
-        actions[2] = Action(liquidityActivityId, address(user1), 100 * 1e18, ActionType.Deposit, blockNum); // duplicate of actions[0]
-        actions[3] = Action(liquidityActivityId, address(user1), 300 * 1e18, ActionType.Deposit, blockNum);
+        actions[0] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0);
+        actions[1] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1);
+        actions[2] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0); // duplicate of actions[0]
+        actions[3] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 2);
 
         // when - process batch
         rewards.batchHandleAction(actions);
 
-        // then - only 3 unique events should be processed (amounts 100, 200, 300)
+        // then - only 3 unique events should be processed (eventIndex 0, 1, 2)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
-        require(stake == 600 * 1e18, "Batch should ignore duplicate hashes");
+        require(stake == 300 * 1e18, "Batch should ignore duplicate hashes");
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -195,8 +193,9 @@ contract Describe_Rewards_Idempotency is Authorizable {
     function it_should_allow_owner_to_emergency_override() {
         // given - process some events in block 100
         uint256 blockNum = 100;
-        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, blockNum);
-        rewards.deposit(liquidityActivityId, address(user1), 200 * 1e18, blockNum);
+        uint256 depositAmount = 100 * 1e18;
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 0);
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
 
         require(rewards.currentBlockHandled() == 100, "currentBlockHandled should be 100");
 
@@ -206,18 +205,17 @@ contract Describe_Rewards_Idempotency is Authorizable {
         // then - currentBlockHandled should be 50
         require(rewards.currentBlockHandled() == 50, "currentBlockHandled should be reset to 50");
 
-        // then - old hashes should be cleared, so same hash can be reprocessed
-        // Deposit same amount as first deposit - would be duplicate if hash set wasn't cleared
-        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, blockNum);
+        // then - old hashes should be cleared, so same blockNumber+eventIndex can be reprocessed
+        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 0);
 
-        // then - stake should be 400 (original 100 + 200 + new 100)
+        // then - stake should be 300 (original 100 + 100 + new 100)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
-        require(stake == 400 * 1e18, "Hash should be reprocessed after emergency override");
+        require(stake == 300 * 1e18, "Hash should be reprocessed after emergency override");
     }
 
     function it_should_prevent_non_owner_from_emergency_override() {
         // given - some state exists
-        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, 100);
+        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, 100, 0);
 
         // when - non-owner tries to call emergencyOverride
         bool reverted = false;

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -19,6 +19,10 @@ contract Describe_Rewards_Management is Authorizable {
     User user1;
     User user2;
 
+    // For idempotency testing - simulate block numbers and unique event hashes
+    uint256 testBlockNumber = 100;
+    uint256 nextEventHash = 1;
+
     function beforeAll() {
         bypassAuthorizations = true;
         // Create test users once
@@ -337,7 +341,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to deposit on OneTime activity
         bool reverted = false;
-        try rewards.deposit(activityId, address(user1), 100) {
+        try rewards.deposit(activityId, address(user1), 100, testBlockNumber, nextEventHash++) {
             reverted = false;
         } catch {
             reverted = true;
@@ -352,7 +356,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to withdraw on OneTime activity
         bool reverted = false;
-        try rewards.withdraw(activityId, address(user1), 100) {
+        try rewards.withdraw(activityId, address(user1), 100, testBlockNumber, nextEventHash++) {
             reverted = false;
         } catch {
             reverted = true;
@@ -367,7 +371,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to call occurred on Position activity
         bool reverted = false;
-        try rewards.occurred(activityId, address(user1), 100) {
+        try rewards.occurred(activityId, address(user1), 100, testBlockNumber, nextEventHash++) {
             reverted = false;
         } catch {
             reverted = true;
@@ -381,7 +385,7 @@ contract Describe_Rewards_Management is Authorizable {
         rewards.addActivity(activityId, "Swap Activity", ActivityType.OneTime, 100, address(this), address(this));
 
         // when - call occurred
-        rewards.occurred(activityId, address(user1), 100);
+        rewards.occurred(activityId, address(user1), 100, testBlockNumber, nextEventHash++);
 
         // then - check user stake increased
         (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -19,9 +19,7 @@ contract Describe_Rewards_Management is Authorizable {
     User user1;
     User user2;
 
-    // For idempotency testing - simulate block numbers and unique event hashes
     uint256 testBlockNumber = 100;
-    uint256 nextEventHash = 1;
 
     function beforeAll() {
         bypassAuthorizations = true;
@@ -341,7 +339,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to deposit on OneTime activity
         bool reverted = false;
-        try rewards.deposit(activityId, address(user1), 100, testBlockNumber, nextEventHash++) {
+        try rewards.deposit(activityId, address(user1), 100, testBlockNumber) {
             reverted = false;
         } catch {
             reverted = true;
@@ -356,7 +354,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to withdraw on OneTime activity
         bool reverted = false;
-        try rewards.withdraw(activityId, address(user1), 100, testBlockNumber, nextEventHash++) {
+        try rewards.withdraw(activityId, address(user1), 100, testBlockNumber) {
             reverted = false;
         } catch {
             reverted = true;
@@ -371,7 +369,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to call occurred on Position activity
         bool reverted = false;
-        try rewards.occurred(activityId, address(user1), 100, testBlockNumber, nextEventHash++) {
+        try rewards.occurred(activityId, address(user1), 100, testBlockNumber) {
             reverted = false;
         } catch {
             reverted = true;
@@ -385,7 +383,7 @@ contract Describe_Rewards_Management is Authorizable {
         rewards.addActivity(activityId, "Swap Activity", ActivityType.OneTime, 100, address(this), address(this));
 
         // when - call occurred
-        rewards.occurred(activityId, address(user1), 100, testBlockNumber, nextEventHash++);
+        rewards.occurred(activityId, address(user1), 100, testBlockNumber);
 
         // then - check user stake increased
         (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -339,7 +339,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to deposit on OneTime activity
         bool reverted = false;
-        try rewards.deposit(activityId, address(user1), 100, testBlockNumber) {
+        try rewards.deposit(activityId, address(user1), 100, testBlockNumber, 0) {
             reverted = false;
         } catch {
             reverted = true;
@@ -354,7 +354,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to withdraw on OneTime activity
         bool reverted = false;
-        try rewards.withdraw(activityId, address(user1), 100, testBlockNumber) {
+        try rewards.withdraw(activityId, address(user1), 100, testBlockNumber, 0) {
             reverted = false;
         } catch {
             reverted = true;
@@ -369,7 +369,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to call occurred on Position activity
         bool reverted = false;
-        try rewards.occurred(activityId, address(user1), 100, testBlockNumber) {
+        try rewards.occurred(activityId, address(user1), 100, testBlockNumber, 0) {
             reverted = false;
         } catch {
             reverted = true;
@@ -383,7 +383,7 @@ contract Describe_Rewards_Management is Authorizable {
         rewards.addActivity(activityId, "Swap Activity", ActivityType.OneTime, 100, address(this), address(this));
 
         // when - call occurred
-        rewards.occurred(activityId, address(user1), 100, testBlockNumber);
+        rewards.occurred(activityId, address(user1), 100, testBlockNumber, 0);
 
         // then - check user stake increased
         (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));


### PR DESCRIPTION
* Problem

The off-chain service reads events from an indexer and sends them to the Rewards contract. Events can be duplicated or arrive out of order, which could cause double-processing (e.g., double deposits).

* Solution

Added block-based idempotency tracking that:
  - Accepts a blockNumber and eventHash with each action
  - Ignores events from older blocks (blockNumber < currentBlock)
  - Ignores duplicate events within the same block (same eventHash)
  - Clears the hash set when moving to a new block (bounded storage)

* Key Behavior

- No errors thrown - duplicates are silently ignored (idempotent)
- Bounded storage - only tracks hashes for the current block
- Off-chain service only needs to remember last processed block to resume after crash