### PR TITLE
6227 oracle messages

### DIFF
--- a/mercata/services/oracle/src/cronScheduler.ts
+++ b/mercata/services/oracle/src/cronScheduler.ts
@@ -133,14 +133,19 @@ function aggregatePrices(
         const sources: Array<{ name: string; price: number }> = [];
         let expectedCount = weekdaySources.length;
 
+        const failedSources: string[] = [];
+
         const collect = (names: string[], symbol: string) => {
+            failedSources.length = 0;
             names.forEach(name => {
                 const result = sourceResults.get(name);
                 const data = result?.success && result?.prices[symbol];
                 if (data) {
                     sources.push({ name, price: data.price });
                 } else if (result?.success) {
-                    logInfo('CronScheduler', `${symbol}: ${name} returned no price (API succeeded but symbol missing from response)`);
+                    failedSources.push(`${name}(no ${symbol})`);
+                } else {
+                    failedSources.push(`${name}(fetch failed)`);
                 }
             });
             return sources.length;
@@ -160,9 +165,11 @@ function aggregatePrices(
                 expectedCount = weekdaySources.length;
             }
         }
-        
+
         const isValid = sources.length >= requiredSources;
-        if (!isValid) logError('CronScheduler', new Error(`Insufficient sources for ${assetKey}: got ${sources.length}, need ${requiredSources}`));
+        if (!isValid) {
+            logError('CronScheduler', new Error(`Insufficient sources for ${assetKey}: got ${sources.length}, need ${requiredSources}. Failed: [${failedSources.join(', ')}]`));
+        }
         
         const medianPrice = isValid ? calculateMedian(sources.map(s => s.price)) : 0;
         

--- a/mercata/services/oracle/src/utils/slackNotifier.ts
+++ b/mercata/services/oracle/src/utils/slackNotifier.ts
@@ -38,40 +38,7 @@ export async function sendWarningToSlack(context: string, message: string, times
 
     await client.chat.postMessage({
         channel,
-        text: `${emoji} ${oracleName} - Warning: ${message.slice(0, 100)}...`,
-        blocks: [
-            {
-                type: 'header',
-                text: {
-                    type: 'plain_text',
-                    text: `${emoji} ${oracleName} - Warning`,
-                    emoji: true
-                }
-            },
-            {
-                type: 'section',
-                fields: [
-                    {
-                        type: 'mrkdwn',
-                        text: `*Context:*\n${context}`
-                    },
-                    {
-                        type: 'mrkdwn',
-                        text: `*Timestamp:*\n${timestamp}`
-                    }
-                ]
-            },
-            {
-                type: 'section',
-                text: {
-                    type: 'mrkdwn',
-                    text: `*Message:*\n\`\`\`${message}\`\`\``
-                }
-            },
-            {
-                type: 'divider'
-            }
-        ]
+        text: `${emoji} *${oracleName}* [${context}] ${message}`,
     });
 
     logInfo('SlackNotifier', `Warning sent to ${channel}`);


### PR DESCRIPTION
1. Minify the format of the Oracle warnings on #ops-monitoring. Make them one line text strings instead of what's on the image
<img width="612" height="187" alt="image" src="https://github.com/user-attachments/assets/3866ae58-1db0-4d93-98b7-d2683b81c833" />


2. Add the names of the failed sources in the error messages like these ones (to see in the oracle-error.flag file):
```
{"timestamp":"2026-02-09T16:45:42.478Z","error":"[ERROR] 2026-02-09T16:45:42.477Z | CronScheduler | Insufficient sources for KAG: got 2, need 3"}
{"timestamp":"2026-02-09T16:45:42.478Z","error":"[ERROR] 2026-02-09T16:45:42.478Z | CronScheduler | Insufficient sources for SUSDS: got 2, need 3"}
{"timestamp":"2026-02-09T17:00:32.755Z","error":"[ERROR] 2026-02-09T17:00:32.755Z | CronScheduler | Insufficient sources for KAG: got 2, need 3"}
{"timestamp":"2026-02-09T17:00:32.755Z","error":"[ERROR] 2026-02-09T17:00:32.755Z | CronScheduler | Insufficient sources for SUSDS: got 2, need 3"}
```