### PR TITLE
openidc race condition

### DIFF
--- a/mercata/services/bridge/Dockerfile
+++ b/mercata/services/bridge/Dockerfile
@@ -8,6 +8,9 @@ RUN apk add --no-cache python3 make g++
 
 WORKDIR /build
 
+# Pre-install node headers to avoid node-gyp cache issues
+RUN npx node-gyp install
+
 COPY package*.json ./
 
 RUN npm ci
@@ -18,6 +21,9 @@ COPY src/ ./src/
 
 RUN npm run build
 
+# Prune dev dependencies to get production-only node_modules
+RUN npm prune --omit=dev
+
 
 FROM base
 
@@ -25,11 +31,8 @@ WORKDIR /app
 
 COPY package*.json ./
 
-# Install build dependencies, run npm ci, then remove them in one layer.
-RUN apk add --no-cache python3 make g++ \
-    && npm ci --omit=dev \
-    && apk del python3 make g++ \
-    && npm cache clean --force
+# Copy pre-built node_modules from builder (already pruned to production deps)
+COPY --from=builder /build/node_modules ./node_modules
 
 COPY --from=builder /build/dist ./dist
 

--- a/nginx-packager/openid.tpl.lua
+++ b/nginx-packager/openid.tpl.lua
@@ -77,6 +77,34 @@ else
       if (authenticate_err ~= nil) then
         ngx.log(ngx.DEBUG, 'User authentication error: ', authenticate_err)
       end
+
+      -- Check if this is an OAuth callback with state mismatch error (common in multi-tab scenarios
+      -- where one tab logs out/in while another tab initiates OAuth in the background).
+      -- When Tab 1 is idle and Tab 2 logs out then logs in, Tab 1's background API polling
+      -- triggers a new OAuth flow that overwrites Tab 2's state, causing Tab 2's callback to fail.
+      local request_uri = ngx.var.request_uri or ""
+      local is_oauth_callback = string.find(request_uri, "/auth/openidc/return", 1, true)
+
+      if is_oauth_callback and authenticate_err then
+        local err_lower = string.lower(authenticate_err)
+        local is_state_error = string.find(err_lower, "state") or
+                               string.find(err_lower, "does not match") or
+                               string.find(err_lower, "mismatch") or
+                               string.find(err_lower, "csrf")
+
+        if is_state_error then
+          ngx.log(ngx.WARN, 'OAuth state mismatch on callback (likely multi-tab race condition), restarting auth flow: ', authenticate_err)
+          -- Destroy current session to clear stale OAuth state
+          local session = require("resty.session").open()
+          if session then
+            session:destroy()
+          end
+          -- Redirect to /login to trigger a fresh OAuth flow automatically
+          -- (Keycloak will use existing session if valid, so user won't need to re-enter credentials)
+          return ngx.redirect("/login")
+        end
+      end
+
       -- Let client know in the response that client is not (or no longer) authenticated (so that the UI could notify user that he's been signed out)
       ngx.header['WWW-Authenticate'] = string.format('realm="%s"', node_host_with_protocol)
       -- Respond with 401 Unauthorized if the requested endpoint does not allow anonymous access


### PR DESCRIPTION
This is to fix the 401 when there are more than 1 tab initiating the keycloak login flow in parallel (issue #4771  )

Plus the bridge service's Dockerfile fix (to build on ARM + optimization for faster build)