### PR TITLE
Revert "Fix BString format to properly escape embedded quotes"

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
@@ -153,7 +153,7 @@ isDefault BDefault = True
 
 instance Format BasicValue where
   format (BInteger i) = show i
-  format (BString s) = show $ UTF8.toString s
+  format (BString s) = ('"' :) . (++ "\"") $ UTF8.toString s
   format (BDecimal v) = show v
   format (BBool True) = "true"
   format (BBool False) = "false"

--- a/strato/VM/SolidVM/solid-vm-model/test/BasicValueStringTest.hs
+++ b/strato/VM/SolidVM/solid-vm-model/test/BasicValueStringTest.hs
@@ -8,13 +8,12 @@
 module BasicValueStringTest (spec) where
 
 import Database.Persist.Class (PersistField (..))
-import SolidVM.Model.Storable (BasicValue (..), basicParse)
+import SolidVM.Model.Storable (BasicValue (..))
 import Test.Hspec
-import Text.Format (format)
 
 spec :: Spec
 spec = do
-  describe "Bug #5727: BasicValue string formatting and parsing" $ do
+  xdescribe "Bug #5727: BasicValue string formatting and parsing" $ do
     -- PersistField instance tests (toPersistValue/fromPersistValue roundtrip)
     -- This is the actual code path that triggers the bug in production
     describe "PersistField instance (database roundtrip)" $ do
@@ -35,52 +34,3 @@ spec = do
       it "roundtrips JSON-like string through toPersistValue/fromPersistValue" $ do
         let bv = BString "{\"action\": \"Deposited\"}"
         fromPersistValue (toPersistValue bv) `shouldBe` Right bv
-
-
-    -- Quote tests - these demonstrate the bug
-    describe "strings with embedded quotes (bug reproduction)" $ do
-      it "roundtrips string with embedded double quote" $ do
-        let bv = BString "say \"hello\""
-        basicParse (format bv) `shouldBe` Just bv
-
-      it "roundtrips string wrapped in quotes" $ do
-        let bv = BString "\"Deposited\""
-        basicParse (format bv) `shouldBe` Just bv
-
-      it "roundtrips string with triple quotes" $ do
-        let bv = BString "\"\"\"Deposited\"\"\""
-        basicParse (format bv) `shouldBe` Just bv
-
-      it "roundtrips string that is just a quote" $ do
-        let bv = BString "\""
-        basicParse (format bv) `shouldBe` Just bv
-
-      it "roundtrips string with quote at beginning" $ do
-        let bv = BString "\"Deposited"
-        basicParse (format bv) `shouldBe` Just bv
-
-      it "roundtrips string with quote at end" $ do
-        let bv = BString "Deposited\""
-        basicParse (format bv) `shouldBe` Just bv
-
-      it "roundtrips string with multiple separate quotes" $ do
-        let bv = BString "\"a\" \"b\" \"c\""
-        basicParse (format bv) `shouldBe` Just bv
-
-      it "roundtrips consecutive quotes" $ do
-        let bv = BString "\"\"\"\""
-        basicParse (format bv) `shouldBe` Just bv
-
-    -- Backslash and quote combinations
-    describe "strings with backslash and quotes" $ do
-      it "roundtrips string with backslash" $ do
-        let bv = BString "back\\slash"
-        basicParse (format bv) `shouldBe` Just bv
-
-      it "roundtrips string with backslash-quote sequence" $ do
-        let bv = BString "\\\""
-        basicParse (format bv) `shouldBe` Just bv
-
-      it "roundtrips string with backslash and quotes" $ do
-        let bv = BString "\\\"Deposited\\\""
-        basicParse (format bv) `shouldBe` Just bv


### PR DESCRIPTION
This reverts commit 6d8d2e77bda2ce3dd496ed70a363f8e5e2542942.

I will later revert tests if we agree that the change should have been done on the API, no VM level