### PR TITLE
Hide inactive token pairs from Swap page and Advanced/Swap view

### DIFF
--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -129,9 +129,12 @@ export const getSwapableTokens = async (
     }
   });
 
-  // Filter out hidden pools
+  // Filter out hidden pools and pools with deactivated tokens
+  const ACTIVE_TOKEN_STATUS = "2";
   const validatedPools = (poolData as (PoolWithTokens & { address: string })[]).filter(
     pool => !config.hiddenSwapPools.has(pool.address)
+      && pool.tokenA.status === ACTIVE_TOKEN_STATUS
+      && pool.tokenB.status === ACTIVE_TOKEN_STATUS
   ) as PoolWithTokens[];
   const tokenAddresses = extractTokenAddresses(validatedPools);
   const priceMap = await getOraclePrices(accessToken, {
@@ -180,12 +183,15 @@ export const getSwapableTokenPairs = async (
     })
   ]);
 
-  // Filter out hidden pools
+  // Filter out hidden pools and pools with deactivated tokens
+  const ACTIVE_TOKEN_STATUS = "2";
   const validatedPoolsA = (poolDataA as (PoolWithTokenB & { address: string })[]).filter(
     pool => !config.hiddenSwapPools.has(pool.address)
+      && pool.tokenB.status === ACTIVE_TOKEN_STATUS
   ) as PoolWithTokenB[];
   const validatedPoolsB = (poolDataB as (PoolWithTokenA & { address: string })[]).filter(
     pool => !config.hiddenSwapPools.has(pool.address)
+      && pool.tokenA.status === ACTIVE_TOKEN_STATUS
   ) as PoolWithTokenA[];
 
   const allTokens: Array<{token: RawToken, poolBalance: string}> = [

--- a/mercata/backend/src/api/services/swapping.service.ts
+++ b/mercata/backend/src/api/services/swapping.service.ts
@@ -66,9 +66,12 @@ export const getPools = async (
     })
   ]);
 
-  // Filter out hidden pools
+  // Filter out hidden pools and pools with deactivated tokens (status !== 2 = ACTIVE)
+  const ACTIVE_TOKEN_STATUS = "2";
   const validatedPools = (poolData as RawGetPool[]).filter(
     pool => !config.hiddenSwapPools.has(pool.address)
+      && pool.tokenA.status === ACTIVE_TOKEN_STATUS
+      && pool.tokenB.status === ACTIVE_TOKEN_STATUS
   );
   const validatedFactory = factoryData[0] as RawPoolFactory;
   const tokenAddresses = extractTokenAddresses(validatedPools);

--- a/mercata/backend/src/config/swapConstants.ts
+++ b/mercata/backend/src/config/swapConstants.ts
@@ -27,6 +27,7 @@ export const SWAP_TOKEN_SELECT_FIELDS = [
   "_symbol",
   "_totalSupply::text",
   "customDecimals",
+  "status",
   `balances:${SWAP_CONTRACTS.Token}-_balances(user:key,balance:value::text)`,
   `images:${SWAP_CONTRACTS.Token}-images(value)`,
 ] as const;

--- a/mercata/packages/shared-types/src/swap-types.ts
+++ b/mercata/packages/shared-types/src/swap-types.ts
@@ -172,6 +172,7 @@ export interface RawToken {
   _symbol: string;
   customDecimals: number;
   _totalSupply: string;
+  status: string;
   balances: TokenBalance[];
   images: Array<{ value: string }>;
 }

--- a/mercata/packages/shared-types/src/swap-types.ts
+++ b/mercata/packages/shared-types/src/swap-types.ts
@@ -186,6 +186,7 @@ export interface RawLPToken {
   _symbol: string;
   customDecimals: number;
   _totalSupply: string;
+  status: string;
   balances: TokenBalance[];
   images: Array<{ value: string }>;
 }


### PR DESCRIPTION
Basically just added `status` field to some interfaces and filtering for the corresponding backend endpoints