### PR TITLE
Oracle: disable KAG source feeds and XAG weekend proxy fallback

### DIFF
--- a/mercata/services/oracle/src/config/assets.json
+++ b/mercata/services/oracle/src/config/assets.json
@@ -28,8 +28,7 @@
     },
     "XAG": {
       "targetAssetAddress": "2c59ef92d08efde71fe1a1cb5b45f4f6d48fcc94",
-      "weekendProxy": "KAG",
-      "equivalentAssets": ["KAG"]
+      "comment": "Weekend fallback intentionally disabled. To restore, set weekendProxy to KAG and equivalentAssets to [\"KAG\"] once KAG feeds are reliable again."
     },
     "XAU": {
       "targetAssetAddress": "cdc93d30182125e05eec985b631c7c61b3f63ff0",

--- a/mercata/services/oracle/src/config/sources.json
+++ b/mercata/services/oracle/src/config/sources.json
@@ -5,7 +5,7 @@
     "parse": "data[].prices[0].value",
     "timestamp": "data[0].prices[0].lastUpdatedAt",
     "apiKeyEnvVar": "ALCHEMY_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "KAG", "WSTETH", "SYRUPUSDC"]
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC"]
   },
   "CoinMarketCap": {
     "url": "https://pro-api.coinmarketcap.com/v2/cryptocurrency/quotes/latest",
@@ -42,14 +42,13 @@
     "parse": "{id}.usd",
     "timestamp": "{id}.last_updated_at",
     "apiKeyEnvVar": "COINGECKO_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "KAG", "WSTETH", "SYRUPUSDC"],
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC"],
     "symbolMapping": {
       "ETH": "ethereum",
       "WBTC": "wrapped-bitcoin",
       "PAXG": "pax-gold",
       "XAUT": "tether-gold",
       "SUSDS": "susds",
-      "KAG": "kinesis-silver",
       "WSTETH": "wrapped-steth",
       "SYRUPUSDC": "syrupusdc"
     }
@@ -67,14 +66,13 @@
     "url": "https://pro-api.llama.fi/${API_KEY}/coins/prices/current/${SYMBOLS}",
     "parse": "defiLlama",
     "apiKeyEnvVar": "DEFILLAMA_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "KAG", "WSTETH", "SYRUPUSDC"],
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC"],
     "symbolMapping": {
       "ETH": "coingecko:ethereum",
       "WBTC": "coingecko:wrapped-bitcoin",
       "PAXG": "coingecko:pax-gold",
       "XAUT": "coingecko:tether-gold",
       "SUSDS": "coingecko:susds",
-      "KAG": "coingecko:kinesis-silver",
       "WSTETH": "coingecko:wrapped-steth",
       "SYRUPUSDC": "coingecko:syrupusdc"
     }


### PR DESCRIPTION
## Summary
- Disable KAG from active oracle source lists/mappings (Alchemy, CoinGecko, DefiLlama)
- Keep KAG asset object as submit:false placeholder
- Disable XAG weekend proxy fallback to KAG by removing weekendProxy/equivalentAssets from XAG

## Alignment with issues
- https://github.com/blockapps/strato-platform/issues/6275
- https://github.com/blockapps/strato-platform/issues/6300

## Validation
- npm --prefix services/oracle run build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables KAG (Kinesis Silver) as a price feed source and removes XAG's (Silver) weekend fallback mechanism. 

- **KAG removed from all sources**: KAG is removed from the `assets` arrays and `symbolMapping` entries of Alchemy, CoinGecko, and DefiLlama. KAG remains in `assets.json` with `submit: false`, so it's still recognized by the system but never fetched or submitted — this is handled gracefully by the existing code in `cronScheduler.ts` and `validateConfig.ts`.
- **XAG weekend proxy disabled**: The `weekendProxy: "KAG"` and `equivalentAssets: ["KAG"]` fields are replaced with a documentation `comment` explaining how to restore them. This means XAG will have no price data during metals market closures (Friday noon ET – Monday 5:30 AM ET) and will be skipped from on-chain submission during those periods.
- The `comment` field added to XAG is purely documentation — it's not read by any code. The `Asset` TypeScript interface doesn't define it, but it's harmless as an extra JSON property.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the code handles missing sources and disabled proxies gracefully, with no risk of runtime errors.
- Config-only changes that disable a feed source (KAG) and a weekend fallback (XAG). The existing codebase handles both scenarios correctly: `submit: false` assets are skipped from validation and submission, and assets that fail to reach MIN_VALID_SOURCES are logged and excluded. Score of 4 (not 5) because the XAG weekend coverage gap is an operational behavior change that should be intentional.
- mercata/services/oracle/src/config/assets.json — verify that skipping XAG price submissions on weekends is the intended behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/services/oracle/src/config/assets.json | Removes `weekendProxy` and `equivalentAssets` from XAG, replacing them with a documentation comment. XAG will no longer have weekend price coverage — it will be skipped during metals market closures. KAG entry is unchanged (`submit: false`). |
| mercata/services/oracle/src/config/sources.json | Removes KAG from Alchemy, CoinGecko, and DefiLlama source configurations (both `assets` arrays and `symbolMapping` entries). Clean removal with no orphaned references. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Cron Trigger] --> B[Fetch from All Sources]
    B --> C{For each asset}
    C --> D[KAG]
    C --> E[XAG]
    C --> F[Other assets]
    
    D --> G{submit === false?}
    G -->|Yes| H[Skip submission]
    
    E --> I{Market closed?}
    I -->|No| J[Fetch from metals sources]
    I -->|Yes - Before PR| K[Use KAG proxy sources]
    I -->|Yes - After PR| L[Fetch from metals sources]
    
    J --> M{>= 3 sources?}
    K --> N{>= 3 sources?}
    L --> O{>= 3 sources?}
    
    M -->|Yes| P[Submit XAG price]
    M -->|No| Q[Skip XAG - failed]
    N -->|Yes| P
    N -->|No| R[Fallback to weekday sources]
    O -->|No| S[Skip XAG - no weekend data]
    
    F --> T[Normal aggregation flow]
    T --> U[Submit valid prices]

    style H fill:#ffd,stroke:#aa0
    style S fill:#fcc,stroke:#c00
    style K fill:#ccc,stroke:#999,stroke-dasharray: 5 5
    style N fill:#ccc,stroke:#999,stroke-dasharray: 5 5
    style R fill:#ccc,stroke:#999,stroke-dasharray: 5 5
```
</details>


<sub>Last reviewed commit: 64e2b27</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->