### PR TITLE
Only emit CodeCollectionAdded when it's actually a new code collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ docker-compose.allDocker.push.yml
 docker-compose.allDocker.push.ecr.yml
 docker-compose.allDocker.yml
 docker-compose.allDocker.ecr.yml
+docker-compose.bridge.push.yml
+docker-compose.bridge.push.ecr.yml
+docker-compose.bridge.yml
+docker-compose.bridge.ecr.yml
 docker-compose.highway.push.yml
 docker-compose.highway.push.ecr.yml
 docker-compose.highway.yml

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -30,7 +30,6 @@ where
 import BlockApps.Logging
 import Blockchain.DB.CodeDB
 import Blockchain.DB.ModifyStateDB (pay)
-import Blockchain.DB.SolidStorageDB
 import Blockchain.Data.AddressStateDB
 import Blockchain.Data.BlockHeader (BlockHeader)
 import qualified Blockchain.Data.BlockHeader as BlockHeader
@@ -227,6 +226,7 @@ createReturnEnv blockData sender' origin' proposer' availableGas newAddress code
   fmap (fmap $ either solidvmErrorResults id) . runSM (Just code) env' gasInfo' $ do
 
     (hsh, cc) <- codeCollectionFromSource isRunningTests True $ DT.encodeUtf8 initCode
+    addNewCodeCollection hsh cc
     let eArgExps = traverse (runParser parseArg initialParserState "" . T.unpack) argsStrings
         !argExps = either (parseError "create arguments") id eArgExps
     argVals <- argsToVals argExps
@@ -2172,6 +2172,7 @@ callBuiltin "create" args@(SString contractName' : SString contractSrc : argVals
   -- testnet won't exist anymore and the stateroot mismatches will be fixed.
   isRunningTests <- Env.runningTests <$> getEnv
   (hsh, cc) <- codeCollectionFromSource isRunningTests True $ BC.pack contractSrc
+  addNewCodeCollection hsh cc
   newAddress <- getNewAddress creator
   execResults <- create' creator newAddress hsh cc contractName' argVals
 
@@ -2194,6 +2195,7 @@ callBuiltin "create2" args@(salt : n@(SString contractName') : SString contractS
   -- testnet won't exist anymore and the stateroot mismatches will be fixed.
   isRunningTests <- Env.runningTests <$> getEnv
   (hsh, cc) <- codeCollectionFromSource isRunningTests True $ BC.pack contractSrc
+  addNewCodeCollection hsh cc
   newAddress <- getNewAddressWithSalt creator salt hsh $ n:argVals
   execResults <- create' creator newAddress hsh cc contractName' argVals
   case erNewContractAddress execResults of
@@ -2293,16 +2295,7 @@ runTheConstructors from to hsh cc contractName' argVals' = do
         _ <- runModifiersAndStatements modContentsList commands
         pure ()
       Nothing -> return ()
-    let getUsername []     = pure "BlockApps"
-        getUsername (x:xs) = do
-          userNameValue <- getSolidStorageKeyVal' x $ MS.StoragePath [MS.Field "username"]
-          case userNameValue of
-            MS.BString userNameString -> pure $ DT.decodeUtf8 userNameString
-            _ -> getUsername xs
-
-    cs <- Mod.get (Mod.Proxy @[CallInfo])
-    userName <- getUsername $ currentAddress <$> cs
-    addNewCodeCollection userName hsh cc
+    userName <- getUsername
     addDelegatecall to to (Just userName) $ T.pack contractName'
 
   return ()

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -45,6 +45,7 @@ module Blockchain.SolidVM.SM
     getBSum,
     addEvent,
     addDelegatecall,
+    getUsername,
     addNewCodeCollection,
     getContractNameAndHash,
     getCodeAndCollection,
@@ -61,6 +62,7 @@ import BlockApps.Logging
 import Blockchain.DB.CodeDB
 import Blockchain.DB.MemAddressStateDB
 import Blockchain.DB.RawStorageDB
+import Blockchain.DB.SolidStorageDB
 import Blockchain.DB.StateDB
 import Blockchain.Data.AddressStateDB
 import Blockchain.Data.BlockSummary
@@ -101,6 +103,7 @@ import qualified Data.Set as S
 import Data.Source
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as DT
 import Debugger
 import SolidVM.Model.CodeCollection (CodeCollection)
 import qualified SolidVM.Model.CodeCollection as CC
@@ -907,8 +910,22 @@ addEvent newEvent = Mod.modify_ (Mod.Proxy @(Q.Seq Event)) $ pure . (Q.|> newEve
 addDelegatecall :: Mod.Modifiable (Q.Seq Action.Delegatecall) m => Address -> Address -> Maybe T.Text -> T.Text -> m ()
 addDelegatecall s c o n = Mod.modify_ (Mod.Proxy @(Q.Seq Action.Delegatecall)) $ pure . (Q.|> Action.Delegatecall s c o n)
 
-addNewCodeCollection :: Mod.Modifiable (OMap.OMap (Text, Keccak256) CodeCollection) m => Text -> Keccak256 -> CodeCollection -> m ()
-addNewCodeCollection userName ch cc = Mod.modify_ (Mod.Proxy @(OMap.OMap (Text, Keccak256) CodeCollection)) $ pure . (OMap.|> ((userName, ch), cc))
+getUsername :: MonadSM m => m Text
+getUsername = do
+  let go []     = pure "BlockApps"
+      go (x:xs) = do
+        userNameValue <- getSolidStorageKeyVal' x $ MS.StoragePath [MS.Field "username"]
+        case userNameValue of
+          MS.BString userNameString -> pure $ DT.decodeUtf8 userNameString
+          _ -> go xs
+
+  cs <- Mod.get (Mod.Proxy @[CallInfo])
+  go $ currentAddress <$> cs
+
+addNewCodeCollection :: MonadSM m => Keccak256 -> CodeCollection -> m ()
+addNewCodeCollection ch cc = do
+  username <- getUsername
+  Mod.modify_ (Mod.Proxy @(OMap.OMap (Text, Keccak256) CodeCollection)) $ pure . (OMap.|> ((username, ch), cc))
 
 getBlockHashWithNumber :: MonadSM m => Integer -> Keccak256 -> m (Maybe Keccak256)
 getBlockHashWithNumber num h = do


### PR DESCRIPTION
## Background
We used to need `CodeCollectionAdded` messages for every contract creation, since Slipstream needed to know which columns existed in the table the contract instance would be indexed in. Now, however, `CodeCollectionAdded` messages are only needed during code collection deployment time, since they are used by Slipstream to create views and foreign key relations based on the code collection's schema. When a new contract instance is created using that code collection, Slipstream only needs the contract's storage diff, and (creator, contract name) pair of the logic contract it is using. The `storage` and `mapping` tables hold all the contract's state in a schema-agnostic manner, and the (creator, contract name) pair links the contract instance to a row in the `contract` table, which allows it to be picked up the view.

Recently, I found that `CodeCollectionAdded` messages were being sent to Slipstream many times over, and fixed the issue in https://github.com/blockapps/strato-platform/pull/6152. This change greatly improved latency for base code collection deployments, and marginally improved overall sync speed.

However, another problem persists, outlined in https://github.com/blockapps/strato-platform/issues/6160. Since each contract creation still emits a `CodeCollectionAdded`, schema changes can effectively be rolled back if a contract is created from an older code collection. This creates the very undesirable choice of either deploying a new base code collection every time a contract is created, or update every contract factory every time a new release comes out.

## Solution
Instead of emitting a `CodeCollectionAdded` for every contract creation, only emit a `CodeCollectionAdded` when in certain situations:
- Contract creation transaction
  - Only emit a `CodeCollectionAdded` from the outermost `create` function, since all inner contract creations will use the same code collection, except:
- Contracts created using the `create` and `create2` builtins
  - These builtins take contract source code as a parameter, thus enabling the deployment of a different code collection than the one used by the contract calling the builtin

## Effects
- Even fewer `CodeCollectionAdded` messages sent to Slipstream
  - Another marginal performance improvement, although probably less than the first PR
- No more errors such as `column BlockApps-Pool.isStable` does not exist, unless a new base code collection is deployed that removes that column
- Does not fix https://github.com/blockapps/strato-platform/issues/5665 : when a new code collection is deployed, Slipstream will still drop views and foreign key relations in cascade mode, which is what causes that issue.
- If BlockApps deploys code collection X, and another user deploys a Proxy and points it to the address of X, that contract will get indexed under BlockApps-X. There is a discussion to be had on whether this is a property we want
  - If we decide we do not want this behavior, the changes implemented in this PR are probably still valid, and we'd just have to figure out a different way to prevent non-BlockApps users from having their contracts indexed under BlockApps Cirrus tables.