### PR TITLE
techdocs to use app.testnet.strato.nexus for testnet node references

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: STRATO Technical Docs
 site_description: STRATO platform technical documentation (use-case first, end-user + developer)
 site_url: https://docs.strato.nexus
 site_author: BlockApps
-copyright: Copyright &copy; 2025 BlockApps - STRATO Platform
+copyright: Copyright &copy; 2026 BlockApps - STRATO Platform
 
 theme:
   name: material

--- a/techdocs/build-apps/contract-addresses.md
+++ b/techdocs/build-apps/contract-addresses.md
@@ -7,7 +7,7 @@ Find deployed contracts and addresses for your STRATO deployment.
     
     **For production, use public endpoints:**
     - Mainnet: `https://app.strato.nexus`
-    - Testnet: `https://buildtest.mercata-testnet.blockapps.net`
+    - Testnet: `https://app.testnet.strato.nexus`
     
     **Contract addresses are the same across all deployments** (query from registries)
 
@@ -157,7 +157,7 @@ http://localhost:8080/smd/
 
 # Production
 https://app.strato.nexus/smd/  (mainnet)
-https://buildtest.mercata-testnet.blockapps.net/smd/  (testnet)
+https://app.testnet.strato.nexus/smd/  (testnet)
 
 # View specific contract
 http://localhost:8080/smd/address/0x.../contracts
@@ -347,7 +347,7 @@ async function getUserCollateral(
 - ✅ Block explorer (SMD): 
   - Local: `http://localhost:8080/smd/`
   - Mainnet: `https://app.strato.nexus/smd/`
-  - Testnet: `https://buildtest.mercata-testnet.blockapps.net/smd/`
+  - Testnet: `https://app.testnet.strato.nexus/smd/`
 - ✅ Query Cirrus for contract code
 - ✅ Check contract name matches expected
 

--- a/techdocs/build-apps/e2e.md
+++ b/techdocs/build-apps/e2e.md
@@ -13,7 +13,7 @@ Complete workflow examples for building on STRATO using REST APIs.
     For production, use public endpoints:
     
     - **Mainnet:** `https://app.strato.nexus`
-    - **Testnet:** `https://buildtest.mercata-testnet.blockapps.net`
+    - **Testnet:** `https://app.testnet.strato.nexus`
     
     **In your code:**
     
@@ -23,7 +23,7 @@ Complete workflow examples for building on STRATO using REST APIs.
     
     // For production (replace localhost with):
     // const NODE_URL = 'https://app.strato.nexus';  // mainnet
-    // const NODE_URL = 'https://buildtest.mercata-testnet.blockapps.net';  // testnet
+    // const NODE_URL = 'https://app.testnet.strato.nexus';  // testnet
     
     const strato = createApiClient(`${NODE_URL}/strato/v2.3`);
     const cirrus = createApiClient(`${NODE_URL}/cirrus/search`);

--- a/techdocs/build-apps/integration.md
+++ b/techdocs/build-apps/integration.md
@@ -13,7 +13,7 @@ Complete walkthrough for integrating with STRATO using REST APIs.
     **For production, use public endpoints:**
     
     - **Mainnet:** `https://app.strato.nexus`
-    - **Testnet:** `https://buildtest.mercata-testnet.blockapps.net`
+    - **Testnet:** `https://app.testnet.strato.nexus`
     
     **Optional local setup:** [Setup Guide](../contribute/setup.md)
 
@@ -39,7 +39,7 @@ const BASE_URL = 'http://localhost:8080';
 
 // For production (replace with):
 // const BASE_URL = 'https://app.strato.nexus';  // mainnet
-// const BASE_URL = 'https://buildtest.mercata-testnet.blockapps.net';  // testnet
+// const BASE_URL = 'https://app.testnet.strato.nexus';  // testnet
 
 const STRATO_API = `${BASE_URL}/strato/v2.3`;  // transactions, keys
 const CIRRUS = `${BASE_URL}/cirrus/search`;     // indexed queries

--- a/techdocs/build-apps/overview.md
+++ b/techdocs/build-apps/overview.md
@@ -37,7 +37,7 @@ Welcome! This guide helps you build external applications that integrate with yo
 Connect to the public STRATO network via REST APIs:
 
 - **Mainnet**: `https://app.strato.nexus/api`
-- **Testnet**: `https://buildtest.mercata-testnet.blockapps.net/api`
+- **Testnet**: `https://app.testnet.strato.nexus/api`
 
 **Option 2: Deploy Your Own Node (Optional)**
 
@@ -83,7 +83,7 @@ You need access to a STRATO endpoint to build apps.
 **Option 1: Use Public Endpoints (Recommended)**
 
 - **Mainnet**: `https://app.strato.nexus`
-- **Testnet**: `https://buildtest.mercata-testnet.blockapps.net`
+- **Testnet**: `https://app.testnet.strato.nexus`
 
 No setup required - just start building!
 

--- a/techdocs/build-apps/quick-reference.md
+++ b/techdocs/build-apps/quick-reference.md
@@ -12,7 +12,7 @@ Quick reference for common STRATO operations using REST APIs.
     
     **For production, use public endpoints:**
     - Mainnet: `https://app.strato.nexus`
-    - Testnet: `https://buildtest.mercata-testnet.blockapps.net`
+    - Testnet: `https://app.testnet.strato.nexus`
     
     **Optional:** [Local setup guide](../contribute/setup.md)
 
@@ -28,7 +28,7 @@ const NODE_URL = 'http://localhost:8080';
 
 // For production (replace with):
 // const NODE_URL = 'https://app.strato.nexus';  // mainnet
-// const NODE_URL = 'https://buildtest.mercata-testnet.blockapps.net';  // testnet
+// const NODE_URL = 'https://app.testnet.strato.nexus';  // testnet
 
 function createApiClient(baseURL: string): AxiosInstance {
   return axios.create({

--- a/techdocs/build-apps/quickstart.md
+++ b/techdocs/build-apps/quickstart.md
@@ -12,7 +12,7 @@ Build your first app on STRATO in 10 minutes using STRATO's REST APIs.
     
     - **Option 1 (Recommended):** Use public endpoints
         - Mainnet: `https://app.strato.nexus/api`
-        - Testnet: `https://buildtest.mercata-testnet.blockapps.net/api`
+        - Testnet: `https://app.testnet.strato.nexus/api`
     - **Option 2 (Optional):** Deploy locally for development
         - See [Setup Guide](../contribute/setup.md) to install
         - Run `./start my_node_name`
@@ -49,7 +49,7 @@ NODE_URL=http://localhost:8080
 
 # For production, use public endpoints:
 # NODE_URL=https://app.strato.nexus  (mainnet)
-# NODE_URL=https://buildtest.mercata-testnet.blockapps.net  (testnet)
+# NODE_URL=https://app.testnet.strato.nexus  (testnet)
 
 # OAuth credentials (required for authentication)
 OAUTH_CLIENT_ID=your_client_id_here
@@ -61,7 +61,7 @@ OAUTH_DISCOVERY_URL=https://keycloak.blockapps.net/auth/realms/mercata
     - **Local dev:** Use `http://localhost:8080` (requires [local STRATO setup](../contribute/setup.md))
     - **Production:** Use public endpoints (no local deployment needed)
         - Mainnet: `https://app.strato.nexus`
-        - Testnet: `https://buildtest.mercata-testnet.blockapps.net`
+        - Testnet: `https://app.testnet.strato.nexus`
 
 ### TypeScript Configuration
 
@@ -92,7 +92,7 @@ Create `tsconfig.json`:
     All code examples use `localhost` for local development. For production:
     
     - Replace `http://localhost:8080` with `https://app.strato.nexus` (mainnet)
-    - Or use `https://buildtest.mercata-testnet.blockapps.net` (testnet)
+    - Or use `https://app.testnet.strato.nexus` (testnet)
 
 Create `src/config.ts`:
 

--- a/techdocs/faq.md
+++ b/techdocs/faq.md
@@ -274,7 +274,7 @@ https://app.strato.nexus/strato-api/eth/v1.2
 
 **Testnet**:
 ```
-https://buildtest.mercata-testnet.blockapps.net/strato-api/eth/v1.2
+https://app.testnet.strato.nexus/strato-api/eth/v1.2
 ```
 
 ### Where can I find smart contract addresses?

--- a/techdocs/reference/api.md
+++ b/techdocs/reference/api.md
@@ -14,7 +14,7 @@ https://app.strato.nexus/api
 
 **Testnet:**
 ```
-https://buildtest.mercata-testnet.blockapps.net/api
+https://app.testnet.strato.nexus/api
 ```
 
 !!! info "Alternative: Core Platform API"
@@ -570,7 +570,7 @@ GET /tokens/v2?order=balance.desc
 For real-time position updates:
 
 ```javascript
-const ws = new WebSocket('wss://buildtest.mercata-testnet.blockapps.net/ws');
+const ws = new WebSocket('wss://app.testnet.strato.nexus/ws');
 
 ws.send(JSON.stringify({
   type: 'subscribe',
@@ -602,7 +602,7 @@ npm install @strato/sdk
 import { StratoClient } from '@strato/sdk';
 
 const client = new StratoClient({
-  baseUrl: 'https://buildtest.mercata-testnet.blockapps.net/api',
+  baseUrl: 'https://app.testnet.strato.nexus/api',
   accessToken: 'eyJhbGc...'
 });
 
@@ -684,7 +684,7 @@ async function fetchAll(endpoint) {
 
 Use testnet for development:
 ```
-https://buildtest.mercata-testnet.blockapps.net/api
+https://app.testnet.strato.nexus/api
 ```
 
 - No real value at risk

--- a/techdocs/reference/architecture.md
+++ b/techdocs/reference/architecture.md
@@ -345,7 +345,7 @@ Allows Pool to call `mint()` on LP Token.
 - Local Cirrus instance
 - Frontend dev server (Vite)
 
-**Testnet (buildtest):**
+**Testnet:**
 
 - Hosted STRATO node
 - Hosted Cirrus + PostgreSQL

--- a/techdocs/reference/interactive-api.md
+++ b/techdocs/reference/interactive-api.md
@@ -12,7 +12,7 @@ High-level API for DeFi operations: lending, CDP, swaps, liquidity, bridge, rewa
     [https://app.strato.nexus/api/docs](https://app.strato.nexus/api/docs)
 
 !!! example "App API - Testnet"
-    [https://buildtest.mercata-testnet.blockapps.net/api/docs](https://buildtest.mercata-testnet.blockapps.net/api/docs)
+    [https://app.testnet.strato.nexus/api/docs](https://app.testnet.strato.nexus/api/docs)
 
 ---
 
@@ -24,7 +24,7 @@ Low-level blockchain API: users, transactions, contracts, blocks.
     [https://app.strato.nexus/docs](https://app.strato.nexus/docs)
 
 !!! info "Core API - Testnet"
-    [https://buildtest.mercata-testnet.blockapps.net/docs](https://buildtest.mercata-testnet.blockapps.net/docs)
+    [https://app.testnet.strato.nexus/docs](https://app.testnet.strato.nexus/docs)
 
 ---
 
@@ -73,7 +73,7 @@ All API requests require authentication via **OAuth 2.0 Bearer token**.
 **Base URLs:**
 
 - **Mainnet**: `https://app.strato.nexus`
-- **Testnet**: `https://buildtest.mercata-testnet.blockapps.net`
+- **Testnet**: `https://app.testnet.strato.nexus`
 
 ---
 

--- a/techdocs/reference/strato-node-api.md
+++ b/techdocs/reference/strato-node-api.md
@@ -36,7 +36,7 @@ https://app.strato.nexus/strato-api
 
 **Testnet:**
 ```
-https://buildtest.mercata-testnet.blockapps.net/strato-api
+https://app.testnet.strato.nexus/strato-api
 ```
 
 ## Authentication
@@ -249,7 +249,7 @@ GET /strato-api/eth/v1.2/logs?address={contractAddress}&fromBlock={start}&toBloc
 #### Subscribe to Events (WebSocket)
 
 ```javascript
-const ws = new WebSocket('wss://buildtest.mercata-testnet.blockapps.net/strato-api/ws');
+const ws = new WebSocket('wss://app.testnet.strato.nexus/strato-api/ws');
 
 ws.send(JSON.stringify({
   type: 'subscribe',


### PR DESCRIPTION
- update the public testnet node to be app.testnet.strato.nexus
- update copyright year to 2026