### PR TITLE
Fix #5986: Make CDP mint more prominent

### DIFF
--- a/mercata/ui/src/pages/Advanced.tsx
+++ b/mercata/ui/src/pages/Advanced.tsx
@@ -48,7 +48,8 @@ const Advanced = () => {
               <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "lending" | "swap" | "liquidations" | "safety" | "mint")} className="w-full">
                 <TabsList className="grid w-full grid-cols-5 mb-4">
                   <TabsTrigger value="mint" className="text-sm sm:text-base">
-                    Mint
+                    <span className="hidden sm:inline">Mint USDST</span>
+                    <span className="sm:hidden">Mint</span>
                   </TabsTrigger>
                   <TabsTrigger value="lending" className="text-sm sm:text-base">
                     <span className="hidden sm:inline">Lending Pools</span>


### PR DESCRIPTION
## Summary
This PR addresses issue #5986.

## Issue
**Make CDP mint more prominent**



## Analysis & Fix
```
fix: Make CDP mint tab more prominent and descriptive (#5986)

Current Behavior:
The "Mint" tab in the Advanced page displays only the word "Mint" as its label,
which is unclear and not descriptive. While other tabs in the same tab bar have
descriptive labels like "Lending Pools", "Swap Pools", and "Safety Module", the
Mint tab shows the same short "Mint" text on both desktop and mobile views. This
makes it less prominent and harder for users to understand that this tab is for
minting USDST stablecoin via Collateralized Debt Positions (CDP).

Root Cause:
The TabsTrigger component for the "mint" tab (Advanced.tsx:50-52) only contained
plain text "Mint" without responsive spans, unlike the other tabs which use a
pattern of showing descriptive text on desktop (e.g., "Lending Pools") and
shorter text on mobile (e.g., "Lending"). This inconsistency made the Mint tab
less clear about its purpose and less visually prominent compared to other tabs.

Fix Applied:
Updated the "Mint" tab label to follow the same responsive pattern as other tabs:
- Desktop (sm and above): Shows "Mint USDST" to clearly indicate the purpose
- Mobile: Shows "Mint" to maintain compact display
This change makes the tab label more descriptive and prominent, helping users
understand that this is where they can mint USDST stablecoin against collateral,
while maintaining consistency with other tab labels in the interface.

Co-Authored-By: Claude <noreply@anthropic.com>
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
