### PR TITLE
fix: prevent negative balance flicker on dashboard

### DIFF
--- a/mercata/ui/src/hooks/useNetBalance.ts
+++ b/mercata/ui/src/hooks/useNetBalance.ts
@@ -123,6 +123,14 @@ export const useNetBalance = ({
     const totalDebt = lendingPoolDebt + cdpDebt;
     const netBalance = total - totalDebt;
 
+   
+    // Prevent flicker: Don't show negative balance if we're still loading assets
+    // If we have debt but no assets, we're likely in a loading state
+    if (netBalance < 0 && total === 0 && totalDebt > 0) {
+      // Skip update - keep previous state to avoid showing negative balance flash
+      return;
+    }
+    
     setResult({
       netBalance,
       cataBalance: cataTotal,


### PR DESCRIPTION
Add check to prevent negative balance flash during asset/debt loading. If netBalance < 0 and total === 0 and totalDebt > 0, skip the update to keep previous state until all data is loaded.

Resolves issue where dashboard briefly shows negative balance while assets are still loading but debt has already been fetched.