### PR TITLE
Fix Asset Details Price History chart

### DIFF
--- a/mercata/ui/src/pages/AssetDetail.tsx
+++ b/mercata/ui/src/pages/AssetDetail.tsx
@@ -14,6 +14,7 @@ import { api } from '@/lib/axios';
 import ConsolidatedPriceChart from '@/components/charts/ConsolidatedPriceChart';
 import CopyButton from '@/components/ui/copy';
 import { addCommasToInput, roundToDecimals } from '@/utils/numberUtils';
+import { usdstAddress } from '@/lib/constants';
 
 type PricePoint = {
   date: string;
@@ -99,10 +100,23 @@ const fetchSwapPoolPrices = async (assetAddress: string): Promise<SwapPricePoint
       return [];
     }
 
-    // Fetch swap history for each pool and combine the data
+    // Only use the USDST-paired pool for STRATO Price calculation
+    const usdstPool = pools.find(pool => {
+      const otherAddr = pool.tokenA?.address?.toLowerCase() === assetAddress.toLowerCase()
+        ? pool.tokenB?.address?.toLowerCase()
+        : pool.tokenA?.address?.toLowerCase();
+      return otherAddr === usdstAddress.toLowerCase();
+    });
+
+    if (!usdstPool) {
+      return [];
+    }
+
+    const selectedPools = [usdstPool];
+
+    // Fetch swap history for selected pool(s)
     const allSwapPrices: SwapPricePoint[] = [];
-    
-    for (const pool of pools) {
+    for (const pool of selectedPools) {
       try {
         // Determine which token is being viewed and which is the other token
         const isViewingAssetTokenB = pool.tokenB?.address?.toLowerCase() === assetAddress.toLowerCase();


### PR DESCRIPTION
Only use ASSETST-USDST swap pool for STRATO Price calculation on Asset Details Price History chart.

When using the other pools,
1) The aggregation is not well handled; it deduplicates arbitrarily by timestamp
2) The latest price of the paired asset is used when calculating the historical price of the asset in question, rather than taking the historical price of each.

As a result, the STRATO Price line on the Price History Chart had a zigzag pattern for assets with multiple swap pools such as ETHST-WBTCST, making it appear as though the prices do a poor job of approaching spot prices when in fact the swap prices are more rational.

Now that those extra pools are excluded, the Price History chart is accurate based on the USDST-paired pool.

Fixes #6282 

This works because all assets who are present in a Swap Pool have a USDST-paired swap pool.

Before:
<img width="3118" height="1104" alt="image" src="https://github.com/user-attachments/assets/940d1ad4-5cb0-478e-8adb-eb164ae8f85f" />

After:
<img width="3118" height="1104" alt="image" src="https://github.com/user-attachments/assets/2dea0421-fefc-4106-b2ac-4b7e4bee7867" />


@greptile Please review

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Restricts STRATO Price calculation on the Price History chart to only use the USDST-paired swap pool, eliminating the zigzag pattern that occurred when aggregating multiple pools. Previously, assets with multiple swap pools (like ETHST-WBTCST) had their historical prices calculated using arbitrary timestamp deduplication and current oracle prices for paired assets rather than historical prices.

**Key Changes:**
- Added import for `usdstAddress` from constants
- Filters all pools to find only the USDST-paired pool for the asset
- Returns empty array if no USDST pool exists (safe since per PR description, all assets in swap pools have a USDST pair)
- Uses single pool instead of iterating through all pools

**Impact:**
- More accurate STRATO Price line on Price History chart
- Better represents actual swap prices approaching spot prices
- Eliminates confusion from multi-pool aggregation artifacts

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is focused and addresses a specific display issue by filtering swap pools to only use USDST-paired pools. The logic is sound, properly handles the case where no USDST pool exists, and simplifies the aggregation by eliminating multiple pools. The fix prevents inaccurate price history visualization without changing core business logic or introducing new dependencies.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/ui/src/pages/AssetDetail.tsx | Filtered swap pools to only use USDST-paired pool for STRATO Price calculation, eliminating zigzag pattern from multiple pool aggregation |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant AssetDetail
    participant API
    participant fetchSwapPoolPrices

    User->>AssetDetail: View Asset Details
    AssetDetail->>fetchSwapPoolPrices: fetchSwapPoolPrices(assetAddress)
    fetchSwapPoolPrices->>API: GET /swap-pools
    API-->>fetchSwapPoolPrices: All pools containing asset
    fetchSwapPoolPrices->>fetchSwapPoolPrices: Filter to find USDST-paired pool only
    alt USDST pool exists
        fetchSwapPoolPrices->>API: GET /swap-history/{usdstPoolAddress}
        API-->>fetchSwapPoolPrices: Swap history for USDST pool
        fetchSwapPoolPrices->>fetchSwapPoolPrices: Calculate USD prices using USDST oracle price
        fetchSwapPoolPrices-->>AssetDetail: SwapPricePoint[] (30 days)
        AssetDetail->>User: Display smooth STRATO Price line
    else No USDST pool found
        fetchSwapPoolPrices-->>AssetDetail: Empty array []
        AssetDetail->>User: Display only Spot price line
    end
```
</details>


<sub>Last reviewed commit: c5dba0c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->