### PR TITLE
Fix #5989:  Redesign Activity Page UI/Flow

### DIFF
--- a/mercata/ui/src/components/dashboard/ActivityFeedList.tsx
+++ b/mercata/ui/src/components/dashboard/ActivityFeedList.tsx
@@ -34,7 +34,12 @@ import { activityFeedApi } from "@/lib/activityFeed";
 import type { Event } from "@mercata/shared-types";
 import { useUser } from "@/context/UserContext";
 
-const ActivityFeedList = () => {
+interface ActivityFeedListProps {
+  myActivityOnly?: boolean;
+  userAddress?: string | null;
+}
+
+const ActivityFeedList = ({ myActivityOnly = false, userAddress: propUserAddress }: ActivityFeedListProps = {}) => {
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
@@ -43,7 +48,8 @@ const ActivityFeedList = () => {
   const [totalEvents, setTotalEvents] = useState(0);
   const [filters, setFilters] = useState<FilterOptions>({});
   const itemsPerPage = 10;
-  const { isLoggedIn, userAddress, isAdmin } = useUser();
+  const { isLoggedIn, userAddress: contextUserAddress, isAdmin } = useUser();
+  const userAddress = propUserAddress || contextUserAddress;
 
   const [filterOptions, setFilterOptions] = useState<{ 
     contractNames: string[]; 
@@ -99,7 +105,7 @@ const ActivityFeedList = () => {
       if (!isLoggedIn) {
         return;
       }
-      
+
       setLoading(true);
       try {
         const offset = (currentPage - 1) * itemsPerPage;
@@ -110,13 +116,18 @@ const ActivityFeedList = () => {
           event_name: filters.event_name ? `eq.${filters.event_name}` : undefined,
           transaction_sender: filters.transaction_sender ? `eq.${filters.transaction_sender}` : undefined
         };
-        
+
+        // If myActivityOnly is true, automatically filter by user address
+        if (myActivityOnly && userAddress) {
+          apiFilters.transaction_sender = `eq.${userAddress}`;
+        }
+
         const response = await activityFeedApi.getEvents({
           offset: offset,
           limit: itemsPerPage,
           ...apiFilters
         });
-        
+
         setEvents(response.events || []);
         setTotalEvents(response.total || 0);
         setTotalPages(Math.ceil((response.total || 0) / itemsPerPage));
@@ -134,7 +145,7 @@ const ActivityFeedList = () => {
     }, 300); // 300ms delay
 
     return () => clearTimeout(timeoutId);
-  }, [currentPage, isLoggedIn, filters]);
+  }, [currentPage, isLoggedIn, filters, myActivityOnly, userAddress]);
 
   // Memoized utility functions to prevent unnecessary re-renders
   const formatAddress = useCallback((address: string | null) => {
@@ -195,7 +206,7 @@ const ActivityFeedList = () => {
   const downloadCSV = useCallback(async () => {
     try {
       setLoading(true);
-      
+
       // Get all events without pagination
       const apiFilters = {
         ...filters,
@@ -203,7 +214,12 @@ const ActivityFeedList = () => {
         event_name: filters.event_name ? `eq.${filters.event_name}` : undefined,
         transaction_sender: filters.transaction_sender ? `eq.${filters.transaction_sender}` : undefined
       };
-      
+
+      // If myActivityOnly is true, automatically filter by user address
+      if (myActivityOnly && userAddress) {
+        apiFilters.transaction_sender = `eq.${userAddress}`;
+      }
+
       const response = await activityFeedApi.getEvents({
         limit: totalEvents || 10000, // Get all events or a large number
         offset: 0,
@@ -285,7 +301,7 @@ const ActivityFeedList = () => {
     } finally {
       setLoading(false);
     }
-  }, [filters, totalEvents, formatTimestamp, formatValue]);
+  }, [filters, totalEvents, formatTimestamp, formatValue, myActivityOnly, userAddress]);
 
   // Memoized computed values to prevent unnecessary recalculations
   const paginationInfo = useMemo(() => {
@@ -443,12 +459,12 @@ const ActivityFeedList = () => {
 
   return (
     <div>
-      <ActivityFeedFilters 
+      <ActivityFeedFilters
         filters={filters}
         onFiltersChange={handleFiltersChange}
         contractNames={filterOptions.contractNames}
         eventNames={filterOptions.eventNames}
-        userAddress={userAddress}
+        userAddress={myActivityOnly ? null : userAddress}
       />
       
       {error && (

--- a/mercata/ui/src/pages/ActivityFeed.tsx
+++ b/mercata/ui/src/pages/ActivityFeed.tsx
@@ -4,25 +4,45 @@ import DashboardHeader from "../components/dashboard/DashboardHeader";
 import MobileSidebar from "../components/dashboard/MobileSidebar";
 import ActivityFeedList from "../components/dashboard/ActivityFeedList";
 import { Activity } from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useSearchParams } from "react-router-dom";
+import { useUser } from "@/context/UserContext";
 
 const ActivityFeed = () => {
+  const [searchParams] = useSearchParams();
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
+  const { userAddress } = useUser();
+
+  const [activeTab, setActiveTab] = useState<"activity" | "my-activity">(() => {
+    const tabParam = searchParams.get("tab");
+    if (tabParam === "my-activity") {
+      return tabParam;
+    }
+    return "activity";
+  });
 
   useEffect(() => {
     document.title = "Activity Feed | STRATO";
   }, []);
 
+  useEffect(() => {
+    const tabParam = searchParams.get("tab");
+    if (tabParam === "activity" || tabParam === "my-activity") {
+      setActiveTab(tabParam);
+    }
+  }, [searchParams]);
+
   return (
     <div className="min-h-screen bg-background">
       <DashboardSidebar />
-      <MobileSidebar 
-        isOpen={isMobileSidebarOpen} 
-        onClose={() => setIsMobileSidebarOpen(false)} 
+      <MobileSidebar
+        isOpen={isMobileSidebarOpen}
+        onClose={() => setIsMobileSidebarOpen(false)}
       />
 
       <div className="transition-all duration-300 md:pl-64" style={{ paddingLeft: 'var(--sidebar-width, 0rem)' }}>
-        <DashboardHeader 
-          title="Activity Feed" 
+        <DashboardHeader
+          title="Activity Feed"
           onMenuClick={() => setIsMobileSidebarOpen(true)}
         />
 
@@ -37,7 +57,24 @@ const ActivityFeed = () => {
             </p>
           </div>
 
-          <ActivityFeedList />
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => setActiveTab(value as "activity" | "my-activity")}
+            className="w-full"
+          >
+            <TabsList className="grid w-full grid-cols-2 mb-6">
+              <TabsTrigger value="activity">Activity</TabsTrigger>
+              <TabsTrigger value="my-activity">My Activity</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="activity">
+              <ActivityFeedList />
+            </TabsContent>
+
+            <TabsContent value="my-activity">
+              <ActivityFeedList myActivityOnly={true} userAddress={userAddress} />
+            </TabsContent>
+          </Tabs>
         </main>
       </div>
     </div>


### PR DESCRIPTION
## Summary
This PR addresses issue #5989.

## Issue
** Redesign Activity Page UI/Flow**

1. Activity Page – UI & Flow Update

- Redesign the Activity page UI based on the new Lovable design.
- Create a new UI and flow for:
                    Activity Tab
                    My Activity Tab


https://stratomer-clone-dash.lovable.app/

## Analysis & Fix
```
feat: Redesign Activity Page UI with Activity and My Activity tabs (#5989)

Current Behavior:
The Activity page displayed all blockchain events in a single view without
any separation between global activity and user-specific activity. Users
had to manually use the "My Transactions" filter button to see only their
own transactions. This created a poor user experience as it required an
extra step and was not immediately obvious to users.

Root Cause:
The original implementation lacked a tabbed interface to separate different
activity views. The ActivityFeed.tsx component rendered a single
ActivityFeedList without any navigation options. The ActivityFeedList.tsx
component did not accept props to control its filtering behavior, making it
difficult to create different pre-filtered views. The UI design followed an
older pattern that did not align with the Lovable design specifications
referenced in the issue.

Fix Applied:
1. ActivityFeed.tsx redesign:
   - Added Tabs component from shadcn/ui to create a two-tab interface
   - Implemented "Activity" tab showing all blockchain events
   - Implemented "My Activity" tab showing only user's transactions
   - Added URL search params support (?tab=activity or ?tab=my-activity)
   - Integrated useSearchParams hook for tab state management
   - Used useUser context to access current user address

2. ActivityFeedList.tsx enhancements:
   - Added ActivityFeedListProps interface with myActivityOnly and userAddress props
   - Modified component to accept optional props for filtered view control
   - Implemented automatic transaction_sender filter when myActivityOnly is true
   - Updated fetchEvents useEffect to apply myActivityOnly filter to API calls
   - Enhanced downloadCSV function to respect myActivityOnly filter
   - Updated dependency arrays to include new props (myActivityOnly, userAddress)
   - Modified ActivityFeedFilters integration to hide "My Transactions" button
     in My Activity tab (since it's redundant when already filtered)

This implementation follows the pattern established in the Rewards page
(Rewards.tsx) which uses a similar tabbed interface for "Activities",
"My Rewards", and "Leaderboard" tabs. The design provides a cleaner,
more intuitive user experience aligned with the Lovable design system.

Co-Authored-By: Claude <noreply@anthropic.com>
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
