### PR TITLE
Refactor Google Analytics integration to use a fixed GA ID and stream…

### DIFF
--- a/mercata/ui/src/main.tsx
+++ b/mercata/ui/src/main.tsx
@@ -13,23 +13,18 @@ if (siteId && siteId.trim() !== '') {
   document.head.appendChild(script);
 }
 
-// Conditionally load Google Analytics
-// Use runtime config (from /config.js) if available, fallback to build-time env var
-const gaId = (window as any).ENV?.GOOGLE_ANALYTICS_ID || import.meta.env.VITE_GOOGLE_ANALYTICS_ID;
-if (gaId && gaId.trim() !== '') {
-  // Load gtag.js library
-  const gtagScript = document.createElement('script');
-  gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
-  gtagScript.async = true;
-  document.head.appendChild(gtagScript);
+// Google tag (gtag.js)
+const gtagScript = document.createElement('script');
+gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-B5TCWNS0BX';
+gtagScript.async = true;
+document.head.appendChild(gtagScript);
 
-  // Initialize dataLayer and gtag (expose gtag globally for custom event tracking)
-  (window as any).dataLayer = (window as any).dataLayer || [];
-  (window as any).gtag = function (...args: any[]) {
-    (window as any).dataLayer.push(args);
-  };
-  (window as any).gtag('js', new Date());
-  (window as any).gtag('config', gaId);
-}
+(window as any).dataLayer = (window as any).dataLayer || [];
+(window as any).gtag = function() {
+  // eslint-disable-next-line prefer-rest-params
+  (window as any).dataLayer.push(arguments);
+};
+(window as any).gtag('js', new Date());
+(window as any).gtag('config', 'G-B5TCWNS0BX');
 
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
…line script loading

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced configurable Google Analytics integration with hardcoded GA ID `G-B5TCWNS0BX`, removing runtime/build-time configurability that was previously available through `GOOGLE_ANALYTICS_ID` environment variable.

Major issues:
- Hardcoded GA tracking ID violates security best practices from the style guide (rule: "Contract addresses should be stored in configuration files")
- Removed conditional loading - GA now loads unconditionally even when no ID is configured
- Breaks existing `docker-run.sh` runtime configuration system and docker-compose environment variable passing
- Breaks fallback to `VITE_GOOGLE_ANALYTICS_ID` build-time env var
- The `public/config.js` file still references `GOOGLE_ANALYTICS_ID` but is now unused

<h3>Confidence Score: 1/5</h3>

- This PR has critical issues and should not be merged without significant revisions
- The PR introduces hardcoded credentials, removes configurability, and breaks existing infrastructure for runtime configuration. This violates the repository's security best practices and will prevent different environments (dev/test/prod) from using different GA IDs.
- `mercata/ui/src/main.tsx` requires immediate attention - revert hardcoded GA ID and restore conditional loading logic

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/ui/src/main.tsx | Hardcoded Google Analytics ID `G-B5TCWNS0BX`, removed runtime configurability, and broke conditional loading. Violates security best practices and existing infrastructure. |

</details>


</details>


<sub>Last reviewed commit: 2ef520a</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - mercata/.cursorrules ([source](https://app.greptile.com/review/custom-context?memory=b6ecc5fd-74eb-4cc2-8685-7ced69870fe0))

<!-- /greptile_comment -->