### PR TITLE
Check for 0 modulus to prevent crash

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1134,7 +1134,12 @@ expToVar' ex@(CC.Binary _ "/=" lhs rhs) = do
     Left 0 -> divideByZero $ unparseExpression ex
     Right 0 -> divideByZero $ unparseExpression ex
     _ -> binopDivide (div) (/) lhs rhs
-expToVar' (CC.Binary _ "%=" lhs rhs) = binopAssign' rem decMod lhs rhs (const byteWidth)
+expToVar' (CC.Binary _ "%=" lhs rhs) = do
+  rhs' <- getRealNum =<< expToVar rhs
+  case rhs' of
+    Left 0 -> divideByZero $ unparseExpression ex
+    Right 0 -> divideByZero $ unparseExpression ex
+    _ -> binopAssign' rem decMod lhs rhs (const byteWidth)
 expToVar' (CC.Binary _ "|=" lhs rhs) = binopAssign (.|.) lhs rhs (max `on` byteWidth)
 expToVar' (CC.Binary _ "&=" lhs rhs) = binopAssign (.&.) lhs rhs (max `on` byteWidth)
 expToVar' (CC.Binary _ "^=" lhs rhs) = binopAssign xor lhs rhs (max `on` byteWidth)
@@ -1306,7 +1311,12 @@ expToVar' ex@(CC.Binary _ "/" expr1 expr2) = do
     Right 0 -> divideByZero $ unparseExpression ex
     _ -> expToVarDivide (div) (/) expr1 expr2
 --modified to use decimal division
-expToVar' (CC.Binary _ "%" expr1 expr2) = expToVarArith rem decMod expr1 expr2 (const byteWidth)
+expToVar' (CC.Binary _ "%" expr1 expr2) = do
+  rhs <- getRealNum =<< expToVar expr2
+  case rhs of
+    Left 0 -> divideByZero $ unparseExpression ex
+    Right 0 -> divideByZero $ unparseExpression ex
+    _ -> expToVarArith rem decMod expr1 expr2 (const byteWidth)
 expToVar' (CC.Binary _ "|" expr1 expr2) = expToVarInteger expr1 (.|.) expr2 SInteger (max `on` byteWidth)
 expToVar' (CC.Binary _ "&" expr1 expr2) = expToVarInteger expr1 (.&.) expr2 SInteger (max `on` byteWidth)
 expToVar' (CC.Binary _ "^" expr1 expr2) = expToVarInteger expr1 xor expr2 SInteger (max `on` byteWidth)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -1134,7 +1134,7 @@ expToVar' ex@(CC.Binary _ "/=" lhs rhs) = do
     Left 0 -> divideByZero $ unparseExpression ex
     Right 0 -> divideByZero $ unparseExpression ex
     _ -> binopDivide (div) (/) lhs rhs
-expToVar' (CC.Binary _ "%=" lhs rhs) = do
+expToVar' ex@(CC.Binary _ "%=" lhs rhs) = do
   rhs' <- getRealNum =<< expToVar rhs
   case rhs' of
     Left 0 -> divideByZero $ unparseExpression ex
@@ -1311,7 +1311,7 @@ expToVar' ex@(CC.Binary _ "/" expr1 expr2) = do
     Right 0 -> divideByZero $ unparseExpression ex
     _ -> expToVarDivide (div) (/) expr1 expr2
 --modified to use decimal division
-expToVar' (CC.Binary _ "%" expr1 expr2) = do
+expToVar' ex@(CC.Binary _ "%" expr1 expr2) = do
   rhs <- getRealNum =<< expToVar expr2
   case rhs of
     Left 0 -> divideByZero $ unparseExpression ex


### PR DESCRIPTION
Performing a modulus by 0 currently causes the entire node to crash, because the Haskell `rem` function is partial. Instead, we should check for a 0 modulus similar to checking for a 0 divisor, and throw a proper divide by zero exception.