### PR TITLE
External functions accept struct types as parameters

### DIFF
--- a/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/ArgValue.hs
+++ b/strato/VM/EVM/evm-solidity/src/BlockApps/Solidity/ArgValue.hs
@@ -20,6 +20,7 @@ import qualified Data.Bimap as Bimap
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Lazy as BSL
 import Data.Decimal
 import Data.Either
 import qualified Data.Map.Strict as Map
@@ -84,6 +85,10 @@ argValueToType v@(ArgString s') = maybe (SimpleType TypeString, v) id $
         '0':'x':_ -> ((SimpleType TypeAddress, v) <$ ((readMaybe s) :: Maybe Address))
                  <|> ((SimpleType typeInt,) . ArgInt <$> ((readMaybe s) :: Maybe Integer))
         '"':_     -> ((SimpleType TypeString,) . ArgString . Text.pack <$> ((readMaybe s) :: Maybe String))
+        -- Try to parse strings that look like JSON arrays
+        '[':_     -> (argValueToType <$> A.decode (BSL.fromStrict $ Text.encodeUtf8 s'))
+        -- Try to parse strings that look like JSON objects
+        '{':_     -> (argValueToType <$> A.decode (BSL.fromStrict $ Text.encodeUtf8 s'))
         _         -> ((SimpleType typeInt,) . ArgInt <$> ((readMaybe s) :: Maybe Integer))
                  <|> ((SimpleType TypeAddress, v) <$ ((readMaybe s) :: Maybe Address))
 argValueToType v@(ArgDecimal _) = (SimpleType TypeDecimal, v)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -459,7 +459,7 @@ call' from to' fnCalltype functionName valList = do
         let isForbidden = theFunction ^. CC.funcVisibility == Just CC.Private || theFunction ^. CC.funcVisibility == Just CC.Internal
         when (isExternal && isForbidden) $
           unknownFunction "logFunctionCall" (functionName, "asdf" :: String) -- contract ^. CC.contractName)
-        validateFunctionArguments theFunction valList >>= \case
+        validateFunctionArguments (contract ^. CC.structs) theFunction valList >>= \case
           Just (theFunction', valList') -> do
             mCallInfo <- getCurrentCallInfoIfExists
             let ro = case mCallInfo of
@@ -1529,15 +1529,15 @@ expToVar' (CC.FunctionCall _ e args) = do
               res <- case M.lookup funcName $ contract' ^. CC.functions of
                 Just func -> if (CC._funcIsFree func)
                   then do
-                    validateFunctionArguments func argVals >>= \case
+                    validateFunctionArguments (contract' ^. CC.structs) func argVals >>= \case
                       Just (mo, argVals') -> runTheCall address codeAddr contract' funcName hsh cc mo argVals' ro True
                       Nothing -> runTheCall address codeAddr contract' funcName hsh cc func argVals ro True
                   else do
-                    validateFunctionArguments func argVals >>= \case
+                    validateFunctionArguments (contract' ^. CC.structs) func argVals >>= \case
                       Just (mo, argVals') -> runTheCall address codeAddr contract' funcName hsh cc mo argVals' ro False
                       Nothing -> case M.lookup funcName $ cc ^. CC.flFuncs of
                         Just ff -> do
-                          validateFunctionArguments ff argVals >>= \case
+                          validateFunctionArguments (contract' ^. CC.structs) ff argVals >>= \case
                             Just (mo, argVals') -> runTheCall address codeAddr contract' funcName hsh cc mo argVals' ro True
                             Nothing -> runTheCall address codeAddr contract' funcName hsh cc func argVals ro False
                         Nothing -> runTheCall address codeAddr contract' funcName hsh cc func argVals ro False
@@ -2236,7 +2236,7 @@ runTheConstructors from to hsh cc contractName' argVals' = do
 
   argVals <- case contract' ^. CC.constructor of
     Nothing -> pure argVals'
-    Just theConstructor -> validateFunctionArguments theConstructor argVals' >>= \case
+    Just theConstructor -> validateFunctionArguments (contract' ^. CC.structs) theConstructor argVals' >>= \case
       Just (_, vals) -> pure vals
       Nothing -> invalidArguments "constructor arguments don't match" (contractName', argVals')
 
@@ -2350,7 +2350,7 @@ runTheCall address' codeAddr contract' funcName hsh cc theFunction argVals' ro f
       Nothing -> if name `elem` contract' ^. CC.parents then return Nothing else missingField "modifier not found" name
   let !theModifiers = catMaybes theModifiers'
 
-  argVals <- validateFunctionArguments theFunction argVals' >>= \case
+  argVals <- validateFunctionArguments (contract' ^. CC.structs) theFunction argVals' >>= \case
     Just (_, av) -> pure av
     Nothing -> typeError
       "the argument values do not match up with the function signature"
@@ -2987,8 +2987,8 @@ solidVMExceptionHandler catchBlockMap ex =
           return res
 
 -- checks if an argument list is valid for a given function signature
-validateFunctionArguments:: MonadSM m => CC.Func -> ValList -> m (Maybe (CC.Func, ValList))
-validateFunctionArguments func argVals = checkFunc $ func : CC._funcOverload func
+validateFunctionArguments:: MonadSM m => M.Map String [(String, CC.FieldType, a)] -> CC.Func -> ValList -> m (Maybe (CC.Func, ValList))
+validateFunctionArguments structDefs func argVals = checkFunc $ func : CC._funcOverload func
   where
     checkFunc [] = pure Nothing
     checkFunc (x:xs) = testMatch x >>= \case
@@ -3026,7 +3026,23 @@ validateFunctionArguments func argVals = checkFunc $ func : CC._funcOverload fun
         -- (SAddress a _, SVMType.String _) -> pure . Just . SString $ show a
         (SAddress a _, SVMType.Int _ _) -> pure . Just . SInteger . fromIntegral $ unAddress a
         (SEnumVal r x y, SVMType.UnknownLabel u) -> pure . bool Nothing (Just $ SEnumVal r x y) $ r == u
-        (SStruct r x, SVMType.UnknownLabel u) -> pure . bool Nothing (Just $ SStruct r x) $ r == u
+        -- Allow SStruct to match UnknownLabel if:
+        -- 1. The struct name matches the expected type, OR
+        -- 2. The struct name is empty (from ObjectLiteral) AND the field names match the struct definition
+        (SStruct r x, SVMType.UnknownLabel u) ->
+          if r == u then pure . Just $ SStruct r x
+          else if r == "" then do
+            -- Look up the struct definition to validate field names
+            case M.lookup u structDefs of
+              Nothing -> pure Nothing  -- Struct not found
+              Just structFields -> do
+                let expectedFieldNames = S.fromList $ map (\(fname, _, _) -> fname) structFields
+                    providedFieldNames = S.fromList $ M.keys x
+                -- Check if provided fields match expected fields
+                if expectedFieldNames == providedFieldNames
+                  then pure . Just $ SStruct u x
+                  else pure Nothing
+          else pure Nothing
         (SContract r x, SVMType.UnknownLabel u) -> pure . bool Nothing (Just $ SContract r x) $ r == u
         (SArray vs, SVMType.Array y ml) ->
           if (Just $ V.length vs) `SVMType.maybeEq` (fromIntegral <$> ml)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1359,6 +1359,11 @@ expToVar' (CC.ArrayExpression _ exps) = do
   vars <- for exps expToVar
   --  return $ Constant $ SArray (error "array type from array literal not known") $ V.fromList vars
   return $ Constant $ SArray $ V.fromList vars
+expToVar' (CC.ObjectLiteral _ fieldMap) = do
+  -- Convert each field expression to a Variable
+  varMap <- traverse expToVar fieldMap
+  -- Create an SStruct with empty name (the struct type name is not needed for field access)
+  return $ Constant $ SStruct "" varMap
 expToVar' (CC.Ternary _ condition expr1 expr2) = do
   c <- getBool =<< expToVar condition
   expToVar $ if c then expr1 else expr2


### PR DESCRIPTION
Fixes #5729

I want to test this tomorrow with more complex contracts but for now I've tested it with `FooBarBaz` contract and it worked calling both `handleAction` and `handleActions`


```
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;


contract record FooBarBaz {

   constructor () {}

   struct Action {
      address sourceContract;
      string eventName;
      uint256 amount;
   }

  event UserStakeUpdated(address sc, string n, uint256 a);


  function handleAction(Action calldata action) external {
     
  }

  function handleActions(Action[] calldata actions) external {
     
  }

}
```