### PR TITLE
Price History chart for LP Tokens

### DIFF
--- a/mercata/backend/src/api/services/oracle.service.ts
+++ b/mercata/backend/src/api/services/oracle.service.ts
@@ -6,12 +6,60 @@ import { extractContractName } from "../../utils/utils";
 import { getPool } from "./lending.service";
 import { PriceHistoryEntry, PriceHistoryResponse, OraclePriceEntry, OraclePriceMap } from "@mercata/shared-types";
 import { toUTCTime } from "../helpers/cirrusHelpers";
+import { calculateLPTokenPrice } from "../helpers/swapping.helper";
+import { getHistory, StorageHistoryElement } from "../helpers/history.helper";
 
 const {
   PriceOracle,
   PriceOracleEvents,
   PriceOracleBatchUpdateEvents,
+  Pool,
 } = constants;
+
+/**
+ * Check if an address is an LP token by querying the PoolFactory's allPools array
+ * @param accessToken - User access token
+ * @param lpTokenAddress - Address to check
+ * @returns Pool info if it's an LP token, null otherwise
+ */
+const findPoolByLPToken = async (
+  accessToken: string,
+  lpTokenAddress: string
+): Promise<{ address: string; tokenA: string; tokenB: string } | null> => {
+  // Query the PoolFactory's allPools array
+  const { data: allPoolsData } = await cirrus.get(accessToken, `/${constants.PoolFactory}-allPools`, {
+    params: {
+      address: `eq.${constants.poolFactory}`,
+      select: "value"
+    }
+  }).catch(() => ({ data: [] }));
+
+  // Get pool addresses from the allPools array
+  const poolAddresses = allPoolsData ? allPoolsData.map((entry: any) => entry.value) : [];
+
+  if (poolAddresses.length === 0) {
+    return null;
+  }
+
+  // Query pools registered in this factory to find one with matching lpToken
+  const { data: poolsData } = await cirrus.get(accessToken, `/${Pool}`, {
+    params: {
+      address: `in.(${poolAddresses.join(',')})`,
+      lpToken: `eq.${lpTokenAddress}`,
+      select: "address,tokenA,tokenB"
+    }
+  }).catch(() => ({ data: [] }));
+
+  if (poolsData && poolsData.length > 0) {
+    return {
+      address: poolsData[0].address,
+      tokenA: poolsData[0].tokenA,
+      tokenB: poolsData[0].tokenB
+    };
+  }
+
+  return null;
+};
 
 export const getOraclePrices = async (
   accessToken: string,
@@ -82,12 +130,7 @@ export const setPrice = async (
   }
 };
 
-export const getPriceHistory = async (
-  accessToken: string,
-  assetAddress: string,
-  rawParams: Record<string, string | undefined> = {}
-): Promise<PriceHistoryResponse> => {
-  try {
+const getOracleAddress = async (accessToken: string): Promise<string> => {
     // Get the oracle address from the lending registry
     const registry = await getPool(accessToken, {
       select: "priceOracle",
@@ -97,16 +140,20 @@ export const getPriceHistory = async (
       throw new Error("Price oracle not found");
     }
 
-    const oracleAddress = registry.priceOracle.address || registry.priceOracle;
+    return registry.priceOracle.address || registry.priceOracle;
+};
 
-    // Calculate time range for the last month
-    const oneMonthAgo = new Date();
-    oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
-
+const fetchPriceEvents = async (
+  accessToken: string,
+  oracleAddress: string,
+  assetAddress: string,
+  oneMonthAgo: Date,
+  order: string
+): Promise<PriceHistoryEntry[]> => {
     const params = {
       address: `eq.${oracleAddress}`,
       block_timestamp: `gte.${toUTCTime(oneMonthAgo)}`,
-      order: rawParams.order || "block_timestamp.asc",
+      order,
     };
 
     // --- Query both tables ---
@@ -160,15 +207,13 @@ export const getPriceHistory = async (
       });
     }
 
-    if (priceEvents.length === 0) {
-      console.log(`[getPriceHistory] No data found for ${assetAddress}`);
-      return { data: [], totalCount: 0 };
-    }
+    return priceEvents;
+};
 
-    // Process events and create hourly data points
+const createHourlyPriceMap = (priceEvents: PriceHistoryEntry[]): Map<string, PriceHistoryEntry> => {
     const hourlyPrices = new Map<string, PriceHistoryEntry>();
 
-    priceEvents.forEach((event: any) => {
+    priceEvents.forEach((event) => {
       const blockTimestamp = event.blockTimestamp;
 
       // Create hourly bucket (round down to the hour)
@@ -182,10 +227,25 @@ export const getPriceHistory = async (
       }
     });
 
-    // If no historical data, return empty
+    return hourlyPrices;
+};
+
+const extractHourlyPriceMap = (priceEvents: PriceHistoryEntry[]): Map<string, string> => {
+    const hourlyMap = createHourlyPriceMap(priceEvents);
+    const priceMap = new Map<string, string>();
+    hourlyMap.forEach((entry, hourKey) => {
+      priceMap.set(hourKey, entry.price);
+    });
+    return priceMap;
+};
+
+const forwardFillPriceHistory = (
+  hourlyPrices: Map<string, PriceHistoryEntry>,
+  assetAddress: string
+): PriceHistoryEntry[] => {
     if (hourlyPrices.size === 0) {
       console.log(`[getPriceHistory] No historical oracle data found for ${assetAddress}`);
-      return { data: [], totalCount: 0 };
+      return [];
     }
 
     // Find the earliest and latest actual data points
@@ -226,13 +286,190 @@ export const getPriceHistory = async (
           blockTimestamp: new Date(currentHour)
         });
       }
-      
     }
 
+    return filledPriceHistory;
+};
+
+export const getPriceHistory = async (
+  accessToken: string,
+  assetAddress: string,
+  rawParams: Record<string, string | undefined> = {}
+): Promise<PriceHistoryResponse> => {
+  try {
+    const matchingPool = await findPoolByLPToken(accessToken, assetAddress);
+
+    if (matchingPool) {
+      return getLPTokenPriceHistoryInternal(accessToken, assetAddress, matchingPool, rawParams);
+    }
+
+    const oracleAddress = await getOracleAddress(accessToken);
+
+    // Calculate time range for the last month
+    const oneMonthAgo = new Date();
+    oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+
+    const priceEvents = await fetchPriceEvents(
+      accessToken,
+      oracleAddress,
+      assetAddress,
+      oneMonthAgo,
+      rawParams.order || "block_timestamp.asc"
+    );
+
+    if (priceEvents.length === 0) {
+      console.log(`[getPriceHistory] No data found for ${assetAddress}`);
+      return { data: [], totalCount: 0 };
+    }
+
+    // Process events and create hourly data points
+    const hourlyPrices = createHourlyPriceMap(priceEvents);
+
+    // If no historical data, return empty
+    if (hourlyPrices.size === 0) {
+      console.log(`[getPriceHistory] No historical oracle data found for ${assetAddress}`);
+      return { data: [], totalCount: 0 };
+    }
+
+    const filledPriceHistory = forwardFillPriceHistory(hourlyPrices, assetAddress);
 
     return { data: filledPriceHistory, totalCount: filledPriceHistory.length };
   } catch (error) {
     console.error('Error fetching price history:', error);
     throw new Error('Failed to fetch price history');
+  }
+};
+
+const getLPTokenPriceHistoryInternal = async (
+  accessToken: string,
+  lpTokenAddress: string,
+  pool: { address: string; tokenA: string; tokenB: string },
+  rawParams: Record<string, string | undefined> = {}
+): Promise<PriceHistoryResponse> => {
+  try {
+    const poolAddress = pool.address;
+    const tokenA = pool.tokenA;
+    const tokenB = pool.tokenB;
+
+    const oracleAddress = await getOracleAddress(accessToken);
+    const oneMonthAgo = new Date();
+    oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+    const order = rawParams.order || "block_timestamp.asc";
+
+    const [tokenAPriceEvents, tokenBPriceEvents] = await Promise.all([
+      fetchPriceEvents(accessToken, oracleAddress, tokenA, oneMonthAgo, order),
+      fetchPriceEvents(accessToken, oracleAddress, tokenB, oneMonthAgo, order)
+    ]);
+
+    const tokenAPriceMap = extractHourlyPriceMap(tokenAPriceEvents);
+    const tokenBPriceMap = extractHourlyPriceMap(tokenBPriceEvents);
+
+    const historyParams = {
+      endTimestamp: Date.now(),
+      interval: 1000 * 60 * 60, // 1 hour
+      numTicks: 24 * 30 // 30 days
+    };
+
+    const poolStorageReducer = (data: any, h: StorageHistoryElement): any => {
+      const tokenABalance = h.data?.tokenABalance || data.tokenABalance || "0";
+      const tokenBBalance = h.data?.tokenBBalance || data.tokenBBalance || "0";
+      return {
+        tokenABalance,
+        tokenBBalance,
+        lpTokenTotalSupply: data.lpTokenTotalSupply || "0"
+      };
+    };
+
+    const lpTokenStorageReducer = (data: any, h: StorageHistoryElement): any => {
+      const lpTokenTotalSupply = h.data?._totalSupply || data.lpTokenTotalSupply || "0";
+      return {
+        tokenABalance: data.tokenABalance || "0",
+        tokenBBalance: data.tokenBBalance || "0",
+        lpTokenTotalSupply
+      };
+    };
+
+    const combinedReducer = (data: any, h: StorageHistoryElement): any => {
+      if (h.address.toLowerCase() === poolAddress.toLowerCase()) {
+        return poolStorageReducer(data, h);
+      } else if (h.address.toLowerCase() === lpTokenAddress.toLowerCase()) {
+        return lpTokenStorageReducer(data, h);
+      }
+      return data;
+    };
+
+    const poolHistory = await getHistory(
+      accessToken,
+      historyParams,
+      [`address.eq.${poolAddress}`, `address.eq.${lpTokenAddress}`],
+      [],
+      [],
+      { tokenABalance: "0", tokenBBalance: "0", lpTokenTotalSupply: "0" },
+      combinedReducer,
+      ((s, _) => s),
+      ((s, _) => s)
+    );
+
+    if (poolHistory.length === 0) {
+      console.log(`[getLPTokenPriceHistory] No pool history found for ${poolAddress}`);
+      return { data: [], totalCount: 0 };
+    }
+
+    const hourlyLPPrices = new Map<string, PriceHistoryEntry>();
+    let lastTokenAPrice = "0";
+    let lastTokenBPrice = "0";
+
+    poolHistory.forEach((snapshot) => {
+      const timestamp = new Date(snapshot.timestamp);
+      timestamp.setMinutes(0, 0, 0);
+      const hourKey = timestamp.toISOString();
+
+      const tokenAPrice = tokenAPriceMap.get(hourKey) || lastTokenAPrice;
+      const tokenBPrice = tokenBPriceMap.get(hourKey) || lastTokenBPrice;
+
+      if (tokenAPrice !== "0") lastTokenAPrice = tokenAPrice;
+      if (tokenBPrice !== "0") lastTokenBPrice = tokenBPrice;
+
+      const { tokenABalance, tokenBBalance, lpTokenTotalSupply } = snapshot.data;
+
+      if (!tokenABalance || !tokenBBalance || !lpTokenTotalSupply ||
+          tokenABalance === "0" || tokenBBalance === "0" || lpTokenTotalSupply === "0") {
+        return;
+      }
+
+      if (tokenAPrice === "0" || tokenBPrice === "0") {
+        return;
+      }
+
+      const lpTokenPrice = calculateLPTokenPrice(
+        tokenABalance,
+        tokenBBalance,
+        tokenAPrice,
+        tokenBPrice,
+        lpTokenTotalSupply
+      );
+
+      if (!hourlyLPPrices.has(hourKey) || timestamp > hourlyLPPrices.get(hourKey)!.blockTimestamp) {
+        hourlyLPPrices.set(hourKey, {
+          id: `lp-${timestamp.getTime()}`,
+          timestamp: timestamp,
+          asset: lpTokenAddress,
+          price: lpTokenPrice,
+          blockTimestamp: timestamp
+        });
+      }
+    });
+
+    if (hourlyLPPrices.size === 0) {
+      console.log(`[getLPTokenPriceHistory] No LP token price data found for ${lpTokenAddress}`);
+      return { data: [], totalCount: 0 };
+    }
+
+    const filledPriceHistory = forwardFillPriceHistory(hourlyLPPrices, lpTokenAddress);
+
+    return { data: filledPriceHistory, totalCount: filledPriceHistory.length };
+  } catch (error) {
+    console.error('Error fetching LP token price history:', error);
+    throw new Error('Failed to fetch LP token price history');
   }
 };

--- a/mercata/backend/src/api/services/oracle.service.ts
+++ b/mercata/backend/src/api/services/oracle.service.ts
@@ -295,6 +295,57 @@ const fetchPoolHistory = async (
     );
 };
 
+const calculateHourlyLPPrices = (
+  poolHistory: Array<{ timestamp: number; data: { tokenABalance: string; tokenBBalance: string; lpTokenTotalSupply: string } }>,
+  tokenAPriceMap: Map<string, string>,
+  tokenBPriceMap: Map<string, string>,
+  lpTokenAddress: string
+): Map<string, PriceHistoryEntry> => {
+    const hourlyLPPrices = new Map<string, PriceHistoryEntry>();
+    let lastTokenAPrice = "0";
+    let lastTokenBPrice = "0";
+
+    poolHistory.forEach((snapshot) => {
+      const timestamp = new Date(snapshot.timestamp);
+      timestamp.setMinutes(0, 0, 0);
+      const hourKey = timestamp.toISOString();
+
+      const tokenAPrice = tokenAPriceMap.get(hourKey) || lastTokenAPrice;
+      const tokenBPrice = tokenBPriceMap.get(hourKey) || lastTokenBPrice;
+
+      if (tokenAPrice !== "0") lastTokenAPrice = tokenAPrice;
+      if (tokenBPrice !== "0") lastTokenBPrice = tokenBPrice;
+
+      const { tokenABalance, tokenBBalance, lpTokenTotalSupply } = snapshot.data;
+
+      if (!tokenABalance || !tokenBBalance || !lpTokenTotalSupply ||
+          tokenABalance === "0" || tokenBBalance === "0" || lpTokenTotalSupply === "0" ||
+          tokenAPrice === "0" || tokenBPrice === "0") {
+        return;
+      }
+
+      const lpTokenPrice = calculateLPTokenPrice(
+        tokenABalance,
+        tokenBBalance,
+        tokenAPrice,
+        tokenBPrice,
+        lpTokenTotalSupply
+      );
+
+      if (!hourlyLPPrices.has(hourKey) || timestamp > hourlyLPPrices.get(hourKey)!.blockTimestamp) {
+        hourlyLPPrices.set(hourKey, {
+          id: `lp-${timestamp.getTime()}`,
+          timestamp: timestamp,
+          asset: lpTokenAddress,
+          price: lpTokenPrice,
+          blockTimestamp: timestamp
+        });
+      }
+    });
+
+    return hourlyLPPrices;
+};
+
 const forwardFillPriceHistory = (
   hourlyPrices: Map<string, PriceHistoryEntry>,
   assetAddress: string
@@ -428,50 +479,12 @@ const getLPTokenPriceHistory = async (
       return { data: [], totalCount: 0 };
     }
 
-    const hourlyLPPrices = new Map<string, PriceHistoryEntry>();
-    let lastTokenAPrice = "0";
-    let lastTokenBPrice = "0";
-
-    poolHistory.forEach((snapshot) => {
-      const timestamp = new Date(snapshot.timestamp);
-      timestamp.setMinutes(0, 0, 0);
-      const hourKey = timestamp.toISOString();
-
-      const tokenAPrice = tokenAPriceMap.get(hourKey) || lastTokenAPrice;
-      const tokenBPrice = tokenBPriceMap.get(hourKey) || lastTokenBPrice;
-
-      if (tokenAPrice !== "0") lastTokenAPrice = tokenAPrice;
-      if (tokenBPrice !== "0") lastTokenBPrice = tokenBPrice;
-
-      const { tokenABalance, tokenBBalance, lpTokenTotalSupply } = snapshot.data;
-
-      if (!tokenABalance || !tokenBBalance || !lpTokenTotalSupply ||
-          tokenABalance === "0" || tokenBBalance === "0" || lpTokenTotalSupply === "0") {
-        return;
-      }
-
-      if (tokenAPrice === "0" || tokenBPrice === "0") {
-        return;
-      }
-
-      const lpTokenPrice = calculateLPTokenPrice(
-        tokenABalance,
-        tokenBBalance,
-        tokenAPrice,
-        tokenBPrice,
-        lpTokenTotalSupply
-      );
-
-      if (!hourlyLPPrices.has(hourKey) || timestamp > hourlyLPPrices.get(hourKey)!.blockTimestamp) {
-        hourlyLPPrices.set(hourKey, {
-          id: `lp-${timestamp.getTime()}`,
-          timestamp: timestamp,
-          asset: lpTokenAddress,
-          price: lpTokenPrice,
-          blockTimestamp: timestamp
-        });
-      }
-    });
+    const hourlyLPPrices = calculateHourlyLPPrices(
+      poolHistory,
+      tokenAPriceMap,
+      tokenBPriceMap,
+      lpTokenAddress
+    );
 
     if (hourlyLPPrices.size === 0) {
       console.log(`[getLPTokenPriceHistory] No LP token price data found for ${lpTokenAddress}`);

--- a/mercata/backend/src/api/services/oracle.service.ts
+++ b/mercata/backend/src/api/services/oracle.service.ts
@@ -353,12 +353,13 @@ export const getPriceHistory = async (
   rawParams: Record<string, string | undefined> = {}
 ): Promise<PriceHistoryResponse> => {
   try {
+    // If the asset is an LP token, calculate the price history as net asset value
     const matchingPool = await findPoolByLPToken(accessToken, assetAddress);
-
     if (matchingPool) {
-      return getLPTokenPriceHistoryInternal(accessToken, assetAddress, matchingPool, rawParams);
+      return getLPTokenPriceHistory(accessToken, assetAddress, matchingPool, rawParams);
     }
 
+    // If the asset is not an LP token, just get the oracle price history
     const oracleAddress = await getOracleAddress(accessToken);
 
     // Calculate time range for the last month
@@ -396,7 +397,7 @@ export const getPriceHistory = async (
   }
 };
 
-const getLPTokenPriceHistoryInternal = async (
+const getLPTokenPriceHistory = async (
   accessToken: string,
   lpTokenAddress: string,
   pool: { address: string; tokenA: string; tokenB: string },

--- a/mercata/backend/src/api/services/oracle.service.ts
+++ b/mercata/backend/src/api/services/oracle.service.ts
@@ -239,6 +239,62 @@ const extractHourlyPriceMap = (priceEvents: PriceHistoryEntry[]): Map<string, st
     return priceMap;
 };
 
+const fetchPoolHistory = async (
+  accessToken: string,
+  poolAddress: string,
+  lpTokenAddress: string
+): Promise<Array<{ timestamp: number; data: { tokenABalance: string; tokenBBalance: string; lpTokenTotalSupply: string } }>> => {
+    const oneMonthAgo = new Date();
+    oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+    const oneMonthInHours = 24 * 30;
+
+    const historyParams = {
+      endTimestamp: Date.now(),
+      interval: 1000 * 60 * 60, // 1 hour
+      numTicks: oneMonthInHours
+    };
+
+    const poolStorageReducer = (data: any, h: StorageHistoryElement): any => {
+      const tokenABalance = h.data?.tokenABalance || data.tokenABalance || "0";
+      const tokenBBalance = h.data?.tokenBBalance || data.tokenBBalance || "0";
+      return {
+        tokenABalance,
+        tokenBBalance,
+        lpTokenTotalSupply: data.lpTokenTotalSupply || "0"
+      };
+    };
+
+    const lpTokenStorageReducer = (data: any, h: StorageHistoryElement): any => {
+      const lpTokenTotalSupply = h.data?._totalSupply || data.lpTokenTotalSupply || "0";
+      return {
+        tokenABalance: data.tokenABalance || "0",
+        tokenBBalance: data.tokenBBalance || "0",
+        lpTokenTotalSupply
+      };
+    };
+
+    const combinedReducer = (data: any, h: StorageHistoryElement): any => {
+      if (h.address.toLowerCase() === poolAddress.toLowerCase()) {
+        return poolStorageReducer(data, h);
+      } else if (h.address.toLowerCase() === lpTokenAddress.toLowerCase()) {
+        return lpTokenStorageReducer(data, h);
+      }
+      return data;
+    };
+
+    return await getHistory(
+      accessToken,
+      historyParams,
+      [`address.eq.${poolAddress}`, `address.eq.${lpTokenAddress}`],
+      [],
+      [],
+      { tokenABalance: "0", tokenBBalance: "0", lpTokenTotalSupply: "0" },
+      combinedReducer,
+      ((s, _) => s),
+      ((s, _) => s)
+    );
+};
+
 const forwardFillPriceHistory = (
   hourlyPrices: Map<string, PriceHistoryEntry>,
   assetAddress: string
@@ -364,51 +420,7 @@ const getLPTokenPriceHistoryInternal = async (
     const tokenAPriceMap = extractHourlyPriceMap(tokenAPriceEvents);
     const tokenBPriceMap = extractHourlyPriceMap(tokenBPriceEvents);
 
-    const historyParams = {
-      endTimestamp: Date.now(),
-      interval: 1000 * 60 * 60, // 1 hour
-      numTicks: 24 * 30 // 30 days
-    };
-
-    const poolStorageReducer = (data: any, h: StorageHistoryElement): any => {
-      const tokenABalance = h.data?.tokenABalance || data.tokenABalance || "0";
-      const tokenBBalance = h.data?.tokenBBalance || data.tokenBBalance || "0";
-      return {
-        tokenABalance,
-        tokenBBalance,
-        lpTokenTotalSupply: data.lpTokenTotalSupply || "0"
-      };
-    };
-
-    const lpTokenStorageReducer = (data: any, h: StorageHistoryElement): any => {
-      const lpTokenTotalSupply = h.data?._totalSupply || data.lpTokenTotalSupply || "0";
-      return {
-        tokenABalance: data.tokenABalance || "0",
-        tokenBBalance: data.tokenBBalance || "0",
-        lpTokenTotalSupply
-      };
-    };
-
-    const combinedReducer = (data: any, h: StorageHistoryElement): any => {
-      if (h.address.toLowerCase() === poolAddress.toLowerCase()) {
-        return poolStorageReducer(data, h);
-      } else if (h.address.toLowerCase() === lpTokenAddress.toLowerCase()) {
-        return lpTokenStorageReducer(data, h);
-      }
-      return data;
-    };
-
-    const poolHistory = await getHistory(
-      accessToken,
-      historyParams,
-      [`address.eq.${poolAddress}`, `address.eq.${lpTokenAddress}`],
-      [],
-      [],
-      { tokenABalance: "0", tokenBBalance: "0", lpTokenTotalSupply: "0" },
-      combinedReducer,
-      ((s, _) => s),
-      ((s, _) => s)
-    );
+    const poolHistory = await fetchPoolHistory(accessToken, poolAddress, lpTokenAddress);
 
     if (poolHistory.length === 0) {
       console.log(`[getLPTokenPriceHistory] No pool history found for ${poolAddress}`);

--- a/mercata/ui/src/components/charts/ConsolidatedPriceChart.tsx
+++ b/mercata/ui/src/components/charts/ConsolidatedPriceChart.tsx
@@ -33,6 +33,7 @@ interface ConsolidatedPriceChartProps {
   swapLoading: boolean;
   title: string;
   subtitle?: string;
+  isLPToken?: boolean;
 }
 
 // Color scheme
@@ -65,8 +66,18 @@ const formatTooltipValue = (value: string | number): string => {
   })}`;
 };
 
-// Custom tooltip component that always shows both prices
-const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: Array<Record<string, unknown>>; label?: string }) => {
+// Custom tooltip component
+const CustomTooltip = ({
+  active,
+  payload,
+  label,
+  isLPToken
+}: {
+  active?: boolean;
+  payload?: Array<Record<string, unknown>>;
+  label?: string;
+  isLPToken?: boolean;
+}) => {
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -76,6 +87,24 @@ const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?:
   const stratoPrice = dataPoint.swapPrice as number | undefined;
   const spotPrice = dataPoint.spotPrice as number | undefined;
 
+  // For LP tokens, only show NAV (spotPrice), not STRATO price
+  if (isLPToken) {
+    return (
+      <div className="rounded-lg border bg-background p-3 shadow-lg">
+        <p className="text-sm font-medium mb-2">{label}</p>
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded-full" style={{ backgroundColor: CHART_COLORS.SPOT }} />
+            <span className="text-sm">
+              Net Asset Value: {spotPrice !== undefined && spotPrice !== null ? formatTooltipValue(spotPrice) : 'N/A'}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // For regular tokens, show both prices
   return (
     <div className="rounded-lg border bg-background p-3 shadow-lg">
       <p className="text-sm font-medium mb-2">{label}</p>
@@ -150,6 +179,7 @@ const ConsolidatedPriceChart: React.FC<ConsolidatedPriceChartProps> = ({
   swapLoading,
   title,
   subtitle,
+  isLPToken = false,
 }) => {
   const renderChart = () => {
     const loading = spotLoading || swapLoading;
@@ -228,7 +258,7 @@ const ConsolidatedPriceChart: React.FC<ConsolidatedPriceChartProps> = ({
         <ChartContainer
           config={{
             spotPrice: {
-              label: "Spot Price",
+              label: isLPToken ? "Net Asset Value" : "Spot Price",
               theme: {
                 light: CHART_COLORS.SPOT,
                 dark: CHART_COLORS.SPOT,
@@ -292,13 +322,13 @@ const ConsolidatedPriceChart: React.FC<ConsolidatedPriceChartProps> = ({
                 iconType="line"
                 wrapperStyle={{ paddingBottom: '10px' }}
                 formatter={(value) => {
-                  if (value === 'spotPrice') return 'Spot Price';
+                  if (value === 'spotPrice') return isLPToken ? 'Net Asset Value' : 'Spot Price';
                   if (value === 'swapPrice') return 'STRATO Price';
                   return value;
                 }}
               />
               
-              <Tooltip content={<CustomTooltip />} />
+              <Tooltip content={<CustomTooltip isLPToken={isLPToken} />} />
               
               {/* Spot Price - Solid line with subtle gradient */}
               {hasSpotData && (

--- a/mercata/ui/src/pages/AssetDetail.tsx
+++ b/mercata/ui/src/pages/AssetDetail.tsx
@@ -45,6 +45,11 @@ interface Pool {
   bToARatio: string;
 }
 
+const isLPToken = (token: Token): boolean => {
+  const symbol = token?.token?._symbol || token?._symbol || '';
+  return symbol.endsWith('-LP');
+};
+
 const fetchPriceHistory = async (assetAddress: string): Promise<PricePoint[]> => {
   try {
     const response = await api.get<{ data: PriceHistoryApiEntry[] }>(`/oracle/price-history/${assetAddress}`);
@@ -212,11 +217,16 @@ const AssetDetail = () => {
           .then(data => setPriceData(data.slice(-(PRICE_WINDOW * 24)))) // Show last N days (24 hours each)
           .finally(() => setPriceDataLoading(false));
 
-        // Fetch swap pool price history
-        setSwapPriceDataLoading(true);
-        fetchSwapPoolPrices(foundAsset.address)
-          .then(data => setSwapPriceData(data))
-          .finally(() => setSwapPriceDataLoading(false));
+        // Only fetch swap pool prices for non-LP tokens
+        if (isLPToken(foundAsset)) {
+          setSwapPriceData([]);
+          setSwapPriceDataLoading(false);
+        } else {
+          setSwapPriceDataLoading(true);
+          fetchSwapPoolPrices(foundAsset.address)
+            .then(data => setSwapPriceData(data))
+            .finally(() => setSwapPriceDataLoading(false));
+        }
       }
     };
 
@@ -466,7 +476,12 @@ const AssetDetail = () => {
                   spotLoading={priceDataLoading}
                   swapLoading={swapPriceDataLoading}
                   title="Price History"
-                  subtitle="Spot price (blue) and STRATO price (orange)"
+                  subtitle={
+                    isLPToken(asset)
+                      ? "Net Asset Value per token, calculated from pool balances and oracle prices"
+                      : "Spot price (blue) and STRATO price (orange)"
+                  }
+                  isLPToken={isLPToken(asset)}
                 />
             </div>
           </div>


### PR DESCRIPTION
Partially addresses #6083

Swap Pool LP Tokens now have Pricing History charts on their asset details:
<img width="3701" height="2341" alt="Screenshot from 2026-01-21 11-59-39" src="https://github.com/user-attachments/assets/2382dfd5-ff9e-4b8b-a774-c249d9bf35d4" />
<img width="3701" height="2341" alt="Screenshot from 2026-01-21 11-59-15" src="https://github.com/user-attachments/assets/584dd08d-7882-41ca-a0cd-db7827a9a58d" />
<img width="3701" height="2341" alt="Screenshot from 2026-01-21 11-58-48" src="https://github.com/user-attachments/assets/42514381-e60a-4cbd-b425-6a0a31312975" />
<img width="3701" height="2341" alt="Screenshot from 2026-01-21 11-58-22" src="https://github.com/user-attachments/assets/1fc8da40-96c2-427e-9b16-2ea1ef39f219" />
<img width="3701" height="2341" alt="Screenshot from 2026-01-21 11-57-57" src="https://github.com/user-attachments/assets/e60d27ff-e3aa-4d58-8733-9bb9a603fd9c" />

Other assets remain as before:
<img width="3701" height="2341" alt="Screenshot from 2026-01-21 11-57-29" src="https://github.com/user-attachments/assets/2670e254-a181-465f-8cba-d417f49cb6a8" />
<img width="3701" height="2341" alt="Screenshot from 2026-01-21 11-56-56" src="https://github.com/user-attachments/assets/6b3354bd-c03a-43db-bc88-9bcd484f7b95" />

No implementation is made for mUSDST or sUSDST pricing.
