### PR TITLE
Fixed LendingPool loan calculation in net balance graph

### DIFF
--- a/mercata/backend/src/api/services/tokens.v2.service.ts
+++ b/mercata/backend/src/api/services/tokens.v2.service.ts
@@ -292,7 +292,7 @@ function processBalanceSnapshot(snapshot: {timestamp: number, data: any}, index:
     const tokenValue = (tokenPrice / 1000000000) * (tokenBalance / 1000000000);
     netBalance += tokenValue;
   }
-  netBalance -= netLoan + ((snapshot.data.userLoan?.scaledDebt || 0) / 1e27);
+  netBalance -= netLoan + parseFloat(snapshot.data.userLoan?.scaledDebt || '0');
   return { timestamp: snapshot.timestamp, data: {netBalance: netBalance / 1e18 }};
 }
 


### PR DESCRIPTION
Fixed the issue where taking out a loan caused the net balance graph to increase by the loan amount due to the user's USDST balance increasing, not subtracting the loan amount from the net balance.

Before change:
<img width="1159" height="532" alt="Screenshot 2025-12-26 at 12 42 56 PM" src="https://github.com/user-attachments/assets/15103e7d-ab1d-4156-ad19-4cc7e7fd50f0" />

After change:
<img width="1158" height="530" alt="Screenshot 2025-12-26 at 12 43 49 PM" src="https://github.com/user-attachments/assets/e202e5bd-9179-4e95-9ddd-f6a00d81b505" />
