### PR TITLE
Fix #5996: Privacy implementation

### DIFF
--- a/strato/core/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
+++ b/strato/core/strato-sequencer/test/Blockchain/Sequencer/SequencerSpec.hs
@@ -50,7 +50,6 @@ import           Blockchain.Data.RLP
 import           Blockchain.Data.Transaction         (createChainMessageTX)
 import           Blockchain.Data.TransactionDef
 import qualified Blockchain.Data.TXOrigin as TO
-import           Blockchain.Privacy.Monad
 import           Blockchain.Sequencer
 import           Blockchain.Sequencer.CablePackage
 import           Blockchain.Sequencer.ChainHelpers
@@ -153,7 +152,6 @@ withTemporaryDepBlockDB genesisBlock m = do
         boot = do
           bootstrapGenesisBlock hsh difficulty
           A.insert (A.Proxy @X509CertInfoState) myAddr $ cmpsToXcis myAddr myCM
-          A.insert (A.Proxy @EmittedBlock) hsh alreadyEmittedBlock
     runNoLoggingT (runSequencerM cfg ctx (boot >> m))
       `finally`
       (removeDirectoryRecursive fullPath >> setCurrentDirectory cwd)-- always clean up


### PR DESCRIPTION
## Summary
This PR addresses issue #5996.

## Issue
**Privacy implementation**



## Analysis & Fix
```
fix: Remove stale privacy module references from test file (#5996)

Current Behavior:
The sequencer test file (SequencerSpec.hs) contains an import statement for
"Blockchain.Privacy.Monad" and uses types (EmittedBlock, alreadyEmittedBlock)
from that module. These references exist even though the privacy module was
completely removed from the codebase in commit 242e85cc6a.

Root Cause:
When the privacy module and its related files were removed in October 2024
(commit 242e85cc6a), the cleanup was incomplete. The sequencer test file was
not updated to remove the privacy import and usage. This went unnoticed
because the tests are currently disabled (commented out in package.yaml at
line 100), so the broken import never caused a compilation failure. The test
file at line 53 still imports "Blockchain.Privacy.Monad", and line 156 still
attempts to insert an EmittedBlock instance that no longer exists in the
codebase.

Fix Applied:
Removed the import statement for Blockchain.Privacy.Monad (line 53) and
removed the code that inserts the EmittedBlock instance (line 156). This
completes the privacy module removal cleanup. When/if these tests are
re-enabled in the future, they will no longer reference the non-existent
privacy module. The test functionality remains intact as the EmittedBlock
registration was part of the removed privacy feature and is not needed for
the core test scenarios.

Co-Authored-By: Claude <noreply@anthropic.com>
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
