### PR TITLE
EOA recovery script

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/scripts/recover-eoa-funds/.env.example
+++ b/scripts/recover-eoa-funds/.env.example
@@ -1,0 +1,14 @@
+# Ethereum private key for the EOA whose funds are being recovered
+PRIVATE_KEY=0xabc123...
+
+# STRATO node URL
+NODE_URL=https://node5.mercata-testnet.blockapps.net
+
+# OAuth credentials (Resource Owner Password Credentials flow)
+STRATO_USERNAME=your_admin_username
+STRATO_PASSWORD=your_admin_password
+
+# OAuth provider (Keycloak)
+OAUTH_URL=https://keycloak.blockapps.net/auth/realms/mercata/.well-known/openid-configuration
+OAUTH_CLIENT_ID=localhost
+OAUTH_CLIENT_SECRET=your_client_secret_here

--- a/scripts/recover-eoa-funds/package-lock.json
+++ b/scripts/recover-eoa-funds/package-lock.json
@@ -1,0 +1,277 @@
+{
+  "name": "scripts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "ethers": "^6.16.0",
+        "yargs": "^18.0.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    }
+  }
+}

--- a/scripts/recover-eoa-funds/package.json
+++ b/scripts/recover-eoa-funds/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "ethers": "^6.16.0",
+    "yargs": "^18.0.0"
+  }
+}

--- a/scripts/recover-eoa-funds/recover-eoa-funds.js
+++ b/scripts/recover-eoa-funds/recover-eoa-funds.js
@@ -1,6 +1,4 @@
-#!/usr/bin/env node
-//
-// recover-eoa-funds.js
+// @file: scripts/recover-eoa-funds/recover-eoa-funds.js
 //
 // Recovers ERC-20 tokens sent to a STRATO address that matches an Ethereum EOA.
 // Since STRATO uses identical secp256k1/keccak256 address derivation, the same
@@ -10,20 +8,17 @@
 // core API. The signature proves ownership of the sending address.
 //
 // Authentication: Uses the same OAuth flow as mercata/contracts/deploy/ scripts.
-// Set OAUTH_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET env vars (or a .env file),
-// then pass --username and --password. Alternatively, pass a pre-acquired token
-// via --auth-token.
+// Set OAUTH_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, USERNAME, PASSWORD, and PRIVATE_KEY
+// in a .env file (see .env.example).
 //
 // Usage:
+//   # Copy .env.example to .env and fill in secrets, then:
 //   node scripts/recover-eoa-funds.js \
-//     --private-key 0xabc123... \
-//     --destination 0x742d35Cc... \
+//     --from 0xSourceEOA... \
+//     --to 0x742d35Cc... \
 //     --token-contract 0x8f3Cf7ad... \
 //     --amount 1000000 \
-//     --nonce 0 \
-//     --strato-url http://localhost \
-//     --network mercata \
-//     --username admin --password secret
+//     --nonce 0
 //
 // Prerequisites:
 //   npm install ethers yargs blockapps-rest dotenv
@@ -34,15 +29,27 @@ const { oauthUtil } = require("blockapps-rest");
 const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
 
+// ── Secrets (from .env only — never passed on the command line) ──────────────
+
+const privateKey = process.env.PRIVATE_KEY;
+const password = process.env.STRATO_PASSWORD;
+const oauthClientSecret = process.env.OAUTH_CLIENT_SECRET;
+
+// Non-secrets from .env
+const oauthUrl = process.env.OAUTH_URL;
+const oauthClientId = process.env.OAUTH_CLIENT_ID;
+const username = process.env.STRATO_USERNAME;
+const stratoUrl = (process.env.NODE_URL || "http://localhost").replace(/\/+$/, "");
+
 // ── CLI argument parsing ────────────────────────────────────────────────────
 
 const argv = yargs(hideBin(process.argv))
-  .option("private-key", {
+  .option("from", {
     type: "string",
     demandOption: true,
-    describe: "Ethereum private key (hex, with or without 0x prefix)",
+    describe: "EOA address whose funds are being recovered (must match PRIVATE_KEY)",
   })
-  .option("destination", {
+  .option("to", {
     type: "string",
     demandOption: true,
     describe: "STRATO address to receive the tokens",
@@ -50,17 +57,12 @@ const argv = yargs(hideBin(process.argv))
   .option("token-contract", {
     type: "string",
     demandOption: true,
-    describe: "ERC-20 token contract address on STRATO",
+    describe: "Token contract address on STRATO (from Asset Details page)",
   })
   .option("amount", {
     type: "string",
     demandOption: true,
-    describe: "Token amount in base units (wei)",
-  })
-  .option("strato-url", {
-    type: "string",
-    default: "http://localhost",
-    describe: "STRATO node URL",
+    describe: "Token amount in base units (wei); i.e. 12000000000000000000 for 12 USDST (which has 18 decimals)",
   })
   .option("network", {
     type: "string",
@@ -76,18 +78,6 @@ const argv = yargs(hideBin(process.argv))
     type: "number",
     default: 100000000,
     describe: "Gas limit for the transaction",
-  })
-  .option("username", {
-    type: "string",
-    describe: "OAuth username (Resource Owner Password Credentials flow)",
-  })
-  .option("password", {
-    type: "string",
-    describe: "OAuth password",
-  })
-  .option("auth-token", {
-    type: "string",
-    describe: "Pre-acquired OAuth Bearer token (alternative to username/password)",
   })
   .option("dry-run", {
     type: "boolean",
@@ -132,25 +122,32 @@ function addressToRlpHex(addr) {
 // ── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
-  const privateKey = argv.privateKey.startsWith("0x")
-    ? argv.privateKey
-    : "0x" + argv.privateKey;
-  const destination = ethers.getAddress(argv.destination);
+  if (!privateKey) {
+    throw new Error("PRIVATE_KEY required in .env");
+  }
+  const privateKeyHex = privateKey.startsWith("0x") ? privateKey : "0x" + privateKey;
+  const from = ethers.getAddress(argv.from);
+  const to = ethers.getAddress(argv.to);
   const tokenContract = ethers.getAddress(argv.tokenContract);
   const amount = argv.amount;
-  const stratoUrl = argv.stratoUrl.replace(/\/+$/, "");
   const network = argv.network;
   const gasLimit = argv.gasLimit;
 
-  // Step 1: Derive STRATO address from private key
+  // Step 1: Derive STRATO address from private key and verify it matches --from
   // Same as Ethereum: pubkey → keccak256 → last 20 bytes
-  // Reference: strato/core/strato-model/.../Address.hs:97-99
-  const signingKey = new ethers.SigningKey(privateKey);
+  const signingKey = new ethers.SigningKey(privateKeyHex);
   const derivedAddress = ethers.computeAddress(signingKey.publicKey);
 
-  console.log("==> Step 1: Address derivation");
-  console.log(`    Derived address: ${derivedAddress}`);
-  console.log(`    Destination:     ${destination}`);
+  if (derivedAddress !== from) {
+    throw new Error(
+      `PRIVATE_KEY derives address ${derivedAddress}, but --from is ${from}. ` +
+      "The private key must correspond to the source EOA."
+    );
+  }
+
+  console.log("==> Step 1: Address verification");
+  console.log(`    From (verified): ${from}`);
+  console.log(`    To:              ${to}`);
   console.log(`    Token contract:  ${tokenContract}`);
   console.log(`    Amount:          ${amount}`);
   console.log(`    Network:         ${network}`);
@@ -177,7 +174,7 @@ async function main() {
   //   _to: address wrapped in literal quotes → "\"0x742d35Cc...\""
   //   _value: plain decimal string → "1000000"
   // Reference: strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs:605-659
-  const args = [`"${destination}"`, amount];
+  const args = [`"${to}"`, amount];
 
   const rlpData = [
     intToRlpHex(2), // type discriminator (MessageTX)
@@ -231,7 +228,7 @@ async function main() {
   // r, s, v are hex strings WITHOUT 0x prefix (parsed by readHex)
   const payload = {
     next: "",
-    from: derivedAddress,
+    from: from,
     nonce: nonce,
     gasLimit: gasLimit,
     to: tokenContract,
@@ -252,32 +249,28 @@ async function main() {
     return;
   }
 
-  // Step 7: Acquire OAuth token if needed
+  // Step 7: Acquire OAuth token
   //
   // Same pattern as mercata/contracts/deploy/auth.js — uses blockapps-rest oauthUtil
   // with Resource Owner Password Credentials grant.
-  // Requires env vars: OAUTH_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET
-  let authToken = argv.authToken;
-  if (!authToken && argv.username && argv.password) {
-    const oauthUrl = process.env.OAUTH_URL;
-    const clientId = process.env.OAUTH_CLIENT_ID;
-    const clientSecret = process.env.OAUTH_CLIENT_SECRET;
-    if (!oauthUrl || !clientId) {
+  let authToken;
+  if (username && password) {
+    if (!oauthUrl || !oauthClientId || !oauthClientSecret) {
       throw new Error(
-        "OAUTH_URL and OAUTH_CLIENT_ID env vars required for username/password auth. " +
-        "See mercata/contracts/scripts/token-transfer/env.example for reference."
+        "OAUTH_URL, OAUTH_CLIENT_ID, and OAUTH_CLIENT_SECRET required in .env for authentication. " +
+        "See .env.example for reference."
       );
     }
-    console.log(`\n==> Authenticating as ${argv.username}...`);
+    console.log(`\n==> Authenticating as ${username}...`);
     const oauth = await oauthUtil.init({
       openIdDiscoveryUrl: oauthUrl,
-      clientId,
-      clientSecret,
+      clientId: oauthClientId,
+      clientSecret: oauthClientSecret,
       tokenField: "access_token",
     });
     const tokenObj = await oauth.getAccessTokenByResourceOwnerCredential(
-      argv.username,
-      argv.password
+      username,
+      password
     );
     authToken = tokenObj.token.access_token;
     console.log("    Authenticated successfully");

--- a/scripts/recover-eoa-funds/recover-eoa-funds.js
+++ b/scripts/recover-eoa-funds/recover-eoa-funds.js
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+//
+// recover-eoa-funds.js
+//
+// Recovers ERC-20 tokens sent to a STRATO address that matches an Ethereum EOA.
+// Since STRATO uses identical secp256k1/keccak256 address derivation, the same
+// private key can sign valid STRATO transactions from that address.
+//
+// This script signs locally and submits a pre-signed transaction via the STRATO
+// core API. The signature proves ownership of the sending address.
+//
+// Authentication: Uses the same OAuth flow as mercata/contracts/deploy/ scripts.
+// Set OAUTH_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET env vars (or a .env file),
+// then pass --username and --password. Alternatively, pass a pre-acquired token
+// via --auth-token.
+//
+// Usage:
+//   node scripts/recover-eoa-funds.js \
+//     --private-key 0xabc123... \
+//     --destination 0x742d35Cc... \
+//     --token-contract 0x8f3Cf7ad... \
+//     --amount 1000000 \
+//     --nonce 0 \
+//     --strato-url http://localhost \
+//     --network mercata \
+//     --username admin --password secret
+//
+// Prerequisites:
+//   npm install ethers yargs blockapps-rest dotenv
+
+require("dotenv").config({ quiet: true });
+const { ethers } = require("ethers");
+const { oauthUtil } = require("blockapps-rest");
+const yargs = require("yargs/yargs");
+const { hideBin } = require("yargs/helpers");
+
+// ── CLI argument parsing ────────────────────────────────────────────────────
+
+const argv = yargs(hideBin(process.argv))
+  .option("private-key", {
+    type: "string",
+    demandOption: true,
+    describe: "Ethereum private key (hex, with or without 0x prefix)",
+  })
+  .option("destination", {
+    type: "string",
+    demandOption: true,
+    describe: "STRATO address to receive the tokens",
+  })
+  .option("token-contract", {
+    type: "string",
+    demandOption: true,
+    describe: "ERC-20 token contract address on STRATO",
+  })
+  .option("amount", {
+    type: "string",
+    demandOption: true,
+    describe: "Token amount in base units (wei)",
+  })
+  .option("strato-url", {
+    type: "string",
+    default: "http://localhost",
+    describe: "STRATO node URL",
+  })
+  .option("network", {
+    type: "string",
+    default: "mercata",
+    describe: "STRATO network name",
+  })
+  .option("nonce", {
+    type: "number",
+    demandOption: true,
+    describe: "Transaction nonce for the sending address",
+  })
+  .option("gas-limit", {
+    type: "number",
+    default: 100000000,
+    describe: "Gas limit for the transaction",
+  })
+  .option("username", {
+    type: "string",
+    describe: "OAuth username (Resource Owner Password Credentials flow)",
+  })
+  .option("password", {
+    type: "string",
+    describe: "OAuth password",
+  })
+  .option("auth-token", {
+    type: "string",
+    describe: "Pre-acquired OAuth Bearer token (alternative to username/password)",
+  })
+  .option("dry-run", {
+    type: "boolean",
+    default: false,
+    describe: "Print the transaction JSON without submitting",
+  })
+  .strict()
+  .help()
+  .parseSync();
+
+// ── RLP encoding helpers ────────────────────────────────────────────────────
+//
+// STRATO's RLP encoding matches standard Ethereum RLP. ethers.encodeRlp()
+// expects hex-string leaf values (0x-prefixed). We convert each type:
+//
+// Integer:  0 → "0x" (empty), 1-127 → single byte, ≥128 → big-endian bytes
+// Address:  always 20 bytes, zero-padded (Data.Binary.encode for Word160)
+// Text:     UTF-8 → hex bytes
+// [Text]:   RLP array of hex-encoded texts
+//
+// Reference: strato/libs/ethereum-rlp/library/Blockchain/Data/RLP.hs:177-206
+
+function intToRlpHex(n) {
+  if (n === 0 || n === 0n) return "0x"; // RLPString empty → serializes as 0x80
+  const big = BigInt(n);
+  let hex = big.toString(16);
+  if (hex.length % 2 !== 0) hex = "0" + hex;
+  return "0x" + hex;
+}
+
+function textToRlpHex(text) {
+  return ethers.hexlify(ethers.toUtf8Bytes(text));
+}
+
+function addressToRlpHex(addr) {
+  // STRATO encodes Address as exactly 20 bytes via Data.Binary.encode on Word160
+  // (putWord32be + putWord64be + putWord64be = 4+8+8 = 20 bytes, big-endian)
+  // Reference: strato/libs/blockapps-haskoin/.../BigWord.hs:297-307
+  return ethers.zeroPadValue(addr, 20);
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const privateKey = argv.privateKey.startsWith("0x")
+    ? argv.privateKey
+    : "0x" + argv.privateKey;
+  const destination = ethers.getAddress(argv.destination);
+  const tokenContract = ethers.getAddress(argv.tokenContract);
+  const amount = argv.amount;
+  const stratoUrl = argv.stratoUrl.replace(/\/+$/, "");
+  const network = argv.network;
+  const gasLimit = argv.gasLimit;
+
+  // Step 1: Derive STRATO address from private key
+  // Same as Ethereum: pubkey → keccak256 → last 20 bytes
+  // Reference: strato/core/strato-model/.../Address.hs:97-99
+  const signingKey = new ethers.SigningKey(privateKey);
+  const derivedAddress = ethers.computeAddress(signingKey.publicKey);
+
+  console.log("==> Step 1: Address derivation");
+  console.log(`    Derived address: ${derivedAddress}`);
+  console.log(`    Destination:     ${destination}`);
+  console.log(`    Token contract:  ${tokenContract}`);
+  console.log(`    Amount:          ${amount}`);
+  console.log(`    Network:         ${network}`);
+
+  // Step 2: Nonce (provided via CLI)
+  const nonce = argv.nonce;
+  console.log(`\n==> Step 2: Nonce: ${nonce}`);
+
+  // Step 3: Construct unsigned MessageTX as STRATO RLP
+  //
+  // partialRLPEncode MessageTX = RLPArray [
+  //   rlpEncode (2::Integer),          -- type discriminator
+  //   rlpEncode transactionNonce,       -- Integer
+  //   rlpEncode transactionGasLimit,    -- Integer
+  //   rlpEncode transactionTo,          -- Address (20 bytes)
+  //   rlpEncode transactionFuncName,    -- Text
+  //   rlpEncode transactionArgs,        -- [Text]
+  //   rlpEncode transactionNetwork      -- Text
+  // ]
+  //
+  // Reference: strato/core/blockapps-data/.../TransactionDef.hs:193-203
+
+  // Args for transfer(address _to, uint256 _value):
+  //   _to: address wrapped in literal quotes → "\"0x742d35Cc...\""
+  //   _value: plain decimal string → "1000000"
+  // Reference: strato/api/bloc/bloc2/src/Bloc/Server/Transaction.hs:605-659
+  const args = [`"${destination}"`, amount];
+
+  const rlpData = [
+    intToRlpHex(2), // type discriminator (MessageTX)
+    intToRlpHex(nonce), // nonce
+    intToRlpHex(gasLimit), // gasLimit
+    addressToRlpHex(tokenContract), // to (token contract address)
+    textToRlpHex("transfer"), // funcName
+    args.map(textToRlpHex), // args as RLP array of texts
+    textToRlpHex(network), // network
+  ];
+
+  console.log("\n==> Step 3: Constructing unsigned TX RLP");
+
+  // Step 4: Hash — keccak256 of RLP-serialized bytes
+  // Reference: strato/core/blockapps-data/.../Transaction.hs:281-282
+  //   partialTransactionHash = hash . rlpSerialize . partialRLPEncode
+  const rlpEncoded = ethers.encodeRlp(rlpData);
+  const txHash = ethers.keccak256(rlpEncoded);
+  console.log(`    RLP encoded: ${rlpEncoded}`);
+  console.log(`    TX hash:     ${txHash}`);
+
+  // Step 5: Sign — secp256k1 sign the 32-byte hash
+  //
+  // STRATO uses v = recovery_id + 27 (getSigVals adds 0x1b)
+  // Reference: strato/core/blockapps-data/.../Transaction.hs:170-175
+  //
+  // R/S swap note: STRATO's secp256k1-haskell wrapper has an internal R/S swap
+  // in the Storable instance for CompactSig (peek names first 32 bytes "s" and
+  // second 32 "r"). signMsg's explicit swap undoes this, so transaction fields
+  // store standard (r, s). recoverPub's swap + CompactSig.poke's S-first layout
+  // reconstructs correct C memory layout. Net result: standard Node.js signatures
+  // work directly without any R/S swap.
+  // Reference: strato/libs/secp256k1-haskell/.../Internal.hs:157-212
+  //            strato/core/strato-model/.../Secp256k1.hs:287-291
+  const sig = signingKey.sign(txHash);
+
+  // ethers v6: sig.r and sig.s are 0x-prefixed 66-char hex strings
+  // sig.v is 27 or 28, sig.yParity is 0 or 1
+  const rHex = sig.r.slice(2); // strip 0x
+  const sHex = sig.s.slice(2); // strip 0x
+  const vHex = sig.v.toString(16); // "1b" or "1c"
+
+  console.log(`    v: 0x${vHex} (${sig.v})`);
+
+  // Step 6: Construct JSON payload
+  //
+  // Must match FromJSON RawTransaction' field names:
+  //   from, nonce, gasLimit, to, funcName, args, network, r, s, v, blockNumber, next
+  // Reference: strato/core/blockDB/.../JsonBlock.hs:97-142
+  //
+  // r, s, v are hex strings WITHOUT 0x prefix (parsed by readHex)
+  const payload = {
+    next: "",
+    from: derivedAddress,
+    nonce: nonce,
+    gasLimit: gasLimit,
+    to: tokenContract,
+    funcName: "transfer",
+    args: args,
+    network: network,
+    r: rHex,
+    s: sHex,
+    v: vHex,
+    blockNumber: -1,
+  };
+
+  console.log("\n==> Step 4: Transaction JSON");
+  console.log(JSON.stringify(payload, null, 2));
+
+  if (argv.dryRun) {
+    console.log("\n==> DRY RUN: not submitting transaction");
+    return;
+  }
+
+  // Step 7: Acquire OAuth token if needed
+  //
+  // Same pattern as mercata/contracts/deploy/auth.js — uses blockapps-rest oauthUtil
+  // with Resource Owner Password Credentials grant.
+  // Requires env vars: OAUTH_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET
+  let authToken = argv.authToken;
+  if (!authToken && argv.username && argv.password) {
+    const oauthUrl = process.env.OAUTH_URL;
+    const clientId = process.env.OAUTH_CLIENT_ID;
+    const clientSecret = process.env.OAUTH_CLIENT_SECRET;
+    if (!oauthUrl || !clientId) {
+      throw new Error(
+        "OAUTH_URL and OAUTH_CLIENT_ID env vars required for username/password auth. " +
+        "See mercata/contracts/scripts/token-transfer/env.example for reference."
+      );
+    }
+    console.log(`\n==> Authenticating as ${argv.username}...`);
+    const oauth = await oauthUtil.init({
+      openIdDiscoveryUrl: oauthUrl,
+      clientId,
+      clientSecret,
+      tokenField: "access_token",
+    });
+    const tokenObj = await oauth.getAccessTokenByResourceOwnerCredential(
+      argv.username,
+      argv.password
+    );
+    authToken = tokenObj.token.access_token;
+    console.log("    Authenticated successfully");
+  }
+
+  // Step 8: POST to STRATO core API
+  //
+  // /strato-api/eth/v1.2/transaction → core API POST /eth/v1.2/transaction
+  //   (accepts RawTransaction' JSON, returns tx hash)
+  //
+  // Reference: strato/api/core/src/Handlers/Transaction.hs:95-97,216-236
+  //            nginx-packager/nginx.tpl.conf:442-446
+  const postUrl = `${stratoUrl}/strato-api/eth/v1.2/transaction`;
+  console.log(`\n==> Step 5: Submitting to ${postUrl}`);
+
+  // User-Agent must match an API client pattern in csrf.lua's whitelist,
+  // otherwise nginx treats this as a browser request and blocks the POST
+  // for missing CSRF token/session cookie.
+  // Reference: nginx-packager/csrf.lua:60-64
+  const headers = {
+    "Content-Type": "application/json",
+    "User-Agent": "node-fetch",
+  };
+  if (authToken) {
+    headers["Authorization"] = `Bearer ${authToken}`;
+  }
+
+  const postResp = await fetch(postUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+
+  const responseText = await postResp.text();
+
+  console.log(`\n==> Step 6: Submission result`);
+  console.log(`    HTTP status: ${postResp.status}`);
+
+  if (!postResp.ok) {
+    console.error(`    Submission FAILED`);
+    console.error(`    Response: ${responseText}`);
+    process.exit(1);
+  }
+
+  // The core API returns the tx hash as a quoted JSON string
+  const submittedHash = responseText.replace(/^"|"$/g, "").trim();
+  console.log(`    Transaction hash: ${submittedHash}`);
+  console.log("    Transaction submitted to sequencer, polling for result...");
+
+  // Step 9: Poll for transaction result
+  //
+  // GET /strato-api/eth/v1.2/transactionResult/{txHash}
+  // Returns [] while pending, then [{ status, message, ... }] when processed.
+  // status is "success" (string) or { stage, type, ... } (Failure object).
+  //
+  // Reference: strato/api/core/src/Handlers/TransactionResult.hs:35,40
+  //            strato/core/blockapps-datadefs/src/Blockchain/Data/DataDefs.txt:99-114
+  //            strato/core/blockapps-datadefs/src/Blockchain/Data/TransactionResultStatus.hs:17-26
+  const resultUrl = `${stratoUrl}/strato-api/eth/v1.2/transactionResult/${submittedHash}`;
+  const maxAttempts = 60;
+  const pollIntervalMs = 2000;
+
+  let txResult = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+
+    const resultResp = await fetch(resultUrl, { headers });
+    if (!resultResp.ok) {
+      console.log(`    Poll ${attempt}: HTTP ${resultResp.status}`);
+      continue;
+    }
+
+    const results = await resultResp.json();
+    if (Array.isArray(results) && results.length > 0) {
+      txResult = results[0];
+      break;
+    }
+    if (attempt % 5 === 0) {
+      console.log(`    Poll ${attempt}/${maxAttempts}: still pending...`);
+    }
+  }
+
+  console.log(`\n==> Step 7: Transaction result`);
+
+  if (!txResult) {
+    console.error("    Timed out waiting for transaction result.");
+    console.error(`    Check manually: GET ${resultUrl}`);
+    process.exit(1);
+  }
+
+  if (txResult.status === "success") {
+    console.log("    Status: SUCCESS");
+    console.log(`    Gas used: ${txResult.gasUsed}`);
+    console.log(`\n    Transfer completed successfully!`);
+  } else {
+    console.error("    Status: FAILED");
+    console.error(`    Message: ${txResult.message}`);
+    if (txResult.status && typeof txResult.status === "object") {
+      console.error(`    Failure stage: ${txResult.status.stage}`);
+      console.error(`    Failure type: ${JSON.stringify(txResult.status.type)}`);
+      if (txResult.status.details) {
+        console.error(`    Details: ${txResult.status.details}`);
+      }
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`\nFatal error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
To recover funds sent to your external Ethereum address via the Transfer feature on STRATO (where Bridge Out was intended instead).

Addresses #6305.

I used this successfully on testnet twice, recovering funds that I transferred to the STRATO account that matches my metamask's sepolia address. https://stratoscan.testnet.strato.nexus/address/ce9108681222062d0dd95b15f6e281194279bdd3

Needs cleaned so that it does not take the private key or other secrets at the command line, and avoid deprecated blockapps-rest package, before we can provide this to users.

