### PR TITLE
Activity identified by events

### DIFF
--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -109,6 +109,14 @@ contract record Rewards is Ownable {
     mapping(address => uint256) public record unclaimedRewards;
 
     // ═══════════════════════════════════════════════════════════════════════
+    // EVENT TO ACTIVITY MAPPING
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // Mapping from sourceContract -> eventName -> activityId (0 means not found)
+    // This enables O(1) lookup of activity by source contract and event name
+    mapping(address => mapping(string => uint256)) public sourceEventToActivityId;
+
+    // ═══════════════════════════════════════════════════════════════════════
     // IDEMPOTENCY STATE
     // ═══════════════════════════════════════════════════════════════════════
 
@@ -335,6 +343,14 @@ contract record Rewards is Ownable {
         require(sourceContract != address(0), "Invalid source contract address");
         require(bytes(name).length > 0, "Name cannot be empty");
 
+        // Check for duplicate event names within the same sourceContract using the mapping
+        for (uint256 evtIdx = 0; evtIdx < actionableEvents.length; evtIdx++) {
+            require(
+                sourceEventToActivityId[sourceContract][actionableEvents[evtIdx].eventName] == 0,
+                "Event name already exists for this source contract"
+            );
+        }
+
         Activity storage activity = activities[activityId];
         activity.name = name;
         activity.activityType = activityType;
@@ -345,9 +361,10 @@ contract record Rewards is Ownable {
         activity.allowedCaller = allowedCaller;
         activity.sourceContract = sourceContract;
 
-        // Copy actionable events
+        // Copy actionable events and register in mapping
         for (uint256 i = 0; i < actionableEvents.length; i++) {
             activity.actionableEvents.push(actionableEvents[i]);
+            sourceEventToActivityId[sourceContract][actionableEvents[i].eventName] = activityId;
         }
 
         activityIds.push(activityId);

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -280,57 +280,11 @@ contract record Rewards is Ownable {
     }
 
     /**
-     * @dev Deposit/increase stake for a user in an activity
-     * @param activityId The activity to deposit into
-     * @param user The user whose stake is increasing
-     * @param amount The amount to deposit
-     * @param blockNumber The block number this event originated from (for idempotency)
-     * @param eventIndex The event index within the block (for idempotency)
+     * @dev Process a single action
+     * @param action The action to process
      */
-    function deposit(
-        uint256 activityId,
-        address user,
-        uint256 amount,
-        uint256 blockNumber,
-        uint256 eventIndex
-    ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Deposit, blockNumber, eventIndex));
-    }
-
-    /**
-     * @dev Withdraw/decrease stake for a user in an activity
-     * @param activityId The activity to withdraw from
-     * @param user The user whose stake is decreasing
-     * @param amount The amount to withdraw
-     * @param blockNumber The block number this event originated from (for idempotency)
-     * @param eventIndex The event index within the block (for idempotency)
-     */
-    function withdraw(
-        uint256 activityId,
-        address user,
-        uint256 amount,
-        uint256 blockNumber,
-        uint256 eventIndex
-    ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Withdraw, blockNumber, eventIndex));
-    }
-
-    /**
-     * @dev Record a one-time action occurrence for a user
-     * @param activityId The one-time activity that occurred
-     * @param user The user who performed the action
-     * @param amount The amount/value of the action
-     * @param blockNumber The block number this event originated from (for idempotency)
-     * @param eventIndex The event index within the block (for idempotency)
-     */
-    function occurred(
-        uint256 activityId,
-        address user,
-        uint256 amount,
-        uint256 blockNumber,
-        uint256 eventIndex
-    ) external {
-        _handleAction(Action(activityId, user, amount, ActionType.Occurred, blockNumber, eventIndex));
+    function handleAction(Action calldata action) external {
+        _handleAction(action);
     }
 
     /**

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -95,6 +95,9 @@ contract record Rewards is Ownable {
     // Array of all activity IDs for enumeration
     uint256[] public activityIds;
 
+    // Counter for generating unique activity IDs (starts at 1, 0 means "not found")
+    uint256 public nextActivityId = 1;
+
     // Total emission rate across all activities (CATA per second)
     uint256 public totalRewardsEmission;
 
@@ -158,41 +161,39 @@ contract record Rewards is Ownable {
 
     /**
      * @dev Register a new Position activity for reward distribution
-     * @param activityId Unique identifier for the activity
      * @param name Human-readable name for the activity
      * @param emissionRate CATA tokens emitted per second for this activity
      * @param sourceContract Address of the contract this activity tracks
      * @param actionableEvents Array of events that can trigger actions (must have at least one)
+     * @return activityId The auto-generated unique identifier for the activity
      */
     function addPositionActivity(
-        uint256 activityId,
         string name,
         uint256 emissionRate,
         address sourceContract,
         ActionableEvent[] actionableEvents
-    ) external onlyOwner {
+    ) external onlyOwner returns (uint256) {
         require(actionableEvents.length > 0, "At least one actionable event required");
-        _addActivity(activityId, name, ActivityType.Position, emissionRate, sourceContract, actionableEvents);
+        return _addActivity(name, ActivityType.Position, emissionRate, sourceContract, actionableEvents);
     }
 
     /**
      * @dev Register a new OneTime activity for reward distribution
-     * @param activityId Unique identifier for the activity
      * @param name Human-readable name for the activity
      * @param emissionRate CATA tokens emitted per second for this activity
      * @param sourceContract Address of the contract this activity tracks
      * @param eventName Name of the event that triggers this one-time action
+     * @return activityId The auto-generated unique identifier for the activity
      */
     function addOneTimeActivity(
-        uint256 activityId,
         string name,
         uint256 emissionRate,
         address sourceContract,
         string eventName
-    ) external onlyOwner {
+    ) external onlyOwner returns (uint256) {
         ActionableEvent[] memory actionableEvents = new ActionableEvent[](1);
         actionableEvents[0] = ActionableEvent(eventName, ActionType.Occurred);
-        _addActivity(activityId, name, ActivityType.OneTime, emissionRate, sourceContract, actionableEvents);
+        return _addActivity(name, ActivityType.OneTime, emissionRate, sourceContract, actionableEvents);
     }
 
     /**
@@ -398,16 +399,15 @@ contract record Rewards is Ownable {
 
     /**
      * @dev Internal function to register a new activity
+     * @return activityId The auto-generated unique identifier for the activity
      */
     function _addActivity(
-        uint256 activityId,
         string name,
         ActivityType activityType,
         uint256 emissionRate,
         address sourceContract,
         ActionableEvent[] actionableEvents
-    ) internal {
-        require(activities[activityId].sourceContract == address(0), "Activity already exists");
+    ) internal returns (uint256) {
         require(sourceContract != address(0), "Invalid source contract address");
         require(bytes(name).length > 0, "Name cannot be empty");
 
@@ -418,6 +418,10 @@ contract record Rewards is Ownable {
                 "Event name already exists for this source contract"
             );
         }
+
+        // Generate unique activity ID
+        uint256 activityId = nextActivityId;
+        nextActivityId++;
 
         Activity storage activity = activities[activityId];
         activity.name = name;
@@ -440,6 +444,8 @@ contract record Rewards is Ownable {
         totalRewardsEmission += emissionRate;
 
         emit ActivityAdded(activityId, name, emissionRate, sourceContract);
+
+        return activityId;
     }
 
     /**

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -54,15 +54,13 @@ struct Activity {
  *
  * This contract implements a global incentives controller that tracks rewards
  * for various protocol activities without requiring users to stake or transfer
- * their LP tokens. Pools and other protocol contracts call handleAction() when
- * user balances change, and the controller tracks accrued rewards using a
- * cumulative index pattern.
+ * their LP tokens.
  *
  * Key features:
  * - No asset custody - contract only tracks accounting state
  * - O(1) gas efficiency - no loops over users or epochs
  * - Global index pattern inspired by Aave's Incentives Controller
- * - Simple pool integration via handleAction() hook
+ * - Simple off-chain service integration via handleAction() hook
  */
 contract record Rewards is Ownable {
 

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -100,8 +100,8 @@ contract record Rewards is Ownable {
     // Total emission rate across all activities (CATA per second)
     uint256 public totalRewardsEmission;
 
-    // User info per activity: activityId => user => RewardsUserInfo
-    mapping(uint256 => mapping(address => RewardsUserInfo)) public record userInfo;
+    // User info per activity: user => activityId => RewardsUserInfo
+    mapping(address => mapping(uint256 => RewardsUserInfo)) public record userInfo;
 
     // Total unclaimed rewards per user
     mapping(address => uint256) public record unclaimedRewards;
@@ -418,7 +418,7 @@ contract record Rewards is Ownable {
         _updateActivityIndex(activityId);
 
         // 2) Settle user's pending rewards using index delta (Aave-style)
-        RewardsUserInfo storage userState = userInfo[activityId][action.user];
+        RewardsUserInfo storage userState = userInfo[action.user][activityId];
         uint256 oldStake = userState.stake;
         uint256 pendingRewards = 0;
 
@@ -473,7 +473,7 @@ contract record Rewards is Ownable {
         _updateActivityIndex(activityId);
 
         Activity storage activity = activities[activityId];
-        RewardsUserInfo storage userState = userInfo[activityId][user];
+        RewardsUserInfo storage userState = userInfo[user][activityId];
         uint256 userStake = userState.stake;
 
         if (userStake > 0) {

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -28,6 +28,11 @@ struct Action {
     uint256 eventIndex;  // Event index within the block (for idempotency)
 }
 
+struct ActionableEvent {
+    string eventName;    // Name of the event that triggers this action
+    ActionType actionType; // The type of action to perform when this event occurs
+}
+
 struct RewardsUserInfo {
     uint256 stake;       // User's effective stake in this activity
     uint256 userIndex;   // Snapshot of accRewardPerStake at last update (Aave-style)
@@ -40,8 +45,9 @@ struct Activity {
     uint256 accRewardPerStake;   // Accumulated reward per 1 unit of stake (scaled by 1e18)
     uint256 lastUpdateTime;      // Last timestamp when the index was updated
     uint256 totalStake;          // Sum of all users' effective stakes for this activity
-    address allowedCaller;       // Address allowed to call deposit/withdraw/occurred for this activity
+    address allowedCaller;       // Address allowed to call handleAction for this activity
     address sourceContract;      // Address of the contract this activity tracks (for external service mapping)
+    ActionableEvent[] actionableEvents; // Events that can trigger actions for this activity
 }
 
 /**
@@ -147,15 +153,18 @@ contract record Rewards is Ownable {
      * @param emissionRate CATA tokens emitted per second for this activity
      * @param allowedCaller Address allowed to call handleAction for this activity
      * @param sourceContract Address of the contract this activity tracks
+     * @param actionableEvents Array of events that can trigger actions (must have at least one)
      */
     function addPositionActivity(
         uint256 activityId,
         string name,
         uint256 emissionRate,
         address allowedCaller,
-        address sourceContract
+        address sourceContract,
+        ActionableEvent[] actionableEvents
     ) external onlyOwner {
-        _addActivity(activityId, name, ActivityType.Position, emissionRate, allowedCaller, sourceContract);
+        require(actionableEvents.length > 0, "At least one actionable event required");
+        _addActivity(activityId, name, ActivityType.Position, emissionRate, allowedCaller, sourceContract, actionableEvents);
     }
 
     /**
@@ -165,15 +174,19 @@ contract record Rewards is Ownable {
      * @param emissionRate CATA tokens emitted per second for this activity
      * @param allowedCaller Address allowed to call handleAction for this activity
      * @param sourceContract Address of the contract this activity tracks
+     * @param eventName Name of the event that triggers this one-time action
      */
     function addOneTimeActivity(
         uint256 activityId,
         string name,
         uint256 emissionRate,
         address allowedCaller,
-        address sourceContract
+        address sourceContract,
+        string eventName
     ) external onlyOwner {
-        _addActivity(activityId, name, ActivityType.OneTime, emissionRate, allowedCaller, sourceContract);
+        ActionableEvent[] memory actionableEvents = new ActionableEvent[](1);
+        actionableEvents[0] = ActionableEvent(eventName, ActionType.Occurred);
+        _addActivity(activityId, name, ActivityType.OneTime, emissionRate, allowedCaller, sourceContract, actionableEvents);
     }
 
     /**
@@ -314,23 +327,28 @@ contract record Rewards is Ownable {
         ActivityType activityType,
         uint256 emissionRate,
         address allowedCaller,
-        address sourceContract
+        address sourceContract,
+        ActionableEvent[] actionableEvents
     ) internal {
         require(activities[activityId].allowedCaller == address(0), "Activity already exists");
         require(allowedCaller != address(0), "Invalid caller address");
         require(sourceContract != address(0), "Invalid source contract address");
         require(bytes(name).length > 0, "Name cannot be empty");
 
-        activities[activityId] = Activity({
-            name: name,
-            activityType: activityType,
-            emissionRate: emissionRate,
-            accRewardPerStake: 0,
-            lastUpdateTime: block.timestamp,
-            totalStake: 0,
-            allowedCaller: allowedCaller,
-            sourceContract: sourceContract
-        });
+        Activity storage activity = activities[activityId];
+        activity.name = name;
+        activity.activityType = activityType;
+        activity.emissionRate = emissionRate;
+        activity.accRewardPerStake = 0;
+        activity.lastUpdateTime = block.timestamp;
+        activity.totalStake = 0;
+        activity.allowedCaller = allowedCaller;
+        activity.sourceContract = sourceContract;
+
+        // Copy actionable events
+        for (uint256 i = 0; i < actionableEvents.length; i++) {
+            activity.actionableEvents.push(actionableEvents[i]);
+        }
 
         activityIds.push(activityId);
 

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -177,41 +177,6 @@ contract record Rewards is Ownable {
     }
 
     /**
-     * @dev Internal function to register a new activity
-     */
-    function _addActivity(
-        uint256 activityId,
-        string name,
-        ActivityType activityType,
-        uint256 emissionRate,
-        address allowedCaller,
-        address sourceContract
-    ) internal {
-        require(activities[activityId].allowedCaller == address(0), "Activity already exists");
-        require(allowedCaller != address(0), "Invalid caller address");
-        require(sourceContract != address(0), "Invalid source contract address");
-        require(bytes(name).length > 0, "Name cannot be empty");
-
-        activities[activityId] = Activity({
-            name: name,
-            activityType: activityType,
-            emissionRate: emissionRate,
-            accRewardPerStake: 0,
-            lastUpdateTime: block.timestamp,
-            totalStake: 0,
-            allowedCaller: allowedCaller,
-            sourceContract: sourceContract
-        });
-
-        activityIds.push(activityId);
-
-        // Update total emission rate
-        totalRewardsEmission += emissionRate;
-
-        emit ActivityAdded(activityId, name, emissionRate, allowedCaller, sourceContract);
-    }
-
-    /**
      * @dev Update the emission rate for an existing activity
      * @param activityId The activity to update
      * @param newEmissionRate The new emission rate (CATA per second)
@@ -339,6 +304,41 @@ contract record Rewards is Ownable {
     // ═════════════════════════════════════════════════════════════════════════
     // INTERNAL FUNCTIONS
     // ═════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @dev Internal function to register a new activity
+     */
+    function _addActivity(
+        uint256 activityId,
+        string name,
+        ActivityType activityType,
+        uint256 emissionRate,
+        address allowedCaller,
+        address sourceContract
+    ) internal {
+        require(activities[activityId].allowedCaller == address(0), "Activity already exists");
+        require(allowedCaller != address(0), "Invalid caller address");
+        require(sourceContract != address(0), "Invalid source contract address");
+        require(bytes(name).length > 0, "Name cannot be empty");
+
+        activities[activityId] = Activity({
+            name: name,
+            activityType: activityType,
+            emissionRate: emissionRate,
+            accRewardPerStake: 0,
+            lastUpdateTime: block.timestamp,
+            totalStake: 0,
+            allowedCaller: allowedCaller,
+            sourceContract: sourceContract
+        });
+
+        activityIds.push(activityId);
+
+        // Update total emission rate
+        totalRewardsEmission += emissionRate;
+
+        emit ActivityAdded(activityId, name, emissionRate, allowedCaller, sourceContract);
+    }
 
     /**
      * @dev Internal function to handle stake changes with idempotency

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -20,12 +20,12 @@ enum ActionType {
 }
 
 struct Action {
-    uint256 activityId;  // The activity being updated
-    address user;        // The user whose stake is changing
-    uint256 amount;      // The amount of stake change
-    ActionType actionType; // The type of action
-    uint256 blockNumber; // Block number this event originated from (for idempotency)
-    uint256 eventIndex;  // Event index within the block (for idempotency)
+    address sourceContract; // The source contract this event originated from
+    string eventName;       // The event name that triggered this action
+    address user;           // The user whose stake is changing
+    uint256 amount;         // The amount of stake change
+    uint256 blockNumber;    // Block number this event originated from (for idempotency)
+    uint256 eventIndex;     // Event index within the block (for idempotency)
 }
 
 struct ActionableEvent {
@@ -112,9 +112,15 @@ contract record Rewards is Ownable {
     // EVENT TO ACTIVITY MAPPING
     // ═══════════════════════════════════════════════════════════════════════
 
-    // Mapping from sourceContract -> eventName -> activityId (0 means not found)
-    // This enables O(1) lookup of activity by source contract and event name
-    mapping(address => mapping(string => uint256)) public sourceEventToActivityId;
+    // Struct to store both activityId and actionType for an event
+    struct EventInfo {
+        uint256 activityId;  // 0 means not found
+        ActionType actionType;
+    }
+
+    // Mapping from sourceContract -> eventName -> EventInfo
+    // This enables O(1) lookup of activity and action type by source contract and event name
+    mapping(address => mapping(string => EventInfo)) public sourceEventInfo;
 
     // ═══════════════════════════════════════════════════════════════════════
     // IDEMPOTENCY STATE
@@ -346,7 +352,7 @@ contract record Rewards is Ownable {
         // Check for duplicate event names within the same sourceContract using the mapping
         for (uint256 evtIdx = 0; evtIdx < actionableEvents.length; evtIdx++) {
             require(
-                sourceEventToActivityId[sourceContract][actionableEvents[evtIdx].eventName] == 0,
+                sourceEventInfo[sourceContract][actionableEvents[evtIdx].eventName].activityId == 0,
                 "Event name already exists for this source contract"
             );
         }
@@ -364,7 +370,7 @@ contract record Rewards is Ownable {
         // Copy actionable events and register in mapping
         for (uint256 i = 0; i < actionableEvents.length; i++) {
             activity.actionableEvents.push(actionableEvents[i]);
-            sourceEventToActivityId[sourceContract][actionableEvents[i].eventName] = activityId;
+            sourceEventInfo[sourceContract][actionableEvents[i].eventName] = EventInfo(activityId, actionableEvents[i].actionType);
         }
 
         activityIds.push(activityId);
@@ -415,26 +421,32 @@ contract record Rewards is Ownable {
         // ACTION PROCESSING
         // ═══════════════════════════════════════════════════════════════════════
 
-        Activity storage activity = activities[action.activityId];
+        // Look up activity and action type by sourceContract and eventName
+        EventInfo storage eventInfo = sourceEventInfo[action.sourceContract][action.eventName];
+        require(eventInfo.activityId != 0, "Activity not found for source/event");
+
+        uint256 activityId = eventInfo.activityId;
+        ActionType actionType = eventInfo.actionType;
+        Activity storage activity = activities[activityId];
 
         // Validate action type against activity type
-        if (action.actionType == ActionType.Deposit || action.actionType == ActionType.Withdraw) {
+        if (actionType == ActionType.Deposit || actionType == ActionType.Withdraw) {
             require(activity.activityType == ActivityType.Position, "Only for Position activities");
         } else {
             require(activity.activityType == ActivityType.OneTime, "Only for OneTime activities");
         }
 
         // Determine if this is an increase or decrease
-        bool isIncrease = (action.actionType != ActionType.Withdraw);
+        bool isIncrease = (actionType != ActionType.Withdraw);
 
         // Access control: only allowed caller can update this activity
         require(msg.sender == activity.allowedCaller, "Caller not allowed");
 
         // 1) Update global index using current totalStake (before user update)
-        _updateActivityIndex(action.activityId);
+        _updateActivityIndex(activityId);
 
         // 2) Settle user's pending rewards using index delta (Aave-style)
-        RewardsUserInfo storage userState = userInfo[action.activityId][action.user];
+        RewardsUserInfo storage userState = userInfo[activityId][action.user];
         uint256 oldStake = userState.stake;
         uint256 pendingRewards = 0;
 
@@ -464,7 +476,7 @@ contract record Rewards is Ownable {
         // 5) Update total stake internally (secure calculation)
         activity.totalStake = activity.totalStake + newStake - oldStake;
 
-        emit UserStakeUpdated(action.activityId, action.user, oldStake, newStake, pendingRewards);
+        emit UserStakeUpdated(activityId, action.user, oldStake, newStake, pendingRewards);
     }
 
     /**

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -141,22 +141,52 @@ contract record Rewards is Ownable {
     }
 
     /**
-     * @dev Register a new activity for reward distribution
+     * @dev Register a new Position activity for reward distribution
      * @param activityId Unique identifier for the activity
      * @param name Human-readable name for the activity
-     * @param activityType Type of activity (Position or OneTime)
      * @param emissionRate CATA tokens emitted per second for this activity
-     * @param allowedCaller Address allowed to call deposit/withdraw/occurred
-     * @param sourceContract Address of the contract this activity tracks (for external service mapping)
+     * @param allowedCaller Address allowed to call handleAction for this activity
+     * @param sourceContract Address of the contract this activity tracks
      */
-    function addActivity(
+    function addPositionActivity(
+        uint256 activityId,
+        string name,
+        uint256 emissionRate,
+        address allowedCaller,
+        address sourceContract
+    ) external onlyOwner {
+        _addActivity(activityId, name, ActivityType.Position, emissionRate, allowedCaller, sourceContract);
+    }
+
+    /**
+     * @dev Register a new OneTime activity for reward distribution
+     * @param activityId Unique identifier for the activity
+     * @param name Human-readable name for the activity
+     * @param emissionRate CATA tokens emitted per second for this activity
+     * @param allowedCaller Address allowed to call handleAction for this activity
+     * @param sourceContract Address of the contract this activity tracks
+     */
+    function addOneTimeActivity(
+        uint256 activityId,
+        string name,
+        uint256 emissionRate,
+        address allowedCaller,
+        address sourceContract
+    ) external onlyOwner {
+        _addActivity(activityId, name, ActivityType.OneTime, emissionRate, allowedCaller, sourceContract);
+    }
+
+    /**
+     * @dev Internal function to register a new activity
+     */
+    function _addActivity(
         uint256 activityId,
         string name,
         ActivityType activityType,
         uint256 emissionRate,
         address allowedCaller,
         address sourceContract
-    ) external onlyOwner {
+    ) internal {
         require(activities[activityId].allowedCaller == address(0), "Activity already exists");
         require(allowedCaller != address(0), "Invalid caller address");
         require(sourceContract != address(0), "Invalid source contract address");

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -235,6 +235,94 @@ contract record Rewards is Ownable {
     }
 
     /**
+     * @dev Update the actionable events for an existing Position activity
+     * @param activityId The activity to update
+     * @param newActionableEvents The new array of actionable events
+     *
+     * WARNING: This function is NOT SAFE to call while the activity has existing stakes.
+     * Changing events mid-operation can cause:
+     * - Events from old configuration to be ignored
+     * - Inconsistent state between user stakes and event mappings
+     * Only use this function when the activity has zero total stake or during initial setup.
+     */
+    function setPositionActivityEvents(
+        uint256 activityId,
+        ActionableEvent[] newActionableEvents
+    ) external onlyOwner {
+        Activity storage activity = activities[activityId];
+        require(activity.sourceContract != address(0), "Activity does not exist");
+        require(activity.activityType == ActivityType.Position, "Only for Position activities");
+        require(newActionableEvents.length > 0, "At least one actionable event required");
+
+        address sourceContract = activity.sourceContract;
+
+        // Check for duplicate event names within the same sourceContract (excluding current activity's events)
+        for (uint256 evtIdx = 0; evtIdx < newActionableEvents.length; evtIdx++) {
+            EventInfo storage existingInfo = sourceEventInfo[sourceContract][newActionableEvents[evtIdx].eventName];
+            require(
+                existingInfo.activityId == 0 || existingInfo.activityId == activityId,
+                "Event name already exists for this source contract"
+            );
+        }
+
+        // Remove old event mappings (delete individual fields as SolidVM requires)
+        for (uint256 i = 0; i < activity.actionableEvents.length; i++) {
+            delete sourceEventInfo[sourceContract][activity.actionableEvents[i].eventName].activityId;
+            delete sourceEventInfo[sourceContract][activity.actionableEvents[i].eventName].actionType;
+        }
+
+        // Clear old actionable events array
+        activity.actionableEvents = [];
+
+        // Add new actionable events and register in mapping
+        for (uint256 j = 0; j < newActionableEvents.length; j++) {
+            activity.actionableEvents.push(newActionableEvents[j]);
+            sourceEventInfo[sourceContract][newActionableEvents[j].eventName] = EventInfo(activityId, newActionableEvents[j].actionType);
+        }
+    }
+
+    /**
+     * @dev Update the event name for an existing OneTime activity
+     * @param activityId The activity to update
+     * @param newEventName The new event name
+     *
+     * WARNING: This function is NOT SAFE to call while the activity has existing stakes.
+     * Changing the event name mid-operation can cause:
+     * - Events with the old name to be ignored
+     * - Inconsistent state between user stakes and event mappings
+     * Only use this function when the activity has zero total stake or during initial setup.
+     */
+    function setOneTimeActivityEvent(
+        uint256 activityId,
+        string newEventName
+    ) external onlyOwner {
+        Activity storage activity = activities[activityId];
+        require(activity.sourceContract != address(0), "Activity does not exist");
+        require(activity.activityType == ActivityType.OneTime, "Only for OneTime activities");
+        require(bytes(newEventName).length > 0, "Event name cannot be empty");
+
+        address sourceContract = activity.sourceContract;
+
+        // Check that new event name doesn't conflict with another activity
+        EventInfo storage existingInfo = sourceEventInfo[sourceContract][newEventName];
+        require(
+            existingInfo.activityId == 0 || existingInfo.activityId == activityId,
+            "Event name already exists for this source contract"
+        );
+
+        // Remove old event mapping (delete individual fields as SolidVM requires)
+        string oldEventName = activity.actionableEvents[0].eventName;
+        delete sourceEventInfo[sourceContract][oldEventName].activityId;
+        delete sourceEventInfo[sourceContract][oldEventName].actionType;
+
+        // Update the event name in actionableEvents array
+        activity.actionableEvents[0].eventName = newEventName;
+
+        // Register new event in mapping
+        sourceEventInfo[sourceContract][newEventName] = EventInfo(activityId, ActionType.Occurred);
+    }
+
+    /**
      * @dev Claim accumulated rewards for the caller
      * @param activityIds Array of activity IDs to settle rewards from
      */

--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -45,7 +45,6 @@ struct Activity {
     uint256 accRewardPerStake;   // Accumulated reward per 1 unit of stake (scaled by 1e18)
     uint256 lastUpdateTime;      // Last timestamp when the index was updated
     uint256 totalStake;          // Sum of all users' effective stakes for this activity
-    address allowedCaller;       // Address allowed to call handleAction for this activity
     address sourceContract;      // Address of the contract this activity tracks (for external service mapping)
     ActionableEvent[] actionableEvents; // Events that can trigger actions for this activity
 }
@@ -73,9 +72,8 @@ contract record Rewards is Ownable {
 
     event ActivityIndexUpdated(uint256 indexed activityId, uint256 accRewardPerStake, uint256 totalStake);
     event UserStakeUpdated(uint256 indexed activityId, address indexed user, uint256 oldStake, uint256 newStake, uint256 pendingRewards);
-    event ActivityAdded(uint256 indexed activityId, string name, uint256 emissionRate, address allowedCaller, address sourceContract);
+    event ActivityAdded(uint256 indexed activityId, string name, uint256 emissionRate, address sourceContract);
     event EmissionRateUpdated(uint256 indexed activityId, uint256 oldRate, uint256 newRate);
-    event AllowedCallerUpdated(uint256 indexed activityId, address oldCaller, address newCaller);
     event SourceContractUpdated(uint256 indexed activityId, address oldSourceContract, address newSourceContract);
     event RewardsClaimed(address indexed user, uint256 amount);
 
@@ -165,7 +163,6 @@ contract record Rewards is Ownable {
      * @param activityId Unique identifier for the activity
      * @param name Human-readable name for the activity
      * @param emissionRate CATA tokens emitted per second for this activity
-     * @param allowedCaller Address allowed to call handleAction for this activity
      * @param sourceContract Address of the contract this activity tracks
      * @param actionableEvents Array of events that can trigger actions (must have at least one)
      */
@@ -173,12 +170,11 @@ contract record Rewards is Ownable {
         uint256 activityId,
         string name,
         uint256 emissionRate,
-        address allowedCaller,
         address sourceContract,
         ActionableEvent[] actionableEvents
     ) external onlyOwner {
         require(actionableEvents.length > 0, "At least one actionable event required");
-        _addActivity(activityId, name, ActivityType.Position, emissionRate, allowedCaller, sourceContract, actionableEvents);
+        _addActivity(activityId, name, ActivityType.Position, emissionRate, sourceContract, actionableEvents);
     }
 
     /**
@@ -186,7 +182,6 @@ contract record Rewards is Ownable {
      * @param activityId Unique identifier for the activity
      * @param name Human-readable name for the activity
      * @param emissionRate CATA tokens emitted per second for this activity
-     * @param allowedCaller Address allowed to call handleAction for this activity
      * @param sourceContract Address of the contract this activity tracks
      * @param eventName Name of the event that triggers this one-time action
      */
@@ -194,13 +189,12 @@ contract record Rewards is Ownable {
         uint256 activityId,
         string name,
         uint256 emissionRate,
-        address allowedCaller,
         address sourceContract,
         string eventName
     ) external onlyOwner {
         ActionableEvent[] memory actionableEvents = new ActionableEvent[](1);
         actionableEvents[0] = ActionableEvent(eventName, ActionType.Occurred);
-        _addActivity(activityId, name, ActivityType.OneTime, emissionRate, allowedCaller, sourceContract, actionableEvents);
+        _addActivity(activityId, name, ActivityType.OneTime, emissionRate, sourceContract, actionableEvents);
     }
 
     /**
@@ -210,7 +204,7 @@ contract record Rewards is Ownable {
      */
     function setEmissionRate(uint256 activityId, uint256 newEmissionRate) external onlyOwner {
         Activity storage activity = activities[activityId];
-        require(activity.allowedCaller != address(0), "Activity does not exist");
+        require(activity.sourceContract != address(0), "Activity does not exist");
 
         // Update index with old emission rate first
         _updateActivityIndex(activityId);
@@ -225,29 +219,13 @@ contract record Rewards is Ownable {
     }
 
     /**
-     * @dev Update the allowed caller for an existing activity
-     * @param activityId The activity to update
-     * @param newAllowedCaller The new address allowed to call deposit/withdraw
-     */
-    function setAllowedCaller(uint256 activityId, address newAllowedCaller) external onlyOwner {
-        Activity storage activity = activities[activityId];
-        require(activity.allowedCaller != address(0), "Activity does not exist");
-        require(newAllowedCaller != address(0), "Invalid caller address");
-
-        address oldCaller = activity.allowedCaller;
-        activity.allowedCaller = newAllowedCaller;
-
-        emit AllowedCallerUpdated(activityId, oldCaller, newAllowedCaller);
-    }
-
-    /**
      * @dev Update the source contract for an existing activity
      * @param activityId The activity to update
      * @param newSourceContract The new source contract address
      */
     function setSourceContract(uint256 activityId, address newSourceContract) external onlyOwner {
         Activity storage activity = activities[activityId];
-        require(activity.allowedCaller != address(0), "Activity does not exist");
+        require(activity.sourceContract != address(0), "Activity does not exist");
         require(newSourceContract != address(0), "Invalid source contract address");
 
         address oldSourceContract = activity.sourceContract;
@@ -305,7 +283,7 @@ contract record Rewards is Ownable {
      * @dev Process a single action
      * @param action The action to process
      */
-    function handleAction(Action calldata action) external {
+    function handleAction(Action calldata action) external onlyOwner {
         _handleAction(action);
     }
 
@@ -313,7 +291,7 @@ contract record Rewards is Ownable {
      * @dev Process multiple actions in a single call
      * @param actions Array of actions to process (each action includes blockNumber for idempotency)
      */
-    function batchHandleAction(Action[] calldata actions) external {
+    function batchHandleAction(Action[] calldata actions) external onlyOwner {
         for (uint256 i = 0; i < actions.length; i++) {
             _handleAction(actions[i]);
         }
@@ -340,12 +318,10 @@ contract record Rewards is Ownable {
         string name,
         ActivityType activityType,
         uint256 emissionRate,
-        address allowedCaller,
         address sourceContract,
         ActionableEvent[] actionableEvents
     ) internal {
-        require(activities[activityId].allowedCaller == address(0), "Activity already exists");
-        require(allowedCaller != address(0), "Invalid caller address");
+        require(activities[activityId].sourceContract == address(0), "Activity already exists");
         require(sourceContract != address(0), "Invalid source contract address");
         require(bytes(name).length > 0, "Name cannot be empty");
 
@@ -364,7 +340,6 @@ contract record Rewards is Ownable {
         activity.accRewardPerStake = 0;
         activity.lastUpdateTime = block.timestamp;
         activity.totalStake = 0;
-        activity.allowedCaller = allowedCaller;
         activity.sourceContract = sourceContract;
 
         // Copy actionable events and register in mapping
@@ -378,7 +353,7 @@ contract record Rewards is Ownable {
         // Update total emission rate
         totalRewardsEmission += emissionRate;
 
-        emit ActivityAdded(activityId, name, emissionRate, allowedCaller, sourceContract);
+        emit ActivityAdded(activityId, name, emissionRate, sourceContract);
     }
 
     /**
@@ -438,9 +413,6 @@ contract record Rewards is Ownable {
 
         // Determine if this is an increase or decrease
         bool isIncrease = (actionType != ActionType.Withdraw);
-
-        // Access control: only allowed caller can update this activity
-        require(msg.sender == activity.allowedCaller, "Caller not allowed");
 
         // 1) Update global index using current totalStake (before user update)
         _updateActivityIndex(activityId);

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -68,7 +68,7 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_for_single_liquidity_provider() {
         // given - user1 deposits 1000 units of liquidity
         uint256 depositAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, testBlockNumber, nextEventIndex++);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, testBlockNumber, nextEventIndex++));
 
         // given - 100 seconds pass
         fastForward(100);
@@ -94,11 +94,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_split_rewards_proportionally_between_two_users() {
         // given - user1 deposits 600 units
         uint256 user1Deposit = 600 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), user1Deposit, testBlockNumber, nextEventIndex++);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), user1Deposit, ActionType.Deposit, testBlockNumber, nextEventIndex++));
 
         // given - user2 deposits 400 units
         uint256 user2Deposit = 400 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user2), user2Deposit, testBlockNumber, nextEventIndex++);
+        rewards.handleAction(Action(liquidityActivityId, address(user2), user2Deposit, ActionType.Deposit, testBlockNumber, nextEventIndex++));
 
         // given - 100 seconds pass
         fastForward(100);
@@ -132,11 +132,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_from_multiple_activities() {
         // given - user1 deposits liquidity (activity 1)
         uint256 liquidityAmount = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), liquidityAmount, testBlockNumber, nextEventIndex++);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), liquidityAmount, ActionType.Deposit, testBlockNumber, nextEventIndex++));
 
         // given - user1 borrows (activity 2)
         uint256 borrowAmount = 500 * 1e18;
-        rewards.deposit(borrowActivityId, address(user1), borrowAmount, testBlockNumber, nextEventIndex++);
+        rewards.handleAction(Action(borrowActivityId, address(user1), borrowAmount, ActionType.Deposit, testBlockNumber, nextEventIndex++));
 
         // given - 100 seconds pass
         fastForward(100);
@@ -167,14 +167,14 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_handle_partial_withdrawal_and_continue_accruing() {
         // given - user1 deposits 1000 units
         uint256 initialDeposit = 1000 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), initialDeposit, testBlockNumber, nextEventIndex++);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), initialDeposit, ActionType.Deposit, testBlockNumber, nextEventIndex++));
 
         // given - 50 seconds pass
         fastForward(50);
 
         // when - user1 withdraws 400 units (leaving 600)
         uint256 withdrawAmount = 400 * 1e18;
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, testBlockNumber, nextEventIndex++);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), withdrawAmount, ActionType.Withdraw, testBlockNumber, nextEventIndex++));
 
         // given - another 50 seconds pass
         fastForward(50);

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -53,8 +53,15 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
         rewards.initialize(tokenAddress);
 
         // Add activities - test contract is the allowed caller (simulating the pool)
-        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), address(this));
-        rewards.addPositionActivity(borrowActivityId, "Lending Pool Borrows", borrowEmissionRate, address(this), address(this));
+        ActionableEvent[] memory liquidityEvents = new ActionableEvent[](2);
+        liquidityEvents[0] = ActionableEvent("Deposit", ActionType.Deposit);
+        liquidityEvents[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
+        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), address(this), liquidityEvents);
+
+        ActionableEvent[] memory borrowEvents = new ActionableEvent[](2);
+        borrowEvents[0] = ActionableEvent("Borrow", ActionType.Deposit);
+        borrowEvents[1] = ActionableEvent("Repay", ActionType.Withdraw);
+        rewards.addPositionActivity(borrowActivityId, "Lending Pool Borrows", borrowEmissionRate, address(this), address(this), borrowEvents);
 
         // Fund the Rewards contract with CATA tokens
         uint256 fundingAmount = 1000000 * 1e18; // 1 million CATA

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -75,7 +75,7 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_for_single_liquidity_provider() {
         // given - user1 deposits 1000 units of liquidity
         uint256 depositAmount = 1000 * 1e18;
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, testBlockNumber, nextEventIndex++));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, testBlockNumber, nextEventIndex++));
 
         // given - 100 seconds pass
         fastForward(100);
@@ -101,11 +101,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_split_rewards_proportionally_between_two_users() {
         // given - user1 deposits 600 units
         uint256 user1Deposit = 600 * 1e18;
-        rewards.handleAction(Action(liquidityActivityId, address(user1), user1Deposit, ActionType.Deposit, testBlockNumber, nextEventIndex++));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), user1Deposit, testBlockNumber, nextEventIndex++));
 
         // given - user2 deposits 400 units
         uint256 user2Deposit = 400 * 1e18;
-        rewards.handleAction(Action(liquidityActivityId, address(user2), user2Deposit, ActionType.Deposit, testBlockNumber, nextEventIndex++));
+        rewards.handleAction(Action(address(this), "Deposit", address(user2), user2Deposit, testBlockNumber, nextEventIndex++));
 
         // given - 100 seconds pass
         fastForward(100);
@@ -139,11 +139,11 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_accrue_rewards_from_multiple_activities() {
         // given - user1 deposits liquidity (activity 1)
         uint256 liquidityAmount = 1000 * 1e18;
-        rewards.handleAction(Action(liquidityActivityId, address(user1), liquidityAmount, ActionType.Deposit, testBlockNumber, nextEventIndex++));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), liquidityAmount, testBlockNumber, nextEventIndex++));
 
         // given - user1 borrows (activity 2)
         uint256 borrowAmount = 500 * 1e18;
-        rewards.handleAction(Action(borrowActivityId, address(user1), borrowAmount, ActionType.Deposit, testBlockNumber, nextEventIndex++));
+        rewards.handleAction(Action(address(this), "Borrow", address(user1), borrowAmount, testBlockNumber, nextEventIndex++));
 
         // given - 100 seconds pass
         fastForward(100);
@@ -174,14 +174,14 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     function it_should_handle_partial_withdrawal_and_continue_accruing() {
         // given - user1 deposits 1000 units
         uint256 initialDeposit = 1000 * 1e18;
-        rewards.handleAction(Action(liquidityActivityId, address(user1), initialDeposit, ActionType.Deposit, testBlockNumber, nextEventIndex++));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), initialDeposit, testBlockNumber, nextEventIndex++));
 
         // given - 50 seconds pass
         fastForward(50);
 
         // when - user1 withdraws 400 units (leaving 600)
         uint256 withdrawAmount = 400 * 1e18;
-        rewards.handleAction(Action(liquidityActivityId, address(user1), withdrawAmount, ActionType.Withdraw, testBlockNumber, nextEventIndex++));
+        rewards.handleAction(Action(address(this), "Withdraw", address(user1), withdrawAmount, testBlockNumber, nextEventIndex++));
 
         // given - another 50 seconds pass
         fastForward(50);

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -52,16 +52,16 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
         rewards = new Rewards(address(this));
         rewards.initialize(tokenAddress);
 
-        // Add activities - test contract is the allowed caller (simulating the pool)
+        // Add activities - test contract is the owner
         ActionableEvent[] memory liquidityEvents = new ActionableEvent[](2);
         liquidityEvents[0] = ActionableEvent("Deposit", ActionType.Deposit);
         liquidityEvents[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), address(this), liquidityEvents);
+        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), liquidityEvents);
 
         ActionableEvent[] memory borrowEvents = new ActionableEvent[](2);
         borrowEvents[0] = ActionableEvent("Borrow", ActionType.Deposit);
         borrowEvents[1] = ActionableEvent("Repay", ActionType.Withdraw);
-        rewards.addPositionActivity(borrowActivityId, "Lending Pool Borrows", borrowEmissionRate, address(this), address(this), borrowEvents);
+        rewards.addPositionActivity(borrowActivityId, "Lending Pool Borrows", borrowEmissionRate, address(this), borrowEvents);
 
         // Fund the Rewards contract with CATA tokens
         uint256 fundingAmount = 1000000 * 1e18; // 1 million CATA

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -19,8 +19,8 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
     User user1;
     User user2;
 
-    uint256 liquidityActivityId = 1;
-    uint256 borrowActivityId = 2;
+    uint256 liquidityActivityId;
+    uint256 borrowActivityId;
     uint256 liquidityEmissionRate = 900; // 900 CATA per second
     uint256 borrowEmissionRate = 100;    // 100 CATA per second
 
@@ -56,12 +56,12 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
         ActionableEvent[] memory liquidityEvents = new ActionableEvent[](2);
         liquidityEvents[0] = ActionableEvent("Deposit", ActionType.Deposit);
         liquidityEvents[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), liquidityEvents);
+        liquidityActivityId = rewards.addPositionActivity("Lending Pool Liquidity", liquidityEmissionRate, address(this), liquidityEvents);
 
         ActionableEvent[] memory borrowEvents = new ActionableEvent[](2);
         borrowEvents[0] = ActionableEvent("Borrow", ActionType.Deposit);
         borrowEvents[1] = ActionableEvent("Repay", ActionType.Withdraw);
-        rewards.addPositionActivity(borrowActivityId, "Lending Pool Borrows", borrowEmissionRate, address(this), borrowEvents);
+        borrowActivityId = rewards.addPositionActivity("Lending Pool Borrows", borrowEmissionRate, address(this), borrowEvents);
 
         // Fund the Rewards contract with CATA tokens
         uint256 fundingAmount = 1000000 * 1e18; // 1 million CATA

--- a/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Earn-and-Claim.test.sol
@@ -53,8 +53,8 @@ contract Describe_Rewards_Earn_and_Claim is Authorizable {
         rewards.initialize(tokenAddress);
 
         // Add activities - test contract is the allowed caller (simulating the pool)
-        rewards.addActivity(liquidityActivityId, "Lending Pool Liquidity", ActivityType.Position, liquidityEmissionRate, address(this), address(this));
-        rewards.addActivity(borrowActivityId, "Lending Pool Borrows", ActivityType.Position, borrowEmissionRate, address(this), address(this));
+        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), address(this));
+        rewards.addPositionActivity(borrowActivityId, "Lending Pool Borrows", borrowEmissionRate, address(this), address(this));
 
         // Fund the Rewards contract with CATA tokens
         uint256 fundingAmount = 1000000 * 1e18; // 1 million CATA

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -70,7 +70,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, eventIndex));
 
         // then - user's stake should only be 1000 (not 2000), proving the duplicate was ignored
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), liquidityActivityId);
         require(stake == depositAmount, "Duplicate event should be ignored - stake should be 1000, not 2000");
     }
 
@@ -90,7 +90,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         rewards.handleAction(Action(address(this), "Deposit", address(user1), 500 * 1e18, olderBlock, 0));
 
         // then - user's stake should still be 1000 (old block event ignored)
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), liquidityActivityId);
         require(stake == depositAmount, "Old block event should be ignored - stake should be 1000, not 1500");
 
         // then - currentBlock should still be 200
@@ -115,7 +115,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, block101, 0));
 
         // then - user's stake should be 1000 (both deposits processed)
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), liquidityActivityId);
         require(stake == depositAmount * 2, "Events in different blocks should both be processed");
 
         // then - currentBlock should be 101
@@ -139,7 +139,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 4));
 
         // then - all 5 deposits should be processed (total 500)
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), liquidityActivityId);
         require(stake == 500 * 1e18, "All unique events in same block should be processed");
     }
 
@@ -161,7 +161,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         rewards.handleAction(Action(address(this), "Withdraw", address(user1), withdrawAmount, blockNum, 1));
 
         // then - stake should be 600 (1000 - 400), not 200 (1000 - 400 - 400)
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), liquidityActivityId);
         require(stake == depositAmount - withdrawAmount, "Duplicate withdraw should be ignored");
     }
 
@@ -185,7 +185,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         rewards.batchHandleAction(actions);
 
         // then - only 3 unique events should be processed (eventIndex 0, 1, 2)
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), liquidityActivityId);
         require(stake == 300 * 1e18, "Batch should ignore duplicate hashes");
     }
 
@@ -212,7 +212,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 0));
 
         // then - stake should be 300 (original 100 + 100 + new 100)
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), liquidityActivityId);
         require(stake == 300 * 1e18, "Hash should be reprocessed after emergency override");
     }
 

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -43,7 +43,10 @@ contract Describe_Rewards_Idempotency is Authorizable {
         rewards = new Rewards(address(this));
         rewards.initialize(tokenAddress);
 
-        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), address(this));
+        ActionableEvent[] memory events = new ActionableEvent[](2);
+        events[0] = ActionableEvent("Deposit", ActionType.Deposit);
+        events[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
+        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), address(this), events);
 
         uint256 fundingAmount = 1000000 * 1e18;
         rewardToken.mint(address(rewards), fundingAmount);

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -62,12 +62,12 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 blockNum = 100;
         uint256 eventIndex = 0;
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, eventIndex));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, eventIndex));
 
         // when - the same event is sent again (same blockNumber and eventIndex)
         // This simulates a duplicate event from the indexer
         // Hash = keccak256(blockNumber, eventIndex) - same = duplicate
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, eventIndex));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, eventIndex));
 
         // then - user's stake should only be 1000 (not 2000), proving the duplicate was ignored
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -83,11 +83,11 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 newerBlock = 200;
         uint256 olderBlock = 100;
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, newerBlock, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, newerBlock, 0));
 
         // when - an event from an older block (100) arrives late
         // This simulates out-of-order or replayed old events
-        rewards.handleAction(Action(liquidityActivityId, address(user1), 500 * 1e18, ActionType.Deposit, olderBlock, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), 500 * 1e18, olderBlock, 0));
 
         // then - user's stake should still be 1000 (old block event ignored)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -107,12 +107,12 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 block100 = 100;
         uint256 block101 = 101;
 
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, block100, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, block100, 0));
 
         // when - move to block 101 with same eventIndex (0)
         // Since blockNumber is part of the hash, this produces a different hash
         // Hash set is also cleared when moving to a new block
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, block101, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, block101, 0));
 
         // then - user's stake should be 1000 (both deposits processed)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -132,11 +132,11 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 100 * 1e18;
 
         // when - process 5 different events in the same block with different eventIndex
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0));
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1));
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 2));
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 3));
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 4));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 1));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 2));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 3));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 4));
 
         // then - all 5 deposits should be processed (total 500)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -152,13 +152,13 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 withdrawAmount = 400 * 1e18;
         uint256 blockNum = 100;
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 0));
 
         // when - withdraw 400 units with eventIndex 1
-        rewards.handleAction(Action(liquidityActivityId, address(user1), withdrawAmount, ActionType.Withdraw, blockNum, 1));
+        rewards.handleAction(Action(address(this), "Withdraw", address(user1), withdrawAmount, blockNum, 1));
 
         // when - duplicate withdraw event (same blockNumber and eventIndex = same hash)
-        rewards.handleAction(Action(liquidityActivityId, address(user1), withdrawAmount, ActionType.Withdraw, blockNum, 1));
+        rewards.handleAction(Action(address(this), "Withdraw", address(user1), withdrawAmount, blockNum, 1));
 
         // then - stake should be 600 (1000 - 400), not 200 (1000 - 400 - 400)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -176,10 +176,10 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 100 * 1e18;
 
         Action[] memory actions = new Action[](4);
-        actions[0] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0);
-        actions[1] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1);
-        actions[2] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0); // duplicate of actions[0]
-        actions[3] = Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 2);
+        actions[0] = Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 0);
+        actions[1] = Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 1);
+        actions[2] = Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 0); // duplicate of actions[0]
+        actions[3] = Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 2);
 
         // when - process batch
         rewards.batchHandleAction(actions);
@@ -197,8 +197,8 @@ contract Describe_Rewards_Idempotency is Authorizable {
         // given - process some events in block 100
         uint256 blockNum = 100;
         uint256 depositAmount = 100 * 1e18;
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0));
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 1));
 
         require(rewards.currentBlockHandled() == 100, "currentBlockHandled should be 100");
 
@@ -209,7 +209,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         require(rewards.currentBlockHandled() == 50, "currentBlockHandled should be reset to 50");
 
         // then - old hashes should be cleared, so same blockNumber+eventIndex can be reprocessed
-        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, blockNum, 0));
 
         // then - stake should be 300 (original 100 + 100 + new 100)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -218,7 +218,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     function it_should_prevent_non_owner_from_emergency_override() {
         // given - some state exists
-        rewards.handleAction(Action(liquidityActivityId, address(user1), 100 * 1e18, ActionType.Deposit, 100, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), 100 * 1e18, 100, 0));
 
         // when - non-owner tries to call emergencyOverride
         bool reverted = false;

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -43,7 +43,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         rewards = new Rewards(address(this));
         rewards.initialize(tokenAddress);
 
-        rewards.addActivity(liquidityActivityId, "Lending Pool Liquidity", ActivityType.Position, liquidityEmissionRate, address(this), address(this));
+        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), address(this));
 
         uint256 fundingAmount = 1000000 * 1e18;
         rewardToken.mint(address(rewards), fundingAmount);

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -19,7 +19,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
     User user1;
     User user2;
 
-    uint256 liquidityActivityId = 1;
+    uint256 liquidityActivityId;
     uint256 liquidityEmissionRate = 900;
 
     function beforeAll() {
@@ -46,7 +46,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         ActionableEvent[] memory events = new ActionableEvent[](2);
         events[0] = ActionableEvent("Deposit", ActionType.Deposit);
         events[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), events);
+        liquidityActivityId = rewards.addPositionActivity("Lending Pool Liquidity", liquidityEmissionRate, address(this), events);
 
         uint256 fundingAmount = 1000000 * 1e18;
         rewardToken.mint(address(rewards), fundingAmount);

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -59,12 +59,12 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 blockNum = 100;
         uint256 eventIndex = 0;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, eventIndex);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, eventIndex));
 
         // when - the same event is sent again (same blockNumber and eventIndex)
         // This simulates a duplicate event from the indexer
         // Hash = keccak256(blockNumber, eventIndex) - same = duplicate
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, eventIndex);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, eventIndex));
 
         // then - user's stake should only be 1000 (not 2000), proving the duplicate was ignored
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -80,11 +80,11 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 newerBlock = 200;
         uint256 olderBlock = 100;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, newerBlock, 0);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, newerBlock, 0));
 
         // when - an event from an older block (100) arrives late
         // This simulates out-of-order or replayed old events
-        rewards.deposit(liquidityActivityId, address(user1), 500 * 1e18, olderBlock, 0);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), 500 * 1e18, ActionType.Deposit, olderBlock, 0));
 
         // then - user's stake should still be 1000 (old block event ignored)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -104,12 +104,12 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 block100 = 100;
         uint256 block101 = 101;
 
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block100, 0);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, block100, 0));
 
         // when - move to block 101 with same eventIndex (0)
         // Since blockNumber is part of the hash, this produces a different hash
         // Hash set is also cleared when moving to a new block
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, block101, 0);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, block101, 0));
 
         // then - user's stake should be 1000 (both deposits processed)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -129,11 +129,11 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 100 * 1e18;
 
         // when - process 5 different events in the same block with different eventIndex
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 0);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 2);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 3);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 4);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0));
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1));
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 2));
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 3));
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 4));
 
         // then - all 5 deposits should be processed (total 500)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -149,13 +149,13 @@ contract Describe_Rewards_Idempotency is Authorizable {
         uint256 depositAmount = 1000 * 1e18;
         uint256 withdrawAmount = 400 * 1e18;
         uint256 blockNum = 100;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 0);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0));
 
         // when - withdraw 400 units with eventIndex 1
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum, 1);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), withdrawAmount, ActionType.Withdraw, blockNum, 1));
 
         // when - duplicate withdraw event (same blockNumber and eventIndex = same hash)
-        rewards.withdraw(liquidityActivityId, address(user1), withdrawAmount, blockNum, 1);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), withdrawAmount, ActionType.Withdraw, blockNum, 1));
 
         // then - stake should be 600 (1000 - 400), not 200 (1000 - 400 - 400)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -194,8 +194,8 @@ contract Describe_Rewards_Idempotency is Authorizable {
         // given - process some events in block 100
         uint256 blockNum = 100;
         uint256 depositAmount = 100 * 1e18;
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 0);
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 1);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0));
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 1));
 
         require(rewards.currentBlockHandled() == 100, "currentBlockHandled should be 100");
 
@@ -206,7 +206,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         require(rewards.currentBlockHandled() == 50, "currentBlockHandled should be reset to 50");
 
         // then - old hashes should be cleared, so same blockNumber+eventIndex can be reprocessed
-        rewards.deposit(liquidityActivityId, address(user1), depositAmount, blockNum, 0);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), depositAmount, ActionType.Deposit, blockNum, 0));
 
         // then - stake should be 300 (original 100 + 100 + new 100)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(liquidityActivityId, address(user1));
@@ -215,7 +215,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
     function it_should_prevent_non_owner_from_emergency_override() {
         // given - some state exists
-        rewards.deposit(liquidityActivityId, address(user1), 100 * 1e18, 100, 0);
+        rewards.handleAction(Action(liquidityActivityId, address(user1), 100 * 1e18, ActionType.Deposit, 100, 0));
 
         // when - non-owner tries to call emergencyOverride
         bool reverted = false;

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -232,4 +232,102 @@ contract Describe_Rewards_Idempotency is Authorizable {
         require(reverted, "Non-owner should not be able to call emergencyOverride");
     }
 
+    // ═════════════════════════════════════════════════════════════════════════
+    // IDEMPOTENCY: Full replay of off-chain service from first event
+    // Simulates a service restart that replays all historical events
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_handle_full_replay_of_all_events_idempotently() {
+        // Setup: Create a second activity (OneTime) for this test
+        uint256 swapActivityId = rewards.addOneTimeActivity("Swap Rewards", 100, address(this), "Swap");
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // FIRST RUN: Process events across multiple blocks
+        // ═══════════════════════════════════════════════════════════════════════
+
+        // Block 100: user1 deposits 1000, user2 deposits 500
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), 1000 * 1e18, 100, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user2), 500 * 1e18, 100, 1));
+
+        // Block 101: user1 swaps 200, user2 deposits 300 more
+        rewards.handleAction(Action(address(this), "Swap", address(user1), 200 * 1e18, 101, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user2), 300 * 1e18, 101, 1));
+
+        // Block 102: user1 withdraws 400, user2 swaps 150
+        rewards.handleAction(Action(address(this), "Withdraw", address(user1), 400 * 1e18, 102, 0));
+        rewards.handleAction(Action(address(this), "Swap", address(user2), 150 * 1e18, 102, 1));
+
+        // Block 103: user1 deposits 250
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), 250 * 1e18, 103, 0));
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // CAPTURE STATE AFTER FIRST RUN
+        // ═══════════════════════════════════════════════════════════════════════
+
+        // Liquidity activity state
+        (uint256 user1LiquidityStake_before, ) = rewards.userInfo(address(user1), liquidityActivityId);
+        (uint256 user2LiquidityStake_before, ) = rewards.userInfo(address(user2), liquidityActivityId);
+
+        // Swap activity state
+        (uint256 user1SwapStake_before, ) = rewards.userInfo(address(user1), swapActivityId);
+        (uint256 user2SwapStake_before, ) = rewards.userInfo(address(user2), swapActivityId);
+
+        // Global state
+        uint256 currentBlock_before = rewards.currentBlockHandled();
+
+        // Verify expected state after first run:
+        // user1 liquidity: 1000 - 400 + 250 = 850
+        require(user1LiquidityStake_before == 850 * 1e18, "User1 liquidity stake should be 850");
+        // user2 liquidity: 500 + 300 = 800
+        require(user2LiquidityStake_before == 800 * 1e18, "User2 liquidity stake should be 800");
+        // user1 swap: 200
+        require(user1SwapStake_before == 200 * 1e18, "User1 swap stake should be 200");
+        // user2 swap: 150
+        require(user2SwapStake_before == 150 * 1e18, "User2 swap stake should be 150");
+        // Current block: 103
+        require(currentBlock_before == 103, "Current block should be 103");
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // SECOND RUN: Replay ALL events from the beginning (service restart)
+        // All events should be ignored as duplicates or old blocks
+        // ═══════════════════════════════════════════════════════════════════════
+
+        // Replay Block 100 events (should be ignored - old block)
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), 1000 * 1e18, 100, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user2), 500 * 1e18, 100, 1));
+
+        // Replay Block 101 events (should be ignored - old block)
+        rewards.handleAction(Action(address(this), "Swap", address(user1), 200 * 1e18, 101, 0));
+        rewards.handleAction(Action(address(this), "Deposit", address(user2), 300 * 1e18, 101, 1));
+
+        // Replay Block 102 events (should be ignored - old block)
+        rewards.handleAction(Action(address(this), "Withdraw", address(user1), 400 * 1e18, 102, 0));
+        rewards.handleAction(Action(address(this), "Swap", address(user2), 150 * 1e18, 102, 1));
+
+        // Replay Block 103 events (should be ignored - same block, duplicate hash)
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), 250 * 1e18, 103, 0));
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // VERIFY STATE UNCHANGED AFTER REPLAY
+        // ═══════════════════════════════════════════════════════════════════════
+
+        // Liquidity activity state
+        (uint256 user1LiquidityStake_after, ) = rewards.userInfo(address(user1), liquidityActivityId);
+        (uint256 user2LiquidityStake_after, ) = rewards.userInfo(address(user2), liquidityActivityId);
+
+        // Swap activity state
+        (uint256 user1SwapStake_after, ) = rewards.userInfo(address(user1), swapActivityId);
+        (uint256 user2SwapStake_after, ) = rewards.userInfo(address(user2), swapActivityId);
+
+        // Global state
+        uint256 currentBlock_after = rewards.currentBlockHandled();
+
+        // Assert nothing changed
+        require(user1LiquidityStake_after == user1LiquidityStake_before, "User1 liquidity stake should be unchanged after replay");
+        require(user2LiquidityStake_after == user2LiquidityStake_before, "User2 liquidity stake should be unchanged after replay");
+        require(user1SwapStake_after == user1SwapStake_before, "User1 swap stake should be unchanged after replay");
+        require(user2SwapStake_after == user2SwapStake_before, "User2 swap stake should be unchanged after replay");
+        require(currentBlock_after == currentBlock_before, "Current block should be unchanged after replay");
+    }
+
 }

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -46,7 +46,7 @@ contract Describe_Rewards_Idempotency is Authorizable {
         ActionableEvent[] memory events = new ActionableEvent[](2);
         events[0] = ActionableEvent("Deposit", ActionType.Deposit);
         events[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), address(this), events);
+        rewards.addPositionActivity(liquidityActivityId, "Lending Pool Liquidity", liquidityEmissionRate, address(this), events);
 
         uint256 fundingAmount = 1000000 * 1e18;
         rewardToken.mint(address(rewards), fundingAmount);

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -339,7 +339,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to deposit on OneTime activity
         bool reverted = false;
-        try rewards.deposit(activityId, address(user1), 100, testBlockNumber, 0) {
+        try rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Deposit, testBlockNumber, 0)) {
             reverted = false;
         } catch {
             reverted = true;
@@ -354,7 +354,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to withdraw on OneTime activity
         bool reverted = false;
-        try rewards.withdraw(activityId, address(user1), 100, testBlockNumber, 0) {
+        try rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Withdraw, testBlockNumber, 0)) {
             reverted = false;
         } catch {
             reverted = true;
@@ -369,7 +369,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then - try to call occurred on Position activity
         bool reverted = false;
-        try rewards.occurred(activityId, address(user1), 100, testBlockNumber, 0) {
+        try rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Occurred, testBlockNumber, 0)) {
             reverted = false;
         } catch {
             reverted = true;
@@ -383,7 +383,7 @@ contract Describe_Rewards_Management is Authorizable {
         rewards.addActivity(activityId, "Swap Activity", ActivityType.OneTime, 100, address(this), address(this));
 
         // when - call occurred
-        rewards.occurred(activityId, address(user1), 100, testBlockNumber, 0);
+        rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Occurred, testBlockNumber, 0));
 
         // then - check user stake increased
         (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -527,4 +527,206 @@ contract Describe_Rewards_Management is Authorizable {
         require(reverted, "Non-owner should not be able to call handleAction");
     }
 
+    // ═════════════════════════════════════════════════════════════════════════
+    // SET POSITION ACTIVITY EVENTS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_change_position_activity_events_and_ignore_old_events() {
+        // given - create activity with event "EventA"
+        uint256 activityId = 1;
+        ActionableEvent[] memory eventsA = new ActionableEvent[](1);
+        eventsA[0] = ActionableEvent("EventA", ActionType.Deposit);
+        rewards.addPositionActivity(activityId, "Test Activity", 100, address(this), eventsA);
+
+        // when - run action with EventA
+        rewards.handleAction(Action(address(this), "EventA", address(user1), 100, testBlockNumber, 0));
+
+        // then - check state: user stake should be 100
+        (uint256 stake, ) = rewards.userInfo(address(user1), activityId);
+        require(stake == 100, "User stake should be 100 after EventA");
+
+        // when - modify activity to use EventB instead
+        ActionableEvent[] memory eventsB = new ActionableEvent[](1);
+        eventsB[0] = ActionableEvent("EventB", ActionType.Deposit);
+        rewards.setPositionActivityEvents(activityId, eventsB);
+
+        // when - try to run EventA again (should be ignored/fail)
+        bool reverted = false;
+        try rewards.handleAction(Action(address(this), "EventA", address(user1), 50, testBlockNumber, 1)) {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+
+        // then - EventA should be rejected since it's no longer registered
+        require(reverted, "EventA should be rejected after changing to EventB");
+
+        // then - stake should remain unchanged at 100
+        (uint256 stakeAfter, ) = rewards.userInfo(address(user1), activityId);
+        require(stakeAfter == 100, "User stake should still be 100");
+
+        // when - run EventB (should work)
+        rewards.handleAction(Action(address(this), "EventB", address(user1), 50, testBlockNumber, 2));
+
+        // then - stake should be 150
+        (uint256 stakeFinal, ) = rewards.userInfo(address(user1), activityId);
+        require(stakeFinal == 150, "User stake should be 150 after EventB");
+    }
+
+    function it_should_prevent_setting_events_on_nonexistent_activity() {
+        // given - no activity exists with id 999
+        ActionableEvent[] memory events = new ActionableEvent[](1);
+        events[0] = ActionableEvent("Event", ActionType.Deposit);
+
+        // when/then
+        bool reverted = false;
+        try rewards.setPositionActivityEvents(999, events) {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Setting events on nonexistent activity should revert");
+    }
+
+    function it_should_prevent_setting_events_on_onetime_activity() {
+        // given - create a OneTime activity
+        uint256 activityId = 1;
+        rewards.addOneTimeActivity(activityId, "OneTime Activity", 100, address(this), "Swap");
+
+        // when/then - try to use setPositionActivityEvents on OneTime activity
+        ActionableEvent[] memory events = new ActionableEvent[](1);
+        events[0] = ActionableEvent("NewEvent", ActionType.Deposit);
+
+        bool reverted = false;
+        try rewards.setPositionActivityEvents(activityId, events) {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "setPositionActivityEvents should fail on OneTime activity");
+    }
+
+    function it_should_prevent_setting_empty_events_on_position_activity() {
+        // given - create a Position activity
+        uint256 activityId = 1;
+        rewards.addPositionActivity(activityId, "Test Activity", 100, address(this), _defaultPositionEvents());
+
+        // when/then - try to set empty events
+        ActionableEvent[] memory emptyEvents = new ActionableEvent[](0);
+
+        bool reverted = false;
+        try rewards.setPositionActivityEvents(activityId, emptyEvents) {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Setting empty events should revert");
+    }
+
+    function it_should_allow_keeping_same_event_when_updating_position_activity() {
+        // given - create activity with EventA and EventB
+        uint256 activityId = 1;
+        ActionableEvent[] memory initialEvents = new ActionableEvent[](2);
+        initialEvents[0] = ActionableEvent("EventA", ActionType.Deposit);
+        initialEvents[1] = ActionableEvent("EventB", ActionType.Withdraw);
+        rewards.addPositionActivity(activityId, "Test Activity", 100, address(this), initialEvents);
+
+        // when - update to keep EventA but change EventB to EventC
+        ActionableEvent[] memory newEvents = new ActionableEvent[](2);
+        newEvents[0] = ActionableEvent("EventA", ActionType.Deposit);  // keep same
+        newEvents[1] = ActionableEvent("EventC", ActionType.Withdraw); // change
+
+        rewards.setPositionActivityEvents(activityId, newEvents);
+
+        // then - EventA should still work
+        rewards.handleAction(Action(address(this), "EventA", address(user1), 100, testBlockNumber, 0));
+        (uint256 stake, ) = rewards.userInfo(address(user1), activityId);
+        require(stake == 100, "EventA should still work");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // SET ONETIME ACTIVITY EVENT
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function it_should_change_onetime_activity_event_and_ignore_old_event() {
+        // given - create OneTime activity with event "EventA"
+        uint256 activityId = 1;
+        rewards.addOneTimeActivity(activityId, "Test OneTime", 100, address(this), "EventA");
+
+        // when - run action with EventA
+        rewards.handleAction(Action(address(this), "EventA", address(user1), 100, testBlockNumber, 0));
+
+        // then - check state: user stake should be 100
+        (uint256 stake, ) = rewards.userInfo(address(user1), activityId);
+        require(stake == 100, "User stake should be 100 after EventA");
+
+        // when - modify activity to use EventB instead
+        rewards.setOneTimeActivityEvent(activityId, "EventB");
+
+        // when - try to run EventA again (should fail)
+        bool reverted = false;
+        try rewards.handleAction(Action(address(this), "EventA", address(user1), 50, testBlockNumber, 1)) {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+
+        // then - EventA should be rejected since it's no longer registered
+        require(reverted, "EventA should be rejected after changing to EventB");
+
+        // then - stake should remain unchanged at 100
+        (uint256 stakeAfter, ) = rewards.userInfo(address(user1), activityId);
+        require(stakeAfter == 100, "User stake should still be 100");
+
+        // when - run EventB (should work)
+        rewards.handleAction(Action(address(this), "EventB", address(user1), 50, testBlockNumber, 2));
+
+        // then - stake should be 150
+        (uint256 stakeFinal, ) = rewards.userInfo(address(user1), activityId);
+        require(stakeFinal == 150, "User stake should be 150 after EventB");
+    }
+
+    function it_should_prevent_setting_event_on_nonexistent_onetime_activity() {
+        // given - no activity exists with id 999
+
+        // when/then
+        bool reverted = false;
+        try rewards.setOneTimeActivityEvent(999, "NewEvent") {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Setting event on nonexistent activity should revert");
+    }
+
+    function it_should_prevent_setting_event_on_position_activity() {
+        // given - create a Position activity
+        uint256 activityId = 1;
+        rewards.addPositionActivity(activityId, "Position Activity", 100, address(this), _defaultPositionEvents());
+
+        // when/then - try to use setOneTimeActivityEvent on Position activity
+        bool reverted = false;
+        try rewards.setOneTimeActivityEvent(activityId, "NewEvent") {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "setOneTimeActivityEvent should fail on Position activity");
+    }
+
+    function it_should_prevent_setting_empty_event_name_on_onetime_activity() {
+        // given - create a OneTime activity
+        uint256 activityId = 1;
+        rewards.addOneTimeActivity(activityId, "Test OneTime", 100, address(this), "Swap");
+
+        // when/then - try to set empty event name
+        bool reverted = false;
+        try rewards.setOneTimeActivityEvent(activityId, "") {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Setting empty event name should revert");
+    }
+
 }

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -92,14 +92,13 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 activityId = 1;
         string memory name = "SwapPool-USDST/ETHST";
         uint256 emissionRate = 100;
-        address allowedCaller = address(user1);
         address sourceContract = address(user1);
 
         // when
-        rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract, _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, name, emissionRate, sourceContract, _defaultPositionEvents());
 
         // then
-        (string memory activityName, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address caller, address source) =
+        (string memory activityName, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address source) =
             rewards.activities(activityId);
 
         require(keccak256(bytes(activityName)) == keccak256(bytes(name)), "Activity name should match");
@@ -108,28 +107,9 @@ contract Describe_Rewards_Management is Authorizable {
         require(accReward == 0, "Initial accRewardPerStake should be 0");
         require(lastUpdate == block.timestamp, "lastUpdateTime should be set to block.timestamp");
         require(totalStake == 0, "Initial totalStake should be 0");
-        require(caller == allowedCaller, "Allowed caller should match");
         require(source == sourceContract, "Source contract should match");
         require(rewards.activityIds(0) == activityId, "Activity ID should be added to array");
         require(rewards.totalRewardsEmission() == emissionRate, "Total rewards emission should match");
-    }
-
-    function it_should_prevent_adding_activity_with_zero_address_caller() {
-        // given
-        uint256 activityId = 1;
-        string memory name = "SwapPool";
-        uint256 emissionRate = 100;
-        address allowedCaller = address(0);
-        address sourceContract = address(user1);
-
-        // when/then
-        bool reverted = false;
-        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract, _defaultPositionEvents()) {
-            reverted = false;
-        } catch {
-            reverted = true;
-        }
-        require(reverted, "Adding activity with zero address caller should revert");
     }
 
     function it_should_prevent_adding_activity_with_empty_name() {
@@ -137,12 +117,11 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 activityId = 1;
         string memory name = "";
         uint256 emissionRate = 100;
-        address allowedCaller = address(user1);
         address sourceContract = address(user1);
 
         // when/then
         bool reverted = false;
-        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract, _defaultPositionEvents()) {
+        try rewards.addPositionActivity(activityId, name, emissionRate, sourceContract, _defaultPositionEvents()) {
             reverted = false;
         } catch {
             reverted = true;
@@ -155,13 +134,12 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 activityId = 1;
         string memory name = "SwapPool";
         uint256 emissionRate = 100;
-        address allowedCaller = address(user1);
         address sourceContract = address(user1);
         ActionableEvent[] memory emptyEvents = new ActionableEvent[](0);
 
         // when/then
         bool reverted = false;
-        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract, emptyEvents) {
+        try rewards.addPositionActivity(activityId, name, emissionRate, sourceContract, emptyEvents) {
             reverted = false;
         } catch {
             reverted = true;
@@ -176,7 +154,7 @@ contract Describe_Rewards_Management is Authorizable {
         ActionableEvent[] memory events1 = new ActionableEvent[](2);
         events1[0] = ActionableEvent("Deposit", ActionType.Deposit);
         events1[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(activityId1, "Activity 1", 100, address(this), sourceA, events1);
+        rewards.addPositionActivity(activityId1, "Activity 1", 100, sourceA, events1);
 
         // when/then - try to add Activity 2 with same sourceContract and event "Deposit"
         uint256 activityId2 = 2;
@@ -184,7 +162,7 @@ contract Describe_Rewards_Management is Authorizable {
         events2[0] = ActionableEvent("Deposit", ActionType.Deposit); // duplicate event name
 
         bool reverted = false;
-        try rewards.addPositionActivity(activityId2, "Activity 2", 200, address(this), sourceA, events2) {
+        try rewards.addPositionActivity(activityId2, "Activity 2", 200, sourceA, events2) {
             reverted = false;
         } catch {
             reverted = true;
@@ -198,7 +176,7 @@ contract Describe_Rewards_Management is Authorizable {
         address sourceA = address(user1);
         ActionableEvent[] memory events1 = new ActionableEvent[](1);
         events1[0] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(activityId1, "Activity 1", 100, address(this), sourceA, events1);
+        rewards.addPositionActivity(activityId1, "Activity 1", 100, sourceA, events1);
 
         // when - add Activity 2 with different sourceContract 0xbb but same event "Withdraw"
         uint256 activityId2 = 2;
@@ -207,11 +185,11 @@ contract Describe_Rewards_Management is Authorizable {
         events2[0] = ActionableEvent("Withdraw", ActionType.Withdraw); // same event name, different source
 
         // then - should succeed
-        rewards.addPositionActivity(activityId2, "Activity 2", 200, address(this), sourceB, events2);
+        rewards.addPositionActivity(activityId2, "Activity 2", 200, sourceB, events2);
 
         // verify both activities exist
-        (string memory name1, , , , , , , ) = rewards.activities(activityId1);
-        (string memory name2, , , , , , , ) = rewards.activities(activityId2);
+        (string memory name1, , , , , , ) = rewards.activities(activityId1);
+        (string memory name2, , , , , , ) = rewards.activities(activityId2);
         require(keccak256(bytes(name1)) == keccak256(bytes("Activity 1")), "Activity 1 should exist");
         require(keccak256(bytes(name2)) == keccak256(bytes("Activity 2")), "Activity 2 should exist");
     }
@@ -222,13 +200,13 @@ contract Describe_Rewards_Management is Authorizable {
         address sourceA = address(user1);
         ActionableEvent[] memory events1 = new ActionableEvent[](1);
         events1[0] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(activityId1, "Activity 1", 100, address(this), sourceA, events1);
+        rewards.addPositionActivity(activityId1, "Activity 1", 100, sourceA, events1);
 
         // given - Activity 2 with same sourceContract 0xaa and event: Deposit
         uint256 activityId2 = 2;
         ActionableEvent[] memory events2 = new ActionableEvent[](1);
         events2[0] = ActionableEvent("Deposit", ActionType.Deposit);
-        rewards.addPositionActivity(activityId2, "Activity 2", 200, address(this), sourceA, events2);
+        rewards.addPositionActivity(activityId2, "Activity 2", 200, sourceA, events2);
 
         // when - try to add Activity 3 with same sourceContract but event: Borrow (non-overlapping)
         uint256 activityId3 = 3;
@@ -236,10 +214,10 @@ contract Describe_Rewards_Management is Authorizable {
         events3[0] = ActionableEvent("Borrow", ActionType.Deposit);
 
         // then - should succeed
-        rewards.addPositionActivity(activityId3, "Activity 3", 300, address(this), sourceA, events3);
+        rewards.addPositionActivity(activityId3, "Activity 3", 300, sourceA, events3);
 
         // verify all three activities exist
-        (string memory name3, , , , , , , ) = rewards.activities(activityId3);
+        (string memory name3, , , , , , ) = rewards.activities(activityId3);
         require(keccak256(bytes(name3)) == keccak256(bytes("Activity 3")), "Activity 3 should exist");
     }
 
@@ -249,13 +227,13 @@ contract Describe_Rewards_Management is Authorizable {
         address sourceA = address(user1);
         ActionableEvent[] memory events1 = new ActionableEvent[](1);
         events1[0] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(activityId1, "Activity 1", 100, address(this), sourceA, events1);
+        rewards.addPositionActivity(activityId1, "Activity 1", 100, sourceA, events1);
 
         // given - Activity 2 with same sourceContract 0xaa and event: Deposit
         uint256 activityId2 = 2;
         ActionableEvent[] memory events2 = new ActionableEvent[](1);
         events2[0] = ActionableEvent("Deposit", ActionType.Deposit);
-        rewards.addPositionActivity(activityId2, "Activity 2", 200, address(this), sourceA, events2);
+        rewards.addPositionActivity(activityId2, "Activity 2", 200, sourceA, events2);
 
         // when/then - try to add Activity 3 with same source and event "Deposit" (conflicts with Activity 2)
         uint256 activityId3 = 3;
@@ -263,7 +241,7 @@ contract Describe_Rewards_Management is Authorizable {
         events3[0] = ActionableEvent("Deposit", ActionType.Deposit); // conflicts with Activity 2
 
         bool reverted = false;
-        try rewards.addPositionActivity(activityId3, "Activity 3", 300, address(this), sourceA, events3) {
+        try rewards.addPositionActivity(activityId3, "Activity 3", 300, sourceA, events3) {
             reverted = false;
         } catch {
             reverted = true;
@@ -275,13 +253,13 @@ contract Describe_Rewards_Management is Authorizable {
         // given - OneTime activity with sourceContract 0xaa and event: Swap
         uint256 activityId1 = 1;
         address sourceA = address(user1);
-        rewards.addOneTimeActivity(activityId1, "Swap Activity", 100, address(this), sourceA, "Swap");
+        rewards.addOneTimeActivity(activityId1, "Swap Activity", 100, sourceA, "Swap");
 
         // when/then - try to add another OneTime activity with same source and event "Swap"
         uint256 activityId2 = 2;
 
         bool reverted = false;
-        try rewards.addOneTimeActivity(activityId2, "Another Swap", 200, address(this), sourceA, "Swap") {
+        try rewards.addOneTimeActivity(activityId2, "Another Swap", 200, sourceA, "Swap") {
             reverted = false;
         } catch {
             reverted = true;
@@ -292,11 +270,11 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_duplicate_activity() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
 
         // when/then - try to add activity with same ID
         bool reverted = false;
-        try rewards.addPositionActivity(activityId, "Activity 2", 200, address(user2), address(user2), _defaultPositionEvents()) {
+        try rewards.addPositionActivity(activityId, "Activity 2", 200, address(user2), _defaultPositionEvents()) {
             reverted = false;
         } catch {
             reverted = true;
@@ -314,13 +292,13 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 emission3 = 300;
 
         // when - using unique events for same source contract
-        rewards.addPositionActivity(activity1, "Activity 1", emission1, address(user1), address(user1), _eventsA1());
+        rewards.addPositionActivity(activity1, "Activity 1", emission1, address(user1), _eventsA1());
         require(rewards.totalRewardsEmission() == emission1, "Total emission after 1st activity");
 
-        rewards.addPositionActivity(activity2, "Activity 2", emission2, address(user1), address(user1), _eventsA2());
+        rewards.addPositionActivity(activity2, "Activity 2", emission2, address(user1), _eventsA2());
         require(rewards.totalRewardsEmission() == emission1 + emission2, "Total emission after 2nd activity");
 
-        rewards.addPositionActivity(activity3, "Activity 3", emission3, address(user1), address(user1), _eventsA3());
+        rewards.addPositionActivity(activity3, "Activity 3", emission3, address(user1), _eventsA3());
         require(rewards.totalRewardsEmission() == emission1 + emission2 + emission3, "Total emission after 3rd activity");
     }
 
@@ -334,14 +312,14 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 initialEmission = 100;
         uint256 newEmission = 200;
 
-        rewards.addPositionActivity(activityId, "Activity 1", initialEmission, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, "Activity 1", initialEmission, address(user1), _defaultPositionEvents());
         require(rewards.totalRewardsEmission() == initialEmission, "Initial total emission");
 
         // when
         rewards.setEmissionRate(activityId, newEmission);
 
         // then
-        (string memory name, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address caller, address source) =
+        (string memory name, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address source) =
             rewards.activities(activityId);
         require(rate == newEmission, "Emission rate should be updated");
         require(rewards.totalRewardsEmission() == newEmission, "Total emission should be updated");
@@ -365,9 +343,9 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 activity1 = 1;
         uint256 activity2 = 2;
         uint256 activity3 = 3;
-        rewards.addPositionActivity(activity1, "Activity 1", 100, address(user1), address(user1), _eventsA1());
-        rewards.addPositionActivity(activity2, "Activity 2", 200, address(user1), address(user1), _eventsA2());
-        rewards.addPositionActivity(activity3, "Activity 3", 300, address(user1), address(user1), _eventsA3());
+        rewards.addPositionActivity(activity1, "Activity 1", 100, address(user1), _eventsA1());
+        rewards.addPositionActivity(activity2, "Activity 2", 200, address(user1), _eventsA2());
+        rewards.addPositionActivity(activity3, "Activity 3", 300, address(user1), _eventsA3());
 
         require(rewards.totalRewardsEmission() == 600, "Initial total emission");
 
@@ -387,65 +365,16 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_allow_setting_emission_rate_to_zero() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
 
         // when
         rewards.setEmissionRate(activityId, 0);
 
         // then
-        (string memory name, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address caller, address source) =
+        (string memory name, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address source) =
             rewards.activities(activityId);
         require(rate == 0, "Emission rate should be 0");
         require(rewards.totalRewardsEmission() == 0, "Total emission should be 0");
-    }
-
-    // ═════════════════════════════════════════════════════════════════════════
-    // ALLOWED CALLER UPDATES
-    // ═════════════════════════════════════════════════════════════════════════
-
-    function it_should_allow_updating_allowed_caller() {
-        // given
-        uint256 activityId = 1;
-        address initialCaller = address(user1);
-        address newCaller = address(user2);
-
-        rewards.addPositionActivity(activityId, "Activity 1", 100, initialCaller, initialCaller, _defaultPositionEvents());
-
-        // when
-        rewards.setAllowedCaller(activityId, newCaller);
-
-        // then
-        (string memory name, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address caller, address source) =
-            rewards.activities(activityId);
-        require(caller == newCaller, "Allowed caller should be updated");
-    }
-
-    function it_should_prevent_updating_allowed_caller_on_nonexistent_activity() {
-        // given - no activity exists with id 999
-
-        // when/then
-        bool reverted = false;
-        try rewards.setAllowedCaller(999, address(user1)) {
-            reverted = false;
-        } catch {
-            reverted = true;
-        }
-        require(reverted, "Updating allowed caller on nonexistent activity should revert");
-    }
-
-    function it_should_prevent_setting_allowed_caller_to_zero_address() {
-        // given
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
-
-        // when/then
-        bool reverted = false;
-        try rewards.setAllowedCaller(activityId, address(0)) {
-            reverted = false;
-        } catch {
-            reverted = true;
-        }
-        require(reverted, "Setting allowed caller to zero address should revert");
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -458,13 +387,13 @@ contract Describe_Rewards_Management is Authorizable {
         address initialSource = address(user1);
         address newSource = address(user2);
 
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), initialSource, _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, "Activity 1", 100, initialSource, _defaultPositionEvents());
 
         // when
         rewards.setSourceContract(activityId, newSource);
 
         // then
-        (string memory name, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address caller, address source) =
+        (string memory name, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address source) =
             rewards.activities(activityId);
         require(source == newSource, "Source contract should be updated");
     }
@@ -485,7 +414,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_setting_source_contract_to_zero_address() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
 
         // when/then
         bool reverted = false;
@@ -504,7 +433,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_fail_on_unknown_event_for_source() {
         // given - add a OneTime activity with "Swap" event
         uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this), "Swap");
+        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), "Swap");
 
         // when/then - try to use an event name that doesn't exist for this source
         bool reverted = false;
@@ -519,7 +448,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_allow_valid_event_on_onetime_activity() {
         // given - add a OneTime activity with "Swap" event
         uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this), "Swap");
+        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), "Swap");
 
         // when - use the registered "Swap" event
         rewards.handleAction(Action(address(this), "Swap", address(user1), 100, testBlockNumber, 0));
@@ -532,7 +461,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_allow_deposit_on_position_activity() {
         // given - add a Position activity with Deposit/Withdraw events
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), address(this), _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), _defaultPositionEvents());
 
         // when - use the registered "Deposit" event
         rewards.handleAction(Action(address(this), "Deposit", address(user1), 100, testBlockNumber, 0));
@@ -545,7 +474,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_allow_withdraw_on_position_activity() {
         // given - add a Position activity with Deposit/Withdraw events
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), address(this), _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), _defaultPositionEvents());
 
         // given - first deposit
         rewards.handleAction(Action(address(this), "Deposit", address(user1), 100, testBlockNumber, 0));
@@ -565,7 +494,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_non_owner_from_updating_emission_rate() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
 
         // when - user1 tries to update emission rate
         bool reverted = false;
@@ -580,22 +509,22 @@ contract Describe_Rewards_Management is Authorizable {
         require(reverted, "Non-owner should not be able to update emission rate");
     }
 
-    function it_should_prevent_non_owner_from_updating_allowed_caller() {
+    function it_should_prevent_non_owner_from_calling_handleAction() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
 
-        // when - user1 tries to update allowed caller
+        // when - user1 (non-owner) tries to call handleAction
         bool reverted = false;
-        try TestUtils.callAs(user1, address(rewards), "setAllowedCaller(uint256, address)",
-            activityId, address(user2)) {
+        try TestUtils.callAs(user1, address(rewards), "handleAction((address,string,address,uint256,uint256,uint256))",
+            address(user1), "Deposit", address(user2), 100, testBlockNumber, 0) {
             reverted = false;
         } catch {
             reverted = true;
         }
 
         // then
-        require(reverted, "Non-owner should not be able to update allowed caller");
+        require(reverted, "Non-owner should not be able to call handleAction");
     }
 
 }

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -89,15 +89,15 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_adding_new_activity() {
         // given
-        uint256 activityId = 1;
         string memory name = "SwapPool-USDST/ETHST";
         uint256 emissionRate = 100;
         address sourceContract = address(user1);
 
         // when
-        rewards.addPositionActivity(activityId, name, emissionRate, sourceContract, _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity(name, emissionRate, sourceContract, _defaultPositionEvents());
 
         // then
+        require(activityId == 1, "First activity ID should be 1");
         (string memory activityName, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address source) =
             rewards.activities(activityId);
 
@@ -114,14 +114,13 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_adding_activity_with_empty_name() {
         // given
-        uint256 activityId = 1;
         string memory name = "";
         uint256 emissionRate = 100;
         address sourceContract = address(user1);
 
         // when/then
         bool reverted = false;
-        try rewards.addPositionActivity(activityId, name, emissionRate, sourceContract, _defaultPositionEvents()) {
+        try rewards.addPositionActivity(name, emissionRate, sourceContract, _defaultPositionEvents()) {
             reverted = false;
         } catch {
             reverted = true;
@@ -131,7 +130,6 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_adding_position_activity_with_empty_events() {
         // given
-        uint256 activityId = 1;
         string memory name = "SwapPool";
         uint256 emissionRate = 100;
         address sourceContract = address(user1);
@@ -139,7 +137,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then
         bool reverted = false;
-        try rewards.addPositionActivity(activityId, name, emissionRate, sourceContract, emptyEvents) {
+        try rewards.addPositionActivity(name, emissionRate, sourceContract, emptyEvents) {
             reverted = false;
         } catch {
             reverted = true;
@@ -149,20 +147,18 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_adding_activity_with_duplicate_event_for_same_source() {
         // given - Activity 1 with sourceContract 0xaa and events: Deposit, Withdraw
-        uint256 activityId1 = 1;
         address sourceA = address(user1);
         ActionableEvent[] memory events1 = new ActionableEvent[](2);
         events1[0] = ActionableEvent("Deposit", ActionType.Deposit);
         events1[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(activityId1, "Activity 1", 100, sourceA, events1);
+        rewards.addPositionActivity("Activity 1", 100, sourceA, events1);
 
         // when/then - try to add Activity 2 with same sourceContract and event "Deposit"
-        uint256 activityId2 = 2;
         ActionableEvent[] memory events2 = new ActionableEvent[](1);
         events2[0] = ActionableEvent("Deposit", ActionType.Deposit); // duplicate event name
 
         bool reverted = false;
-        try rewards.addPositionActivity(activityId2, "Activity 2", 200, sourceA, events2) {
+        try rewards.addPositionActivity("Activity 2", 200, sourceA, events2) {
             reverted = false;
         } catch {
             reverted = true;
@@ -172,20 +168,18 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_same_event_name_for_different_source_contracts() {
         // given - Activity 1 with sourceContract 0xaa and event: Withdraw
-        uint256 activityId1 = 1;
         address sourceA = address(user1);
         ActionableEvent[] memory events1 = new ActionableEvent[](1);
         events1[0] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(activityId1, "Activity 1", 100, sourceA, events1);
+        uint256 activityId1 = rewards.addPositionActivity("Activity 1", 100, sourceA, events1);
 
         // when - add Activity 2 with different sourceContract 0xbb but same event "Withdraw"
-        uint256 activityId2 = 2;
         address sourceB = address(user2);
         ActionableEvent[] memory events2 = new ActionableEvent[](1);
         events2[0] = ActionableEvent("Withdraw", ActionType.Withdraw); // same event name, different source
 
         // then - should succeed
-        rewards.addPositionActivity(activityId2, "Activity 2", 200, sourceB, events2);
+        uint256 activityId2 = rewards.addPositionActivity("Activity 2", 200, sourceB, events2);
 
         // verify both activities exist
         (string memory name1, , , , , , ) = rewards.activities(activityId1);
@@ -196,25 +190,22 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_non_overlapping_events_for_same_source() {
         // given - Activity 1 with sourceContract 0xaa and event: Withdraw
-        uint256 activityId1 = 1;
         address sourceA = address(user1);
         ActionableEvent[] memory events1 = new ActionableEvent[](1);
         events1[0] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(activityId1, "Activity 1", 100, sourceA, events1);
+        rewards.addPositionActivity("Activity 1", 100, sourceA, events1);
 
         // given - Activity 2 with same sourceContract 0xaa and event: Deposit
-        uint256 activityId2 = 2;
         ActionableEvent[] memory events2 = new ActionableEvent[](1);
         events2[0] = ActionableEvent("Deposit", ActionType.Deposit);
-        rewards.addPositionActivity(activityId2, "Activity 2", 200, sourceA, events2);
+        rewards.addPositionActivity("Activity 2", 200, sourceA, events2);
 
         // when - try to add Activity 3 with same sourceContract but event: Borrow (non-overlapping)
-        uint256 activityId3 = 3;
         ActionableEvent[] memory events3 = new ActionableEvent[](1);
         events3[0] = ActionableEvent("Borrow", ActionType.Deposit);
 
         // then - should succeed
-        rewards.addPositionActivity(activityId3, "Activity 3", 300, sourceA, events3);
+        uint256 activityId3 = rewards.addPositionActivity("Activity 3", 300, sourceA, events3);
 
         // verify all three activities exist
         (string memory name3, , , , , , ) = rewards.activities(activityId3);
@@ -223,25 +214,22 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_duplicate_event_across_multiple_existing_activities() {
         // given - Activity 1 with sourceContract 0xaa and event: Withdraw
-        uint256 activityId1 = 1;
         address sourceA = address(user1);
         ActionableEvent[] memory events1 = new ActionableEvent[](1);
         events1[0] = ActionableEvent("Withdraw", ActionType.Withdraw);
-        rewards.addPositionActivity(activityId1, "Activity 1", 100, sourceA, events1);
+        rewards.addPositionActivity("Activity 1", 100, sourceA, events1);
 
         // given - Activity 2 with same sourceContract 0xaa and event: Deposit
-        uint256 activityId2 = 2;
         ActionableEvent[] memory events2 = new ActionableEvent[](1);
         events2[0] = ActionableEvent("Deposit", ActionType.Deposit);
-        rewards.addPositionActivity(activityId2, "Activity 2", 200, sourceA, events2);
+        rewards.addPositionActivity("Activity 2", 200, sourceA, events2);
 
         // when/then - try to add Activity 3 with same source and event "Deposit" (conflicts with Activity 2)
-        uint256 activityId3 = 3;
         ActionableEvent[] memory events3 = new ActionableEvent[](1);
         events3[0] = ActionableEvent("Deposit", ActionType.Deposit); // conflicts with Activity 2
 
         bool reverted = false;
-        try rewards.addPositionActivity(activityId3, "Activity 3", 300, sourceA, events3) {
+        try rewards.addPositionActivity("Activity 3", 300, sourceA, events3) {
             reverted = false;
         } catch {
             reverted = true;
@@ -251,15 +239,12 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_duplicate_event_for_onetime_activity() {
         // given - OneTime activity with sourceContract 0xaa and event: Swap
-        uint256 activityId1 = 1;
         address sourceA = address(user1);
-        rewards.addOneTimeActivity(activityId1, "Swap Activity", 100, sourceA, "Swap");
+        rewards.addOneTimeActivity("Swap Activity", 100, sourceA, "Swap");
 
         // when/then - try to add another OneTime activity with same source and event "Swap"
-        uint256 activityId2 = 2;
-
         bool reverted = false;
-        try rewards.addOneTimeActivity(activityId2, "Another Swap", 200, sourceA, "Swap") {
+        try rewards.addOneTimeActivity("Another Swap", 200, sourceA, "Swap") {
             reverted = false;
         } catch {
             reverted = true;
@@ -267,38 +252,20 @@ contract Describe_Rewards_Management is Authorizable {
         require(reverted, "Should prevent duplicate event name for OneTime activities with same source");
     }
 
-    function it_should_prevent_duplicate_activity() {
-        // given
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
-
-        // when/then - try to add activity with same ID
-        bool reverted = false;
-        try rewards.addPositionActivity(activityId, "Activity 2", 200, address(user2), _defaultPositionEvents()) {
-            reverted = false;
-        } catch {
-            reverted = true;
-        }
-        require(reverted, "Adding duplicate activity should revert");
-    }
-
     function it_should_track_total_emission_when_adding_multiple_activities() {
         // given
-        uint256 activity1 = 1;
-        uint256 activity2 = 2;
-        uint256 activity3 = 3;
         uint256 emission1 = 100;
         uint256 emission2 = 200;
         uint256 emission3 = 300;
 
         // when - using unique events for same source contract
-        rewards.addPositionActivity(activity1, "Activity 1", emission1, address(user1), _eventsA1());
+        rewards.addPositionActivity("Activity 1", emission1, address(user1), _eventsA1());
         require(rewards.totalRewardsEmission() == emission1, "Total emission after 1st activity");
 
-        rewards.addPositionActivity(activity2, "Activity 2", emission2, address(user1), _eventsA2());
+        rewards.addPositionActivity("Activity 2", emission2, address(user1), _eventsA2());
         require(rewards.totalRewardsEmission() == emission1 + emission2, "Total emission after 2nd activity");
 
-        rewards.addPositionActivity(activity3, "Activity 3", emission3, address(user1), _eventsA3());
+        rewards.addPositionActivity("Activity 3", emission3, address(user1), _eventsA3());
         require(rewards.totalRewardsEmission() == emission1 + emission2 + emission3, "Total emission after 3rd activity");
     }
 
@@ -308,11 +275,10 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_updating_emission_rate() {
         // given
-        uint256 activityId = 1;
         uint256 initialEmission = 100;
         uint256 newEmission = 200;
 
-        rewards.addPositionActivity(activityId, "Activity 1", initialEmission, address(user1), _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity("Activity 1", initialEmission, address(user1), _defaultPositionEvents());
         require(rewards.totalRewardsEmission() == initialEmission, "Initial total emission");
 
         // when
@@ -340,12 +306,9 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_maintain_correct_total_emission_when_updating_rates() {
         // given - add three activities with unique events for same source
-        uint256 activity1 = 1;
-        uint256 activity2 = 2;
-        uint256 activity3 = 3;
-        rewards.addPositionActivity(activity1, "Activity 1", 100, address(user1), _eventsA1());
-        rewards.addPositionActivity(activity2, "Activity 2", 200, address(user1), _eventsA2());
-        rewards.addPositionActivity(activity3, "Activity 3", 300, address(user1), _eventsA3());
+        uint256 activity1 = rewards.addPositionActivity("Activity 1", 100, address(user1), _eventsA1());
+        uint256 activity2 = rewards.addPositionActivity("Activity 2", 200, address(user1), _eventsA2());
+        uint256 activity3 = rewards.addPositionActivity("Activity 3", 300, address(user1), _eventsA3());
 
         require(rewards.totalRewardsEmission() == 600, "Initial total emission");
 
@@ -364,8 +327,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_setting_emission_rate_to_zero() {
         // given
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity("Activity 1", 100, address(user1), _defaultPositionEvents());
 
         // when
         rewards.setEmissionRate(activityId, 0);
@@ -383,11 +345,10 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_updating_source_contract() {
         // given
-        uint256 activityId = 1;
         address initialSource = address(user1);
         address newSource = address(user2);
 
-        rewards.addPositionActivity(activityId, "Activity 1", 100, initialSource, _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity("Activity 1", 100, initialSource, _defaultPositionEvents());
 
         // when
         rewards.setSourceContract(activityId, newSource);
@@ -413,8 +374,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_setting_source_contract_to_zero_address() {
         // given
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity("Activity 1", 100, address(user1), _defaultPositionEvents());
 
         // when/then
         bool reverted = false;
@@ -432,8 +392,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_fail_on_unknown_event_for_source() {
         // given - add a OneTime activity with "Swap" event
-        uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), "Swap");
+        rewards.addOneTimeActivity("Swap Activity", 100, address(this), "Swap");
 
         // when/then - try to use an event name that doesn't exist for this source
         bool reverted = false;
@@ -447,8 +406,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_valid_event_on_onetime_activity() {
         // given - add a OneTime activity with "Swap" event
-        uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), "Swap");
+        uint256 activityId = rewards.addOneTimeActivity("Swap Activity", 100, address(this), "Swap");
 
         // when - use the registered "Swap" event
         rewards.handleAction(Action(address(this), "Swap", address(user1), 100, testBlockNumber, 0));
@@ -460,8 +418,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_deposit_on_position_activity() {
         // given - add a Position activity with Deposit/Withdraw events
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity("Liquidity Pool", 100, address(this), _defaultPositionEvents());
 
         // when - use the registered "Deposit" event
         rewards.handleAction(Action(address(this), "Deposit", address(user1), 100, testBlockNumber, 0));
@@ -473,8 +430,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_withdraw_on_position_activity() {
         // given - add a Position activity with Deposit/Withdraw events
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity("Liquidity Pool", 100, address(this), _defaultPositionEvents());
 
         // given - first deposit
         rewards.handleAction(Action(address(this), "Deposit", address(user1), 100, testBlockNumber, 0));
@@ -493,8 +449,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_non_owner_from_updating_emission_rate() {
         // given
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity("Activity 1", 100, address(user1), _defaultPositionEvents());
 
         // when - user1 tries to update emission rate
         bool reverted = false;
@@ -511,8 +466,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_non_owner_from_calling_handleAction() {
         // given
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity("Activity 1", 100, address(user1), _defaultPositionEvents());
 
         // when - user1 (non-owner) tries to call handleAction
         bool reverted = false;
@@ -533,10 +487,9 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_change_position_activity_events_and_ignore_old_events() {
         // given - create activity with event "EventA"
-        uint256 activityId = 1;
         ActionableEvent[] memory eventsA = new ActionableEvent[](1);
         eventsA[0] = ActionableEvent("EventA", ActionType.Deposit);
-        rewards.addPositionActivity(activityId, "Test Activity", 100, address(this), eventsA);
+        uint256 activityId = rewards.addPositionActivity("Test Activity", 100, address(this), eventsA);
 
         // when - run action with EventA
         rewards.handleAction(Action(address(this), "EventA", address(user1), 100, testBlockNumber, 0));
@@ -590,8 +543,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_setting_events_on_onetime_activity() {
         // given - create a OneTime activity
-        uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "OneTime Activity", 100, address(this), "Swap");
+        uint256 activityId = rewards.addOneTimeActivity("OneTime Activity", 100, address(this), "Swap");
 
         // when/then - try to use setPositionActivityEvents on OneTime activity
         ActionableEvent[] memory events = new ActionableEvent[](1);
@@ -608,8 +560,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_setting_empty_events_on_position_activity() {
         // given - create a Position activity
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Test Activity", 100, address(this), _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity("Test Activity", 100, address(this), _defaultPositionEvents());
 
         // when/then - try to set empty events
         ActionableEvent[] memory emptyEvents = new ActionableEvent[](0);
@@ -625,11 +576,10 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_allow_keeping_same_event_when_updating_position_activity() {
         // given - create activity with EventA and EventB
-        uint256 activityId = 1;
         ActionableEvent[] memory initialEvents = new ActionableEvent[](2);
         initialEvents[0] = ActionableEvent("EventA", ActionType.Deposit);
         initialEvents[1] = ActionableEvent("EventB", ActionType.Withdraw);
-        rewards.addPositionActivity(activityId, "Test Activity", 100, address(this), initialEvents);
+        uint256 activityId = rewards.addPositionActivity("Test Activity", 100, address(this), initialEvents);
 
         // when - update to keep EventA but change EventB to EventC
         ActionableEvent[] memory newEvents = new ActionableEvent[](2);
@@ -650,8 +600,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_change_onetime_activity_event_and_ignore_old_event() {
         // given - create OneTime activity with event "EventA"
-        uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Test OneTime", 100, address(this), "EventA");
+        uint256 activityId = rewards.addOneTimeActivity("Test OneTime", 100, address(this), "EventA");
 
         // when - run action with EventA
         rewards.handleAction(Action(address(this), "EventA", address(user1), 100, testBlockNumber, 0));
@@ -701,8 +650,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_setting_event_on_position_activity() {
         // given - create a Position activity
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Position Activity", 100, address(this), _defaultPositionEvents());
+        uint256 activityId = rewards.addPositionActivity("Position Activity", 100, address(this), _defaultPositionEvents());
 
         // when/then - try to use setOneTimeActivityEvent on Position activity
         bool reverted = false;
@@ -716,8 +664,7 @@ contract Describe_Rewards_Management is Authorizable {
 
     function it_should_prevent_setting_empty_event_name_on_onetime_activity() {
         // given - create a OneTime activity
-        uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Test OneTime", 100, address(this), "Swap");
+        uint256 activityId = rewards.addOneTimeActivity("Test OneTime", 100, address(this), "Swap");
 
         // when/then - try to set empty event name
         bool reverted = false;

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -47,6 +47,14 @@ contract Describe_Rewards_Management is Authorizable {
         rewards.initialize(tokenAddress);
     }
 
+    // Helper to create default position events
+    function _defaultPositionEvents() internal pure returns (ActionableEvent[] memory) {
+        ActionableEvent[] memory events = new ActionableEvent[](2);
+        events[0] = ActionableEvent("Deposit", ActionType.Deposit);
+        events[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
+        return events;
+    }
+
     // ═════════════════════════════════════════════════════════════════════════
     // ACTIVITY MANAGEMENT
     // ═════════════════════════════════════════════════════════════════════════
@@ -66,7 +74,7 @@ contract Describe_Rewards_Management is Authorizable {
         address sourceContract = address(user1);
 
         // when
-        rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract);
+        rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract, _defaultPositionEvents());
 
         // then
         (string memory activityName, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address caller, address source) =
@@ -94,7 +102,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then
         bool reverted = false;
-        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract) {
+        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract, _defaultPositionEvents()) {
             reverted = false;
         } catch {
             reverted = true;
@@ -112,7 +120,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then
         bool reverted = false;
-        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract) {
+        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract, _defaultPositionEvents()) {
             reverted = false;
         } catch {
             reverted = true;
@@ -120,14 +128,33 @@ contract Describe_Rewards_Management is Authorizable {
         require(reverted, "Adding activity with empty name should revert");
     }
 
+    function it_should_prevent_adding_position_activity_with_empty_events() {
+        // given
+        uint256 activityId = 1;
+        string memory name = "SwapPool";
+        uint256 emissionRate = 100;
+        address allowedCaller = address(user1);
+        address sourceContract = address(user1);
+        ActionableEvent[] memory emptyEvents = new ActionableEvent[](0);
+
+        // when/then
+        bool reverted = false;
+        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract, emptyEvents) {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Adding position activity with empty events should revert");
+    }
+
     function it_should_prevent_adding_duplicate_activity() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
 
         // when/then - try to add activity with same ID
         bool reverted = false;
-        try rewards.addPositionActivity(activityId, "Activity 2", 200, address(user2), address(user2)) {
+        try rewards.addPositionActivity(activityId, "Activity 2", 200, address(user2), address(user2), _defaultPositionEvents()) {
             reverted = false;
         } catch {
             reverted = true;
@@ -145,13 +172,13 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 emission3 = 300;
 
         // when
-        rewards.addPositionActivity(activity1, "Activity 1", emission1, address(user1), address(user1));
+        rewards.addPositionActivity(activity1, "Activity 1", emission1, address(user1), address(user1), _defaultPositionEvents());
         require(rewards.totalRewardsEmission() == emission1, "Total emission after 1st activity");
 
-        rewards.addPositionActivity(activity2, "Activity 2", emission2, address(user1), address(user1));
+        rewards.addPositionActivity(activity2, "Activity 2", emission2, address(user1), address(user1), _defaultPositionEvents());
         require(rewards.totalRewardsEmission() == emission1 + emission2, "Total emission after 2nd activity");
 
-        rewards.addPositionActivity(activity3, "Activity 3", emission3, address(user1), address(user1));
+        rewards.addPositionActivity(activity3, "Activity 3", emission3, address(user1), address(user1), _defaultPositionEvents());
         require(rewards.totalRewardsEmission() == emission1 + emission2 + emission3, "Total emission after 3rd activity");
     }
 
@@ -165,7 +192,7 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 initialEmission = 100;
         uint256 newEmission = 200;
 
-        rewards.addPositionActivity(activityId, "Activity 1", initialEmission, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", initialEmission, address(user1), address(user1), _defaultPositionEvents());
         require(rewards.totalRewardsEmission() == initialEmission, "Initial total emission");
 
         // when
@@ -196,9 +223,9 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 activity1 = 1;
         uint256 activity2 = 2;
         uint256 activity3 = 3;
-        rewards.addPositionActivity(activity1, "Activity 1", 100, address(user1), address(user1));
-        rewards.addPositionActivity(activity2, "Activity 2", 200, address(user1), address(user1));
-        rewards.addPositionActivity(activity3, "Activity 3", 300, address(user1), address(user1));
+        rewards.addPositionActivity(activity1, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activity2, "Activity 2", 200, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activity3, "Activity 3", 300, address(user1), address(user1), _defaultPositionEvents());
 
         require(rewards.totalRewardsEmission() == 600, "Initial total emission");
 
@@ -218,7 +245,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_allow_setting_emission_rate_to_zero() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
 
         // when
         rewards.setEmissionRate(activityId, 0);
@@ -240,7 +267,7 @@ contract Describe_Rewards_Management is Authorizable {
         address initialCaller = address(user1);
         address newCaller = address(user2);
 
-        rewards.addPositionActivity(activityId, "Activity 1", 100, initialCaller, initialCaller);
+        rewards.addPositionActivity(activityId, "Activity 1", 100, initialCaller, initialCaller, _defaultPositionEvents());
 
         // when
         rewards.setAllowedCaller(activityId, newCaller);
@@ -267,7 +294,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_setting_allowed_caller_to_zero_address() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
 
         // when/then
         bool reverted = false;
@@ -289,7 +316,7 @@ contract Describe_Rewards_Management is Authorizable {
         address initialSource = address(user1);
         address newSource = address(user2);
 
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), initialSource);
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), initialSource, _defaultPositionEvents());
 
         // when
         rewards.setSourceContract(activityId, newSource);
@@ -316,7 +343,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_setting_source_contract_to_zero_address() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
 
         // when/then
         bool reverted = false;
@@ -335,7 +362,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_deposit_on_onetime_activity() {
         // given - add a OneTime activity
         uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this));
+        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this), "Swap");
 
         // when/then - try to deposit on OneTime activity
         bool reverted = false;
@@ -350,7 +377,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_withdraw_on_onetime_activity() {
         // given - add a OneTime activity
         uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this));
+        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this), "Swap");
 
         // when/then - try to withdraw on OneTime activity
         bool reverted = false;
@@ -365,7 +392,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_occurred_on_position_activity() {
         // given - add a Position activity
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), address(this));
+        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), address(this), _defaultPositionEvents());
 
         // when/then - try to call occurred on Position activity
         bool reverted = false;
@@ -380,7 +407,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_allow_occurred_on_onetime_activity() {
         // given - add a OneTime activity
         uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this));
+        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this), "Swap");
 
         // when - call occurred
         rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Occurred, testBlockNumber, 0));
@@ -394,27 +421,10 @@ contract Describe_Rewards_Management is Authorizable {
     // OWNERSHIP & AUTHORIZATION
     // ═════════════════════════════════════════════════════════════════════════
 
-    function it_should_prevent_non_owner_from_adding_activity() {
-        // given
-        uint256 activityId = 1;
-
-        // when - user1 tries to add activity
-        bool reverted = false;
-        try TestUtils.callAs(user1, address(rewards), "addPositionActivity(uint256, string, uint256, address, address)",
-            activityId, "Activity 1", 100, address(user1), address(user1)) {
-            reverted = false;
-        } catch {
-            reverted = true;
-        }
-
-        // then
-        require(reverted, "Non-owner should not be able to add activity");
-    }
-
     function it_should_prevent_non_owner_from_updating_emission_rate() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
 
         // when - user1 tries to update emission rate
         bool reverted = false;
@@ -432,7 +442,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_non_owner_from_updating_allowed_caller() {
         // given
         uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
 
         // when - user1 tries to update allowed caller
         bool reverted = false;

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -454,7 +454,7 @@ contract Describe_Rewards_Management is Authorizable {
         rewards.handleAction(Action(address(this), "Swap", address(user1), 100, testBlockNumber, 0));
 
         // then - check user stake increased
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), activityId);
         require(stake == 100, "User stake should be 100");
     }
 
@@ -467,7 +467,7 @@ contract Describe_Rewards_Management is Authorizable {
         rewards.handleAction(Action(address(this), "Deposit", address(user1), 100, testBlockNumber, 0));
 
         // then - check user stake increased
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), activityId);
         require(stake == 100, "User stake should be 100");
     }
 
@@ -483,7 +483,7 @@ contract Describe_Rewards_Management is Authorizable {
         rewards.handleAction(Action(address(this), "Withdraw", address(user1), 50, testBlockNumber, 1));
 
         // then - check user stake decreased
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), activityId);
         require(stake == 50, "User stake should be 50 after withdrawal");
     }
 

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -66,7 +66,7 @@ contract Describe_Rewards_Management is Authorizable {
         address sourceContract = address(user1);
 
         // when
-        rewards.addActivity(activityId, name, ActivityType.Position, emissionRate, allowedCaller, sourceContract);
+        rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract);
 
         // then
         (string memory activityName, ActivityType activityType, uint256 rate, uint256 accReward, uint256 lastUpdate, uint256 totalStake, address caller, address source) =
@@ -94,7 +94,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then
         bool reverted = false;
-        try rewards.addActivity(activityId, name, ActivityType.Position, emissionRate, allowedCaller, sourceContract) {
+        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract) {
             reverted = false;
         } catch {
             reverted = true;
@@ -112,7 +112,7 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when/then
         bool reverted = false;
-        try rewards.addActivity(activityId, name, ActivityType.Position, emissionRate, allowedCaller, sourceContract) {
+        try rewards.addPositionActivity(activityId, name, emissionRate, allowedCaller, sourceContract) {
             reverted = false;
         } catch {
             reverted = true;
@@ -123,11 +123,11 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_adding_duplicate_activity() {
         // given
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Activity 1", ActivityType.Position, 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
 
         // when/then - try to add activity with same ID
         bool reverted = false;
-        try rewards.addActivity(activityId, "Activity 2", ActivityType.Position, 200, address(user2), address(user2)) {
+        try rewards.addPositionActivity(activityId, "Activity 2", 200, address(user2), address(user2)) {
             reverted = false;
         } catch {
             reverted = true;
@@ -145,13 +145,13 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 emission3 = 300;
 
         // when
-        rewards.addActivity(activity1, "Activity 1", ActivityType.Position, emission1, address(user1), address(user1));
+        rewards.addPositionActivity(activity1, "Activity 1", emission1, address(user1), address(user1));
         require(rewards.totalRewardsEmission() == emission1, "Total emission after 1st activity");
 
-        rewards.addActivity(activity2, "Activity 2", ActivityType.Position, emission2, address(user1), address(user1));
+        rewards.addPositionActivity(activity2, "Activity 2", emission2, address(user1), address(user1));
         require(rewards.totalRewardsEmission() == emission1 + emission2, "Total emission after 2nd activity");
 
-        rewards.addActivity(activity3, "Activity 3", ActivityType.Position, emission3, address(user1), address(user1));
+        rewards.addPositionActivity(activity3, "Activity 3", emission3, address(user1), address(user1));
         require(rewards.totalRewardsEmission() == emission1 + emission2 + emission3, "Total emission after 3rd activity");
     }
 
@@ -165,7 +165,7 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 initialEmission = 100;
         uint256 newEmission = 200;
 
-        rewards.addActivity(activityId, "Activity 1", ActivityType.Position, initialEmission, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", initialEmission, address(user1), address(user1));
         require(rewards.totalRewardsEmission() == initialEmission, "Initial total emission");
 
         // when
@@ -196,9 +196,9 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 activity1 = 1;
         uint256 activity2 = 2;
         uint256 activity3 = 3;
-        rewards.addActivity(activity1, "Activity 1", ActivityType.Position, 100, address(user1), address(user1));
-        rewards.addActivity(activity2, "Activity 2", ActivityType.Position, 200, address(user1), address(user1));
-        rewards.addActivity(activity3, "Activity 3", ActivityType.Position, 300, address(user1), address(user1));
+        rewards.addPositionActivity(activity1, "Activity 1", 100, address(user1), address(user1));
+        rewards.addPositionActivity(activity2, "Activity 2", 200, address(user1), address(user1));
+        rewards.addPositionActivity(activity3, "Activity 3", 300, address(user1), address(user1));
 
         require(rewards.totalRewardsEmission() == 600, "Initial total emission");
 
@@ -218,7 +218,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_allow_setting_emission_rate_to_zero() {
         // given
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Activity 1", ActivityType.Position, 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
 
         // when
         rewards.setEmissionRate(activityId, 0);
@@ -240,7 +240,7 @@ contract Describe_Rewards_Management is Authorizable {
         address initialCaller = address(user1);
         address newCaller = address(user2);
 
-        rewards.addActivity(activityId, "Activity 1", ActivityType.Position, 100, initialCaller, initialCaller);
+        rewards.addPositionActivity(activityId, "Activity 1", 100, initialCaller, initialCaller);
 
         // when
         rewards.setAllowedCaller(activityId, newCaller);
@@ -267,7 +267,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_setting_allowed_caller_to_zero_address() {
         // given
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Activity 1", ActivityType.Position, 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
 
         // when/then
         bool reverted = false;
@@ -289,7 +289,7 @@ contract Describe_Rewards_Management is Authorizable {
         address initialSource = address(user1);
         address newSource = address(user2);
 
-        rewards.addActivity(activityId, "Activity 1", ActivityType.Position, 100, address(user1), initialSource);
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), initialSource);
 
         // when
         rewards.setSourceContract(activityId, newSource);
@@ -316,7 +316,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_setting_source_contract_to_zero_address() {
         // given
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Activity 1", ActivityType.Position, 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
 
         // when/then
         bool reverted = false;
@@ -335,7 +335,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_deposit_on_onetime_activity() {
         // given - add a OneTime activity
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Swap Activity", ActivityType.OneTime, 100, address(this), address(this));
+        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this));
 
         // when/then - try to deposit on OneTime activity
         bool reverted = false;
@@ -350,7 +350,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_withdraw_on_onetime_activity() {
         // given - add a OneTime activity
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Swap Activity", ActivityType.OneTime, 100, address(this), address(this));
+        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this));
 
         // when/then - try to withdraw on OneTime activity
         bool reverted = false;
@@ -365,7 +365,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_occurred_on_position_activity() {
         // given - add a Position activity
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Liquidity Pool", ActivityType.Position, 100, address(this), address(this));
+        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), address(this));
 
         // when/then - try to call occurred on Position activity
         bool reverted = false;
@@ -380,7 +380,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_allow_occurred_on_onetime_activity() {
         // given - add a OneTime activity
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Swap Activity", ActivityType.OneTime, 100, address(this), address(this));
+        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this));
 
         // when - call occurred
         rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Occurred, testBlockNumber, 0));
@@ -400,8 +400,8 @@ contract Describe_Rewards_Management is Authorizable {
 
         // when - user1 tries to add activity
         bool reverted = false;
-        try TestUtils.callAs(user1, address(rewards), "addActivity(uint256, string, uint8, uint256, address, address)",
-            activityId, "Activity 1", uint8(ActivityType.Position), 100, address(user1), address(user1)) {
+        try TestUtils.callAs(user1, address(rewards), "addPositionActivity(uint256, string, uint256, address, address)",
+            activityId, "Activity 1", 100, address(user1), address(user1)) {
             reverted = false;
         } catch {
             reverted = true;
@@ -414,7 +414,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_non_owner_from_updating_emission_rate() {
         // given
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Activity 1", ActivityType.Position, 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
 
         // when - user1 tries to update emission rate
         bool reverted = false;
@@ -432,7 +432,7 @@ contract Describe_Rewards_Management is Authorizable {
     function it_should_prevent_non_owner_from_updating_allowed_caller() {
         // given
         uint256 activityId = 1;
-        rewards.addActivity(activityId, "Activity 1", ActivityType.Position, 100, address(user1), address(user1));
+        rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1));
 
         // when - user1 tries to update allowed caller
         bool reverted = false;

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -501,62 +501,61 @@ contract Describe_Rewards_Management is Authorizable {
     // ACTIVITY TYPE VALIDATION
     // ═════════════════════════════════════════════════════════════════════════
 
-    function it_should_prevent_deposit_on_onetime_activity() {
-        // given - add a OneTime activity
+    function it_should_fail_on_unknown_event_for_source() {
+        // given - add a OneTime activity with "Swap" event
         uint256 activityId = 1;
         rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this), "Swap");
 
-        // when/then - try to deposit on OneTime activity
+        // when/then - try to use an event name that doesn't exist for this source
         bool reverted = false;
-        try rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Deposit, testBlockNumber, 0)) {
+        try rewards.handleAction(Action(address(this), "UnknownEvent", address(user1), 100, testBlockNumber, 0)) {
             reverted = false;
         } catch {
             reverted = true;
         }
-        require(reverted, "Deposit should fail on OneTime activity");
+        require(reverted, "Unknown event should fail");
     }
 
-    function it_should_prevent_withdraw_on_onetime_activity() {
-        // given - add a OneTime activity
+    function it_should_allow_valid_event_on_onetime_activity() {
+        // given - add a OneTime activity with "Swap" event
         uint256 activityId = 1;
         rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this), "Swap");
 
-        // when/then - try to withdraw on OneTime activity
-        bool reverted = false;
-        try rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Withdraw, testBlockNumber, 0)) {
-            reverted = false;
-        } catch {
-            reverted = true;
-        }
-        require(reverted, "Withdraw should fail on OneTime activity");
-    }
-
-    function it_should_prevent_occurred_on_position_activity() {
-        // given - add a Position activity
-        uint256 activityId = 1;
-        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), address(this), _defaultPositionEvents());
-
-        // when/then - try to call occurred on Position activity
-        bool reverted = false;
-        try rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Occurred, testBlockNumber, 0)) {
-            reverted = false;
-        } catch {
-            reverted = true;
-        }
-        require(reverted, "Occurred should fail on Position activity");
-    }
-
-    function it_should_allow_occurred_on_onetime_activity() {
-        // given - add a OneTime activity
-        uint256 activityId = 1;
-        rewards.addOneTimeActivity(activityId, "Swap Activity", 100, address(this), address(this), "Swap");
-
-        // when - call occurred
-        rewards.handleAction(Action(activityId, address(user1), 100, ActionType.Occurred, testBlockNumber, 0));
+        // when - use the registered "Swap" event
+        rewards.handleAction(Action(address(this), "Swap", address(user1), 100, testBlockNumber, 0));
 
         // then - check user stake increased
         (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));
         require(stake == 100, "User stake should be 100");
+    }
+
+    function it_should_allow_deposit_on_position_activity() {
+        // given - add a Position activity with Deposit/Withdraw events
+        uint256 activityId = 1;
+        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), address(this), _defaultPositionEvents());
+
+        // when - use the registered "Deposit" event
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), 100, testBlockNumber, 0));
+
+        // then - check user stake increased
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));
+        require(stake == 100, "User stake should be 100");
+    }
+
+    function it_should_allow_withdraw_on_position_activity() {
+        // given - add a Position activity with Deposit/Withdraw events
+        uint256 activityId = 1;
+        rewards.addPositionActivity(activityId, "Liquidity Pool", 100, address(this), address(this), _defaultPositionEvents());
+
+        // given - first deposit
+        rewards.handleAction(Action(address(this), "Deposit", address(user1), 100, testBlockNumber, 0));
+
+        // when - use the registered "Withdraw" event
+        rewards.handleAction(Action(address(this), "Withdraw", address(user1), 50, testBlockNumber, 1));
+
+        // then - check user stake decreased
+        (uint256 stake, uint256 userIndex) = rewards.userInfo(activityId, address(user1));
+        require(stake == 50, "User stake should be 50 after withdrawal");
     }
 
     // ═════════════════════════════════════════════════════════════════════════

--- a/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Management.test.sol
@@ -55,6 +55,28 @@ contract Describe_Rewards_Management is Authorizable {
         return events;
     }
 
+    // Helper functions to create unique events for testing multiple activities with same source
+    function _eventsA1() internal pure returns (ActionableEvent[] memory) {
+        ActionableEvent[] memory events = new ActionableEvent[](2);
+        events[0] = ActionableEvent("A1Deposit", ActionType.Deposit);
+        events[1] = ActionableEvent("A1Withdraw", ActionType.Withdraw);
+        return events;
+    }
+
+    function _eventsA2() internal pure returns (ActionableEvent[] memory) {
+        ActionableEvent[] memory events = new ActionableEvent[](2);
+        events[0] = ActionableEvent("A2Deposit", ActionType.Deposit);
+        events[1] = ActionableEvent("A2Withdraw", ActionType.Withdraw);
+        return events;
+    }
+
+    function _eventsA3() internal pure returns (ActionableEvent[] memory) {
+        ActionableEvent[] memory events = new ActionableEvent[](2);
+        events[0] = ActionableEvent("A3Deposit", ActionType.Deposit);
+        events[1] = ActionableEvent("A3Withdraw", ActionType.Withdraw);
+        return events;
+    }
+
     // ═════════════════════════════════════════════════════════════════════════
     // ACTIVITY MANAGEMENT
     // ═════════════════════════════════════════════════════════════════════════
@@ -147,7 +169,127 @@ contract Describe_Rewards_Management is Authorizable {
         require(reverted, "Adding position activity with empty events should revert");
     }
 
-    function it_should_prevent_adding_duplicate_activity() {
+    function it_should_prevent_adding_activity_with_duplicate_event_for_same_source() {
+        // given - Activity 1 with sourceContract 0xaa and events: Deposit, Withdraw
+        uint256 activityId1 = 1;
+        address sourceA = address(user1);
+        ActionableEvent[] memory events1 = new ActionableEvent[](2);
+        events1[0] = ActionableEvent("Deposit", ActionType.Deposit);
+        events1[1] = ActionableEvent("Withdraw", ActionType.Withdraw);
+        rewards.addPositionActivity(activityId1, "Activity 1", 100, address(this), sourceA, events1);
+
+        // when/then - try to add Activity 2 with same sourceContract and event "Deposit"
+        uint256 activityId2 = 2;
+        ActionableEvent[] memory events2 = new ActionableEvent[](1);
+        events2[0] = ActionableEvent("Deposit", ActionType.Deposit); // duplicate event name
+
+        bool reverted = false;
+        try rewards.addPositionActivity(activityId2, "Activity 2", 200, address(this), sourceA, events2) {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should prevent duplicate event name for same source contract");
+    }
+
+    function it_should_allow_same_event_name_for_different_source_contracts() {
+        // given - Activity 1 with sourceContract 0xaa and event: Withdraw
+        uint256 activityId1 = 1;
+        address sourceA = address(user1);
+        ActionableEvent[] memory events1 = new ActionableEvent[](1);
+        events1[0] = ActionableEvent("Withdraw", ActionType.Withdraw);
+        rewards.addPositionActivity(activityId1, "Activity 1", 100, address(this), sourceA, events1);
+
+        // when - add Activity 2 with different sourceContract 0xbb but same event "Withdraw"
+        uint256 activityId2 = 2;
+        address sourceB = address(user2);
+        ActionableEvent[] memory events2 = new ActionableEvent[](1);
+        events2[0] = ActionableEvent("Withdraw", ActionType.Withdraw); // same event name, different source
+
+        // then - should succeed
+        rewards.addPositionActivity(activityId2, "Activity 2", 200, address(this), sourceB, events2);
+
+        // verify both activities exist
+        (string memory name1, , , , , , , ) = rewards.activities(activityId1);
+        (string memory name2, , , , , , , ) = rewards.activities(activityId2);
+        require(keccak256(bytes(name1)) == keccak256(bytes("Activity 1")), "Activity 1 should exist");
+        require(keccak256(bytes(name2)) == keccak256(bytes("Activity 2")), "Activity 2 should exist");
+    }
+
+    function it_should_allow_non_overlapping_events_for_same_source() {
+        // given - Activity 1 with sourceContract 0xaa and event: Withdraw
+        uint256 activityId1 = 1;
+        address sourceA = address(user1);
+        ActionableEvent[] memory events1 = new ActionableEvent[](1);
+        events1[0] = ActionableEvent("Withdraw", ActionType.Withdraw);
+        rewards.addPositionActivity(activityId1, "Activity 1", 100, address(this), sourceA, events1);
+
+        // given - Activity 2 with same sourceContract 0xaa and event: Deposit
+        uint256 activityId2 = 2;
+        ActionableEvent[] memory events2 = new ActionableEvent[](1);
+        events2[0] = ActionableEvent("Deposit", ActionType.Deposit);
+        rewards.addPositionActivity(activityId2, "Activity 2", 200, address(this), sourceA, events2);
+
+        // when - try to add Activity 3 with same sourceContract but event: Borrow (non-overlapping)
+        uint256 activityId3 = 3;
+        ActionableEvent[] memory events3 = new ActionableEvent[](1);
+        events3[0] = ActionableEvent("Borrow", ActionType.Deposit);
+
+        // then - should succeed
+        rewards.addPositionActivity(activityId3, "Activity 3", 300, address(this), sourceA, events3);
+
+        // verify all three activities exist
+        (string memory name3, , , , , , , ) = rewards.activities(activityId3);
+        require(keccak256(bytes(name3)) == keccak256(bytes("Activity 3")), "Activity 3 should exist");
+    }
+
+    function it_should_prevent_duplicate_event_across_multiple_existing_activities() {
+        // given - Activity 1 with sourceContract 0xaa and event: Withdraw
+        uint256 activityId1 = 1;
+        address sourceA = address(user1);
+        ActionableEvent[] memory events1 = new ActionableEvent[](1);
+        events1[0] = ActionableEvent("Withdraw", ActionType.Withdraw);
+        rewards.addPositionActivity(activityId1, "Activity 1", 100, address(this), sourceA, events1);
+
+        // given - Activity 2 with same sourceContract 0xaa and event: Deposit
+        uint256 activityId2 = 2;
+        ActionableEvent[] memory events2 = new ActionableEvent[](1);
+        events2[0] = ActionableEvent("Deposit", ActionType.Deposit);
+        rewards.addPositionActivity(activityId2, "Activity 2", 200, address(this), sourceA, events2);
+
+        // when/then - try to add Activity 3 with same source and event "Deposit" (conflicts with Activity 2)
+        uint256 activityId3 = 3;
+        ActionableEvent[] memory events3 = new ActionableEvent[](1);
+        events3[0] = ActionableEvent("Deposit", ActionType.Deposit); // conflicts with Activity 2
+
+        bool reverted = false;
+        try rewards.addPositionActivity(activityId3, "Activity 3", 300, address(this), sourceA, events3) {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should prevent duplicate event name across multiple activities for same source");
+    }
+
+    function it_should_prevent_duplicate_event_for_onetime_activity() {
+        // given - OneTime activity with sourceContract 0xaa and event: Swap
+        uint256 activityId1 = 1;
+        address sourceA = address(user1);
+        rewards.addOneTimeActivity(activityId1, "Swap Activity", 100, address(this), sourceA, "Swap");
+
+        // when/then - try to add another OneTime activity with same source and event "Swap"
+        uint256 activityId2 = 2;
+
+        bool reverted = false;
+        try rewards.addOneTimeActivity(activityId2, "Another Swap", 200, address(this), sourceA, "Swap") {
+            reverted = false;
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should prevent duplicate event name for OneTime activities with same source");
+    }
+
+    function it_should_prevent_duplicate_activity() {
         // given
         uint256 activityId = 1;
         rewards.addPositionActivity(activityId, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
@@ -171,14 +313,14 @@ contract Describe_Rewards_Management is Authorizable {
         uint256 emission2 = 200;
         uint256 emission3 = 300;
 
-        // when
-        rewards.addPositionActivity(activity1, "Activity 1", emission1, address(user1), address(user1), _defaultPositionEvents());
+        // when - using unique events for same source contract
+        rewards.addPositionActivity(activity1, "Activity 1", emission1, address(user1), address(user1), _eventsA1());
         require(rewards.totalRewardsEmission() == emission1, "Total emission after 1st activity");
 
-        rewards.addPositionActivity(activity2, "Activity 2", emission2, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activity2, "Activity 2", emission2, address(user1), address(user1), _eventsA2());
         require(rewards.totalRewardsEmission() == emission1 + emission2, "Total emission after 2nd activity");
 
-        rewards.addPositionActivity(activity3, "Activity 3", emission3, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activity3, "Activity 3", emission3, address(user1), address(user1), _eventsA3());
         require(rewards.totalRewardsEmission() == emission1 + emission2 + emission3, "Total emission after 3rd activity");
     }
 
@@ -219,13 +361,13 @@ contract Describe_Rewards_Management is Authorizable {
     }
 
     function it_should_maintain_correct_total_emission_when_updating_rates() {
-        // given - add three activities
+        // given - add three activities with unique events for same source
         uint256 activity1 = 1;
         uint256 activity2 = 2;
         uint256 activity3 = 3;
-        rewards.addPositionActivity(activity1, "Activity 1", 100, address(user1), address(user1), _defaultPositionEvents());
-        rewards.addPositionActivity(activity2, "Activity 2", 200, address(user1), address(user1), _defaultPositionEvents());
-        rewards.addPositionActivity(activity3, "Activity 3", 300, address(user1), address(user1), _defaultPositionEvents());
+        rewards.addPositionActivity(activity1, "Activity 1", 100, address(user1), address(user1), _eventsA1());
+        rewards.addPositionActivity(activity2, "Activity 2", 200, address(user1), address(user1), _eventsA2());
+        rewards.addPositionActivity(activity3, "Activity 3", 300, address(user1), address(user1), _eventsA3());
 
         require(rewards.totalRewardsEmission() == 600, "Initial total emission");
 


### PR DESCRIPTION
Changes to the contract discussed on today's calls

- [x] allowed caller removed
- [x] two functions to add activity: one time, position
- [x] activity holds events (name, type)
- [x] when action handled, then activity identified by sourceContract and event
- [x] change order of userInfo mapping (first user, then activity)
- [x] drop functions: deposit, withdraw, occurred, single handleAction


