### PR TITLE
Allow Borrow button clickable when HF slider makes the large borrow amount possible

### DIFF
--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -452,6 +452,15 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     return safeParseUnits(borrowAmount || "0", 18) > BigInt(maxAmount);
   }, [borrowAmount, maxAmount]);
 
+  // We handle borrowAmountExceedsMax separately, since it updates on HF slider
+  const setBorrowAmountErrorIgnoringMax = (value: string) => {
+    if (value === "Maximum amount exceeded") {
+      setBorrowAmountError("");
+      return;
+    }
+    setBorrowAmountError(value);
+  };
+
   return (
     <div className="space-y-4 pt-4">
       {/* Header: Borrow USDST */}
@@ -478,7 +487,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
               value={addCommasToInput(borrowAmount)}
               onChange={(e) => {
                 const value = e.target.value;
-                handleAmountInputChange(value, setBorrowAmount, setBorrowAmountError, maxAmount);
+                handleAmountInputChange(value, setBorrowAmount, setBorrowAmountErrorIgnoringMax, maxAmount);
                 handlePollingUpdate(value);
               }}
             />
@@ -499,6 +508,9 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
             MAX
           </Button>
         </div>
+        {borrowAmountError && (
+          <p className="text-red-600 text-sm">{borrowAmountError}</p>
+        )}
       </div>
 
       {/* Health Factor Slider */}


### PR DESCRIPTION
Fixes  #6074

Allow the flow where user enters amount in excess of available to borrow at the current health factor slider value, then slides to the right, making the borrow possible. (Before, this led to the Borrow button remaining grayed out.) Show "Invalid input format" and "Maximum decimal places allowed" and "Amount must be greater than 0" borrow amount input format errors.