### PR TITLE
2 decimals from Borrow Max button

### DIFF
--- a/mercata/ui/src/components/borrow/BorrowForm.tsx
+++ b/mercata/ui/src/components/borrow/BorrowForm.tsx
@@ -83,19 +83,18 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
 
   // Calculate available to borrow based on current health factor setting
   // Includes all available collateral balances (max potential borrowing power)
+  // Amount is in wei; 10n**18n = 1 USD
   const availableToBorrow = useMemo(() => {
+    if (!loans || !collateralInfo || collateralInfo.length === 0) return 0n;
     return calculateAvailableToBorrowUSD(loans, targetHealthFactor, potentialCollateral);
-  }, [loans, targetHealthFactor, potentialCollateral]);
+  }, [loans, collateralInfo, targetHealthFactor, potentialCollateral]);
 
   // Calculate maximum borrowable at slider minimum (riskiest) health factor
+  // Amount is in wei; 10n**18n = 1 USD
   const maxAtMinHF = useMemo(() => {
     return calculateAvailableToBorrowUSD(loans, sliderExtrema.min, potentialCollateral);
   }, [loans, sliderExtrema.min, potentialCollateral]);
 
-  // Max borrowable amount in wei
-  const maxAmount = useMemo(() => {
-    return BigInt(Math.round(Number(availableToBorrow) * 1e18)).toString();
-  }, [availableToBorrow]);
 
   // Current health factor display
   const currentHF = useMemo(() => {
@@ -239,34 +238,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     }
   }, [txFee, voucherBalance, usdstBalance]);
 
-  // Update custom error message when borrow amount exceeds maximum at selected health factor
-  useEffect(() => {
-    if (!borrowAmount || !loans) {
-      setCustomBorrowError("");
-      return;
-    }
 
-    const borrowAmountNum = parseFloat(borrowAmount);
-    if (isNaN(borrowAmountNum) || borrowAmountNum <= 0) {
-      setCustomBorrowError("");
-      return;
-    }
-
-    const borrowAmountWei = safeParseUnits(borrowAmount, 18);
-    const maxAmountWei = BigInt(maxAmount);
-    
-    // Only set custom error if amount exceeds maximum
-    if (borrowAmountWei > maxAmountWei) {
-      const errorMsg = determineErrorMessage(
-        borrowAmountNum,
-        availableToBorrow,
-        maxAtMinHF
-      );
-      setCustomBorrowError(errorMsg);
-    } else {
-      setCustomBorrowError("");
-    }
-  }, [borrowAmount, loans, maxAmount, availableToBorrow, maxAtMinHF]);
 
   // Automatically reset to auto-supply mode when borrow amount or health factor changes
   useEffect(() => {
@@ -449,8 +421,8 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
   }, [sliderExtrema]);
 
   const borrowAmountExceedsMax = useMemo(() => {
-    return safeParseUnits(borrowAmount || "0", 18) > BigInt(maxAmount);
-  }, [borrowAmount, maxAmount]);
+    return safeParseUnits(borrowAmount || "0", 18) > availableToBorrow;
+  }, [borrowAmount, availableToBorrow]);
 
   // We handle borrowAmountExceedsMax separately, since it updates on HF slider
   const setBorrowAmountErrorIgnoringMax = (value: string) => {
@@ -461,6 +433,31 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
     setBorrowAmountError(value);
   };
 
+  // Update custom error message when borrow amount exceeds maximum at selected health factor
+  useEffect(() => {
+    if (!borrowAmount || !loans) {
+      setCustomBorrowError("");
+      return;
+    }
+
+    const borrowAmountNum = parseFloat(borrowAmount);
+    if (isNaN(borrowAmountNum) || borrowAmountNum <= 0) {
+      setCustomBorrowError("");
+      return;
+    }
+
+    if (borrowAmountExceedsMax) {
+      const errorMsg = determineErrorMessage(
+        borrowAmountNum,
+        availableToBorrow,
+        maxAtMinHF
+      );
+      setCustomBorrowError(errorMsg);
+    } else {
+      setCustomBorrowError("");
+    }
+  }, [borrowAmount, loans, availableToBorrow, maxAtMinHF, borrowAmountExceedsMax]);
+
   return (
     <div className="space-y-4 pt-4">
       {/* Header: Borrow USDST */}
@@ -468,7 +465,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
         <h3 className="text-lg font-semibold">Borrow USDST</h3>
         <div className="flex justify-between text-sm">
           <span className="text-muted-foreground">Available to Borrow</span>
-          <span className="font-medium">USDST {Number(availableToBorrow).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          <span className="font-medium">USDST {Number(formatUnits(availableToBorrow, 18)).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
         </div>
         <div className="flex justify-between text-sm">
           <span className="text-muted-foreground">Interest Rate</span>
@@ -487,7 +484,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
               value={addCommasToInput(borrowAmount)}
               onChange={(e) => {
                 const value = e.target.value;
-                handleAmountInputChange(value, setBorrowAmount, setBorrowAmountErrorIgnoringMax, maxAmount);
+                handleAmountInputChange(value, setBorrowAmount, setBorrowAmountErrorIgnoringMax, availableToBorrow.toString());
                 handlePollingUpdate(value);
               }}
             />
@@ -497,12 +494,13 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
             variant="outline"
             onClick={() => {
               try {
-                setBorrowAmount(formatUnits(BigInt(maxAmount)));
+                const formattedMax = Number(formatUnits(availableToBorrow, 18)).toFixed(2);
+                setBorrowAmount(formattedMax);
                 setBorrowAmountError("");
-                handlePollingUpdate(formatUnits(BigInt(maxAmount)));
+                handlePollingUpdate(formattedMax);
               } catch {}
             }}
-            disabled={Number(availableToBorrow) <= 0}
+            disabled={availableToBorrow <= 0n}
             className="px-4"
           >
             MAX
@@ -808,7 +806,7 @@ const BorrowForm = ({ loans, borrowLoading, onBorrow, usdstBalance, voucherBalan
 
       {/* Conditional Warning Messages */}
       {(() => {
-        const isZeroAvailable = Number(availableToBorrow) <= 0;
+        const isZeroAvailable = availableToBorrow <= 0n;
         const eligibleCollateralTokens = collateralInfo || [];
 
         if (isZeroAvailable && eligibleCollateralTokens.length === 0) {

--- a/mercata/ui/src/utils/lendingUtils.ts
+++ b/mercata/ui/src/utils/lendingUtils.ts
@@ -237,9 +237,9 @@ export const calculateAvailableToBorrowUSD = (
   loanData: NewLoanData,
   healthFactor: Number,
   newCollateral: Map<CollateralData, bigint>,
-): Number => {
+): bigint => {
   const targetHFRaw = BigInt(Math.round(Number(healthFactor) * 1e18));
-  if (targetHFRaw <= 0n) return 0;
+  if (targetHFRaw <= 0n) return 0n;
 
   let totalCollateralValueUSD = BigInt(loanData?.totalCollateralValueUSD ?? "0"); // supplied collat, LT weighted
   
@@ -260,11 +260,11 @@ export const calculateAvailableToBorrowUSD = (
 
   // Available to borrow = maxDebt - currentDebt (clamped to 0)
   // Floor to cents in BigInt space to avoid precision loss
-  if (maxDebtForTargetHF <= currentDebtUSD) return 0.00;
+  if (maxDebtForTargetHF <= currentDebtUSD) return 0n;
   const centsInWei = 10n ** 16n; // 0.01 USD = 1e16 wei
-  const availableWei = (maxDebtForTargetHF - currentDebtUSD) / centsInWei * centsInWei;
+  const availableWei = maxDebtForTargetHF - currentDebtUSD;
   const flooredToCentsWei = (availableWei / centsInWei) * centsInWei; // using BigInt floored division
-  return Number(flooredToCentsWei) / 1e18;
+  return flooredToCentsWei;
 };
 
 /**
@@ -308,13 +308,16 @@ export const calculateHFSliderExtrema = (
 // Returns a string including newlines for line breaks; should by formatted by a UI component that parses this. (whitespace-pre-line)
 export const determineErrorMessage = (
   borrowAmount: Number,
-  maxAtRequestedHF: Number,
-  maxAtMinHF: Number
+  maxAtRequestedHF: bigint,
+  maxAtMinHF: bigint
 ) : string => {
+
+  const borrowAmountWei = safeParseUnits(borrowAmount.toString(), 18);
+
   // Check if borrow amount exceeds maximum at requested health factor
-  if (borrowAmount > maxAtRequestedHF) {
+  if (borrowAmountWei > maxAtRequestedHF) {
     // If even at minimum health factor the max is still too low, don't suggest increasing risk
-    if (borrowAmount > maxAtMinHF) {
+    if (borrowAmountWei > maxAtMinHF) {
       return "Borrow amount exceeds the maximum at this health factor.\nConsider bridging in more collateral.";
     }
     // Otherwise, suggest increasing risk level as an option


### PR DESCRIPTION
Keep availableToBorrow as a bigint, avoiding precision loss, and Max button should give a value with only 2 decimals

Fixes #6102