### PR TITLE
feat: add market closure logic and new feeds for metals assets

### DIFF
--- a/mercata/services/oracle/src/config/assets.json
+++ b/mercata/services/oracle/src/config/assets.json
@@ -27,6 +27,15 @@
       "name": "USDST-USD",
       "targetAssetAddress": "937efa7e3a77e20bbdbd7c0d32b6514f368c1010",
       "constantPrice": 1000000000000000000
+    },
+    "PAXG_GOLDST": {
+      "name": "PAXG-USD",
+      "tokenAddress": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
+      "targetAssetAddress": "cdc93d30182125e05eec985b631c7c61b3f63ff0"
+    },
+    "KAG_SILVST": {
+      "name": "KAG-USD",
+      "targetAssetAddress": "2c59ef92d08efde71fe1a1cb5b45f4f6d48fcc94"
     }
   }
 } 

--- a/mercata/services/oracle/src/config/assets.json
+++ b/mercata/services/oracle/src/config/assets.json
@@ -28,13 +28,13 @@
       "targetAssetAddress": "937efa7e3a77e20bbdbd7c0d32b6514f368c1010",
       "constantPrice": 1000000000000000000
     },
-    "PAXG_GOLDST": {
-      "name": "PAXG-USD",
+    "XAU-WEEKEND": {
+      "name": "PAXG-USD-WEEKEND",
       "tokenAddress": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
       "targetAssetAddress": "cdc93d30182125e05eec985b631c7c61b3f63ff0"
     },
-    "KAG_SILVST": {
-      "name": "KAG-USD",
+    "XAG-WEEKEND": {
+      "name": "KAG-USD-WEEKEND",
       "targetAssetAddress": "2c59ef92d08efde71fe1a1cb5b45f4f6d48fcc94"
     }
   }

--- a/mercata/services/oracle/src/config/feeds.json
+++ b/mercata/services/oracle/src/config/feeds.json
@@ -13,7 +13,7 @@
     {
       "name": "metals-weekend",
       "sources": ["CoinMarketCap"],
-      "assets": ["PAXG_GOLDST", "KAG_SILVST"]
+      "assets": ["XAU-WEEKEND", "XAG-WEEKEND"]
     },
     {
       "name": "constant-price",

--- a/mercata/services/oracle/src/config/feeds.json
+++ b/mercata/services/oracle/src/config/feeds.json
@@ -11,6 +11,11 @@
       "assets": ["XAU", "XAG"]
     },
     {
+      "name": "metals-weekend",
+      "sources": ["CoinMarketCap"],
+      "assets": ["PAXG_GOLDST", "KAG_SILVST"]
+    },
+    {
       "name": "constant-price",
       "sources": ["constant"],
       "assets": ["USDST"]

--- a/mercata/services/oracle/src/cronScheduler.ts
+++ b/mercata/services/oracle/src/cronScheduler.ts
@@ -16,9 +16,38 @@ export async function getCronSchedule(): Promise<string> {
     return schedule;
 }
 
+function isMetalsMarketClosed(): boolean {
+    const now = new Date();
+    const etString = now.toLocaleString('en-US', { timeZone: 'America/New_York' });
+    const etDate = new Date(etString);
+    const day = etDate.getDay();
+    const hour = etDate.getHours();
+    const minute = etDate.getMinutes();
+    
+    // Friday after 12:00 PM (noon) ET - LBMA stops
+    if (day === 5 && hour >= 12) return true;
+    // Saturday all day
+    if (day === 6) return true;
+    // Sunday all day
+    if (day === 0) return true;
+    // Monday before 5:30 AM ET - first LBMA auction
+    if (day === 1 && (hour < 5 || (hour === 5 && minute < 30))) return true;
+    
+    return false;
+}
+
 // Process all feeds in parallel and combine results
 async function processAllFeeds(configLoader: ConfigLoader): Promise<void> {
-    const resolvedFeeds = configLoader.getResolvedFeeds();
+    const allFeeds = configLoader.getResolvedFeeds();
+    const marketClosed = isMetalsMarketClosed();
+    
+    const resolvedFeeds = allFeeds.filter(feed => {
+        if (feed.name === 'metals-batch') return !marketClosed;
+        if (feed.name === 'metals-weekend') return marketClosed;
+        return true;
+    });
+    
+    logInfo('CronScheduler', `Metals market ${marketClosed ? 'closed' : 'open'}, using feeds: [${resolvedFeeds.map(f => f.name).join(', ')}]`);
     
     // Process all feeds in parallel
     const feedPromises = resolvedFeeds.map(async (feed) => {


### PR DESCRIPTION
- Implemented `isMetalsMarketClosed` function to determine market status based on time and day.
- Updated `processAllFeeds` to filter feeds based on market closure.
- Added new asset configurations for PAXG-USD and KAG-USD in `assets.json`.
- Introduced a new feed configuration for `metals-weekend` in `feeds.json` to handle weekend data.

This update enhances the handling of metals market schedules and expands the asset and feed configurations accordingly.