### PR TITLE
Add rETH price oracle sources

### DIFF
--- a/mercata/services/oracle/src/config/assets.json
+++ b/mercata/services/oracle/src/config/assets.json
@@ -10,6 +10,9 @@
     "PAXG": {
       "targetAssetAddress": "491cdfe98470bfe69b662ab368826dca0fc2f24d"
     },
+    "RETH": {
+      "targetAssetAddress": "2e4789eb7db143576da25990a3c0298917a8a87d"
+    },
     "SUSDS": {
       "targetAssetAddress": "6e2d93d323edf1b3cc4672a909681b6a430cae64"
     },

--- a/mercata/services/oracle/src/config/sources.json
+++ b/mercata/services/oracle/src/config/sources.json
@@ -5,7 +5,7 @@
     "parse": "data[].prices[0].value",
     "timestamp": "data[0].prices[0].lastUpdatedAt",
     "apiKeyEnvVar": "ALCHEMY_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC"]
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC", "RETH"]
   },
   "CoinMarketCap": {
     "url": "https://pro-api.coinmarketcap.com/v2/cryptocurrency/quotes/latest",
@@ -14,7 +14,7 @@
     "parse": "data.{symbol}[0].quote.USD.price",
     "timestamp": "data.{firstSymbol}[0].quote.USD.last_updated",
     "apiKeyEnvVar": "COINMARKETCAP_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "WSTETH", "SYRUPUSDC"]
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "WSTETH", "SYRUPUSDC", "RETH"]
   },
   "Metals.dev": {
     "url": "https://api.metals.dev/v1/latest",
@@ -42,7 +42,7 @@
     "parse": "{id}.usd",
     "timestamp": "{id}.last_updated_at",
     "apiKeyEnvVar": "COINGECKO_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC"],
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC", "RETH"],
     "symbolMapping": {
       "ETH": "ethereum",
       "WBTC": "wrapped-bitcoin",
@@ -50,7 +50,8 @@
       "XAUT": "tether-gold",
       "SUSDS": "susds",
       "WSTETH": "wrapped-steth",
-      "SYRUPUSDC": "syrupusdc"
+      "SYRUPUSDC": "syrupusdc",
+      "RETH": "rocket-pool-eth"
     }
   },
   "CoinAPI": {
@@ -66,7 +67,7 @@
     "url": "https://pro-api.llama.fi/${API_KEY}/coins/prices/current/${SYMBOLS}",
     "parse": "defiLlama",
     "apiKeyEnvVar": "DEFILLAMA_API_KEY",
-    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC"],
+    "assets": ["ETH", "WBTC", "PAXG", "XAUT", "SUSDS", "WSTETH", "SYRUPUSDC", "RETH"],
     "symbolMapping": {
       "ETH": "coingecko:ethereum",
       "WBTC": "coingecko:wrapped-bitcoin",
@@ -74,7 +75,8 @@
       "XAUT": "coingecko:tether-gold",
       "SUSDS": "coingecko:susds",
       "WSTETH": "coingecko:wrapped-steth",
-      "SYRUPUSDC": "coingecko:syrupusdc"
+      "SYRUPUSDC": "coingecko:syrupusdc",
+      "RETH": "coingecko:rocket-pool-eth"
     }
   },
   "Commodities-API": {


### PR DESCRIPTION
For #6314

Note that the asset configuration includes a STRATO token address for rETHST that is only on testnet at the moment. So long as the nonces line up, it will also work on mainnet, but we'll want to be sure of that.

This is currently deployed to testnet oracle 1.

I notice that the DefiLlama configuration uses the word "coingecko", but the prices are not the same, so perhaps they provide some independent value.

```js
0|oracle  | [FeedLogger] 2026-02-20T19:50:21.287Z | RETH
0|oracle  | ├─ Price: $2276.17279532 USD
0|oracle  | ├─ Sources: 4/4
0|oracle  | ├─ Transaction: 0c63203b6065b147cbc1af7c4bda8dc01ee40fde69bba81a1f31d483e32bfab1
0|oracle  | └─ Source Prices:
0|oracle  |     ├─ Alchemy: $2272.85289767 USD
0|oracle  |     ├─ CoinMarketCap: $2279.12559064 USD
0|oracle  |     ├─ CoinGecko: $2273.22000000 USD
0|oracle  |     └─ DefiLlama: $2284.94211754 USD
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Rocket Pool ETH (RETH) price oracle support with 4 data sources and proper symbol mappings.

**Changes:**
- Added `RETH` entry in `assets.json` with testnet STRATO token address `2e4789eb7db143576da25990a3c0298917a8a87d`
- Added `RETH` to 4 price data sources: Alchemy, CoinMarketCap, CoinGecko, and DefiLlama
- Added symbol mappings: `rocket-pool-eth` for CoinGecko and `coingecko:rocket-pool-eth` for DefiLlama
- Meets MIN_VALID_SOURCES requirement (4 sources > 3 minimum)

**Notes:**
- PR description mentions token address is currently testnet-only, with mainnet compatibility dependent on nonce alignment
- Oracle test output shows all 4 sources returning RETH prices successfully
- Configuration follows existing patterns for other assets like WSTETH and SUSDS

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Configuration-only changes following established patterns, with validation logic ensuring RETH has sufficient sources (4/3 required), correct JSON formatting, and proper symbol mappings matching existing assets
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/services/oracle/src/config/assets.json | Added RETH asset with targetAssetAddress for Rocket Pool ETH price oracle |
| mercata/services/oracle/src/config/sources.json | Added RETH to 4 sources (Alchemy, CoinMarketCap, CoinGecko, DefiLlama) with proper symbol mappings |

</details>


</details>


<sub>Last reviewed commit: 9529a08</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->