### PR TITLE
oracle is now slacking errors when also appending to the error flag file

### DIFF
--- a/mercata/services/oracle/src/utils/logger.ts
+++ b/mercata/services/oracle/src/utils/logger.ts
@@ -1,5 +1,5 @@
 import { healthMonitor } from "./healthMonitor";
-import { sendWarningToSlack } from "./slackNotifier";
+import { sendWarningToSlack, sendErrorToSlack } from "./slackNotifier";
 
 // Utility function to sanitize sensitive data in log messages
 function sanitizeLogMessage(message: string): string {
@@ -49,6 +49,10 @@ export function logError(context: string, error: Error): void {
     healthMonitor.appendToErrorFile(error_message).catch(err => {
         console.error("CRITICAL: Failed to write the error log. That is an unexpected server configuration error, so we exit(1):", err);
         process.exit(1);
+    })
+    sendErrorToSlack(context, sanitizedMessage, logTime).catch(err => {
+        // Log to console only - do not call logError here to avoid infinite recursion
+        console.error(`Failed to send error to Slack: ${err instanceof Error ? err.message : String(err)}`);
     })
 }
 

--- a/mercata/services/oracle/src/utils/slackNotifier.ts
+++ b/mercata/services/oracle/src/utils/slackNotifier.ts
@@ -13,7 +13,7 @@ function getSlackClient(): WebClient | null {
     if (token) {
         slackClient = new WebClient(token);
         const channel = process.env.SLACK_WARNING_CHANNEL || '#ops-monitoring';
-        console.log(`[SlackNotifier] Initialized - warnings will be sent to ${channel}`);
+        console.log(`[SlackNotifier] Initialized - warnings and errors will be sent to ${channel}`);
     } else {
         console.log('[SlackNotifier] SLACK_BOT_TOKEN not set - Slack notifications disabled');
     }
@@ -42,4 +42,19 @@ export async function sendWarningToSlack(context: string, message: string, times
     });
 
     logInfo('SlackNotifier', `Warning sent to ${channel}`);
+}
+
+export async function sendErrorToSlack(context: string, message: string, timestamp: string): Promise<void> {
+    const client = getSlackClient();
+    if (!client) return;
+
+    const channel = process.env.SLACK_WARNING_CHANNEL || '#ops-monitoring';
+    const oracleName = process.env.ORACLE_NAME || 'Dev Oracle';
+
+    await client.chat.postMessage({
+        channel,
+        text: `:rotating_light: *${oracleName}* [ERROR] [${context}] ${message}`,
+    });
+
+    logInfo('SlackNotifier', `Error sent to ${channel}`);
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the oracle's error logging pipeline to also send error-level messages to Slack, complementing the existing warning-to-Slack functionality. Previously, only warnings were forwarded to Slack; errors were only written to the error flag file and console.

- Adds `sendErrorToSlack` function in `slackNotifier.ts` that posts error messages with a `:rotating_light:` emoji to the configured Slack channel
- Integrates the new function into `logError()` in `logger.ts` with proper error handling that avoids infinite recursion by catching Slack failures with `console.error`
- The circular dependency between `logger.ts` and `slackNotifier.ts` is handled correctly — `sendErrorToSlack`'s catch uses `console.error` (not `logError`), breaking the cycle
- Note: when `logWarning` fails to send to Slack, its catch handler calls `logError`, which will now also attempt a Slack send — this means a single Slack outage can cause cascading (but non-recursive) API call attempts

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the changes are small, follow existing patterns, and handle error cases properly.
- The implementation is clean, follows existing code conventions, and correctly prevents infinite recursion. The only concern is a minor style issue (unused timestamp parameter). The code is low-risk since it only adds non-blocking Slack notifications to an existing error path.
- No files require special attention. Both changes are straightforward and follow established patterns.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/services/oracle/src/utils/logger.ts | Adds `sendErrorToSlack` call in `logError()` with proper recursion prevention via `console.error` in the catch handler. Clean integration. |
| mercata/services/oracle/src/utils/slackNotifier.ts | New `sendErrorToSlack` function mirrors the existing `sendWarningToSlack` pattern. The `timestamp` parameter is unused in both functions. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant logger as logger.ts
    participant health as healthMonitor
    participant slack as slackNotifier
    participant SlackAPI as Slack API

    Caller->>logger: logError(context, error)
    logger->>logger: sanitize message
    logger->>logger: console.error (red)
    par Write to error file
        logger->>health: appendToErrorFile(error_message)
        health-->>logger: success / catch → exit(1)
    and Send to Slack (new)
        logger->>slack: sendErrorToSlack(context, msg, time)
        slack->>SlackAPI: chat.postMessage 🚨
        SlackAPI-->>slack: success
        slack->>logger: logInfo("Error sent")
        Note over logger,slack: On failure: console.error only (no recursion)
    end
```
</details>


<sub>Last reviewed commit: 15b1a39</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->