### PR TITLE
rewards page & related ui changes

### DIFF
--- a/mercata/ui/src/components/home/Hero.tsx
+++ b/mercata/ui/src/components/home/Hero.tsx
@@ -75,10 +75,10 @@ const Hero = () => {
                   <ArrowRight className="w-4 h-4 transition-transform duration-200 group-hover:translate-x-1" />
                 </button>
                 <Link
-                  to="/dashboard/stats"
+                  to="/dashboard/rewards"
                   className="inline-flex items-center justify-center gap-2 bg-white dark:bg-slate-800 hover:bg-gray-50 dark:hover:bg-slate-700 text-foreground px-6 py-3 rounded-lg font-medium border border-border transition-all duration-300"
                 >
-                  Explore Stats
+                  Earn Rewards
             </Link>
           </div>
         </div>

--- a/mercata/ui/src/components/rewards/ActivitiesTable.tsx
+++ b/mercata/ui/src/components/rewards/ActivitiesTable.tsx
@@ -139,7 +139,7 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                 <TableHead>
                   <div className="flex items-center gap-1">
                   Est. Incentive APY
-                    <InfoTooltip content="Estimated annual percentage return from CATA incentives, assuming a $25M fully diluted valuation ($0.25/CATA). APR = (annual CATA emitted × $0.25) / TVL." />
+                    <InfoTooltip content="Estimated annual percentage yield from CATA incentives, assuming a $25M fully diluted valuation ($0.25/CATA). APY = (annual CATA emitted × $0.25) / TVL." />
                   </div>
                 </TableHead>
                 <TableHead>Type</TableHead>

--- a/mercata/ui/src/components/rewards/ActivitiesTable.tsx
+++ b/mercata/ui/src/components/rewards/ActivitiesTable.tsx
@@ -2,10 +2,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import { Activity } from "@/services/rewardsService";
 import { formatBalance } from "@/utils/numberUtils";
 import { formatEmissionRatePerDay, formatEmissionRatePerWeek, roundByMagnitude, formatRoundedWithCommas } from "@/services/rewardsService";
-import { formatDistanceToNow } from "date-fns";
 import { Info } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Link } from "react-router-dom";
@@ -20,6 +20,22 @@ interface ActivitiesTableProps {
 const truncateActivityName = (name: string, maxLength: number = 30): string => {
   if (!name || name.length <= maxLength) return name;
   return name.substring(0, maxLength) + "...";
+};
+
+const getEstimatedApyPercent = (activity: Activity): number => {
+  try {
+    if (!activity?.emissionRate || !activity?.totalStakeUsd) return -1;
+
+    const tvlUsd = Number(BigInt(activity.totalStakeUsd)) / 1e18;
+    if (!Number.isFinite(tvlUsd) || tvlUsd <= 0) return -1;
+
+    const annualCata = (Number(BigInt(activity.emissionRate)) / 1e18) * 86400 * 365;
+    if (!Number.isFinite(annualCata) || annualCata < 0) return -1;
+
+    return (annualCata * 0.25 / tvlUsd) * 100;
+  } catch {
+    return -1;
+  }
 };
 
 // Mobile-friendly Info Tooltip component
@@ -71,6 +87,9 @@ const InfoTooltip = ({ content }: { content: string }) => {
 };
 
 export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) => {
+  const loginButtonClass = "bg-gradient-to-r from-[#1f1f5f] via-[#293b7d] to-[#16737d] text-white hover:opacity-90";
+  const sortedActivities = [...activities].sort((a, b) => getEstimatedApyPercent(b) - getEstimatedApyPercent(a));
+
   if (loading) {
     return (
       <Card>
@@ -114,15 +133,16 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>ID</TableHead>
+                {/* <TableHead>ID</TableHead> */}
+                <TableHead>S. No</TableHead>
                 <TableHead>Name</TableHead>
-                <TableHead>Type</TableHead>
                 <TableHead>
                   <div className="flex items-center gap-1">
-                    CATA APR
+                  Est. Incentive APY
                     <InfoTooltip content="Estimated annual percentage return from CATA incentives, assuming a $25M fully diluted valuation ($0.25/CATA). APR = (annual CATA emitted × $0.25) / TVL." />
                   </div>
                 </TableHead>
+                <TableHead>Type</TableHead>
                 <TableHead>
                   <div className="flex items-center gap-1">
                     Emission Rate
@@ -135,14 +155,16 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                     <InfoTooltip content="The total amount staked across all users in this activity. Your share of rewards is proportional to your stake relative to this total.\n\nNote: Different activities may use different stake units (token units, USD-notional, or shares)." />
                   </div>
                 </TableHead>
-                <TableHead>Last Update</TableHead>
+                {/* <TableHead>Last Update</TableHead> */}
+                <TableHead>Earn Now</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {activities.map((activity) => {
+              {sortedActivities.map((activity, index) => {
                 const emissionRateStr = activity?.emissionRate || null;
                 const emissionPerDay = emissionRateStr ? formatEmissionRatePerDay(emissionRateStr) : "?";
                 const emissionPerWeek = emissionRateStr ? formatEmissionRatePerWeek(emissionRateStr) : "?";
+                const estimatedApr = getEstimatedApyPercent(activity);
                 
                 // Format total stake with denomination context
                 const totalStakeStr = activity?.totalStake || null;
@@ -159,17 +181,20 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                   totalStakeFormatted = `$${totalStakeRounded}`;
                 }
                 
-                const lastUpdateTimeStr = activity?.lastUpdateTime || null;
-                const lastUpdate = lastUpdateTimeStr ? new Date(Number(lastUpdateTimeStr) * 1000) : null;
-                const timeAgo = lastUpdate ? formatDistanceToNow(lastUpdate, { addSuffix: true }) : "?";
+                // const lastUpdateTimeStr = activity?.lastUpdateTime || null;
+                // const lastUpdate = lastUpdateTimeStr ? new Date(Number(lastUpdateTimeStr) * 1000) : null;
+                // const timeAgo = lastUpdate ? formatDistanceToNow(lastUpdate, { addSuffix: true }) : "?";
                 const activityLink = activity?.name ? getActivityLink(activity.name) : null;
 
                 return (
                   <TableRow
                     key={activity?.activityId || Math.random()}
                   >
-                    <TableCell className="font-mono font-medium">
+                    {/* <TableCell className="font-mono font-medium">
                       {activity?.activityId !== undefined && activity?.activityId !== null ? activity.activityId : "?"}
+                    </TableCell> */}
+                    <TableCell className="font-mono font-medium">
+                      {index + 1}
                     </TableCell>
                     <TableCell className="font-medium">
                       {activity?.name ? (
@@ -186,21 +211,24 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                       ) : "?"}
                     </TableCell>
                     <TableCell>
+                      {estimatedApr < 0 ? (
+                        <span className="text-muted-foreground">-</span>
+                      ) : (
+                        <span className="font-medium">
+                          {estimatedApr >= 1000
+                            ? `${Math.round(estimatedApr).toLocaleString()}%`
+                            : estimatedApr >= 10
+                              ? `${estimatedApr.toFixed(0)}%`
+                              : `${estimatedApr.toFixed(1)}%`}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell>
                       <Badge variant="secondary">
                         {activity?.activityType !== undefined && activity?.activityType !== null
                           ? (activity.activityType === 1 ? "One-Time" : "Position")
                           : "?"}
                       </Badge>
-                    </TableCell>
-                    <TableCell>
-                      {(() => {
-                        const tvlUsd = activity?.totalStakeUsd ? Number(BigInt(activity.totalStakeUsd)) / 1e18 : 0;
-                        if (!emissionRateStr || tvlUsd <= 0) return <span className="text-muted-foreground">-</span>;
-                        const annualCata = (Number(BigInt(emissionRateStr)) / 1e18) * 86400 * 365;
-                        const apr = (annualCata * 0.25 / tvlUsd) * 100;
-                        const display = apr >= 1000 ? `${Math.round(apr).toLocaleString()}%` : apr >= 10 ? `${apr.toFixed(0)}%` : `${apr.toFixed(1)}%`;
-                        return <span className="font-medium">{display}</span>;
-                      })()}
                     </TableCell>
                     <TableCell>
                       <div>
@@ -224,7 +252,16 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                       </div>
                     </TableCell>
                     <TableCell>{totalStakeFormatted}</TableCell>
-                    <TableCell className="text-sm text-muted-foreground">{timeAgo}</TableCell>
+                    {/* <TableCell className="text-sm text-muted-foreground">{timeAgo}</TableCell> */}
+                    <TableCell>
+                      {activityLink ? (
+                        <Link to={activityLink}>
+                          <Button size="sm" className={loginButtonClass}>Earn Now</Button>
+                        </Link>
+                      ) : (
+                        <Button size="sm" className={loginButtonClass} disabled>Earn Now</Button>
+                      )}
+                    </TableCell>
                   </TableRow>
                 );
               })}

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -6,10 +6,11 @@ import AssetSummary from "../components/dashboard/AssetSummary";
 import AssetsList from "../components/dashboard/AssetsList";
 import DashboardFAQ from "../components/dashboard/DashboardFAQ";
 import BorrowingSection from "../components/dashboard/BorrowingSection";
-import { Wallet, Coins, Shield, Banknote, Loader2, Trophy, UserPlus, Send, Book, ArrowRightLeft } from "lucide-react";
+import { Wallet, Coins, Shield, Banknote, Loader2, Trophy, Send, Book, ArrowRightLeft } from "lucide-react";
 import { useTokenContext } from "@/context/TokenContext";
 import { useUser } from "@/context/UserContext";
 import { usePendingRewards } from "@/hooks/usePendingRewards";
+import { useRewardsActivities } from "@/hooks/useRewardsActivities";
 import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
 import { useNetBalance } from "@/hooks/useNetBalance";
@@ -22,6 +23,7 @@ import { api } from "@/lib/axios";
 import { BalanceSnapshot } from "@mercata/shared-types";
 import { useUserLeaderboardRank } from "@/hooks/useUserLeaderboardRank";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import GuestSignInBanner from "@/components/ui/GuestSignInBanner";
 import LiquidationAlertBanner from "@/components/ui/LiquidationAlertBanner";
 
@@ -29,6 +31,19 @@ const TIME_RANGES = ["1d", "7d", "1m", "3m", "6m", "1y", "all"] as const;
 type TimeRange = typeof TIME_RANGES[number];
 
 type TabType = 'netBalance' | 'rewards' | 'borrowed';
+
+const getEstimatedApyPercent = (emissionRate?: string, totalStakeUsd?: string | null): number => {
+  try {
+    if (!emissionRate || !totalStakeUsd) return 0;
+    const tvlUsd = Number(BigInt(totalStakeUsd)) / 1e18;
+    if (!Number.isFinite(tvlUsd) || tvlUsd <= 0) return 0;
+    const annualCata = (Number(BigInt(emissionRate)) / 1e18) * 86400 * 365;
+    if (!Number.isFinite(annualCata) || annualCata <= 0) return 0;
+    return (annualCata * 0.25 / tvlUsd) * 100;
+  } catch {
+    return 0;
+  }
+};
 
 const Dashboard = () => {
   const [searchParams] = useSearchParams();
@@ -73,8 +88,16 @@ const Dashboard = () => {
   });
 
   const { pendingRewards, refetch: refetchPendingRewards } = usePendingRewards(rewardsEnabled, 30000);
+  const { activities: rewardsActivities, loading: rewardsActivitiesLoading } = useRewardsActivities();
   const [isClaiming, setIsClaiming] = useState(false);
   const { rank: userRank, totalEarned, loading: rankLoading } = useUserLeaderboardRank();
+  const highestIncentiveApy = useMemo(() => {
+    if (!rewardsActivities.length) return 0;
+    return rewardsActivities.reduce((maxApy, activity) => {
+      const apy = getEstimatedApyPercent(activity.emissionRate, activity.totalStakeUsd ?? null);
+      return apy > maxApy ? apy : maxApy;
+    }, 0);
+  }, [rewardsActivities]);
 
   // Extract CATA token from inactive tokens by address
   const cataToken = useMemo(() => 
@@ -400,35 +423,31 @@ const Dashboard = () => {
             />
           </div>
 
-          {/* Refer a Friend Section */}
+          {/* Rewards Section */}
           <div className="mb-4 md:mb-8">
             <div className="bg-card shadow-sm rounded-xl p-4 md:p-6 border border-border">
               <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                 <div className="flex items-center gap-3">
                   <div className="p-2.5 md:p-3 bg-blue-500 rounded-lg shrink-0">
-                    <UserPlus className="text-white" size={20} />
+                    <Coins className="text-white" size={20} />
                   </div>
                   <div>
-                    <h3 className="text-base md:text-lg font-semibold">Refer a Friend</h3>
-                    <p className="text-xs md:text-sm text-muted-foreground">
-                      Send tokens to friends who haven't signed up yet
-                    </p>
+                    <h3 className="text-base md:text-lg font-semibold">Rewards</h3>
+                    <div className="text-xs md:text-sm text-muted-foreground">
+                      {rewardsActivitiesLoading ? (
+                        <Skeleton className="h-4 w-36 mt-1" />
+                      ) : (
+                        <>Earn Upto {highestIncentiveApy.toFixed(2)}% APY</>
+                      )}
+                    </div>
                   </div>
                 </div>
                 <Button
-                  onClick={() => {
-                    // For non-logged-in users, redirect to My Referrals page (guest accessible)
-                    // For logged-in users, redirect to Refer Friend page
-                    if (!isLoggedIn) {
-                      navigate("/dashboard/referrals");
-                    } else {
-                      navigate("/dashboard/refer");
-                    }
-                  }}
+                  onClick={() => navigate("/dashboard/rewards?tab=activities")}
                   className="w-full md:w-auto flex items-center justify-center gap-2"
                 >
-                  <UserPlus className="h-4 w-4" />
-                  Get Started
+                  <Coins className="h-4 w-4" />
+                  Earn Rewards
                 </Button>
               </div>
             </div>

--- a/mercata/ui/src/pages/Rewards.tsx
+++ b/mercata/ui/src/pages/Rewards.tsx
@@ -24,19 +24,8 @@ const Rewards = () => {
   const [searchParams] = useSearchParams();
   const { isLoggedIn } = useUser();
   
-  // Default to leaderboard for guests, my-rewards for logged-in users
-  const [activeTab, setActiveTab] = useState<"activities" | "my-rewards" | "leaderboard">(() => {
-    const tabParam = searchParams.get("tab");
-    if (tabParam === "leaderboard" || tabParam === "activities" || tabParam === "my-rewards") {
-      // If guest tries to access my-rewards directly, redirect to leaderboard
-      if (tabParam === "my-rewards" && !isLoggedIn) {
-        return "leaderboard";
-      }
-      return tabParam;
-    }
-    // Default: leaderboard for guests, my-rewards for logged-in users
-    return isLoggedIn ? "my-rewards" : "leaderboard";
-  });
+
+  const [activeTab, setActiveTab] = useState<"activities" | "my-rewards" | "leaderboard">("activities");
 
   const { state, loading: stateLoading, refetch: refetchState } = useRewards();
   const { activities, loading: activitiesLoading, refetch: refetchActivities } = useRewardsActivities();
@@ -146,8 +135,8 @@ const Rewards = () => {
             className="w-full"
           >
             <TabsList className="grid w-full grid-cols-3 mb-6">
+            <TabsTrigger value="activities">Activities</TabsTrigger>
                <TabsTrigger value="my-rewards">My Rewards</TabsTrigger>
-              <TabsTrigger value="activities">Activities</TabsTrigger>
               <TabsTrigger value="leaderboard">Leaderboard</TabsTrigger>
             </TabsList>
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

UI improvements to emphasize rewards across the platform. The "Activities" tab now displays first by default, activities are sorted by APY (highest first), and new "Earn Now" action buttons link directly to relevant pages.

Key changes:
- Updated hero section CTA from "Explore Stats" to "Earn Rewards"
- Replaced "Refer a Friend" section with rewards section showing highest available APY
- Reordered activities table columns (S. No., Name, APY, Type, Emission Rate, Total Stake, Earn Now)
- Activities now sorted by estimated APY in descending order
- Removed "Last Update" column and ID column
- Changed default tab to "Activities" from context-dependent default
- Added direct "Earn Now" buttons to each activity row

Issue found: Tooltip text still references "APR" but column header changed to "APY" - needs consistency update.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor tooltip inconsistency
- UI changes are straightforward and non-breaking. One tooltip text inconsistency (APR vs APY) should be fixed but won't cause runtime errors.
- mercata/ui/src/components/rewards/ActivitiesTable.tsx requires tooltip text correction

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/ui/src/components/home/Hero.tsx | Updated CTA button to link to rewards page instead of stats page |
| mercata/ui/src/components/rewards/ActivitiesTable.tsx | Reordered columns, added APY calculation, sorting by APY, and action buttons; tooltip text mislabeled |
| mercata/ui/src/pages/Dashboard.tsx | Replaced "Refer a Friend" section with rewards section showing highest APY |
| mercata/ui/src/pages/Rewards.tsx | Changed default tab to "activities" and reordered tab display order |

</details>


</details>


<sub>Last reviewed commit: 344e467</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->