### PR TITLE
Add Vault to mobile UI

### DIFF
--- a/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
+++ b/mercata/ui/src/components/dashboard/MobileBottomNav.tsx
@@ -1,20 +1,21 @@
 import { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { 
-  LayoutDashboard, 
-  ArrowUpDown, 
-  Landmark, 
-  ArrowLeftRight, 
-  Menu, 
-  Send, 
-  Gift, 
-  Activity, 
-  Download, 
-  BarChart3, 
-  Droplets, 
+import {
+  LayoutDashboard,
+  ArrowUpDown,
+  Landmark,
+  ArrowLeftRight,
+  Menu,
+  Send,
+  Gift,
+  Activity,
+  Download,
+  BarChart3,
+  Droplets,
   Shield,
   UserPlus,
-  X 
+  Vault,
+  X
 } from 'lucide-react';
 import { Drawer, DrawerClose, DrawerContent } from '@/components/ui/drawer';
 import { useUser } from '@/context/UserContext';
@@ -30,6 +31,7 @@ const PRIMARY_NAV_ITEMS = [
 // Items shown in "More" drawer
 const MORE_ITEMS = [
   { icon: Send, label: 'Transfer', path: '/dashboard/transfer' },
+  { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
   { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
   { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
   { icon: Download, label: 'Withdrawals', path: '/dashboard/withdrawals' },

--- a/mercata/ui/src/components/dashboard/MobileSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/MobileSidebar.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from 'next-themes';
-import { LayoutDashboard, Wallet, Book, ArrowRightLeft, Send, Shield, X, Activity, BarChart3, Droplets, Download, Coins, UserPlus } from 'lucide-react';
+import { LayoutDashboard, Wallet, Book, ArrowRightLeft, Send, Shield, X, Activity, BarChart3, Droplets, Download, Coins, UserPlus, Vault } from 'lucide-react';
 import { useUser } from '@/context/UserContext';
 import STRATOLOGO from '@/assets/strato.png';
 import STRATOLOGODARK from '@/assets/strato-dark.png';
@@ -22,6 +22,7 @@ const MobileSidebar = ({ isOpen, onClose }: MobileSidebarProps) => {
     { icon: <Send size={20} />, label: 'Transfer', path: '/dashboard/transfer' },
     { icon: <Book size={20} />, label: 'Borrow', path: '/dashboard/borrow' },
     { icon: <ArrowRightLeft size={20} />, label: 'Swap', path: '/dashboard/swap' },
+    { icon: <Vault size={20} />, label: 'Vault', path: '/dashboard/vault' },
     { icon: <Droplets size={20} />, label: 'Advanced', path: '/dashboard/advanced' },
     { icon: <Coins size={20} />, label: 'Rewards', path: '/dashboard/rewards' },
     { icon: <UserPlus size={20} />, label: 'My Referrals', path: '/dashboard/referrals' },

--- a/mercata/ui/src/pages/Vault.tsx
+++ b/mercata/ui/src/pages/Vault.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import DashboardSidebar from "@/components/dashboard/DashboardSidebar";
 import DashboardHeader from "@/components/dashboard/DashboardHeader";
 import MobileSidebar from "@/components/dashboard/MobileSidebar";
+import MobileBottomNav from "@/components/dashboard/MobileBottomNav";
 import VaultOverview from "@/components/vault/VaultOverview";
 import VaultTransactions from "@/components/vault/VaultTransactions";
 import VaultUserPosition from "@/components/vault/VaultUserPosition";
@@ -49,7 +50,7 @@ const Vault = () => {
           onMenuClick={() => setIsMobileSidebarOpen(true)}
         />
 
-        <main className="p-6 space-y-8">
+        <main className="p-4 md:p-6 pb-16 md:pb-6 space-y-8">
           {guestMode && (
             <GuestSignInBanner message="Sign in to deposit or withdraw from the vault" />
           )}
@@ -67,6 +68,8 @@ const Vault = () => {
           <VaultTransactions />
         </main>
       </div>
+
+      <MobileBottomNav />
 
       {/* Modals */}
       {!guestMode && (


### PR DESCRIPTION
## Summary
- Added Vault navigation item to mobile sidebar
- Added Vault to mobile bottom navigation "More" drawer  
- Added MobileBottomNav component to Vault page
- Added responsive bottom padding to Vault page for proper mobile layout

## Changes
### MobileSidebar.tsx
- Imported `Vault` icon from lucide-react
- Added Vault navigation item to `allNavItems` array (positioned after Swap)

### MobileBottomNav.tsx  
- Imported `Vault` icon from lucide-react
- Added Vault to `MORE_ITEMS` array (accessible via "More" button in bottom nav)

### Vault.tsx
- Imported and added `MobileBottomNav` component
- Updated main element padding to `p-4 md:p-6 pb-16 md:pb-6` for proper spacing on mobile

## Test Plan
- [x] Verify Vault appears in mobile sidebar when opened
- [x] Verify Vault appears in "More" drawer on mobile bottom navigation
- [x] Verify active state styling works correctly when on Vault page
- [x] Verify mobile bottom nav displays without obscuring content
- [x] Verify all vault components render correctly on mobile devices
- [x] Test on various mobile screen sizes

Fixes #6249

🤖 Generated with [Claude Code](https://claude.com/claude-code)