### PR TITLE
Implement alternative idempotency solution

### DIFF
--- a/mercata/contracts/concrete/Rewards/Rewards.sol
+++ b/mercata/contracts/concrete/Rewards/Rewards.sol
@@ -125,13 +125,14 @@ contract record Rewards is Ownable {
     // IDEMPOTENCY STATE
     // ═══════════════════════════════════════════════════════════════════════
 
-    // Current block number being processed (for idempotency)
+    // Last block number processed - exposed for off-chain service to know where to resume after crash
+    // This is NOT used in contract logic, only for external visibility
     uint256 public currentBlockHandled;
 
-    // Mapping of event hashes processed in the current block
+    // Mapping of all processed event hashes (persisted forever until retention cleanup)
     mapping(string => bool) public processedHashes;
 
-    // Array of event hashes in current block (for clearing the mapping)
+    // Array of all processed event hashes (for potential future retention cleanup)
     string[] public processedHashList;
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -451,29 +452,22 @@ contract record Rewards is Ownable {
     /**
      * @dev Internal function to handle stake changes with idempotency
      * @param action The action to process (includes blockNumber for idempotency)
+     *
+     * IMPORTANT: The off-chain service MUST send events in correct order:
+     * 1. All events from block N before any events from block N+1
+     * 2. Events within a block must be sent in eventIndex order
+     *
+     * This ordering is required because the rewards logic depends on it
+     * (e.g., a Deposit must be processed before a Withdraw for the same user).
      */
     function _handleAction(Action action) internal {
         // ═══════════════════════════════════════════════════════════════════════
         // IDEMPOTENCY CHECK
         // ═══════════════════════════════════════════════════════════════════════
 
-        // If blockNumber < currentBlockHandled, this is an old event - silently ignore
-        if (action.blockNumber < currentBlockHandled) {
-            return;
-        }
-
-        // If blockNumber > currentBlockHandled, we've moved to a new block
-        if (action.blockNumber > currentBlockHandled) {
-            // Clear the processed hashes from the previous block
-            _clearProcessedHashes();
-            // Update to the new block
-            currentBlockHandled = action.blockNumber;
-        }
-
         // Calculate event hash from blockNumber and eventIndex (uniquely identifies event on chain)
         string eventHash = keccak256(action.blockNumber, action.eventIndex);
 
-        // blockNumber == currentBlockHandled at this point
         // Check if we've already processed this event hash
         if (processedHashes[eventHash]) {
             // Already processed - silently ignore (idempotency)
@@ -483,6 +477,11 @@ contract record Rewards is Ownable {
         // Mark this event hash as processed
         processedHashes[eventHash] = true;
         processedHashList.push(eventHash);
+
+        // Update currentBlockHandled for off-chain service visibility (not used in logic)
+        if (action.blockNumber > currentBlockHandled) {
+            currentBlockHandled = action.blockNumber;
+        }
 
         // ═══════════════════════════════════════════════════════════════════════
         // ACTION PROCESSING

--- a/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
+++ b/mercata/contracts/tests/Rewards/Rewards-Idempotency.test.sol
@@ -75,33 +75,10 @@ contract Describe_Rewards_Idempotency is Authorizable {
     }
 
     // ═════════════════════════════════════════════════════════════════════════
-    // IDEMPOTENCY: Old block events are silently ignored
+    // IDEMPOTENCY: Same eventIndex in different blocks produces different hash
     // ═════════════════════════════════════════════════════════════════════════
 
-    function it_should_ignore_old_block_events() {
-        // given - process an event in block 200
-        uint256 depositAmount = 1000 * 1e18;
-        uint256 newerBlock = 200;
-        uint256 olderBlock = 100;
-        rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, newerBlock, 0));
-
-        // when - an event from an older block (100) arrives late
-        // This simulates out-of-order or replayed old events
-        rewards.handleAction(Action(address(this), "Deposit", address(user1), 500 * 1e18, olderBlock, 0));
-
-        // then - user's stake should still be 1000 (old block event ignored)
-        (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), liquidityActivityId);
-        require(stake == depositAmount, "Old block event should be ignored - stake should be 1000, not 1500");
-
-        // then - currentBlock should still be 200
-        require(rewards.currentBlockHandled() == newerBlock, "currentBlock should remain at 200");
-    }
-
-    // ═════════════════════════════════════════════════════════════════════════
-    // IDEMPOTENCY: Hash set is cleared when moving to a new block
-    // ═════════════════════════════════════════════════════════════════════════
-
-    function it_should_clear_hash_set_when_moving_to_new_block() {
+    function it_should_process_same_event_index_in_different_blocks() {
         // given - process event in block 100, eventIndex 0
         uint256 depositAmount = 500 * 1e18;
         uint256 block100 = 100;
@@ -109,17 +86,17 @@ contract Describe_Rewards_Idempotency is Authorizable {
 
         rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, block100, 0));
 
-        // when - move to block 101 with same eventIndex (0)
+        // when - process event in block 101 with same eventIndex (0)
         // Since blockNumber is part of the hash, this produces a different hash
-        // Hash set is also cleared when moving to a new block
+        // hash(100, 0) != hash(101, 0)
         rewards.handleAction(Action(address(this), "Deposit", address(user1), depositAmount, block101, 0));
 
         // then - user's stake should be 1000 (both deposits processed)
         (uint256 stake, uint256 userIndex) = rewards.userInfo(address(user1), liquidityActivityId);
         require(stake == depositAmount * 2, "Events in different blocks should both be processed");
 
-        // then - currentBlock should be 101
-        require(rewards.currentBlockHandled() == block101, "currentBlock should be 101");
+        // then - currentBlockHandled should be 101 (highest block seen)
+        require(rewards.currentBlockHandled() == block101, "currentBlockHandled should be 101");
     }
 
     // ═════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
@witmk Thank you f[or the feedback](https://github.com/blockapps/strato-platform/issues/5650#issuecomment-3583952744). I've implemented the hash-based idempotency approach as requested. However, I'd like to address several points for the team's consideration:

**1. Event ordering is a requirement regardless of idempotency approach**

The rewards logic inherently requires events to be processed in the correct order. Example:

  - Block 100, Tx 1: User deposits 1000 USDST
  - Block 100, Tx 2: User withdraws 1000 USDST

If processed in wrong order (withdraw before deposit), the contract would attempt to subtract from zero stake, causing incorrect state or failure. This is true for any idempotency implementation—the off-chain service must send events in order because the business logic demands it.

**2. Off-chain service is trusted infrastructure**

The off-chain service is our controlled infrastructure. If compromised, an attacker could send arbitrary fake data (e.g., "User deposited 200M USDST"). The threat model assumes this service operates correctly. Given we must trust it for data correctness, we can also trust it for ordering.

**3. Storage efficiency considerations**

This hash-based approach stores all hashes indefinitely. With high event volume, this mapping grows unbounded. Adding retention-based cleanup introduces complexity:
  - Must store block numbers alongside hashes
  - Cleanup logic to delete hashes older than retention window
  
I've implemented this approach as requested but wanted to document these trade-offs for the team's awareness.
  
**4. Implementation provided**

This PR implements the requested hash-based idempotency. All 45 tests pass. I'm submitting this so the team can evaluate both approaches and decide which better fits our requirements.