### PR TITLE
Fix: add missing Rewards nav to mobile sidebar and make leaderboard table responsive

### DIFF
--- a/mercata/ui/src/components/dashboard/MobileSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/MobileSidebar.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from 'next-themes';
-import { LayoutDashboard, Wallet, Book, ArrowRightLeft, Send, Shield, X, Activity, BarChart3,Droplets, Download } from 'lucide-react';
+import { LayoutDashboard, Wallet, Book, ArrowRightLeft, Send, Shield, X, Activity, BarChart3, Droplets, Download, Coins } from 'lucide-react';
 import { useUser } from '@/context/UserContext';
 import STRATOLOGO from '@/assets/strato.png';
 import STRATOLOGODARK from '@/assets/strato-dark.png';
@@ -23,6 +23,7 @@ const MobileSidebar = ({ isOpen, onClose }: MobileSidebarProps) => {
     { icon: <Book size={20} />, label: 'Borrow', path: '/dashboard/borrow' },
     { icon: <ArrowRightLeft size={20} />, label: 'Swap', path: '/dashboard/swap' },
     { icon: <Droplets size={20} />, label: 'Advanced', path: '/dashboard/advanced' },
+    { icon: <Coins size={20} />, label: 'Rewards', path: '/dashboard/rewards' },
     { icon: <BarChart3 size={20} />, label: 'Mercata Stats', path: '/dashboard/stats' },
     { icon: <Download size={20} />, label: 'Withdrawals', path: '/dashboard/withdrawals' },
     { icon: <Activity size={20} />, label: 'Activity Feed', path: '/dashboard/activity' },

--- a/mercata/ui/src/components/rewards/LeaderboardTable.tsx
+++ b/mercata/ui/src/components/rewards/LeaderboardTable.tsx
@@ -9,6 +9,7 @@ import CopyButton from "@/components/ui/copy";
 import { Badge } from "@/components/ui/badge";
 import { useMemo } from "react";
 import { useUser } from "@/context/UserContext";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 interface LeaderboardTableProps {
   entries?: LeaderboardEntry[];
@@ -39,6 +40,7 @@ export const LeaderboardTable = ({
   onPageChange 
 }: LeaderboardTableProps) => {
   const { userAddress } = useUser();
+  const isMobile = useIsMobile();
   
   const columns: ColumnsType<LeaderboardEntry> = useMemo(() => [
     {
@@ -118,18 +120,20 @@ export const LeaderboardTable = ({
               dataSource={entries}
               rowKey="address"
               loading={loading}
+              scroll={isMobile ? { x: 'max-content' } : undefined}
               pagination={{
                 current: currentPage,
                 pageSize: limit,
                 total: total,
                 showSizeChanger: false,
-                showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} entries`,
+                showTotal: isMobile ? undefined : (total, range) => `${range[0]}-${range[1]} of ${total} entries`,
                 onChange: (page) => {
                   if (onPageChange && !loading) {
                     onPageChange(page);
                   }
                 },
                 className: "mt-4",
+                simple: isMobile,
               }}
               locale={{
                 emptyText: (


### PR DESCRIPTION
#5846 

- Added Rewards navigation item to MobileSidebar to match DashboardSidebar
- Made LeaderboardTable responsive for mobile using useIsMobile hook