### PR TITLE
NGINX_TRUST_PROXY_CIDRS added to support custom proxies to set x-forwarded-for

### DIFF
--- a/docker-compose.allDocker.tpl.yml
+++ b/docker-compose.allDocker.tpl.yml
@@ -256,6 +256,7 @@ services:
     - debugPort=${debugPort}
     - debugWSPort=${debugWSPort}
     - DOCS_HOST=${DOCS_HOST}
+    - NGINX_TRUST_PROXY_CIDRS=${NGINX_TRUST_PROXY_CIDRS}
     - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
     - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
     - OAUTH_SCOPE=${OAUTH_SCOPE}

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -163,6 +163,7 @@ services:
     - debugPort=${debugPort}
     - debugWSPort=${debugWSPort}
     - DOCS_HOST=${DOCS_HOST}
+    - NGINX_TRUST_PROXY_CIDRS=${NGINX_TRUST_PROXY_CIDRS}
     - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
     - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
     - OAUTH_SCOPE=${OAUTH_SCOPE}

--- a/nginx-packager/docker-run.sh
+++ b/nginx-packager/docker-run.sh
@@ -117,6 +117,19 @@ if [ ! -f /usr/local/openresty/nginx/conf/nginx.conf ]; then
   DOCKER_NETWORK_CIDR=$(ip route | awk '/src/ {print $1}')
   sed -i "s|__DOCKER_NETWORK_CIDR__|$DOCKER_NETWORK_CIDR|g" /tmp/nginx.conf
 
+  # Generate set_real_ip_from directives for trusted proxy IPs
+  TRUST_PROXY_LINES=""
+  if [ -n "${NGINX_TRUST_PROXY_CIDRS:-}" ]; then
+    IFS=',' read -ra CIDRS <<< "$NGINX_TRUST_PROXY_CIDRS"
+    for cidr in "${CIDRS[@]}"; do
+      cidr=$(echo "$cidr" | xargs) # trim whitespace
+      if [ -n "$cidr" ]; then
+        TRUST_PROXY_LINES="${TRUST_PROXY_LINES}    set_real_ip_from ${cidr};\n"
+      fi
+    done
+  fi
+  sed -i "s|__TRUST_PROXY_CIDRS__|${TRUST_PROXY_LINES%\\\\n}|g" /tmp/nginx.conf
+
   ########
   ### Generate .lua scripts from templates according to configuration provided
   ########

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -33,7 +33,7 @@ http {
     set_real_ip_from 172.64.0.0/13;
     set_real_ip_from 131.0.72.0/22;
     
-    # Custom CIDRs can be added with NGINX_TRUST_PROXY_CIDR
+    # Custom CIDRs can be added with NGINX_TRUST_PROXY_CIDRS
 __TRUST_PROXY_CIDRS__
 
     log_format json_combined escape=json

--- a/nginx-packager/nginx.tpl.conf
+++ b/nginx-packager/nginx.tpl.conf
@@ -33,9 +33,8 @@ http {
     set_real_ip_from 172.64.0.0/13;
     set_real_ip_from 131.0.72.0/22;
     
-    # Load balancer IPs
-    # TODO: make this optional and configurable with an env var for security reasons and for special cases with different hosting modes
-    set_real_ip_from 10.0.0.0/16;
+    # Custom CIDRs can be added with NGINX_TRUST_PROXY_CIDR
+__TRUST_PROXY_CIDRS__
 
     log_format json_combined escape=json
       '{'


### PR DESCRIPTION
This is to add the CIDR blocks of IPs to trust them to set the X-FORWARDED-FOR.
Previously we only trusted the cloudflare to do that.
When the app is behind the load balancer, its IPs should be added too in order for nginx to set the "remote_addr" in the request correctly (rather than having the proxy's IP in it).
For AWS ALB used for app nodes A and B, the CIDR will be 10.0.0.0/16 (I already set the NGINX_TRUST_PROXY_CIDRS with that value in their strato-run.sh scripts)