### PR TITLE
Minor HF UI tweaks

### DIFF
--- a/mercata/ui/src/components/Positions.tsx
+++ b/mercata/ui/src/components/Positions.tsx
@@ -5,6 +5,7 @@ import { CollateralData, NewLoanData } from "@/interface";
 import { formatUnits } from "ethers";
 import { formatBalance } from "@/utils/numberUtils";
 import { useMobileTooltip } from "@/hooks/use-mobile-tooltip";
+import { getTextColor } from "@/utils/lendingUtils";
 
 interface BorrowingSectionProps {
   userCollaterals: CollateralData[];
@@ -51,15 +52,6 @@ const InfoTooltip = ({ children, content }: { children: React.ReactNode; content
 
 
 const PositionSection = ({ loanData }: BorrowingSectionProps) => {
-  function getTextColor(value: number, maxValue = 10, noLoan = false) {
-    if (noLoan) return 'rgb(0, 255, 0)';
-    const clamped = Math.min(Math.max(value, 1), maxValue);
-    const ratio = (clamped - 1) / (maxValue - 1);
-    const red = Math.round(255 * (1 - ratio));
-    const green = Math.round(255 * ratio);
-    return `rgb(${red}, ${green}, 0)`;
-  }
-
   return (
     <Card className="border border-border shadow-sm">
       <CardHeader className="pb-4">

--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -20,9 +20,10 @@ import {
   sortCollateralAssets,
   calculateMaxCollateralValueUSDCentFloored,
   centCeil,
-  centFloor
+  centFloor,
+  getTextColor,
+  getRiskLabel
 } from "@/utils/lendingUtils";
-import { getRiskLabel } from "@/utils/lendingUtils";
 import { useLendingContext } from "@/context/LendingContext";
 import { handleAmountInputChange } from "@/utils/transferValidation";
 import { UserRewardsData } from "@/services/rewardsService";
@@ -552,9 +553,15 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
           <div className="flex justify-between items-center text-sm border-t pt-3">
             <span className="text-muted-foreground">Health Impact</span>
             <span className="font-medium tabular-nums">
-              {currentHF === null ? 'No Loan' : currentHF.toFixed(2)}
+              {currentHF === null ? (
+                <span style={{ color: getTextColor(0, 3, true) }}>No Loan</span>
+              ) : (
+                <span style={{ color: getTextColor(currentHF, 3) }}>{currentHF.toFixed(2)}</span>
+              )}
               {' → '}
-              {afterBorrowHF && !customBorrowError ? afterBorrowHF.toFixed(2) : '-'}
+              {afterBorrowHF && !customBorrowError ? (
+                <span style={{ color: getTextColor(Number(afterBorrowHF), 3) }}>{Number(afterBorrowHF).toFixed(2)}</span>
+              ) : '-'}
             </span>
           </div>
         </div>

--- a/mercata/ui/src/components/dashboard/BorrowingSection.tsx
+++ b/mercata/ui/src/components/dashboard/BorrowingSection.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { formatUnits } from "ethers";
 import { NewLoanData } from "@/interface";
 import RiskLevelProgress from "@/components/ui/RiskLevelProgress";
+import { getTextColor } from "@/utils/lendingUtils";
 
 interface BorrowingSectionProps {
   loanData?: NewLoanData;
@@ -12,16 +13,6 @@ interface BorrowingSectionProps {
 
 const BorrowingSection = ({ loanData }: BorrowingSectionProps) => {
   const navigate = useNavigate()
-
-  function getTextColor(value: number, maxValue = 10) {
-    const clamped = Math.min(Math.max(value, 1), maxValue);
-    const ratio = (clamped - 1) / (maxValue - 1);
-
-    const red = Math.round(255 * (1 - ratio));
-    const green = Math.round(255 * ratio);
-
-    return `rgb(${red}, ${green}, 0)`;
-  }
 
   // Calculate available borrowing power from loanData
   const availableBorrowingPower = loanData?.maxAvailableToBorrowUSD 
@@ -111,7 +102,7 @@ const BorrowingSection = ({ loanData }: BorrowingSectionProps) => {
 
               <div className="flex flex-col sm:flex-row sm:justify-between gap-1 sm:gap-0">
                 <span className="text-muted-foreground text-sm sm:text-base">Health Factor</span>
-                <span className="font-semibold text-sm sm:text-base" style={{ color: getTextColor((loanData?.healthFactor || 0)) }}>
+                <span className="font-semibold text-sm sm:text-base" style={{ color: getTextColor((loanData?.healthFactor || 0), 3, currentBorrowed === 0) }}>
                   {(() => {
                     // Check if there's no outstanding debt
                     if (currentBorrowed === 0) {

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -30,6 +30,17 @@ export const getHealthFactorColor = (healthFactor: number) => {
   return "text-red-600";
 };
 
+// Get text color for health factor display (RGB color string)
+// Returns green for high values, red for low values, interpolated in between
+export const getTextColor = (value: number, maxValue = 10, noLoan = false): string => {
+  if (noLoan) return 'rgb(0, 255, 0)';
+  const clamped = Math.min(Math.max(value, 1), maxValue);
+  const ratio = (clamped - 1) / (maxValue - 1);
+  const red = Math.round(255 * (1 - ratio));
+  const green = Math.round(255 * ratio);
+  return `rgb(${red}, ${green}, 0)`;
+};
+
 // Calculate health impact of collateral operations (supply/withdraw) using BigInt and healthFactorRaw
 export const calculateCollateralHealthImpact = (
   amountWei: bigint,
@@ -301,7 +312,7 @@ export const calculateHFSliderExtrema = (
     ? Math.max(DEFAULT_MAX_HEALTH_FACTOR, currentHF)
     : DEFAULT_MAX_HEALTH_FACTOR;
   
-  return { min: centCeil(minHF), max: centFloor(maxHF) };
+  return { min: centCeil(minHF), max: Math.round(maxHF * 100) / 100 };
 };
 
 // Determine the error message to display, suggesting options for the user while avoiding unavailable solutions.


### PR DESCRIPTION
Move getTextColor to a single source, align maximum on portfolio and Borrow page, and color the Health Impact HFs. Align left-hand HF slider extreme with current HF, rather than hundredth flooring.

Addresses #6097