### PR TITLE
Fixed quoting issue

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
+++ b/strato/VM/SolidVM/solid-vm-model/src/SolidVM/Model/Storable.hs
@@ -60,7 +60,7 @@ instance IsString BasicValue where
   fromString s = BString $ C8.pack s
 
 instance PersistField BasicValue where
-  toPersistValue = toPersistValue . format
+  toPersistValue = toPersistValue . formatBasicValue
   fromPersistValue v =
     case fromPersistValue v of
       Left e -> Left e
@@ -75,7 +75,7 @@ instance PersistFieldSql BasicValue where
 instance E.SqlString BasicValue where
 
 instance ToHttpApiData BasicValue where
-  toUrlPiece = T.pack . format
+  toUrlPiece = T.pack . formatBasicValue
 
 instance FromHttpApiData BasicValue where
   parseUrlPiece v =
@@ -151,16 +151,20 @@ isDefault (BEnumVal _ _ w) = w == 0
 isDefault (BContract _ a) = a == 0x0
 isDefault BDefault = True
 
+formatBasicValue :: BasicValue -> String
+formatBasicValue (BInteger i) = show i
+formatBasicValue (BString s) = show $ UTF8.toString s
+formatBasicValue (BDecimal v) = show v
+formatBasicValue (BBool True) = "true"
+formatBasicValue (BBool False) = "false"
+formatBasicValue (BAddress a) = "address(" ++ show a ++ ")"
+formatBasicValue (BEnumVal n1 n2 w) = labelToString n1 ++ "." ++ labelToString n2 ++ "." ++ show w
+formatBasicValue (BContract n a) = labelToString n ++ "(" ++ show a ++ ")"
+formatBasicValue BDefault = "<unknown>"
+
 instance Format BasicValue where
-  format (BInteger i) = show i
   format (BString s) = ('"' :) . (++ "\"") $ UTF8.toString s
-  format (BDecimal v) = show v
-  format (BBool True) = "true"
-  format (BBool False) = "false"
-  format (BAddress a) = "address(" ++ show a ++ ")"
-  format (BEnumVal n1 n2 w) = labelToString n1 ++ "." ++ labelToString n2 ++ "." ++ show w
-  format (BContract n a) = labelToString n ++ "(" ++ show a ++ ")"
-  format BDefault = "<unknown>"
+  format bv          = formatBasicValue bv
 
 formatBasicValueForSQL :: BasicValue -> Text
 formatBasicValueForSQL (BInteger i) = T.pack $ show i


### PR DESCRIPTION
Before:
<img width="1221" height="654" alt="Screenshot 2025-12-09 at 5 11 24 PM" src="https://github.com/user-attachments/assets/d082f9f1-b2f6-4e1f-b8eb-a8b7d787d13b" />

After:
<img width="1219" height="958" alt="Screenshot 2025-12-09 at 5 11 33 PM" src="https://github.com/user-attachments/assets/dc1ce217-9822-4c74-8258-7235126fd844" />

Also made sure the changes don't affect sync - it turns out the issue with sync arises because the genesis block code uses the `ToJSON` and `FromJSON` instances of `BasicValue` when creating/reading from `genesis-block.json`. By only changing `BString` formatting for SQL and API related instances, I was able to get around this issue.