### PR TITLE
Show events on the activity feed in alphabetical order

### DIFF
--- a/mercata/ui/src/components/dashboard/ActivityFeedFilters.tsx
+++ b/mercata/ui/src/components/dashboard/ActivityFeedFilters.tsx
@@ -69,9 +69,10 @@ const ActivityFeedFilters = memo(({
     : eventNames;
 
   // Deduplicate event names to prevent "DepositedDeposited" when "All Contracts" is selected
+  // Sort event names alphabetically
   const uniqueEventNames = Array.from(
     new Map(availableEvents.map(event => [event.name, event])).values()
-  );
+  ).sort((a, b) => a.name.localeCompare(b.name));
 
   return (
     <div className="mb-4 sm:mb-6 p-3 sm:p-4 border rounded-lg bg-muted/50 border-border">


### PR DESCRIPTION
..., even when "All Contracts" (the default contract option) is selected.

Fixes #5979

<img width="1661" height="1417" alt="image" src="https://github.com/user-attachments/assets/39bc6495-dee1-4235-b2f2-a11e57e2ed4d" />
