### PR TITLE
Fix Proxy contract table entries to use proxied contract name

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -263,7 +263,7 @@ create' creator newAddress ch cc contractName' valList = do
   void . withCallInfo newAddress newAddress contract' "constructor" ch cc M.empty False False $ pure ()
 
   -- Run the constructor
-  runTheConstructors creator newAddress ch cc contractName' valList
+  runTheConstructors creator newAddress ch cc contractName' valList Nothing
 
   onTraced $ liftIO $ putStrLn $ C.green $ "Done Creating Contract: " ++ show newAddress ++ " of type " ++ labelToString contractName'
 
@@ -2216,8 +2216,12 @@ callBuiltin "fastForward" [SInteger seconds] = do
 
 callBuiltin x args = unknownFunction ("callBuiltin " ++ show args) x
 
-runTheConstructors :: MonadSM m => Address -> Address -> Keccak256 -> CC.CodeCollection -> SolidString -> ValList -> m ()
-runTheConstructors from to hsh cc contractName' argVals' = do
+-- | Run constructors for a contract and its parents.
+-- The last parameter tracks the proxy's logic contract address when deploying a Proxy contract.
+-- When a Proxy is deployed, we want parent contracts (like Ownable) to be registered
+-- with the proxied contract's name instead of their own name.
+runTheConstructors :: MonadSM m => Address -> Address -> Keccak256 -> CC.CodeCollection -> SolidString -> ValList -> Maybe Address -> m ()
+runTheConstructors from to hsh cc contractName' argVals' mProxyLogicAddr = do
   let !contract' =
         fromMaybe (missingType "contract inherits from nonexistent parent" contractName') $
           cc ^. CC.contracts . at contractName'
@@ -2228,6 +2232,11 @@ runTheConstructors from to hsh cc contractName' argVals' = do
             [ ((t, fromMaybe "" n), i)
               | (n, CC.IndexedType {CC.indexedTypeType = t, CC.indexedTypeIndex = i}) <- argPairs
             ]
+      -- Detect if this is a Proxy contract and extract the logic contract address
+      -- The first constructor argument of Proxy is the _logicContract address
+      proxyLogicAddr = case (labelToString contractName', argVals') of
+        ("Proxy", SAddress addr _ : _) -> Just addr
+        _ -> mProxyLogicAddr  -- Propagate from parent call
   onTraced $
     liftIO $
       putStrLn $
@@ -2273,7 +2282,7 @@ runTheConstructors from to hsh cc contractName' argVals' = do
     forM_ (reverse $ contract' ^. CC.parents) $ \parent -> do
       for_ (M.lookup parent . CC._funcConstructorCalls =<< contract' ^. CC.constructor) $ \args'' -> do
         vals <- traverse (getVar <=< expToVar) args''
-        runTheConstructors from to hsh cc parent vals
+        runTheConstructors from to hsh cc parent vals proxyLogicAddr
 
     case contract' ^. CC.constructor of
       Just theFunction -> do
@@ -2303,7 +2312,18 @@ runTheConstructors from to hsh cc contractName' argVals' = do
     cs <- Mod.get (Mod.Proxy @[CallInfo])
     userName <- getUsername $ currentAddress <$> cs
     addNewCodeCollection userName cc
-    addDelegatecall to to (Just userName) $ T.pack contractName'
+
+    -- Determine the contract name for the delegatecall entry
+    -- If we're deploying a Proxy and this is a parent contract (not Proxy itself),
+    -- use the proxied contract's name instead of the parent's name (e.g., "LendingPool" instead of "Ownable")
+    delegatecallContractName <- case (proxyLogicAddr, labelToString contractName') of
+      (Just logicAddr, name) | name /= "Proxy" -> do
+        -- Look up the contract name from the logic contract address
+        (proxiedName, _) <- getContractNameAndHash logicAddr
+        pure $ T.pack proxiedName
+      _ -> pure $ T.pack contractName'
+
+    addDelegatecall to to (Just userName) delegatecallContractName
 
   return ()
 


### PR DESCRIPTION
Fixes #5726 

# The issue & the fix

When deploying a Proxy contract, the contract table in Cirrus was incorrectly creating entries with parent contract names (e.g., "Ownable") instead of the proxied contract's name.

Before: Proxy(lendingPoolImpl, owner) created:
    - (proxyAddr, "Proxy")
    - (proxyAddr, "Ownable")  <- wrong

After: Proxy(lendingPoolImpl, owner) creates:
    - (proxyAddr, "Proxy")
    - (proxyAddr, "LendingPool")  <- correct

Changes to runTheConstructors in SolidVM.hs:
- Add Maybe Address parameter to track proxy's logic contract address
- Detect "Proxy" contracts and extract first constructor arg as logic address
- Propagate logic address through recursive parent constructor calls
- Look up proxied contract name from logic address for parent entrie

# Please note that

We recognize if given contract is a proxy contrat by name (Is is called `Proxy`).

# How it was tested

So this is how I’ve tested it:

1. I’ve spinned off my private network with a single node that is a validator
2. I’ve added Rewards to BaseCodeCollections
3. I’ve called the deploy
```
GLOBAL_ADMIN_NAME=blockapps_test \
GLOBAL_ADMIN_PASSWORD='****' \
OAUTH_URL=https://keycloak.blockapps.net/auth/realms/mercata/.well-known/openid-configuration \
NODE_URL=http://localhost:8081 \
node deploy/deploy.js
```

After this

The `http://localhost:8081/cirrus/search/BlockApps-Rewards` gives two entries

```
[
  {
    "address": "ebde98f2d8faf10059e9ac0f74b7de713bd6af07",
    "block_hash": "df9c5355012a32056549c8e8f964ae8b427f0d608424984c9864c83ec8ac64e3",
    "block_timestamp": "2025-12-02 23:58:16 UTC",
    "block_number": "1",
    "creator": "BlockApps",
    "contract_name": "Rewards",
    "PRECISION_MULTIPLIER": 1e+18,
    "_owner": "00000000000000000000000000000000deadbeef",
    "currentBlockHandled": 0,
    "nextActivityId": 1,
    "rewardToken": "",
    "totalRewardsEmission": 0
  },
  {
    "address": "8ed5f33b47e2812f862049a73715f6027dcb1fea",
    "block_hash": "df9c5355012a32056549c8e8f964ae8b427f0d608424984c9864c83ec8ac64e3",
    "block_timestamp": "2025-12-02 23:58:16 UTC",
    "block_number": "1",
    "creator": "BlockApps",
    "contract_name": "Rewards",
    "PRECISION_MULTIPLIER": 1e+18,
    "_owner": "8107e4a260d96c40644505c792d12cf181c6290f",
    "currentBlockHandled": 0,
    "nextActivityId": 0,
    "rewardToken": "2680dc6693021cd3fefb84351570874fbef8332a",
    "totalRewardsEmission": 0
  }
]
```

2. The `http://localhost:8081/cirrus/search/contract` gives

```
 {"address":"ebde98f2d8faf10059e9ac0f74b7de713bd6af07","creator":"BlockApps","contract_name":"Ownable"}, 
 {"address":"ebde98f2d8faf10059e9ac0f74b7de713bd6af07","creator":"BlockApps","contract_name":"Rewards"}, 
 {"address":"8ed5f33b47e2812f862049a73715f6027dcb1fea","creator":"BlockApps","contract_name":"Rewards"}, 
 {"address":"8ed5f33b47e2812f862049a73715f6027dcb1fea","creator":"BlockApps","contract_name":"Proxy"}, 
```

The `ebde98f2d8faf10059e9ac0f74b7de713bd6af07` is implementation, and `8ed5f33b47e2812f862049a73715f6027dcb1fea` is Proxy