### PR TITLE
Remove the --blockstanbul flag from the Sequencer

### DIFF
--- a/strato/core/blockstanbul/bench/OneNode.hs
+++ b/strato/core/blockstanbul/bench/OneNode.hs
@@ -14,7 +14,7 @@ runBlockstanbul :: StateT BlockstanbulContext (LoggingT IO) a -> IO a
 runBlockstanbul = runNoLoggingT . flip evalStateT benchContext
 
 instance HasBlockstanbulContext (StateT BlockstanbulContext (LoggingT IO)) where
-  getBlockstanbulContext = gets Just
+  getBlockstanbulContext = get
   putBlockstanbulContext = put
 
 sendAllMessagesBench :: Int -> Int -> IO [OutEvent]

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul.hs
@@ -20,7 +20,6 @@ module Blockchain.Blockstanbul
     currentView,
     view,
     sequence,
-    blockstanbulRunning,
     isHistoricBlock,
     blockstanbulSender,
     shortFormat,

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -469,10 +469,6 @@ sendAllMessages wms = do
 currentView :: (HasBlockstanbulContext m) => m View
 currentView = _view <$> getBlockstanbulContext
 
--- TODO remove
-blockstanbulRunning :: HasBlockstanbulContext m => m Bool
-blockstanbulRunning = pure True
-
 recordInEvent :: (MonadIO m) => InEvent -> m ()
 recordInEvent ev =
   let inc txt = liftIO $ withLabel inEventMetric txt incCounter

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/EventLoop.hs
@@ -436,28 +436,23 @@ sendMessages' ::
 sendMessages' wms = do
   -- It may be somewhat confusing, but there are actually 2 StateTs with BlockstanbulContext
   -- Every run of the conduit has one, but the outer monad preserves the context between runs.
-  mCtx <- getBlockstanbulContext
-  case mCtx of
-    Nothing -> do
-      $logErrorS "blockstanbul" "cannot send messages without a BlockstanbulContext"
-      return []
-    Just ctx -> do
-      let base =
-            yieldMany wms
-              .| iterMC recordInEvent
-              .| iterMC (inShortLog "blockstanbul/InShortLog")
-              .| iterMC ($logDebugS "blockstanbul/InEvent" . T.pack . format)
-              .| eventLoop ctx
-              `fuseUpstream` ( iterMC recordOutEvent
-                                 .| iterMC (outShortLog "blockstanbul/OutShortLog")
-                                 .| iterMC ($logDebugS "blockstanbul/OutEvent" . T.pack . format . fromE)
-                             )
-      (ctx', evs) <- runConduit $ fuseBoth base sinkList
-      putBlockstanbulContext ctx'
+  ctx <- getBlockstanbulContext
+  let base =
+        yieldMany wms
+          .| iterMC recordInEvent
+          .| iterMC (inShortLog "blockstanbul/InShortLog")
+          .| iterMC ($logDebugS "blockstanbul/InEvent" . T.pack . format)
+          .| eventLoop ctx
+          `fuseUpstream` ( iterMC recordOutEvent
+                             .| iterMC (outShortLog "blockstanbul/OutShortLog")
+                             .| iterMC ($logDebugS "blockstanbul/OutEvent" . T.pack . format . fromE)
+                         )
+  (ctx', evs) <- runConduit $ fuseBoth base sinkList
+  putBlockstanbulContext ctx'
 
-      recordValidator (_isValidator ctx') (_validatorBehavior ctx')
+  recordValidator (_isValidator ctx') (_validatorBehavior ctx')
 
-      return evs
+  return evs
 
 sendMessages :: (MonadIO m, MonadLogger m, HasBlockstanbulContext m, HasVault m) => [InEvent] -> m [OutEvent]
 sendMessages = fmap (map fromE) . sendMessages'
@@ -472,10 +467,11 @@ sendAllMessages wms = do
     wms' -> (out ++) <$> sendAllMessages wms'
 
 currentView :: (HasBlockstanbulContext m) => m View
-currentView = maybe (View (-1) (-1)) _view <$> getBlockstanbulContext
+currentView = _view <$> getBlockstanbulContext
 
+-- TODO remove
 blockstanbulRunning :: HasBlockstanbulContext m => m Bool
-blockstanbulRunning = isJust <$> getBlockstanbulContext
+blockstanbulRunning = pure True
 
 recordInEvent :: (MonadIO m) => InEvent -> m ()
 recordInEvent ev =

--- a/strato/core/blockstanbul/src/Blockchain/Blockstanbul/StateMachine.hs
+++ b/strato/core/blockstanbul/src/Blockchain/Blockstanbul/StateMachine.hs
@@ -28,7 +28,7 @@ import Text.Format
 import Prelude hiding (round, sequence)
 
 class Monad m => HasBlockstanbulContext m where
-  getBlockstanbulContext :: m (Maybe BlockstanbulContext)
+  getBlockstanbulContext :: m BlockstanbulContext
   putBlockstanbulContext :: BlockstanbulContext -> m ()
 
 type StateMachineM m =

--- a/strato/core/blockstanbul/test/StateMachineSpec.hs
+++ b/strato/core/blockstanbul/test/StateMachineSpec.hs
@@ -61,7 +61,7 @@ runAuthTest = runNoLoggingT . flip evalStateT testContext
 
 instance (Monad m) => HasBlockstanbulContext (StateT BlockstanbulContext m) where
   putBlockstanbulContext = put
-  getBlockstanbulContext = Just <$> get
+  getBlockstanbulContext = get
 
 instance (Monad m) => HasVault (StateT BlockstanbulContext m) where
   sign bs = return $ signMsg myPriv bs

--- a/strato/core/strato-init/src/Blockchain/Init/Generator.hs
+++ b/strato/core/strato-init/src/Blockchain/Init/Generator.hs
@@ -86,7 +86,7 @@ createCommandsFile =
 
 strato-p2p --averageTxsPerBlock=40 --connectionTimeout=3600 --debugFail=true --maxConn=1000 --maxReturnedHeaders=500 --networkID=-1 --sqlPeers=true --minLogLevel=LevelInfo --network=helium +RTS -T -RTS
 
-strato-sequencer --blockstanbul=true --blockstanbul_block_period_ms=1000 --blockstanbul_round_period_s=120 --minLogLevel=LevelInfo --seq_max_events_per_iter=500 --seq_max_us_per_iter=50000 --validatorBehavior=true --test_mode_bypass_blockstanbul=false --network=helium +RTS -T -RTS +RTS -N1
+strato-sequencer --blockstanbul_block_period_ms=1000 --blockstanbul_round_period_s=120 --minLogLevel=LevelInfo --seq_max_events_per_iter=500 --seq_max_us_per_iter=50000 --validatorBehavior=true --test_mode_bypass_blockstanbul=false --network=helium +RTS -T -RTS +RTS -N1
 
 vm-runner --blockstanbul=true --debug=false --debugEnabled=false --debugPort=8051 --debugWSHost=strato --debugWSPort=8052 --diffPublish=true --maxTxsPerBlock=500 --minLogLevel=LevelInfo --networkID=-1 --seqEventsBatchSize=-1 --seqEventsCostHeuristic=20000 --sqlDiff=true --svmDev=false --svmTrace=false --network=helium +RTS -T -RTS +RTS -I2 -N1
 

--- a/strato/core/strato-sequencer/exec-src/Main.hs
+++ b/strato/core/strato-sequencer/exec-src/Main.hs
@@ -78,20 +78,20 @@ main = do
 
   putStrLn $ "strato-sequencer nodeAddress: " ++ format selfAddress
 
-  mCtx <-
-    if not flags_blockstanbul
-      then return Nothing
-      else do
-        unless (flags_blockstanbul_block_period_ms >= 0) . ioError . userError $
-          "--blockstanbul_block_period_ms must be nonnegative"
-        unless (flags_blockstanbul_round_period_s > 0) . ioError . userError $
-          "--blockstanbul_round_period_s must be positive"
+  ctx <- do
+    -- we require this for backward compatibility, this will be removed shortly
+    unless flags_blockstanbul . ioError . userError $
+      "--blockstanbul=true is required"
+    unless (flags_blockstanbul_block_period_ms >= 0) . ioError . userError $
+      "--blockstanbul_block_period_ms must be nonnegative"
+    unless (flags_blockstanbul_round_period_s > 0) . ioError . userError $
+      "--blockstanbul_round_period_s must be positive"
 
-        putStrLn $ "ACTUAL validators list: " ++ show validators
+    putStrLn $ "ACTUAL validators list: " ++ show validators
 
-        let ckpt = def {checkpointValidators = validators, checkpointView=View 0 $ fromIntegral $ bestSequencedBlockNumber bestSequencedBlock}
+    let ckpt = def {checkpointValidators = validators, checkpointView=View 0 $ fromIntegral $ bestSequencedBlockNumber bestSequencedBlock}
 
-        return $ Just $ newContext flags_network ckpt (Just selfAddress) flags_validatorBehavior
+    return $ newContext flags_network ckpt (Just selfAddress) flags_validatorBehavior
 
   cht <- atomically newTMChan
 
@@ -111,6 +111,6 @@ main = do
             kafkaClientId = fromString flags_kafkaclientid,
             redisConn = RBDB.RedisConnection conn
           }
-  race_ (runLoggingT (runSequencerM seqCfg mCtx sequencer ))
+  race_ (runLoggingT (runSequencerM seqCfg ctx sequencer ))
     . run 8050
     $ metricsApp

--- a/strato/core/strato-sequencer/exec-src/Main.hs
+++ b/strato/core/strato-sequencer/exec-src/Main.hs
@@ -79,9 +79,6 @@ main = do
   putStrLn $ "strato-sequencer nodeAddress: " ++ format selfAddress
 
   ctx <- do
-    -- we require this for backward compatibility, this will be removed shortly
-    unless flags_blockstanbul . ioError . userError $
-      "--blockstanbul=true is required"
     unless (flags_blockstanbul_block_period_ms >= 0) . ioError . userError $
       "--blockstanbul_block_period_ms must be nonnegative"
     unless (flags_blockstanbul_round_period_s > 0) . ioError . userError $

--- a/strato/core/strato-sequencer/package.yaml
+++ b/strato/core/strato-sequencer/package.yaml
@@ -50,6 +50,8 @@ library:
     - containers
     - mtl
     - stm-chans
+    - transformers
+    - resourcet
 
 executables:
   strato-sequencer:

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -347,21 +347,14 @@ runConsensus ::
   ) =>
   SequencedBlock -> ConduitT i SeqOutEvent m ()
 runConsensus sb = do
-  hasPBFT <- lift blockstanbulRunning
-  if not hasPBFT
-    then do
-      obs <- lift $ expandBlock sb
-      for_ obs $ \ob -> yieldToP2p [P2pBlock ob]
-      yieldToVm $ map VmBlock obs
-    else do
-      let blk = sequencedBlockToBlock sb
-      routed <-
-        if isHistoricBlock blk
-          then lift $ map (PreviousBlock . outputBlockToBlock) <$> expandBlock sb
-          else pure [UnannouncedBlock blk]
-      -- Blockstanbul will check that the seals and validators match up before
-      -- announcing it to the network or forwarding to the EVM.
-      traverse_ blockstanbulSend' routed
+  let blk = sequencedBlockToBlock sb
+  routed <-
+    if isHistoricBlock blk
+      then lift $ map (PreviousBlock . outputBlockToBlock) <$> expandBlock sb
+      else pure [UnannouncedBlock blk]
+  -- Blockstanbul will check that the seals and validators match up before
+  -- announcing it to the network or forwarding to the EVM.
+  traverse_ blockstanbulSend' routed
 
 transformBlocks ::
   ( MonadLogger m,

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer.hs
@@ -105,11 +105,9 @@ initSequencer :: (
   ConduitT () SeqOutEvent m ()
 initSequencer = do
   let logF = logFF "sequencer"
-  lift getBlockstanbulContext >>= \case
-    Nothing -> pure ()
-    Just ctx -> do
-      let selfAddr = fromJust $ _selfAddr ctx
-      yieldToVm [VmSelfAddress selfAddr]
+  ctx <- lift getBlockstanbulContext
+  let selfAddr = fromJust $ _selfAddr ctx
+  yieldToVm [VmSelfAddress selfAddr]
   logF "Sequencer startup"
   logF "Sequencer initialized"
   bootstrapBlockstanbul
@@ -263,7 +261,7 @@ blockstanbulSend' msg = do
         now <- liftIO getCurrentTime
         when (now < tNext) $
           liftIO . threadDelay . round $ 1e6 * diffUTCTime tNext now
-        ctx <- fmap (fromMaybe $ error "BlockstanbulContext missing") $ getBlockstanbulContext
+        ctx <- getBlockstanbulContext
         Mod.put (Mod.Proxy @BestSequencedBlock) $
           BestSequencedBlock
               (BDB.blockHeaderHash bh)

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer/Bootstrap.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer/Bootstrap.hs
@@ -3,29 +3,29 @@
 
 module Blockchain.Sequencer.Bootstrap (bootstrapSequencer) where
 
-import BlockApps.Logging
 import Blockchain.Constants
 import Blockchain.Data.Block
 import qualified Blockchain.Data.TXOrigin as TO
 import qualified Blockchain.Data.Transaction as TX
-import Blockchain.EthConf as EC
 import Blockchain.Model.WrappedBlock
+import Blockchain.EthConf (runKafkaMConfigured)
 import Blockchain.Sequencer.CablePackage
 import Blockchain.Sequencer.Constants
 import Blockchain.Sequencer.DB.DependentBlockDB
 import Blockchain.Sequencer.Event
 import Blockchain.Sequencer.Kafka (writeSeqVmEvents, writeSeqP2pEvents, assertSequencerTopicsCreation)
-import Blockchain.Sequencer.Monad
 import Blockchain.Strato.Model.Address
 import Blockchain.Strato.Model.Class
-import ClassyPrelude (atomically, fromMaybe, newTMChan)
+import ClassyPrelude (atomically, fromMaybe)
 import Control.Monad.Composable.Kafka
 import qualified Data.ByteString.Char8 as C8
-import Network.HTTP.Client (defaultManagerSettings, newManager)
-import Servant.Client
 
--- bootstrap genesis block into leveldb if needed
+-- | Bootstrap genesis block into LevelDB and Kafka.
 --
+-- This is a one-time initialization that:
+-- 1. Marks the genesis block as 'Emitted' in the DependentBlockDB
+-- 2. Creates the sequencer Kafka topics
+-- 3. Writes the genesis block to the VM and P2P event topics
 bootstrapSequencer :: Block -> IO OutputBlock
 bootstrapSequencer
   Block
@@ -34,7 +34,7 @@ bootstrapSequencer
       blockBlockUncles = us
     } = do
     pkg <- atomically newCablePackage
-    initLevelDB pkg
+    initLevelDB
     initKafka pkg
     return shortCircuit
     where
@@ -56,32 +56,11 @@ bootstrapSequencer
                 otBaseTx = t,
                 otHash = TX.transactionHash t
               }
-      initLevelDB :: CablePackage -> IO ()
-      initLevelDB pkg = do
-        tch <- atomically newTMChan
-
-        -- initialize vault client, TODO: make this URL a cl arg
-        mgr <- newManager defaultManagerSettings
-        vaultWrapperUrl <- parseBaseUrl "http://localhost:8013/strato/v2.3"
-        let clientEnv = mkClientEnv mgr vaultWrapperUrl
-
-            dummySequencerCfg =
-              SequencerConfig
-                { dependentBlockDB = error "Dependent Block DB not initialized",
-                  depBlockDBCacheSize = 0,
-                  depBlockDBPath = dbDir "h" ++ sequencerDependentBlockDBPath,
-                  seenTransactionDBSize = 10,
-                  blockstanbulBlockPeriod = BlockPeriod 0,
-                  blockstanbulRoundPeriod = RoundPeriod 0,
-                  blockstanbulTimeouts = tch,
-                  cablePackage = pkg,
-                  maxEventsPerIter = 65,
-                  maxUsPerIter = 20000,
-                  vaultClient = Just clientEnv,
-                  kafkaClientId = KString $ C8.pack defaultKafkaClientId',
-                  redisConn = error "initLevelDB: redisConn"
-                }
-        runLoggingT . runSequencerM dummySequencerCfg Nothing $ do
+      initLevelDB :: IO ()
+      initLevelDB = do
+        let dbPath = dbDir "h" ++ sequencerDependentBlockDBPath
+            cacheSize = 0
+        runWithDependentBlockDB dbPath cacheSize $
           bootstrapGenesisBlock hash
       initKafka :: CablePackage -> IO ()
       initKafka _ = do

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer/DB/DependentBlockDB.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer/DB/DependentBlockDB.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -128,3 +130,8 @@ buildEmissionChain b =
       return []
   where
     theBlock = sequencedBlockToOutputBlock b
+
+instance (MonadIO m, Accessible DependentBlockDB m) => (Keccak256 `Alters` DependentBlockEntry) m where
+  lookup _ k = lookupDependentBlockDB k
+  insert _ k v = insertDependentBlockDB k v
+  delete _ k = deleteDependentBlockDB k

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer/DB/DependentBlockDB.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer/DB/DependentBlockDB.hs
@@ -19,7 +19,8 @@ module Blockchain.Sequencer.DB.DependentBlockDB (
   deleteDependentBlockDB,
   insertEmitted,
   enqueueIfParentNotEmitted,
-  buildEmissionChain
+  buildEmissionChain,
+  runWithDependentBlockDB
   ) where
 
 import BlockApps.Logging
@@ -30,6 +31,8 @@ import Control.Monad (join)
 import Control.Monad.Change.Alter
 import Control.Monad.Change.Modify
 import Control.Monad.IO.Class
+import Control.Monad.Trans.Reader (ReaderT, runReaderT)
+import Control.Monad.Trans.Resource (runResourceT)
 import Data.Binary
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Text as T
@@ -135,3 +138,16 @@ instance (MonadIO m, Accessible DependentBlockDB m) => (Keccak256 `Alters` Depen
   lookup _ k = lookupDependentBlockDB k
   insert _ k v = insertDependentBlockDB k v
   delete _ k = deleteDependentBlockDB k
+
+-- | Run an action that only needs 'DependentBlockDB' access.
+--
+-- This opens a LevelDB database at the given path and provides the minimal
+-- monad needed to run operations like 'bootstrapGenesisBlock'.
+runWithDependentBlockDB ::
+  FilePath ->  -- ^ Path to the LevelDB database
+  Int ->       -- ^ Cache size (0 = 8MB default)
+  ReaderT DependentBlockDB IO a ->
+  IO a
+runWithDependentBlockDB dbPath cacheSize action = runResourceT $ do
+  db <- LDB.open dbPath LDB.defaultOptions {LDB.createIfMissing = True, LDB.cacheSize = cacheSize}
+  liftIO $ runReaderT action (DependentBlockDB db)

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS -fno-warn-orphans #-}
 
@@ -132,11 +131,6 @@ instance HasNamespace Checkpoint where
   type NSKey Checkpoint = ()
   namespace _ = "chkpt"
 -}
-instance (MonadIO m, Mod.Accessible DependentBlockDB m) => (Keccak256 `A.Alters` DependentBlockEntry) m where
-  lookup _ k = lookupDependentBlockDB k
-  insert _ k v = insertDependentBlockDB k v
-  delete _ k = deleteDependentBlockDB k
-
 instance Monad m => Mod.Modifiable SeenTransactionDB (StateT SequencerContext m) where
   get _ = use seenTransactionDB
   put _ = modify' . (.~) seenTransactionDB

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -78,7 +78,7 @@ data Modification a = Modification a | Deletion deriving (Show)
 
 data SequencerContext = SequencerContext
   { _seenTransactionDB :: !SeenTransactionDB,
-    _blockstanbulContext :: Maybe BlockstanbulContext,
+    _blockstanbulContext :: BlockstanbulContext,
     _latestRoundNumber :: IORef RoundNumber
   }
 
@@ -159,8 +159,8 @@ instance Monad m => (Keccak256 `A.Alters` ()) (StateT SequencerContext m) where
   delete _ = genericDeleteSeenTransactionDB
 
 instance Monad m => HasBlockstanbulContext (StateT SequencerContext m) where
-  getBlockstanbulContext = use blockstanbulContext
-  putBlockstanbulContext = modify' . (.~) (blockstanbulContext . _Just)
+  getBlockstanbulContext = Just <$> use blockstanbulContext
+  putBlockstanbulContext = modify' . (.~) blockstanbulContext
 
 instance (MonadIO m, MonadLogger m) => Mod.Modifiable BestSequencedBlock (ReaderT SequencerConfig m) where
   get _ =
@@ -210,8 +210,8 @@ waitOnVault action = do
       $logInfoS "HasVault" "Got a signature from vault"
       return val
 
-runSequencerM :: SequencerConfig -> Maybe BlockstanbulContext -> SequencerM a -> (LoggingT IO) a
-runSequencerM c mbc m = do
+runSequencerM :: SequencerConfig -> BlockstanbulContext -> SequencerM a -> (LoggingT IO) a
+runSequencerM c bc m = do
   liftIO $ createDirectoryIfMissing False $ dbDir "h"
   a <- runResourceT . runKafkaMConfigured (kafkaClientId c) $ do
     let dbCS = depBlockDBCacheSize c
@@ -222,7 +222,7 @@ runSequencerM c mbc m = do
     flip runReaderT c{dependentBlockDB = depBlock} $ runStateT m
       SequencerContext
         { _seenTransactionDB = mkSeenTxDB stxSize,
-          _blockstanbulContext = mbc,
+          _blockstanbulContext = bc,
           _latestRoundNumber = latestRound
         }
 

--- a/strato/core/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
+++ b/strato/core/strato-sequencer/src/Blockchain/Sequencer/Monad.hs
@@ -159,7 +159,7 @@ instance Monad m => (Keccak256 `A.Alters` ()) (StateT SequencerContext m) where
   delete _ = genericDeleteSeenTransactionDB
 
 instance Monad m => HasBlockstanbulContext (StateT SequencerContext m) where
-  getBlockstanbulContext = Just <$> use blockstanbulContext
+  getBlockstanbulContext = use blockstanbulContext
   putBlockstanbulContext = modify' . (.~) blockstanbulContext
 
 instance (MonadIO m, MonadLogger m) => Mod.Modifiable BestSequencedBlock (ReaderT SequencerConfig m) where

--- a/strato/core/strato-sequencer/src/Flags.hs
+++ b/strato/core/strato-sequencer/src/Flags.hs
@@ -23,8 +23,6 @@ defineFlag "k:kafkaclientid" defaultKafkaClientId' "KafkaClientId (for runKafkaC
 defineFlag "kafkaaddress" ("" :: String) "Alternate kafka instance to connect to."
 
 -- blockstanbul related flags
--- TODO(tim): We may need to specify a starting view, or catch up from the network
-defineFlag "blockstanbul" (False :: Bool) "Whether to run blockstanbul"
 defineFlag "blockstanbul_block_period_ms" (1000 :: Int) "Minimum delay between block creations"
 defineFlag
   "blockstanbul_round_period_s"
@@ -52,7 +50,6 @@ exportFlagsAsMetrics = do
   set "depblockdbcachesize" $ show flags_depblockcachesize
   set "kafkaclientid" $ show flags_kafkaclientid
   set "kafkaaddress" flags_kafkaaddress
-  set "blockstanbul" $ show flags_blockstanbul
   set "blockstanbul_block_period_ms" $ show flags_blockstanbul_block_period_ms
   set "blockstanbul_round_period_s" $ show flags_blockstanbul_round_period_s
   set "vaultWrapperUrl" $ flags_vaultWrapperUrl

--- a/strato/core/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/strato/core/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -107,22 +107,17 @@ myPriv = fromMaybe (error "could not import private key") (importPrivateKey (Lab
 runTestM :: SequencerM a -> IO ()
 runTestM m = do
   gb <- makeGenesisBlock
-  void $ withTemporaryDepBlockDB False gb m
+  void $ withTemporaryDepBlockDB gb m
 
-runPBFTTestM :: SequencerM a -> IO ()
-runPBFTTestM m = do
-  gb <- makeGenesisBlock
-  void $ withTemporaryDepBlockDB True gb m
-
-runPBFTTestMWithGenesis :: (Keccak256 -> SequencerM a) -> IO ()
-runPBFTTestMWithGenesis m = do
+runTestMWithGenesis :: (Keccak256 -> SequencerM a) -> IO ()
+runTestMWithGenesis m = do
   gb <- makeGenesisBlock
   let hsh = blockHash . ingestBlockToBlock $ gb
-  void $ withTemporaryDepBlockDB True gb (m hsh)
+  void $ withTemporaryDepBlockDB gb (m hsh)
 
 
-withTemporaryDepBlockDB :: Bool -> IngestBlock -> SequencerM a -> IO a
-withTemporaryDepBlockDB pbft genesisBlock m = do
+withTemporaryDepBlockDB :: IngestBlock -> SequencerM a -> IO a
+withTemporaryDepBlockDB genesisBlock m = do
     cwd          <- getCurrentDirectory
     randomSuffix <- generate $ (arbitrary :: Gen Integer) `suchThat` (>1000)
     timestamp    <- round <$> getPOSIXTime  :: IO Integer
@@ -151,7 +146,6 @@ withTemporaryDepBlockDB pbft genesisBlock m = do
         myCM = CommonName "BlockApps" "Engineering" "Admin" True
         vals = [chainMemberParsedSetToValidator myCM]
         ctx = newContext (Checkpoint (View 0 0) vals) Nothing True (Just myCM)
-        mCtx = if pbft then Just ctx else Nothing
         hsh = blockHash . ingestBlockToBlock $ genesisBlock
         difficulty = blockHeaderDifficulty . ibBlockData $ genesisBlock
         cmpsToXcis a (CommonName o u n True) = X509CertInfoState a rootCert True [] (T.unpack o) (Just $ T.unpack u) (T.unpack n)
@@ -160,7 +154,7 @@ withTemporaryDepBlockDB pbft genesisBlock m = do
           bootstrapGenesisBlock hsh difficulty
           A.insert (A.Proxy @X509CertInfoState) myAddr $ cmpsToXcis myAddr myCM
           A.insert (A.Proxy @EmittedBlock) hsh alreadyEmittedBlock
-    runNoLoggingT (runSequencerM cfg mCtx (boot >> m))
+    runNoLoggingT (runSequencerM cfg ctx (boot >> m))
       `finally`
       (removeDirectoryRecursive fullPath >> setCurrentDirectory cwd)-- always clean up
 
@@ -203,7 +197,7 @@ spec = do
         it "transformEvents should output blocks in partial order based on parent hash when input is in order" $ do
             gb <- makeGenesisBlock
             inChain <- buildIngestChain gb 8 2
-            outBlocks <- withTemporaryDepBlockDB False gb $ do
+            outBlocks <- withTemporaryDepBlockDB gb $ do
               BatchSeqEvent{..} <- runBatch $ splitEvents (IEBlock <$> inChain)
               return [block | VmBlock block <- _toVm ]
             ret <- validateOrder gb outBlocks
@@ -213,7 +207,7 @@ spec = do
             gb <- makeGenesisBlock
             inChain <- buildIngestChain gb 8 2
             shuffled <- generate $ shuffle inChain
-            outBlocks <- withTemporaryDepBlockDB False gb $ do
+            outBlocks <- withTemporaryDepBlockDB gb $ do
               BatchSeqEvent{..} <- runBatch $ splitEvents (IEBlock <$> shuffled)
               return [block | VmBlock block <- _toVm ]
             ret <- validateOrder gb outBlocks
@@ -224,12 +218,12 @@ spec = do
             ts <- generate arbitrary
             inTxSize <- generate $ choose (10, dedupWindow - 1)
             inTxs  <- generate $ vectorOf inTxSize arbitrary
-            outTxs <- withTemporaryDepBlockDB False gb $ do
+            outTxs <- withTemporaryDepBlockDB gb $ do
               BatchSeqEvent{..} <- runBatch $ splitEvents (IETx ts <$> inTxs)
               return [t | t@VmTx{} <- _toVm]
             -- ^^ in case any arbitrary Txs weren't unique
             let dedupedIn = feedBackOutputsToInput outTxs
-            dedupedOut <- withTemporaryDepBlockDB False gb $ do
+            dedupedOut <- withTemporaryDepBlockDB gb $ do
               _toVm <$> runBatch (splitEvents dedupedIn)
             length dedupedOut `shouldBe` length dedupedIn
 
@@ -238,14 +232,14 @@ spec = do
             ts <- generate arbitrary
             inTxSize <- generate $ choose (2 * dedupWindow, (3 * dedupWindow) - 1)
             inTxs  <- generate . vectorOf inTxSize $ suchThat arbitrary (isNothing . txChainId . itTransaction)
-            outTxs <- withTemporaryDepBlockDB False gb $ do
+            outTxs <- withTemporaryDepBlockDB gb $ do
               BatchSeqEvent{..} <- runBatch $ splitEvents (IETx ts <$> inTxs)
               return [t | t@VmTx{} <- _toVm]
             -- ^^ in case any arbitrary Txs weren't unique
             let dedupedIn          = feedBackOutputsToInput outTxs
                 replicationsNeeded = (dedupWindow `quot` length dedupedIn) + 1
                 replicatedIn       = concat $ replicate replicationsNeeded dedupedIn
-            dedupedOut <- withTemporaryDepBlockDB False gb $ do
+            dedupedOut <- withTemporaryDepBlockDB gb $ do
               BatchSeqEvent{..} <- runBatch $ splitEvents replicatedIn
               return [o | o@(VmTx _ _) <- _toVm]
             length dedupedOut `shouldBe` length dedupedOut
@@ -324,7 +318,7 @@ spec = do
         (_, evs) <- readEventsInBufferedWindow src
         evs `shouldMatchList` map TimerFire [10..19]
 
-      it "should forward new blocks to blockstanbul" . runPBFTTestMWithGenesis $ \h -> do
+      it "should forward new blocks to blockstanbul" . runTestMWithGenesis $ \h -> do
         let b' = makeBlock 1 1
             b = Block (blockBlockData b'){ parentHash = h
                                          , number = 1
@@ -337,7 +331,7 @@ spec = do
         map categorize pbftEvs `shouldMatchList` [PreprepareK, PrepareK, PrepareK, CommitK, CommitK]
         _toVm `shouldContain` [VmCreateBlockCommand]
 
-      it "should replay old blocks in blockstanbul" . runPBFTTestMWithGenesis $ \h -> do
+      it "should replay old blocks in blockstanbul" . runTestMWithGenesis $ \h -> do
         ctx <- fromMaybe (error "context required for PBFT") <$> getBlockstanbulContext
         let blk0 = makeBlock 2 1
             blk1 = Block (blockBlockData blk0){parentHash = h} (blockReceiptTransactions blk0) (blockBlockUncles blk0)
@@ -357,7 +351,7 @@ spec = do
         ctx' <- fromMaybe (error "context required for pbft") <$> getBlockstanbulContext
         _view ctx' `shouldBe` View 0 1
 
-      it "should sequence blocks out of order in blockstanbul" . runPBFTTestMWithGenesis $ \h -> do
+      it "should sequence blocks out of order in blockstanbul" . runTestMWithGenesis $ \h -> do
         ctx <- fromMaybe (error "context required for PBFT") <$> getBlockstanbulContext
         let ieBlk = IEBlock . blockToIngestBlock TO.Morphism
             mkBlkChn :: Int -> Keccak256 -> Integer -> SequencerM [Block]
@@ -478,7 +472,7 @@ spec = do
         map txType txs' `shouldBe` [Message, PrivateHash]
         map (isJust . otPrivatePayload) txs' `shouldBe` [False, False]
 
-      it "should run Blockstanbul with private transactions" . runPBFTTestMWithGenesis $ \h -> do
+      it "should run Blockstanbul with private transactions" . runTestMWithGenesis $ \h -> do
         let iev = iev1' h
         BatchSeqEvent{..} <- runBatch $ do
           checkForUnseq [chainDetails1]
@@ -489,7 +483,7 @@ spec = do
         let obs = [b | VmBlock b <- _toVm]
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs `shouldBe` [[Just Message]]
 
-      it "should run Blockstanbul with delayed private transactions" . runPBFTTestMWithGenesis $ \h -> do
+      it "should run Blockstanbul with delayed private transactions" . runTestMWithGenesis $ \h -> do
         let iev = iev1' h
         b1 <- runBatch $ do
           checkForUnseq [chainDetails1]
@@ -502,7 +496,7 @@ spec = do
         let obs' = [b | VmBlock b <- _toVm b2]
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs' `shouldBe` [[Just Message]]
 
-      it "should not split up block when all chains are known" . runPBFTTestMWithGenesis $ \h -> do
+      it "should not split up block when all chains are known" . runTestMWithGenesis $ \h -> do
         let iev = iev2' h
             ietx = IETx 0 . IngestTx TO.Morphism
         BatchSeqEvent{..} <- runBatch $ do
@@ -515,7 +509,7 @@ spec = do
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs `shouldBe`
           [[Just Message, Just Message]]
 
-      it "should split up block when chain infos are delayed" . runPBFTTestMWithGenesis $ \h -> do
+      it "should split up block when chain infos are delayed" . runTestMWithGenesis $ \h -> do
         let iev = iev2' h
             ietx = IETx 0 . IngestTx TO.Morphism
         b1 <- runBatch $ do
@@ -531,7 +525,7 @@ spec = do
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs' `shouldBe`
           [[Just Message, Nothing], [Just Message, Just Message]]
 
-      it "should split up block when chain infos are staggered" . runPBFTTestMWithGenesis $ \h -> do
+      it "should split up block when chain infos are staggered" . runTestMWithGenesis $ \h -> do
         let iev = iev2' h
             ietx = IETx 0 . IngestTx TO.Morphism
         b1 <- runBatch $ checkForUnseq [ietx tx1, ietx tx2, iev]
@@ -550,7 +544,7 @@ spec = do
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
           [[Just Message, Just Message]]
 
-      it "should hydrate child chain transaction when parent chain is known" . runPBFTTestMWithGenesis $ \h -> do
+      it "should hydrate child chain transaction when parent chain is known" . runTestMWithGenesis $ \h -> do
         let iev = iev4' h
             ietx = IETx 0 . IngestTx TO.Morphism
         b1 <- runBatch $ checkForUnseq [chainDetails1, chainDetails3, ietx tx3, iev]
@@ -561,7 +555,7 @@ spec = do
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs `shouldBe`
           [[Just Message]]
 
-      it "should withhold child chain transactions when parent chain is missing" . runPBFTTestMWithGenesis $ \h -> do
+      it "should withhold child chain transactions when parent chain is missing" . runTestMWithGenesis $ \h -> do
         let iev = iev3' h
             ietx = IETx 0 . IngestTx TO.Morphism
         b1 <- runBatch $ checkForUnseq [ietx tx1, ietx tx3, iev]
@@ -578,7 +572,7 @@ spec = do
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
           [[Just Message, Nothing], [Just Message, Just Message]]
 
-      it "should withhold child chain transactions when parent chain is missing even when there are no transactions on the parent chain" . runPBFTTestMWithGenesis $ \h -> do
+      it "should withhold child chain transactions when parent chain is missing even when there are no transactions on the parent chain" . runTestMWithGenesis $ \h -> do
         let iev = iev4' h
             ietx = IETx 0 . IngestTx TO.Morphism
         b1 <- runBatch $ checkForUnseq [ietx tx3, iev]
@@ -595,7 +589,7 @@ spec = do
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
           [[Just Message]]
 
-      it "should withhold child chain transactions when parent chain parent chain transactions are missing" . runPBFTTestMWithGenesis $ \h -> do
+      it "should withhold child chain transactions when parent chain parent chain transactions are missing" . runTestMWithGenesis $ \h -> do
         let b5' = makeBlockWithTransactions [hashTx1]
             blk5' = Block (blockBlockData b5'){ parentHash = h
                                               , number = 1
@@ -630,7 +624,7 @@ spec = do
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
           [[Just Message], [Just Message]]
 
-      it "should withhold child chain transactions when parent chain parent chain info is missing" . runPBFTTestMWithGenesis $ \h -> do
+      it "should withhold child chain transactions when parent chain parent chain info is missing" . runTestMWithGenesis $ \h -> do
         let b5' = makeBlockWithTransactions [hashTx1]
             blk5' = Block (blockBlockData b5'){ parentHash = h
                                               , number = 1
@@ -665,7 +659,7 @@ spec = do
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
           [[Just Message], [Just Message]]
 
-      it "should re-run blocks when chain info is delayed" . runPBFTTestMWithGenesis $ \h -> do
+      it "should re-run blocks when chain info is delayed" . runTestMWithGenesis $ \h -> do
         let iev = iev1' h
             ietx = IETx 0 . IngestTx TO.Morphism
         b1 <- runBatch $ checkForUnseq [iev]
@@ -684,7 +678,7 @@ spec = do
         map (map (fmap txType . otPrivatePayload) . obReceiptTransactions) obs'' `shouldBe`
           [[Just Message]]
 
-      it "should emit chain info when creation block has already been emitted" . runPBFTTestMWithGenesis $ \h -> do
+      it "should emit chain info when creation block has already been emitted" . runTestMWithGenesis $ \h -> do
         let cInfo' = getChainInfo "emittable"
             ucInfo = chainInfo cInfo'
             cInfo = cInfo'{chainInfo = ucInfo{creationBlock = h}}
@@ -696,7 +690,7 @@ spec = do
         let ogs = [og' | VmGenesis og' <- _toVm b1]
         ogs `shouldBe` [og]
 
-      it "should withhold emitting chain info when creation block has not been emitted" . runPBFTTestMWithGenesis $ \_ -> do
+      it "should withhold emitting chain info when creation block has not been emitted" . runTestMWithGenesis $ \_ -> do
         let cInfo' = getChainInfo "unemittable"
             ucInfo = chainInfo cInfo'
             cInfo = cInfo'{chainInfo = ucInfo{creationBlock = unsafeCreateKeccak256FromWord256 0xdeadbeef}}
@@ -706,7 +700,7 @@ spec = do
         let ogs = [og' | VmGenesis og' <- _toVm b1]
         ogs `shouldBe` []
 
-      it "should withhold chain info until creation block has been emitted" . runPBFTTestMWithGenesis $ \h -> do
+      it "should withhold chain info until creation block has been emitted" . runTestMWithGenesis $ \h -> do
         blk <- mkBlk h 1
         let iblk = blockToIngestBlock TO.Morphism blk
             ieblk = IEBlock iblk

--- a/strato/core/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/strato/core/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -168,7 +168,7 @@ feedBackOutputsToInput = map rebox
 
 mkBlk :: Keccak256 -> Integer -> SequencerM Block
 mkBlk parent num = do
-  ctx <- fromMaybe (error "context required for PBFT") <$> getBlockstanbulContext
+  ctx <- getBlockstanbulContext
   let blk0 = makeBlock 2 1
       blk1 = Block (blockBlockData blk0){parentHash = parent} (blockReceiptTransactions blk0) (blockBlockUncles blk0)
       blk2 = addValidators (_validators ctx) blk1{
@@ -332,7 +332,7 @@ spec = do
         _toVm `shouldContain` [VmCreateBlockCommand]
 
       it "should replay old blocks in blockstanbul" . runTestMWithGenesis $ \h -> do
-        ctx <- fromMaybe (error "context required for PBFT") <$> getBlockstanbulContext
+        ctx <- getBlockstanbulContext
         let blk0 = makeBlock 2 1
             blk1 = Block (blockBlockData blk0){parentHash = h} (blockReceiptTransactions blk0) (blockBlockUncles blk0)
             blk2 = addValidators (_validators ctx) blk1{
@@ -348,11 +348,11 @@ spec = do
         _toVm `shouldContain` [VmCreateBlockCommand]
         map outputBlockToBlock [oblk | P2pBlock oblk <- _toP2p] `shouldMatchList` [blk4]
         map outputBlockToBlock [oblk | VmBlock oblk <- _toVm] `shouldMatchList` [blk4]
-        ctx' <- fromMaybe (error "context required for pbft") <$> getBlockstanbulContext
+        ctx' <- getBlockstanbulContext
         _view ctx' `shouldBe` View 0 1
 
       it "should sequence blocks out of order in blockstanbul" . runTestMWithGenesis $ \h -> do
-        ctx <- fromMaybe (error "context required for PBFT") <$> getBlockstanbulContext
+        ctx <- getBlockstanbulContext
         let ieBlk = IEBlock . blockToIngestBlock TO.Morphism
             mkBlkChn :: Int -> Keccak256 -> Integer -> SequencerM [Block]
             mkBlkChn 0 _ _ = return []
@@ -367,7 +367,7 @@ spec = do
         _toVm `shouldContain` [VmCreateBlockCommand]
         map outputBlockToBlock [oblk | P2pBlock oblk <- _toP2p] `shouldMatchList` blkChn
         map outputBlockToBlock [oblk | VmBlock oblk <- _toVm] `shouldMatchList` blkChn
-        ctx' <- fromMaybe (error "context required for pbft") <$> getBlockstanbulContext
+        ctx' <- getBlockstanbulContext
         _view ctx' `shouldBe` View 0 5
 
       it "should be able to fetch if the write is after the read begins" . runTestM $ do

--- a/strato/extraFiles/strato/doit.sh
+++ b/strato/extraFiles/strato/doit.sh
@@ -163,7 +163,6 @@ function newnode {
 
   echo "Starting strato-sequencer"
   runBackgroundProcess strato-sequencer \
-    --blockstanbul=true \
     --blockstanbul_block_period_ms=${blockstanbulBlockPeriodMs:-1000} \
     --blockstanbul_round_period_s=${blockstanbulRoundPeriodS:-120} \
     --minLogLevel=$seqMinLogLevel \

--- a/strato/simulator/strato-lite/src/Strato/Lite/Core.hs
+++ b/strato/simulator/strato-lite/src/Strato/Lite/Core.hs
@@ -325,10 +325,10 @@ instance {-# OVERLAPPING #-} MonadIO m => (Keccak256 `A.Alters` ()) (CoreT m) wh
 instance {-# OVERLAPPING #-} MonadIO m => HasBlockstanbulContext (CoreT m) where
   getBlockstanbulContext = do
     i <- asks $ _sequencerContext . _corePeerContext
-    liftIO $ _blockstanbulContext <$> readTVarIO i
+    liftIO $ Just . _blockstanbulContext <$> readTVarIO i
   putBlockstanbulContext s = do
     i <- asks $ _sequencerContext . _corePeerContext
-    liftIO $ atomically $ modifyTVar' i (blockstanbulContext ?~ s)
+    liftIO $ atomically $ modifyTVar' i (blockstanbulContext .~ s)
 
 instance {-# OVERLAPPING #-} HasVault m => HasVault (CoreT m) where
   sign bs = lift $ sign bs
@@ -636,7 +636,7 @@ newSequencerContext bc = do
   pure $
     SequencerContext
       { _seenTransactionDB = mkSeenTxDB 1024,
-        _blockstanbulContext = Just bc,
+        _blockstanbulContext = bc,
         _latestRoundNumber = latestRound
       }
 

--- a/strato/simulator/strato-lite/src/Strato/Lite/Core.hs
+++ b/strato/simulator/strato-lite/src/Strato/Lite/Core.hs
@@ -325,7 +325,7 @@ instance {-# OVERLAPPING #-} MonadIO m => (Keccak256 `A.Alters` ()) (CoreT m) wh
 instance {-# OVERLAPPING #-} MonadIO m => HasBlockstanbulContext (CoreT m) where
   getBlockstanbulContext = do
     i <- asks $ _sequencerContext . _corePeerContext
-    liftIO $ Just . _blockstanbulContext <$> readTVarIO i
+    liftIO $ _blockstanbulContext <$> readTVarIO i
   putBlockstanbulContext s = do
     i <- asks $ _sequencerContext . _corePeerContext
     liftIO $ atomically $ modifyTVar' i (blockstanbulContext .~ s)
@@ -791,8 +791,9 @@ corePeerSetup = do
   if bestSequencedBlockNumber bsb' > 0
     then do
       bCtx <- getBlockstanbulContext
-      for_ bCtx $ putBlockstanbulContext . (view . sequence .~ fromIntegral (bestSequencedBlockNumber bsb'))
-                                         . (validators .~ (Set.fromList $ bestSequencedBlockValidators bsb'))
+      putBlockstanbulContext $ (view . sequence .~ fromIntegral (bestSequencedBlockNumber bsb'))
+                             . (validators .~ (Set.fromList $ bestSequencedBlockValidators bsb'))
+                             $ bCtx
       let bh = bestSequencedBlockHash bsb'
       mOB <- A.lookup (A.Proxy @OutputBlock) bh
       case mOB of

--- a/strato/simulator/strato-lite/src/Strato/Lite/Rest/Server.hs
+++ b/strato/simulator/strato-lite/src/Strato/Lite/Rest/Server.hs
@@ -57,11 +57,11 @@ getNodes mgr = liftIO . atomically $ do
       Nothing -> pure $ NodeStatus "0.0.0.0" 0 0 False mExp
       Just (s,c) -> do
         let coreCtx = c ^. corePeerContext
-        mBCtx <- _blockstanbulContext <$> readTVar (coreCtx ^. sequencerContext)
-        let mView = _view <$> mBCtx
-            rNum = maybe 0 (fromIntegral . _round) mView
-            sNum = maybe 0 (fromIntegral . _sequence) mView
-            isVal = maybe False _isValidator mBCtx
+        bCtx <- _blockstanbulContext <$> readTVar (coreCtx ^. sequencerContext)
+        let v = _view bCtx
+            rNum = fromIntegral $ _round v
+            sNum = fromIntegral $ _sequence v
+            isVal = _isValidator bCtx
             Host ip = s ^. simulatorPeerIPAddress
         pure $ NodeStatus ip rNum sNum isVal mExp
 


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/5809

# Approach

## Step 1

The `initLevelDB` in the `bootstrapSequencer` used the `SequencerM` monad, only to get its LevelDB capabilities. 
This led to providing a `dummySequencerCfg` to `runSequencerM`.

This blocked further refactorings that are needed for the `--blockstanbul=true` removal.

## Step 2 

Remove Maybe wrapper from BlockstanbulContext in SequencerContext

## Step 3

Modify `HasBlockstanbulContext` so that `getBlockstanbulContext` reutrns `m BlockstanbulContext` (and not `Maybe (m BlockstanbulContext)`

## Step 4 

Remove the  flag `--blockstanbul`

# Checklist

- [x] Does it compile?
- [x] Can we sync from genesis?