### PR TITLE
Fix #6002: Random OAuth timeouts in the oracle

### DIFF
--- a/mercata/services/oracle/src/utils/oauth.ts
+++ b/mercata/services/oracle/src/utils/oauth.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
-import { logInfo, logError } from './logger';
+import { logInfo } from './logger';
+import { apiGet, apiPost } from './apiClient';
 
 
 const TOKEN_LIFETIME_THRESHOLD_SECONDS = 10;
@@ -31,7 +31,7 @@ class OAuthClient {
 
         try {
             logInfo('OAuth', 'Discovering token endpoint...');
-            const response = await axios.get(this.discoveryUrl, { timeout: 10000 });
+            const response = await apiGet(this.discoveryUrl, { timeout: 10000 }, { logPrefix: 'OAuth' });
             this.tokenEndpoint = response.data.token_endpoint;
 
             if (!this.tokenEndpoint) {
@@ -41,7 +41,6 @@ class OAuthClient {
             logInfo('OAuth', `Token endpoint discovered: ${this.tokenEndpoint}`);
             return this.tokenEndpoint;
         } catch (error: any) {
-            logError('OAuth', new Error(`Failed to call GET ${this.discoveryUrl}: ${error.message}`));
             throw new Error(`OAuth discovery failed: ${error.message}`);
         }
     }
@@ -71,13 +70,13 @@ class OAuthClient {
             tokenData.append('client_id', this.clientId);
             tokenData.append('client_secret', this.clientSecret);
 
-            const response = await axios.post(tokenEndpoint, tokenData, {
+            const response = await apiPost(tokenEndpoint, tokenData, {
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
                     'Accept': 'application/json'
                 },
                 timeout: 10000
-            });
+            }, { logPrefix: 'OAuth' });
 
             if (response.data.access_token) {
                 this.accessToken = response.data.access_token;
@@ -89,10 +88,7 @@ class OAuthClient {
                 throw new Error('No access token in response');
             }
         } catch (error: any) {
-            const errorMessage = error.response?.data?.error_description || error.response?.data?.error || error.message;
-            const endpoint = tokenEndpoint || this.discoveryUrl;
-            logError('OAuth', new Error(`Failed to call POST ${endpoint}: ${errorMessage}`));
-            throw new Error(`OAuth authentication failed: ${errorMessage}`);
+            throw new Error(`OAuth authentication failed: ${error.message}`);
         }
     }
 
@@ -118,7 +114,7 @@ class OAuthClient {
         const keyEndpoint = `${process.env.STRATO_NODE_URL}/strato/v2.3/key`;
         try {
             const accessToken = await this.getAccessToken();
-            const response = await axios.get(
+            const response = await apiGet(
                 keyEndpoint,
                 {
                     headers: {
@@ -126,15 +122,14 @@ class OAuthClient {
                         'Content-Type': 'application/json'
                     },
                     timeout: 10000
-                }
+                },
+                { logPrefix: 'OAuth' }
             );
 
             this.userAddress = response.data.address;
             return this.userAddress!;
         } catch (error: any) {
-            const errorMessage = error.response?.data?.message || error.message;
-            logError('OAuth', new Error(`Failed to call GET ${keyEndpoint}: ${errorMessage}`));
-            throw new Error(`Failed to get user address: ${errorMessage}`);
+            throw new Error(`Failed to get user address: ${error.message}`);
         }
     }
 


### PR DESCRIPTION
## Summary
This PR addresses issue #6002.

## Issue
**Random OAuth timeouts in the oracle**

The oracles occastionally report the timeout on the step to obtain the access token:
```
0|oracle  | [ERROR] 2026-01-13T06:52:40.354Z | OAuth | Error getting access token: timeout of 10000ms exceeded
0|oracle  | [ERROR] 2026-01-13T06:52:40.355Z | CronScheduler | Feed processing error: OAuth authentication failed: timeout of 10000ms exceeded
```
However, on the keycloak side the login is showed successful, e.g. see the screenshot:

<img width="1820" height="414" alt="Image" src="https://github.com/user-attachments/assets/96d81010-f8fd-41ca-9804-10318898edac" />

Might just be the random connectivity issues or packet losses. 

The proper solution is to add a retry here (second attempt to get a token before failing) - use the `withRetry` function.

## Changes
Auto-generated fix by Claude Code. Please review carefully before merging.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
