### PR TITLE
don't rely on curl based on c-ares due to dns resolution issues

### DIFF
--- a/apex/api/docker-run.sh
+++ b/apex/api/docker-run.sh
@@ -27,7 +27,7 @@ sed -i -e 's|__strato_postgres_host__|'"${postgres_host}"'|g' models/strato/eth/
 sed -i -e 's|__strato_postgres_port__|'"${postgres_port}"'|g' models/strato/eth/config.js
 
 echo 'Waiting for strato to be available...'
-until curl --silent --output /dev/null --fail --location ${stratoRoot}/stats/totaltx
+until wget --quiet --spider "${stratoRoot}/stats/totaltx"
 do
   echo "Check at $(date)"
   sleep 1


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `curl` with `wget` to avoid DNS resolution issues related to c-ares library in the startup health check for the strato service.

**Critical Issue Found:**
- The Dockerfile (`apex/api/Dockerfile:4`) installs `curl` but not `wget`, so this change will cause the startup script to fail with "wget: not found" error

**Required Fix:**
- Add `wget` to the `apk add` command in the Dockerfile to make this change functional

<h3>Confidence Score: 0/5</h3>

- This PR will break the container startup and cannot be merged as-is
- The change replaces `curl` with `wget` but the Dockerfile does not install `wget`, causing a critical runtime failure. The script will fail immediately when trying to check if strato is available, preventing the service from starting.
- `apex/api/Dockerfile` must be updated to install `wget` before this PR can be merged

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apex/api/docker-run.sh | Replaced `curl` with `wget` for health check, but `wget` is not installed in the container (Dockerfile line 4) |

</details>


</details>


<sub>Last reviewed commit: 1b6ba07</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->