### PR TITLE
Added verifyP256 builtin to SolidVM

### DIFF
--- a/mercata/contracts/tests/BaseCodeCollection.test.sol
+++ b/mercata/contracts/tests/BaseCodeCollection.test.sol
@@ -198,7 +198,7 @@ contract Describe_Mercata is Authorizable {
         uint x = 102396230969586467009226886506862623657318724148434895532623014254764145364321;
         uint y = 87130768018175665529254388393063563572785429725661944920479895196939055716302;
         bytes authenticatorData = bytes(0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d00000000);
-        bytes clientDataJSON = bytes(0x7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a22534746736247567364577068614345222c226f726967696e223a22687474703a2f2f6c6f63616c686f73743a38303835222c2263726f73734f726967696e223a66616c73657d);
+        bytes clientDataJSON = bytes('{"type":"webauthn.get","challenge":"SGFsbGVsdWphaCE","origin":"http://localhost:8085","crossOrigin":false}');
         bytes clientDataHash = sha256(clientDataJSON);
         bytes fullData = authenticatorData + bytes(clientDataHash);
         bytes h = sha256(fullData);

--- a/mercata/contracts/tests/BaseCodeCollection.test.sol
+++ b/mercata/contracts/tests/BaseCodeCollection.test.sol
@@ -193,16 +193,18 @@ contract Describe_Mercata is Authorizable {
 
     function it_can_verify_p256() {
         string message = "Hallelujah!";
-        uint r = 111812406968280556887309161541670890688342740771217603417112256244675252770954;
-        uint s = 69794988671688531321311227746003226764691315458172986192026128195324243923064;
-        uint x = 102396230969586467009226886506862623657318724148434895532623014254764145364321;
-        uint y = 87130768018175665529254388393063563572785429725661944920479895196939055716302;
+        uint r = 29576957218913890340491659409841852068033084215229700711255507061323143814549;
+        uint s = 101557168712526122138100485234540408883990559892858822894344366649907264877720;
+        uint x = 16241039676017158139658647491575996736571373479493265913891396969380226787542;
+        uint y = 59216528153676978070808029460682524906485316850686665728311789336192423162328;
+        bytes pub = bytes(0x0423e81a4a99319639971cff670b796702ebd275f76b39056ecc06c25911cbe8d682eb5e007feea20a52a2dc4268dd1518975c14889c8d9e58c9861ef49839f1d8);
         bytes authenticatorData = bytes(0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d00000000);
         bytes clientDataJSON = bytes('{"type":"webauthn.get","challenge":"SGFsbGVsdWphaCE","origin":"http://localhost:8085","crossOrigin":false}');
         bytes clientDataHash = sha256(clientDataJSON);
         bytes fullData = authenticatorData + bytes(clientDataHash);
         bytes h = sha256(fullData);
-        require(verifyP256(h, r, s, x, y), "P256 verification failed");
+        require(verifyP256(h, r, s, x, y), "P256 verification by pubkey coordinates failed");
+        require(verifyP256(h, r, s, pub), "P256 verification by pubkey bytestring failed");
     }
 
     string output;

--- a/mercata/contracts/tests/BaseCodeCollection.test.sol
+++ b/mercata/contracts/tests/BaseCodeCollection.test.sol
@@ -191,6 +191,20 @@ contract Describe_Mercata is Authorizable {
         require(success, "Groth16 proof failed!");
     }
 
+    function it_can_verify_p256() {
+        string message = "Hallelujah!";
+        uint r = 111812406968280556887309161541670890688342740771217603417112256244675252770954;
+        uint s = 69794988671688531321311227746003226764691315458172986192026128195324243923064;
+        uint x = 102396230969586467009226886506862623657318724148434895532623014254764145364321;
+        uint y = 87130768018175665529254388393063563572785429725661944920479895196939055716302;
+        bytes authenticatorData = bytes(0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d00000000);
+        bytes clientDataJSON = bytes(0x7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a22534746736247567364577068614345222c226f726967696e223a22687474703a2f2f6c6f63616c686f73743a38303835222c2263726f73734f726967696e223a66616c73657d);
+        bytes clientDataHash = sha256(clientDataJSON);
+        bytes fullData = authenticatorData + bytes(clientDataHash);
+        bytes h = sha256(fullData);
+        require(verifyP256(h, r, s, x, y), "P256 verification failed");
+    }
+
     string output;
 
     function performIssue(uint num, bool should, address isDeadbeef, string message) public {

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1427,6 +1427,7 @@ byteArgs x =
       :| [ intType' x
          , addressType' x
          , Product [stringType' x, stringType' x] x
+         , bytesType' x
          ]
 
 keccak256Args :: SourceAnnotation Text -> Type'
@@ -1506,6 +1507,14 @@ ecrecoverArgs x = Product [ stringType' x
                           , Sum $ (stringType' x) :| [intType' x]
                           ] x
 
+verifyP256Args :: SourceAnnotation Text -> Type'
+verifyP256Args x = Product [ bytesType' x
+                           , Sum $ (stringType' x) :| [intType' x]
+                           , Sum $ (stringType' x) :| [intType' x]
+                           , Sum $ (stringType' x) :| [intType' x]
+                           , Sum $ (stringType' x) :| [intType' x]
+                           ] x
+
 addmodArgs :: SourceAnnotation Text -> Type'
 addmodArgs x = Product [intType' x, intType' x, intType' x] x
 
@@ -1570,6 +1579,7 @@ getVarType' "mulmod" ctx = pure $ Function (mulmodArgs ctx) (intType' ctx) ctx [
 getVarType' "payable" ctx = pure $ Function (payableArgs ctx) (Static (SVMType.Address True) ctx) ctx [] [] False
 getVarType' "blockhash" ctx = pure $ Function (blockhashArgs ctx) (Static (SVMType.Bytes Nothing (Just 32)) ctx) ctx [] [] False
 getVarType' "ecrecover" ctx = pure $ Function (ecrecoverArgs ctx) (addressType' ctx) ctx [] [] False
+getVarType' "verifyP256" ctx = pure $ Function (verifyP256Args ctx) (boolType' ctx) ctx [] [] False
 getVarType' "parseCert" ctx = pure $ Function (parseCertArgs ctx) (certType' ctx) ctx [] [] False
 getVarType' "create" ctx = pure $ Function (createFuncArgs ctx) (addressType' ctx) ctx [] [] False
 getVarType' "create2" ctx = pure $ Function (saltCreateArgs ctx) (addressType' ctx) ctx [] [] False
@@ -1855,7 +1865,7 @@ simpleStatementHelper _ (ExpressionStatement expr) =
 
 tcExpr :: Annotated ExpressionF -> SSS Type'
 tcExpr (Binary x "+" a b) =
-  sumType [intType' x, stringType' x, decimalType' x] ~> tcExpr a <~> tcExpr b
+  sumType [intType' x, stringType' x, decimalType' x, bytesType' x] ~> tcExpr a <~> tcExpr b
 tcExpr (Binary x "-" a b) =
   sumType' (intType' x) (decimalType' x) ~> tcExpr a <~> tcExpr b
 tcExpr (Binary x "*" a b) =

--- a/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
+++ b/strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs
@@ -1508,12 +1508,19 @@ ecrecoverArgs x = Product [ stringType' x
                           ] x
 
 verifyP256Args :: SourceAnnotation Text -> Type'
-verifyP256Args x = Product [ bytesType' x
-                           , Sum $ (stringType' x) :| [intType' x]
-                           , Sum $ (stringType' x) :| [intType' x]
-                           , Sum $ (stringType' x) :| [intType' x]
-                           , Sum $ (stringType' x) :| [intType' x]
-                           ] x
+verifyP256Args x = Sum $
+  Product [ bytesType' x
+          , Sum $ (stringType' x) :| [intType' x]
+          , Sum $ (stringType' x) :| [intType' x]
+          , Sum $ (stringType' x) :| [intType' x]
+          , Sum $ (stringType' x) :| [intType' x]
+          ] x
+  :| [ Product [ bytesType' x
+               , Sum $ (stringType' x) :| [intType' x]
+               , Sum $ (stringType' x) :| [intType' x]
+               , Sum $ (stringType' x) :| [bytesType' x]
+               ] x
+     ]
 
 addmodArgs :: SourceAnnotation Text -> Type'
 addmodArgs x = Product [intType' x, intType' x, intType' x] x

--- a/strato/VM/SolidVM/solid-vm/package.yaml
+++ b/strato/VM/SolidVM/solid-vm/package.yaml
@@ -21,6 +21,7 @@ library:
   - common-log
   - containers
   - cryptohash
+  - crypton
   - data-default
   - debugger
   - Decimal

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2294,6 +2294,7 @@ callBuiltin name [SString s]
 callBuiltin "decimal" args = return $ decimalBuiltin args
 callBuiltin "identity" [v] = return v
 callBuiltin "log" args = SNULL <$ traverse (liftIO . putStrLn <=< showSM) args
+callBuiltin "keccak256" [SBytes bs] = pure . SBytes . keccak256ToByteString $ hash bs
 callBuiltin "keccak256" args = pure . SString . keccak256ToHex . hash . rlpSerialize $ rlpEncodeValues args
 callBuiltin "ecrecover" [SString h, SInteger v, r', s'] = case B16.decode (BC.pack h) of
   Left err -> invalidArguments err ("" :: String)
@@ -2345,6 +2346,7 @@ callBuiltin "verifyP256" ((SBytes h) : r' : s' : p') = case digestFromByteString
     pure $ SBool isValidSig
 callBuiltin "sha256" [SBytes bs] = pure . SBytes $ SHA256.hash bs
 callBuiltin "sha256" args = pure . SString . BC.unpack . B16.encode . SHA256.hash . rlpSerialize $ rlpEncodeValues args
+callBuiltin "ripemd160" [SBytes bs] = pure . SBytes $ RIPEMD160.hash bs
 callBuiltin "ripemd160" args = pure . SString . BC.unpack . B16.encode . RIPEMD160.hash . rlpSerialize $ rlpEncodeValues args
 callBuiltin "modExp" [SInteger b, SInteger e, SInteger m] = pure . SInteger $ Builtins.modExp b e m
 callBuiltin "ecAdd" [SInteger x1, SInteger y1, SInteger x2, SInteger y2] =

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -814,18 +814,18 @@ runStatement (CC.SolidityTryCatchStatement tryExpression returnsDecl statementsF
           sfsRes <- runStatementBlock statementsForSuccess
           return $ sfsRes
         Just xs -> do
-          case aRealVal of
-            STuple vecOfVars -> do
-              let vars = V.toList vecOfVars
-              if length vars /= length returnsDecl
-                then typeError "try/catch statement expected a tuple of the same length as the returns statement" $ show (tryExpression, aRealVal)
-                else do
-                  forM_ (zip vars xs) $ \(var, (name, _)) -> do
-                    val <- getVar var
-                    addLocalVariable name val
-                  sfsRes' <- runStatementBlock statementsForSuccess
-                  return sfsRes'
-            _ -> typeError "try/catch statement expected a tuple" $ show (tryExpression, aRealVal)
+          vecOfVars <- case aRealVal of
+            STuple vec -> pure vec
+            v -> pure . V.singleton $ Constant v
+          let vars = V.toList vecOfVars
+          if length vars /= length returnsDecl
+            then typeError "try/catch statement expected a tuple of the same length as the returns statement" $ show (tryExpression, aRealVal)
+            else do
+              forM_ (zip vars xs) $ \(var, (name, _)) -> do
+                val <- getVar var
+                addLocalVariable name val
+              sfsRes' <- runStatementBlock statementsForSuccess
+              return sfsRes'
 runStatement (CC.TryCatchStatement tryBlock catchBlockMap pos) = do
   solidVMBreakpoint pos
   mRes <- EUnsafe.try $ do
@@ -2239,15 +2239,21 @@ callBuiltin "address" [SBytes bs] = pure . flip SAddress False . Address . bytes
 callBuiltin "address" [SNULL] = return $ SAddress 0 False
 callBuiltin "address" [SReference{}] = return $ SAddress 0 False
 callBuiltin "address" vs = typeError "address cast" $ show vs
-callBuiltin ("addmod") [SInteger a, SInteger b, SInteger c] = return . SInteger $ (a + b) `mod` c
-callBuiltin ("mulmod") [SInteger a, SInteger b, SInteger c] = return . SInteger $ (a * b) `mod` c
-callBuiltin ("blockhash") [SInteger blockNum] | blockNum < 0 = invalidArguments "blockhash() only accepts arguments greater than or equal to 0" [blockNum]
-callBuiltin ("blockhash") [SInteger blockNum] = do
+callBuiltin ("addmod") [a', b', c'] = do
+  (a,b,c) <- (,,) <$> int a' <*> int b' <*> int c'
+  return . SInteger $ (a + b) `mod` c
+callBuiltin ("mulmod") [a', b', c'] = do
+  (a,b,c) <- (,,) <$> int a' <*> int b' <*> int c'
+  return . SInteger $ (a * b) `mod` c
+callBuiltin ("blockhash") [bNum] = do
+  blockNum <- int bNum
+  when (blockNum < 0) $ invalidArguments "blockhash() only accepts arguments greater than or equal to 0" [blockNum]
   env' <- getEnv
   let curBlock = Env.blockHeader env'
   maybeTheHash <- getBlockHashWithNumber blockNum (BlockHeader.parentHash curBlock)
   maybe (invalidArguments "the block number given does not exist" [blockNum]) (return . SString . BC.unpack . keccak256ToByteString) maybeTheHash
-callBuiltin ("selfdestruct") [SAddress a _] = do
+callBuiltin ("selfdestruct") [a'] = do
+  a <- getAddressVal a'
   contract' <- getCurrentAddress
   contractBalance <- addressStateBalance <$> A.lookupWithDefault (A.Proxy @AddressState) contract'
   _destroyRes <- A.adjustWithDefault_ (A.Proxy @AddressState) contract' $ \newAddressState ->
@@ -2260,9 +2266,11 @@ callBuiltin "bool" [SBool b] = return $ SBool b
 callBuiltin "bool" [SString "true"] = return $ SBool True
 callBuiltin "bool" [SString "false"] = return $ SBool False
 callBuiltin "bool" [SNULL] = return $ SBool False
+callBuiltin "bool" [SReference _] = return $ SBool False
 callBuiltin "bool" vs = typeError "bool cast" $ show vs
 callBuiltin "byte" [SInteger n] = return $ SInteger (n .&. 0xff)
 callBuiltin "byte" [SNULL] = return $ SInteger 0
+callBuiltin "byte" [SReference _] = return $ SInteger 0
 callBuiltin "byte" vs = typeError "byte cast" $ show vs
 callBuiltin "bytes" [SInteger i] = pure . SBytes $ integer2Bytes i
 callBuiltin "bytes" [SString s] = pure . SBytes . DT.encodeUtf8 $ T.pack s
@@ -2270,6 +2278,8 @@ callBuiltin "bytes" [SBytes bs] = pure $ SBytes bs
 callBuiltin "bytes" [SString s, SString "utf-8"] = pure . SBytes . DT.encodeUtf8 $ T.pack s
 callBuiltin "bytes" [SString s, SString "raw"] = pure . SBytes $ BC.pack s
 callBuiltin "bytes" [SAddress a _] = pure . SBytes . B.pack . word160ToBytes $ unAddress a
+callBuiltin "bytes" [SNULL] = pure $ SBytes B.empty
+callBuiltin "bytes" [SReference _] = pure $ SBytes B.empty
 callBuiltin "uint" args = return $ intBuiltin False Nothing args
 callBuiltin "int" args = return $ intBuiltin True Nothing args
 -- Handle sized integer type casts (uint256, uint128, uint120, int256, etc.)
@@ -2296,9 +2306,9 @@ callBuiltin "identity" [v] = return v
 callBuiltin "log" args = SNULL <$ traverse (liftIO . putStrLn <=< showSM) args
 callBuiltin "keccak256" [SBytes bs] = pure . SBytes . keccak256ToByteString $ hash bs
 callBuiltin "keccak256" args = pure . SString . keccak256ToHex . hash . rlpSerialize $ rlpEncodeValues args
-callBuiltin "ecrecover" [SString h, SInteger v, r', s'] = case B16.decode (BC.pack h) of
-  Left err -> invalidArguments err ("" :: String)
-  Right bytestringHash -> do
+callBuiltin "ecrecover" [h', v', r', s'] = do
+    bytestringHash <- getBytesVal h'
+    v <- int v'
     rIntHash <- case r' of
       SInteger r -> pure r
       SString r -> case parseBaseInt r 16 of
@@ -2317,10 +2327,9 @@ callBuiltin "ecrecover" [SString h, SInteger v, r', s'] = case B16.decode (BC.pa
     case theSignerAddress of
       Nothing -> return . ((flip SAddress) False) $ fromIntegral theZero
       Just theAddress -> return . ((flip SAddress) False) $ theAddress
-callBuiltin "verifyP256" ((SBytes h) : r' : s' : p') = case digestFromByteString @SHA256 h of
+callBuiltin "verifyP256" (h' : r' : s' : p') = getBytesVal h' >>= \h -> case digestFromByteString @SHA256 h of
   Nothing -> invalidArguments "Could not decode hash from string" h
   Just digest -> do
-    let int = getInt . Constant
     pub <- case p' of
       [x', y'] -> P256.pointFromIntegers <$> ((,) <$> int x' <*> int y')
       [pub'] -> do
@@ -2348,58 +2357,42 @@ callBuiltin "sha256" [SBytes bs] = pure . SBytes $ SHA256.hash bs
 callBuiltin "sha256" args = pure . SString . BC.unpack . B16.encode . SHA256.hash . rlpSerialize $ rlpEncodeValues args
 callBuiltin "ripemd160" [SBytes bs] = pure . SBytes $ RIPEMD160.hash bs
 callBuiltin "ripemd160" args = pure . SString . BC.unpack . B16.encode . RIPEMD160.hash . rlpSerialize $ rlpEncodeValues args
-callBuiltin "modExp" [SInteger b, SInteger e, SInteger m] = pure . SInteger $ Builtins.modExp b e m
-callBuiltin "ecAdd" [SInteger x1, SInteger y1, SInteger x2, SInteger y2] =
+callBuiltin "modExp" [b, e, m] = SInteger <$> (Builtins.modExp <$> int b <*> int e <*> int m)
+callBuiltin "ecAdd" [a, b, c, d] = do
+  (x1, y1, x2, y2) <- (,,,) <$> int a <*> int b <*> int c <*> int d
   let (x, y) = Builtins.ecAdd (x1, y1) (x2, y2)
-   in pure . STuple . V.fromList $ Constant <$> [SInteger x, SInteger y]
-callBuiltin "ecMul" [SInteger x1, SInteger y1, SInteger s] =
+  pure . STuple . V.fromList $ Constant <$> [SInteger x, SInteger y]
+callBuiltin "ecMul" [a, b, c] = do
+  (x1, y1, s) <- (,,) <$> int a <*> int b <*> int c
   let (x, y) = Builtins.ecMul (x1, y1) s
-   in pure . STuple . V.fromList $ Constant <$> [SInteger x, SInteger y]
+  pure . STuple . V.fromList $ Constant <$> [SInteger x, SInteger y]
 callBuiltin "ecPairing" [SVariadic xs] =
-  let go (SInteger x : xs') = (x:) <$> go xs'
-      go []   = Right []
-      go xs' = Left xs'
-   in case go xs of
-        Right points -> pure . SBool $ Builtins.ecPairing points
-        Left xs' -> typeError "invalid args passed to ecPairing" $ show xs'
+  SBool . Builtins.ecPairing <$> traverse int xs
 callBuiltin "ecPairing" [SArray xs] =
   SBool . Builtins.ecPairing <$> traverse getInt (V.toList xs)
-callBuiltin "ecPairing" xs =
-  let go (SInteger x : xs') = (x:) <$> go xs'
-      go []   = Right []
-      go xs' = Left xs'
-   in case go xs of
-        Right points -> pure . SBool $ Builtins.ecPairing points
-        Left xs' -> typeError "invalid args passed to ecPairing" $ show xs'
-callBuiltin "poseidon" [SVariadic xs] =
-  let go !n (SInteger x : xs') = fmap (x:) <$> go (n+1) xs'
-      go !n []   = Right (n, [])
-      go _ xs' = Left xs'
-   in case go (0 :: Int) xs of
-        Right (n, inputs) | n > 0 && n <= 8 -> pure . SInteger $ Builtins.poseidonHash inputs
-        Right _ -> typeError "invalid args passed to poseidon" $ show xs
-        Left xs' -> typeError "invalid args passed to poseidon" $ show xs'
+callBuiltin "ecPairing" xs = do
+  SBool . Builtins.ecPairing <$> traverse int xs
+callBuiltin "poseidon" [SVariadic xs] = case length xs of
+  n | n > 0 && n <= 8 -> SInteger . Builtins.poseidonHash <$> traverse int xs
+  _ -> typeError "invalid args passed to poseidon" $ show xs
 callBuiltin "poseidon" [SArray xs] = case V.length xs of
   n | n > 0 && n <= 8 -> SInteger . Builtins.poseidonHash <$> traverse getInt (V.toList xs)
   _ -> typeError "invalid args passed to poseidon" $ show xs
-callBuiltin "poseidon" xs =
-  let go !n (SInteger x : xs') = fmap (x:) <$> go (n+1) xs'
-      go !n []   = Right (n, [])
-      go _ xs' = Left xs'
-   in case go (0 :: Int) xs of
-        Right (n, inputs) | n > 0 && n <= 8 -> pure . SInteger $ Builtins.poseidonHash inputs
-        Right _ -> typeError "invalid args passed to poseidon" $ show xs
-        Left xs' -> typeError "invalid args passed to poseidon" $ show xs'
-callBuiltin ("payable") [SAddress a _] = return $ SAddress a True
-callBuiltin "require" (SBool cond : msg) = do
+callBuiltin "poseidon" xs = case length xs of
+  n | n > 0 && n <= 8 -> SInteger . Builtins.poseidonHash <$> traverse int xs
+  _ -> typeError "invalid args passed to poseidon" $ show xs
+callBuiltin ("payable") [a] = flip SAddress True <$> getAddressVal a
+callBuiltin "require" (condVar : msg) = do
+  cond <- getBoolVal condVar
   case msg of
     [] -> require cond Nothing
     (SString s : _) -> require cond (Just s)
     (m : _) -> require cond (Just $ show m)
   return SNULL
-callBuiltin "assert" [SBool cond] = SNULL <$ assert cond
+callBuiltin "assert" [cond] = pure . const SNULL =<< assert =<< getBoolVal cond
 
-callBuiltin "create" args@(SString contractName' : SString contractSrc : argVals) = do
+callBuiltin "create" args@(cName : src : argVals) = do
+  (contractName', contractSrc) <- (,) <$> getStringVal cName <*> getStringVal src
   when (contractName' == "" || contractSrc == "") $
     invalidArguments "The contract name and src arguments for the create function should not be empty" args
 
@@ -2422,7 +2415,8 @@ callBuiltin "create" args@(SString contractName' : SString contractSrc : argVals
   case erNewContractAddress execResults of
     Just nca -> pure $ ((flip SAddress) False) nca
     Nothing -> internalError "a call to create did not create an address" execResults
-callBuiltin "create2" args@(salt : n@(SString contractName') : SString contractSrc : argVals) = do
+callBuiltin "create2" args@(salt : n : src : argVals) = do
+  (contractName', contractSrc) <- (,) <$> getStringVal n <*> getStringVal src
   when (contractName' == "" || contractSrc == "") $
     invalidArguments "The contract name and src arguments for the create2 function should not be empty" args
 
@@ -2442,7 +2436,8 @@ callBuiltin "create2" args@(salt : n@(SString contractName') : SString contractS
   case erNewContractAddress execResults of
     Just nca -> pure $ ((flip SAddress) False) nca
     Nothing -> internalError "a call to create did not create an address" execResults
-callBuiltin "fastForward" [SInteger seconds] = do
+callBuiltin "fastForward" [secs] = do
+  seconds <- int secs
   -- Only allow fastForward during testing
   env' <- getEnv
   if not (Env.runningTests env')

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -2316,16 +2316,32 @@ callBuiltin "ecrecover" [SString h, SInteger v, r', s'] = case B16.decode (BC.pa
     case theSignerAddress of
       Nothing -> return . ((flip SAddress) False) $ fromIntegral theZero
       Just theAddress -> return . ((flip SAddress) False) $ theAddress
-callBuiltin "verifyP256" [SBytes h, r', s', x', y'] = case digestFromByteString @SHA256 h of
+callBuiltin "verifyP256" ((SBytes h) : r' : s' : p') = case digestFromByteString @SHA256 h of
   Nothing -> invalidArguments "Could not decode hash from string" h
   Just digest -> do
     let int = getInt . Constant
-    (r,s,x,y) <- (,,,) <$> int r' <*> int s' <*> int x' <*> int y'
+    pub <- case p' of
+      [x', y'] -> P256.pointFromIntegers <$> ((,) <$> int x' <*> int y')
+      [pub'] -> do
+        pubBS' <- case pub' of
+          SBytes bs -> pure bs
+          SString s -> case B16.decode $ DT.encodeUtf8 $ T.pack s of
+            Left e -> invalidArguments "Could not decode public key from string: invalid hex" (s, e)
+            Right b -> pure b
+          _ -> invalidArguments "Could not decode public key: invalid value" pub'
+        pubBS <- case B.length pubBS' of
+          65 -> pure $ B.drop 1 pubBS'
+          64 -> pure pubBS'
+          _ -> invalidArguments "Could not decode public key from bytestring: invalid length" pubBS'
+        case P256.pointFromBinary pubBS of
+          CryptoPassed p -> pure p
+          CryptoFailed e -> invalidArguments "Could not decode public key from bytestring" (pubBS', e)
+      _ -> invalidArguments "Invalid arguments for P-256 public key" p'
+    (r,s) <- (,) <$> int r' <*> int s'
     sig <- case signatureFromIntegers (Mod.Proxy @Curve_P256R1) (r, s) of
       CryptoPassed sig' -> pure sig'
       CryptoFailed e -> invalidArguments "Invalid P256 signature" e
-    let pub = P256.pointFromIntegers (x, y)
-        !isValidSig = verifyDigest (Mod.Proxy @Curve_P256R1) pub sig digest
+    let !isValidSig = verifyDigest (Mod.Proxy @Curve_P256R1) pub sig digest
     pure $ SBool isValidSig
 callBuiltin "sha256" [SBytes bs] = pure . SBytes $ SHA256.hash bs
 callBuiltin "sha256" args = pure . SString . BC.unpack . B16.encode . SHA256.hash . rlpSerialize $ rlpEncodeValues args

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -70,6 +71,11 @@ import qualified Control.Monad.Catch as EUnsafe
 import qualified Control.Monad.Change.Alter as A
 import qualified Control.Monad.Change.Modify as Mod
 import Control.Monad.IO.Class
+import Crypto.ECC (Curve_P256R1)
+import Crypto.Error
+import qualified Crypto.PubKey.ECC.P256 as P256
+import Crypto.PubKey.ECDSA (signatureFromIntegers, verifyDigest)
+import "crypton" Crypto.Hash (SHA256, digestFromByteString)
 import qualified Crypto.Hash.RIPEMD160 as RIPEMD160
 import qualified Crypto.Hash.SHA256 as SHA256
 import Data.Bits
@@ -1940,6 +1946,17 @@ expToVarAdd expr1 expr2 = do
             deductGasForOp . fromIntegral $ length a
             return . Constant $ SString a
           _ -> typeError "expToVarAdd" $ show (i1, i2)
+        SBytes a -> case i2 of
+          SBytes b -> do
+            deductGasForOp . fromIntegral $ ((+) `on` B.length) a b
+            return . Constant . SBytes $ a <> b
+          SNULL -> do
+            deductGasForOp . fromIntegral $ B.length a
+            return . Constant $ SBytes a
+          SReference{} -> do
+            deductGasForOp . fromIntegral $ B.length a
+            return . Constant $ SBytes a
+          _ -> typeError "expToVarAdd" $ show (i1, i2)
         SNULL -> case i2 of
           SNULL -> return $ Constant SNULL
           _ -> addEm i2 i1
@@ -2249,6 +2266,7 @@ callBuiltin "byte" [SNULL] = return $ SInteger 0
 callBuiltin "byte" vs = typeError "byte cast" $ show vs
 callBuiltin "bytes" [SInteger i] = pure . SBytes $ integer2Bytes i
 callBuiltin "bytes" [SString s] = pure . SBytes . DT.encodeUtf8 $ T.pack s
+callBuiltin "bytes" [SBytes bs] = pure $ SBytes bs
 callBuiltin "bytes" [SString s, SString "utf-8"] = pure . SBytes . DT.encodeUtf8 $ T.pack s
 callBuiltin "bytes" [SString s, SString "raw"] = pure . SBytes $ BC.pack s
 callBuiltin "bytes" [SAddress a _] = pure . SBytes . B.pack . word160ToBytes $ unAddress a
@@ -2298,8 +2316,20 @@ callBuiltin "ecrecover" [SString h, SInteger v, r', s'] = case B16.decode (BC.pa
     case theSignerAddress of
       Nothing -> return . ((flip SAddress) False) $ fromIntegral theZero
       Just theAddress -> return . ((flip SAddress) False) $ theAddress
-callBuiltin "sha256" args = pure . SString . BC.unpack . SHA256.hash . rlpSerialize $ rlpEncodeValues args
-callBuiltin "ripemd160" args = pure . SString . BC.unpack . RIPEMD160.hash . rlpSerialize $ rlpEncodeValues args
+callBuiltin "verifyP256" [SBytes h, r', s', x', y'] = case digestFromByteString @SHA256 h of
+  Nothing -> invalidArguments "Could not decode hash from string" h
+  Just digest -> do
+    let int = getInt . Constant
+    (r,s,x,y) <- (,,,) <$> int r' <*> int s' <*> int x' <*> int y'
+    sig <- case signatureFromIntegers (Mod.Proxy @Curve_P256R1) (r, s) of
+      CryptoPassed sig' -> pure sig'
+      CryptoFailed e -> invalidArguments "Invalid P256 signature" e
+    let pub = P256.pointFromIntegers (x, y)
+        !isValidSig = verifyDigest (Mod.Proxy @Curve_P256R1) pub sig digest
+    pure $ SBool isValidSig
+callBuiltin "sha256" [SBytes bs] = pure . SBytes $ SHA256.hash bs
+callBuiltin "sha256" args = pure . SString . BC.unpack . B16.encode . SHA256.hash . rlpSerialize $ rlpEncodeValues args
+callBuiltin "ripemd160" args = pure . SString . BC.unpack . B16.encode . RIPEMD160.hash . rlpSerialize $ rlpEncodeValues args
 callBuiltin "modExp" [SInteger b, SInteger e, SInteger m] = pure . SInteger $ Builtins.modExp b e m
 callBuiltin "ecAdd" [SInteger x1, SInteger y1, SInteger x2, SInteger y2] =
   let (x, y) = Builtins.ecAdd (x1, y1) (x2, y2)

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs
@@ -613,6 +613,7 @@ getVariableOfName name = do
                        "derive",
                        "sha256",
                        "ecrecover",
+                       "verifyP256",
                        "blockhash",
                        "addmod",
                        "mulmod",

--- a/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
+++ b/strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SetGet.hs
@@ -13,9 +13,20 @@ module Blockchain.SolidVM.SetGet
   ( setVar,
     weakGetVar,
     getVar,
+    getIntEither,
+    getIntValEither,
     getInt,
+    getIntVal,
+    int,
     getRealNum,
     getBool,
+    getBoolVal,
+    getAddress,
+    getAddressVal,
+    getString,
+    getStringVal,
+    getBytes,
+    getBytesVal,
     deleteVar,
     toBasic,
     fromBasic,
@@ -25,10 +36,12 @@ module Blockchain.SolidVM.SetGet
 where
 
 import qualified Blockchain.Data.BlockHeader as BlockHeader
+import Blockchain.Data.Util
 import Blockchain.DB.SolidStorageDB
 import qualified Blockchain.SolidVM.Environment as Env
 import Blockchain.SolidVM.Exception
 import Blockchain.SolidVM.SM
+import Blockchain.Strato.Model.Address
 import Blockchain.Strato.Model.Options (computeNetworkID)
 import Control.Monad
 import Control.Monad.IO.Class
@@ -48,6 +61,7 @@ import qualified SolidVM.Model.Storable as MS
 import SolidVM.Model.Value
 import Text.Format
 import Text.Printf
+import Text.Read (readMaybe)
 import UnliftIO
 
 fromBasic :: MS.BasicValue -> Value
@@ -188,14 +202,24 @@ getVar (Constant (SPush v (Just var))) = do
 getVar (Constant v) = return v
 getVar (Variable v) = liftIO $ readIORef v
 
+getIntEither :: MonadSM m => Variable -> m (Either Value Integer)
+getIntEither p = getIntValEither <$> getVar p
+
+getIntValEither :: Value -> Either Value Integer
+getIntValEither = \case
+  SInteger s -> Right s
+  SNULL -> Right 0
+  SReference{} -> Right 0
+  v -> Left v
+
 getInt :: MonadSM m => Variable -> m Integer
-getInt p = do
-  v <- getVar p
-  case v of
-    SInteger s -> return s
-    SNULL -> return 0
-    SReference{} -> pure 0
-    _ -> typeError "getInt" $ show (p, v)
+getInt = either (typeError "getInt" . show) pure <=< getIntEither
+
+getIntVal :: MonadSM m => Value -> m Integer
+getIntVal = either (typeError "getIntVal" . show) pure . getIntValEither
+
+int :: MonadSM m => Value -> m Integer
+int = getIntVal
 
 getRealNum :: MonadSM m => Variable -> m (Either Integer Decimal)
 getRealNum p = do
@@ -208,14 +232,60 @@ getRealNum p = do
     _ -> typeError "getRealNum" $ show (p, v)
 
 getBool :: MonadSM m => Variable -> m Bool
-getBool p = do
-  v <- getVar p
-  case v of
-    SBool b -> return b
-    SInteger i -> return $ i /= 0
-    SNULL -> return False
-    SReference{} -> pure False
-    _ -> typeError "getBool" $ show (p, v)
+getBool = getBoolVal <=< getVar
+
+getBoolVal :: MonadSM m => Value -> m Bool
+getBoolVal = \case
+  SBool b -> return b
+  SInteger i -> return $ i /= 0
+  SNULL -> return False
+  SReference{} -> pure False
+  v -> typeError "getBool" $ show v
+
+getAddress :: MonadSM m => Variable -> m Address
+getAddress = getAddressVal <=< getVar
+
+getAddressVal :: MonadSM m => Value -> m Address
+getAddressVal = \case
+  SInteger i -> pure $ fromIntegral i
+  SAddress a _ -> pure a
+  SContract _ a -> pure a
+  SString s -> case readMaybe s of
+    Nothing -> typeError "getAddress" $ show s
+    Just a -> pure a
+  SBytes b -> pure $ addressFromByteString b
+  SNULL -> pure 0
+  SReference{} -> pure 0
+  v -> typeError "getAddress" $ show v
+
+getString :: MonadSM m => Variable -> m String
+getString = getStringVal <=< getVar
+
+getStringVal :: MonadSM m => Value -> m String
+getStringVal = \case
+  SString s -> pure s
+  SBytes b -> case decodeUtf8' b of
+    Left _ -> pure $ BC.unpack b
+    Right r -> pure $ T.unpack r
+  SNULL -> pure ""
+  SReference{} -> pure ""
+  v -> typeError "getString" $ show v
+
+getBytes :: MonadSM m => Variable -> m BC.ByteString
+getBytes = getBytesVal <=< getVar
+
+getBytesVal :: MonadSM m => Value -> m BC.ByteString
+getBytesVal = \case
+  SInteger i -> pure $ integer2Bytes i
+  SAddress a _ -> pure $ addressToByteString a
+  SContract _ a -> pure $ addressToByteString a
+  SString s -> case B16.decode $ BC.pack s of
+    Right r -> pure r
+    _ -> pure . encodeUtf8 $ T.pack s
+  SBytes b -> pure b
+  SNULL -> pure BC.empty
+  SReference{} -> pure BC.empty
+  v -> typeError "getAddress" $ show v
 
 deleteVar :: MonadSM m => Variable -> m ()
 deleteVar (Constant (SReference (AddressPath addr path))) = do

--- a/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
+++ b/strato/core/strato-model/src/Blockchain/Strato/Model/Address.hs
@@ -18,6 +18,8 @@ module Blockchain.Strato.Model.Address
     stringAddress,
     getNewAddress_unsafe,
     getNewAddressWithSalt_unsafe,
+    addressToByteString,
+    addressFromByteString,
     addressAsNibbleString,
     addressFromNibbleString,
     addressToHex,
@@ -258,12 +260,17 @@ getNewAddressWithSalt_unsafe creator salt codeHash args =
         ++ (rlpEncode <$> args)
    in decode $ BL.drop 12 $ encode theHash
 
+addressToByteString :: Address -> B.ByteString
+addressToByteString (Address s) = BL.toStrict $ encode s
+
+addressFromByteString :: B.ByteString -> Address
+addressFromByteString = Address . decode . BL.fromStrict
+
 addressAsNibbleString :: Address -> N.NibbleString
-addressAsNibbleString (Address s) =
-  byteString2NibbleString $ BL.toStrict $ encode s
+addressAsNibbleString = byteString2NibbleString . addressToByteString
 
 addressFromNibbleString :: N.NibbleString -> Address
-addressFromNibbleString = Address . decode . BL.fromStrict . nibbleString2ByteString
+addressFromNibbleString = addressFromByteString . nibbleString2ByteString
 
 formatAddressWithoutColor :: Address -> String
 formatAddressWithoutColor x = padZeros 40 $ showHex x ""


### PR DESCRIPTION
Passkeys typically use the secp256r1 curve for ECDSA, also known as P-256, instead of the secp256k1 curve, which is commonly used by blockchains, including STRATO.
One of the components of the identity roadmap proposal is to incorporate passkeys as part of a broader account abstraction model on STRATO. This is the first step toward making that a reality.
In this PR, I added the `verifyP256` builtin, which takes a `bytes32` hash of the signed message, signature fields `r` and `s`, and the public key components `x` and `y`, and returns a `bool` of whether the signature matches the public key. Also, I've tweaked the hash builtins to allow for direct hashing when given a single `bytes` argument, whereas currently those builtins RLP-encode their arguments to emulate the behavior of `abi.encode`.
Also, I included a `solid-vm-cli` test showing that `verifyP256` is able to verify a signature from an actual passkey I created. In the future, this would allow users to tie their passkey to a `User` contract, sign batch transactions with their passkey, then send them to a relayer for gas sponsorship, without ever having to create a secp256k1 key.

Currently, these changes sync to both testnet and mainnet, meaning this can be released without adding a hard fork block number, but will require all nodes to be updated before any of the SolidVM changes in this PR are used in a transaction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds P-256 (secp256r1) ECDSA signature verification to SolidVM, enabling WebAuthn passkey support as part of the identity roadmap and account abstraction initiative. The implementation includes:

- **`verifyP256` builtin**: Accepts a SHA256 hash, signature components (r, s), and public key (as x,y coordinates or bytes), returning bool
- **Direct hashing**: Modified `sha256`, `ripemd160`, and `keccak256` to return raw bytes when given a single bytes argument (instead of RLP-encoding), while maintaining backward compatibility with existing multi-argument behavior that returns hex strings
- **Bytes concatenation**: Added support for concatenating bytes with the `+` operator to enable WebAuthn data assembly
- **Comprehensive test**: Includes a real passkey signature verification test demonstrating the complete WebAuthn flow

The changes are backward compatible and deployable without a hard fork, though all nodes must update before using these features in transactions.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations around deployment coordination and testing
- The implementation is well-structured with proper error handling and includes a comprehensive test. However, the score is 4 rather than 5 due to: (1) the hash function behavior change requiring careful validation of existing code that might depend on the old behavior, (2) the need for coordinated deployment across all nodes before use, and (3) limited test coverage beyond the single happy-path WebAuthn test case
- strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs - verify the hash function behavior changes don't break existing contracts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/contracts/tests/BaseCodeCollection.test.sol | Adds comprehensive WebAuthn P-256 signature verification test with real passkey data |
| strato/VM/SolidVM/solid-vm-static-analysis/src/SolidVM/Solidity/StaticAnalysis/Typechecker.hs | Adds type signatures for `verifyP256` builtin and enables bytes concatenation with + operator |
| strato/VM/SolidVM/solid-vm/package.yaml | Adds crypton library dependency for P-256 cryptographic operations |
| strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM.hs | Implements `verifyP256`, bytes concatenation, and direct hashing for sha256/ripemd160/keccak256 |
| strato/VM/SolidVM/solid-vm/src/Blockchain/SolidVM/SM.hs | Registers `verifyP256` as a global builtin function |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User signs with passkey] --> B[Get authenticatorData + clientDataJSON]
    B --> C[Calculate sha256 of clientDataJSON]
    C --> D[Concatenate authenticatorData + hash]
    D --> E[Calculate sha256 of combined data]
    E --> F[Call verifyP256 with hash, r, s, pubkey]
    F --> G{Parse inputs}
    G --> H[Convert hash to SHA256 digest]
    G --> I[Parse public key: x,y coords or bytes]
    G --> J[Parse signature: r, s values]
    H --> K[Verify with P-256 ECDSA]
    I --> K
    J --> K
    K --> L{Valid signature?}
    L -->|Yes| M[Return true]
    L -->|No| N[Return false]
```
</details>


<sub>Last reviewed commit: 6b8164f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->