### PR TITLE
feat: display all navigation items directly in sidebar

### DIFF
--- a/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
+++ b/mercata/ui/src/components/dashboard/DashboardSidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from 'next-themes';
 import { 
@@ -14,8 +14,6 @@ import {
   Droplets, 
   Shield,
   UserPlus,
-  ChevronUp,
-  ChevronDown,
   LucideIcon,
   Vault
 } from 'lucide-react';
@@ -38,9 +36,6 @@ const PRIMARY_NAV_ITEMS: NavItem[] = [
   { icon: ArrowLeftRight, label: 'Swap', path: '/dashboard/swap' },
   { icon: Vault, label: 'Vault', path: '/dashboard/vault' },
   { icon: Gift, label: 'Rewards', path: '/dashboard/rewards' },
-];
-
-const MORE_NAV_ITEMS: NavItem[] = [
   { icon: Activity, label: 'Activity Feed', path: '/dashboard/activity' },
   { icon: Download, label: 'Withdrawals', path: '/dashboard/withdrawals' },
   { icon: BarChart3, label: 'STRATO Stats', path: '/dashboard/stats' },
@@ -53,7 +48,6 @@ const DashboardSidebar = () => {
   const { isAdmin } = useUser();
   const { pathname } = useLocation();
   const { resolvedTheme } = useTheme();
-  const [isMoreOpen, setIsMoreOpen] = useState(false);
 
   useEffect(() => {
     const updateWidth = () => {
@@ -66,18 +60,6 @@ const DashboardSidebar = () => {
     window.addEventListener('resize', updateWidth);
     return () => window.removeEventListener('resize', updateWidth);
   }, []);
-
-  // Auto-expand "More" if any of its items is active
-  useEffect(() => {
-    const isMoreItemActive = MORE_NAV_ITEMS
-      .filter(item => !item.adminOnly || isAdmin)
-      .some(item => 
-        item.path === '/dashboard' ? pathname === '/dashboard' : pathname.startsWith(item.path)
-      );
-    if (isMoreItemActive) {
-      setIsMoreOpen(true);
-    }
-  }, [pathname, isAdmin]);
 
   const isActive = (path: string) => 
     path === '/dashboard' ? pathname === '/dashboard' : pathname.startsWith(path);
@@ -113,33 +95,12 @@ const DashboardSidebar = () => {
       </div>
 
       <nav className="flex-1 py-4 px-3 overflow-y-auto">
-        {/* Primary Navigation */}
+        {/* Navigation */}
         <ul className="space-y-1">
-          {PRIMARY_NAV_ITEMS.map(renderNavItem)}
+          {PRIMARY_NAV_ITEMS
+            .filter(item => !item.adminOnly || isAdmin)
+            .map(renderNavItem)}
         </ul>
-
-        {/* More Section */}
-        <div className="mt-4">
-          <button
-            onClick={() => setIsMoreOpen(!isMoreOpen)}
-            className="flex items-center justify-between w-full px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 rounded-lg transition-colors"
-          >
-            <span>More</span>
-            {isMoreOpen ? (
-              <ChevronUp size={18} className="text-gray-400" />
-            ) : (
-              <ChevronDown size={18} className="text-gray-400" />
-            )}
-          </button>
-          
-          {isMoreOpen && (
-            <ul className="mt-1 space-y-1">
-              {MORE_NAV_ITEMS
-                .filter(item => !item.adminOnly || isAdmin)
-                .map(renderNavItem)}
-            </ul>
-          )}
-        </div>
       </nav>
     </aside>
   );


### PR DESCRIPTION
#6263 
<img width="255" height="822" alt="Screenshot 2026-02-19 at 3 40 25 PM" src="https://github.com/user-attachments/assets/185a9b3c-55b6-422b-b809-430b8dac2266" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the dashboard sidebar by removing the collapsible "More" dropdown section and displaying all 13 navigation items directly in a flat list. The change reduces component complexity by removing state management (`useState`), event handlers, and auto-expand logic while improving user experience by making all navigation options immediately visible.

- Merged `PRIMARY_NAV_ITEMS` and `MORE_NAV_ITEMS` arrays into a single `PRIMARY_NAV_ITEMS` array
- Removed `ChevronUp` and `ChevronDown` icon imports (no longer needed)
- Removed `useState` hook for `isMoreOpen` state
- Removed `useEffect` hook that auto-expanded "More" section when one of its items was active
- Removed collapsible "More" button and conditional rendering logic
- Simplified navigation rendering to a single filtered list
- Reduced component from 148 lines to 110 lines (-38 lines)

This aligns with the style guide principle to "prefer to simplify and remove than add functionality" and follows the "simplest possible way" approach.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactor is a straightforward simplification that removes complexity without introducing new logic or dependencies. All removed code relates to UI state management for the collapsible section, which is no longer needed. The change maintains all existing functionality (navigation, admin filtering, active state detection) while improving UX by making all options immediately visible.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/ui/src/components/dashboard/DashboardSidebar.tsx | Simplified sidebar by removing collapsible "More" section and displaying all navigation items directly in a single flat list |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DashboardSidebar Component] --> B[Logo Section]
    A --> C[Navigation Section]
    
    C --> D{Filter Items}
    D -->|adminOnly check| E[Filtered Nav Items]
    
    E --> F[Portfolio]
    E --> G[Deposit]
    E --> H[Transfer]
    E --> I[Borrow]
    E --> J[Swap]
    E --> K[Vault]
    E --> L[Rewards]
    E --> M[Activity Feed]
    E --> N[Withdrawals]
    E --> O[STRATO Stats]
    E --> P[Advanced]
    E --> Q[My Referrals]
    E --> R[Admin - if isAdmin]
    
    style A fill:#e3f2fd
    style C fill:#c5cae9
    style R fill:#ffcdd2
```
</details>


<sub>Last reviewed commit: b529545</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - mercata/.cursorrules ([source](https://app.greptile.com/review/custom-context?memory=b6ecc5fd-74eb-4cc2-8685-7ced69870fe0))
- Context from `dashboard` - .cursorrules ([source](https://app.greptile.com/review/custom-context?memory=5fe68e45-9393-443a-87c7-f10b62071ba2))

<!-- /greptile_comment -->