### PR TITLE
fixed vault all-time earnings when value is close to 0

### DIFF
--- a/mercata/ui/src/components/vault/VaultUserPosition.tsx
+++ b/mercata/ui/src/components/vault/VaultUserPosition.tsx
@@ -31,7 +31,7 @@ const formatShares = (value: string): string => {
 const formatEarnings = (value: string): { formatted: string; isPositive: boolean; isZero: boolean } => {
   try {
     const num = parseFloat(formatUnits(value, 18));
-    const isZero = num === 0;
+    const isZero = Math.abs(num) < 0.005;
     const isPositive = num >= 0;
     const absFormatted = Math.abs(num).toLocaleString("en-US", {
       minimumFractionDigits: 2,


### PR DESCRIPTION
Fixes #6218

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed display formatting for vault all-time earnings when values are close to zero. Changed the zero-check from exact equality (`num === 0`) to a threshold comparison (`Math.abs(num) < 0.005`) to handle the edge case where values like $0.001 or -$0.003 would display as "+$0.00" or "-$0.00" after rounding, creating visual inconsistency. Now correctly displays "$0.00" without sign prefix for any value that rounds to zero with 2 decimal places.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line change that fixes a specific UI display bug without affecting business logic, data handling, or user actions. The fix is mathematically sound and aligns with the 2-decimal formatting already in place
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/ui/src/components/vault/VaultUserPosition.tsx | Fixed edge case where values close to 0 (< 0.005) displayed with sign prefix but rounded to $0.00 |

</details>


</details>


<sub>Last reviewed commit: 7a1d06d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->