### PR TITLE
Deduplicate CodeCollectionAdded messages

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2302,7 +2302,7 @@ runTheConstructors from to hsh cc contractName' argVals' = do
 
     cs <- Mod.get (Mod.Proxy @[CallInfo])
     userName <- getUsername $ currentAddress <$> cs
-    addNewCodeCollection userName cc
+    addNewCodeCollection userName hsh cc
     addDelegatecall to to (Just userName) $ T.pack contractName'
 
   return ()

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -183,7 +183,7 @@ type MonadSM m =
     Mod.Modifiable Action m,
     Mod.Modifiable (Q.Seq Event) m,
     Mod.Modifiable (Q.Seq Action.Delegatecall) m,
-    Mod.Modifiable [(Text, CodeCollection)] m,
+    Mod.Modifiable (OMap.OMap (Text, Keccak256) CodeCollection) m,
     Mod.Modifiable (Maybe DebugSettings) m,
     MonadUnliftIO m, --todo: remove
     MonadCatch m,
@@ -424,7 +424,7 @@ instance MonadUnliftIO m => Mod.Modifiable (Q.Seq Action.Delegatecall) (SM m) wh
   get _ = gets (Action._delegatecalls . _action)
   put _ q = modify $ action . Action.delegatecalls .~ q
 
-instance MonadUnliftIO m => Mod.Modifiable ([(Text, CodeCollection)]) (SM m) where
+instance MonadUnliftIO m => Mod.Modifiable (OMap.OMap (Text, Keccak256) CodeCollection) (SM m) where
   get _ = gets (Action._newCodeCollections . _action)
   put _ q = modify $ action . Action.newCodeCollections .~ q
 
@@ -512,7 +512,7 @@ startingAction env' =
       _blockNumber = blockHeaderBlockNumber $ Env.blockHeader env',
       _transactionSender = Env.sender env',
       _actionData = OMap.empty,
-      _newCodeCollections = [],
+      _newCodeCollections = OMap.empty,
       _events = Q.empty,
       _delegatecalls = Q.empty
     }
@@ -907,8 +907,8 @@ addEvent newEvent = Mod.modify_ (Mod.Proxy @(Q.Seq Event)) $ pure . (Q.|> newEve
 addDelegatecall :: Mod.Modifiable (Q.Seq Action.Delegatecall) m => Address -> Address -> Maybe T.Text -> T.Text -> m ()
 addDelegatecall s c o n = Mod.modify_ (Mod.Proxy @(Q.Seq Action.Delegatecall)) $ pure . (Q.|> Action.Delegatecall s c o n)
 
-addNewCodeCollection :: Mod.Modifiable [(Text, CodeCollection)] m => Text -> CodeCollection -> m ()
-addNewCodeCollection userName cc = Mod.modify_ (Mod.Proxy @([(Text, CodeCollection)])) $ pure . ((userName, cc):)
+addNewCodeCollection :: Mod.Modifiable (OMap.OMap (Text, Keccak256) CodeCollection) m => Text -> Keccak256 -> CodeCollection -> m ()
+addNewCodeCollection userName ch cc = Mod.modify_ (Mod.Proxy @(OMap.OMap (Text, Keccak256) CodeCollection)) $ pure . (OMap.|> ((userName, ch), cc))
 
 getBlockHashWithNumber :: MonadSM m => Integer -> Keccak256 -> m (Maybe Keccak256)
 getBlockHashWithNumber num h = do

--- a/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
+++ b/strato/core/strato-init/src/Blockchain/GenesisBlock.hs
@@ -293,7 +293,7 @@ populateStorageDBs' genesisInfo genesisBlock genesisChainId sr pub = do
               A._transactionSender = Ad.Address 0,
               A._actionData =
                 OMap.singleton (a, A.ActionData storageDiff),
-              A._newCodeCollections = [],
+              A._newCodeCollections = OMap.empty,
               A._events = addressEvents,
               A._delegatecalls = delegatecalls
             }

--- a/strato/core/vm-runner/src/Blockchain/BlockChain.hs
+++ b/strato/core/vm-runner/src/Blockchain/BlockChain.hs
@@ -325,7 +325,7 @@ sendNewActionMessage b trrs = do
         _blockNumber=blockHeaderBlockNumber bd,
         _transactionSender=0x0,
         _actionData=O.fromList $ M.toList recombined,
-        _newCodeCollections=[],
+        _newCodeCollections=O.empty,
         _events=Seq.fromList $ concat $ map (either (const []) erEvents . trrResult) trrs,
         _delegatecalls=mconcat $ map (either (const Seq.empty) (fromMaybe Seq.empty . fmap _delegatecalls . erAction) . trrResult) trrs
         }
@@ -671,12 +671,12 @@ outputTransactionResult b hashFunction (TxRunResult ot@OutputTx {otHash = theHas
 
 extractCodeCollectionAddedMessages :: Action.Action -> [VMEvent]
 extractCodeCollectionAddedMessages a =
-  let mkCCAnouncement (userName, cc) =
+  let mkCCAnouncement ((userName, _), cc) =
         CodeCollectionAdded
               { codeCollection = const () <$> cc,
                 creator = userName
               }
-  in map mkCCAnouncement $ _newCodeCollections a
+  in map mkCCAnouncement . O.assocs $ _newCodeCollections a
 
 printTransactionMessage ::
   MonadLogger m =>

--- a/strato/core/vm-tools/src/Blockchain/Stream/Action.hs
+++ b/strato/core/vm-tools/src/Blockchain/Stream/Action.hs
@@ -227,7 +227,7 @@ data Action = Action
     _blockNumber :: Integer,
     _transactionSender :: Address,
     _actionData :: OMap.OMap Address ActionData,
-    _newCodeCollections :: [(Text, CodeCollection)],
+    _newCodeCollections :: OMap.OMap (Text, Keccak256) CodeCollection,
     _events :: S.Seq Event,
     _delegatecalls :: S.Seq Delegatecall
   }


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/6151

I found that, during a base code collection deployment, vm-runner 15+ seconds were spent writing events to the `vmevents` Kafka topic, which goes to Slipstream. Upon digging in, I found that SolidVM was emitting a `CodeCollectionAdded` message containing the entire code collection once for every constructor run during code collection creation. Not just once per contract, but potentially multiple per contract, since most contracts run their own constructor, as well as `Ownable`, `ERC20`, etc.

To fix this, I changed how we keep track of code collections in SolidVM: instead of simply having a list of them, I now store them in an ordered Map (`OMap`), which keeps track of their order, but also prevents inserting the same code collection twice. The key of the `OMap` is a `(Text, Keccak256)` pair, where the `Text` is the creator's username (needed for table namespacing), and the `Keccak256` is the hash of the code collection.

Now, when deploying the base code collection, the amount of time spent writing to Kafka is down from 15+ seconds to ~0.6 seconds, measured on a local deployment. Running `npm run deploy` before the changes takes 24+ seconds, and often gives the API timeout error @witmk observed, and after these changes, it runs in just over 8 seconds, with potentially more time to be gained as validators are upgraded.