### PR TITLE
Fix #6003: Add support for PKCE in OAuth implementation

### DIFF
--- a/highway-nginx/openid.tpl.lua
+++ b/highway-nginx/openid.tpl.lua
@@ -49,7 +49,8 @@ local authenticate_opts = {
   logout_path = "/auth/logout",
   post_logout_redirect_uri = node_host_with_protocol,
   -- redirect_after_logout_uri = "/", -- URI to redirect after app and oauth provider logouts, otherwise show "Logged Out" text message on logout_path URI
-  revoke_tokens_on_logout = true
+  revoke_tokens_on_logout = true,
+  use_pkce = true
 }
 
 -- If it is a direct call to APIs (with access_token provided as Bearer token in Authorization header)

--- a/hoogle-nginx/openid.tpl.lua
+++ b/hoogle-nginx/openid.tpl.lua
@@ -129,7 +129,7 @@ authorization_params = { hd="blockapps.net" },
 --   return req
 -- end,
 
--- use_pkce = false,
+use_pkce = true,
 -- when set to true the "Proof Key for Code Exchange" as
 -- defined in RFC 7636 will be used. The code challenge
 -- method will alwas be S256

--- a/mercata/nginx/openid.tpl.lua
+++ b/mercata/nginx/openid.tpl.lua
@@ -34,6 +34,7 @@ local authenticate_opts = {
   post_logout_redirect_uri = node_host_with_protocol,
   -- redirect_after_logout_uri = "/", -- URI to redirect after app and oauth provider logouts, otherwise show "Logged Out" text message on logout_path URI
   revoke_tokens_on_logout = true,
+  use_pkce = true,
   authorization_params = auth_params
 }
 


### PR DESCRIPTION
## Summary
This PR addresses issue #6003.

## Issue
**Add support for PKCE in OAuth implementation**

Add the additional security by using the Proof Key for Code Exchange (PKCE) code challenge (following the RFC 7636) for the browser-based authentication in STRATO.

For details see: https://oauth.net/2/pkce/

It is also a requirement for OAuth support in MCP specification - see https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-code-protection

## Analysis & Fix
```
fix: Add PKCE support to OAuth browser-based authentication (#6003)

Files Changed:
- mercata/nginx/openid.tpl.lua: Added use_pkce = true to authenticate_opts
- highway-nginx/openid.tpl.lua: Added use_pkce = true to authenticate_opts
- hoogle-nginx/openid.tpl.lua: Uncommented and enabled use_pkce = true

Current Behavior:
The OAuth implementation in STRATO uses the Authorization Code flow for
browser-based authentication via the lua-resty-openidc library in nginx.
However, PKCE (Proof Key for Code Exchange) was not enabled, even though
the underlying library supports it.

Without PKCE, the authorization code flow is vulnerable to authorization
code interception attacks, particularly in public clients (browsers) where
the client secret cannot be safely stored. The authorization code can be
intercepted and exchanged for tokens by a malicious actor.

Root Cause:
The nginx OpenID Connect configurations use lua-resty-openidc library which
supports PKCE via the use_pkce configuration option. However, this option
was either:
1. Not set (defaulting to false) in mercata/nginx and highway-nginx
2. Explicitly commented out in hoogle-nginx/openid.tpl.lua

The nginx-packager/openid.tpl.lua already had use_pkce = true enabled
(line 37), but this was not consistently applied across all nginx
configurations that handle browser-based authentication.

The mercata service nginx configs (bridge, referral) only verify bearer
tokens and don't perform authorization code flow, so they don't need PKCE.
The vault-nginx similarly only validates bearer tokens and doesn't need PKCE.

Fix Applied:
Enabled PKCE in all nginx configurations that handle browser-based OAuth
authorization code flow by adding use_pkce = true to the authenticate_opts
table.

When use_pkce = true is set, lua-resty-openidc automatically:
1. Generates a cryptographically random code_verifier (43-128 characters)
2. Creates a code_challenge using S256 method (SHA-256 hash of verifier)
3. Includes code_challenge and code_challenge_method=S256 in authorization request
4. Stores code_verifier in server-side session
5. Sends code_verifier in token exchange request
6. OAuth server validates that SHA256(code_verifier) matches code_challenge

This follows RFC 7636 and the MCP specification requirement for OAuth
authorization code protection.

Impact Analysis:
- Affects: All browser-based authentication flows in STRATO UI (Mercata,
  SMD, Highway, Hoogle)
- Risk: Low - PKCE is backward compatible. OAuth providers that support
  PKCE will use it; providers that don't will ignore the parameters.
  Keycloak (the primary OAuth provider) has supported PKCE since version 7.0.
- Security Improvement: Protects against authorization code interception
  attacks, which is especially important for SPAs and public clients
- No code changes required in backend services - they continue to validate
  tokens as before
- Related: nginx-packager/openid.tpl.lua already has this enabled and
  serves as the reference implementation

Testing Recommendations:
- Test browser-based login flow for Mercata UI
- Test browser-based login flow for SMD UI
- Test browser-based login flow for Highway UI
- Test browser-based login flow for Hoogle UI
- Verify that session management continues to work correctly
- Verify that token refresh continues to work correctly
- Test with both Keycloak and other OAuth providers if applicable
- Verify that existing sessions are not invalidated (PKCE is only used for
  new authorization flows)

Technical Details:
The lua-resty-openidc library (used in all these configs) implements PKCE
according to RFC 7636. When use_pkce = true:
- code_challenge_method is always S256 (SHA-256)
- code_verifier is generated per RFC 7636 (43-128 unreserved characters)
- code_verifier is stored in server-side session (not exposed to browser)
- Protection works even if client_secret is compromised

Confidence Level: High
- Root cause clearly identified - PKCE option was simply not enabled
- Solution follows existing pattern already in nginx-packager/openid.tpl.lua
- PKCE is a standard OAuth extension (RFC 7636) with wide support
- lua-resty-openidc library has built-in PKCE support that just needs enabling
- Changes are minimal and non-breaking (backward compatible)
- All authentication flows continue to work as before, but with added security

Co-Authored-By: Claude <noreply@anthropic.com>
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
