### PR TITLE
Claude Fix #6241: Update Token Status instructions in Admin Panel

### DIFF
--- a/mercata/ui/src/components/admin/SetTokenStatusForm.tsx
+++ b/mercata/ui/src/components/admin/SetTokenStatusForm.tsx
@@ -123,8 +123,8 @@ const SetTokenStatusModal = ({ open, onOpenChange, token }: SetTokenStatusModalP
             <Alert>
               <Info className="h-4 w-4" />
               <AlertDescription>
-                Changing token status affects how the token behaves across the platform. Only the token owner
-                can call this function. Ensure you have the proper permissions before attempting this operation.
+                Changing token status affects how the token behaves across the platform.
+                Only the token owner can call this function.
               </AlertDescription>
             </Alert>
 

--- a/mercata/ui/src/components/admin/SetTokenStatusForm.tsx
+++ b/mercata/ui/src/components/admin/SetTokenStatusForm.tsx
@@ -123,8 +123,8 @@ const SetTokenStatusModal = ({ open, onOpenChange, token }: SetTokenStatusModalP
             <Alert>
               <Info className="h-4 w-4" />
               <AlertDescription>
-                Changing token status affects how the token behaves across the platform. Only the TokenFactory 
-                contract can call this function. Ensure you have the proper permissions before attempting this operation.
+                Changing token status affects how the token behaves across the platform. Only the token owner
+                can call this function. Ensure you have the proper permissions before attempting this operation.
               </AlertDescription>
             </Alert>
 


### PR DESCRIPTION
## Summary

Auto-generated fix for issue #6241

**Files changed:** `mercata/ui/src/components/admin/SetTokenStatusForm.tsx`

**Root cause:** The Alert text in SetTokenStatusForm.tsx incorrectly states 'Only the TokenFactory contract can call this function' when the actual smart contract access control uses the `onlyOwner` modifier. The `setStatus()` function in Token.sol (line 97) is guarded by `onlyOwner`, not `onlyTokenFactory`. Only the token's owner (or admin registry via vote) can call setStatus.

**Caveats:**
- This is a text-only change in a UI info alert — no logic or behavior is affected

**Testing notes:**
- Open the Admin Panel, click 'Set' on any token in the Token Status table, and verify the info alert in the modal now reads 'Only the token owner can call this function' instead of 'Only the TokenFactory contract can call this function'

**Confidence:** 96%

## Confidence Breakdown

{
  "triage": 0.95,
  "research": 0.98,
  "fix": 0.95,
  "review": 0.95
}

## Test Plan

- [ ] Review the changes
- [ ] Run tests
- [ ] Verify fix addresses the issue

---
*Generated by [STRATO Fix All The Things](https://github.com/strato-net/strato-fix-all-the-things)*