### PR TITLE
Allow 12-character token symbols

### DIFF
--- a/mercata/ui/src/components/admin/CreateTokenForm.tsx
+++ b/mercata/ui/src/components/admin/CreateTokenForm.tsx
@@ -205,8 +205,8 @@ const CreateTokenForm = () => {
                 message: 'Symbol must be letters only'
               },
               maxLength: {
-                value: 10,
-                message: 'Symbol must be 10 characters or less'
+                value: 12,
+                message: 'Symbol must be 12 characters or less'
               }
             }}
             render={({ field }) => (


### PR DESCRIPTION
Allow token symbols of up to 12 characters in length through the Admin Create Token UI (rather than 10 character limit).

This is required for #6208 because `syrupUSDCST` is 11 characters long.