### PR TITLE
Fix #6001: Oracle incident Jan 12 - related to Coingecko slow responses

### DIFF
--- a/mercata/services/oracle/src/cronScheduler.ts
+++ b/mercata/services/oracle/src/cronScheduler.ts
@@ -69,19 +69,30 @@ async function processAllFeeds(configLoader: ConfigLoader): Promise<void> {
     const startTime = Date.now();
     let timedOut = false;
 
+    // Create a timeout promise that resolves after timeoutMs
+    const timeoutPromise = new Promise<void>((resolve) =>
+        setTimeout(() => {
+            timedOut = true;
+            resolve();
+        }, timeoutMs)
+    );
+
+    // Collect results as each promise completes, racing against the timeout
     await Promise.race([
-        (async () => {
-            for (const promise of feedPromises) {
+        Promise.all(
+            feedPromises.map(async (promise) => {
                 try {
                     const result = await promise;
-                    completedFeeds.add(result.feedName);
-                    feedResults.push(result);
+                    if (!timedOut) {
+                        completedFeeds.add(result.feedName);
+                        feedResults.push(result);
+                    }
                 } catch (err) {
                     // Individual feed errors are already handled in the promise
                 }
-            }
-        })(),
-        new Promise((resolve) => setTimeout(() => { timedOut = true; resolve(undefined); }, timeoutMs))
+            })
+        ),
+        timeoutPromise
     ]);
 
     // Log timeout info if it occurred
@@ -206,19 +217,30 @@ async function processBatchFeed(feed: any, configLoader: ConfigLoader): Promise<
     const timeoutMs = 30000;
     let timedOut = false;
 
+    // Create a timeout promise that resolves after timeoutMs
+    const timeoutPromise = new Promise<void>((resolve) =>
+        setTimeout(() => {
+            timedOut = true;
+            resolve();
+        }, timeoutMs)
+    );
+
+    // Collect results as each promise completes, racing against the timeout
     await Promise.race([
-        (async () => {
-            for (const promise of fetchTasks) {
+        Promise.all(
+            fetchTasks.map(async (promise) => {
                 try {
                     const result = await promise;
-                    completedSources.add(result.source);
-                    sourceResults.push(result);
+                    if (!timedOut) {
+                        completedSources.add(result.source);
+                        sourceResults.push(result);
+                    }
                 } catch (err) {
                     // Individual source errors are already handled in fetchTasks
                 }
-            }
-        })(),
-        new Promise((resolve) => setTimeout(() => { timedOut = true; resolve(undefined); }, timeoutMs))
+            })
+        ),
+        timeoutPromise
     ]);
 
     // Log timeout info if it occurred


### PR DESCRIPTION
## Summary
This PR addresses issue #6001.

## Issue
**Oracle incident Jan 12 - related to Coingecko slow responses**

Jan 12 12:45 PM
Coingecko API started responding very slow to the Oracle's API calls (~40 sec which is > than the timeout of 30 sec that we have).
Due to a bug in the oracle, the calls to all 3 price sources in the batch were perceived timed out if any of the calls did not get a response within 30 sec.

The temporary workaround was to exclude the coingecko from the source list on the live oracle servers.
The long-term solution is to fix the logic for the batch source calls.

## Analysis & Fix
```
fix: Restore parallel processing in Oracle while maintaining timeout independence (#6001)

Current Behavior:
The previous fix (f52eedcbcb) resolved the issue where all price sources would
be marked as timed out when any single source exceeded the 30-second timeout.
However, it introduced a performance regression by processing source API calls
sequentially rather than in parallel. The sequential approach used a
'for (const promise of fetchTasks)' loop which awaits each promise one after
another, eliminating the speed and redundancy benefits of parallel source fetching.

Root Cause:
The original buggy code used Promise.race([Promise.allSettled(fetchTasks), timeoutPromise]),
which caused the timeout to win when any source exceeded 30 seconds because
Promise.allSettled() waits for ALL promises to complete before resolving.

The interim fix changed to sequential iteration to avoid this issue, but this
meant that if source A takes 15s and source B takes 15s, the total time is 30s
sequentially instead of 15s in parallel.

Fix Applied:
Replaced the sequential 'for...of' loop with Promise.all() wrapping individual
promise handlers. This approach:
- Launches all source API calls in parallel (restoring performance)
- Each promise independently adds its result to sourceResults when it completes
- The Promise.race with the timeout ensures we stop waiting after 30s
- Any sources that complete before timeout are captured, regardless of whether
  other sources are still pending
- The timedOut flag prevents adding results after the timeout expires

Applied the same parallel pattern to both source-level (30s timeout) and
feed-level (60s timeout) processing for consistency.

Co-Authored-By: Claude <noreply@anthropic.com>
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
