### PR TITLE
Add issue dismissal functionality to AdminRegistry contract

### DIFF
--- a/mercata/backend/src/api/controllers/user.controller.ts
+++ b/mercata/backend/src/api/controllers/user.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import RestStatus from "http-status-codes";
-import { getAdmin, isUserAdmin, addAdmin, removeAdmin, castVoteOnIssue, castVoteOnIssueById, getOpenIssues,
+import { getAdmin, isUserAdmin, addAdmin, removeAdmin, castVoteOnIssue, castVoteOnIssueById, dismissIssue, getOpenIssues,
          contractSearch, getContractDetails,
  } from "../services/user.service";
 import { validateUserAddress, validateAddressField } from "../validators/common.validators";
@@ -122,6 +122,28 @@ class UserController {
       const result = await castVoteOnIssueById(accessToken, actorAddress as string, issueId);
       res.status(RestStatus.OK).json({ 
         message: "Vote cast successfully", 
+        issueId,
+        status: result.status,
+        hash: result.hash,
+      });
+      next();
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async dismissIssue(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { accessToken, address: actorAddress } = req;
+      const { issueId } = req.body;
+      
+      const result = await dismissIssue(accessToken, actorAddress as string, issueId);
+      res.status(RestStatus.OK).json({ 
+        message: "Issue dismissed successfully", 
         issueId,
         status: result.status,
         hash: result.hash,

--- a/mercata/backend/src/api/routes/user.routes.ts
+++ b/mercata/backend/src/api/routes/user.routes.ts
@@ -214,6 +214,35 @@ router.post("/admin/vote/by-id", authHandler.authorizeRequest(), UserController.
 
 /**
  * @openapi
+ * /user/admin/dismiss:
+ *   post:
+ *     summary: Dismiss an issue (only works if proposer is the only voter)
+ *     tags: [Admin]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - issueId
+ *             properties:
+ *               issueId:
+ *                 type: string
+ *                 description: The ID of the issue to dismiss
+ *     responses:
+ *       200:
+ *         description: Issue dismissed successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               additionalProperties: true
+ */
+router.post("/admin/dismiss", authHandler.authorizeRequest(), UserController.dismissIssue);
+
+/**
+ * @openapi
  * /user/admin/issues:
  *   get:
  *     summary: List open administrative issues

--- a/mercata/backend/src/api/services/user.service.ts
+++ b/mercata/backend/src/api/services/user.service.ts
@@ -144,6 +144,26 @@ export const castVoteOnIssue = async (
   }
 };
 
+// Dismiss an issue (only works if proposer is the only voter)
+export const dismissIssue = async (
+  accessToken: string,
+  userAddress: string,
+  issueId: string,
+): Promise<{ status: string; hash: string }> => {
+  const tx = await buildFunctionTx({
+    contractName: extractContractName(AdminRegistry),
+    contractAddress: adminRegistry,
+    method: "dismissIssue",
+    args: { _issueId: issueId },
+  }, userAddress, accessToken);
+
+  const { status, hash } = await postAndWaitForTx(accessToken, () =>
+    strato.post(accessToken, StratoPaths.transactionParallel, tx)
+  );
+
+  return { status, hash };
+};
+
 // Cast a vote on an issue by issueId
 export const castVoteOnIssueById = async (
   accessToken: string,

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -60,7 +60,7 @@ contract record AdminRegistry is Ownable {
         require(currentIssues[_issueId], "Issue does not exist or is not active");
         require(votes[_issueId].length == 1, "Only issues with a single vote can be dismissed");
         require(votes[_issueId][0] == msg.sender, "Only the proposer can dismiss their issue");
-        
+
         for (uint i = 0; i < votes[_issueId].length; i++) {
             votesMap[_issueId][votes[_issueId][i]] = 0;
             votes[_issueId][i] = address(0);

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -56,10 +56,18 @@ contract record AdminRegistry is Ownable {
         return adminMap[_admin] > 0;
     }
 
-    function voteToDismissIssue(string _issueId) external returns (bool, variadic) {
+    function dismissIssue(string _issueId) external {
         require(currentIssues[_issueId], "Issue does not exist or is not active");
+        require(votes[_issueId].length == 1, "Only issues with a single vote can be dismissed");
+        require(votes[_issueId][0] == msg.sender, "Only the proposer can dismiss their issue");
         
-        return castVoteOnIssue(this, "_dismissIssueById", _issueId);
+        for (uint i = 0; i < votes[_issueId].length; i++) {
+            votesMap[_issueId][votes[_issueId][i]] = 0;
+            votes[_issueId][i] = address(0);
+        }
+        votes[_issueId].length = 0;
+        delete currentIssues[_issueId];
+        emit IssueDismissed(msg.sender, _issueId);
     }
 
     function castVoteOnIssue(address _target, string _func, variadic _args) public returns (bool, variadic) {
@@ -134,26 +142,16 @@ contract record AdminRegistry is Ownable {
         return keccak256(_target, _func, _args);
     }
 
-    function _clearIssue(string _issueId) internal {
+    function _executeIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal returns (variadic) {
+        variadic ret = _target.call(_func, _args);
         for (uint i = 0; i < votes[_issueId].length; i++) {
             votesMap[_issueId][votes[_issueId][i]] = 0;
             votes[_issueId][i] = address(0);
         }
         votes[_issueId].length = 0;
         delete currentIssues[_issueId];
-    }
-
-    function _executeIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal returns (variadic) {
-        variadic ret = _target.call(_func, _args);
-        _clearIssue(_issueId);
         emit IssueExecuted(msg.sender, _sender, _issueId, _target, _func, _args);
         return ret;
-    }
-
-    function _dismissIssueById(string _targetIssueId) external onlyOwner {
-        require(currentIssues[_targetIssueId], "Issue does not exist or is not active");
-        _clearIssue(_targetIssueId);
-        emit IssueDismissed(msg.sender, _targetIssueId);
     }
 
     function _addAdmin(address _admin) external onlyOwner {
@@ -197,7 +195,6 @@ contract record AdminRegistry is Ownable {
                 _func != "_removeAdmin" &&
                 _func != "_shouldExecute" &&
                 _func != "_swapAdmin" &&
-                _func != "_dismissIssueById" &&
                 _func != "setVotingThreshold" &&
                 _func != "setDefaultVotingThresholdBps" &&
                 _func != "createContract" &&

--- a/mercata/contracts/concrete/Admin/AdminRegistry.sol
+++ b/mercata/contracts/concrete/Admin/AdminRegistry.sol
@@ -18,6 +18,7 @@ contract record AdminRegistry is Ownable {
     event IssueCreated(address sender, address creator, string issueId, address target, string func, variadic args);
     event IssueVoted(address sender, address voter, string issueId, address target, string func, variadic args);
     event IssueExecuted(address sender, address executor, string issueId, address target, string func, variadic args);
+    event IssueDismissed(address sender, string issueId);
 
     bool public initialized = false;
 
@@ -53,6 +54,12 @@ contract record AdminRegistry is Ownable {
 
     function isAdminAddress(address _admin) external returns (bool) {
         return adminMap[_admin] > 0;
+    }
+
+    function voteToDismissIssue(string _issueId) external returns (bool, variadic) {
+        require(currentIssues[_issueId], "Issue does not exist or is not active");
+        
+        return castVoteOnIssue(this, "_dismissIssueById", _issueId);
     }
 
     function castVoteOnIssue(address _target, string _func, variadic _args) public returns (bool, variadic) {
@@ -127,16 +134,26 @@ contract record AdminRegistry is Ownable {
         return keccak256(_target, _func, _args);
     }
 
-    function _executeIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal returns (variadic) {
-        variadic ret = _target.call(_func, _args);
+    function _clearIssue(string _issueId) internal {
         for (uint i = 0; i < votes[_issueId].length; i++) {
             votesMap[_issueId][votes[_issueId][i]] = 0;
             votes[_issueId][i] = address(0);
         }
         votes[_issueId].length = 0;
         delete currentIssues[_issueId];
+    }
+
+    function _executeIssue(address _sender, string _issueId, address _target, string _func, variadic _args) internal returns (variadic) {
+        variadic ret = _target.call(_func, _args);
+        _clearIssue(_issueId);
         emit IssueExecuted(msg.sender, _sender, _issueId, _target, _func, _args);
         return ret;
+    }
+
+    function _dismissIssueById(string _targetIssueId) external onlyOwner {
+        require(currentIssues[_targetIssueId], "Issue does not exist or is not active");
+        _clearIssue(_targetIssueId);
+        emit IssueDismissed(msg.sender, _targetIssueId);
     }
 
     function _addAdmin(address _admin) external onlyOwner {
@@ -180,6 +197,7 @@ contract record AdminRegistry is Ownable {
                 _func != "_removeAdmin" &&
                 _func != "_shouldExecute" &&
                 _func != "_swapAdmin" &&
+                _func != "_dismissIssueById" &&
                 _func != "setVotingThreshold" &&
                 _func != "setDefaultVotingThresholdBps" &&
                 _func != "createContract" &&

--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -575,4 +575,45 @@ contract Describe_AdminRegistry is Authorizable {
         require(adminRegistry.isAdminAddress(admin1), "Admin1 should still be an admin after failed removal");
     }
 
+    // ============ ISSUE DISMISSAL TESTS ============
+
+    function it_admin_registry_can_dismiss_issue_with_voting() {
+        // Create an issue but don't execute it (only one vote)
+        string memory issueId = adminRegistry.getIssueId(address(token), "mint", admin3, 1000e18);
+        adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
+        
+        // Verify issue exists and has votes
+        require(adminRegistry.currentIssues(issueId), "Issue should exist");
+        require(adminRegistry.votesMap(issueId, admin1) > 0, "Issue should have votes");
+        require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted yet");
+        
+        // First vote to dismiss - should not dismiss yet (threshold not met)
+        (bool dismissed1, variadic result1) = adminRegistry.voteToDismissIssue(issueId);
+        require(!dismissed1, "Should not dismiss with only one vote");
+        require(adminRegistry.currentIssues(issueId), "Issue should still exist");
+        
+        // Second vote to dismiss - should dismiss now
+        (bool dismissed2, variadic result2) = user1.do(address(adminRegistry), "voteToDismissIssue", issueId);
+        require(dismissed2, "Should dismiss with two votes");
+        
+        // Verify issue is cleared
+        require(!adminRegistry.currentIssues(issueId), "Issue should be dismissed");
+        require(adminRegistry.votesMap(issueId, admin1) == 0, "Original issue votes should be cleared");
+        require(adminRegistry.votes(issueId, 0) == address(0), "Votes array should be empty");
+        require(ERC20(token).balanceOf(admin3) == 0, "Token should still not be minted");
+    }
+
+    function it_admin_registry_cannot_dismiss_nonexistent_issue() {
+        string memory fakeIssueId = "nonexistent_issue_id";
+        
+        // Try to dismiss an issue that doesn't exist
+        bool reverted = false;
+        try {
+            adminRegistry.voteToDismissIssue(fakeIssueId);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should revert when trying to dismiss non-existent issue");
+    }
+
 }

--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -581,15 +581,15 @@ contract Describe_AdminRegistry is Authorizable {
         // Create an issue but don't execute it (only one vote)
         string memory issueId = adminRegistry.getIssueId(address(token), "mint", admin3, 1000e18);
         adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
-        
+
         // Verify issue exists and has votes
         require(adminRegistry.currentIssues(issueId), "Issue should exist");
         require(adminRegistry.votesMap(issueId, admin1) > 0, "Issue should have votes");
         require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted yet");
-        
+
         // Proposer dismisses their own issue
         adminRegistry.dismissIssue(issueId);
-        
+
         // Verify issue is cleared
         require(!adminRegistry.currentIssues(issueId), "Issue should be dismissed");
         require(adminRegistry.votesMap(issueId, admin1) == 0, "Original issue votes should be cleared");
@@ -601,27 +601,27 @@ contract Describe_AdminRegistry is Authorizable {
         // Add a third admin
         adminRegistry.addAdmin(admin3);
         user1.do(address(adminRegistry), "addAdmin", admin3);
-        
+
         // Set threshold to 100% so 2 votes won't execute (need 3 votes with 3 admins)
         adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
         user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
-        
+
         // Create an issue with proposer's vote
         string memory issueId = adminRegistry.getIssueId(address(token), "mint", nonAdmin, 1000e18);
         adminRegistry.castVoteOnIssue(address(token), "mint", nonAdmin, 1000e18);
-        
+
         // Verify first vote is recorded
         require(adminRegistry.votes(issueId, 0) == admin1, "First vote should be recorded");
         require(adminRegistry.currentIssues(issueId), "Issue should exist");
-        
+
         // Another admin votes on the issue
         user1.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", nonAdmin, 1000e18);
-        
+
         // Verify both votes are recorded and issue still exists (not executed with 2/3 votes, need 3)
         require(adminRegistry.votes(issueId, 0) == admin1, "First vote should still be recorded");
         require(adminRegistry.votes(issueId, 1) == address(user1), "Second vote should be recorded");
         require(adminRegistry.currentIssues(issueId), "Issue should still exist");
-        
+
         // Proposer tries to dismiss - should fail because there are multiple votes
         bool reverted = false;
         try {
@@ -634,7 +634,7 @@ contract Describe_AdminRegistry is Authorizable {
 
     function it_admin_registry_cannot_dismiss_nonexistent_issue() {
         string memory fakeIssueId = "nonexistent_issue_id";
-        
+
         // Try to dismiss an issue that doesn't exist
         bool reverted = false;
         try {

--- a/mercata/contracts/tests/Admin/AdminRegistry.test.sol
+++ b/mercata/contracts/tests/Admin/AdminRegistry.test.sol
@@ -577,7 +577,7 @@ contract Describe_AdminRegistry is Authorizable {
 
     // ============ ISSUE DISMISSAL TESTS ============
 
-    function it_admin_registry_can_dismiss_issue_with_voting() {
+    function it_admin_registry_can_dismiss_issue_as_proposer() {
         // Create an issue but don't execute it (only one vote)
         string memory issueId = adminRegistry.getIssueId(address(token), "mint", admin3, 1000e18);
         adminRegistry.castVoteOnIssue(address(token), "mint", admin3, 1000e18);
@@ -587,14 +587,8 @@ contract Describe_AdminRegistry is Authorizable {
         require(adminRegistry.votesMap(issueId, admin1) > 0, "Issue should have votes");
         require(ERC20(token).balanceOf(admin3) == 0, "Token should not be minted yet");
         
-        // First vote to dismiss - should not dismiss yet (threshold not met)
-        (bool dismissed1, variadic result1) = adminRegistry.voteToDismissIssue(issueId);
-        require(!dismissed1, "Should not dismiss with only one vote");
-        require(adminRegistry.currentIssues(issueId), "Issue should still exist");
-        
-        // Second vote to dismiss - should dismiss now
-        (bool dismissed2, variadic result2) = user1.do(address(adminRegistry), "voteToDismissIssue", issueId);
-        require(dismissed2, "Should dismiss with two votes");
+        // Proposer dismisses their own issue
+        adminRegistry.dismissIssue(issueId);
         
         // Verify issue is cleared
         require(!adminRegistry.currentIssues(issueId), "Issue should be dismissed");
@@ -603,13 +597,48 @@ contract Describe_AdminRegistry is Authorizable {
         require(ERC20(token).balanceOf(admin3) == 0, "Token should still not be minted");
     }
 
+    function it_admin_registry_cannot_dismiss_issue_with_multiple_votes() {
+        // Add a third admin
+        adminRegistry.addAdmin(admin3);
+        user1.do(address(adminRegistry), "addAdmin", admin3);
+        
+        // Set threshold to 100% so 2 votes won't execute (need 3 votes with 3 admins)
+        adminRegistry.castVoteOnIssue(address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(adminRegistry), "setVotingThreshold", address(token), "mint", 10000);
+        
+        // Create an issue with proposer's vote
+        string memory issueId = adminRegistry.getIssueId(address(token), "mint", nonAdmin, 1000e18);
+        adminRegistry.castVoteOnIssue(address(token), "mint", nonAdmin, 1000e18);
+        
+        // Verify first vote is recorded
+        require(adminRegistry.votes(issueId, 0) == admin1, "First vote should be recorded");
+        require(adminRegistry.currentIssues(issueId), "Issue should exist");
+        
+        // Another admin votes on the issue
+        user1.do(address(adminRegistry), "castVoteOnIssue", address(token), "mint", nonAdmin, 1000e18);
+        
+        // Verify both votes are recorded and issue still exists (not executed with 2/3 votes, need 3)
+        require(adminRegistry.votes(issueId, 0) == admin1, "First vote should still be recorded");
+        require(adminRegistry.votes(issueId, 1) == address(user1), "Second vote should be recorded");
+        require(adminRegistry.currentIssues(issueId), "Issue should still exist");
+        
+        // Proposer tries to dismiss - should fail because there are multiple votes
+        bool reverted = false;
+        try {
+            adminRegistry.dismissIssue(issueId);
+        } catch {
+            reverted = true;
+        }
+        require(reverted, "Should revert when trying to dismiss issue with multiple votes");
+    }
+
     function it_admin_registry_cannot_dismiss_nonexistent_issue() {
         string memory fakeIssueId = "nonexistent_issue_id";
         
         // Try to dismiss an issue that doesn't exist
         bool reverted = false;
         try {
-            adminRegistry.voteToDismissIssue(fakeIssueId);
+            adminRegistry.dismissIssue(fakeIssueId);
         } catch {
             reverted = true;
         }

--- a/mercata/ui/src/components/admin/CastVoteModal.tsx
+++ b/mercata/ui/src/components/admin/CastVoteModal.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import CopyButton from '../ui/copy';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface CastVoteModalProps {
   open: boolean;
@@ -18,6 +19,9 @@ interface CastVoteModalProps {
     threshold: number;
   } | null;
   onCastVote: (issueId: string) => Promise<void> | void;
+  onDismissIssue?: (issueId: string) => Promise<void> | void;
+  votes?: Array<{ issueId: string; index: number; voter: string }>;
+  userAddress?: string | null;
 }
 
 const CastVoteModal: React.FC<CastVoteModalProps> = ({
@@ -25,9 +29,13 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
   onOpenChange,
   issue,
   onCastVote,
+  onDismissIssue,
+  votes = [],
+  userAddress,
 }) => {
   const { toast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDismissing, setIsDismissing] = useState(false);
 
   const handleSubmit = async () => {
     if (!issue) return;
@@ -42,12 +50,60 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
       });
 
       onOpenChange(false);
-    } catch (err) {
-      console.error('Cast vote failed:', err);
     } finally {
       setIsSubmitting(false);
     }
   };
+
+  const handleDismiss = async () => {
+    if (!issue || !onDismissIssue) return;
+
+    setIsDismissing(true);
+    try {
+      await onDismissIssue(issue.issueId);
+      
+      toast({
+        title: 'Issue Dismissed Successfully',
+        description: 'The issue has been dismissed.',
+      });
+
+      onOpenChange(false);
+    } finally {
+      setIsDismissing(false);
+    }
+  };
+
+  // Check if dismiss button should be enabled
+  const canDismiss = issue && onDismissIssue && userAddress && votes.length > 0
+    ? (() => {
+        const issueVotes = votes.filter(v => v.issueId === issue.issueId);
+        return issueVotes.length === 1 && issueVotes[0]?.voter === userAddress;
+      })()
+    : false;
+
+  // Get tooltip message for disabled button
+  const getTooltipMessage = (): string | null => {
+    if (!issue || !onDismissIssue || !userAddress || votes.length === 0) {
+      return null;
+    }
+    
+    const issueVotes = votes.filter(v => v.issueId === issue.issueId);
+    if (issueVotes.length === 0) {
+      return null;
+    }
+    
+    if (issueVotes.length > 1) {
+      return "Only issues with a single vote can be dismissed";
+    }
+    
+    if (issueVotes[0]?.voter !== userAddress) {
+      return "Only the proposer can dismiss this issue";
+    }
+    
+    return null;
+  };
+
+  const tooltipMessage = getTooltipMessage();
 
   if (!issue) return null;
 
@@ -127,29 +183,62 @@ const CastVoteModal: React.FC<CastVoteModalProps> = ({
         </div>
 
         {/* Actions */}
-        <div className="flex justify-end gap-3 pt-4 border-t flex-shrink-0">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={isSubmitting}
-            className="bg-strato-blue hover:bg-strato-blue/90"
-          >
-            {isSubmitting ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Casting Vote...
-              </>
-            ) : (
-              'Confirm Vote'
-            )}
-          </Button>
+        <div className="flex justify-between gap-3 pt-4 border-t flex-shrink-0">
+          <div>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={handleDismiss}
+                      disabled={!onDismissIssue || !canDismiss || isDismissing || isSubmitting}
+                      className="text-red-600 border-red-600 hover:bg-red-50"
+                    >
+                      {isDismissing ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Dismissing...
+                        </>
+                      ) : (
+                        'Dismiss Issue'
+                      )}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                {(!onDismissIssue || !canDismiss) && tooltipMessage && (
+                  <TooltipContent>
+                    <p>{tooltipMessage}</p>
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting || isDismissing}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={isSubmitting || isDismissing}
+              className="bg-strato-blue hover:bg-strato-blue/90"
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Casting Vote...
+                </>
+              ) : (
+                'Confirm Vote'
+              )}
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/mercata/ui/src/components/admin/VoteTab.tsx
+++ b/mercata/ui/src/components/admin/VoteTab.tsx
@@ -21,7 +21,7 @@ import { parseJsonBigInt } from '@/utils/numberUtils';
 
 
 const VoteTab = () => {
-  const { userAddress, openIssuesLoading, openIssues, getOpenIssues, castVoteOnIssue, castVoteOnIssueById, addAdmin, removeAdmin } = useUser();
+  const { userAddress, openIssuesLoading, openIssues, getOpenIssues, castVoteOnIssue, castVoteOnIssueById, dismissIssue, addAdmin, removeAdmin } = useUser();
   const [createOpen, setCreateOpen] = useState(false);
   const [voteModalOpen, setVoteModalOpen] = useState(false);
   const [addAdminOpen, setAddAdminOpen] = useState(false);
@@ -393,6 +393,9 @@ const VoteTab = () => {
         onOpenChange={setVoteModalOpen}
         issue={selectedIssue}
         onCastVote={handleCastVoteOnIssueById}
+        onDismissIssue={dismissIssue}
+        votes={votes}
+        userAddress={userAddress}
       />
       <AddAdminModal
         open={addAdminOpen}

--- a/mercata/ui/src/context/UserContext.tsx
+++ b/mercata/ui/src/context/UserContext.tsx
@@ -25,6 +25,7 @@ interface UserContextType {
   getContractDetails: (address: string) => Promise<void>;
   castVoteOnIssue: (target: string, func: string, args: string[]) => Promise<void>;
   castVoteOnIssueById: (issueId: string) => Promise<void>;
+  dismissIssue: (issueId: string) => Promise<void>;
   addAdmin: (userAddress: string) => Promise<void>;
   removeAdmin: (userAddress: string) => Promise<void>;
 }
@@ -167,6 +168,11 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     await getOpenIssues();
   };
 
+  const dismissIssue = async (issueId: string) => {
+    await api.post('/user/admin/dismiss', { issueId });
+    await getOpenIssues();
+  };
+
   const refreshAuth = () => {
     checkAuthenticationStatus();
   };
@@ -197,6 +203,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     getOpenIssues,
     castVoteOnIssue,
     castVoteOnIssueById,
+    dismissIssue,
     addAdmin,
     removeAdmin,
     contractSearch,
@@ -206,7 +213,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     contractDetailsResults,
     contractDetailsResultsLoading,
   }), [userAddress, isLoggedIn, isAdmin, loading, userName,
-    openIssues, openIssuesLoading, getOpenIssues, castVoteOnIssue, castVoteOnIssueById, addAdmin, removeAdmin,
+    openIssues, openIssuesLoading, getOpenIssues, castVoteOnIssue, castVoteOnIssueById, dismissIssue, addAdmin, removeAdmin,
     contractSearch, contractSearchResults, contractSearchResultsLoading,
     getContractDetails, contractDetailsResults, contractDetailsResultsLoading,
   ]);


### PR DESCRIPTION
Adds `dismissIssue` to allow proposers to dismiss their own issues when they are the only voter. Once another admin votes, dismissal is no longer allowed.

**Changes:**
- Added `dismissIssue(string _issueId)` function
- Added `IssueDismissed` event
- Added tests for dismissal scenarios

Enables proposers to withdraw proposals that haven't received other votes.