### PR TITLE
Fix #4810: Breached passwords are allowed for account creation (reported by Crypto Tarzan)

### DIFF
--- a/strato/vault/server/package.yaml
+++ b/strato/vault/server/package.yaml
@@ -25,12 +25,14 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
+    - base16-bytestring
     - blockapps-vault-wrapper-api
     - bytestring
     - cache
     - common-log
     - cryptonite
     - http-client
+    - http-types
     - lens
     - mtl
     - opaleye

--- a/strato/vault/server/src/Strato/Strato23/Server/BreachedPassword.hs
+++ b/strato/vault/server/src/Strato/Strato23/Server/BreachedPassword.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Strato.Strato23.Server.BreachedPassword
+  ( isPasswordBreached,
+  )
+where
+
+import qualified Crypto.Hash.SHA1 as SHA1
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8 as BC8
+import qualified Data.ByteString.Lazy as LB
+import Data.Char (toUpper)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Text.Encoding (encodeUtf8)
+import Network.HTTP.Client
+import Network.HTTP.Types.Status (statusCode)
+
+-- | Check if a password has been breached using the HaveIBeenPwned API
+-- Uses k-anonymity to avoid sending the full password hash to the API
+-- Returns True if the password has been found in breaches, False otherwise
+isPasswordBreached :: Manager -> Text -> IO Bool
+isPasswordBreached manager password = do
+  let passwordBytes = encodeUtf8 password
+      passwordHash = SHA1.hash passwordBytes
+      hashHex = BC8.map toUpper $ B16.encode passwordHash
+      (prefix, suffix) = BS.splitAt 5 hashHex
+
+  -- Construct the API request
+  -- The API uses k-anonymity: we only send the first 5 chars of the hash
+  let url = "https://api.pwnedpasswords.com/range/" ++ BC8.unpack prefix
+  request <- parseRequest url
+  let requestWithHeaders = request
+        { method = "GET"
+        , requestHeaders = [("User-Agent", "STRATO-Vault-Wrapper")]
+        }
+
+  -- Make the request and check the response
+  response <- httpLbs requestWithHeaders manager
+
+  if statusCode (responseStatus response) == 200
+    then do
+      let responseBody = LB.toStrict $ responseBody response
+          matches = checkHashInResponse suffix responseBody
+      return matches
+    else
+      -- If the API is unavailable, we fail open (allow the password)
+      -- This prevents the service from breaking if the API is down
+      return False
+
+-- | Check if our hash suffix appears in the API response
+checkHashInResponse :: ByteString -> ByteString -> Bool
+checkHashInResponse suffix responseBody =
+  let lines' = BC8.lines responseBody
+      -- Each line is formatted as "HASHSUFFIX:COUNT"
+      -- We need to check if our suffix matches any of them
+      matchesLine line =
+        case BC8.split ':' line of
+          (hashSuffix:_) -> hashSuffix == suffix
+          _ -> False
+   in any matchesLine lines'

--- a/strato/vault/server/src/Strato/Strato23/Server/Password.hs
+++ b/strato/vault/server/src/Strato/Strato23/Server/Password.hs
@@ -4,6 +4,7 @@
 
 module Strato.Strato23.Server.Password where
 
+import Control.Monad (when)
 import Control.Monad.IO.Class
 import Control.Monad.Reader
 import qualified Crypto.KDF.Scrypt as Scrypt
@@ -18,6 +19,7 @@ import Database.PostgreSQL.Simple (Connection)
 import Strato.Strato23.Crypto
 import Strato.Strato23.Database.Queries
 import Strato.Strato23.Monad
+import Strato.Strato23.Server.BreachedPassword
 
 superSecretVaultWrapperMessage :: ByteString
 superSecretVaultWrapperMessage =
@@ -51,6 +53,12 @@ setPassword pw conn = do
 
 postPassword :: Text -> VaultM ()
 postPassword password = do
+  -- Check if password has been breached before proceeding
+  manager <- asks httpManager
+  isBreached <- liftIO $ isPasswordBreached manager password
+  when isBreached $
+    vaultWrapperError $ UserError "Password has been found in known data breaches and cannot be used. Please choose a different password."
+
   existingKey <- asks superSecretKey
   doIAlreadyHaveAKey <- liftIO $ readIORef existingKey
 


### PR DESCRIPTION
## Summary
This PR addresses issue #4810.

## Issue
**Breached passwords are allowed for account creation (reported by Crypto Tarzan)**

**FOR SHIBA TARZAN ❤️**

Passwords like "Passw0rd" should not be valid as they are part of breaches data. We would recommend to use api services such has pwndApi, which is highly secure, to verify compromise passwords and reject them.

## Analysis & Fix
```
fix: Reject breached passwords during account creation (#4810)

Current Behavior:
The vault-wrapper password endpoint accepts any password without validating
whether it has been exposed in known data breaches. This allows users to set
weak, commonly-compromised passwords like "Passw0rd" that are trivially
guessable and pose a significant security risk. The postPassword function in
Password.hs only checks if a password is already set, but performs no strength
or breach validation before accepting and storing the password.

Root Cause:
The postPassword function (strato/vault/server/src/Strato/Strato23/Server/Password.hs:53)
immediately proceeds to encrypt and store any provided password without any
validation checks. There is no password policy enforcement, no complexity
requirements, and crucially, no check against known breach databases. This
means the system happily accepts passwords that have appeared in millions of
breached records and are available in common password cracking dictionaries.

Fix Applied:
Implemented breach detection using the HaveIBeenPwned (Pwned Passwords) API
with k-anonymity to protect user privacy. The solution includes:

1. Created BreachedPassword.hs module that:
   - Hashes passwords using SHA1 (as required by the HIBP API)
   - Uses k-anonymity by only sending the first 5 characters of the hash
   - Queries the pwnedpasswords.com API to check if the hash suffix appears
   - Fails open (allows password) if the API is unavailable to prevent service disruption

2. Modified Password.hs to:
   - Call isPasswordBreached before accepting any new password
   - Return a clear error message if the password has been breached
   - Use the existing httpManager from VaultWrapperEnv for API requests

3. Updated package.yaml dependencies to include:
   - base16-bytestring for hex encoding
   - http-types for HTTP status handling

The k-anonymity approach ensures that the actual password is never sent over
the network - only the first 5 hex characters of its SHA1 hash are transmitted,
and we locally check if the remaining hash suffix appears in the response.

Co-Authored-By: Claude <noreply@anthropic.com>
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
