### PR TITLE
toBasic SNULL = Just BDefault

### DIFF
--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -648,19 +648,20 @@ runStatement (CC.RevertStatement mString theArgs pos) = do
   --    revert customError("error message")
   solidVMBreakpoint pos
   g <- getCurrentContract
+  currentBlockNum <- BlockHeader.number . Env.blockHeader <$> getEnv
   case mString of
     Just name -> do
       err <- case M.lookup name $ CC._errors g of
         Just _ -> do
           argVals <- mapM (getVar <=< expToVar) theArgs
-          let listOfVals = mapMaybe (\x -> toBasic x) argVals
+          let listOfVals = mapMaybe (\x -> toBasic currentBlockNum x) argVals
 
           return $ customError "Reverting based on  Error Method:" name listOfVals
         Nothing -> do revertError "REVERT: to initial state" name
       pure $ err
     Nothing -> do
       argVals <- mapM (getVar <=< expToVar) theArgs
-      let listOfVals = mapMaybe (\x -> toBasic x) argVals
+      let listOfVals = mapMaybe (\x -> toBasic currentBlockNum x) argVals
       return $ revertError "REVERT" listOfVals
 
 -- Assignment to an index into an array or mapping
@@ -906,7 +907,8 @@ runStatement (CC.Throw expr pos) = do
       CC.FunctionCall _ (CC.Variable _ n) a -> pure (n, a)
       _ -> invalidArguments "Invalid argument for throw." expr
   argVals <- mapM (getVar <=< expToVar) args
-  let listOfVals = mapMaybe (\x -> toBasic x) argVals
+  currentBlockNum <- BlockHeader.number . Env.blockHeader <$> getEnv
+  let listOfVals = mapMaybe (\x -> toBasic currentBlockNum x) argVals
   customError "Custom user error thrown" name listOfVals
 runStatement (CC.AssemblyStatement (CC.MloadAdd32 dst src) pos) = do
   solidVMBreakpoint pos
@@ -2480,7 +2482,8 @@ runTheConstructors from to hsh cc contractName' argVals' = do
         SVMType.Array _ _ -> return ()
         t -> do
           defVal <- createDefaultValue cc contract' t
-          for_ (toBasic defVal) $ markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n])
+          currentBlockNum <- BlockHeader.number . Env.blockHeader <$> getEnv
+          for_ (toBasic currentBlockNum defVal) $ markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n])
     -- SVMType.Bool -> markDiffForAction to (MS.StoragePath [MS.Field $ BC.pack $ labelToString n]) $ MS.BBool False
 
     forM_ (reverse $ contract' ^. CC.parents) $ \parent -> do

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -24,9 +24,12 @@ module Blockchain.SolidVM.SetGet
   )
 where
 
+import qualified Blockchain.Data.BlockHeader as BlockHeader
 import Blockchain.DB.SolidStorageDB
+import qualified Blockchain.SolidVM.Environment as Env
 import Blockchain.SolidVM.Exception
 import Blockchain.SolidVM.SM
+import Blockchain.Strato.Model.Options (computeNetworkID)
 import Control.Monad
 import Control.Monad.IO.Class
 import qualified Data.ByteString.Char8 as BC
@@ -61,8 +64,8 @@ fromBasic = \case
   MS.BEnumVal k v num -> SEnumVal k v num
   MS.BDefault -> SNULL
 
-toBasic :: Value -> Maybe MS.BasicValue
-toBasic = \case
+toBasic :: Integer -> Value -> Maybe MS.BasicValue
+toBasic currentBlockNum = \case
   SInteger i -> Just $ MS.BInteger i
   SString s -> Just . MS.BString . encodeUtf8 $ T.pack s
   SDecimal v -> Just $ MS.BDecimal $ BC.pack $ show v
@@ -70,8 +73,12 @@ toBasic = \case
   SAddress a _ -> Just $ MS.BAddress a
   SContract n a -> Just $ MS.BContract n a
   SEnumVal k t num -> Just $ MS.BEnumVal k t num
-  SUserDefined _ _ x -> toBasic x
+  SUserDefined _ _ x -> toBasic currentBlockNum x
   SBytes bs -> Just $ MS.BBytes bs
+  SNULL ->
+    let heliumToBasicForkBlock = 33918 :: Integer
+        snullToBasicEnabled = not (computeNetworkID == 114784819836269 && currentBlockNum < heliumToBasicForkBlock)
+     in if snullToBasicEnabled then Just MS.BDefault else Nothing
   _ -> Nothing
 
 setVar :: MonadSM m => Variable -> Value -> m ()
@@ -115,9 +122,11 @@ setVal (STuple dstVector) (STuple srcVector) =
 setVal dst@(SReference (AddressPath addr path)) src = do
   ro <- readOnly <$> getCurrentCallInfo
   when ro $ invalidWrite "Invalid write during read-only access" $ "src: " ++ show src ++ ", dst: " ++ show dst
-  let basicSrc = case src of
-        SString s -> Just . MS.BString . UTF8.fromString $ s
-        _ -> toBasic src
+  basicSrc <- case src of
+    SString s -> pure . Just . MS.BString . UTF8.fromString $ s
+    _ -> do
+      currentBlockNum <- BlockHeader.number . Env.blockHeader <$> getEnv
+      pure $ toBasic currentBlockNum src
   case basicSrc of
     Nothing -> typeError "non basic solidity type cannot be stored atomically" $ show src
     Just b -> do


### PR DESCRIPTION
Fixes https://github.com/blockapps/strato-platform/issues/6271

Makes `toBasic SNULL = Just BDefault`, which prevents the `non basic solidity type cannot be stored atomically` error from happening when adding two uninitialized storage variables.

For example,
```
contract A {
  uint x;
  uint y;

  constructor() {
    x = x + y;
  }
}
```

throws `type error: non basic solidity type cannot be stored atomically` before this change, but successfully sets `x` to 0 after this change (although it is still `BDefault`, meaning omitted from the MP trie)