### PR TITLE
Fix #6003: Add support for PKCE in OAuth implementation

### DIFF
--- a/legacy/pre-erc20-Jun2025/blockapps-rest/src/util/oauth.client.ts
+++ b/legacy/pre-erc20-Jun2025/blockapps-rest/src/util/oauth.client.ts
@@ -143,10 +143,14 @@ const run = async function() {
 
   const oauth = await oauthUtil.init(config.nodes[0].oauth);
 
-  const signinUri = oauth.getSigninURL();
+  // Generate PKCE code verifier and challenge for authorization code flow
+  const codeVerifier = oauth.generateCodeVerifier();
+  const codeChallenge = oauth.generateCodeChallenge(codeVerifier);
+
+  const signinUri = oauth.getSigninURL(undefined, codeChallenge);
   async function requestListener(req, res) {
     // TODO: better route matching
-    
+
     if (req.url === '/') {
       res.writeHead(302, {
         'Location': signinUri
@@ -156,7 +160,7 @@ const run = async function() {
     }
 
     const callbackPath = redirectUriParsed.pathname;
-    
+
     if (req.url.indexOf(callbackPath) !== 0 ) {
       if (req.url !== '/favicon.ico') {
         console.log('Unknown URI was called: ' + req.url);
@@ -165,7 +169,7 @@ const run = async function() {
       res.end();
       return
     }
-    
+
     const urlParts = req.url.split("?");
     if (urlParts.length < 2) {
       console.error("Missing query string in redirectUri callback url.");
@@ -176,7 +180,7 @@ const run = async function() {
       console.error('Missing required query parameter "code" in redirectUri callback');
       return
     }
-    const acToken = await oauth.getAccessTokenByAuthCode(query.code);
+    const acToken = await oauth.getAccessTokenByAuthCode(query.code, codeVerifier);
 
     if (commander.env) {
       envConfig[commander.env] = acToken.token.access_token;

--- a/legacy/pre-erc20-Jun2025/blockapps-rest/src/util/oauth.util.ts
+++ b/legacy/pre-erc20-Jun2025/blockapps-rest/src/util/oauth.util.ts
@@ -6,6 +6,7 @@ import * as getPem from "rsa-pem-from-mod-exp";
 import axios from "axios";
 import "@babel/polyfill";
 import { OAuthUser } from "../types";
+import * as crypto from "crypto";
 
 interface OAuthConfig {
   appTokenCookieName:any,
@@ -77,6 +78,38 @@ class OAuthUtil {
   }
 
   /**
+   * Generate a cryptographically secure random code verifier for PKCE
+   * @method{generateCodeVerifier}
+   * @returns {String} base64url-encoded random string (43-128 characters)
+   */
+  generateCodeVerifier(): string {
+    // RFC 7636 specifies code_verifier should be 43-128 characters
+    // Using 32 random bytes gives us 43 characters after base64url encoding
+    return crypto
+      .randomBytes(32)
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+  }
+
+  /**
+   * Generate a code challenge from a code verifier for PKCE
+   * @method{generateCodeChallenge}
+   * @param {String} codeVerifier
+   * @returns {String} base64url-encoded SHA256 hash of the code verifier
+   */
+  generateCodeChallenge(codeVerifier: string): string {
+    return crypto
+      .createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+  }
+
+  /**
    * This function calls openIdConfigUrl to get openIdConfig and it also fetches
    * any public keys that maybe used to sign tokens
    * @method{getOpenIdConfig}
@@ -143,33 +176,48 @@ class OAuthUtil {
   }
 
   /**
-   * This function gets the sign in url for oauth
+   * This function gets the sign in url for oauth with optional PKCE support
    * @method{getSigninURL}
    * @param {String} state
+   * @param {String} codeChallenge - Optional PKCE code challenge
    * @returns AuthorizationUri
    */
-  getSigninURL(state?) {
-    const authorizationUri = this.oauth2.authorizationCode.authorizeURL({
+  getSigninURL(state?, codeChallenge?) {
+    const authParams: any = {
       redirect_uri: this.redirectUri,
       scope: this.scope,
       state: state || ""
-    });
+    };
+
+    // Add PKCE parameters if code challenge is provided
+    if (codeChallenge) {
+      authParams.code_challenge = codeChallenge;
+      authParams.code_challenge_method = 'S256';
+    }
+
+    const authorizationUri = this.oauth2.authorizationCode.authorizeURL(authParams);
 
     return authorizationUri;
   }
 
   /**
-   * This function gets the access token from the authorization code
+   * This function gets the access token from the authorization code with optional PKCE support
    * @method{getAccessTokenByAuthCode}
    * @param {String} authCode
+   * @param {String} codeVerifier - Optional PKCE code verifier
    * @returns AccessTokenResponse
    */
-  async getAccessTokenByAuthCode(authCode) {
-    const tokenConfig = {
+  async getAccessTokenByAuthCode(authCode, codeVerifier?) {
+    const tokenConfig: any = {
       code: authCode,
       redirect_uri: this.redirectUri,
       scope: this.scope
     };
+
+    // Add PKCE code verifier if provided
+    if (codeVerifier) {
+      tokenConfig.code_verifier = codeVerifier;
+    }
 
     const result = await this.oauth2.authorizationCode.getToken(tokenConfig);
     const accessTokenResponse = this.oauth2.accessToken.create(result);


### PR DESCRIPTION
## Summary
This PR addresses issue #6003.

## Issue
**Add support for PKCE in OAuth implementation**

Add the additional security by using the Proof Key for Code Exchange (PKCE) code challenge (following the RFC 7636) for the browser-based authentication in STRATO.

For details see: https://oauth.net/2/pkce/

It is also a requirement for OAuth support in MCP specification - see https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-code-protection

## Analysis & Fix
```
fix: Add PKCE support to OAuth authorization code flow (#6003)

Current Behavior:
The OAuth implementation in blockapps-rest library supports authorization code
flow but does not include Proof Key for Code Exchange (PKCE) parameters. When
browser-based applications initiate OAuth authorization requests, they send the
authorization code without code_challenge, and the token exchange happens
without code_verifier. This leaves browser-based OAuth flows vulnerable to
authorization code interception attacks, particularly in environments where the
client cannot securely store a client secret.

Root Cause:
The getSigninURL() method in oauth.util.ts (line 151-158) generates the OAuth
authorization URL with only redirect_uri, scope, and state parameters. It does
not generate or accept PKCE parameters (code_challenge and code_challenge_method).
Similarly, getAccessTokenByAuthCode() (line 167-178) exchanges the authorization
code for tokens without including the code_verifier parameter. The library lacks
helper methods to generate cryptographically secure code verifiers and compute
SHA256-based code challenges as specified in RFC 7636.

While the nginx layer (nginx-packager/openid.tpl.lua line 37) has use_pkce=true
enabled and the lua-resty-openidc library handles PKCE automatically for requests
through nginx, the blockapps-rest library itself does not provide PKCE support for
direct OAuth client usage (such as in the oauth.client.ts CLI tool or when used
programmatically in other services).

Fix Applied:
1. Added crypto import to oauth.util.ts for secure random generation
2. Implemented generateCodeVerifier() method that creates a cryptographically
   secure random base64url-encoded string (43 characters from 32 random bytes)
   conforming to RFC 7636 requirements
3. Implemented generateCodeChallenge() method that computes SHA256 hash of the
   code verifier and base64url-encodes it for the S256 challenge method
4. Updated getSigninURL() to accept optional codeChallenge parameter and include
   code_challenge and code_challenge_method=S256 in authorization URL when provided
5. Updated getAccessTokenByAuthCode() to accept optional codeVerifier parameter
   and include it in the token exchange request when provided
6. Updated oauth.client.ts authorization code flow to generate PKCE parameters
   and use them throughout the OAuth flow

The implementation maintains backward compatibility - PKCE parameters are optional,
so existing code without PKCE continues to work. This enables browser-based
applications and the MCP specification requirements (which mandate PKCE for
authorization code flows) to be properly supported.

Co-Authored-By: Claude <noreply@anthropic.com>
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
