### PR TITLE
Activity Feed handles botExecutor for clean Vault Deposit entries

### DIFF
--- a/mercata/backend/src/config/config.ts
+++ b/mercata/backend/src/config/config.ts
@@ -186,12 +186,20 @@ export async function initInternalAddresses() {
   });
   addresses.push(...pools.map((pool: any) => pool.value));
 
-  // Vault Factory --> all vault addresses
+  // Vault Factory --> all vault addresses + their botExecutor addresses
   if (vaultFactory) {
     const { data: vaults } = await cirrus.get(accessToken, "/BlockApps-VaultFactory-allVaults", {
       params: { address: `eq.${vaultFactory}`, select: "value" },
     });
-    addresses.push(...vaults.map((vault: any) => vault.value));
+    const vaultAddresses = vaults.map((v: any) => v.value);
+    addresses.push(...vaultAddresses);
+
+    if (vaultAddresses.length > 0) {
+      const { data: vaultRecords } = await cirrus.get(accessToken, "/BlockApps-Vault", {
+        params: { address: `in.(${vaultAddresses.join(",")})`, select: "botExecutor" },
+      });
+      addresses.push(...vaultRecords.map((v: any) => v.botExecutor));
+    }
   }
 
   internalAddresses = Array.from(new Set(addresses.filter(Boolean)));


### PR DESCRIPTION
Exclude transfers to the vault's botExecutor from the Transfer activity in the activity feed since they are internal to Vault Deposited activities.

A follow-up on #6306

@greptile please review

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended the internal addresses filtering to include vault `botExecutor` addresses, preventing internal vault transfers from appearing as separate Transfer activities in the activity feed.

**Changes made:**
- Fetches all vault addresses from the VaultFactory
- For each vault, queries the `BlockApps-Vault` table to retrieve the `botExecutor` address
- Adds all `botExecutor` addresses to the `internalAddresses` array
- Updated comment to reflect that both vault addresses and their `botExecutor` addresses are included

**Impact:**
When users deposit into vaults, the system transfers tokens to the vault's `botExecutor` address. Previously, these internal transfers appeared as separate "Transfer" activities in the feed. Now they are correctly filtered out, showing only the "Vault Deposited" activity.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple, focused change that extends existing pattern. Follows the same approach used for other protocol addresses. Only adds filtering logic without modifying core business logic. The conditional check for `vaultAddresses.length > 0` prevents unnecessary API calls.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/backend/src/config/config.ts | Adds `botExecutor` addresses from vaults to internal addresses filter list for activity feed |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[initInternalAddresses] --> B[Fetch vault addresses from VaultFactory]
    B --> C{vaultAddresses.length > 0?}
    C -->|Yes| D[Query BlockApps-Vault for botExecutor addresses]
    C -->|No| E[Skip botExecutor fetch]
    D --> F[Add vaultAddresses to internal list]
    D --> G[Add botExecutor addresses to internal list]
    E --> F
    F --> H[Filter addresses with Array.from new Set]
    G --> H
    H --> I[Store in internalAddresses]
    I --> J[Activity Feed filters Transfer events]
    J --> K{from or to in internalAddresses?}
    K -->|Yes| L[Exclude from activity feed]
    K -->|No| M[Show in activity feed]
    
    style D fill:#90EE90
    style G fill:#90EE90
    style L fill:#FFB6C1
```
</details>


<sub>Last reviewed commit: 9fa1b73</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->