### PR TITLE
Feat/rewards cata apr column 16.2

### DIFF
--- a/mercata/backend/src/api/services/rewards.service.ts
+++ b/mercata/backend/src/api/services/rewards.service.ts
@@ -4,6 +4,7 @@ import { cirrus } from "../../utils/mercataApiHelper";
 import stakeSemanticsConfig from "./rewardsStakeSemantics.json";
 import { getCompletePriceMap } from "../helpers/oracle.helper";
 import { getSafetyModuleConfig } from "./safety.service";
+import { getVaultShareTokenAddress } from "./vault.service";
 import {
   calculatePersonalEmissionRate,
   parseActivityType,
@@ -114,6 +115,7 @@ const inferStakeUsdInfo = (
     priceMap: Map<string, string>;
     mTokenAddress: string | null;
     sTokenAddress: string | null;
+    vaultShareTokenAddress: string | null;
   },
   baseActivity: { name: string; sourceContract: string; totalStake: string; stakeDenomination: StakeDenomination; stakeAssetAddress: string | null },
   userStakeWei?: string
@@ -181,6 +183,19 @@ const inferStakeUsdInfo = (
       totalStakeUsd: baseActivity.totalStake || "0",
       userStakeUsd: userStakeWei ?? undefined,
     };
+  }
+
+  // 5) Vault Token: stake is SLP shares (priced via getVaultShareTokenPrice in getCompletePriceMap)
+  if (lower.includes("vault")) {
+    const vaultAddr = (ctx.vaultShareTokenAddress || "").toLowerCase();
+    const price = vaultAddr ? (ctx.priceMap.get(vaultAddr) || null) : null;
+    if (price) {
+      return {
+        stakeUnitPriceUsd: price,
+        totalStakeUsd: mulDiv1e18(baseActivity.totalStake, price),
+        userStakeUsd: userStakeWei ? mulDiv1e18(userStakeWei, price) : undefined,
+      };
+    }
   }
 
   return empty;
@@ -383,15 +398,17 @@ export const fetchUserActivities = async (
     ]);
 
     // Build shared pricing context once (used for LP/share-token TVL conversions)
-    const [priceMap, mTokenAddress] = await Promise.all([
+    const [priceMap, mTokenAddress, vaultShareTokenAddress] = await Promise.all([
       getCompletePriceMap(accessToken),
       getMTokenAddress(accessToken),
+      getVaultShareTokenAddress(accessToken).catch(() => ""),
     ]);
     const { sToken } = getSafetyModuleConfig();
     const pricingCtx = {
       priceMap,
       mTokenAddress,
       sTokenAddress: sToken.address || null,
+      vaultShareTokenAddress: vaultShareTokenAddress || null,
     };
 
     // Combine all data
@@ -477,15 +494,17 @@ export const fetchAllActivities = async (
     }
 
     // Build shared pricing context once (used for LP/share-token TVL conversions)
-    const [priceMap, mTokenAddress] = await Promise.all([
+    const [priceMap, mTokenAddress, vaultShareTokenAddress] = await Promise.all([
       getCompletePriceMap(accessToken),
       getMTokenAddress(accessToken),
+      getVaultShareTokenAddress(accessToken).catch(() => ""),
     ]);
     const { sToken } = getSafetyModuleConfig();
     const pricingCtx = {
       priceMap,
       mTokenAddress,
       sTokenAddress: sToken.address || null,
+      vaultShareTokenAddress: vaultShareTokenAddress || null,
     };
 
     // Combine activities with their states

--- a/mercata/ui/src/components/home/Hero.tsx
+++ b/mercata/ui/src/components/home/Hero.tsx
@@ -75,10 +75,10 @@ const Hero = () => {
                   <ArrowRight className="w-4 h-4 transition-transform duration-200 group-hover:translate-x-1" />
                 </button>
                 <Link
-                  to="/dashboard/stats"
+                  to="/dashboard/rewards"
                   className="inline-flex items-center justify-center gap-2 bg-white dark:bg-slate-800 hover:bg-gray-50 dark:hover:bg-slate-700 text-foreground px-6 py-3 rounded-lg font-medium border border-border transition-all duration-300"
                 >
-                  Explore Stats
+                  Earn Rewards
             </Link>
           </div>
         </div>

--- a/mercata/ui/src/components/rewards/ActivitiesTable.tsx
+++ b/mercata/ui/src/components/rewards/ActivitiesTable.tsx
@@ -139,7 +139,7 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                 <TableHead>
                   <div className="flex items-center gap-1">
                   Est. Incentive APY
-                    <InfoTooltip content="Estimated annual percentage yield from CATA incentives, assuming a $25M fully diluted valuation ($0.25/CATA). APY = (annual CATA emitted × $0.25) / TVL." />
+                    <InfoTooltip content="Estimated annual percentage yield from CATA incentives, assuming a $25M fully diluted valuation." />
                   </div>
                 </TableHead>
                 <TableHead>Type</TableHead>

--- a/mercata/ui/src/components/rewards/ActivitiesTable.tsx
+++ b/mercata/ui/src/components/rewards/ActivitiesTable.tsx
@@ -139,7 +139,7 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                 <TableHead>
                   <div className="flex items-center gap-1">
                   Est. Incentive APY
-                    <InfoTooltip content="Estimated annual percentage return from CATA incentives, assuming a $25M fully diluted valuation ($0.25/CATA). APR = (annual CATA emitted × $0.25) / TVL." />
+                    <InfoTooltip content="Estimated annual percentage yield from CATA incentives, assuming a $25M fully diluted valuation ($0.25/CATA). APY = (annual CATA emitted × $0.25) / TVL." />
                   </div>
                 </TableHead>
                 <TableHead>Type</TableHead>

--- a/mercata/ui/src/components/rewards/ActivitiesTable.tsx
+++ b/mercata/ui/src/components/rewards/ActivitiesTable.tsx
@@ -119,6 +119,12 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                 <TableHead>Type</TableHead>
                 <TableHead>
                   <div className="flex items-center gap-1">
+                    CATA APR
+                    <InfoTooltip content="Estimated annual percentage return from CATA incentives, assuming a $25M fully diluted valuation ($0.25/CATA). APR = (annual CATA emitted × $0.25) / TVL." />
+                  </div>
+                </TableHead>
+                <TableHead>
+                  <div className="flex items-center gap-1">
                     Emission Rate
                     <InfoTooltip content="The rate at which rewards are emitted for this activity (points per second). This is the base emission rate before factoring in your stake." />
                   </div>
@@ -185,6 +191,16 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                           ? (activity.activityType === 1 ? "One-Time" : "Position")
                           : "?"}
                       </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {(() => {
+                        const tvlUsd = activity?.totalStakeUsd ? Number(BigInt(activity.totalStakeUsd)) / 1e18 : 0;
+                        if (!emissionRateStr || tvlUsd <= 0) return <span className="text-muted-foreground">-</span>;
+                        const annualCata = (Number(BigInt(emissionRateStr)) / 1e18) * 86400 * 365;
+                        const apr = (annualCata * 0.25 / tvlUsd) * 100;
+                        const display = apr >= 1000 ? `${Math.round(apr).toLocaleString()}%` : apr >= 10 ? `${apr.toFixed(0)}%` : `${apr.toFixed(1)}%`;
+                        return <span className="font-medium">{display}</span>;
+                      })()}
                     </TableCell>
                     <TableCell>
                       <div>

--- a/mercata/ui/src/components/rewards/ActivitiesTable.tsx
+++ b/mercata/ui/src/components/rewards/ActivitiesTable.tsx
@@ -2,10 +2,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import { Activity } from "@/services/rewardsService";
 import { formatBalance } from "@/utils/numberUtils";
 import { formatEmissionRatePerDay, formatEmissionRatePerWeek, roundByMagnitude, formatRoundedWithCommas } from "@/services/rewardsService";
-import { formatDistanceToNow } from "date-fns";
 import { Info } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Link } from "react-router-dom";
@@ -20,6 +20,22 @@ interface ActivitiesTableProps {
 const truncateActivityName = (name: string, maxLength: number = 30): string => {
   if (!name || name.length <= maxLength) return name;
   return name.substring(0, maxLength) + "...";
+};
+
+const getEstimatedApyPercent = (activity: Activity): number => {
+  try {
+    if (!activity?.emissionRate || !activity?.totalStakeUsd) return -1;
+
+    const tvlUsd = Number(BigInt(activity.totalStakeUsd)) / 1e18;
+    if (!Number.isFinite(tvlUsd) || tvlUsd <= 0) return -1;
+
+    const annualCata = (Number(BigInt(activity.emissionRate)) / 1e18) * 86400 * 365;
+    if (!Number.isFinite(annualCata) || annualCata < 0) return -1;
+
+    return (annualCata * 0.25 / tvlUsd) * 100;
+  } catch {
+    return -1;
+  }
 };
 
 // Mobile-friendly Info Tooltip component
@@ -71,6 +87,9 @@ const InfoTooltip = ({ content }: { content: string }) => {
 };
 
 export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) => {
+  const loginButtonClass = "bg-gradient-to-r from-[#1f1f5f] via-[#293b7d] to-[#16737d] text-white hover:opacity-90";
+  const sortedActivities = [...activities].sort((a, b) => getEstimatedApyPercent(b) - getEstimatedApyPercent(a));
+
   if (loading) {
     return (
       <Card>
@@ -114,15 +133,16 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>ID</TableHead>
+                {/* <TableHead>ID</TableHead> */}
+                <TableHead>S. No</TableHead>
                 <TableHead>Name</TableHead>
-                <TableHead>Type</TableHead>
                 <TableHead>
                   <div className="flex items-center gap-1">
-                    CATA APR
+                  Est. Incentive APY
                     <InfoTooltip content="Estimated annual percentage return from CATA incentives, assuming a $25M fully diluted valuation ($0.25/CATA). APR = (annual CATA emitted × $0.25) / TVL." />
                   </div>
                 </TableHead>
+                <TableHead>Type</TableHead>
                 <TableHead>
                   <div className="flex items-center gap-1">
                     Emission Rate
@@ -135,14 +155,16 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                     <InfoTooltip content="The total amount staked across all users in this activity. Your share of rewards is proportional to your stake relative to this total.\n\nNote: Different activities may use different stake units (token units, USD-notional, or shares)." />
                   </div>
                 </TableHead>
-                <TableHead>Last Update</TableHead>
+                {/* <TableHead>Last Update</TableHead> */}
+                <TableHead>Earn Now</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {activities.map((activity) => {
+              {sortedActivities.map((activity, index) => {
                 const emissionRateStr = activity?.emissionRate || null;
                 const emissionPerDay = emissionRateStr ? formatEmissionRatePerDay(emissionRateStr) : "?";
                 const emissionPerWeek = emissionRateStr ? formatEmissionRatePerWeek(emissionRateStr) : "?";
+                const estimatedApr = getEstimatedApyPercent(activity);
                 
                 // Format total stake with denomination context
                 const totalStakeStr = activity?.totalStake || null;
@@ -159,17 +181,20 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                   totalStakeFormatted = `$${totalStakeRounded}`;
                 }
                 
-                const lastUpdateTimeStr = activity?.lastUpdateTime || null;
-                const lastUpdate = lastUpdateTimeStr ? new Date(Number(lastUpdateTimeStr) * 1000) : null;
-                const timeAgo = lastUpdate ? formatDistanceToNow(lastUpdate, { addSuffix: true }) : "?";
+                // const lastUpdateTimeStr = activity?.lastUpdateTime || null;
+                // const lastUpdate = lastUpdateTimeStr ? new Date(Number(lastUpdateTimeStr) * 1000) : null;
+                // const timeAgo = lastUpdate ? formatDistanceToNow(lastUpdate, { addSuffix: true }) : "?";
                 const activityLink = activity?.name ? getActivityLink(activity.name) : null;
 
                 return (
                   <TableRow
                     key={activity?.activityId || Math.random()}
                   >
-                    <TableCell className="font-mono font-medium">
+                    {/* <TableCell className="font-mono font-medium">
                       {activity?.activityId !== undefined && activity?.activityId !== null ? activity.activityId : "?"}
+                    </TableCell> */}
+                    <TableCell className="font-mono font-medium">
+                      {index + 1}
                     </TableCell>
                     <TableCell className="font-medium">
                       {activity?.name ? (
@@ -186,21 +211,24 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                       ) : "?"}
                     </TableCell>
                     <TableCell>
+                      {estimatedApr < 0 ? (
+                        <span className="text-muted-foreground">-</span>
+                      ) : (
+                        <span className="font-medium">
+                          {estimatedApr >= 1000
+                            ? `${Math.round(estimatedApr).toLocaleString()}%`
+                            : estimatedApr >= 10
+                              ? `${estimatedApr.toFixed(0)}%`
+                              : `${estimatedApr.toFixed(1)}%`}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell>
                       <Badge variant="secondary">
                         {activity?.activityType !== undefined && activity?.activityType !== null
                           ? (activity.activityType === 1 ? "One-Time" : "Position")
                           : "?"}
                       </Badge>
-                    </TableCell>
-                    <TableCell>
-                      {(() => {
-                        const tvlUsd = activity?.totalStakeUsd ? Number(BigInt(activity.totalStakeUsd)) / 1e18 : 0;
-                        if (!emissionRateStr || tvlUsd <= 0) return <span className="text-muted-foreground">-</span>;
-                        const annualCata = (Number(BigInt(emissionRateStr)) / 1e18) * 86400 * 365;
-                        const apr = (annualCata * 0.25 / tvlUsd) * 100;
-                        const display = apr >= 1000 ? `${Math.round(apr).toLocaleString()}%` : apr >= 10 ? `${apr.toFixed(0)}%` : `${apr.toFixed(1)}%`;
-                        return <span className="font-medium">{display}</span>;
-                      })()}
                     </TableCell>
                     <TableCell>
                       <div>
@@ -224,7 +252,16 @@ export const ActivitiesTable = ({ activities, loading }: ActivitiesTableProps) =
                       </div>
                     </TableCell>
                     <TableCell>{totalStakeFormatted}</TableCell>
-                    <TableCell className="text-sm text-muted-foreground">{timeAgo}</TableCell>
+                    {/* <TableCell className="text-sm text-muted-foreground">{timeAgo}</TableCell> */}
+                    <TableCell>
+                      {activityLink ? (
+                        <Link to={activityLink}>
+                          <Button size="sm" className={loginButtonClass}>Earn Now</Button>
+                        </Link>
+                      ) : (
+                        <Button size="sm" className={loginButtonClass} disabled>Earn Now</Button>
+                      )}
+                    </TableCell>
                   </TableRow>
                 );
               })}

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -437,7 +437,7 @@ const Dashboard = () => {
                       {rewardsActivitiesLoading ? (
                         <Skeleton className="h-4 w-36 mt-1" />
                       ) : (
-                        <>Earn Upto {highestIncentiveApy.toFixed(2)}% APY</>
+                        <>Earn up to {highestIncentiveApy.toFixed(2)}% APY</>
                       )}
                     </div>
                   </div>

--- a/mercata/ui/src/pages/Dashboard.tsx
+++ b/mercata/ui/src/pages/Dashboard.tsx
@@ -6,10 +6,11 @@ import AssetSummary from "../components/dashboard/AssetSummary";
 import AssetsList from "../components/dashboard/AssetsList";
 import DashboardFAQ from "../components/dashboard/DashboardFAQ";
 import BorrowingSection from "../components/dashboard/BorrowingSection";
-import { Wallet, Coins, Shield, Banknote, Loader2, Trophy, UserPlus, Send, Book, ArrowRightLeft } from "lucide-react";
+import { Wallet, Coins, Shield, Banknote, Loader2, Trophy, Send, Book, ArrowRightLeft } from "lucide-react";
 import { useTokenContext } from "@/context/TokenContext";
 import { useUser } from "@/context/UserContext";
 import { usePendingRewards } from "@/hooks/usePendingRewards";
+import { useRewardsActivities } from "@/hooks/useRewardsActivities";
 import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
 import { useNetBalance } from "@/hooks/useNetBalance";
@@ -22,6 +23,7 @@ import { api } from "@/lib/axios";
 import { BalanceSnapshot } from "@mercata/shared-types";
 import { useUserLeaderboardRank } from "@/hooks/useUserLeaderboardRank";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import GuestSignInBanner from "@/components/ui/GuestSignInBanner";
 import LiquidationAlertBanner from "@/components/ui/LiquidationAlertBanner";
 
@@ -29,6 +31,19 @@ const TIME_RANGES = ["1d", "7d", "1m", "3m", "6m", "1y", "all"] as const;
 type TimeRange = typeof TIME_RANGES[number];
 
 type TabType = 'netBalance' | 'rewards' | 'borrowed';
+
+const getEstimatedApyPercent = (emissionRate?: string, totalStakeUsd?: string | null): number => {
+  try {
+    if (!emissionRate || !totalStakeUsd) return 0;
+    const tvlUsd = Number(BigInt(totalStakeUsd)) / 1e18;
+    if (!Number.isFinite(tvlUsd) || tvlUsd <= 0) return 0;
+    const annualCata = (Number(BigInt(emissionRate)) / 1e18) * 86400 * 365;
+    if (!Number.isFinite(annualCata) || annualCata <= 0) return 0;
+    return (annualCata * 0.25 / tvlUsd) * 100;
+  } catch {
+    return 0;
+  }
+};
 
 const Dashboard = () => {
   const [searchParams] = useSearchParams();
@@ -73,8 +88,16 @@ const Dashboard = () => {
   });
 
   const { pendingRewards, refetch: refetchPendingRewards } = usePendingRewards(rewardsEnabled, 30000);
+  const { activities: rewardsActivities, loading: rewardsActivitiesLoading } = useRewardsActivities();
   const [isClaiming, setIsClaiming] = useState(false);
   const { rank: userRank, totalEarned, loading: rankLoading } = useUserLeaderboardRank();
+  const highestIncentiveApy = useMemo(() => {
+    if (!rewardsActivities.length) return 0;
+    return rewardsActivities.reduce((maxApy, activity) => {
+      const apy = getEstimatedApyPercent(activity.emissionRate, activity.totalStakeUsd ?? null);
+      return apy > maxApy ? apy : maxApy;
+    }, 0);
+  }, [rewardsActivities]);
 
   // Extract CATA token from inactive tokens by address
   const cataToken = useMemo(() => 
@@ -400,35 +423,31 @@ const Dashboard = () => {
             />
           </div>
 
-          {/* Refer a Friend Section */}
+          {/* Rewards Section */}
           <div className="mb-4 md:mb-8">
             <div className="bg-card shadow-sm rounded-xl p-4 md:p-6 border border-border">
               <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                 <div className="flex items-center gap-3">
                   <div className="p-2.5 md:p-3 bg-blue-500 rounded-lg shrink-0">
-                    <UserPlus className="text-white" size={20} />
+                    <Coins className="text-white" size={20} />
                   </div>
                   <div>
-                    <h3 className="text-base md:text-lg font-semibold">Refer a Friend</h3>
-                    <p className="text-xs md:text-sm text-muted-foreground">
-                      Send tokens to friends who haven't signed up yet
-                    </p>
+                    <h3 className="text-base md:text-lg font-semibold">Rewards</h3>
+                    <div className="text-xs md:text-sm text-muted-foreground">
+                      {rewardsActivitiesLoading ? (
+                        <Skeleton className="h-4 w-36 mt-1" />
+                      ) : (
+                        <>Earn Upto {highestIncentiveApy.toFixed(2)}% APY</>
+                      )}
+                    </div>
                   </div>
                 </div>
                 <Button
-                  onClick={() => {
-                    // For non-logged-in users, redirect to My Referrals page (guest accessible)
-                    // For logged-in users, redirect to Refer Friend page
-                    if (!isLoggedIn) {
-                      navigate("/dashboard/referrals");
-                    } else {
-                      navigate("/dashboard/refer");
-                    }
-                  }}
+                  onClick={() => navigate("/dashboard/rewards?tab=activities")}
                   className="w-full md:w-auto flex items-center justify-center gap-2"
                 >
-                  <UserPlus className="h-4 w-4" />
-                  Get Started
+                  <Coins className="h-4 w-4" />
+                  Earn Rewards
                 </Button>
               </div>
             </div>

--- a/mercata/ui/src/pages/Rewards.tsx
+++ b/mercata/ui/src/pages/Rewards.tsx
@@ -23,19 +23,8 @@ const Rewards = () => {
   const [searchParams] = useSearchParams();
   const { isLoggedIn } = useUser();
   
-  // Default to leaderboard for guests, my-rewards for logged-in users
-  const [activeTab, setActiveTab] = useState<"activities" | "my-rewards" | "leaderboard">(() => {
-    const tabParam = searchParams.get("tab");
-    if (tabParam === "leaderboard" || tabParam === "activities" || tabParam === "my-rewards") {
-      // If guest tries to access my-rewards directly, redirect to leaderboard
-      if (tabParam === "my-rewards" && !isLoggedIn) {
-        return "leaderboard";
-      }
-      return tabParam;
-    }
-    // Default: leaderboard for guests, my-rewards for logged-in users
-    return isLoggedIn ? "my-rewards" : "leaderboard";
-  });
+
+  const [activeTab, setActiveTab] = useState<"activities" | "my-rewards" | "leaderboard">("activities");
 
   const { state, loading: stateLoading, refetch: refetchState } = useRewards();
   const { activities, loading: activitiesLoading, refetch: refetchActivities } = useRewardsActivities();
@@ -146,8 +135,8 @@ const Rewards = () => {
             className="w-full"
           >
             <TabsList className="grid w-full grid-cols-3 mb-6">
+            <TabsTrigger value="activities">Activities</TabsTrigger>
                <TabsTrigger value="my-rewards">My Rewards</TabsTrigger>
-              <TabsTrigger value="activities">Activities</TabsTrigger>
               <TabsTrigger value="leaderboard">Leaderboard</TabsTrigger>
             </TabsList>
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new "Est. Incentive APY" column to the rewards activities table, displaying estimated annual percentage yields based on CATA token incentives. The changes integrate vault share token pricing into the backend rewards service and update UI components to prominently feature rewards-earning opportunities.

**Key Changes:**
- Backend: Added vault share token address fetching and pricing logic for vault activities in rewards TVL calculations
- Activities table: New APY column with sorting (highest first), replaced activity ID with serial numbers, added "Earn Now" action buttons
- Dashboard: Replaced "Refer a Friend" section with "Rewards" section showing highest available APY
- Navigation: Updated default rewards tab to "Activities" and changed Hero CTA from "Explore Stats" to "Earn Rewards"

**Note:** The APY calculation assumes a $25M fully diluted valuation for CATA (hardcoded as `0.25` multiplier). This should be extracted to a shared constant or configuration for maintainability.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor consideration for hardcoded values
- The implementation is solid with proper error handling, but the hardcoded $25M FDV assumption (`0.25` multiplier) in APY calculations across multiple files should ideally be extracted to a shared constant for easier maintenance and updates.
- Pay attention to `ActivitiesTable.tsx` and `Dashboard.tsx` where the `0.25` CATA price multiplier is duplicated

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| mercata/backend/src/api/services/rewards.service.ts | Added vault share token pricing support for rewards TVL calculation |
| mercata/ui/src/components/rewards/ActivitiesTable.tsx | Added Est. Incentive APY column with hardcoded $25M FDV, replaced ID with S.No, added Earn Now buttons |
| mercata/ui/src/pages/Dashboard.tsx | Updated Refer a Friend section to Rewards section with highest APY display |

</details>


</details>


<sub>Last reviewed commit: 6e17c6e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->