### PR TITLE
Fix Swap Pool Liquidity Deposit MAX buttons

### DIFF
--- a/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
@@ -273,10 +273,10 @@ const LiquidityDepositModal = ({
       const bToARatioWei = safeParseUnits(selectedPool.bToARatio, 18);
       
       // Calculate what Token A amount would be needed for full Token B balance
-      const tokenAAmountForFullB = (availableTokenB * aToBRatioWei) / BigInt(10 ** 18);
+      const tokenAAmountForFullB = (availableTokenB * bToARatioWei) / BigInt(10 ** 18);
       
       // Calculate what Token B amount would be needed for full Token A balance  
-      const tokenBAmountForFullA = (availableTokenA * bToARatioWei) / BigInt(10 ** 18);
+      const tokenBAmountForFullA = (availableTokenA * aToBRatioWei) / BigInt(10 ** 18);
       
       let finalTokenAAmount: bigint;
       let finalTokenBAmount: bigint;


### PR DESCRIPTION
Fix Swap Pool Liquidity Deposit MAX buttons by using the correct ratio rather than its reciprocal.

Fixes #6075