### PR TITLE
Claude Fix #5956: Change tx result polling approach in the Bridge

### DIFF
--- a/mercata/services/bridge/src/utils/stratoHelper.ts
+++ b/mercata/services/bridge/src/utils/stratoHelper.ts
@@ -46,6 +46,36 @@ export const until = async <T>(
 };
 
 /**
+ * Evaluate immediate status from resolve=true response
+ * Returns TxResponse if definitive result, undefined if polling needed
+ */
+const getImmediateResult = (
+  response: any[],
+): TxResponse | undefined => {
+  const first = response[0];
+  const status = first?.status;
+
+  switch (status) {
+    case "Success":
+      return { status: "Success", hash: first.hash };
+    case "Failed":
+    case "Failure": {
+      const msg =
+        first.txResult?.message ||
+        first.error ||
+        first.message ||
+        "Transaction failed";
+      throw new Error(extractErrorMessage(msg));
+    }
+    case "Pending":
+    case undefined:
+    default:
+      // Pending, undefined, or unknown status: fall back to polling
+      return undefined;
+  }
+};
+
+/**
  * Post transaction and wait for completion
  */
 export const postAndWaitForTx = async (
@@ -63,7 +93,13 @@ export const postAndWaitForTx = async (
     return r.hash;
   });
 
-  // Poll for results
+  // Check for immediate result from resolve=true
+  const immediate = getImmediateResult(response);
+  if (immediate) {
+    return immediate;
+  }
+
+  // Fallback to polling for results
   const results = await until(
     (res: TxResult[]) => {
       const failed = res.find((r) => r?.status === "Failure");


### PR DESCRIPTION
## Summary

Auto-generated fix for issue #5956

**Files changed:** `mercata/services/bridge/src/utils/stratoHelper.ts`

**Root cause:** The Bridge and Backend transaction helpers (postAndWaitForTx) always poll for transaction results, even when using ?resolve=true which can return immediate results. They extract the transaction hash from the response and immediately start polling /transactions/results, ignoring any status already present in the initial response. The Oracle service has already implemented the improved pattern: check the immediate response status first, and only fall back to polling if the status is Pending or undefined.

**Caveats:**
- Only first transaction result is checked for immediate status (consistent with existing behavior for single tx)
- Error handling for Failed/Failure matches the Oracle's pattern

**Testing notes:**
- Test bridge transactions that complete quickly - should return immediately without polling
- Test bridge transactions that take > 10sec - should fallback to polling correctly
- Test failed transactions - should throw with appropriate error message

**Confidence:** 91%

## Confidence Breakdown

{
  "triage": 0.9,
  "research": 0.95,
  "fix": 0.92,
  "review": 0.88
}

## Test Plan

- [ ] Review the changes
- [ ] Run tests
- [ ] Verify fix addresses the issue

---
*Generated by [STRATO Fix All The Things](https://github.com/strato-net/strato-fix-all-the-things)*