### PR TITLE
Camel-case renamed tokens' symbols

### DIFF
--- a/mercata/backend/src/api/services/tokens.v2.service.ts
+++ b/mercata/backend/src/api/services/tokens.v2.service.ts
@@ -103,8 +103,8 @@ export const getEarningAssets = async (
       totalBalance: totalBalance.toString(),
       isPoolToken:
         t._symbol?.endsWith("-LP") ||
-        t._symbol === "SUSDST" ||
-        t._symbol === "MUSDST" ||
+        t._symbol === "SUSDST" || t._symbol === "safetyUSDST" ||
+        t._symbol === "MUSDST" || t._symbol === "lendUSDST" ||
         t.description === "Liquidity Provider Token",
       value,
     };
@@ -151,8 +151,8 @@ export const getPublicEarningAssets = async (
       totalBalance: totalBalance.toString(),
       isPoolToken:
         t._symbol?.endsWith("-LP") ||
-        t._symbol === "SUSDST" || t._symbol === "SAFETYUSDST" ||
-        t._symbol === "MUSDST" || t._symbol === "LENDUSDST" ||
+        t._symbol === "SUSDST" || t._symbol === "safetyUSDST" ||
+        t._symbol === "MUSDST" || t._symbol === "lendUSDST" ||
         t.description === "Liquidity Provider Token",
       value,
     };
@@ -394,7 +394,7 @@ export const getNetBalanceHistory = async (
   const storageFilters = [
     'data->>lpToken.neq.""',
     'data->>_symbol.like.*-LP',
-    'data->>_symbol.in.(MUSDST,SUSDST,SAFETYUSDST,LENDUSDST)',
+    'data->>_symbol.in.(MUSDST,SUSDST,safetyUSDST,lendUSDST)',
     'data->>sToken.gt.0',
     'and(data->>mToken.gt.0,data->>borrowIndex.gt.0)'
   ]

--- a/mercata/ui/src/components/dashboard/MyPoolParticipationSection.tsx
+++ b/mercata/ui/src/components/dashboard/MyPoolParticipationSection.tsx
@@ -43,7 +43,7 @@ export default function MyPoolParticipationSection({
         return liquidityInfo.supplyAPY?.toFixed(2) || null;
       }
 
-      if (token._symbol === "SUSDST" || token._symbol === "SAFETYUSDST") return null;
+      if (token._symbol === "SUSDST" || token._symbol === "safetyUSDST") return null;
 
       if (
         token._symbol?.endsWith("-LP") ||

--- a/mercata/ui/src/lib/tokenPriority.ts
+++ b/mercata/ui/src/lib/tokenPriority.ts
@@ -29,7 +29,7 @@ export const getTokenPriority = (token: Token): number => {
   if (collateralTokens.includes(symbol)) return 2;
 
   // Priority 3: Special LP Tokens
-  const specialLpTokens = ['MUSDST', 'SUSDST', 'LENDUSDST', 'SAFETYUSDST'];
+  const specialLpTokens = ['MUSDST', 'SUSDST', 'lendUSDST', 'safetyUSDST'];
   if (specialLpTokens.includes(symbol)) return 3;
 
   // Priority 4: LP Tokens (contains "LP" in symbol)


### PR DESCRIPTION
Camel-case renamed tokens' symbols (not just their names) in app-side support for lendUSDST and safetyUSDST