### PR TITLE
Activity List Improvements

### DIFF
--- a/mercata/backend/src/api/services/events.service.ts
+++ b/mercata/backend/src/api/services/events.service.ts
@@ -130,6 +130,34 @@ const getTimeRangeFilter = (timeRange?: string): Record<string, string> => {
   };
 };
 
+/**
+ * Build attribute filters for a set of activity type pairs for a given user address.
+ * Returns deduplicated PostgREST filter conditions.
+ */
+const buildAttributeFilters = (pairs: ActivityTypePair[], userAddress: string): string[] => {
+  const filters: string[] = [];
+  for (const pair of pairs) {
+    if (!pair.filterConfig) {
+      throw new Error(`No filter config provided for activity type: ${pair.contract_name}:${pair.event_name}`);
+    }
+    if (pair.filterConfig.type === "single") {
+      if (!pair.filterConfig.attribute) {
+        throw new Error(`Single filter requires attribute for ${pair.contract_name}:${pair.event_name}`);
+      }
+      filters.push(`attributes->>${pair.filterConfig.attribute}.eq.${userAddress}`);
+    } else {
+      const attributes = pair.filterConfig.attributes || [];
+      if (attributes.length === 0) {
+        throw new Error(`OR filter requires attributes for ${pair.contract_name}:${pair.event_name}`);
+      }
+      for (const attr of attributes) {
+        filters.push(`attributes->>${attr}.eq.${userAddress}`);
+      }
+    }
+  }
+  return [...new Set(filters)];
+};
+
 export const getActivitiesByTypes = async (
   accessToken: string,
   activityTypePairs: ActivityTypePair[],
@@ -145,84 +173,107 @@ export const getActivitiesByTypes = async (
 
   const timeFilter = getTimeRangeFilter(timeRange);
 
-  const contractNames = Array.from(
-    new Set(activityTypePairs.map((pair) => pair.contract_name).filter(Boolean))
-  );
-  const eventNames = Array.from(
-    new Set(activityTypePairs.map((pair) => pair.event_name).filter(Boolean))
-  );
+  // Group pairs by contract_name to avoid cross-product from independent in() lists.
+  // Each group gets its own query with exact contract_name + event_name filtering.
+  const groups = new Map<string, ActivityTypePair[]>();
+  for (const pair of activityTypePairs) {
+    if (!pair.contract_name || !pair.event_name) continue;
+    const existing = groups.get(pair.contract_name);
+    if (existing) {
+      // Avoid duplicate event_names within a group
+      if (!existing.some(p => p.event_name === pair.event_name)) {
+        existing.push(pair);
+      }
+    } else {
+      groups.set(pair.contract_name, [pair]);
+    }
+  }
 
-  if (contractNames.length === 0 || eventNames.length === 0) {
+  if (groups.size === 0) {
     return { events: [], total: 0 };
   }
 
-  const attributeFilters: string[] = [];
-  if (userAddress) {
-    activityTypePairs.forEach((pair) => {
-      if (!pair.filterConfig) {
-        throw new Error(`No filter config provided for activity type: ${pair.contract_name}:${pair.event_name}`);
-      }
+  const groupEntries = Array.from(groups.entries());
 
-      if (pair.filterConfig.type === "single") {
-        if (!pair.filterConfig.attribute) {
-          throw new Error(`Single filter requires attribute for ${pair.contract_name}:${pair.event_name}`);
-        }
-        attributeFilters.push(`attributes->>${pair.filterConfig.attribute}.eq.${userAddress}`);
-        return;
-      }
+  // Build parallel queries: one count + one data query per contract group.
+  // For data, fetch (limit + offset) from each group so merge-sort can produce
+  // the correct global page. Any event in the global top N must be in the top N
+  // of its own group, so this is always correct.
+  const fetchLimit = limit + offset;
 
-      const attributes = pair.filterConfig.attributes || [];
-      if (attributes.length === 0) {
-        throw new Error(`OR filter requires attributes for ${pair.contract_name}:${pair.event_name}`);
-      }
-      attributes.forEach((attr) => {
-        attributeFilters.push(`attributes->>${attr}.eq.${userAddress}`);
-      });
-    });
-  }
-
-  const uniqueAttributeFilters = Array.from(new Set(attributeFilters));
-
-  const params: Record<string, string> = {
-    order: "block_timestamp.desc,id.desc",
-    select: `*,${storageSelect}`,
-    limit: limit.toString(),
-    offset: offset.toString(),
-    "storage.contract.contract_name": `in.(${contractNames.join(",")})`,
-    event_name: `in.(${eventNames.join(",")})`,
-    ...timeFilter,
-  };
-
-  const countParams: Record<string, string> = {
-    select: `${storageSelect},count()`,
-    "storage.contract.contract_name": `in.(${contractNames.join(",")})`,
-    event_name: `in.(${eventNames.join(",")})`,
-    ...timeFilter,
-  };
-
-  if (uniqueAttributeFilters.length > 0) {
-    params.or = `(${uniqueAttributeFilters.join(",")})`;
-    countParams.or = `(${uniqueAttributeFilters.join(",")})`;
-  }
-
-  const [countResponse, eventsResponse] = await Promise.all([
-    cirrus.get(accessToken, `/${constants.Event}`, { params: countParams }),
-    cirrus.get(accessToken, `/${constants.Event}`, { params }),
-  ]);
-
-  const total = (countResponse.data || []).reduce((sum: number, row: any) => {
-    const count = row?.count ? Number(row.count) : 0;
-    return sum + count;
-  }, 0);
-  const data = eventsResponse.data || [];
-
-  const events = (data as any[]).map((event: any) => {
-    const { storage, ...eventWithoutStorage } = event;
-    return {
-      ...eventWithoutStorage,
-      contract_name: event.storage?.contract?.[0]?.contract_name || "",
+  const countPromises = groupEntries.map(([contractName, pairs]) => {
+    const eventNames = pairs.map(p => p.event_name);
+    const countParams: Record<string, string> = {
+      select: `${storageSelect},count()`,
+      "storage.contract.contract_name": `eq.${contractName}`,
+      event_name: eventNames.length === 1
+        ? `eq.${eventNames[0]}`
+        : `in.(${eventNames.join(",")})`,
+      ...timeFilter,
     };
+    if (userAddress) {
+      const attrFilters = buildAttributeFilters(pairs, userAddress);
+      if (attrFilters.length > 0) {
+        countParams.or = `(${attrFilters.join(",")})`;
+      }
+    }
+    return cirrus.get(accessToken, `/${constants.Event}`, { params: countParams });
   });
+
+  const dataPromises = groupEntries.map(([contractName, pairs]) => {
+    const eventNames = pairs.map(p => p.event_name);
+    const params: Record<string, string> = {
+      order: "block_timestamp.desc,id.desc",
+      select: `*,${storageSelect}`,
+      limit: fetchLimit.toString(),
+      offset: "0",
+      "storage.contract.contract_name": `eq.${contractName}`,
+      event_name: eventNames.length === 1
+        ? `eq.${eventNames[0]}`
+        : `in.(${eventNames.join(",")})`,
+      ...timeFilter,
+    };
+    if (userAddress) {
+      const attrFilters = buildAttributeFilters(pairs, userAddress);
+      if (attrFilters.length > 0) {
+        params.or = `(${attrFilters.join(",")})`;
+      }
+    }
+    return cirrus.get(accessToken, `/${constants.Event}`, { params });
+  });
+
+  // Run all queries in parallel
+  const allResults = await Promise.all([...countPromises, ...dataPromises]);
+  const countResults = allResults.slice(0, groupEntries.length);
+  const dataResults = allResults.slice(groupEntries.length);
+
+  // Sum counts across groups for exact total
+  const total = countResults.reduce((sum, res) => {
+    return sum + (res.data || []).reduce((s: number, row: any) => {
+      return s + (Number(row?.count) || 0);
+    }, 0);
+  }, 0);
+
+  // Merge all data results and extract contract_name from storage relationship
+  const allEvents = dataResults.flatMap(res =>
+    (res.data || []).map((event: any) => {
+      const { storage, ...eventWithoutStorage } = event;
+      return {
+        ...eventWithoutStorage,
+        contract_name: event.storage?.contract?.[0]?.contract_name || "",
+      };
+    })
+  );
+
+  // Sort merged results by (block_timestamp desc, id desc) to match DB ordering
+  allEvents.sort((a, b) => {
+    const tsCompare = (b.block_timestamp || "").localeCompare(a.block_timestamp || "");
+    if (tsCompare !== 0) return tsCompare;
+    return (Number(b.id) || 0) - (Number(a.id) || 0);
+  });
+
+  // Apply global pagination: slice [offset, offset + limit]
+  const events = allEvents.slice(offset, offset + limit);
 
   return { events, total };
 };

--- a/mercata/backend/src/api/services/events.service.ts
+++ b/mercata/backend/src/api/services/events.service.ts
@@ -193,12 +193,24 @@ export const getActivitiesByTypes = async (
     return { events: [], total: 0 };
   }
 
-  const groupEntries = Array.from(groups.entries());
+  // Sub-split groups by excludeProtocolAddresses config
+  // So each activity can have its own exclusion filter
+  const groupEntries: [string, ActivityTypePair[]][] = [];
+  for (const [contractName, pairs] of groups) {
+    const byExclusion = new Map<string, ActivityTypePair[]>();
+    for (const pair of pairs) {
+      const key = pair.filterConfig?.excludeProtocolAddresses?.length
+        ? [...pair.filterConfig.excludeProtocolAddresses].sort().join(",")
+        : "";
+      const existing = byExclusion.get(key);
+      if (existing) existing.push(pair);
+      else byExclusion.set(key, [pair]);
+    }
+    for (const subPairs of byExclusion.values()) {
+      groupEntries.push([contractName, subPairs]);
+    }
+  }
 
-  // Build parallel queries: one count + one data query per contract group.
-  // For data, fetch (limit + offset) from each group so merge-sort can produce
-  // the correct global page. Any event in the global top N must be in the top N
-  // of its own group, so this is always correct.
   const fetchLimit = limit + offset;
 
   // Exclude internal transfers involving protocol contracts.

--- a/mercata/backend/src/api/services/events.service.ts
+++ b/mercata/backend/src/api/services/events.service.ts
@@ -1,6 +1,6 @@
 import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
-import { getInternalAddresses } from "../../config/config";
+import { internalAddresses } from "../../config/config";
 import type {
   EventData,
   EventResponse,
@@ -215,7 +215,6 @@ export const getActivitiesByTypes = async (
 
   // Exclude internal transfers involving protocol contracts.
   // Activity types opt in via excludeProtocolAddresses in their filterConfig.
-  const internalAddresses = getInternalAddresses();
   const internalAddrList = internalAddresses.join(",");
 
   const applyFilters = (

--- a/mercata/backend/src/api/services/events.service.ts
+++ b/mercata/backend/src/api/services/events.service.ts
@@ -1,27 +1,11 @@
 import { cirrus } from "../../utils/mercataApiHelper";
 import { constants } from "../../config/constants";
+import { getInternalAddresses } from "../../config/config";
 import type {
   EventData,
   EventResponse,
   ContractInfoResponse,
 } from "@mercata/shared-types";
-
-/**
- * Known protocol contract addresses whose Token:Transfer events are internal
- * (gas fees, pool operations, minting, etc.) and should be hidden from the
- * My Activity / All Activity feed.
- * 
- * @dev TODO: Improve how these are fetched, rather than hardcoding them here.
- */
-const getProtocolAddresses = (): string[] => [
-  "0000000000000000000000000000000000001003", //CollateralVault
-  "0000000000000000000000000000000000001004", //LiquidityPool
-  "0000000000000000000000000000000000001005", //LendingPool
-  "0000000000000000000000000000000000001008", //MercataBridge
-  "000000000000000000000000000000000000100d", //FeeCollector
-  "0000000000000000000000000000000000001011", //CDPEngine
-  "0000000000000000000000000000000000001013", //CDPVault
-].filter((addr): addr is string => Boolean(addr));
 
 export const getEvents = async (
   accessToken: string,
@@ -219,20 +203,19 @@ export const getActivitiesByTypes = async (
 
   // Exclude internal transfers involving protocol contracts.
   // Activity types opt in via excludeProtocolAddresses in their filterConfig.
-  const protocolAddresses = getProtocolAddresses();
-  const protocolAddrList = protocolAddresses.join(",");
+  const internalAddresses = getInternalAddresses();
+  const internalAddrList = internalAddresses.join(",");
 
   const applyFilters = (
     pairs: ActivityTypePair[],
     params: Record<string, string>
   ) => {
-    // Apply protocol address exclusions from filterConfig
-    if (protocolAddrList) {
+    if (internalAddrList) {
       for (const pair of pairs) {
         const attrs = pair.filterConfig?.excludeProtocolAddresses;
         if (attrs) {
           for (const attr of attrs) {
-            params[`attributes->>${attr}`] = `not.in.(${protocolAddrList})`;
+            params[`attributes->>${attr}`] = `not.in.(${internalAddrList})`;
           }
         }
       }

--- a/mercata/backend/src/api/services/events.service.ts
+++ b/mercata/backend/src/api/services/events.service.ts
@@ -6,6 +6,23 @@ import type {
   ContractInfoResponse,
 } from "@mercata/shared-types";
 
+/**
+ * Known protocol contract addresses whose Token:Transfer events are internal
+ * (gas fees, pool operations, minting, etc.) and should be hidden from the
+ * My Activity / All Activity feed.
+ * 
+ * @dev TODO: Improve how these are fetched, rather than hardcoding them here.
+ */
+const getProtocolAddresses = (): string[] => [
+  "0000000000000000000000000000000000001003", //CollateralVault
+  "0000000000000000000000000000000000001004", //LiquidityPool
+  "0000000000000000000000000000000000001005", //LendingPool
+  "0000000000000000000000000000000000001008", //MercataBridge
+  "000000000000000000000000000000000000100d", //FeeCollector
+  "0000000000000000000000000000000000001011", //CDPEngine
+  "0000000000000000000000000000000000001013", //CDPVault
+].filter((addr): addr is string => Boolean(addr));
+
 export const getEvents = async (
   accessToken: string,
   query: Record<string, string> = {}
@@ -87,6 +104,8 @@ export interface FilterConfig {
   type: "single" | "or";
   attribute?: string;
   attributes?: string[];
+  /** Event attribute names to check against the protocol address list for exclusion */
+  excludeProtocolAddresses?: string[];
 }
 
 export interface ActivityTypePair {
@@ -180,10 +199,7 @@ export const getActivitiesByTypes = async (
     if (!pair.contract_name || !pair.event_name) continue;
     const existing = groups.get(pair.contract_name);
     if (existing) {
-      // Avoid duplicate event_names within a group
-      if (!existing.some(p => p.event_name === pair.event_name)) {
-        existing.push(pair);
-      }
+      existing.push(pair);
     } else {
       groups.set(pair.contract_name, [pair]);
     }
@@ -201,6 +217,35 @@ export const getActivitiesByTypes = async (
   // of its own group, so this is always correct.
   const fetchLimit = limit + offset;
 
+  // Exclude internal transfers involving protocol contracts.
+  // Activity types opt in via excludeProtocolAddresses in their filterConfig.
+  const protocolAddresses = getProtocolAddresses();
+  const protocolAddrList = protocolAddresses.join(",");
+
+  const applyFilters = (
+    pairs: ActivityTypePair[],
+    params: Record<string, string>
+  ) => {
+    // Apply protocol address exclusions from filterConfig
+    if (protocolAddrList) {
+      for (const pair of pairs) {
+        const attrs = pair.filterConfig?.excludeProtocolAddresses;
+        if (attrs) {
+          for (const attr of attrs) {
+            params[`attributes->>${attr}`] = `not.in.(${protocolAddrList})`;
+          }
+        }
+      }
+    }
+    // Filter by user address for My Activity
+    if (userAddress) {
+      const attrFilters = buildAttributeFilters(pairs, userAddress);
+      if (attrFilters.length > 0) {
+        params.or = `(${attrFilters.join(",")})`;
+      }
+    }
+  };
+
   const countPromises = groupEntries.map(([contractName, pairs]) => {
     const eventNames = pairs.map(p => p.event_name);
     const countParams: Record<string, string> = {
@@ -211,12 +256,7 @@ export const getActivitiesByTypes = async (
         : `in.(${eventNames.join(",")})`,
       ...timeFilter,
     };
-    if (userAddress) {
-      const attrFilters = buildAttributeFilters(pairs, userAddress);
-      if (attrFilters.length > 0) {
-        countParams.or = `(${attrFilters.join(",")})`;
-      }
-    }
+    applyFilters(pairs, countParams);
     return cirrus.get(accessToken, `/${constants.Event}`, { params: countParams });
   });
 
@@ -233,12 +273,7 @@ export const getActivitiesByTypes = async (
         : `in.(${eventNames.join(",")})`,
       ...timeFilter,
     };
-    if (userAddress) {
-      const attrFilters = buildAttributeFilters(pairs, userAddress);
-      if (attrFilters.length > 0) {
-        params.or = `(${attrFilters.join(",")})`;
-      }
-    }
+    applyFilters(pairs, params);
     return cirrus.get(accessToken, `/${constants.Event}`, { params });
   });
 

--- a/mercata/backend/src/app.ts
+++ b/mercata/backend/src/app.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import cors from "cors";
 import routes from "./api/routes";
-import { initOpenIdConfig, initNetworkConfig } from "./config/config";
+import { initOpenIdConfig, initNetworkConfig, initInternalAddresses } from "./config/config";
 import { errorHandler, notFoundHandler } from "./api/middleware/errorHandler";
 
 const PORT = process.env.PORT || 3001;
@@ -22,6 +22,7 @@ app.use(errorHandler);
   try {
     await initOpenIdConfig();
     await initNetworkConfig();
+    await initInternalAddresses();
     app.listen(PORT, () => {
       console.log(`Server running at http://localhost:${PORT}`);
     });

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -38,6 +38,7 @@ export const nodeUrl = process.env.NODE_URL;
 export const baseUrl = process.env.BASE_URL || "http://localhost";
 
 // Smart contract addresses
+export const burnAddress = process.env.BURN_ADDRESS || "0000000000000000000000000000000000000000";
 export const poolConfigurator = process.env.POOL_CONFIGURATOR || "0000000000000000000000000000000000001006";
 export const lendingRegistry = process.env.LENDING_REGISTRY || "0000000000000000000000000000000000001007";
 export const mercataBridge = process.env.MERCATA_BRIDGE || "0000000000000000000000000000000000001008";
@@ -136,4 +137,94 @@ export async function initNetworkConfig() {
   setRewardsConfig(networkId);
   setReferralConfig(networkId);
   setVaultFactoryConfig(networkId);
+}
+
+// Addresses of internal protocol contracts whose Token:Transfer events should
+// be excluded from the activity feed (gas fees, pool operations, minting, etc.).
+// Populated at startup by initInternalAddresses().
+let internalAddresses: Set<string> = new Set();
+
+export function getInternalAddresses(): string[] {
+  return Array.from(internalAddresses);
+}
+
+/**
+ * Fetch and cache internal protocol contract addresses by querying the on-chain registries and factories.
+ * Must be called after initNetworkConfig() so network-specific addresses are available.
+ * Used to exclude internal transfers from the My Activity / All Activity feed.
+ */
+export async function initInternalAddresses() {
+  const { cirrus } = await import("../utils/mercataApiHelper");
+  const accessToken = await getServiceToken();
+
+  // Static: well-known system contract addresses from config
+  const addresses: string[] = [
+    mercataBridge,
+    burnAddress,
+  ];
+
+  // Network-specific addresses (set by initNetworkConfig)
+  if (rewards) addresses.push(rewards);
+  if (escrow) addresses.push(escrow);
+  if (vaultFactory) addresses.push(vaultFactory);
+
+  // Lending Registry → lendingPool, collateralVault, liquidityPool
+  try {
+    const { data: [lending] } = await cirrus.get(accessToken, "/BlockApps-LendingRegistry", {
+      params: {
+        address: `eq.${lendingRegistry}`,
+        select: "lendingPool:lendingPool_fkey(address),collateralVault:collateralVault_fkey(address),liquidityPool:liquidityPool_fkey(address)",
+      },
+    });
+    if (lending?.lendingPool?.address) addresses.push(lending.lendingPool.address);
+    if (lending?.collateralVault?.address) addresses.push(lending.collateralVault.address);
+    if (lending?.liquidityPool?.address) addresses.push(lending.liquidityPool.address);
+  } catch (err) {
+    console.warn("Failed to fetch lending registry addresses:", err);
+  }
+
+  // CDP Registry → cdpEngine, cdpVault, feeCollector
+  try {
+    const { data: [cdp] } = await cirrus.get(accessToken, "/BlockApps-CDPRegistry", {
+      params: {
+        address: `eq.${cdpRegistry}`,
+        select: "feeCollector,cdpEngine:cdpEngine_fkey(address),cdpVault:cdpVault_fkey(address),cdpReserve:cdpReserve_fkey(address)",
+      },
+    });
+    if (cdp?.feeCollector) addresses.push(cdp.feeCollector);
+    if (cdp?.cdpEngine?.address) addresses.push(cdp.cdpEngine.address);
+    if (cdp?.cdpVault?.address) addresses.push(cdp.cdpVault.address);
+    if (cdp?.cdpReserve?.address) addresses.push(cdp.cdpReserve.address);
+  } catch (err) {
+    console.warn("Failed to fetch CDP registry addresses:", err);
+  }
+
+  // Pool Factory → all swap pool addresses
+  try {
+    const { data: pools } = await cirrus.get(accessToken, "/BlockApps-PoolFactory-allPools", {
+      params: { address: `eq.${poolFactory}`, select: "value" },
+    });
+    for (const pool of pools || []) {
+      if (pool.value) addresses.push(pool.value);
+    }
+  } catch (err) {
+    console.warn("Failed to fetch pool addresses:", err);
+  }
+
+  // Vault Factory → all vault addresses
+  if (vaultFactory) {
+    try {
+      const { data: vaults } = await cirrus.get(accessToken, "/BlockApps-VaultFactory-allVaults", {
+        params: { address: `eq.${vaultFactory}`, select: "value" },
+      });
+      for (const vault of vaults || []) {
+        if (vault.value) addresses.push(vault.value);
+      }
+    } catch (err) {
+      console.warn("Failed to fetch vault addresses:", err);
+    }
+  }
+
+  internalAddresses = new Set(addresses.filter(Boolean));
+  console.log(`Internal addresses loaded: ${internalAddresses.size} addresses`);
 }

--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -87,7 +87,7 @@ export let referralUrl: string | undefined;
 export let escrow: string = '';
 export let vaultFactory: string = '';
 
-export function setBridgeConfig(networkId: string) {
+function setBridgeConfig(networkId: string) {
   if (process.env.BRIDGE_SERVICE_URL) {
     bridgeUrl = process.env.BRIDGE_SERVICE_URL;
   } else {
@@ -95,7 +95,7 @@ export function setBridgeConfig(networkId: string) {
   }
 }
 
-export function setRewardsConfig(networkId: string) {
+function setRewardsConfig(networkId: string) {
   if (process.env.REWARDS) {
     rewards = process.env.REWARDS;
   } else {
@@ -103,7 +103,7 @@ export function setRewardsConfig(networkId: string) {
   }
 }
 
-export function setReferralConfig(networkId: string) {
+function setReferralConfig(networkId: string) {
   if (process.env.ESCROW_ADDRESS) {
     escrow = process.env.ESCROW_ADDRESS;
   } else {
@@ -116,7 +116,7 @@ export function setReferralConfig(networkId: string) {
   }
 }
 
-export function setVaultFactoryConfig(networkId: string) {
+function setVaultFactoryConfig(networkId: string) {
   if (process.env.VAULT_FACTORY) {
     vaultFactory = process.env.VAULT_FACTORY;
   } else {
@@ -142,11 +142,7 @@ export async function initNetworkConfig() {
 // Addresses of internal protocol contracts whose Token:Transfer events should
 // be excluded from the activity feed (gas fees, pool operations, minting, etc.).
 // Populated at startup by initInternalAddresses().
-let internalAddresses: Set<string> = new Set();
-
-export function getInternalAddresses(): string[] {
-  return Array.from(internalAddresses);
-}
+export let internalAddresses: Array<string> = [];
 
 /**
  * Fetch and cache internal protocol contract addresses by querying the on-chain registries and factories.
@@ -164,67 +160,39 @@ export async function initInternalAddresses() {
   ];
 
   // Network-specific addresses (set by initNetworkConfig)
-  if (rewards) addresses.push(rewards);
-  if (escrow) addresses.push(escrow);
-  if (vaultFactory) addresses.push(vaultFactory);
+  addresses.push(rewards || '', escrow, vaultFactory);
 
-  // Lending Registry → lendingPool, collateralVault, liquidityPool
-  try {
-    const { data: [lending] } = await cirrus.get(accessToken, "/BlockApps-LendingRegistry", {
-      params: {
-        address: `eq.${lendingRegistry}`,
-        select: "lendingPool:lendingPool_fkey(address),collateralVault:collateralVault_fkey(address),liquidityPool:liquidityPool_fkey(address)",
-      },
-    });
-    if (lending?.lendingPool?.address) addresses.push(lending.lendingPool.address);
-    if (lending?.collateralVault?.address) addresses.push(lending.collateralVault.address);
-    if (lending?.liquidityPool?.address) addresses.push(lending.liquidityPool.address);
-  } catch (err) {
-    console.warn("Failed to fetch lending registry addresses:", err);
-  }
+  // Lending Registry --> lendingPool, collateralVault, liquidityPool
+  const { data: [lending] } = await cirrus.get(accessToken, "/BlockApps-LendingRegistry", {
+    params: {
+      address: `eq.${lendingRegistry}`,
+      select: "lendingPool:lendingPool_fkey(address),collateralVault:collateralVault_fkey(address),liquidityPool:liquidityPool_fkey(address)",
+    },
+  });
+  addresses.push(lending.lendingPool.address, lending.collateralVault.address, lending.liquidityPool.address);
 
-  // CDP Registry → cdpEngine, cdpVault, feeCollector
-  try {
-    const { data: [cdp] } = await cirrus.get(accessToken, "/BlockApps-CDPRegistry", {
-      params: {
-        address: `eq.${cdpRegistry}`,
-        select: "feeCollector,cdpEngine:cdpEngine_fkey(address),cdpVault:cdpVault_fkey(address),cdpReserve:cdpReserve_fkey(address)",
-      },
-    });
-    if (cdp?.feeCollector) addresses.push(cdp.feeCollector);
-    if (cdp?.cdpEngine?.address) addresses.push(cdp.cdpEngine.address);
-    if (cdp?.cdpVault?.address) addresses.push(cdp.cdpVault.address);
-    if (cdp?.cdpReserve?.address) addresses.push(cdp.cdpReserve.address);
-  } catch (err) {
-    console.warn("Failed to fetch CDP registry addresses:", err);
-  }
+  // CDP Registry --> cdpEngine, cdpVault, feeCollector
+  const { data: [cdp] } = await cirrus.get(accessToken, "/BlockApps-CDPRegistry", {
+    params: {
+      address: `eq.${cdpRegistry}`,
+      select: "feeCollector,cdpEngine:cdpEngine_fkey(address),cdpVault:cdpVault_fkey(address),cdpReserve:cdpReserve_fkey(address)",
+    },
+  });
+  addresses.push(cdp.feeCollector, cdp.cdpEngine.address, cdp.cdpVault.address, cdp.cdpReserve.address);
 
-  // Pool Factory → all swap pool addresses
-  try {
-    const { data: pools } = await cirrus.get(accessToken, "/BlockApps-PoolFactory-allPools", {
-      params: { address: `eq.${poolFactory}`, select: "value" },
-    });
-    for (const pool of pools || []) {
-      if (pool.value) addresses.push(pool.value);
-    }
-  } catch (err) {
-    console.warn("Failed to fetch pool addresses:", err);
-  }
+  // Pool Factory --> all swap pool addresses
+  const { data: pools } = await cirrus.get(accessToken, "/BlockApps-PoolFactory-allPools", {
+    params: { address: `eq.${poolFactory}`, select: "value" },
+  });
+  addresses.push(...pools.map((pool: any) => pool.value));
 
-  // Vault Factory → all vault addresses
+  // Vault Factory --> all vault addresses
   if (vaultFactory) {
-    try {
-      const { data: vaults } = await cirrus.get(accessToken, "/BlockApps-VaultFactory-allVaults", {
-        params: { address: `eq.${vaultFactory}`, select: "value" },
-      });
-      for (const vault of vaults || []) {
-        if (vault.value) addresses.push(vault.value);
-      }
-    } catch (err) {
-      console.warn("Failed to fetch vault addresses:", err);
-    }
+    const { data: vaults } = await cirrus.get(accessToken, "/BlockApps-VaultFactory-allVaults", {
+      params: { address: `eq.${vaultFactory}`, select: "value" },
+    });
+    addresses.push(...vaults.map((vault: any) => vault.value));
   }
 
-  internalAddresses = new Set(addresses.filter(Boolean));
-  console.log(`Internal addresses loaded: ${internalAddresses.size} addresses`);
+  internalAddresses = Array.from(new Set(addresses.filter(Boolean)));
 }

--- a/mercata/ui/src/components/dashboard/activityTypes.tsx
+++ b/mercata/ui/src/components/dashboard/activityTypes.tsx
@@ -122,8 +122,8 @@ export type TokenAddressExtractor = (event: Event) => string[];
  * Filter configuration for backend event filtering
  */
 export type FilterConfig =
-  | { type: "single"; attribute: string }
-  | { type: "or"; attributes: string[] };
+  | { type: "single"; attribute: string; excludeProtocolAddresses?: string[] }
+  | { type: "or"; attributes: string[]; excludeProtocolAddresses?: string[] };
 
 /**
  * Icon and color configuration for activity types
@@ -170,7 +170,7 @@ export const activityTypes: Record<string, ActivityTypeConfig> = {
     contract_name: "Token",
     event_name: "Transfer",
     displayName: "Transfer",
-    filterConfig: { type: "or", attributes: ["from", "to"] },
+    filterConfig: { type: "or", attributes: ["from", "to"], excludeProtocolAddresses: ["from", "to"] },
     iconConfig: { icon: Send, color: "bg-blue-500" },
     getTokenAddress: (event: Event) => [event.address].filter(Boolean),
     handler: (event: Event, tokenSymbols: Map<string, string>, userAddress?: string | null, tokenImages?: Map<string, string>): ActivityCardData => {


### PR DESCRIPTION
## Activity List Improvements
- Fixes "Same Event Name, Different Contract" bug, which allows us to add the Vault Deposited events.
  - (Actually, it looks like they were already added #6239, so this is an active bug in prod.)
- Implements #6237 Filter out Internal Transfers in Activity Page
  - Also filters out direct transfers to protocol contracts, since this is how "internal transfers" are identified, which is acceptable.
  
### Time Profiling of All Activities page with All Types selected
Before:
296 ms on first page
441 ms on final page

After:
537 ms on first page
629 ms on last page

### Shortening of activities list and improved UX
With the internal transactions filtered out, My Activities for my user account went from 24 pages to 8 pages, and it is now easier to find the event I'm looking for.

All Activities is shortened from 6063 to 1200 pages. It is now dominated by orange **Swap** events from `3f5c7de300b7940e46459ed9a8b098f9a8cc2dfb`, the arbitrage bot. 

@greptile Please review

---

### Greptile Summary

This PR addresses two issues in the activity feed: a cross-product query bug and filtering out internal protocol transfers.

**Bug fix — cross-product query**: The previous implementation used independent `in()` lists for contract name and event name, creating unintended matches (e.g., Vault Deposited matching LendingPool Deposited). The fix groups activity type pairs by contract name and issues separate queries per group with exact filtering, then merge-sorts results client-side.

**New feature — internal transfer exclusion**: Adds an `excludeProtocolAddresses` option to FilterConfig that excludes events where specified attributes match known protocol contract addresses (pools, vaults, bridge, burn address, etc.). These addresses are fetched from on-chain registries at startup and cached. Currently only Token Transfer opts in, filtering out transfers where either from or to is a protocol contract.

- The per-group query approach correctly fixes the cross-product bug and the merge-sort pagination logic is sound
- Internal address list is populated once at startup; new pools/vaults created after boot won't be excluded until restart
- Protocol address exclusion filters apply at the query (group) level, not per-event-type, which is fine today but could cause issues if new Token events are added to the same group without wanting the exclusion

### Confidence Score: 4/5

- This PR is safe to merge with minor non-blocking concerns around error handling and future extensibility.
- The core logic changes (group-by-contract querying, merge-sort pagination, protocol address exclusion) are correct and well-structured. The cross-product bug fix is sound. The internal address filtering works correctly for the current set of activity types. Minor concerns: destructuring without null guards in config fetching (caught by try-catch), per-request array allocations, and the group-level exclusion filter design could cause subtle issues if new event types are added to the Token contract group.
- mercata/backend/src/api/services/events.service.ts (exclusion filter design), mercata/backend/src/config/config.ts (error handling in registry queries)
