### PR TITLE
Don't flash old health factor on Lending Pool Collateral Supply modal submission

### DIFF
--- a/mercata/ui/src/components/borrow/CollateralModal.tsx
+++ b/mercata/ui/src/components/borrow/CollateralModal.tsx
@@ -120,14 +120,11 @@ const CollateralModal = ({
         // If user selected at least the max, invoke on-chain max-withdraw to avoid drift issues
         if (amtWei >= maxDisplayAmount && maxDisplayAmount > 0n) {
           onAction('ALL');
-          setAmount("");
           return;
         }
       }
     } catch {}
     onAction(amount);
-    setAmount("");
-    setAmountError("");
   };
 
   // Clear input when modal closes


### PR DESCRIPTION
Fixes #5960

Lending Pool Collateral Supply modal no longer flashes the old health factor while submitting the transaction.
