### PR TITLE
kill local session if the keycloak session expired - to handle repeated refresh errors

### DIFF
--- a/nginx-packager/openid.tpl.lua
+++ b/nginx-packager/openid.tpl.lua
@@ -81,6 +81,15 @@ else
         ngx.log(ngx.DEBUG, 'User authentication error: ', authenticate_err)
       end
 
+      -- Destroy the stale session to prevent repeated refresh token attempts
+      -- against an expired/revoked Keycloak session. Without this, concurrent
+      -- requests each independently try to refresh the same dead token,
+      -- flooding Keycloak with REFRESH_TOKEN_ERROR warnings.
+      local stale_session = require("resty.session").open()
+      if stale_session then
+        stale_session:destroy()
+      end
+
       -- Handle OIDC callback state mismatch (multi-tab race condition):
       -- When multiple tabs initiate auth flows, each overwrites the OIDC state in the shared
       -- session cookie. The tab whose callback arrives with the old state gets this error.

--- a/nginx-packager/openid.tpl.lua
+++ b/nginx-packager/openid.tpl.lua
@@ -58,7 +58,7 @@ if ngx.req.get_headers()["Authorization"] then
 else
   -- Else - use the openidc authenticate flow
 
-  local authenticate_res, authenticate_err
+  local authenticate_res, authenticate_err, authenticate_session
   -- Allow anonymous access only for safe/read-only methods on endpoints that explicitly allow it
   local method = ngx.req.get_method()
   local allow_anonymous_request = ngx.var.allow_optional_anon_access == "true" and (method == "GET" or method == "HEAD" or method == "OPTIONS")
@@ -75,19 +75,25 @@ else
     end
   else
     -- only validate the session (do not redirect automatically for Auth Code Grant flow)
-    authenticate_res, authenticate_err = openidc.authenticate(authenticate_opts, nil, "deny")
+    -- 4th return value is the session object, needed to detect dead refresh tokens below
+    authenticate_res, authenticate_err, _, authenticate_session = openidc.authenticate(authenticate_opts, nil, "deny")
     if (authenticate_res == nil or authenticate_err ~= nil) then
       if (authenticate_err ~= nil) then
         ngx.log(ngx.DEBUG, 'User authentication error: ', authenticate_err)
       end
 
-      -- Destroy the stale session to prevent repeated refresh token attempts
-      -- against an expired/revoked Keycloak session. Without this, concurrent
-      -- requests each independently try to refresh the same dead token,
-      -- flooding Keycloak with REFRESH_TOKEN_ERROR warnings.
-      local stale_session = require("resty.session").open()
-      if stale_session then
-        stale_session:destroy()
+      -- If the session had a refresh token but authenticate() still failed, the
+      -- refresh token is dead. Destroy the session to prevent every subsequent
+      -- request from retrying it and flooding Keycloak with REFRESH_TOKEN_ERROR.
+      -- We check session state because lua-resty-openidc swallows the token
+      -- endpoint error (sets err=nil) and returns generic "unauthorized request".
+      if authenticate_session
+          and authenticate_session.data
+          and authenticate_session.data.authenticated
+          and authenticate_session.data.refresh_token
+      then
+        ngx.log(ngx.DEBUG, "Destroying stale session due to failed token refresh: ", authenticate_err)
+        authenticate_session:destroy()
       end
 
       -- Handle OIDC callback state mismatch (multi-tab race condition):


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added session cleanup logic to handle expired Keycloak refresh tokens by capturing the session object (4th return value) from `openidc.authenticate()` and destroying it when authentication fails despite having a refresh token. This prevents flooding Keycloak with repeated `REFRESH_TOKEN_ERROR` requests on every subsequent API call.

**Key changes:**
- Captures `authenticate_session` as 4th return value from `openidc.authenticate()` on line 79
- Added session validation checks (lines 90-94) to verify session has refresh token
- Calls `authenticate_session:destroy()` when authentication fails with a stale refresh token (line 96)
- Includes debug logging to track session destruction events (line 95)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with low risk - addresses a specific session cleanup issue
- The change is focused and addresses a specific bug (flooding Keycloak with refresh token errors). The logic correctly checks for session existence and refresh token presence before destroying the session. However, since this is marked as [WIP], there may be additional testing or refinement needed before final merge.
- No files require special attention - single focused change with clear purpose

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| nginx-packager/openid.tpl.lua | Added session destruction logic to handle expired Keycloak refresh tokens; captures 4th return value from authenticate() to detect and destroy stale sessions |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Request without Authorization header] --> B{Is UI request?}
    B -->|Yes| C[authenticate with redirect flow]
    B -->|No| D[authenticate with deny mode]
    D --> E[Capture session object 4th return value]
    E --> F{Authentication failed?}
    F -->|No| K[Use access token]
    F -->|Yes| G{Session has refresh_token?}
    G -->|No| H[Handle error normally]
    G -->|Yes| I[Destroy stale session]
    I --> J[Prevent Keycloak flooding]
    J --> H
    H --> L{State mismatch error?}
    L -->|Yes| M[Destroy session and redirect]
    L -->|No| N{Allow anonymous?}
    N -->|No| O[Return 401]
    N -->|Yes| P[Allow request]
```
</details>


<sub>Last reviewed commit: ab5c23c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->