### PR TITLE
Sort Networks in BridgeContext

### DIFF
--- a/mercata/ui/src/context/BridgeContext.tsx
+++ b/mercata/ui/src/context/BridgeContext.tsx
@@ -15,6 +15,7 @@ import {
   NetworkSummary,
   BridgeContextType,
 } from "@/lib/bridge/types";
+import { NETWORK_SORT_PRIORITY } from "@/lib/bridge/constants";
 import { NetworkConfig, BridgeToken, BridgeTransactionResponse, BridgeTransactionTab, WithdrawalRequestParams, TransactionResponse, AutoSaveRequestParams, WithdrawalSummaryResponse } from "@mercata/shared-types";
 
 const BridgeContext = createContext<BridgeContextType | undefined>(undefined);
@@ -81,7 +82,13 @@ export const BridgeProvider = ({ children }: { children: ReactNode }) => {
           depositRouter: cfg.chainInfo.depositRouter,
         }));
 
-      networks.sort((a, b) => a.chainId.localeCompare(b.chainId));
+      // Sort networks by priority
+      const defaultPriority = NETWORK_SORT_PRIORITY.length+1;
+      networks.sort((a, b) => 
+        (NETWORK_SORT_PRIORITY.indexOf(Number(a.chainId))+1 || defaultPriority) -
+        (NETWORK_SORT_PRIORITY.indexOf(Number(b.chainId))+1 || defaultPriority)
+      );
+
       setAvailableNetworks(networks);
       setNetworksLoaded(true);
 

--- a/mercata/ui/src/lib/bridge/constants.ts
+++ b/mercata/ui/src/lib/bridge/constants.ts
@@ -189,6 +189,14 @@ export const SUPPORTED_CHAINS = {
   AVALANCHE: 43114
 } as const;
 
+// Network display priority; first network is default
+export const NETWORK_SORT_PRIORITY: Array<number> = [
+  SUPPORTED_CHAINS.MAINNET,
+  SUPPORTED_CHAINS.SEPOLIA,
+  SUPPORTED_CHAINS.BASE,
+  SUPPORTED_CHAINS.BASE_SEPOLIA,
+];
+
 const chainCache = new Map<number, Chain>();
 
 export async function resolveViemChain(


### PR DESCRIPTION
Custom sort order for chains to/from which to bridge; Ethereum, then Base. Applies both on mainnet and testnet.

Fixes #6242