### PR TITLE
Fix GROUP BY error: replace inline subqueries with jsonb_obj_to_array…

### DIFF
--- a/strato/indexer/slipstream/src/Blockchain/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Blockchain/Slipstream/OutputData.hs
@@ -607,7 +607,7 @@ createIndexTable contract cc (creator, n) inherited = do
       -- histTableName = historyTableName creator a n
       cols = getTableColumnAndType False cc $ map (\(x, y) -> (labelToText x, y ^. varType)) $ Map.toList $ contract ^. storageDefs
       contractCols = ["creator", "contract_name"]
-      cols' = (\(x, t, _) -> (x, t)) <$> cols
+      cols' = [(x, t) | (x, t, _) <- cols, t /= SqlJsonbArray]
       fkeys = mapMaybe (\(x, t, mf) -> (\f -> ForeignKeyInfo tableName (indexTableName creator f) x t) <$> mf) cols
   yield $ CreateView
     tableName

--- a/strato/indexer/slipstream/src/Blockchain/Slipstream/OutputData.hs
+++ b/strato/indexer/slipstream/src/Blockchain/Slipstream/OutputData.hs
@@ -297,11 +297,11 @@ slipstreamQueryText _ CreateView{..} =
                 _ -> ""
             , case t of
                 SqlJsonbArray -> T.concat
-                  [ "THEN (SELECT jsonb_agg(val ORDER BY idx::int) FROM jsonb_each(s."
+                  [ "THEN jsonb_obj_to_array(s."
                   , wrapEscapeDouble dataColumn
                   , "->'"
                   , c
-                  , "') AS e(idx, val) WHERE idx != '_length')"
+                  , "')"
                   , " ELSE '[]'::jsonb"
                   ]
                 SqlJsonb -> T.concat
@@ -344,11 +344,11 @@ slipstreamQueryText _ CreateView{..} =
                   , wrapEscapeDouble dataColumn
                   , ", '"
                   , c
-                  , "') THEN (SELECT jsonb_agg(val ORDER BY idx::int) FROM jsonb_each(s."
+                  , "') THEN jsonb_obj_to_array(s."
                   , wrapEscapeDouble dataColumn
                   , "->'"
                   , c
-                  , "') AS e(idx, val) WHERE idx != '_length')"
+                  , "')"
                   , " ELSE '[]'::jsonb END"
                   ]
                 _ -> T.concat
@@ -1252,6 +1252,7 @@ initialSlipstreamQueries =
       (Just $ Foreign "event_event_array" ["address", "block_hash", "event_index"] globalEventTableName ["address", "block_hash", "event_index"])
       []
   , RawSQL jsonbMergeDeepSQL
+  , RawSQL jsonbObjToArraySQL
   ]
 
 jsonbMergeDeepSQL :: Text
@@ -1288,4 +1289,11 @@ jsonbMergeDeepSQL = T.unlines
   , "  RETURN b;"
   , "END;"
   , "$fn$ LANGUAGE plpgsql IMMUTABLE;"
+  ]
+
+jsonbObjToArraySQL :: Text
+jsonbObjToArraySQL = T.unlines
+  [ "CREATE OR REPLACE FUNCTION jsonb_obj_to_array(obj jsonb) RETURNS jsonb AS $fn$"
+  , "SELECT COALESCE((SELECT jsonb_agg(val ORDER BY idx::int) FROM jsonb_each(obj) AS e(idx, val) WHERE idx != '_length'), '[]'::jsonb);"
+  , "$fn$ LANGUAGE sql IMMUTABLE;"
   ]


### PR DESCRIPTION
… function

The inline SELECT jsonb_agg(...) FROM jsonb_each(...) subqueries in SqlJsonbArray view columns broke PostgREST queries using count() with embedded resources, because PostgreSQL requires all non-aggregate columns in GROUP BY. A SQL function call is compatible with GROUP BY.