### PR TITLE
Fix #6002: Random OAuth timeouts in the oracle

### DIFF
--- a/mercata/services/oracle/src/utils/oauth.ts
+++ b/mercata/services/oracle/src/utils/oauth.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { logInfo, logError } from './logger';
+import { apiPost } from './apiClient';
 
 
 const TOKEN_LIFETIME_THRESHOLD_SECONDS = 10;
@@ -71,13 +72,18 @@ class OAuthClient {
             tokenData.append('client_id', this.clientId);
             tokenData.append('client_secret', this.clientSecret);
 
-            const response = await axios.post(tokenEndpoint, tokenData, {
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                    'Accept': 'application/json'
+            const response = await apiPost(
+                tokenEndpoint,
+                tokenData,
+                {
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                        'Accept': 'application/json'
+                    },
+                    timeout: 10000
                 },
-                timeout: 10000
-            });
+                { logPrefix: 'OAuth' }
+            );
 
             if (response.data.access_token) {
                 this.accessToken = response.data.access_token;
@@ -89,10 +95,8 @@ class OAuthClient {
                 throw new Error('No access token in response');
             }
         } catch (error: any) {
-            const errorMessage = error.response?.data?.error_description || error.response?.data?.error || error.message;
-            const endpoint = tokenEndpoint || this.discoveryUrl;
-            logError('OAuth', new Error(`Failed to call POST ${endpoint}: ${errorMessage}`));
-            throw new Error(`OAuth authentication failed: ${errorMessage}`);
+            // apiPost already logged the error with retry details
+            throw new Error(`OAuth authentication failed: ${error.message}`);
         }
     }
 


### PR DESCRIPTION
## Summary
This PR addresses issue #6002.

## Issue
**Random OAuth timeouts in the oracle**

The oracles occastionally report the timeout on the step to obtain the access token:
```
0|oracle  | [ERROR] 2026-01-13T06:52:40.354Z | OAuth | Error getting access token: timeout of 10000ms exceeded
0|oracle  | [ERROR] 2026-01-13T06:52:40.355Z | CronScheduler | Feed processing error: OAuth authentication failed: timeout of 10000ms exceeded
```
However, on the keycloak side the login is showed successful, e.g. see the screenshot:

<img width="1820" height="414" alt="Image" src="https://github.com/user-attachments/assets/96d81010-f8fd-41ca-9804-10318898edac" />

Might just be the random connectivity issues or packet losses. 

The proper solution is to add a retry here (second attempt to get a token before failing) - use the `withRetry` function.

## Analysis & Fix
```
fix: Add retry logic for OAuth token acquisition (#6002)

Current Behavior:
The oracle occasionally reports "timeout of 10000ms exceeded" errors when
obtaining OAuth access tokens, even though Keycloak successfully processes
the authentication on its end. These intermittent failures cause feed
processing to fail completely.

Root Cause:
The refreshToken() method in oauth.ts uses direct axios.post() calls without
any retry mechanism (line 74-80). When network issues, packet losses, or
temporary connectivity problems occur, the request times out after 10 seconds
and the authentication fails immediately. The codebase already provides a
withRetry utility function in apiClient.ts that implements automatic retry
logic with proper error logging, but it was not being used for OAuth requests.

Fix Applied:
- Imported the apiPost function from apiClient.ts which wraps axios calls
  with retry logic (defaults to 2 attempts per DEFAULT_RETRY_CONFIG)
- Replaced the direct axios.post() call in refreshToken() with apiPost()
- Configured the retry to use 'OAuth' as the log prefix for consistent logging
- Simplified error handling since apiPost already logs detailed error messages
  with retry attempt information

This gives OAuth token requests a second chance to succeed on transient
network issues before failing, matching the retry pattern already established
for other API calls in the codebase.

Co-Authored-By: Claude <noreply@anthropic.com>
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
