### PR TITLE
Changed undefined to 0 for default enum values in jsonSM

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -307,4 +307,4 @@ jsonSM = go False
     go b (SContract _ address) = return . bool id show b $ show address
     go _ (SVariadic xs) = ('[' :) . (++ "]") . intercalate ", " <$> traverse (go True) xs
     go _ (SDecimal v) = return $ show v
-    go _ _ = return "undefined"
+    go _ _ = return "0"


### PR DESCRIPTION
Before change:
`https://validator1.testnet.stratomercata.com/cirrus/search/event?id=eq.36224`
```json
[
{
"id": 36224,
"address": "170147f58738c9f46112a874030420b823901f3b",
"block_hash": "730c948b1ca3f19385cace65b9d0ae4f83fc1dc2c3c6043fb392c6fb51216991",
"block_timestamp": "2025-12-05 19:11:43 UTC",
"block_number": "12296",
"transaction_sender": "99d392f7545c9188389aec3fb7d2af51148828dd",
"event_index": 2,
"event_name": "ActionProcessed",
"attributes": {
"user": "288922eb7e5faa72222a859652ef275a1e6817f4",
"amount": "1000000000000000000",
"eventName": "USDSTMinted",
"actionType": "undefined", // <-- actionType is "undefined"
"activityId": "7",
"eventIndex": "5",
"blockNumber": "12293",
"sourceContract": "0000000000000000000000000000000000001011"
}
}
]
```

After change:
`http://localhost:8080/cirrus/search/event?id=eq.36224`
```json
[
{
"id": 36224,
"address": "170147f58738c9f46112a874030420b823901f3b",
"block_hash": "730c948b1ca3f19385cace65b9d0ae4f83fc1dc2c3c6043fb392c6fb51216991",
"block_timestamp": "2025-12-05 19:11:43 UTC",
"block_number": "12296",
"transaction_sender": "99d392f7545c9188389aec3fb7d2af51148828dd",
"event_index": 2,
"event_name": "ActionProcessed",
"attributes": {
"user": "288922eb7e5faa72222a859652ef275a1e6817f4",
"amount": "1000000000000000000",
"eventName": "USDSTMinted",
"actionType": "0", // <-- actionType is "0"
"activityId": "7",
"eventIndex": "5",
"blockNumber": "12293",
"sourceContract": "0000000000000000000000000000000000001011"
}
}
]
```

This is not the most thorough way to fix this issue, but a more "correct" version would require properly threading event argument type and value information through to Slipstream, which would be more involved than is required right now.