### PR TITLE
Fix "Create Pool" isStable Toggle in Dark Mode

### DIFF
--- a/mercata/ui/src/components/admin/CreatePoolForm.tsx
+++ b/mercata/ui/src/components/admin/CreatePoolForm.tsx
@@ -200,7 +200,7 @@ const CreatePoolForm = () => {
               <FormItem>
                 <FormLabel>Is Stable Pool</FormLabel>
                 <div className="w-80" />
-                <Switch className="dark:bg-input" onCheckedChange={field.onChange} defaultChecked={field.value} />
+                <Switch onCheckedChange={field.onChange} checked={field.value} />
                 <FormDescription>
                   Toggling this field on will result in a stable swap pool being created,
                   rather than a traditional pool using the constant product formula.


### PR DESCRIPTION
Fixes #6286

@greptile Please review

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed the "Is Stable Pool" toggle visibility in dark mode by switching from uncontrolled (`defaultChecked`) to controlled (`checked`) component pattern and removing the dark mode className workaround.

**Key changes:**
- Changed Switch from `defaultChecked={field.value}` to `checked={field.value}` for proper react-hook-form integration
- Removed `className="dark:bg-input"` as the Switch component's built-in styling (`data-[state=unchecked]:bg-input`) now handles dark mode correctly

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple two-line fix that correctly switches from uncontrolled to controlled component pattern, following React best practices and the same pattern used by other form fields in this component (Select inputs use `value` not `defaultValue`)
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/ui/src/components/admin/CreatePoolForm.tsx | Fixed Switch component to use controlled pattern with `checked` prop instead of uncontrolled `defaultChecked`, and removed dark mode className workaround that relied on Tailwind's dark mode utility |

</details>


</details>


<sub>Last reviewed commit: ca15e92</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->