### PR TITLE
New Borrow UX with Risk Slider and Automatic Collateral Supply

### DIFF
--- a/mercata/backend/src/api/helpers/lending.helper.ts
+++ b/mercata/backend/src/api/helpers/lending.helper.ts
@@ -250,6 +250,7 @@ export const calculateCollateralMetrics = (
   userBalanceValue: string;
   collateralizedAmountValue: string;
   maxBorrowingPower: string;
+  unsuppliedBorrowingPower: string;
 } => {
   const balance = toBig(userBalance);
   const collateralized = toBig(collateralizedAmount);
@@ -262,11 +263,15 @@ export const calculateCollateralMetrics = (
   
   // Calculate max borrowing power using LTV: (collateralizedAmount * price * ltv) / (1e18 * 10000)
   const maxBorrowingPower = ((collateralized * price * ltvBasisPoints) / (DECIMALS * 10000n)).toString();
+  
+  // Calculate unsupplied borrowing power: userBalance * price * ltv (for sorting unsupplied collaterals)
+  const unsuppliedBorrowingPower = ((balance * price * ltvBasisPoints) / (DECIMALS * 10000n)).toString();
 
   return {
     userBalanceValue,
     collateralizedAmountValue,
     maxBorrowingPower,
+    unsuppliedBorrowingPower,
   };
 };
 

--- a/mercata/backend/src/api/helpers/lending.helper.ts
+++ b/mercata/backend/src/api/helpers/lending.helper.ts
@@ -273,7 +273,6 @@ export const calculateCollateralMetrics = (
   const unsuppliedBorrowingPower = ((balance * price * ltvBasisPoints) / (DECIMALS * 10000n)).toString();
   
   // Calculate unsupplied LT-weighted collateral value: userBalance * price * lt / (1e18 * 10000)
-  // Used for health factor calculations
   const unsuppliedLTCollateralValue = ((balance * price * ltBasisPoints) / (DECIMALS * 10000n)).toString();
 
   return {

--- a/mercata/backend/src/api/helpers/lending.helper.ts
+++ b/mercata/backend/src/api/helpers/lending.helper.ts
@@ -156,8 +156,14 @@ export const simulateLoan = (
   const priceUSD = toBig(borrowableAssetConfig.price); // 1e18
   const totalBorrowValueUSD = (toBig(totalAmountOwed) * priceUSD) / DECIMALS;
 
-  // 5) Total collateral value for health (USD, 18 decimals)
+  // 5) Total collateral value for health (USD, 18 decimals) - risk-adjusted by LiqThresh
   const totalCollateralValueUSD = calculateTotalCollateralValueForHealth(
+    collaterals,
+    assetConfigs
+  );
+
+  // 5b) Full supplied collateral value (USD, 18 decimals) - no LT adjustment
+  const totalCollateralValueSupplied = calculateUserCollateralValue(
     collaterals,
     assetConfigs
   );
@@ -200,6 +206,7 @@ export const simulateLoan = (
     healthFactorRaw,
     totalBorrowingPowerUSD: maxBorrowingPowerUSD.toString(),
     totalCollateralValueUSD: totalCollateralValueUSD,
+    totalCollateralValueSupplied: totalCollateralValueSupplied,
     maxAvailableToBorrowUSD: maxAvailableToBorrowUSD.toString(),
 
     // Display APR (bps → percent) if needed by callers
@@ -322,6 +329,34 @@ export const calculateUtilizationRate = (
   denom = resN < denom ? (denom - resN) : cashN;
   if (denom === 0n) return 0;
   return Number((debtN * 10000n) / denom) / 100; // percent with 2 decimals
+};
+
+/**
+ * Calculate a single user's total collateral value (raw USD, no liquidation threshold adjustment)
+ * @param collaterals Array of user's collateral assets and amounts
+ * @param assetConfigs Map of asset configurations (for price)
+ * @returns Total collateral value in USD (18 decimals)
+ */
+export const calculateUserCollateralValue = (
+  collaterals: CollateralInfo[],
+  assetConfigs: Map<string, AssetConfig>
+): string => {
+  let totalValue = 0n;
+
+  for (const collateral of collaterals) {
+    const config = assetConfigs.get(collateral.asset);
+    if (!config) continue;
+
+    const collateralAmount = toBig(collateral.amount);
+    if (collateralAmount === 0n) continue;
+
+    const price = toBig(config.price);
+    if (price === 0n) continue;
+
+    totalValue += (collateralAmount * price) / DECIMALS;
+  }
+
+  return totalValue.toString();
 };
 
 /**

--- a/mercata/backend/src/api/helpers/lending.helper.ts
+++ b/mercata/backend/src/api/helpers/lending.helper.ts
@@ -178,7 +178,8 @@ export const simulateLoan = (
       "0", // user token balance not needed here
       collateral.amount,
       cfg.price,                  // USD 1e18
-      cfg.ltv || 0                // bps
+      cfg.ltv || 0,               // bps
+      cfg.liquidationThreshold || 0 // bps
     );
     maxBorrowingPowerUSD += toBig(metrics.maxBorrowingPower);
   }
@@ -239,23 +240,27 @@ export const percentageToHealthFactor = (percentage: number): string => {
  * @param collateralizedAmount Amount of tokens used as collateral
  * @param assetPrice Price of the asset in USD (18 decimals)
  * @param ltv Loan-to-Value ratio in basis points (e.g., 7500 = 75%)
+ * @param liquidationThreshold Liquidation threshold in basis points (e.g., 8000 = 80%)
  * @returns Object with calculated values
  */
 export const calculateCollateralMetrics = (
   userBalance: string,
   collateralizedAmount: string,
   assetPrice: string,
-  ltv: number
+  ltv: number,
+  liquidationThreshold: number
 ): {
   userBalanceValue: string;
   collateralizedAmountValue: string;
   maxBorrowingPower: string;
   unsuppliedBorrowingPower: string;
+  unsuppliedLTCollateralValue: string;
 } => {
   const balance = toBig(userBalance);
   const collateralized = toBig(collateralizedAmount);
   const price = toBig(assetPrice);
   const ltvBasisPoints = BigInt(ltv);
+  const ltBasisPoints = BigInt(liquidationThreshold);
 
   // Calculate values in USD (18 decimals)
   const userBalanceValue = ((balance * price) / DECIMALS).toString();
@@ -266,12 +271,17 @@ export const calculateCollateralMetrics = (
   
   // Calculate unsupplied borrowing power: userBalance * price * ltv (for sorting unsupplied collaterals)
   const unsuppliedBorrowingPower = ((balance * price * ltvBasisPoints) / (DECIMALS * 10000n)).toString();
+  
+  // Calculate unsupplied LT-weighted collateral value: userBalance * price * lt / (1e18 * 10000)
+  // Used for health factor calculations
+  const unsuppliedLTCollateralValue = ((balance * price * ltBasisPoints) / (DECIMALS * 10000n)).toString();
 
   return {
     userBalanceValue,
     collateralizedAmountValue,
     maxBorrowingPower,
     unsuppliedBorrowingPower,
+    unsuppliedLTCollateralValue,
   };
 };
 

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -658,13 +658,11 @@ export const liquidityAndBalance = async (
   const supplyAPY = apyData.supplyAPY * (utilizationRate / 100);
 
   // Total collateral value across all users (USD 1e18)
-  const totalCollateralValue = await Promise.resolve(
-    calculateTotalCollateralValue(
-      registry.lendingPool?.assetConfigs || [],
-      allCollaterals,
-      priceMap,
-      borrowableAsset
-    )
+  const totalCollateralValue = calculateTotalCollateralValue(
+    registry.lendingPool?.assetConfigs || [],
+    allCollaterals,
+    priceMap,
+    borrowableAsset
   );
 
   // Get user's staked balance from RewardsChef

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -522,7 +522,7 @@ export const collateralAndBalance = async (
       const liquidationThreshold = assetConfig?.liquidationThreshold || 0;
 
       // Calculate metrics using the helper function
-      const {userBalanceValue, collateralizedAmountValue, maxBorrowingPower} = calculateCollateralMetrics(
+      const {userBalanceValue, collateralizedAmountValue, maxBorrowingPower, unsuppliedBorrowingPower} = calculateCollateralMetrics(
         userBalance,
         collateralizedAmount,
         assetPrice,
@@ -539,6 +539,7 @@ export const collateralAndBalance = async (
         isCollateralized: collateral?.amount > 0,
         canSupply: BigInt(userBalance) > 0n,
         maxBorrowingPower,
+        unsuppliedBorrowingPower,
         assetPrice,
         ltv,
         liquidationThreshold,

--- a/mercata/backend/src/api/services/lending.service.ts
+++ b/mercata/backend/src/api/services/lending.service.ts
@@ -522,11 +522,12 @@ export const collateralAndBalance = async (
       const liquidationThreshold = assetConfig?.liquidationThreshold || 0;
 
       // Calculate metrics using the helper function
-      const {userBalanceValue, collateralizedAmountValue, maxBorrowingPower, unsuppliedBorrowingPower} = calculateCollateralMetrics(
+      const {userBalanceValue, collateralizedAmountValue, maxBorrowingPower, unsuppliedBorrowingPower, unsuppliedLTCollateralValue} = calculateCollateralMetrics(
         userBalance,
         collateralizedAmount,
         assetPrice,
-        ltv
+        ltv,
+        liquidationThreshold
       );
 
       return {
@@ -540,6 +541,7 @@ export const collateralAndBalance = async (
         canSupply: BigInt(userBalance) > 0n,
         maxBorrowingPower,
         unsuppliedBorrowingPower,
+        unsuppliedLTCollateralValue,
         assetPrice,
         ltv,
         liquidationThreshold,

--- a/mercata/ui/src/components/Positions.tsx
+++ b/mercata/ui/src/components/Positions.tsx
@@ -100,7 +100,7 @@ const PositionSection = ({ loanData }: BorrowingSectionProps) => {
                   <span className="text-muted-foreground text-sm font-medium">Health Factor</span>
                 </InfoTooltip>
                 <div className="flex flex-row gap-3">
-                  <span className="font-semibold text-lg mt-3" style={{ color: getTextColor((loanData?.healthFactor)) }}>
+                  <span className="font-semibold text-lg mt-3" style={{ color: getTextColor(loanData?.healthFactor || 0, 3) }}>
                     {(() => {
                       const totalAmountOwed = loanData?.totalAmountOwed ? parseFloat(formatUnits(loanData.totalAmountOwed.toString(), 18)) : 0;
                       if (totalAmountOwed === 0) {

--- a/mercata/ui/src/components/Positions.tsx
+++ b/mercata/ui/src/components/Positions.tsx
@@ -5,11 +5,6 @@ import { CollateralData, NewLoanData } from "@/interface";
 import { formatUnits } from "ethers";
 import { formatBalance } from "@/utils/numberUtils";
 import { useMobileTooltip } from "@/hooks/use-mobile-tooltip";
-import { useLendingContext } from "@/context/LendingContext";
-import { useLiquidationContext } from "@/context/LiquidationContext";
-import { useUser } from "@/context/UserContext";
-import { Link } from "react-router-dom";
-import { Button } from "@/components/ui/button";
 
 interface BorrowingSectionProps {
   userCollaterals: CollateralData[];
@@ -56,31 +51,13 @@ const InfoTooltip = ({ children, content }: { children: React.ReactNode; content
 
 
 const PositionSection = ({ loanData }: BorrowingSectionProps) => {
-  const { userAddress } = useUser();
-  const { liquidatable, watchlist, loading } = useLiquidationContext();
-
   function getTextColor(value: number, maxValue = 10) {
-  const clamped = Math.min(Math.max(value, 1), maxValue);
-  const ratio = (clamped - 1) / (maxValue - 1);
-
-  const red = Math.round(255 * (1 - ratio));
-  const green = Math.round(255 * ratio);
-
-  return `rgb(${red}, ${green}, 0)`;
-}
-  const { liquidityInfo } = useLendingContext();
-  const borrowIndexDisplay = (() => {
-    try {
-      const idx = liquidityInfo?.borrowIndex;
-      if (!idx) return "0";
-      const s = formatUnits(BigInt(idx), 27);
-      const [w, f = ""] = s.split(".");
-      return f ? `${w}.${f.slice(0, 5)}` : w;
-    } catch {
-      return "0";
-    }
-  })();
-
+    const clamped = Math.min(Math.max(value, 1), maxValue);
+    const ratio = (clamped - 1) / (maxValue - 1);
+    const red = Math.round(255 * (1 - ratio));
+    const green = Math.round(255 * ratio);
+    return `rgb(${red}, ${green}, 0)`;
+  }
 
   return (
     <Card className="border border-border shadow-sm">
@@ -93,6 +70,7 @@ const PositionSection = ({ loanData }: BorrowingSectionProps) => {
         <div className="py-6">
           <div className="space-y-8">
             <div className="flex flex-col gap-4">
+              {/* Total Amount Owed */}
               <div className="flex flex-col space-y-3 p-4 bg-muted/50 rounded-lg">
                 <span className="text-muted-foreground text-sm font-medium">Total Amount Owed</span>
                 <span className="font-semibold text-lg">
@@ -107,53 +85,50 @@ const PositionSection = ({ loanData }: BorrowingSectionProps) => {
                   })()}
                 </span>
               </div>
-              <div className="flex flex-col space-y-3 p-4 bg-muted/50 rounded-lg">
-                <InfoTooltip content="Measures your position's safety. Higher is better. Close to 1.0 means high risk of liquidation. Below 1.0 means your position can be liquidated. No loan means you have no outstanding debt.">
-                  <span className="text-muted-foreground text-sm font-medium">Health Factor</span>
-                </InfoTooltip>
-                <div className="flex flex-row gap-3 ">
-                <span className="font-semibold text-lg mt-3" style={{ color: getTextColor((loanData?.healthFactor)) }}>
-                  {(() => {
-                    // Check if there's no outstanding debt
-                    const totalAmountOwed = loanData?.totalAmountOwed ? parseFloat(formatUnits(loanData.totalAmountOwed.toString(), 18)) : 0;
-                    if (totalAmountOwed === 0) {
-                      return "No Loan";
-                    }
-                    // Check if health factor is valid
-                    if (loanData?.healthFactor !== undefined && !isNaN((loanData.healthFactor))) {
-                      return (loanData.healthFactor).toFixed(2);
-                    }
-                    return "N/A";
-                  })()}
-                </span>
-                {/* Liquidation Risk Button */}
-                {loanData?.healthFactor<1 &&  (
-                  <div className="flex items-center gap-2 text-red-500 text-sm border border-red-500 rounded-md p-2 mt-2"> 
-                      <AlertTriangle className="flex-shrink-0" />
-                      <span className="text-red-500 text-xs sm:text-sm">Your position is at risk—add collateral or repay to restore health.</span>
-                  </div>
-                )}
-              </div>
-              </div>
-              <div className="flex flex-col space-y-3 p-4 bg-muted/50 rounded-lg">
-                <InfoTooltip content="You need to supply tokens as collateral before you can borrow. Click 'Supply' in the Eligible Collateral table below to get started.">
-                  <span className="text-muted-foreground text-sm font-medium">Available Borrowing Power</span>
-                </InfoTooltip>
-                <span className="font-semibold text-lg">
-                  {formatBalance(loanData?.maxAvailableToBorrowUSD || 0n, "USDST", 18, 2, 2)}
-                </span>
-              </div>
-              <div className="flex flex-col space-y-3 p-4 bg-muted/50 rounded-lg">
-                <InfoTooltip content="Global borrow index for the lending pool.">
-                  <span className="text-muted-foreground text-sm font-medium">Borrow Index</span>
-                </InfoTooltip>
-                <span className="font-semibold text-lg">{borrowIndexDisplay}</span>
-              </div>
+
+              {/* Interest Rate */}
               <div className="flex flex-col space-y-3 p-4 bg-muted/50 rounded-lg">
                 <InfoTooltip content="Annual percentage rate you pay on borrowed amounts. This rate applies to your total borrowed amount.">
                   <span className="text-muted-foreground text-sm font-medium">Interest Rate</span>
                 </InfoTooltip>
                 <span className="font-semibold text-lg">{((Number(loanData?.interestRate) || 0) / 100).toFixed(2)}%</span>
+              </div>
+
+              {/* Health Factor */}
+              <div className="flex flex-col space-y-3 p-4 bg-muted/50 rounded-lg">
+                <InfoTooltip content="Measures your position's safety. Higher is better. Close to 1.0 means high risk of liquidation. Below 1.0 means your position can be liquidated. No loan means you have no outstanding debt.">
+                  <span className="text-muted-foreground text-sm font-medium">Health Factor</span>
+                </InfoTooltip>
+                <div className="flex flex-row gap-3">
+                  <span className="font-semibold text-lg mt-3" style={{ color: getTextColor((loanData?.healthFactor)) }}>
+                    {(() => {
+                      const totalAmountOwed = loanData?.totalAmountOwed ? parseFloat(formatUnits(loanData.totalAmountOwed.toString(), 18)) : 0;
+                      if (totalAmountOwed === 0) {
+                        return "No Loan";
+                      }
+                      if (loanData?.healthFactor !== undefined && !isNaN((loanData.healthFactor))) {
+                        return (loanData.healthFactor).toFixed(2);
+                      }
+                      return "N/A";
+                    })()}
+                  </span>
+                  {loanData?.healthFactor < 1 && (
+                    <div className="flex items-center gap-2 text-red-500 text-sm border border-red-500 rounded-md p-2 mt-2">
+                      <AlertTriangle className="flex-shrink-0" />
+                      <span className="text-red-500 text-xs sm:text-sm">Your position is at risk—add collateral or repay to restore health.</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Collateral Supplied */}
+              <div className="flex flex-col space-y-3 p-4 bg-muted/50 rounded-lg">
+                <InfoTooltip content="The total USD value of collateral you have supplied to the lending pool.">
+                  <span className="text-muted-foreground text-sm font-medium">Collateral Supplied</span>
+                </InfoTooltip>
+                <span className="font-semibold text-lg">
+                  {formatBalance(loanData?.totalCollateralValueSupplied || 0n, "USDST", 18, 2, 2)}
+                </span>
               </div>
             </div>
           </div>

--- a/mercata/ui/src/components/Positions.tsx
+++ b/mercata/ui/src/components/Positions.tsx
@@ -127,7 +127,7 @@ const PositionSection = ({ loanData }: BorrowingSectionProps) => {
                   <span className="text-muted-foreground text-sm font-medium">Collateral Supplied</span>
                 </InfoTooltip>
                 <span className="font-semibold text-lg">
-                  {formatBalance(loanData?.totalCollateralValueSupplied || 0n, "USDST", 18, 2, 2)}
+                  {formatBalance(loanData?.totalCollateralValueSupplied || 0n, undefined, 18, 2, 2, true)}
                 </span>
               </div>
             </div>

--- a/mercata/ui/src/components/Positions.tsx
+++ b/mercata/ui/src/components/Positions.tsx
@@ -51,7 +51,8 @@ const InfoTooltip = ({ children, content }: { children: React.ReactNode; content
 
 
 const PositionSection = ({ loanData }: BorrowingSectionProps) => {
-  function getTextColor(value: number, maxValue = 10) {
+  function getTextColor(value: number, maxValue = 10, noLoan = false) {
+    if (noLoan) return 'rgb(0, 255, 0)';
     const clamped = Math.min(Math.max(value, 1), maxValue);
     const ratio = (clamped - 1) / (maxValue - 1);
     const red = Math.round(255 * (1 - ratio));
@@ -100,7 +101,7 @@ const PositionSection = ({ loanData }: BorrowingSectionProps) => {
                   <span className="text-muted-foreground text-sm font-medium">Health Factor</span>
                 </InfoTooltip>
                 <div className="flex flex-row gap-3">
-                  <span className="font-semibold text-lg mt-3" style={{ color: getTextColor(loanData?.healthFactor || 0, 3) }}>
+                  <span className="font-semibold text-lg mt-3" style={{ color: getTextColor(loanData?.healthFactor || 0, 3, !loanData || BigInt(loanData.totalAmountOwed) === 0n) }}>
                     {(() => {
                       const totalAmountOwed = loanData?.totalAmountOwed ? parseFloat(formatUnits(loanData.totalAmountOwed.toString(), 18)) : 0;
                       if (totalAmountOwed === 0) {

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -442,27 +442,29 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         Borrow
       </Button>
 
-      {/* Auto Supply Collateral Checkbox */}
-      <div className="flex items-center space-x-2">
-        <Checkbox
-          id="auto-supply"
-          checked={autoSupplyCollateral}
-          onCheckedChange={handleAutoSupplyChange}
-        />
-        <label
-          htmlFor="auto-supply"
-          className="text-sm text-muted-foreground cursor-pointer select-none"
-        >
-          Automatically supply collateral (if needed)
-        </label>
-      </div>
+      {/* Auto Supply Collateral Checkbox and Dropdown - Only show when collateral is needed */}
+      {collateralTableData.length > 0 && (
+        <>
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="auto-supply"
+              checked={autoSupplyCollateral}
+              onCheckedChange={handleAutoSupplyChange}
+            />
+            <label
+              htmlFor="auto-supply"
+              className="text-sm text-muted-foreground cursor-pointer select-none"
+            >
+              Automatically supply collateral (if needed)
+            </label>
+          </div>
 
-      {/* Additional Collateral Needed Dropdown */}
-      <Collapsible
-        open={isCollateralExpanded}
-        onOpenChange={setIsCollateralExpanded}
-        className="border rounded-lg"
-      >
+          {/* Additional Collateral Needed Dropdown */}
+          <Collapsible
+            open={isCollateralExpanded}
+            onOpenChange={setIsCollateralExpanded}
+            className="border rounded-lg"
+          >
         <CollapsibleTrigger className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium hover:bg-muted/50 transition-colors">
           <span>
             Additional Collateral Needed{' '}
@@ -553,6 +555,8 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           )}
         </CollapsibleContent>
       </Collapsible>
+        </>
+      )}
 
       {/* Transaction Fee */}
       <div className="flex justify-between text-sm">

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -18,7 +18,7 @@ import {
   determineErrorMessage,
   calculateAdditionalCollateralAmountFromValue,
   sortCollateralAssets,
-  calculateMaxCollateralValueFromBalance,
+  calculateMaxCollateralValueUSDCentFloored,
   centCeil
 } from "@/utils/lendingUtils";
 import { getRiskLabel } from "@/utils/loanUtils";
@@ -165,11 +165,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     if (autoSupplyCollateral) return map; // Only check in custom mode
     
     for (const item of collateralTableData) {
-      const balance = BigInt(item.collateral.userBalance ?? "0");
-      const price = BigInt(item.collateral.assetPrice ?? "0");
-      const decimals = BigInt(10) ** BigInt(item.collateral.customDecimals ?? 18);
-      const maxValueWei = calculateMaxCollateralValueFromBalance(balance, price, decimals);
-      const maxValueUSD = Number(maxValueWei) / 1e18;
+      const maxValueUSD = calculateMaxCollateralValueUSDCentFloored(item.collateral);
       
       map.set(item.collateral.address, item.valueUSD > maxValueUSD);
     }
@@ -296,6 +292,12 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     const newValues = new Map(customCollateralValues);
     newValues.set(address, value);
     setCustomCollateralValues(newValues);
+  };
+
+  // Handle clicking available value to fill max
+  const handleFillAddCollatMaxValue = (collateral: CollateralData) => {
+    const maxValueUSD = calculateMaxCollateralValueUSDCentFloored(collateral);
+    handleCustomValueChange(collateral.address, maxValueUSD.toFixed(2));
   };
 
   // Get risk indicator color and label
@@ -647,10 +649,11 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
             <TooltipProvider>
               <div className="space-y-1">
                 {/* Table Header */}
-                <div className="grid grid-cols-3 gap-4 text-xs text-muted-foreground pb-2">
+                <div className="grid grid-cols-4 gap-4 text-xs text-muted-foreground pb-2">
                   <span>Asset</span>
                   <span className="text-center">Amount</span>
                   <span className="text-right">Value</span>
+                  <span className="text-right">Available</span>
                 </div>
 
                 {/* Table Rows */}
@@ -659,11 +662,13 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
                   const fullAmount = item.amount === 0n ? "0" : formatBalance(item.amount, undefined, decimals, 2);
                   const displayAmount = item.amount === 0n ? "0" : formatBalance(item.amount, undefined, decimals, 0, 4);
                   const tokenImage = item.collateral.images?.[0]?.value;
+                  
+                  const maxValueUSD = calculateMaxCollateralValueUSDCentFloored(item.collateral);
 
                   return (
                     <div
                       key={item.collateral.address}
-                      className="grid grid-cols-3 gap-4 items-center py-2 text-sm"
+                      className="grid grid-cols-4 gap-4 items-center py-2 text-sm"
                     >
                       {/* Asset */}
                       <div className="flex items-center gap-2">
@@ -708,6 +713,21 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
                             className={`collateral-value-input w-20 h-7 text-right text-sm px-2 ${collateralExceedsMaxMap.get(item.collateral.address) ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                           />
                         </div>
+                      )}
+
+                      {/* Available */}
+                      {autoSupplyCollateral ? (
+                        <span className="text-right tabular-nums text-muted-foreground">
+                          ${maxValueUSD.toFixed(2)}
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => handleFillAddCollatMaxValue(item.collateral)}
+                          className="text-right tabular-nums text-muted-foreground underline cursor-pointer hover:text-foreground transition-colors"
+                        >
+                          ${maxValueUSD.toFixed(2)}
+                        </button>
                       )}
                     </div>
                   );

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -128,20 +128,16 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       sortCollateralAssets(collateralsArray);
 
       for (const collateral of collateralsArray) {
-        const price = BigInt(collateral.assetPrice ?? "0");
-        const decimals = BigInt(10) ** BigInt(collateral.customDecimals ?? 18);
-        
         // Use custom value if set, otherwise check if in recommendation
         if (customCollateralValues.has(collateral.address)) {
+          const price = BigInt(collateral.assetPrice ?? "0");
+          const decimals = collateral.customDecimals ?? 18;
           const customValue = parseFloat(customCollateralValues.get(collateral.address) || "0");
-          const customValueWei = BigInt(Math.round(customValue * 1e18));
-          const customAmount = calculateAdditionalCollateralAmountFromValue(customValueWei, price, decimals);
+          const customAmount = calculateAdditionalCollateralAmountFromValue(customValue, price, decimals);
           data.push({ collateral, amount: customAmount, valueUSD: customValue });
         } else {
-          // Fallback to recommended amount or 0
-          const recommendedAmount = recommendedCollateral.get(collateral) ?? 0n;
-          const valueUSD = Number((recommendedAmount * price) / decimals) / 1e18;
-          data.push({ collateral, amount: recommendedAmount, valueUSD });
+          // Fallback to 0
+          data.push({ collateral, amount: 0n, valueUSD: 0.00 });
         }
       }
     }
@@ -612,7 +608,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         </CollapsibleTrigger>
         <CollapsibleContent className="px-4 pb-4">
           <style>{`
-            /* Hide number input spinner arrows */
+            /* Hide number input spinner arrows - @dev questionable */
             .collateral-value-input[type="number"]::-webkit-outer-spin-button,
             .collateral-value-input[type="number"]::-webkit-inner-spin-button {
               -webkit-appearance: none;

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -14,7 +14,8 @@ import {
   calculateAfterBorrowHealthFactor,
   recommendCollateralToSupply,
   calculateAdditionalValueNeeded,
-  calculateBorrowTxFee
+  calculateBorrowTxFee,
+  determineErrorMessage
 } from "@/utils/lendingUtils";
 import { getRiskLabel } from "@/utils/loanUtils";
 import { useLendingContext } from "@/context/LendingContext";
@@ -39,6 +40,7 @@ interface BorrowFormProps {
 const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalance, collateralInfo, startPolling, stopPolling, userRewards, rewardsLoading }: BorrowFormProps) => {
   const [borrowAmount, setBorrowAmount] = useState<string>("");
   const [borrowAmountError, setBorrowAmountError] = useState<string>("");
+  const [customBorrowError, setCustomBorrowError] = useState<string>("");
   const [feeError, setFeeError] = useState<string>("");
   const [targetHealthFactor, setTargetHealthFactor] = useState<number>(2.10);
   const [autoSupplyCollateral, setAutoSupplyCollateral] = useState<boolean>(true);
@@ -56,24 +58,32 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     return calculateHFSliderExtrema(loans, collateralInfo);
   }, [loans, collateralInfo]);
 
-  // Calculate available to borrow based on current health factor setting
-  // Includes all available collateral balances (max potential borrowing power)
-  const availableToBorrow = useMemo(() => {
-    if (!loans) return 0;
-    
-    // Build collateral map from all available user balances
-    const potentialCollateral = new Map<CollateralData, bigint>();
+  // Build collateral map from all available user balances (reused for calculations)
+  const potentialCollateral = useMemo(() => {
+    const map = new Map<CollateralData, bigint>();
     if (collateralInfo) {
       for (const collateral of collateralInfo) {
         const balance = BigInt(collateral.userBalance ?? "0");
         if (balance > 0n) {
-          potentialCollateral.set(collateral, balance);
+          map.set(collateral, balance);
         }
       }
     }
-    
+    return map;
+  }, [collateralInfo]);
+
+  // Calculate available to borrow based on current health factor setting
+  // Includes all available collateral balances (max potential borrowing power)
+  const availableToBorrow = useMemo(() => {
+    if (!loans) return 0;
     return calculateAvailableToBorrowUSD(loans, targetHealthFactor, potentialCollateral);
-  }, [loans, targetHealthFactor, collateralInfo]);
+  }, [loans, targetHealthFactor, potentialCollateral]);
+
+  // Calculate maximum borrowable at minimum health factor (riskier)
+  const maxAtMinHF = useMemo(() => {
+    if (!loans) return 0;
+    return calculateAvailableToBorrowUSD(loans, sliderExtrema.min, potentialCollateral);
+  }, [loans, sliderExtrema.min, potentialCollateral]);
 
   // Max borrowable amount in wei
   const maxAmount = useMemo(() => {
@@ -171,6 +181,36 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     }
     return canCover;
   }, [txFee, voucherBalance, usdstBalance]);
+
+  // Update custom error message when borrow amount exceeds maximum at selected health factor
+  useEffect(() => {
+    if (!borrowAmount || !loans) {
+      setCustomBorrowError("");
+      return;
+    }
+
+    const cleanedInput = borrowAmount.replace(/,/g, "");
+    const borrowAmountNum = parseFloat(cleanedInput);
+    if (isNaN(borrowAmountNum) || borrowAmountNum <= 0) {
+      setCustomBorrowError("");
+      return;
+    }
+
+    const borrowAmountWei = safeParseUnits(cleanedInput, 18);
+    const maxAmountWei = BigInt(maxAmount);
+    
+    // Only set custom error if amount exceeds maximum
+    if (borrowAmountWei > maxAmountWei) {
+      const errorMsg = determineErrorMessage(
+        borrowAmountNum,
+        availableToBorrow,
+        maxAtMinHF
+      );
+      setCustomBorrowError(errorMsg);
+    } else {
+      setCustomBorrowError("");
+    }
+  }, [borrowAmount, loans, maxAmount, availableToBorrow, maxAtMinHF]);
 
   // Handle checkbox change - expand when unchecked
   const handleAutoSupplyChange = (checked: boolean) => {
@@ -290,6 +330,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       // Reset form after successful completion
       setBorrowAmount("");
       setBorrowAmountError("");
+      setCustomBorrowError("");
       setFeeError("");
       handlePollingUpdate("");
       
@@ -370,9 +411,6 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
             MAX
           </Button>
         </div>
-        {borrowAmountError && (
-          <p className="text-red-600 text-sm">{borrowAmountError}</p>
-        )}
       </div>
 
       {/* Health Factor Slider */}
@@ -416,11 +454,18 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
             <span className="font-medium tabular-nums">
               {currentHF === null ? 'No Loan' : currentHF.toFixed(2)}
               {' → '}
-              {afterBorrowHF !== null ? afterBorrowHF.toFixed(2) : (borrowAmount ? targetHealthFactor.toFixed(2) : '-')}
+              {afterBorrowHF && !customBorrowError ? afterBorrowHF.toFixed(2) : '-'}
             </span>
           </div>
         </div>
       </TooltipProvider>
+
+      {/* Error Message Box - Above Borrow Button */}
+      {customBorrowError && (
+        <div className="p-4 bg-red-500/10 dark:bg-red-500/20 border border-red-500/30 rounded-lg">
+          <p className="text-red-800 dark:text-red-200 text-sm whitespace-pre-line">{customBorrowError}</p>
+        </div>
+      )}
 
       {/* Borrow Button */}
       <Button
@@ -428,6 +473,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         disabled={
           !borrowAmount ||
           !!borrowAmountError ||
+          !!customBorrowError ||
           !!feeError ||
           safeParseUnits(borrowAmount || "0") <= 0n ||
           borrowLoading ||
@@ -443,7 +489,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       </Button>
 
       {/* Auto Supply Collateral Checkbox and Dropdown - Only show when collateral is needed */}
-      {collateralTableData.length > 0 && (
+      {collateralTableData.length > 0 && !customBorrowError && (
         <>
           <div className="flex items-center space-x-2">
             <Checkbox

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -142,9 +142,9 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     if (autoSupplyCollateral) {
       return totalCollateralValue;
     }
-    // In custom mode, calculate what's needed using minLTV
+    // In custom mode, calculate what's needed to achieve target HF using strictest LT
     if (!loans || !collateralInfo || collateralInfo.length === 0) return 0;
-    const needed = calculateAdditionalValueNeeded(collateralInfo, parseFloat(borrowAmount || "0"), loans);
+    const needed = calculateAdditionalValueNeeded(collateralInfo, parseFloat(borrowAmount || "0"), loans, targetHealthFactor);
     return Number(needed);
   }, [autoSupplyCollateral, totalCollateralValue, loans, collateralInfo, borrowAmount]);
 

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -18,7 +18,8 @@ import {
   determineErrorMessage,
   calculateAdditionalCollateralAmountFromValue,
   sortCollateralAssets,
-  calculateMaxCollateralValueFromBalance
+  calculateMaxCollateralValueFromBalance,
+  centCeil
 } from "@/utils/lendingUtils";
 import { getRiskLabel } from "@/utils/loanUtils";
 import { useLendingContext } from "@/context/LendingContext";
@@ -207,6 +208,13 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     const needed = calculateAdditionalValueNeeded(collateralInfo, parseFloat(borrowAmount || "0"), loans, targetHealthFactor);
     return Number(needed);
   }, [autoSupplyCollateral, totalCollateralValue, loans, collateralInfo, borrowAmount, targetHealthFactor]);
+
+  // Check if sufficient collateral is supplied in custom mode
+  const hasInsufficientCollateral = useMemo(() => {
+    if (autoSupplyCollateral) return false; // Only check in custom mode
+    if (!borrowAmount || parseFloat(borrowAmount) <= 0) return false; // No validation needed if no borrow amount
+    return totalCollateralValue < additionalCollateralNeededValue;
+  }, [autoSupplyCollateral, totalCollateralValue, additionalCollateralNeededValue, borrowAmount]);
 
   // Calculate transaction fee based on number of collateral assets being supplied
   const txFee = useMemo(() => {
@@ -565,7 +573,8 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           borrowLoading ||
           progressModalOpen ||
           safeParseUnits(borrowAmount || "0") > BigInt(maxAmount) ||
-          hasExceededMaxCollateralValue
+          hasExceededMaxCollateralValue ||
+          hasInsufficientCollateral
         }
         className="w-full"
       >
@@ -602,7 +611,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           <span>
             Additional Collateral Needed{' '}
             <span className="text-muted-foreground font-normal">
-              (Value: ${additionalCollateralNeededValue.toFixed(0)})
+              (Value: ${additionalCollateralNeededValue.toFixed(2)})
             </span>
           </span>
           {isCollateralExpanded ? (
@@ -625,7 +634,12 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           `}</style>
           {/* Total Value Header */}
           <div className="text-sm font-medium mb-3 pt-2 border-t">
-            Total Value of Collateral: ${totalCollateralValue.toFixed(0)}
+            Total Value of Collateral: ${totalCollateralValue.toFixed(2)}
+            {hasInsufficientCollateral && (
+              <span className="text-yellow-600 dark:text-yellow-400 ml-2">
+                (${centCeil(additionalCollateralNeededValue - totalCollateralValue).toFixed(2)} more needed)
+              </span>
+            )}
           </div>
 
           {/* Collateral Table */}

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -397,16 +397,18 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         s.id === "borrow" ? { ...s, status: "completed" } : s
       ));
       
-      // Reset form after successful completion
+    } catch (error: any) {
+      // Error already handled in individual steps
+    } finally {
+      // Reset form after completion (success or failure)
       setBorrowAmount("");
       setBorrowAmountError("");
       setCustomBorrowError("");
       setFeeError("");
+      setCustomCollateralValues(new Map());
+      setAutoSupplyCollateral(true);
+      setIsCollateralExpanded(false);
       handlePollingUpdate("");
-      
-    } catch (error: any) {
-      // Error already handled in individual steps
-      console.error("Borrow process failed:", error);
     }
   };
 

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -209,18 +209,17 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   }, [collateralTableData]);
 
   // Check if user can afford the transaction fee (separate from borrow amount)
-  const canAffordFee = useMemo(() => {
+  useEffect(() => {
     const feeWei = safeParseUnits(txFee.fee.toString(), 18);
     const voucherBal = BigInt(voucherBalance || 0);
     const usdstBal = safeParseUnits(usdstBalance || "0", 18);
     
     const canCover = voucherBal >= BigInt(txFee.voucher) || usdstBal >= feeWei;
     if (!canCover) {
-      setFeeError("Insufficient balance to cover transaction fee");
+      setFeeError("Insufficient USDST + voucher balance for transaction fee");
     } else {
       setFeeError("");
     }
-    return canCover;
   }, [txFee, voucherBalance, usdstBalance]);
 
   // Update custom error message when borrow amount exceeds maximum at selected health factor
@@ -230,14 +229,13 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       return;
     }
 
-    const cleanedInput = borrowAmount.replace(/,/g, "");
-    const borrowAmountNum = parseFloat(cleanedInput);
+    const borrowAmountNum = parseFloat(borrowAmount);
     if (isNaN(borrowAmountNum) || borrowAmountNum <= 0) {
       setCustomBorrowError("");
       return;
     }
 
-    const borrowAmountWei = safeParseUnits(cleanedInput, 18);
+    const borrowAmountWei = safeParseUnits(borrowAmount, 18);
     const maxAmountWei = BigInt(maxAmount);
     
     // Only set custom error if amount exceeds maximum
@@ -296,14 +294,12 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   };
 
   // Get risk indicator color and label
-  const getRiskIndicator = (hf: number): { label: string; color: string } => {
-    const label = getRiskLabel(hf);
+  const riskIndicator = useMemo(() => {
+    const label = getRiskLabel(targetHealthFactor);
     if (label === 'Low Risk') return { label, color: 'text-green-500' };
     if (label === 'Moderate Risk') return { label, color: 'text-yellow-500' };
     return { label, color: 'text-red-500' };
-  };
-
-  const riskIndicator = getRiskIndicator(targetHealthFactor);
+  }, [targetHealthFactor]);
 
   // Consolidated polling handler
   const handlePollingUpdate = (amount: string) => {
@@ -322,18 +318,16 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     const collateralToSupply = collateralTableData.filter(item => item.amount > 0n);
     
     // Add collateral supply steps if we have collateral to supply
-    if (collateralToSupply.length > 0) {
-      for (const item of collateralToSupply) {
-        const decimals = item.collateral.customDecimals ?? 18;
-        const formattedAmount = formatUnits(item.amount, decimals);
-        steps.push({
-          id: `supply-${item.collateral.address}`,
-          label: `Supply ${item.collateral._symbol}`,
-          status: "pending",
-          asset: item.collateral,
-          amount: formattedAmount,
-        });
-      }
+    for (const item of collateralToSupply) {
+      const decimals = item.collateral.customDecimals ?? 18;
+      const formattedAmount = formatUnits(item.amount, decimals);
+      steps.push({
+        id: `supply-${item.collateral.address}`,
+        label: `Supply ${item.collateral._symbol}`,
+        status: "pending",
+        asset: item.collateral,
+        amount: formattedAmount,
+      });
     }
     
     // Add borrow step
@@ -419,25 +413,27 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   const handleSliderChange = (values: number[]) => {
     const sliderPos = values[0];
     // Slider goes from max HF (left/0) to min HF (right/range)
-    const range = Number(sliderExtrema.max) - Number(sliderExtrema.min);
     const newHF = Number(sliderExtrema.max) - sliderPos;
     setTargetHealthFactor(Math.round(newHF * 100) / 100);
   };
 
   // Convert HF to slider position
   const sliderPosition = useMemo(() => {
-    const range = Number(sliderExtrema.max) - Number(sliderExtrema.min);
     return Number(sliderExtrema.max) - targetHealthFactor;
   }, [targetHealthFactor, sliderExtrema]);
 
-  const interestRateDisplay = (() => {
-    const raw = (loans as any)?.interestRate; // bps
-    const num = Number(raw);
-    if (!isFinite(num)) return "-";
-    return `${(num / 100).toFixed(2)}%`;
-  })();
+  const interestRateDisplay = useMemo(() => {
+    if (!loans) return "-";
+    return `${(loans.interestRate / 100).toFixed(2)}%`;
+  }, [loans]);
 
-  const sliderRange = Number(sliderExtrema.max) - Number(sliderExtrema.min);
+  const sliderRange = useMemo(() => {
+    return Number(sliderExtrema.max) - Number(sliderExtrema.min);
+  }, [sliderExtrema]);
+
+  const borrowAmountExceedsMax = useMemo(() => {
+    return safeParseUnits(borrowAmount || "0", 18) > BigInt(maxAmount);
+  }, [borrowAmount, maxAmount]);
 
   return (
     <div className="space-y-4 pt-4">
@@ -461,7 +457,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           <div className="relative flex-1">
             <Input
               placeholder="0"
-              className={`pr-20 ${safeParseUnits(borrowAmount || "0", 18) > BigInt(maxAmount) ? 'text-red-600' : ''}`}
+              className={`pr-20 ${borrowAmountExceedsMax ? 'text-red-600' : ''}`}
               value={addCommasToInput(borrowAmount)}
               onChange={(e) => {
                 const value = e.target.value;
@@ -566,7 +562,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           safeParseUnits(borrowAmount || "0") <= 0n ||
           borrowLoading ||
           progressModalOpen ||
-          safeParseUnits(borrowAmount || "0") > BigInt(maxAmount) ||
+          borrowAmountExceedsMax ||
           hasExceededMaxCollateralValue ||
           hasInsufficientCollateral
         }

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -204,7 +204,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
 
   // Calculate transaction fee based on number of collateral assets being supplied
   const txFee = useMemo(() => {
-    const collateralCount = collateralTableData.length;
+    const collateralCount = collateralTableData.filter(item => item.amount > 0n).length;
     return calculateBorrowTxFee(collateralCount);
   }, [collateralTableData]);
 

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -52,13 +52,10 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   const [customCollateralValues, setCustomCollateralValues] = useState<Map<string, string>>(new Map());
   const [progressModalOpen, setProgressModalOpen] = useState(false);
   const [borrowSteps, setBorrowSteps] = useState<BorrowStep[]>([]);
-  const { borrowMax, supplyCollateral } = useLendingContext();
+  const { supplyCollateral } = useLendingContext();
 
   // Calculate slider extrema based on collateral configs
   const sliderExtrema = useMemo(() => {
-    if (!loans || !collateralInfo || collateralInfo.length === 0) {
-      return { min: 1.01, max: 3.00 };
-    }
     return calculateHFSliderExtrema(loans, collateralInfo);
   }, [loans, collateralInfo]);
 
@@ -79,13 +76,11 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   // Calculate available to borrow based on current health factor setting
   // Includes all available collateral balances (max potential borrowing power)
   const availableToBorrow = useMemo(() => {
-    if (!loans) return 0;
     return calculateAvailableToBorrowUSD(loans, targetHealthFactor, potentialCollateral);
   }, [loans, targetHealthFactor, potentialCollateral]);
 
-  // Calculate maximum borrowable at minimum health factor (riskier)
+  // Calculate maximum borrowable at slider minimum (riskiest) health factor
   const maxAtMinHF = useMemo(() => {
-    if (!loans) return 0;
     return calculateAvailableToBorrowUSD(loans, sliderExtrema.min, potentialCollateral);
   }, [loans, sliderExtrema.min, potentialCollateral]);
 
@@ -175,10 +170,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
 
   // Check if any custom collateral values exceed their maximum
   const hasExceededMaxCollateralValue = useMemo(() => {
-    for (const exceedsMax of collateralExceedsMaxMap.values()) {
-      if (exceedsMax) return true;
-    }
-    return false;
+    return [...collateralExceedsMaxMap.values()].some(exceedsMax => exceedsMax);
   }, [collateralExceedsMaxMap]);
 
   // Calculate after-borrow health factor (includes new collateral being supplied)
@@ -187,10 +179,9 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       return null;
     }
     // Build collateral map from table data (includes auto or custom amounts)
-    const newCollateral = new Map<CollateralData, bigint>();
-    for (const item of collateralTableData) {
-      newCollateral.set(item.collateral, item.amount);
-    }
+    const newCollateral = new Map<CollateralData, bigint>(
+      collateralTableData.map(item => [item.collateral, item.amount])
+    );
     return calculateAfterBorrowHealthFactor(loans, parseFloat(borrowAmount), newCollateral);
   }, [loans, borrowAmount, collateralTableData]);
 
@@ -200,7 +191,6 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       return totalCollateralValue;
     }
     // In custom mode, calculate what's needed to achieve target HF using strictest LT
-    if (!loans || !collateralInfo || collateralInfo.length === 0) return 0;
     const needed = calculateAdditionalValueNeeded(collateralInfo, parseFloat(borrowAmount || "0"), loans, targetHealthFactor);
     return Number(needed);
   }, [autoSupplyCollateral, totalCollateralValue, loans, collateralInfo, borrowAmount, targetHealthFactor]);

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -15,7 +15,8 @@ import {
   recommendCollateralToSupply,
   calculateAdditionalValueNeeded,
   calculateBorrowTxFee,
-  determineErrorMessage
+  determineErrorMessage,
+  calculateAdditionalCollateralAmountFromValue
 } from "@/utils/lendingUtils";
 import { getRiskLabel } from "@/utils/loanUtils";
 import { useLendingContext } from "@/context/LendingContext";
@@ -122,7 +123,8 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       // If custom mode, use custom value if set
       if (!autoSupplyCollateral && customCollateralValues.has(collateral.address)) {
         const customValue = parseFloat(customCollateralValues.get(collateral.address) || "0");
-        const customAmount = price > 0n ? BigInt(Math.round(customValue * 1e18)) * decimals / price : 0n;
+        const customValueWei = BigInt(Math.round(customValue * 1e18));
+        const customAmount = calculateAdditionalCollateralAmountFromValue(customValueWei, price, decimals);
         data.push({ collateral, amount: customAmount, valueUSD: customValue });
       } else {
         data.push({ collateral, amount, valueUSD });
@@ -461,7 +463,9 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       </TooltipProvider>
 
       {/* Warning Message Box - Above Borrow Button */}
-      {afterBorrowHF !== null && Number(afterBorrowHF) < 1.6 && (
+      {afterBorrowHF !== null && Number(afterBorrowHF) < 1.6 // Low Health Factor Warning
+       && !customBorrowError // Don't show if overlarge borrow error is already displayed
+       && (
         <div className={`p-4 border rounded-lg ${
           Number(afterBorrowHF) < 1.3
             ? "bg-red-500/10 dark:bg-red-500/20 border-red-500/30"

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -232,13 +232,9 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     }
     
     // Add borrow step
-    const maxWei = BigInt(maxAmount);
-    const wei = safeParseUnits(borrowAmount || "0", 18);
-    const isMaxBorrow = maxWei > 0n && (wei >= maxWei || (maxWei > 0n && wei >= (maxWei - 1n)));
-    
     steps.push({
       id: "borrow",
-      label: isMaxBorrow ? "Borrow Max USDST" : `Borrow ${borrowAmount} USDST`,
+      label: `Borrow ${borrowAmount} USDST`,
       status: "pending",
     });
     
@@ -284,11 +280,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         s.id === "borrow" ? { ...s, status: "processing" } : s
       ));
       
-      if (isMaxBorrow) {
-        await onBorrow('ALL');
-      } else {
-        await onBorrow(borrowAmount);
-      }
+      await onBorrow(borrowAmount);
       
       // Mark borrow as completed
       setBorrowSteps(prev => prev.map(s => 

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -21,6 +21,7 @@ import { useLendingContext } from "@/context/LendingContext";
 import { handleAmountInputChange } from "@/utils/transferValidation";
 import { UserRewardsData } from "@/services/rewardsService";
 import { CompactRewardsDisplay } from "../rewards/CompactRewardsDisplay";
+import BorrowProgressModal, { BorrowStep } from "./BorrowProgressModal";
 
 interface BorrowFormProps {
   loans: NewLoanData | null;
@@ -43,7 +44,9 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   const [autoSupplyCollateral, setAutoSupplyCollateral] = useState<boolean>(true);
   const [isCollateralExpanded, setIsCollateralExpanded] = useState<boolean>(false);
   const [customCollateralValues, setCustomCollateralValues] = useState<Map<string, string>>(new Map());
-  const { borrowMax } = useLendingContext();
+  const [progressModalOpen, setProgressModalOpen] = useState(false);
+  const [borrowSteps, setBorrowSteps] = useState<BorrowStep[]>([]);
+  const { borrowMax, supplyCollateral } = useLendingContext();
 
   // Calculate slider extrema based on collateral configs
   const sliderExtrema = useMemo(() => {
@@ -210,24 +213,98 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   };
 
   const handleBorrow = async () => {
+    // Build steps array
+    const steps: BorrowStep[] = [];
+    
+    // Add collateral supply steps if we have collateral to supply
+    if (collateralTableData.length > 0) {
+      for (const item of collateralTableData) {
+        const decimals = item.collateral.customDecimals ?? 18;
+        const formattedAmount = formatUnits(item.amount, decimals);
+        steps.push({
+          id: `supply-${item.collateral.address}`,
+          label: `Supply ${item.collateral._symbol}`,
+          status: "pending",
+          asset: item.collateral,
+          amount: formattedAmount,
+        });
+      }
+    }
+    
+    // Add borrow step
     const maxWei = BigInt(maxAmount);
     const wei = safeParseUnits(borrowAmount || "0", 18);
-
-    // If at or within 1 wei of the max available, route via parent as 'ALL' to use on-chain borrowMax and parent UX
-    if (maxWei > 0n && (wei >= maxWei || (maxWei > 0n && wei >= (maxWei - 1n)))) {
-      onBorrow('ALL');
+    const isMaxBorrow = maxWei > 0n && (wei >= maxWei || (maxWei > 0n && wei >= (maxWei - 1n)));
+    
+    steps.push({
+      id: "borrow",
+      label: isMaxBorrow ? "Borrow Max USDST" : `Borrow ${borrowAmount} USDST`,
+      status: "pending",
+    });
+    
+    // Initialize modal
+    setBorrowSteps(steps);
+    setProgressModalOpen(true);
+    
+    try {
+      // Execute collateral supplies first
+      for (const item of collateralTableData) {
+        const stepId = `supply-${item.collateral.address}`;
+        
+        // Update step to processing
+        setBorrowSteps(prev => prev.map(s => 
+          s.id === stepId ? { ...s, status: "processing" } : s
+        ));
+        
+        try {
+          await supplyCollateral({
+            asset: item.collateral.address,
+            amount: item.amount.toString(),
+          });
+          
+          // Mark as completed
+          setBorrowSteps(prev => prev.map(s => 
+            s.id === stepId ? { ...s, status: "completed" } : s
+          ));
+        } catch (error: any) {
+          // Mark as error
+          setBorrowSteps(prev => prev.map(s => 
+            s.id === stepId ? { 
+              ...s, 
+              status: "error",
+              error: error.message || "Supply failed"
+            } : s
+          ));
+          throw error; // Stop execution on error
+        }
+      }
+      
+      // Execute borrow step
+      setBorrowSteps(prev => prev.map(s => 
+        s.id === "borrow" ? { ...s, status: "processing" } : s
+      ));
+      
+      if (isMaxBorrow) {
+        await onBorrow('ALL');
+      } else {
+        await onBorrow(borrowAmount);
+      }
+      
+      // Mark borrow as completed
+      setBorrowSteps(prev => prev.map(s => 
+        s.id === "borrow" ? { ...s, status: "completed" } : s
+      ));
+      
+      // Reset form after successful completion
       setBorrowAmount("");
       setBorrowAmountError("");
       setFeeError("");
       handlePollingUpdate("");
-      return;
+      
+    } catch (error: any) {
+      // Error already handled in individual steps
+      console.error("Borrow process failed:", error);
     }
-
-    onBorrow(borrowAmount);
-    setBorrowAmount("");
-    setBorrowAmountError("");
-    setFeeError("");
-    handlePollingUpdate("");
   };
 
   // Handle slider change - convert position to HF value
@@ -362,6 +439,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           !!feeError ||
           safeParseUnits(borrowAmount || "0") <= 0n ||
           borrowLoading ||
+          progressModalOpen ||
           safeParseUnits(borrowAmount || "0") > BigInt(maxAmount)
         }
         className="w-full"
@@ -524,6 +602,16 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
 
         return null;
       })()}
+
+      {/* Borrow Progress Modal */}
+      <BorrowProgressModal
+        open={progressModalOpen}
+        steps={borrowSteps}
+        onClose={() => {
+          setProgressModalOpen(false);
+          setBorrowSteps([]);
+        }}
+      />
     </div>
   );
 };

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -381,7 +381,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
               error: error.message || "Supply failed"
             } : s
           ));
-          throw error; // Stop execution on error
+          throw error; // Don't execute later steps if this fails
         }
       }
       
@@ -389,14 +389,22 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       setBorrowSteps(prev => prev.map(s => 
         s.id === "borrow" ? { ...s, status: "processing" } : s
       ));
-      
-      await onBorrow(borrowAmount);
-      
-      // Mark borrow as completed
-      setBorrowSteps(prev => prev.map(s => 
-        s.id === "borrow" ? { ...s, status: "completed" } : s
-      ));
-      
+      try {
+        await onBorrow(borrowAmount);
+        // Mark borrow as completed
+        setBorrowSteps(prev => prev.map(s => 
+          s.id === "borrow" ? { ...s, status: "completed" } : s
+        ));
+      } catch (error: any) {
+        setBorrowSteps(prev => prev.map(s => 
+          s.id === "borrow" ? { 
+            ...s, 
+            status: "error",
+            error: error.message || "Borrow failed"
+          } : s
+        ));
+        throw error;
+      }
     } catch (error: any) {
       // Error already handled in individual steps
     } finally {

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -371,7 +371,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         <h3 className="text-lg font-semibold">Borrow USDST</h3>
         <div className="flex justify-between text-sm">
           <span className="text-muted-foreground">Available to Borrow</span>
-          <span className="font-medium">USDST {Number(availableToBorrow).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}</span>
+          <span className="font-medium">USDST {Number(availableToBorrow).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
         </div>
         <div className="flex justify-between text-sm">
           <span className="text-muted-foreground">Interest Rate</span>

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -129,7 +129,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       // Extract collaterals into array, sort them, then build data array in sorted order
       const collateralsArray = Array.from(potentialCollateral.keys());
       sortCollateralAssets(collateralsArray);
-      
+
       for (const collateral of collateralsArray) {
         const price = BigInt(collateral.assetPrice ?? "0");
         const decimals = BigInt(10) ** BigInt(collateral.customDecimals ?? 18);

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -263,6 +263,11 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     }
   }, [borrowAmount, loans, maxAmount, availableToBorrow, maxAtMinHF]);
 
+  // Automatically reset to auto-supply mode when borrow amount or health factor changes
+  useEffect(() => {
+    setAutoSupplyCollateral(true);
+  }, [borrowAmount, targetHealthFactor]);
+
   // Handle checkbox change - expand when unchecked
   const handleAutoSupplyChange = (checked: boolean) => {
     setAutoSupplyCollateral(checked);
@@ -426,7 +431,6 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     // Slider goes from max HF (left/0) to min HF (right/range)
     const range = Number(sliderExtrema.max) - Number(sliderExtrema.min);
     const newHF = Number(sliderExtrema.max) - sliderPos;
-    handleAutoSupplyChange(true);
     setTargetHealthFactor(Math.round(newHF * 100) / 100);
   };
 
@@ -472,7 +476,6 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
               onChange={(e) => {
                 const value = e.target.value;
                 handleAmountInputChange(value, setBorrowAmount, setBorrowAmountError, maxAmount);
-                handleAutoSupplyChange(true);
                 handlePollingUpdate(value);
               }}
             />
@@ -483,7 +486,6 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
             onClick={() => {
               try {
                 setBorrowAmount(formatUnits(BigInt(maxAmount)));
-                handleAutoSupplyChange(true);
                 setBorrowAmountError("");
                 handlePollingUpdate(formatUnits(BigInt(maxAmount)));
               } catch {}

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -606,8 +606,8 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
                 {/* Table Rows */}
                 {collateralTableData.map((item) => {
                   const decimals = item.collateral.customDecimals ?? 18;
-                  const fullAmount = formatBalance(item.amount, undefined, decimals, 2);
-                  const displayAmount = formatBalance(item.amount, undefined, decimals, 0, 4);
+                  const fullAmount = item.amount === 0n ? "0" : formatBalance(item.amount, undefined, decimals, 2);
+                  const displayAmount = item.amount === 0n ? "0" : formatBalance(item.amount, undefined, decimals, 0, 4);
                   const tokenImage = item.collateral.images?.[0]?.value;
 
                   return (

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -6,7 +6,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { HelpCircle, ChevronDown, ChevronUp } from "lucide-react";
-import { BORROW_FEE } from "@/lib/constants";
 import { safeParseUnits, addCommasToInput, formatUnits } from "@/utils/numberUtils";
 import { NewLoanData, CollateralData } from "@/interface";
 import { 
@@ -14,7 +13,8 @@ import {
   calculateHFSliderExtrema, 
   calculateAfterBorrowHealthFactor,
   recommendCollateralToSupply,
-  calculateAdditionalValueNeeded
+  calculateAdditionalValueNeeded,
+  calculateBorrowTxFee
 } from "@/utils/lendingUtils";
 import { getRiskLabel } from "@/utils/loanUtils";
 import { useLendingContext } from "@/context/LendingContext";
@@ -72,22 +72,10 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     return calculateAvailableToBorrowUSD(loans, targetHealthFactor, potentialCollateral);
   }, [loans, targetHealthFactor, collateralInfo]);
 
-  // Calculate the max amount considering fees
+  // Max borrowable amount in wei
   const maxAmount = useMemo(() => {
-    const availableWei = BigInt(Math.round(Number(availableToBorrow) * 1e18));
-    const feeWei = safeParseUnits(BORROW_FEE, 18);
-    const voucherBal = BigInt(voucherBalance || 0);
-    const usdstBal = safeParseUnits(usdstBalance || "0", 18);
-    
-    // Check if user can cover fee with vouchers or USDST
-    const canCoverFee = voucherBal >= feeWei * 100n || usdstBal >= feeWei;
-    if (!canCoverFee) {
-      setFeeError("Insufficient balance to cover transaction fee");
-      return "0";
-    }
-    setFeeError("");
-    return availableWei.toString();
-  }, [availableToBorrow, voucherBalance, usdstBalance]);
+    return BigInt(Math.round(Number(availableToBorrow) * 1e18)).toString();
+  }, [availableToBorrow]);
 
   // Current health factor display
   const currentHF = useMemo(() => {
@@ -159,6 +147,27 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     const needed = calculateAdditionalValueNeeded(collateralInfo, parseFloat(borrowAmount || "0"), loans);
     return Number(needed);
   }, [autoSupplyCollateral, totalCollateralValue, loans, collateralInfo, borrowAmount]);
+
+  // Calculate transaction fee based on number of collateral assets being supplied
+  const txFee = useMemo(() => {
+    const collateralCount = collateralTableData.length;
+    return calculateBorrowTxFee(collateralCount);
+  }, [collateralTableData]);
+
+  // Check if user can afford the transaction fee (separate from borrow amount)
+  const canAffordFee = useMemo(() => {
+    const feeWei = safeParseUnits(txFee.fee.toString(), 18);
+    const voucherBal = BigInt(voucherBalance || 0);
+    const usdstBal = safeParseUnits(usdstBalance || "0", 18);
+    
+    const canCover = voucherBal >= BigInt(txFee.voucher) || usdstBal >= feeWei;
+    if (!canCover) {
+      setFeeError("Insufficient balance to cover transaction fee");
+    } else {
+      setFeeError("");
+    }
+    return canCover;
+  }, [txFee, voucherBalance, usdstBalance]);
 
   // Handle checkbox change - expand when unchecked
   const handleAutoSupplyChange = (checked: boolean) => {
@@ -475,6 +484,15 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         </CollapsibleContent>
       </Collapsible>
 
+      {/* Transaction Fee */}
+      <div className="flex justify-between text-sm">
+        <span className="text-muted-foreground underline cursor-help" title="Fee paid to process this transaction">Transaction Fee</span>
+        <span className="font-medium">{txFee.fee.toFixed(2)} USDST ({txFee.voucher} vouchers)</span>
+      </div>
+      {feeError && (
+        <p className="text-yellow-600 text-sm">{feeError}</p>
+      )}
+
       {/* Rewards Display */}
       <CompactRewardsDisplay
         userRewards={userRewards}
@@ -482,15 +500,6 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         inputAmount={borrowAmount}
         actionLabel="Borrow"
       />
-
-      {/* Transaction Fee */}
-      <div className="flex justify-between text-sm">
-        <span className="text-muted-foreground underline cursor-help" title="Fee paid to process this transaction">Transaction Fee</span>
-        <span className="font-medium">{BORROW_FEE} USDST ({parseFloat(BORROW_FEE) * 100} vouchers)</span>
-      </div>
-      {feeError && (
-        <p className="text-yellow-600 text-sm">{feeError}</p>
-      )}
 
       {/* Conditional Warning Messages */}
       {(() => {

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -5,7 +5,7 @@ import { Slider } from "@/components/ui/slider";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { HelpCircle, ChevronDown, ChevronUp } from "lucide-react";
+import { HelpCircle, ChevronDown, ChevronUp, AlertTriangle } from "lucide-react";
 import { safeParseUnits, addCommasToInput, formatUnits } from "@/utils/numberUtils";
 import { NewLoanData, CollateralData } from "@/interface";
 import { 
@@ -459,6 +459,30 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           </div>
         </div>
       </TooltipProvider>
+
+      {/* Warning Message Box - Above Borrow Button */}
+      {afterBorrowHF !== null && Number(afterBorrowHF) < 1.6 && (
+        <div className={`p-4 border rounded-lg ${
+          Number(afterBorrowHF) < 1.3
+            ? "bg-red-500/10 dark:bg-red-500/20 border-red-500/30"
+            : "bg-yellow-500/10 dark:bg-yellow-500/20 border-yellow-500/30"
+        }`}>
+          <div className="flex items-start gap-2">
+            <AlertTriangle className={`h-5 w-5 flex-shrink-0 mt-0.5 ${
+              Number(afterBorrowHF) < 1.3
+                ? "text-red-600 dark:text-red-400"
+                : "text-yellow-600 dark:text-yellow-400"
+            }`} />
+            <p className={`text-sm whitespace-pre-line ${
+              Number(afterBorrowHF) < 1.3
+                ? "text-red-800 dark:text-red-200"
+                : "text-yellow-800 dark:text-yellow-200"
+            }`}>
+              Caution: Borrowing at this risk level can result in liquidation if the collateral drops in value.
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Error Message Box - Above Borrow Button */}
       {customBorrowError && (

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -16,7 +16,8 @@ import {
   calculateAdditionalValueNeeded,
   calculateBorrowTxFee,
   determineErrorMessage,
-  calculateAdditionalCollateralAmountFromValue
+  calculateAdditionalCollateralAmountFromValue,
+  sortCollateralAssets
 } from "@/utils/lendingUtils";
 import { getRiskLabel } from "@/utils/loanUtils";
 import { useLendingContext } from "@/context/LendingContext";
@@ -125,7 +126,11 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       }
     } else {
       // In custom mode, show ALL collateral assets the user possesses
-      for (const [collateral] of potentialCollateral.entries()) {
+      // Extract collaterals into array, sort them, then build data array in sorted order
+      const collateralsArray = Array.from(potentialCollateral.keys());
+      sortCollateralAssets(collateralsArray);
+      
+      for (const collateral of collateralsArray) {
         const price = BigInt(collateral.assetPrice ?? "0");
         const decimals = BigInt(10) ** BigInt(collateral.customDecimals ?? 18);
         

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -1,15 +1,20 @@
 import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { HelpCircle } from "lucide-react";
 import { BORROW_FEE } from "@/lib/constants";
 import { safeParseUnits, addCommasToInput, formatWeiAmount, safeParseFloat, formatUnits } from "@/utils/numberUtils";
-import { NewLoanData, CollateralData, HealthImpactData } from "@/interface";
-import { calculateBorrowHealthImpact } from "@/utils/lendingUtils";
-import RiskLevelProgress from "@/components/ui/RiskLevelProgress";
-import HealthImpactDisplay from "@/components/ui/HealthImpactDisplay";
-import PercentageButtons from "../ui/PercentageButtons";
+import { NewLoanData, CollateralData } from "@/interface";
+import { 
+  calculateAvailableToBorrowUSD, 
+  calculateHFSliderExtrema, 
+  calculateAfterBorrowHealthFactor 
+} from "@/utils/lendingUtils";
+import { getRiskLabel } from "@/utils/loanUtils";
 import { useLendingContext } from "@/context/LendingContext";
-import { computeMaxTransferable, handleAmountInputChange } from "@/utils/transferValidation";
+import { handleAmountInputChange } from "@/utils/transferValidation";
 import { UserRewardsData } from "@/services/rewardsService";
 import { CompactRewardsDisplay } from "../rewards/CompactRewardsDisplay";
 
@@ -30,38 +35,67 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   const [borrowAmount, setBorrowAmount] = useState<string>("");
   const [borrowAmountError, setBorrowAmountError] = useState<string>("");
   const [feeError, setFeeError] = useState<string>("");
-  const [riskLevel, setRiskLevel] = useState(0);
-  const [healthImpact, setHealthImpact] = useState<HealthImpactData>({
-    currentHealthFactor: 0,
-    newHealthFactor: 0,
-    healthImpact: 0,
-    isHealthy: true,
-  });
+  const [targetHealthFactor, setTargetHealthFactor] = useState<number>(2.10);
   const { borrowMax } = useLendingContext();
 
-  const maxAmount = useMemo(() => {
-    return computeMaxTransferable(loans?.maxAvailableToBorrowUSD, false, voucherBalance, usdstBalance, safeParseUnits(BORROW_FEE).toString(), setFeeError);
-  }, [voucherBalance, usdstBalance, loans?.maxAvailableToBorrowUSD]);
-
-  // Calculate risk level for borrow form
-  useEffect(() => {
-    try {
-      const existingBorrowedBigInt = BigInt(loans?.totalAmountOwed || 0);
-      const newBorrowAmountBigInt = safeParseUnits(borrowAmount || "0", 18);
-      const totalBorrowedBigInt = existingBorrowedBigInt + newBorrowAmountBigInt;
-      const collateralValueBigInt = BigInt(loans?.totalCollateralValueUSD || 0);
-
-      if (collateralValueBigInt === 0n) {
-        setRiskLevel(0);
-        return;
-      }
-
-      const risk = Number((totalBorrowedBigInt * 10000n) / collateralValueBigInt) / 100;
-      setRiskLevel(Math.min(risk, 100));
-    } catch {
-      setRiskLevel(0);
+  // Calculate slider extrema based on collateral configs
+  const sliderExtrema = useMemo(() => {
+    if (!loans || !collateralInfo || collateralInfo.length === 0) {
+      return { min: 1.01, max: 3.00 };
     }
-  }, [borrowAmount, loans?.totalCollateralValueUSD, loans?.totalAmountOwed]);
+    return calculateHFSliderExtrema(loans, collateralInfo);
+  }, [loans, collateralInfo]);
+
+  // Calculate available to borrow based on current health factor setting
+  const availableToBorrow = useMemo(() => {
+    if (!loans) return 0;
+    const emptyCollateral = new Map<CollateralData, bigint>();
+    return calculateAvailableToBorrowUSD(loans, targetHealthFactor, emptyCollateral);
+  }, [loans, targetHealthFactor]);
+
+  // Calculate the max amount considering fees
+  const maxAmount = useMemo(() => {
+    const availableWei = BigInt(Math.round(Number(availableToBorrow) * 1e18));
+    const feeWei = safeParseUnits(BORROW_FEE, 18);
+    const voucherBal = BigInt(voucherBalance || 0);
+    const usdstBal = safeParseUnits(usdstBalance || "0", 18);
+    
+    // Check if user can cover fee with vouchers or USDST
+    const canCoverFee = voucherBal >= feeWei * 100n || usdstBal >= feeWei;
+    if (!canCoverFee) {
+      setFeeError("Insufficient balance to cover transaction fee");
+      return "0";
+    }
+    setFeeError("");
+    return availableWei.toString();
+  }, [availableToBorrow, voucherBalance, usdstBalance]);
+
+  // Calculate after-borrow health factor
+  const afterBorrowHF = useMemo(() => {
+    if (!loans || !borrowAmount || parseFloat(borrowAmount) <= 0) {
+      return null;
+    }
+    const emptyCollateral = new Map<CollateralData, bigint>();
+    return calculateAfterBorrowHealthFactor(loans, parseFloat(borrowAmount), emptyCollateral);
+  }, [loans, borrowAmount]);
+
+  // Current health factor display
+  const currentHF = useMemo(() => {
+    if (!loans) return null;
+    const owed = BigInt(loans.totalAmountOwed || 0);
+    if (owed <= 1n) return null; // No loan
+    return loans.healthFactor;
+  }, [loans]);
+
+  // Get risk indicator color and label
+  const getRiskIndicator = (hf: number): { label: string; color: string } => {
+    const label = getRiskLabel(hf);
+    if (label === 'Low Risk') return { label, color: 'text-green-500' };
+    if (label === 'Moderate Risk') return { label, color: 'text-yellow-500' };
+    return { label, color: 'text-red-500' };
+  };
+
+  const riskIndicator = getRiskIndicator(targetHealthFactor);
 
   // Consolidated polling handler
   const handlePollingUpdate = (amount: string) => {
@@ -73,7 +107,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   };
 
   const handleBorrow = async () => {
-    const maxWei = BigInt(loans?.maxAvailableToBorrowUSD || 0);
+    const maxWei = BigInt(maxAmount);
     const wei = safeParseUnits(borrowAmount || "0", 18);
 
     // If at or within 1 wei of the max available, route via parent as 'ALL' to use on-chain borrowMax and parent UX
@@ -93,11 +127,20 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     handlePollingUpdate("");
   };
 
-  useEffect(()=>{
-    const borrowAmountWei = safeParseUnits(borrowAmount || "0", 18);
-    const res = calculateBorrowHealthImpact(borrowAmountWei, loans)    
-    setHealthImpact(res)
-  },[borrowAmount, loans])
+  // Handle slider change - convert position to HF value
+  const handleSliderChange = (values: number[]) => {
+    const sliderPos = values[0];
+    // Slider goes from max HF (left/0) to min HF (right/range)
+    const range = Number(sliderExtrema.max) - Number(sliderExtrema.min);
+    const newHF = Number(sliderExtrema.max) - sliderPos;
+    setTargetHealthFactor(Math.round(newHF * 100) / 100);
+  };
+
+  // Convert HF to slider position
+  const sliderPosition = useMemo(() => {
+    const range = Number(sliderExtrema.max) - Number(sliderExtrema.min);
+    return Number(sliderExtrema.max) - targetHealthFactor;
+  }, [targetHealthFactor, sliderExtrema]);
 
   const interestRateDisplay = (() => {
     const raw = (loans as any)?.interestRate; // bps
@@ -106,103 +149,106 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     return `${(num / 100).toFixed(2)}%`;
   })();
 
+  const sliderRange = Number(sliderExtrema.max) - Number(sliderExtrema.min);
+
   return (
     <div className="space-y-4 pt-4">
-      {/* Loan Details */}
-      <div className="space-y-3">
-        <div className="flex justify-between">
-          <span className="text-sm text-muted-foreground">Available to borrow</span>
-          <span className="font-medium">
-            USDST {safeParseFloat(formatUnits(loans?.maxAvailableToBorrowUSD || 0, 18)) === 0 ? '-' : formatWeiAmount(loans?.maxAvailableToBorrowUSD || '0')}
-          </span>
+      {/* Header: Borrow USDST */}
+      <div className="space-y-1">
+        <h3 className="text-lg font-semibold">Borrow USDST</h3>
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Available to Borrow</span>
+          <span className="font-medium">USDST {Number(availableToBorrow).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}</span>
         </div>
-        <div className="flex justify-between">
-          <span className="text-sm text-muted-foreground">Total Amount Owed</span>
-          <span className="font-medium">
-            {(() => {
-              const owed = (() => { try { return BigInt(loans?.totalAmountOwed || 0); } catch { return 0n; } })();
-              const display = owed <= 1n ? 0n : owed;
-              return `USDST ${formatUnits(display, 18)}`;
-            })()}
-          </span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-sm text-muted-foreground">Interest Rate</span>
-          <span className="font-medium">
-            {interestRateDisplay}
-          </span>
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Interest Rate</span>
+          <span className="font-medium">{interestRateDisplay}</span>
         </div>
       </div>
 
       {/* Borrow Amount Input */}
-      <div className="space-y-3">
-        <label className="text-sm font-medium">Borrow Amount (USDST)</label>
-        <div className="flex justify-between items-center text-xs text-muted-foreground">
-          <span>Min: 0.01 USDST</span>
-          <div>
-            <button
-              type="button"
-              onClick={() => {
-                try {
-                  setBorrowAmount(formatUnits(BigInt(maxAmount)));
-                  setBorrowAmountError("");
-                } catch {}
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Borrow Amount</label>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Input
+              placeholder="0"
+              className={`pr-20 ${safeParseUnits(borrowAmount || "0", 18) > BigInt(maxAmount) ? 'text-red-600' : ''}`}
+              value={addCommasToInput(borrowAmount)}
+              onChange={(e) => {
+                const value = e.target.value;
+                handleAmountInputChange(value, setBorrowAmount, setBorrowAmountError, maxAmount);
+                handlePollingUpdate(value);
               }}
-              disabled={safeParseFloat(formatUnits(loans?.maxAvailableToBorrowUSD || 0, 18)) === 0}
-              className="px-2 py-1 mr-1 bg-muted hover:bg-muted/80 rounded-full text-muted-foreground hover:text-foreground text-xs font-medium transition disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-muted"
-              title={safeParseFloat(formatUnits(loans?.maxAvailableToBorrowUSD || 0, 18)) === 0 ? "No amount available to borrow" : "Set to safe maximum available amount"}
-            >
-              Max :
-            </button>
-            <span>{safeParseFloat(formatUnits(loans?.maxAvailableToBorrowUSD || 0, 18)) === 0 ? '-' : formatWeiAmount(loans?.maxAvailableToBorrowUSD || '0')} USDST</span>
+            />
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">USDST</span>
           </div>
-        </div>
-        <div className="relative">
-          <Input
-            placeholder="0.00"
-            className={`pr-16 ${safeParseUnits(borrowAmount || "0", 18) > BigInt(loans?.maxAvailableToBorrowUSD || 0) ? 'text-red-600' : ''}`}
-            value={addCommasToInput(borrowAmount)}
-            onChange={(e)=>{
-              const value = e.target.value;
-              handleAmountInputChange(value, setBorrowAmount, setBorrowAmountError, maxAmount);
+          <Button
+            variant="outline"
+            onClick={() => {
+              try {
+                setBorrowAmount(formatUnits(BigInt(maxAmount)));
+                setBorrowAmountError("");
+                handlePollingUpdate(formatUnits(BigInt(maxAmount)));
+              } catch {}
             }}
-          />
-          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground">USDST</span>
+            disabled={Number(availableToBorrow) <= 0}
+            className="px-4"
+          >
+            MAX
+          </Button>
         </div>
         {borrowAmountError && (
           <p className="text-red-600 text-sm">{borrowAmountError}</p>
         )}
-        <CompactRewardsDisplay
-          userRewards={userRewards}
-          activityName="Lending Pool Borrow"
-          inputAmount={borrowAmount}
-          actionLabel="Borrow"
-        />
-        <PercentageButtons
-          value={borrowAmount}
-          maxValue={maxAmount}
-          onChange={(val) => {
-            setBorrowAmount(val);
-          }}
-          className="mt-2"
-          disabled={BigInt(maxAmount) < 1e15} // Disable if less than 0.001 USDST (1e15 wei)
-        />
       </div>
 
-      {/* Risk Level */}
-      <RiskLevelProgress riskLevel={riskLevel} />
+      {/* Health Factor Slider */}
+      <TooltipProvider>
+        <div className="space-y-3 py-2">
+          <div className="flex items-center justify-between">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="flex items-center gap-1.5 cursor-help">
+                  <span className="text-base font-semibold">Health Factor</span>
+                  <HelpCircle className="h-4 w-4 text-muted-foreground" />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p>Target health factor after borrowing. Higher = safer position with less borrowing. Lower = riskier with more borrowing.</p>
+              </TooltipContent>
+            </Tooltip>
+            <div className="flex items-center gap-2">
+              <span className="text-xl font-bold tabular-nums">{targetHealthFactor.toFixed(2)}</span>
+              <span className={`text-sm font-medium ${riskIndicator.color}`}>{riskIndicator.label}</span>
+            </div>
+          </div>
 
-      {/* Transaction Fee */}
-      <div className="px-4 py-3 bg-muted/50 rounded-md">
-        <HealthImpactDisplay healthImpact={healthImpact} showWarning={false} className="mb-4" />
-        <div className="flex justify-between text-sm mb-2">
-          <span className="text-muted-foreground">Transaction Fee</span>
-          <span className="font-medium">{BORROW_FEE} USDST ({parseFloat(BORROW_FEE) * 100} voucher)</span>
+          <Slider
+            value={[sliderPosition]}
+            min={0}
+            max={sliderRange}
+            step={0.01}
+            onValueChange={handleSliderChange}
+            className="w-full"
+          />
+
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>Safer</span>
+            <span>Riskier</span>
+          </div>
+
+          {/* Current Loans Health: Before => After */}
+          <div className="flex justify-between items-center text-sm border-t pt-3">
+            <span className="text-muted-foreground">Current Loans Health</span>
+            <span className="font-medium tabular-nums">
+              {currentHF === null ? 'No Loan' : currentHF.toFixed(2)}
+              {' → '}
+              {afterBorrowHF !== null ? afterBorrowHF.toFixed(2) : (borrowAmount ? targetHealthFactor.toFixed(2) : '-')}
+            </span>
+          </div>
         </div>
-        {feeError && (
-          <p className="text-yellow-600 text-sm mt-1">{feeError}</p>
-        )}
-      </div>
+      </TooltipProvider>
 
       {/* Borrow Button */}
       <Button
@@ -223,42 +269,41 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         Borrow
       </Button>
 
+      {/* Rewards Display */}
+      <CompactRewardsDisplay
+        userRewards={userRewards}
+        activityName="Lending Pool Borrow"
+        inputAmount={borrowAmount}
+        actionLabel="Borrow"
+      />
+
+      {/* Transaction Fee */}
+      <div className="flex justify-between text-sm">
+        <span className="text-muted-foreground underline cursor-help" title="Fee paid to process this transaction">Transaction Fee</span>
+        <span className="font-medium">{BORROW_FEE} USDST ({parseFloat(BORROW_FEE) * 100} vouchers)</span>
+      </div>
+      {feeError && (
+        <p className="text-yellow-600 text-sm">{feeError}</p>
+      )}
+
       {/* Conditional Warning Messages */}
       {(() => {
-        const availableToBorrowFormatted = formatUnits(loans?.maxAvailableToBorrowUSD || 0);
-        const isZeroAvailable = safeParseFloat(availableToBorrowFormatted) === 0;
-        
-        // collateralInfo already contains only eligible collateral (balance > 0)
+        const isZeroAvailable = Number(availableToBorrow) <= 0;
         const eligibleCollateralTokens = collateralInfo || [];
 
-        const borrowInfoMessage = (
-          <p className="text-muted-foreground mt-2">
-            Borrowing against your assets allows you to access liquidity
-            without selling your holdings. Be mindful of the risk level, as
-            high borrowing increases liquidation risk during market
-            volatility.
-          </p>
-        );
-
-        if (isZeroAvailable) {
+        if (isZeroAvailable && eligibleCollateralTokens.length === 0) {
           return (
-            <div className="mt-2">
-              <p className="text-muted-foreground">
-                You currently have no available borrowing power. Supply collateral to enable borrowing.
-              </p>
-              {borrowInfoMessage}
-            </div>
+            <p className="text-muted-foreground text-sm mt-2">
+              You have no eligible collateral. Supply assets to enable borrowing.
+            </p>
           );
         }
 
-        if (eligibleCollateralTokens.length === 0) {
+        if (isZeroAvailable) {
           return (
-            <div className="mt-2">
-              <p className="text-muted-foreground">
-                You have no eligible collateral. Supply assets to enable borrowing.
-              </p>
-              {borrowInfoMessage}
-            </div>
+            <p className="text-muted-foreground text-sm mt-2">
+              You currently have no available borrowing power. Supply collateral to enable borrowing.
+            </p>
           );
         }
 

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -21,7 +21,7 @@ import {
   calculateMaxCollateralValueUSDCentFloored,
   centCeil
 } from "@/utils/lendingUtils";
-import { getRiskLabel } from "@/utils/loanUtils";
+import { getRiskLabel } from "@/utils/lendingUtils";
 import { useLendingContext } from "@/context/LendingContext";
 import { handleAmountInputChange } from "@/utils/transferValidation";
 import { UserRewardsData } from "@/services/rewardsService";

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -531,25 +531,11 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       </TooltipProvider>
 
       {/* Warning Message Box - Above Borrow Button */}
-      {afterBorrowHF !== null && Number(afterBorrowHF) < 1.6 // Low Health Factor Warning
-       && !customBorrowError // Don't show if overlarge borrow error is already displayed
-       && (
-        <div className={`p-4 border rounded-lg ${
-          Number(afterBorrowHF) < 1.3
-            ? "bg-red-500/10 dark:bg-red-500/20 border-red-500/30"
-            : "bg-yellow-500/10 dark:bg-yellow-500/20 border-yellow-500/30"
-        }`}>
+      {targetHealthFactor < 1.6 && !customBorrowError && (
+        <div className="p-4 border rounded-lg bg-red-500/10 dark:bg-red-500/20 border-red-500/30">
           <div className="flex items-start gap-2">
-            <AlertTriangle className={`h-5 w-5 flex-shrink-0 mt-0.5 ${
-              Number(afterBorrowHF) < 1.3
-                ? "text-red-600 dark:text-red-400"
-                : "text-yellow-600 dark:text-yellow-400"
-            }`} />
-            <p className={`text-sm whitespace-pre-line ${
-              Number(afterBorrowHF) < 1.3
-                ? "text-red-800 dark:text-red-200"
-                : "text-yellow-800 dark:text-yellow-200"
-            }`}>
+            <AlertTriangle className="h-5 w-5 flex-shrink-0 mt-0.5 text-red-600 dark:text-red-400" />
+            <p className="text-sm whitespace-pre-line text-red-800 dark:text-red-200">
               Caution: Borrowing at this risk level can result in liquidation if the collateral drops in value.
             </p>
           </div>

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -683,14 +683,6 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           );
         }
 
-        if (isZeroAvailable) {
-          return (
-            <p className="text-muted-foreground text-sm mt-2">
-              You currently have no available borrowing power. Supply collateral to enable borrowing.
-            </p>
-          );
-        }
-
         return null;
       })()}
 

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -426,6 +426,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     // Slider goes from max HF (left/0) to min HF (right/range)
     const range = Number(sliderExtrema.max) - Number(sliderExtrema.min);
     const newHF = Number(sliderExtrema.max) - sliderPos;
+    handleAutoSupplyChange(true);
     setTargetHealthFactor(Math.round(newHF * 100) / 100);
   };
 
@@ -471,6 +472,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
               onChange={(e) => {
                 const value = e.target.value;
                 handleAmountInputChange(value, setBorrowAmount, setBorrowAmountError, maxAmount);
+                handleAutoSupplyChange(true);
                 handlePollingUpdate(value);
               }}
             />
@@ -481,6 +483,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
             onClick={() => {
               try {
                 setBorrowAmount(formatUnits(BigInt(maxAmount)));
+                handleAutoSupplyChange(true);
                 setBorrowAmountError("");
                 handlePollingUpdate(formatUnits(BigInt(maxAmount)));
               } catch {}

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -533,12 +533,13 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
       {/* Warning Message Box - Above Borrow Button */}
       {targetHealthFactor < 1.6 && !customBorrowError && (
         <div className="p-4 border rounded-lg bg-red-500/10 dark:bg-red-500/20 border-red-500/30">
-          <div className="flex items-start gap-2">
-            <AlertTriangle className="h-5 w-5 flex-shrink-0 mt-0.5 text-red-600 dark:text-red-400" />
-            <p className="text-sm whitespace-pre-line text-red-800 dark:text-red-200">
-              Caution: Borrowing at this risk level can result in liquidation if the collateral drops in value.
-            </p>
+          <div className="flex items-start gap-2 mb-2">
+            <AlertTriangle className="h-5 w-5 flex-shrink-0 text-red-600 dark:text-red-400" />
+            <p className="text-sm font-semibold text-red-800 dark:text-red-200">High Risk Warning</p>
           </div>
+          <p className="text-sm whitespace-pre-line text-red-800 dark:text-red-200">
+            Borrowing at this risk level can result in liquidation if the collateral drops in value.
+          </p>
         </div>
       )}
 

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -146,7 +146,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     if (!loans || !collateralInfo || collateralInfo.length === 0) return 0;
     const needed = calculateAdditionalValueNeeded(collateralInfo, parseFloat(borrowAmount || "0"), loans, targetHealthFactor);
     return Number(needed);
-  }, [autoSupplyCollateral, totalCollateralValue, loans, collateralInfo, borrowAmount]);
+  }, [autoSupplyCollateral, totalCollateralValue, loans, collateralInfo, borrowAmount, targetHealthFactor]);
 
   // Calculate transaction fee based on number of collateral assets being supplied
   const txFee = useMemo(() => {

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { HelpCircle, ChevronDown, ChevronUp, AlertTriangle } from "lucide-react";
-import { safeParseUnits, addCommasToInput, formatUnits } from "@/utils/numberUtils";
+import { safeParseUnits, addCommasToInput, formatUnits, formatBalance } from "@/utils/numberUtils";
 import { NewLoanData, CollateralData } from "@/interface";
 import { 
   calculateAvailableToBorrowUSD, 
@@ -553,6 +553,17 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           )}
         </CollapsibleTrigger>
         <CollapsibleContent className="px-4 pb-4">
+          <style>{`
+            /* Hide number input spinner arrows */
+            .collateral-value-input[type="number"]::-webkit-outer-spin-button,
+            .collateral-value-input[type="number"]::-webkit-inner-spin-button {
+              -webkit-appearance: none;
+              margin: 0;
+            }
+            .collateral-value-input[type="number"] {
+              -moz-appearance: textfield;
+            }
+          `}</style>
           {/* Total Value Header */}
           <div className="text-sm font-medium mb-3 pt-2 border-t">
             Total Value of Collateral: ${totalCollateralValue.toFixed(0)}
@@ -560,66 +571,76 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
 
           {/* Collateral Table */}
           {collateralTableData.length > 0 ? (
-            <div className="space-y-1">
-              {/* Table Header */}
-              <div className="grid grid-cols-3 gap-4 text-xs text-muted-foreground pb-2">
-                <span>Asset</span>
-                <span className="text-center">Amount</span>
-                <span className="text-right">Value</span>
-              </div>
+            <TooltipProvider>
+              <div className="space-y-1">
+                {/* Table Header */}
+                <div className="grid grid-cols-3 gap-4 text-xs text-muted-foreground pb-2">
+                  <span>Asset</span>
+                  <span className="text-center">Amount</span>
+                  <span className="text-right">Value</span>
+                </div>
 
-              {/* Table Rows */}
-              {collateralTableData.map((item) => {
-                const decimals = item.collateral.customDecimals ?? 18;
-                const formattedAmount = Number(item.amount) / Math.pow(10, decimals);
-                const tokenImage = item.collateral.images?.[0]?.value;
+                {/* Table Rows */}
+                {collateralTableData.map((item) => {
+                  const decimals = item.collateral.customDecimals ?? 18;
+                  const fullAmount = formatBalance(item.amount, undefined, decimals, 2);
+                  const displayAmount = formatBalance(item.amount, undefined, decimals, 0, 4);
+                  const tokenImage = item.collateral.images?.[0]?.value;
 
-                return (
-                  <div
-                    key={item.collateral.address}
-                    className="grid grid-cols-3 gap-4 items-center py-2 text-sm"
-                  >
-                    {/* Asset */}
-                    <div className="flex items-center gap-2">
-                      {tokenImage ? (
-                        <img
-                          src={tokenImage}
-                          alt={item.collateral._symbol}
-                          className="w-5 h-5 rounded-full"
-                        />
+                  return (
+                    <div
+                      key={item.collateral.address}
+                      className="grid grid-cols-3 gap-4 items-center py-2 text-sm"
+                    >
+                      {/* Asset */}
+                      <div className="flex items-center gap-2">
+                        {tokenImage ? (
+                          <img
+                            src={tokenImage}
+                            alt={item.collateral._symbol}
+                            className="w-5 h-5 rounded-full"
+                          />
+                        ) : (
+                          <div className="w-5 h-5 rounded-full bg-muted flex items-center justify-center text-xs">
+                            {item.collateral._symbol?.charAt(0) || '?'}
+                          </div>
+                        )}
+                        <span className="font-medium">{item.collateral._symbol}</span>
+                      </div>
+
+                      {/* Amount */}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="text-center tabular-nums cursor-help">
+                            {displayAmount}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>{fullAmount}</p>
+                        </TooltipContent>
+                      </Tooltip>
+
+                      {/* Value */}
+                      {autoSupplyCollateral ? (
+                        <span className="text-right tabular-nums">
+                          ${item.valueUSD.toFixed(2)}
+                        </span>
                       ) : (
-                        <div className="w-5 h-5 rounded-full bg-muted flex items-center justify-center text-xs">
-                          {item.collateral._symbol?.charAt(0) || '?'}
+                        <div className="flex items-center justify-end gap-1">
+                          <span className="text-muted-foreground">$</span>
+                          <Input
+                            type="number"
+                            value={customCollateralValues.get(item.collateral.address) || item.valueUSD.toFixed(2)}
+                            onChange={(e) => handleCustomValueChange(item.collateral.address, e.target.value)}
+                            className="collateral-value-input w-20 h-7 text-right text-sm px-2"
+                          />
                         </div>
                       )}
-                      <span className="font-medium">{item.collateral._symbol}</span>
                     </div>
-
-                    {/* Amount */}
-                    <span className="text-center tabular-nums">
-                      {formattedAmount.toFixed(4)}
-                    </span>
-
-                    {/* Value */}
-                    {autoSupplyCollateral ? (
-                      <span className="text-right tabular-nums">
-                        ${item.valueUSD.toFixed(0)}
-                      </span>
-                    ) : (
-                      <div className="flex items-center justify-end gap-1">
-                        <span className="text-muted-foreground">$</span>
-                        <Input
-                          type="number"
-                          value={customCollateralValues.get(item.collateral.address) || item.valueUSD.toFixed(0)}
-                          onChange={(e) => handleCustomValueChange(item.collateral.address, e.target.value)}
-                          className="w-20 h-7 text-right text-sm px-2"
-                        />
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+                  );
+                })}
+              </div>
+            </TooltipProvider>
           ) : (
             <p className="text-sm text-muted-foreground py-2">
               {borrowAmount && parseFloat(borrowAmount) > 0

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -113,26 +113,39 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   const collateralTableData = useMemo(() => {
     const data: Array<{ collateral: CollateralData; amount: bigint; valueUSD: number }> = [];
     
-    for (const [collateral, amount] of recommendedCollateral.entries()) {
-      if (amount <= 0n) continue;
-      
-      const price = BigInt(collateral.assetPrice ?? "0");
-      const decimals = BigInt(10) ** BigInt(collateral.customDecimals ?? 18);
-      const valueUSD = Number((amount * price) / decimals) / 1e18;
-      
-      // If custom mode, use custom value if set
-      if (!autoSupplyCollateral && customCollateralValues.has(collateral.address)) {
-        const customValue = parseFloat(customCollateralValues.get(collateral.address) || "0");
-        const customValueWei = BigInt(Math.round(customValue * 1e18));
-        const customAmount = calculateAdditionalCollateralAmountFromValue(customValueWei, price, decimals);
-        data.push({ collateral, amount: customAmount, valueUSD: customValue });
-      } else {
+    if (autoSupplyCollateral) {
+      // In auto mode, only show recommended collateral with amount > 0
+      for (const [collateral, amount] of recommendedCollateral.entries()) {
+        if (amount <= 0n) continue;
+        
+        const price = BigInt(collateral.assetPrice ?? "0");
+        const decimals = BigInt(10) ** BigInt(collateral.customDecimals ?? 18);
+        const valueUSD = Number((amount * price) / decimals) / 1e18;
         data.push({ collateral, amount, valueUSD });
+      }
+    } else {
+      // In custom mode, show ALL collateral assets the user possesses
+      for (const [collateral] of potentialCollateral.entries()) {
+        const price = BigInt(collateral.assetPrice ?? "0");
+        const decimals = BigInt(10) ** BigInt(collateral.customDecimals ?? 18);
+        
+        // Use custom value if set, otherwise check if in recommendation
+        if (customCollateralValues.has(collateral.address)) {
+          const customValue = parseFloat(customCollateralValues.get(collateral.address) || "0");
+          const customValueWei = BigInt(Math.round(customValue * 1e18));
+          const customAmount = calculateAdditionalCollateralAmountFromValue(customValueWei, price, decimals);
+          data.push({ collateral, amount: customAmount, valueUSD: customValue });
+        } else {
+          // Fallback to recommended amount or 0
+          const recommendedAmount = recommendedCollateral.get(collateral) ?? 0n;
+          const valueUSD = Number((recommendedAmount * price) / decimals) / 1e18;
+          data.push({ collateral, amount: recommendedAmount, valueUSD });
+        }
       }
     }
     
     return data;
-  }, [recommendedCollateral, autoSupplyCollateral, customCollateralValues]);
+  }, [recommendedCollateral, autoSupplyCollateral, customCollateralValues, potentialCollateral]);
 
   // Total value of collateral in table
   const totalCollateralValue = useMemo(() => {
@@ -219,10 +232,20 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     setAutoSupplyCollateral(checked);
     if (!checked) {
       setIsCollateralExpanded(true);
-      // Initialize custom values from recommended
+      // Initialize custom values from ALL user-possessed collateral assets
+      // Assets in recommendation get their recommended value, others get 0
       const initialCustomValues = new Map<string, string>();
-      for (const item of collateralTableData) {
-        initialCustomValues.set(item.collateral.address, item.valueUSD.toFixed(2));
+      for (const [collateral] of potentialCollateral.entries()) {
+        const recommendedAmount = recommendedCollateral.get(collateral);
+        if (recommendedAmount && recommendedAmount > 0n) {
+          const price = BigInt(collateral.assetPrice ?? "0");
+          const decimals = BigInt(10) ** BigInt(collateral.customDecimals ?? 18);
+          const valueUSD = Number((recommendedAmount * price) / decimals) / 1e18;
+          initialCustomValues.set(collateral.address, valueUSD.toFixed(2));
+        } else {
+          // Not in recommendation - initialize to zero
+          initialCustomValues.set(collateral.address, "0.00");
+        }
       }
       setCustomCollateralValues(initialCustomValues);
     }

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -17,7 +17,8 @@ import {
   calculateBorrowTxFee,
   determineErrorMessage,
   calculateAdditionalCollateralAmountFromValue,
-  sortCollateralAssets
+  sortCollateralAssets,
+  calculateMaxCollateralValueFromBalance
 } from "@/utils/lendingUtils";
 import { getRiskLabel } from "@/utils/loanUtils";
 import { useLendingContext } from "@/context/LendingContext";
@@ -156,6 +157,32 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   const totalCollateralValue = useMemo(() => {
     return collateralTableData.reduce((sum, item) => sum + item.valueUSD, 0);
   }, [collateralTableData]);
+
+  // Map of collateral addresses to whether their value exceeds maximum
+  const collateralExceedsMaxMap = useMemo(() => {
+    const map = new Map<string, boolean>();
+    if (autoSupplyCollateral) return map; // Only check in custom mode
+    
+    for (const item of collateralTableData) {
+      const balance = BigInt(item.collateral.userBalance ?? "0");
+      const price = BigInt(item.collateral.assetPrice ?? "0");
+      const decimals = BigInt(10) ** BigInt(item.collateral.customDecimals ?? 18);
+      const maxValueWei = calculateMaxCollateralValueFromBalance(balance, price, decimals);
+      const maxValueUSD = Number(maxValueWei) / 1e18;
+      
+      map.set(item.collateral.address, item.valueUSD > maxValueUSD);
+    }
+    
+    return map;
+  }, [autoSupplyCollateral, collateralTableData]);
+
+  // Check if any custom collateral values exceed their maximum
+  const hasExceededMaxCollateralValue = useMemo(() => {
+    for (const exceedsMax of collateralExceedsMaxMap.values()) {
+      if (exceedsMax) return true;
+    }
+    return false;
+  }, [collateralExceedsMaxMap]);
 
   // Calculate after-borrow health factor (includes new collateral being supplied)
   const afterBorrowHF = useMemo(() => {
@@ -537,7 +564,8 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           safeParseUnits(borrowAmount || "0") <= 0n ||
           borrowLoading ||
           progressModalOpen ||
-          safeParseUnits(borrowAmount || "0") > BigInt(maxAmount)
+          safeParseUnits(borrowAmount || "0") > BigInt(maxAmount) ||
+          hasExceededMaxCollateralValue
         }
         className="w-full"
       >
@@ -663,7 +691,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
                             type="number"
                             value={customCollateralValues.get(item.collateral.address) || item.valueUSD.toFixed(2)}
                             onChange={(e) => handleCustomValueChange(item.collateral.address, e.target.value)}
-                            className="collateral-value-input w-20 h-7 text-right text-sm px-2"
+                            className={`collateral-value-input w-20 h-7 text-right text-sm px-2 ${collateralExceedsMaxMap.get(item.collateral.address) ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                           />
                         </div>
                       )}

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -2,15 +2,19 @@ import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { HelpCircle } from "lucide-react";
+import { HelpCircle, ChevronDown, ChevronUp } from "lucide-react";
 import { BORROW_FEE } from "@/lib/constants";
-import { safeParseUnits, addCommasToInput, formatWeiAmount, safeParseFloat, formatUnits } from "@/utils/numberUtils";
+import { safeParseUnits, addCommasToInput, formatUnits } from "@/utils/numberUtils";
 import { NewLoanData, CollateralData } from "@/interface";
 import { 
   calculateAvailableToBorrowUSD, 
   calculateHFSliderExtrema, 
-  calculateAfterBorrowHealthFactor 
+  calculateAfterBorrowHealthFactor,
+  recommendCollateralToSupply,
+  calculateAdditionalValueNeeded
 } from "@/utils/lendingUtils";
 import { getRiskLabel } from "@/utils/loanUtils";
 import { useLendingContext } from "@/context/LendingContext";
@@ -36,6 +40,9 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   const [borrowAmountError, setBorrowAmountError] = useState<string>("");
   const [feeError, setFeeError] = useState<string>("");
   const [targetHealthFactor, setTargetHealthFactor] = useState<number>(2.10);
+  const [autoSupplyCollateral, setAutoSupplyCollateral] = useState<boolean>(true);
+  const [isCollateralExpanded, setIsCollateralExpanded] = useState<boolean>(false);
+  const [customCollateralValues, setCustomCollateralValues] = useState<Map<string, string>>(new Map());
   const { borrowMax } = useLendingContext();
 
   // Calculate slider extrema based on collateral configs
@@ -47,11 +54,23 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   }, [loans, collateralInfo]);
 
   // Calculate available to borrow based on current health factor setting
+  // Includes all available collateral balances (max potential borrowing power)
   const availableToBorrow = useMemo(() => {
     if (!loans) return 0;
-    const emptyCollateral = new Map<CollateralData, bigint>();
-    return calculateAvailableToBorrowUSD(loans, targetHealthFactor, emptyCollateral);
-  }, [loans, targetHealthFactor]);
+    
+    // Build collateral map from all available user balances
+    const potentialCollateral = new Map<CollateralData, bigint>();
+    if (collateralInfo) {
+      for (const collateral of collateralInfo) {
+        const balance = BigInt(collateral.userBalance ?? "0");
+        if (balance > 0n) {
+          potentialCollateral.set(collateral, balance);
+        }
+      }
+    }
+    
+    return calculateAvailableToBorrowUSD(loans, targetHealthFactor, potentialCollateral);
+  }, [loans, targetHealthFactor, collateralInfo]);
 
   // Calculate the max amount considering fees
   const maxAmount = useMemo(() => {
@@ -70,15 +89,6 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     return availableWei.toString();
   }, [availableToBorrow, voucherBalance, usdstBalance]);
 
-  // Calculate after-borrow health factor
-  const afterBorrowHF = useMemo(() => {
-    if (!loans || !borrowAmount || parseFloat(borrowAmount) <= 0) {
-      return null;
-    }
-    const emptyCollateral = new Map<CollateralData, bigint>();
-    return calculateAfterBorrowHealthFactor(loans, parseFloat(borrowAmount), emptyCollateral);
-  }, [loans, borrowAmount]);
-
   // Current health factor display
   const currentHF = useMemo(() => {
     if (!loans) return null;
@@ -86,6 +96,90 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     if (owed <= 1n) return null; // No loan
     return loans.healthFactor;
   }, [loans]);
+
+  // Recommended collateral to supply based on borrow amount and target HF
+  const recommendedCollateral = useMemo(() => {
+    if (!loans || !collateralInfo || collateralInfo.length === 0 || !borrowAmount || parseFloat(borrowAmount) <= 0) {
+      return new Map<CollateralData, bigint>();
+    }
+    // Make a copy of collateralInfo to avoid mutating original
+    const collateralsCopy = [...collateralInfo];
+    return recommendCollateralToSupply(loans, targetHealthFactor, parseFloat(borrowAmount), collateralsCopy);
+  }, [loans, collateralInfo, borrowAmount, targetHealthFactor]);
+
+  // Build collateral table data
+  const collateralTableData = useMemo(() => {
+    const data: Array<{ collateral: CollateralData; amount: bigint; valueUSD: number }> = [];
+    
+    for (const [collateral, amount] of recommendedCollateral.entries()) {
+      if (amount <= 0n) continue;
+      
+      const price = BigInt(collateral.assetPrice ?? "0");
+      const decimals = BigInt(10) ** BigInt(collateral.customDecimals ?? 18);
+      const valueUSD = Number((amount * price) / decimals) / 1e18;
+      
+      // If custom mode, use custom value if set
+      if (!autoSupplyCollateral && customCollateralValues.has(collateral.address)) {
+        const customValue = parseFloat(customCollateralValues.get(collateral.address) || "0");
+        const customAmount = price > 0n ? BigInt(Math.round(customValue * 1e18)) * decimals / price : 0n;
+        data.push({ collateral, amount: customAmount, valueUSD: customValue });
+      } else {
+        data.push({ collateral, amount, valueUSD });
+      }
+    }
+    
+    return data;
+  }, [recommendedCollateral, autoSupplyCollateral, customCollateralValues]);
+
+  // Total value of collateral in table
+  const totalCollateralValue = useMemo(() => {
+    return collateralTableData.reduce((sum, item) => sum + item.valueUSD, 0);
+  }, [collateralTableData]);
+
+  // Calculate after-borrow health factor (includes new collateral being supplied)
+  const afterBorrowHF = useMemo(() => {
+    if (!loans || !borrowAmount || parseFloat(borrowAmount) <= 0) {
+      return null;
+    }
+    // Build collateral map from table data (includes auto or custom amounts)
+    const newCollateral = new Map<CollateralData, bigint>();
+    for (const item of collateralTableData) {
+      newCollateral.set(item.collateral, item.amount);
+    }
+    return calculateAfterBorrowHealthFactor(loans, parseFloat(borrowAmount), newCollateral);
+  }, [loans, borrowAmount, collateralTableData]);
+
+  // Additional collateral needed value (for header)
+  const additionalCollateralNeededValue = useMemo(() => {
+    if (autoSupplyCollateral) {
+      return totalCollateralValue;
+    }
+    // In custom mode, calculate what's needed using minLTV
+    if (!loans || !collateralInfo || collateralInfo.length === 0) return 0;
+    const needed = calculateAdditionalValueNeeded(collateralInfo, parseFloat(borrowAmount || "0"), loans);
+    return Number(needed);
+  }, [autoSupplyCollateral, totalCollateralValue, loans, collateralInfo, borrowAmount]);
+
+  // Handle checkbox change - expand when unchecked
+  const handleAutoSupplyChange = (checked: boolean) => {
+    setAutoSupplyCollateral(checked);
+    if (!checked) {
+      setIsCollateralExpanded(true);
+      // Initialize custom values from recommended
+      const initialCustomValues = new Map<string, string>();
+      for (const item of collateralTableData) {
+        initialCustomValues.set(item.collateral.address, item.valueUSD.toFixed(2));
+      }
+      setCustomCollateralValues(initialCustomValues);
+    }
+  };
+
+  // Handle custom value change
+  const handleCustomValueChange = (address: string, value: string) => {
+    const newValues = new Map(customCollateralValues);
+    newValues.set(address, value);
+    setCustomCollateralValues(newValues);
+  };
 
   // Get risk indicator color and label
   const getRiskIndicator = (hf: number): { label: string; color: string } => {
@@ -268,6 +362,118 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         ) : null}
         Borrow
       </Button>
+
+      {/* Auto Supply Collateral Checkbox */}
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="auto-supply"
+          checked={autoSupplyCollateral}
+          onCheckedChange={handleAutoSupplyChange}
+        />
+        <label
+          htmlFor="auto-supply"
+          className="text-sm text-muted-foreground cursor-pointer select-none"
+        >
+          Automatically supply collateral (if needed)
+        </label>
+      </div>
+
+      {/* Additional Collateral Needed Dropdown */}
+      <Collapsible
+        open={isCollateralExpanded}
+        onOpenChange={setIsCollateralExpanded}
+        className="border rounded-lg"
+      >
+        <CollapsibleTrigger className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium hover:bg-muted/50 transition-colors">
+          <span>
+            Additional Collateral Needed{' '}
+            <span className="text-muted-foreground font-normal">
+              (Value: ${additionalCollateralNeededValue.toFixed(0)})
+            </span>
+          </span>
+          {isCollateralExpanded ? (
+            <ChevronUp className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          )}
+        </CollapsibleTrigger>
+        <CollapsibleContent className="px-4 pb-4">
+          {/* Total Value Header */}
+          <div className="text-sm font-medium mb-3 pt-2 border-t">
+            Total Value of Collateral: ${totalCollateralValue.toFixed(0)}
+          </div>
+
+          {/* Collateral Table */}
+          {collateralTableData.length > 0 ? (
+            <div className="space-y-1">
+              {/* Table Header */}
+              <div className="grid grid-cols-3 gap-4 text-xs text-muted-foreground pb-2">
+                <span>Asset</span>
+                <span className="text-center">Amount</span>
+                <span className="text-right">Value</span>
+              </div>
+
+              {/* Table Rows */}
+              {collateralTableData.map((item) => {
+                const decimals = item.collateral.customDecimals ?? 18;
+                const formattedAmount = Number(item.amount) / Math.pow(10, decimals);
+                const tokenImage = item.collateral.images?.[0]?.value;
+
+                return (
+                  <div
+                    key={item.collateral.address}
+                    className="grid grid-cols-3 gap-4 items-center py-2 text-sm"
+                  >
+                    {/* Asset */}
+                    <div className="flex items-center gap-2">
+                      {tokenImage ? (
+                        <img
+                          src={tokenImage}
+                          alt={item.collateral._symbol}
+                          className="w-5 h-5 rounded-full"
+                        />
+                      ) : (
+                        <div className="w-5 h-5 rounded-full bg-muted flex items-center justify-center text-xs">
+                          {item.collateral._symbol?.charAt(0) || '?'}
+                        </div>
+                      )}
+                      <span className="font-medium">{item.collateral._symbol}</span>
+                    </div>
+
+                    {/* Amount */}
+                    <span className="text-center tabular-nums">
+                      {formattedAmount.toFixed(4)}
+                    </span>
+
+                    {/* Value */}
+                    {autoSupplyCollateral ? (
+                      <span className="text-right tabular-nums">
+                        ${item.valueUSD.toFixed(0)}
+                      </span>
+                    ) : (
+                      <div className="flex items-center justify-end gap-1">
+                        <span className="text-muted-foreground">$</span>
+                        <Input
+                          type="number"
+                          value={customCollateralValues.get(item.collateral.address) || item.valueUSD.toFixed(0)}
+                          onChange={(e) => handleCustomValueChange(item.collateral.address, e.target.value)}
+                          className="w-20 h-7 text-right text-sm px-2"
+                        />
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground py-2">
+              {borrowAmount && parseFloat(borrowAmount) > 0
+                ? "No additional collateral needed"
+                : "Enter a borrow amount to see collateral requirements"}
+            </p>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
 
       {/* Rewards Display */}
       <CompactRewardsDisplay

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -281,9 +281,12 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     // Build steps array
     const steps: BorrowStep[] = [];
     
+    // Filter to only collateral with non-zero amounts
+    const collateralToSupply = collateralTableData.filter(item => item.amount > 0n);
+    
     // Add collateral supply steps if we have collateral to supply
-    if (collateralTableData.length > 0) {
-      for (const item of collateralTableData) {
+    if (collateralToSupply.length > 0) {
+      for (const item of collateralToSupply) {
         const decimals = item.collateral.customDecimals ?? 18;
         const formattedAmount = formatUnits(item.amount, decimals);
         steps.push({
@@ -309,7 +312,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     
     try {
       // Execute collateral supplies first
-      for (const item of collateralTableData) {
+      for (const item of collateralToSupply) {
         const stepId = `supply-${item.collateral.address}`;
         
         // Update step to processing
@@ -473,9 +476,9 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
             <span>Riskier</span>
           </div>
 
-          {/* Current Loans Health: Before => After */}
+          {/* Health Impact: Before => After */}
           <div className="flex justify-between items-center text-sm border-t pt-3">
-            <span className="text-muted-foreground">Current Loans Health</span>
+            <span className="text-muted-foreground">Health Impact</span>
             <span className="font-medium tabular-nums">
               {currentHF === null ? 'No Loan' : currentHF.toFixed(2)}
               {' → '}
@@ -552,7 +555,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
               htmlFor="auto-supply"
               className="text-sm text-muted-foreground cursor-pointer select-none"
             >
-              Automatically supply collateral (if needed)
+              Automatically supply collateral
             </label>
           </div>
 

--- a/mercata/ui/src/components/borrow/BorrowProgressModal.tsx
+++ b/mercata/ui/src/components/borrow/BorrowProgressModal.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+import { Modal } from "antd";
+import { CheckCircle2, Loader2, Circle, AlertCircle } from "lucide-react";
+import { CollateralData } from "@/interface";
+
+export type StepStatus = "pending" | "processing" | "completed" | "error";
+
+export interface BorrowStep {
+  id: string;
+  label: string;
+  status: StepStatus;
+  asset?: CollateralData;
+  amount?: string;
+  error?: string;
+}
+
+interface BorrowProgressModalProps {
+  open: boolean;
+  steps: BorrowStep[];
+  onClose?: () => void;
+}
+
+const BorrowProgressModal: React.FC<BorrowProgressModalProps> = ({
+  open,
+  steps,
+  onClose,
+}) => {
+  const getStepIcon = (status: StepStatus) => {
+    switch (status) {
+      case "completed":
+        return <CheckCircle2 className="w-5 h-5 text-green-500" />;
+      case "processing":
+        return <Loader2 className="w-5 h-5 text-blue-500 animate-spin" />;
+      case "error":
+        return <AlertCircle className="w-5 h-5 text-red-500" />;
+      default:
+        return <Circle className="w-5 h-5 text-muted-foreground" />;
+    }
+  };
+
+  const getStepColor = (status: StepStatus) => {
+    switch (status) {
+      case "completed":
+        return "border-green-500 bg-green-500/10";
+      case "processing":
+        return "border-blue-500 bg-blue-500/10";
+      case "error":
+        return "border-red-500 bg-red-500/10";
+      default:
+        return "border-muted bg-muted/50";
+    }
+  };
+
+  const allCompleted = steps.every((step) => step.status === "completed");
+  const hasError = steps.some((step) => step.status === "error");
+  const isProcessing = steps.some((step) => step.status === "processing");
+
+  return (
+    <Modal
+      title={
+        <div className="flex items-center gap-3">
+          <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
+            hasError ? "bg-red-500/20" : allCompleted ? "bg-green-500/20" : "bg-blue-500/20"
+          }`}>
+            {hasError ? (
+              <AlertCircle className="w-5 h-5 text-red-500" />
+            ) : allCompleted ? (
+              <CheckCircle2 className="w-5 h-5 text-green-500" />
+            ) : (
+              <Loader2 className="w-5 h-5 text-blue-500 animate-spin" />
+            )}
+          </div>
+          <span className="text-lg font-semibold text-foreground">
+            {hasError ? "Borrow Failed" : allCompleted ? "Borrow Complete" : "Processing Borrow"}
+          </span>
+        </div>
+      }
+      open={open}
+      onCancel={allCompleted || hasError ? onClose : undefined}
+      footer={null}
+      closable={allCompleted || hasError}
+      width={600}
+      className="[&_.ant-modal-content]:rounded-xl [&_.ant-modal-content]:bg-card [&_.ant-modal-content]:text-foreground [&_.ant-modal-content]:border-2 [&_.ant-modal-content]:border-blue-200 [&_.ant-modal-content]:dark:border-blue-400 [&_.ant-modal-content]:shadow-[0_0_24px_rgba(59,130,246,0.25)] [&_.ant-modal-content]:dark:shadow-[0_0_24px_rgba(96,165,250,0.35)] [&_.ant-modal-content]:backdrop-blur-sm [&_.ant-modal-header]:border-b [&_.ant-modal-header]:border-border [&_.ant-modal-header]:bg-card [&_.ant-modal-body]:p-6 [&_.ant-modal-body]:text-foreground [&_.ant-modal-title]:text-foreground [&_.ant-modal-close]:text-muted-foreground"
+    >
+      <div className="space-y-4">
+        {/* Steps List */}
+        <div className="space-y-0">
+          {steps.map((step, index) => {
+            const isLast = index === steps.length - 1;
+            const showConnector = !isLast;
+            const nextStepCompleted = !isLast && steps[index + 1]?.status === "completed";
+            
+            return (
+              <div key={step.id} className="relative">
+                <div className="flex items-start gap-4 pb-4">
+                  {/* Step Icon */}
+                  <div className="relative flex-shrink-0">
+                    <div className={`w-10 h-10 rounded-full border-2 flex items-center justify-center ${getStepColor(step.status)}`}>
+                      {getStepIcon(step.status)}
+                    </div>
+                    {/* Connector Line */}
+                    {showConnector && (
+                      <div className={`absolute left-1/2 top-10 w-0.5 h-4 -translate-x-1/2 ${
+                        step.status === "completed" ? "bg-green-500" : "bg-muted"
+                      }`} />
+                    )}
+                  </div>
+                  
+                  {/* Step Content */}
+                  <div className="flex-1 min-w-0 pt-2">
+                    <div className="flex items-center justify-between mb-1">
+                      <span className={`font-medium ${
+                        step.status === "completed" ? "text-green-600 dark:text-green-400" :
+                        step.status === "processing" ? "text-blue-600 dark:text-blue-400" :
+                        step.status === "error" ? "text-red-600 dark:text-red-400" :
+                        "text-muted-foreground"
+                      }`}>
+                        {step.label}
+                      </span>
+                      {step.status === "processing" && (
+                        <span className="text-xs text-muted-foreground">Processing...</span>
+                      )}
+                    </div>
+                    
+                    {step.asset && step.amount && (
+                      <div className="text-sm text-muted-foreground">
+                        {step.amount} {step.asset._symbol}
+                      </div>
+                    )}
+                    
+                    {step.error && (
+                      <div className="mt-2 text-sm text-red-600 dark:text-red-400">
+                        {step.error}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Summary Message */}
+        {allCompleted && (
+          <div className="mt-4 p-4 bg-green-500/10 dark:bg-green-500/20 border border-green-500/30 rounded-lg">
+            <div className="text-sm text-green-800 dark:text-green-200">
+              <div className="font-medium mb-1">Borrow Successful!</div>
+              <div>All steps completed successfully. Your borrow transaction has been processed.</div>
+            </div>
+          </div>
+        )}
+
+        {hasError && (
+          <div className="mt-4 p-4 bg-red-500/10 dark:bg-red-500/20 border border-red-500/30 rounded-lg">
+            <div className="text-sm text-red-800 dark:text-red-200">
+              <div className="font-medium mb-1">Transaction Failed</div>
+              <div>One or more steps failed. Please try again or contact support if the issue persists.</div>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default BorrowProgressModal;

--- a/mercata/ui/src/components/borrow/CollateralManagementTable.tsx
+++ b/mercata/ui/src/components/borrow/CollateralManagementTable.tsx
@@ -93,8 +93,8 @@ const USDValueDisplay = ({ value }: { value: bigint }) => {
     return <div className="text-xs text-muted-foreground">$0.00</div>;
   }
   
-  const displayValue = formatBalance(value, undefined, 18, 0, 2);
-  return <div className="text-xs text-muted-foreground">${displayValue}</div>;
+  const displayValue = formatBalance(value, undefined, 18, 0, 2, true);
+  return <div className="text-xs text-muted-foreground">{displayValue}</div>;
 };
 
 const CollateralManagementTable = ({
@@ -150,6 +150,7 @@ const CollateralManagementTable = ({
                 
                 return (
                   <TableRow key={asset?.address}>
+                    {/* Asset */}
                     <TableCell>
                       <div className="flex items-center gap-2">
                         {asset?.images?.[0] ? (
@@ -172,12 +173,15 @@ const CollateralManagementTable = ({
                         </div>
                       </div>
                     </TableCell>
+                    {/* LTV */}
                     <TableCell>
                       {asset?.ltv ? (Number(asset.ltv) / 100) : 0}%
                     </TableCell>
+                    {/* LT */}
                     <TableCell>
                       {asset?.liquidationThreshold ? (Number(asset.liquidationThreshold) / 100) : 0}%
                     </TableCell>
+                    {/* Supply */}
                     <TableCell>
                       <div className="flex items-center justify-end gap-4">
                         <div className="text-right">
@@ -204,6 +208,7 @@ const CollateralManagementTable = ({
                         </Tooltip>
                       </div>
                     </TableCell>
+                    {/* Withdraw */}
                     <TableCell>
                       <div className="flex items-center justify-end gap-4">
                         <div className="text-right">

--- a/mercata/ui/src/components/borrow/CollateralManagementTable.tsx
+++ b/mercata/ui/src/components/borrow/CollateralManagementTable.tsx
@@ -8,7 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { HelpCircle, ArrowUpCircle, ArrowDownCircle, PauseCircle } from "lucide-react";
 import { formatBalance } from "@/utils/numberUtils";
 import { CollateralData, NewLoanData } from "@/interface";
@@ -66,6 +66,37 @@ const InfoTooltip = ({ children, content }: { children: React.ReactNode; content
   );
 };
 
+// Helper function to format token amount with tooltip
+const TokenAmountDisplay = ({ amount, decimals }: { amount: bigint; decimals: number }) => {
+  if (amount <= 1n) {
+    return <div className="font-medium">0</div>;
+  }
+  
+  const fullAmount = formatBalance(amount, undefined, decimals, 2);
+  const displayAmount = formatBalance(amount, undefined, decimals, 0, 4);
+  
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="font-medium cursor-help">{displayAmount}</div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{fullAmount}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+// Helper function to format USD value (no tooltip, 2 decimals)
+const USDValueDisplay = ({ value }: { value: bigint }) => {
+  if (value <= 1n) {
+    return <div className="text-xs text-muted-foreground">$0.00</div>;
+  }
+  
+  const displayValue = formatBalance(value, undefined, 18, 0, 2);
+  return <div className="text-xs text-muted-foreground">${displayValue}</div>;
+};
+
 const CollateralManagementTable = ({
   collateralInfo,
   loadingCollateral,
@@ -83,9 +114,10 @@ const CollateralManagementTable = ({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
+        <TooltipProvider>
+          <Table>
+            <TableHeader>
+              <TableRow>
               <TableHead>Asset</TableHead>
               <TableHead>
                 <InfoTooltip content="Loan-to-Value ratio: Maximum percentage of collateral value you can borrow against. Higher LTV means more borrowing power but higher risk.">
@@ -97,10 +129,10 @@ const CollateralManagementTable = ({
                   LT
                 </InfoTooltip>
               </TableHead>
-              <TableHead className="text-right">Supply</TableHead>
-              <TableHead className="text-right">Withdraw</TableHead>
-            </TableRow>
-          </TableHeader>
+                <TableHead className="text-right">Supply</TableHead>
+                <TableHead className="text-right">Withdraw</TableHead>
+              </TableRow>
+            </TableHeader>
           <TableBody>
             {loadingCollateral ? (
               <TableRow>
@@ -149,10 +181,11 @@ const CollateralManagementTable = ({
                     <TableCell>
                       <div className="flex items-center justify-end gap-4">
                         <div className="text-right">
-                          <div className="font-medium">{(() => { try { const v = BigInt(asset?.userBalance || 0); return formatBalance(v <= 1n ? 0n : v, undefined, asset?.customDecimals ?? 18, 2); } catch { return formatBalance(0n, undefined, asset?.customDecimals ?? 18, 2); } })()}</div>
-                          <div className="text-xs text-muted-foreground">
-                            ${(() => { try { const v = BigInt(asset?.userBalanceValue || 0); return formatBalance(v <= 1n ? 0n : v, undefined, 18, 1, 2); } catch { return formatBalance(0n, undefined, 18, 1, 2); } })()}
-                          </div>
+                          <TokenAmountDisplay 
+                            amount={BigInt(asset?.userBalance || 0)} 
+                            decimals={asset?.customDecimals ?? 18} 
+                          />
+                          <USDValueDisplay value={BigInt(asset?.userBalanceValue || 0)} />
                         </div>
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -174,12 +207,11 @@ const CollateralManagementTable = ({
                     <TableCell>
                       <div className="flex items-center justify-end gap-4">
                         <div className="text-right">
-                          <div className="font-medium">
-                            {(() => { try { const v = BigInt(asset?.collateralizedAmount || 0); return formatBalance(v <= 1n ? 0n : v, undefined, asset?.customDecimals ?? 18, 2); } catch { return formatBalance(0n, undefined, asset?.customDecimals ?? 18, 2); } })()}
-                          </div>
-                          <div className="text-xs text-muted-foreground">
-                            {(() => { try { const v = BigInt(asset?.collateralizedAmountValue || 0); return formatBalance(v <= 1n ? 0n : v, undefined, 18, 1, 2, true); } catch { return formatBalance(0n, undefined, 18, 1, 2, true); } })()}
-                          </div>
+                          <TokenAmountDisplay 
+                            amount={BigInt(asset?.collateralizedAmount || 0)} 
+                            decimals={asset?.customDecimals ?? 18} 
+                          />
+                          <USDValueDisplay value={BigInt(asset?.collateralizedAmountValue || 0)} />
                         </div>
                         {(() => {
                           const maxWithdrawAmount = getMaxSafeWithdrawAmount(asset, loans);
@@ -235,8 +267,9 @@ const CollateralManagementTable = ({
                 </TableCell>
               </TableRow>
             )}
-          </TableBody>
-        </Table>
+            </TableBody>
+          </Table>
+        </TooltipProvider>
       </CardContent>
     </Card>
   );

--- a/mercata/ui/src/components/borrow/RepayForm.tsx
+++ b/mercata/ui/src/components/borrow/RepayForm.tsx
@@ -9,6 +9,7 @@ import RiskLevelProgress from "@/components/ui/RiskLevelProgress";
 import HealthImpactDisplay from "@/components/ui/HealthImpactDisplay";
 import PercentageButtons from "../ui/PercentageButtons";
 import { computeMaxTransferable, handleAmountInputChange } from "@/utils/transferValidation";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 
 interface RepayFormProps {
   loans: NewLoanData | null;
@@ -17,6 +18,60 @@ interface RepayFormProps {
   usdstBalance: string;
   voucherBalance: string;
 }
+
+// Component to display numbers with 2 decimals, showing full value on hover
+const FormattedAmount = ({ 
+  value, 
+  symbol = "USDST", 
+  className = "" 
+}: { 
+  value: string; 
+  symbol?: string; 
+  className?: string;
+}) => {
+  // Preserve the original string value for full precision display
+  const fullValue = value || "0";
+  
+  // Format to exactly 2 decimals for display using formatCurrency helper
+  const formatted2Decimals = (() => {
+    const numValue = parseFloat(value);
+    if (isNaN(numValue)) return "0.00";
+    // formatCurrency handles locale formatting, then ensure exactly 2 decimals
+    return numValue.toLocaleString("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  })();
+  
+  // Format full value with commas using addCommasToInput helper
+  const fullValueFormatted = fullValue === "0" 
+    ? "0" 
+    : addCommasToInput(fullValue);
+  
+  // Only show tooltip if the formatted value differs from full value
+  const needsTooltip = formatted2Decimals !== fullValueFormatted && fullValueFormatted !== "0";
+  
+  if (!needsTooltip) {
+    return (
+      <span className={className}>
+        {formatted2Decimals} {symbol}
+      </span>
+    );
+  }
+  
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={`cursor-help ${className}`}>
+          {formatted2Decimals} {symbol}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{fullValueFormatted} {symbol}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
 
 const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance }: RepayFormProps) => {
   const [repayAmount, setRepayAmount] = useState<string>("");
@@ -54,7 +109,8 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
 
       const totalBorrowedBigInt = BigInt(loans.totalAmountOwed);
       const collateralValueBigInt = BigInt(loans.totalCollateralValueUSD);
-      const repayAmountWei = safeParseUnits(repayAmount || "0");
+      // If there's an error, treat repay amount as 0 (no repayment)
+      const repayAmountWei = repayAmountError ? 0n : safeParseUnits(repayAmount || "0");
       const newBorrowedAmount = totalBorrowedBigInt - repayAmountWei;
       
       if (newBorrowedAmount <= 0n) {
@@ -67,14 +123,14 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
     } catch {
       setRiskLevel(0);
     }
-  }, [repayAmount, loans?.totalCollateralValueUSD, loans?.totalAmountOwed]);
+  }, [repayAmount, loans?.totalCollateralValueUSD, loans?.totalAmountOwed, repayAmountError]);
 
   // Calculate health impact when repay amount changes
   useEffect(() => {
-    const repayAmountWei = safeParseUnits(repayAmount || "0");
+    const repayAmountWei = repayAmountError ? 0n : safeParseUnits(repayAmount || "0");
     const impact = calculateRepayHealthImpact(repayAmountWei, loans);
     setHealthImpact(impact);
-  }, [repayAmount, loans]);
+  }, [repayAmount, loans, repayAmountError]);
 
   const handleRepay = async () => {
     const owed = BigInt(loans?.totalAmountOwed || 0);
@@ -98,7 +154,8 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
   }
 
   return (
-    <div className="space-y-4 pt-4">
+    <TooltipProvider>
+      <div className="space-y-4 pt-4">
       {/* Loan Details */}
       <div className="space-y-2">
         <div className="flex justify-between items-center">
@@ -108,9 +165,9 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
               try {
                 const bi = BigInt(loans?.totalAmountOwed ?? "0");
                 const display = bi <= 1n ? 0n : bi;
-                return `USDST ${formatUnits(display)}`;
+                return <FormattedAmount value={formatUnits(display)} />;
               } catch {
-                return `USDST 0`;
+                return <FormattedAmount value="0" />;
               }
             })()}
           </span>
@@ -124,9 +181,9 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
                 try {
                   const bi = BigInt(loans?.totalAmountOwedPreview ?? "0");
                   const display = bi <= 1n ? 0n : bi;
-                  return `USDST ${formatUnits(display)}`;
+                  return <FormattedAmount value={formatUnits(display)} />;
                 } catch {
-                  return `USDST 0`;
+                  return <FormattedAmount value="0" />;
                 }
               })()}
             </span>
@@ -134,7 +191,17 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
         )}
         
         <div className="flex justify-between items-center pt-2 border-t">
-          <span className="text-lg">{(() => { try { const bi = BigInt(loans?.totalAmountOwed ?? "0"); const display = bi <= 1n ? 0n : bi; return `USDST ${formatUnits(display)}`; } catch { return `USDST 0`; } })()}</span>
+          <span className="text-lg">
+            {(() => {
+              try {
+                const bi = BigInt(loans?.totalAmountOwed ?? "0");
+                const display = bi <= 1n ? 0n : bi;
+                return <FormattedAmount value={formatUnits(display)} />;
+              } catch {
+                return <FormattedAmount value="0" />;
+              }
+            })()}
+          </span>
         </div>
       </div>
 
@@ -163,9 +230,11 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
             >
               Max :
             </button>
-            <span>{(() => {
-              return BigInt(maxAmount) <= 0n ? '-' : formatCurrency(formatUnits(BigInt(maxAmount)));
-            })()} USDST</span>
+            {BigInt(maxAmount) <= 0n ? (
+              <span>- USDST</span>
+            ) : (
+              <FormattedAmount value={formatUnits(BigInt(maxAmount))} />
+            )}
           </div>
         </div>
         <div className="relative">
@@ -209,7 +278,7 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
         <div className="flex justify-between items-center">
           <span className="text-sm text-muted-foreground">Payment Amount</span>
           <span className="font-medium">
-            {repayAmount ? `${formatCurrency(repayAmount)} USDST` : "0.00 USDST"}
+            <FormattedAmount value={repayAmountError ? "0" : (repayAmount || "0")} />
           </span>
         </div>
         
@@ -219,11 +288,15 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
             {(() => {
               try {
                 const totalOwed = BigInt(loans?.totalAmountOwed || 0);
+                // If there's an error, show full amount owed (no repayment)
+                if (repayAmountError) {
+                  return <FormattedAmount value={formatUnits(totalOwed)} />;
+                }
                 const repayAmountWei = safeParseUnits(repayAmount || "0");
                 const remaining = totalOwed - repayAmountWei;
-                return `${formatCurrency(formatUnits(remaining > 0n ? remaining : 0n))} USDST`;
+                return <FormattedAmount value={formatUnits(remaining > 0n ? remaining : 0n)} />;
               } catch {
-                return `${formatCurrency(formatUnits(BigInt(loans?.totalAmountOwed || "0")))} USDST`;
+                return <FormattedAmount value={formatUnits(BigInt(loans?.totalAmountOwed || "0"))} />;
               }
             })()}
           </span>
@@ -259,7 +332,8 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
           "Repay"
         )}
       </Button>
-    </div>
+      </div>
+    </TooltipProvider>
   );
 };
 

--- a/mercata/ui/src/components/borrow/RepayForm.tsx
+++ b/mercata/ui/src/components/borrow/RepayForm.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { REPAY_FEE } from "@/lib/constants";
-import { safeParseUnits, addCommasToInput, formatCurrency, formatUnits } from "@/utils/numberUtils";
+import { safeParseUnits, addCommasToInput, formatUnits, formatBalance } from "@/utils/numberUtils";
 import { NewLoanData } from "@/interface";
 import { calculateRepayHealthImpact } from "@/utils/lendingUtils";
 import RiskLevelProgress from "@/components/ui/RiskLevelProgress";
@@ -25,49 +25,35 @@ const FormattedAmount = ({
   symbol = "USDST", 
   className = "" 
 }: { 
-  value: string; 
+  value: bigint;
   symbol?: string; 
   className?: string;
 }) => {
-  // Preserve the original string value for full precision display
-  const fullValue = value || "0";
   
-  // Format to exactly 2 decimals for display using formatCurrency helper
-  const formatted2Decimals = (() => {
-    const numValue = parseFloat(value);
-    if (isNaN(numValue)) return "0.00";
-    // formatCurrency handles locale formatting, then ensure exactly 2 decimals
-    return numValue.toLocaleString("en-US", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    });
-  })();
-  
-  // Format full value with commas using addCommasToInput helper
-  const fullValueFormatted = fullValue === "0" 
-    ? "0" 
-    : addCommasToInput(fullValue);
-  
-  // Only show tooltip if the formatted value differs from full value
-  const needsTooltip = formatted2Decimals !== fullValueFormatted && fullValueFormatted !== "0";
-  
-  if (!needsTooltip) {
-    return (
-      <span className={className}>
-        {formatted2Decimals} {symbol}
-      </span>
-    );
+  if (value <= 1n) {
+    return <span className={className}>0.00 {symbol}</span>;
   }
-  
+
+  // Format to exactly 2 decimals for display
+  const displayAmount = formatBalance(value, symbol, 18, 0, 2);
+
+  // Format full value with 2 decimals for tooltip
+  const fullAmount = formatBalance(value, symbol, 18, 2);
+
+  // Only show tooltip if the formatted value differs from full value
+  const needsTooltip = displayAmount !== fullAmount;
+
+  if (!needsTooltip) {
+    return <span className={className}>{displayAmount}</span>;
+  }
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className={`cursor-help ${className}`}>
-          {formatted2Decimals} {symbol}
-        </span>
+        <span className={`cursor-help ${className}`}>{displayAmount}</span>
       </TooltipTrigger>
       <TooltipContent>
-        <p>{fullValueFormatted} {symbol}</p>
+        <p>{fullAmount}</p>
       </TooltipContent>
     </Tooltip>
   );
@@ -163,11 +149,9 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
           <span className="font-normal">
             {(() => {
               try {
-                const bi = BigInt(loans?.totalAmountOwed ?? "0");
-                const display = bi <= 1n ? 0n : bi;
-                return <FormattedAmount value={formatUnits(display)} />;
+                return <FormattedAmount value={BigInt(loans?.totalAmountOwed ?? "0")} />;
               } catch {
-                return <FormattedAmount value="0" />;
+                return <FormattedAmount value={BigInt(0)} />;
               }
             })()}
           </span>
@@ -179,11 +163,9 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
             <span className="font-medium">
               {(() => {
                 try {
-                  const bi = BigInt(loans?.totalAmountOwedPreview ?? "0");
-                  const display = bi <= 1n ? 0n : bi;
-                  return <FormattedAmount value={formatUnits(display)} />;
+                  return <FormattedAmount value={BigInt(loans?.totalAmountOwedPreview ?? "0")} />;
                 } catch {
-                  return <FormattedAmount value="0" />;
+                  return <FormattedAmount value={0n} />;
                 }
               })()}
             </span>
@@ -194,11 +176,9 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
           <span className="text-lg">
             {(() => {
               try {
-                const bi = BigInt(loans?.totalAmountOwed ?? "0");
-                const display = bi <= 1n ? 0n : bi;
-                return <FormattedAmount value={formatUnits(display)} />;
+                return <FormattedAmount value={BigInt(loans?.totalAmountOwed ?? "0")} />;
               } catch {
-                return <FormattedAmount value="0" />;
+                return <FormattedAmount value={0n} />;
               }
             })()}
           </span>
@@ -233,7 +213,7 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
             {BigInt(maxAmount) <= 0n ? (
               <span>- USDST</span>
             ) : (
-              <FormattedAmount value={formatUnits(BigInt(maxAmount))} />
+              <FormattedAmount value={BigInt(maxAmount)} />
             )}
           </div>
         </div>
@@ -278,7 +258,7 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
         <div className="flex justify-between items-center">
           <span className="text-sm text-muted-foreground">Payment Amount</span>
           <span className="font-medium">
-            <FormattedAmount value={repayAmountError ? "0" : (repayAmount || "0")} />
+            <FormattedAmount value={repayAmountError ? 0n : safeParseUnits(repayAmount || "0")} />
           </span>
         </div>
         
@@ -290,13 +270,13 @@ const RepayForm = ({ loans, repayLoading, onRepay, usdstBalance, voucherBalance 
                 const totalOwed = BigInt(loans?.totalAmountOwed || 0);
                 // If there's an error, show full amount owed (no repayment)
                 if (repayAmountError) {
-                  return <FormattedAmount value={formatUnits(totalOwed)} />;
+                  return <FormattedAmount value={totalOwed} />;
                 }
                 const repayAmountWei = safeParseUnits(repayAmount || "0");
                 const remaining = totalOwed - repayAmountWei;
-                return <FormattedAmount value={formatUnits(remaining > 0n ? remaining : 0n)} />;
+                return <FormattedAmount value={remaining > 0n ? remaining : 0n} />;
               } catch {
-                return <FormattedAmount value={formatUnits(BigInt(loans?.totalAmountOwed || "0"))} />;
+                return <FormattedAmount value={BigInt(loans?.totalAmountOwed || "0")} />;
               }
             })()}
           </span>

--- a/mercata/ui/src/interface/index.tsx
+++ b/mercata/ui/src/interface/index.tsx
@@ -199,6 +199,7 @@ export interface CollateralData {
   ltv: string; // Loan-to-Value ratio (e.g., "7500" = 75%)
   maxBorrowingPower: string; // Borrowing power from supplied collateral (collateralizedAmount * price * ltv)
   unsuppliedBorrowingPower: string; // Potential borrowing power from user balance (userBalance * price * ltv)
+  unsuppliedLTCollateralValue: string; // LT-weighted value of unsupplied balance (userBalance * price * lt)
   userBalance: string;
   userBalanceValue: string;
   _name: string;

--- a/mercata/ui/src/interface/index.tsx
+++ b/mercata/ui/src/interface/index.tsx
@@ -197,7 +197,8 @@ export interface CollateralData {
   isCollateralized: boolean;
   liquidationThreshold: string; // Possibly in basis points (e.g., "8000" = 80%)
   ltv: string; // Loan-to-Value ratio (e.g., "7500" = 75%)
-  maxBorrowingPower: string; // Usually a percent string
+  maxBorrowingPower: string; // Borrowing power from supplied collateral (collateralizedAmount * price * ltv)
+  unsuppliedBorrowingPower: string; // Potential borrowing power from user balance (userBalance * price * ltv)
   userBalance: string;
   userBalanceValue: string;
   _name: string;

--- a/mercata/ui/src/interface/index.tsx
+++ b/mercata/ui/src/interface/index.tsx
@@ -312,7 +312,8 @@ export type NewLoanData = {
   healthFactor: number;
   healthFactorRaw: string;
   totalBorrowingPowerUSD: string;
-  totalCollateralValueUSD: string;
+  totalCollateralValueUSD: string;      // risk-adjusted by LT (for health factor)
+  totalCollateralValueSupplied: string; // full supplied collat $ value (for display)
   maxAvailableToBorrowUSD: string;
   interestRate: number;                // bps
   isAboveLiquidationThreshold: boolean;

--- a/mercata/ui/src/pages/Borrow.tsx
+++ b/mercata/ui/src/pages/Borrow.tsx
@@ -277,18 +277,18 @@ const Borrow = () => {
               </CardContent>
             </Card>
 
-            {/* Right Column - Your Position */}
-            <div>
+            {/* Right Column - Your Position and Collateral Management */}
+            <div className="space-y-6">
               <PositionSection loanData={loans} userCollaterals={collateralInfo} />
+              <CollateralManagementTable
+                collateralInfo={collateralInfo}
+                loadingCollateral={loadingCollateral}
+                loans={loans}
+                onSupply={handleSupply}
+                onWithdraw={handleWithdraw}
+              />
             </div>
           </div>
-          <CollateralManagementTable
-            collateralInfo={collateralInfo}
-            loadingCollateral={loadingCollateral}
-            loans={loans}
-            onSupply={handleSupply}
-            onWithdraw={handleWithdraw}
-          />
         </main>
       </div>
 

--- a/mercata/ui/src/pages/Borrow.tsx
+++ b/mercata/ui/src/pages/Borrow.tsx
@@ -190,6 +190,7 @@ const Borrow = () => {
       ]);
     } catch (error) {
       setBorrowLoading(false);
+      throw error;
     }
   };
 

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -207,14 +207,19 @@ export const calculateBorrowHealthImpact = (
   loanData: NewLoanData
 ) => {
   return calculateBorrowOperationHealthImpact(borrowAmountWei, loanData, true);
-}; 
+};
 
 
-// ----
+// Floor the value to the nearest 0.01;
+// e.g. 3.409 -> 3.40, 3.45 --> 3.45
+// @dev could be unreliable with javascript's floating point precision
 const centFloor = (value: Number): Number => {
   return Math.floor(+value * 100) / 100;
 };
 
+// Ceil the value to the nearest 0.01;
+// e.g. 3.401 -> 3.41, 3.45 --> 3.45
+// @dev could be unreliable with javascript's floating point precision
 export const centCeil = (value: Number): Number => {
   return Math.ceil(+value * 100) / 100;
 };
@@ -250,30 +255,42 @@ export const calculateAvailableToBorrowUSD = (
   if (maxDebtForTargetHF <= currentDebtUSD) return 0.00;
   const centsInWei = 10n ** 16n; // 0.01 USD = 1e16 wei
   const availableWei = (maxDebtForTargetHF - currentDebtUSD) / centsInWei * centsInWei;
-  const flooredToCentsWei = (availableWei / centsInWei) * centsInWei; // BigInt division truncates (floors)
+  const flooredToCentsWei = (availableWei / centsInWei) * centsInWei; // using BigInt floored division
   return Number(flooredToCentsWei) / 1e18;
 };
 
+/**
+ * Determine the left-hand low-risk (max) and right-hand high-risk (min) health factors for the slider.
+ * @param loanData - The current loan data fetched from the backend
+ * @param collaterals - The current collateral data fetched from the backend
+ * @param DEFAULT_MAX_HEALTH_FACTOR - The default maximum health factor, overriden if the current health factor is higher. 3.00 by default.
+ * @param BASICALLY_INFINITE_HEALTH - The value above which the health factor is considered infinite. 999999 by default.
+ * @returns The minimum and maximum health factors for the slider
+ */
 export const calculateHFSliderExtrema = (
   loanData: NewLoanData,
   collaterals: CollateralData[],
-  DEFAULT_MAX_HEALTH_FACTOR: Number = 3.00,
+  DEFAULT_MAX_HEALTH_FACTOR: number = 3.00,
+  BASICALLY_INFINITE_HEALTH: number = 999999,
 ) : { min: Number, max: Number } => {
-  const minHF = Math.min(...collaterals.map(c => Number(BigInt(c.liquidationThreshold))/Number(BigInt(c.ltv))));
+  // The slider should only go down to the least risky asset's minimum health factor
+  const minHF = Math.max(...collaterals.map(c => Number(BigInt(c.liquidationThreshold))/Number(BigInt(c.ltv))));
   
   // Check if there's no loan (no debt)
   const hasLoan = BigInt(loanData?.totalAmountOwed ?? "0") > 1n;
   const currentHF = loanData?.healthFactor ?? 0;
-  const isInfiniteHF = !isFinite(currentHF) || currentHF >= 999999;
+  const isInfiniteHF = !isFinite(currentHF) || currentHF >= BASICALLY_INFINITE_HEALTH;
   
   // If no loan, max is DEFAULT_MAX_HEALTH_FACTOR; otherwise use max of default and current HF
   const maxHF = hasLoan && !isInfiniteHF
-    ? Math.max(+DEFAULT_MAX_HEALTH_FACTOR, currentHF)
-    : +DEFAULT_MAX_HEALTH_FACTOR;
+    ? Math.max(DEFAULT_MAX_HEALTH_FACTOR, currentHF)
+    : DEFAULT_MAX_HEALTH_FACTOR;
   
   return { min: centCeil(minHF), max: centFloor(maxHF) };
 };
 
+// Determine the error message to display, suggesting options for the user while avoiding unavailable solutions.
+// Returns a string including newlines for line breaks; should by formatted by a UI component that parses this. (whitespace-pre-line)
 export const determineErrorMessage = (
   borrowAmount: Number,
   maxAtRequestedHF: Number,
@@ -285,14 +302,17 @@ export const determineErrorMessage = (
     if (borrowAmount > maxAtMinHF) {
       return "Borrow amount exceeds the maximum at this health factor.\nConsider bridging in more collateral.";
     }
-    
     // Otherwise, suggest increasing risk level as an option
     return "Borrow amount exceeds the maximum at this health factor.\nConsider bridging in more collateral, or increase risk level.";
   }
-  
   return "";
 };
 
+/**
+ * Calculate the total fees for all of the transactions that will be triggered by this borrow.
+ * @param collateralCount The number of distinct additional collateral assets being supplied.
+ * @returns The fee in USDST numeric (i.e. 0.03) and voucher integer (i.e. 3)
+ */
 export const calculateBorrowTxFee = (collateralCount: number): { fee: number, voucher: number } =>
 {
     const fee = collateralCount * parseFloat(SUPPLY_COLLATERAL_FEE) + parseFloat(BORROW_FEE);
@@ -300,6 +320,13 @@ export const calculateBorrowTxFee = (collateralCount: number): { fee: number, vo
     return { fee, voucher };
 };
 
+/**
+ * TODO describe, TODO review
+ * @param collateralValueUSD TODO
+ * @param price The oracle price of the collateral asset in wei
+ * @param decimals TODO
+ * @returns TODO
+ */
 export const calculateAdditionalCollateralAmountFromValue = (
   collateralValueUSD: bigint,
   price: bigint,
@@ -323,6 +350,14 @@ export const calculateMaxCollateralValueUSDCentFloored = (collateral: Collateral
   return Math.floor(maxValueUSD * 100) / 100; // Floor to cents
 };
 
+/**
+ * TODO describe, TODO review
+ * @param loanData TODO
+ * @param healthFactor TODO
+ * @param borrowAmountUSD TODO
+ * @param collaterals TODO
+ * @returns TODO
+ */
 export const recommendCollateralToSupply = (
   loanData: NewLoanData,
   healthFactor: Number,
@@ -384,12 +419,17 @@ export const recommendCollateralToSupply = (
   return result;
 };
 
+/**
+ * Sort collateral assets in place by unsupplied borrowing power, most to least, with all supplied assets coming first.
+ * - Amongst the collateral asset types the user has already supplied, sort by `asset.balanceOf(user)*lendingPool.config[asset].LTV`
+ * - After all of those, sort remaining collateral the user possesses by `asset.balanceOf(user)*lendingPool.config[asset].LTV`
+ * @param collaterals The array of collateral assets to sort in place.
+ * @param DO_IGNORE_ONE_WEI Whether to consider one wei of an asset supplied to be a non-supplied asset (default true)
+ */
 export const sortCollateralAssets = (
   collaterals: CollateralData[],
   DO_IGNORE_ONE_WEI: boolean = true,
 ) : void => {
-  // - Amongst the collateral asset types the user has already supplied, sort by `asset.balanceOf(user)*lendingPool.config[asset].LTV`
-  // - After all of those, sort remaining collateral the user possesses by `asset.balanceOf(user)*lendingPool.config[asset].LTV`
   const nonexistant = DO_IGNORE_ONE_WEI ? 1n : 0n;
   const isSupplied = (collat: CollateralData) => BigInt(collat.collateralizedAmount) > nonexistant;
   collaterals.sort((a, b) => {
@@ -401,11 +441,20 @@ export const sortCollateralAssets = (
   });
 };
 
-const calculateMinimumLTV = (collaterals: CollateralData[]) : bigint => {
-  if (collaterals.length === 0) return 0n;
-  return collaterals.map(c => BigInt(c.ltv ?? "0")).reduce((a, b) => a < b ? a : b);
+// Get the minimum LTV from the array of collateral assets
+// Returns the minimum LTV in basis points bigint, e.g. 7500n for 75%
+const calculateMinimumLTV = (collaterals: readonly CollateralData[]) : bigint => {
+  return collaterals.map(c => BigInt(c.ltv ?? "0")).reduce(((a, b) => a < b ? a : b), 0n);
 };
 
+/**
+ * TODO describe, TODO review
+ * @param collaterals TODO
+ * @param borrowAmount TODO
+ * @param loanData TODO
+ * @param targetHealthFactor TODO
+ * @returns TODO
+ */
 export const calculateAdditionalValueNeeded = (
   collaterals: CollateralData[],
   borrowAmount: Number,
@@ -442,6 +491,13 @@ export const calculateAdditionalValueNeeded = (
   return Number(additionalValueNeeded) / 1e18;
 };
 
+/**
+ * TODO describe, TODO review
+ * @param loanData TODO
+ * @param borrowAmount TODO
+ * @param newCollateralSupplied TODO
+ * @returns TODO
+ */
 export const calculateAfterBorrowHealthFactor = (
   loanData: NewLoanData,
   borrowAmount: Number,
@@ -466,7 +522,8 @@ export const calculateAfterBorrowHealthFactor = (
   return Number(newHealthFactorRaw) / 1e18;
 };
 
-// @dev TODO: the same is implemented in loanUtils.ts, need to consolidate
+// @dev TODO: the same is implemented in loanUtils.ts;
+// need to consolidate after both PRs are merged
 export const getRiskLabel = (factor: number): string => {
   if (factor >= 2.0) return 'Low Risk';
   if (factor >= 1.5) return 'Moderate Risk';

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -465,3 +465,10 @@ export const calculateAfterBorrowHealthFactor = (
 
   return Number(newHealthFactorRaw) / 1e18;
 };
+
+// @dev TODO: the same is implemented in loanUtils.ts, need to consolidate
+export const getRiskLabel = (factor: number): string => {
+  if (factor >= 2.0) return 'Low Risk';
+  if (factor >= 1.5) return 'Moderate Risk';
+  return 'High Risk';
+};

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -386,7 +386,7 @@ export const recommendCollateralToSupply = (
   return result;
 };
 
-const sortCollateralAssets = (
+export const sortCollateralAssets = (
   collaterals: CollateralData[],
   DO_IGNORE_ONE_WEI: boolean = true,
 ) : void => {

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -359,12 +359,15 @@ export const calculateMaxCollateralValueUSDCentFloored = (collateral: Collateral
 };
 
 /**
- * TODO describe, TODO review
- * @param loanData TODO
- * @param healthFactor TODO
- * @param borrowAmountUSD TODO
- * @param collaterals TODO
- * @returns TODO
+ * Recommends the additional collateral assets to supply to achieve the target health factor.
+ * Sorts the collateral assets according to the sort algorithm specified in the sortCollateralAssets docstring,
+ * and then pulls from the front of the queue until the health factor is met.
+ * This minimizes the number of distinct collateral assets needing to be supplied.
+ * @param loanData The current loan data fetched from the backend
+ * @param healthFactor The target health factor the user is trying to achieve
+ * @param borrowAmountUSD The amount of USDST the user is trying to borrow
+ * @param collaterals mutated; A copy of the current collateral data fetched from the backend. Will be sorted in place.
+ * @returns The recommended additional collateral assets, mapped to the recommended wei amount to supply
  */
 export const recommendCollateralToSupply = (
   loanData: NewLoanData,
@@ -372,44 +375,36 @@ export const recommendCollateralToSupply = (
   borrowAmountUSD: Number,
   collaterals: CollateralData[],
 ) : Map<CollateralData, bigint> => {
-  sortCollateralAssets(collaterals);
-  // TODO this one is AI generated, needs to be verified
-  // Should greedily pull from the front of the queue until the health factor is met
   const result = new Map<CollateralData, bigint>();
 
-  // HF = LT_weighted_collateral / debt
-  // After borrow: targetHF = (currentLTCollat + newLTCollat) / (currentDebt + borrowAmount)
-  // Solve for newLTCollat: newLTCollat = targetHF * (currentDebt + borrowAmount) - currentLTCollat
-
+  // First, sort the collateral assets
+  sortCollateralAssets(collaterals);
+  
   const targetHFRaw = BigInt(Math.round(Number(healthFactor) * 1e18));
   const currentLTCollateral = BigInt(loanData?.totalCollateralValueUSD ?? "0");
   const currentDebt = BigInt(loanData?.totalAmountOwed ?? "0");
   const borrowAmount = BigInt(Math.round(Number(borrowAmountUSD) * 1e18));
 
   const newDebt = currentDebt + borrowAmount;
-  if (newDebt === 0n) return result;
 
   // Required LT-weighted collateral to achieve target HF (add 1 for floored division safety)
-  const requiredTotalLTCollateral = (targetHFRaw * newDebt) / (10n ** 18n) + 1n;
+  const requiredTotalLTCollateral = (targetHFRaw * newDebt) / (10n ** 18n) + 1n; // TODO: review
   let neededLTValue = requiredTotalLTCollateral > currentLTCollateral
     ? requiredTotalLTCollateral - currentLTCollateral
     : 0n;
 
+  // We might not need to supply any additional collateral
   if (neededLTValue === 0n) return result;
 
-  // Greedily iterate through sorted collaterals
+  // Greedily pull from front of sorted collaterals until the health factor is met
   for (const collat of collaterals) {
     if (neededLTValue <= 0n) break;
 
-    const price = BigInt(collat.assetPrice ?? "0");
-    const lt = BigInt(collat.liquidationThreshold ?? "0");
     const available = BigInt(collat.userBalance ?? "0"); // unsupplied balance
-    const decimals = BigInt(10) ** BigInt(collat.customDecimals ?? 18);
-
-    if (price === 0n || lt === 0n || available === 0n) continue;
-
     // LT-weighted value of entire available balance: (amount * price * lt) / (decimals * 10000)
-    const maxLTValue = (available * price * lt) / (decimals * 10000n);
+    const maxLTValue = BigInt(collat.unsuppliedLTCollateralValue ?? "0");
+
+    if (available === 0n || maxLTValue === 0n) continue;
 
     if (maxLTValue <= neededLTValue) {
       // Use entire available balance
@@ -417,8 +412,12 @@ export const recommendCollateralToSupply = (
       neededLTValue -= maxLTValue;
     } else {
       // Calculate exact amount needed for remaining LT value (+ 1 wei for floor safety)
-      // amount = (neededLTValue * decimals * 10000) / (price * lt) + 1
-      const amountNeeded = (neededLTValue * decimals * 10000n) / (price * lt) + 1n;
+      const price = BigInt(collat.assetPrice ?? "0");
+      const lt = BigInt(collat.liquidationThreshold ?? "0");
+      const decimals = BigInt(10) ** BigInt(collat.customDecimals ?? 18);
+      
+      if (price === 0n || lt === 0n) continue;
+      const amountNeeded = (neededLTValue * decimals * 10000n) / (price * lt) + 1n; // TODO: review
       result.set(collat, amountNeeded < available ? amountNeeded : available);
       neededLTValue = 0n;
     }
@@ -456,12 +455,14 @@ const calculateMinimumLTV = (collaterals: readonly CollateralData[]) : bigint =>
 };
 
 /**
- * TODO describe, TODO review
- * @param collaterals TODO
- * @param borrowAmount TODO
- * @param loanData TODO
- * @param targetHealthFactor TODO
- * @returns TODO
+ * Calculates the total USD value of additional collateral which would need
+ * to be supplied to achieve the target health factor after the specified borrow
+ * TODO: review implementation
+ * @param collaterals The current collateral data fetched from the backend
+ * @param borrowAmount The amount of USDST the user is trying to borrow
+ * @param loanData The current loan data fetched from the backend
+ * @param targetHealthFactor The target health factor the user is trying to achieve
+ * @returns The total USD value of additional collateral needed
  */
 export const calculateAdditionalValueNeeded = (
   collaterals: CollateralData[],
@@ -500,11 +501,16 @@ export const calculateAdditionalValueNeeded = (
 };
 
 /**
- * TODO describe, TODO review
- * @param loanData TODO
- * @param borrowAmount TODO
- * @param newCollateralSupplied TODO
- * @returns TODO
+ * Calculates the actual health factor which would be reached after borrowing the specified amount
+ * with the specified additional collateral supplies.
+ * May be healthier than the health factor selected using the slider, if the user is already
+ * in such a good position that borrowing the specified amount with no additional collateral
+ * already achieves a superior health factor.
+ * TODO review
+ * @param loanData The current loan data fetched from the backend
+ * @param borrowAmount The amount of USDST the user is trying to borrow
+ * @param newCollateralSupplied The additional collateral assets, mapped to the wei amount being supplied
+ * @returns The predicted health factor after all the supply and borrow transactions are completed
  */
 export const calculateAfterBorrowHealthFactor = (
   loanData: NewLoanData,

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -246,9 +246,12 @@ export const calculateAvailableToBorrowUSD = (
   const maxDebtForTargetHF = (totalCollateralValueUSD * 10n ** 18n) / targetHFRaw;
 
   // Available to borrow = maxDebt - currentDebt (clamped to 0)
-  return maxDebtForTargetHF > currentDebtUSD
-    ? centFloor(Number((maxDebtForTargetHF - currentDebtUSD) / 10n ** 18n))
-    : 0.00;
+  // Floor to cents in BigInt space to avoid precision loss
+  if (maxDebtForTargetHF <= currentDebtUSD) return 0.00;
+  const centsInWei = 10n ** 16n; // 0.01 USD = 1e16 wei
+  const availableWei = (maxDebtForTargetHF - currentDebtUSD) / centsInWei * centsInWei;
+  const flooredToCentsWei = (availableWei / centsInWei) * centsInWei; // BigInt division truncates (floors)
+  return Number(flooredToCentsWei) / 1e18;
 };
 
 export const calculateHFSliderExtrema = (

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -328,19 +328,20 @@ export const calculateBorrowTxFee = (collateralCount: number): { fee: number, vo
 };
 
 /**
- * TODO describe, TODO review
- * @param collateralValueUSD TODO
+ * Calculate the wei amount of collateral asset whose total value in USD is the provided dollar value
+ * @param collateralValueUSD The user-supplied dollar value from which to calculate the asset amount
  * @param price The oracle price of the collateral asset in wei
- * @param decimals TODO
- * @returns TODO
+ * @param decimals The number of decimals of the collateral asset, defaulting to 18
+ * @returns The amount of collateral asset to supply in wei
  */
 export const calculateAdditionalCollateralAmountFromValue = (
-  collateralValueUSD: bigint,
+  collateralValueUSD: number,
   price: bigint,
-  decimals: bigint, // i.e. 10n**18n, not 18n
+  decimals: number = 18,
 ): bigint => {
+  const collateralValueWei = BigInt(Math.round(collateralValueUSD * 1e18)); // questionable
   if (price === 0n) return 0n;
-  return (collateralValueUSD * decimals) / price;
+  return (collateralValueWei * 10n ** BigInt(decimals)) / price;
 };
 
 /**

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -310,19 +310,17 @@ export const calculateAdditionalCollateralAmountFromValue = (
 };
 
 /**
- * Calculates the max dollar value that the user can supply of the asset
- * @param balance - user's wei balance of the asset
- * @param price - asset price in USD, such as 21200000000000000000n for $21.20
- * @param decimals - asset decimals, such as 10n**18n for 18 decimals
- * @returns the maxmimum value in USD that the user can supply, such as 3400000000000000000n for $3.40
- * @throws if decimals is 0n
+ * Calculates the max dollar value that the user can supply of the asset, floored to cents
+ * @param collateral - the collateral asset to evaluate
+ * @returns the maximum value in USD floored to cents, such as 3.40 for $3.409
  */
-export const calculateMaxCollateralValueFromBalance = (
-  balance: bigint,
-  price: bigint,
-  decimals: bigint, // i.e. 10n**18n, not 18n
-): bigint => {
-  return (balance * price) / decimals;
+export const calculateMaxCollateralValueUSDCentFloored = (collateral: CollateralData): number => {
+  const balance = BigInt(collateral.userBalance ?? "0");
+  const price = BigInt(collateral.assetPrice ?? "0");
+  const decimals = BigInt(10) ** BigInt(collateral.customDecimals ?? 18);
+  const maxValueWei = (balance * price) / decimals
+  const maxValueUSD = Number(maxValueWei) / 1e18;
+  return Math.floor(maxValueUSD * 100) / 100; // Floor to cents
 };
 
 export const recommendCollateralToSupply = (

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -280,11 +280,11 @@ const determineErrorMessage = (
   return ""; //TODO: Implement this
 };
 
-const calculateBorrowTxFee = (collateralCount: number): { fee: Number, voucher: Number } =>
+export const calculateBorrowTxFee = (collateralCount: number): { fee: number, voucher: number } =>
 {
     const fee = collateralCount * parseFloat(SUPPLY_COLLATERAL_FEE) + parseFloat(BORROW_FEE);
     const voucher = Math.round(fee * 100);
-    return { fee, voucher }; // TODO verify no rounding issues, voucher is int
+    return { fee, voucher };
 };
 
 const calculateAdditionalCollateralAmountFromValue = (

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -303,10 +303,26 @@ export const calculateBorrowTxFee = (collateralCount: number): { fee: number, vo
 export const calculateAdditionalCollateralAmountFromValue = (
   collateralValueUSD: bigint,
   price: bigint,
-  decimals: bigint,
+  decimals: bigint, // i.e. 10n**18n, not 18n
 ): bigint => {
   if (price === 0n) return 0n;
   return (collateralValueUSD * decimals) / price;
+};
+
+/**
+ * Calculates the max dollar value that the user can supply of the asset
+ * @param balance - user's wei balance of the asset
+ * @param price - asset price in USD, such as 21200000000000000000n for $21.20
+ * @param decimals - asset decimals, such as 10n**18n for 18 decimals
+ * @returns the maxmimum value in USD that the user can supply, such as 3400000000000000000n for $3.40
+ * @throws if decimals is 0n
+ */
+export const calculateMaxCollateralValueFromBalance = (
+  balance: bigint,
+  price: bigint,
+  decimals: bigint, // i.e. 10n**18n, not 18n
+): bigint => {
+  return (balance * price) / decimals;
 };
 
 export const recommendCollateralToSupply = (

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -300,11 +300,13 @@ export const calculateBorrowTxFee = (collateralCount: number): { fee: number, vo
     return { fee, voucher };
 };
 
-const calculateAdditionalCollateralAmountFromValue = (
+export const calculateAdditionalCollateralAmountFromValue = (
   collateralValueUSD: bigint,
   price: bigint,
+  decimals: bigint,
 ): bigint => {
-  return (collateralValueUSD * 10n ** 18n) / price;
+  if (price === 0n) return 0n;
+  return (collateralValueUSD * decimals) / price;
 };
 
 export const recommendCollateralToSupply = (

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -381,20 +381,34 @@ export const calculateAdditionalValueNeeded = (
   collaterals: CollateralData[],
   borrowAmount: Number,
   loanData: NewLoanData,
+  targetHealthFactor: Number,
 ) : Number => {
-  const minLTV = calculateMinimumLTV(collaterals);
-  if (minLTV === 0n) return 0; // careful with this
+  if (collaterals.length === 0) return 0;
+  
+  // Find minimum LT (strictest for achieving target HF)
+  const minLT = collaterals
+    .map(c => BigInt(c.liquidationThreshold ?? "0"))
+    .reduce((a, b) => a < b ? a : b);
+  if (minLT === 0n) return 0;
 
-  const totalDebtAfterBorrow = BigInt(loanData.totalAmountOwed) + BigInt(Math.round(Number(borrowAmount) * 1e18));
-  const currentBorrowingPowerUSD = BigInt(loanData.totalBorrowingPowerUSD ?? "0");
+  const targetHFRaw = BigInt(Math.round(Number(targetHealthFactor) * 1e18));
+  const currentLTCollateral = BigInt(loanData.totalCollateralValueUSD ?? "0");
+  const currentDebt = BigInt(loanData.totalAmountOwed ?? "0");
+  const newBorrow = BigInt(Math.round(Number(borrowAmount) * 1e18));
+  
+  const newDebt = currentDebt + newBorrow;
+  if (newDebt === 0n) return 0;
 
-  // Borrowing power (LTV-weighted) must be >= total debt to borrow
-  if (currentBorrowingPowerUSD >= totalDebtAfterBorrow) return 0;
-
-  const additionalPowerNeeded = totalDebtAfterBorrow - currentBorrowingPowerUSD;
-
-  // Convert borrowing power to collateral value using minLTV, so it's sufficient regardless of asset chosen
-  const additionalValueNeeded = (additionalPowerNeeded * 10000n) / minLTV;
+  // Required LT-weighted collateral for target HF (+ 1 for floor safety)
+  const requiredLTCollateral = (targetHFRaw * newDebt) / (10n ** 18n) + 1n;
+  
+  if (currentLTCollateral >= requiredLTCollateral) return 0;
+  
+  const neededLTValue = requiredLTCollateral - currentLTCollateral;
+  
+  // Convert LT-weighted value to raw value using minLT
+  // LT_value = raw_value * LT / 10000, so raw_value = LT_value * 10000 / LT
+  const additionalValueNeeded = (neededLTValue * 10000n) / minLT;
 
   return Number(additionalValueNeeded) / 1e18;
 };

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -224,6 +224,13 @@ export const centCeil = (value: Number): Number => {
   return Math.ceil(+value * 100) / 100;
 };
 
+// Ceiling division, helpful when reversing calculations that use floored division
+// @dev b must be > 0n
+const ceilDivBigInt = (a: bigint, b: bigint): bigint => {
+  if (b <= 0n) return 0n; // ERROR!
+  return (a + b - 1n) / b;
+};
+
 // Return the maximum amount that can be borrowed with the given health factor
 export const calculateAvailableToBorrowUSD = (
   loanData: NewLoanData,
@@ -387,8 +394,8 @@ export const recommendCollateralToSupply = (
 
   const newDebt = currentDebt + borrowAmount;
 
-  // Required LT-weighted collateral to achieve target HF (add 1 for floored division safety)
-  const requiredTotalLTCollateral = (targetHFRaw * newDebt) / (10n ** 18n) + 1n; // TODO: review
+  // Required LT-weighted collateral to achieve target HF
+  const requiredTotalLTCollateral = ceilDivBigInt(targetHFRaw * newDebt, 10n ** 18n);
   let neededLTValue = requiredTotalLTCollateral > currentLTCollateral
     ? requiredTotalLTCollateral - currentLTCollateral
     : 0n;
@@ -411,13 +418,13 @@ export const recommendCollateralToSupply = (
       result.set(collat, available);
       neededLTValue -= maxLTValue;
     } else {
-      // Calculate exact amount needed for remaining LT value (+ 1 wei for floor safety)
+      // Calculate exact amount needed for remaining LT value
       const price = BigInt(collat.assetPrice ?? "0");
       const lt = BigInt(collat.liquidationThreshold ?? "0");
       const decimals = BigInt(10) ** BigInt(collat.customDecimals ?? 18);
       
       if (price === 0n || lt === 0n) continue;
-      const amountNeeded = (neededLTValue * decimals * 10000n) / (price * lt) + 1n; // TODO: review
+      const amountNeeded = ceilDivBigInt(neededLTValue * decimals * 10000n, price * lt);
       result.set(collat, amountNeeded < available ? amountNeeded : available);
       neededLTValue = 0n;
     }
@@ -457,7 +464,6 @@ const calculateMinimumLTV = (collaterals: readonly CollateralData[]) : bigint =>
 /**
  * Calculates the total USD value of additional collateral which would need
  * to be supplied to achieve the target health factor after the specified borrow
- * TODO: review implementation
  * @param collaterals The current collateral data fetched from the backend
  * @param borrowAmount The amount of USDST the user is trying to borrow
  * @param loanData The current loan data fetched from the backend
@@ -486,8 +492,8 @@ export const calculateAdditionalValueNeeded = (
   const newDebt = currentDebt + newBorrow;
   if (newDebt === 0n) return 0;
 
-  // Required LT-weighted collateral for target HF (+ 1 for floor safety)
-  const requiredLTCollateral = (targetHFRaw * newDebt) / (10n ** 18n) + 1n;
+  // Required LT-weighted collateral for target HF
+  const requiredLTCollateral = ceilDivBigInt(targetHFRaw * newDebt, 10n ** 18n);
   
   if (currentLTCollateral >= requiredLTCollateral) return 0;
   
@@ -506,9 +512,8 @@ export const calculateAdditionalValueNeeded = (
  * May be healthier than the health factor selected using the slider, if the user is already
  * in such a good position that borrowing the specified amount with no additional collateral
  * already achieves a superior health factor.
- * TODO review
  * @param loanData The current loan data fetched from the backend
- * @param borrowAmount The amount of USDST the user is trying to borrow
+ * @param borrowAmount The amount of USDST the user is trying to borrow; should be > 0
  * @param newCollateralSupplied The additional collateral assets, mapped to the wei amount being supplied
  * @returns The predicted health factor after all the supply and borrow transactions are completed
  */
@@ -518,7 +523,7 @@ export const calculateAfterBorrowHealthFactor = (
   newCollateralSupplied: Map<CollateralData, bigint>
 ) : Number => {
   const totalDebtAfterBorrow = BigInt(loanData.totalAmountOwed) + BigInt(Math.round(Number(borrowAmount) * 1e18));
-  if (totalDebtAfterBorrow === 0n) return Infinity; // maybe zero can be used for no loan
+  if (totalDebtAfterBorrow === 0n) return 0; // should not occur
 
   // Sum LT-weighted value of new collateral
   let newCollateralLTValue = 0n;

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -1,4 +1,5 @@
 import { CollateralData, NewLoanData } from "@/interface";
+import { SUPPLY_COLLATERAL_FEE, BORROW_FEE } from "@/lib/constants";
 
 export const getMaxSafeWithdrawAmount = (
   asset: CollateralData,
@@ -52,6 +53,7 @@ export const calculateCollateralHealthImpact = (
   const currentTotalBorrowValueUSD = currentHealthFactorRaw === 0n
     ? 0n
     : (currentCollateralValueUSD * 10n ** 18n) / currentHealthFactorRaw;
+  console.log("derived, real:", currentTotalBorrowValueUSD, loanData?.totalAmountOwed);
 
   // If there's no outstanding loan, collateral operations are always healthy
   if (currentTotalBorrowValueUSD === 0n) {
@@ -206,3 +208,199 @@ export const calculateBorrowHealthImpact = (
 ) => {
   return calculateBorrowOperationHealthImpact(borrowAmountWei, loanData, true);
 }; 
+
+
+// ----
+const centFloor = (value: Number): Number => {
+  return Math.floor(+value * 100) / 100;
+};
+
+const centCeil = (value: Number): Number => {
+  return Math.ceil(+value * 100) / 100;
+};
+
+// Return the maximum amount that can be borrowed with the given health factor
+const calculateAvailableToBorrowUSD = (
+  loanData: NewLoanData,
+  healthFactor: Number,
+  newCollateral: Map<CollateralData, bigint>,
+): Number => {
+  const targetHFRaw = BigInt(Math.round(Number(healthFactor) * 1e18));
+
+  let totalCollateralValueUSD = BigInt(loanData?.totalCollateralValueUSD ?? "0"); // supplied collat, LT weighted
+  for (const [collat, amount] of newCollateral.entries()) { // Add new collateral value (LT weighted)
+    totalCollateralValueUSD += (BigInt(collat.liquidationThreshold) * amount) / 10000n;
+  }
+
+  const currentDebtUSD = BigInt(loanData?.totalAmountOwed ?? "0");
+
+  // Calculate max debt for target health factor
+  const maxDebtForTargetHF = (totalCollateralValueUSD * 10n ** 18n) / targetHFRaw;
+
+  // Available to borrow = maxDebt - currentDebt (clamped to 0)
+  return maxDebtForTargetHF > currentDebtUSD
+    ? centFloor(Number((maxDebtForTargetHF - currentDebtUSD) / 10n ** 18n))
+    : 0.00;
+};
+
+const calculateHFSliderExtrema = (
+  loanData: NewLoanData,
+  collaterals: CollateralData[],
+  DEFAULT_MAX_HEALTH_FACTOR: Number = 3.00,
+) : { min: Number, max: Number } => {
+  const minHF = Math.min(...collaterals.map(c => Number(BigInt(c.liquidationThreshold))/Number(BigInt(c.ltv))));
+  const maxHF = Math.max(+DEFAULT_MAX_HEALTH_FACTOR, loanData.healthFactor);
+  return { min: centCeil(minHF), max: centFloor(maxHF) };
+};
+
+const determineErrorMessage = (
+  borrowAmount: Number,
+  requestedHealthFactor: Number,
+  loanData: NewLoanData,
+  collaterals: CollateralData[]
+) : string => {
+  return ""; //TODO: Implement this
+};
+
+const calculateBorrowTxFee = (collateralCount: number): { fee: Number, voucher: Number } =>
+{
+    const fee = collateralCount * parseFloat(SUPPLY_COLLATERAL_FEE) + parseFloat(BORROW_FEE);
+    const voucher = Math.round(fee * 100);
+    return { fee, voucher }; // TODO verify no rounding issues, voucher is int
+};
+
+const calculateAdditionalCollateralAmountFromValue = (
+  collateralValueUSD: bigint,
+  price: bigint,
+): bigint => {
+  return (collateralValueUSD * 10n ** 18n) / price;
+};
+
+const recommendCollateralToSupply = (
+  loanData: NewLoanData,
+  healthFactor: Number,
+  borrowAmountUSD: Number,
+  collaterals: CollateralData[],
+) : Map<CollateralData, bigint> => {
+  sortCollateralAssets(collaterals);
+  // TODO this one is AI generated, needs to be verified
+  // Should greedily pull from the front of the queue until the health factor is met
+  const result = new Map<CollateralData, bigint>();
+
+  // HF = LT_weighted_collateral / debt
+  // After borrow: targetHF = (currentLTCollat + newLTCollat) / (currentDebt + borrowAmount)
+  // Solve for newLTCollat: newLTCollat = targetHF * (currentDebt + borrowAmount) - currentLTCollat
+
+  const targetHFRaw = BigInt(Math.round(Number(healthFactor) * 1e18));
+  const currentLTCollateral = BigInt(loanData?.totalCollateralValueUSD ?? "0");
+  const currentDebt = BigInt(loanData?.totalAmountOwed ?? "0");
+  const borrowAmount = BigInt(Math.round(Number(borrowAmountUSD) * 1e18));
+
+  const newDebt = currentDebt + borrowAmount;
+  if (newDebt === 0n) return result;
+
+  // Required LT-weighted collateral to achieve target HF (add 1 for floored division safety)
+  const requiredTotalLTCollateral = (targetHFRaw * newDebt) / (10n ** 18n) + 1n;
+  let neededLTValue = requiredTotalLTCollateral > currentLTCollateral
+    ? requiredTotalLTCollateral - currentLTCollateral
+    : 0n;
+
+  if (neededLTValue === 0n) return result;
+
+  // Greedily iterate through sorted collaterals
+  for (const collat of collaterals) {
+    if (neededLTValue <= 0n) break;
+
+    const price = BigInt(collat.assetPrice ?? "0");
+    const lt = BigInt(collat.liquidationThreshold ?? "0");
+    const available = BigInt(collat.userBalance ?? "0"); // unsupplied balance
+    const decimals = BigInt(10) ** BigInt(collat.customDecimals ?? 18);
+
+    if (price === 0n || lt === 0n || available === 0n) continue;
+
+    // LT-weighted value of entire available balance: (amount * price * lt) / (decimals * 10000)
+    const maxLTValue = (available * price * lt) / (decimals * 10000n);
+
+    if (maxLTValue <= neededLTValue) {
+      // Use entire available balance
+      result.set(collat, available);
+      neededLTValue -= maxLTValue;
+    } else {
+      // Calculate exact amount needed for remaining LT value (+ 1 wei for floor safety)
+      // amount = (neededLTValue * decimals * 10000) / (price * lt) + 1
+      const amountNeeded = (neededLTValue * decimals * 10000n) / (price * lt) + 1n;
+      result.set(collat, amountNeeded < available ? amountNeeded : available);
+      neededLTValue = 0n;
+    }
+  }
+
+  return result;
+};
+
+const sortCollateralAssets = (
+  collaterals: CollateralData[],
+  DO_IGNORE_ONE_WEI: boolean = true,
+) : void => {
+  // - Amongst the collateral asset types the user has already supplied, sort by `asset.balanceOf(user)*lendingPool.config[asset].LTV`
+  // - After all of those, sort remaining collateral the user possesses by `asset.balanceOf(user)*lendingPool.config[asset].LTV`
+  const nonexistant = DO_IGNORE_ONE_WEI ? 1n : 0n;
+  const isSupplied = (collat: CollateralData) => BigInt(collat.collateralizedAmount) > nonexistant;
+  collaterals.sort((a, b) => {
+    // Supplied collaterals come FIRST
+    if (isSupplied(a) && !isSupplied(b)) return -1;
+    if (!isSupplied(a) && isSupplied(b)) return 1;
+    // Within groups, sort by borrowing power descending (higher first)
+    return -Number(BigInt(a.unsuppliedBorrowingPower) - BigInt(b.unsuppliedBorrowingPower));
+  });
+};
+
+const calculateMinimumLTV = (collaterals: CollateralData[]) : bigint => {
+  if (collaterals.length === 0) return 0n;
+  return collaterals.map(c => BigInt(c.ltv ?? "0")).reduce((a, b) => a < b ? a : b);
+};
+
+const calculateAdditionalValueNeeded = (
+  collaterals: CollateralData[],
+  borrowAmount: Number,
+  loanData: NewLoanData,
+) : Number => {
+  const minLTV = calculateMinimumLTV(collaterals);
+  if (minLTV === 0n) return 0; // careful with this
+
+  const totalDebtAfterBorrow = BigInt(loanData.totalAmountOwed) + BigInt(Math.round(Number(borrowAmount) * 1e18));
+  const currentBorrowingPowerUSD = BigInt(loanData.totalBorrowingPowerUSD ?? "0");
+
+  // Borrowing power (LTV-weighted) must be >= total debt to borrow
+  if (currentBorrowingPowerUSD >= totalDebtAfterBorrow) return 0;
+
+  const additionalPowerNeeded = totalDebtAfterBorrow - currentBorrowingPowerUSD;
+
+  // Convert borrowing power to collateral value using minLTV, so it's sufficient regardless of asset chosen
+  const additionalValueNeeded = (additionalPowerNeeded * 10000n) / minLTV;
+
+  return Number(additionalValueNeeded) / 1e18;
+};
+
+const calculateAfterBorrowHealthFactor = (
+  loanData: NewLoanData,
+  borrowAmount: Number,
+  newCollateralSupplied: Map<CollateralData, bigint>
+) : Number => {
+  const totalDebtAfterBorrow = BigInt(loanData.totalAmountOwed) + BigInt(Math.round(Number(borrowAmount) * 1e18));
+  if (totalDebtAfterBorrow === 0n) return Infinity; // maybe zero can be used for no loan
+
+  // Sum LT-weighted value of new collateral
+  let newCollateralLTValue = 0n;
+  for (const [collat, amount] of newCollateralSupplied.entries()) {
+    const price = BigInt(collat.assetPrice ?? "0");
+    const lt = BigInt(collat.liquidationThreshold ?? "0");
+    newCollateralLTValue += (amount * price * lt) / (10n**18n * 10000n);
+  }
+
+  const totalLTCollateralAfterBorrow = BigInt(loanData.totalCollateralValueUSD ?? "0") + newCollateralLTValue;
+
+  // HF = (LT-weighted collateral * 1e18) / debt
+  const newHealthFactorRaw = (totalLTCollateralAfterBorrow * 10n ** 18n) / totalDebtAfterBorrow;
+
+  return Number(newHealthFactorRaw) / 1e18;
+};

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -53,7 +53,6 @@ export const calculateCollateralHealthImpact = (
   const currentTotalBorrowValueUSD = currentHealthFactorRaw === 0n
     ? 0n
     : (currentCollateralValueUSD * 10n ** 18n) / currentHealthFactorRaw;
-  console.log("derived, real:", currentTotalBorrowValueUSD, loanData?.totalAmountOwed);
 
   // If there's no outstanding loan, collateral operations are always healthy
   if (currentTotalBorrowValueUSD === 0n) {
@@ -209,6 +208,7 @@ export const calculateBorrowHealthImpact = (
   return calculateBorrowOperationHealthImpact(borrowAmountWei, loanData, true);
 };
 
+// Below: Utilities for New Borrow UX with Risk Slider and Automatic Collateral Supply
 
 // Floor the value to the nearest 0.01;
 // e.g. 3.409 -> 3.40, 3.45 --> 3.45
@@ -264,6 +264,7 @@ export const calculateAvailableToBorrowUSD = (
  * @param loanData - The current loan data fetched from the backend
  * @param collaterals - The current collateral data fetched from the backend
  * @param DEFAULT_MAX_HEALTH_FACTOR - The default maximum health factor, overriden if the current health factor is higher. 3.00 by default.
+ * @param DEFAULT_MIN_HEALTH_FACTOR - The default minimum health factor, used only when data is unavailable. 1.07 by default.
  * @param BASICALLY_INFINITE_HEALTH - The value above which the health factor is considered infinite. 999999 by default.
  * @returns The minimum and maximum health factors for the slider
  */
@@ -271,8 +272,14 @@ export const calculateHFSliderExtrema = (
   loanData: NewLoanData,
   collaterals: CollateralData[],
   DEFAULT_MAX_HEALTH_FACTOR: number = 3.00,
+  DEFAULT_MIN_HEALTH_FACTOR: number = 1.07,
   BASICALLY_INFINITE_HEALTH: number = 999999,
 ) : { min: Number, max: Number } => {
+  // If no data is available, use the defaults
+  if (!loanData || !collaterals || collaterals.length === 0) {
+    return { min: DEFAULT_MIN_HEALTH_FACTOR, max: DEFAULT_MAX_HEALTH_FACTOR };
+  }
+
   // The slider should only go down to the least risky asset's minimum health factor
   const minHF = Math.max(...collaterals.map(c => Number(BigInt(c.liquidationThreshold))/Number(BigInt(c.ltv))));
   
@@ -461,7 +468,7 @@ export const calculateAdditionalValueNeeded = (
   loanData: NewLoanData,
   targetHealthFactor: Number,
 ) : Number => {
-  if (collaterals.length === 0) return 0;
+  if (!loanData || !collaterals || collaterals.length === 0) return 0;
   
   // Find minimum LT (strictest for achieving target HF)
   const minLT = collaterals

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -249,7 +249,17 @@ export const calculateHFSliderExtrema = (
   DEFAULT_MAX_HEALTH_FACTOR: Number = 3.00,
 ) : { min: Number, max: Number } => {
   const minHF = Math.min(...collaterals.map(c => Number(BigInt(c.liquidationThreshold))/Number(BigInt(c.ltv))));
-  const maxHF = Math.max(+DEFAULT_MAX_HEALTH_FACTOR, loanData.healthFactor);
+  
+  // Check if there's no loan (no debt)
+  const hasLoan = BigInt(loanData?.totalAmountOwed ?? "0") > 1n;
+  const currentHF = loanData?.healthFactor ?? 0;
+  const isInfiniteHF = !isFinite(currentHF) || currentHF >= 999999;
+  
+  // If no loan, max is DEFAULT_MAX_HEALTH_FACTOR; otherwise use max of default and current HF
+  const maxHF = hasLoan && !isInfiniteHF
+    ? Math.max(+DEFAULT_MAX_HEALTH_FACTOR, currentHF)
+    : +DEFAULT_MAX_HEALTH_FACTOR;
+  
   return { min: centCeil(minHF), max: centFloor(maxHF) };
 };
 

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -271,13 +271,23 @@ export const calculateHFSliderExtrema = (
   return { min: centCeil(minHF), max: centFloor(maxHF) };
 };
 
-const determineErrorMessage = (
+export const determineErrorMessage = (
   borrowAmount: Number,
-  requestedHealthFactor: Number,
-  loanData: NewLoanData,
-  collaterals: CollateralData[]
+  maxAtRequestedHF: Number,
+  maxAtMinHF: Number
 ) : string => {
-  return ""; //TODO: Implement this
+  // Check if borrow amount exceeds maximum at requested health factor
+  if (borrowAmount > maxAtRequestedHF) {
+    // If even at minimum health factor the max is still too low, don't suggest increasing risk
+    if (borrowAmount > maxAtMinHF) {
+      return "Borrow amount exceeds the maximum at this health factor.\nConsider bridging in more collateral.";
+    }
+    
+    // Otherwise, suggest increasing risk level as an option
+    return "Borrow amount exceeds the maximum at this health factor.\nConsider bridging in more collateral, or increase risk level.";
+  }
+  
+  return "";
 };
 
 export const calculateBorrowTxFee = (collateralCount: number): { fee: number, voucher: number } =>

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -226,10 +226,18 @@ export const calculateAvailableToBorrowUSD = (
   newCollateral: Map<CollateralData, bigint>,
 ): Number => {
   const targetHFRaw = BigInt(Math.round(Number(healthFactor) * 1e18));
+  if (targetHFRaw <= 0n) return 0;
 
   let totalCollateralValueUSD = BigInt(loanData?.totalCollateralValueUSD ?? "0"); // supplied collat, LT weighted
-  for (const [collat, amount] of newCollateral.entries()) { // Add new collateral value (LT weighted)
-    totalCollateralValueUSD += (BigInt(collat.liquidationThreshold) * amount) / 10000n;
+  
+  // Add new collateral value (LT weighted): (amount * price * LT) / (decimals * 10000)
+  for (const [collat, amount] of newCollateral.entries()) {
+    const price = BigInt(collat.assetPrice ?? "0");
+    const lt = BigInt(collat.liquidationThreshold ?? "0");
+    const decimals = BigInt(10) ** BigInt(collat.customDecimals ?? 18);
+    if (price > 0n && lt > 0n) {
+      totalCollateralValueUSD += (amount * price * lt) / (decimals * 10000n);
+    }
   }
 
   const currentDebtUSD = BigInt(loanData?.totalAmountOwed ?? "0");
@@ -286,7 +294,7 @@ const calculateAdditionalCollateralAmountFromValue = (
   return (collateralValueUSD * 10n ** 18n) / price;
 };
 
-const recommendCollateralToSupply = (
+export const recommendCollateralToSupply = (
   loanData: NewLoanData,
   healthFactor: Number,
   borrowAmountUSD: Number,
@@ -369,7 +377,7 @@ const calculateMinimumLTV = (collaterals: CollateralData[]) : bigint => {
   return collaterals.map(c => BigInt(c.ltv ?? "0")).reduce((a, b) => a < b ? a : b);
 };
 
-const calculateAdditionalValueNeeded = (
+export const calculateAdditionalValueNeeded = (
   collaterals: CollateralData[],
   borrowAmount: Number,
   loanData: NewLoanData,

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -220,7 +220,7 @@ const centCeil = (value: Number): Number => {
 };
 
 // Return the maximum amount that can be borrowed with the given health factor
-const calculateAvailableToBorrowUSD = (
+export const calculateAvailableToBorrowUSD = (
   loanData: NewLoanData,
   healthFactor: Number,
   newCollateral: Map<CollateralData, bigint>,
@@ -243,7 +243,7 @@ const calculateAvailableToBorrowUSD = (
     : 0.00;
 };
 
-const calculateHFSliderExtrema = (
+export const calculateHFSliderExtrema = (
   loanData: NewLoanData,
   collaterals: CollateralData[],
   DEFAULT_MAX_HEALTH_FACTOR: Number = 3.00,
@@ -381,7 +381,7 @@ const calculateAdditionalValueNeeded = (
   return Number(additionalValueNeeded) / 1e18;
 };
 
-const calculateAfterBorrowHealthFactor = (
+export const calculateAfterBorrowHealthFactor = (
   loanData: NewLoanData,
   borrowAmount: Number,
   newCollateralSupplied: Map<CollateralData, bigint>

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -215,7 +215,7 @@ const centFloor = (value: Number): Number => {
   return Math.floor(+value * 100) / 100;
 };
 
-const centCeil = (value: Number): Number => {
+export const centCeil = (value: Number): Number => {
   return Math.ceil(+value * 100) / 100;
 };
 


### PR DESCRIPTION
This is the Borrow user experience refresh that we have been working on, updated to address Victor's comments and implement the design from his Lovable [https://stratomer-clone-dash.lovable.app/borrow](https://stratomer-clone-dash.lovable.app/borrow).

It lives at [https://workspace-adrian-a4x5z31.blockapps.net/](https://workspace-adrian-a4x5z31.blockapps.net/), a testnet node, for testing.

Addresses #5784

This branch includes only the relevant commits.

---
### Specifications
After reviewing the workspace implementations, Victor has created and shared a design for the borrowing interfaces:\
https://stratomer-clone-dash.lovable.app/borrow for the Lending Pool\
https://stratomer-clone-dash.lovable.app/advanced for the CDP mint

- The CDP Mint and Lending Pool Borrow will have basically the same UX.
- Instead of showing Available to Borrow as the absolute maximum you can borrow, it will be determined by health factor; it's the maximum that you can borrow at the selected health factor.
- There will be a MAX button which fills that Available to Borrow in the borrow amount field.
- The health factor slider will default to 2.1
  - The health factor slider will be a fixed range and will max out at some predetermined value around ~~3.13~~ **3.00**
  - ~~The minimum health factor should be the same for both the CDP and Lending borrow as well.~~
  - The HF slider will be granular and smooth.
- The HF slider may be manipulated prior to entering a borrow amount.
- We offer various messaging to help the user understand; for example, if the user cannot borrow the amount they specify (we allow specifying in excess of Available to Borrow), we explain that they can increase risk or bridge in more collateral; whereas if no possible risk level makes their borrow amount possible, we recommend only to bridge in more collateral.
- The additional collateral section should be oriented around dollar value of assets.
  - Instead of a Customize button, we will have a default-on checkbox to automatically handle collateral supply
  - And there is an expandable section that shows the collateral assets being recommended, default closed.
- You can uncheck the automatic checkbox, and the dropdown will expand.
  - All collateral assets the user possesses should be shown
  - The value field for each will be editable
  - When the total value equals the Needed collateral amount, the user may execute the borrow
    - If it's lesser, the borrow button is gray. Add a "Supply $_ more to achieve desired loan health"
    - Avoid permitting the borrow when the total collateral value is greater than is needed :hourglass_flowing_sand: 
      - Less important than undersupply (which will cause the borrow tx to fail to reach the requested health) but we still are worried about the user accidentally supplying more collateral than they intended.
- in terms of the algorithm:
  - minimize the number of types of collateral being used
  - if someone has already supplied say SILVST and GOLDST in the pool, try to maximize the assets that I've already supplied first.
  - Coherent synthesis: Amongst those collat you have already supplied, sort by borrowing power of yet unsupplied quantity of each asset. If all of the already-supplied collat are maxed out, then use unsupplied assets sorted by borrowing power as well.
- We would like the slider to have a consistent minimum between the two pools
- When the user's current health factor is already greater than the predetermined max (3.00), allow them to select that health factor in the slider
- When the (HF, Borrow Amount) combo is not achievable due to the loan being too *healthy* with 0 additional collateral, show the actual After HF value next in the health impact arrow, but show the HF slider indicator value as being whatever the slider is set to. Allow the borrow.

---

Adrian, Victor, and Maxim discussed the outstanding questions:

- Q1: Just confirming - When the automatic collateral supply checkbox is checked, we don't show what collateral assets we're recommending supply, just the total dollar value? (And they can see the asset breakdown by expanding the Additonal Collateral Needed dropdown)
  - A1: Correct.

- Q2: Do we want to allow the borrow when the total value of the custom collateral supplied is in excess of the amount needed to reach the selected health factor? We mentioned that we will have the borrow button grayed out while the total is less than is needed, but maybe we allow it when it's greater.
  - A2: Let's require them to get the exact right dollar amount; we're worried about them accidentally supplying more collateral than they meant to by mistake. Assume that the health factor they entered is the one they want for this purpose.

- Q3: Kind of related, when the health factor slider is at an aggressive value relative to the current collateral supplied, do we want to have a minimum borrow amount that would be needed to actually hit that health factor? Or is it okay to let the user select a 1.2 health factor, borrow $100 with no additional collateral, and after the transaction see a 2.6 health factor? (Because they already had $325 collateral supplied with No Loan before this borrow operation.)
  - A3: In this case, let's treat the health factor they specified as sort of a floor; the health factor shouldn't end up any worse than that, but they won't mind if it's better. Let's use the Before --> After arrow to display to them what the actual health factor will be, and the slider number (next to the low/med/high risk pill) will still show the selected health factor, not the resultant one. So yes, it's okay to let the user select a 1.2 health factor and $100 borrow amount, and we will show 2.6 as the After HF value.

- Q4: Should we use the dynamic MinCR and LTV values when determining the minima of the sliders for CDP and Borrow page respectively?
  - A4: I believe the answer to this was a yes, but that if there are multiple different minima based on different assets' configurations, we should choose the least aggressive ({1.07, 1.04, 1.03} --> 1.07). The lending pool and CDP do not need to have the same minimum if the assets are so configured onchain as to imply different minima. @ Victor Please correct me if I misunderstood here; I no longer feel super clear.
  - Victor: Yes, that's correct.

---

Recent issues identified:
- progress modal bug: borrow fails, but shows success in modal :white_check_mark: 
- too many decimals in progress modal :ok: 
- round available to borrow to the cent floor :white_check_mark:  - confirm that max's error was fixed
- round additional collateral to cent with hover :white_check_mark:
- prevent total value != value needed :white_check_mark:
- when i uncheck Automatic, all of the assets I possess should show up, with zero initial amount and value for the ones that were not in the recommendation. :white_check_mark: 
- nonblocking error message when health factor too risky :white_check_mark: 
- show less decimals in repay :white_check_mark:
- When user's custom collateral's value total does not equal the value needed, show an indication and prevent form submission. :white_check_mark:
- Even if the recommended collateral assets do not include them, show all collateral assets the of which the user has a current balance when in custom mode. :white_check_mark:
- Additional Collateral Section should clear on borrow (even in custom mode) :white_check_mark: 
- Also realized the lovable doesn't have an interface for limiting the collateral supply to the user's possessed balance; will have to come up with something for that. :white_check_mark:
- Warning message and probably a Max button for when users exceed their balance of an additional collateral asset and the box goes red :white_check_mark:
- Don't allow total additional collateral value to much exceed additional collateral value needed (allowing a little bit is probably a good idea) :wrench: 
- anything high risk, make the red warning show up :white_check_mark:
- based on the slider, not what the actual risk factor will be :white_check_mark:- Show how much value of the asset you have available, dollar denominated, as another additional collat column :white_check_mark:- Supplied Collateral should be in $, not USDST :white_check_mark:
- The additional collateral value input fields were unintuitive, difficult to edit. Probably in the same way as the old Borrow Amount input. :hourglass_flowing_sand:
- Please be as consistent as possible between the Borrow and Mint :hourglass_flowing_sand:
- Have a title for the warning box :white_check_mark: 
- Make the Max button give cent-decimal values like $2103.65 :wrench: 
- if the borrow amount or hf is updated ideally it should go back to the state with the collateral checkbox checked :white_check_mark: 
- Avoid `($0.01 more needed)` when unchecking from automatic to custom additional collateral table :wrench: 

And some test cases:
- Borrowing max at riskiest health factor succeeds, and after this no further borrowing is possible, even at the riskiest health factor :white_check_mark:
- Prior to fixing collateral supply max limit, used it as a chance to verify that the progress modal properly fails when supply collateral fails. :white_check_mark: 
  - Just have to do similar for the borrow (right now the subroutine catches the error and doesn't throw it). :white_check_mark:  
- In custom mode, all assets of which the user possesses a nonzero balance are shown. First, those assets which the user has already supplied are shown, in order from greatest to least available borrowing power. Below, those assets of which the user has supplied none as collateral to the lending pool appear, in order from greatest to least available borrowing power. :white_check_mark:

Some Questions:
- Do we want to make the "Consider more risk" error message clickable, taking them to the least risky HF at which they can borrow that amount? I did a user interview and they asked for this, but there's also the concern that we'd be making it easier for them to take a risky loan. :grey_question:
- Confirm thresholds for High/Moderate/Low Risk etc. and color scheme for the indications thereof :question:
- Max button for individual additional collateral asset in custom mode? Maybe just when the user has exceeded the max, as an easy way to get them back to a working value? :white_check_mark: 

Not addressed (in related components, not Borrow flow):
- show No Loan in effect of repay
- allow amount to equal the cent ceil of the amount owed in repay form
- show less decimals in collateral management Supply and Withdraw modals
- convert Supply and Withdraw modals to being dollar-value-based, or add a toggle to do so

Additionally, there are questions regarding desired behaviour when LTV/LT configurations of different assets differ. In particular, this means that Additional Value Needed is no longer well-defined, because the amount of dollar value of collateral needed depends on how much each asset contributes to the borrowing power.