### PR TITLE
Swap pool deposit amounts don't pollute modal for other swap pools

### DIFF
--- a/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
+++ b/mercata/ui/src/components/dashboard/LiquidityDepositModal.tsx
@@ -103,7 +103,7 @@ const LiquidityDepositModal = ({
   const handleClose = () => {
     setToken1Amount('');
     setToken2Amount('');
-    setDepositMode('A');
+    setDepositMode('A&B');
     setStakeLPToken(rewardsEnabled); // Reset to default based on rewardsEnabled
     onClose();
   };
@@ -408,7 +408,7 @@ const LiquidityDepositModal = ({
 
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Deposit Liquidity</DialogTitle>


### PR DESCRIPTION
Switching between swap pool liquidity deposit modals for different swap pools clears the amount fields.

Fixes #6077 